### PR TITLE
fix: PluginLoader builds wrong module name for nested group paths

### DIFF
--- a/mloda/core/abstract_plugins/plugin_loader/plugin_loader.py
+++ b/mloda/core/abstract_plugins/plugin_loader/plugin_loader.py
@@ -86,7 +86,7 @@ class PluginLoader:
         for item in group_path.rglob("*.py"):  # Finds all .py files in the directory
             if item.name == "__init__.py":
                 continue  # Skip __init__.py
-            relative_path = item.relative_to(group_path.parent).with_suffix("")  # Relative path without .py
+            relative_path = item.relative_to(self._get_group_path("")).with_suffix("")  # Relative path without .py
             module_path = ".".join(relative_path.parts)  # Convert to module path
             self._load_plugin(module_path)
 

--- a/tests/test_core/test_abstract_plugins/test_plugin_loader/test_plugin_loader.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_loader/test_plugin_loader.py
@@ -86,6 +86,13 @@ class TestPluginLoader:
 
         mock_load.assert_called_once_with("feature_group/input_data/read_files")
 
+    def test_load_nested_group_builds_correct_module_path(self) -> None:
+        """Nested group paths like 'feature_group/input_data/read_files' produce correct module names."""
+        plugin_loader = PluginLoader()
+        plugin_loader.load_group("feature_group/input_data/read_files")
+        assert "mloda_plugins.feature_group.input_data.read_files.csv" in plugin_loader.plugins
+        assert "mloda_plugins.feature_group.input_data.read_files.parquet" in plugin_loader.plugins
+
     def test_load_matching_only_loads_transformer_files(self) -> None:
         """load_matching with '*transformer*' loads only transformer files, not dataframe/filter/merge."""
         from unittest.mock import MagicMock, call


### PR DESCRIPTION
## Summary
- Fix `_load_plugins_from_path` to compute `relative_path` from the base package root instead of `group_path.parent`
- Previously, nested paths like `feature_group/input_data/read_files` produced `mloda_plugins.read_files.csv` instead of `mloda_plugins.feature_group.input_data.read_files.csv`
- Add test for nested group path loading

## Test plan
- [x] New test: `test_load_nested_group_builds_correct_module_path` passes
- [x] All 9 plugin loader tests pass

Closes #215