### PR TITLE
chore: add tool usage constraints to TDD agents

### DIFF
--- a/.claude/agents/green-agent.md
+++ b/.claude/agents/green-agent.md
@@ -27,6 +27,8 @@ Test-Driven Development Green Phase specialist. Writes minimal code to make fail
 - **NEVER** implement beyond what the tests require
 - **NEVER** add features not covered by failing tests
 - **NEVER** break existing tests
+- **NEVER** use compound shell commands (`&&`, `;`, `||`) in Bash tool calls. Run each command as a separate Bash tool call. No exceptions.
+- **NEVER** use Bash for file operations when dedicated tools exist. Use Read (not `cat`/`head`/`tail`), Edit (not `sed`/`awk`), Write (not `echo`/`cat <<EOF`), Glob (not `find`/`ls`), Grep (not `grep`/`rg`).
 - **MUST** follow mloda coding conventions from CLAUDE.md
 - **MUST** validate all tests pass after implementation
 

--- a/.claude/agents/red-agent.md
+++ b/.claude/agents/red-agent.md
@@ -25,6 +25,8 @@ Test-Driven Development Red Phase specialist. Creates failing tests that clearly
 ## Constraints
 - **NEVER** write implementation code - only tests
 - **NEVER** make tests pass - they must fail initially
+- **NEVER** use compound shell commands (`&&`, `;`, `||`) in Bash tool calls. Run each command as a separate Bash tool call. No exceptions.
+- **NEVER** use Bash for file operations when dedicated tools exist. Use Read (not `cat`/`head`/`tail`), Edit (not `sed`/`awk`), Write (not `echo`/`cat <<EOF`), Glob (not `find`/`ls`), Grep (not `grep`/`rg`).
 - **MUST** validate test failures before completion
 - **MUST** ensure tests fail for the expected reasons, not due to syntax errors
 


### PR DESCRIPTION
Prevent red and green agents from using compound shell commands and from using Bash for file operations where dedicated tools (Read, Edit, Write, Glob, Grep) should be used instead.