### PR TITLE
fix: unify SingleFilter.name as str across filter engines

### DIFF
--- a/attribution/ATTRIBUTION.md
+++ b/attribution/ATTRIBUTION.md
@@ -12,7 +12,7 @@
 | charset-normalizer                     | 3.4.6           | MIT                                  |
 | click                                  | 8.3.1           | BSD-3-Clause                         |
 | comm                                   | 0.2.3           | BSD License                          |
-| cyclonedx-python-lib                   | 9.1.0           | Apache Software License              |
+| cyclonedx-python-lib                   | 11.7.0          | Apache Software License              |
 | debugpy                                | 1.8.20          | MIT License                          |
 | decorator                              | 5.2.1           | BSD License                          |
 | defusedxml                             | 0.7.1           | Python Software Foundation License   |
@@ -65,7 +65,7 @@
 | pexpect                                | 4.9.0           | ISC License (ISCL)                   |
 | pip-api                                | 0.0.34          | Apache Software License              |
 | pip-requirements-parser                | 32.0.1          | MIT                                  |
-| pip_audit                              | 2.9.0           | Apache Software License              |
+| pip_audit                              | 2.10.0          | Apache Software License              |
 | platformdirs                           | 4.9.4           | MIT License                          |
 | pluggy                                 | 1.6.0           | MIT License                          |
 | polars                                 | 1.39.3          | MIT License                          |
@@ -105,6 +105,7 @@
 | testbook                               | 0.4.2           | BSD License                          |
 | threadpoolctl                          | 3.6.0           | BSD License                          |
 | toml                                   | 0.10.2          | MIT License                          |
+| tomli_w                                | 1.2.0           | MIT License                          |
 | tornado                                | 6.5.5           | Apache Software License              |
 | tqdm                                   | 4.67.3          | MPL-2.0 AND MIT                      |
 | traitlets                              | 5.14.3          | BSD License                          |

--- a/mloda/core/abstract_plugins/components/feature.py
+++ b/mloda/core/abstract_plugins/components/feature.py
@@ -163,6 +163,14 @@ class Feature:
 
         return hash((self.name, self.options, self.domain, compute_frameworks_hashable, self.data_type, child_options))
 
+    def __repr__(self) -> str:
+        parts = [f"name={self.name.name!r}"]
+        if self.data_type is not None:
+            parts.append(f"data_type={self.data_type!r}")
+        if self.options and (self.options.group or self.options.context):
+            parts.append(f"options={self.options!r}")
+        return f"Feature({', '.join(parts)})"
+
     def is_different_data_type(self, other: Feature) -> bool:
         return self.name == other.name and self.data_type != other.data_type
 

--- a/mloda/core/filter/single_filter.py
+++ b/mloda/core/filter/single_filter.py
@@ -27,7 +27,7 @@ class SingleFilter:
         self.filter_feature = self.handle_filter_feature(filter_feature)
         self.filter_type = self.handle_filter_type(filter_type)
         self.parameter = self.handle_parameter(parameter)
-        self.name = self.filter_feature.name
+        self.name = str(self.filter_feature.name)
 
         self.uuid = uuid.uuid4()
 

--- a/mloda_plugins/compute_framework/base_implementations/polars/polars_filter_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/polars/polars_filter_engine.py
@@ -21,7 +21,7 @@ class PolarsFilterEngine(BaseFilterEngine):
         if min_parameter is None or max_parameter is None:
             raise ValueError(f"Filter parameter {filter_feature.parameter} not supported")
 
-        filter_feature_name = filter_feature.name.name
+        filter_feature_name = filter_feature.name
 
         if max_operator is True:
             return data.filter(
@@ -34,7 +34,7 @@ class PolarsFilterEngine(BaseFilterEngine):
 
     @classmethod
     def do_min_filter(cls, data: Any, filter_feature: SingleFilter) -> Any:
-        column_name = filter_feature.name.name
+        column_name = filter_feature.name
 
         # Extract the value from the parameter
         value = filter_feature.parameter.value
@@ -46,7 +46,7 @@ class PolarsFilterEngine(BaseFilterEngine):
 
     @classmethod
     def do_max_filter(cls, data: Any, filter_feature: SingleFilter) -> Any:
-        column_name = filter_feature.name.name
+        column_name = filter_feature.name
 
         # Check if this is a complex parameter with max/max_exclusive or a simple one with value
         has_max = filter_feature.parameter.max_value is not None
@@ -83,7 +83,7 @@ class PolarsFilterEngine(BaseFilterEngine):
 
     @classmethod
     def do_equal_filter(cls, data: Any, filter_feature: SingleFilter) -> Any:
-        column_name = filter_feature.name.name
+        column_name = filter_feature.name
 
         # Extract the value from the parameter
         value = filter_feature.parameter.value
@@ -95,7 +95,7 @@ class PolarsFilterEngine(BaseFilterEngine):
 
     @classmethod
     def do_regex_filter(cls, data: Any, filter_feature: SingleFilter) -> Any:
-        column_name = filter_feature.name.name
+        column_name = filter_feature.name
 
         # Extract the value from the parameter
         value = filter_feature.parameter.value
@@ -107,7 +107,7 @@ class PolarsFilterEngine(BaseFilterEngine):
 
     @classmethod
     def do_categorical_inclusion_filter(cls, data: Any, filter_feature: SingleFilter) -> Any:
-        column_name = filter_feature.name.name
+        column_name = filter_feature.name
 
         # Extract the values from the parameter
         values = filter_feature.parameter.values

--- a/mloda_plugins/compute_framework/base_implementations/pyarrow/pyarrow_filter_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/pyarrow/pyarrow_filter_engine.py
@@ -19,8 +19,7 @@ class PyArrowFilterEngine(BaseFilterEngine):
         if min_parameter is None or max_parameter is None:
             raise ValueError(f"Filter parameter {filter_feature.parameter} not supported")
 
-        # Get the string name from the FeatureName object
-        column_name = str(filter_feature.name)
+        column_name = filter_feature.name
 
         # Create boolean masks using PyArrow compute
         min_mask = pc.greater_equal(data[column_name], min_parameter)
@@ -36,8 +35,7 @@ class PyArrowFilterEngine(BaseFilterEngine):
 
     @classmethod
     def do_min_filter(cls, data: Any, filter_feature: SingleFilter) -> Any:
-        # Get the string name from the FeatureName object
-        column_name = str(filter_feature.name)
+        column_name = filter_feature.name
 
         # Extract the value from the parameter
         value = filter_feature.parameter.value
@@ -51,8 +49,7 @@ class PyArrowFilterEngine(BaseFilterEngine):
 
     @classmethod
     def do_max_filter(cls, data: Any, filter_feature: SingleFilter) -> Any:
-        # Get the string name from the FeatureName object
-        column_name = str(filter_feature.name)
+        column_name = filter_feature.name
 
         # Check if this is a complex parameter with max/max_exclusive or a simple one with value
         has_max = filter_feature.parameter.max_value is not None
@@ -93,8 +90,7 @@ class PyArrowFilterEngine(BaseFilterEngine):
 
     @classmethod
     def do_equal_filter(cls, data: Any, filter_feature: SingleFilter) -> Any:
-        # Get the string name from the FeatureName object
-        column_name = str(filter_feature.name)
+        column_name = filter_feature.name
 
         # Extract the value from the parameter
         value = filter_feature.parameter.value
@@ -108,8 +104,7 @@ class PyArrowFilterEngine(BaseFilterEngine):
 
     @classmethod
     def do_regex_filter(cls, data: Any, filter_feature: SingleFilter) -> Any:
-        # Get the string name from the FeatureName object
-        column_name = str(filter_feature.name)
+        column_name = filter_feature.name
 
         # Extract the value from the parameter
         value = filter_feature.parameter.value
@@ -125,8 +120,7 @@ class PyArrowFilterEngine(BaseFilterEngine):
 
     @classmethod
     def do_categorical_inclusion_filter(cls, data: Any, filter_feature: SingleFilter) -> Any:
-        # Get the string name from the FeatureName object
-        column_name = str(filter_feature.name)
+        column_name = filter_feature.name
 
         # Extract the values from the parameter
         values = filter_feature.parameter.values

--- a/mloda_plugins/compute_framework/base_implementations/spark/spark_filter_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/spark/spark_filter_engine.py
@@ -23,7 +23,7 @@ class SparkFilterEngine(BaseFilterEngine):
         if min_parameter is None or max_parameter is None:
             raise ValueError(f"Filter parameter {filter_feature.parameter} not supported")
 
-        column_name = filter_feature.name.name
+        column_name = filter_feature.name
 
         if max_operator is True:
             condition = (F.col(column_name) >= min_parameter) & (F.col(column_name) < max_parameter)
@@ -34,7 +34,7 @@ class SparkFilterEngine(BaseFilterEngine):
 
     @classmethod
     def do_min_filter(cls, data: Any, filter_feature: SingleFilter) -> Any:
-        column_name = filter_feature.name.name
+        column_name = filter_feature.name
 
         # Extract the value from the parameter
 
@@ -47,7 +47,7 @@ class SparkFilterEngine(BaseFilterEngine):
 
     @classmethod
     def do_max_filter(cls, data: Any, filter_feature: SingleFilter) -> Any:
-        column_name = filter_feature.name.name
+        column_name = filter_feature.name
 
         # Check if this is a complex parameter with max/max_exclusive or a simple one with value
 
@@ -89,7 +89,7 @@ class SparkFilterEngine(BaseFilterEngine):
 
     @classmethod
     def do_equal_filter(cls, data: Any, filter_feature: SingleFilter) -> Any:
-        column_name = filter_feature.name.name
+        column_name = filter_feature.name
 
         # Extract the value from the parameter
 
@@ -102,7 +102,7 @@ class SparkFilterEngine(BaseFilterEngine):
 
     @classmethod
     def do_regex_filter(cls, data: Any, filter_feature: SingleFilter) -> Any:
-        column_name = filter_feature.name.name
+        column_name = filter_feature.name
 
         # Extract the value from the parameter
 
@@ -116,7 +116,7 @@ class SparkFilterEngine(BaseFilterEngine):
 
     @classmethod
     def do_categorical_inclusion_filter(cls, data: Any, filter_feature: SingleFilter) -> Any:
-        column_name = filter_feature.name.name
+        column_name = filter_feature.name
 
         # Extract the values from the parameter
 

--- a/mloda_plugins/compute_framework/base_implementations/sql/sql_base_filter_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/sql/sql_base_filter_engine.py
@@ -37,7 +37,7 @@ class SqlBaseFilterEngine(BaseFilterEngine):
         if min_parameter is None or max_parameter is None:
             raise ValueError(f"Filter parameter {filter_feature.parameter} not supported")
 
-        filter_feature_name = filter_feature.name.name
+        filter_feature_name = filter_feature.name
 
         if max_operator is True:
             condition = f"{quote_ident(filter_feature_name)} >= ? AND {quote_ident(filter_feature_name)} < ?"
@@ -48,7 +48,7 @@ class SqlBaseFilterEngine(BaseFilterEngine):
 
     @classmethod
     def do_min_filter(cls, data: Any, filter_feature: SingleFilter) -> Any:
-        column_name = filter_feature.name.name
+        column_name = filter_feature.name
         value = filter_feature.parameter.value
 
         if value is None:
@@ -59,7 +59,7 @@ class SqlBaseFilterEngine(BaseFilterEngine):
 
     @classmethod
     def do_max_filter(cls, data: Any, filter_feature: SingleFilter) -> Any:
-        column_name = filter_feature.name.name
+        column_name = filter_feature.name
 
         has_max = filter_feature.parameter.max_value is not None
         has_value = filter_feature.parameter.value is not None
@@ -97,7 +97,7 @@ class SqlBaseFilterEngine(BaseFilterEngine):
 
     @classmethod
     def do_equal_filter(cls, data: Any, filter_feature: SingleFilter) -> Any:
-        column_name = filter_feature.name.name
+        column_name = filter_feature.name
         value = filter_feature.parameter.value
 
         if value is None:
@@ -108,7 +108,7 @@ class SqlBaseFilterEngine(BaseFilterEngine):
 
     @classmethod
     def do_regex_filter(cls, data: Any, filter_feature: SingleFilter) -> Any:
-        column_name = filter_feature.name.name
+        column_name = filter_feature.name
         value = filter_feature.parameter.value
 
         if value is None:
@@ -119,7 +119,7 @@ class SqlBaseFilterEngine(BaseFilterEngine):
 
     @classmethod
     def do_categorical_inclusion_filter(cls, data: Any, filter_feature: SingleFilter) -> Any:
-        column_name = filter_feature.name.name
+        column_name = filter_feature.name
         values = filter_feature.parameter.values
 
         if values is None:

--- a/tests/test_core/test_abstract_plugins/test_components/test_feature.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_feature.py
@@ -1,6 +1,7 @@
 import pytest
 from mloda.provider import ComputeFramework
 from mloda.user import Feature
+from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.core.abstract_plugins.components.utils import get_all_subclasses
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame  # noqa: F401
 
@@ -45,3 +46,13 @@ def test_feature_set_domain() -> None:
 
     # Test when neither domain nor domain_options are set
     assert feature._set_domain(None, None) is None
+
+
+def test_feature_repr_name_only() -> None:
+    feature = Feature(name="my_feature")
+    assert repr(feature) == "Feature(name='my_feature')"
+
+
+def test_feature_repr_with_data_type() -> None:
+    feature = Feature(name="my_feature", data_type=DataType.INT32)
+    assert repr(feature) == "Feature(name='my_feature', data_type=<DataType.INT32: 'INT32'>)"


### PR DESCRIPTION
## Summary
- Store `SingleFilter.name` as `str` instead of `FeatureName`, fixing pandas KeyError on column lookups
- Simplify all filter engines to use `filter_feature.name` directly
- Add `__repr__` to `Feature`

## Test plan
- [x] All 11 pandas filter engine tests pass
- [x] Both time window global filter tests pass