### PR TITLE
docs: fix documentation issues for data user experience

### DIFF
--- a/docs/docs/chapter1/installation.md
+++ b/docs/docs/chapter1/installation.md
@@ -24,8 +24,7 @@ print(metadata.version("mloda"))
 Try this 30-second example:
 
 ``` python
-import mloda
-from mloda.user import PluginLoader
+from mloda.user import mloda, PluginLoader
 PluginLoader.all()
 
 result = mloda.run_all(
@@ -37,5 +36,8 @@ result = mloda.run_all(
     }}
 )
 ```
+
+`api_data` passes inline data to mloda. Each top-level key (e.g. `"SampleData"`)
+is a label grouping related columns. Features are matched to columns by name.
 
 Next: [API Request](https://mloda-ai.github.io/mloda/chapter1/api-request/) | [Feature Groups](https://mloda-ai.github.io/mloda/chapter1/feature-groups/)

--- a/mloda_plugins/feature_group/experimental/sklearn/scaling/base.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/scaling/base.py
@@ -64,7 +64,7 @@ class ScalingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     )
 
     # The Engine will automatically parse this into a feature with name
-    # "standard_scaled__income"
+    # "income__standard_scaled"
     ```
     """
 

--- a/mloda_plugins/feature_group/experimental/text_cleaning/base.py
+++ b/mloda_plugins/feature_group/experimental/text_cleaning/base.py
@@ -17,57 +17,6 @@ from mloda_plugins.feature_group.default_options_key import DefaultOptionKeys
 
 
 class TextCleaningFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-    # Option key for the list of operations
-    CLEANING_OPERATIONS = "cleaning_operations"
-
-    # Define supported cleaning operations with their descriptions
-    SUPPORTED_OPERATIONS = {
-        "normalize": "Convert text to lowercase and remove accents",
-        "remove_stopwords": "Remove common stopwords",
-        "remove_punctuation": "Remove punctuation marks",
-        "remove_special_chars": "Remove special characters",
-        "normalize_whitespace": "Normalize whitespace",
-        "remove_urls": "Remove URLs and email addresses",
-    }
-
-    # Define prefix pattern and pattern
-    PATTERN = "__"
-    PREFIX_PATTERN = r".*__cleaned_text$"
-
-    # In-feature configuration for FeatureChainParserMixin
-    MIN_IN_FEATURES = 1
-    MAX_IN_FEATURES = 1
-
-    # Property mapping for configuration-based features
-    PROPERTY_MAPPING = {
-        CLEANING_OPERATIONS: {
-            **SUPPORTED_OPERATIONS,  # All supported operations as valid options
-            DefaultOptionKeys.context: True,  # Mark as context parameter
-            DefaultOptionKeys.strict_validation: True,  # Enable strict validation
-            DefaultOptionKeys.validation_function: lambda operations: (
-                # Handle both actual tuples/lists and string representations
-                (
-                    isinstance(operations, (tuple, list))
-                    and all(op in TextCleaningFeatureGroup.SUPPORTED_OPERATIONS for op in operations)
-                )
-                or (
-                    isinstance(operations, str)
-                    and operations.startswith("(")
-                    and operations.endswith(")")
-                    and all(
-                        op.strip("'\" ,") in TextCleaningFeatureGroup.SUPPORTED_OPERATIONS
-                        for op in operations.strip("()").split(",")
-                        if op.strip("'\" ,")
-                    )
-                )
-            ),
-        },
-        DefaultOptionKeys.in_features: {
-            "explanation": "Source feature to apply text cleaning operations to",
-            DefaultOptionKeys.context: True,
-        },
-    }
-
     """
     Base class for all text cleaning feature groups.
 
@@ -119,6 +68,57 @@ class TextCleaningFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     - The input data must contain the source feature to be used for text cleaning
     - The source feature must contain text data
     """
+
+    # Option key for the list of operations
+    CLEANING_OPERATIONS = "cleaning_operations"
+
+    # Define supported cleaning operations with their descriptions
+    SUPPORTED_OPERATIONS = {
+        "normalize": "Convert text to lowercase and remove accents",
+        "remove_stopwords": "Remove common stopwords",
+        "remove_punctuation": "Remove punctuation marks",
+        "remove_special_chars": "Remove special characters",
+        "normalize_whitespace": "Normalize whitespace",
+        "remove_urls": "Remove URLs and email addresses",
+    }
+
+    # Define prefix pattern and pattern
+    PATTERN = "__"
+    PREFIX_PATTERN = r".*__cleaned_text$"
+
+    # In-feature configuration for FeatureChainParserMixin
+    MIN_IN_FEATURES = 1
+    MAX_IN_FEATURES = 1
+
+    # Property mapping for configuration-based features
+    PROPERTY_MAPPING = {
+        CLEANING_OPERATIONS: {
+            **SUPPORTED_OPERATIONS,  # All supported operations as valid options
+            DefaultOptionKeys.context: True,  # Mark as context parameter
+            DefaultOptionKeys.strict_validation: True,  # Enable strict validation
+            DefaultOptionKeys.validation_function: lambda operations: (
+                # Handle both actual tuples/lists and string representations
+                (
+                    isinstance(operations, (tuple, list))
+                    and all(op in TextCleaningFeatureGroup.SUPPORTED_OPERATIONS for op in operations)
+                )
+                or (
+                    isinstance(operations, str)
+                    and operations.startswith("(")
+                    and operations.endswith(")")
+                    and all(
+                        op.strip("'\" ,") in TextCleaningFeatureGroup.SUPPORTED_OPERATIONS
+                        for op in operations.strip("()").split(",")
+                        if op.strip("'\" ,")
+                    )
+                )
+            ),
+        },
+        DefaultOptionKeys.in_features: {
+            "explanation": "Source feature to apply text cleaning operations to",
+            DefaultOptionKeys.context: True,
+        },
+    }
 
     @classmethod
     def _extract_operations_and_source_feature(cls, feature: Feature) -> tuple[tuple[Any, Any], str]:

--- a/mloda_plugins/feature_group/experimental/time_window/base.py
+++ b/mloda_plugins/feature_group/experimental/time_window/base.py
@@ -20,10 +20,6 @@ from mloda_plugins.feature_group.default_options_key import DefaultOptionKeys
 
 
 class TimeWindowFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-    # Option keys for time window configuration
-    WINDOW_FUNCTION = "window_function"
-    WINDOW_SIZE = "window_size"
-    TIME_UNIT = "time_unit"
     """
     Base class for all time window feature groups.
 
@@ -73,6 +69,11 @@ class TimeWindowFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     - You can specify a custom time column by setting the reference_time option in the feature group options
 
     """
+
+    # Option keys for time window configuration
+    WINDOW_FUNCTION = "window_function"
+    WINDOW_SIZE = "window_size"
+    TIME_UNIT = "time_unit"
 
     @classmethod
     def get_reference_time_column(cls, options: Optional[Options] = None) -> str:

--- a/mloda_plugins/feature_group/input_data/read_db_feature.py
+++ b/mloda_plugins/feature_group/input_data/read_db_feature.py
@@ -7,6 +7,12 @@ from mloda_plugins.feature_group.input_data.read_db import ReadDB
 
 
 class ReadDBFeature(FeatureGroup):
+    """Load features from database sources.
+
+    Delegates to ``ReadDB``, which executes queries against a configured
+    database connection and returns the result as a compute-framework object.
+    """
+
     @classmethod
     def input_data(cls) -> Optional[BaseInputData]:
         return ReadDB()

--- a/mloda_plugins/feature_group/input_data/read_document_feature.py
+++ b/mloda_plugins/feature_group/input_data/read_document_feature.py
@@ -7,6 +7,12 @@ from mloda_plugins.feature_group.input_data.read_document import ReadDocument
 
 
 class ReadDocumentFeature(FeatureGroup):
+    """Load features from document sources (PDFs, text files, etc.).
+
+    Delegates to ``ReadDocument``, which extracts structured data from
+    document formats and returns the result as a compute-framework object.
+    """
+
     @classmethod
     def input_data(cls) -> Optional[BaseInputData]:
         return ReadDocument()

--- a/mloda_plugins/feature_group/input_data/read_file_feature.py
+++ b/mloda_plugins/feature_group/input_data/read_file_feature.py
@@ -7,6 +7,13 @@ from mloda_plugins.feature_group.input_data.read_file import ReadFile
 
 
 class ReadFileFeature(FeatureGroup):
+    """Load features from file-based data sources (CSV, Parquet, JSON, etc.).
+
+    This is the default input FeatureGroup for file reads. It delegates to
+    ``ReadFile``, which selects a reader based on the file extension provided
+    in the feature options.
+    """
+
     @classmethod
     def input_data(cls) -> Optional[BaseInputData]:
         return ReadFile()


### PR DESCRIPTION
## Summary
- **6.1**: Fix broken Quick Start import (`import mloda` -> `from mloda.user import mloda`), add brief `api_data` explanation
- **6.2**: Add docstrings to `ReadFileFeature`, `ReadDBFeature`, `ReadDocumentFeature` (were completely undocumented)
- **6.3**: Move misplaced docstrings in `TimeWindowFeatureGroup` and `TextCleaningFeatureGroup` from after class attributes to immediately after class declaration (were dead code)
- **6.4**: Fix reversed feature name in `ScalingFeatureGroup` docstring: `"standard_scaled__income"` -> `"income__standard_scaled"`

## Test plan
- [x] No logic changes, documentation/docstring only
- [ ] Run `tox` to confirm no regressions

Ref: ticket 278, issues 6.1, 6.2, 6.3, 6.4