### PR TITLE
fix: separate metadata from valid values in PROPERTY_MAPPING

### DIFF
--- a/docs/docs/in_depth/feature-chain-parser.md
+++ b/docs/docs/in_depth/feature-chain-parser.md
@@ -126,11 +126,15 @@ class MyFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         "operation_type": {
             "sum": "Sum operation",
             "avg": "Average operation",
-            DefaultOptionKeys.mloda_context: True,
+            "_meta": {
+                DefaultOptionKeys.mloda_context: True,
+            },
         },
         DefaultOptionKeys.in_features: {
-            "explanation": "Source feature",
-            DefaultOptionKeys.mloda_context: True,
+            "_meta": {
+                "explanation": "Source feature",
+                DefaultOptionKeys.mloda_context: True,
+            },
         },
     }
 
@@ -243,9 +247,11 @@ def _is_list_of_strings(value):
 class GroupAggregation(FeatureChainParserMixin, FeatureGroup):
     PROPERTY_MAPPING = {
         "partition_by": {
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.type_validator: _is_list_of_strings,
+            "_meta": {
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: False,
+                DefaultOptionKeys.type_validator: _is_list_of_strings,
+            },
         },
     }
 ```
@@ -272,14 +278,18 @@ class MyFeatureGroup(FeatureGroup):
             "sum": "Sum aggregation",
             "avg": "Average aggregation", 
             "max": "Maximum aggregation",
-            DefaultOptionKeys.context: True,  # Context parameter
-            DefaultOptionKeys.strict_validation: True,  # Strict validation
+            "_meta": {
+                DefaultOptionKeys.context: True,  # Context parameter
+                DefaultOptionKeys.strict_validation: True,  # Strict validation
+            },
         },
         # Source feature parameter
         DefaultOptionKeys.in_features: {
-            "explanation": "Source feature for the operation",
-            DefaultOptionKeys.context: True,  # Context parameter
-            DefaultOptionKeys.strict_validation: False,  # Flexible validation
+            "_meta": {
+                "explanation": "Source feature for the operation",
+                DefaultOptionKeys.context: True,  # Context parameter
+                DefaultOptionKeys.strict_validation: False,  # Flexible validation
+            },
         },
     }
 ```
@@ -358,10 +368,12 @@ For complex validation beyond simple value lists:
 ``` python
 PROPERTY_MAPPING = {
     "dimension": {
-        "explanation": "Number of dimensions for reduction",
-        DefaultOptionKeys.context: True,
-        DefaultOptionKeys.strict_validation: True,
-        DefaultOptionKeys.validation_function: lambda x: isinstance(x, int) and x > 0,
+        "_meta": {
+            "explanation": "Number of dimensions for reduction",
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: True,
+            DefaultOptionKeys.validation_function: lambda x: isinstance(x, int) and x > 0,
+        },
     },
 }
 ```
@@ -375,8 +387,10 @@ PROPERTY_MAPPING = {
     "window_size": {
         "7": "7-day window",
         "30": "30-day window",
-        DefaultOptionKeys.default: "7",  # Default value
-        DefaultOptionKeys.context: True,
+        "_meta": {
+            DefaultOptionKeys.default: "7",  # Default value
+            DefaultOptionKeys.context: True,
+        },
     },
 }
 ```
@@ -389,15 +403,19 @@ PROPERTY_MAPPING = {
     "data_source": {
         "production": "Production data",
         "staging": "Staging data", 
-        DefaultOptionKeys.group: True,  # Explicit group parameter
-        DefaultOptionKeys.strict_validation: True,
+        "_meta": {
+            DefaultOptionKeys.group: True,  # Explicit group parameter
+            DefaultOptionKeys.strict_validation: True,
+        },
     },
     # Context parameter - doesn't affect resolution
     "algorithm_type": {
         "kmeans": "K-means clustering",
         "dbscan": "DBSCAN clustering",
-        DefaultOptionKeys.context: True,  # Context parameter
-        DefaultOptionKeys.strict_validation: False,  # Flexible validation
+        "_meta": {
+            DefaultOptionKeys.context: True,  # Context parameter
+            DefaultOptionKeys.strict_validation: False,  # Flexible validation
+        },
     },
 }
 ```

--- a/docs/docs/in_depth/feature-group-matching.md
+++ b/docs/docs/in_depth/feature-group-matching.md
@@ -38,13 +38,17 @@ PROPERTY_MAPPING = {
         "sum": "Sum aggregation",
         "avg": "Average aggregation",
         "max": "Maximum aggregation",
-        DefaultOptionKeys.context: True,
-        DefaultOptionKeys.strict_validation: True,
+        "_meta": {
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: True,
+        },
     },
     DefaultOptionKeys.in_features: {
-        "explanation": "Source feature for aggregation",
-        DefaultOptionKeys.context: True,
-        DefaultOptionKeys.strict_validation: False,
+        "_meta": {
+            "explanation": "Source feature for aggregation",
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: False,
+        },
     },
 }
 ```
@@ -77,10 +81,12 @@ For complex validation beyond simple value lists:
 ```python
 PROPERTY_MAPPING = {
     "window_size": {
-        "explanation": "Size of the time window",
-        DefaultOptionKeys.context: True,
-        DefaultOptionKeys.strict_validation: True,
-        DefaultOptionKeys.validation_function: lambda x: isinstance(x, int) and x > 0,
+        "_meta": {
+            "explanation": "Size of the time window",
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: True,
+            DefaultOptionKeys.validation_function: lambda x: isinstance(x, int) and x > 0,
+        },
     },
 }
 ```

--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -4,6 +4,8 @@
 
 PROPERTY_MAPPING defines parameter validation and classification for modern feature groups using the unified parser approach.
 
+Each entry maps a parameter name to a dict. The dict's top-level keys are valid option values; all metadata (classification flags, validators, defaults, explanation strings) lives inside a nested `"_meta"` sub-dict. This separation prevents collisions between valid values and metadata key names.
+
 ## Basic Structure
 
 ``` python
@@ -13,13 +15,17 @@ PROPERTY_MAPPING = {
     "parameter_name": {
         "value1": "Description of value1",
         "value2": "Description of value2",
-        DefaultOptionKeys.context: True,  # Parameter classification
-        DefaultOptionKeys.strict_validation: True,  # Validation mode
+        "_meta": {
+            DefaultOptionKeys.context: True,  # Parameter classification
+            DefaultOptionKeys.strict_validation: True,  # Validation mode
+        },
     },
     DefaultOptionKeys.in_features: {
-        "explanation": "Source feature description",
-        DefaultOptionKeys.context: True,
-        DefaultOptionKeys.strict_validation: False,  # Flexible validation
+        "_meta": {
+            "explanation": "Source feature description",
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: False,  # Flexible validation
+        },
     },
 }
 ```
@@ -30,20 +36,22 @@ PROPERTY_MAPPING = {
 # Context parameter (doesn't affect Feature Group splitting)
 "aggregation_type": {
     "sum": "Sum aggregation",
-    DefaultOptionKeys.context: True,
+    "_meta": {DefaultOptionKeys.context: True},
 }
 
 # Group parameter (affects Feature Group splitting)
 "data_source": {
     "production": "Production data",
-    DefaultOptionKeys.group: True,
+    "_meta": {DefaultOptionKeys.group: True},
 }
 
 # Order-by parameter (defines sort order for sequential operations)
 DefaultOptionKeys.order_by: {
-    "explanation": "Column(s) controlling row order for rank, offset, or frame_aggregate",
-    DefaultOptionKeys.context: True,
-    DefaultOptionKeys.strict_validation: False,
+    "_meta": {
+        "explanation": "Column(s) controlling row order for rank, offset, or frame_aggregate",
+        DefaultOptionKeys.context: True,
+        DefaultOptionKeys.strict_validation: False,
+    },
 }
 ```
 
@@ -54,7 +62,7 @@ DefaultOptionKeys.order_by: {
 "algorithm_type": {
     "kmeans": "K-means clustering",
     "dbscan": "DBSCAN clustering", 
-    DefaultOptionKeys.strict_validation: True,  # Only listed values allowed
+    "_meta": {DefaultOptionKeys.strict_validation: True},  # Only listed values allowed
 }
 ```
 
@@ -65,9 +73,11 @@ parsed elements. The parser unpacks lists and calls the function on each element
 
 ``` python
 "window_size": {
-    "explanation": "Size of time window",
-    DefaultOptionKeys.validation_function: lambda x: isinstance(x, int) and x > 0,
-    DefaultOptionKeys.strict_validation: True,
+    "_meta": {
+        "explanation": "Size of time window",
+        DefaultOptionKeys.validation_function: lambda x: isinstance(x, int) and x > 0,
+        DefaultOptionKeys.strict_validation: True,
+    },
 }
 ```
 
@@ -83,10 +93,12 @@ def _is_list_of_strings(value):
     return isinstance(value, list) and all(isinstance(item, str) for item in value)
 
 "partition_by": {
-    "explanation": "List of columns to partition by",
-    DefaultOptionKeys.context: True,
-    DefaultOptionKeys.strict_validation: False,
-    DefaultOptionKeys.type_validator: _is_list_of_strings,
+    "_meta": {
+        "explanation": "List of columns to partition by",
+        DefaultOptionKeys.context: True,
+        DefaultOptionKeys.strict_validation: False,
+        DefaultOptionKeys.type_validator: _is_list_of_strings,
+    },
 }
 ```
 
@@ -100,7 +112,7 @@ must be pure functions with no side effects.
 "method": {
     "linear": "Linear interpolation",
     "cubic": "Cubic interpolation",
-    DefaultOptionKeys.default: "linear",  # Default if not specified
+    "_meta": {DefaultOptionKeys.default: "linear"},  # Default if not specified
 }
 ```
 
@@ -112,12 +124,16 @@ class MyFeatureGroup(FeatureGroup):
         "operation_type": {
             "sum": "Sum operation",
             "avg": "Average operation",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
+            "_meta": {
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: True,
+            },
         },
         DefaultOptionKeys.in_features: {
-            "explanation": "Source feature",
-            DefaultOptionKeys.context: True,
+            "_meta": {
+                "explanation": "Source feature",
+                DefaultOptionKeys.context: True,
+            },
         },
     }
     
@@ -159,14 +175,18 @@ def _needs_order_by(options: Options) -> bool:
 PROPERTY_MAPPING = {
     "aggregation_type": {
         "sum": "Sum", "avg": "Average", "first": "First", "last": "Last",
-        DefaultOptionKeys.context: True,
-        DefaultOptionKeys.strict_validation: True,
+        "_meta": {
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: True,
+        },
     },
     "order_by": {
-        "explanation": "Column to order by within each partition",
-        DefaultOptionKeys.context: True,
-        DefaultOptionKeys.strict_validation: False,
-        DefaultOptionKeys.required_when: _needs_order_by,
+        "_meta": {
+            "explanation": "Column to order by within each partition",
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: False,
+            DefaultOptionKeys.required_when: _needs_order_by,
+        },
     },
 }
 ```

--- a/memory-bank/feature_groups.md
+++ b/memory-bank/feature_groups.md
@@ -187,10 +187,14 @@ graph LR
 PROPERTY_MAPPING = {
     AGGREGATION_TYPE: {
         **AGGREGATION_TYPES_DICT,
-        DefaultOptionKeys.context: True,  # Context parameter
+        "_meta": {
+            DefaultOptionKeys.context: True,  # Context parameter
+        },
     },
     DefaultOptionKeys.in_features: {
-        DefaultOptionKeys.context: True,
+        "_meta": {
+            DefaultOptionKeys.context: True,
+        },
     },
 }
 ```

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -17,6 +17,24 @@ CHAIN_SEPARATOR = "__"  # Separates chained transformations (source→suffix)
 COLUMN_SEPARATOR = "~"  # Separates multi-column output index
 INPUT_SEPARATOR = "&"  # Separates multiple input features
 
+# Key used to nest metadata within PROPERTY_MAPPING entries.
+# Metadata (context, strict_validation, validation_function, etc.) lives under
+# this key, keeping it separate from valid option values. This prevents silent
+# collisions when a valid value name matches a metadata key string.
+METADATA_KEY = "_meta"
+
+# Metadata keys recognised in the legacy flat PROPERTY_MAPPING format (before
+# the _meta sub-dict was introduced). Used only for backward compatibility.
+_LEGACY_METADATA_KEYS = frozenset({
+    DefaultOptionKeys.default,
+    DefaultOptionKeys.context,
+    DefaultOptionKeys.group,
+    DefaultOptionKeys.strict_validation,
+    DefaultOptionKeys.validation_function,
+    DefaultOptionKeys.required_when,
+    DefaultOptionKeys.type_validator,
+})
+
 
 class FeatureChainParser:
     """
@@ -98,6 +116,23 @@ class FeatureChainParser:
         return True
 
     @classmethod
+    def _get_metadata(cls, property_value: Any) -> Dict[str, Any]:
+        """Extract the metadata dict from a PROPERTY_MAPPING entry.
+
+        Supports both the new nested format (metadata under ``_meta`` key)
+        and the legacy flat format (metadata keys mixed with valid values).
+        The new format is preferred; the legacy path exists for backward
+        compatibility with external plugins that have not migrated yet.
+        """
+        if not isinstance(property_value, dict):
+            return {}
+        if METADATA_KEY in property_value:
+            meta = property_value[METADATA_KEY]
+            return meta if isinstance(meta, dict) else {}
+        # Legacy flat format: collect known metadata keys
+        return {k: v for k, v in property_value.items() if k in _LEGACY_METADATA_KEYS}
+
+    @classmethod
     def _can_skip_required_check(cls, property_value: Any) -> bool:
         """Check if the base parser should treat this property as optional.
 
@@ -109,24 +144,23 @@ class FeatureChainParser:
         """
         if not isinstance(property_value, dict):
             return False
-        return DefaultOptionKeys.default in property_value or DefaultOptionKeys.required_when in property_value
+        meta = cls._get_metadata(property_value)
+        return DefaultOptionKeys.default in meta or DefaultOptionKeys.required_when in meta
 
     @classmethod
     def _is_context_parameter(cls, property_value: Any) -> bool:
         """Check if property is marked as context parameter in mapping."""
-        return isinstance(property_value, dict) and property_value.get(DefaultOptionKeys.context, False)
+        return bool(cls._get_metadata(property_value).get(DefaultOptionKeys.context, False))
 
     @classmethod
     def _is_strict_validation(cls, property_value: Any) -> bool:
         """Check if property requires strict validation (values must be in mapping)."""
-        return isinstance(property_value, dict) and property_value.get(DefaultOptionKeys.strict_validation, False)
+        return bool(cls._get_metadata(property_value).get(DefaultOptionKeys.strict_validation, False))
 
     @classmethod
     def _get_validation_function(cls, property_value: Any) -> Any:
         """Get validation function from property mapping if present."""
-        if isinstance(property_value, dict):
-            return property_value.get(DefaultOptionKeys.validation_function, None)
-        return None
+        return cls._get_metadata(property_value).get(DefaultOptionKeys.validation_function, None)
 
     @classmethod
     def _validate_property_value(
@@ -190,19 +224,16 @@ class FeatureChainParser:
 
     @classmethod
     def _extract_property_values(cls, property_value: Any) -> Any:
-        """Extract property values, removing metadata keys."""
+        """Extract valid option values from a PROPERTY_MAPPING entry, removing metadata.
+
+        With the new ``_meta`` format only the ``_meta`` key is stripped.
+        For the legacy flat format the known metadata keys are stripped instead.
+        """
         if isinstance(property_value, dict):
-            # Remove metadata keys, keep only the actual valid values
-            metadata_keys = {
-                DefaultOptionKeys.default,
-                DefaultOptionKeys.context,
-                DefaultOptionKeys.group,
-                DefaultOptionKeys.strict_validation,
-                DefaultOptionKeys.validation_function,
-                DefaultOptionKeys.required_when,
-                DefaultOptionKeys.type_validator,
-            }
-            return {k: v for k, v in property_value.items() if k not in metadata_keys}
+            if METADATA_KEY in property_value:
+                return {k: v for k, v in property_value.items() if k != METADATA_KEY}
+            # Legacy flat format
+            return {k: v for k, v in property_value.items() if k not in _LEGACY_METADATA_KEYS}
         return property_value
 
     @classmethod

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -235,7 +235,8 @@ class FeatureChainParserMixin:
             for key, mapping_entry in property_mapping.items():
                 if not isinstance(mapping_entry, dict):
                     continue
-                predicate = mapping_entry.get(DefaultOptionKeys.required_when)
+                meta = FeatureChainParser._get_metadata(mapping_entry)
+                predicate = meta.get(DefaultOptionKeys.required_when)
                 if predicate is None:
                     continue
                 if not callable(predicate):
@@ -260,7 +261,8 @@ class FeatureChainParserMixin:
             for key, mapping_entry in property_mapping.items():
                 if not isinstance(mapping_entry, dict):
                     continue
-                validator = mapping_entry.get(DefaultOptionKeys.type_validator)
+                meta = FeatureChainParser._get_metadata(mapping_entry)
+                validator = meta.get(DefaultOptionKeys.type_validator)
                 if validator is None:
                     continue
                 value = options.get(key)
@@ -308,7 +310,10 @@ class FeatureChainParserMixin:
     def _has_required_when_predicates(property_mapping: Dict[str, Any]) -> bool:
         """Return True if any entry in property_mapping uses required_when."""
         for value in property_mapping.values():
-            if isinstance(value, dict) and DefaultOptionKeys.required_when in value:
+            if not isinstance(value, dict):
+                continue
+            meta = FeatureChainParser._get_metadata(value)
+            if DefaultOptionKeys.required_when in meta:
                 return True
         return False
 

--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -42,8 +42,10 @@ class FeatureGroup(ABC):
                 "operation_type": {
                     "add": "Addition",
                     "sub": "Subtraction",
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: True,
+                    "_meta": {
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: True,
+                    },
                 },
             }
 
@@ -70,9 +72,12 @@ class FeatureGroup(ABC):
     PROPERTY_MAPPING: ClassVar[Optional[Dict[str, Any]]] = None
     """Override in subclasses to declare configurable parameters.
 
-    Each key is a parameter name. Each value is a dict containing valid
-    values, metadata flags (``DefaultOptionKeys.context``,
-    ``DefaultOptionKeys.strict_validation``, etc.), and optional validators.
+    Each key is a parameter name. Each value is a dict whose top-level
+    entries are valid option values and whose ``"_meta"`` sub-dict holds
+    metadata flags (``DefaultOptionKeys.context``,
+    ``DefaultOptionKeys.strict_validation``, etc.) and optional validators.
+    Separating metadata into ``"_meta"`` prevents collisions between
+    valid values and metadata key names.
     See ``docs/in_depth/property-mapping.md`` for the full specification.
     """
 

--- a/mloda/provider/__init__.py
+++ b/mloda/provider/__init__.py
@@ -66,6 +66,7 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
     CHAIN_SEPARATOR,
     COLUMN_SEPARATOR,
     INPUT_SEPARATOR,
+    METADATA_KEY,
 )
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
 
@@ -114,6 +115,7 @@ __all__ = [
     "CHAIN_SEPARATOR",
     "COLUMN_SEPARATOR",
     "INPUT_SEPARATOR",
+    "METADATA_KEY",
     "FeatureChainParserMixin",
     # Transformers
     "BaseTransformer",

--- a/mloda_plugins/feature_group/experimental/aggregated_feature_group/base.py
+++ b/mloda_plugins/feature_group/experimental/aggregated_feature_group/base.py
@@ -108,13 +108,17 @@ class AggregatedFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     PROPERTY_MAPPING = {
         AGGREGATION_TYPE: {
             **AGGREGATION_TYPES,  # All supported aggregation types as valid values
-            DefaultOptionKeys.context: True,  # Mark as context parameter
-            DefaultOptionKeys.strict_validation: True,  # Enable strict validation
+            "_meta": {
+                DefaultOptionKeys.context: True,  # Mark as context parameter
+                DefaultOptionKeys.strict_validation: True,  # Enable strict validation
+            },
         },
         DefaultOptionKeys.in_features: {
-            "explanation": "Source feature to aggregate",
-            DefaultOptionKeys.context: True,  # Mark as context parameter
-            DefaultOptionKeys.strict_validation: False,  # Flexible validation
+            "_meta": {
+                "explanation": "Source feature to aggregate",
+                DefaultOptionKeys.context: True,  # Mark as context parameter
+                DefaultOptionKeys.strict_validation: False,  # Flexible validation
+            },
         },
     }
 

--- a/mloda_plugins/feature_group/experimental/clustering/base.py
+++ b/mloda_plugins/feature_group/experimental/clustering/base.py
@@ -114,28 +114,36 @@ class ClusteringFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     PROPERTY_MAPPING = {
         ALGORITHM: {
             **CLUSTERING_ALGORITHMS,  # All supported algorithms as valid values
-            DefaultOptionKeys.context: True,  # Mark as context parameter
-            DefaultOptionKeys.strict_validation: True,  # Enable strict validation
+            "_meta": {
+                DefaultOptionKeys.context: True,  # Mark as context parameter
+                DefaultOptionKeys.strict_validation: True,  # Enable strict validation
+            },
         },
         K_VALUE: {
-            "explanation": "Number of clusters or 'auto' for automatic determination",
-            DefaultOptionKeys.context: True,  # Mark as context parameter
-            DefaultOptionKeys.strict_validation: True,  # Enable strict validation
-            DefaultOptionKeys.validation_function: lambda value: (
-                value == "auto" or (isinstance(value, (int, str)) and str(value).isdigit() and int(value) > 0)
-            ),
+            "_meta": {
+                "explanation": "Number of clusters or 'auto' for automatic determination",
+                DefaultOptionKeys.context: True,  # Mark as context parameter
+                DefaultOptionKeys.strict_validation: True,  # Enable strict validation
+                DefaultOptionKeys.validation_function: lambda value: (
+                    value == "auto" or (isinstance(value, (int, str)) and str(value).isdigit() and int(value) > 0)
+                ),
+            },
         },
         DefaultOptionKeys.in_features: {
-            "explanation": "Source features to use for clustering",
-            DefaultOptionKeys.context: True,  # Mark as context parameter
-            DefaultOptionKeys.strict_validation: False,  # Flexible validation
+            "_meta": {
+                "explanation": "Source features to use for clustering",
+                DefaultOptionKeys.context: True,  # Mark as context parameter
+                DefaultOptionKeys.strict_validation: False,  # Flexible validation
+            },
         },
         OUTPUT_PROBABILITIES: {
-            "explanation": "Whether to output cluster probabilities/distances as separate columns using ~N suffix pattern",
-            DefaultOptionKeys.context: True,  # Mark as context parameter
-            DefaultOptionKeys.strict_validation: False,  # Flexible validation
-            DefaultOptionKeys.default: False,  # Default is False (don't output probabilities)
-            DefaultOptionKeys.validation_function: lambda value: isinstance(value, bool),
+            "_meta": {
+                "explanation": "Whether to output cluster probabilities/distances as separate columns using ~N suffix pattern",
+                DefaultOptionKeys.context: True,  # Mark as context parameter
+                DefaultOptionKeys.strict_validation: False,  # Flexible validation
+                DefaultOptionKeys.default: False,  # Default is False (don't output probabilities)
+                DefaultOptionKeys.validation_function: lambda value: isinstance(value, bool),
+            },
         },
     }
 

--- a/mloda_plugins/feature_group/experimental/data_quality/missing_value/base.py
+++ b/mloda_plugins/feature_group/experimental/data_quality/missing_value/base.py
@@ -167,21 +167,29 @@ class MissingValueFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     PROPERTY_MAPPING = {
         IMPUTATION_METHOD: {
             **IMPUTATION_METHODS,
-            DefaultOptionKeys.context: True,
+            "_meta": {
+                DefaultOptionKeys.context: True,
+            },
         },
         DefaultOptionKeys.in_features: {
-            "explanation": "Source feature to impute missing values",
-            DefaultOptionKeys.context: True,
+            "_meta": {
+                "explanation": "Source feature to impute missing values",
+                DefaultOptionKeys.context: True,
+            },
         },
         "constant_value": {
-            "explanation": "Constant value to use for constant imputation method",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.default: None,  # Default is None, required only for constant method
+            "_meta": {
+                "explanation": "Constant value to use for constant imputation method",
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.default: None,  # Default is None, required only for constant method
+            },
         },
         "group_by_features": {
-            "explanation": "Optional list of features to group by before imputation",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.default: None,  # Default is None (no grouping)
+            "_meta": {
+                "explanation": "Optional list of features to group by before imputation",
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.default: None,  # Default is None (no grouping)
+            },
         },
     }
 

--- a/mloda_plugins/feature_group/experimental/dimensionality_reduction/base.py
+++ b/mloda_plugins/feature_group/experimental/dimensionality_reduction/base.py
@@ -123,48 +123,60 @@ class DimensionalityReductionFeatureGroup(FeatureChainParserMixin, FeatureGroup)
     PROPERTY_MAPPING = {
         ALGORITHM: {
             **REDUCTION_ALGORITHMS,
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
+            "_meta": {
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: True,
+            },
         },
         DIMENSION: {
-            "explanation": "Target dimension for the reduction (positive integer)",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.validation_function: lambda value: (
-                isinstance(value, (int, str)) and str(value).isdigit() and int(value) > 0
-            ),
+            "_meta": {
+                "explanation": "Target dimension for the reduction (positive integer)",
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: True,
+                DefaultOptionKeys.validation_function: lambda value: (
+                    isinstance(value, (int, str)) and str(value).isdigit() and int(value) > 0
+                ),
+            },
         },
         DefaultOptionKeys.in_features: {
-            "explanation": "Source features to use for dimensionality reduction",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
+            "_meta": {
+                "explanation": "Source features to use for dimensionality reduction",
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: False,
+            },
         },
         # t-SNE specific parameters
         TSNE_MAX_ITER: {
-            "explanation": "Maximum number of iterations for t-SNE optimization",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            "default": 250,
-            DefaultOptionKeys.validation_function: lambda value: (
-                isinstance(value, (int, str)) and str(value).isdigit() and int(value) > 0
-            ),
+            "_meta": {
+                "explanation": "Maximum number of iterations for t-SNE optimization",
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: False,
+                DefaultOptionKeys.default: 250,
+                DefaultOptionKeys.validation_function: lambda value: (
+                    isinstance(value, (int, str)) and str(value).isdigit() and int(value) > 0
+                ),
+            },
         },
         TSNE_N_ITER_WITHOUT_PROGRESS: {
-            "explanation": "Maximum iterations without progress before early stopping (t-SNE)",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            "default": 50,
-            DefaultOptionKeys.validation_function: lambda value: (
-                isinstance(value, (int, str)) and str(value).isdigit() and int(value) > 0
-            ),
+            "_meta": {
+                "explanation": "Maximum iterations without progress before early stopping (t-SNE)",
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: False,
+                DefaultOptionKeys.default: 50,
+                DefaultOptionKeys.validation_function: lambda value: (
+                    isinstance(value, (int, str)) and str(value).isdigit() and int(value) > 0
+                ),
+            },
         },
         TSNE_METHOD: {
             "barnes_hut": "Barnes-Hut approximation (faster, O(n log n))",
             "exact": "Exact method (slower, O(n^2))",
-            "explanation": "t-SNE computation method",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            "default": "barnes_hut",
+            "_meta": {
+                "explanation": "t-SNE computation method",
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: False,
+                DefaultOptionKeys.default: "barnes_hut",
+            },
         },
         # PCA specific parameters
         PCA_SVD_SOLVER: {
@@ -172,30 +184,36 @@ class DimensionalityReductionFeatureGroup(FeatureChainParserMixin, FeatureGroup)
             "full": "Full SVD using LAPACK",
             "arpack": "Truncated SVD using ARPACK",
             "randomized": "Randomized SVD",
-            "explanation": "SVD solver algorithm for PCA",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            "default": "auto",
+            "_meta": {
+                "explanation": "SVD solver algorithm for PCA",
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: False,
+                DefaultOptionKeys.default: "auto",
+            },
         },
         # ICA specific parameters
         ICA_MAX_ITER: {
-            "explanation": "Maximum number of iterations for ICA",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            "default": 200,
-            DefaultOptionKeys.validation_function: lambda value: (
-                isinstance(value, (int, str)) and str(value).isdigit() and int(value) > 0
-            ),
+            "_meta": {
+                "explanation": "Maximum number of iterations for ICA",
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: False,
+                DefaultOptionKeys.default: 200,
+                DefaultOptionKeys.validation_function: lambda value: (
+                    isinstance(value, (int, str)) and str(value).isdigit() and int(value) > 0
+                ),
+            },
         },
         # Isomap specific parameters
         ISOMAP_N_NEIGHBORS: {
-            "explanation": "Number of neighbors for Isomap",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            "default": 5,
-            DefaultOptionKeys.validation_function: lambda value: (
-                isinstance(value, (int, str)) and str(value).isdigit() and int(value) > 0
-            ),
+            "_meta": {
+                "explanation": "Number of neighbors for Isomap",
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: False,
+                DefaultOptionKeys.default: 5,
+                DefaultOptionKeys.validation_function: lambda value: (
+                    isinstance(value, (int, str)) and str(value).isdigit() and int(value) > 0
+                ),
+            },
         },
     }
 

--- a/mloda_plugins/feature_group/experimental/dimensionality_reduction/pandas.py
+++ b/mloda_plugins/feature_group/experimental/dimensionality_reduction/pandas.py
@@ -27,7 +27,7 @@ except ImportError:
     SKLEARN_AVAILABLE = False
 
 
-from mloda.provider import ComputeFramework
+from mloda.provider import ComputeFramework, DefaultOptionKeys
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 from mloda_plugins.feature_group.experimental.dimensionality_reduction.base import DimensionalityReductionFeatureGroup
 
@@ -141,35 +141,35 @@ class PandasDimensionalityReductionFeatureGroup(DimensionalityReductionFeatureGr
             if svd_solver is None:
                 svd_solver = DimensionalityReductionFeatureGroup.PROPERTY_MAPPING[
                     DimensionalityReductionFeatureGroup.PCA_SVD_SOLVER
-                ]["default"]
+                ]["_meta"][DefaultOptionKeys.default]
             return cls._perform_pca_reduction(X_scaled, dimension, svd_solver)
         elif algorithm == "tsne":
             max_iter_val = options.get(DimensionalityReductionFeatureGroup.TSNE_MAX_ITER)
             if max_iter_val is None:
                 max_iter_val = DimensionalityReductionFeatureGroup.PROPERTY_MAPPING[
                     DimensionalityReductionFeatureGroup.TSNE_MAX_ITER
-                ]["default"]
+                ]["_meta"][DefaultOptionKeys.default]
             max_iter = int(max_iter_val)
 
             n_iter_without_progress_val = options.get(DimensionalityReductionFeatureGroup.TSNE_N_ITER_WITHOUT_PROGRESS)
             if n_iter_without_progress_val is None:
                 n_iter_without_progress_val = DimensionalityReductionFeatureGroup.PROPERTY_MAPPING[
                     DimensionalityReductionFeatureGroup.TSNE_N_ITER_WITHOUT_PROGRESS
-                ]["default"]
+                ]["_meta"][DefaultOptionKeys.default]
             n_iter_without_progress = int(n_iter_without_progress_val)
 
             method = options.get(DimensionalityReductionFeatureGroup.TSNE_METHOD)
             if method is None:
                 method = DimensionalityReductionFeatureGroup.PROPERTY_MAPPING[
                     DimensionalityReductionFeatureGroup.TSNE_METHOD
-                ]["default"]
+                ]["_meta"][DefaultOptionKeys.default]
             return cls._perform_tsne_reduction(X_scaled, dimension, max_iter, n_iter_without_progress, method)
         elif algorithm == "ica":
             max_iter_val = options.get(DimensionalityReductionFeatureGroup.ICA_MAX_ITER)
             if max_iter_val is None:
                 max_iter_val = DimensionalityReductionFeatureGroup.PROPERTY_MAPPING[
                     DimensionalityReductionFeatureGroup.ICA_MAX_ITER
-                ]["default"]
+                ]["_meta"][DefaultOptionKeys.default]
             max_iter = int(max_iter_val)
             return cls._perform_ica_reduction(X_scaled, dimension, max_iter)
         elif algorithm == "lda":
@@ -179,7 +179,7 @@ class PandasDimensionalityReductionFeatureGroup(DimensionalityReductionFeatureGr
             if n_neighbors_val is None:
                 n_neighbors_val = DimensionalityReductionFeatureGroup.PROPERTY_MAPPING[
                     DimensionalityReductionFeatureGroup.ISOMAP_N_NEIGHBORS
-                ]["default"]
+                ]["_meta"][DefaultOptionKeys.default]
             n_neighbors = int(n_neighbors_val)
             return cls._perform_isomap_reduction(X_scaled, dimension, n_neighbors)
         else:

--- a/mloda_plugins/feature_group/experimental/forecasting/base.py
+++ b/mloda_plugins/feature_group/experimental/forecasting/base.py
@@ -137,33 +137,43 @@ class ForecastingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     PROPERTY_MAPPING = {
         ALGORITHM: {
             **FORECASTING_ALGORITHMS,
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
+            "_meta": {
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: True,
+            },
         },
         HORIZON: {
-            "explanation": "Forecast horizon (number of time units to predict)",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.validation_function: lambda x: (
-                (isinstance(x, int) or (isinstance(x, str) and x.isdigit())) and int(x) > 0
-            ),
+            "_meta": {
+                "explanation": "Forecast horizon (number of time units to predict)",
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: True,
+                DefaultOptionKeys.validation_function: lambda x: (
+                    (isinstance(x, int) or (isinstance(x, str) and x.isdigit())) and int(x) > 0
+                ),
+            },
         },
         TIME_UNIT: {
             **TIME_UNITS,
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
+            "_meta": {
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: True,
+            },
         },
         DefaultOptionKeys.in_features: {
-            "explanation": "Source feature to generate forecasts for",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
+            "_meta": {
+                "explanation": "Source feature to generate forecasts for",
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: False,
+            },
         },
         OUTPUT_CONFIDENCE_INTERVALS: {
-            "explanation": "Whether to output confidence intervals as separate columns using ~lower and ~upper suffix pattern",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.default: False,  # Default is False (don't output confidence intervals)
-            DefaultOptionKeys.validation_function: lambda value: isinstance(value, bool),
+            "_meta": {
+                "explanation": "Whether to output confidence intervals as separate columns using ~lower and ~upper suffix pattern",
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: False,
+                DefaultOptionKeys.default: False,  # Default is False (don't output confidence intervals)
+                DefaultOptionKeys.validation_function: lambda value: isinstance(value, bool),
+            },
         },
     }
 

--- a/mloda_plugins/feature_group/experimental/geo_distance/base.py
+++ b/mloda_plugins/feature_group/experimental/geo_distance/base.py
@@ -105,20 +105,24 @@ class GeoDistanceFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     PROPERTY_MAPPING = {
         DISTANCE_TYPE: {
             **DISTANCE_TYPES,
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
+            "_meta": {
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: True,
+            },
         },
         DefaultOptionKeys.in_features: {
-            "explanation": "Source features (exactly 2 point features required)",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.validation_function: lambda x: (
-                # Accept individual strings (when parser iterates over list elements)
-                isinstance(x, str)
-                or
-                # Accept collections with exactly 2 elements (when validating the whole list)
-                (isinstance(x, (list, tuple, frozenset, set)) and len(x) == 2)
-            ),
+            "_meta": {
+                "explanation": "Source features (exactly 2 point features required)",
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: True,
+                DefaultOptionKeys.validation_function: lambda x: (
+                    # Accept individual strings (when parser iterates over list elements)
+                    isinstance(x, str)
+                    or
+                    # Accept collections with exactly 2 elements (when validating the whole list)
+                    (isinstance(x, (list, tuple, frozenset, set)) and len(x) == 2)
+                ),
+            },
         },
     }
 

--- a/mloda_plugins/feature_group/experimental/node_centrality/base.py
+++ b/mloda_plugins/feature_group/experimental/node_centrality/base.py
@@ -142,23 +142,31 @@ class NodeCentralityFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         # Context parameters (don't affect Feature Group resolution)
         CENTRALITY_TYPE: {
             **CENTRALITY_TYPES,  # All supported centrality types as valid options
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
+            "_meta": {
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: True,
+            },
         },
         GRAPH_TYPE: {
             **GRAPH_TYPES,  # All supported graph types as valid options
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.default: "undirected",
+            "_meta": {
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: True,
+                DefaultOptionKeys.default: "undirected",
+            },
         },
         WEIGHT_COLUMN: {
-            "explanation": "Column name for edge weights (optional)",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.default: None,
+            "_meta": {
+                "explanation": "Column name for edge weights (optional)",
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.default: None,
+            },
         },
         DefaultOptionKeys.in_features: {
-            "explanation": "Source feature representing the nodes for centrality calculation",
-            DefaultOptionKeys.context: True,
+            "_meta": {
+                "explanation": "Source feature representing the nodes for centrality calculation",
+                DefaultOptionKeys.context: True,
+            },
         },
     }
 

--- a/mloda_plugins/feature_group/experimental/sklearn/encoding/base.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/encoding/base.py
@@ -182,13 +182,17 @@ class EncodingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     PROPERTY_MAPPING = {
         ENCODER_TYPE: {
             **SUPPORTED_ENCODERS,  # All supported encoder types as valid options
-            DefaultOptionKeys.context: True,  # Context parameter
-            DefaultOptionKeys.strict_validation: True,  # Enable strict validation
+            "_meta": {
+                DefaultOptionKeys.context: True,  # Context parameter
+                DefaultOptionKeys.strict_validation: True,  # Enable strict validation
+            },
         },
         DefaultOptionKeys.in_features: {
-            "explanation": "Source feature to encode",
-            DefaultOptionKeys.context: True,  # Context parameter
-            DefaultOptionKeys.strict_validation: False,  # Flexible validation
+            "_meta": {
+                "explanation": "Source feature to encode",
+                DefaultOptionKeys.context: True,  # Context parameter
+                DefaultOptionKeys.strict_validation: False,  # Flexible validation
+            },
         },
     }
 

--- a/mloda_plugins/feature_group/experimental/sklearn/pipeline/base.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/pipeline/base.py
@@ -92,22 +92,30 @@ class SklearnPipelineFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     PROPERTY_MAPPING = {
         PIPELINE_NAME: {
             **PIPELINE_TYPES,  # All supported pipeline types as valid options
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.default: None,  # Default is None as steps + params also work
+            "_meta": {
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.default: None,  # Default is None as steps + params also work
+            },
         },
         PIPELINE_STEPS: {
-            "explanation": "List of pipeline steps as (name, transformer) tuples",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.default: None,  # Default is None as pipeline_types also work
+            "_meta": {
+                "explanation": "List of pipeline steps as (name, transformer) tuples",
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.default: None,  # Default is None as pipeline_types also work
+            },
         },
         PIPELINE_PARAMS: {
-            "explanation": "Pipeline parameters dictionary",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.default: None,  # Default is None as pipeline_types also work
+            "_meta": {
+                "explanation": "Pipeline parameters dictionary",
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.default: None,  # Default is None as pipeline_types also work
+            },
         },
         DefaultOptionKeys.in_features: {
-            "explanation": "Source features for sklearn pipeline (comma-separated)",
-            DefaultOptionKeys.context: True,
+            "_meta": {
+                "explanation": "Source features for sklearn pipeline (comma-separated)",
+                DefaultOptionKeys.context: True,
+            },
         },
     }
 

--- a/mloda_plugins/feature_group/experimental/sklearn/scaling/base.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/scaling/base.py
@@ -92,13 +92,17 @@ class ScalingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     PROPERTY_MAPPING = {
         SCALER_TYPE: {
             **SUPPORTED_SCALERS,  # All supported scaler types as valid options
-            DefaultOptionKeys.context: True,  # Context parameter
-            DefaultOptionKeys.strict_validation: True,  # Enable strict validation
+            "_meta": {
+                DefaultOptionKeys.context: True,  # Context parameter
+                DefaultOptionKeys.strict_validation: True,  # Enable strict validation
+            },
         },
         DefaultOptionKeys.in_features: {
-            "explanation": "Source feature to scale",
-            DefaultOptionKeys.context: True,  # Context parameter
-            DefaultOptionKeys.strict_validation: False,  # Flexible validation
+            "_meta": {
+                "explanation": "Source feature to scale",
+                DefaultOptionKeys.context: True,  # Context parameter
+                DefaultOptionKeys.strict_validation: False,  # Flexible validation
+            },
         },
     }
 

--- a/mloda_plugins/feature_group/experimental/text_cleaning/base.py
+++ b/mloda_plugins/feature_group/experimental/text_cleaning/base.py
@@ -95,29 +95,33 @@ class TextCleaningFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     PROPERTY_MAPPING = {
         CLEANING_OPERATIONS: {
             **SUPPORTED_OPERATIONS,  # All supported operations as valid options
-            DefaultOptionKeys.context: True,  # Mark as context parameter
-            DefaultOptionKeys.strict_validation: True,  # Enable strict validation
-            DefaultOptionKeys.validation_function: lambda operations: (
-                # Handle both actual tuples/lists and string representations
-                (
-                    isinstance(operations, (tuple, list))
-                    and all(op in TextCleaningFeatureGroup.SUPPORTED_OPERATIONS for op in operations)
-                )
-                or (
-                    isinstance(operations, str)
-                    and operations.startswith("(")
-                    and operations.endswith(")")
-                    and all(
-                        op.strip("'\" ,") in TextCleaningFeatureGroup.SUPPORTED_OPERATIONS
-                        for op in operations.strip("()").split(",")
-                        if op.strip("'\" ,")
+            "_meta": {
+                DefaultOptionKeys.context: True,  # Mark as context parameter
+                DefaultOptionKeys.strict_validation: True,  # Enable strict validation
+                DefaultOptionKeys.validation_function: lambda operations: (
+                    # Handle both actual tuples/lists and string representations
+                    (
+                        isinstance(operations, (tuple, list))
+                        and all(op in TextCleaningFeatureGroup.SUPPORTED_OPERATIONS for op in operations)
                     )
-                )
-            ),
+                    or (
+                        isinstance(operations, str)
+                        and operations.startswith("(")
+                        and operations.endswith(")")
+                        and all(
+                            op.strip("'\" ,") in TextCleaningFeatureGroup.SUPPORTED_OPERATIONS
+                            for op in operations.strip("()").split(",")
+                            if op.strip("'\" ,")
+                        )
+                    )
+                ),
+            },
         },
         DefaultOptionKeys.in_features: {
-            "explanation": "Source feature to apply text cleaning operations to",
-            DefaultOptionKeys.context: True,
+            "_meta": {
+                "explanation": "Source feature to apply text cleaning operations to",
+                DefaultOptionKeys.context: True,
+            },
         },
     }
 

--- a/mloda_plugins/feature_group/experimental/time_window/base.py
+++ b/mloda_plugins/feature_group/experimental/time_window/base.py
@@ -127,29 +127,37 @@ class TimeWindowFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         # Window function parameter (context parameter)
         WINDOW_FUNCTION: {
             **WINDOW_FUNCTIONS,  # Reference existing WINDOW_FUNCTIONS dict
-            DefaultOptionKeys.context: True,  # Mark as context parameter
-            DefaultOptionKeys.strict_validation: True,  # Enable strict validation
+            "_meta": {
+                DefaultOptionKeys.context: True,  # Mark as context parameter
+                DefaultOptionKeys.strict_validation: True,  # Enable strict validation
+            },
         },
         # Window size parameter (context parameter)
         WINDOW_SIZE: {
-            "explanation": "Size of the time window (must be positive integer)",
-            DefaultOptionKeys.context: True,  # Mark as context parameter
-            DefaultOptionKeys.strict_validation: True,  # Enable strict validation
-            DefaultOptionKeys.validation_function: lambda x: (
-                (isinstance(x, int) and x > 0) or (isinstance(x, str) and x.isdigit() and int(x) > 0)
-            ),
+            "_meta": {
+                "explanation": "Size of the time window (must be positive integer)",
+                DefaultOptionKeys.context: True,  # Mark as context parameter
+                DefaultOptionKeys.strict_validation: True,  # Enable strict validation
+                DefaultOptionKeys.validation_function: lambda x: (
+                    (isinstance(x, int) and x > 0) or (isinstance(x, str) and x.isdigit() and int(x) > 0)
+                ),
+            },
         },
         # Time unit parameter (context parameter)
         TIME_UNIT: {
             **TIME_UNITS,  # Reference existing TIME_UNITS dict
-            DefaultOptionKeys.context: True,  # Mark as context parameter
-            DefaultOptionKeys.strict_validation: True,  # Enable strict validation
+            "_meta": {
+                DefaultOptionKeys.context: True,  # Mark as context parameter
+                DefaultOptionKeys.strict_validation: True,  # Enable strict validation
+            },
         },
         # Source feature parameter (context parameter)
         DefaultOptionKeys.in_features: {
-            "explanation": "Source feature to apply time window operation to",
-            DefaultOptionKeys.context: True,  # Mark as context parameter
-            DefaultOptionKeys.strict_validation: False,  # Flexible validation
+            "_meta": {
+                "explanation": "Source feature to apply time window operation to",
+                DefaultOptionKeys.context: True,  # Mark as context parameter
+                DefaultOptionKeys.strict_validation: False,  # Flexible validation
+            },
         },
     }
 

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_feature_chain_parser_mixin.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_feature_chain_parser_mixin.py
@@ -21,8 +21,10 @@ class MockFeatureGroup(FeatureChainParserMixin):
         "operation": {
             "op1": "Operation 1",
             "op2": "Operation 2",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
+            "_meta": {
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: True,
+            },
         }
     }
 
@@ -36,8 +38,10 @@ class MockFeatureGroupCustomSeparator(FeatureChainParserMixin):
         "operation": {
             "op1": "Operation 1",
             "op2": "Operation 2",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
+            "_meta": {
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: True,
+            },
         }
     }
 
@@ -51,8 +55,10 @@ class MockFeatureGroupWithMinMax(FeatureChainParserMixin):
     PROPERTY_MAPPING = {
         "operation": {
             "op1": "Operation 1",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
+            "_meta": {
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: True,
+            },
         }
     }
 
@@ -76,8 +82,10 @@ class MockFeatureGroupWithoutMinMax(FeatureChainParserMixin):
     PROPERTY_MAPPING = {
         "operation": {
             "op1": "Operation 1",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
+            "_meta": {
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: True,
+            },
         }
     }
 
@@ -89,8 +97,10 @@ class MockFeatureGroupWithValidationHook(FeatureChainParserMixin):
     PROPERTY_MAPPING = {
         "operation": {
             "op1": "Operation 1",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
+            "_meta": {
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: True,
+            },
         }
     }
 
@@ -465,9 +475,11 @@ class TestFeatureChainParserMixinListValuedOptions:
         class ListValuedFeatureGroup(FeatureChainParserMixin):
             PROPERTY_MAPPING = {
                 "partition_by": {
-                    "explanation": "List of columns to partition by",
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: False,
+                    "_meta": {
+                        "explanation": "List of columns to partition by",
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: False,
+                    },
                 },
             }
 
@@ -481,9 +493,11 @@ class TestFeatureChainParserMixinListValuedOptions:
         class TupleValuedFeatureGroup(FeatureChainParserMixin):
             PROPERTY_MAPPING = {
                 "partition_by": {
-                    "explanation": "Columns to partition by",
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: False,
+                    "_meta": {
+                        "explanation": "Columns to partition by",
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: False,
+                    },
                 },
             }
 
@@ -497,8 +511,10 @@ class TestFeatureChainParserMixinListValuedOptions:
 
         property_mapping = {
             "partition_by": {
-                DefaultOptionKeys.context: True,
-                DefaultOptionKeys.strict_validation: False,
+                "_meta": {
+                    DefaultOptionKeys.context: True,
+                    DefaultOptionKeys.strict_validation: False,
+                },
             },
         }
         options = Options(context={"partition_by": ["col1", "col2", "col3"]})

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_required_when.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_required_when.py
@@ -44,14 +44,18 @@ class MockWithConditionalRequired(FeatureChainParserMixin):
             "avg": "Average of values",
             "first": "First value (requires order_by)",
             "last": "Last value (requires order_by)",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
+            "_meta": {
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: True,
+            },
         },
         "order_by": {
-            "explanation": "Column to order by within each partition",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.required_when: _needs_order_by,
+            "_meta": {
+                "explanation": "Column to order by within each partition",
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: False,
+                DefaultOptionKeys.required_when: _needs_order_by,
+            },
         },
     }
 
@@ -86,20 +90,24 @@ class TestRequiredWhenUnit:
     def test_extract_property_values_strips_required_when(self) -> None:
         """required_when callable must be stripped from extracted property values."""
         mapping_entry = {
-            "explanation": "Column to order by within each partition",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.required_when: _needs_order_by,
+            "_meta": {
+                "explanation": "Column to order by within each partition",
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: False,
+                DefaultOptionKeys.required_when: _needs_order_by,
+            },
         }
         extracted = FeatureChainParser._extract_property_values(mapping_entry)
         assert DefaultOptionKeys.required_when not in extracted
-        assert "explanation" in extracted
+        assert "explanation" not in extracted
 
     def test_can_skip_required_check_with_required_when(self) -> None:
         """Properties with required_when should be skippable in the base required check."""
         prop_with_required_when = {
-            "explanation": "test",
-            DefaultOptionKeys.required_when: _needs_order_by,
+            "_meta": {
+                "explanation": "test",
+                DefaultOptionKeys.required_when: _needs_order_by,
+            },
         }
         assert FeatureChainParser._can_skip_required_check(prop_with_required_when) is True
 
@@ -107,7 +115,9 @@ class TestRequiredWhenUnit:
         """Properties with default should be skippable in the base required check."""
         prop_with_default = {
             "val1": "desc",
-            DefaultOptionKeys.default: "val1",
+            "_meta": {
+                DefaultOptionKeys.default: "val1",
+            },
         }
         assert FeatureChainParser._can_skip_required_check(prop_with_default) is True
 
@@ -115,7 +125,9 @@ class TestRequiredWhenUnit:
         """Properties without default or required_when are required."""
         prop_required = {
             "val1": "desc",
-            DefaultOptionKeys.strict_validation: True,
+            "_meta": {
+                DefaultOptionKeys.strict_validation: True,
+            },
         }
         assert FeatureChainParser._can_skip_required_check(prop_required) is False
 
@@ -127,14 +139,18 @@ class TestRequiredWhenUnit:
             PROPERTY_MAPPING = {
                 "aggregation_type": {
                     "sum": "Sum",
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: True,
+                    "_meta": {
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: True,
+                    },
                 },
                 "order_by": {
-                    "explanation": "sort column",
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: False,
-                    DefaultOptionKeys.required_when: "not_a_callable",
+                    "_meta": {
+                        "explanation": "sort column",
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: False,
+                        DefaultOptionKeys.required_when: "not_a_callable",
+                    },
                 },
             }
 
@@ -158,15 +174,19 @@ class TestRequiredWhenUnit:
                 "aggregation_type": {
                     "sum": "Sum",
                     "first": "First",
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: True,
+                    "_meta": {
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: True,
+                    },
                 },
                 "order_by": {
-                    "explanation": "sort column",
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: False,
-                    DefaultOptionKeys.default: "id",
-                    DefaultOptionKeys.required_when: _always_required,
+                    "_meta": {
+                        "explanation": "sort column",
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: False,
+                        DefaultOptionKeys.default: "id",
+                        DefaultOptionKeys.required_when: _always_required,
+                    },
                 },
             }
 
@@ -261,14 +281,18 @@ class ConditionalRequiredFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         "aggregation_type": {
             "sum": "Sum of values",
             "first": "First value (requires order_by)",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
+            "_meta": {
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: True,
+            },
         },
         "order_by": {
-            "explanation": "Column to order by within each partition",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.required_when: _run_all_needs_order_by,
+            "_meta": {
+                "explanation": "Column to order by within each partition",
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: False,
+                DefaultOptionKeys.required_when: _run_all_needs_order_by,
+            },
         },
     }
 
@@ -336,3 +360,142 @@ class TestRequiredWhenRunAll:
                 compute_frameworks={PandasDataFrame},
                 plugin_collector=plugin_collector,
             )
+
+
+class TestMetadataKeyCollision:
+    """Tests proving that valid values named after metadata keys work with _meta format.
+
+    This is the core scenario described in GitHub issue #254: if a user creates a
+    feature group whose valid values include a string that collides with a metadata
+    key name (e.g. "context", "default", "group"), the value must not be silently
+    removed by the metadata filter.
+    """
+
+    def test_value_named_context_is_accepted(self) -> None:
+        """A valid option value literally named "context" must not be silently dropped."""
+
+        class FGWithContextValue(FeatureChainParserMixin):
+            PROPERTY_MAPPING = {
+                "scope": {
+                    "context": "Context-level scope",
+                    "global": "Global scope",
+                    "_meta": {
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: True,
+                    },
+                },
+            }
+
+        options = Options(context={"scope": "context"})
+        assert FGWithContextValue.match_feature_group_criteria("feat", options) is True
+
+    def test_value_named_default_is_accepted(self) -> None:
+        """A valid option value literally named "default" must not be silently dropped."""
+
+        class FGWithDefaultValue(FeatureChainParserMixin):
+            PROPERTY_MAPPING = {
+                "mode": {
+                    "default": "Use default mode",
+                    "custom": "Use custom mode",
+                    "_meta": {
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: True,
+                    },
+                },
+            }
+
+        options = Options(context={"mode": "default"})
+        assert FGWithDefaultValue.match_feature_group_criteria("feat", options) is True
+
+    def test_value_named_group_is_accepted(self) -> None:
+        """A valid option value literally named "group" must not be silently dropped."""
+
+        class FGWithGroupValue(FeatureChainParserMixin):
+            PROPERTY_MAPPING = {
+                "agg_type": {
+                    "group": "Group aggregation",
+                    "individual": "Individual aggregation",
+                    "_meta": {
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: True,
+                    },
+                },
+            }
+
+        options = Options(context={"agg_type": "group"})
+        assert FGWithGroupValue.match_feature_group_criteria("feat", options) is True
+
+    def test_collision_values_rejected_when_invalid(self) -> None:
+        """Strict validation still rejects values not in the mapping."""
+
+        class FGWithCollisionValues(FeatureChainParserMixin):
+            PROPERTY_MAPPING = {
+                "scope": {
+                    "context": "Context scope",
+                    "default": "Default scope",
+                    "_meta": {
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: True,
+                    },
+                },
+            }
+
+        options = Options(context={"scope": "nonexistent"})
+        assert FGWithCollisionValues.match_feature_group_criteria("feat", options) is False
+
+    def test_extract_preserves_collision_values(self) -> None:
+        """_extract_property_values must keep values named after metadata keys."""
+        mapping_entry = {
+            "context": "Context scope",
+            "default": "Default scope",
+            "group": "Group scope",
+            "_meta": {
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: True,
+            },
+        }
+        extracted = FeatureChainParser._extract_property_values(mapping_entry)
+        assert "context" in extracted
+        assert "default" in extracted
+        assert "group" in extracted
+        assert "_meta" not in extracted
+
+    def test_legacy_flat_format_still_works(self) -> None:
+        """Backward compatibility: legacy flat format (without _meta) still works."""
+
+        class FGLegacyFormat(FeatureChainParserMixin):
+            PROPERTY_MAPPING = {
+                "operation": {
+                    "sum": "Sum",
+                    "avg": "Average",
+                    DefaultOptionKeys.context: True,
+                    DefaultOptionKeys.strict_validation: True,
+                },
+            }
+
+        options = Options(context={"operation": "sum"})
+        assert FGLegacyFormat.match_feature_group_criteria("feat", options) is True
+
+    def test_get_metadata_new_format(self) -> None:
+        """_get_metadata extracts metadata from the _meta sub-dict."""
+        entry = {
+            "val1": "desc",
+            "_meta": {
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: True,
+            },
+        }
+        meta = FeatureChainParser._get_metadata(entry)
+        assert meta[DefaultOptionKeys.context] is True
+        assert meta[DefaultOptionKeys.strict_validation] is True
+
+    def test_get_metadata_legacy_format(self) -> None:
+        """_get_metadata falls back to collecting known keys from flat dict."""
+        entry = {
+            "val1": "desc",
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: True,
+        }
+        meta = FeatureChainParser._get_metadata(entry)
+        assert meta[DefaultOptionKeys.context] is True
+        assert meta[DefaultOptionKeys.strict_validation] is True

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_type_constraints.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_type_constraints.py
@@ -49,14 +49,18 @@ class MockWithTypeConstraint(FeatureChainParserMixin):
         "operation": {
             "sum": "Sum of values",
             "avg": "Average of values",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
+            "_meta": {
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: True,
+            },
         },
         "partition_by": {
-            "explanation": "List of columns to partition by",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.type_validator: _is_list_of_strings,
+            "_meta": {
+                "explanation": "List of columns to partition by",
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: False,
+                DefaultOptionKeys.type_validator: _is_list_of_strings,
+            },
         },
     }
 
@@ -70,9 +74,11 @@ class MockStrictWithTypeValidator(FeatureChainParserMixin):
         "mode": {
             "fast": "Fast mode",
             "slow": "Slow mode",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.type_validator: lambda v: isinstance(v, str),
+            "_meta": {
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: True,
+                DefaultOptionKeys.type_validator: lambda v: isinstance(v, str),
+            },
         },
     }
 
@@ -92,9 +98,11 @@ class MockStrictWithOrthogonalTypeValidator(FeatureChainParserMixin):
             "fast": "Fast mode",
             "slow": "Slow mode",
             "ok": "OK mode",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.type_validator: _max_length_3,
+            "_meta": {
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: True,
+                DefaultOptionKeys.type_validator: _max_length_3,
+            },
         },
     }
 
@@ -106,10 +114,12 @@ class MockWithRaisingValidator(FeatureChainParserMixin):
 
     PROPERTY_MAPPING = {
         "items": {
-            "explanation": "A list of items",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.type_validator: _raising_validator,
+            "_meta": {
+                "explanation": "A list of items",
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: False,
+                DefaultOptionKeys.type_validator: _raising_validator,
+            },
         },
     }
 
@@ -122,8 +132,10 @@ class MockWithoutTypeConstraint(FeatureChainParserMixin):
     PROPERTY_MAPPING = {
         "operation": {
             "sum": "Sum of values",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
+            "_meta": {
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: True,
+            },
         },
     }
 
@@ -257,14 +269,18 @@ class TypeValidatedAggregation(FeatureChainParserMixin, FeatureGroup):
     PROPERTY_MAPPING = {
         "aggregation_type": {
             "sum": "Sum of values",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
+            "_meta": {
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: True,
+            },
         },
         "partition_by": {
-            "explanation": "List of columns to partition by",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.type_validator: _is_list_of_strings,
+            "_meta": {
+                "explanation": "List of columns to partition by",
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: False,
+                DefaultOptionKeys.type_validator: _is_list_of_strings,
+            },
         },
     }
 

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_resolve_operation.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_resolve_operation.py
@@ -30,8 +30,10 @@ class MockResolverFG(FeatureChainParserMixin):
         "aggregation_type": {
             "sum": "Sum",
             "avg": "Average",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
+            "_meta": {
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: True,
+            },
         },
     }
 

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_strict_validation_returns_false.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_strict_validation_returns_false.py
@@ -16,7 +16,9 @@ class BaseMode(FeatureChainParserMixin):
         "mode": {
             "mode_a": "Mode A",
             "mode_b": "Mode B",
-            DefaultOptionKeys.strict_validation: True,
+            "_meta": {
+                DefaultOptionKeys.strict_validation: True,
+            },
         }
     }
 
@@ -27,7 +29,9 @@ class SubGroupA(BaseMode):
     PROPERTY_MAPPING = {
         "mode": {
             "mode_a": "Mode A",
-            DefaultOptionKeys.strict_validation: True,
+            "_meta": {
+                DefaultOptionKeys.strict_validation: True,
+            },
         }
     }
 
@@ -38,7 +42,9 @@ class SubGroupB(BaseMode):
     PROPERTY_MAPPING = {
         "mode": {
             "mode_b": "Mode B",
-            DefaultOptionKeys.strict_validation: True,
+            "_meta": {
+                DefaultOptionKeys.strict_validation: True,
+            },
         }
     }
 
@@ -48,8 +54,10 @@ class SubGroupWithValidationFunction(BaseMode):
 
     PROPERTY_MAPPING = {
         "mode": {
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.validation_function: lambda v: v.startswith("valid_"),
+            "_meta": {
+                DefaultOptionKeys.strict_validation: True,
+                DefaultOptionKeys.validation_function: lambda v: v.startswith("valid_"),
+            },
         }
     }
 

--- a/tests/test_plugins/integration_plugins/chainer/chainer_context_feature.py
+++ b/tests/test_plugins/integration_plugins/chainer/chainer_context_feature.py
@@ -24,28 +24,36 @@ class ChainedContextFeatureGroupTest(FeatureGroup):
         "ident": {
             "identifier1": "explanation",
             "identifier2": "explanation",
-            DefaultOptionKeys.context: True,  # Mark as context parameter
-            DefaultOptionKeys.strict_validation: True,  # Enable strict validation for ident
+            "_meta": {
+                DefaultOptionKeys.context: True,  # Mark as context parameter
+                DefaultOptionKeys.strict_validation: True,  # Enable strict validation for ident
+            },
         },
         "property2": {
             "value1": "explanation",
             "value2": "explanation",
             "specific_val_3_test": "explanation",  # Special case for testing
-            DefaultOptionKeys.strict_validation: True,  # Enable strict validation for property2
-            DefaultOptionKeys.default: "value1",  # Default value
-            # Not marked as context -> defaults to group parameter
+            "_meta": {
+                DefaultOptionKeys.strict_validation: True,  # Enable strict validation for property2
+                DefaultOptionKeys.default: "value1",  # Default value
+                # Not marked as context -> defaults to group parameter
+            },
         },
         "property3": {
             "opt_val1": "explanation",
             "opt_val2": "explanation",
-            DefaultOptionKeys.default: "opt_val1",  # Default value
-            DefaultOptionKeys.context: True,  # Mark as context parameter
-            DefaultOptionKeys.strict_validation: False,  # Disable strict validation for property3
+            "_meta": {
+                DefaultOptionKeys.default: "opt_val1",  # Default value
+                DefaultOptionKeys.context: True,  # Mark as context parameter
+                DefaultOptionKeys.strict_validation: False,  # Disable strict validation for property3
+            },
         },
         DefaultOptionKeys.in_features: {
-            "explanation": "explanation",
-            DefaultOptionKeys.context: True,  # Mark as context parameter
-            # No strict validation for source feature -> defaults to flexible
+            "_meta": {
+                "explanation": "explanation",
+                DefaultOptionKeys.context: True,  # Mark as context parameter
+                # No strict validation for source feature -> defaults to flexible
+            },
         },
     }
 

--- a/tests/test_plugins/integration_plugins/chainer/context/test_parameter_resolution_unit.py
+++ b/tests/test_plugins/integration_plugins/chainer/context/test_parameter_resolution_unit.py
@@ -26,7 +26,9 @@ class TestParameterResolutionUnit:
             "ident": {
                 "identifier1": "explanation",
                 "identifier2": "explanation",
-                DefaultOptionKeys.context: True,  # Mark as context parameter
+                "_meta": {
+                    DefaultOptionKeys.context: True,  # Mark as context parameter
+                },
             },
             "property2": {
                 "value1": "explanation",
@@ -37,12 +39,16 @@ class TestParameterResolutionUnit:
             "property3": {
                 "opt_val1": "explanation",
                 "opt_val2": "explanation",
-                DefaultOptionKeys.default: "opt_val1",  # Default value
-                DefaultOptionKeys.context: True,  # Mark as context parameter
+                "_meta": {
+                    DefaultOptionKeys.default: "opt_val1",  # Default value
+                    DefaultOptionKeys.context: True,  # Mark as context parameter
+                },
             },
             DefaultOptionKeys.in_features: {
-                "explanation": "explanation",
-                DefaultOptionKeys.context: True,  # Mark as context parameter
+                "_meta": {
+                    "explanation": "explanation",
+                    DefaultOptionKeys.context: True,  # Mark as context parameter
+                },
             },
         }
 
@@ -266,8 +272,10 @@ class TestParameterResolutionUnit:
         property_value_with_default = {
             "opt_val1": "explanation",
             "opt_val2": "explanation",
-            DefaultOptionKeys.default: "opt_val1",
-            DefaultOptionKeys.context: True,
+            "_meta": {
+                DefaultOptionKeys.default: "opt_val1",
+                DefaultOptionKeys.context: True,
+            },
         }
 
         extracted = FeatureChainParser._extract_property_values(property_value_with_default)
@@ -330,18 +338,26 @@ class TestParameterResolutionUnit:
             "strict_param": {
                 "allowed_value1": "explanation",
                 "allowed_value2": "explanation",
-                DefaultOptionKeys.strict_validation: True,  # Explicit strict validation
-                DefaultOptionKeys.context: True,
+                "_meta": {
+                    DefaultOptionKeys.strict_validation: True,  # Explicit strict validation
+                    DefaultOptionKeys.context: True,
+                },
             },
             "flexible_param": {
-                DefaultOptionKeys.strict_validation: False,  # Explicit flexible validation
-                DefaultOptionKeys.context: True,
+                "_meta": {
+                    DefaultOptionKeys.strict_validation: False,  # Explicit flexible validation
+                    DefaultOptionKeys.context: True,
+                },
             },
             "default_flexible_param": {
-                DefaultOptionKeys.context: True,
+                "_meta": {
+                    DefaultOptionKeys.context: True,
+                },
             },
             DefaultOptionKeys.in_features: {
-                DefaultOptionKeys.context: True,
+                "_meta": {
+                    DefaultOptionKeys.context: True,
+                },
             },
         }
 
@@ -426,7 +442,9 @@ class TestParameterResolutionUnit:
         # Test: Property with explicit strict validation = True
         strict_property = {
             "value1": "explanation",
-            DefaultOptionKeys.strict_validation: True,
+            "_meta": {
+                DefaultOptionKeys.strict_validation: True,
+            },
         }
         assert FeatureChainParser._is_strict_validation(strict_property) is True, (
             "Should identify strict validation = True"
@@ -435,7 +453,9 @@ class TestParameterResolutionUnit:
         # Test: Property with explicit strict validation = False
         flexible_property = {
             "value1": "explanation",
-            DefaultOptionKeys.strict_validation: False,
+            "_meta": {
+                DefaultOptionKeys.strict_validation: False,
+            },
         }
         assert FeatureChainParser._is_strict_validation(flexible_property) is False, (
             "Should identify strict validation = False"
@@ -444,7 +464,9 @@ class TestParameterResolutionUnit:
         # Test: Property without strict validation flag (defaults to False)
         default_property = {
             "value1": "explanation",
-            DefaultOptionKeys.context: True,
+            "_meta": {
+                DefaultOptionKeys.context: True,
+            },
         }
         assert FeatureChainParser._is_strict_validation(default_property) is False, (
             "Should default to strict validation = False"
@@ -469,25 +491,33 @@ class TestParameterResolutionUnit:
             "algorithm_type": {
                 "sum": "explanation",
                 "avg": "explanation",
-                # No strict_validation flag -> defaults to False (flexible)
-                DefaultOptionKeys.context: True,
+                "_meta": {
+                    # No strict_validation flag -> defaults to False (flexible)
+                    DefaultOptionKeys.context: True,
+                },
             },
             "data_source": {
                 "production": "explanation",
                 "staging": "explanation",
-                DefaultOptionKeys.strict_validation: True,  # Restrict data sources
-                DefaultOptionKeys.group: True,  # This affects grouping
+                "_meta": {
+                    DefaultOptionKeys.strict_validation: True,  # Restrict data sources
+                    DefaultOptionKeys.group: True,  # This affects grouping
+                },
             },
             "debug_mode": {
                 "true": "explanation",
                 "false": "explanation",
-                DefaultOptionKeys.strict_validation: False,  # Explicit flexible validation
-                DefaultOptionKeys.context: True,
+                "_meta": {
+                    DefaultOptionKeys.strict_validation: False,  # Explicit flexible validation
+                    DefaultOptionKeys.context: True,
+                },
             },
             DefaultOptionKeys.in_features: {
-                "explanation": "explanation",
-                # No strict_validation flag -> defaults to False (flexible)
-                DefaultOptionKeys.context: True,
+                "_meta": {
+                    "explanation": "explanation",
+                    # No strict_validation flag -> defaults to False (flexible)
+                    DefaultOptionKeys.context: True,
+                },
             },
         }
 

--- a/tests/test_plugins/integration_plugins/chainer/propagate_context_feature.py
+++ b/tests/test_plugins/integration_plugins/chainer/propagate_context_feature.py
@@ -22,19 +22,25 @@ class PropagateContextFeatureGroupTest(FeatureGroup):
         "ident": {
             "identifier1": "multiplier 2",
             "identifier2": "multiplier 3",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
+            "_meta": {
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: True,
+            },
         },
         "env": {
             "prod": "production offset 1000",
             "staging": "staging offset 500",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.default: None,
+            "_meta": {
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: False,
+                DefaultOptionKeys.default: None,
+            },
         },
         DefaultOptionKeys.in_features: {
-            "explanation": "explanation",
-            DefaultOptionKeys.context: True,
+            "_meta": {
+                "explanation": "explanation",
+                DefaultOptionKeys.context: True,
+            },
         },
     }
 

--- a/tests/test_plugins/integration_plugins/chainer/test_list_valued_options_e2e.py
+++ b/tests/test_plugins/integration_plugins/chainer/test_list_valued_options_e2e.py
@@ -55,13 +55,17 @@ class ListValuedFeatureGroup(FeatureGroup):
 
     PROPERTY_MAPPING = {
         "columns": {
-            "explanation": "List of columns to combine in order",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
+            "_meta": {
+                "explanation": "List of columns to combine in order",
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: False,
+            },
         },
         DefaultOptionKeys.in_features: {
-            "explanation": "Source features",
-            DefaultOptionKeys.context: True,
+            "_meta": {
+                "explanation": "Source features",
+                DefaultOptionKeys.context: True,
+            },
         },
     }
 


### PR DESCRIPTION
## Summary

- Introduces a `"_meta"` sub-dict within each PROPERTY_MAPPING entry to hold all metadata (context, strict_validation, validation_function, default, required_when, type_validator, explanation), keeping valid option values at the top level
- Eliminates silent value collision when a valid option name matches a metadata key string (e.g. "context", "default", "group")
- Adds backward compatibility: core accessor methods support both the new `_meta` format and the legacy flat format for external plugins
- Adds `TestMetadataKeyCollision` test class proving values named "context", "default", "group" work correctly
- Migrates all 12 internal plugins, 9 test files, and documentation to the new format
- Exports `METADATA_KEY` constant from `mloda.provider` for plugin authors

Closes #254

## Test plan

- [x] All 124 feature chainer unit/integration tests pass
- [x] Full tox suite: 2267 passed (13 pre-existing failures unrelated to this change)
- [x] New `TestMetadataKeyCollision` tests verify the fix for the core issue
- [x] Backward compatibility tests confirm legacy flat format still works