### PR TITLE
fix: detect metadata key collisions in PROPERTY_MAPPING at class definition time

### DIFF
--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -183,6 +183,35 @@ The predicate must satisfy:
 - **Must be a pure function** (no side effects).
 - Non-bool truthy return values are treated as `True`.
 
+## Reserved Keys
+
+The following string keys are reserved for metadata inside PROPERTY_MAPPING
+entries and must **not** be used as valid option value names:
+
+| Reserved key             | Used for                              | Expected type |
+|--------------------------|---------------------------------------|---------------|
+| `"default"`              | `DefaultOptionKeys.default`           | any           |
+| `"context"`              | `DefaultOptionKeys.context`           | `bool`        |
+| `"group"`                | `DefaultOptionKeys.group`             | `bool`        |
+| `"strict_validation"`    | `DefaultOptionKeys.strict_validation` | `bool`        |
+| `"validation_function"`  | `DefaultOptionKeys.validation_function` | callable    |
+| `"required_when"`        | `DefaultOptionKeys.required_when`     | callable      |
+| `"type_validator"`       | `DefaultOptionKeys.type_validator`    | callable      |
+
+`DefaultOptionKeys` inherits from `str`, so `DefaultOptionKeys.context` and
+the plain string `"context"` are identical as dict keys. If you write a
+PROPERTY_MAPPING entry where a valid option value has the same name as a
+reserved key, Python's dict silently merges them and the value is lost.
+
+mloda validates this at class definition time: if a subclass of
+`FeatureChainParserMixin` defines a PROPERTY_MAPPING where a reserved key
+holds a value whose type does not match the expected metadata type (e.g. a
+`str` where a `bool` is expected), a `ValueError` is raised immediately.
+
+If you need an option value that reads like a reserved key, use a synonym or
+prefix (e.g. `"default_mode"` instead of `"default"`, `"by_group"` instead
+of `"group"`).
+
 ## Context Propagation
 
 By default, context parameters are local: they do not flow through feature dependency chains. This is correct for feature-specific config like aggregation types.

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -96,6 +96,62 @@ class FeatureChainParserMixin:
     MIN_IN_FEATURES: int = 1
     MAX_IN_FEATURES: Optional[int] = None
 
+    # Expected value types for metadata keys in PROPERTY_MAPPING entries.
+    # DefaultOptionKeys inherits from str, so e.g. DefaultOptionKeys.context
+    # == "context".  If a plugin author accidentally uses one of these strings
+    # as a valid option value name, Python's dict silently merges the two keys
+    # and the intended value is lost.  __init_subclass__ uses this table to
+    # catch such collisions at class definition time.
+    _METADATA_EXPECTED_TYPES: Dict[str, type] = {
+        DefaultOptionKeys.context: bool,
+        DefaultOptionKeys.group: bool,
+        DefaultOptionKeys.strict_validation: bool,
+    }
+    _METADATA_CALLABLE_KEYS: Set[str] = {
+        DefaultOptionKeys.validation_function,
+        DefaultOptionKeys.required_when,
+        DefaultOptionKeys.type_validator,
+    }
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        mapping = getattr(cls, "PROPERTY_MAPPING", None)
+        if mapping is None:
+            return
+        for param_name, entry in mapping.items():
+            if not isinstance(entry, dict):
+                continue
+            cls._validate_property_mapping_entry(param_name, entry)
+
+    @classmethod
+    def _validate_property_mapping_entry(cls, param_name: str, entry: Dict[str, Any]) -> None:
+        """Raise ValueError if a PROPERTY_MAPPING entry has a likely key collision."""
+        for key, expected_type in cls._METADATA_EXPECTED_TYPES.items():
+            if key not in entry:
+                continue
+            value = entry[key]
+            if not isinstance(value, expected_type):
+                raise ValueError(
+                    f"PROPERTY_MAPPING['{param_name}']: key '{key.value}' holds a "
+                    f"{type(value).__name__} (expected {expected_type.__name__}). "
+                    f"Because DefaultOptionKeys inherits from str, the plain string "
+                    f"'{key.value}' and DefaultOptionKeys.{key.name} are the same "
+                    f"dict key. If you intended '{key.value}' as a valid option "
+                    f"value, rename it to avoid collision (e.g. '{key.value}_mode')."
+                )
+        for key in cls._METADATA_CALLABLE_KEYS:
+            if key not in entry:
+                continue
+            if not callable(entry[key]):
+                raise ValueError(
+                    f"PROPERTY_MAPPING['{param_name}']: key '{key.value}' holds a "
+                    f"non-callable {type(entry[key]).__name__}. "
+                    f"Because DefaultOptionKeys inherits from str, the plain string "
+                    f"'{key.value}' and DefaultOptionKeys.{key.name} are the same "
+                    f"dict key. If you intended '{key.value}' as a valid option "
+                    f"value, rename it to avoid collision."
+                )
+
     @classmethod
     def _validate_string_match(cls, _feature_name: str, _operation_config: str, _in_feature: str) -> bool:
         """

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_required_when.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_required_when.py
@@ -119,28 +119,24 @@ class TestRequiredWhenUnit:
         }
         assert FeatureChainParser._can_skip_required_check(prop_required) is False
 
-    def test_non_callable_required_when_is_skipped(self) -> None:
-        """A non-callable required_when value should not crash; the option is treated as optional."""
-
-        class MockWithBadPredicate(FeatureChainParserMixin):
-            PREFIX_PATTERN = r".*__([\w]+)_windowed$"
-            PROPERTY_MAPPING = {
-                "aggregation_type": {
-                    "sum": "Sum",
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: True,
-                },
-                "order_by": {
-                    "explanation": "sort column",
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: False,
-                    DefaultOptionKeys.required_when: "not_a_callable",
-                },
-            }
-
-        options = Options(context={"aggregation_type": "sum"})
-        result = MockWithBadPredicate.match_feature_group_criteria("my_feature", options)
-        assert result is True
+    def test_non_callable_required_when_is_rejected_at_class_definition(self) -> None:
+        """A non-callable required_when value is caught at class definition time."""
+        with pytest.raises(ValueError, match="required_when"):
+            class MockWithBadPredicate(FeatureChainParserMixin):
+                PREFIX_PATTERN = r".*__([\w]+)_windowed$"
+                PROPERTY_MAPPING = {
+                    "aggregation_type": {
+                        "sum": "Sum",
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: True,
+                    },
+                    "order_by": {
+                        "explanation": "sort column",
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: False,
+                        DefaultOptionKeys.required_when: "not_a_callable",
+                    },
+                }
 
     def test_required_when_with_default_value_interaction(self) -> None:
         """When a property has both required_when and default, default takes effect in base parser.
@@ -336,3 +332,89 @@ class TestRequiredWhenRunAll:
                 compute_frameworks={PandasDataFrame},
                 plugin_collector=plugin_collector,
             )
+
+
+class TestMetadataKeyCollisionDetection:
+    """Tests for __init_subclass__ validation that detects key-name collisions
+    between valid option values and reserved DefaultOptionKeys metadata keys.
+
+    DefaultOptionKeys inherits from str, so DefaultOptionKeys.context ==
+    "context".  If a plugin author uses "context" as a valid option value,
+    Python's dict silently merges the keys and the value is lost.  The
+    validation catches this at class definition time.
+    """
+
+    def test_rejects_string_value_for_context_key(self) -> None:
+        """A string where DefaultOptionKeys.context expects bool is caught."""
+        with pytest.raises(ValueError, match="context"):
+            class Bad(FeatureChainParserMixin):
+                PROPERTY_MAPPING = {
+                    "scope": {
+                        DefaultOptionKeys.context: "Context-level scope",
+                    },
+                }
+
+    def test_rejects_string_value_for_group_key(self) -> None:
+        """A string where DefaultOptionKeys.group expects bool is caught."""
+        with pytest.raises(ValueError, match="group"):
+            class Bad(FeatureChainParserMixin):
+                PROPERTY_MAPPING = {
+                    "partition_strategy": {
+                        DefaultOptionKeys.group: "Group by partition key",
+                    },
+                }
+
+    def test_rejects_string_value_for_strict_validation_key(self) -> None:
+        """A string where DefaultOptionKeys.strict_validation expects bool is caught."""
+        with pytest.raises(ValueError, match="strict_validation"):
+            class Bad(FeatureChainParserMixin):
+                PROPERTY_MAPPING = {
+                    "mode": {
+                        DefaultOptionKeys.strict_validation: "Strict mode",
+                    },
+                }
+
+    def test_rejects_non_callable_validation_function(self) -> None:
+        """A non-callable for DefaultOptionKeys.validation_function is caught."""
+        with pytest.raises(ValueError, match="validation_function"):
+            class Bad(FeatureChainParserMixin):
+                PROPERTY_MAPPING = {
+                    "mode": {
+                        DefaultOptionKeys.validation_function: "Custom validation",
+                    },
+                }
+
+    def test_accepts_correct_metadata_types(self) -> None:
+        """Normal PROPERTY_MAPPING entries must not trigger validation errors."""
+        class Good(FeatureChainParserMixin):
+            PROPERTY_MAPPING = {
+                "operation": {
+                    "sum": "Sum of values",
+                    "avg": "Average of values",
+                    DefaultOptionKeys.context: True,
+                    DefaultOptionKeys.strict_validation: True,
+                },
+            }
+
+        assert Good.PROPERTY_MAPPING is not None
+
+    def test_accepts_callable_metadata(self) -> None:
+        """Callable values for validation_function / required_when are fine."""
+        class Good(FeatureChainParserMixin):
+            PROPERTY_MAPPING = {
+                "order_by": {
+                    "explanation": "Column to order by",
+                    DefaultOptionKeys.context: True,
+                    DefaultOptionKeys.required_when: _needs_order_by,
+                    DefaultOptionKeys.validation_function: lambda x: isinstance(x, str),
+                },
+            }
+
+        assert Good.PROPERTY_MAPPING is not None
+
+    def test_accepts_no_property_mapping(self) -> None:
+        """Classes without PROPERTY_MAPPING are fine."""
+        class Good(FeatureChainParserMixin):
+            PREFIX_PATTERN = r".*__([\w]+)_test$"
+
+        assert not hasattr(Good, "PROPERTY_MAPPING") or Good.PROPERTY_MAPPING is None


### PR DESCRIPTION
## Summary

- Adds `__init_subclass__` validation to `FeatureChainParserMixin` that checks each PROPERTY_MAPPING entry when the class is defined
- If a reserved metadata key (e.g. `"context"`, `"group"`) holds a value of the wrong type (str where bool expected), raises `ValueError` immediately with a clear message explaining the collision
- Documents all reserved keys and the collision mechanism in `docs/in_depth/property-mapping.md`

Lightweight fix for the silent-failure scenario described in #254: instead of restructuring the PROPERTY_MAPPING format (30-file refactor), catch the collision early with a type check at class definition time.

Closes #254

## Test plan

- [x] 7 new tests in `TestMetadataKeyCollisionDetection` verify detection of collisions for `context`, `group`, `strict_validation`, `validation_function`, and verify no false positives
- [x] Updated existing `test_non_callable_required_when_is_skipped` to verify the error is now caught at class definition time
- [x] Full tox: 2265 passed (14 pre-existing failures unrelated to this change)