### PR TITLE
feat: add public order() method to DuckdbRelation

### DIFF
--- a/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_relation.py
+++ b/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_relation.py
@@ -127,6 +127,10 @@ class DuckdbRelation:
         new_rel = self._relation.limit(n)
         return DuckdbRelation(self._connection, new_rel)
 
+    def order(self, *columns: str) -> "DuckdbRelation":
+        """Return a new relation sorted by the given columns."""
+        return DuckdbRelation(self._connection, self._relation.order(", ".join(columns)))
+
     def drop(self) -> None:
         """No-op: native relations have no persistent state to clean up."""
         pass

--- a/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_relation.py
+++ b/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_relation.py
@@ -87,3 +87,39 @@ class TestDuckdbRelation(RelationTestMixin):
         assert len(result) == 2
         assert "val" in result.columns
         assert "score" in result.columns
+
+    # --- Order ---
+
+    def test_order_single_column(self, sample_relation: "DuckdbRelation") -> None:
+        ordered = sample_relation.order("age")
+        ids = self.get_column_values(ordered, "id")
+        assert ids == [1, 2, 3, 4, 5]
+
+    def test_order_single_column_desc(self, sample_relation: "DuckdbRelation") -> None:
+        ordered = sample_relation.order("age DESC")
+        ids = self.get_column_values(ordered, "id")
+        assert ids == [5, 4, 3, 2, 1]
+
+    def test_order_multiple_columns(self, sample_relation: "DuckdbRelation") -> None:
+        ordered = sample_relation.order("category", "age")
+        categories = self.get_column_values(ordered, "category")
+        ages = self.get_column_values(ordered, "age")
+        assert categories == ["A", "A", "B", "B", "C"]
+        assert ages == [25, 35, 30, 45, 40]
+
+    def test_order_preserves_all_columns(self, sample_relation: "DuckdbRelation") -> None:
+        ordered = sample_relation.order("age")
+        assert ordered.columns == ["id", "age", "name", "category"]
+
+    def test_order_preserves_row_count(self, sample_relation: "DuckdbRelation") -> None:
+        ordered = sample_relation.order("age")
+        assert len(ordered) == 5
+
+    def test_order_does_not_mutate_original(self, sample_relation: "DuckdbRelation") -> None:
+        sample_relation.order("age DESC")
+        ids = self.get_column_values(sample_relation, "id")
+        assert ids == [1, 2, 3, 4, 5]
+
+    def test_order_returns_duckdb_relation(self, sample_relation: "DuckdbRelation") -> None:
+        ordered = sample_relation.order("age")
+        assert isinstance(ordered, DuckdbRelation)


### PR DESCRIPTION
## Summary

- Add `order(*columns: str)` method to `DuckdbRelation` that delegates to DuckDB native `relation.order()`, joining multiple column expressions with commas
- Supports single columns (`"age"`), direction modifiers (`"age DESC"`), and multiple columns (`"category", "age"`)

Closes #251
Unblocks mloda-ai/mloda-registry#112

## Context

Downstream code (mloda-registry) currently accesses `data._relation.order()` directly to restore row order after window functions that include `ORDER BY`. This adds a proper public API so the private attribute is no longer needed.

Three existing usages in mloda-registry that access `_relation` to call `.order()`:
- `duckdb_aggregation.py` (sort aggregation results)
- `duckdb_frame_aggregate.py` (restore row order after window function)
- `duckdb_window_aggregation.py` (restore row order after window function)

## Test plan

- [x] `test_order_single_column` - ascending sort by single column
- [x] `test_order_single_column_desc` - descending sort with `"col DESC"` syntax
- [x] `test_order_multiple_columns` - multi-column sort via multiple args
- [x] `test_order_preserves_all_columns` - all columns retained after ordering
- [x] `test_order_preserves_row_count` - row count unchanged
- [x] `test_order_does_not_mutate_original` - original relation immutable
- [x] `test_order_returns_duckdb_relation` - correct return type
- [x] All 41 DuckDB relation tests pass
- [x] Full tox suite: no new failures (all failures are pre-existing)