### PR TITLE
fix: add 'explanation' to PROPERTY_MAPPING metadata_keys filter

### DIFF
--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -194,6 +194,8 @@ class FeatureChainParser:
         if isinstance(property_value, dict):
             # Remove metadata keys, keep only the actual valid values
             metadata_keys = {
+                # Plain string metadata key used for human-readable documentation
+                "explanation",
                 DefaultOptionKeys.default,
                 DefaultOptionKeys.context,
                 DefaultOptionKeys.group,

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_required_when.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_required_when.py
@@ -93,7 +93,17 @@ class TestRequiredWhenUnit:
         }
         extracted = FeatureChainParser._extract_property_values(mapping_entry)
         assert DefaultOptionKeys.required_when not in extracted
-        assert "explanation" in extracted
+        assert "explanation" not in extracted
+
+    def test_extract_property_values_strips_explanation(self) -> None:
+        """'explanation' is documentation metadata and must be stripped from extracted property values."""
+        mapping_entry = {
+            "explanation": "Column to order by within each partition",
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: False,
+        }
+        extracted = FeatureChainParser._extract_property_values(mapping_entry)
+        assert "explanation" not in extracted
 
     def test_can_skip_required_check_with_required_when(self) -> None:
         """Properties with required_when should be skippable in the base required check."""


### PR DESCRIPTION
## Summary

- Adds `"explanation"` to the `metadata_keys` set in `_extract_property_values` so it is filtered out as metadata instead of leaking through as a valid property value
- Fixes the existing test assertion that was verifying the buggy behavior (`"explanation" in extracted` -> `"explanation" not in extracted`)
- Adds a dedicated test for explanation stripping

## Problem

30+ plugins use `"explanation"` as inline documentation inside PROPERTY_MAPPING entries. The `metadata_keys` filter in `_extract_property_values` did not include it, so after extraction `"explanation"` survived as a valid property value. While harmless today (all affected entries use `strict_validation: False` or have a `validation_function`), this would silently accept `"explanation"` as a valid option value if strict membership validation were enabled.

## Test plan

- [x] New test `test_extract_property_values_strips_explanation` asserts `"explanation"` is filtered
- [x] Updated existing test to assert correct behavior
- [x] All 89 feature chainer tests pass
- [x] Full tox suite: 2259 passed (14 pre-existing failures unrelated to this change)

Closes #253