### PR TITLE
fix: drop misleading re-aliases from provider __init__.py

### DIFF
--- a/docs/docs/in_depth/data-access-patterns.md
+++ b/docs/docs/in_depth/data-access-patterns.md
@@ -77,9 +77,9 @@ MatchData is **only** used in these specific scenarios:
 
 ### Example Implementation
 ``` python
-from mloda.provider import ConnectionMatcherMixin, FeatureGroup
+from mloda.provider import MatchData, FeatureGroup
 
-class DuckDBFeatureGroup(FeatureGroup, ConnectionMatcherMixin):
+class DuckDBFeatureGroup(FeatureGroup, MatchData):
     @classmethod
     def match_data_access(
         cls,
@@ -103,7 +103,7 @@ class DuckDBFeatureGroup(FeatureGroup, ConnectionMatcherMixin):
 | **Primary Purpose** | Data loading and access | Connection object matching for stateful frameworks |
 | **When Used** | All feature groups that load data | Only feature groups requiring framework connection objects |
 | **Scope** | Universal data access pattern | Specialized for stateful compute frameworks |
-| **Usage Pattern** | `input_data()` method in feature groups | Multiple inheritance: `FeatureGroup, ConnectionMatcherMixin` |
+| **Usage Pattern** | `input_data()` method in feature groups | Multiple inheritance: `FeatureGroup, MatchData` |
 | **Connection Dependency** | Works with or without connections | Specifically designed for connection objects |
 | **Framework Support** | All compute frameworks | Only stateful frameworks (DuckDB, database connections) |
 
@@ -123,7 +123,7 @@ BaseInputData and MatchData serve **different purposes** and are used in **diffe
 
 ### Combined Usage Example
 ``` python
-class DuckDBAnalyticsFeature(FeatureGroup, ConnectionMatcherMixin):
+class DuckDBAnalyticsFeature(FeatureGroup, MatchData):
     @classmethod
     def input_data(cls) -> Optional[BaseInputData]:
         # BaseInputData for general data loading
@@ -133,7 +133,7 @@ class DuckDBAnalyticsFeature(FeatureGroup, ConnectionMatcherMixin):
     def match_data_access(cls, feature_name: str, options: Options,
                          data_access_collection: Optional[DataAccessCollection] = None,
                          framework_connection_object: Optional[Any] = None) -> Any:
-        # ConnectionMatcherMixin for connection object matching
+        # MatchData for connection object matching
         if framework_connection_object and isinstance(framework_connection_object, duckdb.DuckDBPyConnection):
             return framework_connection_object
         return None
@@ -159,14 +159,14 @@ class CsvProcessingFeature(FeatureGroup):
 **Pattern**: Both BaseInputData and MatchData are needed
 
 ``` python
-class DuckDBAnalyticsFeature(FeatureGroup, ConnectionMatcherMixin):
+class DuckDBAnalyticsFeature(FeatureGroup, MatchData):
     @classmethod
     def input_data(cls) -> Optional[BaseInputData]:
         return ReadFile()  # BaseInputData for data loading
 
     @classmethod
     def match_data_access(cls, ...):
-        # ConnectionMatcherMixin for connection matching
+        # MatchData for connection matching
         return appropriate_duckdb_connection
 ```
 

--- a/mloda/provider/__init__.py
+++ b/mloda/provider/__init__.py
@@ -32,16 +32,14 @@ from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 
 # Input data classes
 from mloda.core.abstract_plugins.components.input_data.base_input_data import BaseInputData
-from mloda.core.abstract_plugins.components.input_data.api.api_input_data import ApiInputData as ApiData
-from mloda_plugins.feature_group.input_data.api_data.api_data import ApiInputDataFeature as ApiDataFeatureGroup
-from mloda.core.abstract_plugins.components.input_data.api.base_api_data import BaseApiData as BaseApiDataSchema
-from mloda.core.abstract_plugins.components.input_data.api.api_input_data_collection import (
-    ApiInputDataCollection as ApiDataCollection,
-)
+from mloda.core.abstract_plugins.components.input_data.api.api_input_data import ApiInputData
+from mloda_plugins.feature_group.input_data.api_data.api_data import ApiInputDataFeature
+from mloda.core.abstract_plugins.components.input_data.api.base_api_data import BaseApiData
+from mloda.core.abstract_plugins.components.input_data.api.api_input_data_collection import ApiInputDataCollection
 from mloda.core.abstract_plugins.components.input_data.creator.data_creator import DataCreator
 
 # Match data
-from mloda.core.abstract_plugins.components.match_data.match_data import MatchData as ConnectionMatcherMixin
+from mloda.core.abstract_plugins.components.match_data.match_data import MatchData
 
 # Artifact
 from mloda.core.abstract_plugins.components.base_artifact import BaseArtifact
@@ -90,13 +88,13 @@ __all__ = [
     "FeatureSet",
     # Input data
     "BaseInputData",
-    "ApiData",
-    "ApiDataFeatureGroup",
-    "BaseApiDataSchema",
-    "ApiDataCollection",
+    "ApiInputData",
+    "ApiInputDataFeature",
+    "BaseApiData",
+    "ApiInputDataCollection",
     "DataCreator",
     # Match data
-    "ConnectionMatcherMixin",
+    "MatchData",
     # Artifact
     "BaseArtifact",
     # Validators

--- a/mloda_plugins/feature_group/input_data/api_data/api_data.py
+++ b/mloda_plugins/feature_group/input_data/api_data/api_data.py
@@ -1,6 +1,6 @@
 from typing import Any, Optional
 from mloda.provider import FeatureGroup
-from mloda.provider import FeatureSet, ApiData as ApiInputData, BaseInputData
+from mloda.provider import FeatureSet, ApiInputData, BaseInputData
 
 
 class ApiInputDataFeature(FeatureGroup):

--- a/tests/test_core/test_api/test_prepare_run.py
+++ b/tests/test_core/test_api/test_prepare_run.py
@@ -9,7 +9,7 @@ These tests define the contract for a two-phase execution model:
 from typing import Any, List, Optional, Set, Union
 
 from mloda.user import mloda, mlodaAPI, Feature, PluginCollector
-from mloda.provider import FeatureGroup, FeatureSet, ApiDataFeatureGroup
+from mloda.provider import FeatureGroup, FeatureSet, ApiInputDataFeature
 from mloda.user import Options, FeatureName, Index
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 
@@ -35,7 +35,7 @@ class PrepareRunApiFeature(FeatureGroup):
 
 _enabled = PluginCollector.enabled_feature_groups(
     {
-        ApiDataFeatureGroup,
+        ApiInputDataFeature,
         PrepareRunApiFeature,
     }
 )

--- a/tests/test_core/test_setup/test_polymorphic_link_resolution.py
+++ b/tests/test_core/test_setup/test_polymorphic_link_resolution.py
@@ -22,7 +22,7 @@ from mloda.user import Options
 from mloda.user import PluginCollector
 from mloda.user import mloda
 from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
-from mloda.provider import ApiDataFeatureGroup
+from mloda.provider import ApiInputDataFeature
 
 
 # =============================================================================
@@ -209,10 +209,10 @@ class AssemblerWithMixedLink(FeatureGroup):
     def input_features(self, options: Options, feature_name: FeatureName) -> Optional[Set[Feature]]:
         idx = Index((BaseFeatureGroupA.ROW_INDEX,))
 
-        # Base class + External concrete class (ApiDataFeatureGroup has no subclass)
+        # Base class + External concrete class (ApiInputDataFeature has no subclass)
         link = Link.inner(
             JoinSpec(BaseFeatureGroupA, idx),  # Base class -> resolves to ConcreteFeatureGroupA
-            JoinSpec(ApiDataFeatureGroup, idx),  # External concrete class (no subclass)
+            JoinSpec(ApiInputDataFeature, idx),  # External concrete class (no subclass)
         )
 
         return {
@@ -241,7 +241,7 @@ class TestAsymmetricPolymorphicLinkResolution:
             compute_frameworks={PythonDictFramework},
             api_data={"UserQuery": {"_idx": [0], "user_query": ["test query"]}},
             plugin_collector=PluginCollector.enabled_feature_groups(
-                {AssemblerWithMixedLink, ConcreteFeatureGroupA, ApiDataFeatureGroup}
+                {AssemblerWithMixedLink, ConcreteFeatureGroupA, ApiInputDataFeature}
             ),
         )
 

--- a/tests/test_mloda_imports.py
+++ b/tests/test_mloda_imports.py
@@ -122,13 +122,13 @@ def test_import_provider_base_classes() -> None:
         FeatureSet,
         # Input data
         BaseInputData,
-        ApiData,
-        ApiDataFeatureGroup,
-        BaseApiDataSchema,
-        ApiDataCollection,
+        ApiInputData,
+        ApiInputDataFeature,
+        BaseApiData,
+        ApiInputDataCollection,
         DataCreator,
         # Match data
-        ConnectionMatcherMixin,
+        MatchData,
         # Artifact
         BaseArtifact,
         # Validators
@@ -159,13 +159,13 @@ def test_import_provider_base_classes() -> None:
     assert FeatureSet is not None
     # Input data
     assert BaseInputData is not None
-    assert ApiData is not None
-    assert ApiDataFeatureGroup is not None
-    assert BaseApiDataSchema is not None
-    assert ApiDataCollection is not None
+    assert ApiInputData is not None
+    assert ApiInputDataFeature is not None
+    assert BaseApiData is not None
+    assert ApiInputDataCollection is not None
     assert DataCreator is not None
     # Match data
-    assert ConnectionMatcherMixin is not None
+    assert MatchData is not None
     # Artifact
     assert BaseArtifact is not None
     # Validators

--- a/tests/test_plugins/api/test_simplified_api_data.py
+++ b/tests/test_plugins/api/test_simplified_api_data.py
@@ -25,7 +25,7 @@ from mloda.user import Link, JoinSpec
 from mloda.user import Options
 from mloda.user import PluginCollector
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
-from mloda.provider import ApiDataFeatureGroup
+from mloda.provider import ApiInputDataFeature
 
 
 # ============================================================================
@@ -103,7 +103,7 @@ class SimplifiedApiJoinFeature(FeatureGroup):
         """Define input features with a LEFT join link."""
         # Create the link: LEFT join on api_id = creator_id
         link = Link.left(
-            JoinSpec(ApiDataFeatureGroup, Index(("api_id",))), JoinSpec(CreatorDataFeature, Index(("creator_id",)))
+            JoinSpec(ApiInputDataFeature, Index(("api_id",))), JoinSpec(CreatorDataFeature, Index(("creator_id",)))
         )
 
         return {
@@ -130,21 +130,21 @@ class TestSimplifiedApiData:
 
     _enabled_simple = PluginCollector.enabled_feature_groups(
         {
-            ApiDataFeatureGroup,
+            ApiInputDataFeature,
             SimpleApiFeature,
         }
     )
 
     _enabled_multikey = PluginCollector.enabled_feature_groups(
         {
-            ApiDataFeatureGroup,
+            ApiInputDataFeature,
             MultiKeyApiFeature,
         }
     )
 
     _enabled_join = PluginCollector.enabled_feature_groups(
         {
-            ApiDataFeatureGroup,
+            ApiInputDataFeature,
             CreatorDataFeature,
             SimplifiedApiJoinFeature,
         }

--- a/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_integration.py
+++ b/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_integration.py
@@ -1,4 +1,4 @@
-from mloda.provider import ConnectionMatcherMixin
+from mloda.provider import MatchData
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
 import pytest
@@ -67,7 +67,7 @@ class DuckDBTestDataCreator(ATestDataCreator):
         return duckdb_test_dict
 
 
-class ATestDuckDBFeatureGroup(FeatureGroup, ConnectionMatcherMixin):
+class ATestDuckDBFeatureGroup(FeatureGroup, MatchData):
     @classmethod
     def match_data_access(
         cls,

--- a/tests/test_plugins/compute_framework/base_implementations/iceberg/test_iceberg_integration.py
+++ b/tests/test_plugins/compute_framework/base_implementations/iceberg/test_iceberg_integration.py
@@ -11,7 +11,7 @@ from mloda.user import Options
 from mloda.user import PluginCollector
 from mloda.provider import DataCreator
 from mloda.provider import BaseInputData
-from mloda.provider import ConnectionMatcherMixin
+from mloda.provider import MatchData
 from mloda.provider import ComputeFramework
 from mloda.user import mloda
 from mloda.user import ParallelizationMode
@@ -110,7 +110,7 @@ class IcebergTestDataCreator(FeatureGroup):
         return {IcebergFramework}
 
 
-class ATestIcebergFeatureGroup(FeatureGroup, ConnectionMatcherMixin):
+class ATestIcebergFeatureGroup(FeatureGroup, MatchData):
     """Base class for Iceberg feature groups."""
 
     @classmethod

--- a/tests/test_plugins/compute_framework/base_implementations/spark/test_spark_integration.py
+++ b/tests/test_plugins/compute_framework/base_implementations/spark/test_spark_integration.py
@@ -24,7 +24,7 @@ ensure proper resource management across all test methods.
 from typing import Any, Dict, Optional, Set, Type, Union
 import pytest
 
-from mloda.provider import ConnectionMatcherMixin
+from mloda.provider import MatchData
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
 from mloda.provider import FeatureGroup
@@ -93,7 +93,7 @@ class SparkTestDataCreator(ATestDataCreator):
         return spark_test_dict
 
 
-class ATestSparkFeatureGroup(FeatureGroup, ConnectionMatcherMixin):
+class ATestSparkFeatureGroup(FeatureGroup, MatchData):
     @classmethod
     def match_data_access(
         cls,

--- a/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_integration.py
+++ b/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_integration.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional, Set, Type, Union
 
 import pytest
 
-from mloda.provider import ConnectionMatcherMixin
+from mloda.provider import MatchData
 from mloda.provider import ComputeFramework
 from mloda.provider import FeatureGroup
 from mloda.provider import FeatureSet
@@ -49,7 +49,7 @@ class SqliteTestDataCreator(ATestDataCreator):
         return sqlite_test_dict
 
 
-class ATestSqliteFeatureGroup(FeatureGroup, ConnectionMatcherMixin):
+class ATestSqliteFeatureGroup(FeatureGroup, MatchData):
     @classmethod
     def match_data_access(
         cls,

--- a/tests/test_plugins/feature_group/experimental/llm/test_llm.py
+++ b/tests/test_plugins/feature_group/experimental/llm/test_llm.py
@@ -8,7 +8,7 @@ from mloda_plugins.feature_group.experimental.llm.installed_packages_feature_gro
 from mloda_plugins.feature_group.experimental.llm.llm_api.claude import ClaudeRequestLoop
 from mloda_plugins.feature_group.experimental.llm.llm_api.openai import OpenAIRequestLoop
 from mloda_plugins.feature_group.experimental.llm.tools.available.multiply import MultiplyTool
-from mloda.provider import ApiDataFeatureGroup
+from mloda.provider import ApiInputDataFeature
 import pytest
 
 from mloda_plugins.feature_group.experimental.llm.llm_api.gemini import GeminiRequestLoop
@@ -101,7 +101,7 @@ class TestPlugInLLM:
         api_data_index = Index(("InputData1",))
 
         link = Link.outer(
-            JoinSpec(InstalledPackagesFeatureGroup, installed), JoinSpec(ApiDataFeatureGroup, api_data_index)
+            JoinSpec(InstalledPackagesFeatureGroup, installed), JoinSpec(ApiInputDataFeature, api_data_index)
         )
 
         _test_classes = [OpenAIRequestLoop, GeminiRequestLoop]

--- a/tests/test_plugins/feature_group/experimental/test_source_input_features/test_input_features.py
+++ b/tests/test_plugins/feature_group/experimental/test_source_input_features/test_input_features.py
@@ -19,7 +19,7 @@ from mloda_plugins.compute_framework.base_implementations.pandas.dataframe impor
 from mloda.provider import DefaultOptionKeys
 from mloda_plugins.feature_group.experimental.source_input_feature import SourceInputFeature
 
-from mloda.provider import ApiDataFeatureGroup
+from mloda.provider import ApiInputDataFeature
 from mloda_plugins.feature_group.input_data.read_file_feature import ReadFileFeature
 from mloda_plugins.feature_group.input_data.read_files.csv import CsvReader
 
@@ -61,7 +61,7 @@ class TestInputFeatures:
     _requested_name = "InputFeatureGroupTest"
     _enabled = PluginCollector.enabled_feature_groups(
         {
-            ApiDataFeatureGroup,
+            ApiInputDataFeature,
             InputFeatureGroupTest,
             FeatureInputFeatureTest,
             FeatureInputCreatorTest,

--- a/tests/test_plugins/integration_plugins/test_api_link_join.py
+++ b/tests/test_plugins/integration_plugins/test_api_link_join.py
@@ -2,7 +2,7 @@
 Integration test: ApiInputDataCollection with Links and Joins.
 
 Three features:
-1. ApiDataFeatureGroup (existing) - receives mloda data
+1. ApiInputDataFeature (existing) - receives mloda data
 2. CreatorDataFeature (custom) - creates own data via DataCreator
 3. JoinedFeature (custom) - depends on both with a join
 """
@@ -20,7 +20,7 @@ from mloda.user import Options
 from mloda.user import PluginCollector
 from mloda.user import mloda
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
-from mloda.provider import ApiDataFeatureGroup
+from mloda.provider import ApiInputDataFeature
 
 
 # ============================================================================
@@ -53,7 +53,7 @@ class LeftJoinedFeature(FeatureGroup):
 
         # Create the link: LEFT join on api_id = creator_id
         link = Link.left(
-            JoinSpec(ApiDataFeatureGroup, Index(("api_id",))), JoinSpec(CreatorDataFeature, Index(("creator_id",)))
+            JoinSpec(ApiInputDataFeature, Index(("api_id",))), JoinSpec(CreatorDataFeature, Index(("creator_id",)))
         )
 
         # Return features - attach link to one of them
@@ -81,7 +81,7 @@ class AppendedFeature(FeatureGroup):
 
         # Create the link: APPEND stacks data vertically
         link = Link.append(
-            JoinSpec(ApiDataFeatureGroup, Index(("api_id",))), JoinSpec(CreatorDataFeature, Index(("creator_id",)))
+            JoinSpec(ApiInputDataFeature, Index(("api_id",))), JoinSpec(CreatorDataFeature, Index(("creator_id",)))
         )
 
         # Return features - attach link to one of them
@@ -109,7 +109,7 @@ class TestApiLinkJoin:
 
     _enabled_left = PluginCollector.enabled_feature_groups(
         {
-            ApiDataFeatureGroup,
+            ApiInputDataFeature,
             CreatorDataFeature,
             LeftJoinedFeature,
         }
@@ -117,7 +117,7 @@ class TestApiLinkJoin:
 
     _enabled_append = PluginCollector.enabled_feature_groups(
         {
-            ApiDataFeatureGroup,
+            ApiInputDataFeature,
             CreatorDataFeature,
             AppendedFeature,
         }


### PR DESCRIPTION
## Summary

- Removes all 5 re-aliases in `mloda/provider/__init__.py` that renamed classes to completely different names on re-export
- Re-exports using original class names: `MatchData`, `ApiInputData`, `BaseApiData`, `ApiInputDataFeature`, `ApiInputDataCollection`
- Updates all 14 consumer files (tests, docs, plugins) to use the original names
- Eliminates the double-aliasing round-trip in `api_data.py` (`ApiInputData` -> `ApiData` -> `ApiInputData`)

## Aliases removed

| Original (now exported) | Old alias (removed) | Problem |
|---|---|---|
| `MatchData` | `ConnectionMatcherMixin` | Not a mixin; misleading suffix |
| `ApiInputData` | `ApiData` | Overly generic; caused double-aliasing |
| `BaseApiData` | `BaseApiDataSchema` | Implies schema validation that doesn't exist |
| `ApiInputDataFeature` | `ApiDataFeatureGroup` | Drops "Input"; less specific |
| `ApiInputDataCollection` | `ApiDataCollection` | Drops "Input" qualifier |

## Test plan

- [x] All 32 tests in changed files pass
- [x] Full `tox` run: 2267 passed (13 pre-existing failures unrelated to this change)

Closes #262