### PR TITLE
fix: correct initialized_connection_object(s) typo in docs

### DIFF
--- a/docs/docs/chapter1/compute-frameworks.md
+++ b/docs/docs/chapter1/compute-frameworks.md
@@ -188,7 +188,7 @@ connection = duckdb.connect()
 
 # Set up data access with connection
 data_access_collection = DataAccessCollection(
-    initialized_connection_object={connection}
+    initialized_connection_objects={connection}
 )
 
 feature = Feature("id", options={"compute_framework": "DuckDBFramework"})

--- a/docs/docs/in_depth/framework-connection-object.md
+++ b/docs/docs/in_depth/framework-connection-object.md
@@ -88,7 +88,7 @@ import duckdb
 connection = duckdb.connect()
 
 # Set up data access
-data_access_collection = DataAccessCollection(initialized_connection_object={connection})
+data_access_collection = DataAccessCollection(initialized_connection_objects={connection})
 
 # Run with DuckDB framework
 result = mloda.run_all(


### PR DESCRIPTION
## Summary

- Fixes `initialized_connection_object` (singular) to `initialized_connection_objects` (plural) in two doc files
- `docs/docs/chapter1/compute-frameworks.md` line 191
- `docs/docs/in_depth/framework-connection-object.md` line 91
- The singular form would raise `TypeError` at runtime due to unexpected keyword argument

## Test plan

- [x] Verified the correct parameter name matches `DataAccessCollection.__init__` signature

Closes #272