### PR TITLE
fix: remove need-help.md and fix grammar in error messages

### DIFF
--- a/docs/docs/in_depth/join_data.md
+++ b/docs/docs/in_depth/join_data.md
@@ -304,7 +304,7 @@ class PandasMergeEngine(BaseMergeEngine):
 
         else:
             raise ValueError(
-                f"JoinType {join_type} {left_index} {right_index} are not yet implemented {self.__class__.__name__}"
+                f"JoinType {join_type} {left_index} {right_index} is not yet implemented in {self.__class__.__name__}"
             )
 ```
 

--- a/docs/docs/need-help.md
+++ b/docs/docs/need-help.md
@@ -1,5 +1,0 @@
-# Need Help?
-
-If you have any questions or need assistance, please reach out to our support team at [issues](https://github.com/mloda-ai/mloda/issues).
-
-or reach out to me personally at [info@mloda.ai](mailto:info@mloda.ai).

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -51,10 +51,9 @@ nav:
     - License - Apache 2.0: license.md
   - Need Help?:
     - FAQ: faq.md
-    - Need Help: need-help.md
 
   # todo
-  #- Extender in Depth: need-help.md
+  #- Extender in Depth: TBD
 
 theme:
   name: readthedocs

--- a/mloda/core/abstract_plugins/components/merge/base_merge_engine.py
+++ b/mloda/core/abstract_plugins/components/merge/base_merge_engine.py
@@ -39,22 +39,22 @@ class BaseMergeEngine(ABC):
         pass
 
     def merge_inner(self, left_data: Any, right_data: Any, left_index: Index, right_index: Index) -> Any:
-        raise ValueError(f"JoinType inner are not yet implemented {self.__class__.__name__}")
+        raise ValueError(f"JoinType inner is not yet implemented in {self.__class__.__name__}")
 
     def merge_left(self, left_data: Any, right_data: Any, left_index: Index, right_index: Index) -> Any:
-        raise ValueError(f"JoinType left are not yet implemented {self.__class__.__name__}")
+        raise ValueError(f"JoinType left is not yet implemented in {self.__class__.__name__}")
 
     def merge_right(self, left_data: Any, right_data: Any, left_index: Index, right_index: Index) -> Any:
-        raise ValueError(f"JoinType right are not yet implemented {self.__class__.__name__}")
+        raise ValueError(f"JoinType right is not yet implemented in {self.__class__.__name__}")
 
     def merge_full_outer(self, left_data: Any, right_data: Any, left_index: Index, right_index: Index) -> Any:
-        raise ValueError(f"JoinType full outer are not yet implemented {self.__class__.__name__}")
+        raise ValueError(f"JoinType full outer is not yet implemented in {self.__class__.__name__}")
 
     def merge_append(self, left_data: Any, right_data: Any, left_index: Index, right_index: Index) -> Any:
-        raise ValueError(f"JoinType append are not yet implemented {self.__class__.__name__}")
+        raise ValueError(f"JoinType append is not yet implemented in {self.__class__.__name__}")
 
     def merge_union(self, left_data: Any, right_data: Any, left_index: Index, right_index: Index) -> Any:
-        raise ValueError(f"JoinType union are not yet implemented {self.__class__.__name__}")
+        raise ValueError(f"JoinType union is not yet implemented in {self.__class__.__name__}")
 
     @final
     def merge(self, left_data: Any, right_data: Any, jointype: JoinType, left_index: Index, right_index: Index) -> Any:

--- a/mloda/core/abstract_plugins/compute_framework.py
+++ b/mloda/core/abstract_plugins/compute_framework.py
@@ -457,7 +457,7 @@ Available join types:
             return transformer_cls.transform(_from_fw, _to_fw, data, None)
 
         raise ValueError(
-            f"Conversion from {type(data)} to {cls.expected_data_framework()} is not supported. This can be created, when a flyserver was used."
+            f"Conversion from {type(data)} to {cls.expected_data_framework()} is not supported. This can happen when a FlightServer was used."
         )
 
     @final

--- a/mloda/core/filter/single_filter.py
+++ b/mloda/core/filter/single_filter.py
@@ -54,7 +54,7 @@ class SingleFilter:
 
     def handle_parameter(self, parameter: Dict[str, Any]) -> FilterParameterImpl:
         if not isinstance(parameter, dict):
-            raise ValueError(f"Filter parameter is no dictionary: {parameter}.")
+            raise ValueError(f"Filter parameter is not a dictionary: {parameter}.")
 
         elif not parameter:
             raise ValueError(f"Dictionary is empty: {parameter}.")

--- a/mloda_plugins/compute_framework/base_implementations/pyarrow/pyarrow_merge_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/pyarrow/pyarrow_merge_engine.py
@@ -67,7 +67,7 @@ class PyArrowMergeEngine(BaseMergeEngine):
         https://github.com/apache/arrow/issues/30950 Currently, not existing in base pyarrow.
         If needed, one could add it.
         """
-        raise ValueError(f"JoinType union are not yet implemented {self.__class__.__name__}")
+        raise ValueError(f"JoinType union is not yet implemented in {self.__class__.__name__}")
 
     def join_logic(
         self, join_type: str, left_data: Any, right_data: Any, left_index: Index, right_index: Index, jointype: JoinType


### PR DESCRIPTION
## Summary
- Remove placeholder `need-help.md` that only said "reach out to me personally" with no useful content
- Fix grammar in error messages: "are not yet implemented" -> "is not yet implemented in", "is no dictionary" -> "is not a dictionary", "flyserver" -> "FlightServer"
- Update docs code example and mkdocs nav to match

Closes #283
Closes #282