### PR TITLE
fix: move misplaced comment before ClusteringFeatureGroup docstring

### DIFF
--- a/mloda_plugins/feature_group/experimental/clustering/base.py
+++ b/mloda_plugins/feature_group/experimental/clustering/base.py
@@ -18,7 +18,6 @@ from mloda.provider import DefaultOptionKeys
 
 
 class ClusteringFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-    # Option keys for clustering configuration
     """
     Base class for all clustering feature groups.
 
@@ -89,6 +88,7 @@ class ClusteringFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     - For algorithms that don't require a specific number of clusters (like DBSCAN), use 'auto' as the k_value
     """
 
+    # Option keys for clustering configuration
     ALGORITHM = "algorithm"
     K_VALUE = "k_value"
     OUTPUT_PROBABILITIES = "output_probabilities"


### PR DESCRIPTION
## Summary

- Moves `# Option keys for clustering configuration` comment from before the docstring to before the attribute block it describes in `ClusteringFeatureGroup`
- `TimeWindowFeatureGroup` and `TextCleaningFeatureGroup` were inspected and already have correctly placed docstrings (no changes needed)

## Test plan

- [x] Verified `ClusteringFeatureGroup.__doc__` is now immediately after the class line
- [x] Confirmed the other two classes already had correct docstring placement

Closes #289