### PR TITLE
fix: correct inverted validation condition in data-quality doc

### DIFF
--- a/docs/docs/in_depth/data-quality.md
+++ b/docs/docs/in_depth/data-quality.md
@@ -39,7 +39,7 @@ class DocSimpleValidateInputFeatures(FeatureGroup):
     def validate_input_features(cls, data: Any, features: FeatureSet) -> None:
         """This function is a naive implementation of a validator."""
 
-        if len(data["BaseValidateInputFeaturesBase"]) == 3:
+        if len(data["BaseValidateInputFeaturesBase"]) != 3:
             raise ValueError("Data should have 3 elements")
 ```
 


### PR DESCRIPTION
## Summary
- Fix inverted validation logic in `docs/docs/in_depth/data-quality.md`: the condition `== 3` raised "Data should have 3 elements" which contradicts itself
- Flip to `!= 3` so the guard matches its error message

Closes #268