### PR TITLE
fix: correct typos in docs, comments, and public API method names

### DIFF
--- a/docs/docs/chapter1/compute-frameworks.md
+++ b/docs/docs/chapter1/compute-frameworks.md
@@ -125,7 +125,7 @@ In this case, the feature group ExampleB will only run on the PyArrowTable frame
 
 | Framework | Technology | Strengths | Best For | Dependencies |
 |-----------|------------|-----------|----------|--------------|
-| **PandasDataFrame** | pandas DataFrame | Rich data transformation, familiar mloda | Development, data exploration, smaller datasets | pandas, numpy |
+| **PandasDataFrame** | pandas DataFrame | Rich data transformation, familiar API | Development, data exploration, smaller datasets | pandas, numpy |
 | **PyArrowTable** | Apache Arrow Tables | Memory-efficient, high performance, columnar format | Production, big data, interoperability | pyarrow |
 | **PolarsDataFrame** | Polars DataFrame | Fast, memory-efficient, eager evaluation | Development, immediate results | polars |
 | **PolarsLazyDataFrame** | Polars LazyFrame | Query optimization, lazy evaluation | Large datasets, performance optimization | polars |

--- a/docs/docs/examples/mloda_basics/4_ml_data_providers_user_steward.ipynb
+++ b/docs/docs/examples/mloda_basics/4_ml_data_providers_user_steward.ipynb
@@ -8,7 +8,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## Roles in mloda\n\nIn this notebook, we will describe three roles which exists in the mloda framework.\n\n- Providers: Provide access to raw data, business-layer data, or aggregated data.\n  - A data scientist or analyst might create simpler datasets or analytical outputs\n  - A data engineer might design access to complex data infrastructures, such as data lakes or warehouses\n  - Shares plug-ins and with it access to data\n\n- Data User: Interacts with mloda by applying plug-ins while making requests via the mlodaAPI.\n  - A data scientist or analyst who needs data and data transformations (features)\n  - Consumes features from other parts of the organizations\n\n- Steward: Ensures lifetime value, availability and governance of data and features"
+   "source": "## Roles in mloda\n\nIn this notebook, we will describe three roles which exists in the mloda framework.\n\n- Providers: Provide access to raw data, business-layer data, or aggregated data.\n  - A data scientist or analyst might create simpler datasets or analytical outputs\n  - A data engineer might design access to complex data infrastructures, such as data lakes or warehouses\n  - Shares plugins and with it access to data\n\n- Data User: Interacts with mloda by applying plugins while making requests via the mlodaAPI.\n  - A data scientist or analyst who needs data and data transformations (features)\n  - Consumes features from other parts of the organizations\n\n- Steward: Ensures lifetime value, availability and governance of data and features"
   },
   {
    "cell_type": "markdown",
@@ -123,56 +123,12 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "### FeatureGroup mloda (plug-in) in short\n\nIn mloda, a provider defines access by creating feature groups. Here's an example implementation:\n\n```python\nclass FeatureGroupClass(FeatureGroup):\n\n    # Root feature definition\n    @classmethod\n    def input_data(...)\n        ...\n\n    # Features derived from other features\n    def input_features(...)\n        ...\n\n    @classmethod\n    def calculate_feature(...)\n        ...\n```"
+   "source": "### FeatureGroup mloda (plugin) in short\n\nIn mloda, a provider defines access by creating feature groups. Here's an example implementation:\n\n```python\nclass FeatureGroupClass(FeatureGroup):\n\n    # Root feature definition\n    @classmethod\n    def input_data(...)\n        ...\n\n    # Features derived from other features\n    def input_features(...)\n        ...\n\n    @classmethod\n    def calculate_feature(...)\n        ...\n```"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "### Simple example implementation of the FeatureGroup mloda\n",
-    "\n",
-    "In the background, mloda loads the plug-ins, which were created before, like this one.\n",
-    "\n",
-    "```python\n",
-    "class ReadFileFeature(FeatureGroup):\n",
-    "    @classmethod\n",
-    "    def input_data(cls) -> Optional[BaseInputData]:\n",
-    "        return ReadFile()\n",
-    "\n",
-    "    @classmethod\n",
-    "    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:\n",
-    "        reader = cls.input_data()\n",
-    "        if reader is not None:\n",
-    "            data = reader.load(features)\n",
-    "            return data\n",
-    "        raise ValueError(f\"Reading file failed for feature {features.get_name_of_one_feature()}.\")\n",
-    "```\n",
-    "\n",
-    "We use composition to read different data sources. A ReadFile object looks like this:\n",
-    "\n",
-    "```python\n",
-    "class CsvReader(ReadFile):\n",
-    "    @classmethod\n",
-    "    def suffix(cls) -> Tuple[str, ...]:\n",
-    "        return (\n",
-    "            \".csv\",\n",
-    "            \".CSV\",\n",
-    "        )\n",
-    "\n",
-    "    @classmethod\n",
-    "    def load_data(cls, data_access: Any, features: FeatureSet) -> Any:\n",
-    "        result = pyarrow_csv.read_csv(data_access)\n",
-    "        return result.select(list(features.get_all_names()))\n",
-    "\n",
-    "    @classmethod\n",
-    "    def get_column_names(cls, file_name: str) -> Any:\n",
-    "        read_options = pyarrow_csv.ReadOptions(skip_rows_after_names=1)\n",
-    "        table = pyarrow_csv.read_csv(file_name, read_options=read_options)\n",
-    "        return table.schema.names\n",
-    "```\n",
-    "\n",
-    "As you can see, the implementation is flexible in the sense that if you need something, you can adjust it quite easily. The other files like .json, .parquet and the sqlite access are implemented in a similar fashion."
-   ]
+   "source": "### Simple example implementation of the FeatureGroup mloda\n\nIn the background, mloda loads the plugins, which were created before, like this one.\n\n```python\nclass ReadFileFeature(FeatureGroup):\n    @classmethod\n    def input_data(cls) -> Optional[BaseInputData]:\n        return ReadFile()\n\n    @classmethod\n    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:\n        reader = cls.input_data()\n        if reader is not None:\n            data = reader.load(features)\n            return data\n        raise ValueError(f\"Reading file failed for feature {features.get_name_of_one_feature()}.\")\n```\n\nWe use composition to read different data sources. A ReadFile object looks like this:\n\n```python\nclass CsvReader(ReadFile):\n    @classmethod\n    def suffix(cls) -> Tuple[str, ...]:\n        return (\n            \".csv\",\n            \".CSV\",\n        )\n\n    @classmethod\n    def load_data(cls, data_access: Any, features: FeatureSet) -> Any:\n        result = pyarrow_csv.read_csv(data_access)\n        return result.select(list(features.get_all_names()))\n\n    @classmethod\n    def get_column_names(cls, file_name: str) -> Any:\n        read_options = pyarrow_csv.ReadOptions(skip_rows_after_names=1)\n        table = pyarrow_csv.read_csv(file_name, read_options=read_options)\n        return table.schema.names\n```\n\nAs you can see, the implementation is flexible in the sense that if you need something, you can adjust it quite easily. The other files like .json, .parquet and the sqlite access are implemented in a similar fashion."
   },
   {
    "cell_type": "code",
@@ -211,21 +167,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "### Complex plug-ins\n",
-    "\n",
-    "These can be quite varied:\n",
-    "\n",
-    "- aggregate features\n",
-    "- entity features\n",
-    "- historical features\n",
-    "\n",
-    "Additionally, one can also write feature groups for:\n",
-    "\n",
-    "- using feature stores\n",
-    "- using orchestrator steps\n",
-    "- lazy evaluated functions\n"
-   ]
+   "source": "### Complex plugins\n\nThese can be quite varied:\n\n- aggregate features\n- entity features\n- historical features\n\nAdditionally, one can also write feature groups for:\n\n- using feature stores\n- using orchestrator steps\n- lazy evaluated functions\n"
   },
   {
    "cell_type": "markdown",
@@ -270,55 +212,12 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## Data User Role\n",
-    "\n",
-    "The Data User plays a pivotal role in configuring and utilizing the mloda API for machine learning and data workflows. The mloda API offers flexible configurations to cater to diverse use cases across the ML lifecycle. Below is an outline of the configurations and features that define the Data User's role:\n",
-    "\n",
-    "```python\n",
-    "class mlodaAPI:\n",
-    "    def __init__(\n",
-    "        self,\n",
-    "        requested_features: Union[Features, list[Union[Feature, str]]],\n",
-    "        compute_frameworks: Union[Set[Type[ComputeFramework]], Optional[list[str]]] = None,\n",
-    "        links: Optional[Set[Link]] = None,\n",
-    "        data_access_collection: Optional[DataAccessCollection] = None,\n",
-    "        global_filter: Optional[GlobalFilter] = None,\n",
-    "        api_input_data_collection: Optional[ApiInputDataCollection] = None,\n",
-    "        plugin_collector: Optional[PluginCollector] = None,\n",
-    "    ) -> None:\n",
-    "\n",
-    "data = mlodamloda.run_all(requested_feature,...)\n",
-    "```\n",
-    "\n",
-    "Let's use the mloda to further explain the Data User role. As shown above, there are several configurations to consider. The key ones are:\n",
-    "\n",
-    "- Which features to request and if the compute_frameworks should be limited?\n",
-    "- How data is linked?\n",
-    "- What specific access rights and permissions does the user have?\n",
-    "- How data is refined to meet the requirements of the use case?\n",
-    "\n",
-    "With all the given configurations, the mloda core is designed, whenever feasible, to follow the process: \n",
-    "\n",
-    "- First, formulate an optimized execution plan\n",
-    "- Second, to execute the plan accordingly\n",
-    "\n",
-    "What the user mostly gains is that the process is repeatable and can be run in most environments, as long as the plug-ins are available and the accesses exist (firewalls, credentials). \n",
-    "\n",
-    "The data user could run mloda API in following scenarios:\n",
-    "\n",
-    "- POC notebooks\n",
-    "- Production code scenarios (model training or realtime prediction)\n",
-    "- Micro service endpont\n",
-    "- KPI or QA test data ingestion\n",
-    "\n",
-    "With this, the whole ml lifecycle is represented and plug-ins can be reused in a testable and repeatable way along this cycle."
-   ]
+   "source": "## Data User Role\n\nThe Data User plays a pivotal role in configuring and utilizing the mloda API for machine learning and data workflows. The mloda API offers flexible configurations to cater to diverse use cases across the ML lifecycle. Below is an outline of the configurations and features that define the Data User's role:\n\n```python\nclass mlodaAPI:\n    def __init__(\n        self,\n        requested_features: Union[Features, list[Union[Feature, str]]],\n        compute_frameworks: Union[Set[Type[ComputeFramework]], Optional[list[str]]] = None,\n        links: Optional[Set[Link]] = None,\n        data_access_collection: Optional[DataAccessCollection] = None,\n        global_filter: Optional[GlobalFilter] = None,\n        api_input_data_collection: Optional[ApiInputDataCollection] = None,\n        plugin_collector: Optional[PluginCollector] = None,\n    ) -> None:\n\ndata = mlodamloda.run_all(requested_feature,...)\n```\n\nLet's use the mloda to further explain the Data User role. As shown above, there are several configurations to consider. The key ones are:\n\n- Which features to request and if the compute_frameworks should be limited?\n- How data is linked?\n- What specific access rights and permissions does the user have?\n- How data is refined to meet the requirements of the use case?\n\nWith all the given configurations, the mloda core is designed, whenever feasible, to follow the process: \n\n- First, formulate an optimized execution plan\n- Second, to execute the plan accordingly\n\nWhat the user mostly gains is that the process is repeatable and can be run in most environments, as long as the plugins are available and the accesses exist (firewalls, credentials). \n\nThe data user could run mloda API in following scenarios:\n\n- POC notebooks\n- Production code scenarios (model training or realtime prediction)\n- Micro service endpont\n- KPI or QA test data ingestion\n\nWith this, the whole ml lifecycle is represented and plugins can be reused in a testable and repeatable way along this cycle."
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## Steward Role\n\nStewards typically operate at various levels within an organization.\n\nIt can be the one who produces the data, the business stakeholder responsible for the service, or, in some cases, may not be explicitly defined.\n\nIn mloda, the steward is the one in control of the governance. However, as to date, this system is not included in this open-source offering, as this platform is reserved for development until the plugin ecosystem has a higher degree of maturity.\n\nWe have the plug-in functionalities to integrate governance and operations systems in place. Two simple examples can be:\n\n#### Using organization wide logging\n\n```python\nclass OtelExtender(Extender):\n    def __init__(self) -> None:\n        if trace is None:\n            return\n\n        # Function to be wrapped by the Extender\n        self.wrapped = {ExtenderHook.FEATURE_GROUP_CALCULATE_FEATURE}\n\n    def wraps(self) -> Set[ExtenderHook]:\n        return self.wrapped\n\n    def __call__(self, func: Any, *args: Any, **kwargs: Any) -> Any:\n        logger.warning(\"OtelExtender\")\n        result = func(*args, **kwargs)\n        return result\n```\n\n#### Logging data size\n\n```python\nclass LogSizeOfData(Extender):\n\n    def wraps(self) -> Set[ExtenderHook]:\n        # Function to be wrapped by the Extender\n        return {ExtenderHook.VALIDATE_INPUT_FEATURE}\n\n    def __call__(self, func: Any, *args: Any, **kwargs: Any) -> Any:\n        result = func(*args, **kwargs)\n        size = sys.getsizeof(result)\n        print(f\"Size: {size}\")\n        return result\n```"
+   "source": "## Steward Role\n\nStewards typically operate at various levels within an organization.\n\nIt can be the one who produces the data, the business stakeholder responsible for the service, or, in some cases, may not be explicitly defined.\n\nIn mloda, the steward is the one in control of the governance. However, as to date, this system is not included in this open-source offering, as this platform is reserved for development until the plugin ecosystem has a higher degree of maturity.\n\nWe have the plugin functionalities to integrate governance and operations systems in place. Two simple examples can be:\n\n#### Using organization wide logging\n\n```python\nclass OtelExtender(Extender):\n    def __init__(self) -> None:\n        if trace is None:\n            return\n\n        # Function to be wrapped by the Extender\n        self.wrapped = {ExtenderHook.FEATURE_GROUP_CALCULATE_FEATURE}\n\n    def wraps(self) -> Set[ExtenderHook]:\n        return self.wrapped\n\n    def __call__(self, func: Any, *args: Any, **kwargs: Any) -> Any:\n        logger.warning(\"OtelExtender\")\n        result = func(*args, **kwargs)\n        return result\n```\n\n#### Logging data size\n\n```python\nclass LogSizeOfData(Extender):\n\n    def wraps(self) -> Set[ExtenderHook]:\n        # Function to be wrapped by the Extender\n        return {ExtenderHook.VALIDATE_INPUT_FEATURE}\n\n    def __call__(self, func: Any, *args: Any, **kwargs: Any) -> Any:\n        result = func(*args, **kwargs)\n        size = sys.getsizeof(result)\n        print(f\"Size: {size}\")\n        return result\n```"
   },
   {
    "cell_type": "markdown",

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -60,21 +60,21 @@ mloda automatically manages feature dependencies, ensuring transformations are h
 
 The Core Engine orchestrates dependencies between Feature Groups, compute frameworks, and extenders. Dependencies can include data collections, links, joins, filters, or hierarchical feature relations. 
 
-The Core Engine creates an execution plan based on these dependencies and then runs the plan to execute feature calculations. This approach has the side effect that users describe the solution rather than the programm the solution itself. It is in that regard closer to databases paradigm than database paradigm.
+The Core Engine creates an execution plan based on these dependencies and then runs the plan to execute feature calculations. This approach has the side effect that users describe the solution rather than program it. In that regard it is closer to a declarative paradigm (like SQL) than an imperative one.
 
 #### How does mloda ensure data governance and quality control?
 
 mloda uses multiple mechanisms for governance and quality control. The extender feature logs relevant technical details, and users can incorporate data quality checks directly into feature definitions. Unit and integration testing are also simple to set up, enhancing reliability.
 
-#### How do plug-ins work in mloda, and can I develop my own plug-ins?
+#### How do plugins work in mloda, and can I develop my own plugins?
 
-mloda automatically selects the appropriate plug-ins for a given feature. 
+mloda automatically selects the appropriate plugins for a given feature. 
 
-Users can develop custom plug-ins to extend the platform's capabilities, and contributions are always welcome—feedback and design critiques are also greatly appreciated!
+Users can develop custom plugins to extend the platform's capabilities, and contributions are always welcome. Feedback and design critiques are also greatly appreciated!
 
 #### How do I join a feature group with itself (self-join)?
 
-When you need to use the same feature group on both sides of a join, you'll need to use pointer fields to distinguish between the left and right instances. See the [Join data guide - Same-Class Joins section](in_depth/join_data.md#same-class-joins-with-discriminators) for details and examples.
+When you need to use the same feature group on both sides of a join, you'll need to use discriminators to distinguish between the left and right instances. See the [Join data guide - Same-Class Joins section](in_depth/join_data.md#same-class-joins-with-discriminators) for details and examples.
 
 ## Technical and Integration
 

--- a/docs/docs/in_depth/access-feature-data.md
+++ b/docs/docs/in_depth/access-feature-data.md
@@ -29,7 +29,7 @@ List options:
 
 4.  **Initialized connection object:** Stores connection objects that are already initialized: (DBConnectionObject)
 
-5.  **Unitialized connection object:** Stores not initialized connection objects: (UninitializedDBConnection)
+5.  **Uninitialized connection object:** Stores not initialized connection objects: (UninitializedDBConnection)
 
 You can apply these options like so:
 
@@ -148,7 +148,7 @@ In this case, we need to provide the specific reader class: CsvReader.
 
 ``` python
 
-# This feature is already implemented as plug-in, so do not run it again. This will raise intentional errors.
+# This feature is already implemented as plugin, so do not run it again. This will raise intentional errors.
 class ReadFileFeature(FeatureGroup):
     @classmethod
     def input_data(cls) -> Optional[BaseInputData]:
@@ -291,7 +291,7 @@ Output
 1          TestValue6
 ```
 
-Finally, as also the most important way to get data, is actually to depent on data inside the framework already. For this purpose, a feature can load data depending on other features.
+Finally, as also the most important way to get data, is actually to depend on data inside the framework already. For this purpose, a feature can load data depending on other features.
 
 #### Input features 
 

--- a/docs/docs/in_depth/artifacts.md
+++ b/docs/docs/in_depth/artifacts.md
@@ -8,7 +8,7 @@ Example use cases are embeddings, Feature Matrices, Model Checkpoints and more.
 Artifacts are managed through a set of abstract and concrete classes that define how artifacts are created, saved, and loaded. The primary classes involved in artifact management include:
 
 - `BaseArtifact`: The base class for all artifacts.
-- `FeatureGroup`: The base class for feature groups, including methods for artifact management. This class may contain a `BaseArtfact`.
+- `FeatureGroup`: The base class for feature groups, including methods for artifact management. This class may contain a `BaseArtifact`.
 
 ## Key Components
 

--- a/docs/docs/in_depth/feature-group-testing.md
+++ b/docs/docs/in_depth/feature-group-testing.md
@@ -1,8 +1,5 @@
 # Feature Group Testing
 
-
-Most feature groups were generated automatically by using an agent. It is good practise to give the agents examples of other tests. Some agents tend to skip tests. Please be aware of that.
-
 This guide outlines key aspects to test in feature groups and provides brief examples.
 
 ## What to Test

--- a/docs/docs/in_depth/filter_data.md
+++ b/docs/docs/in_depth/filter_data.md
@@ -34,7 +34,7 @@ The GlobalFilter provides methods to add filters to the collection. The prefered
 -   filter_type
 -   parameter
 
-**add_time_and_time_travel_filters**: Adds time and time travel filtering to the GlobalFiltering. This is a convenience mloda. Due to the complexity of time in data/ml/ai projects, this function should be used.
+**add_time_and_time_travel_filters**: Adds time and time travel filtering to the GlobalFiltering. This is a convenience method. Due to the complexity of time in data/ml/ai projects, this function should be used.
 
 This method is useful for **filtering data based on time ranges** (event) and **validity periods** (valid).
 

--- a/docs/docs/in_depth/join_data.md
+++ b/docs/docs/in_depth/join_data.md
@@ -41,7 +41,7 @@ multi_column_index = Index(('user_id', 'timestamp'))
 is_multi = multi_column_index.is_multi_index()  # Returns True
 
 # Check if single column is a part of a composite index
-is_a_part_of = single_column_index.is_a_part_of_(multi_column_index) # Returns True
+is_a_part_of = single_column_index.is_a_part_of(multi_column_index) # Returns True
 ```
 
 #### JoinType

--- a/mloda/core/abstract_plugins/components/index/index.py
+++ b/mloda/core/abstract_plugins/components/index/index.py
@@ -23,7 +23,7 @@ class Index:
     def __hash__(self) -> int:
         return hash(self.index)
 
-    def is_a_part_of_(self, other: Index) -> bool:
+    def is_a_part_of(self, other: Index) -> bool:
         len_index = len(self.index)
 
         # index is larger

--- a/mloda/core/abstract_plugins/components/input_data/base_input_data.py
+++ b/mloda/core/abstract_plugins/components/input_data/base_input_data.py
@@ -40,9 +40,9 @@ class BaseInputData(ABC):
     @classmethod
     def feature_scope_data_access(cls, options: Options, feature_name: str) -> bool:
         """
-        We check for the feature scrope data access if any child classes match the data access.
+        We check for the feature scope data access if any child classes match the data access.
         """
-        subclasses = get_all_filtereted_subclasses(BaseInputData, cls)
+        subclasses = get_all_filtered_subclasses(BaseInputData, cls)
         for subclass in subclasses:
             for key, value in options.items():
                 _key = cls.deal_with_base_input_data_name_as_cls_or_str(key)
@@ -98,7 +98,7 @@ class BaseInputData(ABC):
         """
         We check for data access collection if any child classes match the data access.
         """
-        subclasses = get_all_filtereted_subclasses(BaseInputData, cls)
+        subclasses = get_all_filtered_subclasses(BaseInputData, cls)
 
         for subclass in subclasses:
             matched_data_access = subclass.match_subclass_data_access(  # type: ignore[attr-defined]
@@ -215,7 +215,7 @@ def _collect_filtered_subclasses(cls: Any, parent_class: Any) -> List[Type[BaseI
     return result
 
 
-def get_all_filtereted_subclasses(cls: Any, parent_class: Any) -> List[Type[BaseInputData]]:
+def get_all_filtered_subclasses(cls: Any, parent_class: Any) -> List[Type[BaseInputData]]:
     filtered_subclasses = _collect_filtered_subclasses(cls, parent_class)
     if not filtered_subclasses:
         auto_load_group = getattr(parent_class, "_auto_load_group", None)

--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -312,7 +312,7 @@ class FeatureGroup(ABC):
             return None
 
         for supported_index_column in supported_index_columns:
-            if index.is_a_part_of_(supported_index_column):
+            if index.is_a_part_of(supported_index_column):
                 return True
 
         return False

--- a/mloda/core/core/engine.py
+++ b/mloda/core/core/engine.py
@@ -240,7 +240,7 @@ class Engine:
         features: Features,
     ) -> None:
         if self.global_filter:
-            matched_filters = self.global_filter.identity_matched_filters(
+            matched_filters = self.global_filter.identify_matched_filters(
                 feature_group_class, feature, self.data_access_collection
             )
 

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -67,7 +67,7 @@ class GlobalFilter:
             self.collection[(feature_group, filtered_feature_name)] = set([single_filter])
         self.collection[(feature_group, filtered_feature_name)].add(single_filter)
 
-    def identity_matched_filters(
+    def identify_matched_filters(
         self,
         feature_group: Type[FeatureGroup],
         feat: Feature,

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -779,7 +779,7 @@ class ExecutionPlan:
         if link_fw[0].jointype in (JoinType.APPEND, JoinType.UNION):
             if left_uuids is None or right_uuids is None:
                 raise ValueError(
-                    "This should not happen. Did you set an index for the append or union? Are the features unique? Link and Hash are not unique properties. In this, case, set an arbritarys options."
+                    "This should not happen. Did you set an index for the append or union? Are the features unique? Link and Hash are not unique properties. In this case, set arbitrary options."
                 )
             if unique_solution_counter > 0:
                 return (left_uuids, right_uuids)

--- a/tests/test_core/test_abstract_plugins/test_plugin_loader/test_plugin_loader.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_loader/test_plugin_loader.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 from mloda.core.abstract_plugins.components.input_data.base_input_data import (
     _collect_filtered_subclasses,
-    get_all_filtereted_subclasses,
+    get_all_filtered_subclasses,
 )
 from mloda.user import PluginLoader
 
@@ -42,7 +42,7 @@ class TestPluginLoader:
         PluginLoader._disabled_groups.discard("_test_group")
 
     def test_disable_auto_load_suppresses_lazy_load(self) -> None:
-        """When auto-load is disabled for a group, get_all_filtereted_subclasses returns empty without loading."""
+        """When auto-load is disabled for a group, get_all_filtered_subclasses returns empty without loading."""
         from unittest.mock import MagicMock
 
         from mloda_plugins.feature_group.input_data.read_file import ReadFile
@@ -58,7 +58,7 @@ class TestPluginLoader:
                     "mloda.core.abstract_plugins.plugin_loader.plugin_loader.PluginLoader.load_group",
                     mock_load,
                 ):
-                    result = get_all_filtereted_subclasses(ReadFile, ReadFile)
+                    result = get_all_filtered_subclasses(ReadFile, ReadFile)
             assert result == []
             mock_load.assert_not_called()
         finally:
@@ -82,7 +82,7 @@ class TestPluginLoader:
                 "mloda.core.abstract_plugins.plugin_loader.plugin_loader.PluginLoader.load_group",
                 mock_load,
             ):
-                get_all_filtereted_subclasses(ReadFile, ReadFile)
+                get_all_filtered_subclasses(ReadFile, ReadFile)
 
         mock_load.assert_called_once_with("feature_group/input_data/read_files")
 

--- a/tests/test_core/test_renamed_methods.py
+++ b/tests/test_core/test_renamed_methods.py
@@ -1,0 +1,47 @@
+"""Tests for method renames introduced by issue #266."""
+
+from mloda.core.abstract_plugins.components.index.index import Index
+from mloda.core.abstract_plugins.components.input_data.base_input_data import get_all_filtered_subclasses
+from mloda.core.filter.global_filter import GlobalFilter
+
+
+class TestRenamedGetAllFilteredSubclasses:
+    def test_importable(self) -> None:
+        assert callable(get_all_filtered_subclasses)
+
+
+class TestRenamedIdentifyMatchedFilters:
+    def test_method_exists(self) -> None:
+        gf = GlobalFilter()
+        assert hasattr(gf, "identify_matched_filters")
+        assert callable(gf.identify_matched_filters)
+
+
+class TestRenamedIsAPartOf:
+    def test_method_exists(self) -> None:
+        idx = Index(("a",))
+        assert hasattr(idx, "is_a_part_of")
+        assert callable(idx.is_a_part_of)
+
+    def test_single_is_part_of_multi(self) -> None:
+        single = Index(("user_id",))
+        multi = Index(("user_id", "timestamp"))
+        assert single.is_a_part_of(multi) is True
+
+    def test_multi_is_not_part_of_single(self) -> None:
+        single = Index(("user_id",))
+        multi = Index(("user_id", "timestamp"))
+        assert multi.is_a_part_of(single) is False
+
+    def test_equal_indexes(self) -> None:
+        idx = Index(("user_id",))
+        assert idx.is_a_part_of(Index(("user_id",))) is True
+
+    def test_disjoint_indexes(self) -> None:
+        a = Index(("user_id",))
+        b = Index(("timestamp",))
+        assert a.is_a_part_of(b) is False
+
+    def test_old_name_removed(self) -> None:
+        idx = Index(("a",))
+        assert not hasattr(idx, "is_a_part_of_")


### PR DESCRIPTION
## Summary

- Fix 8 documentation/comment typos: BaseArtfact, Unitialized, depent, scrope, arbritarys, "familiar mloda", "convenience mloda", "pointer fields" (should be "discriminators")
- Rewrite incoherent FAQ sentence about declarative vs imperative paradigms (#275)
- Unify "plug-in" to "plugin" across FAQ and notebook (#276)
- Remove agent mention from user-facing docs (#287)
- Rename 3 misspelled public methods and update all call sites (#266):
  - `get_all_filtereted_subclasses` -> `get_all_filtered_subclasses`
  - `identity_matched_filters` -> `identify_matched_filters`
  - `is_a_part_of_` -> `is_a_part_of`

Closes #266, closes #275, closes #276, closes #280, closes #287

## Test plan

- [x] 8 new tests in `tests/test_core/test_renamed_methods.py` verify renamed methods are importable and functional
- [x] Existing `test_plugin_loader.py` tests updated and passing
- [x] Full test suite: 2281 passed, 124 skipped (2 notebook kernel timeout flakes unrelated to changes)
- [x] Grep verification: zero remaining occurrences of any fixed typo