### PR TITLE
fix: resolve PROPERTY_MAPPING inconsistencies across experimental plugins

### DIFF
--- a/mloda_plugins/feature_group/experimental/data_quality/missing_value/base.py
+++ b/mloda_plugins/feature_group/experimental/data_quality/missing_value/base.py
@@ -168,19 +168,23 @@ class MissingValueFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         IMPUTATION_METHOD: {
             **IMPUTATION_METHODS,
             DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: True,
         },
         DefaultOptionKeys.in_features: {
             "explanation": "Source feature to impute missing values",
             DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: False,
         },
         "constant_value": {
             "explanation": "Constant value to use for constant imputation method",
             DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: False,
             DefaultOptionKeys.default: None,  # Default is None, required only for constant method
         },
         "group_by_features": {
             "explanation": "Optional list of features to group by before imputation",
             DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: False,
             DefaultOptionKeys.default: None,  # Default is None (no grouping)
         },
     }

--- a/mloda_plugins/feature_group/experimental/dimensionality_reduction/base.py
+++ b/mloda_plugins/feature_group/experimental/dimensionality_reduction/base.py
@@ -144,7 +144,7 @@ class DimensionalityReductionFeatureGroup(FeatureChainParserMixin, FeatureGroup)
             "explanation": "Maximum number of iterations for t-SNE optimization",
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: False,
-            "default": 250,
+            DefaultOptionKeys.default: 250,
             DefaultOptionKeys.validation_function: lambda value: (
                 isinstance(value, (int, str)) and str(value).isdigit() and int(value) > 0
             ),
@@ -153,7 +153,7 @@ class DimensionalityReductionFeatureGroup(FeatureChainParserMixin, FeatureGroup)
             "explanation": "Maximum iterations without progress before early stopping (t-SNE)",
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: False,
-            "default": 50,
+            DefaultOptionKeys.default: 50,
             DefaultOptionKeys.validation_function: lambda value: (
                 isinstance(value, (int, str)) and str(value).isdigit() and int(value) > 0
             ),
@@ -163,8 +163,8 @@ class DimensionalityReductionFeatureGroup(FeatureChainParserMixin, FeatureGroup)
             "exact": "Exact method (slower, O(n^2))",
             "explanation": "t-SNE computation method",
             DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            "default": "barnes_hut",
+            DefaultOptionKeys.strict_validation: True,
+            DefaultOptionKeys.default: "barnes_hut",
         },
         # PCA specific parameters
         PCA_SVD_SOLVER: {
@@ -174,15 +174,15 @@ class DimensionalityReductionFeatureGroup(FeatureChainParserMixin, FeatureGroup)
             "randomized": "Randomized SVD",
             "explanation": "SVD solver algorithm for PCA",
             DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            "default": "auto",
+            DefaultOptionKeys.strict_validation: True,
+            DefaultOptionKeys.default: "auto",
         },
         # ICA specific parameters
         ICA_MAX_ITER: {
             "explanation": "Maximum number of iterations for ICA",
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: False,
-            "default": 200,
+            DefaultOptionKeys.default: 200,
             DefaultOptionKeys.validation_function: lambda value: (
                 isinstance(value, (int, str)) and str(value).isdigit() and int(value) > 0
             ),
@@ -192,7 +192,7 @@ class DimensionalityReductionFeatureGroup(FeatureChainParserMixin, FeatureGroup)
             "explanation": "Number of neighbors for Isomap",
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: False,
-            "default": 5,
+            DefaultOptionKeys.default: 5,
             DefaultOptionKeys.validation_function: lambda value: (
                 isinstance(value, (int, str)) and str(value).isdigit() and int(value) > 0
             ),

--- a/mloda_plugins/feature_group/experimental/dimensionality_reduction/pandas.py
+++ b/mloda_plugins/feature_group/experimental/dimensionality_reduction/pandas.py
@@ -27,7 +27,7 @@ except ImportError:
     SKLEARN_AVAILABLE = False
 
 
-from mloda.provider import ComputeFramework
+from mloda.provider import ComputeFramework, DefaultOptionKeys
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 from mloda_plugins.feature_group.experimental.dimensionality_reduction.base import DimensionalityReductionFeatureGroup
 
@@ -141,35 +141,35 @@ class PandasDimensionalityReductionFeatureGroup(DimensionalityReductionFeatureGr
             if svd_solver is None:
                 svd_solver = DimensionalityReductionFeatureGroup.PROPERTY_MAPPING[
                     DimensionalityReductionFeatureGroup.PCA_SVD_SOLVER
-                ]["default"]
+                ][DefaultOptionKeys.default]
             return cls._perform_pca_reduction(X_scaled, dimension, svd_solver)
         elif algorithm == "tsne":
             max_iter_val = options.get(DimensionalityReductionFeatureGroup.TSNE_MAX_ITER)
             if max_iter_val is None:
                 max_iter_val = DimensionalityReductionFeatureGroup.PROPERTY_MAPPING[
                     DimensionalityReductionFeatureGroup.TSNE_MAX_ITER
-                ]["default"]
+                ][DefaultOptionKeys.default]
             max_iter = int(max_iter_val)
 
             n_iter_without_progress_val = options.get(DimensionalityReductionFeatureGroup.TSNE_N_ITER_WITHOUT_PROGRESS)
             if n_iter_without_progress_val is None:
                 n_iter_without_progress_val = DimensionalityReductionFeatureGroup.PROPERTY_MAPPING[
                     DimensionalityReductionFeatureGroup.TSNE_N_ITER_WITHOUT_PROGRESS
-                ]["default"]
+                ][DefaultOptionKeys.default]
             n_iter_without_progress = int(n_iter_without_progress_val)
 
             method = options.get(DimensionalityReductionFeatureGroup.TSNE_METHOD)
             if method is None:
                 method = DimensionalityReductionFeatureGroup.PROPERTY_MAPPING[
                     DimensionalityReductionFeatureGroup.TSNE_METHOD
-                ]["default"]
+                ][DefaultOptionKeys.default]
             return cls._perform_tsne_reduction(X_scaled, dimension, max_iter, n_iter_without_progress, method)
         elif algorithm == "ica":
             max_iter_val = options.get(DimensionalityReductionFeatureGroup.ICA_MAX_ITER)
             if max_iter_val is None:
                 max_iter_val = DimensionalityReductionFeatureGroup.PROPERTY_MAPPING[
                     DimensionalityReductionFeatureGroup.ICA_MAX_ITER
-                ]["default"]
+                ][DefaultOptionKeys.default]
             max_iter = int(max_iter_val)
             return cls._perform_ica_reduction(X_scaled, dimension, max_iter)
         elif algorithm == "lda":
@@ -179,7 +179,7 @@ class PandasDimensionalityReductionFeatureGroup(DimensionalityReductionFeatureGr
             if n_neighbors_val is None:
                 n_neighbors_val = DimensionalityReductionFeatureGroup.PROPERTY_MAPPING[
                     DimensionalityReductionFeatureGroup.ISOMAP_N_NEIGHBORS
-                ]["default"]
+                ][DefaultOptionKeys.default]
             n_neighbors = int(n_neighbors_val)
             return cls._perform_isomap_reduction(X_scaled, dimension, n_neighbors)
         else:

--- a/mloda_plugins/feature_group/experimental/node_centrality/base.py
+++ b/mloda_plugins/feature_group/experimental/node_centrality/base.py
@@ -154,11 +154,13 @@ class NodeCentralityFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         WEIGHT_COLUMN: {
             "explanation": "Column name for edge weights (optional)",
             DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: False,
             DefaultOptionKeys.default: None,
         },
         DefaultOptionKeys.in_features: {
             "explanation": "Source feature representing the nodes for centrality calculation",
             DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: False,
         },
     }
 

--- a/mloda_plugins/feature_group/experimental/sklearn/pipeline/base.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/pipeline/base.py
@@ -93,21 +93,25 @@ class SklearnPipelineFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         PIPELINE_NAME: {
             **PIPELINE_TYPES,  # All supported pipeline types as valid options
             DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: True,
             DefaultOptionKeys.default: None,  # Default is None as steps + params also work
         },
         PIPELINE_STEPS: {
             "explanation": "List of pipeline steps as (name, transformer) tuples",
             DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: False,
             DefaultOptionKeys.default: None,  # Default is None as pipeline_types also work
         },
         PIPELINE_PARAMS: {
             "explanation": "Pipeline parameters dictionary",
             DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: False,
             DefaultOptionKeys.default: None,  # Default is None as pipeline_types also work
         },
         DefaultOptionKeys.in_features: {
             "explanation": "Source features for sklearn pipeline (comma-separated)",
             DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: False,
         },
     }
 

--- a/mloda_plugins/feature_group/experimental/text_cleaning/base.py
+++ b/mloda_plugins/feature_group/experimental/text_cleaning/base.py
@@ -118,6 +118,7 @@ class TextCleaningFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         DefaultOptionKeys.in_features: {
             "explanation": "Source feature to apply text cleaning operations to",
             DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: False,
         },
     }
 

--- a/tests/test_plugins/feature_group/experimental/test_property_mapping_consistency.py
+++ b/tests/test_plugins/feature_group/experimental/test_property_mapping_consistency.py
@@ -1,0 +1,101 @@
+from typing import Any, Dict, List, Tuple, Type
+
+import pytest
+
+from mloda.provider import DefaultOptionKeys
+from mloda_plugins.feature_group.experimental.aggregated_feature_group.base import AggregatedFeatureGroup
+from mloda_plugins.feature_group.experimental.clustering.base import ClusteringFeatureGroup
+from mloda_plugins.feature_group.experimental.data_quality.missing_value.base import MissingValueFeatureGroup
+from mloda_plugins.feature_group.experimental.dimensionality_reduction.base import DimensionalityReductionFeatureGroup
+from mloda_plugins.feature_group.experimental.forecasting.base import ForecastingFeatureGroup
+from mloda_plugins.feature_group.experimental.geo_distance.base import GeoDistanceFeatureGroup
+from mloda_plugins.feature_group.experimental.node_centrality.base import NodeCentralityFeatureGroup
+from mloda_plugins.feature_group.experimental.sklearn.encoding.base import EncodingFeatureGroup
+from mloda_plugins.feature_group.experimental.sklearn.pipeline.base import SklearnPipelineFeatureGroup
+from mloda_plugins.feature_group.experimental.sklearn.scaling.base import ScalingFeatureGroup
+from mloda_plugins.feature_group.experimental.text_cleaning.base import TextCleaningFeatureGroup
+from mloda_plugins.feature_group.experimental.time_window.base import TimeWindowFeatureGroup
+
+ALL_PLUGINS: List[Type[Any]] = [
+    AggregatedFeatureGroup,
+    ClusteringFeatureGroup,
+    MissingValueFeatureGroup,
+    DimensionalityReductionFeatureGroup,
+    ForecastingFeatureGroup,
+    GeoDistanceFeatureGroup,
+    NodeCentralityFeatureGroup,
+    EncodingFeatureGroup,
+    SklearnPipelineFeatureGroup,
+    ScalingFeatureGroup,
+    TextCleaningFeatureGroup,
+    TimeWindowFeatureGroup,
+]
+
+METADATA_KEYS: Tuple[Any, ...] = (
+    DefaultOptionKeys.context,
+    DefaultOptionKeys.default,
+    DefaultOptionKeys.strict_validation,
+    DefaultOptionKeys.validation_function,
+    DefaultOptionKeys.required_when,
+    DefaultOptionKeys.type_validator,
+    DefaultOptionKeys.in_features,
+    DefaultOptionKeys.group,
+    "explanation",
+)
+
+DOK_VALUES: List[str] = [dok.value for dok in DefaultOptionKeys]
+
+
+@pytest.mark.parametrize("plugin_cls", ALL_PLUGINS, ids=lambda c: c.__name__)
+class TestPropertyMappingConsistency:
+
+    def test_every_entry_has_explicit_strict_validation(self, plugin_cls: Type[Any]) -> None:
+        mapping: Dict[str, Any] = plugin_cls.PROPERTY_MAPPING
+        violations: List[str] = []
+        for prop_key, entry in mapping.items():
+            if not isinstance(entry, dict):
+                continue
+            if DefaultOptionKeys.strict_validation not in entry:
+                violations.append(str(prop_key))
+        assert violations == [], (
+            f"{plugin_cls.__name__} PROPERTY_MAPPING entries missing "
+            f"DefaultOptionKeys.strict_validation: {violations}"
+        )
+
+    def test_no_raw_string_metadata_keys(self, plugin_cls: Type[Any]) -> None:
+        mapping: Dict[str, Any] = plugin_cls.PROPERTY_MAPPING
+        violations: List[Tuple[str, str]] = []
+        for prop_key, entry in mapping.items():
+            if not isinstance(entry, dict):
+                continue
+            for key in entry:
+                if key in DOK_VALUES and not isinstance(key, DefaultOptionKeys):
+                    violations.append((str(prop_key), str(key)))
+        assert violations == [], (
+            f"{plugin_cls.__name__} PROPERTY_MAPPING uses raw strings where "
+            f"DefaultOptionKeys enum members should be used: {violations}"
+        )
+
+    def test_enum_entries_have_strict_validation_true(self, plugin_cls: Type[Any]) -> None:
+        mapping: Dict[str, Any] = plugin_cls.PROPERTY_MAPPING
+        violations: List[str] = []
+        for prop_key, entry in mapping.items():
+            if not isinstance(entry, dict):
+                continue
+            if DefaultOptionKeys.validation_function in entry:
+                continue
+            non_metadata_keys = [
+                k
+                for k in entry
+                if k not in METADATA_KEYS
+                and not (k in DOK_VALUES and not isinstance(k, DefaultOptionKeys))
+            ]
+            if len(non_metadata_keys) < 2:
+                continue
+            sv_value = entry.get(DefaultOptionKeys.strict_validation)
+            if sv_value is not True:
+                violations.append(str(prop_key))
+        assert violations == [], (
+            f"{plugin_cls.__name__} PROPERTY_MAPPING entries with enumerated values "
+            f"should have strict_validation=True: {violations}"
+        )


### PR DESCRIPTION
## Summary

Fixes #294. Resolves three categories of PROPERTY_MAPPING inconsistencies across experimental plugins:

- **Raw string keys**: Replaced 6 raw `"default"` string keys with `DefaultOptionKeys.default` in `DimensionalityReductionFeatureGroup` (base + pandas accessor)
- **Missing `strict_validation`**: Added explicit `strict_validation` to all entries in `MissingValueFeatureGroup` (4), `SklearnPipelineFeatureGroup` (4), `NodeCentralityFeatureGroup` (2), and `TextCleaningFeatureGroup` (1)
- **Incorrect `strict_validation` on enum entries**: Changed `strict_validation` from `False` to `True` for `TSNE_METHOD`, `PCA_SVD_SOLVER` (closed enum sets), and added `True` for `IMPUTATION_METHOD` and `PIPELINE_NAME`

Added parametric consistency tests covering all 12 experimental plugins to prevent regressions. The naming inconsistency of supported-items dicts (e.g. `AGGREGATION_TYPES` vs `SUPPORTED_OPERATIONS`) was intentionally not addressed as it would be a breaking change requiring a separate discussion.

## Files changed
- `dimensionality_reduction/base.py`: 6x `"default"` to `DefaultOptionKeys.default`, 2x `strict_validation: False` to `True`
- `dimensionality_reduction/pandas.py`: Added `DefaultOptionKeys` import, 6x `["default"]` to `[DefaultOptionKeys.default]`
- `missing_value/base.py`: Added `strict_validation` to all 4 entries
- `sklearn/pipeline/base.py`: Added `strict_validation` to all 4 entries
- `node_centrality/base.py`: Added `strict_validation` to 2 entries
- `text_cleaning/base.py`: Added `strict_validation` to 1 entry
- NEW `test_property_mapping_consistency.py`: 36 parametric tests across all 12 plugins

## Test plan
- [x] All 36 new consistency tests pass
- [x] Full test suite passes (2316 passed, 0 failed)
- [ ] CI checks green