### PR TITLE
fix: replace absolute doc URLs with relative paths

### DIFF
--- a/docs/docs/chapter1/api-request.md
+++ b/docs/docs/chapter1/api-request.md
@@ -2,7 +2,7 @@
 
 This example demonstrates a simple request to the mloda API. You describe WHAT data you need - mloda resolves HOW to get it.
 
-> **Tip:** For AI agents or quick prototyping, you can also use inline data with `api_data` - see the [30-second example](https://mloda-ai.github.io/mloda/#30-second-example).
+> **Tip:** For AI agents or quick prototyping, you can also use inline data with `api_data` - see the [30-second example](installation.md#4-quick-start).
 
 In this example, mloda automatically determines that a **CsvReader** feature group will fulfill the request and respond with the resulting DataFrame.
 
@@ -86,4 +86,4 @@ features = load_features_from_config(llm_request, format="json")
 result = mloda.run_all(features=features, compute_frameworks=["PandasDataFrame"], ...)
 ```
 
-See [Feature Configuration](https://mloda-ai.github.io/mloda/in_depth/feature-config/) for more details on JSON-based configuration.
+See [Feature Configuration](../in_depth/feature-config.md) for more details on JSON-based configuration.

--- a/docs/docs/chapter1/installation.md
+++ b/docs/docs/chapter1/installation.md
@@ -40,4 +40,4 @@ result = mloda.run_all(
 `api_data` passes inline data to mloda. Each top-level key (e.g. `"SampleData"`)
 is a label grouping related columns. Features are matched to columns by name.
 
-Next: [API Request](https://mloda-ai.github.io/mloda/chapter1/api-request/) | [Feature Groups](https://mloda-ai.github.io/mloda/chapter1/feature-groups/)
+Next: [API Request](api-request.md) | [Feature Groups](feature-groups.md)

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -34,7 +34,7 @@ Yes. Plugins are small, template-like structures that are easy for AI to generat
 
 #### How do I install mloda? How do I get started with mloda?
 
-Installation is straightforward via pip or by cloning the repository. [Installation guide and step-by-step guide](https://mloda-ai.github.io/mloda/chapter1/installation/)
+Installation is straightforward via pip or by cloning the repository. [Installation guide and step-by-step guide](chapter1/installation.md)
 
 #### What are the prerequisites for using mloda? 
 
@@ -44,7 +44,7 @@ You'll learn a lot along the way!
 
 #### How do I create my first feature group using mloda? 
 
-Feature Groups define dependencies and calculations. To create your first Feature Group, check out this [basic example here](https://mloda-ai.github.io/mloda/chapter1/feature-groups/). For more advanced topics, see our [in-depth documentation on feature groups](https://mloda-ai.github.io/mloda/in_depth/feature-chain-parser/).
+Feature Groups define dependencies and calculations. To create your first Feature Group, check out this [basic example here](chapter1/feature-groups.md). For more advanced topics, see our [in-depth documentation on feature groups](in_depth/feature-chain-parser.md).
 
 ## Features and Functionality
 

--- a/docs/docs/in_depth/data-quality.md
+++ b/docs/docs/in_depth/data-quality.md
@@ -235,7 +235,7 @@ Output similar to:
 #### Artifacts
 
 `Artifacts` can also be used for validation as the full mloda is available. A use case could be to store statistics of a feature and then validate them later on.
-For more details on artifacts, refer to the [artifact documentation](https://mloda-ai.github.io/mloda/in_depth/artifacts/).
+For more details on artifacts, refer to the [artifact documentation](artifacts.md).
 
 #### Conclusion
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -6,9 +6,9 @@
 
 mloda provides **declarative data access** for AI agents, ML pipelines, and data teams. Instead of writing complex data retrieval code, users describe WHAT they need, mloda resolves HOW to get it through its plugin system.
 
-[Get started with mloda here.](https://mloda-ai.github.io/mloda/chapter1/installation/)
+[Get started with mloda here.](chapter1/installation.md)
 
-mloda's plugin system **automatically selects the right plugins for each task**, enabling efficient querying and processing of complex features. [Learn more about the mloda API here.](https://mloda-ai.github.io/mloda/in_depth/mloda-api/) By defining feature dependencies, transformations, and metadata processes, mloda minimizes duplication and fosters reusability.
+mloda's plugin system **automatically selects the right plugins for each task**, enabling efficient querying and processing of complex features. [Learn more about the mloda API here.](in_depth/mloda-api.md) By defining feature dependencies, transformations, and metadata processes, mloda minimizes duplication and fosters reusability.
 
 Plugins are **small, template-like structures** - easy to test, easy to debug, and AI-friendly. Let AI generate plugins for you, or share them across projects, teams, and organizations.
 
@@ -51,23 +51,23 @@ Plugins are **small, template-like structures** - easy to test, easy to debug, a
 mloda addresses common challenges in data and feature engineering by leveraging two key components:
 
 #### Plugins
-  - Feature Groups: **Define feature dependencies**, such as creating a composite label based on features e.g. user activity, purchase history, and support interactions. Once defined, only the label needs to be requested, as dependencies are resolved automatically, simplifying processing. [Learn more here.](https://mloda-ai.github.io/mloda/chapter1/feature-groups/)
+  - Feature Groups: **Define feature dependencies**, such as creating a composite label based on features e.g. user activity, purchase history, and support interactions. Once defined, only the label needs to be requested, as dependencies are resolved automatically, simplifying processing. [Learn more here.](chapter1/feature-groups.md)
 
-  - Compute Frameworks: Defines the **technology stack**, like Spark or Pandas, along with support for different storage engines such as Parquet, Delta Lake, or PostgreSQL, to execute feature transformations and computations, ensuring efficient processing at scale. [Learn more here.](https://mloda-ai.github.io/mloda/chapter1/compute-frameworks/)
+  - Compute Frameworks: Defines the **technology stack**, like Spark or Pandas, along with support for different storage engines such as Parquet, Delta Lake, or PostgreSQL, to execute feature transformations and computations, ensuring efficient processing at scale. [Learn more here.](chapter1/compute-frameworks.md)
 
-  - Extenders: Automates **metadata extraction processes**, helping you enhance data governance, compliance, and traceability, such as analyzing how often features are used by models or analysts, or understanding where the data is coming from. [Learn more here.](https://mloda-ai.github.io/mloda/chapter1/extender/)
+  - Extenders: Automates **metadata extraction processes**, helping you enhance data governance, compliance, and traceability, such as analyzing how often features are used by models or analysts, or understanding where the data is coming from. [Learn more here.](chapter1/extender.md)
 
 #### Core
   - Core Engine: **Handles dependencies between features and computations** by coordinating linking, joining, filtering, and ordering operations to ensure optimized data processing. For example, in customer segmentation, the core engine would link and filter different data sources, such as demographics, purchasing history, and online behavior, to create relevant features.
 
 ## Contributing to mloda
 
-We welcome contributions from the community to help us improve and expand mloda. Whether you're interested in developing plugins or adding new features, your input is invaluable. [Learn more here.](https://mloda-ai.github.io/mloda/development/)
+We welcome contributions from the community to help us improve and expand mloda. Whether you're interested in developing plugins or adding new features, your input is invaluable. [Learn more here.](development.md)
 
 
 ## Frequently Asked Questions (FAQ)
 
-If you have additional questions about mloda visit our [FAQ](https://mloda-ai.github.io/mloda/faq) section, raise an [issue](https://github.com/mloda-ai/mloda/issues/) on our GitHub repository, or email us at [info@mloda.ai](mailto:info@mloda.ai).
+If you have additional questions about mloda visit our [FAQ](faq.md) section, raise an [issue](https://github.com/mloda-ai/mloda/issues/) on our GitHub repository, or email us at [info@mloda.ai](mailto:info@mloda.ai).
 
 
 ## License

--- a/tests/test_documentation/test_documentation.py
+++ b/tests/test_documentation/test_documentation.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import re
 import pytest
 
 from mktestdocs import check_md_file
@@ -42,6 +43,58 @@ class DokuValidateInputFeatureExtender(Extender):
 @pytest.mark.parametrize("fpath", Path("docs").glob("**/*.md"), ids=str)
 def test_files_good(fpath: Any) -> None:
     check_md_file(fpath=fpath, memory=True)
+
+
+DOCS_ROOT = Path("docs/docs")
+ABSOLUTE_LINK_PATTERN = re.compile(r"\[([^\]]*)\]\(https://mloda-ai\.github\.io/mloda/[^)]*\)")
+MARKDOWN_LINK_PATTERN = re.compile(r"\[([^\]]*)\]\(([^)]+)\)")
+HEADING_PATTERN = re.compile(r"^#{1,6}\s+(.+)$", re.MULTILINE)
+
+
+def _heading_to_anchor(heading: str) -> str:
+    anchor = heading.strip().lower()
+    anchor = re.sub(r"[^\w\s-]", "", anchor)
+    anchor = re.sub(r"\s+", "-", anchor)
+    return anchor
+
+
+def _extract_headings(md_path: Path) -> set[str]:
+    text = md_path.read_text(encoding="utf-8")
+    return {_heading_to_anchor(m.group(1)) for m in HEADING_PATTERN.finditer(text)}
+
+
+@pytest.mark.parametrize("fpath", sorted(DOCS_ROOT.rglob("*.md")), ids=str)
+def test_no_absolute_site_links(fpath: Path) -> None:
+    text = fpath.read_text(encoding="utf-8")
+    matches = ABSOLUTE_LINK_PATTERN.findall(text)
+    assert not matches, f"{fpath} contains absolute mloda-ai.github.io links (should be relative): {matches}"
+
+
+@pytest.mark.parametrize("fpath", sorted(DOCS_ROOT.rglob("*.md")), ids=str)
+def test_internal_link_targets_exist(fpath: Path) -> None:
+    text = fpath.read_text(encoding="utf-8")
+    errors: list[str] = []
+
+    for match in MARKDOWN_LINK_PATTERN.finditer(text):
+        link_text, target = match.group(1), match.group(2)
+
+        if target.startswith(("http://", "https://", "mailto:", "#")):
+            continue
+
+        path_part, _, anchor = target.partition("#")
+
+        if path_part:
+            resolved = (fpath.parent / path_part).resolve()
+            if not resolved.exists():
+                errors.append(f"[{link_text}]({target}) -> file not found: {resolved}")
+                continue
+
+            if anchor:
+                headings = _extract_headings(resolved)
+                if anchor not in headings:
+                    errors.append(f"[{link_text}]({target}) -> anchor #{anchor} not found in {resolved.name}")
+
+    assert not errors, f"{fpath} has broken internal links:\n" + "\n".join(errors)
 
 
 # Temporarily disabled - README being refactored


### PR DESCRIPTION
## Summary

- Convert all 14 absolute `mloda-ai.github.io` links across 5 doc files to relative paths, fixing broken local `mkdocs serve` previews
- Fix broken `#30-second-example` anchor in `api-request.md` to point to `installation.md#4-quick-start` where the example actually lives
- Add two parametrized regression tests: one ensures no absolute site links creep back in, the other validates all internal link targets (files and anchors) resolve correctly

## Test plan

- [x] `test_no_absolute_site_links` passes for all 32 doc files
- [x] `test_internal_link_targets_exist` passes for all 32 doc files
- [x] `mypy --strict` passes on the test file
- [x] `ruff format` passes
- [x] Full `tox` run: 2 pre-existing failures unrelated to this change (plugin_docs case-sensitivity test, notebook ZMQ timeout), all other 2357 tests pass

Closes #281