### PR TITLE
fix: align _add_result_to_data() signature with common interface

### DIFF
--- a/mloda_plugins/feature_group/experimental/sklearn/encoding/base.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/encoding/base.py
@@ -279,7 +279,7 @@ class EncodingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             result = cls._apply_encoder(data, base_source_feature, fitted_encoder)
 
             # Add result to data (handling multiple columns for OneHotEncoder)
-            data = cls._add_result_to_data(data, feature.get_name(), result, encoder_type)
+            data = cls._add_result_to_data(data, feature.get_name(), result)
 
         return data
 
@@ -519,7 +519,7 @@ class EncodingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 
     @classmethod
     @abstractmethod
-    def _add_result_to_data(cls, data: Any, feature_name: str, result: Any, encoder_type: str) -> Any:
+    def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:
         """
         Add the result to the data.
 
@@ -527,7 +527,6 @@ class EncodingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             data: The input data
             feature_name: The name of the feature to add
             result: The result to add
-            encoder_type: The type of encoder used
 
         Returns:
             The updated data

--- a/mloda_plugins/feature_group/experimental/sklearn/encoding/pandas.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/encoding/pandas.py
@@ -32,49 +32,43 @@ class PandasEncodingFeatureGroup(EncodingFeatureGroup):
             raise ValueError(f"Source feature '{feature_name}' not found in data")
 
     @classmethod
-    def _add_result_to_data(cls, data: Any, feature_name: str, result: Any, encoder_type: str) -> Any:
+    def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:
         """Add the result to the DataFrame."""
         import re
 
-        # Handle different result types from sklearn encoders
-        if encoder_type == "onehot":
-            # Check if this is a request for a specific OneHot column (e.g., category__onehot_encoded~1)
-            onehot_column_match = re.match(r"^(.+)__onehot_encoded~(\d+)$", feature_name)
+        # Convert sparse matrix to dense if needed
+        if hasattr(result, "toarray"):
+            result = result.toarray()
 
-            # OneHotEncoder returns a sparse matrix or dense array with multiple columns
-            if hasattr(result, "toarray"):
-                # Convert sparse matrix to dense
-                result = result.toarray()
-
-            if hasattr(result, "shape") and len(result.shape) == 2 and result.shape[1] > 1:
-                if onehot_column_match:
-                    # Specific column requested - only add that column
-                    requested_column_index = int(onehot_column_match.group(2))
+        # Handle different result shapes
+        if hasattr(result, "shape") and len(result.shape) == 2:
+            if result.shape[1] > 1:
+                # Multi-column result (e.g., from OneHotEncoder)
+                # Check if a specific column is requested via ~N suffix
+                column_match = re.match(r"^(.+)~(\d+)$", feature_name)
+                if column_match:
+                    requested_column_index = int(column_match.group(2))
                     if requested_column_index < result.shape[1]:
                         data[feature_name] = result[:, requested_column_index]
                     else:
                         raise ValueError(
-                            f"Requested OneHot column index {requested_column_index} is out of range. Available columns: 0-{result.shape[1] - 1}"
+                            f"Requested column index {requested_column_index} is out of range. "
+                            f"Available columns: 0-{result.shape[1] - 1}"
                         )
                 else:
-                    # Full OneHot encoding requested - create all columns with ~ separator
+                    # Full multi-column encoding - create all columns with ~ separator
                     named_columns = cls.apply_naming_convention(result, feature_name)
                     for col_name, col_data in named_columns.items():
                         data[col_name] = col_data
             else:
-                # Single column or unexpected format
-                data[feature_name] = result.flatten() if hasattr(result, "flatten") else result
-        else:
-            # LabelEncoder and OrdinalEncoder return single column results
-            if hasattr(result, "shape") and len(result.shape) == 2:
-                # 2D result - flatten to 1D
+                # Single column 2D result - flatten to 1D
                 data[feature_name] = result.flatten()
-            elif hasattr(result, "shape") and len(result.shape) == 1:
-                # 1D result
-                data[feature_name] = result
-            else:
-                # Scalar or other result type
-                data[feature_name] = result
+        elif hasattr(result, "shape") and len(result.shape) == 1:
+            # 1D result
+            data[feature_name] = result
+        else:
+            # Scalar or other result type
+            data[feature_name] = result
 
         return data
 

--- a/tests/test_plugins/feature_group/experimental/sklearn/test_encoding_feature_group/test_pandas_encoding_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/sklearn/test_encoding_feature_group/test_pandas_encoding_feature_group.py
@@ -128,7 +128,7 @@ class TestPandasEncodingFeatureGroup:
         data = pd.DataFrame({"category": ["A", "B", "C"], "value": [1, 2, 3]})
         result = np.array([0, 1, 2])
 
-        updated_data = PandasEncodingFeatureGroup._add_result_to_data(data, "category__label_encoded", result, "label")
+        updated_data = PandasEncodingFeatureGroup._add_result_to_data(data, "category__label_encoded", result)
 
         # Check that new column was added
         assert "category__label_encoded" in updated_data.columns
@@ -144,9 +144,7 @@ class TestPandasEncodingFeatureGroup:
         # OneHotEncoder returns 2D array with multiple columns
         result = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
 
-        updated_data = PandasEncodingFeatureGroup._add_result_to_data(
-            data, "category__onehot_encoded", result, "onehot"
-        )
+        updated_data = PandasEncodingFeatureGroup._add_result_to_data(data, "category__onehot_encoded", result)
 
         # Check that multiple columns were added with ~ separator
         assert "category__onehot_encoded~0" in updated_data.columns
@@ -168,9 +166,7 @@ class TestPandasEncodingFeatureGroup:
         # OneHotEncoder with only one category
         result = np.array([[1], [1], [1]])
 
-        updated_data = PandasEncodingFeatureGroup._add_result_to_data(
-            data, "category__onehot_encoded", result, "onehot"
-        )
+        updated_data = PandasEncodingFeatureGroup._add_result_to_data(data, "category__onehot_encoded", result)
 
         # Should add single column without ~ separator
         assert "category__onehot_encoded" in updated_data.columns
@@ -182,9 +178,7 @@ class TestPandasEncodingFeatureGroup:
         # OrdinalEncoder returns 2D array but single column
         result = np.array([[0], [1], [2]])
 
-        updated_data = PandasEncodingFeatureGroup._add_result_to_data(
-            data, "category__ordinal_encoded", result, "ordinal"
-        )
+        updated_data = PandasEncodingFeatureGroup._add_result_to_data(data, "category__ordinal_encoded", result)
 
         # Check that new column was added (flattened from 2D)
         assert "category__ordinal_encoded" in updated_data.columns
@@ -203,7 +197,7 @@ class TestPandasEncodingFeatureGroup:
         mock_sparse_result.toarray.return_value = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
 
         updated_data = PandasEncodingFeatureGroup._add_result_to_data(
-            data, "category__onehot_encoded", mock_sparse_result, "onehot"
+            data, "category__onehot_encoded", mock_sparse_result
         )
 
         # Verify toarray was called
@@ -213,6 +207,30 @@ class TestPandasEncodingFeatureGroup:
         assert "category__onehot_encoded~0" in updated_data.columns
         assert "category__onehot_encoded~1" in updated_data.columns
         assert "category__onehot_encoded~2" in updated_data.columns
+
+    def test_add_result_to_data_specific_column_request(self) -> None:
+        """Test adding results when a specific column is requested via ~N suffix."""
+        data = pd.DataFrame({"category": ["A", "B", "C"], "value": [1, 2, 3]})
+        result = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+
+        updated_data = PandasEncodingFeatureGroup._add_result_to_data(data, "category__onehot_encoded~1", result)
+
+        # Should only add the specific requested column
+        assert "category__onehot_encoded~1" in updated_data.columns
+        assert list(updated_data["category__onehot_encoded~1"]) == [0, 1, 0]
+        # Should NOT add other columns
+        assert "category__onehot_encoded~0" not in updated_data.columns
+        assert "category__onehot_encoded~2" not in updated_data.columns
+
+    def test_add_result_to_data_column_index_out_of_range(self) -> None:
+        """Test that requesting a column index out of range raises ValueError."""
+        data = pd.DataFrame({"category": ["A", "B", "C"], "value": [1, 2, 3]})
+        result = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+
+        import pytest
+
+        with pytest.raises(ValueError, match="out of range"):
+            PandasEncodingFeatureGroup._add_result_to_data(data, "category__onehot_encoded~5", result)
 
     @patch(
         "mloda_plugins.feature_group.experimental.sklearn.encoding.pandas.PandasEncodingFeatureGroup._import_sklearn_components"


### PR DESCRIPTION
## Summary

- Removes the extra `encoder_type` parameter from `EncodingFeatureGroup._add_result_to_data()` so it matches the standard 3-argument signature (`cls, data, feature_name, result`) used by all other feature groups
- Replaces `encoder_type`-based branching with shape-based logic (matching the pattern in `PandasScalingFeatureGroup`), inferring multi-column vs single-column handling from `result.shape` and `~N` suffix patterns in `feature_name`
- Adds tests for specific column selection via `~N` suffix and out-of-range column index error handling

Closes #297

## Test plan

- [x] All 7 `_add_result_to_data` unit tests pass with new 3-arg signature
- [x] End-to-end label encoding and onehot encoding tests pass
- [x] New `test_add_result_to_data_specific_column_request` validates `~N` column selection
- [x] New `test_add_result_to_data_column_index_out_of_range` validates error on bad index
- [x] Full tox suite: 2297 passed, 124 skipped
- [x] mypy strict: no issues
- [x] ruff, bandit: clean