### PR TITLE
fix: rename FilterType enum members to UPPER_CASE

### DIFF
--- a/docs/docs/in_depth/filter_data.md
+++ b/docs/docs/in_depth/filter_data.md
@@ -16,12 +16,12 @@ This class is supposed to created similarity in the framework and by framework u
 
 ``` python
 class FilterType(Enum):
-    min = "min"
-    max = "max"
-    equal = "equal"
-    range = "range"
-    regex = "regex"
-    categorical_inclusion = "categorical_inclusion"
+    MIN = "min"
+    MAX = "max"
+    EQUAL = "equal"
+    RANGE = "range"
+    REGEX = "regex"
+    CATEGORICAL_INCLUSION = "categorical_inclusion"
 ```
 
 #### GlobalFilter

--- a/mloda/core/filter/filter_type_enum.py
+++ b/mloda/core/filter/filter_type_enum.py
@@ -2,9 +2,9 @@ from enum import Enum
 
 
 class FilterType(Enum):
-    min = "min"
-    max = "max"
-    equal = "equal"
-    range = "range"
-    regex = "regex"
-    categorical_inclusion = "categorical_inclusion"
+    MIN = "min"
+    MAX = "max"
+    EQUAL = "equal"
+    RANGE = "range"
+    REGEX = "regex"
+    CATEGORICAL_INCLUSION = "categorical_inclusion"

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -217,7 +217,7 @@ class GlobalFilter:
         _time_from = self._check_and_convert_time_info(time_from)
         _time_to = self._check_and_convert_time_info(time_to)
         self.add_filter(
-            filter_feature, FilterType.range, {"min": _time_from, "max": _time_to, "max_exclusive": max_exclusive}
+            filter_feature, FilterType.RANGE, {"min": _time_from, "max": _time_to, "max_exclusive": max_exclusive}
         )
 
     def _check_and_convert_time_info(self, time_with_tz: datetime) -> str:

--- a/tests/test_core/test_filter/test_filter_type_enum.py
+++ b/tests/test_core/test_filter/test_filter_type_enum.py
@@ -1,0 +1,34 @@
+from mloda.core.filter.filter_type_enum import FilterType
+
+
+class TestFilterTypeEnum:
+    def test_members_are_upper_case(self) -> None:
+        """FilterType enum members must follow Python UPPER_CASE convention (PEP 8)."""
+        for member in FilterType:
+            assert member.name == member.name.upper(), (
+                f"FilterType.{member.name} should be FilterType.{member.name.upper()}"
+            )
+
+    def test_values_are_lowercase_strings(self) -> None:
+        """Enum values must remain lowercase strings for backward compatibility."""
+        expected = {
+            "MIN": "min",
+            "MAX": "max",
+            "EQUAL": "equal",
+            "RANGE": "range",
+            "REGEX": "regex",
+            "CATEGORICAL_INCLUSION": "categorical_inclusion",
+        }
+        for name, value in expected.items():
+            member = FilterType[name]
+            assert member.value == value, f"FilterType.{name}.value should be {value!r}, got {member.value!r}"
+
+    def test_expected_members_exist(self) -> None:
+        """All expected filter types are present."""
+        expected_names = {"MIN", "MAX", "EQUAL", "RANGE", "REGEX", "CATEGORICAL_INCLUSION"}
+        actual_names = {m.name for m in FilterType}
+        assert actual_names == expected_names
+
+    def test_member_count(self) -> None:
+        """Guard against accidental additions or removals."""
+        assert len(FilterType) == 6

--- a/tests/test_core/test_filter/test_global_filter.py
+++ b/tests/test_core/test_filter/test_global_filter.py
@@ -14,7 +14,7 @@ class TestGlobalFilter:
         """Set up test variables."""
         self.global_filter = GlobalFilter()
         self.feature = Feature("age")
-        self.filter_type = FilterType.range
+        self.filter_type = FilterType.RANGE
         self.parameter = {"min": 25, "max": 50}
 
     def test_add_single_filter(self) -> None:
@@ -42,7 +42,7 @@ class TestGlobalFilter:
     def test_adding_different_filters(self) -> None:
         """Test that adding different filters works correctly."""
         self.global_filter.add_filter(self.feature, self.filter_type, self.parameter)
-        self.global_filter.add_filter(Feature("salary"), FilterType.equal, {"value": 50000})
+        self.global_filter.add_filter(Feature("salary"), FilterType.EQUAL, {"value": 50000})
 
         # Assert that two distinct filters have been added
         assert len(self.global_filter.filters) == 2
@@ -57,7 +57,7 @@ class TestGlobalFilterTimeTravel:
         """Set up test variables."""
         self.global_filter = GlobalFilter()
         self.feature = Feature("age")
-        self.filter_type = FilterType.range
+        self.filter_type = FilterType.RANGE
         self.parameter = {"min": 25, "max": 50}
 
     def test_add_single_filter(self) -> None:
@@ -85,7 +85,7 @@ class TestGlobalFilterTimeTravel:
     def test_adding_different_filters(self) -> None:
         """Test that adding different filters works correctly."""
         self.global_filter.add_filter(self.feature, self.filter_type, self.parameter)
-        self.global_filter.add_filter(Feature("salary"), FilterType.equal, {"value": 50000})
+        self.global_filter.add_filter(Feature("salary"), FilterType.EQUAL, {"value": 50000})
 
         # Assert that two distinct filters have been added
         assert len(self.global_filter.filters) == 2

--- a/tests/test_core/test_filter/test_single_filter.py
+++ b/tests/test_core/test_filter/test_single_filter.py
@@ -10,7 +10,7 @@ class TestSingleFilter:
     def setup_method(self) -> None:
         """Set up test variables."""
         self.feature = Feature("age")
-        self.filter_type = FilterType.range
+        self.filter_type = FilterType.RANGE
         self.parameter = {"min": 25, "max": 50}
 
     def test_single_filter_initialization(self) -> None:

--- a/tests/test_core/test_filter/test_single_filter_parameter_integration.py
+++ b/tests/test_core/test_filter/test_single_filter_parameter_integration.py
@@ -12,7 +12,7 @@ def test_parameter_is_filter_parameter_impl() -> None:
     """Test SingleFilter.parameter is a FilterParameterImpl instance."""
     single_filter = SingleFilter(
         filter_feature="age",
-        filter_type=FilterType.range,
+        filter_type=FilterType.RANGE,
         parameter={"min": 25, "max": 50},
     )
     assert isinstance(single_filter.parameter, FilterParameterImpl)
@@ -22,7 +22,7 @@ def test_parameter_satisfies_filter_parameter_protocol() -> None:
     """Test SingleFilter.parameter satisfies FilterParameter protocol."""
     single_filter = SingleFilter(
         filter_feature="age",
-        filter_type=FilterType.range,
+        filter_type=FilterType.RANGE,
         parameter={"min": 25, "max": 50},
     )
     assert isinstance(single_filter.parameter, FilterParameter)
@@ -35,7 +35,7 @@ def test_value_property_for_min_filter() -> None:
     """Test accessing parameter.value for a min filter."""
     single_filter = SingleFilter(
         filter_feature="temperature",
-        filter_type=FilterType.min,
+        filter_type=FilterType.MIN,
         parameter={"value": 0},
     )
     assert single_filter.parameter.value == 0
@@ -45,7 +45,7 @@ def test_value_property_for_max_filter() -> None:
     """Test accessing parameter.value for a max filter."""
     single_filter = SingleFilter(
         filter_feature="temperature",
-        filter_type=FilterType.max,
+        filter_type=FilterType.MAX,
         parameter={"value": 100},
     )
     assert single_filter.parameter.value == 100
@@ -55,7 +55,7 @@ def test_value_property_for_equal_filter() -> None:
     """Test accessing parameter.value for an equal filter."""
     single_filter = SingleFilter(
         filter_feature="status",
-        filter_type=FilterType.equal,
+        filter_type=FilterType.EQUAL,
         parameter={"value": "active"},
     )
     assert single_filter.parameter.value == "active"
@@ -65,7 +65,7 @@ def test_values_property_for_categorical_inclusion() -> None:
     """Test accessing parameter.values for categorical_inclusion filter."""
     single_filter = SingleFilter(
         filter_feature="category",
-        filter_type=FilterType.categorical_inclusion,
+        filter_type=FilterType.CATEGORICAL_INCLUSION,
         parameter={"values": ["A", "B", "C"]},
     )
     assert single_filter.parameter.values == ["A", "B", "C"]
@@ -75,7 +75,7 @@ def test_range_filter_min_value_property() -> None:
     """Test accessing parameter.min_value for range filter."""
     single_filter = SingleFilter(
         filter_feature="age",
-        filter_type=FilterType.range,
+        filter_type=FilterType.RANGE,
         parameter={"min": 25, "max": 50},
     )
     assert single_filter.parameter.min_value == 25
@@ -85,7 +85,7 @@ def test_range_filter_max_value_property() -> None:
     """Test accessing parameter.max_value for range filter."""
     single_filter = SingleFilter(
         filter_feature="age",
-        filter_type=FilterType.range,
+        filter_type=FilterType.RANGE,
         parameter={"min": 25, "max": 50},
     )
     assert single_filter.parameter.max_value == 50
@@ -95,7 +95,7 @@ def test_range_filter_max_exclusive_property() -> None:
     """Test accessing parameter.max_exclusive for range filter."""
     single_filter = SingleFilter(
         filter_feature="score",
-        filter_type=FilterType.range,
+        filter_type=FilterType.RANGE,
         parameter={"min": 0, "max": 100, "max_exclusive": True},
     )
     assert single_filter.parameter.max_exclusive is True
@@ -105,7 +105,7 @@ def test_range_filter_max_exclusive_default_false() -> None:
     """Test parameter.max_exclusive defaults to False."""
     single_filter = SingleFilter(
         filter_feature="age",
-        filter_type=FilterType.range,
+        filter_type=FilterType.RANGE,
         parameter={"min": 25, "max": 50},
     )
     assert single_filter.parameter.max_exclusive is False
@@ -115,7 +115,7 @@ def test_value_property_returns_none_when_not_present() -> None:
     """Test parameter.value returns None when not present."""
     single_filter = SingleFilter(
         filter_feature="age",
-        filter_type=FilterType.range,
+        filter_type=FilterType.RANGE,
         parameter={"min": 25, "max": 50},
     )
     assert single_filter.parameter.value is None
@@ -125,7 +125,7 @@ def test_values_property_returns_none_when_not_present() -> None:
     """Test parameter.values returns None when not present."""
     single_filter = SingleFilter(
         filter_feature="age",
-        filter_type=FilterType.range,
+        filter_type=FilterType.RANGE,
         parameter={"min": 25, "max": 50},
     )
     assert single_filter.parameter.values is None
@@ -138,7 +138,7 @@ def test_single_filter_is_hashable() -> None:
     """Test SingleFilter instances are hashable."""
     single_filter = SingleFilter(
         filter_feature="age",
-        filter_type=FilterType.range,
+        filter_type=FilterType.RANGE,
         parameter={"min": 25, "max": 50},
     )
     hash_value = hash(single_filter)
@@ -149,12 +149,12 @@ def test_equal_filters_have_equal_hashes() -> None:
     """Test equal SingleFilters have the same hash."""
     single_filter1 = SingleFilter(
         filter_feature="age",
-        filter_type=FilterType.range,
+        filter_type=FilterType.RANGE,
         parameter={"min": 25, "max": 50},
     )
     single_filter2 = SingleFilter(
         filter_feature="age",
-        filter_type=FilterType.range,
+        filter_type=FilterType.RANGE,
         parameter={"min": 25, "max": 50},
     )
     assert hash(single_filter1) == hash(single_filter2)
@@ -164,17 +164,17 @@ def test_single_filter_can_be_used_in_set() -> None:
     """Test SingleFilter can be added to a set."""
     single_filter1 = SingleFilter(
         filter_feature="age",
-        filter_type=FilterType.range,
+        filter_type=FilterType.RANGE,
         parameter={"min": 25, "max": 50},
     )
     single_filter2 = SingleFilter(
         filter_feature="age",
-        filter_type=FilterType.range,
+        filter_type=FilterType.RANGE,
         parameter={"min": 25, "max": 50},
     )
     single_filter3 = SingleFilter(
         filter_feature="temperature",
-        filter_type=FilterType.min,
+        filter_type=FilterType.MIN,
         parameter={"value": 0},
     )
 
@@ -186,7 +186,7 @@ def test_single_filter_can_be_dict_key() -> None:
     """Test SingleFilter can be used as dictionary key."""
     single_filter = SingleFilter(
         filter_feature="age",
-        filter_type=FilterType.range,
+        filter_type=FilterType.RANGE,
         parameter={"min": 25, "max": 50},
     )
     filter_dict = {single_filter: "test_value"}
@@ -200,12 +200,12 @@ def test_filters_with_same_parameters_are_equal() -> None:
     """Test SingleFilters with identical parameters are equal."""
     single_filter1 = SingleFilter(
         filter_feature="age",
-        filter_type=FilterType.range,
+        filter_type=FilterType.RANGE,
         parameter={"min": 25, "max": 50},
     )
     single_filter2 = SingleFilter(
         filter_feature="age",
-        filter_type=FilterType.range,
+        filter_type=FilterType.RANGE,
         parameter={"min": 25, "max": 50},
     )
     assert single_filter1 == single_filter2
@@ -215,12 +215,12 @@ def test_filters_with_different_parameters_are_not_equal() -> None:
     """Test SingleFilters with different parameters are not equal."""
     single_filter1 = SingleFilter(
         filter_feature="age",
-        filter_type=FilterType.range,
+        filter_type=FilterType.RANGE,
         parameter={"min": 25, "max": 50},
     )
     single_filter2 = SingleFilter(
         filter_feature="age",
-        filter_type=FilterType.range,
+        filter_type=FilterType.RANGE,
         parameter={"min": 30, "max": 60},
     )
     assert single_filter1 != single_filter2
@@ -230,12 +230,12 @@ def test_filters_with_different_features_are_not_equal() -> None:
     """Test SingleFilters with different features are not equal."""
     single_filter1 = SingleFilter(
         filter_feature="age",
-        filter_type=FilterType.range,
+        filter_type=FilterType.RANGE,
         parameter={"min": 25, "max": 50},
     )
     single_filter2 = SingleFilter(
         filter_feature="temperature",
-        filter_type=FilterType.range,
+        filter_type=FilterType.RANGE,
         parameter={"min": 25, "max": 50},
     )
     assert single_filter1 != single_filter2
@@ -245,12 +245,12 @@ def test_filters_with_different_types_are_not_equal() -> None:
     """Test SingleFilters with different filter types are not equal."""
     single_filter1 = SingleFilter(
         filter_feature="value",
-        filter_type=FilterType.min,
+        filter_type=FilterType.MIN,
         parameter={"value": 25},
     )
     single_filter2 = SingleFilter(
         filter_feature="value",
-        filter_type=FilterType.max,
+        filter_type=FilterType.MAX,
         parameter={"value": 25},
     )
     assert single_filter1 != single_filter2
@@ -260,12 +260,12 @@ def test_filter_equality_with_unordered_parameters() -> None:
     """Test parameter order doesn't affect equality."""
     single_filter1 = SingleFilter(
         filter_feature="age",
-        filter_type=FilterType.range,
+        filter_type=FilterType.RANGE,
         parameter={"min": 25, "max": 50, "max_exclusive": True},
     )
     single_filter2 = SingleFilter(
         filter_feature="age",
-        filter_type=FilterType.range,
+        filter_type=FilterType.RANGE,
         parameter={"max": 50, "max_exclusive": True, "min": 25},
     )
     assert single_filter1 == single_filter2

--- a/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_filter_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_filter_engine.py
@@ -68,7 +68,7 @@ class TestDuckDBFilterEngine(FilterEngineTestMixin):
         extended_data = DuckdbRelation.from_arrow(conn, arrow_table)
 
         feature = Feature("age")
-        filter_type = FilterType.min
+        filter_type = FilterType.MIN
         parameter = {"value": 30}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -94,7 +94,7 @@ class TestDuckDBFilterEngine(FilterEngineTestMixin):
         empty_data = DuckdbRelation.from_arrow(conn, arrow_table)
 
         feature = Feature("age")
-        filter_type = FilterType.min
+        filter_type = FilterType.MIN
         parameter = {"value": 30}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -115,7 +115,7 @@ class TestDuckDBFilterEngine(FilterEngineTestMixin):
         data = DuckdbRelation.from_arrow(conn, arrow_table)
 
         feature = Feature("status")
-        filter_type = FilterType.equal
+        filter_type = FilterType.EQUAL
         parameter = {"value": "active"}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -138,7 +138,7 @@ class TestDuckDBFilterEngine(FilterEngineTestMixin):
         data = DuckdbRelation.from_arrow(conn, arrow_table)
 
         feature = Feature("is_active")
-        filter_type = FilterType.equal
+        filter_type = FilterType.EQUAL
         parameter = {"value": True}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -166,7 +166,7 @@ class TestDuckDBFilterEngine(FilterEngineTestMixin):
         data = DuckdbRelation.from_arrow(conn, arrow_table)
 
         feature = Feature("email")
-        filter_type = FilterType.regex
+        filter_type = FilterType.REGEX
         parameter = {"value": r"\.com$"}
         single_filter = SingleFilter(feature, filter_type, parameter)
 

--- a/tests/test_plugins/compute_framework/base_implementations/filter_engine_test_mixin.py
+++ b/tests/test_plugins/compute_framework/base_implementations/filter_engine_test_mixin.py
@@ -60,7 +60,7 @@ class FilterEngineTestMixin:
     def test_do_range_filter(self, filter_engine: Any, sample_data: Any) -> None:
         """Test range filter with min and max values."""
         feature = Feature("age")
-        filter_type = FilterType.range
+        filter_type = FilterType.RANGE
         parameter = {"min": 30, "max": 40, "max_exclusive": False}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -73,7 +73,7 @@ class FilterEngineTestMixin:
     def test_do_range_filter_exclusive(self, filter_engine: Any, sample_data: Any) -> None:
         """Test range filter with exclusive max value."""
         feature = Feature("age")
-        filter_type = FilterType.range
+        filter_type = FilterType.RANGE
         parameter = {"min": 30, "max": 40, "max_exclusive": True}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -86,7 +86,7 @@ class FilterEngineTestMixin:
     def test_do_min_filter(self, filter_engine: Any, sample_data: Any) -> None:
         """Test min filter."""
         feature = Feature("age")
-        filter_type = FilterType.min
+        filter_type = FilterType.MIN
         parameter = {"value": 40}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -99,7 +99,7 @@ class FilterEngineTestMixin:
     def test_do_max_filter(self, filter_engine: Any, sample_data: Any) -> None:
         """Test max filter."""
         feature = Feature("age")
-        filter_type = FilterType.max
+        filter_type = FilterType.MAX
         parameter = {"value": 30}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -112,7 +112,7 @@ class FilterEngineTestMixin:
     def test_do_max_filter_with_tuple(self, filter_engine: Any, sample_data: Any) -> None:
         """Test max filter with tuple parameter."""
         feature = Feature("age")
-        filter_type = FilterType.max
+        filter_type = FilterType.MAX
         parameter = {"max": 35, "max_exclusive": True}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -125,7 +125,7 @@ class FilterEngineTestMixin:
     def test_do_equal_filter(self, filter_engine: Any, sample_data: Any) -> None:
         """Test equal filter."""
         feature = Feature("age")
-        filter_type = FilterType.equal
+        filter_type = FilterType.EQUAL
         parameter = {"value": 35}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -138,7 +138,7 @@ class FilterEngineTestMixin:
     def test_do_regex_filter(self, filter_engine: Any, sample_data: Any) -> None:
         """Test regex filter."""
         feature = Feature("name")
-        filter_type = FilterType.regex
+        filter_type = FilterType.REGEX
         parameter = {"value": "^A"}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -151,7 +151,7 @@ class FilterEngineTestMixin:
     def test_do_categorical_inclusion_filter(self, filter_engine: Any, sample_data: Any) -> None:
         """Test categorical inclusion filter."""
         feature = Feature("category")
-        filter_type = FilterType.categorical_inclusion
+        filter_type = FilterType.CATEGORICAL_INCLUSION
         parameter = {"values": ["A", "B"]}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -165,8 +165,8 @@ class FilterEngineTestMixin:
         """Test applying multiple filters."""
         feature = Feature("age")
         filters = [
-            SingleFilter(feature, FilterType.min, {"value": 30}),
-            SingleFilter(Feature("category"), FilterType.equal, {"value": "A"}),
+            SingleFilter(feature, FilterType.MIN, {"value": 30}),
+            SingleFilter(Feature("category"), FilterType.EQUAL, {"value": "A"}),
         ]
 
         class MockFeatureSet:
@@ -192,7 +192,7 @@ class FilterEngineTestMixin:
     def test_do_range_filter_missing_parameters(self, filter_engine: Any, sample_data: Any) -> None:
         """Test range filter with missing parameters."""
         feature = Feature("age")
-        filter_type = FilterType.range
+        filter_type = FilterType.RANGE
         parameter = {"min": 30}  # Missing max parameter
         single_filter = SingleFilter(feature, filter_type, parameter)
 

--- a/tests/test_plugins/compute_framework/base_implementations/iceberg/test_iceberg_filter_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/iceberg/test_iceberg_filter_engine.py
@@ -56,7 +56,7 @@ class TestIcebergFilterEngine:
     def test_build_iceberg_expression_equal(self) -> None:
         """Test building equal filter expression."""
         feature = Feature("age")
-        filter_type = FilterType.equal
+        filter_type = FilterType.EQUAL
         parameter = {"value": 30}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -69,7 +69,7 @@ class TestIcebergFilterEngine:
     def test_build_iceberg_expression_min(self) -> None:
         """Test building min filter expression."""
         feature = Feature("age")
-        filter_type = FilterType.min
+        filter_type = FilterType.MIN
         parameter = {"value": 25}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -79,7 +79,7 @@ class TestIcebergFilterEngine:
     def test_build_iceberg_expression_max_simple(self) -> None:
         """Test building max filter expression with simple parameter."""
         feature = Feature("age")
-        filter_type = FilterType.max
+        filter_type = FilterType.MAX
         parameter = {"value": 50}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -89,7 +89,7 @@ class TestIcebergFilterEngine:
     def test_build_iceberg_expression_max_complex(self) -> None:
         """Test building max filter expression with complex parameter."""
         feature = Feature("age")
-        filter_type = FilterType.max
+        filter_type = FilterType.MAX
         parameter = {"max": 50, "max_exclusive": True}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -99,7 +99,7 @@ class TestIcebergFilterEngine:
     def test_build_iceberg_expression_range(self) -> None:
         """Test building range filter expression."""
         feature = Feature("age")
-        filter_type = FilterType.range
+        filter_type = FilterType.RANGE
         parameter = {"min": 25, "max": 50, "max_exclusive": False}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -109,7 +109,7 @@ class TestIcebergFilterEngine:
     def test_build_iceberg_expression_range_exclusive(self) -> None:
         """Test building range filter expression with exclusive max."""
         feature = Feature("age")
-        filter_type = FilterType.range
+        filter_type = FilterType.RANGE
         parameter = {"min": 25, "max": 50, "max_exclusive": True}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -119,7 +119,7 @@ class TestIcebergFilterEngine:
     def test_build_iceberg_expression_unsupported(self) -> None:
         """Test building expression for unsupported filter type."""
         feature = Feature("name")
-        filter_type = FilterType.regex
+        filter_type = FilterType.REGEX
         parameter = {"value": "^A"}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -129,7 +129,7 @@ class TestIcebergFilterEngine:
     def test_extract_parameter_value(self) -> None:
         """Test extracting parameter values."""
         feature = Feature("age")
-        filter_type = FilterType.equal
+        filter_type = FilterType.EQUAL
         parameter = {"value": 30}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -143,7 +143,7 @@ class TestIcebergFilterEngine:
     def test_has_parameter(self) -> None:
         """Test checking if parameter exists."""
         feature = Feature("age")
-        filter_type = FilterType.max
+        filter_type = FilterType.MAX
         parameter = {"max": 50, "max_exclusive": True}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -154,7 +154,7 @@ class TestIcebergFilterEngine:
     def test_apply_filters_iceberg_table(self, mock_iceberg_table: Mock, mock_feature_set: Mock) -> None:
         """Test applying filters to Iceberg table."""
         # Create filters
-        age_filter = SingleFilter(Feature("age"), FilterType.min, {"value": 25})
+        age_filter = SingleFilter(Feature("age"), FilterType.MIN, {"value": 25})
         mock_feature_set.filters = [age_filter]
 
         # Apply filters
@@ -201,8 +201,8 @@ class TestIcebergFilterEngine:
     def test_apply_filters_multiple_filters(self, mock_iceberg_table: Mock, mock_feature_set: Mock) -> None:
         """Test applying multiple filters."""
         # Create multiple filters
-        age_filter = SingleFilter(Feature("age"), FilterType.min, {"value": 25})
-        name_filter = SingleFilter(Feature("name"), FilterType.equal, {"value": "Alice"})
+        age_filter = SingleFilter(Feature("age"), FilterType.MIN, {"value": 25})
+        name_filter = SingleFilter(Feature("name"), FilterType.EQUAL, {"value": "Alice"})
         mock_feature_set.filters = [age_filter, name_filter]
 
         # Apply filters
@@ -216,8 +216,8 @@ class TestIcebergFilterEngine:
     def test_apply_filters_filtered_features(self, mock_iceberg_table: Mock, mock_feature_set: Mock) -> None:
         """Test applying filters where some features are not in the feature set."""
         # Create filter for feature not in feature set
-        unknown_filter = SingleFilter(Feature("unknown_column"), FilterType.equal, {"value": "test"})
-        age_filter = SingleFilter(Feature("age"), FilterType.min, {"value": 25})
+        unknown_filter = SingleFilter(Feature("unknown_column"), FilterType.EQUAL, {"value": "test"})
+        age_filter = SingleFilter(Feature("age"), FilterType.MIN, {"value": 25})
         mock_feature_set.filters = [unknown_filter, age_filter]
 
         # Apply filters
@@ -268,7 +268,7 @@ class TestIcebergFilterEngineUnavailable:
         """Test building expression when Iceberg expressions are not available."""
         with patch("mloda_plugins.compute_framework.base_implementations.iceberg.iceberg_filter_engine.EqualTo", None):
             feature = Feature("age")
-            filter_type = FilterType.equal
+            filter_type = FilterType.EQUAL
             parameter = {"value": 30}
             single_filter = SingleFilter(feature, filter_type, parameter)
 

--- a/tests/test_plugins/compute_framework/base_implementations/polars/test_polars_filter_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/polars/test_polars_filter_engine.py
@@ -57,7 +57,7 @@ class TestPolarsFilterEngine(FilterEngineTestMixin):
         )
 
         feature = Feature("age")
-        filter_type = FilterType.min
+        filter_type = FilterType.MIN
         parameter = {"value": 30}
         single_filter = SingleFilter(feature, filter_type, parameter)
 

--- a/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_filter_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_filter_engine.py
@@ -44,7 +44,7 @@ class TestPythonDictFilterEngine(FilterEngineTestMixin):
     def test_do_min_filter_missing_value(self, sample_data: Any) -> None:
         """Test min filter with missing value parameter."""
         feature = Feature("age")
-        filter_type = FilterType.min
+        filter_type = FilterType.MIN
         parameter = {"invalid": 30}  # Wrong parameter name
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -54,7 +54,7 @@ class TestPythonDictFilterEngine(FilterEngineTestMixin):
     def test_do_equal_filter_missing_value(self, sample_data: Any) -> None:
         """Test equal filter with missing value parameter."""
         feature = Feature("age")
-        filter_type = FilterType.equal
+        filter_type = FilterType.EQUAL
         parameter = {"invalid": 30}  # Wrong parameter name
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -64,7 +64,7 @@ class TestPythonDictFilterEngine(FilterEngineTestMixin):
     def test_do_regex_filter_missing_value(self, sample_data: Any) -> None:
         """Test regex filter with missing value parameter."""
         feature = Feature("name")
-        filter_type = FilterType.regex
+        filter_type = FilterType.REGEX
         parameter = {"invalid": "^A"}  # Wrong parameter name
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -74,7 +74,7 @@ class TestPythonDictFilterEngine(FilterEngineTestMixin):
     def test_do_categorical_inclusion_filter_missing_values(self, sample_data: Any) -> None:
         """Test categorical inclusion filter with missing values parameter."""
         feature = Feature("category")
-        filter_type = FilterType.categorical_inclusion
+        filter_type = FilterType.CATEGORICAL_INCLUSION
         parameter = {"invalid": ["A", "B"]}  # Wrong parameter name
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -86,7 +86,7 @@ class TestPythonDictFilterEngine(FilterEngineTestMixin):
         data_with_none = sample_data + [{"id": 6, "age": None, "name": "Frank", "category": "A"}]
 
         feature = Feature("age")
-        filter_type = FilterType.min
+        filter_type = FilterType.MIN
         parameter = {"value": 30}
         single_filter = SingleFilter(feature, filter_type, parameter)
 

--- a/tests/test_plugins/compute_framework/base_implementations/spark/test_spark_filter_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/spark/test_spark_filter_engine.py
@@ -75,7 +75,7 @@ class TestSparkFilterEngine:
     def test_range_filter_inclusive(self, sample_data: Any) -> None:
         """Test range filter with inclusive bounds."""
         feature = Feature("age")
-        filter_type = FilterType.range
+        filter_type = FilterType.RANGE
         parameter = {"min": 25, "max": 35, "max_exclusive": False}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -90,7 +90,7 @@ class TestSparkFilterEngine:
     def test_range_filter_exclusive_max(self, sample_data: Any) -> None:
         """Test range filter with exclusive max bound."""
         feature = Feature("age")
-        filter_type = FilterType.range
+        filter_type = FilterType.RANGE
         parameter = {"min": 25, "max": 35, "max_exclusive": True}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -105,7 +105,7 @@ class TestSparkFilterEngine:
     def test_range_filter_missing_parameters(self, sample_data: Any) -> None:
         """Test range filter with missing parameters."""
         feature = Feature("age")
-        filter_type = FilterType.range
+        filter_type = FilterType.RANGE
         parameter = {"min": 25}  # Missing max parameter
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -115,7 +115,7 @@ class TestSparkFilterEngine:
     def test_min_filter(self, sample_data: Any) -> None:
         """Test minimum value filter."""
         feature = Feature("age")
-        filter_type = FilterType.min
+        filter_type = FilterType.MIN
         parameter = {"value": 30}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -131,7 +131,7 @@ class TestSparkFilterEngine:
     def test_min_filter_missing_value(self, sample_data: Any) -> None:
         """Test min filter with missing value parameter."""
         feature = Feature("age")
-        filter_type = FilterType.min
+        filter_type = FilterType.MIN
         parameter = {"invalid": 30}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -141,7 +141,7 @@ class TestSparkFilterEngine:
     def test_max_filter_simple(self, sample_data: Any) -> None:
         """Test maximum value filter with simple value parameter."""
         feature = Feature("age")
-        filter_type = FilterType.max
+        filter_type = FilterType.MAX
         parameter = {"value": 30}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -156,7 +156,7 @@ class TestSparkFilterEngine:
     def test_max_filter_complex_inclusive(self, sample_data: Any) -> None:
         """Test maximum value filter with complex max parameter (inclusive)."""
         feature = Feature("age")
-        filter_type = FilterType.max
+        filter_type = FilterType.MAX
         parameter = {"max": 30, "max_exclusive": False}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -171,7 +171,7 @@ class TestSparkFilterEngine:
     def test_max_filter_complex_exclusive(self, sample_data: Any) -> None:
         """Test maximum value filter with complex max_exclusive parameter."""
         feature = Feature("age")
-        filter_type = FilterType.max
+        filter_type = FilterType.MAX
         parameter = {"max": 30, "max_exclusive": True}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -186,7 +186,7 @@ class TestSparkFilterEngine:
     def test_max_filter_invalid_parameters(self, sample_data: Any) -> None:
         """Test max filter with invalid parameters."""
         feature = Feature("age")
-        filter_type = FilterType.max
+        filter_type = FilterType.MAX
         parameter = {"invalid": 30}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -196,7 +196,7 @@ class TestSparkFilterEngine:
     def test_max_filter_with_min_parameter(self, sample_data: Any) -> None:
         """Test max filter with min parameter (should raise error)."""
         feature = Feature("age")
-        filter_type = FilterType.max
+        filter_type = FilterType.MAX
         parameter = {"min": 20, "max": 30}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -206,7 +206,7 @@ class TestSparkFilterEngine:
     def test_equal_filter(self, sample_data: Any) -> None:
         """Test equality filter."""
         feature = Feature("age")
-        filter_type = FilterType.equal
+        filter_type = FilterType.EQUAL
         parameter = {"value": 30}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -221,7 +221,7 @@ class TestSparkFilterEngine:
     def test_equal_filter_string(self, sample_data: Any) -> None:
         """Test equality filter on string column."""
         feature = Feature("name")
-        filter_type = FilterType.equal
+        filter_type = FilterType.EQUAL
         parameter = {"value": "Alice"}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -236,7 +236,7 @@ class TestSparkFilterEngine:
     def test_equal_filter_boolean(self, sample_data: Any) -> None:
         """Test equality filter on boolean column."""
         feature = Feature("is_active")
-        filter_type = FilterType.equal
+        filter_type = FilterType.EQUAL
         parameter = {"value": True}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -251,7 +251,7 @@ class TestSparkFilterEngine:
     def test_equal_filter_missing_value(self, sample_data: Any) -> None:
         """Test equal filter with missing value parameter."""
         feature = Feature("age")
-        filter_type = FilterType.equal
+        filter_type = FilterType.EQUAL
         parameter = {"invalid": 30}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -261,7 +261,7 @@ class TestSparkFilterEngine:
     def test_regex_filter(self, sample_data: Any) -> None:
         """Test regex filter."""
         feature = Feature("name")
-        filter_type = FilterType.regex
+        filter_type = FilterType.REGEX
         parameter = {"value": "^A.*"}  # Names starting with 'A'
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -275,7 +275,7 @@ class TestSparkFilterEngine:
     def test_regex_filter_multiple_matches(self, sample_data: Any) -> None:
         """Test regex filter with multiple matches."""
         feature = Feature("name")
-        filter_type = FilterType.regex
+        filter_type = FilterType.REGEX
         parameter = {"value": ".*e$"}  # Names ending with 'e'
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -290,7 +290,7 @@ class TestSparkFilterEngine:
     def test_regex_filter_missing_value(self, sample_data: Any) -> None:
         """Test regex filter with missing value parameter."""
         feature = Feature("name")
-        filter_type = FilterType.regex
+        filter_type = FilterType.REGEX
         parameter = {"invalid": "^A.*"}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -300,7 +300,7 @@ class TestSparkFilterEngine:
     def test_categorical_inclusion_filter(self, sample_data: Any) -> None:
         """Test categorical inclusion filter."""
         feature = Feature("category")
-        filter_type = FilterType.categorical_inclusion
+        filter_type = FilterType.CATEGORICAL_INCLUSION
         parameter = {"values": ["A", "B"]}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -315,7 +315,7 @@ class TestSparkFilterEngine:
     def test_categorical_inclusion_filter_single_value(self, sample_data: Any) -> None:
         """Test categorical inclusion filter with single value."""
         feature = Feature("category")
-        filter_type = FilterType.categorical_inclusion
+        filter_type = FilterType.CATEGORICAL_INCLUSION
         parameter = {"values": ["C"]}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -330,7 +330,7 @@ class TestSparkFilterEngine:
     def test_categorical_inclusion_filter_missing_values(self, sample_data: Any) -> None:
         """Test categorical inclusion filter with missing values parameter."""
         feature = Feature("category")
-        filter_type = FilterType.categorical_inclusion
+        filter_type = FilterType.CATEGORICAL_INCLUSION
         parameter = {"invalid": ["A", "B"]}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -340,7 +340,7 @@ class TestSparkFilterEngine:
     def test_filter_on_float_column(self, sample_data: Any) -> None:
         """Test filters on float/double columns."""
         feature = Feature("score")
-        filter_type = FilterType.range
+        filter_type = FilterType.RANGE
         parameter = {"min": 80.0, "max": 90.0, "max_exclusive": False}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -356,7 +356,7 @@ class TestSparkFilterEngine:
     def test_filter_empty_result(self, sample_data: Any) -> None:
         """Test filter that returns empty result."""
         feature = Feature("age")
-        filter_type = FilterType.equal
+        filter_type = FilterType.EQUAL
         parameter = {"value": 100}  # No one is 100 years old
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -369,7 +369,7 @@ class TestSparkFilterEngine:
     def test_filter_nonexistent_column(self, sample_data: Any) -> None:
         """Test filter on nonexistent column."""
         feature = Feature("nonexistent")
-        filter_type = FilterType.equal
+        filter_type = FilterType.EQUAL
         parameter = {"value": 30}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -391,7 +391,7 @@ class TestSparkFilterEngine:
 
         # Test regex filter for emails ending with .com
         feature = Feature("email")
-        filter_type = FilterType.regex
+        filter_type = FilterType.REGEX
         parameter = {"value": r"\.com$"}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -414,7 +414,7 @@ class TestSparkFilterEngine:
 
         # Test min filter - should exclude null values
         feature = Feature("age")
-        filter_type = FilterType.min
+        filter_type = FilterType.MIN
         parameter = {"value": 30}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -440,7 +440,7 @@ class TestSparkFilterEngine:
 
         # Test min filter on empty data
         feature = Feature("age")
-        filter_type = FilterType.min
+        filter_type = FilterType.MIN
         parameter = {"value": 30}
         single_filter = SingleFilter(feature, filter_type, parameter)
 

--- a/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_filter_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_filter_engine.py
@@ -48,7 +48,7 @@ class TestSqliteFilterEngine(FilterEngineTestMixin):
         data = SqliteRelation.from_arrow(connection, arrow_table)
 
         feature = Feature("age")
-        filter_type = FilterType.min
+        filter_type = FilterType.MIN
         parameter = {"value": 30}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -70,7 +70,7 @@ class TestSqliteFilterEngine(FilterEngineTestMixin):
         empty_data = SqliteRelation.from_arrow(connection, arrow_table)
 
         feature = Feature("age")
-        filter_type = FilterType.min
+        filter_type = FilterType.MIN
         parameter = {"value": 30}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -88,7 +88,7 @@ class TestSqliteFilterEngine(FilterEngineTestMixin):
         data = SqliteRelation.from_arrow(connection, arrow_table)
 
         feature = Feature("status")
-        filter_type = FilterType.equal
+        filter_type = FilterType.EQUAL
         parameter = {"value": "active"}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -114,7 +114,7 @@ class TestSqliteFilterEngine(FilterEngineTestMixin):
         data = SqliteRelation.from_arrow(connection, arrow_table)
 
         feature = Feature("email")
-        filter_type = FilterType.regex
+        filter_type = FilterType.REGEX
         parameter = {"value": r"\.com$"}
         single_filter = SingleFilter(feature, filter_type, parameter)
 
@@ -145,7 +145,7 @@ class TestAdversarialInputs:
     ) -> None:
         """Filter value containing SQL injection payload must not execute injected SQL."""
         feature = Feature("name")
-        single_filter = SingleFilter(feature, FilterType.equal, {"value": "'; DROP TABLE users; --"})
+        single_filter = SingleFilter(feature, FilterType.EQUAL, {"value": "'; DROP TABLE users; --"})
         result = SqliteFilterEngine.do_equal_filter(base_data, single_filter)
         # Should return 0 rows (no row has that exact value), not crash
         assert len(result) == 0
@@ -153,7 +153,7 @@ class TestAdversarialInputs:
     def test_filter_value_with_or_injection(self, base_data: SqliteRelation, connection: sqlite3.Connection) -> None:
         """Filter value '1 OR 1=1' must be treated as a literal string, not SQL."""
         feature = Feature("name")
-        single_filter = SingleFilter(feature, FilterType.equal, {"value": "1 OR 1=1"})
+        single_filter = SingleFilter(feature, FilterType.EQUAL, {"value": "1 OR 1=1"})
         result = SqliteFilterEngine.do_equal_filter(base_data, single_filter)
         # Should return 0 rows, not all rows
         assert len(result) == 0
@@ -164,7 +164,7 @@ class TestAdversarialInputs:
         """Categorical values containing single quotes must be handled safely."""
         feature = Feature("name")
         single_filter = SingleFilter(
-            feature, FilterType.categorical_inclusion, {"values": ["alice", "bob's value", "'; DROP TABLE --"]}
+            feature, FilterType.CATEGORICAL_INCLUSION, {"values": ["alice", "bob's value", "'; DROP TABLE --"]}
         )
         result = SqliteFilterEngine.do_categorical_inclusion_filter(base_data, single_filter)
         # Only 'alice' matches; the others are literal strings with no match
@@ -176,7 +176,7 @@ class TestAdversarialInputs:
     ) -> None:
         """Numeric filter with a legitimate numeric value should work correctly."""
         feature = Feature("value")
-        single_filter = SingleFilter(feature, FilterType.min, {"value": 20})
+        single_filter = SingleFilter(feature, FilterType.MIN, {"value": 20})
         result = SqliteFilterEngine.do_min_filter(base_data, single_filter)
         assert len(result) == 2
         values = sorted(result.df()["value"].tolist())


### PR DESCRIPTION
## Summary
- Rename `FilterType` enum members from lowercase (`min`, `max`, `equal`, `range`, `regex`, `categorical_inclusion`) to UPPER_CASE (`MIN`, `MAX`, `EQUAL`, `RANGE`, `REGEX`, `CATEGORICAL_INCLUSION`) per PEP 8 convention
- String values remain unchanged (`"min"`, `"max"`, etc.) so downstream behavior is unaffected
- Update all references across source, tests, and docs
- Add `test_filter_type_enum.py` with tests enforcing the UPPER_CASE naming convention

Closes #270

## Test plan
- [x] New tests in `test_filter_type_enum.py` verify member names are UPPER_CASE, values are lowercase strings, expected members exist, and member count is 6
- [x] All 95 filter tests pass
- [x] Full tox suite passes (2407 passed, 124 skipped): pytest, ruff, mypy --strict, bandit