### PR TITLE
fix: remove try/except blocks violating project convention

### DIFF
--- a/mloda_plugins/feature_group/experimental/forecasting/base.py
+++ b/mloda_plugins/feature_group/experimental/forecasting/base.py
@@ -276,12 +276,9 @@ class ForecastingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             raise ValueError(f"Unsupported time unit: {time_unit}. Supported units: {', '.join(cls.TIME_UNITS.keys())}")
 
         # Convert horizon to integer
-        try:
-            horizon = int(horizon_str)
-            if horizon <= 0:
-                raise ValueError("Horizon must be positive")
-        except ValueError:
+        if not horizon_str.isdigit() or int(horizon_str) <= 0:
             raise ValueError(f"Invalid horizon: {horizon_str}. Must be a positive integer.")
+        horizon = int(horizon_str)
 
         return algorithm, horizon, time_unit
 
@@ -301,11 +298,7 @@ class ForecastingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             True if valid, False otherwise
         """
         if FeatureChainParser.is_chained_feature(feature_name):
-            try:
-                # Use existing validation logic that validates algorithm, horizon, and time_unit
-                cls.parse_forecast_suffix(feature_name)
-            except ValueError:
-                # If validation fails, this feature doesn't match
+            if not cls._has_valid_forecast_suffix(feature_name):
                 return False
         return True
 
@@ -438,6 +431,37 @@ class ForecastingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         return algorithm, horizon, time_unit, source_features[0]
 
     @classmethod
+    def _has_valid_forecast_suffix(cls, feature_name: str) -> bool:
+        """Check if feature_name has a suffix matching the forecast pattern."""
+        suffix_start = feature_name.find("__")
+        if suffix_start == -1:
+            return False
+        suffix = feature_name[suffix_start + 2 :]
+        parts = suffix.split("_")
+        if len(parts) < 3 or parts[1] != "forecast":
+            return False
+        if parts[0] not in cls.FORECASTING_ALGORITHMS:
+            return False
+        horizon_time = parts[2]
+        # Find where digits end and time unit begins
+        digit_end = 0
+        for i, char in enumerate(horizon_time):
+            if not char.isdigit():
+                digit_end = i
+                break
+        else:
+            return False
+        if digit_end == 0:
+            return False
+        time_unit = horizon_time[digit_end:]
+        if time_unit not in cls.TIME_UNITS:
+            return False
+        horizon_str = horizon_time[:digit_end]
+        if int(horizon_str) <= 0:
+            return False
+        return True
+
+    @classmethod
     def _extract_forecast_params(cls, feature: Feature) -> tuple[Optional[str], Optional[int], Optional[str]]:
         """
         Extract forecast-specific parameters (algorithm, horizon, time_unit) from a feature.
@@ -449,18 +473,12 @@ class ForecastingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 
         Returns:
             Tuple of (algorithm, horizon, time_unit), where any value may be None if not found
-
-        Raises:
-            ValueError: If string-based parsing fails validation
         """
         # Try string-based first using parse_forecast_suffix
         feature_name_str = feature.name.name if hasattr(feature.name, "name") else str(feature.name)
-        if FeatureChainParser.is_chained_feature(feature_name_str):
-            try:
-                algorithm, horizon, time_unit = cls.parse_forecast_suffix(feature_name_str)
-                return algorithm, horizon, time_unit
-            except ValueError:
-                pass
+        if cls._has_valid_forecast_suffix(feature_name_str):
+            algorithm, horizon, time_unit = cls.parse_forecast_suffix(feature_name_str)
+            return algorithm, horizon, time_unit
         # Fall back to config
         algorithm = feature.options.get(cls.ALGORITHM)
         horizon = feature.options.get(cls.HORIZON)

--- a/mloda_plugins/feature_group/experimental/geo_distance/base.py
+++ b/mloda_plugins/feature_group/experimental/geo_distance/base.py
@@ -126,18 +126,15 @@ class GeoDistanceFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         """Extract point features from either configuration-based options or string parsing."""
 
         # Try string-based parsing first
-        try:
-            # For L->R: "point1&point2__distance_type_distance"
-            # We need to extract everything before the last "__"
-            feature_name_str = feature_name.name if hasattr(feature_name, "name") else str(feature_name)
-            parts = feature_name_str.rsplit("__", 1)
-            if len(parts) == 2:
-                # parts[0] contains "point1&point2", parts[1] contains "distance_type_distance"
-                point_parts = parts[0].split("&", 1)
-                if len(point_parts) == 2:
-                    return {Feature(point_parts[0]), Feature(point_parts[1])}
-        except (ValueError, AttributeError):
-            pass
+        # For L->R: "point1&point2__distance_type_distance"
+        # We need to extract everything before the last "__"
+        feature_name_str = feature_name.name if hasattr(feature_name, "name") else str(feature_name)
+        parts = feature_name_str.rsplit("__", 1)
+        if len(parts) == 2:
+            # parts[0] contains "point1&point2", parts[1] contains "distance_type_distance"
+            point_parts = parts[0].split("&", 1)
+            if len(point_parts) == 2:
+                return {Feature(point_parts[0]), Feature(point_parts[1])}
 
         # Fall back to configuration-based approach
         source_features = options.get_in_features()

--- a/mloda_plugins/feature_group/experimental/sklearn/encoding/base.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/encoding/base.py
@@ -417,23 +417,17 @@ class EncodingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         Raises:
             ValueError: If encoder type mismatch is detected
         """
-        try:
-            expected_class_name = cls.SUPPORTED_ENCODERS.get(encoder_type)
-            if expected_class_name is None:
-                raise ValueError(f"Unsupported encoder type: {encoder_type}")
+        expected_class_name = cls.SUPPORTED_ENCODERS.get(encoder_type)
+        if expected_class_name is None:
+            raise ValueError(f"Unsupported encoder type: {encoder_type}")
 
-            actual_class_name: str = fitted_encoder.__class__.__name__
-            if actual_class_name != expected_class_name:
-                raise ValueError(
-                    f"Artifact encoder type mismatch: expected {encoder_type} "
-                    f"({expected_class_name}), but loaded artifact contains {actual_class_name}"
-                )
-            return True
-        except Exception as e:
-            if isinstance(e, ValueError):
-                raise  # Re-raise ValueError as-is
-            # For other exceptions, wrap in ValueError
-            raise ValueError(f"Error validating encoder type: {str(e)}")
+        actual_class_name: str = fitted_encoder.__class__.__name__
+        if actual_class_name != expected_class_name:
+            raise ValueError(
+                f"Artifact encoder type mismatch: expected {encoder_type} "
+                f"({expected_class_name}), but loaded artifact contains {actual_class_name}"
+            )
+        return True
 
     @classmethod
     def _create_and_fit_encoder(cls, data: Any, source_feature: str, encoder_type: str) -> Any:

--- a/mloda_plugins/feature_group/experimental/sklearn/pipeline/base.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/pipeline/base.py
@@ -512,13 +512,11 @@ class SklearnPipelineFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         Returns:
             True if the pipeline matches the configuration
         """
-        try:
-            # Basic check: compare number of steps
-            if hasattr(fitted_pipeline, "steps"):
-                return len(fitted_pipeline.steps) == len(config["steps"])
+        if not hasattr(fitted_pipeline, "steps"):
             return False
-        except Exception:
+        if "steps" not in config:
             return False
+        return len(fitted_pipeline.steps) == len(config["steps"])
 
     @classmethod
     def _create_and_fit_pipeline(cls, data: Any, source_features: List[Any], config: Dict[str, Any]) -> Any:

--- a/mloda_plugins/feature_group/experimental/sklearn/scaling/base.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/scaling/base.py
@@ -291,23 +291,17 @@ class ScalingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         Raises:
             ValueError: If scaler type mismatch is detected
         """
-        try:
-            expected_class_name = cls.SUPPORTED_SCALERS.get(scaler_type)
-            if expected_class_name is None:
-                raise ValueError(f"Unsupported scaler type: {scaler_type}")
+        expected_class_name = cls.SUPPORTED_SCALERS.get(scaler_type)
+        if expected_class_name is None:
+            raise ValueError(f"Unsupported scaler type: {scaler_type}")
 
-            actual_class_name: str = fitted_scaler.__class__.__name__
-            if actual_class_name != expected_class_name:
-                raise ValueError(
-                    f"Artifact scaler type mismatch: expected {scaler_type} "
-                    f"({expected_class_name}), but loaded artifact contains {actual_class_name}"
-                )
-            return True
-        except Exception as e:
-            if isinstance(e, ValueError):
-                raise  # Re-raise ValueError as-is
-            # For other exceptions, wrap in ValueError
-            raise ValueError(f"Error validating scaler type: {str(e)}")
+        actual_class_name: str = fitted_scaler.__class__.__name__
+        if actual_class_name != expected_class_name:
+            raise ValueError(
+                f"Artifact scaler type mismatch: expected {scaler_type} "
+                f"({expected_class_name}), but loaded artifact contains {actual_class_name}"
+            )
+        return True
 
     @classmethod
     def _create_and_fit_scaler(cls, data: Any, source_feature: str, scaler_type: str) -> Any:

--- a/mloda_plugins/feature_group/experimental/time_window/base.py
+++ b/mloda_plugins/feature_group/experimental/time_window/base.py
@@ -184,6 +184,24 @@ class TimeWindowFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         return set(source_features) | {time_filter_feature}
 
     @classmethod
+    def _has_valid_time_window_suffix(cls, feature_name: str) -> bool:
+        """Check if feature_name has a suffix matching the time window pattern."""
+        suffix_start = feature_name.rfind("__")
+        if suffix_start == -1:
+            return False
+        suffix = feature_name[suffix_start + 2 :]
+        parts = suffix.split("_")
+        if len(parts) != 4 or parts[3] != "window":
+            return False
+        if parts[0] not in cls.WINDOW_FUNCTIONS:
+            return False
+        if parts[2] not in cls.TIME_UNITS:
+            return False
+        if not parts[1].isdigit() or int(parts[1]) <= 0:
+            return False
+        return True
+
+    @classmethod
     def _extract_time_window_params(cls, feature: Feature) -> tuple[Optional[str], Optional[int], Optional[str]]:
         """
         Extract time window parameters (window_function, window_size, time_unit) from a feature.
@@ -199,11 +217,9 @@ class TimeWindowFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         feature_name = feature.get_name()
 
         # Try string-based parsing first
-        try:
+        if cls._has_valid_time_window_suffix(feature_name):
             window_function, window_size, time_unit = cls.parse_time_window_prefix(feature_name)
             return window_function, window_size, time_unit
-        except ValueError:
-            pass
 
         # Fall back to configuration
         window_function = feature.options.get(cls.WINDOW_FUNCTION)
@@ -286,12 +302,9 @@ class TimeWindowFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             raise ValueError(f"Unsupported time unit: {time_unit}. Supported units: {', '.join(cls.TIME_UNITS.keys())}")
 
         # Convert window size to integer
-        try:
-            window_size = int(window_size_str)
-            if window_size <= 0:
-                raise ValueError("Window size must be positive")
-        except ValueError:
+        if not window_size_str.isdigit() or int(window_size_str) <= 0:
             raise ValueError(f"Invalid window size: {window_size_str}. Must be a positive integer.")
+        window_size = int(window_size_str)
 
         return window_function, window_size, time_unit
 

--- a/tests/test_plugins/feature_group/experimental/test_forecasting/test_forecasting_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/test_forecasting/test_forecasting_feature_group.py
@@ -201,3 +201,38 @@ class TestForecastingFeatureGroup:
         options.add_to_group(DefaultOptionKeys.reference_time.value, 123)  # Not a string
         with pytest.raises(ValueError):
             ForecastingFeatureGroup.get_reference_time_column(options)
+
+    def test_has_valid_forecast_suffix_valid(self) -> None:
+        """Test that _has_valid_forecast_suffix returns True for valid feature names."""
+        assert ForecastingFeatureGroup._has_valid_forecast_suffix("sales__linear_forecast_7day") is True
+        assert ForecastingFeatureGroup._has_valid_forecast_suffix("price__ridge_forecast_30week") is True
+        assert ForecastingFeatureGroup._has_valid_forecast_suffix("demand__randomforest_forecast_3month") is True
+        assert ForecastingFeatureGroup._has_valid_forecast_suffix("temp__gbr_forecast_12hour") is True
+
+    def test_has_valid_forecast_suffix_invalid(self) -> None:
+        """Test that _has_valid_forecast_suffix returns False for invalid feature names."""
+        assert ForecastingFeatureGroup._has_valid_forecast_suffix("invalid_feature_name") is False
+        assert ForecastingFeatureGroup._has_valid_forecast_suffix("sales__linear_7day") is False
+        assert ForecastingFeatureGroup._has_valid_forecast_suffix("sales__unknown_forecast_7day") is False
+        assert ForecastingFeatureGroup._has_valid_forecast_suffix("sales__linear_forecast_day") is False
+        assert ForecastingFeatureGroup._has_valid_forecast_suffix("sales__linear_forecast_7invalid") is False
+
+    def test_extract_forecast_params_string_based(self) -> None:
+        """Test that _extract_forecast_params extracts parameters from a string-based feature name."""
+        feature = Feature("sales__linear_forecast_7day")
+        algorithm, horizon, time_unit = ForecastingFeatureGroup._extract_forecast_params(feature)
+        assert algorithm == "linear"
+        assert horizon == 7
+        assert time_unit == "day"
+
+    def test_extract_forecast_params_config_fallback(self) -> None:
+        """Test that _extract_forecast_params falls back to configuration-based options."""
+        options = Options()
+        options.add_to_group(ForecastingFeatureGroup.ALGORITHM, "ridge")
+        options.add_to_group(ForecastingFeatureGroup.HORIZON, "14")
+        options.add_to_group(ForecastingFeatureGroup.TIME_UNIT, "day")
+        feature = Feature("some_feature", options)
+        algorithm, horizon, time_unit = ForecastingFeatureGroup._extract_forecast_params(feature)
+        assert algorithm == "ridge"
+        assert horizon == 14
+        assert time_unit == "day"

--- a/tests/test_plugins/feature_group/experimental/test_time_window_feature_group/test_base_time_window_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/test_time_window_feature_group/test_base_time_window_feature_group.py
@@ -267,3 +267,43 @@ class TestTimeWindowFeatureGroup:
         # Verify that the method can be called without error
         concrete_fg = ConcreteTimeWindowFeatureGroup()
         concrete_fg._check_reference_time_column_is_datetime(None, "test_column")
+
+    def test_has_valid_time_window_suffix_valid(self) -> None:
+        """Test that _has_valid_time_window_suffix returns True for valid feature names."""
+        assert TimeWindowFeatureGroup._has_valid_time_window_suffix("temperature__avg_3_day_window") is True
+        assert TimeWindowFeatureGroup._has_valid_time_window_suffix("humidity__max_7_hour_window") is True
+        assert TimeWindowFeatureGroup._has_valid_time_window_suffix("pressure__min_2_minute_window") is True
+        assert TimeWindowFeatureGroup._has_valid_time_window_suffix("cpu__sum_10_second_window") is True
+        # Chained feature: the last __ segment should still be valid
+        assert TimeWindowFeatureGroup._has_valid_time_window_suffix("price__mean_imputed__sum_7_day_window") is True
+
+    def test_has_valid_time_window_suffix_invalid(self) -> None:
+        """Test that _has_valid_time_window_suffix returns False for invalid feature names."""
+        # No double underscore separator
+        assert TimeWindowFeatureGroup._has_valid_time_window_suffix("invalid_feature_name") is False
+        # Missing "window" suffix
+        assert TimeWindowFeatureGroup._has_valid_time_window_suffix("temp__avg_3_day") is False
+        # Unsupported window function
+        assert TimeWindowFeatureGroup._has_valid_time_window_suffix("temp__invalid_3_day_window") is False
+        # Unsupported time unit
+        assert TimeWindowFeatureGroup._has_valid_time_window_suffix("temp__avg_3_invalid_window") is False
+        # Non-numeric window size
+        assert TimeWindowFeatureGroup._has_valid_time_window_suffix("temp__avg_zero_day_window") is False
+        # Zero window size
+        assert TimeWindowFeatureGroup._has_valid_time_window_suffix("temp__avg_0_day_window") is False
+
+    def test_extract_time_window_params_string_based(self) -> None:
+        """Test _extract_time_window_params with a string-parseable feature name."""
+        feature = Feature("temperature__avg_3_day_window")
+        result = TimeWindowFeatureGroup._extract_time_window_params(feature)
+        assert result == ("avg", 3, "day")
+
+    def test_extract_time_window_params_config_fallback(self) -> None:
+        """Test _extract_time_window_params falls back to configuration-based options."""
+        options = Options()
+        options.add_to_group(TimeWindowFeatureGroup.WINDOW_FUNCTION, "sum")
+        options.add_to_group(TimeWindowFeatureGroup.WINDOW_SIZE, "5")
+        options.add_to_group(TimeWindowFeatureGroup.TIME_UNIT, "hour")
+        feature = Feature("some_feature", options)
+        result = TimeWindowFeatureGroup._extract_time_window_params(feature)
+        assert result == ("sum", 5, "hour")


### PR DESCRIPTION
## Summary

- Remove try/except blocks from six experimental plugin files, replacing them with explicit conditional checks (LBYL) per project convention
- Add `_has_valid_time_window_suffix` and `_has_valid_forecast_suffix` validation methods to check suffix structure before calling parse methods
- Remove dead-code try/except wrappers in encoding, scaling, and pipeline where operations cannot raise
- Fix internal try/except int-conversion blocks in `parse_time_window_prefix` and `parse_forecast_suffix` with `isdigit()` checks
- Add tests for new validation methods and previously untested `_extract_time_window_params` and `_extract_forecast_params` methods

Closes #302

## Test plan

- [x] All 2413 existing tests pass with `PYTEST_WORKERS=1 tox`
- [x] mypy strict passes
- [x] bandit passes
- [x] ruff formatting clean
- [x] No remaining try/except blocks in target files (only legitimate `except ImportError` for sklearn imports remain)
- [x] New tests cover both string-based parsing path and config-fallback path for time_window and forecasting