### PR TITLE
fix: clean up mkdocs.yml nav order, stale TODO, and missing search plugin (#292)

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -10,12 +10,12 @@ nav:
     - Provider, User, Steward in mloda: examples/mloda_basics/4_ml_data_providers_user_steward.ipynb
   - Getting Started:
     - Installation: chapter1/installation.md
-    - Base Usage: examples/base_usage.ipynb
-    - sklearn Integration Tutorial: examples/sklearn_integration_basic.ipynb
     - API Request: chapter1/api-request.md
     - Feature Groups: chapter1/feature-groups.md
     - Compute Frameworks: chapter1/compute-frameworks.md
     - Extender: chapter1/extender.md
+    - Base Usage: examples/base_usage.ipynb
+    - sklearn Integration Tutorial: examples/sklearn_integration_basic.ipynb
   - In Depth - Basics:
     - mloda API: in_depth/mloda-api.md
     - Streaming: in_depth/streaming.md
@@ -52,13 +52,11 @@ nav:
   - Need Help?:
     - FAQ: faq.md
 
-  # todo
-  #- Extender in Depth: TBD
-
 theme:
   name: readthedocs
 
 plugins:
+  - search
   - mkdocs-jupyter:
       include: ["*.ipynb"] 
       execute: false

--- a/tests/test_documentation/test_mkdocs_config.py
+++ b/tests/test_documentation/test_mkdocs_config.py
@@ -1,0 +1,77 @@
+"""Tests for mkdocs.yml configuration integrity."""
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+MKDOCS_YML = Path("docs/mkdocs.yml")
+
+
+def _load_mkdocs_config() -> dict[str, Any]:
+    result: dict[str, Any] = yaml.safe_load(MKDOCS_YML.read_text(encoding="utf-8"))
+    return result
+
+
+def test_no_stale_todo_comments_in_mkdocs_yml() -> None:
+    """Ensure mkdocs.yml contains no stale TODO/TBD comments."""
+    raw_text = MKDOCS_YML.read_text(encoding="utf-8")
+    lines_with_todo = [
+        (i + 1, line.rstrip())
+        for i, line in enumerate(raw_text.splitlines())
+        if line.strip().startswith("#") and any(marker in line.upper() for marker in ("TODO", "TBD"))
+    ]
+    assert not lines_with_todo, f"mkdocs.yml contains stale TODO/TBD comments: {lines_with_todo}"
+
+
+def test_search_plugin_configured() -> None:
+    """When plugins are explicitly listed, the search plugin must be included."""
+    config = _load_mkdocs_config()
+    plugins = config.get("plugins", [])
+
+    plugin_names: list[str] = []
+    for entry in plugins:
+        if isinstance(entry, str):
+            plugin_names.append(entry)
+        elif isinstance(entry, dict):
+            plugin_names.extend(entry.keys())
+
+    assert "search" in plugin_names, (
+        f"'search' plugin missing from explicit plugins list: {plugin_names}. "
+        "When plugins are explicitly configured in mkdocs.yml, the default search "
+        "plugin is disabled and must be re-added manually."
+    )
+
+
+def test_getting_started_text_guides_before_notebooks() -> None:
+    """In Getting Started, .md guides should appear before .ipynb notebooks."""
+    config = _load_mkdocs_config()
+    nav = config.get("nav", [])
+
+    getting_started_items = None
+    for section in nav:
+        if isinstance(section, dict) and "Getting Started" in section:
+            getting_started_items = section["Getting Started"]
+            break
+
+    assert getting_started_items is not None, "Getting Started section not found in nav"
+
+    paths: list[str] = []
+    for item in getting_started_items:
+        if isinstance(item, dict):
+            for path in item.values():
+                if isinstance(path, str):
+                    paths.append(path)
+
+    md_indices = [i for i, p in enumerate(paths) if p.endswith(".md")]
+    ipynb_indices = [i for i, p in enumerate(paths) if p.endswith(".ipynb")]
+
+    if md_indices and ipynb_indices:
+        last_md = max(md_indices)
+        first_ipynb = min(ipynb_indices)
+        assert last_md < first_ipynb, (
+            f"Text guides (.md) should appear before notebooks (.ipynb) in Getting Started. "
+            f"Last .md at index {last_md}, first .ipynb at index {first_ipynb}. "
+            f"Order: {paths}"
+        )


### PR DESCRIPTION
## Summary

- Remove dangling `# todo` / `#- Extender in Depth: TBD` comment (stale, never resolved)
- Add `search` plugin to `plugins:` list (explicitly listing plugins without it disables the mkdocs default search)
- Reorder "Getting Started" navigation so text-based guides (.md) precede interactive notebooks (.ipynb), improving reading flow for new users
- Add three regression tests in `tests/test_documentation/test_mkdocs_config.py` to prevent these issues from recurring

Closes #292

## Test plan

- [x] `PYTEST_WORKERS=1 tox` passes (2456 passed, 124 skipped)
- [x] `mypy --strict` passes
- [x] `ruff format` passes
- [x] `bandit` passes
- [x] Three new tests validate: no TODO/TBD comments, search plugin present, text-before-notebooks nav order