### PR TITLE
fix: add context and guidance to opaque validation errors (#285)

### DIFF
--- a/mloda/core/abstract_plugins/compute_framework.py
+++ b/mloda/core/abstract_plugins/compute_framework.py
@@ -309,7 +309,10 @@ class ComputeFramework(ABC):
             return
 
         if not isinstance(self.data, self.expected_data_framework()):
-            raise ValueError(f"Data type {type(self.data)} is not supported by {self.__class__.__name__}")
+            raise ValueError(
+                f"Data type {type(self.data)} is not supported by {self.__class__.__name__}. "
+                f"Expected: {self.expected_data_framework()}."
+            )
 
     @final
     def add_already_calculated_children_and_drop_if_possible(

--- a/mloda_plugins/feature_group/input_data/read_db.py
+++ b/mloda_plugins/feature_group/input_data/read_db.py
@@ -50,12 +50,19 @@ class ReadDB(BaseInputData):
 
     def init_reader(self, options: Optional[Options]) -> Tuple["ReadDB", Any]:
         if options is None:
-            raise ValueError("Options were not set.")
+            raise ValueError(
+                f"Options were not set for {self.__class__.__name__}. "
+                f"Provide an Options object containing a 'BaseInputData' key "
+                f"with a (reader_class, data_access) tuple."
+            )
 
         reader_data_access = options["BaseInputData"]
 
         if reader_data_access is None:
-            raise ValueError("Reader data access was not set.")
+            raise ValueError(
+                f"'BaseInputData' key is missing or None in the provided Options for {self.__class__.__name__}. "
+                f"Set options with Options(group={{'BaseInputData': (ReaderClass, credentials_dict)}})."
+            )
 
         reader, data_access = reader_data_access
         return reader(), data_access
@@ -98,7 +105,10 @@ class ReadDB(BaseInputData):
     @classmethod
     def match_read_db_data_access(cls, data_accesses: List[Any], feature_names: List[str]) -> Any:
         if len(feature_names) > 1:
-            raise ValueError("This should not happen.")
+            raise ValueError(
+                f"ReadDB.match_read_db_data_access expected exactly one feature name, "
+                f"but received {len(feature_names)}: {feature_names}."
+            )
 
         for data_access in data_accesses:
             try:
@@ -118,10 +128,13 @@ class ReadDB(BaseInputData):
     @classmethod
     def get_connection(cls, credentials: Any) -> Any:
         """Establishes a database connection using the provided credentials."""
-        connection = None
         connection = cls.connect(credentials)
         if connection is None:
-            raise ValueError("Connection to database failed.")
+            raise ValueError(
+                f"Connection to database failed for {cls.__name__}. "
+                f"The connect() method returned None. "
+                f"Verify that the database credentials are correct and the database server is reachable."
+            )
         return connection
 
     @classmethod

--- a/mloda_plugins/feature_group/input_data/read_file.py
+++ b/mloda_plugins/feature_group/input_data/read_file.py
@@ -85,12 +85,19 @@ class ReadFile(BaseInputData):
 
     def init_reader(self, options: Optional[Options]) -> Tuple["ReadFile", Any]:
         if options is None:
-            raise ValueError("Options were not set.")
+            raise ValueError(
+                f"Options were not set for {self.__class__.__name__}. "
+                f"Provide an Options object containing a 'BaseInputData' key "
+                f"with a (reader_class, data_access) tuple."
+            )
 
         reader_data_access = options.get("BaseInputData")
 
         if reader_data_access is None:
-            raise ValueError("Reader data access was not set.")
+            raise ValueError(
+                f"'BaseInputData' key is missing or None in the provided Options for {self.__class__.__name__}. "
+                f"Set options with Options(group={{'BaseInputData': (ReaderClass, 'path/to/file')}})."
+            )
 
         reader, data_access = reader_data_access
         return reader(), data_access

--- a/tests/test_core/test_abstract_plugins/test_abstract_compute_framework.py
+++ b/tests/test_core/test_abstract_plugins/test_abstract_compute_framework.py
@@ -1,4 +1,8 @@
+import pytest
+from uuid import uuid4
+
 from mloda.provider import ComputeFramework
+from mloda.core.abstract_plugins.components.parallelization_modes import ParallelizationMode
 
 
 class BaseTestComputeFramework1(ComputeFramework):
@@ -11,3 +15,28 @@ class BaseTestComputeFramework2(ComputeFramework):
 
 class BaseTestComputeFramework3(ComputeFramework):
     pass
+
+
+class TestComputeFrameworkValidationErrors:
+    def test_validate_expected_framework_includes_expected_type(self) -> None:
+        """The error message should contain 'Expected:' and the expected data framework type name.
+
+        Currently the message only says the data type is not supported, without telling the user
+        what type was expected. The improved message should include 'Expected:' followed by the
+        expected framework type.
+        """
+
+        class DictFramework(ComputeFramework):
+            @classmethod
+            def expected_data_framework(cls) -> type:
+                return dict
+
+        fw = DictFramework(
+            mode=ParallelizationMode.SYNC,
+            children_if_root=frozenset(),
+            uuid=uuid4(),
+        )
+        fw.data = "this is a string, not a dict"
+
+        with pytest.raises(ValueError, match=r"Expected:"):
+            fw.validate_expected_framework()

--- a/tests/test_plugins/feature_group/input_data/test_read_dbs/test_read_db.py
+++ b/tests/test_plugins/feature_group/input_data/test_read_dbs/test_read_db.py
@@ -135,6 +135,57 @@ class TestReadDB:
         with pytest.raises(NotImplementedError):
             ReadDB.get_connection(None)
 
+    def test_init_reader_none_options_message(self) -> None:
+        """When init_reader is called with None, the error should mention the class name.
+
+        Currently the message is a generic 'Options were not set.' without indicating
+        which ReadDB subclass encountered the problem.
+        """
+
+        class CustomReadDB(ReadDB):
+            @classmethod
+            def connect(cls, credentials: Any) -> Any:
+                return None
+
+        reader = CustomReadDB()
+        with pytest.raises(ValueError, match=r"CustomReadDB"):
+            reader.init_reader(None)
+
+    def test_init_reader_missing_base_input_data_message(self) -> None:
+        """When options lack BaseInputData key, the error should mention 'BaseInputData'.
+
+        Currently the message is a generic 'Reader data access was not set.' without
+        telling the user which key is missing from options.
+        """
+        read_db = ReadDB()
+        with pytest.raises(ValueError, match=r"BaseInputData"):
+            read_db.init_reader(Options())
+
+    def test_match_read_db_data_access_multiple_features_message(self) -> None:
+        """When match_read_db_data_access receives multiple feature names, the error
+        should mention the number of feature names received.
+
+        Currently the message is just 'This should not happen.' which gives no context
+        about the actual problem or how many feature names were passed.
+        """
+        with pytest.raises(ValueError, match=r"2"):
+            ReadDB.match_read_db_data_access([], ["feat_a", "feat_b"])
+
+    def test_get_connection_returns_none_message(self) -> None:
+        """When connect() returns None, the error should mention the subclass name.
+
+        Currently the message is a generic 'Connection to database failed.' without
+        indicating which ReadDB subclass failed to connect.
+        """
+
+        class NoneConnectDB(ReadDB):
+            @classmethod
+            def connect(cls, credentials: Any) -> None:
+                return None
+
+        with pytest.raises(ValueError, match=r"NoneConnectDB"):
+            NoneConnectDB.get_connection("dummy")
+
     def test_read_db_success(self) -> None:
         class MockReadDB(ReadDB):
             @classmethod

--- a/tests/test_plugins/feature_group/input_data/test_read_files/test_read_file.py
+++ b/tests/test_plugins/feature_group/input_data/test_read_files/test_read_file.py
@@ -209,6 +209,49 @@ class TestInputData:
                 assert v[0] == -4.757493165076248
 
 
+class TestReadFileValidationErrors:
+    def test_init_reader_none_options_message(self) -> None:
+        """When init_reader is called with None, the error should mention the class name.
+
+        Currently the message is a generic 'Options were not set.' without indicating
+        which reader class encountered the problem.
+        """
+
+        class MyCustomReader(ReadFile):
+            @classmethod
+            def get_column_names(cls, file_name: str) -> List[str]:
+                return []
+
+            @classmethod
+            def suffix(cls) -> Tuple[str, ...]:
+                return (".csv",)
+
+        reader = MyCustomReader()
+        with pytest.raises(ValueError, match=r"MyCustomReader"):
+            reader.init_reader(None)
+
+    def test_init_reader_missing_base_input_data_message(self) -> None:
+        """When options lack BaseInputData, the error should mention 'BaseInputData'.
+
+        Currently the message is a generic 'Reader data access was not set.' without
+        telling the user which key is missing.
+        """
+
+        class AnotherReader(ReadFile):
+            @classmethod
+            def get_column_names(cls, file_name: str) -> List[str]:
+                return []
+
+            @classmethod
+            def suffix(cls) -> Tuple[str, ...]:
+                return (".csv",)
+
+        reader = AnotherReader()
+        options = Options(group={"SomeOtherKey": "value"})
+        with pytest.raises(ValueError, match=r"BaseInputData"):
+            reader.init_reader(options)
+
+
 class TestReadFile:
     def test_validate_columns(self) -> None:
         class TestReadFile(ReadFile):


### PR DESCRIPTION
## Summary
- Improved 7 opaque validation error messages across `compute_framework.py`, `read_file.py`, and `read_db.py` so each message answers: what went wrong, what was the actual state, and what should the user do to fix it
- Added 7 targeted tests verifying that error messages contain contextual information (class names, expected types, actionable guidance)
- Removed dead `connection = None` assignment in `read_db.py:get_connection`

### Error messages improved

| Location | Before | After |
|----------|--------|-------|
| `compute_framework.py` `validate_expected_framework` | "Data type X is not supported by Y" | Adds "Expected: Z" with the expected framework type |
| `read_file.py` `init_reader` (no options) | "Options were not set." | Includes class name and guidance to provide BaseInputData key |
| `read_file.py` `init_reader` (missing key) | "Reader data access was not set." | Mentions BaseInputData key and shows example Options usage |
| `read_db.py` `init_reader` (no options) | "Options were not set." | Includes class name and guidance to provide BaseInputData key |
| `read_db.py` `init_reader` (missing key) | "Reader data access was not set." | Mentions BaseInputData key and shows example Options usage |
| `read_db.py` `match_read_db_data_access` | "This should not happen." | Reports the actual count and list of feature names received |
| `read_db.py` `get_connection` | "Connection to database failed." | Includes subclass name and actionable troubleshooting steps |

Closes #285

## Test plan
- [x] 7 new tests verify error messages contain contextual info (`pytest.raises` with `match=`)
- [x] Full `tox` suite passes (2509 passed, 124 skipped)
- [x] `ruff format`, `ruff check`, `mypy --strict`, and `bandit` all clean