### PR TITLE
fix: unify source feature check signatures across all plugins (#296)

### DIFF
--- a/mloda_plugins/feature_group/experimental/dimensionality_reduction/base.py
+++ b/mloda_plugins/feature_group/experimental/dimensionality_reduction/base.py
@@ -5,7 +5,7 @@ Base implementation for dimensionality reduction feature groups.
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Any, Optional
+from typing import Any, List, Optional
 
 from mloda.provider import FeatureGroup
 from mloda.user import Feature
@@ -354,8 +354,7 @@ class DimensionalityReductionFeatureGroup(FeatureChainParserMixin, FeatureGroup)
             )
 
             # Check if all source features exist
-            for source_feature in source_features:
-                cls._check_source_feature_exists(data, source_feature)
+            cls._check_source_features_exist(data, source_features)
 
             # Perform dimensionality reduction
             result = cls._perform_reduction(data, algorithm, dimension, source_features, options)
@@ -366,16 +365,16 @@ class DimensionalityReductionFeatureGroup(FeatureChainParserMixin, FeatureGroup)
 
     @classmethod
     @abstractmethod
-    def _check_source_feature_exists(cls, data: Any, feature_name: str) -> None:
+    def _check_source_features_exist(cls, data: Any, feature_names: List[str]) -> None:
         """
-        Check if the source feature exists in the data.
+        Check if the source features exist in the data.
 
         Args:
             data: The input data
-            feature_name: The name of the feature to check
+            feature_names: List of feature names to check
 
         Raises:
-            ValueError: If the feature does not exist in the data
+            ValueError: If a feature does not exist in the data
         """
         ...
 

--- a/mloda_plugins/feature_group/experimental/dimensionality_reduction/pandas.py
+++ b/mloda_plugins/feature_group/experimental/dimensionality_reduction/pandas.py
@@ -38,19 +38,20 @@ class PandasDimensionalityReductionFeatureGroup(DimensionalityReductionFeatureGr
         return {PandasDataFrame}
 
     @classmethod
-    def _check_source_feature_exists(cls, data: pd.DataFrame, feature_name: str) -> None:
+    def _check_source_features_exist(cls, data: pd.DataFrame, feature_names: List[str]) -> None:
         """
-        Check if the source feature exists in the DataFrame.
+        Check if the source features exist in the DataFrame.
 
         Args:
             data: The pandas DataFrame
-            feature_name: The name of the feature to check
+            feature_names: List of feature names to check
 
         Raises:
-            ValueError: If the feature does not exist in the DataFrame
+            ValueError: If a feature does not exist in the DataFrame
         """
-        if feature_name not in data.columns:
-            raise ValueError(f"Feature '{feature_name}' not found in the data")
+        for feature_name in feature_names:
+            if feature_name not in data.columns:
+                raise ValueError(f"Feature '{feature_name}' not found in the data")
 
     @classmethod
     def _add_result_to_data(cls, data: "pd.DataFrame", feature_name: str, result: "NDArray[Any]") -> "pd.DataFrame":

--- a/mloda_plugins/feature_group/experimental/geo_distance/base.py
+++ b/mloda_plugins/feature_group/experimental/geo_distance/base.py
@@ -5,7 +5,7 @@ Base implementation for geo distance feature groups.
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Any, Optional, Set
+from typing import Any, List, Optional, Set
 
 from mloda.provider import FeatureGroup
 from mloda.user import Feature
@@ -199,7 +199,7 @@ class GeoDistanceFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         for feature in features.features:
             distance_type, point1_feature, point2_feature = cls._extract_geo_distance_parameters(feature)
 
-            cls._check_point_features_exist(data, point1_feature, point2_feature)
+            cls._check_source_features_exist(data, [point1_feature, point2_feature])
 
             if distance_type not in cls.DISTANCE_TYPES:
                 raise ValueError(f"Unsupported distance type: {distance_type}")
@@ -275,17 +275,16 @@ class GeoDistanceFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 
     @classmethod
     @abstractmethod
-    def _check_point_features_exist(cls, data: Any, point1_feature: str, point2_feature: str) -> None:
+    def _check_source_features_exist(cls, data: Any, feature_names: List[str]) -> None:
         """
-        Check if the point features exist in the data.
+        Check if the source features exist in the data.
 
         Args:
             data: The input data
-            point1_feature: The name of the first point feature
-            point2_feature: The name of the second point feature
+            feature_names: List of feature names to check
 
         Raises:
-            ValueError: If either feature does not exist in the data
+            ValueError: If a feature does not exist in the data
         """
         ...
 

--- a/mloda_plugins/feature_group/experimental/geo_distance/pandas.py
+++ b/mloda_plugins/feature_group/experimental/geo_distance/pandas.py
@@ -4,7 +4,7 @@ Pandas implementation for geo distance feature groups.
 
 from __future__ import annotations
 
-from typing import Any, Set, Type
+from typing import Any, List, Set, Type
 
 import numpy as np
 
@@ -21,12 +21,11 @@ class PandasGeoDistanceFeatureGroup(GeoDistanceFeatureGroup):
         return {PandasDataFrame}
 
     @classmethod
-    def _check_point_features_exist(cls, data: Any, point1_feature: str, point2_feature: str) -> None:
-        """Check if the point features exist in the DataFrame."""
-        if point1_feature not in data.columns:
-            raise ValueError(f"Point feature '{point1_feature}' not found in data")
-        if point2_feature not in data.columns:
-            raise ValueError(f"Point feature '{point2_feature}' not found in data")
+    def _check_source_features_exist(cls, data: Any, feature_names: List[str]) -> None:
+        """Check if the source features exist in the DataFrame."""
+        for feature_name in feature_names:
+            if feature_name not in data.columns:
+                raise ValueError(f"Source feature '{feature_name}' not found in data")
 
     @classmethod
     def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:

--- a/mloda_plugins/feature_group/experimental/node_centrality/base.py
+++ b/mloda_plugins/feature_group/experimental/node_centrality/base.py
@@ -5,7 +5,7 @@ Base implementation for node centrality feature groups.
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Any, Optional
+from typing import Any, List, Optional
 
 from mloda.provider import FeatureGroup
 from mloda.user import Feature
@@ -236,7 +236,7 @@ class NodeCentralityFeatureGroup(FeatureChainParserMixin, FeatureGroup):
                 )
 
             # Check if source feature exists
-            cls._check_source_feature_exists(data, source_feature_str)
+            cls._check_source_features_exist(data, [source_feature_str])
 
             # Calculate centrality
             result = cls._calculate_centrality(data, centrality_type, source_feature_str, graph_type, weight_column)
@@ -297,16 +297,16 @@ class NodeCentralityFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 
     @classmethod
     @abstractmethod
-    def _check_source_feature_exists(cls, data: Any, feature_name: str) -> None:
+    def _check_source_features_exist(cls, data: Any, feature_names: List[str]) -> None:
         """
-        Check if the source feature exists in the data.
+        Check if the source features exist in the data.
 
         Args:
             data: The input data
-            feature_name: The name of the feature to check
+            feature_names: List of feature names to check
 
         Raises:
-            ValueError: If the feature does not exist in the data
+            ValueError: If a feature does not exist in the data
         """
         ...
 

--- a/mloda_plugins/feature_group/experimental/node_centrality/pandas.py
+++ b/mloda_plugins/feature_group/experimental/node_centrality/pandas.py
@@ -4,7 +4,7 @@ Pandas implementation for node centrality feature groups.
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional, cast
+from typing import Any, Dict, List, Optional, cast
 
 
 try:
@@ -26,19 +26,20 @@ class PandasNodeCentralityFeatureGroup(NodeCentralityFeatureGroup):
         return {PandasDataFrame}
 
     @classmethod
-    def _check_source_feature_exists(cls, data: pd.DataFrame, feature_name: str) -> None:
+    def _check_source_features_exist(cls, data: pd.DataFrame, feature_names: List[str]) -> None:
         """
-        Check if the source feature exists in the DataFrame.
+        Check if the source features exist in the DataFrame.
 
         Args:
             data: The pandas DataFrame
-            feature_name: The name of the feature to check
+            feature_names: List of feature names to check
 
         Raises:
-            ValueError: If the feature does not exist in the DataFrame
+            ValueError: If a feature does not exist in the DataFrame
         """
-        if feature_name not in data.columns:
-            raise ValueError(f"Feature '{feature_name}' not found in the data")
+        for feature_name in feature_names:
+            if feature_name not in data.columns:
+                raise ValueError(f"Feature '{feature_name}' not found in the data")
 
     @classmethod
     def _add_result_to_data(cls, data: pd.DataFrame, feature_name: str, result: pd.Series) -> pd.DataFrame:

--- a/mloda_plugins/feature_group/experimental/sklearn/encoding/base.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/encoding/base.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import datetime
 from abc import abstractmethod
-from typing import Any, Dict, Optional, Set, Type
+from typing import Any, Dict, List, Optional, Set, Type
 
 from mloda.provider import FeatureGroup
 from mloda.user import Feature
@@ -249,7 +249,7 @@ class EncodingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             base_source_feature = cls.get_column_base_feature(source_feature)
 
             # Check that source feature exists
-            cls._check_source_feature_exists(data, base_source_feature)
+            cls._check_source_features_exist(data, [base_source_feature])
 
             # Create unique artifact key that includes encoder type and source feature
             # This ensures different encoders on different features get separate artifacts
@@ -498,16 +498,16 @@ class EncodingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 
     @classmethod
     @abstractmethod
-    def _check_source_feature_exists(cls, data: Any, feature_name: str) -> None:
+    def _check_source_features_exist(cls, data: Any, feature_names: List[str]) -> None:
         """
-        Check if the source feature exists in the data.
+        Check if the source features exist in the data.
 
         Args:
             data: The input data
-            feature_name: The name of the feature to check
+            feature_names: List of feature names to check
 
         Raises:
-            ValueError: If the feature does not exist in the data
+            ValueError: If a feature does not exist in the data
         """
         ...
 

--- a/mloda_plugins/feature_group/experimental/sklearn/encoding/pandas.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/encoding/pandas.py
@@ -4,7 +4,7 @@ Pandas implementation for scikit-learn encoding feature groups.
 
 from __future__ import annotations
 
-from typing import Any, Set, Type
+from typing import Any, List, Set, Type
 
 from mloda.provider import ComputeFramework
 
@@ -26,10 +26,11 @@ class PandasEncodingFeatureGroup(EncodingFeatureGroup):
         return {PandasDataFrame}
 
     @classmethod
-    def _check_source_feature_exists(cls, data: Any, feature_name: str) -> None:
-        """Check if the feature exists in the DataFrame."""
-        if feature_name not in data.columns:
-            raise ValueError(f"Source feature '{feature_name}' not found in data")
+    def _check_source_features_exist(cls, data: Any, feature_names: List[str]) -> None:
+        """Check if the features exist in the DataFrame."""
+        for feature_name in feature_names:
+            if feature_name not in data.columns:
+                raise ValueError(f"Source feature '{feature_name}' not found in data")
 
     @classmethod
     def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:

--- a/mloda_plugins/feature_group/experimental/sklearn/pipeline/base.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/pipeline/base.py
@@ -208,8 +208,7 @@ class SklearnPipelineFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             pipeline_name, source_features = cls._extract_pipeline_name_and_source_features(feature)
 
             # Check that all source features exist
-            for source_feature in source_features:
-                cls._check_source_feature_exists(data, source_feature)
+            cls._check_source_features_exist(data, source_features)
 
             # Get pipeline configuration from options or create default
             pipeline_config = cls._get_pipeline_config_from_feature(feature, pipeline_name)
@@ -586,16 +585,16 @@ class SklearnPipelineFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 
     @classmethod
     @abstractmethod
-    def _check_source_feature_exists(cls, data: Any, feature_name: str) -> None:
+    def _check_source_features_exist(cls, data: Any, feature_names: List[str]) -> None:
         """
-        Check if the source feature exists in the data.
+        Check if the source features exist in the data.
 
         Args:
             data: The input data
-            feature_name: The name of the feature to check
+            feature_names: List of feature names to check
 
         Raises:
-            ValueError: If the feature does not exist in the data
+            ValueError: If a feature does not exist in the data
         """
         ...
 

--- a/mloda_plugins/feature_group/experimental/sklearn/pipeline/pandas.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/pipeline/pandas.py
@@ -4,7 +4,7 @@ Pandas implementation for scikit-learn pipeline feature groups.
 
 from __future__ import annotations
 
-from typing import Any, Set, Type
+from typing import Any, List, Set, Type
 
 from mloda.provider import ComputeFramework
 
@@ -26,10 +26,11 @@ class PandasSklearnPipelineFeatureGroup(SklearnPipelineFeatureGroup):
         return {PandasDataFrame}
 
     @classmethod
-    def _check_source_feature_exists(cls, data: Any, feature_name: str) -> None:
-        """Check if the feature exists in the DataFrame."""
-        if feature_name not in data.columns:
-            raise ValueError(f"Source feature '{feature_name}' not found in data")
+    def _check_source_features_exist(cls, data: Any, feature_names: List[str]) -> None:
+        """Check if the features exist in the DataFrame."""
+        for feature_name in feature_names:
+            if feature_name not in data.columns:
+                raise ValueError(f"Source feature '{feature_name}' not found in data")
 
     @classmethod
     def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:

--- a/mloda_plugins/feature_group/experimental/sklearn/scaling/base.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/scaling/base.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import datetime
 from abc import abstractmethod
-from typing import Any, Dict, Optional, Type
+from typing import Any, Dict, List, Optional, Type
 
 from mloda.provider import FeatureGroup
 from mloda.user import Feature
@@ -138,7 +138,7 @@ class ScalingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             scaler_type, source_feature = cls._extract_scaler_type_and_source_feature(feature)
 
             # Check that source feature exists
-            cls._check_source_feature_exists(data, source_feature)
+            cls._check_source_features_exist(data, [source_feature])
 
             # Create unique artifact key for this scaler
             artifact_key = f"{source_feature}__{scaler_type}_scaled"
@@ -360,16 +360,16 @@ class ScalingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 
     @classmethod
     @abstractmethod
-    def _check_source_feature_exists(cls, data: Any, feature_name: str) -> None:
+    def _check_source_features_exist(cls, data: Any, feature_names: List[str]) -> None:
         """
-        Check if the source feature exists in the data.
+        Check if the source features exist in the data.
 
         Args:
             data: The input data
-            feature_name: The name of the feature to check
+            feature_names: List of feature names to check
 
         Raises:
-            ValueError: If the feature does not exist in the data
+            ValueError: If a feature does not exist in the data
         """
         ...
 

--- a/mloda_plugins/feature_group/experimental/sklearn/scaling/pandas.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/scaling/pandas.py
@@ -4,7 +4,7 @@ Pandas implementation for scikit-learn scaling feature groups.
 
 from __future__ import annotations
 
-from typing import Any, Set, Type
+from typing import Any, List, Set, Type
 
 from mloda.provider import ComputeFramework
 
@@ -26,10 +26,11 @@ class PandasScalingFeatureGroup(ScalingFeatureGroup):
         return {PandasDataFrame}
 
     @classmethod
-    def _check_source_feature_exists(cls, data: Any, feature_name: str) -> None:
-        """Check if the feature exists in the DataFrame."""
-        if feature_name not in data.columns:
-            raise ValueError(f"Source feature '{feature_name}' not found in data")
+    def _check_source_features_exist(cls, data: Any, feature_names: List[str]) -> None:
+        """Check if the features exist in the DataFrame."""
+        for feature_name in feature_names:
+            if feature_name not in data.columns:
+                raise ValueError(f"Source feature '{feature_name}' not found in data")
 
     @classmethod
     def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:

--- a/mloda_plugins/feature_group/experimental/text_cleaning/base.py
+++ b/mloda_plugins/feature_group/experimental/text_cleaning/base.py
@@ -5,7 +5,7 @@ Base implementation for text cleaning feature groups.
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Any, Optional
+from typing import Any, List, Optional
 
 from mloda.provider import FeatureGroup
 from mloda.user import Feature
@@ -190,7 +190,7 @@ class TextCleaningFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             operations, source_feature = cls._extract_operations_and_source_feature(feature)
 
             # Check if source feature exists
-            cls._check_source_feature_exists(data, source_feature)
+            cls._check_source_features_exist(data, [source_feature])
 
             # Validate operations
             for operation in operations:
@@ -213,16 +213,16 @@ class TextCleaningFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 
     @classmethod
     @abstractmethod
-    def _check_source_feature_exists(cls, data: Any, feature_name: str) -> None:
+    def _check_source_features_exist(cls, data: Any, feature_names: List[str]) -> None:
         """
-        Check if the source feature exists in the data.
+        Check if the source features exist in the data.
 
         Args:
             data: The input data
-            feature_name: The name of the feature to check
+            feature_names: List of feature names to check
 
         Raises:
-            ValueError: If the feature does not exist in the data
+            ValueError: If a feature does not exist in the data
         """
         ...
 

--- a/mloda_plugins/feature_group/experimental/text_cleaning/pandas.py
+++ b/mloda_plugins/feature_group/experimental/text_cleaning/pandas.py
@@ -45,19 +45,20 @@ class PandasTextCleaningFeatureGroup(TextCleaningFeatureGroup):
         return {PandasDataFrame}
 
     @classmethod
-    def _check_source_feature_exists(cls, data: pd.DataFrame, feature_name: str) -> None:
+    def _check_source_features_exist(cls, data: pd.DataFrame, feature_names: list[str]) -> None:
         """
-        Check if the source feature exists in the DataFrame.
+        Check if the source features exist in the DataFrame.
 
         Args:
             data: The pandas DataFrame
-            feature_name: The name of the feature to check
+            feature_names: List of feature names to check
 
         Raises:
-            ValueError: If the feature does not exist in the DataFrame
+            ValueError: If a feature does not exist in the DataFrame
         """
-        if feature_name not in data.columns:
-            raise ValueError(f"Feature '{feature_name}' not found in the data")
+        for feature_name in feature_names:
+            if feature_name not in data.columns:
+                raise ValueError(f"Feature '{feature_name}' not found in the data")
 
     @classmethod
     def _get_source_text(cls, data: pd.DataFrame, feature_name: str) -> pd.Series:

--- a/mloda_plugins/feature_group/experimental/text_cleaning/python_dict.py
+++ b/mloda_plugins/feature_group/experimental/text_cleaning/python_dict.py
@@ -39,14 +39,14 @@ class PythonDictTextCleaningFeatureGroup(TextCleaningFeatureGroup):
         return {PythonDictFramework}
 
     @classmethod
-    def _check_source_feature_exists(cls, data: List[Dict[str, Any]], feature_name: str) -> None:
+    def _check_source_features_exist(cls, data: List[Dict[str, Any]], feature_names: List[str]) -> None:
         if not data:
             raise ValueError("Data cannot be empty")
 
-        # Check if feature exists in any row
-        feature_exists = any(feature_name in row for row in data)
-        if not feature_exists:
-            raise ValueError(f"Feature '{feature_name}' not found in the data")
+        for feature_name in feature_names:
+            feature_exists = any(feature_name in row for row in data)
+            if not feature_exists:
+                raise ValueError(f"Feature '{feature_name}' not found in the data")
 
     @classmethod
     def _get_source_text(cls, data: List[Dict[str, Any]], feature_name: str) -> List[str]:

--- a/tests/test_plugins/feature_group/experimental/sklearn/test_encoding_feature_group/test_pandas_encoding_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/sklearn/test_encoding_feature_group/test_pandas_encoding_feature_group.py
@@ -21,21 +21,22 @@ class TestPandasEncodingFeatureGroup:
         frameworks = PandasEncodingFeatureGroup.compute_framework_rule()
         assert frameworks == {PandasDataFrame}
 
-    def test_check_source_feature_exists_valid(self) -> None:
+    def test_check_source_features_exist_valid(self) -> None:
         """Test checking for existing source features."""
         data = pd.DataFrame({"category": ["A", "B", "C"], "value": [1, 2, 3]})
 
-        # Should not raise for existing feature
-        PandasEncodingFeatureGroup._check_source_feature_exists(data, "category")
-        PandasEncodingFeatureGroup._check_source_feature_exists(data, "value")
+        # Should not raise for existing features
+        PandasEncodingFeatureGroup._check_source_features_exist(data, ["category"])
+        PandasEncodingFeatureGroup._check_source_features_exist(data, ["value"])
+        PandasEncodingFeatureGroup._check_source_features_exist(data, ["category", "value"])
 
-    def test_check_source_feature_exists_invalid(self) -> None:
+    def test_check_source_features_exist_invalid(self) -> None:
         """Test checking for non-existing source features."""
         data = pd.DataFrame({"category": ["A", "B", "C"], "value": [1, 2, 3]})
 
         # Should raise for non-existing feature
         try:
-            PandasEncodingFeatureGroup._check_source_feature_exists(data, "nonexistent")
+            PandasEncodingFeatureGroup._check_source_features_exist(data, ["nonexistent"])
             assert False, "Should have raised ValueError"
         except ValueError as e:
             assert "Source feature 'nonexistent' not found in data" in str(e)

--- a/tests/test_plugins/feature_group/experimental/sklearn/test_pipeline_feature_group/test_pandas_pipeline_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/sklearn/test_pipeline_feature_group/test_pandas_pipeline_feature_group.py
@@ -21,20 +21,21 @@ class TestPandasSklearnPipelineFeatureGroup:
         rule = PandasSklearnPipelineFeatureGroup.compute_framework_rule()
         assert PandasDataFrame in rule
 
-    def test_check_source_feature_exists_valid(self) -> None:
+    def test_check_source_features_exist_valid(self) -> None:
         """Test checking for existing source features."""
         df = pd.DataFrame({"feature1": [1, 2, 3], "feature2": [4, 5, 6]})
 
         # Should not raise exception for existing features
-        PandasSklearnPipelineFeatureGroup._check_source_feature_exists(df, "feature1")
-        PandasSklearnPipelineFeatureGroup._check_source_feature_exists(df, "feature2")
+        PandasSklearnPipelineFeatureGroup._check_source_features_exist(df, ["feature1"])
+        PandasSklearnPipelineFeatureGroup._check_source_features_exist(df, ["feature2"])
+        PandasSklearnPipelineFeatureGroup._check_source_features_exist(df, ["feature1", "feature2"])
 
-    def test_check_source_feature_exists_invalid(self) -> None:
+    def test_check_source_features_exist_invalid(self) -> None:
         """Test checking for non-existing source features."""
         df = pd.DataFrame({"feature1": [1, 2, 3], "feature2": [4, 5, 6]})
 
         with pytest.raises(ValueError, match="Source feature 'nonexistent' not found in data"):
-            PandasSklearnPipelineFeatureGroup._check_source_feature_exists(df, "nonexistent")
+            PandasSklearnPipelineFeatureGroup._check_source_features_exist(df, ["nonexistent"])
 
     def test_add_result_to_data_1d_array(self) -> None:
         """Test adding 1D array result to DataFrame."""

--- a/tests/test_plugins/feature_group/experimental/test_base_aggregated_feature_group/test_polars_lazy_aggregated_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/test_base_aggregated_feature_group/test_polars_lazy_aggregated_feature_group.py
@@ -82,14 +82,14 @@ class TestPolarsLazyAggregatedFeatureGroup:
         """Test compute_framework_rule method."""
         assert PolarsLazyAggregatedFeatureGroup.compute_framework_rule() == {PolarsLazyDataFrame}
 
-    def test_check_source_feature_exists_valid(self, sample_lazy_dataframe: Any) -> None:
-        """Test _check_source_feature_exists with valid feature."""
+    def test_check_source_features_exist_valid(self, sample_lazy_dataframe: Any) -> None:
+        """Test _check_source_features_exist with valid feature."""
         # Should not raise an exception
         PolarsLazyAggregatedFeatureGroup._check_source_features_exist(sample_lazy_dataframe, ["sales"])
         PolarsLazyAggregatedFeatureGroup._check_source_features_exist(sample_lazy_dataframe, ["price"])
 
-    def test_check_source_feature_exists_invalid(self, sample_lazy_dataframe: Any) -> None:
-        """Test _check_source_feature_exists with invalid feature."""
+    def test_check_source_features_exist_invalid(self, sample_lazy_dataframe: Any) -> None:
+        """Test _check_source_features_exist with invalid feature."""
         with pytest.raises(ValueError, match="None of the source features"):
             PolarsLazyAggregatedFeatureGroup._check_source_features_exist(sample_lazy_dataframe, ["missing"])
 

--- a/tests/test_plugins/feature_group/experimental/test_check_source_features_signature.py
+++ b/tests/test_plugins/feature_group/experimental/test_check_source_features_signature.py
@@ -1,0 +1,112 @@
+"""
+Tests that all experimental feature group plugins use the unified
+_check_source_features_exist(cls, data, feature_names: List[str]) signature.
+
+This validates issue #296: source feature check methods should have a single,
+consistent signature across all plugins.
+"""
+
+import inspect
+from typing import Any
+
+import pytest
+
+from mloda_plugins.feature_group.experimental.aggregated_feature_group.pandas import (
+    PandasAggregatedFeatureGroup,
+)
+from mloda_plugins.feature_group.experimental.clustering.pandas import PandasClusteringFeatureGroup
+from mloda_plugins.feature_group.experimental.data_quality.missing_value.pandas import (
+    PandasMissingValueFeatureGroup,
+)
+from mloda_plugins.feature_group.experimental.dimensionality_reduction.pandas import (
+    PandasDimensionalityReductionFeatureGroup,
+)
+from mloda_plugins.feature_group.experimental.geo_distance.pandas import PandasGeoDistanceFeatureGroup
+from mloda_plugins.feature_group.experimental.node_centrality.pandas import PandasNodeCentralityFeatureGroup
+from mloda_plugins.feature_group.experimental.sklearn.encoding.pandas import PandasEncodingFeatureGroup
+from mloda_plugins.feature_group.experimental.sklearn.pipeline.pandas import (
+    PandasSklearnPipelineFeatureGroup,
+)
+from mloda_plugins.feature_group.experimental.sklearn.scaling.pandas import PandasScalingFeatureGroup
+from mloda_plugins.feature_group.experimental.text_cleaning.pandas import PandasTextCleaningFeatureGroup
+
+try:
+    from mloda_plugins.feature_group.experimental.time_window.pandas import PandasTimeWindowFeatureGroup
+
+    HAS_TIME_WINDOW_PANDAS = True
+except ImportError:
+    HAS_TIME_WINDOW_PANDAS = False
+
+try:
+    from mloda_plugins.feature_group.experimental.forecasting.pandas import PandasForecastingFeatureGroup
+
+    HAS_FORECASTING_PANDAS = True
+except ImportError:
+    HAS_FORECASTING_PANDAS = False
+
+
+import pandas as pd
+
+
+ALL_PANDAS_CLASSES = [
+    PandasAggregatedFeatureGroup,
+    PandasClusteringFeatureGroup,
+    PandasMissingValueFeatureGroup,
+    PandasDimensionalityReductionFeatureGroup,
+    PandasGeoDistanceFeatureGroup,
+    PandasNodeCentralityFeatureGroup,
+    PandasEncodingFeatureGroup,
+    PandasSklearnPipelineFeatureGroup,
+    PandasScalingFeatureGroup,
+    PandasTextCleaningFeatureGroup,
+]
+
+if HAS_TIME_WINDOW_PANDAS:
+    ALL_PANDAS_CLASSES.append(PandasTimeWindowFeatureGroup)
+
+if HAS_FORECASTING_PANDAS:
+    ALL_PANDAS_CLASSES.append(PandasForecastingFeatureGroup)
+
+
+@pytest.mark.parametrize("cls", ALL_PANDAS_CLASSES, ids=lambda c: c.__name__)
+class TestUnifiedCheckSourceFeaturesSignature:
+    """Verify every concrete plugin exposes _check_source_features_exist(cls, data, feature_names: List[str])."""
+
+    def test_method_exists(self, cls: Any) -> None:
+        """Every plugin must define _check_source_features_exist."""
+        assert hasattr(cls, "_check_source_features_exist"), f"{cls.__name__} is missing _check_source_features_exist"
+
+    def test_method_signature_has_three_params(self, cls: Any) -> None:
+        """Signature must be (cls, data, feature_names)."""
+        sig = inspect.signature(cls._check_source_features_exist)
+        params = list(sig.parameters.keys())
+        assert len(params) == 2, (
+            f"{cls.__name__}._check_source_features_exist has params {params}, expected (data, feature_names)"
+        )
+        assert params[1] == "feature_names", (
+            f"{cls.__name__}._check_source_features_exist second param is '{params[1]}', expected 'feature_names'"
+        )
+
+    def test_accepts_list_of_strings(self, cls: Any) -> None:
+        """Method must accept a List[str] as feature_names."""
+        df = pd.DataFrame({"col_a": [1, 2], "col_b": [3, 4]})
+        # Should not raise for existing features
+        cls._check_source_features_exist(df, ["col_a"])
+
+    def test_raises_on_missing_feature(self, cls: Any) -> None:
+        """Method must raise ValueError when a feature is missing."""
+        df = pd.DataFrame({"col_a": [1, 2], "col_b": [3, 4]})
+        with pytest.raises(ValueError):
+            cls._check_source_features_exist(df, ["nonexistent_column"])
+
+    def test_old_singular_method_absent(self, cls: Any) -> None:
+        """Old singular _check_source_feature_exists must not be present."""
+        assert not hasattr(cls, "_check_source_feature_exists"), (
+            f"{cls.__name__} still has the old singular _check_source_feature_exists method"
+        )
+
+    def test_old_point_method_absent(self, cls: Any) -> None:
+        """Old _check_point_features_exist must not be present."""
+        assert not hasattr(cls, "_check_point_features_exist"), (
+            f"{cls.__name__} still has the old _check_point_features_exist method"
+        )

--- a/tests/test_plugins/feature_group/experimental/test_dimensionality_reduction_feature_group/test_pandas_dimensionality_reduction_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/test_dimensionality_reduction_feature_group/test_pandas_dimensionality_reduction_feature_group.py
@@ -47,14 +47,17 @@ class TestPandasDimensionalityReductionFeatureGroup:
 
         return df
 
-    def test_check_source_feature_exists(self, sample_data: pd.DataFrame) -> None:
-        """Test the _check_source_feature_exists method."""
+    def test_check_source_features_exist(self, sample_data: pd.DataFrame) -> None:
+        """Test the _check_source_features_exist method."""
         # Valid feature
-        PandasDimensionalityReductionFeatureGroup._check_source_feature_exists(sample_data, "feature0")
+        PandasDimensionalityReductionFeatureGroup._check_source_features_exist(sample_data, ["feature0"])
+
+        # Multiple valid features
+        PandasDimensionalityReductionFeatureGroup._check_source_features_exist(sample_data, ["feature0", "feature1"])
 
         # Invalid feature
         with pytest.raises(ValueError):
-            PandasDimensionalityReductionFeatureGroup._check_source_feature_exists(sample_data, "invalid_feature")
+            PandasDimensionalityReductionFeatureGroup._check_source_features_exist(sample_data, ["invalid_feature"])
 
     def test_add_result_to_data(self, sample_data: pd.DataFrame) -> None:
         """Test the _add_result_to_data method."""

--- a/tests/test_plugins/feature_group/experimental/test_geo_distance_feature_group/test_geo_distance.py
+++ b/tests/test_plugins/feature_group/experimental/test_geo_distance_feature_group/test_geo_distance.py
@@ -77,17 +77,17 @@ class TestPandasGeoDistanceFeatureGroup:
             }
         )
 
-    def test_check_point_features_exist(self) -> None:
-        """Test checking if point features exist."""
+    def test_check_source_features_exist(self) -> None:
+        """Test checking if source features exist."""
         # Test with existing features
-        PandasGeoDistanceFeatureGroup._check_point_features_exist(self.df, "sf", "nyc")
+        PandasGeoDistanceFeatureGroup._check_source_features_exist(self.df, ["sf", "nyc"])
 
         # Test with non-existing features
         with pytest.raises(ValueError):
-            PandasGeoDistanceFeatureGroup._check_point_features_exist(self.df, "sf", "invalid")
+            PandasGeoDistanceFeatureGroup._check_source_features_exist(self.df, ["sf", "invalid"])
 
         with pytest.raises(ValueError):
-            PandasGeoDistanceFeatureGroup._check_point_features_exist(self.df, "invalid", "nyc")
+            PandasGeoDistanceFeatureGroup._check_source_features_exist(self.df, ["invalid", "nyc"])
 
     def test_haversine_distance(self) -> None:
         """Test calculation of haversine distance."""

--- a/tests/test_plugins/feature_group/experimental/test_node_centrality_feature_group/test_pandas_node_centrality_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/test_node_centrality_feature_group/test_pandas_node_centrality_feature_group.py
@@ -27,14 +27,17 @@ class TestPandasNodeCentralityFeatureGroup:
         ]
         return pd.DataFrame(edges)
 
-    def test_check_source_feature_exists(self, sample_data: pd.DataFrame) -> None:
-        """Test the _check_source_feature_exists method."""
+    def test_check_source_features_exist(self, sample_data: pd.DataFrame) -> None:
+        """Test the _check_source_features_exist method."""
         # Valid feature
-        PandasNodeCentralityFeatureGroup._check_source_feature_exists(sample_data, "source")
+        PandasNodeCentralityFeatureGroup._check_source_features_exist(sample_data, ["source"])
+
+        # Multiple valid features
+        PandasNodeCentralityFeatureGroup._check_source_features_exist(sample_data, ["source", "target"])
 
         # Invalid feature
         with pytest.raises(ValueError):
-            PandasNodeCentralityFeatureGroup._check_source_feature_exists(sample_data, "invalid_feature")
+            PandasNodeCentralityFeatureGroup._check_source_features_exist(sample_data, ["invalid_feature"])
 
     def test_add_result_to_data(self, sample_data: pd.DataFrame) -> None:
         """Test the _add_result_to_data method."""

--- a/tests/test_plugins/feature_group/experimental/test_text_cleaning/test_text_cleaning_pandas.py
+++ b/tests/test_plugins/feature_group/experimental/test_text_cleaning/test_text_cleaning_pandas.py
@@ -32,14 +32,14 @@ class TestPandasTextCleaningFeatureGroup:
             }
         )
 
-    def test_check_source_feature_exists(self) -> None:
+    def test_check_source_features_exist(self) -> None:
         """Test that the source feature existence check works correctly."""
         # Feature exists
-        PandasTextCleaningFeatureGroup._check_source_feature_exists(self.df, "text")
+        PandasTextCleaningFeatureGroup._check_source_features_exist(self.df, ["text"])
 
         # Feature doesn't exist
         with pytest.raises(ValueError) as excinfo:
-            PandasTextCleaningFeatureGroup._check_source_feature_exists(self.df, "nonexistent")
+            PandasTextCleaningFeatureGroup._check_source_features_exist(self.df, ["nonexistent"])
 
         assert "not found in the data" in str(excinfo.value)
 

--- a/tests/test_plugins/feature_group/experimental/test_text_cleaning/test_text_cleaning_python_dict.py
+++ b/tests/test_plugins/feature_group/experimental/test_text_cleaning/test_text_cleaning_python_dict.py
@@ -90,20 +90,20 @@ class TestPythonDictTextCleaningFeatureGroup:
         """Test compute_framework_rule method."""
         assert PythonDictTextCleaningFeatureGroup.compute_framework_rule() == {PythonDictFramework}
 
-    def test_check_source_feature_exists(self) -> None:
+    def test_check_source_features_exist(self) -> None:
         """Test that the source feature existence check works correctly."""
         # Feature exists
-        PythonDictTextCleaningFeatureGroup._check_source_feature_exists(self.data, "text")
+        PythonDictTextCleaningFeatureGroup._check_source_features_exist(self.data, ["text"])
 
         # Feature doesn't exist
         with pytest.raises(ValueError) as excinfo:
-            PythonDictTextCleaningFeatureGroup._check_source_feature_exists(self.data, "nonexistent")
+            PythonDictTextCleaningFeatureGroup._check_source_features_exist(self.data, ["nonexistent"])
 
         assert "not found in the data" in str(excinfo.value)
 
         # Empty data
         with pytest.raises(ValueError, match="Data cannot be empty"):
-            PythonDictTextCleaningFeatureGroup._check_source_feature_exists([], "text")
+            PythonDictTextCleaningFeatureGroup._check_source_features_exist([], ["text"])
 
     def test_get_source_text(self) -> None:
         """Test that the source text is correctly retrieved."""


### PR DESCRIPTION
## Summary

- Standardized all experimental feature group plugins to use a single `_check_source_features_exist(cls, data, feature_names: List[str])` signature
- Renamed singular `_check_source_feature_exists(data, feature_name: str)` in 6 plugin families (Encoding, Scaling, Pipeline, DimensionalityReduction, TextCleaning, NodeCentrality)
- Renamed `_check_point_features_exist(data, point1, point2)` in GeoDistance
- Added parametrized test validating the unified contract across all 12 concrete implementations

## Test plan

- [x] All 2543 existing tests pass
- [x] New `test_check_source_features_signature.py` validates unified signature across all plugins
- [x] ruff format/check clean
- [x] mypy strict clean
- [x] bandit clean
- [x] Full tox run green

Closes #296