### PR TITLE
fix: align DefaultOptionKeys.time_travel value with its name

### DIFF
--- a/docs/docs/in_depth/filter_data.md
+++ b/docs/docs/in_depth/filter_data.md
@@ -52,7 +52,7 @@ Parameters:
 -   valid_to (Optional[datetime]): End of the validity period (optional, with timezone).
 -   max_exclusive (bool): If True, the upper bounds (event_to, valid_to) are treated as exclusive.
 -   event_time_column: The column name containing event timestamps. Default is "reference_time".
--   validity_time_column: The column name containing validity timestamps. Default is "time_travel_filter".
+-   validity_time_column: The column name containing validity timestamps. Default is "time_travel".
 
 The **single_filters** created will be converted to UTC as ISO 8601 formatted strings to ensure consistency
     across time zones and avoid ambiguity when comparing or processing time-based data.
@@ -96,7 +96,7 @@ global_filter.filters
 Result
 
 ``` python
-{<SingleFilter(feature_name=time_travel_filter, type=range, parameters=(('max', '2022-12-31T00:00:00+00:00'), ('max_exclusive', True), ('min', '2022-01-01T00:00:00+00:00')))>,
+{<SingleFilter(feature_name=time_travel, type=range, parameters=(('max', '2022-12-31T00:00:00+00:00'), ('max_exclusive', True), ('min', '2022-01-01T00:00:00+00:00')))>,
  <SingleFilter(feature_name=reference_time, type=range, parameters=(('max', '2023-12-31T00:00:00+00:00'), ('max_exclusive', True), ('min', '2023-01-01T00:00:00+00:00')))>}
 ```
 

--- a/mloda/core/abstract_plugins/components/default_options_key.py
+++ b/mloda/core/abstract_plugins/components/default_options_key.py
@@ -10,7 +10,7 @@ class DefaultOptionKeys(str, Enum):
 
     Time-Related Keys:
     - `reference_time`: Key for the event timestamp column. Value: "reference_time"
-    - `time_travel`: Key for the validity timestamp column. Value: "time_travel_filter"
+    - `time_travel`: Key for the validity timestamp column. Value: "time_travel"
 
     Data Shaping Keys:
     - `group`: Key for grouping/partitioning columns. Value: "group"
@@ -23,7 +23,7 @@ class DefaultOptionKeys(str, Enum):
     in_features = "in_features"
     feature_chainer_parser_key = "feature_chainer_parser_key"
     reference_time = "reference_time"
-    time_travel = "time_travel_filter"
+    time_travel = "time_travel"
     default = "default"
     context = "context"
     group = "group"

--- a/tests/test_core/test_filter/test_time_travel.py
+++ b/tests/test_core/test_filter/test_time_travel.py
@@ -59,7 +59,7 @@ class TimeTravelPositiveFilterTest(FeatureGroup):
         _: Options,
         _2=None,
     ) -> bool:
-        if str(feature_name) in ["TimeTravelPositiveFilterTest", "reference_time", "time_travel_filter"]:
+        if str(feature_name) in ["TimeTravelPositiveFilterTest", "reference_time", "time_travel"]:
             return True
         return False
 

--- a/tests/test_plugins/feature_group/experimental/test_default_options_key.py
+++ b/tests/test_plugins/feature_group/experimental/test_default_options_key.py
@@ -17,7 +17,7 @@ class TestDefaultOptionKeys:
 
     def test_time_travel_value(self) -> None:
         """Verify DefaultOptionKeys.time_travel has the correct value."""
-        assert DefaultOptionKeys.time_travel.value == "time_travel_filter"
+        assert DefaultOptionKeys.time_travel.value == "time_travel"
 
     def test_time_related_keys_are_strings(self) -> None:
         """Verify time-related keys have string values."""
@@ -38,3 +38,23 @@ class TestDefaultOptionKeys:
         assert hasattr(DefaultOptionKeys, "time_travel")
         assert hasattr(DefaultOptionKeys, "reference_time")
         assert hasattr(DefaultOptionKeys, "order_by")
+
+    def test_all_member_names_match_values(self) -> None:
+        """Every enum member's name must equal its value to prevent silent mismatches.
+
+        A str-enum whose name differs from its value causes silent failures
+        when users pass the name as a string literal instead of the enum.
+        See: https://github.com/mloda-ai/mloda/issues/271
+        """
+        for member in DefaultOptionKeys:
+            assert member.name == member.value, (
+                f"DefaultOptionKeys.{member.name} has value {member.value!r}; name and value must be identical"
+            )
+
+    def test_string_literal_matches_enum(self) -> None:
+        """Using a string literal equal to the enum name must match the enum value.
+
+        This verifies the str-enum contract: DefaultOptionKeys.X == "X" for all X.
+        """
+        for member in DefaultOptionKeys:
+            assert member == member.name

--- a/tests/test_plugins/feature_group/test_default_options_key_graduation.py
+++ b/tests/test_plugins/feature_group/test_default_options_key_graduation.py
@@ -39,9 +39,21 @@ class TestDefaultOptionKeysCoreLocation:
         from mloda.provider import DefaultOptionKeys
 
         assert DefaultOptionKeys.reference_time.value == "reference_time"
-        assert DefaultOptionKeys.time_travel.value == "time_travel_filter"
+        assert DefaultOptionKeys.time_travel.value == "time_travel"
         assert DefaultOptionKeys.group.value == "group"
         assert DefaultOptionKeys.order_by.value == "order_by"
+
+    def test_all_member_names_match_values(self) -> None:
+        """Every enum member's name must equal its value to prevent silent mismatches.
+
+        See: https://github.com/mloda-ai/mloda/issues/271
+        """
+        from mloda.provider import DefaultOptionKeys
+
+        for member in DefaultOptionKeys:
+            assert member.name == member.value, (
+                f"DefaultOptionKeys.{member.name} has value {member.value!r}; name and value must be identical"
+            )
 
     def test_core_and_provider_same_class(self) -> None:
         from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys as Core


### PR DESCRIPTION
## Summary

- **Fixes the name/value mismatch** in `DefaultOptionKeys.time_travel`: the enum member name was `time_travel` but its string value was `"time_travel_filter"`, the only member in the entire enum with this inconsistency
- **Breaking change for string literal users**: anyone hardcoding `"time_travel_filter"` instead of using the enum must update to `"time_travel"` (this is the exact silent-failure scenario the issue describes)
- **Adds regression tests** that enforce `name == value` for all enum members, preventing this class of bug from recurring
- **Updates documentation** (`filter_data.md`) to reflect the corrected default value

## Impact

**Data users**: Using `"time_travel"` as a string key now correctly matches `DefaultOptionKeys.time_travel`, fixing the silent failure described in #271.

**Data producers**: The default `validity_time_column` in `add_time_and_time_travel_filters` now resolves to `"time_travel"` instead of `"time_travel_filter"`. Plugin authors matching against this string in `match_feature_group_criteria` must update accordingly.

## Test plan

- [x] All 2512 existing tests pass (no regressions)
- [x] New `test_all_member_names_match_values` test guards against future mismatches
- [x] New `test_string_literal_matches_enum` test verifies the str-enum contract
- [x] `ruff format`, `ruff check`, `mypy --strict`, `bandit` all pass
- [ ] CI checks pass on GitHub

Closes #271