### PR TITLE
fix: remove try/except blocks and undeclared deps from attribution script (#312)

### DIFF
--- a/attribution/ATTRIBUTION.md
+++ b/attribution/ATTRIBUTION.md
@@ -1,123 +1,121 @@
-| Name                                   | Version         | License                              |
-|----------------------------------------|-----------------|--------------------------------------|
-| CacheControl                           | 0.14.4          | Apache-2.0                           |
-| PyYAML                                 | 6.0.3           | MIT License                          |
-| Pygments                               | 2.19.2          | BSD License                          |
-| annotated-types                        | 0.7.0           | MIT License                          |
-| asttokens                              | 3.0.1           | Apache 2.0                           |
-| attrs                                  | 26.1.0          | MIT                                  |
-| bandit                                 | 1.9.4           | Apache-2.0                           |
-| cachetools                             | 6.2.6           | MIT                                  |
-| certifi                                | 2026.2.25       | Mozilla Public License 2.0 (MPL 2.0) |
-| charset-normalizer                     | 3.4.6           | MIT                                  |
-| click                                  | 8.3.1           | BSD-3-Clause                         |
-| comm                                   | 0.2.3           | BSD License                          |
-| cyclonedx-python-lib                   | 11.7.0          | Apache Software License              |
-| debugpy                                | 1.8.20          | MIT License                          |
-| decorator                              | 5.2.1           | BSD License                          |
-| defusedxml                             | 0.7.1           | Python Software Foundation License   |
-| duckdb                                 | 1.5.1           | MIT License                          |
-| exceptiongroup                         | 1.3.1           | MIT License                          |
-| execnet                                | 2.1.2           | MIT License                          |
-| executing                              | 2.2.1           | MIT License                          |
-| fastjsonschema                         | 2.21.2          | BSD License                          |
-| filelock                               | 3.25.2          | MIT License                          |
-| fsspec                                 | 2026.2.0        | BSD-3-Clause                         |
-| idna                                   | 3.11            | BSD-3-Clause                         |
-| importlib_metadata                     | 8.7.1           | Apache-2.0                           |
-| iniconfig                              | 2.3.0           | MIT                                  |
-| ipykernel                              | 7.2.0           | BSD-3-Clause                         |
-| ipython                                | 8.38.0          | BSD License                          |
-| jedi                                   | 0.19.2          | MIT License                          |
-| joblib                                 | 1.5.3           | BSD-3-Clause                         |
-| jsonschema                             | 4.26.0          | MIT                                  |
-| jsonschema-specifications              | 2025.9.1        | MIT                                  |
-| jupyter_client                         | 8.8.0           | BSD License                          |
-| jupyter_core                           | 5.9.1           | BSD-3-Clause                         |
-| librt                                  | 0.8.1           | MIT License                          |
-| markdown-it-py                         | 4.0.0           | MIT License                          |
-| matplotlib-inline                      | 0.2.1           | UNKNOWN                              |
-| mdurl                                  | 0.1.2           | MIT License                          |
-| mktestdocs                             | 0.2.5           | MIT                                  |
-| mloda                                  | 0.5.5           | Apache-2.0                           |
-| mmh3                                   | 5.2.1           | MIT License                          |
-| msgpack                                | 1.1.2           | Apache-2.0                           |
-| mypy                                   | 1.19.1          | MIT License                          |
-| mypy_extensions                        | 1.1.0           | MIT                                  |
-| nbclient                               | 0.10.4          | BSD License                          |
-| nbformat                               | 5.10.4          | BSD License                          |
-| nest-asyncio                           | 1.6.0           | BSD License                          |
-| nltk                                   | 3.9.4           | Apache Software License              |
-| numpy                                  | 2.2.6           | BSD License                          |
-| opentelemetry-api                      | 1.40.0          | Apache-2.0                           |
-| opentelemetry-instrumentation          | 0.61b0          | Apache Software License              |
-| opentelemetry-instrumentation-logging  | 0.61b0          | Apache Software License              |
-| opentelemetry-instrumentation-requests | 0.61b0          | Apache Software License              |
-| opentelemetry-sdk                      | 1.40.0          | Apache-2.0                           |
-| opentelemetry-semantic-conventions     | 0.61b0          | Apache-2.0                           |
-| opentelemetry-util-http                | 0.61b0          | Apache Software License              |
-| packageurl-python                      | 0.17.6          | MIT License                          |
-| packaging                              | 26.0            | Apache-2.0 OR BSD-2-Clause           |
-| pandas                                 | 2.3.3           | BSD License                          |
-| pandera                                | 0.30.1          | MIT License                          |
-| parso                                  | 0.8.6           | MIT License                          |
-| pathspec                               | 1.0.4           | Mozilla Public License 2.0 (MPL 2.0) |
-| pexpect                                | 4.9.0           | ISC License (ISCL)                   |
-| pip-api                                | 0.0.34          | Apache Software License              |
-| pip-requirements-parser                | 32.0.1          | MIT                                  |
-| pip_audit                              | 2.10.0          | Apache Software License              |
-| platformdirs                           | 4.9.4           | MIT License                          |
-| pluggy                                 | 1.6.0           | MIT License                          |
-| polars                                 | 1.39.3          | MIT License                          |
-| polars-runtime-32                      | 1.39.3          | MIT License                          |
-| prompt_toolkit                         | 3.0.52          | BSD License                          |
-| psutil                                 | 7.2.2           | BSD-3-Clause                         |
-| ptyprocess                             | 0.7.0           | ISC License (ISCL)                   |
-| pure_eval                              | 0.2.3           | MIT License                          |
-| py-serializable                        | 2.1.0           | Apache Software License              |
-| pyarrow                                | 23.0.1          | Apache-2.0                           |
-| pydantic                               | 2.12.5          | MIT                                  |
-| pydantic_core                          | 2.41.5          | MIT                                  |
-| pyiceberg                              | 0.11.1          | Apache-2.0                           |
-| pyparsing                              | 3.3.2           | MIT                                  |
-| pyroaring                              | 1.0.4           | MIT License                          |
-| pytest                                 | 9.0.2           | MIT                                  |
-| pytest-order                           | 1.3.0           | MIT License                          |
-| pytest-timeout                         | 2.4.0           | DFSG approved; MIT License           |
-| pytest-xdist                           | 3.8.0           | MIT                                  |
-| python-dateutil                        | 2.9.0.post0     | Apache Software License; BSD License |
-| pytz                                   | 2026.1.post1    | MIT License                          |
-| pyzmq                                  | 27.1.0          | BSD License                          |
-| referencing                            | 0.37.0          | MIT                                  |
-| regex                                  | 2026.2.28       | Apache-2.0 AND CNRI-Python           |
-| requests                               | 2.33.0          | Apache Software License              |
-| rich                                   | 14.3.3          | MIT License                          |
-| rpds-py                                | 0.30.0          | MIT                                  |
-| ruff                                   | 0.15.7          | MIT License                          |
-| scikit-learn                           | 1.7.2           | BSD-3-Clause                         |
-| scipy                                  | 1.15.3          | BSD License                          |
-| six                                    | 1.17.0          | MIT License                          |
-| sortedcontainers                       | 2.4.0           | Apache Software License              |
-| stack-data                             | 0.6.3           | MIT License                          |
-| stevedore                              | 5.7.0           | Apache Software License              |
-| strictyaml                             | 1.7.3           | MIT License                          |
-| tenacity                               | 9.1.4           | Apache Software License              |
-| testbook                               | 0.4.2           | BSD License                          |
-| threadpoolctl                          | 3.6.0           | BSD License                          |
-| toml                                   | 0.10.2          | MIT License                          |
-| tomli_w                                | 1.2.0           | MIT License                          |
-| tornado                                | 6.5.5           | Apache Software License              |
-| tqdm                                   | 4.67.3          | MPL-2.0 AND MIT                      |
-| traitlets                              | 5.14.3          | BSD License                          |
-| typeguard                              | 4.5.1           | MIT                                  |
-| types-PyYAML                           | 6.0.12.20250915 | Apache-2.0                           |
-| types-requests                         | 2.32.4.20260324 | Apache-2.0                           |
-| types-toml                             | 0.10.8.20240310 | Apache Software License              |
-| typing-inspect                         | 0.9.0           | MIT License                          |
-| typing-inspection                      | 0.4.2           | MIT                                  |
-| typing_extensions                      | 4.15.0          | PSF-2.0                              |
-| tzdata                                 | 2025.3          | Apache-2.0                           |
-| urllib3                                | 2.6.3           | MIT                                  |
-| wrapt                                  | 1.17.3          | BSD License                          |
-| zipp                                   | 3.23.0          | MIT                                  |
-| zstandard                              | 0.25.0          | BSD-3-Clause                         |
+| Name                                   | Version         | License                                            |
+|----------------------------------------|-----------------|----------------------------------------------------|
+| CacheControl                           | 0.14.4          | Apache-2.0                                         |
+| PyYAML                                 | 6.0.3           | MIT License                                        |
+| Pygments                               | 2.20.0          | BSD-2-Clause                                       |
+| annotated-types                        | 0.7.0           | MIT License                                        |
+| asttokens                              | 3.0.1           | Apache 2.0                                         |
+| attrs                                  | 26.1.0          | MIT                                                |
+| bandit                                 | 1.9.4           | Apache-2.0                                         |
+| cachetools                             | 6.2.6           | MIT                                                |
+| certifi                                | 2026.2.25       | Mozilla Public License 2.0 (MPL 2.0)               |
+| charset-normalizer                     | 3.4.7           | MIT                                                |
+| click                                  | 8.3.2           | BSD-3-Clause                                       |
+| comm                                   | 0.2.3           | BSD License                                        |
+| cyclonedx-python-lib                   | 11.7.0          | Apache Software License                            |
+| debugpy                                | 1.8.20          | MIT License                                        |
+| decorator                              | 5.2.1           | BSD License                                        |
+| defusedxml                             | 0.7.1           | Python Software Foundation License                 |
+| duckdb                                 | 1.5.1           | MIT License                                        |
+| execnet                                | 2.1.2           | MIT License                                        |
+| executing                              | 2.2.1           | MIT License                                        |
+| fastjsonschema                         | 2.21.2          | BSD License                                        |
+| filelock                               | 3.25.2          | MIT License                                        |
+| fsspec                                 | 2026.3.0        | BSD-3-Clause                                       |
+| idna                                   | 3.11            | BSD-3-Clause                                       |
+| importlib_metadata                     | 8.7.1           | Apache-2.0                                         |
+| iniconfig                              | 2.3.0           | MIT                                                |
+| ipykernel                              | 7.2.0           | BSD-3-Clause                                       |
+| ipython                                | 9.12.0          | BSD-3-Clause                                       |
+| ipython_pygments_lexers                | 1.1.1           | BSD License                                        |
+| jedi                                   | 0.19.2          | MIT License                                        |
+| joblib                                 | 1.5.3           | BSD-3-Clause                                       |
+| jsonschema                             | 4.26.0          | MIT                                                |
+| jsonschema-specifications              | 2025.9.1        | MIT                                                |
+| jupyter_client                         | 8.8.0           | BSD License                                        |
+| jupyter_core                           | 5.9.1           | BSD-3-Clause                                       |
+| librt                                  | 0.8.1           | MIT License                                        |
+| markdown-it-py                         | 4.0.0           | MIT License                                        |
+| matplotlib-inline                      | 0.2.1           | UNKNOWN                                            |
+| mdurl                                  | 0.1.2           | MIT License                                        |
+| mktestdocs                             | 0.2.5           | MIT                                                |
+| mloda                                  | 0.5.7           | Apache-2.0                                         |
+| mmh3                                   | 5.2.1           | MIT License                                        |
+| msgpack                                | 1.1.2           | Apache-2.0                                         |
+| mypy                                   | 1.20.0          | MIT                                                |
+| mypy_extensions                        | 1.1.0           | MIT                                                |
+| nbclient                               | 0.10.4          | BSD License                                        |
+| nbformat                               | 5.10.4          | BSD License                                        |
+| nest-asyncio                           | 1.6.0           | BSD License                                        |
+| nltk                                   | 3.9.4           | Apache Software License                            |
+| numpy                                  | 2.4.4           | BSD-3-Clause AND 0BSD AND MIT AND Zlib AND CC0-1.0 |
+| opentelemetry-api                      | 1.40.0          | Apache-2.0                                         |
+| opentelemetry-instrumentation          | 0.61b0          | Apache Software License                            |
+| opentelemetry-instrumentation-logging  | 0.61b0          | Apache Software License                            |
+| opentelemetry-instrumentation-requests | 0.61b0          | Apache Software License                            |
+| opentelemetry-sdk                      | 1.40.0          | Apache-2.0                                         |
+| opentelemetry-semantic-conventions     | 0.61b0          | Apache-2.0                                         |
+| opentelemetry-util-http                | 0.61b0          | Apache Software License                            |
+| packageurl-python                      | 0.17.6          | MIT License                                        |
+| packaging                              | 26.0            | Apache-2.0 OR BSD-2-Clause                         |
+| pandas                                 | 3.0.2           | BSD License                                        |
+| pandera                                | 0.30.1          | MIT License                                        |
+| parso                                  | 0.8.6           | MIT License                                        |
+| pathspec                               | 1.0.4           | Mozilla Public License 2.0 (MPL 2.0)               |
+| pexpect                                | 4.9.0           | ISC License (ISCL)                                 |
+| pip-api                                | 0.0.34          | Apache Software License                            |
+| pip-requirements-parser                | 32.0.1          | MIT                                                |
+| pip_audit                              | 2.10.0          | Apache Software License                            |
+| platformdirs                           | 4.9.4           | MIT License                                        |
+| pluggy                                 | 1.6.0           | MIT License                                        |
+| polars                                 | 1.39.3          | MIT License                                        |
+| polars-runtime-32                      | 1.39.3          | MIT License                                        |
+| prompt_toolkit                         | 3.0.52          | BSD License                                        |
+| psutil                                 | 7.2.2           | BSD-3-Clause                                       |
+| ptyprocess                             | 0.7.0           | ISC License (ISCL)                                 |
+| pure_eval                              | 0.2.3           | MIT License                                        |
+| py-serializable                        | 2.1.0           | Apache Software License                            |
+| pyarrow                                | 23.0.1          | Apache-2.0                                         |
+| pydantic                               | 2.12.5          | MIT                                                |
+| pydantic_core                          | 2.41.5          | MIT                                                |
+| pyiceberg                              | 0.11.1          | Apache-2.0                                         |
+| pyparsing                              | 3.3.2           | MIT                                                |
+| pyroaring                              | 1.0.4           | MIT License                                        |
+| pytest                                 | 9.0.2           | MIT                                                |
+| pytest-order                           | 1.3.0           | MIT License                                        |
+| pytest-timeout                         | 2.4.0           | DFSG approved; MIT License                         |
+| pytest-xdist                           | 3.8.0           | MIT                                                |
+| python-dateutil                        | 2.9.0.post0     | Apache Software License; BSD License               |
+| pyzmq                                  | 27.1.0          | BSD License                                        |
+| referencing                            | 0.37.0          | MIT                                                |
+| regex                                  | 2026.4.4        | Apache-2.0 AND CNRI-Python                         |
+| requests                               | 2.33.1          | Apache Software License                            |
+| rich                                   | 14.3.3          | MIT License                                        |
+| rpds-py                                | 0.30.0          | MIT                                                |
+| ruff                                   | 0.15.9          | MIT License                                        |
+| scikit-learn                           | 1.8.0           | BSD-3-Clause                                       |
+| scipy                                  | 1.17.1          | BSD License                                        |
+| six                                    | 1.17.0          | MIT License                                        |
+| sortedcontainers                       | 2.4.0           | Apache Software License                            |
+| stack-data                             | 0.6.3           | MIT License                                        |
+| stevedore                              | 5.7.0           | Apache Software License                            |
+| strictyaml                             | 1.7.3           | MIT License                                        |
+| tenacity                               | 9.1.4           | Apache Software License                            |
+| testbook                               | 0.4.2           | BSD License                                        |
+| threadpoolctl                          | 3.6.0           | BSD License                                        |
+| tomli                                  | 2.4.1           | MIT                                                |
+| tomli_w                                | 1.2.0           | MIT License                                        |
+| tornado                                | 6.5.5           | Apache Software License                            |
+| tqdm                                   | 4.67.3          | MPL-2.0 AND MIT                                    |
+| traitlets                              | 5.14.3          | BSD License                                        |
+| typeguard                              | 4.5.1           | MIT                                                |
+| types-PyYAML                           | 6.0.12.20250915 | Apache-2.0                                         |
+| types-requests                         | 2.33.0.20260402 | Apache-2.0                                         |
+| types-toml                             | 0.10.8.20240310 | Apache Software License                            |
+| typing-inspect                         | 0.9.0           | MIT License                                        |
+| typing-inspection                      | 0.4.2           | MIT                                                |
+| typing_extensions                      | 4.15.0          | PSF-2.0                                            |
+| urllib3                                | 2.6.3           | MIT                                                |
+| wrapt                                  | 1.17.3          | BSD License                                        |
+| zipp                                   | 3.23.0          | MIT                                                |
+| zstandard                              | 0.25.0          | BSD-3-Clause                                       |

--- a/attribution/attributions.py
+++ b/attribution/attributions.py
@@ -1,33 +1,31 @@
+import os
 import shutil
 import subprocess  # nosec
+import sys
 from typing import Any, List
-import requests
-import toml
-import os
+from urllib.request import urlopen
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 
 def download_files(base_url: str, files: List[str], output_dir: str = ".") -> None:
     """Downloads files from a given base URL."""
     for f in files:
         url = f"{base_url}{f}"
-        try:
-            with requests.get(url, stream=True) as r:
-                r.raise_for_status()
-                with open(os.path.join(output_dir, f), "wb") as out:
-                    for chunk in r.iter_content(8192):
-                        out.write(chunk)
-            print(f"Downloaded {f} successfully.")
-        except requests.exceptions.RequestException as e:
-            print(f"Error downloading {f}: {e}")
+        with urlopen(url) as response:  # nosec
+            with open(os.path.join(output_dir, f), "wb") as out:
+                while chunk := response.read(8192):
+                    out.write(chunk)
+        print(f"Downloaded {f} successfully.")
 
 
 def get_version(path: str = "pyproject.toml") -> Any:
     """Extracts the version from a pyproject.toml file."""
-    try:
-        return toml.load(path)["project"]["version"]
-    except (FileNotFoundError, toml.TomlDecodeError, KeyError) as e:
-        print(f"Error reading version: {e}")
-        return None
+    with open(path, "rb") as f:
+        return tomllib.load(f)["project"]["version"]
 
 
 def remove_tox() -> bool:
@@ -35,12 +33,8 @@ def remove_tox() -> bool:
     tox_dir = ".tox"
     if os.path.exists(tox_dir):
         print(f"Removing existing {tox_dir} directory...")
-        try:
-            shutil.rmtree(tox_dir)
-            print(f"{tox_dir} directory removed successfully.")
-        except OSError as e:
-            print(f"Error removing {tox_dir}: {e}")
-            return False
+        shutil.rmtree(tox_dir)
+        print(f"{tox_dir} directory removed successfully.")
     else:
         print(f"{tox_dir} does not exist. Continuing.")
     return True
@@ -49,13 +43,9 @@ def remove_tox() -> bool:
 def run_tox() -> bool:
     """Executes the tox command"""
     print("Running tox command...")
-    try:
-        subprocess.run(["tox"], check=True)
-        print("tox command executed successfully.")
-        return True
-    except subprocess.CalledProcessError as e:
-        print(f"Error running tox: {e}")
-        return False
+    subprocess.run(["tox"], check=True)
+    print("tox command executed successfully.")
+    return True
 
 
 def add_file_to_git(files: List[str], out: str) -> None:
@@ -63,11 +53,8 @@ def add_file_to_git(files: List[str], out: str) -> None:
     for file in files:
         file_path = os.path.join(out, file)
         print(f"Adding {file_path} to git staging area.")
-        try:
-            subprocess.run(["git", "add", file_path], check=True)
-            print(f"{file_path} was successfully added to the git staging area.")
-        except subprocess.CalledProcessError as e:
-            print(f"Error adding {file_path} to git index {e}")
+        subprocess.run(["git", "add", file_path], check=True)
+        print(f"{file_path} was successfully added to the git staging area.")
 
 
 if __name__ == "__main__":
@@ -79,20 +66,18 @@ if __name__ == "__main__":
     """
 
     files = ["THIRD_PARTY_LICENSES.md"]
-    base = f"https://github.com/mloda-ai/mloda/releases/download/{get_version()}/"
+    version = get_version()
+    print(f"Version: {version}")
+
+    base = f"https://github.com/mloda-ai/mloda/releases/download/{version}/"
     out = "attribution/"
 
-    try:
-        if version := get_version():
-            print(f"Version: {version}")
-            download_files(base, files, out)
-            add_file_to_git(files, out)
-            remove_tox()
-            os.environ["TOX_WRITE_THIRD_PARTY_LICENSES"] = "true"
-            run_tox()
-        else:
-            print("Exiting")
+    download_files(base, files, out)
+    add_file_to_git(files, out)
+    remove_tox()
 
+    os.environ["TOX_WRITE_THIRD_PARTY_LICENSES"] = "true"
+    try:
+        run_tox()
     finally:
-        if "TOX_WRITE_THIRD_PARTY_LICENSES" in os.environ:
-            del os.environ["TOX_WRITE_THIRD_PARTY_LICENSES"]
+        del os.environ["TOX_WRITE_THIRD_PARTY_LICENSES"]

--- a/tests/test_attributions.py
+++ b/tests/test_attributions.py
@@ -1,0 +1,96 @@
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from attribution.attributions import add_file_to_git, download_files, get_version, remove_tox, run_tox
+
+
+class TestGetVersion:
+    def test_reads_version_from_valid_pyproject(self, tmp_path: Path) -> None:
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text('[project]\nversion = "1.2.3"\n')
+        assert get_version(str(pyproject)) == "1.2.3"
+
+    def test_raises_on_missing_file(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            get_version(str(tmp_path / "nonexistent.toml"))
+
+    def test_raises_on_missing_key(self, tmp_path: Path) -> None:
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text("[project]\n")
+        with pytest.raises(KeyError):
+            get_version(str(pyproject))
+
+
+class TestDownloadFiles:
+    @patch("attribution.attributions.urlopen")
+    def test_downloads_file_to_output_dir(self, mock_urlopen: MagicMock, tmp_path: Path) -> None:
+        mock_response = MagicMock()
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_response.read = MagicMock(side_effect=[b"file content", b""])
+
+        mock_urlopen.return_value = mock_response
+
+        download_files("https://example.com/", ["test.txt"], str(tmp_path))
+
+        mock_urlopen.assert_called_once_with("https://example.com/test.txt")
+        assert (tmp_path / "test.txt").read_bytes() == b"file content"
+
+    @patch("attribution.attributions.urlopen")
+    def test_downloads_multiple_files(self, mock_urlopen: MagicMock, tmp_path: Path) -> None:
+        mock_response = MagicMock()
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_response.read = MagicMock(side_effect=[b"content1", b"", b"content2", b""])
+
+        mock_urlopen.return_value = mock_response
+
+        download_files("https://example.com/", ["a.txt", "b.txt"], str(tmp_path))
+
+        assert mock_urlopen.call_count == 2
+
+
+class TestRemoveTox:
+    def test_removes_existing_tox_directory(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        tox_dir = tmp_path / ".tox"
+        tox_dir.mkdir()
+        (tox_dir / "somefile").touch()
+
+        assert remove_tox() is True
+        assert not tox_dir.exists()
+
+    def test_returns_true_when_tox_does_not_exist(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        assert remove_tox() is True
+
+
+class TestRunTox:
+    @patch("attribution.attributions.subprocess.run")
+    def test_calls_tox(self, mock_run: MagicMock) -> None:
+        assert run_tox() is True
+        mock_run.assert_called_once_with(["tox"], check=True)
+
+    @patch("attribution.attributions.subprocess.run", side_effect=subprocess.CalledProcessError(1, "tox"))
+    def test_raises_on_tox_failure(self, mock_run: MagicMock) -> None:
+        with pytest.raises(subprocess.CalledProcessError):
+            run_tox()
+
+
+class TestAddFileToGit:
+    @patch("attribution.attributions.subprocess.run")
+    def test_stages_files(self, mock_run: MagicMock) -> None:
+        add_file_to_git(["a.md", "b.md"], "output/")
+        assert mock_run.call_args_list == [
+            call(["git", "add", os.path.join("output/", "a.md")], check=True),
+            call(["git", "add", os.path.join("output/", "b.md")], check=True),
+        ]
+
+    @patch("attribution.attributions.subprocess.run", side_effect=subprocess.CalledProcessError(1, "git"))
+    def test_raises_on_git_failure(self, mock_run: MagicMock) -> None:
+        with pytest.raises(subprocess.CalledProcessError):
+            add_file_to_git(["file.md"], "output/")


### PR DESCRIPTION
## Summary
- Replace undeclared `requests` dependency with stdlib `urllib.request` for file downloads
- Replace undeclared `toml` dependency with `tomllib`/`tomli` (matching existing project pattern in `test_project_structure.py`)
- Remove all six try/except blocks from `attribution/attributions.py` to comply with project convention; errors now propagate naturally
- Regenerate `ATTRIBUTION.md` to fix stale Pygments version (2.19.2 -> 2.20.0)
- Add unit tests for all five attribution utility functions (`get_version`, `download_files`, `remove_tox`, `run_tox`, `add_file_to_git`)

## Test plan
- [x] All new tests pass (`tests/test_attributions.py`)
- [x] Full `tox` suite green (2699 passed, 124 skipped)
- [x] `ruff format` and `ruff check` clean
- [x] `mypy --strict` clean
- [x] `bandit` clean
- [x] `ATTRIBUTION.md` regenerated with correct Pygments 2.20.0

Closes #312