### PR TITLE
fix: remove dead PATTERN attribute and use CHAIN_SEPARATOR constant (#301)

### DIFF
--- a/mloda_plugins/feature_group/experimental/clustering/base.py
+++ b/mloda_plugins/feature_group/experimental/clustering/base.py
@@ -9,7 +9,7 @@ from typing import Any, List, Optional, Set, Union
 
 from mloda.provider import FeatureGroup
 from mloda.user import Feature
-from mloda.provider import FeatureChainParser
+from mloda.provider import CHAIN_SEPARATOR, FeatureChainParser
 from mloda.provider import (
     FeatureChainParserMixin,
 )
@@ -166,7 +166,7 @@ class ClusteringFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             ValueError: If the suffix doesn't match the expected pattern
         """
         # Extract the suffix part (everything after the double underscore)
-        suffix_start = feature_name.find("__")
+        suffix_start = feature_name.find(CHAIN_SEPARATOR)
         if suffix_start == -1:
             raise ValueError(
                 f"Invalid clustering feature name format: {feature_name}. Missing double underscore separator."

--- a/mloda_plugins/feature_group/experimental/dimensionality_reduction/base.py
+++ b/mloda_plugins/feature_group/experimental/dimensionality_reduction/base.py
@@ -9,7 +9,7 @@ from typing import Any, List, Optional
 
 from mloda.provider import FeatureGroup
 from mloda.user import Feature
-from mloda.provider import FeatureChainParser
+from mloda.provider import CHAIN_SEPARATOR, FeatureChainParser
 from mloda.provider import (
     FeatureChainParserMixin,
 )
@@ -214,13 +214,13 @@ class DimensionalityReductionFeatureGroup(FeatureChainParserMixin, FeatureGroup)
             ValueError: If the suffix doesn't match the expected pattern
         """
         # Extract the suffix part (everything after the last double underscore)
-        suffix_start = feature_name.rfind("__")
+        suffix_start = feature_name.rfind(CHAIN_SEPARATOR)
         if suffix_start == -1:
             raise ValueError(
                 f"Invalid dimensionality reduction feature name format: {feature_name}. Missing double underscore separator."
             )
 
-        suffix = feature_name[suffix_start + 2 :]  # Skip the "__"
+        suffix = feature_name[suffix_start + len(CHAIN_SEPARATOR) :]
 
         # Parse the suffix components
         parts = suffix.split("_")

--- a/mloda_plugins/feature_group/experimental/forecasting/base.py
+++ b/mloda_plugins/feature_group/experimental/forecasting/base.py
@@ -10,7 +10,7 @@ from typing import Any, List, Optional, Set, Type
 from mloda.provider import FeatureGroup
 from mloda.provider import BaseArtifact
 from mloda.user import Feature
-from mloda.provider import FeatureChainParser, FeatureChainParserMixin, FeatureSet
+from mloda.provider import CHAIN_SEPARATOR, FeatureChainParser, FeatureChainParserMixin, FeatureSet
 from mloda.user import FeatureName
 from mloda.user import Options
 from mloda.provider import DefaultOptionKeys
@@ -235,7 +235,7 @@ class ForecastingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             ValueError: If the suffix doesn't match the expected pattern
         """
         # Extract the suffix part (everything after the double underscore)
-        suffix_start = feature_name.find("__")
+        suffix_start = feature_name.find(CHAIN_SEPARATOR)
         if suffix_start == -1:
             raise ValueError(
                 f"Invalid forecast feature name format: {feature_name}. Missing double underscore separator."
@@ -433,7 +433,7 @@ class ForecastingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     @classmethod
     def _has_valid_forecast_suffix(cls, feature_name: str) -> bool:
         """Check if feature_name has a suffix matching the forecast pattern."""
-        suffix_start = feature_name.find("__")
+        suffix_start = feature_name.find(CHAIN_SEPARATOR)
         if suffix_start == -1:
             return False
         suffix = feature_name[suffix_start + 2 :]

--- a/mloda_plugins/feature_group/experimental/geo_distance/base.py
+++ b/mloda_plugins/feature_group/experimental/geo_distance/base.py
@@ -12,7 +12,7 @@ from mloda.user import Feature
 from mloda.user import FeatureName
 from mloda.provider import FeatureSet
 from mloda.user import Options
-from mloda.provider import FeatureChainParser
+from mloda.provider import CHAIN_SEPARATOR, FeatureChainParser
 from mloda.provider import (
     FeatureChainParserMixin,
 )
@@ -129,7 +129,7 @@ class GeoDistanceFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         # For L->R: "point1&point2__distance_type_distance"
         # We need to extract everything before the last "__"
         feature_name_str = feature_name
-        parts = feature_name_str.rsplit("__", 1)
+        parts = feature_name_str.rsplit(CHAIN_SEPARATOR, 1)
         if len(parts) == 2:
             # parts[0] contains "point1&point2", parts[1] contains "distance_type_distance"
             point_parts = parts[0].split("&", 1)
@@ -165,7 +165,7 @@ class GeoDistanceFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         """Extract the two point features from the feature name."""
         # For L->R: "point1&point2__distance_type_distance"
         # Split from right to remove the distance suffix
-        parts = feature_name.rsplit("__", 1)
+        parts = feature_name.rsplit(CHAIN_SEPARATOR, 1)
         if len(parts) != 2:
             raise ValueError(
                 f"Invalid geo distance feature name format: {feature_name}. Missing double underscore separator."

--- a/mloda_plugins/feature_group/experimental/node_centrality/base.py
+++ b/mloda_plugins/feature_group/experimental/node_centrality/base.py
@@ -9,7 +9,7 @@ from typing import Any, List, Optional
 
 from mloda.provider import FeatureGroup
 from mloda.user import Feature
-from mloda.provider import FeatureChainParser
+from mloda.provider import CHAIN_SEPARATOR, FeatureChainParser
 from mloda.provider import (
     FeatureChainParserMixin,
 )
@@ -179,7 +179,7 @@ class NodeCentralityFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             ValueError: If the suffix doesn't match the expected pattern
         """
         # Extract the suffix part (everything after the LAST double underscore for L→R format)
-        suffix_start = feature_name.rfind("__")
+        suffix_start = feature_name.rfind(CHAIN_SEPARATOR)
         if suffix_start == -1:
             raise ValueError(
                 f"Invalid centrality feature name format: {feature_name}. Missing double underscore separator."

--- a/mloda_plugins/feature_group/experimental/node_centrality/pandas.py
+++ b/mloda_plugins/feature_group/experimental/node_centrality/pandas.py
@@ -14,7 +14,7 @@ except ImportError:
     pd = None
     np = None  # type: ignore
 
-from mloda.provider import ComputeFramework
+from mloda.provider import CHAIN_SEPARATOR, ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 from mloda_plugins.feature_group.experimental.node_centrality.base import NodeCentralityFeatureGroup
 
@@ -60,10 +60,10 @@ class PandasNodeCentralityFeatureGroup(NodeCentralityFeatureGroup):
         node_to_score = result.to_dict()
 
         # Check if the feature name follows the expected format with a double underscore
-        if "__" in feature_name:
+        if CHAIN_SEPARATOR in feature_name:
             # Extract the node feature name from the feature name (L→R format: source__operation)
             # Get everything BEFORE the last "__"
-            node_feature = feature_name[: feature_name.rfind("__")]
+            node_feature = feature_name[: feature_name.rfind(CHAIN_SEPARATOR)]
 
             # If the node feature is in the DataFrame, use it to map nodes to scores
             if node_feature in data.columns:

--- a/mloda_plugins/feature_group/experimental/sklearn/encoding/base.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/encoding/base.py
@@ -170,8 +170,6 @@ class EncodingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         "ordinal": "OrdinalEncoder",
     }
 
-    # Define patterns for parsing
-    PATTERN = "__"
     PREFIX_PATTERN = r".*__(onehot|label|ordinal)_encoded(~\d+)?$"
 
     # In-feature configuration for FeatureChainParserMixin

--- a/mloda_plugins/feature_group/experimental/sklearn/pipeline/base.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/pipeline/base.py
@@ -115,8 +115,6 @@ class SklearnPipelineFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         },
     }
 
-    # Define patterns for parsing
-    PATTERN = "__"
     PREFIX_PATTERN = r".*__sklearn_pipeline_([\w]+)$"
 
     # In-feature configuration for FeatureChainParserMixin

--- a/mloda_plugins/feature_group/experimental/sklearn/scaling/base.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/scaling/base.py
@@ -80,8 +80,6 @@ class ScalingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         "normalizer": "Normalizer",
     }
 
-    # Define patterns for parsing
-    PATTERN = "__"
     PREFIX_PATTERN = r".*__(standard|minmax|robust|normalizer)_scaled$"
 
     # In-feature configuration for FeatureChainParserMixin

--- a/mloda_plugins/feature_group/experimental/text_cleaning/base.py
+++ b/mloda_plugins/feature_group/experimental/text_cleaning/base.py
@@ -83,8 +83,7 @@ class TextCleaningFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         "remove_urls": "Remove URLs and email addresses",
     }
 
-    # Define prefix pattern and pattern
-    PATTERN = "__"
+    # Define prefix pattern
     PREFIX_PATTERN = r".*__cleaned_text$"
 
     # In-feature configuration for FeatureChainParserMixin

--- a/mloda_plugins/feature_group/experimental/time_window/base.py
+++ b/mloda_plugins/feature_group/experimental/time_window/base.py
@@ -9,7 +9,7 @@ from typing import Any, List, Optional, Set
 
 from mloda.provider import FeatureGroup
 from mloda.user import Feature
-from mloda.provider import FeatureChainParser
+from mloda.provider import CHAIN_SEPARATOR, FeatureChainParser
 from mloda.provider import (
     FeatureChainParserMixin,
 )
@@ -153,8 +153,7 @@ class TimeWindowFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         },
     }
 
-    # Define the pattern separator and regex for this feature group
-    PATTERN = "__"
+    # Define the regex pattern for this feature group
     PREFIX_PATTERN = r".*__([\w]+)_(\d+)_([\w]+)_window$"
 
     # In-feature configuration for FeatureChainParserMixin
@@ -186,7 +185,7 @@ class TimeWindowFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     @classmethod
     def _has_valid_time_window_suffix(cls, feature_name: str) -> bool:
         """Check if feature_name has a suffix matching the time window pattern."""
-        suffix_start = feature_name.rfind("__")
+        suffix_start = feature_name.rfind(CHAIN_SEPARATOR)
         if suffix_start == -1:
             return False
         suffix = feature_name[suffix_start + 2 :]
@@ -272,7 +271,7 @@ class TimeWindowFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         """
         # Extract the suffix part (everything after the last double underscore before the window pattern)
         # Use rfind to support chained features in L->R format (e.g., price__mean_imputed__sum_7_day_window)
-        suffix_start = feature_name.rfind("__")
+        suffix_start = feature_name.rfind(CHAIN_SEPARATOR)
         if suffix_start == -1:
             raise ValueError(
                 f"Invalid time window feature name format: {feature_name}. Missing double underscore separator."

--- a/tests/test_plugins/test_pattern_consistency.py
+++ b/tests/test_plugins/test_pattern_consistency.py
@@ -1,0 +1,126 @@
+"""Tests that enforce consistent usage of CHAIN_SEPARATOR across experimental plugins.
+
+These tests detect two categories of violations:
+1. Dead-code PATTERN = "__" class attributes that are never read by framework code.
+2. Hardcoded "__" string literals in method bodies that should use CHAIN_SEPARATOR.
+"""
+
+import ast
+import pathlib
+import re
+from typing import List
+
+
+PLUGIN_DIR = pathlib.Path("mloda_plugins/feature_group/experimental")
+
+
+def _collect_python_files() -> List[pathlib.Path]:
+    """Collect all Python files under the experimental plugins directory."""
+    return sorted(PLUGIN_DIR.rglob("*.py"))
+
+
+class TestNoPatternAttribute:
+    """No plugin should define a class-level PATTERN = "__" attribute.
+
+    The PATTERN attribute is dead code: it is never read by any framework
+    code. Plugins that need the chain separator should import and use
+    CHAIN_SEPARATOR from mloda.provider instead.
+    """
+
+    def test_no_class_level_pattern_attribute(self) -> None:
+        """Scan all experimental plugin files for class-level PATTERN = '__' assignments."""
+        violations = []
+
+        for py_file in _collect_python_files():
+            source = py_file.read_text(encoding="utf-8")
+            tree = ast.parse(source, filename=str(py_file))
+
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.ClassDef):
+                    continue
+
+                for child in node.body:
+                    if not isinstance(child, ast.Assign):
+                        continue
+
+                    for target in child.targets:
+                        if not isinstance(target, ast.Name):
+                            continue
+                        if target.id != "PATTERN":
+                            continue
+
+                        # Check if the value is the string "__"
+                        value = child.value
+                        if isinstance(value, ast.Constant) and value.value == "__":
+                            violations.append(
+                                f"{py_file}:{child.lineno} - "
+                                f"class {node.name} defines dead-code "
+                                f'PATTERN = "__" attribute'
+                            )
+
+        assert violations == [], (
+            "Found class-level PATTERN = '__' attributes that are dead code. "
+            "Remove them; plugins should use CHAIN_SEPARATOR from "
+            "mloda.provider instead.\n\nViolations:\n" + "\n".join(violations)
+        )
+
+
+class TestNoHardcodedChainSeparator:
+    """No plugin should hardcode "__" string literals in method bodies.
+
+    All uses of the chain separator should go through the CHAIN_SEPARATOR
+    constant imported from mloda.provider.
+    """
+
+    # Lines matching any of these patterns are allowed to contain "__".
+    _ALLOWED_LINE_PATTERNS = [
+        re.compile(r"^\s*(PREFIX_PATTERN|SUFFIX_PATTERN)\s*="),  # regex pattern assignments
+        re.compile(r"^\s*CHAIN_SEPARATOR\s*="),  # the constant definition itself
+        re.compile(r"^\s*#"),  # comment lines
+        re.compile(r"^\s*(from|import)\s"),  # import lines
+        re.compile(r"^\s*PATTERN\s*="),  # PATTERN assignments (caught by the other test)
+    ]
+
+    def test_no_hardcoded_double_underscore_literals(self) -> None:
+        """Scan experimental plugin source lines for hardcoded '__' string literals."""
+        violations = []
+
+        for py_file in _collect_python_files():
+            source = py_file.read_text(encoding="utf-8")
+            lines = source.splitlines()
+
+            in_docstring = False
+            for lineno_0, line in enumerate(lines, start=1):
+                stripped = line.strip()
+
+                # Track docstring regions (triple-quoted strings).
+                # Count triple-quote occurrences to toggle docstring state.
+                triple_double = stripped.count('"""')
+                triple_single = stripped.count("'''")
+                triple_count = triple_double + triple_single
+
+                if triple_count == 1:
+                    # Opening or closing a docstring
+                    in_docstring = not in_docstring
+                    continue
+                elif triple_count >= 2:
+                    # Docstring opens and closes on the same line
+                    continue
+
+                if in_docstring:
+                    continue
+
+                # Skip lines matching allowed patterns
+                if any(pat.search(line) for pat in self._ALLOWED_LINE_PATTERNS):
+                    continue
+
+                # Check for standalone "__" string literal (quoted)
+                # Match both single and double quoted variants
+                if '"__"' in line or "'__'" in line:
+                    violations.append(f"{py_file}:{lineno_0} - hardcoded '__' literal: {stripped}")
+
+        assert violations == [], (
+            "Found hardcoded '__' string literals in plugin code. "
+            "Use CHAIN_SEPARATOR from mloda.provider instead.\n\n"
+            "Violations:\n" + "\n".join(violations)
+        )


### PR DESCRIPTION
## Summary
- Removed unused `PATTERN = "__"` class attribute from 5 plugins (sklearn/pipeline, sklearn/scaling, sklearn/encoding, text_cleaning, time_window) since no framework code reads it
- Replaced 12 hardcoded `"__"` string literals across 7 plugins (clustering, node_centrality, geo_distance, forecasting, dimensionality_reduction, time_window) with `CHAIN_SEPARATOR` constant from `mloda.provider`
- Added regression tests (`test_pattern_consistency.py`) that scan plugin sources via AST and text analysis to prevent reintroduction

## Test plan
- [x] New `test_no_class_level_pattern_attribute` passes (AST scan, detects dead PATTERN attributes)
- [x] New `test_no_hardcoded_double_underscore_literals` passes (text scan, detects hardcoded "__")
- [x] Full `tox` suite green (2704 passed, ruff, mypy --strict, bandit all clean)

Closes #301