### PR TITLE
refactor: rename similarity hash methods for clarity

### DIFF
--- a/docs/docs/examples/mloda_basics/3_ml_data_feature_feature_groups.ipynb
+++ b/docs/docs/examples/mloda_basics/3_ml_data_feature_feature_groups.ipynb
@@ -120,29 +120,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## What if we have multiple Features sharing the same FeatureGroup?\n",
-    "\n",
-    "To group features under the same FeatureGroup, we use the FeatureSet object.\n",
-    "\n",
-    "For features to share a FeatureSet, they must also have the same configuration and compute_framework.\n",
-    "If the configurations differ, mloda will automatically create separate FeatureSets.\n",
-    "\n",
-    "```python\n",
-    "def has_similarity_properties(self) -> int:\n",
-    "    compute_frameworks_hashable = (\n",
-    "        frozenset(self.compute_frameworks) if self.compute_frameworks is not None else None\n",
-    "    )\n",
-    "    return hash((self.options, compute_frameworks_hashable))\n",
-    "```\n",
-    "\n",
-    "Examples:\n",
-    "\n",
-    " - Testing migrations: Feature(A, Polars), Feature(B, Pandas)\n",
-    " - Sliding time windows: Feature(A, 10 days), Feature(B, 20 days)\n",
-    "\n",
-    "This means inbetween Data to Feature, we have another abstraction, the FeatureSet."
-   ]
+   "source": "## What if we have multiple Features sharing the same FeatureGroup?\n\nTo group features under the same FeatureGroup, we use the FeatureSet object.\n\nFor features to share a FeatureSet, they must also have the same configuration and compute_framework.\nIf the configurations differ, mloda will automatically create separate FeatureSets.\n\n```python\ndef similarity_hash(self) -> int:\n    compute_frameworks_hashable = (\n        frozenset(self.compute_frameworks) if self.compute_frameworks is not None else None\n    )\n    return hash((self.options, compute_frameworks_hashable))\n```\n\nExamples:\n\n - Testing migrations: Feature(A, Polars), Feature(B, Pandas)\n - Sliding time windows: Feature(A, 10 days), Feature(B, 20 days)\n\nThis means inbetween Data to Feature, we have another abstraction, the FeatureSet."
   },
   {
    "cell_type": "markdown",

--- a/mloda/core/abstract_plugins/components/feature.py
+++ b/mloda/core/abstract_plugins/components/feature.py
@@ -203,7 +203,7 @@ class Feature:
     def is_different_data_type(self, other: Feature) -> bool:
         return self.name == other.name and self.data_type != other.data_type
 
-    def has_similarity_properties(self) -> int:
+    def similarity_hash(self) -> int:
         """Hash for grouping features by compute framework, options, and data type.
 
         When data_type is None, it's excluded from the hash so None-typed features
@@ -216,8 +216,8 @@ class Feature:
             return hash((self.options, compute_frameworks_hashable, self.data_type))
         return hash((self.options, compute_frameworks_hashable))
 
-    def base_similarity_properties(self) -> int:
-        """Base hash excluding data_type - used for lenient grouping of None-typed features."""
+    def base_similarity_hash(self) -> int:
+        """Base hash excluding data_type, used for lenient grouping of None-typed features."""
         compute_frameworks_hashable = (
             frozenset(self.compute_frameworks) if self.compute_frameworks is not None else None
         )

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -1096,18 +1096,18 @@ class ExecutionPlan:
             if feature.data_type is None:
                 none_typed_features.append(feature)
             else:
-                f_hash = feature.has_similarity_properties()
+                f_hash = feature.similarity_hash()
                 hash_collector[f_hash].add(feature)
 
         # Second pass: assign None-typed features to existing groups with matching base hash
         for feature in none_typed_features:
-            base_hash = feature.base_similarity_properties()
+            base_hash = feature.base_similarity_hash()
             assigned = False
 
             # Find an existing group with matching base properties
             for existing_hash, group in hash_collector.items():
                 any_feature = next(iter(group))
-                if any_feature.base_similarity_properties() == base_hash:
+                if any_feature.base_similarity_hash() == base_hash:
                     hash_collector[existing_hash].add(feature)
                     assigned = True
                     break

--- a/tests/test_core/test_abstract_plugins/test_components/test_feature_datatype.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_feature_datatype.py
@@ -1,16 +1,16 @@
 """Tests for Feature data_type handling and similarity properties.
 
 These tests validate:
-1. has_similarity_properties() includes data_type when explicitly set
-2. base_similarity_properties() excludes data_type for lenient grouping
+1. similarity_hash() includes data_type when explicitly set
+2. base_similarity_hash() excludes data_type for lenient grouping
 3. is_different_data_type() correctly identifies features with different data types
 """
 
 from mloda.user import Feature
 
 
-def test_has_similarity_properties_includes_data_type() -> None:
-    """Test that has_similarity_properties() includes data_type when explicitly set.
+def test_similarity_hash_includes_data_type() -> None:
+    """Test that similarity_hash() includes data_type when explicitly set.
 
     Two features with the same name and options but different explicit data types
     should have DIFFERENT similarity property hashes.
@@ -21,8 +21,8 @@ def test_has_similarity_properties_includes_data_type() -> None:
     feature_int32 = Feature.int32_of("age")
     feature_int64 = Feature.int64_of("age")
 
-    hash_int32 = feature_int32.has_similarity_properties()
-    hash_int64 = feature_int64.has_similarity_properties()
+    hash_int32 = feature_int32.similarity_hash()
+    hash_int64 = feature_int64.similarity_hash()
 
     assert hash_int32 != hash_int64, (
         "Features with different explicit data types should have different hashes. "
@@ -30,7 +30,7 @@ def test_has_similarity_properties_includes_data_type() -> None:
     )
 
 
-def test_has_similarity_properties_none_type_uses_base_hash() -> None:
+def test_similarity_hash_none_type_uses_base_hash() -> None:
     """Test that features with data_type=None use the base hash (no data_type).
 
     None-typed features (like index columns) should have the same hash as
@@ -40,14 +40,14 @@ def test_has_similarity_properties_none_type_uses_base_hash() -> None:
     feature_untyped = Feature.not_typed("id")
 
     # Untyped feature should use base hash
-    assert feature_untyped.has_similarity_properties() == feature_untyped.base_similarity_properties()
+    assert feature_untyped.similarity_hash() == feature_untyped.base_similarity_hash()
 
     # Typed feature should have different hash than its base (includes data_type)
-    assert feature_typed.has_similarity_properties() != feature_typed.base_similarity_properties()
+    assert feature_typed.similarity_hash() != feature_typed.base_similarity_hash()
 
 
-def test_base_similarity_properties_excludes_data_type() -> None:
-    """Test that base_similarity_properties() excludes data_type.
+def test_base_similarity_hash_excludes_data_type() -> None:
+    """Test that base_similarity_hash() excludes data_type.
 
     This allows None-typed features to match typed features during lenient grouping.
     """
@@ -56,9 +56,9 @@ def test_base_similarity_properties_excludes_data_type() -> None:
     feature_untyped = Feature.not_typed("age")
 
     # All should have the same base hash (excludes data_type)
-    base_int32 = feature_int32.base_similarity_properties()
-    base_int64 = feature_int64.base_similarity_properties()
-    base_untyped = feature_untyped.base_similarity_properties()
+    base_int32 = feature_int32.base_similarity_hash()
+    base_int64 = feature_int64.base_similarity_hash()
+    base_untyped = feature_untyped.base_similarity_hash()
 
     assert base_int32 == base_int64 == base_untyped, (
         "All features with same options should have same base hash. "
@@ -104,3 +104,19 @@ def test_is_different_data_type_correct_behavior() -> None:
     assert feature_age.is_different_data_type(feature_height) is False, (
         "Features with different names should return False regardless of data types"
     )
+
+
+def test_similarity_hash_returns_int() -> None:
+    """Verify similarity_hash() and base_similarity_hash() exist and return int."""
+    feature = Feature.int32_of("age")
+
+    assert isinstance(feature.similarity_hash(), int)
+    assert isinstance(feature.base_similarity_hash(), int)
+
+
+def test_old_method_names_removed() -> None:
+    """Verify the old method names no longer exist on Feature."""
+    feature = Feature.int32_of("age")
+
+    assert not hasattr(feature, "has_similarity_properties")
+    assert not hasattr(feature, "base_similarity_properties")

--- a/tests/test_core/test_integration/test_core/test_datatype_enforcement.py
+++ b/tests/test_core/test_integration/test_core/test_datatype_enforcement.py
@@ -69,8 +69,8 @@ class TestDataTypeEnforcementSeparation:
         feature_int32 = Feature.int32_of("age")
         feature_int64 = Feature.int64_of("age")
 
-        hash_int32 = feature_int32.has_similarity_properties()
-        hash_int64 = feature_int64.has_similarity_properties()
+        hash_int32 = feature_int32.similarity_hash()
+        hash_int64 = feature_int64.similarity_hash()
 
         # Different types should produce different hashes
         assert hash_int32 != hash_int64, "Same feature with different types should have different hashes"
@@ -80,8 +80,8 @@ class TestDataTypeEnforcementSeparation:
         feature_int32_a = Feature.int32_of("age")
         feature_int32_b = Feature.int32_of("age")
 
-        hash_a = feature_int32_a.has_similarity_properties()
-        hash_b = feature_int32_b.has_similarity_properties()
+        hash_a = feature_int32_a.similarity_hash()
+        hash_b = feature_int32_b.similarity_hash()
 
         # Same types should produce identical hashes
         assert hash_a == hash_b, "Same feature with same type should have identical hashes"
@@ -91,8 +91,8 @@ class TestDataTypeEnforcementSeparation:
         feature_untyped_a = Feature.not_typed("age")
         feature_untyped_b = Feature.not_typed("age")
 
-        hash_a = feature_untyped_a.has_similarity_properties()
-        hash_b = feature_untyped_b.has_similarity_properties()
+        hash_a = feature_untyped_a.similarity_hash()
+        hash_b = feature_untyped_b.similarity_hash()
 
         # Untyped features should have identical hashes
         assert hash_a == hash_b, "Untyped features with same name should have identical hashes"
@@ -102,8 +102,8 @@ class TestDataTypeEnforcementSeparation:
         feature_typed = Feature.int32_of("age")
         feature_untyped = Feature.not_typed("age")
 
-        hash_typed = feature_typed.has_similarity_properties()
-        hash_untyped = feature_untyped.has_similarity_properties()
+        hash_typed = feature_typed.similarity_hash()
+        hash_untyped = feature_untyped.similarity_hash()
 
         # Typed vs untyped should produce different hashes
         assert hash_typed != hash_untyped, "Typed and untyped features should have different hashes"


### PR DESCRIPTION
## Summary

- Rename `has_similarity_properties()` to `similarity_hash()` and `base_similarity_properties()` to `base_similarity_hash()` on `Feature`
- These methods return hash integers, not booleans; the old predicate-style names were misleading
- Update all call sites in `execution_plan.py`, tests, and documentation notebook

Closes #263

## Test plan

- [x] All existing tests updated to use new method names
- [x] Added `test_similarity_hash_returns_int` verifying both methods return `int`
- [x] Added `test_old_method_names_removed` verifying old names no longer exist on `Feature`
- [x] `tox` passes (2725 tests, ruff, mypy, bandit)
- [x] Grep for old method names returns zero production/test hits