### PR TITLE
docs: add Code of Conduct and link from CONTRIBUTING

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -25,7 +25,3 @@ This applies in all project spaces (GitHub issues, pull requests, discussions, c
 ## Enforcement
 
 If you experience or witness behavior that violates this code, report it to **conduct@mloda.ai**. Reports are reviewed confidentially. Maintainers may warn, temporarily ban, or permanently remove anyone whose behavior is judged to violate this code.
-
-## Attribution
-
-Inspired by the [Contributor Covenant](https://www.contributor-covenant.org/), simplified for readability.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,31 @@
+# Code of Conduct
+
+We want mloda to be a project where anyone can contribute, ask questions, or share ideas without worrying about how they will be treated.
+
+## Expected behavior
+
+- Be respectful and constructive in discussions, reviews, and issues.
+- Assume good intent. Ask for clarification before assuming bad intent.
+- Welcome newcomers. Everyone was new once.
+- Give and receive feedback graciously.
+- Focus on what is best for the project and the community.
+
+## Unacceptable behavior
+
+- Harassment, discrimination, or personal attacks of any kind.
+- Trolling, insulting comments, or sustained disruption of discussion.
+- Publishing someone's private information without their explicit permission.
+- Sexualized language or imagery, or unwelcome sexual attention.
+- Any behavior that a reasonable person would consider inappropriate in a professional setting.
+
+## Scope
+
+This applies in all project spaces (GitHub issues, pull requests, discussions, code review) and when representing the project in public.
+
+## Enforcement
+
+If you experience or witness behavior that violates this code, report it to **conduct@mloda.ai**. Reports are reviewed confidentially. Maintainers may warn, temporarily ban, or permanently remove anyone whose behavior is judged to violate this code.
+
+## Attribution
+
+Inspired by the [Contributor Covenant](https://www.contributor-covenant.org/), simplified for readability.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 We welcome contributions from the community. Whether you are fixing bugs, adding features, or developing plugins, your input is invaluable.
 
+By participating in this project, you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md).
+
 ## Getting Started
 
 ### Prerequisites


### PR DESCRIPTION
## Summary
- Adds a short, plain-English `CODE_OF_CONDUCT.md` at the repo root, with `conduct@mloda.ai` as the enforcement contact.
- Links the Code of Conduct from `CONTRIBUTING.md` so participation expectations are visible to new contributors.

This is part of the contributor-attraction work: the Code of Conduct is a prerequisite for GitHub's community profile and for listings on directories like Up For Grabs and CodeTriage.

## Test plan
- [ ] Verify GitHub renders `CODE_OF_CONDUCT.md` on the community profile (Insights -> Community Standards) once merged.
- [ ] Confirm the link in `CONTRIBUTING.md` resolves on GitHub.