### PR TITLE
fix: silence mypy errors on pyarrow.* submodules

### DIFF
--- a/mloda/core/abstract_plugins/components/framework_transformer/cfw_transformer.py
+++ b/mloda/core/abstract_plugins/components/framework_transformer/cfw_transformer.py
@@ -6,7 +6,7 @@ from mloda.core.abstract_plugins.components.utils import get_all_subclasses
 try:
     import pyarrow as pa
 except ImportError:
-    pa = None
+    pa = None  # type: ignore[assignment]
 
 
 class ComputeFrameworkTransformer:

--- a/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_relation.py
+++ b/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_relation.py
@@ -11,7 +11,7 @@ except ImportError:
 try:
     import pyarrow as pa
 except ImportError:
-    pa = None
+    pa = None  # type: ignore[assignment]
 
 from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import inline_params, quote_ident
 

--- a/mloda_plugins/compute_framework/base_implementations/iceberg/iceberg_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/iceberg/iceberg_framework.py
@@ -12,7 +12,7 @@ try:
 except ImportError:
     Catalog = None  # type: ignore[assignment,misc]
     IcebergTable = None  # type: ignore[assignment,misc]
-    pa = None
+    pa = None  # type: ignore[assignment]
 
 
 class IcebergFramework(ComputeFramework):

--- a/mloda_plugins/compute_framework/base_implementations/iceberg/iceberg_pyarrow_transformer.py
+++ b/mloda_plugins/compute_framework/base_implementations/iceberg/iceberg_pyarrow_transformer.py
@@ -6,7 +6,7 @@ try:
     import pyarrow as pa
 except ImportError:
     IcebergTable = None  # type: ignore[assignment,misc]
-    pa = None
+    pa = None  # type: ignore[assignment]
 
 
 class IcebergPyArrowTransformer(BaseTransformer):

--- a/mloda_plugins/compute_framework/base_implementations/pandas/pandas_pyarrow_transformer.py
+++ b/mloda_plugins/compute_framework/base_implementations/pandas/pandas_pyarrow_transformer.py
@@ -10,7 +10,7 @@ except ImportError:
 try:
     import pyarrow as pa
 except ImportError:
-    pa = None
+    pa = None  # type: ignore[assignment]
 
 
 class PandasPyArrowTransformer(BaseTransformer):

--- a/mloda_plugins/compute_framework/base_implementations/polars/polars_lazy_pyarrow_transformer.py
+++ b/mloda_plugins/compute_framework/base_implementations/polars/polars_lazy_pyarrow_transformer.py
@@ -10,7 +10,7 @@ except ImportError:
 try:
     import pyarrow as pa
 except ImportError:
-    pa = None
+    pa = None  # type: ignore[assignment]
 
 
 class PolarsLazyPyArrowTransformer(BaseTransformer):

--- a/mloda_plugins/compute_framework/base_implementations/polars/polars_pyarrow_transformer.py
+++ b/mloda_plugins/compute_framework/base_implementations/polars/polars_pyarrow_transformer.py
@@ -10,7 +10,7 @@ except ImportError:
 try:
     import pyarrow as pa
 except ImportError:
-    pa = None
+    pa = None  # type: ignore[assignment]
 
 
 class PolarsPyArrowTransformer(BaseTransformer):

--- a/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_pyarrow_transformer.py
+++ b/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_pyarrow_transformer.py
@@ -5,7 +5,7 @@ from mloda.provider import BaseTransformer
 try:
     import pyarrow as pa
 except ImportError:
-    pa = None
+    pa = None  # type: ignore[assignment]
 
 
 class PythonDictPyArrowTransformer(BaseTransformer):

--- a/mloda_plugins/compute_framework/base_implementations/spark/spark_pyarrow_transformer.py
+++ b/mloda_plugins/compute_framework/base_implementations/spark/spark_pyarrow_transformer.py
@@ -11,7 +11,7 @@ except ImportError:
 try:
     import pyarrow as pa
 except ImportError:
-    pa = None
+    pa = None  # type: ignore[assignment]
 
 
 class SparkPyArrowTransformer(BaseTransformer):

--- a/mloda_plugins/compute_framework/base_implementations/sql/sql_base_pyarrow_transformer.py
+++ b/mloda_plugins/compute_framework/base_implementations/sql/sql_base_pyarrow_transformer.py
@@ -5,7 +5,7 @@ from mloda.provider import BaseTransformer
 try:
     import pyarrow as pa
 except ImportError:
-    pa = None
+    pa = None  # type: ignore[assignment]
 
 
 class SqlBasePyArrowTransformer(BaseTransformer):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,15 @@ module = "mloda_plugins.compute_framework.base_implementations.iceberg.iceberg_f
 disable_error_code = ["misc", "call-arg", "arg-type"]
 
 [[tool.mypy.overrides]]
-module = "pyarrow.*"
+module = [
+    "pyarrow.compute",
+    "pyarrow.csv",
+    "pyarrow.feather",
+    "pyarrow.flight",
+    "pyarrow.json",
+    "pyarrow.orc",
+    "pyarrow.parquet",
+]
 follow_imports = "skip"
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,10 @@ namespace_packages = true
 module = "mloda_plugins.compute_framework.base_implementations.iceberg.iceberg_filter_engine"
 disable_error_code = ["misc", "call-arg", "arg-type"]
 
+[[tool.mypy.overrides]]
+module = "pyarrow.*"
+follow_imports = "skip"
+
 [tool.ruff]
 line-length = 120
 

--- a/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_filter_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_filter_engine.py
@@ -23,7 +23,7 @@ try:
 except ImportError:
     logger.warning("DuckDB or PyArrow is not installed. Some tests will be skipped.")
     duckdb = None  # type: ignore[assignment]
-    pa = None
+    pa = None  # type: ignore[assignment]
 
 
 @pytest.mark.skipif(duckdb is None or pa is None, reason="DuckDB or PyArrow is not installed. Skipping this test.")

--- a/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_framework.py
+++ b/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_framework.py
@@ -23,7 +23,7 @@ try:
 except ImportError:
     logger.warning("DuckDB is not installed. Some tests will be skipped.")
     duckdb = None  # type: ignore[assignment]
-    pa = None
+    pa = None  # type: ignore[assignment]
 
 
 class TestDuckDBFrameworkAvailability:

--- a/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_integration.py
+++ b/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_integration.py
@@ -31,7 +31,7 @@ try:
     import pyarrow as pa
 except ImportError:
     logger.warning("PyArrow is not installed. Some tests will be skipped.")
-    pa = None
+    pa = None  # type: ignore[assignment]
 
 
 @pytest.fixture

--- a/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_merge_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_merge_engine.py
@@ -20,7 +20,7 @@ try:
 except ImportError:
     logger.warning("DuckDB or PyArrow is not installed. Some tests will be skipped.")
     duckdb = None  # type: ignore[assignment]
-    pa = None
+    pa = None  # type: ignore[assignment]
 
 
 @pytest.mark.skipif(duckdb is None or pa is None, reason="DuckDB or PyArrow is not installed. Skipping this test.")

--- a/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_pyarrow_transformer.py
+++ b/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_pyarrow_transformer.py
@@ -19,7 +19,7 @@ try:
     import pyarrow as pa
 except ImportError:
     logger.warning("PyArrow is not installed. Some tests will be skipped.")
-    pa = None
+    pa = None  # type: ignore[assignment]
 
 
 @pytest.mark.skipif(duckdb is None or pa is None, reason="DuckDB or PyArrow is not installed. Skipping this test.")

--- a/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_relation.py
+++ b/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_relation.py
@@ -18,7 +18,7 @@ try:
 except ImportError:
     logger.warning("DuckDB or PyArrow is not installed. Some tests will be skipped.")
     duckdb = None  # type: ignore[assignment]
-    pa = None
+    pa = None  # type: ignore[assignment]
 
 
 @pytest.mark.skipif(duckdb is None or pa is None, reason="DuckDB or PyArrow is not installed.")

--- a/tests/test_plugins/compute_framework/base_implementations/iceberg/test_iceberg_filter_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/iceberg/test_iceberg_filter_engine.py
@@ -18,7 +18,7 @@ try:
 except ImportError:
     logger.warning("PyIceberg or PyArrow is not installed. Some tests will be skipped.")
     pyiceberg = None  # type: ignore
-    pa = None
+    pa = None  # type: ignore[assignment]
     IcebergTable = None  # type: ignore
     GreaterThan = None  # type: ignore
     LessThan = None  # type: ignore

--- a/tests/test_plugins/compute_framework/base_implementations/iceberg/test_iceberg_framework.py
+++ b/tests/test_plugins/compute_framework/base_implementations/iceberg/test_iceberg_framework.py
@@ -19,7 +19,7 @@ try:
 except ImportError:
     logger.warning("PyIceberg or PyArrow is not installed. Some tests will be skipped.")
     pyiceberg = None  # type: ignore
-    pa = None
+    pa = None  # type: ignore[assignment]
     IcebergTable = None  # type: ignore
     Catalog = None  # type: ignore
 

--- a/tests/test_plugins/compute_framework/base_implementations/iceberg/test_iceberg_integration.py
+++ b/tests/test_plugins/compute_framework/base_implementations/iceberg/test_iceberg_integration.py
@@ -31,7 +31,7 @@ try:
 except ImportError:
     logger.warning("PyIceberg or PyArrow is not installed. Some tests will be skipped.")
     pyiceberg = None  # type: ignore
-    pa = None
+    pa = None  # type: ignore[assignment]
     IcebergTable = None  # type: ignore
     Catalog = None  # type: ignore
 

--- a/tests/test_plugins/compute_framework/base_implementations/iceberg/test_iceberg_transformer.py
+++ b/tests/test_plugins/compute_framework/base_implementations/iceberg/test_iceberg_transformer.py
@@ -15,7 +15,7 @@ try:
 except ImportError:
     logger.warning("PyIceberg or PyArrow is not installed. Some tests will be skipped.")
     pyiceberg = None  # type: ignore
-    pa = None
+    pa = None  # type: ignore[assignment]
     IcebergTable = None  # type: ignore
 
 

--- a/tests/test_plugins/compute_framework/base_implementations/polars/test_polars_lazy_pyarrow_transformer.py
+++ b/tests/test_plugins/compute_framework/base_implementations/polars/test_polars_lazy_pyarrow_transformer.py
@@ -19,7 +19,7 @@ try:
     import pyarrow as pa
 except ImportError:
     logger.warning("PyArrow is not installed. Some tests will be skipped.")
-    pa = None
+    pa = None  # type: ignore[assignment]
 
 
 class TestPolarsLazyPyArrowTransformerAvailability:

--- a/tests/test_plugins/compute_framework/base_implementations/polars/test_polars_pyarrow_transformer.py
+++ b/tests/test_plugins/compute_framework/base_implementations/polars/test_polars_pyarrow_transformer.py
@@ -17,7 +17,7 @@ try:
     import pyarrow as pa
 except ImportError:
     logger.warning("PyArrow is not installed. Some tests will be skipped.")
-    pa = None
+    pa = None  # type: ignore[assignment]
 
 
 @pytest.mark.skipif(pl is None or pa is None, reason="Polars or PyArrow is not installed. Skipping this test.")

--- a/tests/test_plugins/compute_framework/base_implementations/pyarrow/test_pyarrow_merge_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/pyarrow/test_pyarrow_merge_engine.py
@@ -10,7 +10,7 @@ from tests.test_plugins.compute_framework.test_tooling.multi_index.multi_index_t
 try:
     import pyarrow as pa
 except ImportError:
-    pa = None
+    pa = None  # type: ignore[assignment]
 
 
 class TestPyArrowMergeEngineMultiIndex(MultiIndexMergeEngineTestBase):

--- a/tests/test_plugins/compute_framework/base_implementations/spark/test_spark_integration.py
+++ b/tests/test_plugins/compute_framework/base_implementations/spark/test_spark_integration.py
@@ -64,7 +64,7 @@ try:
     import pyarrow as pa
 except ImportError:
     logger.warning("PyArrow is not installed. Some tests will be skipped.")
-    pa = None
+    pa = None  # type: ignore[assignment]
 
 
 # Test data for Spark integration tests

--- a/tests/test_plugins/compute_framework/base_implementations/spark/test_spark_pyarrow_transformer.py
+++ b/tests/test_plugins/compute_framework/base_implementations/spark/test_spark_pyarrow_transformer.py
@@ -52,7 +52,7 @@ try:
     PYARROW_AVAILABLE = True
 except ImportError:
     logger.warning("PyArrow is not installed. Some tests will be skipped.")
-    pa = None
+    pa = None  # type: ignore[assignment]
     PYARROW_AVAILABLE = False
 
 

--- a/tests/test_plugins/compute_framework/test_tooling/multi_index/test_data_converter.py
+++ b/tests/test_plugins/compute_framework/test_tooling/multi_index/test_data_converter.py
@@ -14,7 +14,7 @@ from mloda.user import PluginLoader
 try:
     import pyarrow as pa
 except ImportError:
-    pa = None
+    pa = None  # type: ignore[assignment]
 
 
 # Load plugins once at module import time


### PR DESCRIPTION
## Summary

PyArrow 24 ships stricter type stubs that miss many dynamic and unexported attributes (`pyarrow.compute.if_else`, `pyarrow.flight.FlightClient`, `pyarrow.json.read_json`, `pyarrow.csv.read_csv`, `pyarrow.parquet.read_table`, etc.). The functions exist at runtime, but mypy `--strict` raises 169 `attr-defined` and `no-untyped-call` errors across 49 files. This broke CI on every full-build matrix env (`build (3.10, -e python310)` through `python313`) since the `pyarrow.json` and `pyarrow.csv` submodules drifted, while `core` and `installed` envs kept passing because they don't run mypy.

Two minimal fixes restore green:

- **`pyproject.toml`** -- add a mypy override with `follow_imports = "skip"` for the `pyarrow.*` wildcard, so submodule attribute access falls back to `Any`. The base `pyarrow` module (`pa.Table`, `pa.Schema`, etc.) is still type-checked.
- **`pa = None` fallbacks** -- add `# type: ignore[assignment]` on every `pa = None` line that follows a failed `import pyarrow as pa`, matching the existing pattern already used for `duckdb` and `pyiceberg` in those files.

## Test plan

- [x] `mypy --strict --ignore-missing-imports .` -- `Success: no issues found in 626 source files`
- [x] `ruff format --check` -- clean
- [x] `ruff check` -- clean
- [x] `bandit -c pyproject.toml -r -q .` -- clean
- [x] `pytest -n 8 --timeout=10 --ignore=tests/test_examples` -- 2988 passed, 147 skipped (matches expected skip count)
- [ ] CI build matrix on Python 3.10 / 3.11 / 3.12 / 3.13 (verify on this PR)