### PR TITLE
docs: rework contributor onboarding (README, CONTRIBUTING, dev guide, docs site)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,13 +71,9 @@ pytest -n auto --timeout=10
 
 ## Ways to Contribute
 
-### Core Development
-
-For contributions to the mloda core framework, see our [Documentation](https://mloda-ai.github.io/mloda/).
-
 ### Plugin Development
 
-The easiest way to extend mloda is by creating plugins. The [mloda-registry](https://github.com/mloda-ai/mloda-registry) contains 40+ guides organized as a step-by-step journey:
+The easiest way to extend mloda is by creating plugins. The [mloda-registry](https://github.com/mloda-ai/mloda-registry) hosts 40+ guides under [`docs/guides/`](https://github.com/mloda-ai/mloda-registry/tree/main/docs/guides), organized as a step-by-step journey:
 
 1. **Using plugins**: Learn to use and discover existing plugins.
 2. **Creating plugins**: Build a plugin in your project, then package it.
@@ -87,6 +83,10 @@ The easiest way to extend mloda is by creating plugins. The [mloda-registry](htt
 Start with the [Plugin Journey overview](https://github.com/mloda-ai/mloda-registry/blob/main/docs/guides/index.md) to find the right guide for your level.
 
 To scaffold a new standalone plugin package with pre-configured CI/CD, use the [mloda-plugin-template](https://github.com/mloda-ai/mloda-plugin-template).
+
+### Core Development
+
+For contributions to the mloda core framework, see our [Documentation](https://mloda-ai.github.io/mloda/).
 
 ### Report Issues
 

--- a/README.md
+++ b/README.md
@@ -317,7 +317,21 @@ Most plugins currently live in `mloda_plugins/` within this repository. The goal
 
 ## Contributing
 
-We welcome contributions! Build plugins, improve docs, or add features.
+We welcome contributions.
 
-- **[GitHub Issues](https://github.com/mloda-ai/mloda/issues/)** - Report bugs or request features
-- **[Development Guide](https://mloda-ai.github.io/mloda/development/)** - How to contribute
+**Plugin development:** see the [mloda-registry guides](https://github.com/mloda-ai/mloda-registry/tree/main/docs/guides) (40+ step-by-step), or scaffold a new package with the [mloda-plugin-template](https://github.com/mloda-ai/mloda-plugin-template).
+
+**Core framework:** start with [`good first issue`](https://github.com/mloda-ai/mloda/labels/good%20first%20issue) or [`help wanted`](https://github.com/mloda-ai/mloda/labels/help%20wanted), then:
+
+```bash
+git clone https://github.com/mloda-ai/mloda.git
+cd mloda
+uv sync --all-extras
+source .venv/bin/activate
+tox  # full test, lint, type-check, and security suite
+```
+
+If `tox` passes, you're set. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full PR workflow and code style, and the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+- [GitHub Issues](https://github.com/mloda-ai/mloda/issues/) - report bugs or request features
+- [Development Guide](https://mloda-ai.github.io/mloda/development/) - in-depth contributor docs

--- a/docs/docs/development.md
+++ b/docs/docs/development.md
@@ -1,60 +1,26 @@
 ## Development Setup (for Contributors)
 
-If you are contributing to mloda or working on its development, follow these steps to set up your environment, including using the provided dev container and running tests with tox.
+Thanks for your interest in contributing to mloda. The canonical contributor guide is [CONTRIBUTING.md](https://github.com/mloda-ai/mloda/blob/main/CONTRIBUTING.md), and all participants are expected to follow our [Code of Conduct](https://github.com/mloda-ai/mloda/blob/main/CODE_OF_CONDUCT.md). This page covers two topics that are specific to working on the docs and the dev environment.
 
-By contributing, you agree that your contributions will be licensed under the [Apache License, Version 2.0](https://github.com/mloda-ai/mloda/blob/main/LICENSE).
+#### Dev Container (Optional)
 
+Prerequisite: Docker.
 
-#### 1. Clone the repository:
-```bash
-git clone https://github.com/mloda-ai/mloda.git
-```
+- Open the project in a dev container (in VS Code or a compatible tool).
+- The dev container includes all necessary dependencies and tools to work on mloda.
 
-#### 2. Dev Container (Optional)
-Prerequisite:
-docker
+If you don't use Docker, follow the local setup in [CONTRIBUTING.md](https://github.com/mloda-ai/mloda/blob/main/CONTRIBUTING.md#local-development-setup) (`uv sync --all-extras`, then `source .venv/bin/activate`).
 
--   Open the project in a dev container (in VS Code or a compatible tool).
--   Start developing: The dev container includes all necessary dependencies and tools to work on mloda.
+#### Building the docs locally
 
-If you don't want to or can't use docker, skip step 2.
-Instead you can run it in the current machine with
-```bash
-pip install -r tests/requirements-test.txt && pip install tox
-```
+After completing the setup in CONTRIBUTING.md, you can preview docs changes with:
 
-#### 3. Running Tests with Tox
-We use tox to run tests in multiple environments.
-
-This is to ensure that adjustments are working and integrated well.
-
-Run main test suite:
-```bash
-tox
-```
-
-Run core test suite:
-```bash
-tox -e core
-```
-
-Run installed module test suite: 
-```bash
-tox -e installed
-```
-
-#### 4. Docs 
-You can adjust the docs under the folder docs.
-To view local changes, use:
 ```bash
 mkdocs serve --config-file docs/mkdocs.yml
 ```
 
-#### 5. Contribute
+#### Where to start
 
-Want to contribute? You can:
-
--   Create an Issue: If you find a bug or have a feature request or have an idea, feel free to create an issue.
--   Submit a Pull Request (PR): If you'd like to contribute code, you can open a pull request with your changes.
-
-
+- Plugin contributions: see the [mloda-registry guides](https://github.com/mloda-ai/mloda-registry/tree/main/docs/guides) and the [mloda-plugin-template](https://github.com/mloda-ai/mloda-plugin-template).
+- Core framework contributions: browse issues labeled [`good first issue`](https://github.com/mloda-ai/mloda/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) and [`help wanted`](https://github.com/mloda-ai/mloda/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22).
+- Bugs and feature requests: open an [issue](https://github.com/mloda-ai/mloda/issues/).

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -62,7 +62,7 @@ mloda addresses common challenges in data and feature engineering by leveraging 
 
 ## Contributing to mloda
 
-We welcome contributions from the community to help us improve and expand mloda. Whether you're interested in developing plugins or adding new features, your input is invaluable. [Learn more here.](development.md)
+We welcome contributions, whether you are developing plugins or working on the core framework. See [CONTRIBUTING.md](https://github.com/mloda-ai/mloda/blob/main/CONTRIBUTING.md), our [Code of Conduct](https://github.com/mloda-ai/mloda/blob/main/CODE_OF_CONDUCT.md), and the [contributor page](development.md) for details.
 
 
 ## Frequently Asked Questions (FAQ)


### PR DESCRIPTION
## Summary

Closes the README and docs-site onboarding gap from tk-290. Before this PR, the previous Contributing section in README.md was two links and gave new contributors no on-ramp, and the mkdocs Development Guide still recommended the older `pip install -r tests/requirements-test.txt && pip install tox` flow without linking CONTRIBUTING.md or the Code of Conduct. Goal: someone landing on the README is ~10 minutes from a working dev setup, or pointed at the right repo for plugin work, with consistent guidance whether they read the README, CONTRIBUTING.md, or the docs site.

**`README.md`:**
- Quick-start block for the core framework path (clone, `uv sync --all-extras`, `source .venv/bin/activate`, `tox`).
- Plugin development path that points at the [mloda-registry guides](https://github.com/mloda-ai/mloda-registry/tree/main/docs/guides) and the [mloda-plugin-template](https://github.com/mloda-ai/mloda-plugin-template) up front, so plugin contributors don't read core setup steps they don't need.
- Links to `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, and filtered issue lists for [`good first issue`](https://github.com/mloda-ai/mloda/labels/good%20first%20issue) and [`help wanted`](https://github.com/mloda-ai/mloda/labels/help%20wanted).

**`CONTRIBUTING.md`:**
- Move Plugin Development above Core Development under "Ways to Contribute". Plugins are the easier on-ramp.
- Add a direct link to the `docs/guides/` directory alongside the existing Plugin Journey index link.

**`docs/docs/development.md` (rewrite):**
- Treat `CONTRIBUTING.md` as the canonical setup guide and link to its `#local-development-setup` anchor.
- Drop the duplicated Clone and Tox sections that now live in `CONTRIBUTING.md`.
- Keep the optional Dev Container guidance and the `mkdocs serve` snippet, since those are unique to this page.
- Add a "Where to start" section pointing plugin contributors at the registry guides and core contributors at the `good first issue` / `help wanted` filtered issue lists.

**`docs/docs/index.md` (one-line edit):**
- Extend the Contributing paragraph to link `CONTRIBUTING.md`, the Code of Conduct, and the development page.

`docs/docs/faq.md` and `docs/mkdocs.yml` deliberately untouched (no churn for no clarity gain).

## Test plan
- [ ] Verify README and CONTRIBUTING render correctly on GitHub.
- [ ] Run `mkdocs serve --config-file docs/mkdocs.yml` and confirm the home page and Development Guide render correctly.
- [ ] Click each new link to confirm it resolves: `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, registry guides, plugin template, label filters, the relative `development.md` link from `index.md`.