### PR TITLE
docs: align development page with CONTRIBUTING and add CoC links

### DIFF
--- a/docs/docs/development.md
+++ b/docs/docs/development.md
@@ -1,60 +1,26 @@
 ## Development Setup (for Contributors)
 
-If you are contributing to mloda or working on its development, follow these steps to set up your environment, including using the provided dev container and running tests with tox.
+Thanks for your interest in contributing to mloda. The canonical contributor guide is [CONTRIBUTING.md](https://github.com/mloda-ai/mloda/blob/main/CONTRIBUTING.md), and all participants are expected to follow our [Code of Conduct](https://github.com/mloda-ai/mloda/blob/main/CODE_OF_CONDUCT.md). This page covers two topics that are specific to working on the docs and the dev environment.
 
-By contributing, you agree that your contributions will be licensed under the [Apache License, Version 2.0](https://github.com/mloda-ai/mloda/blob/main/LICENSE).
+#### Dev Container (Optional)
 
+Prerequisite: Docker.
 
-#### 1. Clone the repository:
-```bash
-git clone https://github.com/mloda-ai/mloda.git
-```
+- Open the project in a dev container (in VS Code or a compatible tool).
+- The dev container includes all necessary dependencies and tools to work on mloda.
 
-#### 2. Dev Container (Optional)
-Prerequisite:
-docker
+If you don't use Docker, follow the local setup in [CONTRIBUTING.md](https://github.com/mloda-ai/mloda/blob/main/CONTRIBUTING.md#local-development-setup) (`uv sync --all-extras`, then `source .venv/bin/activate`).
 
--   Open the project in a dev container (in VS Code or a compatible tool).
--   Start developing: The dev container includes all necessary dependencies and tools to work on mloda.
+#### Building the docs locally
 
-If you don't want to or can't use docker, skip step 2.
-Instead you can run it in the current machine with
-```bash
-pip install -r tests/requirements-test.txt && pip install tox
-```
+After completing the setup in CONTRIBUTING.md, you can preview docs changes with:
 
-#### 3. Running Tests with Tox
-We use tox to run tests in multiple environments.
-
-This is to ensure that adjustments are working and integrated well.
-
-Run main test suite:
-```bash
-tox
-```
-
-Run core test suite:
-```bash
-tox -e core
-```
-
-Run installed module test suite: 
-```bash
-tox -e installed
-```
-
-#### 4. Docs 
-You can adjust the docs under the folder docs.
-To view local changes, use:
 ```bash
 mkdocs serve --config-file docs/mkdocs.yml
 ```
 
-#### 5. Contribute
+#### Where to start
 
-Want to contribute? You can:
-
--   Create an Issue: If you find a bug or have a feature request or have an idea, feel free to create an issue.
--   Submit a Pull Request (PR): If you'd like to contribute code, you can open a pull request with your changes.
-
-
+- Plugin contributions: see the [mloda-registry guides](https://github.com/mloda-ai/mloda-registry/tree/main/docs/guides) and the [mloda-plugin-template](https://github.com/mloda-ai/mloda-plugin-template).
+- Core framework contributions: browse issues labeled [`good first issue`](https://github.com/mloda-ai/mloda/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) and [`help wanted`](https://github.com/mloda-ai/mloda/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22).
+- Bugs and feature requests: open an [issue](https://github.com/mloda-ai/mloda/issues/).

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -62,7 +62,7 @@ mloda addresses common challenges in data and feature engineering by leveraging 
 
 ## Contributing to mloda
 
-We welcome contributions from the community to help us improve and expand mloda. Whether you're interested in developing plugins or adding new features, your input is invaluable. [Learn more here.](development.md)
+We welcome contributions, whether you are developing plugins or working on the core framework. See [CONTRIBUTING.md](https://github.com/mloda-ai/mloda/blob/main/CONTRIBUTING.md), our [Code of Conduct](https://github.com/mloda-ai/mloda/blob/main/CODE_OF_CONDUCT.md), and the [contributor page](development.md) for details.
 
 
 ## Frequently Asked Questions (FAQ)


### PR DESCRIPTION
## Summary

Continues the contributor-onboarding work from tk-290. The mkdocs site under \`docs/docs/\` predated \`CONTRIBUTING.md\` and the Code of Conduct, so its Development Guide still recommended the older \`pip install -r tests/requirements-test.txt && pip install tox\` flow and neither page linked CONTRIBUTING.md or CODE_OF_CONDUCT.md.

**\`docs/docs/development.md\` rewrite:**
- Treat CONTRIBUTING.md as the canonical setup guide and link to it (with anchor) for the local dev flow.
- Drop the duplicate clone + tox sections that now live in CONTRIBUTING.md.
- Keep the optional Dev Container guidance and the \`mkdocs serve\` snippet, since those are unique to this page.
- Add a "Where to start" section pointing plugin contributors at the [mloda-registry guides](https://github.com/mloda-ai/mloda-registry/tree/main/docs/guides) and core contributors at the [\`good first issue\`](https://github.com/mloda-ai/mloda/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) and [\`help wanted\`](https://github.com/mloda-ai/mloda/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) labels.

**\`docs/docs/index.md\` one-line edit:**
- Extend the Contributing paragraph to link CONTRIBUTING.md, the Code of Conduct, and the development page.

\`faq.md\` and \`mkdocs.yml\` deliberately untouched (no churn for no clarity gain).

## Test plan
- [ ] Run \`mkdocs serve --config-file docs/mkdocs.yml\` and confirm both pages render correctly.
- [ ] Click each external link to verify it resolves on GitHub (CONTRIBUTING.md, CODE_OF_CONDUCT.md, registry guides, plugin template, label filters).
- [ ] Confirm the relative \`development.md\` link from the home page still works.