### PR TITLE
chore: AI agent guidance (issue template, AGENTS.md, Project Practices)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/issue.yml
+++ b/.github/ISSUE_TEMPLATE/issue.yml
@@ -1,0 +1,48 @@
+name: Issue
+description: Report a bug, request a feature, or propose a small task.
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One-sentence description of the bug, request, or task.
+      placeholder: e.g. "DuckdbRelation.aggregate raises TypeError when called with a single column."
+    validations:
+      required: true
+  - type: textarea
+    id: details
+    attributes:
+      label: Reproduction or motivation
+      description: |
+        For bugs: minimal reproduction steps, then expected vs. actual behavior.
+        For features and tasks: motivation, current workaround if any, and desired behavior.
+      placeholder: |
+        Steps to reproduce:
+        1.
+        2.
+
+        Expected:
+        Actual:
+    validations:
+      required: true
+  - type: textarea
+    id: pointers
+    attributes:
+      label: Code pointers (optional)
+      description: Files and line numbers where the work happens or where the bug originates. Helps newcomers find their starting point quickly.
+      placeholder: e.g. mloda/core/foo.py:42
+  - type: textarea
+    id: dod
+    attributes:
+      label: Definition of done (optional)
+      description: What counts as complete. Behavior, tests, docs.
+      placeholder: |
+        - [ ] Function returns X for input Y
+        - [ ] Test added in tests/...
+        - [ ] tox passes
+  - type: input
+    id: environment
+    attributes:
+      label: Environment (optional, bugs only)
+      description: Python version, OS, mloda version.
+      placeholder: Python 3.12, Linux, mloda 0.6.1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+See [CLAUDE.md](./CLAUDE.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,10 +78,10 @@ source .venv/bin/activate
 - **Python**: supported range is `>=3.10,<3.14`; CI matrixes 3.10, 3.11, 3.12, 3.13.
 - **Type hints**: use modern forms (`list[str]`, `dict[str, int]`, `X | None`). Ruff enforces this via `UP006` and `UP007`.
 - **Formatting**: ruff format with line length 120.
-- **Tests**: must be parallel-safe (pytest-xdist) and finish under the 10-second timeout. The default tox env asserts `EXPECTED_SKIP_COUNT=147`; if a test you add is skipped, update the count or unskip it.
+- **Tests**: every new feature or bug fix must come with tests; follow the patterns in the existing `tests/` tree. Tests must be parallel-safe (pytest-xdist) and finish under the 10-second timeout. The default tox env asserts `EXPECTED_SKIP_COUNT=147`; if a test you add is skipped, update the count or unskip it.
 - **Supply chain**: `[tool.uv] exclude-newer = "7 days"` in `pyproject.toml` defers new dependency releases by 7 days. Do not edit this without a reason.
 - **Licenses**: dependencies must satisfy the allowlist in `tox.ini` (Apache-2.0, BSD, MIT, MPL-2.0, PSF, ISC, LGPLv2+). Adding a dependency with a non-listed license fails tox.
-- **Commits**: use [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, `docs:`, `test:`, `refactor:`). semantic-release reads these to compute the next version.
+- **Commits**: use [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, `docs:`, `test:`, `refactor:`, `minor:`). semantic-release computes the next version. This project deviates from the standard: the minor version (middle number) bumps only on `minor:` commits; `feat:` is treated as a patch bump.
 
 ## Issue Creation
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,18 @@ source .venv/bin/activate
 - Avoid try/except blocks
 - Never mention agents in commit messages, PR descriptions, or any user-facing text (no `Co-Authored-By` agent lines, no agent names)
 
+## Project Practices
+
+`tox` is the gate. It runs `pytest -n 8 --timeout=10`, then `ruff format --check`, `ruff check`, a `pip-licenses` allowlist check, `mypy --strict --ignore-missing-imports`, and `bandit`. All of these must pass before a PR is mergeable.
+
+- **Python**: supported range is `>=3.10,<3.14`; CI matrixes 3.10, 3.11, 3.12, 3.13.
+- **Type hints**: use modern forms (`list[str]`, `dict[str, int]`, `X | None`). Ruff enforces this via `UP006` and `UP007`.
+- **Formatting**: ruff format with line length 120.
+- **Tests**: must be parallel-safe (pytest-xdist) and finish under the 10-second timeout. The default tox env asserts `EXPECTED_SKIP_COUNT=147`; if a test you add is skipped, update the count or unskip it.
+- **Supply chain**: `[tool.uv] exclude-newer = "7 days"` in `pyproject.toml` defers new dependency releases by 7 days. Do not edit this without a reason.
+- **Licenses**: dependencies must satisfy the allowlist in `tox.ini` (Apache-2.0, BSD, MIT, MPL-2.0, PSF, ISC, LGPLv2+). Adding a dependency with a non-listed license fails tox.
+- **Commits**: use [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, `docs:`, `test:`, `refactor:`). semantic-release reads these to compute the next version.
+
 ## Issue Creation
 
 When filing a GitHub issue (via `gh issue create` or otherwise), follow the structure in `.github/ISSUE_TEMPLATE/issue.yml`:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,17 @@ source .venv/bin/activate
 - Avoid try/except blocks
 - Never mention agents in commit messages, PR descriptions, or any user-facing text (no `Co-Authored-By` agent lines, no agent names)
 
+## Issue Creation
+
+When filing a GitHub issue (via `gh issue create` or otherwise), follow the structure in `.github/ISSUE_TEMPLATE/issue.yml`:
+
+- Summary in one sentence
+- Reproduction (for bugs) or motivation (for features)
+- Code pointers if relevant (`file:line`)
+- Definition of done if scoped (what counts as complete)
+
+Issues that meet this bar are eligible for the `good first issue` label without further sharpening.
+
 ## Memory Bank
 
 The `memory-bank/` directory contains project context documentation. Read relevant files at the start of tasks to understand the project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ For contributions to the mloda core framework, see our [Documentation](https://m
 
 ### Report Issues
 
-Found a bug or have a feature request? [Open an issue](https://github.com/mloda-ai/mloda/issues/).
+Found a bug or have a feature request? [Open an issue](https://github.com/mloda-ai/mloda/issues/). The issue template will prompt you for a summary, reproduction or motivation, optional code pointers, and an optional definition of done.
 
 ## Pull Request Workflow
 


### PR DESCRIPTION
## Summary

Until now the repo had no GitHub issue template, no AGENTS.md, and CLAUDE.md captured only a thin slice of the practices the project actually follows. As part of tk-290, this PR formalises three pieces of AI-agent and contributor guidance so any new issue or new agent inherits the project's conventions.

**`.github/ISSUE_TEMPLATE/issue.yml`** -- single unified GitHub form. Required: summary and reproduction/motivation. Optional: code pointers, definition of done, environment.

**`.github/ISSUE_TEMPLATE/config.yml`** -- `blank_issues_enabled: false`, so the template is the default path.

**`AGENTS.md`** -- one-line pointer to `CLAUDE.md`, mirroring the workspace convention (`nexus-tk/AGENTS.md` does the same). Lets agents that look for `AGENTS.md` first (Codex, Cursor, etc.) be redirected to the canonical guidance.

**`CLAUDE.md` -- two new sections:**
- *Project Practices* (new, between Coding Instructions and Issue Creation) -- summarises what `tox` enforces (pytest, ruff format/check, mypy strict, bandit, pip-licenses allowlist), the supported Python range (3.10-3.13), modern type hints (`list[str]`, `X | None`), the 7-day `uv exclude-newer` supply-chain delay, the license allowlist, and Conventional Commits. Sourced from `pyproject.toml`, `tox.ini`, and CI workflows.
- *Issue Creation* -- short pointer at the new issue template fields so Claude Code follows the same structure when filing issues.

**`CONTRIBUTING.md`** -- one-line note in *Report Issues* about the template fields.

## Test plan
- [ ] Open the *New issue* page on the repo after merge and confirm the form renders the five fields.
- [ ] Confirm blank issues are disabled (no "open a blank issue" link visible on the chooser page).
- [ ] Confirm `AGENTS.md` renders as a one-line pointer.
- [ ] Confirm the new *Project Practices* section in `CLAUDE.md` renders cleanly (bullets, inline code spans, the Conventional Commits link).