### PR TITLE
Include string dtype in select_dtypes and update LDA test

### DIFF
--- a/mloda_plugins/feature_group/experimental/dimensionality_reduction/pandas.py
+++ b/mloda_plugins/feature_group/experimental/dimensionality_reduction/pandas.py
@@ -310,7 +310,7 @@ class PandasDimensionalityReductionFeatureGroup(DimensionalityReductionFeatureGr
 
         # LDA requires a target variable
         # We'll try to find a categorical column in the DataFrame
-        categorical_columns = df.select_dtypes(include=["object", "category"]).columns
+        categorical_columns = df.select_dtypes(include=["object", "string", "category"]).columns
 
         if len(categorical_columns) == 0:
             raise ValueError("LDA requires a categorical target variable, but none was found in the data")

--- a/tests/test_plugins/feature_group/experimental/test_dimensionality_reduction_feature_group/test_pandas_dimensionality_reduction_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/test_dimensionality_reduction_feature_group/test_pandas_dimensionality_reduction_feature_group.py
@@ -132,6 +132,9 @@ class TestPandasDimensionalityReductionFeatureGroup:
 
     def test_perform_lda_reduction(self, sample_data: pd.DataFrame) -> None:
         """Test the _perform_lda_reduction method."""
+
+        sample_data["category"] = pd.array(sample_data["category"], dtype="string")
+
         # Extract features
         X = sample_data[["feature0", "feature1", "feature2"]].values
 


### PR DESCRIPTION
Added "string" to select_dtypes in the Pandas plugin to ensure compatibility with the Pandas 3.0 migration.
Updated the LDA test to exercise StringDtype columns, confirming that tests now pass warning-free in pytest. Closes #395 