### PR TITLE
feat(duckdb): add public project, aggregate, query API on DuckdbRelation

### DIFF
--- a/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_relation.py
+++ b/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_relation.py
@@ -61,6 +61,36 @@ class DuckdbRelation:
             new_rel = self._relation.project(projection)
         return DuckdbRelation(self._connection, new_rel)
 
+    def project(self, expression: str) -> "DuckdbRelation":
+        """Project columns using a raw SQL projection string.
+
+        Public, underscore-free equivalent of ``select(_raw_sql=expression)``.
+        Bypasses identifier quoting; never pass user-controlled input.
+        """
+        new_rel = self._relation.project(expression)
+        return DuckdbRelation(self._connection, new_rel)
+
+    def aggregate(self, agg_expr: str, group_by: str = "") -> "DuckdbRelation":
+        """GROUP BY aggregation. Thin wrapper around ``DuckDBPyRelation.aggregate``.
+
+        Both arguments are SQL fragments inlined verbatim; never pass
+        user-controlled input.
+        """
+        if group_by:
+            new_rel = self._relation.aggregate(agg_expr, group_by)
+        else:
+            new_rel = self._relation.aggregate(agg_expr)
+        return DuckdbRelation(self._connection, new_rel)
+
+    def query(self, alias: str, sql: str) -> "DuckdbRelation":
+        """Execute a full SELECT statement against this relation under ``alias``.
+
+        Thin wrapper around ``DuckDBPyRelation.query``. The SQL is inlined
+        verbatim; never pass user-controlled input.
+        """
+        new_rel = self._relation.query(alias, sql)
+        return DuckdbRelation(self._connection, new_rel)
+
     def set_alias(self, alias: str) -> "DuckdbRelation":
         new_rel = DuckdbRelation(self._connection, self._relation.set_alias(alias))
         new_rel._alias = alias

--- a/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_relation.py
+++ b/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_relation.py
@@ -123,3 +123,54 @@ class TestDuckdbRelation(RelationTestMixin):
     def test_order_returns_duckdb_relation(self, sample_relation: "DuckdbRelation") -> None:
         ordered = sample_relation.order("age")
         assert isinstance(ordered, DuckdbRelation)
+
+    # --- Project (public raw projection) ---
+
+    def test_project_basic_expression(self, sample_relation: "DuckdbRelation") -> None:
+        result = sample_relation.project("id, age * 2 AS double_age")
+        ages = self.get_column_values(result, "double_age")
+        assert ages == [50, 60, 70, 80, 90]
+
+    def test_project_returns_duckdb_relation(self, sample_relation: "DuckdbRelation") -> None:
+        result = sample_relation.project("id")
+        assert isinstance(result, DuckdbRelation)
+
+    def test_project_preserves_row_count(self, sample_relation: "DuckdbRelation") -> None:
+        result = sample_relation.project("id, age")
+        assert len(result) == 5
+
+    # --- Aggregate ---
+
+    def test_aggregate_with_group_by(self, sample_relation: "DuckdbRelation") -> None:
+        result = sample_relation.aggregate("category, COUNT(*) AS n", "category").order("category")
+        cats = self.get_column_values(result, "category")
+        counts = self.get_column_values(result, "n")
+        assert cats == ["A", "B", "C"]
+        assert counts == [2, 2, 1]
+
+    def test_aggregate_without_group_by(self, sample_relation: "DuckdbRelation") -> None:
+        result = sample_relation.aggregate("COUNT(*) AS total")
+        assert self.get_column_values(result, "total") == [5]
+
+    def test_aggregate_returns_duckdb_relation(self, sample_relation: "DuckdbRelation") -> None:
+        result = sample_relation.aggregate("COUNT(*) AS total")
+        assert isinstance(result, DuckdbRelation)
+
+    # --- Query ---
+
+    def test_query_basic(self, sample_relation: "DuckdbRelation") -> None:
+        result = sample_relation.query("data", "SELECT id, age FROM data WHERE age >= 35 ORDER BY id")
+        ids = self.get_column_values(result, "id")
+        assert ids == [3, 4, 5]
+
+    def test_query_with_window_function(self, sample_relation: "DuckdbRelation") -> None:
+        result = sample_relation.query(
+            "data",
+            "SELECT id, ROW_NUMBER() OVER (PARTITION BY category ORDER BY age) AS rn FROM data ORDER BY id",
+        )
+        rns = self.get_column_values(result, "rn")
+        assert rns == [1, 1, 2, 1, 2]
+
+    def test_query_returns_duckdb_relation(self, sample_relation: "DuckdbRelation") -> None:
+        result = sample_relation.query("data", "SELECT * FROM data LIMIT 1")
+        assert isinstance(result, DuckdbRelation)


### PR DESCRIPTION
Closes #389 (minimum deliverables only).

Adds three public methods to `DuckdbRelation` so downstream plugins can stop reaching into `_relation` or relying on the `select(_raw_sql=...)` escape hatch:

- `project(expression)` — public, underscore-free equivalent of `select(_raw_sql=...)`.
- `aggregate(agg_expr, group_by="")` — wraps `DuckDBPyRelation.aggregate`. Optional `group_by` so the existing `count_star()` use case is also expressible publicly without a meaningless GROUP BY.
- `query(alias, sql)` — wraps `DuckDBPyRelation.query`.

Each docstring repeats the SQL-injection contract from the class docstring. All three follow the existing pattern (delegate to native, wrap, return new instance).

The `with_row_number(...)`, structured `window(...)`, and collision-safe naming items listed in the issue under "nice-to-have follow-ups" are deferred — they touch helper-column naming policy and would balloon the PR.

Tests: 8 new test methods covering the basic projection / aggregation / query / window-function-via-query paths, return type, row-count preservation, and a no-group-by aggregate. Uses the existing `sample_relation` fixture, no new dependencies. `EXPECTED_SKIP_COUNT=147` invariant unchanged (DuckDB is available in test env, none skipped).

Local validation: `pytest -n 8 --timeout=10` (50/50 pass), `ruff format --check`, `ruff check`, and `bandit` all clean. The two `mypy --strict` errors on the touched files (`L14` of `duckdb_relation.py` and `L21` of the test file) pre-existed on `main`.