### PR TITLE
feat(duckdb): add public project, aggregate, query API on DuckdbRelation

### DIFF
--- a/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_relation.py
+++ b/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_relation.py
@@ -27,8 +27,6 @@ class DuckdbRelation:
     - DuckDB's Relational API does not support PEP 249 parameterized queries,
       so ``filter()`` falls back to ``inline_params`` / ``quote_value`` for
       literal values. See ``sql_utils`` module docstring for details.
-    - ``_raw_sql`` on ``select()`` bypasses quoting; callers must not pass
-      user-controlled input.
     """
 
     def __init__(self, connection: duckdb.DuckDBPyConnection, relation: duckdb.DuckDBPyRelation) -> None:
@@ -52,19 +50,15 @@ class DuckdbRelation:
         new_rel = self._relation.filter(condition)
         return DuckdbRelation(self._connection, new_rel)
 
-    def select(self, *columns: str, _raw_sql: Optional[str] = None) -> "DuckdbRelation":
-        """Project columns. _raw_sql bypasses quoting: never pass user-controlled input."""
-        if _raw_sql is not None:
-            new_rel = self._relation.project(_raw_sql)
-        else:
-            projection = ", ".join(quote_ident(c) for c in columns)
-            new_rel = self._relation.project(projection)
+    def select(self, *columns: str) -> "DuckdbRelation":
+        """Project named columns, quoting each identifier."""
+        projection = ", ".join(quote_ident(c) for c in columns)
+        new_rel = self._relation.project(projection)
         return DuckdbRelation(self._connection, new_rel)
 
     def project(self, expression: str) -> "DuckdbRelation":
         """Project columns using a raw SQL projection string.
 
-        Public, underscore-free equivalent of ``select(_raw_sql=expression)``.
         Bypasses identifier quoting; never pass user-controlled input.
         """
         new_rel = self._relation.project(expression)
@@ -76,19 +70,16 @@ class DuckdbRelation:
         Both arguments are SQL fragments inlined verbatim; never pass
         user-controlled input.
         """
-        if group_by:
-            new_rel = self._relation.aggregate(agg_expr, group_by)
-        else:
-            new_rel = self._relation.aggregate(agg_expr)
+        new_rel = self._relation.aggregate(agg_expr, group_by) if group_by else self._relation.aggregate(agg_expr)
         return DuckdbRelation(self._connection, new_rel)
 
-    def query(self, alias: str, sql: str) -> "DuckdbRelation":
-        """Execute a full SELECT statement against this relation under ``alias``.
+    def query(self, view_name: str, sql: str) -> "DuckdbRelation":
+        """Execute a full SELECT statement against this relation under ``view_name``.
 
-        Thin wrapper around ``DuckDBPyRelation.query``. The SQL is inlined
-        verbatim; never pass user-controlled input.
+        Thin wrapper around ``DuckDBPyRelation.query``. SQL is inlined verbatim;
+        never pass user-controlled input.
         """
-        new_rel = self._relation.query(alias, sql)
+        new_rel = self._relation.query(view_name, sql)
         return DuckdbRelation(self._connection, new_rel)
 
     def set_alias(self, alias: str) -> "DuckdbRelation":

--- a/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_relation.py
+++ b/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_relation.py
@@ -61,6 +61,36 @@ class DuckdbRelation:
             new_rel = self._relation.project(projection)
         return DuckdbRelation(self._connection, new_rel)
 
+    def project(self, expression: str) -> "DuckdbRelation":
+        """Project columns using a raw SQL projection string.
+
+        Public, underscore-free equivalent of ``select(_raw_sql=expression)``.
+        Bypasses identifier quoting; never pass user-controlled input.
+        """
+        new_rel = self._relation.project(expression)
+        return DuckdbRelation(self._connection, new_rel)
+
+    def aggregate(self, agg_expr: str, group_by: str = "") -> "DuckdbRelation":
+        """GROUP BY aggregation. Thin wrapper around ``DuckDBPyRelation.aggregate``.
+
+        Both arguments are SQL fragments inlined verbatim; never pass
+        user-controlled input.
+        """
+        if group_by:
+            new_rel = self._relation.aggregate(agg_expr, group_by)
+        else:
+            new_rel = self._relation.aggregate(agg_expr)
+        return DuckdbRelation(self._connection, new_rel)
+
+    def query(self, alias: str, sql: str) -> "DuckdbRelation":
+        """Execute a full SELECT statement against this relation under ``alias``.
+
+        Thin wrapper around ``DuckDBPyRelation.query``. The SQL is inlined
+        verbatim; never pass user-controlled input.
+        """
+        new_rel = self._relation.query(alias, sql)
+        return DuckdbRelation(self._connection, new_rel)
+
     def set_alias(self, alias: str) -> "DuckdbRelation":
         new_rel = DuckdbRelation(self._connection, self._relation.set_alias(alias))
         new_rel._alias = alias

--- a/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_integration.py
+++ b/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_integration.py
@@ -129,11 +129,11 @@ class DuckDBSimpleTransformFeatureGroup(ATestDuckDBFeatureGroup):
 
             if feature_name == "doubled_value":
                 # Add doubled_value column using DuckDB SQL
-                result_data = result_data.select(_raw_sql="*, value * 2 AS doubled_value")
+                result_data = result_data.project("*, value * 2 AS doubled_value")
 
             elif feature_name == "score_plus_ten":
                 # Add score_plus_ten column using DuckDB SQL
-                result_data = result_data.select(_raw_sql="*, score + 10 AS score_plus_ten")
+                result_data = result_data.project("*, score + 10 AS score_plus_ten")
 
         return result_data
 
@@ -157,7 +157,7 @@ class DuckDBSecondTransformFeatureGroup(ATestDuckDBFeatureGroup):
 
             if feature_name == "quadrupled_value":
                 # Add quadrupled_value column using DuckDB SQL
-                result_data = result_data.select(_raw_sql="*, doubled_value * 2 AS quadrupled_value")
+                result_data = result_data.project("*, doubled_value * 2 AS quadrupled_value")
 
         return result_data
 
@@ -187,15 +187,11 @@ class DuckDBAggregationFeatureGroup(ATestDuckDBFeatureGroup):
 
             if feature_name == "avg_value_by_category":
                 # Calculate average value by category
-                result_data = result_data.select(
-                    _raw_sql="*, AVG(value) OVER (PARTITION BY category) AS avg_value_by_category"
-                )
+                result_data = result_data.project("*, AVG(value) OVER (PARTITION BY category) AS avg_value_by_category")
 
             elif feature_name == "count_by_category":
                 # Count records by category
-                result_data = result_data.select(
-                    _raw_sql="*, COUNT(*) OVER (PARTITION BY category) AS count_by_category"
-                )
+                result_data = result_data.project("*, COUNT(*) OVER (PARTITION BY category) AS count_by_category")
 
         return result_data
 

--- a/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_mask_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_mask_engine.py
@@ -42,6 +42,6 @@ if DUCKDB_AVAILABLE:
 
         def evaluate_mask(self, mask: Any, data: DuckdbRelation) -> list[bool]:
             bool_expr = f"CASE WHEN {mask} THEN 1 ELSE 0 END AS __match__"
-            projected = data.select(_raw_sql=bool_expr)
+            projected = data.project(bool_expr)
             arrow = projected.to_arrow_table()
             return [bool(arrow.column("__match__")[i].as_py()) for i in range(arrow.num_rows)]

--- a/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_relation.py
+++ b/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_relation.py
@@ -42,6 +42,18 @@ class TestDuckdbRelation(RelationTestMixin):
     def get_column_values(self, result: Any, column: str) -> list[Any]:
         return result.df()[column].tolist()  # type: ignore[no-any-return]
 
+    # --- Select ---
+
+    def test_select_raw_sql_expression(self, sample_relation: "DuckdbRelation") -> None:
+        result = sample_relation.project("*, age * 2 AS doubled_age")
+        assert "doubled_age" in result.columns
+        assert len(result) == 5
+
+    def test_select_raw_sql_window_function(self, sample_relation: "DuckdbRelation") -> None:
+        result = sample_relation.project("*, AVG(age) OVER () AS avg_age")
+        assert "avg_age" in result.columns
+        assert len(result) == 5
+
     # DuckDB-specific tests
 
     def test_stores_connection_and_relation(self, connection: Any) -> None:
@@ -174,3 +186,20 @@ class TestDuckdbRelation(RelationTestMixin):
     def test_query_returns_duckdb_relation(self, sample_relation: "DuckdbRelation") -> None:
         result = sample_relation.query("data", "SELECT * FROM data LIMIT 1")
         assert isinstance(result, DuckdbRelation)
+
+    # --- Injection-contract (verbatim passthrough) ---
+
+    def test_project_passes_expression_verbatim(self, sample_relation: "DuckdbRelation") -> None:
+        """project() must pass the caller's expression unchanged; quoting would turn function calls into string literals."""
+        result = sample_relation.project("UPPER(name) AS upper_name")
+        assert self.get_column_values(result, "upper_name") == ["ALICE", "BOB", "CHARLIE", "DAVID", "EVE"]
+
+    def test_aggregate_passes_expression_verbatim(self, sample_relation: "DuckdbRelation") -> None:
+        """aggregate() must pass the caller's SQL fragment unchanged; quoting would break FILTER (WHERE ...) syntax."""
+        result = sample_relation.aggregate("COUNT(*) FILTER (WHERE age > 30) AS over_30")
+        assert self.get_column_values(result, "over_30") == [3]
+
+    def test_query_passes_sql_verbatim(self, sample_relation: "DuckdbRelation") -> None:
+        """query() must pass the caller's SQL string unchanged; quoting would prevent execution of the SELECT statement."""
+        result = sample_relation.query("t", "SELECT UPPER(name) AS upper_name FROM t ORDER BY upper_name")
+        assert self.get_column_values(result, "upper_name") == ["ALICE", "BOB", "CHARLIE", "DAVID", "EVE"]

--- a/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_relation.py
+++ b/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_relation.py
@@ -123,3 +123,54 @@ class TestDuckdbRelation(RelationTestMixin):
     def test_order_returns_duckdb_relation(self, sample_relation: "DuckdbRelation") -> None:
         ordered = sample_relation.order("age")
         assert isinstance(ordered, DuckdbRelation)
+
+    # --- Project (public raw projection) ---
+
+    def test_project_basic_expression(self, sample_relation: "DuckdbRelation") -> None:
+        result = sample_relation.project("id, age * 2 AS double_age")
+        ages = self.get_column_values(result, "double_age")
+        assert ages == [50, 60, 70, 80, 90]
+
+    def test_project_returns_duckdb_relation(self, sample_relation: "DuckdbRelation") -> None:
+        result = sample_relation.project("id")
+        assert isinstance(result, DuckdbRelation)
+
+    def test_project_preserves_row_count(self, sample_relation: "DuckdbRelation") -> None:
+        result = sample_relation.project("id, age")
+        assert len(result) == 5
+
+    # --- Aggregate ---
+
+    def test_aggregate_with_group_by(self, sample_relation: "DuckdbRelation") -> None:
+        result = sample_relation.aggregate("category, COUNT(*) AS n", "category").order("category")
+        cats = self.get_column_values(result, "category")
+        counts = self.get_column_values(result, "n")
+        assert cats == ["A", "B", "C"]
+        assert counts == [2, 2, 1]
+
+    def test_aggregate_without_group_by(self, sample_relation: "DuckdbRelation") -> None:
+        result = sample_relation.aggregate("COUNT(*) AS total")
+        assert self.get_column_values(result, "total") == [5]
+
+    def test_aggregate_returns_duckdb_relation(self, sample_relation: "DuckdbRelation") -> None:
+        result = sample_relation.aggregate("COUNT(*) AS total")
+        assert isinstance(result, DuckdbRelation)
+
+    # --- Query ---
+
+    def test_query_basic(self, sample_relation: "DuckdbRelation") -> None:
+        result = sample_relation.query("data", "SELECT id, age FROM data WHERE age >= 35 ORDER BY id")
+        ids = self.get_column_values(result, "id")
+        assert ids == [3, 4, 5]
+
+    def test_query_with_window_function(self, sample_relation: "DuckdbRelation") -> None:
+        result = sample_relation.query(
+            "data",
+            "SELECT id, ROW_NUMBER() OVER (PARTITION BY category ORDER BY age) AS rn FROM data ORDER BY id",
+        )
+        rns = self.get_column_values(result, "rn")
+        assert rns == [1, 1, 2, 1, 2]
+
+    def test_query_returns_duckdb_relation(self, sample_relation: "DuckdbRelation") -> None:
+        result = sample_relation.query("data", "SELECT * FROM data LIMIT 1")
+        assert isinstance(result, DuckdbRelation)


### PR DESCRIPTION
Supersedes #403 (mvanhorn's original PR) — all review items addressed before merge.

Closes #389 (minimum deliverables only).

Adds three public methods to `DuckdbRelation` so downstream plugins can stop reaching into `_relation` or relying on the `select(_raw_sql=...)` escape hatch:

- `project(expression)` — raw SQL projection, bypasses quoting.
- `aggregate(agg_expr, group_by="")` — wraps `DuckDBPyRelation.aggregate`. Optional `group_by` so the existing `count_star()` use case is expressible publicly without a meaningless GROUP BY.
- `query(view_name, sql)` — wraps `DuckDBPyRelation.query`.

## Review items addressed (none skipped)

**Non-optional:**
- `alias` renamed to `view_name` in `query()` — public API name fixed before it ships.

**Should fix:**
- `_raw_sql` removed from `DuckdbRelation.select()` — eliminates the API duplication #389 was trying to clean up. All callers in `test_duckdb_integration.py` and `test_duckdb_mask_engine.py` migrated to `project()`. The two shared mixin tests are overridden in `TestDuckdbRelation` to use `project()`; SQLite's mixin tests are unchanged.
- Injection-contract tests added for all three methods — verify that SQL fragments (function calls, `FILTER (WHERE ...)`, full `SELECT`) pass through verbatim. Guards against a well-meaning future refactor silently adding quoting.

**Optional:**
- `aggregate()` if/else collapsed to a single conditional expression.
- Docstrings updated: stale `_raw_sql` back-reference removed from `project()`, wording tightened on `aggregate()` and `query()`, `_raw_sql` bullet dropped from the class docstring.

## Tests

11 new test methods total (8 from original PR + 3 injection-contract). `EXPECTED_SKIP_COUNT=147` invariant unchanged. The two `mypy --strict` errors on `duckdb_relation.py:14` and the test file pre-existed on `main` and are unaffected.