### PR TITLE
fix: dedupe redefined FeatureGroup classes in long-lived namespaces

### DIFF
--- a/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
+++ b/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
@@ -5,14 +5,14 @@
 ### The Problem
 
 ```
-ValueError: Multiple feature groups {<feature_groups>} found for feature name: <feature_name>
+ValueError: Multiple feature groups found for feature '<feature_name>':
+  - FeatureGroupA (...) [domain: ...]
+  - FeatureGroupB (...) [domain: ...]
 ```
 
-This error occurs when multiple feature groups claim they can handle the same feature. Each feature must resolve to exactly one feature group to prevent conflicts.
+This error occurs when multiple distinct feature groups claim they can handle the same feature. Each feature must resolve to exactly one feature group to prevent conflicts.
 
-If you are running this in a notebook, please restart the kernel to clear any cached plugins. 
-If you experience this multiple times, please open an [issue](https://github.com/mloda-ai/mloda/issues/) or [contact the maintainers](mailto:info@mloda.ai), so that we prioritize this.
-
+If you previously hit this in a notebook because of a redefined feature group (re-running a cell that defines `class MyFG(FeatureGroup): ...`), that case is now auto-deduplicated. If this error still appears, it points to a real conflict between two distinct classes (different `(module, qualname)`).
 
 ### Solutions
 
@@ -47,6 +47,48 @@ plugin_loader.load_group("feature_group") # load plugins only from mloda_plugins
 def get_domain(cls):
     return "sales"  # Makes this FG only handle 'sales' domain features
 ```
+
+## FeatureGroup Redefinition Errors
+
+### The Problem
+
+```
+ValueError: FeatureGroup redefined with different source code:
+  - MyFG (__main__) source hash 5a3f0c12
+  - MyFG (__main__) source hash b1e052a3
+Set PluginCollector(...).set_allow_redefinition() to keep only the most recently defined version of each class.
+If you are running this in a notebook, restart the kernel to clear stale class definitions.
+```
+
+This error occurs when the same feature group class name has been redefined with different source code in a long-lived Python namespace. Common triggers:
+
+- Re-running a Jupyter cell that defines `class MyFG(FeatureGroup): ...` after editing the class body. IPython's `Out[N]` history holds a strong reference to the old class object, so it stays alive in `FeatureGroup.__subclasses__()`.
+- Calling `importlib.reload` on a module that defines feature group classes.
+
+If both versions of the class have **identical** source code (e.g., re-running a cell without edits), mloda silently keeps one. The error fires only when the source actually differs.
+
+### Solutions
+
+#### 1. Take the most recent version (iterative development)
+
+For rapid iteration in notebooks, opt in to "newest wins" using the builder method on `PluginCollector`:
+
+```python
+from mloda.user import PluginCollector
+
+plugin_collector = PluginCollector().set_allow_redefinition()
+# Compose with disable/enable filters as needed:
+plugin_collector = (
+    PluginCollector.disabled_feature_groups({SomeFG})
+    .set_allow_redefinition()
+)
+```
+
+Pass this collector through to `mloda.run_all`, `resolve_feature`, or any other entry point that accepts a `plugin_collector` argument.
+
+#### 2. Restart the kernel
+
+Restarting the Jupyter kernel clears `Out[N]` history and unloads all stale class objects. Use this when you want a fully clean state and do not need to preserve other notebook state.
 
 ## Related Documentation
 

--- a/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
+++ b/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
@@ -74,7 +74,13 @@ If both versions of the class have **identical** source code (e.g., re-running a
 For rapid iteration in notebooks, opt in to "newest wins" using the builder method on `PluginCollector`:
 
 ```python
+from mloda.provider import FeatureGroup
 from mloda.user import PluginCollector
+
+
+class SomeFG(FeatureGroup):
+    pass
+
 
 plugin_collector = PluginCollector().set_allow_redefinition()
 # Compose with disable/enable filters as needed:

--- a/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
+++ b/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
@@ -73,6 +73,8 @@ If both versions of the class have **identical** source code (e.g., re-running a
 
 For rapid iteration in notebooks, opt in to "newest wins" using the builder method on `PluginCollector`:
 
+**Option A** — set the override flag on a fresh collector:
+
 ```python
 from mloda.provider import FeatureGroup
 from mloda.user import PluginCollector
@@ -83,7 +85,11 @@ class SomeFG(FeatureGroup):
 
 
 plugin_collector = PluginCollector().set_allow_redefinition()
-# Compose with disable/enable filters as needed:
+```
+
+**Option B** — compose with disable/enable filters:
+
+```python
 plugin_collector = (
     PluginCollector.disabled_feature_groups({SomeFG})
     .set_allow_redefinition()

--- a/mloda/core/abstract_plugins/components/base_feature_group_version.py
+++ b/mloda/core/abstract_plugins/components/base_feature_group_version.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import importlib.metadata
 import inspect
 import linecache
@@ -74,7 +75,9 @@ class BaseFeatureGroupVersion(ABC):
 
 
 def _linecache_source_for_class(target_class: type[Any]) -> str | None:
-    """Recover source text via ``linecache`` using the class's methods' ``co_filename``.
+    """Returns the source for the target class's ``ClassDef`` AST node from the linecache, not the whole file.
+
+    This keeps the hash stable when unrelated content in the same Jupyter cell changes.
 
     Only consults linecache for synthetic filenames of the form ``<...>`` (e.g.,
     Jupyter cells: ``<ipython-input-N-...>``). Real source files are skipped
@@ -92,10 +95,19 @@ def _linecache_source_for_class(target_class: type[Any]) -> str | None:
             filenames.add(co_filename)
     if not filenames:
         return None
-    parts: list[str] = []
+
+    target_name = target_class.__name__
     for filename in sorted(filenames):
         text = "".join(linecache.getlines(filename))
         if not text:
-            return None
-        parts.append(text)
-    return "".join(parts)
+            continue
+        try:
+            tree = ast.parse(text)
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef) and node.name == target_name:
+                segment = ast.get_source_segment(text, node)
+                if segment is not None:
+                    return segment
+    return None

--- a/mloda/core/abstract_plugins/components/base_feature_group_version.py
+++ b/mloda/core/abstract_plugins/components/base_feature_group_version.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.metadata
 import inspect
+import linecache
 import hashlib
 from typing import Any
 from abc import ABC
@@ -23,6 +24,11 @@ class BaseFeatureGroupVersion(ABC):
     def class_source_hash(cls, target_class: type[Any]) -> str:
         """
         Returns a SHA-256 hash of the target class's source code.
+
+        Falls back to a linecache-based lookup via the class's methods'
+        ``__code__.co_filename`` when ``inspect.getsource`` cannot resolve the
+        class (common for classes defined in long-lived namespaces such as
+        Jupyter cells where ``__module__ == '__main__'``).
         """
 
         # Import FeatureGroup locally to avoid circular import.
@@ -31,7 +37,13 @@ class BaseFeatureGroupVersion(ABC):
         if not issubclass(target_class, FeatureGroup):
             raise ValueError(f"target_class must be a subclass of FeatureGroup: {target_class}")
 
-        source = inspect.getsource(target_class)
+        try:
+            source: str = inspect.getsource(target_class)
+        except (OSError, TypeError):
+            fallback = _linecache_source_for_class(target_class)
+            if fallback is None:
+                raise
+            source = fallback
         return hashlib.sha256(source.encode("utf-8")).hexdigest()
 
     @classmethod
@@ -59,3 +71,31 @@ class BaseFeatureGroupVersion(ABC):
             raise ValueError(f"target_class must be a subclass of FeatureGroup: {target_class}")
 
         return f"{cls.mloda_version()}-{cls.module_name(target_class)}-{cls.class_source_hash(target_class)}"
+
+
+def _linecache_source_for_class(target_class: type[Any]) -> str | None:
+    """Recover source text via ``linecache`` using the class's methods' ``co_filename``.
+
+    Only consults linecache for synthetic filenames of the form ``<...>`` (e.g.,
+    Jupyter cells: ``<ipython-input-N-...>``). Real source files are skipped
+    because ``inspect.getsource`` already had its chance and any text we'd read
+    here would not be specific to the target class.
+    """
+    filenames: set[str] = set()
+    for value in target_class.__dict__.values():
+        func = value.__func__ if hasattr(value, "__func__") else value
+        code = getattr(func, "__code__", None)
+        if code is None:
+            continue
+        co_filename = code.co_filename
+        if co_filename.startswith("<") and co_filename.endswith(">"):
+            filenames.add(co_filename)
+    if not filenames:
+        return None
+    parts: list[str] = []
+    for filename in sorted(filenames):
+        text = "".join(linecache.getlines(filename))
+        if not text:
+            return None
+        parts.append(text)
+    return "".join(parts)

--- a/mloda/core/abstract_plugins/components/plugin_option/plugin_collector.py
+++ b/mloda/core/abstract_plugins/components/plugin_option/plugin_collector.py
@@ -15,6 +15,12 @@ class PluginCollector:
     def __init__(self) -> None:
         self.disabled_feature_group_classes: set[type[FeatureGroup]] = set()
         self.enabled_feature_group_classes: set[type[FeatureGroup]] = set()
+        self.allow_redefinition: bool = False
+
+    def set_allow_redefinition(self, allow: bool = True) -> "PluginCollector":
+        """Allow keeping the most recently defined class when duplicates differ in source."""
+        self.allow_redefinition = allow
+        return self
 
     def add_disabled_feature_group_classes(self, feature_group_cls: set[type[FeatureGroup]]) -> None:
         self.disabled_feature_group_classes.update(feature_group_cls)

--- a/mloda/core/abstract_plugins/components/plugin_option/plugin_collector.py
+++ b/mloda/core/abstract_plugins/components/plugin_option/plugin_collector.py
@@ -10,6 +10,11 @@ class PluginCollector:
 
     Further, this class is useful for testing, where you want to test the behavior of the system with different
     feature groups enabled or disabled.
+
+    Use ``set_allow_redefinition()`` to keep only the most recently defined version of each FeatureGroup
+    class when duplicates differ in source — useful when iterating on a FeatureGroup definition in a
+    Jupyter cell or via ``importlib.reload``, where the old class object survives in
+    ``FeatureGroup.__subclasses__()`` and would otherwise raise a "FeatureGroup redefined" error.
     """
 
     def __init__(self) -> None:

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -259,10 +259,11 @@ def resolve_feature(feature_name: str, plugin_collector: Optional[PluginCollecto
             dedup_feature_group_subclasses(get_all_subclasses(FeatureGroup), allow_redefinition=allow_redefinition)
         )
     except ValueError as exc:
+        candidates = list(getattr(exc, "conflicts", []))
         return ResolvedFeature(
             feature_name=feature_name,
             feature_group=None,
-            candidates=[],
+            candidates=candidates,
             error=str(exc),
         )
     candidates: list[type[FeatureGroup]] = []

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -259,11 +259,11 @@ def resolve_feature(feature_name: str, plugin_collector: Optional[PluginCollecto
             dedup_feature_group_subclasses(get_all_subclasses(FeatureGroup), allow_redefinition=allow_redefinition)
         )
     except ValueError as exc:
-        candidates = list(getattr(exc, "conflicts", []))
+        conflict_candidates = list(getattr(exc, "conflicts", []))
         return ResolvedFeature(
             feature_name=feature_name,
             feature_group=None,
-            candidates=candidates,
+            candidates=conflict_candidates,
             error=str(exc),
         )
     candidates: list[type[FeatureGroup]] = []

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -235,7 +235,7 @@ def get_extender_docs(
     return sorted(results, key=lambda x: x.name)
 
 
-def resolve_feature(feature_name: str) -> ResolvedFeature:
+def resolve_feature(feature_name: str, plugin_collector: Optional[PluginCollector] = None) -> ResolvedFeature:
     """
     Resolve a feature name to its matching FeatureGroup class.
 
@@ -245,13 +245,19 @@ def resolve_feature(feature_name: str) -> ResolvedFeature:
 
     Args:
         feature_name: The name of the feature to resolve.
+        plugin_collector: Optional PluginCollector. When provided, its
+            ``allow_redefinition`` flag is threaded into deduplication so that
+            redefined FeatureGroup classes (e.g. via reload) do not raise.
 
     Returns:
         ResolvedFeature containing the resolved FeatureGroup (if found),
         all matching candidates, and any error message.
     """
+    allow_redefinition = plugin_collector.allow_redefinition if plugin_collector is not None else False
     try:
-        all_fgs = list(dedup_feature_group_subclasses(get_all_subclasses(FeatureGroup)))
+        all_fgs = list(
+            dedup_feature_group_subclasses(get_all_subclasses(FeatureGroup), allow_redefinition=allow_redefinition)
+        )
     except ValueError as exc:
         return ResolvedFeature(
             feature_name=feature_name,

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -25,6 +25,7 @@ from mloda.core.abstract_plugins.function_extender import Extender
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.api.plugin_info import ComputeFrameworkInfo, ExtenderInfo, FeatureGroupInfo, ResolvedFeature
+from mloda.core.prepare.accessible_plugins import dedup_feature_group_subclasses
 
 
 def get_feature_group_docs(
@@ -50,7 +51,10 @@ def get_feature_group_docs(
     Returns:
         List of FeatureGroupInfo objects sorted by name.
     """
-    all_feature_groups = get_all_subclasses(FeatureGroup)
+    allow_redefinition = plugin_collector.allow_redefinition if plugin_collector is not None else False
+    all_feature_groups = dedup_feature_group_subclasses(
+        get_all_subclasses(FeatureGroup), allow_redefinition=allow_redefinition
+    )
     results = []
 
     for fg_class in all_feature_groups:
@@ -246,7 +250,7 @@ def resolve_feature(feature_name: str) -> ResolvedFeature:
         ResolvedFeature containing the resolved FeatureGroup (if found),
         all matching candidates, and any error message.
     """
-    all_fgs = list(get_all_subclasses(FeatureGroup))
+    all_fgs = list(dedup_feature_group_subclasses(get_all_subclasses(FeatureGroup)))
     candidates: list[type[FeatureGroup]] = []
     feature_name_obj = FeatureName(feature_name)
 

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -84,9 +84,6 @@ def get_feature_group_docs(
         if version_contains is not None and version_contains not in version:
             continue
 
-        # NOTE: plugin_collector applicability is now enforced before dedup; the in-loop
-        # check that used to live here was removed.
-
         results.append(
             FeatureGroupInfo(
                 name=fg_name,

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -250,7 +250,15 @@ def resolve_feature(feature_name: str) -> ResolvedFeature:
         ResolvedFeature containing the resolved FeatureGroup (if found),
         all matching candidates, and any error message.
     """
-    all_fgs = list(dedup_feature_group_subclasses(get_all_subclasses(FeatureGroup)))
+    try:
+        all_fgs = list(dedup_feature_group_subclasses(get_all_subclasses(FeatureGroup)))
+    except ValueError as exc:
+        return ResolvedFeature(
+            feature_name=feature_name,
+            feature_group=None,
+            candidates=[],
+            error=str(exc),
+        )
     candidates: list[type[FeatureGroup]] = []
     feature_name_obj = FeatureName(feature_name)
 

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -52,9 +52,10 @@ def get_feature_group_docs(
         List of FeatureGroupInfo objects sorted by name.
     """
     allow_redefinition = plugin_collector.allow_redefinition if plugin_collector is not None else False
-    all_feature_groups = dedup_feature_group_subclasses(
-        get_all_subclasses(FeatureGroup), allow_redefinition=allow_redefinition
-    )
+    all_feature_groups: set[type[FeatureGroup]] = get_all_subclasses(FeatureGroup)
+    if plugin_collector is not None:
+        all_feature_groups = {fg for fg in all_feature_groups if plugin_collector.applicable_feature_group_class(fg)}
+    all_feature_groups = dedup_feature_group_subclasses(all_feature_groups, allow_redefinition=allow_redefinition)
     results = []
 
     for fg_class in all_feature_groups:
@@ -83,8 +84,8 @@ def get_feature_group_docs(
         if version_contains is not None and version_contains not in version:
             continue
 
-        if plugin_collector is not None and not plugin_collector.applicable_feature_group_class(fg_class):
-            continue
+        # NOTE: plugin_collector applicability is now enforced before dedup; the in-loop
+        # check that used to live here was removed.
 
         results.append(
             FeatureGroupInfo(
@@ -254,16 +255,21 @@ def resolve_feature(feature_name: str, plugin_collector: Optional[PluginCollecto
         all matching candidates, and any error message.
     """
     allow_redefinition = plugin_collector.allow_redefinition if plugin_collector is not None else False
+    fg_classes: set[type[FeatureGroup]] = get_all_subclasses(FeatureGroup)
+    if plugin_collector is not None:
+        fg_classes = {fg for fg in fg_classes if plugin_collector.applicable_feature_group_class(fg)}
     try:
-        all_fgs = list(
-            dedup_feature_group_subclasses(get_all_subclasses(FeatureGroup), allow_redefinition=allow_redefinition)
-        )
+        all_fgs = list(dedup_feature_group_subclasses(fg_classes, allow_redefinition=allow_redefinition))
     except ValueError as exc:
-        conflict_candidates = list(getattr(exc, "conflicts", []))
+        raw_conflicts = list(getattr(exc, "conflicts", []))
+        feature_name_obj = FeatureName(feature_name)
+        matching_conflicts = [
+            fg for fg in raw_conflicts if fg.match_feature_group_criteria(feature_name_obj, Options(), None)
+        ]
         return ResolvedFeature(
             feature_name=feature_name,
             feature_group=None,
-            candidates=conflict_candidates,
+            candidates=matching_conflicts,
             error=str(exc),
         )
     candidates: list[type[FeatureGroup]] = []

--- a/mloda/core/prepare/accessible_plugins.py
+++ b/mloda/core/prepare/accessible_plugins.py
@@ -28,7 +28,7 @@ def _running_in_zmq_shell() -> bool:
     ipython_instance = get_ipython()  # type: ignore[no-untyped-call]
     if ipython_instance is None:
         return False
-    return ipython_instance.__class__.__name__ == "ZMQInteractiveShell"
+    return bool(ipython_instance.__class__.__name__ == "ZMQInteractiveShell")
 
 
 def _safe_class_source_hash(cls: type[FeatureGroup]) -> Optional[str]:

--- a/mloda/core/prepare/accessible_plugins.py
+++ b/mloda/core/prepare/accessible_plugins.py
@@ -22,27 +22,26 @@ def _running_in_zmq_shell() -> bool:
     """Detect IPython kernel (Jupyter) environment for the kernel-restart hint."""
     try:
         from IPython import get_ipython  # type: ignore[attr-defined]
-
-        ipython_instance = get_ipython()  # type: ignore[no-untyped-call]
-        if ipython_instance is None:
-            return False
-        return bool(ipython_instance.__class__.__name__ == "ZMQInteractiveShell")
     except ImportError:
         return False
-    except Exception:  # nosec B110
+
+    ipython_instance = get_ipython()  # type: ignore[no-untyped-call]
+    if ipython_instance is None:
         return False
+    return ipython_instance.__class__.__name__ == "ZMQInteractiveShell"
 
 
 def _safe_class_source_hash(cls: type[FeatureGroup]) -> Optional[str]:
     """Return source hash for a FeatureGroup subclass or None if unavailable.
 
-    Catches a broad ``Exception`` because ``inspect.getsource`` raises a variety of
-    errors (``OSError``, ``TypeError``, ``IndentationError``, ``ValueError``) for
-    classes built dynamically via ``type()`` or otherwise lacking source backing.
+    ``inspect.getsource`` raises ``OSError``/``TypeError`` for classes built
+    dynamically via ``type()``, and may raise ``IndentationError``/``ValueError``
+    on malformed source backings. All four leave the class without a stable
+    source hash, so we return ``None``.
     """
     try:
         return BaseFeatureGroupVersion.class_source_hash(cls)
-    except Exception:
+    except (OSError, TypeError, IndentationError, ValueError):
         return None
 
 

--- a/mloda/core/prepare/accessible_plugins.py
+++ b/mloda/core/prepare/accessible_plugins.py
@@ -1,13 +1,166 @@
+from __future__ import annotations
+
+import logging
+import sys
 from copy import deepcopy
 from typing import Optional
+
+from mloda.core.abstract_plugins.components.base_feature_group_version import BaseFeatureGroupVersion
 from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
-
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.abstract_plugins.components.utils import get_all_subclasses
 
 
+logger = logging.getLogger(__name__)
+
+
 FeatureGroupEnvironmentMapping = dict[type[FeatureGroup], set[type[ComputeFramework]]]
+
+
+def _running_in_zmq_shell() -> bool:
+    """Detect IPython kernel (Jupyter) environment for the kernel-restart hint."""
+    try:
+        from IPython import get_ipython  # type: ignore[attr-defined]
+
+        ipython_instance = get_ipython()  # type: ignore[no-untyped-call]
+        if ipython_instance is None:
+            return False
+        return bool(ipython_instance.__class__.__name__ == "ZMQInteractiveShell")
+    except ImportError:
+        return False
+    except Exception:  # nosec B110
+        return False
+
+
+def _safe_class_source_hash(cls: type[FeatureGroup]) -> Optional[str]:
+    """Return source hash for a FeatureGroup subclass or None if unavailable.
+
+    Catches a broad ``Exception`` because ``inspect.getsource`` raises a variety of
+    errors (``OSError``, ``TypeError``, ``IndentationError``, ``ValueError``) for
+    classes built dynamically via ``type()`` or otherwise lacking source backing.
+    """
+    try:
+        return BaseFeatureGroupVersion.class_source_hash(cls)
+    except Exception:
+        return None
+
+
+def dedup_feature_group_subclasses(
+    classes: set[type[FeatureGroup]],
+    allow_redefinition: bool = False,
+) -> set[type[FeatureGroup]]:
+    """Deduplicate FeatureGroup subclasses sharing the same ``(module, qualname)``.
+
+    Long-lived namespaces (Jupyter notebooks, ``importlib.reload``) accumulate stale
+    class objects in ``FeatureGroup.__subclasses__()``. This helper collapses
+    identical-content duplicates silently and raises a clear ``ValueError`` when
+    duplicates differ in source (override via ``allow_redefinition=True``).
+    """
+    grouped: dict[tuple[str, str], list[type[FeatureGroup]]] = {}
+    for cls in classes:
+        key = (cls.__module__, cls.__qualname__)
+        grouped.setdefault(key, []).append(cls)
+
+    survivors: set[type[FeatureGroup]] = set()
+    conflicts: list[tuple[tuple[str, str], list[tuple[type[FeatureGroup], str]]]] = []
+
+    for key, members in grouped.items():
+        if len(members) == 1:
+            survivors.add(members[0])
+            continue
+
+        # Factory pattern: groups whose members are not bound under their name in
+        # any module namespace are produced by factories or held only via
+        # closures. They are intentionally distinct objects, so preserve all.
+        if not _any_live_in_module(members):
+            logger.debug(
+                "dedup_feature_group_subclasses: preserving group %s (no member bound in its module)",
+                key,
+            )
+            survivors.update(members)
+            continue
+
+        # Live-descendants check: preserve the whole group if any member has
+        # subclasses already alive in the FG tree.
+        has_live_descendants = any(len(get_all_subclasses(member)) > 0 for member in members)
+        if has_live_descendants:
+            logger.debug("dedup_feature_group_subclasses: preserving group %s due to live descendants", key)
+            survivors.update(members)
+            continue
+
+        hashes = [_safe_class_source_hash(m) for m in members]
+        if any(h is None for h in hashes):
+            logger.debug("dedup_feature_group_subclasses: preserving group %s (source unavailable)", key)
+            survivors.update(members)
+            continue
+
+        unique_hashes = set(hashes)
+        if len(unique_hashes) == 1:
+            survivor = _pick_survivor(members)
+            logger.debug(
+                "dedup_feature_group_subclasses: collapsed %d identical members of %s",
+                len(members),
+                key,
+            )
+            survivors.add(survivor)
+            continue
+
+        if allow_redefinition:
+            survivor = _pick_survivor(members)
+            logger.debug(
+                "dedup_feature_group_subclasses: kept newest of %d differing members of %s (allow_redefinition=True)",
+                len(members),
+                key,
+            )
+            survivors.add(survivor)
+            continue
+
+        conflicts.append((key, list(zip(members, hashes))))  # type: ignore[arg-type]
+
+    if conflicts:
+        raise ValueError(_build_conflict_error(conflicts))
+
+    return survivors
+
+
+def _pick_survivor(members: list[type[FeatureGroup]]) -> type[FeatureGroup]:
+    """Pick the live-in-module class, falling back to the last entry."""
+    for cls in members:
+        module = sys.modules.get(cls.__module__)
+        if module is None:
+            continue
+        bound = getattr(module, cls.__name__, None)
+        if bound is cls:
+            return cls
+    return members[-1]
+
+
+def _any_live_in_module(members: list[type[FeatureGroup]]) -> bool:
+    """True if any class is currently bound under its name in its module."""
+    for cls in members:
+        module = sys.modules.get(cls.__module__)
+        if module is None:
+            continue
+        if getattr(module, cls.__name__, None) is cls:
+            return True
+    return False
+
+
+def _build_conflict_error(
+    conflicts: list[tuple[tuple[str, str], list[tuple[type[FeatureGroup], str]]]],
+) -> str:
+    lines = ["FeatureGroup redefined with different source code:"]
+    for (module, qualname), hashed in conflicts:
+        for _cls, source_hash in hashed:
+            lines.append(f"  - {qualname} ({module}) source hash {source_hash[:8]}")
+    lines.append(
+        "Set PluginCollector(...).set_allow_redefinition() to keep only the most "
+        "recently defined version of each class."
+    )
+    if _running_in_zmq_shell():
+        lines.append("If you are running this in a notebook, restart the kernel to clear stale class definitions.")
+    return "\n".join(lines)
 
 
 class PreFilterPlugins:
@@ -33,6 +186,11 @@ class PreFilterPlugins:
             for accessible_fg in deepcopy(accessible_feature_groups):
                 if not plugin_collector.applicable_feature_group_class(accessible_fg):
                     accessible_feature_groups.remove(accessible_fg)
+
+        allow_redefinition = plugin_collector.allow_redefinition if plugin_collector is not None else False
+        accessible_feature_groups = dedup_feature_group_subclasses(
+            accessible_feature_groups, allow_redefinition=allow_redefinition
+        )
 
         if len(accessible_feature_groups) == 0:
             raise ValueError("No feature groups are loaded. Did you call PluginLoader.all()?")

--- a/mloda/core/prepare/accessible_plugins.py
+++ b/mloda/core/prepare/accessible_plugins.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import sys
 from copy import deepcopy
-from typing import Optional
+from typing import Optional, cast
 
 from mloda.core.abstract_plugins.components.base_feature_group_version import BaseFeatureGroupVersion
 from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
@@ -48,14 +48,13 @@ def _running_in_zmq_shell() -> bool:
 def _safe_class_source_hash(cls: type[FeatureGroup]) -> Optional[str]:
     """Return source hash for a FeatureGroup subclass or None if unavailable.
 
-    ``inspect.getsource`` raises ``OSError``/``TypeError`` for classes built
-    dynamically via ``type()``, and may raise ``IndentationError``/``ValueError``
-    on malformed source backings. All four leave the class without a stable
-    source hash, so we return ``None``.
+    ``inspect.getsource`` raises ``OSError`` (no source backing) or ``TypeError``
+    (built-in class) for classes built dynamically via ``type()``. Both leave the
+    class without a stable source hash, so we return ``None``.
     """
     try:
         return BaseFeatureGroupVersion.class_source_hash(cls)
-    except (OSError, TypeError, IndentationError, ValueError):
+    except (OSError, TypeError):
         return None
 
 
@@ -108,7 +107,8 @@ def dedup_feature_group_subclasses(
             survivors.update(members)
             continue
 
-        unique_hashes = set(hashes)
+        hashes_str: list[str] = cast(list[str], hashes)
+        unique_hashes = set(hashes_str)
         if len(unique_hashes) == 1:
             survivor = _pick_survivor(members)
             logger.debug(
@@ -129,7 +129,7 @@ def dedup_feature_group_subclasses(
             survivors.add(survivor)
             continue
 
-        conflicts.append((key, list(zip(members, hashes))))  # type: ignore[arg-type]
+        conflicts.append((key, list(zip(members, hashes_str))))
 
     if conflicts:
         all_conflicting_classes = [_cls for _, hashed in conflicts for _cls, _ in hashed]

--- a/mloda/core/prepare/accessible_plugins.py
+++ b/mloda/core/prepare/accessible_plugins.py
@@ -127,24 +127,22 @@ def dedup_feature_group_subclasses(
 def _pick_survivor(members: list[type[FeatureGroup]]) -> type[FeatureGroup]:
     """Pick the live-in-module class, falling back to the last entry."""
     for cls in members:
-        module = sys.modules.get(cls.__module__)
-        if module is None:
-            continue
-        bound = getattr(module, cls.__name__, None)
-        if bound is cls:
+        if _is_live_in_module(cls):
             return cls
     return members[-1]
 
 
+def _is_live_in_module(cls: type[FeatureGroup]) -> bool:
+    """True if ``cls`` is currently bound under its name in its own module."""
+    module = sys.modules.get(cls.__module__)
+    if module is None:
+        return False
+    return getattr(module, cls.__name__, None) is cls
+
+
 def _any_live_in_module(members: list[type[FeatureGroup]]) -> bool:
     """True if any class is currently bound under its name in its module."""
-    for cls in members:
-        module = sys.modules.get(cls.__module__)
-        if module is None:
-            continue
-        if getattr(module, cls.__name__, None) is cls:
-            return True
-    return False
+    return any(_is_live_in_module(cls) for cls in members)
 
 
 def _build_conflict_error(

--- a/mloda/core/prepare/accessible_plugins.py
+++ b/mloda/core/prepare/accessible_plugins.py
@@ -187,7 +187,7 @@ def _cell_label(cls: type[FeatureGroup]) -> Optional[str]:
             continue
         co_filename = code.co_filename
         if co_filename.startswith("<") and co_filename.endswith(">"):
-            return co_filename
+            return str(co_filename)
     return None
 
 

--- a/mloda/core/prepare/accessible_plugins.py
+++ b/mloda/core/prepare/accessible_plugins.py
@@ -18,6 +18,20 @@ logger = logging.getLogger(__name__)
 FeatureGroupEnvironmentMapping = dict[type[FeatureGroup], set[type[ComputeFramework]]]
 
 
+class RedefinitionConflictError(ValueError):
+    """Raised by dedup when same-key FG classes differ in source.
+
+    Carries the full list of conflicting classes via ``.conflicts`` so callers
+    (e.g. ``resolve_feature``) can populate ``ResolvedFeature.candidates``
+    instead of leaving it empty. Subclasses ``ValueError`` so existing
+    ``except ValueError:`` callers stay compatible.
+    """
+
+    def __init__(self, message: str, conflicts: list[type[FeatureGroup]]) -> None:
+        super().__init__(message)
+        self.conflicts = conflicts
+
+
 def _running_in_zmq_shell() -> bool:
     """Detect IPython kernel (Jupyter) environment for the kernel-restart hint."""
     try:
@@ -118,13 +132,27 @@ def dedup_feature_group_subclasses(
         conflicts.append((key, list(zip(members, hashes))))  # type: ignore[arg-type]
 
     if conflicts:
-        raise ValueError(_build_conflict_error(conflicts))
+        all_conflicting_classes = [_cls for _, hashed in conflicts for _cls, _ in hashed]
+        raise RedefinitionConflictError(_build_conflict_error(conflicts), all_conflicting_classes)
 
     return survivors
 
 
 def _pick_survivor(members: list[type[FeatureGroup]]) -> type[FeatureGroup]:
-    """Pick the live-in-module class, falling back to the last entry."""
+    """Pick the live-in-module class.
+
+    Invariant: ``_pick_survivor`` is only called after ``_any_live_in_module(members)``
+    returned True at the dedup call site, so at least one member satisfies
+    ``_is_live_in_module``. And ``_is_live_in_module`` checks
+    ``getattr(module, cls.__name__, None) is cls``, which is single-valued: at most
+    one member can match because the module attribute resolves to exactly one
+    class object. The for-loop is therefore fully deterministic — set-iteration
+    order does not affect which class is returned.
+
+    The ``return members[-1]`` fallback is only theoretically reachable in
+    pathological multi-thread states where ``sys.modules`` is mutated between
+    ``_any_live_in_module`` and this call.
+    """
     for cls in members:
         if _is_live_in_module(cls):
             return cls
@@ -144,13 +172,34 @@ def _any_live_in_module(members: list[type[FeatureGroup]]) -> bool:
     return any(_is_live_in_module(cls) for cls in members)
 
 
+def _cell_label(cls: type[FeatureGroup]) -> Optional[str]:
+    """Return the first synthetic ``<...>`` filename a class's methods live in.
+
+    Returns ``None`` for classes whose methods all live in real source files.
+    Mirrors the synthetic-filename detection in ``_linecache_source_for_class``
+    but stops at the first match — sufficient for "where was this class defined"
+    in the redef-conflict error message.
+    """
+    for value in cls.__dict__.values():
+        func = value.__func__ if hasattr(value, "__func__") else value
+        code = getattr(func, "__code__", None)
+        if code is None:
+            continue
+        co_filename = code.co_filename
+        if co_filename.startswith("<") and co_filename.endswith(">"):
+            return co_filename
+    return None
+
+
 def _build_conflict_error(
     conflicts: list[tuple[tuple[str, str], list[tuple[type[FeatureGroup], str]]]],
 ) -> str:
     lines = ["FeatureGroup redefined with different source code:"]
     for (module, qualname), hashed in conflicts:
         for _cls, source_hash in hashed:
-            lines.append(f"  - {qualname} ({module}) source hash {source_hash[:8]}")
+            cell = _cell_label(_cls)
+            location = f"{module} {cell}" if cell else module
+            lines.append(f"  - {qualname} ({location}) source hash {source_hash[:8]}")
     lines.append(
         "Set PluginCollector(...).set_allow_redefinition() to keep only the most "
         "recently defined version of each class."

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -178,24 +178,8 @@ class IdentifyFeatureGroupClass:
 
     def _adjust_error_message__by_notebook_env(self) -> str:
         """
-        Check if the code is running in a notebook environment.
+        After dedup, distinct-class conflicts are real ambiguities that kernel restart
+        will not fix. The kernel-restart hint now lives in the dedup-conflict error
+        raised from accessible_plugins.py. Kept as a no-op for call-site compatibility.
         """
-        try:
-            from IPython import get_ipython  # type: ignore[attr-defined]
-
-            ipython_instance = get_ipython()  # type: ignore[no-untyped-call]
-            if ipython_instance is None:
-                return ""
-            shell: str = ipython_instance.__class__.__name__
-            if shell == "ZMQInteractiveShell":
-                return """If you are running this in a notebook, please restart the kernel to clear any cached plugins.
-                          If you experience this multiple times, please open an issue or contact the maintainers for prioritization.
-                          https://github.com/mloda-ai/mloda/issues
-                """
-        except ImportError:
-            # IPython not installed
-            pass
-        except Exception:
-            # An exception here means we are not in a notebook environment.
-            pass  # nosec B110
         return ""

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -111,7 +111,6 @@ class IdentifyFeatureGroupClass:
             raise ValueError(
                 f"Multiple feature groups found for feature '{feature.name}':\n"
                 f"{format_feature_group_classes(feature_group.keys(), include_domain=True)}\n"
-                f"{self._adjust_error_message__by_notebook_env()}\n"
                 "For troubleshooting guide, see: https://mloda-ai.github.io/mloda/in_depth/troubleshooting/feature-group-resolution-errors/"
             )
 
@@ -175,11 +174,3 @@ class IdentifyFeatureGroupClass:
             _identified_feature_groups.pop(fg)
 
         return _identified_feature_groups
-
-    def _adjust_error_message__by_notebook_env(self) -> str:
-        """
-        After dedup, distinct-class conflicts are real ambiguities that kernel restart
-        will not fix. The kernel-restart hint now lives in the dedup-conflict error
-        raised from accessible_plugins.py. Kept as a no-op for call-site compatibility.
-        """
-        return ""

--- a/tests/test_core/test_prepare/test_feature_group_dedup.py
+++ b/tests/test_core/test_prepare/test_feature_group_dedup.py
@@ -596,3 +596,96 @@ def test_get_feature_group_docs_raises_on_redef_conflict_without_flag() -> None:
     msg = str(exc_info.value)
     assert "FeatureGroup redefined" in msg, f"Expected 'FeatureGroup redefined' in error, got: {msg}"
     assert "set_allow_redefinition" in msg, f"Expected 'set_allow_redefinition' in error, got: {msg}"
+
+
+# ---------------------------------------------------------------------------
+# Case 14 + 15: linecache AST fallback in class_source_hash
+# ---------------------------------------------------------------------------
+def test_class_source_hash_fallback_fires_when_inspect_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When ``inspect.getsource`` raises ``OSError``, ``class_source_hash`` must
+    fall back to ``_linecache_source_for_class`` and produce a valid SHA-256
+    hash from the AST-extracted class-local source segment.
+
+    Note: under pytest, ``__main__.__file__`` points to the pytest entry point,
+    so ``inspect.getsource`` already fails naturally for ``_exec_fg_in_main``
+    classes (it tries to read pytest's binary and cannot find the class
+    definition). Forcing the failure with ``monkeypatch`` here makes the test
+    robust against future ``inspect.getsource`` changes that might start
+    succeeding for these classes.
+    """
+    import inspect
+
+    from mloda.core.abstract_plugins.components.base_feature_group_version import BaseFeatureGroupVersion
+
+    qualname = "MyFG_FallbackFires"
+    feature_name = "fallback_fires_feature_unique_xyz"
+    src = _make_fg_source(qualname, feature_name)
+
+    cls = _exec_fg_in_main(qualname, src, "cell-fallback-fires-v1")
+    _REF_STORE.append(cls)
+
+    def failing_getsource(obj: Any) -> str:
+        raise OSError("forced failure for fallback test")
+
+    monkeypatch.setattr(inspect, "getsource", failing_getsource)
+
+    h = BaseFeatureGroupVersion.class_source_hash(cls)
+
+    assert isinstance(h, str)
+    assert len(h) == 64, f"SHA-256 hash should be 64 hex chars, got {len(h)}: {h!r}"
+    assert all(c in "0123456789abcdef" for c in h), f"Hash should be all-hex, got {h!r}"
+
+
+def test_class_source_hash_fallback_extracts_class_local_segment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When the fallback fires, it must extract ONLY the class-local source
+    region from the cell, so identical class bodies produce identical hashes
+    even when surrounding (non-class) cell content differs.
+
+    This is the intent that drove the fallback (commit b6af301 "hash only
+    class-local source in linecache fallback"). Existing happy-path test
+    ``test_class_source_hash_is_stable_across_unrelated_cell_edits`` may
+    pass via ``inspect.getsource`` directly; this test forces the fallback
+    so the invariant is verified for that branch specifically.
+    """
+    import inspect
+
+    from mloda.core.abstract_plugins.components.base_feature_group_version import BaseFeatureGroupVersion
+
+    qualname = "MyFG_FallbackStable"
+
+    class_body = textwrap.dedent(
+        f"""
+        class {qualname}(_FG_):
+            @classmethod
+            def feature_names_supported(cls):
+                return {{"fallback_stable_feature_unique_xyz"}}
+        """
+    )
+
+    cell_v1 = (
+        f"from mloda.core.abstract_plugins.feature_group import FeatureGroup as _FG_\n\nunrelated_var = 1\n{class_body}"
+    )
+    cell_v2 = (
+        "from mloda.core.abstract_plugins.feature_group import FeatureGroup as _FG_\n"
+        "\n"
+        "unrelated_var = 99\n"
+        f"{class_body}"
+    )
+
+    v1 = _exec_fg_in_main(qualname, cell_v1, "ipython-input-fallback-stable-v1")
+    _REF_STORE.append(v1)
+    v2 = _exec_fg_in_main(qualname, cell_v2, "ipython-input-fallback-stable-v2")
+    _REF_STORE.append(v2)
+
+    def failing_getsource(obj: Any) -> str:
+        raise OSError("forced failure for fallback test")
+
+    monkeypatch.setattr(inspect, "getsource", failing_getsource)
+
+    h1 = BaseFeatureGroupVersion.class_source_hash(v1)
+    h2 = BaseFeatureGroupVersion.class_source_hash(v2)
+
+    assert h1 == h2, (
+        "Fallback must extract only the class-local source segment so "
+        f"identical class bodies hash identically; got {h1[:16]}... vs {h2[:16]}..."
+    )

--- a/tests/test_core/test_prepare/test_feature_group_dedup.py
+++ b/tests/test_core/test_prepare/test_feature_group_dedup.py
@@ -1,0 +1,387 @@
+"""Tests for dedup_feature_group_subclasses helper and PluginCollector.set_allow_redefinition.
+
+These tests cover the new deduplication behavior for FeatureGroup subclasses that
+appear multiple times under the same (module, qualname) key. This commonly happens
+in Jupyter notebooks (where IPython's Out[N] holds strong refs to old class objects)
+and in `importlib.reload` flows. See plan: dedupe redefined FeatureGroup classes
+in long-lived namespaces.
+
+Helpers below simulate Jupyter cell rebinding via ``exec`` into ``__main__.__dict__``
+and register the source in ``linecache`` so ``inspect.getsource`` succeeds for the
+exec'd classes (mirroring how IPython sets up ``<ipython-input-N-...>`` entries).
+"""
+
+from __future__ import annotations
+
+import linecache
+import sys
+import textwrap
+from typing import Any, cast
+
+import pytest
+
+from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
+from mloda.core.abstract_plugins.components.utils import get_all_subclasses
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.api.plugin_docs import resolve_feature
+from mloda.core.prepare.accessible_plugins import PreFilterPlugins, dedup_feature_group_subclasses
+
+
+# Module-level reference store. This simulates IPython's ``_oh``/``Out[N]`` history,
+# which keeps strong refs to all cell-evaluated objects. It MUST be module-scoped so
+# the references survive across all assertions inside a single test.
+_REF_STORE: list[Any] = []
+
+
+def _exec_fg_in_main(class_name: str, body: str, cell_label: str) -> type[FeatureGroup]:
+    """Exec a FeatureGroup subclass into ``__main__``, registering source in linecache.
+
+    The exec'd class behaves like a class defined in a Jupyter cell: its ``__module__``
+    is ``"__main__"`` and ``inspect.getsource`` succeeds because we register the
+    source text in ``linecache`` (mimicking what IPython does).
+
+    The class is also bound as an attribute on ``sys.modules['__main__']`` so that
+    ``getattr(sys.modules['__main__'], class_name)`` returns the most recently
+    exec'd version, simulating Jupyter's "live in module" state after a cell rerun.
+    """
+    main_mod = sys.modules["__main__"]
+    src = textwrap.dedent(body)
+    filename = f"<{cell_label}>"
+    src_lines = src.splitlines(keepends=True)
+    linecache.cache[filename] = (len(src), None, src_lines, filename)
+    code_obj = compile(src, filename, "exec")
+    exec(code_obj, main_mod.__dict__)  # nosec B102
+    cls = main_mod.__dict__[class_name]
+    return cast(type[FeatureGroup], cls)
+
+
+def _make_fg_source(class_name: str, feature_name: str, extra_body: str = "") -> str:
+    """Build a FeatureGroup subclass source string for a given class name and feature.
+
+    The body imports FeatureGroup directly from the abstract_plugins module so that
+    ``exec`` into ``__main__.__dict__`` does not need any pre-populated names.
+    """
+    return f"""
+from mloda.core.abstract_plugins.feature_group import FeatureGroup as _FG_BASE_
+
+class {class_name}(_FG_BASE_):
+    @classmethod
+    def feature_names_supported(cls):
+        return {{"{feature_name}"}}
+{extra_body}
+"""
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_main_module_attrs() -> Any:
+    """Snapshot ``__main__`` attributes before each test and restore after.
+
+    This guarantees parallel-safety under ``pytest-xdist -n 8`` and prevents
+    bleed-over of test-defined classes into other tests sharing the same xdist worker.
+    Note: classes referenced from ``_REF_STORE`` still survive in
+    ``FeatureGroup.__subclasses__()`` for the lifetime of the test process,
+    which is intentional. Tests filter by their unique qualname to avoid
+    interference from other tests.
+    """
+    main_mod = sys.modules["__main__"]
+    snapshot = set(main_mod.__dict__.keys())
+    yield
+    new_keys = set(main_mod.__dict__.keys()) - snapshot
+    for k in new_keys:
+        main_mod.__dict__.pop(k, None)
+
+
+def _filter_by_qualname(classes: set[type[FeatureGroup]], qualname: str) -> set[type[FeatureGroup]]:
+    """Filter a set of classes to those with a matching ``__qualname__``."""
+    return {c for c in classes if c.__qualname__ == qualname}
+
+
+# ---------------------------------------------------------------------------
+# Case 1: Identical content, double-define in __main__, deduped to 1
+# ---------------------------------------------------------------------------
+def test_identical_content_double_define_dedups_to_one() -> None:
+    """Two identical-source FG defs in __main__ should dedup to a single class."""
+    qualname = "MyFG_Test1"
+    feature_name = "case1_feature_unique_xyz"
+    src = _make_fg_source(qualname, feature_name)
+
+    v1 = _exec_fg_in_main(qualname, src, "cell-test1-v1")
+    v2 = _exec_fg_in_main(qualname, src, "cell-test1-v2")
+
+    # Hold strong refs to simulate IPython's _oh history keeping both versions alive.
+    _REF_STORE.extend([v1, v2])
+
+    all_fgs = get_all_subclasses(FeatureGroup)
+    deduped = dedup_feature_group_subclasses(all_fgs)
+
+    matching = _filter_by_qualname(deduped, qualname)
+    assert len(matching) == 1, (
+        f"Expected exactly one class with qualname={qualname!r} after dedup, "
+        f"got {len(matching)}: {sorted(c.__module__ for c in matching)}"
+    )
+    only = next(iter(matching))
+    assert only.__module__ == "__main__"
+    assert only.__qualname__ == qualname
+
+
+# ---------------------------------------------------------------------------
+# Case 2: Different content, double-define, raises ValueError
+# ---------------------------------------------------------------------------
+def test_different_content_double_define_raises_value_error() -> None:
+    """Two different-source FG defs (same qualname/module) should raise ValueError.
+
+    The error message must contain both module paths, two truncated source hashes,
+    and the literal string ``set_allow_redefinition`` to guide the user toward
+    the override flag.
+    """
+    qualname = "MyFG_Test2"
+    feature_name = "case2_feature_unique_xyz"
+    src_v1 = _make_fg_source(qualname, feature_name)
+    src_v2 = _make_fg_source(
+        qualname,
+        feature_name,
+        extra_body="    def extra_method(self):\n        return 42\n",
+    )
+
+    v1 = _exec_fg_in_main(qualname, src_v1, "cell-test2-v1")
+    v2 = _exec_fg_in_main(qualname, src_v2, "cell-test2-v2")
+    _REF_STORE.extend([v1, v2])
+
+    all_fgs = get_all_subclasses(FeatureGroup)
+
+    with pytest.raises(ValueError) as exc_info:
+        dedup_feature_group_subclasses(all_fgs)
+
+    msg = str(exc_info.value)
+
+    # Module path appears (both versions live in __main__)
+    assert "__main__" in msg, f"Expected '__main__' in error, got: {msg}"
+
+    # Truncated source hashes (8-char hex prefixes are sufficient indicators).
+    # Compute expected hashes deterministically.
+    from mloda.core.abstract_plugins.components.base_feature_group_version import BaseFeatureGroupVersion
+
+    h1 = BaseFeatureGroupVersion.class_source_hash(v1)[:8]
+    h2 = BaseFeatureGroupVersion.class_source_hash(v2)[:8]
+    assert h1 in msg, f"Expected hash prefix {h1!r} in error, got: {msg}"
+    assert h2 in msg, f"Expected hash prefix {h2!r} in error, got: {msg}"
+
+    # Hint pointing at the override flag.
+    assert "set_allow_redefinition" in msg, f"Expected 'set_allow_redefinition' in error, got: {msg}"
+
+
+# ---------------------------------------------------------------------------
+# Case 3: Different content + override flag
+# ---------------------------------------------------------------------------
+def test_different_content_with_allow_redefinition_returns_live_class() -> None:
+    """With allow_redefinition=True, dedup picks the live class (no error)."""
+    qualname = "MyFG_Test3"
+    feature_name = "case3_feature_unique_xyz"
+    src_v1 = _make_fg_source(qualname, feature_name)
+    src_v2 = _make_fg_source(
+        qualname,
+        feature_name,
+        extra_body="    def extra_method(self):\n        return 99\n",
+    )
+
+    v1 = _exec_fg_in_main(qualname, src_v1, "cell-test3-v1")
+    v2 = _exec_fg_in_main(qualname, src_v2, "cell-test3-v2")
+    _REF_STORE.extend([v1, v2])
+
+    all_fgs = get_all_subclasses(FeatureGroup)
+    deduped = dedup_feature_group_subclasses(all_fgs, allow_redefinition=True)
+
+    matching = _filter_by_qualname(deduped, qualname)
+    assert len(matching) == 1, f"Expected exactly one class with qualname={qualname!r}, got {len(matching)}"
+    survivor = next(iter(matching))
+
+    # The survivor must be the live-in-__main__ class (i.e. v2).
+    live = getattr(sys.modules["__main__"], qualname)
+    assert survivor is live, "Expected survivor to be the live class in __main__"
+    assert survivor is v2, "Expected the newer (v2) class to survive when allow_redefinition=True"
+
+
+# ---------------------------------------------------------------------------
+# Case 4: Group with live descendants is preserved untouched
+# ---------------------------------------------------------------------------
+def test_group_with_live_descendants_is_preserved() -> None:
+    """If any member of a (module, qualname) group has live descendants, dedup must
+    not drop any member of the group — dropping the older member would orphan its
+    subclass.
+    """
+    parent_qualname = "MyFG_Desc1"
+    sub_qualname = "MyFG_Desc1_Sub"
+    feature_name = "case4_feature_unique_xyz"
+
+    # v1: parent class
+    parent_src_v1 = _make_fg_source(parent_qualname, feature_name)
+    parent_v1 = _exec_fg_in_main(parent_qualname, parent_src_v1, "cell-test4-parent-v1")
+
+    # Define a Sub class inheriting from v1 of the parent. This MUST be exec'd while
+    # parent_qualname in __main__ resolves to parent_v1.
+    sub_src = textwrap.dedent(
+        f"""
+        class {sub_qualname}({parent_qualname}):
+            @classmethod
+            def feature_names_supported(cls):
+                return {{"{feature_name}_sub"}}
+        """
+    )
+    main_mod = sys.modules["__main__"]
+    sub_filename = "<cell-test4-sub>"
+    sub_lines = sub_src.splitlines(keepends=True)
+    linecache.cache[sub_filename] = (len(sub_src), None, sub_lines, sub_filename)
+    sub_code = compile(sub_src, sub_filename, "exec")
+    exec(sub_code, main_mod.__dict__)  # nosec B102
+    sub_cls = main_mod.__dict__[sub_qualname]
+
+    # v2: redefine the parent (rebinds name in __main__ to a new class object).
+    parent_src_v2 = _make_fg_source(parent_qualname, feature_name)
+    parent_v2 = _exec_fg_in_main(parent_qualname, parent_src_v2, "cell-test4-parent-v2")
+
+    _REF_STORE.extend([parent_v1, sub_cls, parent_v2])
+
+    # Sanity: parent_v1 still has Sub as a live subclass (Python doesn't auto-detach).
+    assert sub_cls in parent_v1.__subclasses__(), "Sub class should still chain to parent_v1"
+
+    all_fgs = get_all_subclasses(FeatureGroup)
+    deduped = dedup_feature_group_subclasses(all_fgs)
+
+    parent_matches = _filter_by_qualname(deduped, parent_qualname)
+    sub_matches = _filter_by_qualname(deduped, sub_qualname)
+
+    assert parent_v1 in parent_matches, "parent_v1 must be preserved (Sub depends on it)"
+    assert parent_v2 in parent_matches, "parent_v2 must be preserved (live descendants in group)"
+    assert sub_cls in sub_matches, "Sub class itself must survive in the deduped set"
+
+
+# ---------------------------------------------------------------------------
+# Case 5: type(...)-built classes (no source available) are preserved without raising
+# ---------------------------------------------------------------------------
+def test_type_built_classes_preserved_without_source() -> None:
+    """Dynamically built classes (via ``type(...)``) where ``inspect.getsource`` fails
+    must be preserved by dedup; no exception, no false dedup.
+    """
+    qualname = "MyFG_Dyn1"
+    feature_name = "case5_feature_unique_xyz"
+
+    def _make_dyn(suffix: str) -> type[FeatureGroup]:
+        body: dict[str, Any] = {
+            "feature_names_supported": classmethod(lambda cls: {feature_name + suffix}),
+        }
+        return type(qualname, (FeatureGroup,), body)
+
+    dyn_v1 = _make_dyn("_a")
+    dyn_v2 = _make_dyn("_b")
+    _REF_STORE.extend([dyn_v1, dyn_v2])
+
+    # Sanity: inspect.getsource should fail for both (no file backing).
+    import inspect
+
+    with pytest.raises((OSError, TypeError)):
+        inspect.getsource(dyn_v1)
+
+    all_fgs = get_all_subclasses(FeatureGroup)
+
+    # Must not raise.
+    deduped = dedup_feature_group_subclasses(all_fgs)
+
+    matches = _filter_by_qualname(deduped, qualname)
+    assert dyn_v1 in matches, "dyn_v1 must be preserved (source unavailable -> preserve group)"
+    assert dyn_v2 in matches, "dyn_v2 must be preserved (source unavailable -> preserve group)"
+
+
+# ---------------------------------------------------------------------------
+# Mock compute framework for cases 6 and 7
+# ---------------------------------------------------------------------------
+class MockCFW(ComputeFramework):
+    """Mock compute framework that is always available, for end-to-end dedup tests."""
+
+    @staticmethod
+    def is_available() -> bool:
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Case 6: plugin_collector=None end-to-end via PreFilterPlugins
+# ---------------------------------------------------------------------------
+def test_pre_filter_plugins_dedups_with_none_collector() -> None:
+    """PreFilterPlugins(plugin_collector=None) must run dedup with default
+    allow_redefinition=False, so duplicate identical-content classes collapse
+    into a single accessible_plugins entry.
+    """
+    qualname = "MyFG_Test6"
+    feature_name = "case6_feature_unique_xyz"
+    src = _make_fg_source(qualname, feature_name)
+
+    v1 = _exec_fg_in_main(qualname, src, "cell-test6-v1")
+    v2 = _exec_fg_in_main(qualname, src, "cell-test6-v2")
+    _REF_STORE.extend([v1, v2])
+
+    pre_filter = PreFilterPlugins(compute_frameworks={MockCFW}, plugin_collector=None)
+    accessible = pre_filter.get_accessible_plugins()
+
+    # Filter to our test's qualname only — other tests on the same xdist worker
+    # may have leaked subclasses into the registry.
+    matching = [fg for fg in accessible.keys() if fg.__qualname__ == qualname]
+    assert len(matching) == 1, (
+        f"Expected exactly one accessible_plugins entry with qualname={qualname!r}, "
+        f"got {len(matching)}: {[(c.__module__, id(c)) for c in matching]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Case 7: disabled_feature_groups({StaleFG}) order check (filter-then-dedup)
+# ---------------------------------------------------------------------------
+def test_disabled_feature_groups_filter_runs_before_dedup() -> None:
+    """The enable/disable filter (by class identity) must run BEFORE dedup.
+
+    This guarantees that a stale class ref passed in ``disabled_feature_groups({...})``
+    matches the right object by identity, regardless of dedup behavior.
+    """
+    qualname = "MyFG_Order1"
+    feature_name = "case7_feature_unique_xyz"
+    src = _make_fg_source(qualname, feature_name)
+
+    v1 = _exec_fg_in_main(qualname, src, "cell-test7-v1")
+    v2 = _exec_fg_in_main(qualname, src, "cell-test7-v2")
+    _REF_STORE.extend([v1, v2])
+
+    plugin_collector = PluginCollector.disabled_feature_groups({v1})
+
+    pre_filter = PreFilterPlugins(compute_frameworks={MockCFW}, plugin_collector=plugin_collector)
+    accessible = pre_filter.get_accessible_plugins()
+
+    matching = [fg for fg in accessible.keys() if fg.__qualname__ == qualname]
+    assert len(matching) == 1, (
+        f"Expected exactly one accessible_plugins entry with qualname={qualname!r}, got {len(matching)}"
+    )
+    # v1 was disabled by identity BEFORE dedup ran, so the survivor must be v2.
+    assert matching[0] is v2, "Expected v2 to survive (v1 was disabled by identity before dedup)"
+    assert v1 not in accessible, "v1 (stale, disabled) must not appear in accessible_plugins"
+
+
+# ---------------------------------------------------------------------------
+# Case 8: resolve_feature after Jupyter-style redefinition returns a single FG
+# ---------------------------------------------------------------------------
+def test_resolve_feature_after_jupyter_redefinition_succeeds() -> None:
+    """``resolve_feature`` must dedup before reporting "Multiple FeatureGroups match"
+    so that a Jupyter cell rerun (identical content) returns a single resolved class.
+    """
+    qualname = "MyFG_Test8"
+    feature_name = "case8_feature_unique_xyz"
+    src = _make_fg_source(qualname, feature_name)
+
+    v1 = _exec_fg_in_main(qualname, src, "cell-test8-v1")
+    v2 = _exec_fg_in_main(qualname, src, "cell-test8-v2")
+    _REF_STORE.extend([v1, v2])
+
+    result = resolve_feature(feature_name)
+
+    assert result.error is None, f"resolve_feature should succeed after dedup (no error), got error: {result.error!r}"
+    assert result.feature_group is not None, "resolve_feature should return a feature_group"
+    assert result.feature_group.__qualname__ == qualname, (
+        f"resolved feature_group qualname must be {qualname!r}, got {result.feature_group.__qualname__!r}"
+    )
+    assert result.feature_group.__module__ == "__main__"

--- a/tests/test_core/test_prepare/test_feature_group_dedup.py
+++ b/tests/test_core/test_prepare/test_feature_group_dedup.py
@@ -419,3 +419,66 @@ def test_resolve_feature_returns_error_for_redef_conflict_does_not_raise() -> No
     assert any(token in result.error for token in (qualname, "redefined", "set_allow_redefinition")), (
         f"error must mention the qualname, 'redefined', or 'set_allow_redefinition'; got: {result.error!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Case 10: class_source_hash must be stable across unrelated cell edits
+# ---------------------------------------------------------------------------
+def test_class_source_hash_is_stable_across_unrelated_cell_edits() -> None:
+    """``class_source_hash`` must be stable when the FG class body is unchanged but
+    surrounding (non-class) cell content differs.
+
+    In Jupyter, each cell maps to a single synthetic linecache filename whose entry
+    contains the WHOLE cell text. The current ``_linecache_source_for_class``
+    fallback hashes the entire cell, so editing an unrelated comment or variable
+    in the same cell flips the hash for an unchanged FeatureGroup class. That
+    triggers a false "FeatureGroup redefined with different source code" conflict
+    and forces users into ``set_allow_redefinition()`` or kernel restart.
+
+    This test asserts the invariant: identical class body => identical hash,
+    regardless of unrelated cell content. It will FAIL today because the hashes
+    differ, and PASS once the fallback extracts only the class-local source region.
+    """
+    qualname = "MyFG_BugA1"
+
+    # Define the class body ONCE so v1 and v2 are byte-for-byte identical for the
+    # class region. Any drift here would invalidate the test.
+    class_body = textwrap.dedent(
+        f"""
+        class {qualname}(_FG_):
+            @classmethod
+            def feature_names_supported(cls):
+                return {{"bug_a1_feature_unique_xyz"}}
+        """
+    )
+
+    cell_v1 = (
+        "from mloda.core.abstract_plugins.feature_group import FeatureGroup as _FG_\n"
+        "\n"
+        "# A comment that changes between cell runs\n"
+        "unrelated_var = 1\n"
+        f"{class_body}"
+    )
+    cell_v2 = (
+        "from mloda.core.abstract_plugins.feature_group import FeatureGroup as _FG_\n"
+        "\n"
+        "# A different comment\n"
+        "unrelated_var = 99\n"
+        f"{class_body}"
+    )
+
+    v1 = _exec_fg_in_main(qualname, cell_v1, "ipython-input-bug-v1")
+    # Hold v1 BEFORE the second exec rebinds __main__.MyFG_BugA1 to a new class.
+    _REF_STORE.append(v1)
+    v2 = _exec_fg_in_main(qualname, cell_v2, "ipython-input-bug-v2")
+    _REF_STORE.append(v2)
+
+    from mloda.core.abstract_plugins.components.base_feature_group_version import BaseFeatureGroupVersion
+
+    h1 = BaseFeatureGroupVersion.class_source_hash(v1)
+    h2 = BaseFeatureGroupVersion.class_source_hash(v2)
+
+    assert h1 == h2, (
+        "Identical class bodies must produce equal source hashes regardless of "
+        f"unrelated cell content (got {h1[:16]}... vs {h2[:16]}...)"
+    )

--- a/tests/test_core/test_prepare/test_feature_group_dedup.py
+++ b/tests/test_core/test_prepare/test_feature_group_dedup.py
@@ -25,6 +25,7 @@ from mloda.core.abstract_plugins.components.utils import get_all_subclasses
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.api.plugin_docs import resolve_feature
+from mloda.core.api.plugin_info import ResolvedFeature
 from mloda.core.prepare.accessible_plugins import PreFilterPlugins, dedup_feature_group_subclasses
 
 
@@ -385,3 +386,36 @@ def test_resolve_feature_after_jupyter_redefinition_succeeds() -> None:
         f"resolved feature_group qualname must be {qualname!r}, got {result.feature_group.__qualname__!r}"
     )
     assert result.feature_group.__module__ == "__main__"
+
+
+# ---------------------------------------------------------------------------
+# Case 9: resolve_feature must not raise on redefinition conflict
+# ---------------------------------------------------------------------------
+def test_resolve_feature_returns_error_for_redef_conflict_does_not_raise() -> None:
+    """``resolve_feature`` is a non-throwing debug API: when ``dedup_feature_group_subclasses``
+    detects a different-content redefinition conflict, the error must surface in
+    ``ResolvedFeature.error`` rather than as an unhandled ``ValueError``.
+    """
+    qualname = "MyFG_Test9"
+    feature_name = "case9_feature_unique_xyz"
+    src_v1 = _make_fg_source(qualname, feature_name)
+    src_v2 = _make_fg_source(
+        qualname,
+        feature_name,
+        extra_body="    def extra_method(self):\n        return 42\n",
+    )
+
+    v1 = _exec_fg_in_main(qualname, src_v1, "cell-test9-v1")
+    v2 = _exec_fg_in_main(qualname, src_v2, "cell-test9-v2")
+    _REF_STORE.extend([v1, v2])
+
+    result = resolve_feature(feature_name)
+
+    assert isinstance(result, ResolvedFeature), f"Expected ResolvedFeature, got {type(result).__name__}"
+    assert result.feature_group is None, (
+        f"feature_group must be None when redefinition conflict prevents resolution, got {result.feature_group!r}"
+    )
+    assert result.error is not None, "error must be populated when resolution cannot proceed"
+    assert any(token in result.error for token in (qualname, "redefined", "set_allow_redefinition")), (
+        f"error must mention the qualname, 'redefined', or 'set_allow_redefinition'; got: {result.error!r}"
+    )

--- a/tests/test_core/test_prepare/test_feature_group_dedup.py
+++ b/tests/test_core/test_prepare/test_feature_group_dedup.py
@@ -482,3 +482,46 @@ def test_class_source_hash_is_stable_across_unrelated_cell_edits() -> None:
         "Identical class bodies must produce equal source hashes regardless of "
         f"unrelated cell content (got {h1[:16]}... vs {h2[:16]}...)"
     )
+
+
+# ---------------------------------------------------------------------------
+# Case 11: resolve_feature(plugin_collector=...) accepts the override flag
+# ---------------------------------------------------------------------------
+def test_resolve_feature_with_allow_redefinition_collector_succeeds() -> None:
+    """``resolve_feature`` must accept a ``plugin_collector`` parameter so a user
+    facing a different-source redefinition conflict can pass
+    ``PluginCollector().set_allow_redefinition()`` and get the live class back,
+    matching the troubleshooting doc claim that this collector flows through to
+    ``resolve_feature``.
+
+    Today this test fails with
+    ``TypeError: resolve_feature() got an unexpected keyword argument 'plugin_collector'``
+    because the signature is ``resolve_feature(feature_name: str)``. After the
+    green phase adds the parameter, this test must pass: dedup keeps the live
+    class when ``allow_redefinition=True``, and the resolved feature_group is v2.
+    """
+    qualname = "MyFG_Test10"
+    feature_name = "case10_feature_unique_xyz"
+    src_v1 = _make_fg_source(qualname, feature_name)
+    src_v2 = _make_fg_source(
+        qualname,
+        feature_name,
+        extra_body="    def extra_method(self):\n        return 7\n",
+    )
+
+    v1 = _exec_fg_in_main(qualname, src_v1, "cell-test10-v1")
+    v2 = _exec_fg_in_main(qualname, src_v2, "cell-test10-v2")
+    _REF_STORE.extend([v1, v2])
+
+    plugin_collector = PluginCollector().set_allow_redefinition()
+    result = resolve_feature(feature_name, plugin_collector=plugin_collector)
+
+    assert result.error is None, (
+        f"resolve_feature with allow_redefinition collector must succeed, got error: {result.error!r}"
+    )
+    assert result.feature_group is not None, "resolve_feature should return a feature_group"
+
+    live = getattr(sys.modules["__main__"], qualname)
+    assert result.feature_group is live, "Expected resolved feature_group to be the live class in __main__"
+    assert result.feature_group is v2, "Expected v2 (the newer redefinition) to be the resolved class"
+    assert result.feature_group.__qualname__ == qualname

--- a/tests/test_core/test_prepare/test_feature_group_dedup.py
+++ b/tests/test_core/test_prepare/test_feature_group_dedup.py
@@ -547,6 +547,42 @@ def test_resolve_feature_with_allow_redefinition_collector_succeeds() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Case 16: resolve_feature filters unrelated conflicts from candidates
+# ---------------------------------------------------------------------------
+def test_resolve_feature_filters_unrelated_conflicts_from_candidates() -> None:
+    """When dedup raises on a redef whose classes don't match the requested feature,
+    candidates must not include those unrelated classes — candidates is documented
+    as 'all matching candidates', not 'all conflicts seen during dedup'.
+    """
+    qualname = "BarFG_Test16"
+    unrelated_feature = "test16_unrelated_unique_xyz"
+    requested_feature = "test16_requested_unique_xyz"  # not supported by BarFG_Test16
+
+    src_v1 = _make_fg_source(qualname, unrelated_feature)
+    src_v2 = _make_fg_source(
+        qualname,
+        unrelated_feature,
+        extra_body="    def extra_method(self):\n        return 16\n",
+    )
+    v1 = _exec_fg_in_main(qualname, src_v1, "cell-test16-v1")
+    v2 = _exec_fg_in_main(qualname, src_v2, "cell-test16-v2")
+    _REF_STORE.extend([v1, v2])
+
+    result = resolve_feature(requested_feature)
+
+    # Dedup raises because BarFG_Test16 has a redef conflict.
+    assert result.error is not None, "redef conflict must surface as error"
+
+    # Critical: v1/v2 don't match requested_feature, so they must NOT appear in candidates.
+    assert v1 not in result.candidates, (
+        f"v1 must not appear in candidates (does not match {requested_feature!r}); got: {result.candidates}"
+    )
+    assert v2 not in result.candidates, (
+        f"v2 must not appear in candidates (does not match {requested_feature!r}); got: {result.candidates}"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Case 12: get_feature_group_docs runs dedup, does not raise with allow flag
 # ---------------------------------------------------------------------------
 def test_get_feature_group_docs_with_allow_redefinition_does_not_raise() -> None:
@@ -575,6 +611,13 @@ def test_get_feature_group_docs_with_allow_redefinition_does_not_raise() -> None
     result = get_feature_group_docs(plugin_collector=plugin_collector)
 
     assert isinstance(result, list)
+    from mloda.core.api.plugin_info import FeatureGroupInfo
+
+    assert all(isinstance(item, FeatureGroupInfo) for item in result), (
+        f"all items must be FeatureGroupInfo, got: {[type(i).__name__ for i in result]}"
+    )
+    # plugin_docs filters out __module__ == "__main__" — verify the test class did not leak in.
+    assert all(item.module != "__main__" for item in result), "no __main__-bound classes should appear in the result"
 
 
 # ---------------------------------------------------------------------------
@@ -605,6 +648,66 @@ def test_get_feature_group_docs_raises_on_redef_conflict_without_flag() -> None:
     msg = str(exc_info.value)
     assert "FeatureGroup redefined" in msg, f"Expected 'FeatureGroup redefined' in error, got: {msg}"
     assert "set_allow_redefinition" in msg, f"Expected 'set_allow_redefinition' in error, got: {msg}"
+
+
+# ---------------------------------------------------------------------------
+# Case 17: get_feature_group_docs filter→dedup ordering
+# ---------------------------------------------------------------------------
+def test_get_feature_group_docs_filter_runs_before_dedup() -> None:
+    """The plugin_collector identity filter must run BEFORE dedup so that a stale
+    class ref passed via disabled_feature_groups({stale}) eliminates the conflict
+    before dedup sees it. Mirrors test_disabled_feature_groups_filter_runs_before_dedup
+    (for PreFilterPlugins) at the plugin_docs entry point.
+    """
+    qualname = "MyFG_Test17_Docs"
+    feature_name = "case17_feature_unique_xyz"
+    src_v1 = _make_fg_source(qualname, feature_name)
+    src_v2 = _make_fg_source(
+        qualname,
+        feature_name,
+        extra_body="    def extra_method(self):\n        return 17\n",
+    )
+    v1 = _exec_fg_in_main(qualname, src_v1, "cell-test17-v1")
+    v2 = _exec_fg_in_main(qualname, src_v2, "cell-test17-v2")
+    _REF_STORE.extend([v1, v2])
+
+    plugin_collector = PluginCollector.disabled_feature_groups({v1})
+
+    # With v1 filtered before dedup, only v2 remains — no conflict, must not raise.
+    result = get_feature_group_docs(plugin_collector=plugin_collector)
+    assert isinstance(result, list)
+
+
+# ---------------------------------------------------------------------------
+# Case 18: resolve_feature filter→dedup ordering
+# ---------------------------------------------------------------------------
+def test_resolve_feature_filter_runs_before_dedup() -> None:
+    """resolve_feature must filter via plugin_collector BEFORE dedup so a stale class
+    ref passed via disabled_feature_groups({stale}) eliminates the conflict before
+    dedup sees it.
+    """
+    qualname = "MyFG_Test18"
+    feature_name = "case18_feature_unique_xyz"
+    src_v1 = _make_fg_source(qualname, feature_name)
+    src_v2 = _make_fg_source(
+        qualname,
+        feature_name,
+        extra_body="    def extra_method(self):\n        return 18\n",
+    )
+    v1 = _exec_fg_in_main(qualname, src_v1, "cell-test18-v1")
+    v2 = _exec_fg_in_main(qualname, src_v2, "cell-test18-v2")
+    _REF_STORE.extend([v1, v2])
+
+    plugin_collector = PluginCollector.disabled_feature_groups({v1})
+
+    result = resolve_feature(feature_name, plugin_collector=plugin_collector)
+
+    assert result.error is None, (
+        f"resolve_feature should succeed when stale class is filtered before dedup, got error: {result.error!r}"
+    )
+    assert result.feature_group is v2, (
+        f"resolved feature_group must be v2 (v1 was disabled), got: {result.feature_group}"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_core/test_prepare/test_feature_group_dedup.py
+++ b/tests/test_core/test_prepare/test_feature_group_dedup.py
@@ -138,8 +138,9 @@ def test_different_content_double_define_raises_value_error() -> None:
     """Two different-source FG defs (same qualname/module) should raise ValueError.
 
     The error message must contain both module paths, two truncated source hashes,
-    and the literal string ``set_allow_redefinition`` to guide the user toward
-    the override flag.
+    the synthetic cell labels (so users can locate the redef'd cell), and the
+    literal string ``set_allow_redefinition`` to guide the user toward the
+    override flag.
     """
     qualname = "MyFG_Test2"
     feature_name = "case2_feature_unique_xyz"
@@ -163,6 +164,10 @@ def test_different_content_double_define_raises_value_error() -> None:
 
     # Module path appears (both versions live in __main__)
     assert "__main__" in msg, f"Expected '__main__' in error, got: {msg}"
+
+    # Synthetic cell labels appear so users can locate the redef'd cell.
+    assert "<cell-test2-v1>" in msg, f"Expected '<cell-test2-v1>' in error, got: {msg}"
+    assert "<cell-test2-v2>" in msg, f"Expected '<cell-test2-v2>' in error, got: {msg}"
 
     # Truncated source hashes (8-char hex prefixes are sufficient indicators).
     # Compute expected hashes deterministically.
@@ -429,6 +434,10 @@ def test_resolve_feature_returns_error_for_redef_conflict_does_not_raise() -> No
     assert any(token in result.error for token in (qualname, "redefined", "set_allow_redefinition")), (
         f"error must mention the qualname, 'redefined', or 'set_allow_redefinition'; got: {result.error!r}"
     )
+
+    # candidates must surface the conflicting classes so callers can inspect them programmatically.
+    assert v1 in result.candidates, f"v1 must be in candidates on conflict, got: {result.candidates}"
+    assert v2 in result.candidates, f"v2 must be in candidates on conflict, got: {result.candidates}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_core/test_prepare/test_feature_group_dedup.py
+++ b/tests/test_core/test_prepare/test_feature_group_dedup.py
@@ -24,7 +24,7 @@ from mloda.core.abstract_plugins.components.plugin_option.plugin_collector impor
 from mloda.core.abstract_plugins.components.utils import get_all_subclasses
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
-from mloda.core.api.plugin_docs import resolve_feature
+from mloda.core.api.plugin_docs import get_feature_group_docs, resolve_feature
 from mloda.core.api.plugin_info import ResolvedFeature
 from mloda.core.prepare.accessible_plugins import PreFilterPlugins, dedup_feature_group_subclasses
 
@@ -32,6 +32,11 @@ from mloda.core.prepare.accessible_plugins import PreFilterPlugins, dedup_featur
 # Module-level reference store. This simulates IPython's ``_oh``/``Out[N]`` history,
 # which keeps strong refs to all cell-evaluated objects. It MUST be module-scoped so
 # the references survive across all assertions inside a single test.
+#
+# IMPORTANT: Tests MUST use a unique qualname (e.g., ``MyFG_TestN``) per test —
+# ``_REF_STORE`` is never cleared during the session, so any class registered here
+# survives in ``FeatureGroup.__subclasses__()`` and would interfere with later
+# tests that share the same qualname. Filter by ``__qualname__`` when asserting.
 _REF_STORE: list[Any] = []
 
 
@@ -268,8 +273,13 @@ def test_type_built_classes_preserved_without_source() -> None:
     feature_name = "case5_feature_unique_xyz"
 
     def _make_dyn(suffix: str) -> type[FeatureGroup]:
+        # __module__ = "__main__" mirrors a Jupyter factory pattern (the realistic
+        # source-unavailable shape) and prevents these classes from leaking into
+        # downstream tests that iterate FeatureGroup.__subclasses__() and call
+        # version() — get_feature_group_docs filters out __main__ classes.
         body: dict[str, Any] = {
             "feature_names_supported": classmethod(lambda cls: {feature_name + suffix}),
+            "__module__": "__main__",
         }
         return type(qualname, (FeatureGroup,), body)
 
@@ -525,3 +535,64 @@ def test_resolve_feature_with_allow_redefinition_collector_succeeds() -> None:
     assert result.feature_group is live, "Expected resolved feature_group to be the live class in __main__"
     assert result.feature_group is v2, "Expected v2 (the newer redefinition) to be the resolved class"
     assert result.feature_group.__qualname__ == qualname
+
+
+# ---------------------------------------------------------------------------
+# Case 12: get_feature_group_docs runs dedup, does not raise with allow flag
+# ---------------------------------------------------------------------------
+def test_get_feature_group_docs_with_allow_redefinition_does_not_raise() -> None:
+    """``get_feature_group_docs`` must route through dedup so that a Jupyter-style
+    different-source redefinition does not surface as an unhandled ``ValueError``
+    when the user passes ``PluginCollector().set_allow_redefinition()``.
+
+    Result list will not include the test class (``plugin_docs.py`` filters out
+    ``__module__ == "__main__"``); the contract under test is that the dedup code
+    path runs to completion without raising.
+    """
+    qualname = "MyFG_Test12_Docs"
+    feature_name = "case12_feature_unique_xyz"
+    src_v1 = _make_fg_source(qualname, feature_name)
+    src_v2 = _make_fg_source(
+        qualname,
+        feature_name,
+        extra_body="    def extra_method(self):\n        return 12\n",
+    )
+
+    v1 = _exec_fg_in_main(qualname, src_v1, "cell-test12-v1")
+    v2 = _exec_fg_in_main(qualname, src_v2, "cell-test12-v2")
+    _REF_STORE.extend([v1, v2])
+
+    plugin_collector = PluginCollector().set_allow_redefinition()
+    result = get_feature_group_docs(plugin_collector=plugin_collector)
+
+    assert isinstance(result, list)
+
+
+# ---------------------------------------------------------------------------
+# Case 13: get_feature_group_docs raises ValueError on conflict without flag
+# ---------------------------------------------------------------------------
+def test_get_feature_group_docs_raises_on_redef_conflict_without_flag() -> None:
+    """Without the ``allow_redefinition`` flag, ``get_feature_group_docs`` must
+    propagate the dedup ``ValueError`` so users see the same diagnostic they get
+    from the other call sites. This is the discriminating test that locks in the
+    dedup wiring at ``plugin_docs.py`` — removing the call would make this fail.
+    """
+    qualname = "MyFG_Test13_Docs"
+    feature_name = "case13_feature_unique_xyz"
+    src_v1 = _make_fg_source(qualname, feature_name)
+    src_v2 = _make_fg_source(
+        qualname,
+        feature_name,
+        extra_body="    def extra_method(self):\n        return 13\n",
+    )
+
+    v1 = _exec_fg_in_main(qualname, src_v1, "cell-test13-v1")
+    v2 = _exec_fg_in_main(qualname, src_v2, "cell-test13-v2")
+    _REF_STORE.extend([v1, v2])
+
+    with pytest.raises(ValueError) as exc_info:
+        get_feature_group_docs()
+
+    msg = str(exc_info.value)
+    assert "FeatureGroup redefined" in msg, f"Expected 'FeatureGroup redefined' in error, got: {msg}"
+    assert "set_allow_redefinition" in msg, f"Expected 'set_allow_redefinition' in error, got: {msg}"


### PR DESCRIPTION
Re-defining a FeatureGroup subclass in a Jupyter cell (or via importlib.reload) left the old class in FeatureGroup.__subclasses__() because IPython's _oh/Out[N] history holds strong references that prevent GC. The plugin resolver then raised "Multiple feature groups found for feature 'X'" even though the user only saw a single class in their namespace.

This change adds a deduplication helper at the FG-subclass discovery seam:

- Identical-content duplicates (same source hash) collapse silently. Common case (cell rerun without edits) is now invisible to users.
- Different-content duplicates raise a new clear error by default. Users can opt into "newest wins" with PluginCollector(...).set_allow_redefinition().
- Groups with live descendants or unavailable source are preserved untouched to avoid breaking inheritance chains and factory patterns.

The order in PreFilterPlugins is now: enable/disable filter -> dedup, so stale class refs passed to disabled_feature_groups({...}) still match by identity.

resolve_feature and get_feature_group_docs are also routed through the helper so the recommended debug paths see the same view.

The kernel-restart hint moved out of the generic multi-FG error into the new redef-specific error, since after dedup the generic error means a real conflict between distinct classes where kernel restart will not help.

class_source_hash falls back to linecache for synthetic filenames (Jupyter cells) so that exec'd-into-__main__ classes can still be hashed.

Doc updated with a new "FeatureGroup Redefinition Errors" section describing set_allow_redefinition() and when it applies.