### PR TITLE
chore(deps): bump mistune to 3.2.1 (CVE-2026-33079)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,7 @@ extend-select = ["UP006", "UP007"]
 "docs/**/*.ipynb" = ["E402"]
 
 [tool.uv]
-exclude-newer = "7 days"
+exclude-newer = "2026-05-04T00:00:00Z"  # was "7 days"; pinned to cover mistune 3.2.1 (CVE-2026-33079). Revert to "7 days" once 3.2.1 ages past the rolling window (~2026-05-10).
 
 [project.scripts]
 mloda = "mloda_plugins.feature_group.experimental.llm.cli:main"

--- a/uv.lock
+++ b/uv.lock
@@ -12,8 +12,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "P7D"
+exclude-newer = "2026-05-04T00:00:00Z"
 
 [[package]]
 name = "annotated-types"
@@ -1007,14 +1006,14 @@ wheels = [
 
 [[package]]
 name = "mistune"
-version = "3.2.0"
+version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/55/d01f0c4b45ade6536c51170b9043db8b2ec6ddf4a35c7ea3f5f559ac935b/mistune-3.2.0.tar.gz", hash = "sha256:708487c8a8cdd99c9d90eb3ed4c3ed961246ff78ac82f03418f5183ab70e398a", size = 95467, upload-time = "2025-12-23T11:36:34.994Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/84/620cc3f7e3adf6f5067e10f4dbae71295d8f9e16d5d3f9ef97c40f2f592c/mistune-3.2.1.tar.gz", hash = "sha256:7c8e5501d38bac1582e067e46c8343f17d57ea1aaa735823f3aba1fd59c88a28", size = 98003, upload-time = "2026-05-03T14:33:22.312Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/f7/4a5e785ec9fbd65146a27b6b70b6cdc161a66f2024e4b04ac06a67f5578b/mistune-3.2.0-py3-none-any.whl", hash = "sha256:febdc629a3c78616b94393c6580551e0e34cc289987ec6c35ed3f4be42d0eee1", size = 53598, upload-time = "2025-12-23T11:36:33.211Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/7f/a946aa4f8752b37102b41e64dca18a1976ac705c3a0d1dfe74d820a02552/mistune-3.2.1-py3-none-any.whl", hash = "sha256:78cdb0ba5e938053ccf63651b352508d2efa9411dc8810bfb05f2dc5140c0048", size = 53749, upload-time = "2026-05-03T14:33:20.551Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bumps mistune from 3.2.0 to 3.2.1 in `uv.lock` to clear [GHSA-8mp2-v27r-99xp / CVE-2026-33079](https://github.com/mloda-ai/mloda/security/dependabot/19), a high-severity ReDoS in `LINK_TITLE_RE` reachable through normal markdown parsing (transitive dep via mkdocs-jupyter / nbconvert).
- Temporarily pins `tool.uv.exclude-newer` to `2026-05-04T00:00:00Z` so the 3.2.1 release (uploaded 2026-05-03) clears the supply-chain deferral window. Should be reverted to `"7 days"` once 3.2.1 ages past the rolling window (~2026-05-10).

## Test plan
- [x] `uv lock --upgrade-package mistune` cleanly bumps only the mistune entry.
- [x] `uv sync --all-extras` is stable (re-running it produces no further diff).
- [x] Full `tox` run: 3002 passed, 147 skipped (matches `EXPECTED_SKIP_COUNT`). Two pre-existing flaky 10s-timeout failures in `tests/test_examples/mloda_basics/test_mloda_basics_notebooks.py` (notebooks 2 and 4) reproduce on a clean main as well — unrelated to this change.