### PR TITLE
fix(deps): bump urllib3 2.6.3 -> 2.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,8 @@ extend-select = ["UP006", "UP007"]
 "docs/**/*.ipynb" = ["E402"]
 
 [tool.uv]
-exclude-newer = "2026-05-04T00:00:00Z"  # was "7 days"; pinned to cover mistune 3.2.1 (CVE-2026-33079). Revert to "7 days" once 3.2.1 ages past the rolling window (~2026-05-10).
+exclude-newer = "7 days"
+constraint-dependencies = ["urllib3>=2.7.0"]
 
 [project.scripts]
 mloda = "mloda_plugins.feature_group.experimental.llm.cli:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,8 +143,7 @@ extend-select = ["UP006", "UP007"]
 "docs/**/*.ipynb" = ["E402"]
 
 [tool.uv]
-exclude-newer = "7 days"
-constraint-dependencies = ["urllib3>=2.7.0"]
+exclude-newer = "2026-05-04T00:00:00Z"  # was "7 days"; pinned to cover mistune 3.2.1 (CVE-2026-33079). Revert to "7 days" once 3.2.1 ages past the rolling window (~2026-05-10).
 
 [project.scripts]
 mloda = "mloda_plugins.feature_group.experimental.llm.cli:main"

--- a/uv.lock
+++ b/uv.lock
@@ -12,14 +12,10 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "P7D"
+exclude-newer = "2026-05-04T00:00:00Z"
 
 [options.exclude-newer-package]
 urllib3 = "2026-06-02T00:00:00Z"
-
-[manifest]
-constraints = [{ name = "urllib3", specifier = ">=2.7.0" }]
 
 [[package]]
 name = "annotated-types"

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,14 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-04T00:00:00Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
+[options.exclude-newer-package]
+urllib3 = "2026-06-02T00:00:00Z"
+
+[manifest]
+constraints = [{ name = "urllib3", specifier = ">=2.7.0" }]
 
 [[package]]
 name = "annotated-types"
@@ -1113,7 +1120,7 @@ wheels = [
 
 [[package]]
 name = "mloda"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "pyarrow" },
@@ -3446,11 +3453,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Bumps `urllib3` from 2.6.3 to 2.7.0 to close two HIGH-severity Dependabot alerts
- Adds `constraint-dependencies = ["urllib3>=2.7.0"]` in `[tool.uv]` to enforce the security floor on future `uv lock` runs
- urllib3 is a transitive dependency (pulled in by `requests` and `types-requests`, both test-only extras)

Closes Dependabot alerts [#21](https://github.com/mloda-ai/mloda/security/dependabot/21) (CVE-2026-44432) and [#22](https://github.com/mloda-ai/mloda/security/dependabot/22) (CVE-2026-44431).

## CVEs addressed

| Alert | CVE | Severity | Summary |
|-------|-----|----------|---------|
| #22 | CVE-2026-44431 | High | Sensitive headers forwarded across origins in proxied low-level redirects |
| #21 | CVE-2026-44432 | High | Decompression-bomb safeguards bypassed in streaming API |

## Note on exclude-newer

urllib3 2.7.0 was published 2026-05-07 — inside the `exclude-newer = "7 days"` stability window at time of lock. The lock was regenerated with `--exclude-newer-package urllib3=2026-06-01` to allow it. After 2026-05-14 a plain `uv lock` will work without that flag.

## Test plan

- [ ] CI passes (pytest matrix across Python 3.10–3.13)
- [ ] Dependabot alerts #21 and #22 marked resolved after merge