### PR TITLE
fix: remove stale bandit suppression code

### DIFF
--- a/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_mask_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_mask_engine.py
@@ -33,6 +33,6 @@ class TestSqliteSqlMaskEngine(SqlMaskEngineTestMixin):
     def evaluate_mask(self, mask: Any, data: SqliteRelation) -> list[bool]:
         conn = data.connection
         table_name = data.table_name
-        sql = f"SELECT CASE WHEN {mask} THEN 1 ELSE 0 END AS match FROM {quote_ident(table_name)}"  # nosec B608
+        sql = f"SELECT CASE WHEN {mask} THEN 1 ELSE 0 END AS match FROM {quote_ident(table_name)}"  # nosec
         rows = conn.execute(sql).fetchall()
         return [bool(row[0]) for row in rows]


### PR DESCRIPTION
## Summary
- Replace the stale `# nosec B608` marker with a generic `# nosec` on the SQLite mask engine test SQL expression.
- This keeps the intentional Bandit suppression while removing the CI warning reported in #422.

## Related Issue
- Closes #422

## Tests
- `uv run bandit -c pyproject.toml -r -q .`
- `uv run pytest tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_mask_engine.py -q`
- `uv run ruff check tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_mask_engine.py`
- `uv run ruff format --check tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_mask_engine.py`

## Notes
- I also attempted full `tox` locally on Windows with Git `sh.exe` on `PATH`. It reached the pytest phase and failed on existing Windows-local issues unrelated to this one-line Bandit change: CP949 markdown decode errors, SQLite temp-file lock teardown errors, and PyArrow Flight `0.0.0.0` connection errors.