### PR TITLE
fix: read project structure files as utf-8

### DIFF
--- a/tests/test_project_structure.py
+++ b/tests/test_project_structure.py
@@ -13,6 +13,10 @@ from packaging.requirements import Requirement
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
 
+def _read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
 class TestContributingFile:
     """Validate that CONTRIBUTING.md has substantive content for contributors."""
 
@@ -20,71 +24,71 @@ class TestContributingFile:
         assert (PROJECT_ROOT / "CONTRIBUTING.md").is_file(), "CONTRIBUTING.md must exist at project root"
 
     def test_contributing_has_dev_setup_section(self) -> None:
-        content = (PROJECT_ROOT / "CONTRIBUTING.md").read_text()
+        content = _read_text(PROJECT_ROOT / "CONTRIBUTING.md")
         content_lower = content.lower()
         assert "development" in content_lower or "setup" in content_lower or "getting started" in content_lower, (
             "CONTRIBUTING.md must include a development setup section"
         )
 
     def test_contributing_mentions_uv(self) -> None:
-        content = (PROJECT_ROOT / "CONTRIBUTING.md").read_text()
+        content = _read_text(PROJECT_ROOT / "CONTRIBUTING.md")
         assert "uv" in content, "CONTRIBUTING.md must mention uv as the dependency manager"
 
     def test_contributing_mentions_tox(self) -> None:
-        content = (PROJECT_ROOT / "CONTRIBUTING.md").read_text()
+        content = _read_text(PROJECT_ROOT / "CONTRIBUTING.md")
         assert "tox" in content, "CONTRIBUTING.md must mention tox as the test runner"
 
     def test_contributing_mentions_python_version(self) -> None:
-        content = (PROJECT_ROOT / "CONTRIBUTING.md").read_text()
+        content = _read_text(PROJECT_ROOT / "CONTRIBUTING.md")
         assert "3.10" in content, "CONTRIBUTING.md must specify the minimum supported Python version (3.10)"
 
     def test_contributing_has_code_style_section(self) -> None:
-        content = (PROJECT_ROOT / "CONTRIBUTING.md").read_text()
+        content = _read_text(PROJECT_ROOT / "CONTRIBUTING.md")
         content_lower = content.lower()
         assert "code style" in content_lower or "coding standard" in content_lower or "style" in content_lower, (
             "CONTRIBUTING.md must include a code style section"
         )
 
     def test_contributing_mentions_ruff(self) -> None:
-        content = (PROJECT_ROOT / "CONTRIBUTING.md").read_text()
+        content = _read_text(PROJECT_ROOT / "CONTRIBUTING.md")
         assert "ruff" in content, "CONTRIBUTING.md must mention ruff as the linter/formatter"
 
     def test_contributing_mentions_mypy(self) -> None:
-        content = (PROJECT_ROOT / "CONTRIBUTING.md").read_text()
+        content = _read_text(PROJECT_ROOT / "CONTRIBUTING.md")
         assert "mypy" in content, "CONTRIBUTING.md must mention mypy for type checking"
 
     def test_contributing_has_pr_workflow_section(self) -> None:
-        content = (PROJECT_ROOT / "CONTRIBUTING.md").read_text()
+        content = _read_text(PROJECT_ROOT / "CONTRIBUTING.md")
         content_lower = content.lower()
         assert "pull request" in content_lower or "pr" in content_lower, (
             "CONTRIBUTING.md must describe the pull request workflow"
         )
 
     def test_contributing_mentions_license(self) -> None:
-        content = (PROJECT_ROOT / "CONTRIBUTING.md").read_text()
+        content = _read_text(PROJECT_ROOT / "CONTRIBUTING.md")
         assert "Apache" in content, "CONTRIBUTING.md must mention the Apache 2.0 license"
 
     def test_contributing_has_plugin_development_section(self) -> None:
-        content = (PROJECT_ROOT / "CONTRIBUTING.md").read_text()
+        content = _read_text(PROJECT_ROOT / "CONTRIBUTING.md")
         content_lower = content.lower()
         assert "plugin" in content_lower, "CONTRIBUTING.md must cover plugin development"
 
     def test_contributing_mentions_registry_guides(self) -> None:
-        content = (PROJECT_ROOT / "CONTRIBUTING.md").read_text()
+        content = _read_text(PROJECT_ROOT / "CONTRIBUTING.md")
         assert "mloda-registry" in content, "CONTRIBUTING.md must reference the mloda-registry guides"
         assert "guides" in content.lower(), "CONTRIBUTING.md must mention the plugin development guides"
 
     def test_contributing_mentions_plugin_template(self) -> None:
-        content = (PROJECT_ROOT / "CONTRIBUTING.md").read_text()
+        content = _read_text(PROJECT_ROOT / "CONTRIBUTING.md")
         assert "mloda-plugin-template" in content, "CONTRIBUTING.md must reference the mloda-plugin-template"
 
     def test_contributing_describes_fork_workflow(self) -> None:
-        content = (PROJECT_ROOT / "CONTRIBUTING.md").read_text()
+        content = _read_text(PROJECT_ROOT / "CONTRIBUTING.md")
         content_lower = content.lower()
         assert "fork" in content_lower, "CONTRIBUTING.md must describe the fork workflow for external contributors"
 
     def test_contributing_clarifies_pytest_is_not_sufficient(self) -> None:
-        content = (PROJECT_ROOT / "CONTRIBUTING.md").read_text()
+        content = _read_text(PROJECT_ROOT / "CONTRIBUTING.md")
         content_lower = content.lower()
         assert "not a substitute" in content_lower or "not sufficient" in content_lower, (
             "CONTRIBUTING.md must clarify that running pytest alone is not a substitute for tox"
@@ -99,7 +103,7 @@ class TestLicenseFile:
         assert not (PROJECT_ROOT / "LICENSE.TXT").exists(), "LICENSE.TXT should not exist; use LICENSE instead"
 
     def test_license_is_apache2(self) -> None:
-        content = (PROJECT_ROOT / "LICENSE").read_text()
+        content = _read_text(PROJECT_ROOT / "LICENSE")
         assert "Apache License, Version 2.0" in content
 
 
@@ -170,7 +174,7 @@ class TestRuffConfig:
         violations: list[str] = []
         for source_dir in source_dirs:
             for py_file in source_dir.rglob("*.py"):
-                for i, line in enumerate(py_file.read_text().splitlines(), start=1):
+                for i, line in enumerate(_read_text(py_file).splitlines(), start=1):
                     if not line.startswith("from typing import"):
                         continue
                     imported = {name.strip() for name in line.split("import")[1].split(",")}


### PR DESCRIPTION
## Summary
- read project-structure text fixtures with explicit UTF-8 encoding
- avoid Windows CP949 decode failures when tests scan source files containing Unicode characters
- keep the change scoped to the CP949 failure class from #424

## Test plan
- `python -c "import locale, sys; print(locale.getpreferredencoding(False), sys.flags.utf8_mode)"` -> `cp949 0`
- `pytest tests/test_project_structure.py -q` -> 26 passed
- `ruff format --check tests/test_project_structure.py`
- `ruff check tests/test_project_structure.py`

Addresses the CP949 decode part of #424.