### PR TITLE
fix: use loopback flight location by default

### DIFF
--- a/mloda/core/runtime/flight/flight_server.py
+++ b/mloda/core/runtime/flight/flight_server.py
@@ -10,7 +10,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def create_location(host: str = "0.0.0.0") -> str:
+def create_location(host: str = "127.0.0.1") -> str:
     sock = socket.socket()
     sock.bind(("", 0))
     port = sock.getsockname()[1]

--- a/tests/test_core/test_flight/test_flight_server.py
+++ b/tests/test_core/test_flight/test_flight_server.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 import pytest
 import pyarrow as pa
 import pyarrow.flight as flight
-from mloda.core.runtime.flight.flight_server import FlightServer
+from mloda.core.runtime.flight.flight_server import FlightServer, create_location
 
 
 class TestFlightServerUnit:
@@ -56,6 +56,11 @@ class TestFlightServerUnit:
         non_existent_ticket = flight.Ticket(b"non_existent_table")
         with pytest.raises(KeyError):
             self.server.do_get(self.context, non_existent_ticket)
+
+    def test_create_location_uses_loopback_host_by_default(self) -> None:
+        location = create_location()
+
+        assert location.startswith("grpc://127.0.0.1:")
 
 
 class TestFlightServerIntegration:


### PR DESCRIPTION
## Summary

- change the default Flight location host from `0.0.0.0` to `127.0.0.1`
- add a regression check for the default `create_location()` host
- keep this scoped to the PyArrow Flight failure class from #424

On Windows, `tests/test_core/test_flight/test_flight_server.py::TestFlightServerIntegration::test_server_operations` failed before this change because the client tried to connect to `grpc://0.0.0.0:<port>`, which produced `WSA Error 10049`. `0.0.0.0` is useful as a bind-all address, but it is not a portable client target.

This follows #426 and intentionally leaves the SQLite temp-file lock class from #424 separate.

## Tests

- `.venv\Scripts\python.exe -m pytest tests\test_core\test_flight\test_flight_server.py -q`
- `.venv\Scripts\python.exe -m pytest tests\test_core\test_artifacts\test_artifacts.py::TestBaseArtifacts::test_basic_artifact_feature -q`
- `.venv\Scripts\python.exe -m pytest tests\test_plugins\compute_framework\base_implementations\sqlite -q`
- `.venv\Scripts\ruff.exe format --check mloda\core\runtime\flight\flight_server.py tests\test_core\test_flight\test_flight_server.py`
- `.venv\Scripts\ruff.exe check mloda\core\runtime\flight\flight_server.py tests\test_core\test_flight\test_flight_server.py`

Part of #424.