### PR TITLE
fix(validator): don't crash run_all() on non-Arrow data when a type is declared

### DIFF
--- a/mloda/core/abstract_plugins/components/validators/datatype_validator.py
+++ b/mloda/core/abstract_plugins/components/validators/datatype_validator.py
@@ -68,6 +68,17 @@ class DataTypeValidator:
         """
         from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
 
+        # Type validation currently relies on the Arrow data model: it reads
+        # ``data.column_names`` and ``data.schema.field(...)``. Other compute
+        # frameworks (e.g. a pandas ``DataFrame``) do not expose those, so
+        # without this guard a feature that declares ``return_data_type_rule``
+        # makes ``mlodaAPI.run_all()`` crash with
+        # ``AttributeError: 'DataFrame' object has no attribute 'column_names'``.
+        # Skip gracefully instead of crashing until per-framework type
+        # extraction is added (see follow-up note in the PR).
+        if not (hasattr(data, "column_names") and hasattr(data, "schema")):
+            return
+
         for feature in features.features:
             if feature.data_type is None:
                 continue

--- a/tests/test_core/test_abstract_plugins/test_components/test_validators/test_datatype_validator.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_validators/test_datatype_validator.py
@@ -138,3 +138,82 @@ class TestValidate:
 
         with pytest.raises(DataTypeMismatchError):
             DataTypeValidator.validate(table, feature_set)
+
+
+class TestNonArrowDataModel:
+    """Regression: a FeatureGroup that declares return_data_type_rule must not
+    crash mlodaAPI.run_all() on a non-Arrow compute framework (e.g. pandas).
+
+    Before the fix, validate() unconditionally read ``data.column_names`` /
+    ``data.schema``; on a pandas DataFrame that raised
+    ``AttributeError: 'DataFrame' object has no attribute 'column_names'`` and
+    failed the whole run.
+    """
+
+    def test_validate_skips_non_arrow_data_without_crashing(self) -> None:
+        import pandas as pd
+
+        df = pd.DataFrame({"age": [25, 30]})
+        feature_set = FeatureSet()
+        feature_set.add(Feature.int32_of("age"))
+
+        # Must not raise AttributeError; non-Arrow data is skipped.
+        DataTypeValidator.validate(df, feature_set)
+
+    def test_typed_feature_group_runs_through_run_all_on_pandas(self) -> None:
+        from typing import Any, Optional
+
+        import pandas as pd
+
+        from mloda.provider import ComputeFramework, DataCreator, FeatureGroup
+        from mloda.user import Feature as UFeature
+        from mloda.user import PluginCollector, mloda
+        from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import (
+            PandasDataFrame,
+        )
+
+        class _Src(FeatureGroup):
+            @classmethod
+            def input_data(cls) -> Optional[Any]:
+                return DataCreator({"price"})
+
+            @classmethod
+            def calculate_feature(cls, data: Any, features: Any) -> Any:
+                return pd.DataFrame({"price": [1.0, 2.0, 3.0]})
+
+            @classmethod
+            def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+                return {PandasDataFrame}
+
+        class _Typed(FeatureGroup):
+            """Declares a fixed return type — this is what used to crash."""
+
+            @classmethod
+            def feature_names_supported(cls) -> set[str]:
+                return {"price_typed"}
+
+            @classmethod
+            def input_features(cls, options: Any, feature_name: Any) -> Any:
+                return {UFeature("price")}
+
+            @classmethod
+            def return_data_type_rule(cls, feature: Any) -> Any:
+                return DataType.DOUBLE
+
+            @classmethod
+            def calculate_feature(cls, data: Any, features: Any) -> Any:
+                data["price_typed"] = data["price"] * 2.0
+                return data
+
+            @classmethod
+            def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+                return {PandasDataFrame}
+
+        pc = PluginCollector.enabled_feature_groups({_Src, _Typed})
+        results = mloda.run_all(
+            [UFeature("price_typed")],
+            compute_frameworks={PandasDataFrame},
+            plugin_collector=pc,
+        )
+        df = next(d for d in results if "price_typed" in d.columns)
+        assert df["price_typed"].tolist() == [2.0, 4.0, 6.0]


### PR DESCRIPTION
Fixes #428   <!-- replace with the issue number after filing ISSUE.md -->

### Problem

`DataTypeValidator.validate()` reads `data.column_names` and
`data.schema.field(...)` unconditionally. Those are PyArrow‑only. Any
`FeatureGroup` that declares `return_data_type_rule()` therefore makes
`mlodaAPI.run_all()` raise
`AttributeError: 'DataFrame' object has no attribute 'column_names'` on the
pandas compute framework (and any non‑Arrow data model), aborting the run.

### Change

Guard at the top of `validate()`: if the data object does not expose the
Arrow schema API (`column_names` + `schema`), return without validating
instead of crashing. This restores backward‑compatible behaviour for
non‑Arrow frameworks (they were effectively unvalidated before anyone could
declare types). Arrow‑backed runs are completely unchanged.

~11 lines of production code; the rest of the diff is tests.

### Tests

`tests/.../test_datatype_validator.py`, new `TestNonArrowDataModel`:

1. `validate()` is a no‑op on a `pandas.DataFrame` (no `AttributeError`).
2. A `FeatureGroup` declaring `return_data_type_rule` now runs **end‑to‑end
   through `mlodaAPI.run_all()` on the pandas framework** and returns correct
   values (this is the exact scenario that used to crash).

All existing `DataTypeValidator` tests still pass (Arrow path unchanged).

### Follow‑up (intentionally out of scope here)

This makes typed FeatureGroups *safe* on non‑Arrow frameworks but does not yet
*enforce* the declared type there. A structural follow‑up should add a
per‑framework column→`DataType` resolver (mloda already has per‑framework
`_extract_column_names`), and have `validate()` consume that instead of
introspecting raw `data`. Filed/notes available on request.
