### PR TITLE
fix: close flight location socket on bind errors

### DIFF
--- a/mloda/core/runtime/flight/flight_server.py
+++ b/mloda/core/runtime/flight/flight_server.py
@@ -1,3 +1,4 @@
+from contextlib import closing
 from typing import Any
 from uuid import uuid4
 from pyarrow import flight
@@ -11,10 +12,9 @@ logger = logging.getLogger(__name__)
 
 
 def create_location(host: str = "127.0.0.1") -> str:
-    sock = socket.socket()
-    sock.bind(("", 0))
-    port = sock.getsockname()[1]
-    sock.close()
+    with closing(socket.socket()) as sock:
+        sock.bind(("", 0))
+        port = sock.getsockname()[1]
     return f"grpc://{host}:{port}"
 
 

--- a/tests/test_core/test_flight/test_flight_server.py
+++ b/tests/test_core/test_flight/test_flight_server.py
@@ -62,6 +62,27 @@ class TestFlightServerUnit:
 
         assert location.startswith("grpc://127.0.0.1:")
 
+    def test_create_location_closes_socket_when_bind_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        class FailingBindSocket:
+            closed = False
+
+            def bind(self, _address: tuple[str, int]) -> None:
+                raise OSError("bind failed")
+
+            def getsockname(self) -> tuple[str, int]:
+                raise AssertionError("getsockname should not be called after bind fails")
+
+            def close(self) -> None:
+                self.closed = True
+
+        failing_socket = FailingBindSocket()
+        monkeypatch.setattr("mloda.core.runtime.flight.flight_server.socket.socket", lambda: failing_socket)
+
+        with pytest.raises(OSError, match="bind failed"):
+            create_location()
+
+        assert failing_socket.closed
+
 
 class TestFlightServerIntegration:
     server: Any = None


### PR DESCRIPTION
Summary
- wrap the temporary socket in `create_location()` with `contextlib.closing`
- add regression coverage for a `bind()` failure, asserting the socket is closed while the original `OSError` propagates
- keep the returned `grpc://{host}:{port}` location format unchanged

Fixes #430.

Validation
- `uv run --frozen pytest tests/test_core/test_flight/test_flight_server.py -k create_location -q` -> 2 passed, 3 deselected
- `uv run --frozen pytest tests/test_core/test_flight/test_flight_server.py -q` -> 5 passed
- `uv run --frozen pytest tests/test_core/test_flight -q` -> 5 passed
- `.tox/python314/bin/pytest tests/test_core/test_flight/test_flight_server.py -q` -> 5 passed
- `.tox/python314/bin/ruff format --check --line-length 120 mloda/core/runtime/flight/flight_server.py tests/test_core/test_flight/test_flight_server.py` -> 2 files already formatted
- `.tox/python314/bin/ruff check --line-length 120 mloda/core/runtime/flight/flight_server.py tests/test_core/test_flight/test_flight_server.py` -> all checks passed
- `.tox/python314/bin/mypy --strict --ignore-missing-imports mloda/core/runtime/flight/flight_server.py tests/test_core/test_flight/test_flight_server.py` -> success
- `.tox/python314/bin/bandit -c pyproject.toml -q mloda/core/runtime/flight/flight_server.py tests/test_core/test_flight/test_flight_server.py` -> passed
- `git diff --check` -> passed
- `git diff | gitleaks stdin --no-banner --redact --timeout 30` -> no leaks found

Notes
- I also attempted the repo-level gate with `UV_FROZEN=1 uv run --frozen --with tox --with tox-uv python -m tox -e python314`; it reached repo-wide pytest and failed on unrelated Python 3.14/macOS timeout failures outside the flight-server tests (`14 failed, 3012 passed, 147 skipped`).
- This is scoped to closing the temporary socket on exceptions in `create_location()` and does not change the existing free-port reservation behavior.
