### PR TITLE
fix: avoid flight location port race

### DIFF
--- a/mloda/core/runtime/flight/flight_server.py
+++ b/mloda/core/runtime/flight/flight_server.py
@@ -1,9 +1,7 @@
-from contextlib import closing
 from typing import Any
 from uuid import uuid4
 from pyarrow import flight
 import pyarrow as pa
-import socket
 import os
 
 import logging
@@ -12,10 +10,7 @@ logger = logging.getLogger(__name__)
 
 
 def create_location(host: str = "127.0.0.1") -> str:
-    with closing(socket.socket()) as sock:
-        sock.bind(("", 0))
-        port = sock.getsockname()[1]
-    return f"grpc://{host}:{port}"
+    return f"grpc://{host}:0"
 
 
 class FlightServer(flight.FlightServerBase):  # type: ignore[misc]
@@ -30,6 +25,8 @@ class FlightServer(flight.FlightServerBase):  # type: ignore[misc]
         super().__init__(
             self.location,
         )
+        location_prefix = str(self.location).rsplit(":", 1)[0]
+        self.location = f"{location_prefix}:{self.port}"
 
         self.uuid = uuid4()
 

--- a/mloda/core/runtime/flight/runner_flight_server.py
+++ b/mloda/core/runtime/flight/runner_flight_server.py
@@ -17,18 +17,21 @@ class ParallelRunnerFlightServer:
         self.final_tasks: list[Any] = []
         self.queue: Any
 
-    def start_flight_server(self, location: Any) -> None:
+    def start_flight_server(self, location: Any, location_queue: Any) -> None:
         flight_server = FlightServer(location=location)
+        location_queue.put(flight_server.location)
         flight_server.serve()
 
     def start_flight_server_process(self) -> None:
         if not self.flight_server_process:
-            self.location = create_location()
+            location = create_location()
+            location_queue: multiprocessing.Queue[Any] = multiprocessing.Queue()
             self.flight_server_process = multiprocessing.Process(
                 target=self.start_flight_server,
-                args=(self.location,),
+                args=(location, location_queue),
             )
             self.flight_server_process.start()
+            self.location = location_queue.get(timeout=10)
 
     def end_flight_server_process(self) -> None:
         if self.flight_server_process:

--- a/tests/test_core/test_flight/test_flight_server.py
+++ b/tests/test_core/test_flight/test_flight_server.py
@@ -62,26 +62,11 @@ class TestFlightServerUnit:
 
         assert location.startswith("grpc://127.0.0.1:")
 
-    def test_create_location_closes_socket_when_bind_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        class FailingBindSocket:
-            closed = False
+    def test_create_location_requests_system_assigned_port_by_default(self) -> None:
+        assert create_location() == "grpc://127.0.0.1:0"
 
-            def bind(self, _address: tuple[str, int]) -> None:
-                raise OSError("bind failed")
-
-            def getsockname(self) -> tuple[str, int]:
-                raise AssertionError("getsockname should not be called after bind fails")
-
-            def close(self) -> None:
-                self.closed = True
-
-        failing_socket = FailingBindSocket()
-        monkeypatch.setattr("mloda.core.runtime.flight.flight_server.socket.socket", lambda: failing_socket)
-
-        with pytest.raises(OSError, match="bind failed"):
-            create_location()
-
-        assert failing_socket.closed
+    def test_create_location_requests_system_assigned_port_for_custom_host(self) -> None:
+        assert create_location("0.0.0.0") == "grpc://0.0.0.0:0"
 
 
 class TestFlightServerIntegration:

--- a/tests/test_core/test_runtime/test_flight_server_error_messages.py
+++ b/tests/test_core/test_runtime/test_flight_server_error_messages.py
@@ -1,8 +1,44 @@
 """Tests for improved error messages in ParallelRunnerFlightServer."""
 
+from typing import Any
+
 import pytest
 
 from mloda.core.runtime.flight.runner_flight_server import ParallelRunnerFlightServer
+
+
+class TestFlightServerProcessLocation:
+    def test_start_flight_server_process_publishes_child_bound_location(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        published_location = "grpc://127.0.0.1:39123"
+
+        class BoundFlightServer:
+            def __init__(self, location: str) -> None:
+                assert location == "grpc://127.0.0.1:0"
+                self.location = published_location
+
+            def serve(self) -> None:
+                return None
+
+        class InlineProcess:
+            def __init__(self, target: Any, args: tuple[Any, ...]) -> None:
+                self.target = target
+                self.args = args
+                self.started = False
+
+            def start(self) -> None:
+                self.started = True
+                self.target(*self.args)
+
+        monkeypatch.setattr(
+            "mloda.core.runtime.flight.runner_flight_server.create_location", lambda: "grpc://127.0.0.1:0"
+        )
+        monkeypatch.setattr("mloda.core.runtime.flight.runner_flight_server.FlightServer", BoundFlightServer)
+        monkeypatch.setattr("mloda.core.runtime.flight.runner_flight_server.multiprocessing.Process", InlineProcess)
+
+        server = ParallelRunnerFlightServer()
+        server.start_flight_server_process()
+
+        assert server.location == published_location
 
 
 class TestFlightServerLocationNoneError:


### PR DESCRIPTION
## Summary

- let PyArrow Flight bind a system-assigned port directly with `grpc://{host}:0`
- update `FlightServer.location` after startup so clients receive the actual bound port
- publish the child Flight server's bound location back to the parent process before `get_location()` is used

Fixes #431.

## Validation

- `.tox/python314/bin/pytest tests/test_core/test_flight/test_flight_server.py tests/test_core/test_runtime/test_flight_server_error_messages.py -q`
- `.tox/python314/bin/pytest tests/test_core/test_flight -q`
- `.tox/python314/bin/pytest tests/test_core/test_filter/test_filter_integration.py::TestGlobalFilter::test_basic_global_filter -q`
- `.tox/python314/bin/ruff format --check --line-length 120 mloda/core/runtime/flight/flight_server.py mloda/core/runtime/flight/runner_flight_server.py tests/test_core/test_flight/test_flight_server.py tests/test_core/test_runtime/test_flight_server_error_messages.py`
- `.tox/python314/bin/ruff check --line-length 120 mloda/core/runtime/flight/flight_server.py mloda/core/runtime/flight/runner_flight_server.py tests/test_core/test_flight/test_flight_server.py tests/test_core/test_runtime/test_flight_server_error_messages.py`
- `.tox/python314/bin/mypy --strict --ignore-missing-imports mloda/core/runtime/flight/flight_server.py mloda/core/runtime/flight/runner_flight_server.py tests/test_core/test_flight/test_flight_server.py tests/test_core/test_runtime/test_flight_server_error_messages.py`
- `.tox/python314/bin/bandit -c pyproject.toml -q mloda/core/runtime/flight/flight_server.py mloda/core/runtime/flight/runner_flight_server.py`
- `git diff --check`
- `git diff | gitleaks stdin --no-banner --redact --timeout 30`

The filter integration test covers the multiprocessing mode and verifies the parent process can use the child-published Flight location.

Full `tox` was not rerun locally in this cycle. Prior local full-tox attempts on this macOS/Python 3.14 host hit unrelated repo-wide timeout failures, so this PR was validated with the focused Flight/runtime checks above.
