### PR TITLE
fix(filter)!: pass native datetime bounds to filter engines

### DIFF
--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -212,23 +212,15 @@ class GlobalFilter:
     def _add_range_filter(
         self, filter_feature: str | Feature, time_from: datetime, time_to: datetime, max_exclusive: bool
     ) -> None:
-        _time_from = self._check_and_convert_time_info(time_from)
-        _time_to = self._check_and_convert_time_info(time_to)
+        _time_from = self._normalize_to_utc(time_from)
+        _time_to = self._normalize_to_utc(time_to)
         self.add_filter(
             filter_feature, FilterType.RANGE, {"min": _time_from, "max": _time_to, "max_exclusive": max_exclusive}
         )
 
-    def _check_and_convert_time_info(self, time_with_tz: datetime) -> str:
-        """
-        Checks that the provided datetime has timezone information and converts it to ISO 8601 format
-        in UTC for filtering.
-
-        We are working with tzinfo, as this is since python 3.9 included in the standard library.
-        Most libraries can handle it or at least use pandas for transformations.
-        """
-
+    def _normalize_to_utc(self, time_with_tz: datetime) -> datetime:
+        """Validate tz-aware datetime and normalize to UTC for filtering."""
         if time_with_tz.tzinfo is None:
             raise ValueError(f"Timezone information is missing in {time_with_tz}")
 
-        # Convert to UTC and return the ISO 8601 formatted string
-        return time_with_tz.astimezone(timezone.utc).isoformat()
+        return time_with_tz.astimezone(timezone.utc)

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -219,7 +219,8 @@ class GlobalFilter:
             filter_feature, FilterType.RANGE, {"min": _time_from, "max": _time_to, "max_exclusive": max_exclusive}
         )
 
-    def _normalize_to_utc(self, time_with_tz: datetime) -> datetime:
+    @staticmethod
+    def _normalize_to_utc(time_with_tz: datetime) -> datetime:
         """Validate tz-aware datetime and normalize to UTC for filtering."""
         if time_with_tz.tzinfo is None:
             raise ValueError(f"Timezone information is missing in {time_with_tz}")

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -213,8 +213,8 @@ class GlobalFilter:
     def _add_range_filter(
         self, filter_feature: str | Feature, time_from: datetime, time_to: datetime, max_exclusive: bool
     ) -> None:
-        _time_from = self._normalize_to_utc(time_from)
-        _time_to = self._normalize_to_utc(time_to)
+        _time_from = GlobalFilter._normalize_to_utc(time_from)
+        _time_to = GlobalFilter._normalize_to_utc(time_to)
         self.add_filter(
             filter_feature, FilterType.RANGE, {"min": _time_from, "max": _time_to, "max_exclusive": max_exclusive}
         )

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -196,8 +196,9 @@ class GlobalFilter:
         - event_time_column: the column name for the event time filter. Default is DefaultOptionKeys.reference_time.
         - validity_time_column: the column name for the validity time filter. Default is DefaultOptionKeys.time_travel.
 
-        The `single_filters` created will be converted to UTC as ISO 8601 formatted strings to ensure consistency
-        across time zones and avoid ambiguity when comparing or processing time-based data.
+        The bounds stored on the created `single_filters` are tz-aware `datetime` objects normalized to UTC,
+        so each filter engine can compare them directly against the framework's native temporal column type
+        without re-parsing. Breaking change since 0.6.x: previously these bounds were ISO 8601 strings.
         """
 
         self._add_range_filter(event_time_column, event_from, event_to, max_exclusive)

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -198,7 +198,7 @@ class GlobalFilter:
 
         The bounds stored on the created `single_filters` are tz-aware `datetime` objects normalized to UTC,
         so each filter engine can compare them directly against the framework's native temporal column type
-        without re-parsing. Breaking change since 0.6.x: previously these bounds were ISO 8601 strings.
+        without re-parsing.
         """
 
         self._add_range_filter(event_time_column, event_from, event_to, max_exclusive)

--- a/mloda_plugins/compute_framework/base_implementations/sql/sql_utils.py
+++ b/mloda_plugins/compute_framework/base_implementations/sql/sql_utils.py
@@ -7,7 +7,8 @@ SQL injection prevention follows two layers:
 - Literal values should use PEP 249 (DB-API 2.0) parameterized queries
   whenever the backend supports them. ``quote_value`` and ``inline_params``
   exist as a fallback for backends whose API lacks PEP 249 parameter binding.
-  They accept only (None, bool, int, float, str); unsupported types raise.
+  They accept primitive scalars (None, bool, int, float, str) and datetime;
+  unsupported types raise.
 """
 
 import math

--- a/mloda_plugins/compute_framework/base_implementations/sql/sql_utils.py
+++ b/mloda_plugins/compute_framework/base_implementations/sql/sql_utils.py
@@ -11,6 +11,7 @@ SQL injection prevention follows two layers:
 """
 
 import math
+from datetime import datetime
 from typing import Any
 
 
@@ -29,6 +30,10 @@ def quote_value(value: Any) -> str:
         if not math.isfinite(value):
             raise ValueError(f"Cannot convert non-finite float to SQL: {value!r}")
         return str(value)
+    if isinstance(value, datetime):
+        # ISO 8601 string literal. DuckDB / SQLite / most engines auto-cast against
+        # a temporal column. isoformat() emits no embedded single quotes.
+        return f"'{value.isoformat()}'"
     if isinstance(value, str):
         escaped = value.replace("'", "''")
         return f"'{escaped}'"

--- a/tests/test_core/test_filter/test_global_filter.py
+++ b/tests/test_core/test_filter/test_global_filter.py
@@ -186,20 +186,24 @@ class TestGlobalFilterTimeTravel:
         with pytest.raises(ValueError):
             self.global_filter.add_time_and_time_travel_filters(event_from, event_to, valid_from)
 
-    def test_check_and_convert_time_info(self) -> None:
-        """Test the _check_and_convert_time_info method."""
+    def test_normalize_to_utc(self) -> None:
+        """Test the _normalize_to_utc method returns a UTC-normalized datetime (not a string)."""
         time_with_tz = datetime(2023, 1, 1, tzinfo=timezone.utc)
-        converted_time = self.global_filter._check_and_convert_time_info(time_with_tz)
+        converted_time = self.global_filter._normalize_to_utc(time_with_tz)
 
-        # Assert that the time is correctly converted to ISO 8601 format in UTC
-        assert converted_time == "2023-01-01T00:00:00+00:00"
+        # The bound must be a native datetime (not a stringified ISO 8601 value) so that
+        # filter engines can compare it against tz-aware timestamp columns directly.
+        assert isinstance(converted_time, datetime)
+        assert not isinstance(converted_time, str)
+        assert converted_time == datetime(2023, 1, 1, tzinfo=timezone.utc)
+        assert converted_time.tzinfo == timezone.utc
 
-    def test_check_and_convert_time_info_without_tz(self) -> None:
-        """Test the _check_and_convert_time_info method with missing timezone info."""
+    def test_normalize_to_utc_without_tz(self) -> None:
+        """Test the _normalize_to_utc method with missing timezone info."""
         time_without_tz = datetime(2023, 1, 1)
 
         with pytest.raises(ValueError):
-            self.global_filter._check_and_convert_time_info(time_without_tz)
+            self.global_filter._normalize_to_utc(time_without_tz)
 
     def test_add_time_filters_with_event_time_column(self) -> None:
         """Test adding time filters with the new event_time_column parameter name."""

--- a/tests/test_core/test_filter/test_global_filter.py
+++ b/tests/test_core/test_filter/test_global_filter.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -188,14 +188,17 @@ class TestGlobalFilterTimeTravel:
 
     def test_normalize_to_utc(self) -> None:
         """Test the _normalize_to_utc method returns a UTC-normalized datetime (not a string)."""
+        # Identity case: already-UTC input passes through unchanged.
         time_with_tz = datetime(2023, 1, 1, tzinfo=timezone.utc)
         converted_time = self.global_filter._normalize_to_utc(time_with_tz)
-
-        # The bound must be a native datetime (not a stringified ISO 8601 value) so that
-        # filter engines can compare it against tz-aware timestamp columns directly.
-        assert isinstance(converted_time, datetime)
         assert converted_time == datetime(2023, 1, 1, tzinfo=timezone.utc)
         assert converted_time.tzinfo == timezone.utc
+
+        # Conversion case: a non-UTC tz must shift to UTC.
+        time_offset = datetime(2023, 1, 1, 12, tzinfo=timezone(timedelta(hours=5)))
+        converted_offset = self.global_filter._normalize_to_utc(time_offset)
+        assert converted_offset == datetime(2023, 1, 1, 7, tzinfo=timezone.utc)
+        assert converted_offset.tzinfo == timezone.utc
 
     def test_normalize_to_utc_without_tz(self) -> None:
         """Test the _normalize_to_utc method with missing timezone info."""

--- a/tests/test_core/test_filter/test_global_filter.py
+++ b/tests/test_core/test_filter/test_global_filter.py
@@ -194,7 +194,6 @@ class TestGlobalFilterTimeTravel:
         # The bound must be a native datetime (not a stringified ISO 8601 value) so that
         # filter engines can compare it against tz-aware timestamp columns directly.
         assert isinstance(converted_time, datetime)
-        assert not isinstance(converted_time, str)
         assert converted_time == datetime(2023, 1, 1, tzinfo=timezone.utc)
         assert converted_time.tzinfo == timezone.utc
 

--- a/tests/test_core/test_filter/test_time_travel.py
+++ b/tests/test_core/test_filter/test_time_travel.py
@@ -41,14 +41,19 @@ class TimeTravelPositiveFilterTest(FeatureGroup):
         if len(features.filters) != 1:  # type: ignore
             raise ValueError("Test Filter not found")
 
+        now_utc = datetime.now(tz=timezone.utc)
+        ts_array = pa.array(
+            [
+                (now_utc - timedelta(days=10)).replace(tzinfo=None),  # 10 days ago - within range
+                (now_utc - timedelta(days=30)).replace(tzinfo=None),  # 30 days ago - outside range
+                (now_utc - timedelta(days=30)).replace(tzinfo=None),  # 30 days ago - outside range
+            ],
+            type=pa.timestamp("us", tz="UTC"),
+        )
         return pa.table(
             {
                 cls.get_class_name(): [1, 2, 3],
-                "reference_time": [
-                    (datetime.now(tz=timezone.utc) - timedelta(days=10)).isoformat(),  # 10 days ago - within range
-                    (datetime.now(tz=timezone.utc) - timedelta(days=30)).isoformat(),  # 30 days ago - outside range
-                    (datetime.now(tz=timezone.utc) - timedelta(days=30)).isoformat(),  # 30 days ago - outside range
-                ],
+                "reference_time": ts_array,
             }
         )
 

--- a/tests/test_core/test_filter/test_time_travel.py
+++ b/tests/test_core/test_filter/test_time_travel.py
@@ -41,6 +41,7 @@ class TimeTravelPositiveFilterTest(FeatureGroup):
         if len(features.filters) != 1:  # type: ignore
             raise ValueError("Test Filter not found")
 
+        # Snapshot `now` once so the three row timestamps are mutually consistent.
         now_utc = datetime.now(tz=timezone.utc)
         ts_array = pa.array(
             [

--- a/tests/test_core/test_filter/test_time_travel.py
+++ b/tests/test_core/test_filter/test_time_travel.py
@@ -43,6 +43,8 @@ class TimeTravelPositiveFilterTest(FeatureGroup):
 
         # Snapshot `now` once so the three row timestamps are mutually consistent.
         now_utc = datetime.now(tz=timezone.utc)
+        # pa.array with a tz-typed timestamp interprets naive datetimes as already in that tz;
+        # tz-aware datetimes are rejected on some PyArrow versions, hence the .replace(tzinfo=None).
         ts_array = pa.array(
             [
                 (now_utc - timedelta(days=10)).replace(tzinfo=None),  # 10 days ago - within range

--- a/tests/test_core/test_filter/test_time_window_filter_engines.py
+++ b/tests/test_core/test_filter/test_time_window_filter_engines.py
@@ -1,0 +1,203 @@
+"""
+Integration tests for GlobalFilter time range filtering against tz-aware
+timestamp columns across compute frameworks.
+
+These tests verify that ``GlobalFilter.add_time_and_time_travel_filters`` produces
+filter bounds that filter engines can compare against tz-aware (UTC) temporal
+columns. On the current implementation the bounds are stringified ISO 8601
+values which the PyArrow and python_dict filter engines cannot compare to a
+real timestamp/datetime column:
+
+* PyArrow raises ``ArrowNotImplementedError`` from
+  ``pc.greater_equal(timestamp[us, tz=UTC], string)``.
+* python_dict raises ``TypeError: '<=' not supported between instances of 'str'
+  and 'datetime.datetime'``.
+
+The tests are designed to fail on current main and pass once the bounds are
+returned as UTC-normalized ``datetime`` objects.
+
+Note on pandas: empirically the pandas filter engine silently coerces the
+stringified bound back into a tz-aware Timestamp via ``Series.__ge__``, so it
+does not raise on current main. A pandas regression guard can be added as a
+follow-up but is not part of this Red phase, since it would pass both before
+and after the fix.
+"""
+
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+import pyarrow as pa
+
+from mloda.provider import BaseInputData
+from mloda.provider import ComputeFramework
+from mloda.provider import DataCreator
+from mloda.provider import DefaultOptionKeys
+from mloda.provider import FeatureGroup
+from mloda.provider import FeatureSet
+from mloda.user import GlobalFilter
+from mloda.user import PluginCollector
+from mloda.user import mloda
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
+    PythonDictFramework,
+)
+
+
+# TODO(#435): Polars is not covered in this integration test. The shared
+# ``ATestDataCreator`` only maps Pandas/PyArrow conversions and there is no
+# polars time-window plugin to reuse; wiring a polars-native source FG is
+# scope creep for the Red phase. PyArrow + python_dict already exercise the
+# GlobalFilter -> tz-aware-column code path. A polars regression test can be
+# added in a follow-up after the Green-phase fix lands.
+
+
+# Test data covering rows inside and outside the filter window [Jan 5, Jan 11).
+# Indices 4..9 (timestamps Jan 5..Jan 10) are the only rows that must survive.
+TIMESTAMPS_ISO: list[str] = [
+    "2023-01-01T00:00:00+00:00",
+    "2023-01-02T00:00:00+00:00",
+    "2023-01-03T00:00:00+00:00",
+    "2023-01-04T00:00:00+00:00",
+    "2023-01-05T00:00:00+00:00",  # in window
+    "2023-01-06T00:00:00+00:00",  # in window
+    "2023-01-07T00:00:00+00:00",  # in window
+    "2023-01-08T00:00:00+00:00",  # in window
+    "2023-01-09T00:00:00+00:00",  # in window
+    "2023-01-10T00:00:00+00:00",  # in window
+    "2023-01-11T00:00:00+00:00",  # boundary, excluded (max_exclusive=True)
+    "2023-01-12T00:00:00+00:00",
+]
+TEMPERATURES: list[int] = [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]
+
+EVENT_FROM = datetime(2023, 1, 5, tzinfo=timezone.utc)
+EVENT_TO = datetime(2023, 1, 11, tzinfo=timezone.utc)
+
+# Rows that must survive the filter (Jan 5..Jan 10, inclusive of start, exclusive of end).
+EXPECTED_TEMPERATURES: list[int] = [14, 15, 16, 17, 18, 19]
+EXPECTED_ROW_COUNT: int = len(EXPECTED_TEMPERATURES)
+
+
+class TestGlobalFilterTimeRangePyArrow:
+    """GlobalFilter time range filtering on a tz-aware PyArrow timestamp column."""
+
+    def test_pyarrow_tz_aware_time_range_filter(self) -> None:
+        """The PyArrow filter engine must accept the GlobalFilter bound against a tz-aware timestamp column."""
+
+        class PyArrowTzAwareSource(FeatureGroup):
+            @classmethod
+            def input_data(cls) -> Optional[BaseInputData]:
+                return DataCreator({"temperature", DefaultOptionKeys.reference_time})
+
+            @classmethod
+            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                # Build a tz-aware UTC timestamp column natively in PyArrow so the
+                # filter engine has to compare timestamp[us, tz=UTC] against the
+                # GlobalFilter bound directly.
+                timestamps_naive = [datetime.fromisoformat(ts).replace(tzinfo=None) for ts in TIMESTAMPS_ISO]
+                ts_array = pa.array(timestamps_naive, type=pa.timestamp("us", tz="UTC"))
+                return pa.table(
+                    {
+                        "temperature": pa.array(TEMPERATURES),
+                        DefaultOptionKeys.reference_time: ts_array,
+                    }
+                )
+
+            @classmethod
+            def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+                return {PyArrowTable}
+
+        global_filter = GlobalFilter()
+        global_filter.add_time_and_time_travel_filters(event_from=EVENT_FROM, event_to=EVENT_TO)
+
+        plugin_collector = PluginCollector.enabled_feature_groups({PyArrowTzAwareSource})
+
+        # On current main this call raises because the PyArrow filter engine cannot
+        # compare timestamp[us, tz=UTC] to the stringified bound produced by
+        # _check_and_convert_time_info. After the Green-phase fix the call succeeds
+        # and we verify the surviving rows.
+        result = mloda.run_all(
+            ["temperature", DefaultOptionKeys.reference_time],
+            compute_frameworks={PyArrowTable},
+            plugin_collector=plugin_collector,
+            global_filter=global_filter,
+        )
+
+        assert len(result) > 0, "No results returned from mloda.run_all"
+
+        temperature_table = None
+        for table in result:
+            if "temperature" in table.schema.names:
+                temperature_table = table
+                break
+
+        assert temperature_table is not None, "PyArrow Table with temperature column not found"
+
+        actual_temps = sorted(temperature_table.column("temperature").to_pylist())
+        assert actual_temps == EXPECTED_TEMPERATURES, (
+            f"Expected only in-window temperatures {EXPECTED_TEMPERATURES}, got {actual_temps}"
+        )
+        assert temperature_table.num_rows == EXPECTED_ROW_COUNT, (
+            f"Expected {EXPECTED_ROW_COUNT} rows after tz-aware filtering, got {temperature_table.num_rows}"
+        )
+
+
+class TestGlobalFilterTimeRangePythonDict:
+    """GlobalFilter time range filtering on a python_dict list of tz-aware datetimes."""
+
+    def test_python_dict_tz_aware_time_range_filter(self) -> None:
+        """The python_dict filter engine must accept the GlobalFilter bound against tz-aware datetime values."""
+
+        class PythonDictTzAwareSource(FeatureGroup):
+            @classmethod
+            def input_data(cls) -> Optional[BaseInputData]:
+                return DataCreator({"temperature", DefaultOptionKeys.reference_time})
+
+            @classmethod
+            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                # Emit native tz-aware datetime values inside the row dicts so the
+                # filter engine compares datetime <-> bound directly.
+                return [
+                    {
+                        "temperature": TEMPERATURES[i],
+                        DefaultOptionKeys.reference_time: datetime.fromisoformat(TIMESTAMPS_ISO[i]),
+                    }
+                    for i in range(len(TIMESTAMPS_ISO))
+                ]
+
+            @classmethod
+            def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+                return {PythonDictFramework}
+
+        global_filter = GlobalFilter()
+        global_filter.add_time_and_time_travel_filters(event_from=EVENT_FROM, event_to=EVENT_TO)
+
+        plugin_collector = PluginCollector.enabled_feature_groups({PythonDictTzAwareSource})
+
+        # On current main this raises ``TypeError: '<=' not supported between
+        # instances of 'str' and 'datetime.datetime'`` because the GlobalFilter
+        # bound is an ISO 8601 string. After the Green-phase fix the bound is a
+        # ``datetime`` and the filter returns the in-window rows.
+        result = mloda.run_all(
+            ["temperature", DefaultOptionKeys.reference_time],
+            compute_frameworks={PythonDictFramework},
+            plugin_collector=plugin_collector,
+            global_filter=global_filter,
+        )
+
+        assert len(result) > 0, "No results returned from mloda.run_all"
+
+        rows = None
+        for candidate in result:
+            if candidate and isinstance(candidate, list) and "temperature" in candidate[0]:
+                rows = candidate
+                break
+
+        assert rows is not None, "python_dict result with temperature column not found"
+
+        actual_temps = sorted(row["temperature"] for row in rows)
+        assert actual_temps == EXPECTED_TEMPERATURES, (
+            f"Expected only in-window temperatures {EXPECTED_TEMPERATURES}, got {actual_temps}"
+        )
+        assert len(rows) == EXPECTED_ROW_COUNT, (
+            f"Expected {EXPECTED_ROW_COUNT} rows after tz-aware filtering, got {len(rows)}"
+        )

--- a/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_filter_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_filter_engine.py
@@ -14,6 +14,11 @@ from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_relation
 from tests.test_plugins.compute_framework.base_implementations.filter_engine_test_mixin import (
     FilterEngineTestMixin,
 )
+from tests.test_plugins.compute_framework.base_implementations.time_range_filter_engine_test_mixin import (
+    SAMPLE_IDS,
+    SAMPLE_TIMESTAMPS,
+    TimeRangeFilterEngineTestMixin,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -27,8 +32,8 @@ except ImportError:
 
 
 @pytest.mark.skipif(duckdb is None or pa is None, reason="DuckDB or PyArrow is not installed. Skipping this test.")
-class TestDuckDBFilterEngine(FilterEngineTestMixin):
-    """Unit tests for the DuckDBFilterEngine class using shared mixin."""
+class TestDuckDBFilterEngine(FilterEngineTestMixin, TimeRangeFilterEngineTestMixin):
+    """Unit tests for the DuckDBFilterEngine class using shared mixins."""
 
     @pytest.fixture
     def filter_engine(self) -> Any:
@@ -51,6 +56,23 @@ class TestDuckDBFilterEngine(FilterEngineTestMixin):
     def get_column_values(self, result: Any, column: str) -> list[Any]:
         """Extract column values from DuckDB relation via pandas DataFrame."""
         return result.df()[column].tolist()  # type: ignore[no-any-return]
+
+    @pytest.fixture
+    def time_filter_engine(self) -> Any:
+        return DuckDBFilterEngine
+
+    @pytest.fixture
+    def sample_time_data(self, connection: Any) -> Any:
+        # pa.array with a tz-typed timestamp interprets naive datetimes as already in that tz;
+        # tz-aware datetimes are rejected on some PyArrow versions.
+        naive_ts = [ts.replace(tzinfo=None) for ts in SAMPLE_TIMESTAMPS]
+        arrow_table = pa.table(
+            {"id": pa.array(SAMPLE_IDS), "ts": pa.array(naive_ts, type=pa.timestamp("us", tz="UTC"))}
+        )
+        return DuckdbRelation.from_arrow(connection, arrow_table)
+
+    def get_id_column_values(self, result: Any) -> list[int]:
+        return list(result.df()["id"].tolist())
 
     # Framework-specific tests below
 

--- a/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_filter_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_filter_engine.py
@@ -58,10 +58,6 @@ class TestDuckDBFilterEngine(FilterEngineTestMixin, TimeRangeFilterEngineTestMix
         return result.df()[column].tolist()  # type: ignore[no-any-return]
 
     @pytest.fixture
-    def time_filter_engine(self) -> Any:
-        return DuckDBFilterEngine
-
-    @pytest.fixture
     def sample_time_data(self, connection: Any) -> Any:
         # pa.array with a tz-typed timestamp interprets naive datetimes as already in that tz;
         # tz-aware datetimes are rejected on some PyArrow versions.

--- a/tests/test_plugins/compute_framework/base_implementations/pandas/test_pandas_filter_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/pandas/test_pandas_filter_engine.py
@@ -42,10 +42,6 @@ class TestPandasFilterEngine(FilterEngineTestMixin, TimeRangeFilterEngineTestMix
         return result[column].tolist()  # type: ignore[no-any-return]
 
     @pytest.fixture
-    def time_filter_engine(self) -> Any:
-        return PandasFilterEngine
-
-    @pytest.fixture
     def sample_time_data(self) -> Any:
         return pd.DataFrame({"id": SAMPLE_IDS, "ts": pd.to_datetime(SAMPLE_TIMESTAMPS, utc=True)})
 

--- a/tests/test_plugins/compute_framework/base_implementations/pandas/test_pandas_filter_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/pandas/test_pandas_filter_engine.py
@@ -10,10 +10,15 @@ from mloda_plugins.compute_framework.base_implementations.pandas.pandas_filter_e
 from tests.test_plugins.compute_framework.base_implementations.filter_engine_test_mixin import (
     FilterEngineTestMixin,
 )
+from tests.test_plugins.compute_framework.base_implementations.time_range_filter_engine_test_mixin import (
+    SAMPLE_IDS,
+    SAMPLE_TIMESTAMPS,
+    TimeRangeFilterEngineTestMixin,
+)
 
 
-class TestPandasFilterEngine(FilterEngineTestMixin):
-    """Unit tests for the PandasFilterEngine class using shared mixin."""
+class TestPandasFilterEngine(FilterEngineTestMixin, TimeRangeFilterEngineTestMixin):
+    """Unit tests for the PandasFilterEngine class using shared mixins."""
 
     @pytest.fixture
     def filter_engine(self) -> Any:
@@ -35,3 +40,14 @@ class TestPandasFilterEngine(FilterEngineTestMixin):
     def get_column_values(self, result: Any, column: str) -> list[Any]:
         """Extract column values from pandas DataFrame."""
         return result[column].tolist()  # type: ignore[no-any-return]
+
+    @pytest.fixture
+    def time_filter_engine(self) -> Any:
+        return PandasFilterEngine
+
+    @pytest.fixture
+    def sample_time_data(self) -> Any:
+        return pd.DataFrame({"id": SAMPLE_IDS, "ts": pd.to_datetime(SAMPLE_TIMESTAMPS, utc=True)})
+
+    def get_id_column_values(self, result: Any) -> list[int]:
+        return list(result["id"].tolist())

--- a/tests/test_plugins/compute_framework/base_implementations/polars/test_polars_filter_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/polars/test_polars_filter_engine.py
@@ -54,10 +54,6 @@ class TestPolarsFilterEngine(FilterEngineTestMixin, TimeRangeFilterEngineTestMix
         return result[column].to_list()  # type: ignore[no-any-return]
 
     @pytest.fixture
-    def time_filter_engine(self) -> Any:
-        return PolarsFilterEngine
-
-    @pytest.fixture
     def sample_time_data(self) -> Any:
         return pl.DataFrame(
             {"id": SAMPLE_IDS, "ts": SAMPLE_TIMESTAMPS},

--- a/tests/test_plugins/compute_framework/base_implementations/polars/test_polars_filter_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/polars/test_polars_filter_engine.py
@@ -13,6 +13,11 @@ from mloda_plugins.compute_framework.base_implementations.polars.polars_filter_e
 from tests.test_plugins.compute_framework.base_implementations.filter_engine_test_mixin import (
     FilterEngineTestMixin,
 )
+from tests.test_plugins.compute_framework.base_implementations.time_range_filter_engine_test_mixin import (
+    SAMPLE_IDS,
+    SAMPLE_TIMESTAMPS,
+    TimeRangeFilterEngineTestMixin,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -24,8 +29,8 @@ except ImportError:
 
 
 @pytest.mark.skipif(pl is None, reason="Polars is not installed. Skipping this test.")
-class TestPolarsFilterEngine(FilterEngineTestMixin):
-    """Unit tests for the PolarsFilterEngine class using shared mixin."""
+class TestPolarsFilterEngine(FilterEngineTestMixin, TimeRangeFilterEngineTestMixin):
+    """Unit tests for the PolarsFilterEngine class using shared mixins."""
 
     @pytest.fixture
     def filter_engine(self) -> Any:
@@ -47,6 +52,20 @@ class TestPolarsFilterEngine(FilterEngineTestMixin):
     def get_column_values(self, result: Any, column: str) -> list[Any]:
         """Extract column values from Polars DataFrame."""
         return result[column].to_list()  # type: ignore[no-any-return]
+
+    @pytest.fixture
+    def time_filter_engine(self) -> Any:
+        return PolarsFilterEngine
+
+    @pytest.fixture
+    def sample_time_data(self) -> Any:
+        return pl.DataFrame(
+            {"id": SAMPLE_IDS, "ts": SAMPLE_TIMESTAMPS},
+            schema={"id": pl.Int64, "ts": pl.Datetime(time_unit="us", time_zone="UTC")},
+        )
+
+    def get_id_column_values(self, result: Any) -> list[int]:
+        return list(result["id"].to_list())
 
     # Framework-specific tests below
 

--- a/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_filter_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_filter_engine.py
@@ -45,10 +45,6 @@ class TestPythonDictFilterEngine(FilterEngineTestMixin, TimeRangeFilterEngineTes
         return [row[column] for row in result]
 
     @pytest.fixture
-    def time_filter_engine(self) -> Any:
-        return PythonDictFilterEngine
-
-    @pytest.fixture
     def sample_time_data(self) -> Any:
         return [{"id": SAMPLE_IDS[i], "ts": SAMPLE_TIMESTAMPS[i]} for i in range(len(SAMPLE_IDS))]
 

--- a/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_filter_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_filter_engine.py
@@ -14,10 +14,15 @@ from mloda_plugins.compute_framework.base_implementations.python_dict.python_dic
 from tests.test_plugins.compute_framework.base_implementations.filter_engine_test_mixin import (
     FilterEngineTestMixin,
 )
+from tests.test_plugins.compute_framework.base_implementations.time_range_filter_engine_test_mixin import (
+    SAMPLE_IDS,
+    SAMPLE_TIMESTAMPS,
+    TimeRangeFilterEngineTestMixin,
+)
 
 
-class TestPythonDictFilterEngine(FilterEngineTestMixin):
-    """Unit tests for the PythonDictFilterEngine class using shared mixin."""
+class TestPythonDictFilterEngine(FilterEngineTestMixin, TimeRangeFilterEngineTestMixin):
+    """Unit tests for the PythonDictFilterEngine class using shared mixins."""
 
     @pytest.fixture
     def filter_engine(self) -> Any:
@@ -38,6 +43,17 @@ class TestPythonDictFilterEngine(FilterEngineTestMixin):
     def get_column_values(self, result: Any, column: str) -> list[Any]:
         """Extract column values from list of dicts."""
         return [row[column] for row in result]
+
+    @pytest.fixture
+    def time_filter_engine(self) -> Any:
+        return PythonDictFilterEngine
+
+    @pytest.fixture
+    def sample_time_data(self) -> Any:
+        return [{"id": SAMPLE_IDS[i], "ts": SAMPLE_TIMESTAMPS[i]} for i in range(len(SAMPLE_IDS))]
+
+    def get_id_column_values(self, result: Any) -> list[int]:
+        return [row["id"] for row in result]
 
     # Framework-specific tests below
 

--- a/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_filter_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_filter_engine.py
@@ -13,9 +13,14 @@ from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_relation
 from tests.test_plugins.compute_framework.base_implementations.filter_engine_test_mixin import (
     FilterEngineTestMixin,
 )
+from tests.test_plugins.compute_framework.base_implementations.time_range_filter_engine_test_mixin import (
+    SAMPLE_IDS,
+    SAMPLE_TIMESTAMPS,
+    TimeRangeFilterEngineTestMixin,
+)
 
 
-class TestSqliteFilterEngine(FilterEngineTestMixin):
+class TestSqliteFilterEngine(FilterEngineTestMixin, TimeRangeFilterEngineTestMixin):
     @pytest.fixture
     def filter_engine(self) -> Any:
         return SqliteFilterEngine
@@ -35,6 +40,23 @@ class TestSqliteFilterEngine(FilterEngineTestMixin):
     def get_column_values(self, result: Any, column: str) -> list[Any]:
         values: list[Any] = result.df()[column].tolist()
         return values
+
+    @pytest.fixture
+    def time_filter_engine(self) -> Any:
+        return SqliteFilterEngine
+
+    @pytest.fixture
+    def sample_time_data(self, connection: sqlite3.Connection) -> Any:
+        # pa.array with a tz-typed timestamp interprets naive datetimes as already in that tz;
+        # tz-aware datetimes are rejected on some PyArrow versions.
+        naive_ts = [ts.replace(tzinfo=None) for ts in SAMPLE_TIMESTAMPS]
+        arrow_table = pa.table(
+            {"id": pa.array(SAMPLE_IDS), "ts": pa.array(naive_ts, type=pa.timestamp("us", tz="UTC"))}
+        )
+        return SqliteRelation.from_arrow(connection, arrow_table)
+
+    def get_id_column_values(self, result: Any) -> list[int]:
+        return list(result.df()["id"].tolist())
 
     def test_filter_with_null_values(self, connection: sqlite3.Connection) -> None:
         arrow_table = pa.Table.from_pydict(

--- a/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_filter_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_filter_engine.py
@@ -42,10 +42,6 @@ class TestSqliteFilterEngine(FilterEngineTestMixin, TimeRangeFilterEngineTestMix
         return values
 
     @pytest.fixture
-    def time_filter_engine(self) -> Any:
-        return SqliteFilterEngine
-
-    @pytest.fixture
     def sample_time_data(self, connection: sqlite3.Connection) -> Any:
         # pa.array with a tz-typed timestamp interprets naive datetimes as already in that tz;
         # tz-aware datetimes are rejected on some PyArrow versions.

--- a/tests/test_plugins/compute_framework/base_implementations/time_range_filter_engine_test_mixin.py
+++ b/tests/test_plugins/compute_framework/base_implementations/time_range_filter_engine_test_mixin.py
@@ -1,0 +1,65 @@
+"""
+Shared test mixin for tz-aware datetime bounds on BaseFilterEngine range filters.
+
+Regression guard for #435: GlobalFilter time-range bounds reach engines as
+tz-aware ``datetime`` objects. Engines must be able to compare them against the
+framework's native temporal column type without re-parsing.
+
+Each framework-specific test class that mixes this in provides:
+- ``time_filter_engine`` fixture: the engine class under test.
+- ``sample_time_data`` fixture: framework-native data with columns
+  ``id`` (1..6) and ``ts`` (Jan 1..Jan 6, 2023 at midnight UTC, tz-aware).
+- ``get_id_column_values`` method: extract the ``id`` column from a result.
+"""
+
+from abc import abstractmethod
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from mloda.user import Feature
+from mloda.user import FilterType
+from mloda.user import SingleFilter
+
+
+SAMPLE_IDS: list[int] = [1, 2, 3, 4, 5, 6]
+SAMPLE_TIMESTAMPS: list[datetime] = [datetime(2023, 1, day, tzinfo=timezone.utc) for day in range(1, 7)]
+
+RANGE_MIN = datetime(2023, 1, 2, tzinfo=timezone.utc)
+RANGE_MAX = datetime(2023, 1, 5, tzinfo=timezone.utc)
+EXPECTED_IDS_EXCLUSIVE: list[int] = [2, 3, 4]
+
+
+class TimeRangeFilterEngineTestMixin:
+    """Shared tz-aware range filter test for BaseFilterEngine implementations."""
+
+    @pytest.fixture
+    @abstractmethod
+    def time_filter_engine(self) -> Any:
+        """Return the filter engine class to test."""
+        raise NotImplementedError
+
+    @pytest.fixture
+    @abstractmethod
+    def sample_time_data(self) -> Any:
+        """Return framework-native data with columns ``id`` and tz-aware ``ts``."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_id_column_values(self, result: Any) -> list[int]:
+        """Extract the ``id`` column from a filter result as a list of ints."""
+        raise NotImplementedError
+
+    def test_do_range_filter_tz_aware_datetime_bounds(self, time_filter_engine: Any, sample_time_data: Any) -> None:
+        """Range filter with tz-aware UTC datetime bounds against a tz-aware temporal column."""
+        single_filter = SingleFilter(
+            Feature("ts"),
+            FilterType.RANGE,
+            {"min": RANGE_MIN, "max": RANGE_MAX, "max_exclusive": True},
+        )
+
+        result = time_filter_engine.do_range_filter(sample_time_data, single_filter)
+
+        ids = sorted(self.get_id_column_values(result))
+        assert ids == EXPECTED_IDS_EXCLUSIVE

--- a/tests/test_plugins/compute_framework/base_implementations/time_range_filter_engine_test_mixin.py
+++ b/tests/test_plugins/compute_framework/base_implementations/time_range_filter_engine_test_mixin.py
@@ -1,12 +1,13 @@
 """
-Shared test mixin for tz-aware datetime bounds on BaseFilterEngine range filters.
+Shared test mixin for tz-aware datetime bounds on BaseFilterEngine implementations.
 
-Regression guard for #435: GlobalFilter time-range bounds reach engines as
-tz-aware ``datetime`` objects. Engines must be able to compare them against the
-framework's native temporal column type without re-parsing.
+Regression guard for #435: GlobalFilter time-range / min / max bounds reach
+engines as tz-aware ``datetime`` objects. Engines must be able to compare them
+against the framework's native temporal column type without re-parsing.
 
-Each framework-specific test class that mixes this in provides:
-- ``time_filter_engine`` fixture: the engine class under test.
+Designed to compose with ``FilterEngineTestMixin``: the ``filter_engine``
+fixture is reused, so each consumer only adds:
+
 - ``sample_time_data`` fixture: framework-native data with columns
   ``id`` (1..6) and ``ts`` (Jan 1..Jan 6, 2023 at midnight UTC, tz-aware).
 - ``get_id_column_values`` method: extract the ``id`` column from a result.
@@ -28,17 +29,17 @@ SAMPLE_TIMESTAMPS: list[datetime] = [datetime(2023, 1, day, tzinfo=timezone.utc)
 
 RANGE_MIN = datetime(2023, 1, 2, tzinfo=timezone.utc)
 RANGE_MAX = datetime(2023, 1, 5, tzinfo=timezone.utc)
-EXPECTED_IDS_EXCLUSIVE: list[int] = [2, 3, 4]
+EXPECTED_IDS_RANGE_EXCLUSIVE: list[int] = [2, 3, 4]
+
+MIN_BOUND = datetime(2023, 1, 4, tzinfo=timezone.utc)
+EXPECTED_IDS_MIN: list[int] = [4, 5, 6]
+
+MAX_BOUND = datetime(2023, 1, 3, tzinfo=timezone.utc)
+EXPECTED_IDS_MAX: list[int] = [1, 2, 3]
 
 
 class TimeRangeFilterEngineTestMixin:
-    """Shared tz-aware range filter test for BaseFilterEngine implementations."""
-
-    @pytest.fixture
-    @abstractmethod
-    def time_filter_engine(self) -> Any:
-        """Return the filter engine class to test."""
-        raise NotImplementedError
+    """Shared tz-aware datetime-bound tests for BaseFilterEngine implementations."""
 
     @pytest.fixture
     @abstractmethod
@@ -51,7 +52,7 @@ class TimeRangeFilterEngineTestMixin:
         """Extract the ``id`` column from a filter result as a list of ints."""
         raise NotImplementedError
 
-    def test_do_range_filter_tz_aware_datetime_bounds(self, time_filter_engine: Any, sample_time_data: Any) -> None:
+    def test_do_range_filter_tz_aware_datetime_bounds(self, filter_engine: Any, sample_time_data: Any) -> None:
         """Range filter with tz-aware UTC datetime bounds against a tz-aware temporal column."""
         single_filter = SingleFilter(
             Feature("ts"),
@@ -59,7 +60,25 @@ class TimeRangeFilterEngineTestMixin:
             {"min": RANGE_MIN, "max": RANGE_MAX, "max_exclusive": True},
         )
 
-        result = time_filter_engine.do_range_filter(sample_time_data, single_filter)
+        result = filter_engine.do_range_filter(sample_time_data, single_filter)
 
         ids = sorted(self.get_id_column_values(result))
-        assert ids == EXPECTED_IDS_EXCLUSIVE
+        assert ids == EXPECTED_IDS_RANGE_EXCLUSIVE
+
+    def test_do_min_filter_tz_aware_datetime_bound(self, filter_engine: Any, sample_time_data: Any) -> None:
+        """Min filter with a tz-aware UTC datetime bound against a tz-aware temporal column."""
+        single_filter = SingleFilter(Feature("ts"), FilterType.MIN, {"value": MIN_BOUND})
+
+        result = filter_engine.do_min_filter(sample_time_data, single_filter)
+
+        ids = sorted(self.get_id_column_values(result))
+        assert ids == EXPECTED_IDS_MIN
+
+    def test_do_max_filter_tz_aware_datetime_bound(self, filter_engine: Any, sample_time_data: Any) -> None:
+        """Max filter with a tz-aware UTC datetime bound against a tz-aware temporal column."""
+        single_filter = SingleFilter(Feature("ts"), FilterType.MAX, {"value": MAX_BOUND})
+
+        result = filter_engine.do_max_filter(sample_time_data, single_filter)
+
+        ids = sorted(self.get_id_column_values(result))
+        assert ids == EXPECTED_IDS_MAX

--- a/tests/test_plugins/feature_group/experimental/test_time_window_feature_group/test_global_filter_tz_aware_time_range.py
+++ b/tests/test_plugins/feature_group/experimental/test_time_window_feature_group/test_global_filter_tz_aware_time_range.py
@@ -1,32 +1,29 @@
 """
-Integration tests for GlobalFilter time range filtering against tz-aware
-timestamp columns across compute frameworks.
+Regression guard for #435: GlobalFilter time-range bounds must be comparable against
+tz-aware temporal columns at each compute framework's filter engine.
 
-These tests verify that ``GlobalFilter.add_time_and_time_travel_filters`` produces
-filter bounds that filter engines can compare against tz-aware (UTC) temporal
-columns. On the current implementation the bounds are stringified ISO 8601
-values which the PyArrow and python_dict filter engines cannot compare to a
-real timestamp/datetime column:
+Before the fix, ``GlobalFilter.add_time_and_time_travel_filters`` stringified bounds
+via ``datetime.isoformat()``. The PyArrow filter engine then raised
+``ArrowNotImplementedError: Function 'greater_equal' has no kernel matching input
+types (timestamp[us, tz=UTC], string)``, and the python_dict engine raised
+``TypeError: '<=' not supported between instances of 'str' and 'datetime.datetime'``.
 
-* PyArrow raises ``ArrowNotImplementedError`` from
-  ``pc.greater_equal(timestamp[us, tz=UTC], string)``.
-* python_dict raises ``TypeError: '<=' not supported between instances of 'str'
-  and 'datetime.datetime'``.
+These tests pin the contract that bounds reach engines as tz-aware ``datetime``
+objects and survive the round trip end-to-end through ``mloda.run_all`` for the
+three engines that previously broke under tz-aware columns: PyArrow, python_dict,
+and Polars.
 
-The tests are designed to fail on current main and pass once the bounds are
-returned as UTC-normalized ``datetime`` objects.
-
-Note on pandas: empirically the pandas filter engine silently coerces the
-stringified bound back into a tz-aware Timestamp via ``Series.__ge__``, so it
-does not raise on current main. A pandas regression guard can be added as a
-follow-up but is not part of this Red phase, since it would pass both before
-and after the fix.
+Note on pandas: the pandas filter engine silently coerced the stringified bound
+back into a tz-aware Timestamp via ``Series.__ge__`` even before the fix, so a
+dedicated pandas regression test would pass both before and after #435 and is
+omitted as redundant.
 """
 
 from datetime import datetime, timezone
 from typing import Any, Optional
 
 import pyarrow as pa
+import pytest
 
 from mloda.provider import BaseInputData
 from mloda.provider import ComputeFramework
@@ -37,22 +34,20 @@ from mloda.provider import FeatureSet
 from mloda.user import GlobalFilter
 from mloda.user import PluginCollector
 from mloda.user import mloda
+from mloda_plugins.compute_framework.base_implementations.polars.dataframe import PolarsDataFrame
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
 from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
     PythonDictFramework,
 )
 
-
-# TODO(#435): Polars is not covered in this integration test. The shared
-# ``ATestDataCreator`` only maps Pandas/PyArrow conversions and there is no
-# polars time-window plugin to reuse; wiring a polars-native source FG is
-# scope creep for the Red phase. PyArrow + python_dict already exercise the
-# GlobalFilter -> tz-aware-column code path. A polars regression test can be
-# added in a follow-up after the Green-phase fix lands.
+try:
+    import polars as pl
+except ImportError:
+    pl = None  # type: ignore[assignment]
 
 
-# Test data covering rows inside and outside the filter window [Jan 5, Jan 11).
-# Indices 4..9 (timestamps Jan 5..Jan 10) are the only rows that must survive.
+# Indices 4..9 (timestamps Jan 5..Jan 10) are the only rows that must survive
+# the [Jan 5, Jan 11) window with max_exclusive=True.
 TIMESTAMPS_ISO: list[str] = [
     "2023-01-01T00:00:00+00:00",
     "2023-01-02T00:00:00+00:00",
@@ -72,17 +67,22 @@ TEMPERATURES: list[int] = [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]
 EVENT_FROM = datetime(2023, 1, 5, tzinfo=timezone.utc)
 EVENT_TO = datetime(2023, 1, 11, tzinfo=timezone.utc)
 
-# Rows that must survive the filter (Jan 5..Jan 10, inclusive of start, exclusive of end).
 EXPECTED_TEMPERATURES: list[int] = [14, 15, 16, 17, 18, 19]
 EXPECTED_ROW_COUNT: int = len(EXPECTED_TEMPERATURES)
 
 
+def _naive_timestamps() -> list[datetime]:
+    return [datetime.fromisoformat(ts).replace(tzinfo=None) for ts in TIMESTAMPS_ISO]
+
+
+def _tz_aware_timestamps() -> list[datetime]:
+    return [datetime.fromisoformat(ts) for ts in TIMESTAMPS_ISO]
+
+
 class TestGlobalFilterTimeRangePyArrow:
-    """GlobalFilter time range filtering on a tz-aware PyArrow timestamp column."""
+    """Regression guard for #435 on the PyArrow filter engine."""
 
     def test_pyarrow_tz_aware_time_range_filter(self) -> None:
-        """The PyArrow filter engine must accept the GlobalFilter bound against a tz-aware timestamp column."""
-
         class PyArrowTzAwareSource(FeatureGroup):
             @classmethod
             def input_data(cls) -> Optional[BaseInputData]:
@@ -90,11 +90,7 @@ class TestGlobalFilterTimeRangePyArrow:
 
             @classmethod
             def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                # Build a tz-aware UTC timestamp column natively in PyArrow so the
-                # filter engine has to compare timestamp[us, tz=UTC] against the
-                # GlobalFilter bound directly.
-                timestamps_naive = [datetime.fromisoformat(ts).replace(tzinfo=None) for ts in TIMESTAMPS_ISO]
-                ts_array = pa.array(timestamps_naive, type=pa.timestamp("us", tz="UTC"))
+                ts_array = pa.array(_naive_timestamps(), type=pa.timestamp("us", tz="UTC"))
                 return pa.table(
                     {
                         "temperature": pa.array(TEMPERATURES),
@@ -111,10 +107,6 @@ class TestGlobalFilterTimeRangePyArrow:
 
         plugin_collector = PluginCollector.enabled_feature_groups({PyArrowTzAwareSource})
 
-        # On current main this call raises because the PyArrow filter engine cannot
-        # compare timestamp[us, tz=UTC] to the stringified bound produced by
-        # _check_and_convert_time_info. After the Green-phase fix the call succeeds
-        # and we verify the surviving rows.
         result = mloda.run_all(
             ["temperature", DefaultOptionKeys.reference_time],
             compute_frameworks={PyArrowTable},
@@ -136,16 +128,14 @@ class TestGlobalFilterTimeRangePyArrow:
         assert actual_temps == EXPECTED_TEMPERATURES, (
             f"Expected only in-window temperatures {EXPECTED_TEMPERATURES}, got {actual_temps}"
         )
-        assert temperature_table.num_rows == EXPECTED_ROW_COUNT, (
-            f"Expected {EXPECTED_ROW_COUNT} rows after tz-aware filtering, got {temperature_table.num_rows}"
-        )
+        assert temperature_table.num_rows == EXPECTED_ROW_COUNT
 
 
 class TestGlobalFilterTimeRangePythonDict:
-    """GlobalFilter time range filtering on a python_dict list of tz-aware datetimes."""
+    """Regression guard for #435 on the python_dict filter engine."""
 
     def test_python_dict_tz_aware_time_range_filter(self) -> None:
-        """The python_dict filter engine must accept the GlobalFilter bound against tz-aware datetime values."""
+        timestamps = _tz_aware_timestamps()
 
         class PythonDictTzAwareSource(FeatureGroup):
             @classmethod
@@ -154,14 +144,12 @@ class TestGlobalFilterTimeRangePythonDict:
 
             @classmethod
             def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                # Emit native tz-aware datetime values inside the row dicts so the
-                # filter engine compares datetime <-> bound directly.
                 return [
                     {
                         "temperature": TEMPERATURES[i],
-                        DefaultOptionKeys.reference_time: datetime.fromisoformat(TIMESTAMPS_ISO[i]),
+                        DefaultOptionKeys.reference_time: timestamps[i],
                     }
-                    for i in range(len(TIMESTAMPS_ISO))
+                    for i in range(len(timestamps))
                 ]
 
             @classmethod
@@ -173,10 +161,6 @@ class TestGlobalFilterTimeRangePythonDict:
 
         plugin_collector = PluginCollector.enabled_feature_groups({PythonDictTzAwareSource})
 
-        # On current main this raises ``TypeError: '<=' not supported between
-        # instances of 'str' and 'datetime.datetime'`` because the GlobalFilter
-        # bound is an ISO 8601 string. After the Green-phase fix the bound is a
-        # ``datetime`` and the filter returns the in-window rows.
         result = mloda.run_all(
             ["temperature", DefaultOptionKeys.reference_time],
             compute_frameworks={PythonDictFramework},
@@ -195,9 +179,61 @@ class TestGlobalFilterTimeRangePythonDict:
         assert rows is not None, "python_dict result with temperature column not found"
 
         actual_temps = sorted(row["temperature"] for row in rows)
-        assert actual_temps == EXPECTED_TEMPERATURES, (
-            f"Expected only in-window temperatures {EXPECTED_TEMPERATURES}, got {actual_temps}"
+        assert actual_temps == EXPECTED_TEMPERATURES
+        assert len(rows) == EXPECTED_ROW_COUNT
+
+
+@pytest.mark.skipif(pl is None, reason="Polars is not installed")
+class TestGlobalFilterTimeRangePolars:
+    """Regression guard for #435 on the Polars filter engine."""
+
+    def test_polars_tz_aware_time_range_filter(self) -> None:
+        timestamps = _tz_aware_timestamps()
+
+        class PolarsTzAwareSource(FeatureGroup):
+            @classmethod
+            def input_data(cls) -> Optional[BaseInputData]:
+                return DataCreator({"temperature", DefaultOptionKeys.reference_time})
+
+            @classmethod
+            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                return pl.DataFrame(
+                    {
+                        "temperature": TEMPERATURES,
+                        DefaultOptionKeys.reference_time: timestamps,
+                    },
+                    schema={
+                        "temperature": pl.Int64,
+                        DefaultOptionKeys.reference_time: pl.Datetime(time_unit="us", time_zone="UTC"),
+                    },
+                )
+
+            @classmethod
+            def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+                return {PolarsDataFrame}
+
+        global_filter = GlobalFilter()
+        global_filter.add_time_and_time_travel_filters(event_from=EVENT_FROM, event_to=EVENT_TO)
+
+        plugin_collector = PluginCollector.enabled_feature_groups({PolarsTzAwareSource})
+
+        result = mloda.run_all(
+            ["temperature", DefaultOptionKeys.reference_time],
+            compute_frameworks={PolarsDataFrame},
+            plugin_collector=plugin_collector,
+            global_filter=global_filter,
         )
-        assert len(rows) == EXPECTED_ROW_COUNT, (
-            f"Expected {EXPECTED_ROW_COUNT} rows after tz-aware filtering, got {len(rows)}"
-        )
+
+        assert len(result) > 0, "No results returned from mloda.run_all"
+
+        temperature_df = None
+        for df in result:
+            if "temperature" in df.columns:
+                temperature_df = df
+                break
+
+        assert temperature_df is not None, "Polars DataFrame with temperature column not found"
+
+        actual_temps = sorted(temperature_df["temperature"].to_list())
+        assert actual_temps == EXPECTED_TEMPERATURES
+        assert temperature_df.height == EXPECTED_ROW_COUNT

--- a/tests/test_plugins/feature_group/experimental/test_time_window_feature_group/test_global_filter_tz_aware_time_range.py
+++ b/tests/test_plugins/feature_group/experimental/test_time_window_feature_group/test_global_filter_tz_aware_time_range.py
@@ -25,15 +25,15 @@ from typing import Any, Optional
 import pyarrow as pa
 import pytest
 
-from mloda.provider import BaseInputData
-from mloda.provider import ComputeFramework
-from mloda.provider import DataCreator
-from mloda.provider import DefaultOptionKeys
-from mloda.provider import FeatureGroup
-from mloda.provider import FeatureSet
-from mloda.user import GlobalFilter
-from mloda.user import PluginCollector
-from mloda.user import mloda
+from mloda.provider import (
+    BaseInputData,
+    ComputeFramework,
+    DataCreator,
+    DefaultOptionKeys,
+    FeatureGroup,
+    FeatureSet,
+)
+from mloda.user import GlobalFilter, PluginCollector, mloda
 from mloda_plugins.compute_framework.base_implementations.polars.dataframe import PolarsDataFrame
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
 from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
@@ -79,161 +79,156 @@ def _tz_aware_timestamps() -> list[datetime]:
     return [datetime.fromisoformat(ts) for ts in TIMESTAMPS_ISO]
 
 
-class TestGlobalFilterTimeRangePyArrow:
+def test_pyarrow_tz_aware_time_range_filter() -> None:
     """Regression guard for #435 on the PyArrow filter engine."""
 
-    def test_pyarrow_tz_aware_time_range_filter(self) -> None:
-        class PyArrowTzAwareSource(FeatureGroup):
-            @classmethod
-            def input_data(cls) -> Optional[BaseInputData]:
-                return DataCreator({"temperature", DefaultOptionKeys.reference_time})
+    class PyArrowTzAwareSource(FeatureGroup):
+        @classmethod
+        def input_data(cls) -> Optional[BaseInputData]:
+            return DataCreator({"temperature", DefaultOptionKeys.reference_time})
 
-            @classmethod
-            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                ts_array = pa.array(_naive_timestamps(), type=pa.timestamp("us", tz="UTC"))
-                return pa.table(
-                    {
-                        "temperature": pa.array(TEMPERATURES),
-                        DefaultOptionKeys.reference_time: ts_array,
-                    }
-                )
+        @classmethod
+        def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+            ts_array = pa.array(_naive_timestamps(), type=pa.timestamp("us", tz="UTC"))
+            return pa.table(
+                {
+                    "temperature": pa.array(TEMPERATURES),
+                    DefaultOptionKeys.reference_time: ts_array,
+                }
+            )
 
-            @classmethod
-            def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
-                return {PyArrowTable}
+        @classmethod
+        def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+            return {PyArrowTable}
 
-        global_filter = GlobalFilter()
-        global_filter.add_time_and_time_travel_filters(event_from=EVENT_FROM, event_to=EVENT_TO)
+    global_filter = GlobalFilter()
+    global_filter.add_time_and_time_travel_filters(event_from=EVENT_FROM, event_to=EVENT_TO)
 
-        plugin_collector = PluginCollector.enabled_feature_groups({PyArrowTzAwareSource})
+    plugin_collector = PluginCollector.enabled_feature_groups({PyArrowTzAwareSource})
 
-        result = mloda.run_all(
-            ["temperature", DefaultOptionKeys.reference_time],
-            compute_frameworks={PyArrowTable},
-            plugin_collector=plugin_collector,
-            global_filter=global_filter,
-        )
+    result = mloda.run_all(
+        ["temperature", DefaultOptionKeys.reference_time],
+        compute_frameworks={PyArrowTable},
+        plugin_collector=plugin_collector,
+        global_filter=global_filter,
+    )
 
-        assert len(result) > 0, "No results returned from mloda.run_all"
+    assert len(result) > 0, "No results returned from mloda.run_all"
 
-        temperature_table = None
-        for table in result:
-            if "temperature" in table.schema.names:
-                temperature_table = table
-                break
+    temperature_table = None
+    for table in result:
+        if "temperature" in table.schema.names:
+            temperature_table = table
+            break
 
-        assert temperature_table is not None, "PyArrow Table with temperature column not found"
+    assert temperature_table is not None, "PyArrow Table with temperature column not found"
 
-        actual_temps = sorted(temperature_table.column("temperature").to_pylist())
-        assert actual_temps == EXPECTED_TEMPERATURES, (
-            f"Expected only in-window temperatures {EXPECTED_TEMPERATURES}, got {actual_temps}"
-        )
-        assert temperature_table.num_rows == EXPECTED_ROW_COUNT
+    actual_temps = sorted(temperature_table.column("temperature").to_pylist())
+    assert actual_temps == EXPECTED_TEMPERATURES, (
+        f"Expected only in-window temperatures {EXPECTED_TEMPERATURES}, got {actual_temps}"
+    )
+    assert temperature_table.num_rows == EXPECTED_ROW_COUNT
 
 
-class TestGlobalFilterTimeRangePythonDict:
+def test_python_dict_tz_aware_time_range_filter() -> None:
     """Regression guard for #435 on the python_dict filter engine."""
+    timestamps = _tz_aware_timestamps()
 
-    def test_python_dict_tz_aware_time_range_filter(self) -> None:
-        timestamps = _tz_aware_timestamps()
+    class PythonDictTzAwareSource(FeatureGroup):
+        @classmethod
+        def input_data(cls) -> Optional[BaseInputData]:
+            return DataCreator({"temperature", DefaultOptionKeys.reference_time})
 
-        class PythonDictTzAwareSource(FeatureGroup):
-            @classmethod
-            def input_data(cls) -> Optional[BaseInputData]:
-                return DataCreator({"temperature", DefaultOptionKeys.reference_time})
+        @classmethod
+        def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+            return [
+                {
+                    "temperature": TEMPERATURES[i],
+                    DefaultOptionKeys.reference_time: timestamps[i],
+                }
+                for i in range(len(timestamps))
+            ]
 
-            @classmethod
-            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                return [
-                    {
-                        "temperature": TEMPERATURES[i],
-                        DefaultOptionKeys.reference_time: timestamps[i],
-                    }
-                    for i in range(len(timestamps))
-                ]
+        @classmethod
+        def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+            return {PythonDictFramework}
 
-            @classmethod
-            def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
-                return {PythonDictFramework}
+    global_filter = GlobalFilter()
+    global_filter.add_time_and_time_travel_filters(event_from=EVENT_FROM, event_to=EVENT_TO)
 
-        global_filter = GlobalFilter()
-        global_filter.add_time_and_time_travel_filters(event_from=EVENT_FROM, event_to=EVENT_TO)
+    plugin_collector = PluginCollector.enabled_feature_groups({PythonDictTzAwareSource})
 
-        plugin_collector = PluginCollector.enabled_feature_groups({PythonDictTzAwareSource})
+    result = mloda.run_all(
+        ["temperature", DefaultOptionKeys.reference_time],
+        compute_frameworks={PythonDictFramework},
+        plugin_collector=plugin_collector,
+        global_filter=global_filter,
+    )
 
-        result = mloda.run_all(
-            ["temperature", DefaultOptionKeys.reference_time],
-            compute_frameworks={PythonDictFramework},
-            plugin_collector=plugin_collector,
-            global_filter=global_filter,
-        )
+    assert len(result) > 0, "No results returned from mloda.run_all"
 
-        assert len(result) > 0, "No results returned from mloda.run_all"
+    rows = None
+    for candidate in result:
+        if candidate and isinstance(candidate, list) and "temperature" in candidate[0]:
+            rows = candidate
+            break
 
-        rows = None
-        for candidate in result:
-            if candidate and isinstance(candidate, list) and "temperature" in candidate[0]:
-                rows = candidate
-                break
+    assert rows is not None, "python_dict result with temperature column not found"
 
-        assert rows is not None, "python_dict result with temperature column not found"
-
-        actual_temps = sorted(row["temperature"] for row in rows)
-        assert actual_temps == EXPECTED_TEMPERATURES
-        assert len(rows) == EXPECTED_ROW_COUNT
+    actual_temps = sorted(row["temperature"] for row in rows)
+    assert actual_temps == EXPECTED_TEMPERATURES
+    assert len(rows) == EXPECTED_ROW_COUNT
 
 
 @pytest.mark.skipif(pl is None, reason="Polars is not installed")
-class TestGlobalFilterTimeRangePolars:
+def test_polars_tz_aware_time_range_filter() -> None:
     """Regression guard for #435 on the Polars filter engine."""
+    timestamps = _tz_aware_timestamps()
 
-    def test_polars_tz_aware_time_range_filter(self) -> None:
-        timestamps = _tz_aware_timestamps()
+    class PolarsTzAwareSource(FeatureGroup):
+        @classmethod
+        def input_data(cls) -> Optional[BaseInputData]:
+            return DataCreator({"temperature", DefaultOptionKeys.reference_time})
 
-        class PolarsTzAwareSource(FeatureGroup):
-            @classmethod
-            def input_data(cls) -> Optional[BaseInputData]:
-                return DataCreator({"temperature", DefaultOptionKeys.reference_time})
+        @classmethod
+        def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+            return pl.DataFrame(
+                {
+                    "temperature": TEMPERATURES,
+                    DefaultOptionKeys.reference_time: timestamps,
+                },
+                schema={
+                    "temperature": pl.Int64,
+                    DefaultOptionKeys.reference_time: pl.Datetime(time_unit="us", time_zone="UTC"),
+                },
+            )
 
-            @classmethod
-            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                return pl.DataFrame(
-                    {
-                        "temperature": TEMPERATURES,
-                        DefaultOptionKeys.reference_time: timestamps,
-                    },
-                    schema={
-                        "temperature": pl.Int64,
-                        DefaultOptionKeys.reference_time: pl.Datetime(time_unit="us", time_zone="UTC"),
-                    },
-                )
+        @classmethod
+        def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+            return {PolarsDataFrame}
 
-            @classmethod
-            def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
-                return {PolarsDataFrame}
+    global_filter = GlobalFilter()
+    global_filter.add_time_and_time_travel_filters(event_from=EVENT_FROM, event_to=EVENT_TO)
 
-        global_filter = GlobalFilter()
-        global_filter.add_time_and_time_travel_filters(event_from=EVENT_FROM, event_to=EVENT_TO)
+    plugin_collector = PluginCollector.enabled_feature_groups({PolarsTzAwareSource})
 
-        plugin_collector = PluginCollector.enabled_feature_groups({PolarsTzAwareSource})
+    result = mloda.run_all(
+        ["temperature", DefaultOptionKeys.reference_time],
+        compute_frameworks={PolarsDataFrame},
+        plugin_collector=plugin_collector,
+        global_filter=global_filter,
+    )
 
-        result = mloda.run_all(
-            ["temperature", DefaultOptionKeys.reference_time],
-            compute_frameworks={PolarsDataFrame},
-            plugin_collector=plugin_collector,
-            global_filter=global_filter,
-        )
+    assert len(result) > 0, "No results returned from mloda.run_all"
 
-        assert len(result) > 0, "No results returned from mloda.run_all"
+    temperature_df = None
+    for df in result:
+        if "temperature" in df.columns:
+            temperature_df = df
+            break
 
-        temperature_df = None
-        for df in result:
-            if "temperature" in df.columns:
-                temperature_df = df
-                break
+    assert temperature_df is not None, "Polars DataFrame with temperature column not found"
 
-        assert temperature_df is not None, "Polars DataFrame with temperature column not found"
-
-        actual_temps = sorted(temperature_df["temperature"].to_list())
-        assert actual_temps == EXPECTED_TEMPERATURES
-        assert temperature_df.height == EXPECTED_ROW_COUNT
+    actual_temps = sorted(temperature_df["temperature"].to_list())
+    assert actual_temps == EXPECTED_TEMPERATURES
+    assert temperature_df.height == EXPECTED_ROW_COUNT

--- a/tests/test_plugins/feature_group/experimental/test_time_window_feature_group/test_global_filter_tz_aware_time_range.py
+++ b/tests/test_plugins/feature_group/experimental/test_time_window_feature_group/test_global_filter_tz_aware_time_range.py
@@ -110,6 +110,66 @@ def test_pyarrow_tz_aware_time_range_filter() -> None:
     assert temperature_table.num_rows == EXPECTED_ROW_COUNT
 
 
+def test_pyarrow_tz_aware_time_range_filter_with_validity_window() -> None:
+    """Regression guard for #435 on the time-travel (validity_from / validity_to) path.
+
+    The fix sits in the shared ``_add_range_filter`` helper, so both the event-time
+    and validity-time bounds go through the same normalization. This case pins the
+    second invocation explicitly.
+    """
+
+    class PyArrowTzAwareValiditySource(FeatureGroup):
+        @classmethod
+        def input_data(cls) -> Optional[BaseInputData]:
+            return DataCreator({"temperature", DefaultOptionKeys.reference_time, "valid_time"})
+
+        @classmethod
+        def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+            naive_ts = [ts.replace(tzinfo=None) for ts in TIMESTAMPS_UTC]
+            ts_array = pa.array(naive_ts, type=pa.timestamp("us", tz="UTC"))
+            return pa.table(
+                {
+                    "temperature": pa.array(TEMPERATURES),
+                    DefaultOptionKeys.reference_time: ts_array,
+                    "valid_time": ts_array,
+                }
+            )
+
+        @classmethod
+        def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+            return {PyArrowTable}
+
+    global_filter = GlobalFilter()
+    global_filter.add_time_and_time_travel_filters(
+        event_from=EVENT_FROM,
+        event_to=EVENT_TO,
+        valid_from=EVENT_FROM,
+        valid_to=EVENT_TO,
+        validity_time_column="valid_time",
+    )
+
+    plugin_collector = PluginCollector.enabled_feature_groups({PyArrowTzAwareValiditySource})
+
+    result = mloda.run_all(
+        ["temperature", DefaultOptionKeys.reference_time, "valid_time"],
+        compute_frameworks={PyArrowTable},
+        plugin_collector=plugin_collector,
+        global_filter=global_filter,
+    )
+
+    temperature_table = None
+    for table in result:
+        if "temperature" in table.schema.names:
+            temperature_table = table
+            break
+
+    assert temperature_table is not None, "PyArrow Table with temperature column not found"
+
+    actual_temps = sorted(temperature_table.column("temperature").to_pylist())
+    assert actual_temps == EXPECTED_TEMPERATURES
+    assert temperature_table.num_rows == EXPECTED_ROW_COUNT
+
+
 def test_python_dict_tz_aware_time_range_filter() -> None:
     """Regression guard for #435 on the python_dict filter engine."""
 

--- a/tests/test_plugins/feature_group/experimental/test_time_window_feature_group/test_global_filter_tz_aware_time_range.py
+++ b/tests/test_plugins/feature_group/experimental/test_time_window_feature_group/test_global_filter_tz_aware_time_range.py
@@ -46,22 +46,9 @@ except ImportError:
     pl = None  # type: ignore[assignment]
 
 
-# Indices 4..9 (timestamps Jan 5..Jan 10) are the only rows that must survive
-# the [Jan 5, Jan 11) window with max_exclusive=True.
-TIMESTAMPS_ISO: list[str] = [
-    "2023-01-01T00:00:00+00:00",
-    "2023-01-02T00:00:00+00:00",
-    "2023-01-03T00:00:00+00:00",
-    "2023-01-04T00:00:00+00:00",
-    "2023-01-05T00:00:00+00:00",  # in window
-    "2023-01-06T00:00:00+00:00",  # in window
-    "2023-01-07T00:00:00+00:00",  # in window
-    "2023-01-08T00:00:00+00:00",  # in window
-    "2023-01-09T00:00:00+00:00",  # in window
-    "2023-01-10T00:00:00+00:00",  # in window
-    "2023-01-11T00:00:00+00:00",  # boundary, excluded (max_exclusive=True)
-    "2023-01-12T00:00:00+00:00",
-]
+# Timestamps Jan 1..Jan 12 at midnight UTC. Indices 4..9 (Jan 5..Jan 10) are the
+# only rows that must survive the [Jan 5, Jan 11) window with max_exclusive=True.
+TIMESTAMPS_UTC: list[datetime] = [datetime(2023, 1, day, tzinfo=timezone.utc) for day in range(1, 13)]
 TEMPERATURES: list[int] = [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]
 
 EVENT_FROM = datetime(2023, 1, 5, tzinfo=timezone.utc)
@@ -69,14 +56,6 @@ EVENT_TO = datetime(2023, 1, 11, tzinfo=timezone.utc)
 
 EXPECTED_TEMPERATURES: list[int] = [14, 15, 16, 17, 18, 19]
 EXPECTED_ROW_COUNT: int = len(EXPECTED_TEMPERATURES)
-
-
-def _naive_timestamps() -> list[datetime]:
-    return [datetime.fromisoformat(ts).replace(tzinfo=None) for ts in TIMESTAMPS_ISO]
-
-
-def _tz_aware_timestamps() -> list[datetime]:
-    return [datetime.fromisoformat(ts) for ts in TIMESTAMPS_ISO]
 
 
 def test_pyarrow_tz_aware_time_range_filter() -> None:
@@ -89,7 +68,10 @@ def test_pyarrow_tz_aware_time_range_filter() -> None:
 
         @classmethod
         def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-            ts_array = pa.array(_naive_timestamps(), type=pa.timestamp("us", tz="UTC"))
+            # pa.array with a tz-typed timestamp interprets naive datetimes as already in that tz;
+            # tz-aware datetimes are rejected on some PyArrow versions.
+            naive_ts = [ts.replace(tzinfo=None) for ts in TIMESTAMPS_UTC]
+            ts_array = pa.array(naive_ts, type=pa.timestamp("us", tz="UTC"))
             return pa.table(
                 {
                     "temperature": pa.array(TEMPERATURES),
@@ -113,8 +95,6 @@ def test_pyarrow_tz_aware_time_range_filter() -> None:
         global_filter=global_filter,
     )
 
-    assert len(result) > 0, "No results returned from mloda.run_all"
-
     temperature_table = None
     for table in result:
         if "temperature" in table.schema.names:
@@ -132,7 +112,6 @@ def test_pyarrow_tz_aware_time_range_filter() -> None:
 
 def test_python_dict_tz_aware_time_range_filter() -> None:
     """Regression guard for #435 on the python_dict filter engine."""
-    timestamps = _tz_aware_timestamps()
 
     class PythonDictTzAwareSource(FeatureGroup):
         @classmethod
@@ -144,9 +123,9 @@ def test_python_dict_tz_aware_time_range_filter() -> None:
             return [
                 {
                     "temperature": TEMPERATURES[i],
-                    DefaultOptionKeys.reference_time: timestamps[i],
+                    DefaultOptionKeys.reference_time: TIMESTAMPS_UTC[i],
                 }
-                for i in range(len(timestamps))
+                for i in range(len(TIMESTAMPS_UTC))
             ]
 
         @classmethod
@@ -165,8 +144,6 @@ def test_python_dict_tz_aware_time_range_filter() -> None:
         global_filter=global_filter,
     )
 
-    assert len(result) > 0, "No results returned from mloda.run_all"
-
     rows = None
     for candidate in result:
         if candidate and isinstance(candidate, list) and "temperature" in candidate[0]:
@@ -183,7 +160,6 @@ def test_python_dict_tz_aware_time_range_filter() -> None:
 @pytest.mark.skipif(pl is None, reason="Polars is not installed")
 def test_polars_tz_aware_time_range_filter() -> None:
     """Regression guard for #435 on the Polars filter engine."""
-    timestamps = _tz_aware_timestamps()
 
     class PolarsTzAwareSource(FeatureGroup):
         @classmethod
@@ -195,7 +171,7 @@ def test_polars_tz_aware_time_range_filter() -> None:
             return pl.DataFrame(
                 {
                     "temperature": TEMPERATURES,
-                    DefaultOptionKeys.reference_time: timestamps,
+                    DefaultOptionKeys.reference_time: TIMESTAMPS_UTC,
                 },
                 schema={
                     "temperature": pl.Int64,
@@ -218,8 +194,6 @@ def test_polars_tz_aware_time_range_filter() -> None:
         plugin_collector=plugin_collector,
         global_filter=global_filter,
     )
-
-    assert len(result) > 0, "No results returned from mloda.run_all"
 
     temperature_df = None
     for df in result:


### PR DESCRIPTION
## Summary

- Fixes #435: `GlobalFilter.add_time_and_time_travel_filters` produced ISO 8601 string bounds that filter engines could not compare against real temporal columns. PyArrow raised `ArrowNotImplementedError` against `timestamp[us, tz=UTC]`; python_dict raised `TypeError` comparing `str` to `datetime`.
- One-line semantic change in `mloda/core/filter/global_filter.py`: rename `_check_and_convert_time_info` → `_normalize_to_utc` and drop `.isoformat()`. The public `add_time_and_time_travel_filters` docstring is updated to match the new contract (it previously described the stringification behaviour that was the bug).
- No engine code changes. Engines now receive a `datetime` and each framework handles it natively:
  - **PyArrow / Polars / python_dict**: previously broken; now correct via native datetime comparison.
  - **pandas**: previously worked by silent string-coercion in `Series.__ge__`; still works, now via direct Timestamp comparison.
  - **Spark**: `Column.__ge__` accepts `datetime` via implicit `lit()`.
  - **SQL / SQLite / DuckDB**: previously worked because the driver parsed the ISO string back to a timestamp; now relies on the DB-API datetime adapter instead. Different mechanism, same observable result.
  - **Iceberg**: `apply_filters` builds pyiceberg expressions (`GreaterThanOrEqual(Reference(col), bound)`). Bound now arrives as a real `datetime`, which pyiceberg coerces correctly against `timestamptz` columns — a path that was effectively reliant on whatever string-coercion pyiceberg happened to do, and is now well-typed.
- Regression coverage for tz-aware UTC timestamp filtering through `mloda.run_all` lives at `tests/test_plugins/feature_group/experimental/test_time_window_feature_group/test_global_filter_tz_aware_time_range.py` and covers **PyArrow, python_dict, and Polars**.
- Updates `test_time_travel.py` source FG to emit `reference_time` as a real tz-aware UTC PyArrow timestamp column (it had been emitting `.isoformat()` strings to match the old broken contract).

## Breaking change

`SingleFilter.parameter.{min_value, max_value}` for time-range filters is now `datetime`, not `str`. External consumers that read these fields directly must adapt.

**Note on semantic-release.** This repo's `.releaserc.yaml` uses an explicit `releaseRules` list that maps `fix` → `patch` (and `feat` → `patch`, per the project deviation documented in `CLAUDE.md`). The `!` suffix and `BREAKING CHANGE:` footer here are correct conventional-commits markers; if the project intends `!` to trigger a major bump, the `releaseRules` may need an explicit `{breaking: true, release: "major"}` entry. Flagging for maintainer confirmation — I have not changed the release config in this PR.

## Test plan

- [x] TDD red→green: failing tests for the four expected failure modes (missing method × 2, `ArrowNotImplementedError`, `TypeError str-vs-datetime`) → minimal fix → green.
- [x] 192/192 pass in `tests/test_core/test_filter/` + `tests/test_plugins/feature_group/experimental/test_time_window_feature_group/` under `-n 8 --timeout=10`.
- [x] `ruff format --check` and `ruff check` clean on the full tree.
- [x] `mypy --strict --ignore-missing-imports` clean on touched files (a pre-existing unused-`type: ignore` in `cfw_transformer.py` is untouched here).
- [x] `bandit` clean.
- [ ] Full `tox` flakes on `test_notebook_4_mloda_basics` under `-n 8 --timeout=10`. Confirmed by baselining: clean `main` flakes on the same notebook test with the same xdist timeout pattern. Pre-existing environmental flakiness; passes in isolation.

## Follow-ups (out of scope)

- Typed parameter classes per filter kind (e.g. `RangeFilter`, `TimeRangeFilter`) to replace `dict[str, Any]` in `SingleFilter.parameter` — the architecturally cleaner fix that would have made this category of bug type-checkable.
- Iceberg / DuckDB / Spark regression tests parallel to the PyArrow/Polars/python_dict ones added here. Those engines tolerated the old contract by coincidence; a regression guard for each would harden the cross-engine contract.
- Clearer engine-side error when the bound's tz-awareness disagrees with the column's (today the error comes from the framework's kernel, which is harder to attribute).
- Confirm `releaseRules` intent for `BREAKING CHANGE:` footers in this repo (see Breaking change note above).
