### PR TITLE
fix: report flight child startup failures

### DIFF
--- a/mloda/core/runtime/flight/runner_flight_server.py
+++ b/mloda/core/runtime/flight/runner_flight_server.py
@@ -1,4 +1,8 @@
+from __future__ import annotations
+
 import multiprocessing
+import queue
+import time
 
 from typing import Any
 
@@ -8,6 +12,9 @@ from mloda.core.abstract_plugins.components.error_utils import internal_invarian
 from mloda.core.runtime.flight.flight_server import FlightServer, create_location
 
 logger = logging.getLogger(__name__)
+
+LOCATION_PUBLISH_TIMEOUT_SECONDS = 5.0
+LOCATION_PUBLISH_POLL_SECONDS = 0.1
 
 
 class ParallelRunnerFlightServer:
@@ -31,12 +38,44 @@ class ParallelRunnerFlightServer:
                 args=(location, location_queue),
             )
             self.flight_server_process.start()
-            self.location = location_queue.get(timeout=10)
+            try:
+                self.location = self.wait_for_flight_server_location(location_queue)
+            except Exception:
+                self.end_flight_server_process()
+                raise
+
+    def wait_for_flight_server_location(self, location_queue: multiprocessing.Queue[Any]) -> Any:
+        deadline = time.monotonic() + LOCATION_PUBLISH_TIMEOUT_SECONDS
+        while True:
+            try:
+                return location_queue.get(timeout=LOCATION_PUBLISH_POLL_SECONDS)
+            except queue.Empty as exc:
+                if self.flight_server_process is not None and not self.flight_server_process.is_alive():
+                    self.flight_server_process.join(timeout=1)
+                    try:
+                        return location_queue.get_nowait()
+                    except queue.Empty:
+                        raise RuntimeError(self.flight_server_start_error_message()) from exc
+
+                if time.monotonic() >= deadline:
+                    raise TimeoutError(self.flight_server_start_error_message()) from exc
+
+    def flight_server_start_error_message(self) -> str:
+        exitcode = None if self.flight_server_process is None else self.flight_server_process.exitcode
+        is_alive = False if self.flight_server_process is None else self.flight_server_process.is_alive()
+        return internal_invariant_error(
+            "ParallelRunnerFlightServer child process did not publish its Flight location.",
+            actual_values=f"exitcode={exitcode}, is_alive={is_alive}",
+            hint="Check the child process logs for FlightServer startup failures before retrying.",
+        )
 
     def end_flight_server_process(self) -> None:
         if self.flight_server_process:
-            self.flight_server_process.terminate()
+            if self.flight_server_process.is_alive():
+                self.flight_server_process.terminate()
             self.flight_server_process.join()
+            self.flight_server_process = None
+            self.location = None
 
     def get_location(self) -> Any:
         if self.location is None:

--- a/tests/test_core/test_runtime/test_flight_server_error_messages.py
+++ b/tests/test_core/test_runtime/test_flight_server_error_messages.py
@@ -40,6 +40,44 @@ class TestFlightServerProcessLocation:
 
         assert server.location == published_location
 
+    def test_start_flight_server_process_reaps_child_when_location_not_published(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        class DeadProcess:
+            def __init__(self, target: Any, args: tuple[Any, ...]) -> None:
+                self.target = target
+                self.args = args
+                self.exitcode: int | None = None
+                self.join_called = False
+                self.terminate_called = False
+
+            def start(self) -> None:
+                self.exitcode = 1
+
+            def is_alive(self) -> bool:
+                return False
+
+            def join(self, timeout: float | None = None) -> None:
+                self.join_called = True
+
+            def terminate(self) -> None:
+                self.terminate_called = True
+
+        monkeypatch.setattr(
+            "mloda.core.runtime.flight.runner_flight_server.create_location", lambda: "grpc://127.0.0.1:0"
+        )
+        monkeypatch.setattr("mloda.core.runtime.flight.runner_flight_server.multiprocessing.Process", DeadProcess)
+
+        server = ParallelRunnerFlightServer()
+
+        with pytest.raises(RuntimeError, match="did not publish its Flight location") as exc_info:
+            server.start_flight_server_process()
+
+        assert "exitcode" in str(exc_info.value)
+        assert "1" in str(exc_info.value)
+        assert server.flight_server_process is None
+        assert server.location is None
+
 
 class TestFlightServerLocationNoneError:
     """Tests that get_location() with None location produces an actionable error."""


### PR DESCRIPTION
## Summary

- Detect when the Flight child process exits before publishing its bound location.
- Raise a contextual internal invariant error instead of leaking `queue.Empty`.
- Reap and reset the failed child process so the runner is not left wedged.
- Add regression coverage for the child-dies-before-publish path.

Closes #438.

## Validation

- `.tox/python314/bin/pytest tests/test_core/test_flight tests/test_core/test_runtime/test_flight_server_error_messages.py -q`
- `.tox/python314/bin/pytest tests/test_core/test_filter/test_filter_integration.py::TestGlobalFilter::test_basic_global_filter -q`
- `.tox/python314/bin/ruff format --check --line-length 120 mloda/core/runtime/flight/runner_flight_server.py tests/test_core/test_runtime/test_flight_server_error_messages.py`
- `.tox/python314/bin/ruff check --line-length 120 mloda/core/runtime/flight/runner_flight_server.py tests/test_core/test_runtime/test_flight_server_error_messages.py`
- `.tox/python314/bin/mypy --strict --ignore-missing-imports mloda/core/runtime/flight/runner_flight_server.py tests/test_core/test_runtime/test_flight_server_error_messages.py`
- `.tox/python314/bin/bandit -c pyproject.toml -q mloda/core/runtime/flight/runner_flight_server.py`
- `git diff --check HEAD~1 HEAD`
- `git show --format= --patch HEAD | gitleaks stdin --no-banner --redact --timeout 30`

## Notes

This follows up the merged port-0 binding flow from #436. It is scoped to startup failure handling in `ParallelRunnerFlightServer`; full `tox` was not rerun locally.
