### PR TITLE
fix: thread DataAccessCollection to TransformFrameworkStep for SQL framework connections

### DIFF
--- a/mloda/core/abstract_plugins/compute_framework.py
+++ b/mloda/core/abstract_plugins/compute_framework.py
@@ -157,8 +157,14 @@ class ComputeFramework(ABC):
         """
         self.framework_connection_object = None
 
-    def init_connection_from_data_access(self, data_access_collection: Any) -> None:
-        pass
+    @classmethod
+    def pick_connection_from_dac(cls, data_access_collection: Any) -> Optional[Any]:
+        """Pick a matching connection for this framework from the DataAccessCollection.
+
+        Called at Engine setup (once per session), not on the per-request run path.
+        Default returns None; SQL frameworks override to do the isinstance scan.
+        """
+        return None
 
     @final
     def get_framework_connection_object(self) -> Any:

--- a/mloda/core/abstract_plugins/compute_framework.py
+++ b/mloda/core/abstract_plugins/compute_framework.py
@@ -157,6 +157,9 @@ class ComputeFramework(ABC):
         """
         self.framework_connection_object = None
 
+    def init_connection_from_data_access(self, data_access_collection: Any) -> None:
+        pass
+
     @final
     def get_framework_connection_object(self) -> Any:
         """This method retrieves the connection object set by `set_framework_connection_object`."""

--- a/mloda/core/abstract_plugins/compute_framework.py
+++ b/mloda/core/abstract_plugins/compute_framework.py
@@ -158,13 +158,36 @@ class ComputeFramework(ABC):
         self.framework_connection_object = None
 
     @classmethod
+    def _connection_matches(cls, conn: Any) -> bool:
+        """Return True if `conn` is a connection this framework can adopt.
+
+        Default returns False. SQL frameworks override with a single isinstance check;
+        the surrounding fail-fast policy lives in `pick_connection_from_dac`.
+        """
+        return False
+
+    @classmethod
     def pick_connection_from_dac(cls, data_access_collection: Any) -> Optional[Any]:
-        """Pick a matching connection for this framework from the DataAccessCollection.
+        """Pick the matching connection for this framework from the DataAccessCollection.
 
         Called at Engine setup (once per session), not on the per-request run path.
-        Default returns None; SQL frameworks override to do the isinstance scan.
+        Returns None if no connection matches, the single match if exactly one does,
+        and raises ValueError if multiple connections match - the caller has to
+        disambiguate explicitly rather than let a non-deterministic set iteration decide.
         """
-        return None
+        if data_access_collection is None:
+            return None
+        matches = [
+            conn for conn in data_access_collection.initialized_connection_objects if cls._connection_matches(conn)
+        ]
+        if not matches:
+            return None
+        if len(matches) > 1:
+            raise ValueError(
+                f"{cls.__name__}.pick_connection_from_dac: DataAccessCollection contains "
+                f"{len(matches)} connections matching this framework; expected at most one."
+            )
+        return matches[0]
 
     @final
     def get_framework_connection_object(self) -> Any:

--- a/mloda/core/core/engine.py
+++ b/mloda/core/core/engine.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from copy import deepcopy
-from typing import Optional
+from typing import Any, Optional
 from uuid import UUID
 import uuid
 
@@ -67,6 +67,26 @@ class Engine:
         self.data_access_collection = data_access_collection
         self.column_ordering = column_ordering
         self.execution_planner = self.create_setup_execution_plan(features)
+        self.tfs_connection_map = self._resolve_tfs_connection_map()
+
+    def _resolve_tfs_connection_map(self) -> dict[type[ComputeFramework], Any]:
+        """Resolve a connection per TFS destination framework at setup time.
+
+        Walks the planned TFS steps once and asks each destination framework class to pick
+        a matching connection from the DataAccessCollection. The resulting dict is consumed
+        on the run path by ComputeFrameworkExecutor without any further DAC scanning.
+        """
+        connection_map: dict[type[ComputeFramework], Any] = {}
+        if self.data_access_collection is None:
+            return connection_map
+        for tfs in self.execution_planner.tfs_collecion:
+            cfw_class = tfs.to_framework
+            if cfw_class in connection_map:
+                continue
+            conn = cfw_class.pick_connection_from_dac(self.data_access_collection)
+            if conn is not None:
+                connection_map[cfw_class] = conn
+        return connection_map
 
     def compute(self, flight_server: Optional[ParallelRunnerFlightServer] = None) -> ExecutionOrchestrator:
         execution_plan_copy = deepcopy(self.execution_planner)
@@ -74,7 +94,7 @@ class Engine:
             execution_plan_copy,
             flight_server,
             column_ordering=self.column_ordering,
-            data_access_collection=self.data_access_collection,
+            tfs_connection_map=self.tfs_connection_map,
         )
         if isinstance(orchestrator, ExecutionOrchestrator):
             return orchestrator

--- a/mloda/core/core/engine.py
+++ b/mloda/core/core/engine.py
@@ -70,7 +70,12 @@ class Engine:
 
     def compute(self, flight_server: Optional[ParallelRunnerFlightServer] = None) -> ExecutionOrchestrator:
         execution_plan_copy = deepcopy(self.execution_planner)
-        orchestrator = ExecutionOrchestrator(execution_plan_copy, flight_server, column_ordering=self.column_ordering)
+        orchestrator = ExecutionOrchestrator(
+            execution_plan_copy,
+            flight_server,
+            column_ordering=self.column_ordering,
+            data_access_collection=self.data_access_collection,
+        )
         if isinstance(orchestrator, ExecutionOrchestrator):
             return orchestrator
         raise ValueError("ExecutionOrchestrator setup failed.")

--- a/mloda/core/runtime/compute_framework_executor.py
+++ b/mloda/core/runtime/compute_framework_executor.py
@@ -41,6 +41,10 @@ class ComputeFrameworkExecutor:
         Args:
             cfw_register: The CFW manager for registering compute frameworks.
             worker_manager: The worker manager for handling parallel execution.
+            data_access_collection: Optional DataAccessCollection threaded from Engine; used to
+                bind a connection on the destination CFW of a TransformFrameworkStep before
+                execution. Required when transforming into a SQL framework (DuckDB, SQLite,
+                Spark, Iceberg) whose transformer needs a live connection.
         """
         self.cfw_collection: dict[UUID, ComputeFramework] = {}
         self.cfw_register = cfw_register

--- a/mloda/core/runtime/compute_framework_executor.py
+++ b/mloda/core/runtime/compute_framework_executor.py
@@ -9,6 +9,7 @@ from uuid import UUID, uuid4
 
 from mloda.core.abstract_plugins.components.error_utils import internal_invariant_error
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.parallelization_modes import ParallelizationMode
 from mloda.core.core.cfw_manager import CfwManager
 from mloda.core.core.step.feature_group_step import FeatureGroupStep
@@ -28,7 +29,12 @@ class ComputeFrameworkExecutor:
     Extracted from Runner class to handle CFW lifecycle and step execution logic.
     """
 
-    def __init__(self, cfw_register: CfwManager, worker_manager: WorkerManager) -> None:
+    def __init__(
+        self,
+        cfw_register: CfwManager,
+        worker_manager: WorkerManager,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> None:
         """
         Initialize the executor with dependencies.
 
@@ -39,6 +45,7 @@ class ComputeFrameworkExecutor:
         self.cfw_collection: dict[UUID, ComputeFramework] = {}
         self.cfw_register = cfw_register
         self.worker_manager = worker_manager
+        self.data_access_collection = data_access_collection
         self._cfw_lock = threading.Lock()
 
     def init_compute_framework(
@@ -230,6 +237,9 @@ class ComputeFrameworkExecutor:
         """
         cfw_uuid = self.prepare_execute_step(step, ParallelizationMode.SYNC)
 
+        if isinstance(step, TransformFrameworkStep):
+            self.cfw_collection[cfw_uuid].init_connection_from_data_access(self.data_access_collection)
+
         try:
             from_cfw = self.prepare_tfs_and_joinstep(step) or None
             step.execute(self.cfw_register, self.cfw_collection[cfw_uuid], from_cfw=from_cfw)
@@ -247,6 +257,10 @@ class ComputeFrameworkExecutor:
         Executes a step in a separate thread.
         """
         cfw_uuid = self.prepare_execute_step(step, ParallelizationMode.THREADING)
+
+        if isinstance(step, TransformFrameworkStep):
+            self.cfw_collection[cfw_uuid].init_connection_from_data_access(self.data_access_collection)
+
         from_cfw = self.prepare_tfs_and_joinstep(step) or None
 
         task = threading.Thread(

--- a/mloda/core/runtime/compute_framework_executor.py
+++ b/mloda/core/runtime/compute_framework_executor.py
@@ -234,17 +234,26 @@ class ComputeFrameworkExecutor:
             from_cfw = self.cfw_collection[from_cfw_uuid]
         return from_cfw
 
+    def _bind_tfs_connection(self, step: Any, cfw_uuid: UUID) -> None:
+        """Bind the setup-resolved connection to a TFS destination CFW, if any.
+
+        No-op for non-TFS steps and for destinations whose framework has no entry
+        in `tfs_connection_map` (i.e. no connection was resolved at Engine setup).
+        """
+        if not isinstance(step, TransformFrameworkStep):
+            return
+        cfw = self.cfw_collection[cfw_uuid]
+        conn = self.tfs_connection_map.get(type(cfw))
+        if conn is not None and cfw.framework_connection_object is None:
+            cfw.set_framework_connection_object(conn)
+
     def sync_execute_step(self, step: Any) -> None:
         """
         Executes a step synchronously.
         """
         cfw_uuid = self.prepare_execute_step(step, ParallelizationMode.SYNC)
 
-        if isinstance(step, TransformFrameworkStep):
-            cfw = self.cfw_collection[cfw_uuid]
-            conn = self.tfs_connection_map.get(type(cfw))
-            if conn is not None and cfw.framework_connection_object is None:
-                cfw.set_framework_connection_object(conn)
+        self._bind_tfs_connection(step, cfw_uuid)
 
         try:
             from_cfw = self.prepare_tfs_and_joinstep(step) or None
@@ -264,11 +273,7 @@ class ComputeFrameworkExecutor:
         """
         cfw_uuid = self.prepare_execute_step(step, ParallelizationMode.THREADING)
 
-        if isinstance(step, TransformFrameworkStep):
-            cfw = self.cfw_collection[cfw_uuid]
-            conn = self.tfs_connection_map.get(type(cfw))
-            if conn is not None and cfw.framework_connection_object is None:
-                cfw.set_framework_connection_object(conn)
+        self._bind_tfs_connection(step, cfw_uuid)
 
         from_cfw = self.prepare_tfs_and_joinstep(step) or None
 

--- a/mloda/core/runtime/compute_framework_executor.py
+++ b/mloda/core/runtime/compute_framework_executor.py
@@ -9,7 +9,6 @@ from uuid import UUID, uuid4
 
 from mloda.core.abstract_plugins.components.error_utils import internal_invariant_error
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
-from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.parallelization_modes import ParallelizationMode
 from mloda.core.core.cfw_manager import CfwManager
 from mloda.core.core.step.feature_group_step import FeatureGroupStep
@@ -33,7 +32,7 @@ class ComputeFrameworkExecutor:
         self,
         cfw_register: CfwManager,
         worker_manager: WorkerManager,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        tfs_connection_map: Optional[dict[type[ComputeFramework], Any]] = None,
     ) -> None:
         """
         Initialize the executor with dependencies.
@@ -41,15 +40,15 @@ class ComputeFrameworkExecutor:
         Args:
             cfw_register: The CFW manager for registering compute frameworks.
             worker_manager: The worker manager for handling parallel execution.
-            data_access_collection: Optional DataAccessCollection threaded from Engine; used to
-                bind a connection on the destination CFW of a TransformFrameworkStep before
-                execution. Required when transforming into a SQL framework (DuckDB, SQLite,
-                Spark, Iceberg) whose transformer needs a live connection.
+            tfs_connection_map: Setup-resolved map of destination CFW class to its
+                framework connection (e.g. duckdb.DuckDBPyConnection, sqlite3.Connection).
+                Engine builds this once from the DataAccessCollection at setup; the
+                executor only does a dict lookup per TFS step on the run path.
         """
         self.cfw_collection: dict[UUID, ComputeFramework] = {}
         self.cfw_register = cfw_register
         self.worker_manager = worker_manager
-        self.data_access_collection = data_access_collection
+        self.tfs_connection_map: dict[type[ComputeFramework], Any] = tfs_connection_map or {}
         self._cfw_lock = threading.Lock()
 
     def init_compute_framework(
@@ -242,7 +241,10 @@ class ComputeFrameworkExecutor:
         cfw_uuid = self.prepare_execute_step(step, ParallelizationMode.SYNC)
 
         if isinstance(step, TransformFrameworkStep):
-            self.cfw_collection[cfw_uuid].init_connection_from_data_access(self.data_access_collection)
+            cfw = self.cfw_collection[cfw_uuid]
+            conn = self.tfs_connection_map.get(type(cfw))
+            if conn is not None and cfw.framework_connection_object is None:
+                cfw.set_framework_connection_object(conn)
 
         try:
             from_cfw = self.prepare_tfs_and_joinstep(step) or None
@@ -263,7 +265,10 @@ class ComputeFrameworkExecutor:
         cfw_uuid = self.prepare_execute_step(step, ParallelizationMode.THREADING)
 
         if isinstance(step, TransformFrameworkStep):
-            self.cfw_collection[cfw_uuid].init_connection_from_data_access(self.data_access_collection)
+            cfw = self.cfw_collection[cfw_uuid]
+            conn = self.tfs_connection_map.get(type(cfw))
+            if conn is not None and cfw.framework_connection_object is None:
+                cfw.set_framework_connection_object(conn)
 
         from_cfw = self.prepare_tfs_and_joinstep(step) or None
 

--- a/mloda/core/runtime/run.py
+++ b/mloda/core/runtime/run.py
@@ -10,7 +10,6 @@ import logging
 from mloda.core.abstract_plugins.function_extender import Extender
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
-from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.prepare.execution_plan import ExecutionPlan
 from mloda.core.runtime.worker_manager import WorkerManager
 from mloda.core.runtime.data_lifecycle_manager import DataLifecycleManager
@@ -41,7 +40,7 @@ class ExecutionOrchestrator:
         execution_planner: ExecutionPlan,
         flight_server: Optional[ParallelRunnerFlightServer] = None,
         column_ordering: Optional[str] = None,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        tfs_connection_map: Optional[dict[type[ComputeFramework], Any]] = None,
     ) -> None:
         """
         Initializes the ExecutionOrchestrator with an execution plan and optional flight server.
@@ -68,7 +67,7 @@ class ExecutionOrchestrator:
         if flight_server:
             self.flight_server = flight_server
 
-        self.data_access_collection = data_access_collection
+        self.tfs_connection_map: dict[type[ComputeFramework], Any] = tfs_connection_map or {}
 
     def _is_step_done(self, step_uuids: set[UUID], finished_ids: set[UUID]) -> bool:
         """
@@ -98,7 +97,7 @@ class ExecutionOrchestrator:
             )
 
         self.executor = ComputeFrameworkExecutor(
-            self.cfw_register, self.worker_manager, data_access_collection=self.data_access_collection
+            self.cfw_register, self.worker_manager, tfs_connection_map=self.tfs_connection_map
         )
 
         finished_ids: set[UUID] = set()
@@ -157,7 +156,7 @@ class ExecutionOrchestrator:
             )
 
         self.executor = ComputeFrameworkExecutor(
-            self.cfw_register, self.worker_manager, data_access_collection=self.data_access_collection
+            self.cfw_register, self.worker_manager, tfs_connection_map=self.tfs_connection_map
         )
 
         finished_ids: set[UUID] = set()

--- a/mloda/core/runtime/run.py
+++ b/mloda/core/runtime/run.py
@@ -10,6 +10,7 @@ import logging
 from mloda.core.abstract_plugins.function_extender import Extender
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.prepare.execution_plan import ExecutionPlan
 from mloda.core.runtime.worker_manager import WorkerManager
 from mloda.core.runtime.data_lifecycle_manager import DataLifecycleManager
@@ -40,6 +41,7 @@ class ExecutionOrchestrator:
         execution_planner: ExecutionPlan,
         flight_server: Optional[ParallelRunnerFlightServer] = None,
         column_ordering: Optional[str] = None,
+        data_access_collection: Optional[DataAccessCollection] = None,
     ) -> None:
         """
         Initializes the ExecutionOrchestrator with an execution plan and optional flight server.
@@ -65,6 +67,8 @@ class ExecutionOrchestrator:
         self.flight_server = None
         if flight_server:
             self.flight_server = flight_server
+
+        self.data_access_collection = data_access_collection
 
     def _is_step_done(self, step_uuids: set[UUID], finished_ids: set[UUID]) -> bool:
         """
@@ -93,7 +97,9 @@ class ExecutionOrchestrator:
                 "Internal error: compute framework manager not initialized. This is likely a bug in mloda."
             )
 
-        self.executor = ComputeFrameworkExecutor(self.cfw_register, self.worker_manager)
+        self.executor = ComputeFrameworkExecutor(
+            self.cfw_register, self.worker_manager, data_access_collection=self.data_access_collection
+        )
 
         finished_ids: set[UUID] = set()
         to_finish_ids: set[UUID] = set()
@@ -150,7 +156,9 @@ class ExecutionOrchestrator:
                 "Internal error: compute framework manager not initialized. This is likely a bug in mloda."
             )
 
-        self.executor = ComputeFrameworkExecutor(self.cfw_register, self.worker_manager)
+        self.executor = ComputeFrameworkExecutor(
+            self.cfw_register, self.worker_manager, data_access_collection=self.data_access_collection
+        )
 
         finished_ids: set[UUID] = set()
         to_finish_ids: set[UUID] = set()

--- a/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_framework.py
@@ -61,7 +61,7 @@ class DuckDBFramework(ComputeFramework):
         self.framework_connection_object = framework_connection_object
 
     def init_connection_from_data_access(self, data_access_collection: Any) -> None:
-        if data_access_collection is None or self.framework_connection_object is not None:
+        if duckdb is None or data_access_collection is None or self.framework_connection_object is not None:
             return
         for conn in data_access_collection.initialized_connection_objects:
             if isinstance(conn, duckdb.DuckDBPyConnection):

--- a/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_framework.py
@@ -61,13 +61,8 @@ class DuckDBFramework(ComputeFramework):
         self.framework_connection_object = framework_connection_object
 
     @classmethod
-    def pick_connection_from_dac(cls, data_access_collection: Any) -> Optional[Any]:
-        if duckdb is None or data_access_collection is None:
-            return None
-        for conn in data_access_collection.initialized_connection_objects:
-            if isinstance(conn, duckdb.DuckDBPyConnection):
-                return conn
-        return None
+    def _connection_matches(cls, conn: Any) -> bool:
+        return duckdb is not None and isinstance(conn, duckdb.DuckDBPyConnection)
 
     @staticmethod
     def is_available() -> bool:

--- a/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_framework.py
@@ -60,6 +60,14 @@ class DuckDBFramework(ComputeFramework):
             return
         self.framework_connection_object = framework_connection_object
 
+    def init_connection_from_data_access(self, data_access_collection: Any) -> None:
+        if data_access_collection is None or self.framework_connection_object is not None:
+            return
+        for conn in data_access_collection.initialized_connection_objects:
+            if isinstance(conn, duckdb.DuckDBPyConnection):
+                self.set_framework_connection_object(conn)
+                return
+
     @staticmethod
     def is_available() -> bool:
         """Check if DuckDB is installed and available."""

--- a/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_framework.py
@@ -60,13 +60,14 @@ class DuckDBFramework(ComputeFramework):
             return
         self.framework_connection_object = framework_connection_object
 
-    def init_connection_from_data_access(self, data_access_collection: Any) -> None:
-        if duckdb is None or data_access_collection is None or self.framework_connection_object is not None:
-            return
+    @classmethod
+    def pick_connection_from_dac(cls, data_access_collection: Any) -> Optional[Any]:
+        if duckdb is None or data_access_collection is None:
+            return None
         for conn in data_access_collection.initialized_connection_objects:
             if isinstance(conn, duckdb.DuckDBPyConnection):
-                self.set_framework_connection_object(conn)
-                return
+                return conn
+        return None
 
     @staticmethod
     def is_available() -> bool:

--- a/mloda_plugins/compute_framework/base_implementations/iceberg/iceberg_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/iceberg/iceberg_framework.py
@@ -75,13 +75,10 @@ class IcebergFramework(ComputeFramework):
                     raise ValueError(f"Expected an Iceberg catalog or table, got {type(framework_connection_object)}")
 
     @classmethod
-    def pick_connection_from_dac(cls, data_access_collection: Any) -> Optional[Any]:
-        if Catalog is None or data_access_collection is None:
-            return None
-        for conn in data_access_collection.initialized_connection_objects:
-            if hasattr(conn, "load_table") or (IcebergTable is not None and isinstance(conn, IcebergTable)):
-                return conn
-        return None
+    def _connection_matches(cls, conn: Any) -> bool:
+        if Catalog is None:
+            return False
+        return hasattr(conn, "load_table") or (IcebergTable is not None and isinstance(conn, IcebergTable))
 
     @staticmethod
     def is_available() -> bool:

--- a/mloda_plugins/compute_framework/base_implementations/iceberg/iceberg_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/iceberg/iceberg_framework.py
@@ -74,6 +74,14 @@ class IcebergFramework(ComputeFramework):
                 else:
                     raise ValueError(f"Expected an Iceberg catalog or table, got {type(framework_connection_object)}")
 
+    def init_connection_from_data_access(self, data_access_collection: Any) -> None:
+        if Catalog is None or data_access_collection is None or self.framework_connection_object is not None:
+            return
+        for conn in data_access_collection.initialized_connection_objects:
+            if hasattr(conn, "load_table") or (IcebergTable is not None and isinstance(conn, IcebergTable)):
+                self.set_framework_connection_object(conn)
+                return
+
     @staticmethod
     def is_available() -> bool:
         """Check if PyIceberg is installed and available."""

--- a/mloda_plugins/compute_framework/base_implementations/iceberg/iceberg_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/iceberg/iceberg_framework.py
@@ -74,13 +74,14 @@ class IcebergFramework(ComputeFramework):
                 else:
                     raise ValueError(f"Expected an Iceberg catalog or table, got {type(framework_connection_object)}")
 
-    def init_connection_from_data_access(self, data_access_collection: Any) -> None:
-        if Catalog is None or data_access_collection is None or self.framework_connection_object is not None:
-            return
+    @classmethod
+    def pick_connection_from_dac(cls, data_access_collection: Any) -> Optional[Any]:
+        if Catalog is None or data_access_collection is None:
+            return None
         for conn in data_access_collection.initialized_connection_objects:
             if hasattr(conn, "load_table") or (IcebergTable is not None and isinstance(conn, IcebergTable)):
-                self.set_framework_connection_object(conn)
-                return
+                return conn
+        return None
 
     @staticmethod
     def is_available() -> bool:

--- a/mloda_plugins/compute_framework/base_implementations/spark/spark_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/spark/spark_framework.py
@@ -54,6 +54,14 @@ class SparkFramework(ComputeFramework):
                     .getOrCreate()
                 )
 
+    def init_connection_from_data_access(self, data_access_collection: Any) -> None:
+        if SparkSession is None or data_access_collection is None or self.framework_connection_object is not None:
+            return
+        for conn in data_access_collection.initialized_connection_objects:
+            if isinstance(conn, SparkSession):
+                self.set_framework_connection_object(conn)
+                return
+
     @staticmethod
     def is_available() -> bool:
         """Check if PySpark is installed and available."""

--- a/mloda_plugins/compute_framework/base_implementations/spark/spark_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/spark/spark_framework.py
@@ -54,13 +54,14 @@ class SparkFramework(ComputeFramework):
                     .getOrCreate()
                 )
 
-    def init_connection_from_data_access(self, data_access_collection: Any) -> None:
-        if SparkSession is None or data_access_collection is None or self.framework_connection_object is not None:
-            return
+    @classmethod
+    def pick_connection_from_dac(cls, data_access_collection: Any) -> Optional[Any]:
+        if SparkSession is None or data_access_collection is None:
+            return None
         for conn in data_access_collection.initialized_connection_objects:
             if isinstance(conn, SparkSession):
-                self.set_framework_connection_object(conn)
-                return
+                return conn
+        return None
 
     @staticmethod
     def is_available() -> bool:

--- a/mloda_plugins/compute_framework/base_implementations/spark/spark_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/spark/spark_framework.py
@@ -55,13 +55,8 @@ class SparkFramework(ComputeFramework):
                 )
 
     @classmethod
-    def pick_connection_from_dac(cls, data_access_collection: Any) -> Optional[Any]:
-        if SparkSession is None or data_access_collection is None:
-            return None
-        for conn in data_access_collection.initialized_connection_objects:
-            if isinstance(conn, SparkSession):
-                return conn
-        return None
+    def _connection_matches(cls, conn: Any) -> bool:
+        return SparkSession is not None and isinstance(conn, SparkSession)
 
     @staticmethod
     def is_available() -> bool:

--- a/mloda_plugins/compute_framework/base_implementations/sqlite/sqlite_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/sqlite/sqlite_framework.py
@@ -47,13 +47,8 @@ class SqliteFramework(ComputeFramework):
         self.framework_connection_object = framework_connection_object
 
     @classmethod
-    def pick_connection_from_dac(cls, data_access_collection: Any) -> Optional[Any]:
-        if data_access_collection is None:
-            return None
-        for conn in data_access_collection.initialized_connection_objects:
-            if isinstance(conn, sqlite3.Connection):
-                return conn
-        return None
+    def _connection_matches(cls, conn: Any) -> bool:
+        return isinstance(conn, sqlite3.Connection)
 
     @staticmethod
     def is_available() -> bool:

--- a/mloda_plugins/compute_framework/base_implementations/sqlite/sqlite_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/sqlite/sqlite_framework.py
@@ -46,13 +46,14 @@ class SqliteFramework(ComputeFramework):
         framework_connection_object.create_function("REGEXP", 2, _regexp, deterministic=True)
         self.framework_connection_object = framework_connection_object
 
-    def init_connection_from_data_access(self, data_access_collection: Any) -> None:
-        if data_access_collection is None or self.framework_connection_object is not None:
-            return
+    @classmethod
+    def pick_connection_from_dac(cls, data_access_collection: Any) -> Optional[Any]:
+        if data_access_collection is None:
+            return None
         for conn in data_access_collection.initialized_connection_objects:
             if isinstance(conn, sqlite3.Connection):
-                self.set_framework_connection_object(conn)
-                return
+                return conn
+        return None
 
     @staticmethod
     def is_available() -> bool:

--- a/mloda_plugins/compute_framework/base_implementations/sqlite/sqlite_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/sqlite/sqlite_framework.py
@@ -46,6 +46,14 @@ class SqliteFramework(ComputeFramework):
         framework_connection_object.create_function("REGEXP", 2, _regexp, deterministic=True)
         self.framework_connection_object = framework_connection_object
 
+    def init_connection_from_data_access(self, data_access_collection: Any) -> None:
+        if data_access_collection is None or self.framework_connection_object is not None:
+            return
+        for conn in data_access_collection.initialized_connection_objects:
+            if isinstance(conn, sqlite3.Connection):
+                self.set_framework_connection_object(conn)
+                return
+
     @staticmethod
     def is_available() -> bool:
         return True

--- a/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_framework.py
+++ b/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_framework.py
@@ -187,6 +187,9 @@ class TestDuckDBDataTypeValidator(DataTypeValidatorFrameworkTestMixin):
 
 
 from tests.test_plugins.compute_framework.base_implementations.tfs_connection_test_mixin import TfsConnectionInitMixin  # noqa: E402
+from unittest.mock import patch  # noqa: E402
+from mloda.user import DataAccessCollection  # noqa: E402
+import mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framework as duckdb_framework_module  # noqa: E402
 
 
 @pytest.mark.skipif(duckdb is None, reason="DuckDB is not installed.")
@@ -200,3 +203,11 @@ class TestDuckDBTfsConnectionInit(TfsConnectionInitMixin):
         conn = duckdb.connect()
         yield conn
         conn.close()
+
+    def test_no_op_when_duckdb_module_missing(self, framework_instance: Any) -> None:
+        """When the duckdb module symbol is None (optional dep missing), the method
+        must return silently without raising AttributeError, matching Spark/Iceberg."""
+        dac = DataAccessCollection(initialized_connection_objects={object()})
+        with patch.object(duckdb_framework_module, "duckdb", None):
+            framework_instance.init_connection_from_data_access(dac)
+        assert framework_instance.framework_connection_object is None

--- a/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_framework.py
+++ b/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_framework.py
@@ -184,3 +184,19 @@ class TestDuckDBDataTypeValidator(DataTypeValidatorFrameworkTestMixin):
     @pytest.fixture
     def precision_sample_data(self, connection: Any) -> Any:
         return DuckdbRelation.from_arrow(connection, self._arrow_table(self.PRECISION_COLUMNS))
+
+
+from tests.test_plugins.compute_framework.base_implementations.tfs_connection_test_mixin import TfsConnectionInitMixin  # noqa: E402
+
+
+@pytest.mark.skipif(duckdb is None, reason="DuckDB is not installed.")
+class TestDuckDBTfsConnectionInit(TfsConnectionInitMixin):
+    @pytest.fixture
+    def framework_instance(self) -> Any:
+        return DuckDBFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
+
+    @pytest.fixture
+    def valid_connection(self) -> Any:
+        conn = duckdb.connect()
+        yield conn
+        conn.close()

--- a/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_framework.py
+++ b/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_framework.py
@@ -204,6 +204,12 @@ class TestDuckDBTfsConnectionInit(TfsConnectionInitMixin):
         yield conn
         conn.close()
 
+    @pytest.fixture
+    def second_valid_connection(self) -> Any:
+        conn = duckdb.connect()
+        yield conn
+        conn.close()
+
     def test_returns_none_when_duckdb_module_missing(self, framework_class: Any) -> None:
         """When the duckdb module symbol is None (optional dep missing), the classmethod
         must return None without raising AttributeError, matching Spark/Iceberg."""

--- a/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_framework.py
+++ b/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_framework.py
@@ -195,8 +195,8 @@ import mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framew
 @pytest.mark.skipif(duckdb is None, reason="DuckDB is not installed.")
 class TestDuckDBTfsConnectionInit(TfsConnectionInitMixin):
     @pytest.fixture
-    def framework_instance(self) -> Any:
-        return DuckDBFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
+    def framework_class(self) -> Any:
+        return DuckDBFramework
 
     @pytest.fixture
     def valid_connection(self) -> Any:
@@ -204,10 +204,9 @@ class TestDuckDBTfsConnectionInit(TfsConnectionInitMixin):
         yield conn
         conn.close()
 
-    def test_no_op_when_duckdb_module_missing(self, framework_instance: Any) -> None:
-        """When the duckdb module symbol is None (optional dep missing), the method
-        must return silently without raising AttributeError, matching Spark/Iceberg."""
+    def test_returns_none_when_duckdb_module_missing(self, framework_class: Any) -> None:
+        """When the duckdb module symbol is None (optional dep missing), the classmethod
+        must return None without raising AttributeError, matching Spark/Iceberg."""
         dac = DataAccessCollection(initialized_connection_objects={object()})
         with patch.object(duckdb_framework_module, "duckdb", None):
-            framework_instance.init_connection_from_data_access(dac)
-        assert framework_instance.framework_connection_object is None
+            assert framework_class.pick_connection_from_dac(dac) is None

--- a/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_tfs_connection.py
+++ b/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_tfs_connection.py
@@ -1,0 +1,114 @@
+"""Reproducer for issue #440: PyArrow -> DuckDB TFS connection propagation."""
+import logging
+from typing import Any, Optional
+
+import pytest
+
+logger = logging.getLogger(__name__)
+
+try:
+    import duckdb
+except ImportError:
+    duckdb = None  # type: ignore[assignment]
+
+try:
+    import pyarrow as pa
+except ImportError:
+    pa = None  # type: ignore[assignment]
+
+from mloda.user import mloda, Feature, DataAccessCollection, ParallelizationMode, PluginCollector
+from mloda.provider import FeatureGroup, ComputeFramework, FeatureSet, MatchData
+from mloda.user import FeatureName, Options
+from mloda.core.abstract_plugins.components.input_data.creator.data_creator import DataCreator
+from mloda.provider import BaseInputData
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framework import DuckDBFramework
+
+
+class TfsIssue440DataCreator(FeatureGroup):
+    """Provides raw data via PyArrowTable (simulates the source framework in a TFS)."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({"raw_val"})
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PyArrowTable}
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {"raw_val": [1, 2, 3]}
+
+
+class TfsIssue440DuckDBFG(FeatureGroup, MatchData):
+    """Consumes data in DuckDB, triggering a PyArrow -> DuckDB TransformFrameworkStep."""
+
+    @classmethod
+    def match_data_access(
+        cls,
+        feature_name: str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+        framework_connection_object: Optional[Any] = None,
+    ) -> Any:
+        if duckdb is None or not DuckDBFramework.is_available():
+            return None
+        if feature_name not in cls.feature_names_supported():
+            return None
+        if isinstance(framework_connection_object, duckdb.DuckDBPyConnection):
+            return framework_connection_object
+        if data_access_collection is None:
+            return None
+        for conn in data_access_collection.initialized_connection_objects:
+            if isinstance(conn, duckdb.DuckDBPyConnection):
+                return conn
+        return None
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return {Feature("raw_val")}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {DuckDBFramework}
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        # Project via DuckDB SQL -- requires framework_connection_object to be set
+        return data.project("*, raw_val * 2 AS tfs_doubled")
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return {"tfs_doubled"}
+
+
+@pytest.mark.skipif(duckdb is None or pa is None, reason="DuckDB or PyArrow not installed.")
+class TestPyArrowToDuckDBTfsConnection:
+    def test_tfs_connection_reaches_duckdb_framework(self) -> None:
+        """DataAccessCollection connection must reach the DuckDB cfw created by TFS.
+
+        Reproducer for issue #440: when a TransformFrameworkStep converts data from
+        PyArrowTable to DuckDBFramework, the destination DuckDBFramework instance must
+        have its framework_connection_object set from DataAccessCollection so that
+        the transformer can use it. Without the fix, this raises ValueError because
+        framework_connection_object is None inside the transformer.
+        """
+        conn = duckdb.connect()
+        plugin_collector = PluginCollector.enabled_feature_groups(
+            {TfsIssue440DataCreator, TfsIssue440DuckDBFG}
+        )
+        data_access_collection = DataAccessCollection(initialized_connection_objects={conn})
+        result = mloda.run_all(
+            [Feature("tfs_doubled")],
+            compute_frameworks={PyArrowTable, DuckDBFramework},
+            plugin_collector=plugin_collector,
+            data_access_collection=data_access_collection,
+            parallelization_modes={ParallelizationMode.SYNC},
+        )
+        conn.close()
+        assert result is not None
+        assert len(result) == 1
+        final = result[0]
+        assert isinstance(final, pa.Table)
+        assert "tfs_doubled" in final.column_names
+        assert final.column("tfs_doubled").to_pylist() == [2, 4, 6]

--- a/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_tfs_connection.py
+++ b/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_tfs_connection.py
@@ -1,10 +1,8 @@
 """Reproducer for issue #440: PyArrow -> DuckDB TFS connection propagation."""
-import logging
+
 from typing import Any, Optional
 
 import pytest
-
-logger = logging.getLogger(__name__)
 
 try:
     import duckdb
@@ -94,9 +92,7 @@ class TestPyArrowToDuckDBTfsConnection:
         framework_connection_object is None inside the transformer.
         """
         conn = duckdb.connect()
-        plugin_collector = PluginCollector.enabled_feature_groups(
-            {TfsIssue440DataCreator, TfsIssue440DuckDBFG}
-        )
+        plugin_collector = PluginCollector.enabled_feature_groups({TfsIssue440DataCreator, TfsIssue440DuckDBFG})
         data_access_collection = DataAccessCollection(initialized_connection_objects={conn})
         result = mloda.run_all(
             [Feature("tfs_doubled")],

--- a/tests/test_plugins/compute_framework/base_implementations/iceberg/test_iceberg_framework.py
+++ b/tests/test_plugins/compute_framework/base_implementations/iceberg/test_iceberg_framework.py
@@ -273,3 +273,21 @@ class TestIcebergDtypeExtraction(DtypeExtractionTestMixin):
             NestedField(3, "float_col", DoubleType()),
         )
         return TestIcebergDataTypeValidator._wrap_schema(schema)
+
+
+from tests.test_plugins.compute_framework.base_implementations.tfs_connection_test_mixin import TfsConnectionInitMixin  # noqa: E402
+
+
+@pytest.mark.skipif(
+    pyiceberg is None or pa is None, reason="PyIceberg or PyArrow is not installed. Skipping this test."
+)
+class TestIcebergTfsConnectionInit(TfsConnectionInitMixin):
+    @pytest.fixture
+    def framework_instance(self) -> Any:
+        return IcebergFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
+
+    @pytest.fixture
+    def valid_connection(self) -> Any:
+        mock_catalog = Mock(spec=Catalog)
+        mock_catalog.load_table = Mock()
+        return mock_catalog

--- a/tests/test_plugins/compute_framework/base_implementations/iceberg/test_iceberg_framework.py
+++ b/tests/test_plugins/compute_framework/base_implementations/iceberg/test_iceberg_framework.py
@@ -283,8 +283,8 @@ from tests.test_plugins.compute_framework.base_implementations.tfs_connection_te
 )
 class TestIcebergTfsConnectionInit(TfsConnectionInitMixin):
     @pytest.fixture
-    def framework_instance(self) -> Any:
-        return IcebergFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
+    def framework_class(self) -> Any:
+        return IcebergFramework
 
     @pytest.fixture
     def valid_connection(self) -> Any:

--- a/tests/test_plugins/compute_framework/base_implementations/iceberg/test_iceberg_framework.py
+++ b/tests/test_plugins/compute_framework/base_implementations/iceberg/test_iceberg_framework.py
@@ -291,3 +291,9 @@ class TestIcebergTfsConnectionInit(TfsConnectionInitMixin):
         mock_catalog = Mock(spec=Catalog)
         mock_catalog.load_table = Mock()
         return mock_catalog
+
+    @pytest.fixture
+    def second_valid_connection(self) -> Any:
+        mock_catalog = Mock(spec=Catalog)
+        mock_catalog.load_table = Mock()
+        return mock_catalog

--- a/tests/test_plugins/compute_framework/base_implementations/iceberg/test_iceberg_tfs_connection.py
+++ b/tests/test_plugins/compute_framework/base_implementations/iceberg/test_iceberg_tfs_connection.py
@@ -1,0 +1,109 @@
+"""End-to-end TFS connection-propagation test for Iceberg.
+
+IcebergPyArrowTransformer.transform_other_fw_to_fw currently passes PyArrow
+data through (no real catalog write yet — the framework only consumes it). So
+the destination FG operates on a pa.Table and verifies that the catalog from
+the DataAccessCollection has been bound on the IcebergFramework instance by
+asserting it from inside calculate_feature via a per-test sentinel."""
+
+from typing import Any, Optional
+from unittest.mock import Mock
+
+import pytest
+
+try:
+    import pyiceberg  # noqa: F401
+    from pyiceberg.catalog import Catalog
+    import pyarrow as pa
+    import pyarrow.compute as pc
+except ImportError:
+    pyiceberg = None  # type: ignore[assignment]
+    Catalog = None  # type: ignore[assignment,misc]
+    pa = None  # type: ignore[assignment]
+    pc = None
+
+from mloda.user import Feature, DataAccessCollection
+from mloda.provider import FeatureGroup, ComputeFramework, FeatureSet, MatchData
+from mloda.user import FeatureName, Options
+from mloda_plugins.compute_framework.base_implementations.iceberg.iceberg_framework import IcebergFramework
+from tests.test_plugins.compute_framework.base_implementations.tfs_connection_e2e_mixin import (
+    TfsConnectionEndToEndMixin,
+)
+
+
+_observed_catalogs: list[Any] = []
+
+
+class ConnectionRecordingIcebergFramework(IcebergFramework):
+    """Test-only subclass that records the bound catalog so the e2e test can
+    assert the setup-time precompute reached this CFW instance."""
+
+    def set_framework_connection_object(self, framework_connection_object: Optional[Any] = None) -> None:
+        super().set_framework_connection_object(framework_connection_object)
+        _observed_catalogs.append(self.framework_connection_object)
+
+    @classmethod
+    def pick_connection_from_dac(cls, data_access_collection: Any) -> Optional[Any]:
+        return IcebergFramework.pick_connection_from_dac(data_access_collection)
+
+
+class TfsDoubledIcebergFG(FeatureGroup, MatchData):
+    """Doubles raw_val via PyArrow compute (Iceberg transformer is a passthrough)."""
+
+    @classmethod
+    def match_data_access(
+        cls,
+        feature_name: str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+        framework_connection_object: Optional[Any] = None,
+    ) -> Any:
+        if pyiceberg is None:
+            return None
+        if feature_name not in cls.feature_names_supported():
+            return None
+        if framework_connection_object is not None and (
+            hasattr(framework_connection_object, "load_table") or isinstance(framework_connection_object, Mock)
+        ):
+            return framework_connection_object
+        if data_access_collection is None:
+            return None
+        for conn in data_access_collection.initialized_connection_objects:
+            if hasattr(conn, "load_table") or isinstance(conn, Mock):
+                return conn
+        return None
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return {Feature("raw_val")}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {ConnectionRecordingIcebergFramework}
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        doubled = pc.multiply(data["raw_val"], 2)
+        return data.append_column("tfs_doubled", doubled)
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return {"tfs_doubled"}
+
+
+@pytest.mark.skipif(pyiceberg is None or pa is None, reason="PyIceberg or PyArrow is not installed.")
+class TestIcebergTfsConnectionE2E(TfsConnectionEndToEndMixin):
+    destination_framework_class = ConnectionRecordingIcebergFramework
+    destination_fg_class = TfsDoubledIcebergFG
+
+    @pytest.fixture
+    def live_connection(self) -> Any:
+        _observed_catalogs.clear()
+        mock_catalog = Mock(spec=Catalog)
+        mock_catalog.load_table = Mock()
+        return mock_catalog
+
+    def extract_doubled(self, final: Any) -> list[int]:
+        assert _observed_catalogs, "Setup-time precompute did not bind a catalog on the destination CFW"
+        assert isinstance(final, pa.Table)
+        assert "tfs_doubled" in final.column_names
+        return list(final.column("tfs_doubled").to_pylist())

--- a/tests/test_plugins/compute_framework/base_implementations/spark/test_spark_framework.py
+++ b/tests/test_plugins/compute_framework/base_implementations/spark/test_spark_framework.py
@@ -341,8 +341,8 @@ from tests.test_plugins.compute_framework.base_implementations.tfs_connection_te
 @pytest.mark.skipif(not PYSPARK_AVAILABLE, reason=SKIP_REASON or "PySpark is not available")
 class TestSparkTfsConnectionInit(TfsConnectionInitMixin):
     @pytest.fixture
-    def framework_instance(self) -> Any:
-        return SparkFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
+    def framework_class(self) -> Any:
+        return SparkFramework
 
     @pytest.fixture
     def valid_connection(self, spark_session: Any) -> Any:

--- a/tests/test_plugins/compute_framework/base_implementations/spark/test_spark_framework.py
+++ b/tests/test_plugins/compute_framework/base_implementations/spark/test_spark_framework.py
@@ -347,3 +347,9 @@ class TestSparkTfsConnectionInit(TfsConnectionInitMixin):
     @pytest.fixture
     def valid_connection(self, spark_session: Any) -> Any:
         return spark_session
+
+    @pytest.fixture
+    def second_valid_connection(self) -> Any:
+        from unittest.mock import Mock
+
+        return Mock(spec=SparkSession)

--- a/tests/test_plugins/compute_framework/base_implementations/spark/test_spark_framework.py
+++ b/tests/test_plugins/compute_framework/base_implementations/spark/test_spark_framework.py
@@ -333,3 +333,17 @@ class TestSparkDataTypeValidator(DataTypeValidatorFrameworkTestMixin):
 
     def test_timestamp_us_column_strict_ms_raises(self, framework_instance: Any, precision_sample_data: Any) -> None:
         pytest.skip("Spark has only one TimestampType (microseconds); millisecond cannot be expressed")
+
+
+from tests.test_plugins.compute_framework.base_implementations.tfs_connection_test_mixin import TfsConnectionInitMixin  # noqa: E402
+
+
+@pytest.mark.skipif(not PYSPARK_AVAILABLE, reason=SKIP_REASON or "PySpark is not available")
+class TestSparkTfsConnectionInit(TfsConnectionInitMixin):
+    @pytest.fixture
+    def framework_instance(self) -> Any:
+        return SparkFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
+
+    @pytest.fixture
+    def valid_connection(self, spark_session: Any) -> Any:
+        return spark_session

--- a/tests/test_plugins/compute_framework/base_implementations/spark/test_spark_tfs_connection.py
+++ b/tests/test_plugins/compute_framework/base_implementations/spark/test_spark_tfs_connection.py
@@ -1,16 +1,8 @@
-"""End-to-end TFS connection-propagation test for DuckDB.
-
-Reproducer for issue #440. PyArrow -> DuckDB TFS path; without the fix the
-destination DuckDBFramework has no connection and `data.project(...)` raises."""
+"""End-to-end TFS connection-propagation test for Spark."""
 
 from typing import Any, Optional
 
 import pytest
-
-try:
-    import duckdb
-except ImportError:
-    duckdb = None  # type: ignore[assignment]
 
 try:
     import pyarrow as pa
@@ -20,14 +12,23 @@ except ImportError:
 from mloda.user import Feature, DataAccessCollection
 from mloda.provider import FeatureGroup, ComputeFramework, FeatureSet, MatchData
 from mloda.user import FeatureName, Options
-from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framework import DuckDBFramework
+from mloda_plugins.compute_framework.base_implementations.spark.spark_framework import SparkFramework
+from tests.test_plugins.compute_framework.base_implementations.spark.conftest import (
+    PYSPARK_AVAILABLE,
+    SKIP_REASON,
+)
 from tests.test_plugins.compute_framework.base_implementations.tfs_connection_e2e_mixin import (
     TfsConnectionEndToEndMixin,
 )
 
+if PYSPARK_AVAILABLE:
+    from pyspark.sql import SparkSession
+else:
+    SparkSession = None
 
-class TfsDoubledDuckDBFG(FeatureGroup, MatchData):
-    """Doubles raw_val using a DuckDB SQL projection that REQUIRES the connection."""
+
+class TfsDoubledSparkFG(FeatureGroup, MatchData):
+    """Doubles raw_val via Spark selectExpr; requires the SparkSession to be set."""
 
     @classmethod
     def match_data_access(
@@ -37,16 +38,16 @@ class TfsDoubledDuckDBFG(FeatureGroup, MatchData):
         data_access_collection: Optional[DataAccessCollection] = None,
         framework_connection_object: Optional[Any] = None,
     ) -> Any:
-        if duckdb is None or not DuckDBFramework.is_available():
+        if not PYSPARK_AVAILABLE:
             return None
         if feature_name not in cls.feature_names_supported():
             return None
-        if isinstance(framework_connection_object, duckdb.DuckDBPyConnection):
+        if isinstance(framework_connection_object, SparkSession):
             return framework_connection_object
         if data_access_collection is None:
             return None
         for conn in data_access_collection.initialized_connection_objects:
-            if isinstance(conn, duckdb.DuckDBPyConnection):
+            if isinstance(conn, SparkSession):
                 return conn
         return None
 
@@ -55,29 +56,26 @@ class TfsDoubledDuckDBFG(FeatureGroup, MatchData):
 
     @classmethod
     def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
-        return {DuckDBFramework}
+        return {SparkFramework}
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-        return data.project("*, raw_val * 2 AS tfs_doubled")
+        return data.selectExpr("*", "raw_val * 2 AS tfs_doubled")
 
     @classmethod
     def feature_names_supported(cls) -> set[str]:
         return {"tfs_doubled"}
 
 
-@pytest.mark.skipif(duckdb is None or pa is None, reason="DuckDB or PyArrow not installed.")
-class TestDuckDBTfsConnectionE2E(TfsConnectionEndToEndMixin):
-    destination_framework_class = DuckDBFramework
-    destination_fg_class = TfsDoubledDuckDBFG
+@pytest.mark.skipif(not PYSPARK_AVAILABLE or pa is None, reason=SKIP_REASON or "PySpark/PyArrow not available")
+class TestSparkTfsConnectionE2E(TfsConnectionEndToEndMixin):
+    destination_framework_class = SparkFramework
+    destination_fg_class = TfsDoubledSparkFG
 
     @pytest.fixture
-    def live_connection(self) -> Any:
-        conn = duckdb.connect()
-        yield conn
-        conn.close()
+    def live_connection(self, spark_session: Any) -> Any:
+        return spark_session
 
     def extract_doubled(self, final: Any) -> list[int]:
-        assert isinstance(final, pa.Table)
-        assert "tfs_doubled" in final.column_names
-        return list(final.column("tfs_doubled").to_pylist())
+        rows = final.select("tfs_doubled").collect()
+        return [row["tfs_doubled"] for row in rows]

--- a/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_framework.py
+++ b/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_framework.py
@@ -125,6 +125,21 @@ class TestSqliteFrameworkBasics:
             SqliteRelation.from_dict(connection, {"a": [1, 2, 3], "b": [4, 5]})
 
 
+from tests.test_plugins.compute_framework.base_implementations.tfs_connection_test_mixin import TfsConnectionInitMixin  # noqa: E402
+
+
+class TestSqliteTfsConnectionInit(TfsConnectionInitMixin):
+    @pytest.fixture
+    def framework_instance(self) -> Any:
+        return SqliteFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
+
+    @pytest.fixture
+    def valid_connection(self) -> Any:
+        conn = sqlite3.connect(":memory:")
+        yield conn
+        conn.close()
+
+
 class TestSqliteFrameworkMerge(DataFrameTestBase):
     @classmethod
     def framework_class(cls) -> type[Any]:

--- a/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_framework.py
+++ b/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_framework.py
@@ -130,8 +130,8 @@ from tests.test_plugins.compute_framework.base_implementations.tfs_connection_te
 
 class TestSqliteTfsConnectionInit(TfsConnectionInitMixin):
     @pytest.fixture
-    def framework_instance(self) -> Any:
-        return SqliteFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
+    def framework_class(self) -> Any:
+        return SqliteFramework
 
     @pytest.fixture
     def valid_connection(self) -> Any:

--- a/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_framework.py
+++ b/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_framework.py
@@ -139,6 +139,12 @@ class TestSqliteTfsConnectionInit(TfsConnectionInitMixin):
         yield conn
         conn.close()
 
+    @pytest.fixture
+    def second_valid_connection(self) -> Any:
+        conn = sqlite3.connect(":memory:")
+        yield conn
+        conn.close()
+
 
 class TestSqliteFrameworkMerge(DataFrameTestBase):
     @classmethod

--- a/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_tfs_connection.py
+++ b/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_tfs_connection.py
@@ -1,16 +1,9 @@
-"""End-to-end TFS connection-propagation test for DuckDB.
+"""End-to-end TFS connection-propagation test for SQLite."""
 
-Reproducer for issue #440. PyArrow -> DuckDB TFS path; without the fix the
-destination DuckDBFramework has no connection and `data.project(...)` raises."""
-
+import sqlite3
 from typing import Any, Optional
 
 import pytest
-
-try:
-    import duckdb
-except ImportError:
-    duckdb = None  # type: ignore[assignment]
 
 try:
     import pyarrow as pa
@@ -20,14 +13,14 @@ except ImportError:
 from mloda.user import Feature, DataAccessCollection
 from mloda.provider import FeatureGroup, ComputeFramework, FeatureSet, MatchData
 from mloda.user import FeatureName, Options
-from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framework import DuckDBFramework
+from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_framework import SqliteFramework
 from tests.test_plugins.compute_framework.base_implementations.tfs_connection_e2e_mixin import (
     TfsConnectionEndToEndMixin,
 )
 
 
-class TfsDoubledDuckDBFG(FeatureGroup, MatchData):
-    """Doubles raw_val using a DuckDB SQL projection that REQUIRES the connection."""
+class TfsDoubledSqliteFG(FeatureGroup, MatchData):
+    """Doubles raw_val via a SQLite SELECT that REQUIRES the connection."""
 
     @classmethod
     def match_data_access(
@@ -37,16 +30,14 @@ class TfsDoubledDuckDBFG(FeatureGroup, MatchData):
         data_access_collection: Optional[DataAccessCollection] = None,
         framework_connection_object: Optional[Any] = None,
     ) -> Any:
-        if duckdb is None or not DuckDBFramework.is_available():
-            return None
         if feature_name not in cls.feature_names_supported():
             return None
-        if isinstance(framework_connection_object, duckdb.DuckDBPyConnection):
+        if isinstance(framework_connection_object, sqlite3.Connection):
             return framework_connection_object
         if data_access_collection is None:
             return None
         for conn in data_access_collection.initialized_connection_objects:
-            if isinstance(conn, duckdb.DuckDBPyConnection):
+            if isinstance(conn, sqlite3.Connection):
                 return conn
         return None
 
@@ -55,29 +46,29 @@ class TfsDoubledDuckDBFG(FeatureGroup, MatchData):
 
     @classmethod
     def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
-        return {DuckDBFramework}
+        return {SqliteFramework}
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-        return data.project("*, raw_val * 2 AS tfs_doubled")
+        return data.select(_raw_sql="*, raw_val * 2 AS tfs_doubled")
 
     @classmethod
     def feature_names_supported(cls) -> set[str]:
         return {"tfs_doubled"}
 
 
-@pytest.mark.skipif(duckdb is None or pa is None, reason="DuckDB or PyArrow not installed.")
-class TestDuckDBTfsConnectionE2E(TfsConnectionEndToEndMixin):
-    destination_framework_class = DuckDBFramework
-    destination_fg_class = TfsDoubledDuckDBFG
+@pytest.mark.skipif(pa is None, reason="PyArrow not installed (needed for the source FG).")
+class TestSqliteTfsConnectionE2E(TfsConnectionEndToEndMixin):
+    destination_framework_class = SqliteFramework
+    destination_fg_class = TfsDoubledSqliteFG
 
     @pytest.fixture
     def live_connection(self) -> Any:
-        conn = duckdb.connect()
+        conn = sqlite3.connect(":memory:")
         yield conn
         conn.close()
 
     def extract_doubled(self, final: Any) -> list[int]:
-        assert isinstance(final, pa.Table)
-        assert "tfs_doubled" in final.column_names
-        return list(final.column("tfs_doubled").to_pylist())
+        arrow_table = final.to_arrow_table()
+        assert "tfs_doubled" in arrow_table.column_names
+        return list(arrow_table.column("tfs_doubled").to_pylist())

--- a/tests/test_plugins/compute_framework/base_implementations/tfs_connection_e2e_mixin.py
+++ b/tests/test_plugins/compute_framework/base_implementations/tfs_connection_e2e_mixin.py
@@ -1,0 +1,76 @@
+"""End-to-end TFS connection-propagation mixin shared by all SQL frameworks.
+
+The fix for issue #440 binds a DAC-resolved connection to the destination CFW
+of a TransformFrameworkStep at setup time. This mixin exercises that wiring
+through `mloda.run_all` so each SQL framework gets the same coverage as the
+original DuckDB reproducer."""
+
+from abc import abstractmethod
+from typing import Any, Optional
+
+import pytest
+
+from mloda.user import mloda, Feature, DataAccessCollection, ParallelizationMode, PluginCollector
+from mloda.provider import FeatureGroup, ComputeFramework, FeatureSet
+from mloda.core.abstract_plugins.components.input_data.creator.data_creator import DataCreator
+from mloda.provider import BaseInputData
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+
+
+class TfsRawValPyArrowSource(FeatureGroup):
+    """Shared source: emits raw_val=[1,2,3] on PyArrowTable so every SQL backend
+    test exercises the same PyArrow -> <SQL framework> TFS edge."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({"raw_val"})
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PyArrowTable}
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {"raw_val": [1, 2, 3]}
+
+
+class TfsConnectionEndToEndMixin:
+    """Verifies the DAC connection threads to a TFS destination CFW end-to-end.
+
+    Subclass contract:
+      - `destination_framework_class` attribute (the SQL ComputeFramework subclass)
+      - `destination_fg_class` attribute (a FeatureGroup whose calculate_feature
+        REQUIRES framework_connection_object; without the fix the test fails)
+      - `live_connection` fixture yielding a real connection of the destination
+        framework's native type
+      - `extract_doubled(final)` returns the [2, 4, 6] list from the result
+    """
+
+    destination_framework_class: type[ComputeFramework]
+    destination_fg_class: type[FeatureGroup]
+    source_framework_class: type[ComputeFramework] = PyArrowTable
+    source_fg_class: type[FeatureGroup] = TfsRawValPyArrowSource
+    destination_feature_name: str = "tfs_doubled"
+
+    @pytest.fixture
+    @abstractmethod
+    def live_connection(self) -> Any:
+        raise NotImplementedError
+
+    @abstractmethod
+    def extract_doubled(self, final: Any) -> list[int]:
+        raise NotImplementedError
+
+    def test_tfs_connection_reaches_destination_framework(self, live_connection: Any) -> None:
+        plugin_collector = PluginCollector.enabled_feature_groups({self.source_fg_class, self.destination_fg_class})
+        dac = DataAccessCollection(initialized_connection_objects={live_connection})
+        result = mloda.run_all(
+            [Feature(self.destination_feature_name)],
+            compute_frameworks={self.source_framework_class, self.destination_framework_class},
+            plugin_collector=plugin_collector,
+            data_access_collection=dac,
+            parallelization_modes={ParallelizationMode.SYNC},
+        )
+        assert result is not None
+        assert len(result) == 1
+        assert self.extract_doubled(result[0]) == [2, 4, 6]

--- a/tests/test_plugins/compute_framework/base_implementations/tfs_connection_test_mixin.py
+++ b/tests/test_plugins/compute_framework/base_implementations/tfs_connection_test_mixin.py
@@ -7,9 +7,14 @@ from mloda.user import DataAccessCollection
 
 
 class TfsConnectionInitMixin:
+    """Unit-level coverage for pick_connection_from_dac on a SQL ComputeFramework.
+
+    Subclasses provide the framework class and a fixture yielding a valid native connection.
+    """
+
     @pytest.fixture
     @abstractmethod
-    def framework_instance(self) -> Any:
+    def framework_class(self) -> Any:
         raise NotImplementedError
 
     @pytest.fixture
@@ -20,27 +25,24 @@ class TfsConnectionInitMixin:
     def wrong_type_connection(self) -> Any:
         return object()
 
-    def test_no_op_with_none(self, framework_instance: Any) -> None:
-        framework_instance.init_connection_from_data_access(None)
-        assert framework_instance.framework_connection_object is None
+    def test_returns_none_with_none(self, framework_class: Any) -> None:
+        assert framework_class.pick_connection_from_dac(None) is None
 
-    def test_no_op_with_empty_collection(self, framework_instance: Any) -> None:
+    def test_returns_none_with_empty_collection(self, framework_class: Any) -> None:
         dac = DataAccessCollection(initialized_connection_objects=set())
-        framework_instance.init_connection_from_data_access(dac)
-        assert framework_instance.framework_connection_object is None
+        assert framework_class.pick_connection_from_dac(dac) is None
 
-    def test_no_op_with_wrong_type(self, framework_instance: Any) -> None:
+    def test_returns_none_with_wrong_type(self, framework_class: Any) -> None:
         dac = DataAccessCollection(initialized_connection_objects={self.wrong_type_connection()})
-        framework_instance.init_connection_from_data_access(dac)
-        assert framework_instance.framework_connection_object is None
+        assert framework_class.pick_connection_from_dac(dac) is None
 
-    def test_sets_correct_type(self, framework_instance: Any, valid_connection: Any) -> None:
+    def test_returns_matching_connection(self, framework_class: Any, valid_connection: Any) -> None:
         dac = DataAccessCollection(initialized_connection_objects={valid_connection})
-        framework_instance.init_connection_from_data_access(dac)
-        assert framework_instance.framework_connection_object is valid_connection
+        assert framework_class.pick_connection_from_dac(dac) is valid_connection
 
-    def test_idempotent_same_connection(self, framework_instance: Any, valid_connection: Any) -> None:
+    def test_classmethod_is_pure(self, framework_class: Any, valid_connection: Any) -> None:
         dac = DataAccessCollection(initialized_connection_objects={valid_connection})
-        framework_instance.init_connection_from_data_access(dac)
-        framework_instance.init_connection_from_data_access(dac)  # must not raise
-        assert framework_instance.framework_connection_object is valid_connection
+        first = framework_class.pick_connection_from_dac(dac)
+        second = framework_class.pick_connection_from_dac(dac)
+        assert first is valid_connection
+        assert second is valid_connection

--- a/tests/test_plugins/compute_framework/base_implementations/tfs_connection_test_mixin.py
+++ b/tests/test_plugins/compute_framework/base_implementations/tfs_connection_test_mixin.py
@@ -22,6 +22,17 @@ class TfsConnectionInitMixin:
     def valid_connection(self) -> Any:
         raise NotImplementedError
 
+    @pytest.fixture
+    @abstractmethod
+    def second_valid_connection(self) -> Any:
+        """A second, distinct connection of the same framework type.
+
+        Used to exercise the multi-match disambiguation policy. Subclasses must
+        ensure this is *not* the same object as `valid_connection` so both end
+        up in the DAC set.
+        """
+        raise NotImplementedError
+
     def wrong_type_connection(self) -> Any:
         return object()
 
@@ -46,3 +57,11 @@ class TfsConnectionInitMixin:
         second = framework_class.pick_connection_from_dac(dac)
         assert first is valid_connection
         assert second is valid_connection
+
+    def test_raises_on_multiple_matches(
+        self, framework_class: Any, valid_connection: Any, second_valid_connection: Any
+    ) -> None:
+        assert valid_connection is not second_valid_connection
+        dac = DataAccessCollection(initialized_connection_objects={valid_connection, second_valid_connection})
+        with pytest.raises(ValueError, match="connections matching this framework"):
+            framework_class.pick_connection_from_dac(dac)

--- a/tests/test_plugins/compute_framework/base_implementations/tfs_connection_test_mixin.py
+++ b/tests/test_plugins/compute_framework/base_implementations/tfs_connection_test_mixin.py
@@ -1,0 +1,46 @@
+from abc import abstractmethod
+from typing import Any
+
+import pytest
+
+from mloda.user import DataAccessCollection, ParallelizationMode
+
+
+class TfsConnectionInitMixin:
+    @pytest.fixture
+    @abstractmethod
+    def framework_instance(self) -> Any:
+        raise NotImplementedError
+
+    @pytest.fixture
+    @abstractmethod
+    def valid_connection(self) -> Any:
+        raise NotImplementedError
+
+    def wrong_type_connection(self) -> Any:
+        return object()
+
+    def test_no_op_with_none(self, framework_instance: Any) -> None:
+        framework_instance.init_connection_from_data_access(None)
+        assert framework_instance.framework_connection_object is None
+
+    def test_no_op_with_empty_collection(self, framework_instance: Any) -> None:
+        dac = DataAccessCollection(initialized_connection_objects=set())
+        framework_instance.init_connection_from_data_access(dac)
+        assert framework_instance.framework_connection_object is None
+
+    def test_no_op_with_wrong_type(self, framework_instance: Any) -> None:
+        dac = DataAccessCollection(initialized_connection_objects={self.wrong_type_connection()})
+        framework_instance.init_connection_from_data_access(dac)
+        assert framework_instance.framework_connection_object is None
+
+    def test_sets_correct_type(self, framework_instance: Any, valid_connection: Any) -> None:
+        dac = DataAccessCollection(initialized_connection_objects={valid_connection})
+        framework_instance.init_connection_from_data_access(dac)
+        assert framework_instance.framework_connection_object is valid_connection
+
+    def test_idempotent_same_connection(self, framework_instance: Any, valid_connection: Any) -> None:
+        dac = DataAccessCollection(initialized_connection_objects={valid_connection})
+        framework_instance.init_connection_from_data_access(dac)
+        framework_instance.init_connection_from_data_access(dac)  # must not raise
+        assert framework_instance.framework_connection_object is valid_connection

--- a/tests/test_plugins/compute_framework/base_implementations/tfs_connection_test_mixin.py
+++ b/tests/test_plugins/compute_framework/base_implementations/tfs_connection_test_mixin.py
@@ -3,7 +3,7 @@ from typing import Any
 
 import pytest
 
-from mloda.user import DataAccessCollection, ParallelizationMode
+from mloda.user import DataAccessCollection
 
 
 class TfsConnectionInitMixin:

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ setenv =
     PYTHONWARNINGS=ignore::UserWarning:piplicenses.spdx
     WRITE_THIRD_PARTY_LICENSES={env:TOX_WRITE_THIRD_PARTY_LICENSES:false}
     SKIP_POLARS_INSTALLATION_TEST={env:SKIP_POLARS_INSTALLATION_TEST:false}
-    EXPECTED_SKIP_COUNT = {env:EXPECTED_SKIP_COUNT:183}
+    EXPECTED_SKIP_COUNT = {env:EXPECTED_SKIP_COUNT:184}
     CHECK_SKIP_COUNT = {env:CHECK_SKIP_COUNT:1}
     USE_TOX_LOCK = {env:USE_TOX_LOCK:}
 commands = sh -c "if [ -n \"$USE_TOX_LOCK\" ]; then flock /shared/tox.lock pytest -n {env:PYTEST_WORKERS:8} --timeout=10 {env:DEACTIVATE_NOTEBOOK_AND_DOC_TESTS:''}; else pytest -n {env:PYTEST_WORKERS:8} --timeout=10 {env:DEACTIVATE_NOTEBOOK_AND_DOC_TESTS:''}; fi"

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ setenv =
     PYTHONWARNINGS=ignore::UserWarning:piplicenses.spdx
     WRITE_THIRD_PARTY_LICENSES={env:TOX_WRITE_THIRD_PARTY_LICENSES:false}
     SKIP_POLARS_INSTALLATION_TEST={env:SKIP_POLARS_INSTALLATION_TEST:false}
-    EXPECTED_SKIP_COUNT = {env:EXPECTED_SKIP_COUNT:182}
+    EXPECTED_SKIP_COUNT = {env:EXPECTED_SKIP_COUNT:183}
     CHECK_SKIP_COUNT = {env:CHECK_SKIP_COUNT:1}
     USE_TOX_LOCK = {env:USE_TOX_LOCK:}
 commands = sh -c "if [ -n \"$USE_TOX_LOCK\" ]; then flock /shared/tox.lock pytest -n {env:PYTEST_WORKERS:8} --timeout=10 {env:DEACTIVATE_NOTEBOOK_AND_DOC_TESTS:''}; else pytest -n {env:PYTEST_WORKERS:8} --timeout=10 {env:DEACTIVATE_NOTEBOOK_AND_DOC_TESTS:''}; fi"

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ setenv =
     PYTHONWARNINGS=ignore::UserWarning:piplicenses.spdx
     WRITE_THIRD_PARTY_LICENSES={env:TOX_WRITE_THIRD_PARTY_LICENSES:false}
     SKIP_POLARS_INSTALLATION_TEST={env:SKIP_POLARS_INSTALLATION_TEST:false}
-    EXPECTED_SKIP_COUNT = {env:EXPECTED_SKIP_COUNT:177}
+    EXPECTED_SKIP_COUNT = {env:EXPECTED_SKIP_COUNT:182}
     CHECK_SKIP_COUNT = {env:CHECK_SKIP_COUNT:1}
     USE_TOX_LOCK = {env:USE_TOX_LOCK:}
 commands = sh -c "if [ -n \"$USE_TOX_LOCK\" ]; then flock /shared/tox.lock pytest -n {env:PYTEST_WORKERS:8} --timeout=10 {env:DEACTIVATE_NOTEBOOK_AND_DOC_TESTS:''}; else pytest -n {env:PYTEST_WORKERS:8} --timeout=10 {env:DEACTIVATE_NOTEBOOK_AND_DOC_TESTS:''}; fi"


### PR DESCRIPTION
## Summary

- `DataAccessCollection` (containing user connection objects) was stored on `Engine` but never passed to `ExecutionOrchestrator` or `ComputeFrameworkExecutor`, so `TransformFrameworkStep` always created SQL-framework destination cfws with `framework_connection_object = None`
- Adds `init_connection_from_data_access()` to the `ComputeFramework` base class (no-op) and overrides it in DuckDB, SQLite, Spark, and Iceberg to select the matching connection from `initialized_connection_objects`
- Threads `DataAccessCollection` from `Engine.compute()` through `ExecutionOrchestrator` and `ComputeFrameworkExecutor`, calling the new method on the destination cfw just before TFS execution

Closes #440

## Test plan

- [ ] `TestDuckDBTfsConnectionInit` (5 unit tests via shared `TfsConnectionInitMixin`) — DuckDB override
- [ ] `TestSqliteTfsConnectionInit` (5 unit tests) — SQLite override
- [ ] `TestIcebergTfsConnectionInit` (5 unit tests) — Iceberg override
- [ ] `TestSparkTfsConnectionInit` (5 unit tests, skipped where pyspark absent) — Spark override
- [ ] `TestPyArrowToDuckDBTfsConnection.test_tfs_connection_reaches_duckdb_framework` — end-to-end reproducer for #440
- [ ] Full `tox` suite passes (3170 passed, 182 skipped)