### PR TITLE
test(iceberg): add TestIcebergDtypeExtraction mixin coverage

### DIFF
--- a/tests/test_plugins/compute_framework/base_implementations/iceberg/test_iceberg_framework.py
+++ b/tests/test_plugins/compute_framework/base_implementations/iceberg/test_iceberg_framework.py
@@ -10,6 +10,9 @@ from tests.test_plugins.compute_framework.base_implementations.datatype_validato
     ColumnSpec,
     DataTypeValidatorFrameworkTestMixin,
 )
+from tests.test_plugins.compute_framework.base_implementations.dtype_extraction_test_mixin import (
+    DtypeExtractionTestMixin,
+)
 from tests.test_plugins.compute_framework.test_tooling.availability_test_helper import (
     assert_unavailable_when_import_blocked,
 )
@@ -244,3 +247,29 @@ class TestIcebergDataTypeValidator(DataTypeValidatorFrameworkTestMixin):
 
     def test_timestamp_us_column_strict_ms_raises(self, framework_instance: Any, precision_sample_data: Any) -> None:
         pytest.skip("Iceberg has only one TimestampType (microseconds per spec); millisecond cannot be expressed")
+
+
+@pytest.mark.skipif(
+    pyiceberg is None or pa is None, reason="PyIceberg or PyArrow is not installed. Skipping this test."
+)
+class TestIcebergDtypeExtraction(DtypeExtractionTestMixin):
+    """Test IcebergFramework._extract_column_dtype using shared mixin.
+
+    Iceberg tables need catalog context to construct, so the fixture wraps a real
+    ``pyiceberg.schema.Schema`` (carrying real ``LongType``/``StringType``/``DoubleType``
+    field types) inside a ``Mock`` IcebergTable, reusing TestIcebergDataTypeValidator's
+    ``_wrap_schema`` helper.
+    """
+
+    @pytest.fixture
+    def framework_instance(self) -> Any:
+        return IcebergFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
+
+    @pytest.fixture
+    def dtype_sample_data(self) -> Any:
+        schema = Schema(
+            NestedField(1, "int_col", LongType()),
+            NestedField(2, "str_col", StringType()),
+            NestedField(3, "float_col", DoubleType()),
+        )
+        return TestIcebergDataTypeValidator._wrap_schema(schema)


### PR DESCRIPTION
## Summary

- Adds `TestIcebergDtypeExtraction(DtypeExtractionTestMixin)` to the Iceberg test file, mirroring the pattern already present on the eight other compute frameworks (pandas, polars eager/lazy, pyarrow, duckdb, spark, sqlite, python_dict).
- Fixture wraps a real `pyiceberg.schema.Schema` (`LongType`/`StringType`/`DoubleType` fields) in a `Mock(spec=IcebergTable)` via the existing `TestIcebergDataTypeValidator._wrap_schema` static method — no helper duplication, no refactor of working code.
- All six mixin assertions (`test_extract_{int,string,float}_column_dtype_*`, `test_extract_missing_column_returns_none`, `test_int_dtype_is_not_string`, `test_string_dtype_is_not_numeric`) pass against the existing `IcebergFramework._extract_column_dtype` (introduced in #434).

Closes #439.

## Issue checklist divergence (deliberate)

The issue DoD asks for `pytest.skip(...)` calls and an `EXPECTED_SKIP_COUNT` bump for Iceberg's single-precision `TimestampType` limitation. That rationale applies to the sibling `DataTypeValidatorFrameworkTestMixin` (already handled on `TestIcebergDataTypeValidator`, lines 242-246). `DtypeExtractionTestMixin` has no timestamp tests — confirmed by reading the mixin file — so neither skips nor a count bump apply here. `EXPECTED_SKIP_COUNT=177` is unchanged.

## Test plan

- [x] Targeted: \`pytest tests/test_plugins/compute_framework/base_implementations/iceberg/test_iceberg_framework.py::TestIcebergDtypeExtraction -v\` — 6 passed
- [x] Full Iceberg file under tox-style parallelism: \`pytest tests/test_plugins/compute_framework/base_implementations/iceberg/ -n 8 --timeout=10\` — 32 passed, 5 skipped (pre-existing)
- [x] \`ruff format --check\`, \`ruff check\`, \`mypy --strict --ignore-missing-imports .\` (630 files), \`bandit -c pyproject.toml -r -q .\` — all clean
- [x] \`EXPECTED_SKIP_COUNT=177\` assertion holds in full \`tox -e python310\`

## Pre-existing CI flakiness (not introduced here)

Under \`pytest -n 8 --timeout=10\`, some \`test_plugin_docs.py\` and \`test_mloda_basics_notebooks.py\` tests intermittently fail — different tests across runs. Reproducible on \`main\` (33 errors observed) and pass in isolation on this branch. Unrelated to this change.