### PR TITLE
fix(sqlite): register explicit datetime/date adapters

### DIFF
--- a/mloda_plugins/compute_framework/base_implementations/sqlite/sqlite_relation.py
+++ b/mloda_plugins/compute_framework/base_implementations/sqlite/sqlite_relation.py
@@ -9,11 +9,15 @@ import pyarrow as pa
 from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import quote_ident
 
 
-# Python 3.12 deprecates the default sqlite3 datetime adapters. Register explicit
-# ISO-format adapters so datetime values inserted via executemany() no longer emit
-# DeprecationWarning on every row. Adapters are module-global in sqlite3.
-sqlite3.register_adapter(datetime.date, lambda d: d.isoformat())
-sqlite3.register_adapter(datetime.datetime, lambda d: d.isoformat())
+# Python 3.12 deprecated the built-in sqlite3 datetime adapters; explicit ISO-format
+# registration silences the per-row DeprecationWarning emitted by executemany().
+# Side effect: sqlite3.register_adapter is module-global, so every sqlite3.Connection
+# in the process (including ones not created via SqliteRelation) picks these up.
+# Adapter-only, no converter: mloda reads sqlite data back through Arrow as text and
+# never sets detect_types, so the read path is unaffected. The T-separator output
+# matches the existing literal-SQL pipeline in sql_utils.quote_value (value.isoformat()).
+sqlite3.register_adapter(datetime.date, datetime.date.isoformat)
+sqlite3.register_adapter(datetime.datetime, datetime.datetime.isoformat)
 
 
 def _next_table_name() -> str:

--- a/mloda_plugins/compute_framework/base_implementations/sqlite/sqlite_relation.py
+++ b/mloda_plugins/compute_framework/base_implementations/sqlite/sqlite_relation.py
@@ -1,3 +1,4 @@
+import datetime
 import re
 import sqlite3
 import uuid
@@ -6,6 +7,13 @@ from typing import Any, Optional
 import pyarrow as pa
 
 from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import quote_ident
+
+
+# Python 3.12 deprecates the default sqlite3 datetime adapters. Register explicit
+# ISO-format adapters so datetime values inserted via executemany() no longer emit
+# DeprecationWarning on every row. Adapters are module-global in sqlite3.
+sqlite3.register_adapter(datetime.date, lambda d: d.isoformat())
+sqlite3.register_adapter(datetime.datetime, lambda d: d.isoformat())
 
 
 def _next_table_name() -> str:

--- a/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_relation.py
+++ b/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_relation.py
@@ -1,4 +1,6 @@
+import datetime
 import sqlite3
+import warnings
 from typing import Any
 
 import pyarrow as pa
@@ -135,3 +137,19 @@ class TestInferSqliteType:
         """TEXT dominates: a string before a float must not be overridden by the float."""
         result = _infer_sqlite_type_from_values(["hello", 1.5])
         assert result == "TEXT", f"Expected TEXT but got {result}"
+
+
+class TestSqliteDatetimeAdapter:
+    def test_inserting_datetime_does_not_emit_default_adapter_warning(self, connection: sqlite3.Connection) -> None:
+        """Inserting datetime/date values must not trigger Python 3.12's default-adapter DeprecationWarning."""
+        data: dict[str, list[Any]] = {
+            "ts": [datetime.datetime(2024, 1, 1, 12, 0), datetime.datetime(2024, 1, 2, 12, 0)],
+            "d": [datetime.date(2024, 1, 1), datetime.date(2024, 1, 2)],
+        }
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            SqliteRelation.from_dict(connection, data)
+        adapter_warnings = [w for w in caught if "default" in str(w.message) and "adapter" in str(w.message)]
+        assert adapter_warnings == [], (
+            f"Unexpected default-adapter warnings: {[str(w.message) for w in adapter_warnings]}"
+        )

--- a/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_relation.py
+++ b/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_relation.py
@@ -146,10 +146,35 @@ class TestSqliteDatetimeAdapter:
             "ts": [datetime.datetime(2024, 1, 1, 12, 0), datetime.datetime(2024, 1, 2, 12, 0)],
             "d": [datetime.date(2024, 1, 1), datetime.date(2024, 1, 2)],
         }
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
             SqliteRelation.from_dict(connection, data)
-        adapter_warnings = [w for w in caught if "default" in str(w.message) and "adapter" in str(w.message)]
-        assert adapter_warnings == [], (
-            f"Unexpected default-adapter warnings: {[str(w.message) for w in adapter_warnings]}"
+
+    def test_inserting_datetime_via_from_arrow_does_not_emit_default_adapter_warning(
+        self, connection: sqlite3.Connection
+    ) -> None:
+        """from_arrow's executemany path must also be free of the default-adapter DeprecationWarning."""
+        arrow_table = pa.table(
+            {
+                "ts": pa.array(
+                    [datetime.datetime(2024, 1, 1, 12, 0), datetime.datetime(2024, 1, 2, 12, 0)],
+                    type=pa.timestamp("us"),
+                ),
+                "d": pa.array([datetime.date(2024, 1, 1), datetime.date(2024, 1, 2)], type=pa.date32()),
+            }
         )
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            SqliteRelation.from_arrow(connection, arrow_table)
+
+    def test_direct_executemany_with_datetime_does_not_emit_default_adapter_warning(self) -> None:
+        """Module-global adapter registration must cover any sqlite3 connection, not only SqliteRelation."""
+        conn = sqlite3.connect(":memory:")
+        conn.execute("CREATE TABLE t (ts TEXT)")
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            conn.executemany(
+                "INSERT INTO t VALUES (?)",
+                [(datetime.datetime(2024, 1, 1, 12, 0),), (datetime.datetime(2024, 1, 2, 12, 0),)],
+            )
+        conn.close()


### PR DESCRIPTION
## Summary
- Python 3.12 deprecated the default `sqlite3` datetime adapters. Every row inserted via `executemany()` in `SqliteRelation.from_arrow` / `from_dict` triggered a `DeprecationWarning`. Downstream this floods test output (mloda-registry sees ~5,500 of them per `tox` run, tracked in mloda-registry#170).
- Register explicit ISO-format adapters for `datetime.date` and `datetime.datetime` at module load in `sqlite_relation.py`. Adapters are module-global on `sqlite3`, so this also covers any caller that creates their own `sqlite3.Connection` after importing the SQLite framework.
- No converter registration: round-trip read of these values would require `detect_types` on user-provided connections, which is out of scope. The DeprecationWarning is the immediate pain point.

## Test plan
- [x] New `TestSqliteDatetimeAdapter::test_inserting_datetime_does_not_emit_default_adapter_warning` asserts no default-adapter warning fires on `from_dict()` with `datetime` values
- [x] Full `tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_relation.py` passes (41 tests)
- [x] `ruff format --check`, `ruff check`, `mypy --strict` all pass on touched files
- [ ] Once merged: bump mloda in `mloda-registry` to confirm `tox` warning count drops below the 100 target tracked in mloda-registry#170

Refs mloda-registry#170