### PR TITLE
chore(tox): default tox lock to portable path

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -16,7 +16,7 @@ x-agent-common: &agent-common
     - SETUID
     - KILL
   environment:
-    - USE_TOX_LOCK=1
+    - TOX_LOCK_PATH=/shared/tox.lock
   depends_on:
     mloda-base:
       condition: service_completed_successfully

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ For quick iteration during development, you can run only the tests. Note that th
 pytest -n auto --timeout=10
 ```
 
-When multiple processes run `tox` on the same host (e.g., parallel agents), they serialize on `$TOX_LOCK_PATH` (default `/tmp/mloda-tox.lock`). Override the path if `/tmp` is not appropriate for your setup.
+When multiple processes run `tox` on the same host (e.g., parallel agents), their `pytest` step serializes on `$TOX_LOCK_PATH` (default `/tmp/mloda-tox.lock`) when `flock` is available. Override the path if `/tmp` is not appropriate for your setup, or unset it to disable. On hosts without `flock` (macOS without `util-linux`, Windows outside WSL), the lock is skipped automatically and `tox` runs unwrapped.
 
 ## Ways to Contribute
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ For quick iteration during development, you can run only the tests. Note that th
 pytest -n auto --timeout=10
 ```
 
-When multiple processes run `tox` on the same host (e.g., parallel agents), their `pytest` step serializes on `$TOX_LOCK_PATH` (default `/tmp/mloda-tox.lock`) when `flock` is available. Override the path if `/tmp` is not appropriate for your setup, or unset it to disable. On hosts without `flock` (macOS without `util-linux`, Windows outside WSL), the lock is skipped automatically and `tox` runs unwrapped.
+When multiple processes run `tox` on the same host (e.g., parallel agents), their `pytest` step serializes on `$TOX_LOCK_PATH` (default `/tmp/mloda-tox.lock`) when `flock` is available. The file is created world-writable so any local user can share the lock; if you prefer a per-user lock, point `TOX_LOCK_PATH` at a path under `$HOME` (literal path, not `~`). Set `TOX_LOCK_PATH=` (empty) to disable. On hosts without `flock` (macOS: `brew install flock`; Windows: use WSL) or where the lock file is not writable (read-only `/tmp`, foreign ownership), the lock is skipped automatically and `tox` runs unwrapped.
 
 ## Ways to Contribute
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,8 @@ For quick iteration during development, you can run only the tests. Note that th
 pytest -n auto --timeout=10
 ```
 
+When multiple processes run `tox` on the same host (e.g., parallel agents), they serialize on `$TOX_LOCK_PATH` (default `/tmp/mloda-tox.lock`). Override the path if `/tmp` is not appropriate for your setup.
+
 ## Ways to Contribute
 
 ### Plugin Development

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ setenv =
     EXPECTED_SKIP_COUNT = {env:EXPECTED_SKIP_COUNT:184}
     CHECK_SKIP_COUNT = {env:CHECK_SKIP_COUNT:1}
     TOX_LOCK_PATH = {env:TOX_LOCK_PATH:/tmp/mloda-tox.lock}
-commands = sh -c "flock $TOX_LOCK_PATH pytest -n {env:PYTEST_WORKERS:8} --timeout=10 {env:DEACTIVATE_NOTEBOOK_AND_DOC_TESTS:''}"
+commands = sh -c "if [ -n \"$TOX_LOCK_PATH\" ] && command -v flock >/dev/null 2>&1; then flock \"$TOX_LOCK_PATH\" pytest -n {env:PYTEST_WORKERS:8} --timeout=10 {env:DEACTIVATE_NOTEBOOK_AND_DOC_TESTS:''}; else pytest -n {env:PYTEST_WORKERS:8} --timeout=10 {env:DEACTIVATE_NOTEBOOK_AND_DOC_TESTS:''}; fi"
            ruff format --check --line-length 120 .
            ruff check --line-length 120 .
            sh -c "if [ \"$WRITE_THIRD_PARTY_LICENSES\" = \"true\" ]; then pip-licenses --format=plain-vertical --with-urls --with-license-file | sed '/\/home\//d' > attribution/THIRD_PARTY_LICENSES.md; fi"

--- a/tox.ini
+++ b/tox.ini
@@ -24,8 +24,8 @@ setenv =
     SKIP_POLARS_INSTALLATION_TEST={env:SKIP_POLARS_INSTALLATION_TEST:false}
     EXPECTED_SKIP_COUNT = {env:EXPECTED_SKIP_COUNT:184}
     CHECK_SKIP_COUNT = {env:CHECK_SKIP_COUNT:1}
-    USE_TOX_LOCK = {env:USE_TOX_LOCK:}
-commands = sh -c "if [ -n \"$USE_TOX_LOCK\" ]; then flock /shared/tox.lock pytest -n {env:PYTEST_WORKERS:8} --timeout=10 {env:DEACTIVATE_NOTEBOOK_AND_DOC_TESTS:''}; else pytest -n {env:PYTEST_WORKERS:8} --timeout=10 {env:DEACTIVATE_NOTEBOOK_AND_DOC_TESTS:''}; fi"
+    TOX_LOCK_PATH = {env:TOX_LOCK_PATH:/tmp/mloda-tox.lock}
+commands = sh -c "flock $TOX_LOCK_PATH pytest -n {env:PYTEST_WORKERS:8} --timeout=10 {env:DEACTIVATE_NOTEBOOK_AND_DOC_TESTS:''}"
            ruff format --check --line-length 120 .
            ruff check --line-length 120 .
            sh -c "if [ \"$WRITE_THIRD_PARTY_LICENSES\" = \"true\" ]; then pip-licenses --format=plain-vertical --with-urls --with-license-file | sed '/\/home\//d' > attribution/THIRD_PARTY_LICENSES.md; fi"

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ setenv =
     EXPECTED_SKIP_COUNT = {env:EXPECTED_SKIP_COUNT:184}
     CHECK_SKIP_COUNT = {env:CHECK_SKIP_COUNT:1}
     TOX_LOCK_PATH = {env:TOX_LOCK_PATH:/tmp/mloda-tox.lock}
-commands = sh -c "if [ -n \"$TOX_LOCK_PATH\" ] && command -v flock >/dev/null 2>&1; then flock \"$TOX_LOCK_PATH\" pytest -n {env:PYTEST_WORKERS:8} --timeout=10 {env:DEACTIVATE_NOTEBOOK_AND_DOC_TESTS:''}; else pytest -n {env:PYTEST_WORKERS:8} --timeout=10 {env:DEACTIVATE_NOTEBOOK_AND_DOC_TESTS:''}; fi"
+commands = sh -c "set -- pytest -n {env:PYTEST_WORKERS:8} --timeout=10 {env:DEACTIVATE_NOTEBOOK_AND_DOC_TESTS:''}; if [ -n \"$TOX_LOCK_PATH\" ] && command -v flock >/dev/null 2>&1; then [ -e \"$TOX_LOCK_PATH\" ] || (umask 0 && : > \"$TOX_LOCK_PATH\") 2>/dev/null; if [ -w \"$TOX_LOCK_PATH\" ]; then exec flock \"$TOX_LOCK_PATH\" \"$@\"; fi; fi; exec \"$@\""
            ruff format --check --line-length 120 .
            ruff check --line-length 120 .
            sh -c "if [ \"$WRITE_THIRD_PARTY_LICENSES\" = \"true\" ]; then pip-licenses --format=plain-vertical --with-urls --with-license-file | sed '/\/home\//d' > attribution/THIRD_PARTY_LICENSES.md; fi"


### PR DESCRIPTION
## Summary

- Drop the `USE_TOX_LOCK` gate in `tox.ini`; replace with `TOX_LOCK_PATH` defaulting to `/tmp/mloda-tox.lock`, so `flock` is always active with a path writable on any POSIX host.
- Update `.devcontainer/docker-compose.yml` to set `TOX_LOCK_PATH=/shared/tox.lock`, preserving cross-container serialization on the existing `shared_locks` volume.
- Add a one-line note in `CONTRIBUTING.md` under "Running Checks Locally" describing the lock and how to override the path.

### Why

The default `[testenv]` already wrapped pytest in `flock /shared/tox.lock` when `USE_TOX_LOCK` was set, but `/shared` only exists inside the devcontainer. On a plain developer host the lock was unusable, so multiple parallel `tox` invocations would each spawn `pytest -n 8` and saturate the box. With this change the serialization works out of the box on any setup; CI is unaffected because GH runners are isolated and an uncontended `flock` is essentially free.

## Test plan

- [x] `tox.ini` parses cleanly with the new `setenv` / `commands` block.
- [x] `flock /tmp/mloda-tox.lock pytest -n 8 --timeout=10 tests/test_core/test_python_version.py` passes on a host without `/shared`.
- [x] Concurrent `flock $TOX_LOCK_PATH` from two processes serializes (process B starts after process A releases).
- [ ] CI green on the full matrix.
- [ ] Devcontainer rebuild: `tox` in two agent containers concurrently still serializes on `/shared/tox.lock`.