### PR TITLE
feat: expose relation dtype accessors

### DIFF
--- a/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_framework.py
@@ -104,7 +104,7 @@ class DuckDBFramework(ComputeFramework):
 
     def _extract_column_dtype(self, data: Any, column_name: str) -> str | None:
         if column_name in data.columns:
-            dtypes = data._relation.dtypes
+            dtypes = data.types
             idx = data.columns.index(column_name)
             return str(dtypes[idx])
         return None
@@ -113,7 +113,7 @@ class DuckDBFramework(ComputeFramework):
         if column_name not in data.columns:
             return None
         idx = data.columns.index(column_name)
-        duckdb_type = data._relation.dtypes[idx]
+        duckdb_type = data.types[idx]
         type_str = str(duckdb_type).upper()
         if type_str in _DUCKDB_TYPE_MAP:
             return _DUCKDB_TYPE_MAP[type_str]

--- a/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_relation.py
+++ b/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_relation.py
@@ -42,6 +42,10 @@ class DuckdbRelation:
     def columns(self) -> list[str]:
         return self._relation.columns
 
+    @property
+    def types(self) -> list[Any]:
+        return list(self._relation.dtypes)
+
     def filter(self, condition: str, params: tuple[Any, ...] = ()) -> "DuckdbRelation":
         """Apply a filter condition. Params are inlined via ``quote_value``
         because DuckDB's Relational API lacks PEP 249 parameter binding."""

--- a/mloda_plugins/compute_framework/base_implementations/sqlite/sqlite_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/sqlite/sqlite_framework.py
@@ -12,17 +12,8 @@ from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_filter_e
 from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_mask_engine import SqliteMaskEngine
 from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_merge_engine import SqliteMergeEngine
 from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_relation import SqliteRelation
-from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import quote_ident
 
 logger = logging.getLogger(__name__)
-
-
-_SQLITE_TYPE_MAP: dict[str, DataType] = {
-    "integer": DataType.INT64,
-    "real": DataType.DOUBLE,
-    "text": DataType.STRING,
-    "blob": DataType.BINARY,
-}
 
 
 def _regexp(pattern: str, string: Optional[str]) -> bool:
@@ -77,23 +68,16 @@ class SqliteFramework(ComputeFramework):
         return set(data.columns)
 
     def _extract_column_dtype(self, data: Any, column_name: str) -> str | None:
-        if not hasattr(data, "connection") or column_name not in data.columns:
+        if not hasattr(data, "columns") or column_name not in data.columns:
             return None
-        cursor = data.connection.execute(f"PRAGMA table_info({quote_ident(data.table_name)})")
-        for row in cursor.fetchall():
-            if row[1] == column_name:
-                return str(row[2]).lower()
-        return None
+        idx = data.columns.index(column_name)
+        return str(data.types[idx])
 
     def _extract_column_data_type(self, data: Any, column_name: str) -> Optional[DataType]:
-        if not hasattr(data, "connection") or column_name not in data.columns:
+        if not hasattr(data, "columns") or column_name not in data.columns:
             return None
-        cursor = data.connection.execute(f"PRAGMA table_info({quote_ident(data.table_name)})")
-        for row in cursor.fetchall():
-            if row[1] == column_name:
-                type_str = str(row[2]).lower()
-                return _SQLITE_TYPE_MAP.get(type_str)
-        return None
+        idx = data.columns.index(column_name)
+        return DataType.from_arrow_type_safe(data.types[idx])
 
     def transform(
         self,

--- a/mloda_plugins/compute_framework/base_implementations/sqlite/sqlite_relation.py
+++ b/mloda_plugins/compute_framework/base_implementations/sqlite/sqlite_relation.py
@@ -2,6 +2,7 @@ import datetime
 import re
 import sqlite3
 import uuid
+from collections.abc import Sequence
 from typing import Any, Optional
 
 import pyarrow as pa
@@ -35,18 +36,18 @@ def _arrow_type_to_sqlite(arrow_type: pa.DataType) -> str:
 
 
 def _infer_sqlite_type_from_values(values: list[Any]) -> str:
+    non_null_values = [value for value in values if value is not None]
+    if not non_null_values:
+        return "TEXT"
+    if all(isinstance(value, (bytes, bytearray)) for value in non_null_values):
+        return "BLOB"
+
     result = "INTEGER"  # default when all non-None are bool/int
-    found_non_none = False
-    for v in values:
-        if v is None:
-            continue
-        found_non_none = True
+    for v in non_null_values:
         if not isinstance(v, (bool, int, float)):
             return "TEXT"  # TEXT dominates; safe to return early
         if isinstance(v, float) and result == "INTEGER":
             result = "REAL"  # REAL upgrades INTEGER but not TEXT
-    if not found_non_none:
-        return "TEXT"
     return result
 
 
@@ -59,6 +60,75 @@ def _sqlite_affinity_to_arrow_type(affinity: str) -> pa.DataType:
     if "BLOB" in upper:
         return pa.large_binary()
     return pa.string()
+
+
+def _infer_arrow_type_from_values(values: list[Any]) -> pa.DataType:
+    non_null_values = [value for value in values if value is not None]
+    if not non_null_values:
+        return pa.string()
+    if all(isinstance(value, bool) for value in non_null_values):
+        return pa.bool_()
+    if all(isinstance(value, datetime.datetime) for value in non_null_values):
+        return pa.timestamp("us")
+    if all(isinstance(value, datetime.date) and not isinstance(value, datetime.datetime) for value in non_null_values):
+        return pa.date32()
+    if all(isinstance(value, (bytes, bytearray)) for value in non_null_values):
+        return pa.large_binary()
+    if all(isinstance(value, (bool, int, float)) for value in non_null_values):
+        if any(isinstance(value, float) for value in non_null_values):
+            return pa.float64()
+        return pa.int64()
+    return pa.string()
+
+
+def _raw_sql_projection_starts_with_star(projection: str) -> bool:
+    return re.match(r"^\*\s*(?:,|$)", projection.lstrip()) is not None
+
+
+def _values_for_arrow_type(values: list[Any], arrow_type: pa.DataType) -> list[Any]:
+    if pa.types.is_boolean(arrow_type):
+        return [None if value is None else bool(value) for value in values]
+    if pa.types.is_timestamp(arrow_type):
+        return [datetime.datetime.fromisoformat(value) if isinstance(value, str) else value for value in values]
+    if pa.types.is_date(arrow_type):
+        return [datetime.date.fromisoformat(value) if isinstance(value, str) else value for value in values]
+    return values
+
+
+def _compatible_arrow_type(left_type: pa.DataType | None, right_type: pa.DataType | None) -> pa.DataType | None:
+    if left_type is None or right_type is None:
+        return None
+    if left_type == right_type:
+        return left_type
+    if pa.types.is_integer(left_type) and pa.types.is_integer(right_type):
+        if pa.types.is_signed_integer(left_type) or pa.types.is_signed_integer(right_type):
+            width = max(left_type.bit_width, right_type.bit_width)
+            if width <= 8:
+                return pa.int8()
+            if width <= 16:
+                return pa.int16()
+            if width <= 32:
+                return pa.int32()
+            return pa.int64()
+
+        width = max(left_type.bit_width, right_type.bit_width)
+        if width <= 8:
+            return pa.uint8()
+        if width <= 16:
+            return pa.uint16()
+        if width <= 32:
+            return pa.uint32()
+        return pa.uint64()
+    if pa.types.is_floating(left_type) and pa.types.is_floating(right_type):
+        return pa.float64() if max(left_type.bit_width, right_type.bit_width) > 32 else pa.float32()
+    if (
+        pa.types.is_integer(left_type)
+        and pa.types.is_floating(right_type)
+        or pa.types.is_floating(left_type)
+        and pa.types.is_integer(right_type)
+    ):
+        return pa.float64()
+    return left_type
 
 
 class SqliteRelation:
@@ -75,12 +145,19 @@ class SqliteRelation:
       user-controlled input.
     """
 
-    def __init__(self, connection: sqlite3.Connection, table_name: str, _is_view: bool = False) -> None:
+    def __init__(
+        self,
+        connection: sqlite3.Connection,
+        table_name: str,
+        _is_view: bool = False,
+        _types: Optional[Sequence[pa.DataType | None]] = None,
+    ) -> None:
         self._connection = connection
         self._table_name = table_name
         self._alias: Optional[str] = None
         self._is_view = _is_view
         self._cached_columns: Optional[list[str]] = None
+        self._cached_types: Optional[list[pa.DataType | None]] = list(_types) if _types is not None else None
 
     @property
     def connection(self) -> sqlite3.Connection:
@@ -97,29 +174,125 @@ class SqliteRelation:
             self._cached_columns = [desc[0] for desc in cursor.description]
         return self._cached_columns
 
+    @property
+    def types(self) -> list[pa.DataType]:
+        columns = self.columns
+        type_hints = self._types_for_current_columns()
+        if type_hints is not None:
+            return type_hints
+        type_map = self._sqlite_affinity_types_by_column()
+        return [type_map.get(column, pa.string()) for column in columns]
+
+    def _sqlite_affinity_types_by_column(self) -> dict[str, pa.DataType]:
+        cursor = self._connection.execute(f"PRAGMA table_info({quote_ident(self._table_name)})")
+        return {row[1]: _sqlite_affinity_to_arrow_type(str(row[2])) for row in cursor.fetchall()}
+
+    def _type_hints_for_current_columns(self) -> Optional[list[pa.DataType | None]]:
+        if self._cached_types is None or len(self._cached_types) != len(self.columns):
+            return None
+        return list(self._cached_types)
+
+    def _types_for_current_columns(self) -> Optional[list[pa.DataType]]:
+        type_hints = self._type_hints_for_current_columns()
+        if type_hints is None:
+            return None
+        if any(arrow_type is None for arrow_type in type_hints):
+            return self._types_with_inferred_unknown_hints(type_hints)
+        return [arrow_type for arrow_type in type_hints if arrow_type is not None]
+
+    def _types_with_inferred_unknown_hints(self, type_hints: list[pa.DataType | None]) -> list[pa.DataType]:
+        unknown_indexes = [idx for idx, arrow_type in enumerate(type_hints) if arrow_type is None]
+        values_by_index: dict[int, list[Any]] = {idx: [] for idx in unknown_indexes}
+        cursor = self._connection.execute(f"SELECT * FROM {quote_ident(self._table_name)}")  # nosec
+        for row in cursor.fetchall():
+            for idx in unknown_indexes:
+                values_by_index[idx].append(row[idx])
+
+        resolved_hints = list(type_hints)
+        for idx in unknown_indexes:
+            resolved_hints[idx] = _infer_arrow_type_from_values(values_by_index[idx])
+        self._cached_types = resolved_hints
+        return [arrow_type for arrow_type in resolved_hints if arrow_type is not None]
+
+    def _types_for_projection(self, columns: list[str]) -> Optional[list[pa.DataType | None]]:
+        current_type_hints = self._types_for_current_columns()
+        if current_type_hints is None:
+            return None
+        type_map = dict(zip(self.columns, current_type_hints, strict=True))
+        if any(column not in type_map for column in columns):
+            return None
+        return [type_map[column] for column in columns]
+
+    def _types_for_raw_sql_projection(
+        self, projection: str, output_columns: list[str]
+    ) -> Optional[list[pa.DataType | None]]:
+        if not _raw_sql_projection_starts_with_star(projection):
+            return None
+        source_columns = self.columns
+        source_type_hints = self._types_for_current_columns()
+        if source_type_hints is None or len(output_columns) < len(source_columns):
+            return None
+        if output_columns[: len(source_columns)] != source_columns:
+            return None
+        return source_type_hints + [None] * (len(output_columns) - len(source_columns))
+
+    @staticmethod
+    def _types_for_join_projection(
+        left_cols: list[str],
+        left_types: Optional[Sequence[pa.DataType | None]],
+        right_cols: list[str],
+        right_types: Optional[Sequence[pa.DataType | None]],
+        shared: set[str],
+        coalesce_shared: bool = False,
+    ) -> Optional[list[pa.DataType | None]]:
+        if left_types is None or right_types is None:
+            return None
+        left_type_map = dict(zip(left_cols, left_types, strict=True))
+        right_type_map = dict(zip(right_cols, right_types, strict=True))
+        output_types = [
+            _compatible_arrow_type(left_type_map[column], right_type_map[column])
+            if coalesce_shared and column in shared
+            else left_type_map[column]
+            for column in left_cols
+        ]
+        output_types.extend(right_type_map[column] for column in right_cols if column not in shared)
+        return output_types
+
     def filter(self, condition: str, params: tuple[Any, ...] = ()) -> "SqliteRelation":
         """Apply a filter condition using PEP 249 parameterized queries."""
         new_name = _next_table_name()
+        types = self._types_for_current_columns()
         sql = (
             f"CREATE TEMP TABLE {quote_ident(new_name)} AS "  # nosec
             f"SELECT * FROM {quote_ident(self._table_name)} WHERE {condition}"
         )
         self._connection.execute(sql, params)
-        return SqliteRelation(self._connection, new_name, _is_view=False)
+        return SqliteRelation(
+            self._connection,
+            new_name,
+            _is_view=False,
+            _types=types,
+        )
 
     def select(self, *columns: str, _raw_sql: Optional[str] = None) -> "SqliteRelation":
         """Project columns. _raw_sql bypasses quoting: never pass user-controlled input."""
         new_name = _next_table_name()
         if _raw_sql is not None:
             projection = _raw_sql
+            types: Optional[list[pa.DataType | None]] = None
         else:
             projection = ", ".join(quote_ident(c) for c in columns)
+            types = self._types_for_projection(list(columns))
         sql = f"CREATE TEMP VIEW {quote_ident(new_name)} AS SELECT {projection} FROM {quote_ident(self._table_name)}"  # nosec
         self._connection.execute(sql)
-        return SqliteRelation(self._connection, new_name, _is_view=True)
+        if _raw_sql is not None:
+            cursor = self._connection.execute(f"SELECT * FROM {quote_ident(new_name)} LIMIT 0")  # nosec
+            output_columns = [desc[0] for desc in cursor.description]
+            types = self._types_for_raw_sql_projection(projection, output_columns)
+        return SqliteRelation(self._connection, new_name, _is_view=True, _types=types)
 
     def set_alias(self, alias: str) -> "SqliteRelation":
-        rel = SqliteRelation(self._connection, self._table_name, self._is_view)
+        rel = SqliteRelation(self._connection, self._table_name, self._is_view, self._types_for_current_columns())
         rel._alias = alias
         return rel
 
@@ -128,11 +301,17 @@ class SqliteRelation:
 
     def limit(self, n: int) -> "SqliteRelation":
         new_name = _next_table_name()
+        types = self._types_for_current_columns()
         sql = (
             f"CREATE TEMP VIEW {quote_ident(new_name)} AS SELECT * FROM {quote_ident(self._table_name)} LIMIT {int(n)}"  # nosec
         )
         self._connection.execute(sql)
-        return SqliteRelation(self._connection, new_name, _is_view=True)
+        return SqliteRelation(
+            self._connection,
+            new_name,
+            _is_view=True,
+            _types=types,
+        )
 
     def drop(self) -> None:
         """Drop the underlying temp table or view."""
@@ -176,18 +355,23 @@ class SqliteRelation:
             sql_left_table = other._table_name
             sql_left_alias = other_alias
             sql_left_cols = other_cols
+            sql_left_types = other._types_for_current_columns()
             sql_right_table = self._table_name
             sql_right_alias = self_alias
             sql_right_cols = self_cols
+            sql_right_types = self._types_for_current_columns()
         else:
             sql_left_table = self._table_name
             sql_left_alias = self_alias
             sql_left_cols = self_cols
+            sql_left_types = self._types_for_current_columns()
             sql_right_table = other._table_name
             sql_right_alias = other_alias
             sql_right_cols = other_cols
+            sql_right_types = other._types_for_current_columns()
 
         projection = self._build_join_projection(sql_left_alias, sql_left_cols, sql_right_alias, sql_right_cols, shared)
+        types = self._types_for_join_projection(sql_left_cols, sql_left_types, sql_right_cols, sql_right_types, shared)
 
         sql = (
             f"CREATE TEMP VIEW {quote_ident(new_table)} AS "  # nosec
@@ -196,7 +380,7 @@ class SqliteRelation:
             f"ON {condition}"
         )
         self._connection.execute(sql)
-        return SqliteRelation(self._connection, new_table, _is_view=True)
+        return SqliteRelation(self._connection, new_table, _is_view=True, _types=types)
 
     def _full_outer_join(
         self,
@@ -236,9 +420,17 @@ class SqliteRelation:
             f"{where_clause}"
         )
 
+        types = self._types_for_join_projection(
+            self_cols,
+            self._types_for_current_columns(),
+            other_cols,
+            other._types_for_current_columns(),
+            shared,
+            coalesce_shared=True,
+        )
         sql = f"CREATE TEMP VIEW {quote_ident(new_table)} AS {left_sql} UNION ALL {right_sql}"
         self._connection.execute(sql)
-        return SqliteRelation(self._connection, new_table, _is_view=True)
+        return SqliteRelation(self._connection, new_table, _is_view=True, _types=types)
 
     @staticmethod
     def _build_join_projection(
@@ -266,7 +458,9 @@ class SqliteRelation:
 
     def append_column(self, name: str, values: list[Any]) -> "SqliteRelation":
         """Return a new relation with an additional column appended positionally."""
+        current_types = self._types_for_current_columns()
         new_col_rel = SqliteRelation.from_dict(self._connection, {name: values})
+        new_col_types = new_col_rel._types_for_current_columns()
         rn = "__mloda_rn__"
         qrn = quote_ident(rn)
         left_name = _next_table_name()
@@ -293,7 +487,8 @@ class SqliteRelation:
             f"INNER JOIN {quote_ident(right_name)} "
             f"ON {quote_ident(left_name)}.{qrn} = {quote_ident(right_name)}.{qrn}"
         )
-        return SqliteRelation(self._connection, result_name, _is_view=True)
+        types = current_types + new_col_types if current_types is not None and new_col_types is not None else None
+        return SqliteRelation(self._connection, result_name, _is_view=True, _types=types)
 
     def to_arrow_table(self) -> pa.Table:
         cursor = self._connection.execute(f"SELECT * FROM {quote_ident(self._table_name)}")  # nosec
@@ -301,9 +496,7 @@ class SqliteRelation:
         rows = cursor.fetchall()
 
         if not rows:
-            pragma_cursor = self._connection.execute(f"PRAGMA table_info({quote_ident(self._table_name)})")
-            type_map = {row[1]: row[2] for row in pragma_cursor.fetchall()}
-            arrays = [pa.array([], type=_sqlite_affinity_to_arrow_type(type_map.get(c, "TEXT"))) for c in cols]
+            arrays = [pa.array([], type=arrow_type) for arrow_type in self.types]
             return pa.table(dict(zip(cols, arrays)))
 
         col_data: dict[str, list[Any]] = {c: [] for c in cols}
@@ -311,7 +504,14 @@ class SqliteRelation:
             for c, val in zip(cols, row):
                 col_data[c].append(val)
 
-        return pa.table(col_data)
+        type_hints = self._types_for_current_columns()
+        if type_hints is None:
+            return pa.table(col_data)
+
+        arrays = []
+        for column, arrow_type in zip(cols, type_hints, strict=True):
+            arrays.append(pa.array(_values_for_arrow_type(col_data[column], arrow_type), type=arrow_type))
+        return pa.table(dict(zip(cols, arrays, strict=True)))
 
     def df(self) -> Any:
         return self.to_arrow_table().to_pandas()
@@ -337,7 +537,7 @@ class SqliteRelation:
             rows = list(zip(*(col.to_pylist() for col in arrow_table.columns)))
             connection.executemany(insert_sql, rows)
 
-        return cls(connection, table_name)
+        return cls(connection, table_name, _types=list(arrow_table.schema.types))
 
     @classmethod
     def from_dict(cls, connection: sqlite3.Connection, data: dict[str, list[Any]]) -> "SqliteRelation":
@@ -347,7 +547,8 @@ class SqliteRelation:
         if not cols:
             raise ValueError("Cannot create relation from empty dictionary")
 
-        col_defs = ", ".join(f"{quote_ident(c)} {_infer_sqlite_type_from_values(data[c])}" for c in cols)
+        sqlite_types = {column: _infer_sqlite_type_from_values(data[column]) for column in cols}
+        col_defs = ", ".join(f"{quote_ident(c)} {sqlite_types[c]}" for c in cols)
         connection.execute(f"CREATE TEMP TABLE {quote_ident(table_name)} ({col_defs})")
 
         num_rows = len(data[cols[0]])
@@ -362,4 +563,5 @@ class SqliteRelation:
                 rows.append(row)
             connection.executemany(insert_sql, rows)
 
-        return cls(connection, table_name)
+        types = [_infer_arrow_type_from_values(data[column]) for column in cols]
+        return cls(connection, table_name, _types=types)

--- a/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_relation.py
+++ b/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_relation.py
@@ -42,6 +42,24 @@ class TestDuckdbRelation(RelationTestMixin):
     def get_column_values(self, result: Any, column: str) -> list[Any]:
         return result.df()[column].tolist()  # type: ignore[no-any-return]
 
+    def test_types_exposes_relation_types_aligned_with_columns(self, connection: Any) -> None:
+        arrow = pa.table(
+            {
+                "id": pa.array([1, 2], type=pa.int64()),
+                "score": pa.array([1.5, 2.5], type=pa.float64()),
+                "name": pa.array(["Alice", "Bob"], type=pa.string()),
+                "flag": pa.array([True, False], type=pa.bool_()),
+            }
+        )
+        rel = DuckdbRelation.from_arrow(connection, arrow)
+
+        assert list(zip(rel.columns, (str(dtype) for dtype in rel.types), strict=True)) == [
+            ("id", "BIGINT"),
+            ("score", "DOUBLE"),
+            ("name", "VARCHAR"),
+            ("flag", "BOOLEAN"),
+        ]
+
     # --- Select ---
 
     def test_select_raw_sql_expression(self, sample_relation: "DuckdbRelation") -> None:

--- a/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_framework.py
+++ b/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_framework.py
@@ -4,8 +4,7 @@ from typing import Any, Optional
 import pyarrow as pa
 import pytest
 
-from mloda.user import FeatureName
-from mloda.user import ParallelizationMode
+from mloda.user import DataType, FeatureName, ParallelizationMode
 from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_framework import SqliteFramework, _regexp
 from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_relation import SqliteRelation
 from tests.test_plugins.compute_framework.test_tooling.dataframe_test_base import DataFrameTestBase
@@ -192,6 +191,22 @@ class TestSqliteDtypeExtraction(DtypeExtractionTestMixin):
             {"int_col": [1, 2, 3], "str_col": ["a", "b", "c"], "float_col": [1.0, 2.0, 3.0]}
         )
         return SqliteRelation.from_arrow(connection, arrow_table)
+
+    def test_extract_raw_sql_expression_column_data_type_is_numeric(
+        self, connection: sqlite3.Connection, framework_instance: SqliteFramework
+    ) -> None:
+        rel = SqliteRelation.from_arrow(connection, pa.table({"id": pa.array([1, 2], type=pa.int32())}))
+        projected = rel.select(_raw_sql="*, id + 1 AS next_id")
+        materialized_type = projected.to_arrow_table().schema.field("next_id").type
+
+        assert pa.types.is_integer(materialized_type)
+        assert {
+            "dtype": framework_instance._extract_column_dtype(projected, "next_id"),
+            "data_type": framework_instance._extract_column_data_type(projected, "next_id"),
+        } == {
+            "dtype": str(materialized_type),
+            "data_type": DataType.INT64,
+        }
 
 
 class TestSqliteDataTypeValidator(DataTypeValidatorFrameworkTestMixin):

--- a/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_relation.py
+++ b/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_relation.py
@@ -37,6 +37,173 @@ class TestSqliteRelation(RelationTestMixin):
         values: list[Any] = result.df()[column].tolist()
         return values
 
+    def test_types_exposes_arrow_schema_from_arrow_aligned_with_columns(self, connection: sqlite3.Connection) -> None:
+        arrow = pa.table(
+            {
+                "id": pa.array([1, 2], type=pa.int64()),
+                "score": pa.array([1.5, 2.5], type=pa.float64()),
+                "name": pa.array(["Alice", "Bob"], type=pa.string()),
+                "flag": pa.array([True, False], type=pa.bool_()),
+            }
+        )
+        rel = SqliteRelation.from_arrow(connection, arrow)
+
+        assert list(zip(rel.columns, rel.types, strict=True)) == [
+            ("id", pa.int64()),
+            ("score", pa.float64()),
+            ("name", pa.string()),
+            ("flag", pa.bool_()),
+        ]
+
+    def test_to_arrow_table_preserves_arrow_schema_for_non_empty_from_arrow(
+        self, connection: sqlite3.Connection
+    ) -> None:
+        arrow = pa.table(
+            {
+                "id": pa.array([1, 2], type=pa.int32()),
+                "score": pa.array([1.5, 2.5], type=pa.float32()),
+                "flag": pa.array([True, False], type=pa.bool_()),
+            }
+        )
+        rel = SqliteRelation.from_arrow(connection, arrow)
+
+        result = rel.to_arrow_table()
+        flag_values = result.column("flag").to_pylist()
+
+        assert {
+            "schema": result.schema,
+            "flag_value_types": [type(value) for value in flag_values],
+            "flag_values": flag_values,
+        } == {
+            "schema": arrow.schema,
+            "flag_value_types": [bool, bool],
+            "flag_values": [True, False],
+        }
+
+    def test_raw_sql_star_projection_preserves_passthrough_arrow_types(self, connection: sqlite3.Connection) -> None:
+        timestamps = [
+            datetime.datetime(2024, 1, 1, 12, 0, 0, 123456),
+            datetime.datetime(2024, 1, 2, 13, 30, 0, 654321),
+        ]
+        arrow = pa.table(
+            {
+                "id": pa.array([1, 2], type=pa.int32()),
+                "flag": pa.array([True, False], type=pa.bool_()),
+                "ts": pa.array(timestamps, type=pa.timestamp("us")),
+            }
+        )
+        rel = SqliteRelation.from_arrow(connection, arrow)
+
+        projected = rel.select(_raw_sql="*, id + 1 AS next_id")
+        result = projected.to_arrow_table()
+
+        projected_types_by_name = dict(zip(projected.columns, projected.types, strict=True))
+        next_id_relation_type = projected_types_by_name["next_id"]
+        next_id_materialized_type = result.schema.field("next_id").type
+        flag_values = result.column("flag").to_pylist()
+
+        assert {
+            "projected_passthrough_types": [projected_types_by_name[column] for column in arrow.column_names],
+            "materialized_passthrough_types": [result.schema.field(column).type for column in arrow.column_names],
+            "next_id_relation_type": next_id_relation_type,
+            "next_id_materialized_type": next_id_materialized_type,
+            "next_id_relation_is_string": pa.types.is_string(next_id_relation_type),
+            "next_id_relation_is_numeric": pa.types.is_integer(next_id_relation_type)
+            or pa.types.is_floating(next_id_relation_type),
+            "flag_values": flag_values,
+            "flag_value_types": [type(value) for value in flag_values],
+            "ts_values": result.column("ts").to_pylist(),
+        } == {
+            "projected_passthrough_types": [pa.int32(), pa.bool_(), pa.timestamp("us")],
+            "materialized_passthrough_types": [pa.int32(), pa.bool_(), pa.timestamp("us")],
+            "next_id_relation_type": next_id_materialized_type,
+            "next_id_materialized_type": pa.int64(),
+            "next_id_relation_is_string": False,
+            "next_id_relation_is_numeric": True,
+            "flag_values": [True, False],
+            "flag_value_types": [bool, bool],
+            "ts_values": timestamps,
+        }
+
+    def test_raw_sql_expression_type_survives_empty_filter(self, connection: sqlite3.Connection) -> None:
+        rel = SqliteRelation.from_arrow(
+            connection,
+            pa.table({"id": pa.array([1, 2], type=pa.int32())}),
+        )
+
+        projected = rel.select(_raw_sql="*, id + 1 AS next_id")
+        empty = projected.filter("id > ?", (10,))
+        types_by_name = dict(zip(empty.columns, empty.types, strict=True))
+        result = empty.to_arrow_table()
+
+        assert {
+            "row_count": result.num_rows,
+            "relation_next_id_type": types_by_name["next_id"],
+            "arrow_next_id_type": result.schema.field("next_id").type,
+        } == {
+            "row_count": 0,
+            "relation_next_id_type": pa.int64(),
+            "arrow_next_id_type": pa.int64(),
+        }
+
+    def test_append_column_preserves_bool_arrow_type(self, connection: sqlite3.Connection) -> None:
+        base = SqliteRelation.from_arrow(connection, pa.table({"id": pa.array([1, 2], type=pa.int32())}))
+
+        result = base.append_column("flag", [True, False])
+        arrow = result.to_arrow_table()
+        types_by_name = dict(zip(result.columns, result.types, strict=True))
+        flag_values = arrow.column("flag").to_pylist()
+
+        assert {
+            "relation_flag_type": types_by_name["flag"],
+            "arrow_flag_type": arrow.schema.field("flag").type,
+            "flag_values": flag_values,
+            "flag_value_types": [type(value) for value in flag_values],
+        } == {
+            "relation_flag_type": pa.bool_(),
+            "arrow_flag_type": pa.bool_(),
+            "flag_values": [True, False],
+            "flag_value_types": [bool, bool],
+        }
+
+    def test_from_dict_preserves_bytes_as_large_binary(self, connection: sqlite3.Connection) -> None:
+        rel = SqliteRelation.from_dict(connection, {"payload": [b"abc", b"\xff\x00"]})
+        expected_type = pa.large_binary()
+
+        types_by_name = dict(zip(rel.columns, rel.types, strict=True))
+        assert types_by_name["payload"] == expected_type
+
+        arrow = rel.to_arrow_table()
+        assert arrow.schema.field("payload").type == expected_type
+        assert arrow.column("payload").to_pylist() == [b"abc", b"\xff\x00"]
+
+    def test_raw_sql_all_null_expression_type_is_order_independent(self, connection: sqlite3.Connection) -> None:
+        rel = SqliteRelation.from_arrow(connection, pa.table({"id": pa.array([1, 2], type=pa.int32())}))
+
+        materialized_first = rel.select(_raw_sql="*, NULL AS empty_value")
+        materialized_first_arrow = materialized_first.to_arrow_table()
+        materialized_first_types = dict(zip(materialized_first.columns, materialized_first.types, strict=True))
+
+        types_first = rel.select(_raw_sql="*, NULL AS empty_value")
+        types_first_types = dict(zip(types_first.columns, types_first.types, strict=True))
+        types_first_arrow = types_first.to_arrow_table()
+
+        assert {
+            "materialized_first_relation_type": materialized_first_types["empty_value"],
+            "materialized_first_arrow_type": materialized_first_arrow.schema.field("empty_value").type,
+            "types_first_relation_type": types_first_types["empty_value"],
+            "types_first_arrow_type": types_first_arrow.schema.field("empty_value").type,
+            "materialized_first_values": materialized_first_arrow.column("empty_value").to_pylist(),
+            "types_first_values": types_first_arrow.column("empty_value").to_pylist(),
+        } == {
+            "materialized_first_relation_type": pa.string(),
+            "materialized_first_arrow_type": pa.string(),
+            "types_first_relation_type": pa.string(),
+            "types_first_arrow_type": pa.string(),
+            "materialized_first_values": [None, None],
+            "types_first_values": [None, None],
+        }
+
     def test_drop_removes_table(self, sample_relation: SqliteRelation) -> None:
         """drop() should drop the underlying temp table so it can no longer be queried."""
         table_name = sample_relation.table_name
@@ -65,6 +232,25 @@ class TestSqliteRelation(RelationTestMixin):
         assert pa.types.is_string(result.schema.field("name").type) or pa.types.is_large_string(
             result.schema.field("name").type
         ), f"Expected string type for 'name', got {result.schema.field('name').type}"
+
+    def test_outer_join_shared_key_uses_wider_right_dtype(self, connection: sqlite3.Connection) -> None:
+        right_only_idx = 2**40
+        left = SqliteRelation.from_arrow(connection, pa.table({"idx": pa.array([1], type=pa.int32())}))
+        right = SqliteRelation.from_arrow(connection, pa.table({"idx": pa.array([right_only_idx], type=pa.int64())}))
+
+        result = left.join(right, "idx", how="outer")
+        arrow = result.to_arrow_table()
+        types_by_name = dict(zip(result.columns, result.types, strict=True))
+
+        assert {
+            "relation_idx_type": types_by_name["idx"],
+            "arrow_idx_type": arrow.schema.field("idx").type,
+            "idx_values": sorted(arrow.column("idx").to_pylist()),
+        } == {
+            "relation_idx_type": pa.int64(),
+            "arrow_idx_type": pa.int64(),
+            "idx_values": [1, right_only_idx],
+        }
 
     def test_join_with_sql_injection_alias(self, connection: sqlite3.Connection) -> None:
         """A crafted alias must not be interpreted as SQL."""


### PR DESCRIPTION
Closes #456

## Why this is more than a thin property wrapper
DuckDB already exposes backend types on the underlying relation, so its public accessor is direct. SQLite is different: reducing `from_arrow` input to `PRAGMA table_info` / declared affinity loses source Arrow detail, including the `bool -> INTEGER` case called out in #456.

This PR keeps the PRAGMA-derived result as a fallback for SQLite-only relations, but preserves source Arrow type hints when mloda already has them. For columns with preserved hints, `.types` supports downstream validation without requiring private relation access, SQLite-specific SQL, or relation materialization; unknown SQLite expression columns still use best-effort inference.

## Summary
- Add public `DuckdbRelation.types` and `SqliteRelation.types` accessors aligned with `.columns`.
- Update DuckDB and SQLite framework dtype extraction to use those public relation accessors.
- Preserve SQLite Arrow type hints from `from_arrow` / `from_dict` through schema materialization, raw SQL star projections, appended columns, empty derived relations, and full outer joins.
- Keep PRAGMA-derived SQLite affinities as a best-effort fallback when no source schema hint exists.

## Validation
- `uv run pytest tests/test_plugins/compute_framework/base_implementations/duckdb tests/test_plugins/compute_framework/base_implementations/sqlite -q` -> `384 passed, 6 skipped`
- `.tox\python313\Scripts\python.exe -m pytest tests/test_plugins/compute_framework/base_implementations/duckdb tests/test_plugins/compute_framework/base_implementations/sqlite -q` -> `384 passed, 6 skipped`
- `uv run ruff format --check --line-length 120 <changed files>` -> `7 files already formatted`
- `uv run ruff check --line-length 120 <changed files>` -> `All checks passed`
- `uv run mypy --strict --ignore-missing-imports <changed files>` -> `Success: no issues found in 7 source files`
- `git diff --check` -> passed
- `uv run bandit -c pyproject.toml -r -q .` -> passed
- `uv run pip-licenses --ignore-packages matplotlib-inline --allow-only=<tox.ini allowlist>` -> passed

I also attempted full `tox -e python313` on Windows. It reached the full pytest suite after adding Git Bash `sh`, but failed before later tox steps on Windows-environment issues outside the changed DuckDB/SQLite modules: docs markdown decoding under the `gbk` locale, an existing Windows path used as a pytest regex, and xdist worker crashes in unrelated tests.

## Maintainer note
This is intentionally broader than a thin accessor because #456 allows retaining the source Arrow schema instead of using a PRAGMA-only best-effort fallback for SQLite. I can narrow or split the PR if you prefer to land only the minimal accessor first.
