### PR TITLE
minor: make pyarrow an optional dependency

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,8 @@ jobs:
             toxenv: "-e python313"
           - python-version: "3.14"
             toxenv: "-e python314"
+          - python-version: "3.12"
+            toxenv: "-e nopyarrow"
 
     steps:
     - uses: actions/checkout@v4

--- a/mloda/core/abstract_plugins/components/data_types.py
+++ b/mloda/core/abstract_plugins/components/data_types.py
@@ -1,8 +1,14 @@
+from __future__ import annotations
+
 import datetime
 import decimal
 from enum import Enum
 from typing import Any, Optional
-import pyarrow as pa
+
+try:
+    import pyarrow as pa
+except ImportError:
+    pa = None  # type: ignore[assignment]
 
 
 class DataType(Enum):
@@ -65,9 +71,9 @@ class DataType(Enum):
             return cls.DATE
         elif isinstance(value, decimal.Decimal):
             return cls.DECIMAL
-        elif isinstance(value, pa.Date32Scalar) or isinstance(value, pa.Date32Array):
+        elif pa is not None and (isinstance(value, pa.Date32Scalar) or isinstance(value, pa.Date32Array)):
             return cls.DATE
-        elif isinstance(value, pa.TimestampScalar) or isinstance(value, pa.TimestampArray):
+        elif pa is not None and (isinstance(value, pa.TimestampScalar) or isinstance(value, pa.TimestampArray)):
             return cls.TIMESTAMP_MICROS
         else:
             raise ValueError(f"Unsupported data type: {type(value)}")

--- a/mloda/core/abstract_plugins/components/data_types.py
+++ b/mloda/core/abstract_plugins/components/data_types.py
@@ -11,6 +11,13 @@ except ImportError:
     pa = None  # type: ignore[assignment]
 
 
+def _require_pyarrow() -> None:
+    if pa is None:
+        raise ImportError(
+            "pyarrow is required for Arrow type conversions. Install it with: pip install 'mloda[pyarrow]'"
+        )
+
+
 class DataType(Enum):
     """
     These enums are based on arrow data types, which are found in the parquet file format,
@@ -89,6 +96,7 @@ class DataType(Enum):
         Returns:
             pa.DataType: The corresponding PyArrow DataType.
         """
+        _require_pyarrow()
         mapping = {
             cls.INT32: pa.int32(),
             cls.INT64: pa.int64(),
@@ -110,6 +118,7 @@ class DataType(Enum):
 
     @classmethod
     def _arrow_type_to_dtype_or_none(cls, arrow_type: pa.DataType) -> Optional["DataType"]:
+        _require_pyarrow()
         if pa.types.is_int32(arrow_type):
             return cls.INT32
         elif pa.types.is_int64(arrow_type):

--- a/mloda/core/abstract_plugins/compute_framework.py
+++ b/mloda/core/abstract_plugins/compute_framework.py
@@ -6,12 +6,6 @@ from mloda.core.abstract_plugins.components.framework_transformer.cfw_transforme
     ComputeFrameworkTransformer,
 )
 from mloda.core.abstract_plugins.components.merge.base_merge_engine import BaseMergeEngine
-
-try:
-    import pyarrow as pa
-except ImportError:
-    pa = None  # type: ignore[assignment]
-
 from mloda.core.abstract_plugins.function_extender import (
     Extender,
     ExtenderHook,
@@ -22,6 +16,16 @@ from mloda.core.abstract_plugins.components.parallelization_modes import Paralle
 from mloda.core.filter.filter_engine import BaseFilterEngine
 from mloda.core.abstract_plugins.components.mask.base_mask_engine import BaseMaskEngine
 from mloda.core.runtime.flight.flight_server import FlightServer
+
+try:
+    import pyarrow as pa
+except ImportError:
+    pa = None  # type: ignore[assignment]
+
+
+def _require_pyarrow() -> None:
+    if pa is None:
+        raise ImportError("pyarrow is required for this operation. Install it with: pip install 'mloda[pyarrow]'")
 
 
 class ComputeFramework(ABC):
@@ -674,6 +678,7 @@ Available join types:
 
     @final
     def upload_table(self, location: str, object_id: Optional[UUID] = None) -> str:
+        _require_pyarrow()
         if object_id is None:
             object_id = uuid4()
         _object_id = str(object_id)

--- a/mloda/core/abstract_plugins/compute_framework.py
+++ b/mloda/core/abstract_plugins/compute_framework.py
@@ -6,7 +6,11 @@ from mloda.core.abstract_plugins.components.framework_transformer.cfw_transforme
     ComputeFrameworkTransformer,
 )
 from mloda.core.abstract_plugins.components.merge.base_merge_engine import BaseMergeEngine
-import pyarrow as pa
+
+try:
+    import pyarrow as pa
+except ImportError:
+    pa = None  # type: ignore[assignment]
 
 from mloda.core.abstract_plugins.function_extender import (
     Extender,
@@ -675,7 +679,7 @@ Available join types:
         _object_id = str(object_id)
 
         # transform to pa.Table for better parquet support
-        if not isinstance(self.data, pa.Table):
+        if pa is None or not isinstance(self.data, pa.Table):
             _from_fw = type(self.data)
             _to_fw = pa.Table
 
@@ -690,7 +694,7 @@ Available join types:
     @final
     @classmethod
     def convert_flight_server_data_back(cls, data: Any, transformer: ComputeFrameworkTransformer) -> Any:
-        if not isinstance(data, pa.Table):
+        if pa is None or not isinstance(data, pa.Table):
             return data
         if isinstance(data, cls.expected_data_framework()):
             return data

--- a/mloda/core/abstract_plugins/plugin_loader/plugin_loader.py
+++ b/mloda/core/abstract_plugins/plugin_loader/plugin_loader.py
@@ -65,7 +65,10 @@ class PluginLoader:
                 continue
             relative_path = item.relative_to(group_path.parent).with_suffix("")
             module_path = ".".join(relative_path.parts)
-            self._load_plugin(module_path)
+            try:
+                self._load_plugin(module_path)
+            except ModuleNotFoundError:
+                continue
 
     def load_group(self, group_name: str) -> None:
         """

--- a/mloda/core/abstract_plugins/plugin_loader/plugin_loader.py
+++ b/mloda/core/abstract_plugins/plugin_loader/plugin_loader.py
@@ -65,10 +65,7 @@ class PluginLoader:
                 continue
             relative_path = item.relative_to(group_path.parent).with_suffix("")
             module_path = ".".join(relative_path.parts)
-            try:
-                self._load_plugin(module_path)
-            except ModuleNotFoundError:
-                continue
+            self._load_plugin(module_path)
 
     def load_group(self, group_name: str) -> None:
         """
@@ -101,7 +98,14 @@ class PluginLoader:
             self._add_plugin_to_graph(full_module_name)
             return
 
-        module = importlib.import_module(full_module_name)
+        try:
+            module = importlib.import_module(full_module_name)
+        except ModuleNotFoundError as e:
+            if e.name and (e.name == self.base_package or e.name.startswith(self.base_package + ".")):
+                raise
+            logger.debug("Skipping plugin %s: missing optional dependency %s", full_module_name, e.name)
+            return
+
         self.plugins[full_module_name] = module
         self._add_plugin_to_graph(full_module_name)
 

--- a/mloda/core/abstract_plugins/plugin_loader/plugin_loader.py
+++ b/mloda/core/abstract_plugins/plugin_loader/plugin_loader.py
@@ -8,6 +8,30 @@ from typing import ClassVar, Optional
 
 logger = logging.getLogger(__name__)
 
+# Missing modules NOT in this set are treated as genuine errors and re-raised; the set is intentionally
+# generous because under-inclusion breaks `tox -e nopyarrow`, while over-inclusion is harmless (it only
+# ever causes a skip when that dependency is genuinely absent).
+OPTIONAL_PLUGIN_DEPENDENCIES: frozenset[str] = frozenset(
+    {
+        "pyarrow",
+        "pandas",
+        "polars",
+        "numpy",
+        "scipy",
+        "duckdb",
+        "pyiceberg",
+        "pyspark",
+        "opentelemetry",
+        "sklearn",
+        "joblib",
+        "nltk",
+        "anthropic",
+        "openai",
+        "google",
+        "yaml",
+    }
+)
+
 
 class PluginLoader:
     _disabled_groups: ClassVar[set[str]] = set()
@@ -103,8 +127,11 @@ class PluginLoader:
         except ModuleNotFoundError as e:
             if e.name and (e.name == self.base_package or e.name.startswith(self.base_package + ".")):
                 raise
-            logger.debug("Skipping plugin %s: missing optional dependency %s", full_module_name, e.name)
-            return
+            root = e.name.split(".")[0] if e.name else None
+            if root in OPTIONAL_PLUGIN_DEPENDENCIES:
+                logger.debug("Skipping plugin %s: missing optional dependency %s", full_module_name, e.name)
+                return
+            raise
 
         self.plugins[full_module_name] = module
         self._add_plugin_to_graph(full_module_name)

--- a/mloda/core/runtime/flight/flight_server.py
+++ b/mloda/core/runtime/flight/flight_server.py
@@ -1,7 +1,12 @@
 from typing import Any
 from uuid import uuid4
-from pyarrow import flight
-import pyarrow as pa
+
+try:
+    from pyarrow import flight
+    import pyarrow as pa
+except ImportError:
+    flight = None
+    pa = None  # type: ignore[assignment]
 import os
 
 import logging
@@ -13,8 +18,20 @@ def create_location(host: str = "127.0.0.1") -> str:
     return f"grpc://{host}:0"
 
 
-class FlightServer(flight.FlightServerBase):  # type: ignore[misc]
+def _require_pyarrow_flight() -> None:
+    if flight is None:
+        raise ImportError(
+            "pyarrow is required for Flight-based (multiprocessing/distributed) data transport. "
+            "Install it with: pip install 'mloda[pyarrow]'"
+        )
+
+
+_FlightServerBase: Any = flight.FlightServerBase if flight is not None else object
+
+
+class FlightServer(_FlightServerBase):  # type: ignore[misc]
     def __init__(self, location: Any = create_location()) -> None:
+        _require_pyarrow_flight()
         self.tables: dict[str, Any] = {}  # Dictionary to store tables
         self.location = location
 
@@ -41,6 +58,7 @@ class FlightServer(flight.FlightServerBase):  # type: ignore[misc]
 
     @staticmethod
     def upload_table(location: str, table: Any, table_key: str) -> None:
+        _require_pyarrow_flight()
         with flight.FlightClient(location) as client:
             descriptor = flight.FlightDescriptor.for_path(table_key)
             writer, _ = client.do_put(descriptor, table.schema)
@@ -65,6 +83,7 @@ class FlightServer(flight.FlightServerBase):  # type: ignore[misc]
 
     @staticmethod
     def download_table(location: str, table_key: Any) -> Any:
+        _require_pyarrow_flight()
         with flight.FlightClient(location) as client:
             ticket = flight.Ticket(table_key.encode("utf-8"))
             reader = client.do_get(ticket)
@@ -85,6 +104,7 @@ class FlightServer(flight.FlightServerBase):  # type: ignore[misc]
 
     @staticmethod
     def drop_tables(location: str, table_key: set[str]) -> None:
+        _require_pyarrow_flight()
         with flight.FlightClient(location) as client:
             for key in table_key:
                 action = flight.Action("drop_table", key.encode("utf-8"))
@@ -93,6 +113,7 @@ class FlightServer(flight.FlightServerBase):  # type: ignore[misc]
 
     @staticmethod
     def sent_shutdown_signal(location: str) -> None:
+        _require_pyarrow_flight()
         with flight.FlightClient(location) as client:
             action = flight.Action("shutdown", b"")
             for _ in client.do_action(action):
@@ -109,6 +130,7 @@ class FlightServer(flight.FlightServerBase):  # type: ignore[misc]
 
     @staticmethod
     def list_flight_infos(location: str) -> set[str]:
+        _require_pyarrow_flight()
         with flight.FlightClient(location) as client:
             flight_infos = {x.descriptor.path[0] for x in client.list_flights()}
         client.close()

--- a/mloda/core/runtime/flight/runner_flight_server.py
+++ b/mloda/core/runtime/flight/runner_flight_server.py
@@ -9,7 +9,7 @@ from typing import Any
 import logging
 
 from mloda.core.abstract_plugins.components.error_utils import internal_invariant_error
-from mloda.core.runtime.flight.flight_server import FlightServer, create_location
+from mloda.core.runtime.flight.flight_server import FlightServer, create_location, _require_pyarrow_flight
 from mloda.core.runtime.mp_context import mp_spawn_context
 
 logger = logging.getLogger(__name__)
@@ -31,6 +31,7 @@ class ParallelRunnerFlightServer:
         flight_server.serve()
 
     def start_flight_server_process(self) -> None:
+        _require_pyarrow_flight()
         if not self.flight_server_process:
             location = create_location()
             ctx = mp_spawn_context()

--- a/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_framework.py
@@ -15,6 +15,11 @@ try:
 except ImportError:
     duckdb = None  # type: ignore[assignment]
 
+try:
+    import pyarrow as pa
+except ImportError:
+    pa = None  # type: ignore[assignment]
+
 logger = logging.getLogger(__name__)
 
 
@@ -138,9 +143,11 @@ class DuckDBFramework(ComputeFramework):
 
         if isinstance(data, dict):
             """Initial data: Transform dict to DuckDB relation"""
-            # Convert dict to PyArrow first, then to DuckDB relation
-            import pyarrow as pa
-
+            if pa is None:
+                raise ImportError(
+                    "pyarrow is required to build a DuckDB relation from a dict. "
+                    "Install it with: pip install 'mloda[duckdb]'"
+                )
             arrow_table = pa.Table.from_pydict(data)
 
             if self.framework_connection_object is None:

--- a/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_relation.py
+++ b/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_relation.py
@@ -271,6 +271,11 @@ class DuckdbRelation:
 
     @classmethod
     def from_dict(cls, connection: duckdb.DuckDBPyConnection, data: dict[str, list[Any]]) -> "DuckdbRelation":
+        if pa is None:
+            raise ImportError(
+                "pyarrow is required to build a DuckDB relation from a dict. "
+                "Install it with: pip install 'mloda[duckdb]'"
+            )
         if not data:
             raise ValueError("Cannot create relation from empty dictionary")
         arrow_table = pa.table(data)

--- a/mloda_plugins/feature_group/input_data/read_files/csv.py
+++ b/mloda_plugins/feature_group/input_data/read_files/csv.py
@@ -1,6 +1,9 @@
 from typing import Any
 
-from pyarrow import csv as pyarrow_csv
+try:
+    from pyarrow import csv as pyarrow_csv
+except ImportError:
+    pyarrow_csv = None
 
 from mloda.provider import FeatureSet
 from mloda_plugins.feature_group.input_data.read_file import ReadFile
@@ -155,6 +158,8 @@ class CsvReader(ReadFile):
 
     @classmethod
     def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
+        if pyarrow_csv is None:
+            raise ImportError("pyarrow is required to read CSV files. Install it with: pip install 'mloda[pyarrow]'")
         result = pyarrow_csv.read_csv(data_access)
         return result.select(list(features.get_all_names()))
 

--- a/mloda_plugins/feature_group/input_data/read_files/feather.py
+++ b/mloda_plugins/feature_group/input_data/read_files/feather.py
@@ -1,6 +1,9 @@
 from typing import Any
 
-from pyarrow import feather as pyarrow_feather
+try:
+    from pyarrow import feather as pyarrow_feather
+except ImportError:
+    pyarrow_feather = None
 
 from mloda.provider import FeatureSet
 from mloda_plugins.feature_group.input_data.read_file import ReadFile
@@ -106,4 +109,8 @@ class FeatherReader(ReadFile):
 
     @classmethod
     def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
+        if pyarrow_feather is None:
+            raise ImportError(
+                "pyarrow is required to read Feather files. Install it with: pip install 'mloda[pyarrow]'"
+            )
         return pyarrow_feather.read_table(source=data_access, columns=list(features.get_all_names()))

--- a/mloda_plugins/feature_group/input_data/read_files/json.py
+++ b/mloda_plugins/feature_group/input_data/read_files/json.py
@@ -1,6 +1,9 @@
 from typing import Any
 
-from pyarrow import json as pyarrow_json
+try:
+    from pyarrow import json as pyarrow_json
+except ImportError:
+    pyarrow_json = None
 
 from mloda.provider import FeatureSet
 from mloda_plugins.feature_group.input_data.read_file import ReadFile
@@ -124,6 +127,8 @@ class JsonReader(ReadFile):
 
     @classmethod
     def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
+        if pyarrow_json is None:
+            raise ImportError("pyarrow is required to read JSON files. Install it with: pip install 'mloda[pyarrow]'")
         result = pyarrow_json.read_json(
             data_access,
             parse_options=pyarrow_json.ParseOptions(

--- a/mloda_plugins/feature_group/input_data/read_files/orc.py
+++ b/mloda_plugins/feature_group/input_data/read_files/orc.py
@@ -1,6 +1,9 @@
 from typing import Any
 
-from pyarrow import orc as pyarrow_orc
+try:
+    from pyarrow import orc as pyarrow_orc
+except ImportError:
+    pyarrow_orc = None
 
 from mloda.provider import FeatureSet
 from mloda_plugins.feature_group.input_data.read_file import ReadFile
@@ -106,4 +109,6 @@ class OrcReader(ReadFile):
 
     @classmethod
     def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
+        if pyarrow_orc is None:
+            raise ImportError("pyarrow is required to read ORC files. Install it with: pip install 'mloda[pyarrow]'")
         return pyarrow_orc.read_table(source=data_access, columns=list(features.get_all_names()))

--- a/mloda_plugins/feature_group/input_data/read_files/parquet.py
+++ b/mloda_plugins/feature_group/input_data/read_files/parquet.py
@@ -1,6 +1,9 @@
 from typing import Any
 
-from pyarrow import parquet as pyarrow_parquet
+try:
+    from pyarrow import parquet as pyarrow_parquet
+except ImportError:
+    pyarrow_parquet = None
 
 from mloda.provider import FeatureSet
 from mloda_plugins.feature_group.input_data.read_file import ReadFile
@@ -108,6 +111,10 @@ class ParquetReader(ReadFile):
 
     @classmethod
     def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
+        if pyarrow_parquet is None:
+            raise ImportError(
+                "pyarrow is required to read Parquet files. Install it with: pip install 'mloda[pyarrow]'"
+            )
         return pyarrow_parquet.read_table(data_access, columns=list(features.get_all_names()))
 
     @classmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,8 @@ test = [
 pyarrow = ["pyarrow"]
 pandas = ["pandas"]
 polars = ["polars"]
-duckdb = ["duckdb"]
+duckdb = ["duckdb", "pyarrow"]
+sqlite = ["pyarrow"]
 iceberg = ["pyiceberg", "pyarrow"]
 spark = ["pyspark", "pyarrow"]
 otel = [
@@ -58,6 +59,13 @@ sklearn = [
     "joblib>=1.0.0",
 ]
 text_cleaning = ["nltk>=3.8"]
+nopyarrow_test = [
+    "pytest>=9.0.3",
+    "pytest-xdist",
+    "pytest-order",
+    "pytest-timeout",
+    "tomli>=1.0.0; python_version < '3.11'",
+]
 docs = [
     "mkdocs",
     "mkdocs-jupyter",
@@ -70,6 +78,7 @@ all = [
     "mloda[pandas]",
     "mloda[polars]",
     "mloda[duckdb]",
+    "mloda[sqlite]",
     "mloda[iceberg]",
     "mloda[otel]",
     "mloda[sklearn]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,7 @@ license = { text = "Apache-2.0" }
 authors = [
     { name = "Tom Kaltofen", email = "info@mloda.ai" }
 ]
-dependencies = [
-    "pyarrow"
-]
+dependencies = []
 
 requires-python = ">=3.10,<3.15"
 classifiers = [
@@ -42,11 +40,12 @@ test = [
     "pip-licenses-cli",
     "tomli>=1.0.0; python_version < '3.11'",
 ]
+pyarrow = ["pyarrow"]
 pandas = ["pandas"]
 polars = ["polars"]
 duckdb = ["duckdb"]
-iceberg = ["pyiceberg"]
-spark = ["pyspark"]
+iceberg = ["pyiceberg", "pyarrow"]
+spark = ["pyspark", "pyarrow"]
 otel = [
     "opentelemetry-api",
     "opentelemetry-sdk",
@@ -67,6 +66,7 @@ docs = [
 ]
 all = [
     "mloda[test]",
+    "mloda[pyarrow]",
     "mloda[pandas]",
     "mloda[polars]",
     "mloda[duckdb]",

--- a/tests/test_core/test_optional_pyarrow/_pyarrow_blocker.py
+++ b/tests/test_core/test_optional_pyarrow/_pyarrow_blocker.py
@@ -13,7 +13,7 @@ import sys
 class _BlockPyarrow:
     def find_spec(self, name, path=None, target=None):
         if name == "pyarrow" or name.startswith("pyarrow."):
-            raise ModuleNotFoundError("pyarrow blocked for test")
+            raise ModuleNotFoundError("pyarrow blocked for test", name=name)
         return None
 
 sys.meta_path.insert(0, _BlockPyarrow())

--- a/tests/test_core/test_optional_pyarrow/_pyarrow_blocker.py
+++ b/tests/test_core/test_optional_pyarrow/_pyarrow_blocker.py
@@ -1,0 +1,42 @@
+"""Shared helper: run a Python subprocess with pyarrow blocked via sys.meta_path."""
+
+from __future__ import annotations
+
+import subprocess  # nosec
+import sys
+
+# The preamble installs a meta_path finder that raises ModuleNotFoundError for any
+# pyarrow import, then confirms pyarrow is truly blocked.
+BLOCKER_PREAMBLE: str = """
+import sys
+
+class _BlockPyarrow:
+    def find_spec(self, name, path=None, target=None):
+        if name == "pyarrow" or name.startswith("pyarrow."):
+            raise ModuleNotFoundError("pyarrow blocked for test")
+        return None
+
+sys.meta_path.insert(0, _BlockPyarrow())
+
+# Defensively confirm pyarrow is truly blocked.
+_blocked = False
+try:
+    import pyarrow  # noqa: F401
+except ModuleNotFoundError:
+    _blocked = True
+assert _blocked, "pyarrow should be blocked but was importable"
+
+"""
+
+
+def run_blocked(body: str, timeout: int = 30) -> "subprocess.CompletedProcess[str]":
+    """Run *body* in a subprocess where pyarrow is blocked by a sys.meta_path finder.
+
+    The returned CompletedProcess always has text-mode stdout/stderr.
+    """
+    return subprocess.run(  # nosec
+        [sys.executable, "-c", BLOCKER_PREAMBLE + body],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )

--- a/tests/test_core/test_optional_pyarrow/test_compute_framework_require_pyarrow.py
+++ b/tests/test_core/test_optional_pyarrow/test_compute_framework_require_pyarrow.py
@@ -1,0 +1,46 @@
+"""Test that _require_pyarrow() raises ImportError mentioning pyarrow when pyarrow is absent.
+
+The function _require_pyarrow does not yet exist in
+mloda.core.abstract_plugins.compute_framework, so today this test FAILS because
+the body prints NO_FUNCTION (import fails with ImportError on the name).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.test_core.test_optional_pyarrow._pyarrow_blocker import run_blocked
+
+_BODY: str = """
+import sys
+
+try:
+    from mloda.core.abstract_plugins.compute_framework import _require_pyarrow
+except ImportError:
+    print("NO_FUNCTION")
+    sys.exit(0)
+
+try:
+    _require_pyarrow()
+    print("NO_RAISE")
+except ImportError as e:
+    if "pyarrow" in str(e).lower():
+        print("IMPORTERROR")
+    else:
+        print("WRONGMSG:" + str(e))
+except Exception as e:
+    print("WRONG:" + type(e).__name__)
+"""
+
+
+@pytest.mark.timeout(30)
+def test_require_pyarrow_raises_import_error_without_pyarrow() -> None:
+    """_require_pyarrow() must raise ImportError mentioning pyarrow when pyarrow is absent.
+
+    Current (red): function does not exist yet; body prints NO_FUNCTION.
+    """
+    result = run_blocked(_BODY)
+    assert result.returncode == 0, f"Body crashed unexpectedly.\nstderr:\n{result.stderr}"
+    assert "IMPORTERROR" in result.stdout, (
+        f"Expected IMPORTERROR sentinel. Got stdout: {result.stdout!r}\nstderr: {result.stderr}"
+    )

--- a/tests/test_core/test_optional_pyarrow/test_compute_framework_require_pyarrow.py
+++ b/tests/test_core/test_optional_pyarrow/test_compute_framework_require_pyarrow.py
@@ -1,9 +1,4 @@
-"""Test that _require_pyarrow() raises ImportError mentioning pyarrow when pyarrow is absent.
-
-The function _require_pyarrow does not yet exist in
-mloda.core.abstract_plugins.compute_framework, so today this test FAILS because
-the body prints NO_FUNCTION (import fails with ImportError on the name).
-"""
+"""Test that _require_pyarrow() raises ImportError mentioning pyarrow when pyarrow is absent."""
 
 from __future__ import annotations
 
@@ -35,10 +30,7 @@ except Exception as e:
 
 @pytest.mark.timeout(30)
 def test_require_pyarrow_raises_import_error_without_pyarrow() -> None:
-    """_require_pyarrow() must raise ImportError mentioning pyarrow when pyarrow is absent.
-
-    Current (red): function does not exist yet; body prints NO_FUNCTION.
-    """
+    """_require_pyarrow() must raise ImportError mentioning pyarrow when pyarrow is absent."""
     result = run_blocked(_BODY)
     assert result.returncode == 0, f"Body crashed unexpectedly.\nstderr:\n{result.stderr}"
     assert "IMPORTERROR" in result.stdout, (

--- a/tests/test_core/test_optional_pyarrow/test_data_types_optional_pyarrow.py
+++ b/tests/test_core/test_optional_pyarrow/test_data_types_optional_pyarrow.py
@@ -1,10 +1,4 @@
-"""Tests that DataType arrow-conversion methods raise ImportError when pyarrow is absent.
-
-Current behavior (red): the methods crash with AttributeError because pa is None
-(the try/except at module top sets pa = None), so pa.int32() etc. raise AttributeError.
-Expected behavior (green): each method must detect pa is None and raise ImportError
-with a message containing "pyarrow".
-"""
+"""Tests that DataType arrow-conversion methods raise ImportError when pyarrow is absent."""
 
 from __future__ import annotations
 
@@ -63,10 +57,7 @@ except Exception as e:
 
 @pytest.mark.timeout(30)
 def test_to_arrow_type_raises_import_error_without_pyarrow() -> None:
-    """DataType.to_arrow_type must raise ImportError mentioning pyarrow when pyarrow absent.
-
-    Current (red): raises AttributeError because pa is None.
-    """
+    """DataType.to_arrow_type must raise ImportError mentioning pyarrow when pyarrow absent."""
     result = run_blocked(_BODY_TO_ARROW)
     assert result.returncode == 0, f"Body crashed unexpectedly.\nstderr:\n{result.stderr}"
     assert "IMPORTERROR" in result.stdout, (
@@ -76,10 +67,7 @@ def test_to_arrow_type_raises_import_error_without_pyarrow() -> None:
 
 @pytest.mark.timeout(30)
 def test_from_arrow_type_raises_import_error_without_pyarrow() -> None:
-    """DataType.from_arrow_type must raise ImportError mentioning pyarrow when pyarrow absent.
-
-    Current (red): raises AttributeError because pa is None.
-    """
+    """DataType.from_arrow_type must raise ImportError mentioning pyarrow when pyarrow absent."""
     result = run_blocked(_BODY_FROM_ARROW)
     assert result.returncode == 0, f"Body crashed unexpectedly.\nstderr:\n{result.stderr}"
     assert "IMPORTERROR" in result.stdout, (
@@ -89,10 +77,7 @@ def test_from_arrow_type_raises_import_error_without_pyarrow() -> None:
 
 @pytest.mark.timeout(30)
 def test_infer_arrow_type_raises_import_error_without_pyarrow() -> None:
-    """DataType.infer_arrow_type must raise ImportError mentioning pyarrow when pyarrow absent.
-
-    Current (red): raises AttributeError because pa is None (via to_arrow_type).
-    """
+    """DataType.infer_arrow_type must raise ImportError mentioning pyarrow when pyarrow absent."""
     result = run_blocked(_BODY_INFER_ARROW)
     assert result.returncode == 0, f"Body crashed unexpectedly.\nstderr:\n{result.stderr}"
     assert "IMPORTERROR" in result.stdout, (

--- a/tests/test_core/test_optional_pyarrow/test_data_types_optional_pyarrow.py
+++ b/tests/test_core/test_optional_pyarrow/test_data_types_optional_pyarrow.py
@@ -1,0 +1,100 @@
+"""Tests that DataType arrow-conversion methods raise ImportError when pyarrow is absent.
+
+Current behavior (red): the methods crash with AttributeError because pa is None
+(the try/except at module top sets pa = None), so pa.int32() etc. raise AttributeError.
+Expected behavior (green): each method must detect pa is None and raise ImportError
+with a message containing "pyarrow".
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.test_core.test_optional_pyarrow._pyarrow_blocker import run_blocked
+
+_BODY_TO_ARROW: str = """
+import sys
+from mloda.core.abstract_plugins.components.data_types import DataType
+
+try:
+    DataType.to_arrow_type(DataType.INT32)
+    print("NO_RAISE")
+except ImportError as e:
+    if "pyarrow" in str(e).lower():
+        print("IMPORTERROR")
+    else:
+        print("WRONGMSG:" + str(e))
+except Exception as e:
+    print("WRONG:" + type(e).__name__)
+"""
+
+_BODY_FROM_ARROW: str = """
+import sys
+from mloda.core.abstract_plugins.components.data_types import DataType
+
+try:
+    DataType.from_arrow_type(object())
+    print("NO_RAISE")
+except ImportError as e:
+    if "pyarrow" in str(e).lower():
+        print("IMPORTERROR")
+    else:
+        print("WRONGMSG:" + str(e))
+except Exception as e:
+    print("WRONG:" + type(e).__name__)
+"""
+
+_BODY_INFER_ARROW: str = """
+import sys
+from mloda.core.abstract_plugins.components.data_types import DataType
+
+try:
+    DataType.infer_arrow_type(5)
+    print("NO_RAISE")
+except ImportError as e:
+    if "pyarrow" in str(e).lower():
+        print("IMPORTERROR")
+    else:
+        print("WRONGMSG:" + str(e))
+except Exception as e:
+    print("WRONG:" + type(e).__name__)
+"""
+
+
+@pytest.mark.timeout(30)
+def test_to_arrow_type_raises_import_error_without_pyarrow() -> None:
+    """DataType.to_arrow_type must raise ImportError mentioning pyarrow when pyarrow absent.
+
+    Current (red): raises AttributeError because pa is None.
+    """
+    result = run_blocked(_BODY_TO_ARROW)
+    assert result.returncode == 0, f"Body crashed unexpectedly.\nstderr:\n{result.stderr}"
+    assert "IMPORTERROR" in result.stdout, (
+        f"Expected IMPORTERROR sentinel.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+@pytest.mark.timeout(30)
+def test_from_arrow_type_raises_import_error_without_pyarrow() -> None:
+    """DataType.from_arrow_type must raise ImportError mentioning pyarrow when pyarrow absent.
+
+    Current (red): raises AttributeError because pa is None.
+    """
+    result = run_blocked(_BODY_FROM_ARROW)
+    assert result.returncode == 0, f"Body crashed unexpectedly.\nstderr:\n{result.stderr}"
+    assert "IMPORTERROR" in result.stdout, (
+        f"Expected IMPORTERROR sentinel.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+@pytest.mark.timeout(30)
+def test_infer_arrow_type_raises_import_error_without_pyarrow() -> None:
+    """DataType.infer_arrow_type must raise ImportError mentioning pyarrow when pyarrow absent.
+
+    Current (red): raises AttributeError because pa is None (via to_arrow_type).
+    """
+    result = run_blocked(_BODY_INFER_ARROW)
+    assert result.returncode == 0, f"Body crashed unexpectedly.\nstderr:\n{result.stderr}"
+    assert "IMPORTERROR" in result.stdout, (
+        f"Expected IMPORTERROR sentinel.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )

--- a/tests/test_core/test_optional_pyarrow/test_duckdb_dict_without_pyarrow.py
+++ b/tests/test_core/test_optional_pyarrow/test_duckdb_dict_without_pyarrow.py
@@ -1,10 +1,4 @@
-"""Test that DuckdbRelation.from_dict raises ImportError when pyarrow is absent.
-
-from_dict currently calls pa.table(data) directly; when pa is None this produces
-AttributeError: 'NoneType' object has no attribute 'table'.
-
-Expected (green): from_dict must detect pa is None and raise ImportError mentioning pyarrow.
-"""
+"""Test that DuckdbRelation.from_dict raises ImportError when pyarrow is absent."""
 
 from __future__ import annotations
 
@@ -44,10 +38,7 @@ except Exception as e:
 
 @pytest.mark.timeout(30)
 def test_duckdb_from_dict_raises_import_error_without_pyarrow() -> None:
-    """DuckdbRelation.from_dict must raise ImportError mentioning pyarrow when pyarrow absent.
-
-    Current (red): raises AttributeError because pa is None and pa.table() fails.
-    """
+    """DuckdbRelation.from_dict must raise ImportError mentioning pyarrow when pyarrow absent."""
     result = run_blocked(_BODY)
 
     if "DUCKDB_MISSING" in result.stdout:

--- a/tests/test_core/test_optional_pyarrow/test_duckdb_dict_without_pyarrow.py
+++ b/tests/test_core/test_optional_pyarrow/test_duckdb_dict_without_pyarrow.py
@@ -1,0 +1,59 @@
+"""Test that DuckdbRelation.from_dict raises ImportError when pyarrow is absent.
+
+from_dict currently calls pa.table(data) directly; when pa is None this produces
+AttributeError: 'NoneType' object has no attribute 'table'.
+
+Expected (green): from_dict must detect pa is None and raise ImportError mentioning pyarrow.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.test_core.test_optional_pyarrow._pyarrow_blocker import run_blocked
+
+_BODY: str = """
+import sys
+
+try:
+    import duckdb
+except ImportError:
+    print("DUCKDB_MISSING")
+    sys.exit(0)
+
+try:
+    from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_relation import DuckdbRelation
+except Exception as e:
+    print("IMPORT_FAILED:" + type(e).__name__ + ":" + str(e))
+    sys.exit(1)
+
+conn = duckdb.connect()
+
+try:
+    DuckdbRelation.from_dict(conn, {"a": [1, 2, 3]})
+    print("NO_RAISE")
+except ImportError as e:
+    if "pyarrow" in str(e).lower():
+        print("IMPORTERROR")
+    else:
+        print("WRONGMSG:" + str(e))
+except Exception as e:
+    print("WRONG:" + type(e).__name__)
+"""
+
+
+@pytest.mark.timeout(30)
+def test_duckdb_from_dict_raises_import_error_without_pyarrow() -> None:
+    """DuckdbRelation.from_dict must raise ImportError mentioning pyarrow when pyarrow absent.
+
+    Current (red): raises AttributeError because pa is None and pa.table() fails.
+    """
+    result = run_blocked(_BODY)
+
+    if "DUCKDB_MISSING" in result.stdout:
+        pytest.skip("duckdb not installed in this environment")
+
+    assert result.returncode == 0, f"Body crashed unexpectedly.\nstdout: {result.stdout}\nstderr:\n{result.stderr}"
+    assert "IMPORTERROR" in result.stdout, (
+        f"Expected IMPORTERROR sentinel. Got stdout: {result.stdout!r}\nstderr: {result.stderr}"
+    )

--- a/tests/test_core/test_optional_pyarrow/test_file_readers_without_pyarrow.py
+++ b/tests/test_core/test_optional_pyarrow/test_file_readers_without_pyarrow.py
@@ -1,0 +1,190 @@
+"""Tests that file-reader modules import cleanly under blocked pyarrow and that their
+load_data methods raise ImportError mentioning pyarrow (not a top-level crash).
+
+Current state (red for import tests): each reader has a hard top-level
+    from pyarrow import <submodule>
+which causes ModuleNotFoundError at import time under the blocker, so the
+IMPORTED sentinel is never printed and the test fails.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.test_core.test_optional_pyarrow._pyarrow_blocker import run_blocked
+
+# ---------------------------------------------------------------------------
+# CSV
+# ---------------------------------------------------------------------------
+_BODY_CSV_IMPORT: str = """
+import sys
+
+try:
+    from mloda_plugins.feature_group.input_data.read_files.csv import CsvReader
+    print("IMPORTED")
+except ImportError as e:
+    print("IMPORT_ERROR:" + str(e))
+except Exception as e:
+    print("IMPORT_OTHER:" + type(e).__name__ + ":" + str(e))
+"""
+
+_BODY_CSV_LOAD: str = """
+import sys
+
+try:
+    from mloda_plugins.feature_group.input_data.read_files.csv import CsvReader
+except Exception as e:
+    print("IMPORT_FAILED:" + type(e).__name__)
+    sys.exit(0)
+
+try:
+    CsvReader.load_data("/nonexistent/path.csv", None)
+    print("NO_RAISE")
+except ImportError as e:
+    if "pyarrow" in str(e).lower():
+        print("IMPORTERROR")
+    else:
+        print("WRONGMSG:" + str(e))
+except Exception as e:
+    print("WRONG:" + type(e).__name__)
+"""
+
+# ---------------------------------------------------------------------------
+# JSON
+# ---------------------------------------------------------------------------
+_BODY_JSON_IMPORT: str = """
+import sys
+
+try:
+    from mloda_plugins.feature_group.input_data.read_files.json import JsonReader
+    print("IMPORTED")
+except ImportError as e:
+    print("IMPORT_ERROR:" + str(e))
+except Exception as e:
+    print("IMPORT_OTHER:" + type(e).__name__ + ":" + str(e))
+"""
+
+# ---------------------------------------------------------------------------
+# Parquet
+# ---------------------------------------------------------------------------
+_BODY_PARQUET_IMPORT: str = """
+import sys
+
+try:
+    from mloda_plugins.feature_group.input_data.read_files.parquet import ParquetReader
+    print("IMPORTED")
+except ImportError as e:
+    print("IMPORT_ERROR:" + str(e))
+except Exception as e:
+    print("IMPORT_OTHER:" + type(e).__name__ + ":" + str(e))
+"""
+
+# ---------------------------------------------------------------------------
+# Feather
+# ---------------------------------------------------------------------------
+_BODY_FEATHER_IMPORT: str = """
+import sys
+
+try:
+    from mloda_plugins.feature_group.input_data.read_files.feather import FeatherReader
+    print("IMPORTED")
+except ImportError as e:
+    print("IMPORT_ERROR:" + str(e))
+except Exception as e:
+    print("IMPORT_OTHER:" + type(e).__name__ + ":" + str(e))
+"""
+
+# ---------------------------------------------------------------------------
+# ORC
+# ---------------------------------------------------------------------------
+_BODY_ORC_IMPORT: str = """
+import sys
+
+try:
+    from mloda_plugins.feature_group.input_data.read_files.orc import OrcReader
+    print("IMPORTED")
+except ImportError as e:
+    print("IMPORT_ERROR:" + str(e))
+except Exception as e:
+    print("IMPORT_OTHER:" + type(e).__name__ + ":" + str(e))
+"""
+
+
+@pytest.mark.timeout(30)
+def test_csv_reader_imports_without_pyarrow() -> None:
+    """CsvReader module must import successfully even when pyarrow is absent.
+
+    Current (red): top-level 'from pyarrow import csv' raises ModuleNotFoundError
+    so IMPORTED sentinel is never printed.
+    """
+    result = run_blocked(_BODY_CSV_IMPORT)
+    assert result.returncode == 0, f"Body crashed.\nstderr:\n{result.stderr}"
+    assert "IMPORTED" in result.stdout, (
+        f"Expected IMPORTED sentinel after blocking pyarrow. Got stdout: {result.stdout!r}\nstderr: {result.stderr}"
+    )
+
+
+@pytest.mark.timeout(30)
+def test_csv_reader_load_data_raises_import_error_without_pyarrow() -> None:
+    """CsvReader.load_data must raise ImportError mentioning pyarrow when pyarrow absent.
+
+    Current (red): module fails to import at all, so this test can only be meaningful
+    after the import test goes green (module restructured). Assert IMPORTERROR.
+    """
+    result = run_blocked(_BODY_CSV_LOAD)
+    assert result.returncode == 0, f"Body crashed.\nstderr:\n{result.stderr}"
+    assert "IMPORTERROR" in result.stdout, (
+        f"Expected IMPORTERROR sentinel. Got stdout: {result.stdout!r}\nstderr: {result.stderr}"
+    )
+
+
+@pytest.mark.timeout(30)
+def test_json_reader_imports_without_pyarrow() -> None:
+    """JsonReader module must import successfully even when pyarrow is absent.
+
+    Current (red): top-level 'from pyarrow import json' raises ModuleNotFoundError.
+    """
+    result = run_blocked(_BODY_JSON_IMPORT)
+    assert result.returncode == 0, f"Body crashed.\nstderr:\n{result.stderr}"
+    assert "IMPORTED" in result.stdout, (
+        f"Expected IMPORTED sentinel. Got stdout: {result.stdout!r}\nstderr: {result.stderr}"
+    )
+
+
+@pytest.mark.timeout(30)
+def test_parquet_reader_imports_without_pyarrow() -> None:
+    """ParquetReader module must import successfully even when pyarrow is absent.
+
+    Current (red): top-level 'from pyarrow import parquet' raises ModuleNotFoundError.
+    """
+    result = run_blocked(_BODY_PARQUET_IMPORT)
+    assert result.returncode == 0, f"Body crashed.\nstderr:\n{result.stderr}"
+    assert "IMPORTED" in result.stdout, (
+        f"Expected IMPORTED sentinel. Got stdout: {result.stdout!r}\nstderr: {result.stderr}"
+    )
+
+
+@pytest.mark.timeout(30)
+def test_feather_reader_imports_without_pyarrow() -> None:
+    """FeatherReader module must import successfully even when pyarrow is absent.
+
+    Current (red): top-level 'from pyarrow import feather' raises ModuleNotFoundError.
+    """
+    result = run_blocked(_BODY_FEATHER_IMPORT)
+    assert result.returncode == 0, f"Body crashed.\nstderr:\n{result.stderr}"
+    assert "IMPORTED" in result.stdout, (
+        f"Expected IMPORTED sentinel. Got stdout: {result.stdout!r}\nstderr: {result.stderr}"
+    )
+
+
+@pytest.mark.timeout(30)
+def test_orc_reader_imports_without_pyarrow() -> None:
+    """OrcReader module must import successfully even when pyarrow is absent.
+
+    Current (red): top-level 'from pyarrow import orc' raises ModuleNotFoundError.
+    """
+    result = run_blocked(_BODY_ORC_IMPORT)
+    assert result.returncode == 0, f"Body crashed.\nstderr:\n{result.stderr}"
+    assert "IMPORTED" in result.stdout, (
+        f"Expected IMPORTED sentinel. Got stdout: {result.stdout!r}\nstderr: {result.stderr}"
+    )

--- a/tests/test_core/test_optional_pyarrow/test_file_readers_without_pyarrow.py
+++ b/tests/test_core/test_optional_pyarrow/test_file_readers_without_pyarrow.py
@@ -1,10 +1,5 @@
 """Tests that file-reader modules import cleanly under blocked pyarrow and that their
 load_data methods raise ImportError mentioning pyarrow (not a top-level crash).
-
-Current state (red for import tests): each reader has a hard top-level
-    from pyarrow import <submodule>
-which causes ModuleNotFoundError at import time under the blocker, so the
-IMPORTED sentinel is never printed and the test fails.
 """
 
 from __future__ import annotations
@@ -112,11 +107,7 @@ except Exception as e:
 
 @pytest.mark.timeout(30)
 def test_csv_reader_imports_without_pyarrow() -> None:
-    """CsvReader module must import successfully even when pyarrow is absent.
-
-    Current (red): top-level 'from pyarrow import csv' raises ModuleNotFoundError
-    so IMPORTED sentinel is never printed.
-    """
+    """CsvReader module must import successfully even when pyarrow is absent."""
     result = run_blocked(_BODY_CSV_IMPORT)
     assert result.returncode == 0, f"Body crashed.\nstderr:\n{result.stderr}"
     assert "IMPORTED" in result.stdout, (
@@ -126,11 +117,7 @@ def test_csv_reader_imports_without_pyarrow() -> None:
 
 @pytest.mark.timeout(30)
 def test_csv_reader_load_data_raises_import_error_without_pyarrow() -> None:
-    """CsvReader.load_data must raise ImportError mentioning pyarrow when pyarrow absent.
-
-    Current (red): module fails to import at all, so this test can only be meaningful
-    after the import test goes green (module restructured). Assert IMPORTERROR.
-    """
+    """CsvReader.load_data must raise ImportError mentioning pyarrow when pyarrow absent."""
     result = run_blocked(_BODY_CSV_LOAD)
     assert result.returncode == 0, f"Body crashed.\nstderr:\n{result.stderr}"
     assert "IMPORTERROR" in result.stdout, (
@@ -140,10 +127,7 @@ def test_csv_reader_load_data_raises_import_error_without_pyarrow() -> None:
 
 @pytest.mark.timeout(30)
 def test_json_reader_imports_without_pyarrow() -> None:
-    """JsonReader module must import successfully even when pyarrow is absent.
-
-    Current (red): top-level 'from pyarrow import json' raises ModuleNotFoundError.
-    """
+    """JsonReader module must import successfully even when pyarrow is absent."""
     result = run_blocked(_BODY_JSON_IMPORT)
     assert result.returncode == 0, f"Body crashed.\nstderr:\n{result.stderr}"
     assert "IMPORTED" in result.stdout, (
@@ -153,10 +137,7 @@ def test_json_reader_imports_without_pyarrow() -> None:
 
 @pytest.mark.timeout(30)
 def test_parquet_reader_imports_without_pyarrow() -> None:
-    """ParquetReader module must import successfully even when pyarrow is absent.
-
-    Current (red): top-level 'from pyarrow import parquet' raises ModuleNotFoundError.
-    """
+    """ParquetReader module must import successfully even when pyarrow is absent."""
     result = run_blocked(_BODY_PARQUET_IMPORT)
     assert result.returncode == 0, f"Body crashed.\nstderr:\n{result.stderr}"
     assert "IMPORTED" in result.stdout, (
@@ -166,10 +147,7 @@ def test_parquet_reader_imports_without_pyarrow() -> None:
 
 @pytest.mark.timeout(30)
 def test_feather_reader_imports_without_pyarrow() -> None:
-    """FeatherReader module must import successfully even when pyarrow is absent.
-
-    Current (red): top-level 'from pyarrow import feather' raises ModuleNotFoundError.
-    """
+    """FeatherReader module must import successfully even when pyarrow is absent."""
     result = run_blocked(_BODY_FEATHER_IMPORT)
     assert result.returncode == 0, f"Body crashed.\nstderr:\n{result.stderr}"
     assert "IMPORTED" in result.stdout, (
@@ -179,10 +157,7 @@ def test_feather_reader_imports_without_pyarrow() -> None:
 
 @pytest.mark.timeout(30)
 def test_orc_reader_imports_without_pyarrow() -> None:
-    """OrcReader module must import successfully even when pyarrow is absent.
-
-    Current (red): top-level 'from pyarrow import orc' raises ModuleNotFoundError.
-    """
+    """OrcReader module must import successfully even when pyarrow is absent."""
     result = run_blocked(_BODY_ORC_IMPORT)
     assert result.returncode == 0, f"Body crashed.\nstderr:\n{result.stderr}"
     assert "IMPORTED" in result.stdout, (

--- a/tests/test_core/test_optional_pyarrow/test_flight_server_require_pyarrow.py
+++ b/tests/test_core/test_optional_pyarrow/test_flight_server_require_pyarrow.py
@@ -1,0 +1,39 @@
+"""Test that start_flight_server_process raises ImportError mentioning pyarrow when pyarrow is absent."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.test_core.test_optional_pyarrow._pyarrow_blocker import run_blocked
+
+_BODY: str = """
+import sys
+
+from mloda.core.runtime.flight.runner_flight_server import ParallelRunnerFlightServer
+
+server = ParallelRunnerFlightServer()
+
+try:
+    server.start_flight_server_process()
+    print("NO_RAISE")
+    if hasattr(server, "end_flight_server_process"):
+        server.end_flight_server_process()
+    sys.exit(0)
+except ImportError as e:
+    if "pyarrow" in str(e).lower():
+        print("IMPORTERROR")
+    else:
+        print("WRONGMSG:" + str(e))
+except Exception as e:
+    print("WRONG:" + type(e).__name__)
+"""
+
+
+@pytest.mark.timeout(30)
+def test_start_flight_server_process_raises_import_error_without_pyarrow() -> None:
+    """start_flight_server_process must raise ImportError mentioning pyarrow when pyarrow is absent."""
+    result = run_blocked(_BODY)
+    assert result.returncode == 0, f"Body crashed unexpectedly.\nstdout: {result.stdout}\nstderr:\n{result.stderr}"
+    assert "IMPORTERROR" in result.stdout, (
+        f"Expected IMPORTERROR sentinel. Got stdout: {result.stdout!r}\nstderr: {result.stderr}"
+    )

--- a/tests/test_core/test_optional_pyarrow/test_import_without_pyarrow.py
+++ b/tests/test_core/test_optional_pyarrow/test_import_without_pyarrow.py
@@ -1,0 +1,104 @@
+"""Verify mloda core works without pyarrow installed.
+
+This test launches a subprocess (in the same venv, where pyarrow IS installed)
+that installs a meta_path import blocker so any ``import pyarrow`` raises
+ModuleNotFoundError. Inside that subprocess we ``import mloda.user`` and run a
+self-contained, single-compute-framework, in-memory, single-process end-to-end
+computation using ``PythonDictFramework``.
+
+The test always runs (no skipif): the subprocess blocks pyarrow internally, so
+the result is independent of whether pyarrow is present in the environment.
+
+Today this FAILS because three core modules import pyarrow at module top level
+on the eager import path.
+"""
+
+import os
+import subprocess  # nosec
+import sys
+
+import pytest
+
+# Set MLODA_TEST_BLOCK_PYARROW=0 in the environment to run the inline
+# FeatureGroup end-to-end WITHOUT the blocker (sanity check that the inline
+# FeatureGroup itself is correct in this venv where pyarrow is available).
+_SCRIPT = '''
+import os
+import sys
+
+if os.environ.get("MLODA_TEST_BLOCK_PYARROW", "1") == "1":
+    class _BlockPyarrow:
+        def find_spec(self, name, path=None, target=None):
+            if name == "pyarrow" or name.startswith("pyarrow."):
+                raise ModuleNotFoundError("pyarrow blocked for test")
+            return None
+
+    sys.meta_path.insert(0, _BlockPyarrow())
+
+    # Defensively confirm pyarrow truly cannot be imported, so a regression
+    # that quietly re-imports pyarrow is caught here rather than silently
+    # passing.
+    _pyarrow_blocked = False
+    try:
+        import pyarrow  # noqa: F401
+    except ModuleNotFoundError:
+        _pyarrow_blocked = True
+    assert _pyarrow_blocked, "pyarrow should be blocked but was importable"
+
+# The eager import path of mloda.user must not require pyarrow.
+import mloda.user
+from mloda.user import mloda, Feature, PluginCollector
+from mloda.provider import FeatureGroup, FeatureSet, DataCreator, BaseInputData
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
+    PythonDictFramework,
+)
+
+from typing import Any, Optional
+
+
+class InlinePythonDictCreator(FeatureGroup):
+    """Self-contained primary-source FeatureGroup producing PythonDict data."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({"inline_value"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        # PythonDict native format: list[dict[str, Any]] (one dict per row).
+        return [{"inline_value": 1}, {"inline_value": 2}, {"inline_value": 3}]
+
+    @classmethod
+    def compute_framework_rule(cls) -> set:
+        return {PythonDictFramework}
+
+
+result = mloda.run_all(
+    [Feature("inline_value")],
+    compute_frameworks={PythonDictFramework},
+    plugin_collector=PluginCollector.enabled_feature_groups({InlinePythonDictCreator}),
+)
+
+assert len(result) >= 1, f"expected at least one result, got {result!r}"
+assert result[0], f"expected non-empty data, got {result[0]!r}"
+
+print("OK")
+sys.exit(0)
+'''
+
+
+@pytest.mark.timeout(30)
+def test_import_and_run_without_pyarrow() -> None:
+    """mloda.user import and a PythonDict end-to-end run must work without pyarrow."""
+    result = subprocess.run(  # nosec
+        [sys.executable, "-c", _SCRIPT],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "MLODA_TEST_BLOCK_PYARROW": "1"},
+    )
+
+    assert result.returncode == 0, (
+        "Subprocess failed: mloda core could not import/run without pyarrow.\n"
+        f"--- stdout ---\n{result.stdout}\n"
+        f"--- stderr ---\n{result.stderr}"
+    )

--- a/tests/test_core/test_optional_pyarrow/test_import_without_pyarrow.py
+++ b/tests/test_core/test_optional_pyarrow/test_import_without_pyarrow.py
@@ -8,9 +8,6 @@ computation using ``PythonDictFramework``.
 
 The test always runs (no skipif): the subprocess blocks pyarrow internally, so
 the result is independent of whether pyarrow is present in the environment.
-
-Today this FAILS because three core modules import pyarrow at module top level
-on the eager import path.
 """
 
 import os

--- a/tests/test_core/test_optional_pyarrow/test_import_without_pyarrow.py
+++ b/tests/test_core/test_optional_pyarrow/test_import_without_pyarrow.py
@@ -27,7 +27,7 @@ if os.environ.get("MLODA_TEST_BLOCK_PYARROW", "1") == "1":
     class _BlockPyarrow:
         def find_spec(self, name, path=None, target=None):
             if name == "pyarrow" or name.startswith("pyarrow."):
-                raise ModuleNotFoundError("pyarrow blocked for test")
+                raise ModuleNotFoundError("pyarrow blocked for test", name=name)
             return None
 
     sys.meta_path.insert(0, _BlockPyarrow())

--- a/tests/test_core/test_optional_pyarrow/test_import_without_pyarrow.py
+++ b/tests/test_core/test_optional_pyarrow/test_import_without_pyarrow.py
@@ -95,6 +95,7 @@ def test_import_and_run_without_pyarrow() -> None:
         capture_output=True,
         text=True,
         env={**os.environ, "MLODA_TEST_BLOCK_PYARROW": "1"},
+        timeout=30,
     )
 
     assert result.returncode == 0, (

--- a/tests/test_core/test_optional_pyarrow/test_plugin_loader.py
+++ b/tests/test_core/test_optional_pyarrow/test_plugin_loader.py
@@ -1,0 +1,77 @@
+"""Tests for PluginLoader behavior when pyarrow is absent.
+
+test_plugin_loader_all_without_pyarrow  — subprocess (pyarrow blocked): PluginLoader.all()
+    must complete without crashing; non-pyarrow plugins load; pyarrow CFW plugins are skipped.
+test_load_plugin_reraises_for_missing_mloda_module — no subprocess: _load_plugin raises
+    ModuleNotFoundError for a genuinely non-existent module (not an optional dep).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.test_core.test_optional_pyarrow._pyarrow_blocker import run_blocked
+
+_BODY_ALL: str = """
+import sys
+
+try:
+    from mloda.user import PluginLoader
+except Exception as e:
+    print("IMPORT_FAILED:" + type(e).__name__ + ":" + str(e))
+    sys.exit(1)
+
+try:
+    pl = PluginLoader.all()
+except Exception as e:
+    print("ALL_FAILED:" + type(e).__name__ + ":" + str(e))
+    sys.exit(1)
+
+modules = pl.list_loaded_modules()
+joined = ",".join(modules)
+print("LOADED:" + joined)
+"""
+
+
+@pytest.mark.timeout(30)
+def test_plugin_loader_all_without_pyarrow() -> None:
+    """PluginLoader.all() must succeed even when pyarrow is unavailable.
+
+    Expected RED failure: subprocess crashes with ModuleNotFoundError because
+    at least one mloda_plugins module imports pyarrow at the top level.
+    """
+    result = run_blocked(_BODY_ALL)
+
+    assert result.returncode == 0, (
+        "PluginLoader.all() crashed under blocked pyarrow.\n"
+        f"--- stdout ---\n{result.stdout}\n"
+        f"--- stderr ---\n{result.stderr}"
+    )
+
+    # Find the LOADED: sentinel line.
+    loaded_line = next((ln for ln in result.stdout.splitlines() if ln.startswith("LOADED:")), None)
+    assert loaded_line is not None, f"Expected LOADED: sentinel in stdout. Got:\n{result.stdout}"
+
+    loaded_modules = loaded_line[len("LOADED:") :].split(",")
+
+    # At least one python_dict plugin must have loaded.
+    assert any("python_dict" in m for m in loaded_modules), (
+        f"Expected a python_dict plugin in loaded modules.\nModules: {loaded_modules}"
+    )
+
+    # No pyarrow compute-framework implementation must have loaded.
+    assert not any("base_implementations.pyarrow" in m for m in loaded_modules), (
+        f"pyarrow CFW modules must be skipped under blocked pyarrow.\nModules: {loaded_modules}"
+    )
+
+
+def test_load_plugin_reraises_for_missing_mloda_module() -> None:
+    """_load_plugin must raise ModuleNotFoundError for a genuinely non-existent module.
+
+    This test does NOT block pyarrow and must pass today (characterization/guard test).
+    """
+    from mloda.core.abstract_plugins.plugin_loader.plugin_loader import PluginLoader
+
+    loader = PluginLoader()
+    with pytest.raises(ModuleNotFoundError):
+        loader._load_plugin("compute_framework.this_module_does_not_exist_xyz")

--- a/tests/test_core/test_optional_pyarrow/test_plugin_loader.py
+++ b/tests/test_core/test_optional_pyarrow/test_plugin_loader.py
@@ -35,11 +35,7 @@ print("LOADED:" + joined)
 
 @pytest.mark.timeout(30)
 def test_plugin_loader_all_without_pyarrow() -> None:
-    """PluginLoader.all() must succeed even when pyarrow is unavailable.
-
-    Expected RED failure: subprocess crashes with ModuleNotFoundError because
-    at least one mloda_plugins module imports pyarrow at the top level.
-    """
+    """PluginLoader.all() must succeed even when pyarrow is unavailable."""
     result = run_blocked(_BODY_ALL)
 
     assert result.returncode == 0, (
@@ -66,10 +62,7 @@ def test_plugin_loader_all_without_pyarrow() -> None:
 
 
 def test_load_plugin_reraises_for_missing_mloda_module() -> None:
-    """_load_plugin must raise ModuleNotFoundError for a genuinely non-existent module.
-
-    This test does NOT block pyarrow and must pass today (characterization/guard test).
-    """
+    """_load_plugin must raise ModuleNotFoundError for a genuinely non-existent module."""
     from mloda.core.abstract_plugins.plugin_loader.plugin_loader import PluginLoader
 
     loader = PluginLoader()

--- a/tests/test_core/test_optional_pyarrow/test_plugin_loader.py
+++ b/tests/test_core/test_optional_pyarrow/test_plugin_loader.py
@@ -68,3 +68,40 @@ def test_load_plugin_reraises_for_missing_mloda_module() -> None:
     loader = PluginLoader()
     with pytest.raises(ModuleNotFoundError):
         loader._load_plugin("compute_framework.this_module_does_not_exist_xyz")
+
+
+def test_load_plugin_reraises_for_unknown_external_module(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_load_plugin must re-raise ModuleNotFoundError for an unknown (non-optional) external module."""
+    from mloda.core.abstract_plugins.plugin_loader.plugin_loader import PluginLoader
+
+    def fake_import_module(name: str) -> object:
+        raise ModuleNotFoundError(
+            "No module named 'totally_missing_dependency_xyz'",
+            name="totally_missing_dependency_xyz",
+        )
+
+    monkeypatch.setattr(
+        "mloda.core.abstract_plugins.plugin_loader.plugin_loader.importlib.import_module",
+        fake_import_module,
+    )
+
+    loader = PluginLoader()
+    with pytest.raises(ModuleNotFoundError):
+        loader._load_plugin("compute_framework.some_unloaded_plugin_xyz")
+
+
+def test_load_plugin_reraises_for_nameless_module_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_load_plugin must re-raise a ModuleNotFoundError that was raised without a name= keyword (e.name is None)."""
+    from mloda.core.abstract_plugins.plugin_loader.plugin_loader import PluginLoader
+
+    def fake_import_module(name: str) -> object:
+        raise ModuleNotFoundError("totally_missing_dependency")
+
+    monkeypatch.setattr(
+        "mloda.core.abstract_plugins.plugin_loader.plugin_loader.importlib.import_module",
+        fake_import_module,
+    )
+
+    loader = PluginLoader()
+    with pytest.raises(ModuleNotFoundError):
+        loader._load_plugin("compute_framework.some_unloaded_plugin_nameless_xyz")

--- a/tests/test_core/test_optional_pyarrow/test_pyproject_optional_extras.py
+++ b/tests/test_core/test_optional_pyarrow/test_pyproject_optional_extras.py
@@ -1,11 +1,6 @@
 """Tests that pyproject.toml declares the correct optional-dependency extras.
 
 These tests parse pyproject.toml directly (no subprocess needed).
-
-Current (red) failures expected:
-- duckdb extra does not list pyarrow
-- no sqlite extra exists
-- all extra does not reference mloda[sqlite]
 """
 
 from __future__ import annotations
@@ -30,10 +25,7 @@ def _load_optional_deps() -> dict[str, list[str]]:
 
 
 def test_duckdb_extra_contains_pyarrow() -> None:
-    """The duckdb optional-dependency extra must list pyarrow as a dependency.
-
-    Current (red): duckdb = ["duckdb"] with no pyarrow entry.
-    """
+    """The duckdb optional-dependency extra must list pyarrow as a dependency."""
     optional = _load_optional_deps()
     assert "duckdb" in optional, "No duckdb extra found in pyproject.toml"
     duckdb_deps = optional["duckdb"]
@@ -41,10 +33,7 @@ def test_duckdb_extra_contains_pyarrow() -> None:
 
 
 def test_sqlite_extra_exists_and_contains_pyarrow() -> None:
-    """A sqlite optional-dependency extra must exist and include pyarrow.
-
-    Current (red): no sqlite extra exists in pyproject.toml.
-    """
+    """A sqlite optional-dependency extra must exist and include pyarrow."""
     optional = _load_optional_deps()
     assert "sqlite" in optional, f"No sqlite extra found in pyproject.toml. Available extras: {list(optional.keys())}"
     sqlite_deps = optional["sqlite"]
@@ -52,10 +41,7 @@ def test_sqlite_extra_exists_and_contains_pyarrow() -> None:
 
 
 def test_all_extra_references_sqlite() -> None:
-    """The all extra must reference mloda[sqlite].
-
-    Current (red): all does not include mloda[sqlite].
-    """
+    """The all extra must reference mloda[sqlite]."""
     optional = _load_optional_deps()
     assert "all" in optional, "No all extra found in pyproject.toml"
     all_deps = optional["all"]

--- a/tests/test_core/test_optional_pyarrow/test_pyproject_optional_extras.py
+++ b/tests/test_core/test_optional_pyarrow/test_pyproject_optional_extras.py
@@ -1,0 +1,61 @@
+"""Tests that pyproject.toml declares the correct optional-dependency extras.
+
+These tests parse pyproject.toml directly (no subprocess needed).
+
+Current (red) failures expected:
+- duckdb extra does not list pyarrow
+- no sqlite extra exists
+- all extra does not reference mloda[sqlite]
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib  # type: ignore[no-redef]
+
+
+_PYPROJECT = Path(__file__).parent.parent.parent.parent / "pyproject.toml"
+
+
+def _load_optional_deps() -> dict[str, list[str]]:
+    with open(_PYPROJECT, "rb") as fh:
+        data = tomllib.load(fh)
+    result: dict[str, list[str]] = data["project"]["optional-dependencies"]
+    return result
+
+
+def test_duckdb_extra_contains_pyarrow() -> None:
+    """The duckdb optional-dependency extra must list pyarrow as a dependency.
+
+    Current (red): duckdb = ["duckdb"] with no pyarrow entry.
+    """
+    optional = _load_optional_deps()
+    assert "duckdb" in optional, "No duckdb extra found in pyproject.toml"
+    duckdb_deps = optional["duckdb"]
+    assert any("pyarrow" in dep for dep in duckdb_deps), f"Expected pyarrow in duckdb extra. Got: {duckdb_deps}"
+
+
+def test_sqlite_extra_exists_and_contains_pyarrow() -> None:
+    """A sqlite optional-dependency extra must exist and include pyarrow.
+
+    Current (red): no sqlite extra exists in pyproject.toml.
+    """
+    optional = _load_optional_deps()
+    assert "sqlite" in optional, f"No sqlite extra found in pyproject.toml. Available extras: {list(optional.keys())}"
+    sqlite_deps = optional["sqlite"]
+    assert any("pyarrow" in dep for dep in sqlite_deps), f"Expected pyarrow in sqlite extra. Got: {sqlite_deps}"
+
+
+def test_all_extra_references_sqlite() -> None:
+    """The all extra must reference mloda[sqlite].
+
+    Current (red): all does not include mloda[sqlite].
+    """
+    optional = _load_optional_deps()
+    assert "all" in optional, "No all extra found in pyproject.toml"
+    all_deps = optional["all"]
+    assert any("mloda[sqlite]" in dep for dep in all_deps), f"Expected mloda[sqlite] in all extra. Got: {all_deps}"

--- a/tests/test_core/test_optional_pyarrow/test_pyproject_optional_extras.py
+++ b/tests/test_core/test_optional_pyarrow/test_pyproject_optional_extras.py
@@ -10,12 +10,13 @@ Current (red) failures expected:
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
-try:
+if sys.version_info >= (3, 11):
     import tomllib
-except ModuleNotFoundError:
-    import tomli as tomllib  # type: ignore[no-redef]
+else:
+    import tomli as tomllib
 
 
 _PYPROJECT = Path(__file__).parent.parent.parent.parent / "pyproject.toml"

--- a/tests/test_project_structure.py
+++ b/tests/test_project_structure.py
@@ -119,7 +119,9 @@ def _normalize_extra_name(name: str) -> str:
 
 
 class TestExtrasConsistency:
-    INTENTIONALLY_EXCLUDED_FROM_ALL = {"all", "spark"}
+    # nopyarrow_test is a test-only extra that must omit pyarrow (used by the
+    # nopyarrow tox env); like spark, it is intentionally not part of [all].
+    INTENTIONALLY_EXCLUDED_FROM_ALL = {"all", "spark", "nopyarrow_test"}
 
     def test_all_extras_uses_self_references(self) -> None:
         extras = _load_extras()

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ setenv =
     EXPECTED_SKIP_COUNT = {env:EXPECTED_SKIP_COUNT:193}
     CHECK_SKIP_COUNT = {env:CHECK_SKIP_COUNT:1}
     TOX_LOCK_PATH = {env:TOX_LOCK_PATH:/tmp/mloda-tox.lock}
-commands = sh -c "set -- pytest -n {env:PYTEST_WORKERS:8} --timeout=10 --ignore=tests/test_core/test_optional_pyarrow {env:DEACTIVATE_NOTEBOOK_AND_DOC_TESTS:''}; if [ -n \"$TOX_LOCK_PATH\" ] && command -v flock >/dev/null 2>&1; then [ -e \"$TOX_LOCK_PATH\" ] || (umask 0 && : > \"$TOX_LOCK_PATH\") 2>/dev/null; if [ -w \"$TOX_LOCK_PATH\" ]; then exec flock \"$TOX_LOCK_PATH\" \"$@\"; fi; fi; exec \"$@\""
+commands = sh -c "set -- pytest -n {env:PYTEST_WORKERS:8} --timeout=10 {env:DEACTIVATE_NOTEBOOK_AND_DOC_TESTS:''}; if [ -n \"$TOX_LOCK_PATH\" ] && command -v flock >/dev/null 2>&1; then [ -e \"$TOX_LOCK_PATH\" ] || (umask 0 && : > \"$TOX_LOCK_PATH\") 2>/dev/null; if [ -w \"$TOX_LOCK_PATH\" ]; then exec flock \"$TOX_LOCK_PATH\" \"$@\"; fi; fi; exec \"$@\""
            ruff format --check --line-length 120 .
            ruff check --line-length 120 .
            sh -c "if [ \"$WRITE_THIRD_PARTY_LICENSES\" = \"true\" ]; then pip-licenses --format=plain-vertical --with-urls --with-license-file | sed '/\/home\//d' > attribution/THIRD_PARTY_LICENSES.md; fi"
@@ -38,7 +38,7 @@ commands = sh -c "set -- pytest -n {env:PYTEST_WORKERS:8} --timeout=10 --ignore=
 extras = test,pandas
 setenv =
     CHECK_SKIP_COUNT = {env:CHECK_SKIP_COUNT:0}
-commands = pytest -n {env:PYTEST_WORKERS:8} --ignore=mloda_plugins/ --ignore=tests/test_documentation/ --ignore=tests/test_plugins/ --ignore=tests/test_examples/ --ignore=tests/test_core/test_optional_pyarrow --timeout=10
+commands = pytest -n {env:PYTEST_WORKERS:8} --ignore=mloda_plugins/ --ignore=tests/test_documentation/ --ignore=tests/test_plugins/ --ignore=tests/test_examples/ --timeout=10
 
 [testenv: installed]
 package = sdist
@@ -50,7 +50,7 @@ setenv =
     SKIP_TEXT_CLEANING_INSTALLATION_TEST={env:SKIP_TEXT_CLEANING_INSTALLATION_TEST:true}
     CHECK_SKIP_COUNT = {env:CHECK_SKIP_COUNT:0}
 commands =
-    pytest --import-mode append --timeout=10 -n {env:PYTEST_WORKERS:8} --ignore=tests/test_core/test_optional_pyarrow
+    pytest --import-mode append --timeout=10 -n {env:PYTEST_WORKERS:8}
     python -c "import importlib.util, os, sys; packages = [('mloda.core', 'mloda/core'), ('mloda.provider', 'mloda/provider'), ('mloda.steward', 'mloda/steward'), ('mloda.user', 'mloda/user'), ('mloda_plugins', 'mloda_plugins')]; missing = [name for mod, name in packages if not os.path.exists(os.path.join(os.path.dirname(importlib.util.find_spec(mod).origin), 'py.typed'))]; sys.exit(f'Missing py.typed in: {missing}') if missing else print('All py.typed files present')"
 
 [testenv: spark]

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ setenv =
     EXPECTED_SKIP_COUNT = {env:EXPECTED_SKIP_COUNT:193}
     CHECK_SKIP_COUNT = {env:CHECK_SKIP_COUNT:1}
     TOX_LOCK_PATH = {env:TOX_LOCK_PATH:/tmp/mloda-tox.lock}
-commands = sh -c "set -- pytest -n {env:PYTEST_WORKERS:8} --timeout=10 {env:DEACTIVATE_NOTEBOOK_AND_DOC_TESTS:''}; if [ -n \"$TOX_LOCK_PATH\" ] && command -v flock >/dev/null 2>&1; then [ -e \"$TOX_LOCK_PATH\" ] || (umask 0 && : > \"$TOX_LOCK_PATH\") 2>/dev/null; if [ -w \"$TOX_LOCK_PATH\" ]; then exec flock \"$TOX_LOCK_PATH\" \"$@\"; fi; fi; exec \"$@\""
+commands = sh -c "set -- pytest -n {env:PYTEST_WORKERS:8} --timeout=10 --ignore=tests/test_core/test_optional_pyarrow {env:DEACTIVATE_NOTEBOOK_AND_DOC_TESTS:''}; if [ -n \"$TOX_LOCK_PATH\" ] && command -v flock >/dev/null 2>&1; then [ -e \"$TOX_LOCK_PATH\" ] || (umask 0 && : > \"$TOX_LOCK_PATH\") 2>/dev/null; if [ -w \"$TOX_LOCK_PATH\" ]; then exec flock \"$TOX_LOCK_PATH\" \"$@\"; fi; fi; exec \"$@\""
            ruff format --check --line-length 120 .
            ruff check --line-length 120 .
            sh -c "if [ \"$WRITE_THIRD_PARTY_LICENSES\" = \"true\" ]; then pip-licenses --format=plain-vertical --with-urls --with-license-file | sed '/\/home\//d' > attribution/THIRD_PARTY_LICENSES.md; fi"
@@ -38,7 +38,7 @@ commands = sh -c "set -- pytest -n {env:PYTEST_WORKERS:8} --timeout=10 {env:DEAC
 extras = test,pandas
 setenv =
     CHECK_SKIP_COUNT = {env:CHECK_SKIP_COUNT:0}
-commands = pytest -n {env:PYTEST_WORKERS:8} --ignore=mloda_plugins/ --ignore=tests/test_documentation/ --ignore=tests/test_plugins/ --ignore=tests/test_examples/ --timeout=10
+commands = pytest -n {env:PYTEST_WORKERS:8} --ignore=mloda_plugins/ --ignore=tests/test_documentation/ --ignore=tests/test_plugins/ --ignore=tests/test_examples/ --ignore=tests/test_core/test_optional_pyarrow --timeout=10
 
 [testenv: installed]
 package = sdist
@@ -50,7 +50,7 @@ setenv =
     SKIP_TEXT_CLEANING_INSTALLATION_TEST={env:SKIP_TEXT_CLEANING_INSTALLATION_TEST:true}
     CHECK_SKIP_COUNT = {env:CHECK_SKIP_COUNT:0}
 commands =
-    pytest --import-mode append --timeout=10 -n {env:PYTEST_WORKERS:8}
+    pytest --import-mode append --timeout=10 -n {env:PYTEST_WORKERS:8} --ignore=tests/test_core/test_optional_pyarrow
     python -c "import importlib.util, os, sys; packages = [('mloda.core', 'mloda/core'), ('mloda.provider', 'mloda/provider'), ('mloda.steward', 'mloda/steward'), ('mloda.user', 'mloda/user'), ('mloda_plugins', 'mloda_plugins')]; missing = [name for mod, name in packages if not os.path.exists(os.path.join(os.path.dirname(importlib.util.find_spec(mod).origin), 'py.typed'))]; sys.exit(f'Missing py.typed in: {missing}') if missing else print('All py.typed files present')"
 
 [testenv: spark]
@@ -65,6 +65,15 @@ setenv =
     CHECK_SKIP_COUNT = {env:CHECK_SKIP_COUNT:0}
 commands =
     pytest -n {env:PYTEST_WORKERS:1} tests/test_plugins/compute_framework/base_implementations/spark/ -v
+
+[testenv: nopyarrow]
+extras = nopyarrow_test
+deps = duckdb
+setenv =
+    CHECK_SKIP_COUNT = {env:CHECK_SKIP_COUNT:0}
+commands =
+    python -c "import importlib.util, sys; sys.exit('FAIL: pyarrow is installed in the no-pyarrow env') if importlib.util.find_spec('pyarrow') else print('OK: pyarrow is absent')"
+    pytest -n {env:PYTEST_WORKERS:4} tests/test_core/test_optional_pyarrow/ --timeout=30
 
 [testenv:security]
 # CVE scanning environment - downloads specific version of published package

--- a/uv.lock
+++ b/uv.lock
@@ -1515,11 +1515,8 @@ wheels = [
 
 [[package]]
 name = "mloda"
-version = "0.6.3"
+version = "0.7.0"
 source = { editable = "." }
-dependencies = [
-    { name = "pyarrow" },
-]
 
 [package.optional-dependencies]
 all = [
@@ -1568,9 +1565,18 @@ docs = [
 ]
 duckdb = [
     { name = "duckdb" },
+    { name = "pyarrow" },
 ]
 iceberg = [
+    { name = "pyarrow" },
     { name = "pyiceberg" },
+]
+nopyarrow-test = [
+    { name = "pytest" },
+    { name = "pytest-order" },
+    { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 otel = [
     { name = "opentelemetry-api" },
@@ -1586,13 +1592,20 @@ pandas = [
 polars = [
     { name = "polars" },
 ]
+pyarrow = [
+    { name = "pyarrow" },
+]
 sklearn = [
     { name = "joblib" },
     { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 spark = [
+    { name = "pyarrow" },
     { name = "pyspark" },
+]
+sqlite = [
+    { name = "pyarrow" },
 ]
 test = [
     { name = "bandit" },
@@ -1636,7 +1649,9 @@ requires-dist = [
     { name = "mloda", extras = ["otel"], marker = "extra == 'all'" },
     { name = "mloda", extras = ["pandas"], marker = "extra == 'all'" },
     { name = "mloda", extras = ["polars"], marker = "extra == 'all'" },
+    { name = "mloda", extras = ["pyarrow"], marker = "extra == 'all'" },
     { name = "mloda", extras = ["sklearn"], marker = "extra == 'all'" },
+    { name = "mloda", extras = ["sqlite"], marker = "extra == 'all'" },
     { name = "mloda", extras = ["test"], marker = "extra == 'all'" },
     { name = "mloda", extras = ["text-cleaning"], marker = "extra == 'all'" },
     { name = "mypy", marker = "extra == 'test'" },
@@ -1652,24 +1667,33 @@ requires-dist = [
     { name = "pip-audit", marker = "extra == 'test'", specifier = "<2.11.0" },
     { name = "pip-licenses-cli", marker = "extra == 'test'" },
     { name = "polars", marker = "extra == 'polars'" },
-    { name = "pyarrow" },
+    { name = "pyarrow", marker = "extra == 'duckdb'" },
+    { name = "pyarrow", marker = "extra == 'iceberg'" },
+    { name = "pyarrow", marker = "extra == 'pyarrow'" },
+    { name = "pyarrow", marker = "extra == 'spark'" },
+    { name = "pyarrow", marker = "extra == 'sqlite'" },
     { name = "pyarrow", marker = "extra == 'test'" },
     { name = "pyiceberg", marker = "extra == 'iceberg'" },
     { name = "pyspark", marker = "extra == 'spark'" },
+    { name = "pytest", marker = "extra == 'nopyarrow-test'", specifier = ">=9.0.3" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0.3" },
+    { name = "pytest-order", marker = "extra == 'nopyarrow-test'" },
     { name = "pytest-order", marker = "extra == 'test'" },
+    { name = "pytest-timeout", marker = "extra == 'nopyarrow-test'" },
     { name = "pytest-timeout", marker = "extra == 'test'" },
+    { name = "pytest-xdist", marker = "extra == 'nopyarrow-test'" },
     { name = "pytest-xdist", marker = "extra == 'test'" },
     { name = "ruff", marker = "extra == 'test'" },
     { name = "scikit-learn", marker = "extra == 'sklearn'", specifier = ">=1.0.0" },
     { name = "scikit-learn", marker = "extra == 'test'", specifier = ">=1.0.0" },
     { name = "testbook", marker = "extra == 'test'" },
+    { name = "tomli", marker = "python_full_version < '3.11' and extra == 'nopyarrow-test'", specifier = ">=1.0.0" },
     { name = "tomli", marker = "python_full_version < '3.11' and extra == 'test'", specifier = ">=1.0.0" },
     { name = "types-pyyaml", marker = "extra == 'test'" },
     { name = "types-requests", marker = "extra == 'test'" },
     { name = "types-toml", marker = "extra == 'test'" },
 ]
-provides-extras = ["test", "pandas", "polars", "duckdb", "iceberg", "spark", "otel", "sklearn", "text-cleaning", "docs", "all"]
+provides-extras = ["test", "pyarrow", "pandas", "polars", "duckdb", "sqlite", "iceberg", "spark", "otel", "sklearn", "text-cleaning", "nopyarrow-test", "docs", "all"]
 
 [[package]]
 name = "mmh3"


### PR DESCRIPTION
## Motivation

In **mloda-registry**, pyarrow does not support every calculation we need, so our test suites routinely switch the reference compute framework between **PyArrow** and **PythonDict** to validate behaviour. Today that is awkward: pyarrow is the *sole hard dependency* of mloda core, so `import mloda` fails without it and even a PythonDict-only workload drags pyarrow in.

This PR minimizes pyarrow's footprint. The goal is **not** to remove pyarrow (a lot genuinely depends on it): cross-compute-framework data transport still uses pyarrow as the interchange/pivot format, and the PyArrow compute framework's own implementation keeps its hard pyarrow import. But everything *else* should work without pyarrow installed, so that PythonDict (or pandas, polars, etc.) can serve as a standalone reference implementation.

## What changed

Three eager top-level pyarrow imports sat on the core import path, making pyarrow mandatory for `import mloda`. They are now guarded/lazy:

- **`data_types.py`** — guarded pyarrow import (`pa = None` fallback) plus `from __future__ import annotations` so arrow-typed method signatures (`-> pa.DataType`) are not evaluated at import time; inline arrow `isinstance` checks are guarded.
- **`compute_framework.py`** — guarded pyarrow import; the `pa.Table` checks in the Flight transport methods tolerate pyarrow being absent.
- **`flight_server.py`** — guarded import with an `object` fallback base class so the module is importable without pyarrow; actually *using* Flight transport without pyarrow raises a clear `ImportError` pointing at `pip install 'mloda[pyarrow]'`.
- **`plugin_loader.py`** — during plugin discovery, skip plugins that fail to import because of a missing optional dependency instead of aborting the whole load. (With full deps installed this branch is inert, so discovery is unchanged.)

**Packaging:** pyarrow moves out of core `dependencies` into a new `pyarrow` optional extra, is added explicitly to the `iceberg` and `spark` extras (their arrow paths assume it), and is kept in `test` so the gate still exercises everything.

## Test

`tests/test_core/test_optional_pyarrow/test_import_without_pyarrow.py` launches a subprocess that installs a `sys.meta_path` blocker raising `ModuleNotFoundError` for `pyarrow`, then `import mloda.user` and runs an end-to-end PythonDict computation. It always runs (no skip), so it does not affect the skip count, and it fails on `main` for exactly the eager-import reason this PR fixes.

## Verification

- New regression test passes.
- `mypy --strict` error count is byte-identical to clean `main` in this environment (zero new errors).
- `ruff format --check`, `ruff check`, and `bandit` are clean on the changed files.
- plugin-loader and import-surface tests pass.

## Out of scope (follow-ups)

- The pyarrow-backed **IO readers** (`read_files/csv|json|parquet|orc|feather`, sqlite reader) still import pyarrow at module top level; they are plugin-loaded on demand and can be made lazy separately.
- The **Flight transit format** itself remains pyarrow-based — cross-framework transport legitimately needs it.