### PR TITLE
docs: drop PGP-key offer from security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,8 +24,7 @@ Instead, use one of these private channels:
    [Security tab](https://github.com/mloda-ai/mloda/security/advisories/new)
    and click **Report a vulnerability**. This keeps the report, discussion, and
    coordinated disclosure in one place.
-2. **Email** — write to **security@mloda.ai**. Encrypt with our PGP key on
-   request if the details are sensitive.
+2. **Email** — write to **security@mloda.ai**.
 
 Please include as much of the following as you can:
 


### PR DESCRIPTION
## Summary

Removes the "Encrypt with our PGP key on request" line from `SECURITY.md`.

## Why

GitHub Private Vulnerability Reporting (the preferred channel) already provides
a secure, private reporting path. Advertising a PGP key we don't actively
maintain creates an obligation we can't reliably meet — a researcher asking for
the key and getting no response is worse than not offering it. The plain email
fallback remains.

Follow-up to #471.