### PR TITLE
fix: support propagate_context_keys in load_features_from_config

### DIFF
--- a/docs/docs/in_depth/feature-config.md
+++ b/docs/docs/in_depth/feature-config.md
@@ -115,7 +115,7 @@ Note: `options` and `group_options`/`context_options` are mutually exclusive.
 
 ## Worked Example: Window, Rank, and Percentile Features
 
-Row-preserving operations (window aggregation, rank, percentile) cannot be requested by a bare name: the Feature Group only matches when the request also carries the options its matcher needs. Put those options in `context_options`. The feature name encodes the operation (`{source}__{operation}`), and the matcher reads the partition/order from `context_options`.
+Row-preserving operations (window aggregation, rank, percentile) cannot be requested by a bare name: the Feature Group only matches when the request also carries the partition/order options its matcher needs. The feature name encodes the operation (`{source}__{operation}`); the matcher then requires those options to be present. It reads them via `options.get` (group first, then context), so they resolve from either side, but `context_options` is the right home.
 
 ```json
 [

--- a/docs/docs/in_depth/feature-config.md
+++ b/docs/docs/in_depth/feature-config.md
@@ -113,6 +113,41 @@ For explicit separation of group and context parameters:
 
 Note: `options` and `group_options`/`context_options` are mutually exclusive.
 
+## Worked Example: Window, Rank, and Percentile Features
+
+Row-preserving operations (window aggregation, rank, percentile) cannot be requested by a bare name: the Feature Group only matches when the request also carries the options its matcher needs. Put those options in `context_options`. The feature name encodes the operation (`{source}__{operation}`), and the matcher reads the partition/order from `context_options`.
+
+```json
+[
+    {
+        "name": "steps__sum_window",
+        "context_options": {"partition_by": ["subject_id"]}
+    },
+    {
+        "name": "price__last_window",
+        "context_options": {"partition_by": ["region"], "order_by": "timestamp"}
+    },
+    {
+        "name": "sales__row_number_ranked",
+        "context_options": {"partition_by": ["region"], "order_by": "sales"}
+    },
+    {
+        "name": "sales__p95_percentile",
+        "context_options": {"partition_by": ["region"]}
+    }
+]
+```
+
+Key names per operation (from the registry `data_operations` packages):
+
+| Operation | Name pattern | Required `context_options` |
+|-----------|--------------|----------------------------|
+| Window aggregation | `{source}__{agg}_window` (`sum`, `avg`, `first`, `last`, ...) | `partition_by` (list); `order_by` (string) is required for order-dependent aggregations like `first`/`last` |
+| Rank | `{source}__{rank_type}_ranked` (`row_number`, `dense_rank`, `ntile_N`, ...) | `partition_by` (list), `order_by` (string) |
+| Percentile | `{source}__p{N}_percentile` (e.g. `p50`, `p95`) | `partition_by` (list) |
+
+Use `context_options` (not `group_options`) for these: the partition/order are operation parameters, not identity that should split the Feature Group.
+
 ## Feature Chaining with in_features
 
 Define dependent features using `in_features`:

--- a/mloda/core/api/feature_config/loader.py
+++ b/mloda/core/api/feature_config/loader.py
@@ -6,6 +6,10 @@ to mloda Feature instances.
 """
 
 from typing import Any
+
+# Import from the component modules, NOT the `mloda.user` facade: that facade
+# imports load_features_from_config from this module, so a facade import here
+# creates a circular import (guarded by test_import_isolation.py).
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.api.feature_config.parser import parse_json

--- a/mloda/core/api/feature_config/loader.py
+++ b/mloda/core/api/feature_config/loader.py
@@ -6,8 +6,8 @@ to mloda Feature instances.
 """
 
 from typing import Any
-from mloda.user import Feature
-from mloda.user import Options
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.api.feature_config.parser import parse_json
 from mloda.core.api.feature_config.models import FeatureConfig
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
@@ -92,7 +92,13 @@ def load_features_from_config(config_str: str, format: str = "json") -> list[Fea
                 if item.in_features:
                     # Always convert to frozenset for consistency
                     context[DefaultOptionKeys.in_features] = frozenset(item.in_features)
-                options = Options(group=item.group_options or {}, context=context)
+                options = Options(
+                    group=item.group_options or {},
+                    context=context,
+                    propagate_context_keys=frozenset(item.propagate_context_keys)
+                    if item.propagate_context_keys
+                    else None,
+                )
                 feature = Feature(name=feature_name, options=options)
                 features.append(feature)
             # Check if in_features exists and create Options accordingly

--- a/mloda/core/api/feature_config/models.py
+++ b/mloda/core/api/feature_config/models.py
@@ -18,12 +18,18 @@ class FeatureConfig:
     in_features: Optional[list[str]] = None
     group_options: Optional[dict[str, Any]] = None
     context_options: Optional[dict[str, Any]] = None
+    propagate_context_keys: Optional[list[str]] = None
     column_index: Optional[int] = None
 
     def __post_init__(self) -> None:
         """Validate that options and group_options/context_options are mutually exclusive."""
         if self.options and (self.group_options or self.context_options):
             raise ValueError("Cannot use both 'options' and 'group_options'/'context_options'")
+        if self.propagate_context_keys and not self.context_options:
+            raise ValueError(
+                "'propagate_context_keys' requires 'context_options'; "
+                "it is meaningless without context options and would otherwise be silently dropped"
+            )
 
 
 def feature_config_schema() -> dict[str, Any]:
@@ -40,6 +46,7 @@ def feature_config_schema() -> dict[str, Any]:
             "in_features": {"type": "array", "items": {"type": "string"}},
             "group_options": {"type": "object"},
             "context_options": {"type": "object"},
+            "propagate_context_keys": {"type": "array", "items": {"type": "string"}},
             "column_index": {"type": "integer"},
         },
         "required": ["name"],

--- a/tests/test_core/test_api/feature_config/test_feature_config_options.py
+++ b/tests/test_core/test_api/feature_config/test_feature_config_options.py
@@ -192,3 +192,179 @@ def test_validate_options_mutual_exclusion() -> None:
             context_options={"alpha": "beta"},
         )
     assert "options" in str(exc_info.value).lower()
+
+
+def test_parse_propagate_context_keys() -> None:
+    """Test parsing JSON with a propagate_context_keys field.
+
+    The propagate_context_keys field lists context option keys that should be
+    propagated. parse_json must accept this field and store it on the resulting
+    FeatureConfig instance.
+
+    Example:
+        {
+            "name": "f",
+            "context_options": {"session_id": "abc"},
+            "propagate_context_keys": ["session_id"]
+        }
+    """
+    config_str = """[
+        {
+            "name": "f",
+            "context_options": {"session_id": "abc"},
+            "propagate_context_keys": ["session_id"]
+        }
+    ]"""
+
+    result = parse_json(config_str)
+
+    assert len(result) == 1
+    assert isinstance(result[0], FeatureConfig)
+    assert result[0].name == "f"
+    assert result[0].context_options == {"session_id": "abc"}
+    assert result[0].propagate_context_keys == ["session_id"]
+
+
+def test_parse_propagate_context_keys_defaults_none() -> None:
+    """Test that propagate_context_keys defaults to None when absent.
+
+    When a feature configuration does not include propagate_context_keys, the
+    FeatureConfig instance should report None for that field.
+    """
+    config_str = """[
+        {
+            "name": "f",
+            "context_options": {"session_id": "abc"}
+        }
+    ]"""
+
+    result = parse_json(config_str)
+
+    assert len(result) == 1
+    assert isinstance(result[0], FeatureConfig)
+    assert result[0].propagate_context_keys is None
+
+
+def test_load_threads_propagate_context_keys_into_options() -> None:
+    """Test that the loader threads propagate_context_keys into the Feature's Options.
+
+    When a feature config specifies context_options and propagate_context_keys,
+    the loader should build a Feature whose Options carries the propagate keys as
+    a frozenset.
+    """
+    from mloda.core.api.feature_config.loader import load_features_from_config
+    from mloda.user import Feature
+
+    config_str = """[
+        {
+            "name": "f",
+            "context_options": {"session_id": "abc"},
+            "propagate_context_keys": ["session_id"]
+        }
+    ]"""
+
+    result = load_features_from_config(config_str)
+
+    assert len(result) == 1
+    assert isinstance(result[0], Feature)
+    assert result[0].options.context == {"session_id": "abc"}
+    assert result[0].options.propagate_context_keys == frozenset({"session_id"})
+
+
+def test_load_propagate_context_keys_defaults_empty_frozenset() -> None:
+    """Test that propagate_context_keys defaults to an empty frozenset in Options.
+
+    When propagate_context_keys is absent, the resulting Feature's Options should
+    use the default empty frozenset.
+    """
+    from mloda.core.api.feature_config.loader import load_features_from_config
+    from mloda.user import Feature
+
+    config_str = """[
+        {
+            "name": "f",
+            "context_options": {"session_id": "abc"}
+        }
+    ]"""
+
+    result = load_features_from_config(config_str)
+
+    assert len(result) == 1
+    assert isinstance(result[0], Feature)
+    assert result[0].options.propagate_context_keys == frozenset()
+
+
+def test_load_documented_propagate_context_keys_example() -> None:
+    """Test the documented end-to-end propagate_context_keys example.
+
+    The documentation advertises a config of the form below. It should produce a
+    single Feature whose context holds both keys and whose Options propagates the
+    documented key.
+
+    Example:
+        [{"name": "my_feature",
+          "context_options": {"session_id": "abc123", "window_function": "sum"},
+          "propagate_context_keys": ["session_id"]}]
+    """
+    from mloda.core.api.feature_config.loader import load_features_from_config
+    from mloda.user import Feature
+
+    config_str = """[
+        {
+            "name": "my_feature",
+            "context_options": {"session_id": "abc123", "window_function": "sum"},
+            "propagate_context_keys": ["session_id"]
+        }
+    ]"""
+
+    result = load_features_from_config(config_str)
+
+    assert len(result) == 1
+    assert isinstance(result[0], Feature)
+    assert result[0].name == "my_feature"
+    assert result[0].options.context == {"session_id": "abc123", "window_function": "sum"}
+    assert result[0].options.propagate_context_keys == frozenset({"session_id"})
+
+
+def test_propagate_context_keys_requires_context_options() -> None:
+    """Test that propagate_context_keys requires context_options.
+
+    propagate_context_keys only makes sense alongside context_options. A
+    FeatureConfig that sets propagate_context_keys without any context_options
+    (using plain options or nothing) must raise a ValueError in __post_init__,
+    so the field is never silently dropped by the loader's plain-options branch.
+    """
+    # No context_options at all
+    with pytest.raises(ValueError) as exc_info:
+        FeatureConfig(name="bad_feature", propagate_context_keys=["session_id"])
+    assert "propagate_context_keys" in str(exc_info.value).lower()
+
+    # Plain options instead of context_options
+    with pytest.raises(ValueError) as exc_info:
+        FeatureConfig(
+            name="bad_feature_2",
+            options={"foo": "bar"},
+            propagate_context_keys=["session_id"],
+        )
+    assert "propagate_context_keys" in str(exc_info.value).lower()
+
+
+def test_load_propagate_key_not_in_context_raises() -> None:
+    """Test that a propagate key absent from context surfaces a ValueError.
+
+    The Options validator requires every propagate key to be present in context.
+    When propagate_context_keys references a key not in context_options, the
+    error should surface end-to-end through load_features_from_config.
+    """
+    from mloda.core.api.feature_config.loader import load_features_from_config
+
+    config_str = """[
+        {
+            "name": "f",
+            "context_options": {"a": 1},
+            "propagate_context_keys": ["b"]
+        }
+    ]"""
+
+    with pytest.raises(ValueError):
+        load_features_from_config(config_str)

--- a/tests/test_core/test_api/feature_config/test_feature_config_schema.py
+++ b/tests/test_core/test_api/feature_config/test_feature_config_schema.py
@@ -20,3 +20,18 @@ def test_feature_config_schema_structure() -> None:
 
     assert "name" in schema["properties"], "'name' should be in schema properties"
     assert "name" in schema["required"], "'name' should be in required fields"
+
+
+def test_feature_config_schema_includes_propagate_context_keys() -> None:
+    """Test that the schema advertises the propagate_context_keys field.
+
+    The schema should expose propagate_context_keys as an array of strings so
+    that the documented configuration field is discoverable.
+    """
+    schema = feature_config_schema()
+
+    assert "propagate_context_keys" in schema["properties"], "'propagate_context_keys' should be in schema properties"
+
+    prop = schema["properties"]["propagate_context_keys"]
+    assert prop["type"] == "array", "'propagate_context_keys' should be an array"
+    assert prop["items"] == {"type": "string"}, "'propagate_context_keys' items should be strings"

--- a/tests/test_core/test_api/feature_config/test_import_isolation.py
+++ b/tests/test_core/test_api/feature_config/test_import_isolation.py
@@ -1,0 +1,44 @@
+"""
+Import-isolation regression tests for the feature_config submodules.
+
+These tests guard against a circular import between the feature_config
+loader/models/parser and the ``mloda.user`` facade. Each submodule must be
+importable in a fresh interpreter, i.e. before ``mloda.user`` has been
+initialized. If a submodule imports ``Feature``/``Options`` back from
+``mloda.user`` (instead of their defining modules), importing it first raises
+an ImportError from a partially-initialized ``mloda.user``.
+"""
+
+import subprocess  # nosec B404
+import sys
+
+import pytest
+
+
+FEATURE_CONFIG_MODULES = [
+    "mloda.core.api.feature_config.loader",
+    "mloda.core.api.feature_config.models",
+    "mloda.core.api.feature_config.parser",
+]
+
+
+@pytest.mark.parametrize("module_name", FEATURE_CONFIG_MODULES)
+def test_submodule_imports_in_fresh_interpreter(module_name: str) -> None:
+    """Each feature_config submodule must import in a fresh interpreter.
+
+    Spawning a new interpreter and importing only the submodule reproduces the
+    "import the submodule before mloda.user" condition that triggered the
+    circular import. A non-zero return code means the cycle has returned.
+    """
+    # Safe: fixed argv (sys.executable + hardcoded module name), no shell, no user input.
+    result = subprocess.run(  # nosec B603
+        [sys.executable, "-c", f"import {module_name}"],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, (
+        f"Importing {module_name} in a fresh interpreter failed; "
+        f"a circular import with mloda.user has likely returned.\n"
+        f"stderr:\n{result.stderr}"
+    )


### PR DESCRIPTION
## Summary

The JSON feature-config docs (both `docs/in_depth/feature-config.md` and the mloda-registry guide) advertise a `propagate_context_keys` field, but the loader rejected any config that used it:

```
TypeError: FeatureConfig.__init__() got an unexpected keyword argument 'propagate_context_keys'
```

A consumer copy-pasting the documented example crashed. This wires the field through end to end so the documented behavior actually works, and adds a concrete worked example for the features that need it.

## Motivation

Surfaced by the prototype pilots (plugin-prototypes issue #20, "Learning 6"): each pilot harness writes ad-hoc JSON request fixtures for window / rank / percentile features and discovers the option schema by trial and error. On review, the schema *is* documented, but (a) the documented `propagate_context_keys` field was never implemented in the loader, and (b) the docs only showed generic placeholders, not the real matcher keys those operations require.

## Changes

- `FeatureConfig`: add `propagate_context_keys: list[str] | None`; `__post_init__` requires `context_options` when it is set (otherwise the loader's plain-options branch would silently drop it).
- `feature_config_schema()`: advertise the field (array of strings).
- `load_features_from_config`: thread the field into `Options(propagate_context_keys=...)`. Key-in-context validation is delegated to the existing `OptionsValidator`.
- Loader imports `Feature`/`Options` from their defining modules instead of the `mloda.user` facade, breaking a latent import cycle that otherwise blocked collecting the `feature_config` test package in isolation.
- Docs: add a concrete window / rank / percentile worked example using the real keys (`partition_by`, `order_by`) and a key-name table.

## Tests

8 new tests covering parse, load-into-`Options`, defaults, the documented example, the `requires context_options` guard, the not-in-context validation path, and the schema property.

Full `tox` passes: 3414 passed, 185 skipped; ruff format + check, mypy --strict, bandit all green.