### PR TITLE
fix: stop SQL merge engines leaking per-merge temp views (#475)

### DIFF
--- a/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_merge_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_merge_engine.py
@@ -1,4 +1,3 @@
-import uuid
 from datetime import timedelta
 from typing import Any
 
@@ -19,6 +18,17 @@ class DuckDBMergeEngine(SqlBaseMergeEngine):
         if duckdb is None:
             raise ImportError("DuckDB is not installed. To be able to use this framework, please install duckdb.")
 
+    def _merge_relations(self, left_data: Any, right_data: Any, union_all: bool) -> Any:
+        if self.framework_connection is None:
+            raise ValueError("Framework connection is not set. Please set the framework connection before merging.")
+        left_proj, right_proj = self._union_projections(left_data, right_data)
+        left_rel = left_data._relation.project(left_proj)
+        right_rel = right_data._relation.project(right_proj)
+        unioned = left_rel.union(right_rel)
+        if not union_all:
+            unioned = unioned.distinct()
+        return DuckdbRelation(self.framework_connection, unioned)
+
     def merge_asof(
         self,
         left_data: Any,
@@ -36,30 +46,23 @@ class DuckDBMergeEngine(SqlBaseMergeEngine):
         right_by = right_index.index if right_index.is_multi_index() else (right_index.index[0],)
 
         if asof_config.direction == "backward":
-            op = ">=" if asof_config.allow_exact_matches else ">"
+            op, time_order = (">=" if asof_config.allow_exact_matches else ">"), "DESC"
         else:
-            op = "<=" if asof_config.allow_exact_matches else "<"
-
-        left_name = f"_left_{uuid.uuid4().hex}"
-        right_name = f"_right_{uuid.uuid4().hex}"
-        self._register_table(left_name, left_data)
-        self._register_table(right_name, right_data)
-
-        conds = [
-            f"left_rel.{quote_ident(left)} = right_rel.{quote_ident(right)}" for left, right in zip(left_by, right_by)
-        ]
-        lt = quote_ident(asof_config.left_time_column)
-        rt = quote_ident(asof_config.right_time_column)
-        conds.append(f"left_rel.{lt} {op} right_rel.{rt}")
-        on_clause = " AND ".join(conds)
+            op, time_order = ("<=" if asof_config.allow_exact_matches else "<"), "ASC"
 
         left_cols = self.get_column_names(left_data)
         right_cols = self.get_column_names(right_data)
+        right_extra = [c for c in right_cols if c not in left_cols]
 
-        # tolerance: NULL out the right columns (LEFT semantics keep the row) when the
-        # time gap exceeds tolerance. Expressed in the projection so the asof inequality
-        # remains the last ON condition (a DuckDB ASOF JOIN requirement).
-        tol_guard = ""
+        lt, rt = asof_config.left_time_column, asof_config.right_time_column
+
+        rmap = {c: f"_mloda_r_{c}" for c in right_cols}
+        left_rel = left_data._relation.project("*, ROW_NUMBER() OVER () AS _mloda_lid").set_alias("L")
+        right_proj = ", ".join(f"{quote_ident(c)} AS {quote_ident(rmap[c])}" for c in right_cols)
+        right_rel = right_data._relation.project(right_proj).set_alias("R")
+
+        conds = [f"L.{quote_ident(lb)} = R.{quote_ident(rmap[rb])}" for lb, rb in zip(left_by, right_by)]
+        conds.append(f"L.{quote_ident(lt)} {op} R.{quote_ident(rmap[rt])}")
         if asof_config.tolerance is not None:
             if isinstance(asof_config.tolerance, timedelta):
                 raise ValueError(
@@ -67,41 +70,23 @@ class DuckDBMergeEngine(SqlBaseMergeEngine):
                     "tolerance (e.g. epoch seconds matching the time column)."
                 )
             tol = float(asof_config.tolerance)
-            if asof_config.direction == "backward":
-                gap = f"(left_rel.{lt} - right_rel.{rt})"
-            else:
-                gap = f"(right_rel.{rt} - left_rel.{lt})"
-            tol_guard = f"{gap} <= {tol}"
+            conds.append(f"ABS(L.{quote_ident(lt)} - R.{quote_ident(rmap[rt])}) <= {tol}")
+        on_clause = " AND ".join(conds)
 
-        def project(col: str, rel: str) -> str:
-            ref = f"{rel}.{quote_ident(col)}"
-            if rel == "right_rel" and tol_guard:
-                return f"CASE WHEN {tol_guard} THEN {ref} ELSE NULL END AS {quote_ident(col)}"
-            return f"{ref} AS {quote_ident(col)}"
+        joined = left_rel.join(right_rel, on_clause, how="left")
 
-        proj = [project(c, "left_rel") for c in left_cols]
-        proj += [project(c, "right_rel") for c in right_cols if c not in left_cols]
-        projection = ", ".join(proj)
-
-        sql = (
-            f"SELECT {projection} FROM {quote_ident(left_name)} AS left_rel "  # nosec
-            f"ASOF LEFT JOIN {quote_ident(right_name)} AS right_rel ON {on_clause}"
+        qrt = quote_ident(rmap[rt])
+        order_keys = [f"({qrt} IS NULL)", f"{qrt} {time_order}"]
+        order_keys += [f"{quote_ident(rmap[c])} ASC" for c in right_extra]
+        ranked = joined.project(
+            f"*, ROW_NUMBER() OVER (PARTITION BY _mloda_lid ORDER BY {', '.join(order_keys)}) AS _mloda_rn"
         )
-        return self._execute_sql(sql)
+        picked = ranked.filter("_mloda_rn = 1")
 
-    def _execute_sql(self, sql: str) -> Any:
-        if self.framework_connection is None:
-            raise ValueError("Framework connection is not set.")
-        result = self.framework_connection.sql(sql)
+        final_proj = [f"{quote_ident(c)} AS {quote_ident(c)}" for c in left_cols]
+        final_proj += [f"{quote_ident(rmap[c])} AS {quote_ident(c)}" for c in right_extra]
+        result = picked.project(", ".join(final_proj))
         return DuckdbRelation(self.framework_connection, result)
-
-    def _register_table(self, name: str, data: Any) -> None:
-        if self.framework_connection is None:
-            raise ValueError("Framework connection is not set.")
-        if isinstance(data, DuckdbRelation):
-            data._relation.create_view(name, replace=True)
-        else:
-            self.framework_connection.register(name, data)
 
     def _set_alias(self, data: Any, alias: str) -> Any:
         return data.set_alias(alias)

--- a/mloda_plugins/compute_framework/base_implementations/sql/sql_base_merge_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/sql/sql_base_merge_engine.py
@@ -1,4 +1,3 @@
-import uuid
 from abc import abstractmethod
 from typing import Any
 
@@ -11,22 +10,16 @@ from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import q
 class SqlBaseMergeEngine(BaseMergeEngine):
     """Shared SQL merge logic for SQL-based merge engines.
 
-    All identifiers are quoted via ``quote_ident``. Table names used in
-    ``_merge_relations`` are internally generated UUIDs, never user input.
+    All identifiers are quoted via ``quote_ident``.
 
     Subclasses must implement:
-    - _execute_sql(sql): Execute SQL and return a relation/result
-    - _register_table(name, data): Register data as a named table for SQL queries
+    - _merge_relations(left, right, union_all): Build a union/append of two relations
     - _set_alias(data, alias): Set an alias on a relation
     - _join_relation(left, right, condition, how): Execute a join between two relations
     """
 
     @abstractmethod
-    def _execute_sql(self, sql: str) -> Any:
-        raise NotImplementedError
-
-    @abstractmethod
-    def _register_table(self, name: str, data: Any) -> None:
+    def _merge_relations(self, left_data: Any, right_data: Any, union_all: bool) -> Any:
         raise NotImplementedError
 
     @abstractmethod
@@ -55,31 +48,19 @@ class SqlBaseMergeEngine(BaseMergeEngine):
     def merge_append(self, left_data: Any, right_data: Any, left_index: Index, right_index: Index) -> Any:
         return self._merge_relations(left_data, right_data, union_all=True)
 
-    def _merge_relations(self, left_data: Any, right_data: Any, union_all: bool) -> Any:
-        def build_projection(cols_present: Any, all_cols: list[str]) -> str:
-            return ", ".join(
-                [quote_ident(col) if col in cols_present else f"NULL AS {quote_ident(col)}" for col in all_cols]
-            )
-
+    def _union_projections(self, left_data: Any, right_data: Any) -> tuple[str, str]:
+        """Build (left_projection, right_projection) over the sorted union of both column sets,
+        NULL-filling columns missing from each side. All identifiers are quoted via quote_ident."""
         left_cols = set(self.get_column_names(left_data))
         right_cols = set(self.get_column_names(right_data))
         all_cols = sorted(left_cols.union(right_cols))
 
-        left_proj = build_projection(left_cols, all_cols)
-        right_proj = build_projection(right_cols, all_cols)
+        def build(cols_present: set[str]) -> str:
+            return ", ".join(
+                quote_ident(col) if col in cols_present else f"NULL AS {quote_ident(col)}" for col in all_cols
+            )
 
-        union_keyword = "UNION ALL" if union_all else "UNION"
-
-        if self.framework_connection is None:
-            raise ValueError("Framework connection is not set. Please set the framework connection before merging.")
-
-        left_name = f"_left_{uuid.uuid4().hex}"
-        right_name = f"_right_{uuid.uuid4().hex}"
-        self._register_table(left_name, left_data)
-        self._register_table(right_name, right_data)
-
-        sql = f" SELECT {left_proj} FROM {quote_ident(left_name)} {union_keyword} SELECT {right_proj} FROM {quote_ident(right_name)} "  # nosec
-        return self._execute_sql(sql)
+        return build(left_cols), build(right_cols)
 
     def get_column_names(self, data: Any) -> list[str]:
         if hasattr(data, "columns"):

--- a/mloda_plugins/compute_framework/base_implementations/sqlite/sqlite_merge_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/sqlite/sqlite_merge_engine.py
@@ -1,5 +1,4 @@
 import sqlite3
-import uuid
 from datetime import timedelta
 from typing import Any
 
@@ -11,6 +10,16 @@ from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_relation
 
 
 class SqliteMergeEngine(SqlBaseMergeEngine):
+    def _merge_relations(self, left_data: Any, right_data: Any, union_all: bool) -> Any:
+        if self.framework_connection is None:
+            raise ValueError("Framework connection is not set. Please set the framework connection before merging.")
+        left_proj, right_proj = self._union_projections(left_data, right_data)
+        union_keyword = "UNION ALL" if union_all else "UNION"
+        left_ref = quote_ident(left_data.table_name)
+        right_ref = quote_ident(right_data.table_name)
+        sql = f" SELECT {left_proj} FROM {left_ref} {union_keyword} SELECT {right_proj} FROM {right_ref} "  # nosec
+        return self._execute_sql(sql)
+
     def merge_asof(
         self,
         left_data: Any,
@@ -34,10 +43,8 @@ class SqliteMergeEngine(SqlBaseMergeEngine):
             op = ">=" if asof_config.allow_exact_matches else ">"
             time_order = "ASC"
 
-        left_name = f"_left_{uuid.uuid4().hex}"
-        right_name = f"_right_{uuid.uuid4().hex}"
-        self._register_table(left_name, left_data)
-        self._register_table(right_name, right_data)
+        left_ref = quote_ident(left_data.table_name)
+        right_ref = quote_ident(right_data.table_name)
 
         lt = quote_ident(asof_config.left_time_column)
         rt = quote_ident(asof_config.right_time_column)
@@ -76,8 +83,8 @@ class SqliteMergeEngine(SqlBaseMergeEngine):
             f"SELECT {outer_projection} FROM ("  # nosec
             f"SELECT {inner_projection}, "
             f"ROW_NUMBER() OVER (PARTITION BY L.{lid} ORDER BY {order_clause}) AS {rn} "
-            f"FROM (SELECT *, ROW_NUMBER() OVER () AS {lid} FROM {quote_ident(left_name)}) AS L "
-            f"LEFT JOIN {quote_ident(right_name)} AS R ON {on_clause}"
+            f"FROM (SELECT *, ROW_NUMBER() OVER () AS {lid} FROM {left_ref}) AS L "
+            f"LEFT JOIN {right_ref} AS R ON {on_clause}"
             f") WHERE {rn} = 1"
         )
         return self._execute_sql(sql)
@@ -87,16 +94,8 @@ class SqliteMergeEngine(SqlBaseMergeEngine):
             raise ValueError("Framework connection is not set.")
         conn: sqlite3.Connection = self.framework_connection
         new_table = _next_table_name()
-        conn.execute(f"CREATE TEMP VIEW {quote_ident(new_table)} AS {sql}")
+        conn.execute(f"CREATE TEMP VIEW {quote_ident(new_table)} AS {sql}")  # nosec
         return SqliteRelation(conn, new_table, _is_view=True)
-
-    def _register_table(self, name: str, data: Any) -> None:
-        if self.framework_connection is None:
-            raise ValueError("Framework connection is not set.")
-        conn: sqlite3.Connection = self.framework_connection
-        rel: SqliteRelation = data
-        conn.execute(f"DROP VIEW IF EXISTS {quote_ident(name)}")
-        conn.execute(f"CREATE TEMP VIEW {quote_ident(name)} AS SELECT * FROM {quote_ident(rel.table_name)}")  # nosec
 
     def _set_alias(self, data: Any, alias: str) -> Any:
         return data.set_alias(alias)

--- a/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_merge_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_merge_engine.py
@@ -3,6 +3,7 @@ import pytest
 
 from mloda.user import JoinType
 from mloda.user import Index
+from mloda.core.abstract_plugins.components.link import AsOfJoinConfig
 from mloda.provider import BaseMergeEngine
 from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_merge_engine import DuckDBMergeEngine
 from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_relation import DuckdbRelation
@@ -302,6 +303,56 @@ class TestDuckDBMergeEngine:
         assert engine.column_exists_in_result(data, "col1") is True
         assert engine.column_exists_in_result(data, "col2") is True
         assert engine.column_exists_in_result(data, "nonexistent") is False
+
+
+@pytest.mark.skipif(duckdb is None or pa is None, reason="DuckDB or PyArrow is not installed. Skipping this test.")
+class TestDuckDBMergeEngineViewLeak:
+    """Regression tests for issue #475: SQL merge engines must not leak per-merge temp views.
+
+    merge_union, merge_append and merge_asof register uniquely-named `_left_<uuid>` /
+    `_right_<uuid>` views on every call. On a long-lived connection these accumulate and
+    are never dropped. These tests run many merges through ONE connection and assert the
+    catalog does not retain the temp registration views, while results stay correct.
+    """
+
+    @staticmethod
+    def _leaked_view_count(connection: Any) -> int:
+        rows = connection.sql(
+            "SELECT count(*) FROM duckdb_views() WHERE view_name LIKE '_left_%' OR view_name LIKE '_right_%'"
+        ).fetchall()
+        return int(rows[0][0])
+
+    def test_merge_union_does_not_leak_views(self, connection: Any, index_obj: Any) -> None:
+        engine = DuckDBMergeEngine(connection)
+        for _ in range(5):
+            left = DuckdbRelation.from_arrow(connection, pa.Table.from_pydict({"idx": [1, 3], "col1": ["a", "b"]}))
+            right = DuckdbRelation.from_arrow(connection, pa.Table.from_pydict({"idx": [1, 2], "col2": ["x", "z"]}))
+            result_df = engine.merge_union(left, right, index_obj, index_obj).df()
+            assert sorted(result_df["idx"].tolist()) == [1, 1, 2, 3]
+
+        assert self._leaked_view_count(connection) == 0
+
+    def test_merge_append_does_not_leak_views(self, connection: Any, index_obj: Any) -> None:
+        engine = DuckDBMergeEngine(connection)
+        for _ in range(5):
+            left = DuckdbRelation.from_arrow(connection, pa.Table.from_pydict({"idx": [1, 3], "col1": ["a", "b"]}))
+            right = DuckdbRelation.from_arrow(connection, pa.Table.from_pydict({"idx": [1, 2], "col2": ["x", "z"]}))
+            result_df = engine.merge_append(left, right, index_obj, index_obj).df()
+            assert len(result_df) == 4
+
+        assert self._leaked_view_count(connection) == 0
+
+    def test_merge_asof_does_not_leak_views(self, connection: Any) -> None:
+        engine = DuckDBMergeEngine(connection)
+        cfg = AsOfJoinConfig(left_time_column="t", right_time_column="t", direction="backward")
+        for _ in range(5):
+            left = DuckdbRelation.from_arrow(connection, pa.Table.from_pydict({"k": [1], "t": [10], "lv": [100]}))
+            right = DuckdbRelation.from_arrow(connection, pa.Table.from_pydict({"k": [1], "t": [8], "rv": [7]}))
+            result_df = engine.merge_asof(left, right, Index(("k",)), Index(("k",)), cfg).df()
+            assert len(result_df) == 1
+            assert result_df["rv"].tolist()[0] == 7
+
+        assert self._leaked_view_count(connection) == 0
 
 
 @pytest.mark.skipif(duckdb is None or pa is None, reason="DuckDB or PyArrow is not installed. Skipping this test.")

--- a/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_merge_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_merge_engine.py
@@ -6,6 +6,7 @@ import pytest
 
 from mloda.user import JoinType
 from mloda.user import Index
+from mloda.core.abstract_plugins.components.link import AsOfJoinConfig
 from mloda.provider import BaseMergeEngine
 from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_framework import _regexp
 from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_merge_engine import SqliteMergeEngine
@@ -293,16 +294,61 @@ class TestSqliteMergeEngine:
         assert set(result_df["idx"].tolist()) == {2, 3, 4}
 
 
+class TestSqliteMergeEngineViewLeak:
+    """Regression tests for issue #475: SQL merge engines must not leak per-merge temp views.
+
+    merge_union, merge_append and merge_asof register uniquely-named `_left_<uuid>` /
+    `_right_<uuid>` temp views on every call and never drop them. On a long-lived connection
+    these accumulate. These tests run many merges through ONE connection and assert the
+    catalog does not retain the temp registration views, while results stay correct.
+    """
+
+    @staticmethod
+    def _leaked_view_count(connection: sqlite3.Connection) -> int:
+        row = connection.execute(
+            "SELECT count(*) FROM sqlite_temp_master WHERE type='view' "
+            "AND (name LIKE '_left_%' OR name LIKE '_right_%')"
+        ).fetchone()
+        return int(row[0])
+
+    def test_merge_union_does_not_leak_views(self, connection: sqlite3.Connection, index_obj: Index) -> None:
+        engine = SqliteMergeEngine(connection)
+        for _ in range(5):
+            left = SqliteRelation.from_arrow(connection, pa.Table.from_pydict({"idx": [1, 3], "col1": ["a", "b"]}))
+            right = SqliteRelation.from_arrow(connection, pa.Table.from_pydict({"idx": [1, 2], "col2": ["x", "z"]}))
+            table = engine.merge_union(left, right, index_obj, index_obj).to_arrow_table()
+            assert table.num_rows <= 4
+            assert set(table.column("idx").to_pylist()) == {1, 2, 3}
+
+        assert self._leaked_view_count(connection) == 0
+
+    def test_merge_append_does_not_leak_views(self, connection: sqlite3.Connection, index_obj: Index) -> None:
+        engine = SqliteMergeEngine(connection)
+        for _ in range(5):
+            left = SqliteRelation.from_arrow(connection, pa.Table.from_pydict({"idx": [1, 3], "col1": ["a", "b"]}))
+            right = SqliteRelation.from_arrow(connection, pa.Table.from_pydict({"idx": [1, 2], "col2": ["x", "z"]}))
+            table = engine.merge_append(left, right, index_obj, index_obj).to_arrow_table()
+            assert table.num_rows == 4
+
+        assert self._leaked_view_count(connection) == 0
+
+    def test_merge_asof_does_not_leak_views(self, connection: sqlite3.Connection) -> None:
+        engine = SqliteMergeEngine(connection)
+        cfg = AsOfJoinConfig(left_time_column="t", right_time_column="t", direction="backward")
+        for _ in range(5):
+            left = SqliteRelation.from_arrow(connection, pa.Table.from_pydict({"k": [1], "t": [10], "lv": [100]}))
+            right = SqliteRelation.from_arrow(connection, pa.Table.from_pydict({"k": [1], "t": [8], "rv": [7]}))
+            table = engine.merge_asof(left, right, Index(("k",)), Index(("k",)), cfg).to_arrow_table()
+            assert table.num_rows == 1
+            assert table.column("rv").to_pylist()[0] == 7
+
+        assert self._leaked_view_count(connection) == 0
+
+
 def test_execute_sql_raises_value_error_when_no_connection() -> None:
     engine = SqliteMergeEngine()
     with pytest.raises(ValueError, match="Framework connection is not set"):
         engine._execute_sql("SELECT 1")
-
-
-def test_register_table_raises_value_error_when_no_connection() -> None:
-    engine = SqliteMergeEngine()
-    with pytest.raises(ValueError, match="Framework connection is not set"):
-        engine._register_table("some_table", None)
 
 
 class TestSqliteMergeEngineMultiIndex(MultiIndexMergeEngineTestBase):


### PR DESCRIPTION
## Summary

Fixes #475. The DuckDB and SQLite SQL merge engines registered uniquely-named `_left_<uuid>` / `_right_<uuid>` temp views on every union/append (`_merge_relations`) and `merge_asof`, and never dropped them. Because the names were random UUIDs, `replace=True` never replaced anything, so the views accumulated on a long-lived connection (catalog bloat plus retained source relations).

## Approach: never create the wrapper views (every merge path stays lazy)

Rather than dropping the views after the fact (which would force materializing each result), the fix avoids creating them in the first place, so no merge result is materialized:

- **SQLite** (`_merge_relations` + `merge_asof`): reference each input relation's own `table_name` directly in the SQL instead of registering `_left_`/`_right_` wrapper views. The result stays a lazy `TEMP VIEW`.
- **DuckDB `_merge_relations`** (union/append): build the result with the native relational API (`project` + `union`/`distinct`); no catalog views, result stays lazy.
- **DuckDB `merge_asof`**: reimplemented via the relational API (non-equi `LEFT JOIN` + `ROW_NUMBER` window + filter) instead of native `ASOF JOIN` over named views. The native ASOF operator is only reachable through SQL that names its inputs, which would require the leaking temp views; the relational form stays fully lazy and creates no catalog objects, **mirroring the SQLite engine's existing asof implementation**.

Shared union-projection logic moved into `_union_projections`; `_merge_relations` is abstract and implemented per engine. `_execute_sql` is now SQLite-only and dropped from the base interface. Inner/left/right/outer joins were never affected (they use the relational API directly).

### Trade-off (DuckDB asof)

The relational form replaces DuckDB's specialized sort-merge `ASOF JOIN` with a non-equi join + window. For very large / long-history asof joins the native operator can be faster, since the inequality join can expand to more candidate rows before the window prunes to one match per left row. It remains lazy (so the optimizer still helps) and matches the SQLite engine, which we judged the right call for a leak-free, fully-lazy design. The semantics are verified identical by the shared asof suite below.

## Verification

- **Lazy, zero catalog growth**: every merge result is an unexecuted relation; repeated union/append/asof merges on one connection create no `_left_%`/`_right_%` views, and downstream ops chain without forcing a copy.
- **Semantics unchanged**: DuckDB asof passes the full shared `AsofMergeEngineTestBase` (backward/forward, exact-match on/off, tolerance numeric/none, multi-key, differing names) plus the `nearest`/`timedelta` error cases and the end-to-end `asof_run_all` suite.
- **`tox` green**: 3525 passed, 193 skipped; ruff format/check, license allowlist, mypy --strict, bandit all clean.

## Tests

Added `TestDuckDBMergeEngineViewLeak` and `TestSqliteMergeEngineViewLeak` (union/append/asof: repeated merges on one connection assert no leftover registration views + correct results). Removed an obsolete test for the now-deleted SQLite `_register_table`.