### PR TITLE
fix: collision-safe helper-column naming across compute frameworks

### DIFF
--- a/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_relation.py
+++ b/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_relation.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Sequence
 from typing import Any, Literal, Optional, cast
 
 try:
@@ -14,9 +13,9 @@ try:
 except ImportError:
     pa = None  # type: ignore[assignment]
 
+from mloda_plugins.compute_framework.base_implementations.sql.sql_base_relation import SqlBaseRelation
 from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import (
     inline_params,
-    pick_helper_column_name,
     quote_ident,
 )
 from mloda_plugins.compute_framework.base_implementations.sql.sql_window import (
@@ -26,8 +25,6 @@ from mloda_plugins.compute_framework.base_implementations.sql.sql_window import 
     Preceding,
     Unbounded,
     WindowFrame,
-    render_over_clause,
-    validate_window,
 )
 
 __all__ = [
@@ -41,7 +38,7 @@ __all__ = [
 ]
 
 
-class DuckdbRelation:
+class DuckdbRelation(SqlBaseRelation):
     """Lazy wrapper around DuckDBPyRelation.
 
     All operations delegate to DuckDB's native lazy Relational API;
@@ -202,57 +199,17 @@ class DuckdbRelation:
         result: int = row[0]
         return result
 
-    def with_row_number(
-        self,
-        alias: str,
-        *,
-        partition_by: Sequence[str] = (),
-        order_by: Sequence[str | OrderBy] = (),
-    ) -> "DuckdbRelation":
-        """Append a ROW_NUMBER() window column named ``alias``.
-
-        All identifiers in ``partition_by`` / ``order_by`` and the ``alias`` are quoted
-        via ``quote_ident``. Raises ``ValueError`` if ``alias`` collides with an existing
-        column (comparison is case-insensitive).
-        With no partition_by/order_by, row-number assignment order is
-        implementation-defined; pass order_by for a deterministic numbering.
-        """
-        if alias.casefold() in {c.casefold() for c in self.columns}:
-            raise ValueError(f"Column {alias!r} already exists in the relation")
-        over_sql = render_over_clause(partition_by, order_by, None)
-        return self.project(f"*, ROW_NUMBER() OVER ({over_sql}) AS {quote_ident(alias)}")
-
-    def window(
-        self,
-        func: str,
-        alias: str,
-        *,
-        partition_by: Sequence[str] = (),
-        order_by: Sequence[str | OrderBy] = (),
-        frame: WindowFrame | None = None,
-    ) -> "DuckdbRelation":
-        """Append a window-function column ``alias`` computed by ``func`` over the OVER clause.
-
-        ``func`` is a raw SQL fragment inlined verbatim; never pass user-controlled input.
-        The ``alias`` and every identifier in ``partition_by`` / ``order_by`` are quoted
-        via ``quote_ident``.
-        Raises ``ValueError`` if ``alias`` collides with an existing column (comparison is case-insensitive).
-        """
-        if alias.casefold() in {c.casefold() for c in self.columns}:
-            raise ValueError(f"Column {alias!r} already exists in the relation")
-        validate_window(order_by, frame)
-        over_sql = render_over_clause(partition_by, order_by, frame)
-        return self.project(f"*, {func} OVER ({over_sql}) AS {quote_ident(alias)}")
+    def _project_raw(self, projection: str) -> "DuckdbRelation":
+        return self.project(projection)
 
     def append_column(self, name: str, values: list[Any]) -> "DuckdbRelation":
         """Return a new relation with an additional column appended positionally.
 
         Raises ``ValueError`` if ``name`` collides with an existing column (comparison is case-insensitive).
         """
-        if name.casefold() in {c.casefold() for c in self.columns}:
-            raise ValueError(f"Column {name!r} already exists in the relation")
+        self._ensure_column_absent(name)
         new_col_rel = DuckdbRelation.from_dict(self._connection, {name: values})
-        rn = pick_helper_column_name(taken=set(self.columns) | {name})
+        rn = self._pick_helper_column(name)
         qrn = quote_ident(rn)
         left = self._relation.project(f"*, ROW_NUMBER() OVER () AS {qrn}")
         right = new_col_rel._relation.project(f"*, ROW_NUMBER() OVER () AS {qrn}")

--- a/mloda_plugins/compute_framework/base_implementations/pyarrow/pyarrow_merge_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/pyarrow/pyarrow_merge_engine.py
@@ -7,6 +7,7 @@ from mloda.core.abstract_plugins.components.link import AsOfJoinConfig
 from mloda.user import Index
 from mloda.user import JoinType
 from mloda.provider import BaseMergeEngine
+from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import pick_helper_column_name
 
 try:
     import pandas as pd
@@ -121,10 +122,7 @@ class PyArrowMergeEngine(BaseMergeEngine):
             if left_index.index[0] != right_index.index[0]:
                 # PyArrow drops the index column in all cases.
                 # Thus, we create a copy of the index column and append it to the right_data to avoid this in case of different index columns.
-                _right_index = "mloda_right_index"
-                if _right_index in right_data.column_names:
-                    raise ValueError(f"Column name {_right_index} already exists in right_data.")
-
+                _right_index = pick_helper_column_name(taken=set(right_data.column_names), prefix="mloda_right_index")
                 right_data = right_data.append_column(_right_index, right_data[right_index.index[0]])
                 left_keys = [left_index.index[0]]
                 right_keys = [_right_index]

--- a/mloda_plugins/compute_framework/base_implementations/spark/spark_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/spark/spark_framework.py
@@ -8,6 +8,7 @@ from mloda.provider import ComputeFramework
 from mloda.provider import BaseFilterEngine, BaseMaskEngine
 from mloda_plugins.compute_framework.base_implementations.spark.spark_filter_engine import SparkFilterEngine
 from mloda_plugins.compute_framework.base_implementations.spark.spark_mask_engine import SparkMaskEngine
+from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import pick_helper_column_name
 
 try:
     from pyspark.sql import SparkSession, DataFrame
@@ -222,8 +223,10 @@ class SparkFramework(ComputeFramework):
 
                 window_spec = Window.orderBy(F.monotonically_increasing_id())
 
+                rn = pick_helper_column_name(taken=set(self.data.columns))
+
                 # Add row numbers to existing DataFrame
-                existing_with_row_num = self.data.withColumn("__row_num", F.row_number().over(window_spec))
+                existing_with_row_num = self.data.withColumn(rn, F.row_number().over(window_spec))
 
                 # Create new DataFrame with the new column
                 if self.framework_connection_object is None:
@@ -236,14 +239,14 @@ class SparkFramework(ComputeFramework):
                     [(i + 1, val) for i, val in enumerate(data_list)],
                     StructType(
                         [
-                            StructField("__row_num", IntegerType(), False),
+                            StructField(rn, IntegerType(), False),
                             StructField(feature_name, self._infer_spark_type(data_list[0] if data_list else ""), True),
                         ]
                     ),
                 )
 
                 # Join the DataFrames and drop the row number column
-                result = existing_with_row_num.join(new_data_df, "__row_num").drop("__row_num")
+                result = existing_with_row_num.join(new_data_df, rn).drop(rn)
                 return result
 
             raise ValueError(f"Only one feature can be added at a time: {feature_names}")

--- a/mloda_plugins/compute_framework/base_implementations/sql/sql_base_relation.py
+++ b/mloda_plugins/compute_framework/base_implementations/sql/sql_base_relation.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from typing import TypeVar
+
+from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import pick_helper_column_name, quote_ident
+from mloda_plugins.compute_framework.base_implementations.sql.sql_window import (
+    OrderBy,
+    WindowFrame,
+    render_over_clause,
+    validate_window,
+)
+
+RelT = TypeVar("RelT", bound="SqlBaseRelation")
+
+
+class SqlBaseRelation(ABC):
+    """Shared base for SQL relation wrappers (DuckDB, SQLite, and future backends).
+
+    Provides collision-safe helper-column naming and the ``with_row_number`` /
+    ``window`` window-function methods once, so every SQL backend inherits them.
+
+    Contract for subclasses: a new ``*Relation`` MUST route any internally
+    generated helper column through ``_pick_helper_column`` and guard
+    user-supplied column names with ``_ensure_column_absent`` so collision-safe
+    naming is automatic rather than a per-backend convention that is easy to drop.
+
+    Subclasses implement two primitives:
+    - ``columns``: the current column names.
+    - ``_project_raw``: materialize ``SELECT {projection} FROM <self>`` as a new
+      relation of the same type (the projection is a trusted SQL fragment).
+    Subclasses MAY override the version-guard hooks (no-ops by default).
+    """
+
+    @property
+    @abstractmethod
+    def columns(self) -> list[str]: ...
+
+    @abstractmethod
+    def _project_raw(self: RelT, projection: str) -> RelT:
+        """Materialize ``SELECT {projection} FROM <self>`` as a new relation."""
+
+    def _ensure_column_absent(self, name: str) -> None:
+        """Raise ``ValueError`` if ``name`` collides with an existing column (case-insensitive)."""
+        if name.casefold() in {c.casefold() for c in self.columns}:
+            raise ValueError(f"Column {name!r} already exists in the relation")
+
+    def _pick_helper_column(self, *also_taken: str) -> str:
+        """Return a helper-column name free of every current column and ``also_taken`` (case-insensitive)."""
+        return pick_helper_column_name(taken=set(self.columns) | set(also_taken))
+
+    def _assert_window_supported(self) -> None:
+        """Hook: raise if the backend cannot run window functions. No-op by default."""
+
+    def _assert_nulls_supported(self, order_by: Sequence[str | OrderBy]) -> None:
+        """Hook: raise if the backend cannot honor NULLS FIRST/LAST. No-op by default."""
+
+    def with_row_number(
+        self: RelT,
+        alias: str,
+        *,
+        partition_by: Sequence[str] = (),
+        order_by: Sequence[str | OrderBy] = (),
+    ) -> RelT:
+        """Append a ROW_NUMBER() window column named ``alias``.
+
+        All identifiers in ``partition_by`` / ``order_by`` and the ``alias`` are quoted
+        via ``quote_ident``. Raises ``ValueError`` if ``alias`` collides with an existing
+        column (case-insensitive). With no partition_by/order_by, row-number assignment
+        order is implementation-defined; pass order_by for a deterministic numbering.
+        """
+        self._ensure_column_absent(alias)
+        self._assert_window_supported()
+        self._assert_nulls_supported(order_by)
+        over_sql = render_over_clause(partition_by, order_by, None)
+        return self._project_raw(f"*, ROW_NUMBER() OVER ({over_sql}) AS {quote_ident(alias)}")
+
+    def window(
+        self: RelT,
+        func: str,
+        alias: str,
+        *,
+        partition_by: Sequence[str] = (),
+        order_by: Sequence[str | OrderBy] = (),
+        frame: WindowFrame | None = None,
+    ) -> RelT:
+        """Append a window-function column ``alias`` computed by ``func`` over the OVER clause.
+
+        ``func`` is a raw SQL fragment inlined verbatim; never pass user-controlled input.
+        The ``alias`` and every identifier in ``partition_by`` / ``order_by`` are quoted via
+        ``quote_ident``. Raises ``ValueError`` if ``alias`` collides with an existing column
+        (case-insensitive).
+        """
+        self._ensure_column_absent(alias)
+        self._assert_window_supported()
+        self._assert_nulls_supported(order_by)
+        validate_window(order_by, frame)
+        over_sql = render_over_clause(partition_by, order_by, frame)
+        return self._project_raw(f"*, {func} OVER ({over_sql}) AS {quote_ident(alias)}")

--- a/mloda_plugins/compute_framework/base_implementations/sqlite/sqlite_relation.py
+++ b/mloda_plugins/compute_framework/base_implementations/sqlite/sqlite_relation.py
@@ -7,13 +7,9 @@ from typing import Any, Optional
 
 import pyarrow as pa
 
-from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import pick_helper_column_name, quote_ident
-from mloda_plugins.compute_framework.base_implementations.sql.sql_window import (
-    OrderBy,
-    WindowFrame,
-    render_over_clause,
-    validate_window,
-)
+from mloda_plugins.compute_framework.base_implementations.sql.sql_base_relation import SqlBaseRelation
+from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import quote_ident
+from mloda_plugins.compute_framework.base_implementations.sql.sql_window import OrderBy
 
 
 # Python 3.12 deprecated the built-in sqlite3 datetime adapters; explicit ISO-format
@@ -149,7 +145,7 @@ def _compatible_arrow_type(left_type: pa.DataType | None, right_type: pa.DataTyp
     return left_type
 
 
-class SqliteRelation:
+class SqliteRelation(SqlBaseRelation):
     """Lazy relation wrapper around a sqlite3 connection and table name.
 
     Each mutating operation (filter, select) creates a new temp view/table
@@ -490,78 +486,28 @@ class SqliteRelation:
                 select_parts.append(f"{qr}.{qc} AS {qc}")
         return ", ".join(select_parts)
 
-    def with_row_number(
-        self,
-        alias: str,
-        *,
-        partition_by: Sequence[str] = (),
-        order_by: Sequence[str | OrderBy] = (),
-    ) -> "SqliteRelation":
-        """Append a ROW_NUMBER() window column named ``alias``.
-
-        All identifiers in ``partition_by`` / ``order_by`` and the ``alias`` are quoted
-        via ``quote_ident``. Raises ``ValueError`` if ``alias`` collides with an existing
-        column (comparison is case-insensitive).
-        With no partition_by/order_by, row-number assignment order is
-        implementation-defined; pass order_by for a deterministic numbering.
-        Raises ``ValueError`` on SQLite < 3.28.0 (window functions unsupported);
-        ``NULLS`` placement in ``order_by`` additionally requires SQLite >= 3.30.0.
-        """
-        if alias.casefold() in {c.casefold() for c in self.columns}:
-            raise ValueError(f"Column {alias!r} already exists in the relation")
-        _assert_window_supported()
-        _assert_nulls_supported(order_by)
-        over_sql = render_over_clause(partition_by, order_by, None)
+    def _project_raw(self, projection: str) -> "SqliteRelation":
         new_name = _next_table_name()
         sql = (
             f"CREATE TEMP VIEW {quote_ident(new_name)} AS "  # nosec
-            f"SELECT *, ROW_NUMBER() OVER ({over_sql}) AS {quote_ident(alias)} "
-            f"FROM {quote_ident(self._table_name)}"
+            f"SELECT {projection} FROM {quote_ident(self._table_name)}"
         )
         self._connection.execute(sql)
         return SqliteRelation(self._connection, new_name, _is_view=True)
 
-    def window(
-        self,
-        func: str,
-        alias: str,
-        *,
-        partition_by: Sequence[str] = (),
-        order_by: Sequence[str | OrderBy] = (),
-        frame: WindowFrame | None = None,
-    ) -> "SqliteRelation":
-        """Append a window-function column ``alias`` computed by ``func`` over the OVER clause.
-
-        ``func`` is a raw SQL fragment inlined verbatim; never pass user-controlled input.
-        The ``alias`` and every identifier in ``partition_by`` / ``order_by`` are quoted
-        via ``quote_ident``.
-        Raises ``ValueError`` if ``alias`` collides with an existing column (comparison is case-insensitive).
-        Raises ``ValueError`` on SQLite < 3.28.0 (window functions unsupported);
-        ``NULLS`` placement in ``order_by`` additionally requires SQLite >= 3.30.0.
-        """
-        if alias.casefold() in {c.casefold() for c in self.columns}:
-            raise ValueError(f"Column {alias!r} already exists in the relation")
+    def _assert_window_supported(self) -> None:
         _assert_window_supported()
+
+    def _assert_nulls_supported(self, order_by: Sequence[str | OrderBy]) -> None:
         _assert_nulls_supported(order_by)
-        validate_window(order_by, frame)
-        over_sql = render_over_clause(partition_by, order_by, frame)
-        new_name = _next_table_name()
-        sql = (
-            f"CREATE TEMP VIEW {quote_ident(new_name)} AS "  # nosec
-            f"SELECT *, {func} OVER ({over_sql}) AS {quote_ident(alias)} "
-            f"FROM {quote_ident(self._table_name)}"
-        )
-        self._connection.execute(sql)
-        return SqliteRelation(self._connection, new_name, _is_view=True)
 
     def append_column(self, name: str, values: list[Any]) -> "SqliteRelation":
         """Return a new relation with an additional column appended positionally."""
-        if name.casefold() in {c.casefold() for c in self.columns}:
-            raise ValueError(f"Column {name!r} already exists in the relation")
+        self._ensure_column_absent(name)
         current_types = self._types_for_current_columns()
         new_col_rel = SqliteRelation.from_dict(self._connection, {name: values})
         new_col_types = new_col_rel._types_for_current_columns()
-        rn = pick_helper_column_name(taken=set(self.columns) | {name})
+        rn = self._pick_helper_column(name)
         qrn = quote_ident(rn)
         left_name = _next_table_name()
         right_name = _next_table_name()

--- a/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_relation.py
+++ b/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_relation.py
@@ -299,39 +299,5 @@ class TestDuckdbRelation(SqlRelationWindowTestMixin, RelationTestMixin):
         assert arrow.column("__mloda_rn__").to_pylist() == ["x", "y", "z"]
         assert arrow.column("c").to_pylist() == [7, 8, 9]
 
-    def test_append_column_when_name_param_collides_with_helper_candidate(self, connection: Any) -> None:
-        """Helper picker must consider both self.columns AND the incoming name parameter."""
-        rel = DuckdbRelation.from_dict(connection, {"a": [1, 2, 3]})
-        result = rel.append_column("__mloda_rn0__", [7, 8, 9])
-        assert set(result.columns) == {"a", "__mloda_rn0__"}
-        assert len(result) == 3
-        arrow = result.to_arrow_table()
-        assert arrow.column("__mloda_rn0__").to_pylist() == [7, 8, 9]
-
-    def test_append_column_when_multiple_helper_candidates_exist(self, connection: Any) -> None:
-        """Helper picker must scan upward and pick the lowest free __mloda_rn{n}__."""
-        rel = DuckdbRelation.from_dict(
-            connection,
-            {"__mloda_rn0__": [1, 2], "__mloda_rn1__": [3, 4], "x": [5, 6]},
-        )
-        result = rel.append_column("y", [7, 8])
-        assert set(result.columns) == {"__mloda_rn0__", "__mloda_rn1__", "x", "y"}
-        arrow = result.to_arrow_table()
-        assert arrow.column("__mloda_rn0__").to_pylist() == [1, 2]
-        assert arrow.column("__mloda_rn1__").to_pylist() == [3, 4]
-        assert arrow.column("x").to_pylist() == [5, 6]
-        assert arrow.column("y").to_pylist() == [7, 8]
-
-    # --- append_column / with_row_number / window: alias collision with existing column ---
-
-    def test_append_column_raises_when_name_already_exists(self, connection: Any) -> None:
-        """append_column must reject ``name`` colliding with an existing column instead of silently corrupting the schema."""
-        rel = DuckdbRelation.from_dict(connection, {"a": [1, 2, 3], "b": [4, 5, 6]})
-        with pytest.raises(ValueError, match="b"):
-            rel.append_column("b", [10, 20, 30])
-
-    def test_append_column_raises_on_case_only_collision(self, connection: Any) -> None:
-        """DuckDB identifiers are case-insensitive: 'foo' must collide with existing 'Foo'."""
-        rel = DuckdbRelation.from_dict(connection, {"Foo": [1, 2, 3], "b": [4, 5, 6]})
-        with pytest.raises(ValueError, match="foo"):
-            rel.append_column("foo", [10, 20, 30])
+    # NOTE: helper-name collision and append_column name-collision tests now live in
+    # RelationTestMixin so both DuckDB and SQLite inherit and run them.

--- a/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_relation.py
+++ b/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_relation.py
@@ -298,6 +298,3 @@ class TestDuckdbRelation(SqlRelationWindowTestMixin, RelationTestMixin):
         arrow = result.to_arrow_table()
         assert arrow.column("__mloda_rn__").to_pylist() == ["x", "y", "z"]
         assert arrow.column("c").to_pylist() == [7, 8, 9]
-
-    # NOTE: helper-name collision and append_column name-collision tests now live in
-    # RelationTestMixin so both DuckDB and SQLite inherit and run them.

--- a/tests/test_plugins/compute_framework/base_implementations/pyarrow/test_pyarrow_merge_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/pyarrow/test_pyarrow_merge_engine.py
@@ -2,6 +2,7 @@ from typing import Any, Optional
 import pytest
 
 from mloda.provider import BaseMergeEngine
+from mloda.user import Index
 from mloda_plugins.compute_framework.base_implementations.pyarrow.pyarrow_merge_engine import PyArrowMergeEngine
 from tests.test_plugins.compute_framework.test_tooling.multi_index.multi_index_test_base import (
     MultiIndexMergeEngineTestBase,
@@ -11,6 +12,37 @@ try:
     import pyarrow as pa
 except ImportError:
     pa = None  # type: ignore[assignment]
+
+
+@pytest.mark.skipif(pa is None, reason="PyArrow is not installed. Skipping this test.")
+class TestPyArrowMergeEngineHelperColumnCollision:
+    """Regression: the different-index-name path must not collide with a user column."""
+
+    def test_merge_inner_different_index_names_with_existing_mloda_right_index(self) -> None:
+        """When left/right index columns differ, join_logic copies the right index into a helper
+        column. It currently hardcodes ``mloda_right_index`` and raises ValueError if that name is
+        already a column in right_data. The fix picks a collision-free helper name instead, so the
+        merge must succeed AND preserve the user's ``mloda_right_index`` column values.
+        """
+        left = pa.Table.from_pydict({"left_id": [1, 2, 3], "lval": ["a", "b", "c"]})
+        right = pa.Table.from_pydict(
+            {
+                "right_id": [2, 3, 4],
+                "mloda_right_index": [99, 88, 77],  # user column that collides with the legacy helper name
+                "rval": ["x", "y", "z"],
+            }
+        )
+
+        engine = PyArrowMergeEngine()
+        result = engine.merge_inner(left, right, Index(("left_id",)), Index(("right_id",)))
+
+        rows = result.to_pylist()
+        # Inner join on left_id == right_id matches right_id in {2, 3}
+        by_key = {row["left_id"]: row for row in rows}
+        assert set(by_key.keys()) == {2, 3}
+        # The user's mloda_right_index column must survive with its original values per matched row
+        assert by_key[2]["mloda_right_index"] == 99
+        assert by_key[3]["mloda_right_index"] == 88
 
 
 class TestPyArrowMergeEngineMultiIndex(MultiIndexMergeEngineTestBase):

--- a/tests/test_plugins/compute_framework/base_implementations/pyarrow/test_pyarrow_merge_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/pyarrow/test_pyarrow_merge_engine.py
@@ -19,16 +19,17 @@ class TestPyArrowMergeEngineHelperColumnCollision:
     """Regression: the different-index-name path must not collide with a user column."""
 
     def test_merge_inner_different_index_names_with_existing_mloda_right_index(self) -> None:
-        """When left/right index columns differ, join_logic copies the right index into a helper
-        column. It currently hardcodes ``mloda_right_index`` and raises ValueError if that name is
-        already a column in right_data. The fix picks a collision-free helper name instead, so the
-        merge must succeed AND preserve the user's ``mloda_right_index`` column values.
+        """Merging with different left/right index names must not collide with a user column.
+
+        The different-index-name path copies the right index into an internal helper column.
+        When a user column is already named ``mloda_right_index``, the merge must still succeed,
+        preserve that user column's values, and not leak the helper into the output schema.
         """
         left = pa.Table.from_pydict({"left_id": [1, 2, 3], "lval": ["a", "b", "c"]})
         right = pa.Table.from_pydict(
             {
                 "right_id": [2, 3, 4],
-                "mloda_right_index": [99, 88, 77],  # user column that collides with the legacy helper name
+                "mloda_right_index": [99, 88, 77],  # user column named like the internal helper
                 "rval": ["x", "y", "z"],
             }
         )

--- a/tests/test_plugins/compute_framework/base_implementations/pyarrow/test_pyarrow_merge_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/pyarrow/test_pyarrow_merge_engine.py
@@ -43,6 +43,8 @@ class TestPyArrowMergeEngineHelperColumnCollision:
         # The user's mloda_right_index column must survive with its original values per matched row
         assert by_key[2]["mloda_right_index"] == 99
         assert by_key[3]["mloda_right_index"] == 88
+        # The synthetic join-key helper must NOT leak into the output schema.
+        assert set(result.column_names) == {"left_id", "lval", "right_id", "mloda_right_index", "rval"}
 
 
 class TestPyArrowMergeEngineMultiIndex(MultiIndexMergeEngineTestBase):

--- a/tests/test_plugins/compute_framework/base_implementations/relation_test_mixin.py
+++ b/tests/test_plugins/compute_framework/base_implementations/relation_test_mixin.py
@@ -226,6 +226,45 @@ class RelationTestMixin:
         assert set(result.columns) == {"a", "c"}
         assert len(result) == 3
 
+    # --- append_column: helper-name collision and name-collision contract ---
+
+    def test_append_column_when_name_param_collides_with_helper_candidate(
+        self, connection: Any, relation_class: Any
+    ) -> None:
+        """Helper picker must consider both self.columns AND the incoming name parameter."""
+        rel = relation_class.from_dict(connection, {"a": [1, 2, 3]})
+        result = rel.append_column("__mloda_rn0__", [7, 8, 9])
+        assert set(result.columns) == {"a", "__mloda_rn0__"}
+        assert len(result) == 3
+        arrow = result.to_arrow_table()
+        assert arrow.column("__mloda_rn0__").to_pylist() == [7, 8, 9]
+
+    def test_append_column_when_multiple_helper_candidates_exist(self, connection: Any, relation_class: Any) -> None:
+        """Helper picker must scan upward and pick the lowest free __mloda_rn{n}__."""
+        rel = relation_class.from_dict(
+            connection,
+            {"__mloda_rn0__": [1, 2], "__mloda_rn1__": [3, 4], "x": [5, 6]},
+        )
+        result = rel.append_column("y", [7, 8])
+        assert set(result.columns) == {"__mloda_rn0__", "__mloda_rn1__", "x", "y"}
+        arrow = result.to_arrow_table()
+        assert arrow.column("__mloda_rn0__").to_pylist() == [1, 2]
+        assert arrow.column("__mloda_rn1__").to_pylist() == [3, 4]
+        assert arrow.column("x").to_pylist() == [5, 6]
+        assert arrow.column("y").to_pylist() == [7, 8]
+
+    def test_append_column_raises_when_name_already_exists(self, connection: Any, relation_class: Any) -> None:
+        """append_column must reject ``name`` colliding with an existing column instead of silently corrupting the schema."""
+        rel = relation_class.from_dict(connection, {"a": [1, 2, 3], "b": [4, 5, 6]})
+        with pytest.raises(ValueError, match="b"):
+            rel.append_column("b", [10, 20, 30])
+
+    def test_append_column_raises_on_case_only_collision(self, connection: Any, relation_class: Any) -> None:
+        """SQL identifiers are case-insensitive: 'foo' must collide with existing 'Foo'."""
+        rel = relation_class.from_dict(connection, {"Foo": [1, 2, 3], "b": [4, 5, 6]})
+        with pytest.raises(ValueError, match="foo"):
+            rel.append_column("foo", [10, 20, 30])
+
     # --- Join: reserved-word column name ---
 
     def test_join_bare_column_reserved_word(self, connection: Any, relation_class: Any) -> None:

--- a/tests/test_plugins/compute_framework/base_implementations/spark/test_spark_framework.py
+++ b/tests/test_plugins/compute_framework/base_implementations/spark/test_spark_framework.py
@@ -271,6 +271,41 @@ class TestSparkFrameworkComputeFramework:
         assert result is not None
         assert result.count() == 0
 
+    def test_add_column_preserves_existing_user_row_num_column(self, spark_session: Any) -> None:
+        """add_column must not clobber a pre-existing user column literally named ``__row_num``.
+
+        The add-column path (transform with an iterable of values + a single feature name)
+        internally uses a row-number helper column to align the new values with existing rows.
+        If that helper hardcodes ``__row_num`` it silently overwrites/drops a user column of the
+        same name. This regression builds a DataFrame that already owns ``__row_num`` and asserts
+        both the new feature column and the original ``__row_num`` survive intact.
+        """
+        spark_framework = SparkFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
+        spark_framework.set_framework_connection_object(spark_session)
+
+        existing = spark_session.createDataFrame(
+            [
+                {"__row_num": 100, "other": "a"},
+                {"__row_num": 200, "other": "b"},
+                {"__row_num": 300, "other": "c"},
+            ]
+        )
+        spark_framework.data = existing
+
+        result = spark_framework.transform([10, 20, 30], {"new_feature"})
+        rows = result.collect()
+
+        by_other = {row["other"]: row for row in rows}
+        assert set(by_other.keys()) == {"a", "b", "c"}
+        # (a) the new column exists with the expected values, aligned per original row
+        assert by_other["a"]["new_feature"] == 10
+        assert by_other["b"]["new_feature"] == 20
+        assert by_other["c"]["new_feature"] == 30
+        # (b) the original __row_num column survives with its original distinctive values
+        assert "__row_num" in result.columns
+        assert sorted(row["__row_num"] for row in rows) == [100, 200, 300]
+        assert {by_other["a"]["__row_num"], by_other["b"]["__row_num"], by_other["c"]["__row_num"]} == {100, 200, 300}
+
     def test_infer_spark_type(self, spark_session: Any) -> None:
         """Test Spark type inference."""
         from pyspark.sql.types import BooleanType, IntegerType, DoubleType, StringType

--- a/tests/test_plugins/compute_framework/base_implementations/spark/test_spark_framework.py
+++ b/tests/test_plugins/compute_framework/base_implementations/spark/test_spark_framework.py
@@ -274,11 +274,9 @@ class TestSparkFrameworkComputeFramework:
     def test_add_column_preserves_existing_user_row_num_column(self, spark_session: Any) -> None:
         """add_column must not clobber a pre-existing user column literally named ``__row_num``.
 
-        The add-column path (transform with an iterable of values + a single feature name)
-        internally uses a row-number helper column to align the new values with existing rows.
-        If that helper hardcodes ``__row_num`` it silently overwrites/drops a user column of the
-        same name. This regression builds a DataFrame that already owns ``__row_num`` and asserts
-        both the new feature column and the original ``__row_num`` survive intact.
+        The add-column path uses an internal row-number helper column to align new values with
+        existing rows. A DataFrame that already owns ``__row_num`` must keep it intact alongside
+        the newly added feature column.
         """
         spark_framework = SparkFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
         spark_framework.set_framework_connection_object(spark_session)

--- a/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_relation.py
+++ b/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_relation.py
@@ -275,17 +275,9 @@ class TestSqliteRelation(SqlRelationWindowTestMixin, RelationTestMixin):
         assert arrow.column("b").to_pylist() == [4, 5, 6]
         assert arrow.column("c").to_pylist() == [7, 8, 9]
 
-    def test_append_column_raises_when_name_already_exists(self, connection: sqlite3.Connection) -> None:
-        """append_column must reject ``name`` colliding with an existing column instead of silently corrupting the schema."""
-        rel = SqliteRelation.from_dict(connection, {"a": [1, 2, 3], "b": [4, 5, 6]})
-        with pytest.raises(ValueError, match="b"):
-            rel.append_column("b", [10, 20, 30])
-
-    def test_append_column_raises_on_case_only_collision(self, connection: sqlite3.Connection) -> None:
-        """append_column must reject ``name`` that case-insensitively collides with an existing column, since SQLite treats quoted identifiers as case-insensitive in resolution."""
-        rel = SqliteRelation.from_dict(connection, {"Foo": [1, 2, 3], "b": [4, 5, 6]})
-        with pytest.raises(ValueError, match="foo"):
-            rel.append_column("foo", [10, 20, 30])
+    # NOTE: test_append_column_raises_when_name_already_exists and
+    # test_append_column_raises_on_case_only_collision now live in RelationTestMixin
+    # (single source of truth for both DuckDB and SQLite).
 
     def test_join_with_sql_injection_alias(self, connection: sqlite3.Connection) -> None:
         """A crafted alias must not be interpreted as SQL."""

--- a/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_relation.py
+++ b/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_relation.py
@@ -275,10 +275,6 @@ class TestSqliteRelation(SqlRelationWindowTestMixin, RelationTestMixin):
         assert arrow.column("b").to_pylist() == [4, 5, 6]
         assert arrow.column("c").to_pylist() == [7, 8, 9]
 
-    # NOTE: test_append_column_raises_when_name_already_exists and
-    # test_append_column_raises_on_case_only_collision now live in RelationTestMixin
-    # (single source of truth for both DuckDB and SQLite).
-
     def test_join_with_sql_injection_alias(self, connection: sqlite3.Connection) -> None:
         """A crafted alias must not be interpreted as SQL."""
         left = SqliteRelation.from_dict(connection, {"idx": [1, 2], "val": ["a", "b"]})

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ setenv =
     PYTHONWARNINGS=ignore::UserWarning:piplicenses.spdx
     WRITE_THIRD_PARTY_LICENSES={env:TOX_WRITE_THIRD_PARTY_LICENSES:false}
     SKIP_POLARS_INSTALLATION_TEST={env:SKIP_POLARS_INSTALLATION_TEST:false}
-    EXPECTED_SKIP_COUNT = {env:EXPECTED_SKIP_COUNT:193}
+    EXPECTED_SKIP_COUNT = {env:EXPECTED_SKIP_COUNT:194}
     CHECK_SKIP_COUNT = {env:CHECK_SKIP_COUNT:1}
     TOX_LOCK_PATH = {env:TOX_LOCK_PATH:/tmp/mloda-tox.lock}
 commands = sh -c "set -- pytest -n {env:PYTEST_WORKERS:8} --timeout=10 {env:DEACTIVATE_NOTEBOOK_AND_DOC_TESTS:''}; if [ -n \"$TOX_LOCK_PATH\" ] && command -v flock >/dev/null 2>&1; then [ -e \"$TOX_LOCK_PATH\" ] || (umask 0 && : > \"$TOX_LOCK_PATH\") 2>/dev/null; if [ -w \"$TOX_LOCK_PATH\" ]; then exec flock \"$TOX_LOCK_PATH\" \"$@\"; fi; fi; exec \"$@\""


### PR DESCRIPTION
Closes #467.

## Problem

`pick_helper_column_name` (collision-safe helper-column naming, #405) was wired in only for DuckDB and SQLite. Two gaps remained:

1. **Spark silently collided** on a hardcoded `"__row_num"` helper. If the incoming DataFrame already had a user column named `__row_num`, `withColumn("__row_num", ...)` replaced it and the trailing `.join(..., "__row_num").drop("__row_num")` removed it: silent data loss, no error.
2. **No shared SQL relation base**, so the collision-safe logic was duplicated between `DuckdbRelation` and `SqliteRelation` and a future SQL backend would not inherit it.

Plus the PyArrow merge engine hardcoded `mloda_right_index` and *rejected* on collision rather than picking a free name.

## Changes

- **Spark** (`spark_framework.py`): the row-number helper is now `pick_helper_column_name(taken=set(self.data.columns))`. A user column named `__row_num` is preserved intact.
- **PyArrow** (`pyarrow_merge_engine.py`): the right-index copy helper is now `pick_helper_column_name(taken=set(right_data.column_names), prefix="mloda_right_index")`; the reject-on-collision `ValueError` is gone. PyArrow drops the join key from the output, so the renamed helper never appears in the result schema.
- **Shared `SqlBaseRelation`** (`sql/sql_base_relation.py`): `with_row_number` / `window` and the collision-safe naming helpers (`_ensure_column_absent`, `_pick_helper_column`) now live in one place, implemented over an abstract `columns` property + `_project_raw` primitive and overridable version-guard hooks. `DuckdbRelation` and `SqliteRelation` inherit them; the emitted SQL is byte-identical to before. `append_column` stays backend-specific (SQLite's type propagation has no DuckDB analog) but routes its collision-safe naming through the shared helpers. The base documents the collision-safe-naming contract for any future backend.

## Tests

- Spark regression test (preserves a user `__row_num` column). Skip-gated like the rest of the Spark suite (needs Java); `EXPECTED_SKIP_COUNT` bumped 193 → 194.
- PyArrow regression test (merge succeeds and preserves a user `mloda_right_index` column instead of raising).
- The `append_column` collision / helper-candidate tests moved from the DuckDB-only file into the shared `relation_test_mixin.py`, so both DuckDB and SQLite now exercise them.

## Validation

- Relation + merge suites (pyarrow / duckdb / sqlite / sql): all pass.
- `ruff format --check` and `ruff check`: clean.
- `mypy --strict`: no new errors introduced.

Follow-up to #405; the core-side counterpart to the registry's adoption in mloda-ai/mloda-registry#181.