### PR TITLE
fix: silence Polars asof 'Sortedness' UserWarning on by-group joins (#480)

### DIFF
--- a/mloda_plugins/compute_framework/base_implementations/polars/polars_merge_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/polars/polars_merge_engine.py
@@ -60,7 +60,7 @@ class PolarsMergeEngine(BaseMergeEngine):
             kwargs["tolerance"] = asof_config.tolerance
 
         result = left_sorted.join_asof(
-            right_sorted, left_on=lt, right_on=rt, by_left=by_left, by_right=by_right, **kwargs
+            right_sorted, left_on=lt, right_on=rt, by_left=by_left, by_right=by_right, check_sortedness=False, **kwargs
         )
 
         # Re-add any right by-key whose name differs from its left counterpart (polars drops it).

--- a/tests/test_plugins/compute_framework/test_tooling/asof/asof_merge_engine_test_base.py
+++ b/tests/test_plugins/compute_framework/test_tooling/asof/asof_merge_engine_test_base.py
@@ -6,6 +6,7 @@ for point-in-time (as-of) merge operations across all compute frameworks.
 """
 
 import math
+import warnings
 from abc import ABC, abstractmethod
 from collections import Counter
 from typing import Any, Optional
@@ -190,3 +191,24 @@ class AsofMergeEngineTestBase(ABC):
     def test_differing_names(self) -> None:
         """Vector G: differing by-key and time-column names; both by-key columns survive."""
         self._run_asof_test("differing_names")
+
+    def test_no_sortedness_warning_with_by_groups(self) -> None:
+        """An ASOF join with `by` groups must not emit a 'Sortedness' warning.
+
+        Polars' ``join_asof`` warns ("Sortedness of columns cannot be checked when
+        'by' groups provided") whenever ``by_left``/``by_right`` are passed; the fix
+        is to pass ``check_sortedness=False``. The warning is framework-specific
+        (only polars emits it), so we record all warnings and assert none mention
+        "Sortedness" rather than turning every UserWarning into an error -- this keeps
+        the test framework-safe for pandas/duckdb that inherit this base class.
+
+        For the lazy polars engine the warning is deferred until the LazyFrame is
+        collected, so the capture must wrap the whole scenario run (including the
+        conversion/collect inside ``_run_asof_test``), not just the merge_asof call.
+        """
+        with warnings.catch_warnings(record=True) as recorded:
+            warnings.simplefilter("always")
+            self._run_asof_test("multi_by_key")
+
+        offending = [str(w.message) for w in recorded if "Sortedness" in str(w.message)]
+        assert not offending, f"Unexpected 'Sortedness' warning(s) emitted: {offending}"


### PR DESCRIPTION
## Summary

Fixes #480. The Polars `join_asof` path emitted `UserWarning: Sortedness of columns cannot be checked when 'by' groups provided` once per asof join, producing ~20 identical warnings in a normal CI run.

The asof frames are already globally sorted (`left_data.sort(lt)` / `right_data.sort(rt)`), and a global sort guarantees per-group sortedness as well. Polars simply cannot verify per-group ordering when `by` groups are passed, so it warns. We pass `check_sortedness=False` to `join_asof`, suppressing a check that is satisfied by construction rather than masking a real ordering bug.

Fixed at the source (not via a `pytest.ini` filter) so end users do not see the warning either. The change lives in `PolarsMergeEngine.merge_asof`, which `PolarsLazyMergeEngine` inherits, so both the eager and lazy engines are covered by the one-line change.

## Test

Adds a regression test in the shared `AsofMergeEngineTestBase` (`test_no_sortedness_warning_with_by_groups`) that runs a `by`-group scenario and asserts no recorded warning mentions "Sortedness". It:

- wraps the **whole** scenario run including the lazy `collect()` (where the warning materializes for the lazy engine), not just the `merge_asof` call, and
- matches the "Sortedness" substring rather than turning every `UserWarning` into an error, so it stays framework-safe for the pandas/duckdb engines that also inherit this base.

Confirmed red before the fix (eager + lazy) and green after.

## Definition of done

- A Polars ASOF join with `by` groups produces no `UserWarning` about sortedness. ✅
- `pytest tests/test_plugins/compute_framework/base_implementations/polars/test_polars_asof_merge_engine.py -W error::UserWarning` → `18 passed`, zero warnings. ✅