### PR TITLE
Clarify return_data_type_rule failure contract

### DIFF
--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -261,6 +261,8 @@ class FeatureGroup(ABC):
         If this feature group always returns a specific data type, this method should
         return that data type. Otherwise, it should return None, indicating that the
         data type is not fixed and may vary depending on the input or computation.
+        If the data type cannot be determined during planning, return None instead
+        of raising an exception.
         """
         return None
 

--- a/mloda/core/core/engine.py
+++ b/mloda/core/core/engine.py
@@ -367,7 +367,10 @@ class Engine:
         return feature
 
     def set_data_type(self, feature: Feature, feature_group_class: type[FeatureGroup]) -> Optional[DataType]:
-        fg_data_type = feature_group_class.return_data_type_rule(feature)
+        try:
+            fg_data_type = feature_group_class.return_data_type_rule(feature)
+        except Exception:
+            fg_data_type = None
         if feature.data_type and fg_data_type:
             if feature.data_type != fg_data_type:
                 raise ValueError(

--- a/tests/test_core/test_core/test_engine.py
+++ b/tests/test_core/test_core/test_engine.py
@@ -2,6 +2,8 @@ from typing import Any
 from unittest.mock import patch
 from mloda.user import DataType
 
+from mloda.provider import FeatureGroup
+from mloda.user import Feature
 from mloda.user import FeatureName
 from mloda.core.core.engine import Engine
 from mloda.core.prepare.accessible_plugins import PreFilterPlugins
@@ -25,6 +27,17 @@ from tests.test_core.test_abstract_plugins.test_abstract_feature_group import (
 
 
 class TestEngine:
+    def test_set_data_type_treats_raising_return_data_type_rule_as_undeclared(self) -> None:
+        class MisbehavingDataTypeRuleFeatureGroup(FeatureGroup):
+            @classmethod
+            def return_data_type_rule(cls, feature: Feature) -> DataType | None:
+                raise ValueError("type cannot be inferred")
+
+        engine = object.__new__(Engine)
+        feature = Feature.str_of("typed_feature")
+
+        assert engine.set_data_type(feature, MisbehavingDataTypeRuleFeatureGroup) == DataType.STRING
+
     def test_init_engine(self) -> None:
         with (
             patch(


### PR DESCRIPTION
## Summary
- clarify that `return_data_type_rule` should return `None` during planning when it cannot determine a fixed data type
- guard the engine call so a raising rule is treated as an undeclared feature-group type instead of failing planning
- add a regression test for preserving an explicitly typed feature when the feature-group rule raises

Fixes #483

## Test plan
- RED: `uv run --no-project --with pytest --with numpy python -m pytest tests/test_core/test_core/test_engine.py::TestEngine::test_set_data_type_treats_raising_return_data_type_rule_as_undeclared -q` failed with `ValueError: type cannot be inferred`
- GREEN: the same targeted test passes
- `uv run --no-project --with pytest --with numpy python -m pytest tests/test_core/test_core/test_engine.py -q`
- `uv run --no-project --with ruff ruff check mloda/core/core/engine.py mloda/core/abstract_plugins/feature_group.py tests/test_core/test_core/test_engine.py`
- `uv run --no-project --with ruff ruff format --check mloda/core/core/engine.py mloda/core/abstract_plugins/feature_group.py tests/test_core/test_core/test_engine.py`
- `git diff --check -- mloda/core/core/engine.py mloda/core/abstract_plugins/feature_group.py tests/test_core/test_core/test_engine.py`