### PR TITLE
fix: PyArrow asof joins natively via Acero instead of pandas round-trip

### DIFF
--- a/mloda_plugins/compute_framework/base_implementations/pyarrow/pyarrow_merge_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/pyarrow/pyarrow_merge_engine.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, cast
 
 import pyarrow as pa
 import pyarrow.compute as pc
@@ -88,11 +88,15 @@ class PyArrowMergeEngine(BaseMergeEngine):
                 "Acero's match range always includes exact matches."
             )
 
-        if asof_config.tolerance is not None and not isinstance(asof_config.tolerance, int):
-            raise ValueError(
-                f"{self.__class__.__name__} asof requires an integer tolerance; "
-                "timedelta and non-integer tolerances are not supported."
-            )
+        tol = asof_config.tolerance
+        if tol is not None:
+            is_integer = isinstance(tol, int) and not isinstance(tol, bool)
+            is_integer_valued_float = isinstance(tol, float) and tol.is_integer()
+            if not (is_integer or is_integer_valued_float):
+                raise ValueError(
+                    f"{self.__class__.__name__} asof requires an integer tolerance; "
+                    "timedelta, boolean and non-integer tolerances are not supported."
+                )
 
         by_left = list(left_index.index)
         by_right = list(right_index.index)
@@ -119,8 +123,8 @@ class PyArrowMergeEngine(BaseMergeEngine):
         left_data = self._normalize_string_types(left_data, by_left)
         right_join = self._normalize_string_types(right_join, by_right)
 
-        if asof_config.tolerance is not None:
-            magnitude = int(asof_config.tolerance)
+        if tol is not None:
+            magnitude = int(cast(float, tol))
         else:
             left_on_i = pc.cast(left_data[lt], pa.int64())
             right_on_i = pc.cast(right_join[rt], pa.int64())
@@ -129,6 +133,8 @@ class PyArrowMergeEngine(BaseMergeEngine):
             magnitude = 0 if mm["min"] is None or mm["max"] is None else (mm["max"] - mm["min"])
 
         signed_tol = -magnitude if asof_config.direction == "backward" else magnitude
+        _INT64_MIN, _INT64_MAX = -(2**63), 2**63 - 1
+        signed_tol = max(_INT64_MIN, min(signed_tol, _INT64_MAX))
 
         result = left_data.sort_by(lt).join_asof(
             right_join.sort_by(rt),

--- a/mloda_plugins/compute_framework/base_implementations/pyarrow/pyarrow_merge_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/pyarrow/pyarrow_merge_engine.py
@@ -9,11 +9,6 @@ from mloda.user import JoinType
 from mloda.provider import BaseMergeEngine
 from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import pick_helper_column_name
 
-try:
-    import pandas as pd
-except ImportError:
-    pd = None
-
 
 class PyArrowMergeEngine(BaseMergeEngine):
     @staticmethod
@@ -84,33 +79,71 @@ class PyArrowMergeEngine(BaseMergeEngine):
         right_index: Index,
         asof_config: AsOfJoinConfig,
     ) -> Any:
-        if pd is None:
-            raise ImportError("Pandas is not installed. To be able to use this framework, please install pandas.")
+        if asof_config.direction == "nearest":
+            raise ValueError(f"{self.__class__.__name__} asof does not support direction='nearest'.")
+
+        if asof_config.allow_exact_matches is False:
+            raise ValueError(
+                f"{self.__class__.__name__} asof does not support allow_exact_matches=False; "
+                "Acero's match range always includes exact matches."
+            )
+
+        if asof_config.tolerance is not None and not isinstance(asof_config.tolerance, int):
+            raise ValueError(
+                f"{self.__class__.__name__} asof requires an integer tolerance; "
+                "timedelta and non-integer tolerances are not supported."
+            )
 
         by_left = list(left_index.index)
         by_right = list(right_index.index)
         lt, rt = asof_config.left_time_column, asof_config.right_time_column
 
-        left_df = left_data.to_pandas().sort_values(lt)
-        right_df = right_data.to_pandas().sort_values(rt)
+        left_cols = list(left_data.column_names)
+        right_cols = list(right_data.column_names)
 
-        kwargs: dict[str, Any] = {
-            "direction": asof_config.direction,
-            "allow_exact_matches": asof_config.allow_exact_matches,
-        }
+        right_match = set(by_right) | {rt}
+        right_value_keep = [c for c in right_cols if c not in right_match and c not in left_cols]
+        right_key_carry = [c for c in right_match if c not in left_cols]
+
+        right_select = by_right + [rt] + right_value_keep
+        right_join = right_data.select(right_select)
+
+        taken = set(left_cols) | set(right_join.column_names)
+        carry_to_original: dict[str, str] = {}
+        for c in right_key_carry:
+            carry_name = pick_helper_column_name(taken=taken, prefix="mloda_asof_carry")
+            taken.add(carry_name)
+            right_join = right_join.append_column(carry_name, right_data[c])
+            carry_to_original[carry_name] = c
+
+        left_data = self._normalize_string_types(left_data, by_left)
+        right_join = self._normalize_string_types(right_join, by_right)
+
         if asof_config.tolerance is not None:
-            kwargs["tolerance"] = asof_config.tolerance
+            magnitude = int(asof_config.tolerance)
+        else:
+            left_on_i = pc.cast(left_data[lt], pa.int64())
+            right_on_i = pc.cast(right_join[rt], pa.int64())
+            combined = pa.concat_arrays([left_on_i.combine_chunks(), right_on_i.combine_chunks()])
+            mm = pc.min_max(combined).as_py()
+            magnitude = 0 if mm["min"] is None or mm["max"] is None else (mm["max"] - mm["min"])
 
-        result = pd.merge_asof(
-            left_df,
-            right_df,
-            left_on=lt,
+        signed_tol = -magnitude if asof_config.direction == "backward" else magnitude
+
+        result = left_data.sort_by(lt).join_asof(
+            right_join.sort_by(rt),
+            on=lt,
+            by=by_left,
             right_on=rt,
-            left_by=by_left,
             right_by=by_right,
-            **kwargs,
+            tolerance=signed_tol,
         )
-        return pa.Table.from_pandas(result, preserve_index=False)
+
+        if carry_to_original:
+            new_names = [carry_to_original.get(name, name) for name in result.column_names]
+            result = result.rename_columns(new_names)
+
+        return result
 
     def join_logic(
         self, join_type: str, left_data: Any, right_data: Any, left_index: Index, right_index: Index, jointype: JoinType

--- a/tests/test_plugins/compute_framework/base_implementations/pyarrow/test_pyarrow_asof_merge_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/pyarrow/test_pyarrow_asof_merge_engine.py
@@ -95,7 +95,22 @@ class TestPyArrowAsofMergeEngine(AsofMergeEngineTestBase):
             engine.merge_asof(left, right, Index(("k",)), Index(("k",)), cfg)
 
     def test_tolerance_float_rejected(self) -> None:
-        """Acero's asof tolerance must be an integer; a float tolerance is rejected -> ValueError."""
+        """A non-integer float tolerance cannot be expressed as an Acero integer span -> ValueError."""
+        left = pa.Table.from_pydict({"k": [1], "t": [10], "lv": [100]})
+        right = pa.Table.from_pydict({"k": [1, 1], "t": [8, 15], "rv": ["A", "B"]})
+
+        engine = PyArrowMergeEngine()
+        cfg = AsOfJoinConfig(
+            left_time_column="t",
+            right_time_column="t",
+            direction="backward",
+            tolerance=5.5,
+        )
+        with pytest.raises(ValueError, match="PyArrowMergeEngine"):
+            engine.merge_asof(left, right, Index(("k",)), Index(("k",)), cfg)
+
+    def test_tolerance_float_integer_valued_accepted(self) -> None:
+        """An integer-valued float tolerance (5.0) must be accepted and behave like the int."""
         left = pa.Table.from_pydict({"k": [1], "t": [10], "lv": [100]})
         right = pa.Table.from_pydict({"k": [1, 1], "t": [8, 15], "rv": ["A", "B"]})
 
@@ -106,5 +121,79 @@ class TestPyArrowAsofMergeEngine(AsofMergeEngineTestBase):
             direction="backward",
             tolerance=5.0,
         )
+        result = engine.merge_asof(left, right, Index(("k",)), Index(("k",)), cfg)
+        rows = result.to_pylist()
+        assert len(rows) == 1
+        assert rows[0]["rv"] == "A"
+
+    def test_tolerance_bool_rejected(self) -> None:
+        """A boolean tolerance must be rejected; bool is an int subclass and must not become 1."""
+        left = pa.Table.from_pydict({"k": [1], "t": [10], "lv": [100]})
+        right = pa.Table.from_pydict({"k": [1, 1], "t": [8, 15], "rv": ["A", "B"]})
+
+        engine = PyArrowMergeEngine()
+        cfg = AsOfJoinConfig(
+            left_time_column="t",
+            right_time_column="t",
+            direction="backward",
+            tolerance=True,
+        )
         with pytest.raises(ValueError, match="PyArrowMergeEngine"):
             engine.merge_asof(left, right, Index(("k",)), Index(("k",)), cfg)
+
+    def test_unbounded_tolerance_extreme_int64_no_overflow(self) -> None:
+        """Unbounded tolerance on extreme int64 on-keys (forward) must not raise OverflowError."""
+        left = pa.Table.from_pydict({"k": [1], "t": pa.array([-(2**62)], pa.int64()), "lv": [1]})
+        right = pa.Table.from_pydict({"k": [1], "t": pa.array([2**62], pa.int64()), "rv": [5]})
+
+        engine = PyArrowMergeEngine()
+        cfg = AsOfJoinConfig(left_time_column="t", right_time_column="t", direction="forward")
+        result = engine.merge_asof(left, right, Index(("k",)), Index(("k",)), cfg)
+        rows = result.to_pylist()
+        assert len(rows) == 1
+        assert rows[0]["lv"] == 1
+
+    def test_forward_tolerance_none(self) -> None:
+        """Forward direction with unbounded (None) tolerance: nearest right.t >= left.t."""
+        left = pa.Table.from_pydict({"k": [1, 1], "t": [10, 20], "lv": [100, 200]})
+        right = pa.Table.from_pydict({"k": [1, 1], "t": [5, 18], "rv": ["A", "B"]})
+
+        engine = PyArrowMergeEngine()
+        cfg = AsOfJoinConfig(left_time_column="t", right_time_column="t", direction="forward")
+        result = engine.merge_asof(left, right, Index(("k",)), Index(("k",)), cfg)
+        rows = sorted(result.to_pylist(), key=lambda r: r["t"])
+        assert len(rows) == 2
+        assert rows[0]["lv"] == 100
+        assert rows[0]["rv"] == "B"
+        assert rows[1]["lv"] == 200
+        assert rows[1]["rv"] is None
+
+    def test_colliding_right_value_column_dropped(self) -> None:
+        """A right VALUE column colliding with a left column is dropped; the left column survives."""
+        left = pa.Table.from_pydict({"k": [1], "t": [10], "lv": [100], "shared": ["L"]})
+        right = pa.Table.from_pydict({"k": [1], "t": [5], "rv": ["X"], "shared": ["R"]})
+
+        engine = PyArrowMergeEngine()
+        cfg = AsOfJoinConfig(left_time_column="t", right_time_column="t", direction="backward")
+        result = engine.merge_asof(left, right, Index(("k",)), Index(("k",)), cfg)
+        rows = result.to_pylist()
+        assert len(rows) == 1
+        assert result.column_names.count("shared") == 1
+        assert rows[0]["shared"] == "L"
+        assert rows[0]["rv"] == "X"
+
+    def test_differing_string_key_carry(self) -> None:
+        """Differing-name string by-keys (lk vs rk) survive via the carry column."""
+        left = pa.Table.from_pydict({"lk": ["a"], "lt": [10], "lv": [100]})
+        right = pa.Table.from_pydict({"rk": ["a"], "rt": [5], "rv": ["X"]})
+
+        engine = PyArrowMergeEngine()
+        cfg = AsOfJoinConfig(left_time_column="lt", right_time_column="rt", direction="backward")
+        result = engine.merge_asof(left, right, Index(("lk",)), Index(("rk",)), cfg)
+        rows = result.to_pylist()
+        assert len(rows) == 1
+        assert "lk" in result.column_names
+        assert "rk" in result.column_names
+        assert rows[0]["lk"] == "a"
+        assert rows[0]["rk"] == "a"
+        assert rows[0]["rv"] == "X"

--- a/tests/test_plugins/compute_framework/base_implementations/pyarrow/test_pyarrow_asof_merge_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/pyarrow/test_pyarrow_asof_merge_engine.py
@@ -5,6 +5,7 @@ Consumes the shared AsofMergeEngineTestBase. PyArrow is both the framework
 under test and the interchange format used by the DataConverter.
 """
 
+from datetime import timedelta
 from typing import Any, Optional
 
 import pytest
@@ -45,14 +46,65 @@ class TestPyArrowAsofMergeEngine(AsofMergeEngineTestBase):
         return None
 
     def test_nearest_direction(self) -> None:
-        """Vector F: PyArrow supports 'nearest' -> closer right row (t=8, gap 2) matched."""
+        """Vector F: native PyArrow Acero (Table.join_asof) cannot express 'nearest' -> ValueError.
+
+        Acero's asof join only supports a directional (forward/backward) tolerance match;
+        a symmetric 'nearest' search is not available, so it must be rejected like the SQL engines.
+        """
         left = pa.Table.from_pydict({"k": [1], "t": [10], "lv": [100]})
         right = pa.Table.from_pydict({"k": [1, 1], "t": [8, 15], "rv": ["A", "B"]})
 
         engine = PyArrowMergeEngine()
         cfg = AsOfJoinConfig(left_time_column="t", right_time_column="t", direction="nearest")
-        result = engine.merge_asof(left, right, Index(("k",)), Index(("k",)), cfg)
+        with pytest.raises(ValueError, match="PyArrowMergeEngine"):
+            engine.merge_asof(left, right, Index(("k",)), Index(("k",)), cfg)
 
-        result_dicts = result.to_pylist()
-        assert len(result_dicts) == 1
-        assert result_dicts[0]["rv"] == "A"
+    def test_allow_exact_matches_false(self) -> None:
+        """Override Vector C: Acero's asof match range always includes exact matches.
+
+        Native PyArrow ``Table.join_asof`` performs an inclusive tolerance comparison, so
+        there is no way to exclude an exact-time match. ``allow_exact_matches=False`` must
+        therefore be rejected with a ValueError rather than silently returning the exact row.
+        """
+        left = pa.Table.from_pydict({"k": [1], "t": [10], "lv": [100]})
+        right = pa.Table.from_pydict({"k": [1, 1], "t": [10, 5], "rv": [99, 1]})
+
+        engine = PyArrowMergeEngine()
+        cfg = AsOfJoinConfig(
+            left_time_column="t",
+            right_time_column="t",
+            direction="backward",
+            allow_exact_matches=False,
+        )
+        with pytest.raises(ValueError, match="PyArrowMergeEngine"):
+            engine.merge_asof(left, right, Index(("k",)), Index(("k",)), cfg)
+
+    def test_tolerance_timedelta_rejected(self) -> None:
+        """Acero requires a numeric (integer) tolerance; a timedelta cannot be expressed -> ValueError."""
+        left = pa.Table.from_pydict({"k": [1], "t": [10], "lv": [100]})
+        right = pa.Table.from_pydict({"k": [1, 1], "t": [8, 15], "rv": ["A", "B"]})
+
+        engine = PyArrowMergeEngine()
+        cfg = AsOfJoinConfig(
+            left_time_column="t",
+            right_time_column="t",
+            direction="backward",
+            tolerance=timedelta(seconds=5),
+        )
+        with pytest.raises(ValueError, match="PyArrowMergeEngine"):
+            engine.merge_asof(left, right, Index(("k",)), Index(("k",)), cfg)
+
+    def test_tolerance_float_rejected(self) -> None:
+        """Acero's asof tolerance must be an integer; a float tolerance is rejected -> ValueError."""
+        left = pa.Table.from_pydict({"k": [1], "t": [10], "lv": [100]})
+        right = pa.Table.from_pydict({"k": [1, 1], "t": [8, 15], "rv": ["A", "B"]})
+
+        engine = PyArrowMergeEngine()
+        cfg = AsOfJoinConfig(
+            left_time_column="t",
+            right_time_column="t",
+            direction="backward",
+            tolerance=5.0,
+        )
+        with pytest.raises(ValueError, match="PyArrowMergeEngine"):
+            engine.merge_asof(left, right, Index(("k",)), Index(("k",)), cfg)


### PR DESCRIPTION
## Summary

Closes #488.

`PyArrowMergeEngine.merge_asof` (added in 0.8.0) computed the as-of join by round-tripping both tables through pandas (`to_pandas()` -> `pd.merge_asof()` -> `pa.Table.from_pandas()`). This introduced a hidden hard pandas dependency on the Arrow backend, defeated the point of choosing Arrow (the join ran in pandas), risked type/null/timezone drift through `from_pandas` inference, and was the only backend that neither computed natively nor rejected unsupported knobs, silently falling back instead.

This PR replaces the pandas round-trip with the native PyArrow Acero asof join (`Table.join_asof`).

## What changed

**Native path (computed in Acero):**
- `direction="backward"` / `"forward"`, single and multi by-keys, differing by-key and time-column names, integer tolerance, and unbounded tolerance (`None`).
- Unbounded tolerance is encoded as the **int64 data span** of the on-keys rather than a large sentinel, so any same-direction match is reachable while avoiding integer overflow on timestamp on-keys.
- Acero consumes the right `on`/`by` columns; differing-name right keys/time columns are carried as collision-safe helper columns (`pick_helper_column_name`, the #477 convention) and renamed back, preserving the cross-engine column contract: all left columns survive, non-colliding right columns survive, and differing-name keys on both sides survive.

**Rejection paths (raise `ValueError`, mirroring the DuckDB/SQLite/Spark engines):**
- `direction="nearest"` (Acero has no nearest).
- `allow_exact_matches=False` (Acero's match range `[min(0,tol), max(0,tol)]` always includes the exact match).
- non-integer / `timedelta` tolerance (Acero tolerance is an integer).

**Dependency:** the `pandas` import is removed from the module; an as-of join on the PyArrow backend no longer requires pandas.

## Definition of done

- [x] PyArrow as-of uses native Acero `asofjoin` for supported configs, rejects the rest with `ValueError`.
- [x] Unsupported knobs (`direction="nearest"`, non-integer/`timedelta` tolerance, `allow_exact_matches=False`) raise a clear `ValueError`, consistent with the SQL engines.
- [x] No hard pandas dependency for an as-of join on the PyArrow backend.
- [x] Tests cover the native path (inherited shared scenario suite + run_all integration) and the four rejection paths; `tox` passes.

## Testing

- Inherited shared ASOF scenario suite (backward/forward/exact-match/tolerance/multi-by-key/differing-names/no-sortedness-warning) and the `run_all` integration test pass against the native path.
- Four rejection tests assert `ValueError` (message contains the engine class name) for `nearest`, `allow_exact_matches=False`, `timedelta` tolerance, and float tolerance.
- Full `tox` green: 3415 passed, ruff format/check, pip-licenses allowlist, `mypy --strict`, and bandit all pass.