### PR TITLE
feat: match-time compute-framework capability hook (#482)

### DIFF
--- a/docs/docs/in_depth/compute-framework-integration.md
+++ b/docs/docs/in_depth/compute-framework-integration.md
@@ -18,6 +18,38 @@ def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
     # Or return True to support all available compute frameworks
 ```
 
+### Declaring an Operation Unsupported on a Framework
+
+`compute_framework_rule` is a static, class-level set: it cannot say "this
+feature group runs on SQLite in general, but *this particular operation* is
+unsupported there." For that, override `supports_compute_framework`, a
+per-feature hook evaluated at match time:
+
+``` python
+@classmethod
+def supports_compute_framework(cls, feature_name, options, compute_framework) -> bool:
+    """Reject an operation on a specific framework. Default returns True."""
+    if compute_framework is SQLiteFramework and is_median_op(feature_name, options):
+        return False  # median is unsupported on SQLite
+    return True
+```
+
+Returning `False` removes that framework from the candidate set **for this
+feature only**:
+
+- If another framework can still run the operation, the matcher routes around
+  the rejected one silently (no error).
+- If the only remaining candidate is the rejected framework (for example, the
+  user pinned the feature to it), resolution fails with a dedicated,
+  actionable error that names the unsupported and supported frameworks, e.g.
+  `Unsupported compute framework(s) for feature 'X': ['SQLiteFramework']. Supported on: ['DuckDBFramework', 'PandasDataFrame'].`
+
+This is distinct from the "no feature group found" error, so an unsupported
+operation is no longer indistinguishable from an unknown feature. Prefer this
+hook over raising a generic error from inside `calculate_feature`: the
+rejection happens during planning rather than at compute time, and the message
+is built for you.
+
 ### Framework-Specific Implementations
 
 Feature groups follow a layered architecture:

--- a/docs/docs/in_depth/compute-framework-integration.md
+++ b/docs/docs/in_depth/compute-framework-integration.md
@@ -50,6 +50,13 @@ hook over raising a generic error from inside `calculate_feature`: the
 rejection happens during planning rather than at compute time, and the message
 is built for you.
 
+The debug inspector `resolve_feature(name)` reflects the hook too: its
+`ResolvedFeature` result carries `supported_compute_frameworks` and
+`unsupported_compute_frameworks` (evaluated under default options, since the
+inspector does not know the caller's `Options`), and a feature that matches a
+group but is unsupported on every installed framework resolves to
+`feature_group=None` with a capability error rather than appearing runnable.
+
 ### Framework-Specific Implementations
 
 Feature groups follow a layered architecture:

--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -461,6 +461,26 @@ class FeatureGroup(ABC):
             )
         return rule
 
+    @classmethod
+    def supports_compute_framework(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        compute_framework: type[ComputeFramework],
+    ) -> bool:
+        """Per-feature, per-framework capability check evaluated at match time.
+
+        Returns ``True`` (the default) to allow the framework. Override to declare
+        that a specific operation (encoded in ``feature_name``/``options``) is
+        unsupported on ``compute_framework`` -- return ``False`` and the matcher
+        removes that framework from the candidate set for this feature only.
+        Unlike ``compute_framework_rule`` (a static class-level set), this hook sees
+        the concrete feature, so it can reject an op on one backend while allowing
+        others. If every candidate framework is rejected, the matcher surfaces a
+        distinguishable error instead of a generic "no feature group" message.
+        """
+        return True
+
     @final
     @classmethod
     def get_class_name(cls) -> str:

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -26,6 +26,7 @@ from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.api.plugin_info import ComputeFrameworkInfo, ExtenderInfo, FeatureGroupInfo, ResolvedFeature
 from mloda.core.prepare.accessible_plugins import dedup_feature_group_subclasses
+from mloda.core.prepare.identify_feature_group import split_frameworks_by_capability
 
 
 def get_feature_group_docs(
@@ -284,6 +285,24 @@ def resolve_feature(feature_name: str, plugin_collector: Optional[PluginCollecto
             error=f"No FeatureGroup found for feature name: {feature_name}",
         )
 
+    supported, rejected = split_frameworks_by_capability(candidates, feature_name_obj, Options())
+    supported_names = sorted(c.get_class_name() for c in supported)
+    rejected_names = sorted(c.get_class_name() for c in rejected)
+
+    if not supported and rejected:
+        return ResolvedFeature(
+            feature_name=feature_name,
+            feature_group=None,
+            candidates=candidates,
+            error=(
+                f"Feature '{feature_name}' matches {[c.get_class_name() for c in candidates]} "
+                f"but is unsupported on all installed compute frameworks "
+                f"(evaluated under default options): {rejected_names}."
+            ),
+            supported_compute_frameworks=[],
+            unsupported_compute_frameworks=rejected_names,
+        )
+
     filtered = _filter_subclasses(candidates)
 
     if len(filtered) == 1:
@@ -292,6 +311,8 @@ def resolve_feature(feature_name: str, plugin_collector: Optional[PluginCollecto
             feature_group=filtered[0],
             candidates=candidates,
             error=None,
+            supported_compute_frameworks=supported_names,
+            unsupported_compute_frameworks=rejected_names,
         )
 
     conflicting_names = [fg.__name__ for fg in filtered]
@@ -300,6 +321,8 @@ def resolve_feature(feature_name: str, plugin_collector: Optional[PluginCollecto
         feature_group=None,
         candidates=candidates,
         error=f"Multiple FeatureGroups match feature name '{feature_name}': {conflicting_names}",
+        supported_compute_frameworks=supported_names,
+        unsupported_compute_frameworks=rejected_names,
     )
 
 

--- a/mloda/core/api/plugin_info.py
+++ b/mloda/core/api/plugin_info.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -41,3 +41,7 @@ class ResolvedFeature:
     feature_group: Optional[type["FeatureGroup"]]
     candidates: list[type["FeatureGroup"]]
     error: Optional[str]
+    # Frameworks supporting the feature, evaluated under default options.
+    supported_compute_frameworks: list[str] = field(default_factory=list)
+    # Frameworks rejecting the feature, evaluated under default options.
+    unsupported_compute_frameworks: list[str] = field(default_factory=list)

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -21,6 +21,8 @@ class IdentifyFeatureGroupClass:
         links: Optional[set[Link]],
         data_access_collection: Optional[DataAccessCollection] = None,
     ):
+        self._criteria_matched_feature_groups: set[type[FeatureGroup]] = set()
+
         feature_group = self._filter_loop(feature, accessible_plugins, links, data_access_collection)
 
         self.validate(feature_group, feature, accessible_plugins)
@@ -42,14 +44,22 @@ class IdentifyFeatureGroupClass:
             if not self._filter_feature_group_by_domain(feature_group, feature):
                 continue
 
-            if not self._filter_feature_group_by_framework(compute_frameworks, feature):
+            self._criteria_matched_feature_groups.add(feature_group)
+
+            supported_frameworks = {
+                cfw
+                for cfw in compute_frameworks
+                if feature_group.supports_compute_framework(feature.name, feature.options, cfw)
+            }
+
+            if not self._filter_feature_group_by_framework(supported_frameworks, feature):
                 continue
 
             if not self._filter_feature_group_by_links(feature_group, links):
                 continue
 
-            if compute_frameworks:
-                _identified_feature_groups[feature_group] = compute_frameworks
+            if supported_frameworks:
+                _identified_feature_groups[feature_group] = supported_frameworks
 
         _identified_feature_groups = self.filter_subclasses(_identified_feature_groups)
         return _identified_feature_groups
@@ -120,9 +130,39 @@ class IdentifyFeatureGroupClass:
                 f"Feature {feature.name} {format_feature_group_class(feature_group_class)} has no compute framework."
             )
 
+    def _capability_rejection_message(
+        self, feature: Feature, accessible_plugins: FeatureGroupEnvironmentMapping
+    ) -> Optional[str]:
+        rejected: set[type[ComputeFramework]] = set()
+        supported: set[type[ComputeFramework]] = set()
+
+        for fg in self._criteria_matched_feature_groups:
+            for cfw in accessible_plugins.get(fg, set()):
+                if fg.supports_compute_framework(feature.name, feature.options, cfw):
+                    supported.add(cfw)
+                else:
+                    rejected.add(cfw)
+
+        if not rejected:
+            return None
+
+        rejected_names = sorted(fw.get_class_name() for fw in rejected)
+        msg = f"Unsupported compute framework(s) for feature '{str(feature.name)}': {rejected_names}."
+
+        if supported:
+            supported_names = sorted(fw.get_class_name() for fw in supported)
+            msg += f" Supported on: {supported_names}."
+
+        msg += " Pin the feature to a supported compute framework or override supports_compute_framework."
+        return msg
+
     def _build_no_feature_group_error(
         self, feature: Feature, accessible_plugins: FeatureGroupEnvironmentMapping
     ) -> str:
+        capability_message = self._capability_rejection_message(feature, accessible_plugins)
+        if capability_message is not None:
+            return capability_message
+
         feature_name = str(feature.name)
         msg = f"No feature groups found for feature name: '{feature_name}'."
 

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -1,8 +1,10 @@
 from difflib import get_close_matches
-from typing import Optional
+from typing import Iterable, Optional
 
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup, format_feature_group_class
 from mloda.core.abstract_plugins.components.feature import Feature
@@ -11,6 +13,31 @@ from mloda.core.abstract_plugins.components.link import Link
 import logging
 
 logger = logging.getLogger(__name__)
+
+
+def split_frameworks_by_capability(
+    feature_groups: Iterable[type[FeatureGroup]],
+    feature_name: FeatureName | str,
+    options: Options,
+) -> tuple[set[type[ComputeFramework]], set[type[ComputeFramework]]]:
+    """Split each feature group's available frameworks into (supported, rejected)
+    by the match-time capability hook.
+
+    For each feature group, considers the frameworks it declares via
+    compute_framework_definition() that are currently available
+    (ComputeFramework.is_available()), and partitions them by
+    supports_compute_framework(feature_name, options, cfw)."""
+    supported: set[type[ComputeFramework]] = set()
+    rejected: set[type[ComputeFramework]] = set()
+    for fg in feature_groups:
+        for cfw in fg.compute_framework_definition():
+            if not cfw.is_available():
+                continue
+            if fg.supports_compute_framework(feature_name, options, cfw):
+                supported.add(cfw)
+            else:
+                rejected.add(cfw)
+    return supported, rejected
 
 
 class IdentifyFeatureGroupClass:
@@ -131,17 +158,9 @@ class IdentifyFeatureGroupClass:
             )
 
     def _capability_rejection_message(self, feature: Feature) -> Optional[str]:
-        rejected: set[type[ComputeFramework]] = set()
-        supported: set[type[ComputeFramework]] = set()
-
-        for fg in self._criteria_matched_feature_groups:
-            for cfw in fg.compute_framework_definition():
-                if not cfw.is_available():
-                    continue
-                if fg.supports_compute_framework(feature.name, feature.options, cfw):
-                    supported.add(cfw)
-                else:
-                    rejected.add(cfw)
+        supported, rejected = split_frameworks_by_capability(
+            self._criteria_matched_feature_groups, feature.name, feature.options
+        )
 
         if not rejected:
             return None

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -130,14 +130,14 @@ class IdentifyFeatureGroupClass:
                 f"Feature {feature.name} {format_feature_group_class(feature_group_class)} has no compute framework."
             )
 
-    def _capability_rejection_message(
-        self, feature: Feature, accessible_plugins: FeatureGroupEnvironmentMapping
-    ) -> Optional[str]:
+    def _capability_rejection_message(self, feature: Feature) -> Optional[str]:
         rejected: set[type[ComputeFramework]] = set()
         supported: set[type[ComputeFramework]] = set()
 
         for fg in self._criteria_matched_feature_groups:
-            for cfw in accessible_plugins.get(fg, set()):
+            for cfw in fg.compute_framework_definition():
+                if not cfw.is_available():
+                    continue
                 if fg.supports_compute_framework(feature.name, feature.options, cfw):
                     supported.add(cfw)
                 else:
@@ -159,7 +159,7 @@ class IdentifyFeatureGroupClass:
     def _build_no_feature_group_error(
         self, feature: Feature, accessible_plugins: FeatureGroupEnvironmentMapping
     ) -> str:
-        capability_message = self._capability_rejection_message(feature, accessible_plugins)
+        capability_message = self._capability_rejection_message(feature)
         if capability_message is not None:
             return capability_message
 

--- a/tests/test_core/test_api/test_capability_run_all.py
+++ b/tests/test_core/test_api/test_capability_run_all.py
@@ -1,0 +1,83 @@
+"""End-to-end regression lock for the compute-framework capability hook (issue #482).
+
+These tests prove the capability hook fires through the REAL ``mlodaAPI.run_all``
+path, not just the resolver unit. They use only the always-installed frameworks
+``PandasDataFrame`` and ``PythonDictFramework`` so they never skip (which would
+break the tox EXPECTED_SKIP_COUNT).
+
+Both tests are expected to PASS against the already-merged capability behaviour;
+they lock the current end-to-end contract in place.
+"""
+
+from typing import Any, Optional
+
+import pandas as pd
+
+from mloda.provider import FeatureGroup, FeatureSet, DataCreator, BaseInputData
+from mloda.user import Feature, mloda
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame  # noqa: F401
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
+    PythonDictFramework,
+)
+
+
+FEAT = "E2ECapRunAllFeature"
+
+
+class E2ECapRunAllFeatureGroup(FeatureGroup):
+    """Root feature group that rejects PythonDictFramework only.
+
+    Declared module-level so it registers as a discoverable FeatureGroup. It
+    produces a single root feature via ``DataCreator`` and declares the operation
+    unsupported on ``PythonDictFramework`` so route-around is deterministic.
+    """
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({FEAT})
+
+    @classmethod
+    def supports_compute_framework(
+        cls,
+        feature_name: Any,
+        options: Any,
+        compute_framework: Any,
+    ) -> bool:
+        return compute_framework is not PythonDictFramework
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return pd.DataFrame({FEAT: [1, 2, 3]})
+
+
+class TestCapabilityRunAllEndToEnd:
+    """Capability hook fires through the real ``mlodaAPI.run_all`` path."""
+
+    def test_pinned_to_unsupported_framework_raises_capability_error(self) -> None:
+        """Pinning the run to the only-rejected framework raises a capability error."""
+        try:
+            mloda.run_all([Feature(FEAT)], compute_frameworks=["PythonDictFramework"])
+        except ValueError as exc:
+            message = str(exc)
+        else:
+            raise AssertionError("Expected a ValueError when pinned to the unsupported framework")
+
+        lowered = message.lower()
+        assert "unsupported" in lowered, f"Capability error must signal 'unsupported', got: {message}"
+        assert "PythonDictFramework" in message, f"Error must name the rejected framework, got: {message}"
+        assert "Did you mean" not in message, f"Capability error must skip the fuzzy suggestion path, got: {message}"
+
+    def test_route_around_to_pandas_returns_dataframe(self) -> None:
+        """With both frameworks enabled, the run routes around to Pandas and computes."""
+        result = mloda.run_all(
+            [Feature(FEAT)],
+            compute_frameworks=["PandasDataFrame", "PythonDictFramework"],
+        )
+
+        assert isinstance(result, list)
+        assert len(result) == 1, f"Expected exactly one result frame, got: {result}"
+
+        frame = result[0]
+        assert isinstance(frame, pd.DataFrame), f"Route-around must produce a pandas DataFrame, got: {type(frame)}"
+        assert FEAT in frame.columns, f"Result must contain column '{FEAT}', got columns: {list(frame.columns)}"
+        assert len(frame) == 3, f"Result must have 3 rows, got: {len(frame)}"

--- a/tests/test_core/test_api/test_resolve_feature.py
+++ b/tests/test_core/test_api/test_resolve_feature.py
@@ -10,12 +10,88 @@ import pytest
 from typing import Optional
 
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.api.plugin_info import ResolvedFeature
 from mloda.core.api.plugin_docs import resolve_feature
 from mloda.user import PluginLoader
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
+    PythonDictFramework,
+)
+
+
+SPLIT_CAP_FEATURE = "SplitCapResolveFeature"
+ALL_REJECTED_CAP_FEATURE = "AllRejectedCapResolveFeature"
+
+
+class SplitCapResolveFeatureGroup(FeatureGroup):
+    """Supports the op on PandasDataFrame but rejects PythonDictFramework.
+
+    Bounded compute_framework_rule so compute_framework_definition() is exactly
+    {PandasDataFrame, PythonDictFramework} and the capability split is deterministic.
+    """
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame, PythonDictFramework}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        if isinstance(feature_name, FeatureName):
+            feature_name = str(feature_name)
+        return feature_name == SPLIT_CAP_FEATURE
+
+    @classmethod
+    def supports_compute_framework(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        compute_framework: type[ComputeFramework],
+    ) -> bool:
+        return compute_framework is not PythonDictFramework
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class AllRejectedCapResolveFeatureGroup(FeatureGroup):
+    """Rejects the op on every framework in its bounded definition."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame, PythonDictFramework}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        if isinstance(feature_name, FeatureName):
+            feature_name = str(feature_name)
+        return feature_name == ALL_REJECTED_CAP_FEATURE
+
+    @classmethod
+    def supports_compute_framework(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        compute_framework: type[ComputeFramework],
+    ) -> bool:
+        return False
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -260,3 +336,64 @@ class TestResolveFeatureSubclassFiltering:
             candidate_names = [c.__name__ for c in result.candidates]
             # At minimum, we should see our test classes if they matched
             assert any("CandidatesTest" in name for name in candidate_names) or len(result.candidates) >= 1
+
+
+class TestResolveFeatureCapabilityAware:
+    """Capability-aware resolution: resolve_feature reports the supported/unsupported split.
+
+    These tests pin the PLANNED contract and are expected to FAIL until
+    resolve_feature and ResolvedFeature are made capability-aware (issue #482).
+    """
+
+    def test_resolved_feature_has_capability_fields_defaulting_empty(self) -> None:
+        """ResolvedFeature gains two new list fields defaulting to empty lists.
+
+        The existing 4-positional-arg constructor must still work.
+        """
+        result = ResolvedFeature("n", None, [], None)
+        assert result.supported_compute_frameworks == []
+        assert result.unsupported_compute_frameworks == []
+
+    def test_split_resolution_reports_supported_and_unsupported(self) -> None:
+        """A feature supported on one framework but rejected on another still resolves.
+
+        feature_group is not None and error is None, but the capability split is
+        reported: the rejected framework appears in unsupported, the supporting one
+        in supported.
+        """
+        result = resolve_feature(SPLIT_CAP_FEATURE)
+
+        # It still resolves: a supporting framework exists.
+        assert result.feature_group is not None
+        assert result.error is None
+
+        # The capability split is reported (subset membership only).
+        assert "PythonDictFramework" in result.unsupported_compute_frameworks
+        assert "PandasDataFrame" in result.supported_compute_frameworks
+        assert "PandasDataFrame" not in result.unsupported_compute_frameworks
+
+    def test_all_rejected_resolution_fails_with_capability_error(self) -> None:
+        """When every framework in the definition rejects the op, resolution fails.
+
+        feature_group is None, error names the unsupported framework(s) and includes
+        the 'default options' caveat, and the split lists both frameworks as
+        unsupported with none supported.
+        """
+        result = resolve_feature(ALL_REJECTED_CAP_FEATURE)
+
+        assert result.feature_group is None
+        assert result.error is not None
+
+        lowered = result.error.lower()
+        assert "unsupported" in lowered, f"Error must signal 'unsupported', got: {result.error}"
+        assert "PandasDataFrame" in result.error, f"Error must name PandasDataFrame, got: {result.error}"
+        assert "PythonDictFramework" in result.error, f"Error must name PythonDictFramework, got: {result.error}"
+        assert "default options" in result.error, (
+            f"Error must include the 'default options' caveat, got: {result.error}"
+        )
+
+        # The split lists both frameworks as unsupported and none as supported (subset membership only).
+        assert "PythonDictFramework" in result.unsupported_compute_frameworks
+        assert "PandasDataFrame" in result.unsupported_compute_frameworks
+        assert "PandasDataFrame" not in result.supported_compute_frameworks
+        assert "PythonDictFramework" not in result.supported_compute_frameworks

--- a/tests/test_core/test_prepare/test_compute_framework_capability.py
+++ b/tests/test_core/test_prepare/test_compute_framework_capability.py
@@ -125,6 +125,63 @@ class RejectAllCapabilityFeatureGroup(FeatureGroup):
         return None
 
 
+class PandasLikeFG(FeatureGroup):
+    """Declares only CapabilityFwA and supports the op on it (default hook).
+
+    Mirrors an installed/declared backend whose framework may or may not be
+    enabled for a particular run.
+    """
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CapabilityFwA}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        if isinstance(feature_name, FeatureName):
+            feature_name = str(feature_name)
+        return feature_name == CAPABILITY_FEATURE
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class SqliteLikeFG(FeatureGroup):
+    """Declares only CapabilityFwB and rejects the op on it."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CapabilityFwB}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        if isinstance(feature_name, FeatureName):
+            feature_name = str(feature_name)
+        return feature_name == CAPABILITY_FEATURE
+
+    @classmethod
+    def supports_compute_framework(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        compute_framework: type[ComputeFramework],
+    ) -> bool:
+        return compute_framework is not CapabilityFwB
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
 class TestComputeFrameworkCapabilityHook:
     """Capability-hook contract for compute-framework support at match time."""
 
@@ -279,4 +336,47 @@ class TestComputeFrameworkCapabilityHook:
         )
         assert "No feature groups found for feature name" not in capability_message, (
             f"Capability error must be distinguishable from the unknown-feature error, but got: {capability_message}"
+        )
+
+    def test_supported_list_includes_declared_but_not_enabled_framework(self) -> None:
+        """A declared+available+supporting framework appears in 'Supported on' even if not enabled this run.
+
+        Change B: the 'Supported on' list must be derived from each criteria-matched
+        feature group's ``compute_framework_definition()`` intersected with availability
+        and ``supports_compute_framework``, NOT from the run-enabled set. Here CapabilityFwA
+        is declared by ``PandasLikeFG`` and available, but is NOT enabled for this run
+        (its accessible_plugins value is an empty set). It must still show up as supported.
+        """
+        feature = Feature(CAPABILITY_FEATURE)
+        feature._set_compute_frameworks({CapabilityFwB})
+
+        # FwA declared by PandasLikeFG but NOT enabled (empty set); FwB enabled for SqliteLikeFG.
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            PandasLikeFG: set(),
+            SqliteLikeFG: {CapabilityFwB},
+        }
+
+        with pytest.raises(ValueError) as exc_info:
+            IdentifyFeatureGroupClass(
+                feature=feature,
+                accessible_plugins=accessible_plugins,
+                links=None,
+                data_access_collection=None,
+            )
+
+        error_message = str(exc_info.value)
+        lowered = error_message.lower()
+
+        assert "unsupported" in lowered or "not supported" in lowered, (
+            f"Capability error must signal an unsupported framework, but got: {error_message}"
+        )
+        assert CapabilityFwB.get_class_name() in error_message, (
+            f"Error must name the unsupported framework '{CapabilityFwB.get_class_name()}', but got: {error_message}"
+        )
+        assert CapabilityFwA.get_class_name() in error_message, (
+            "Error 'Supported on' list must include the declared+available+supporting framework "
+            f"'{CapabilityFwA.get_class_name()}' even though it was not enabled this run, but got: {error_message}"
+        )
+        assert "Did you mean" not in error_message, (
+            f"Capability error must skip the fuzzy suggestion path, but got: {error_message}"
         )

--- a/tests/test_core/test_prepare/test_compute_framework_capability.py
+++ b/tests/test_core/test_prepare/test_compute_framework_capability.py
@@ -1,0 +1,282 @@
+"""Tests for the MATCH-TIME compute-framework capability hook (issue #482).
+
+These tests pin down the contract for a sanctioned way for a FeatureGroup to
+declare an operation unsupported on a given compute framework, evaluated during
+feature -> feature-group resolution.
+
+Contract under test (to be implemented by the Green agent):
+
+1. ``FeatureGroup.supports_compute_framework(feature_name, options, compute_framework) -> bool``
+   classmethod, default ``True``. Arg order mirrors ``match_feature_group_criteria``.
+2. ``IdentifyFeatureGroupClass._filter_loop`` narrows the candidate compute-framework
+   set per feature using the hook (route-around when an unsupported framework is not
+   the only candidate).
+3. When the only candidate is an unsupported framework (e.g. user pin), a DEDICATED,
+   distinguishable ``ValueError`` is raised that names the unsupported and supported
+   framework(s) and skips the fuzzy "Did you mean" suggestion path.
+
+All tests are written to FAIL until the feature exists.
+"""
+
+from typing import Optional
+
+import pytest
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+
+
+CAPABILITY_FEATURE = "capability_test_feature"
+
+
+class CapabilityFwA(ComputeFramework):
+    """First compute framework used in capability tests."""
+
+    pass
+
+
+class CapabilityFwB(ComputeFramework):
+    """Second compute framework used in capability tests."""
+
+    pass
+
+
+class PlainCapabilityFeatureGroup(FeatureGroup):
+    """Plain feature group that does NOT override supports_compute_framework.
+
+    Used to assert the default hook behaviour and no-regression resolution.
+    """
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        if isinstance(feature_name, FeatureName):
+            feature_name = str(feature_name)
+        return feature_name == CAPABILITY_FEATURE
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class RejectBCapabilityFeatureGroup(FeatureGroup):
+    """Feature group that declares the operation unsupported on CapabilityFwB.
+
+    supports_compute_framework returns False for CapabilityFwB and True otherwise.
+    """
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        if isinstance(feature_name, FeatureName):
+            feature_name = str(feature_name)
+        return feature_name == CAPABILITY_FEATURE
+
+    @classmethod
+    def supports_compute_framework(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        compute_framework: type[ComputeFramework],
+    ) -> bool:
+        return compute_framework is not CapabilityFwB
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class RejectAllCapabilityFeatureGroup(FeatureGroup):
+    """Feature group that declares the operation unsupported on every framework."""
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        if isinstance(feature_name, FeatureName):
+            feature_name = str(feature_name)
+        return feature_name == CAPABILITY_FEATURE
+
+    @classmethod
+    def supports_compute_framework(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        compute_framework: type[ComputeFramework],
+    ) -> bool:
+        return False
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class TestComputeFrameworkCapabilityHook:
+    """Capability-hook contract for compute-framework support at match time."""
+
+    def test_default_hook_is_true_and_no_regression(self) -> None:
+        """Default hook returns True and resolution keeps every declared framework."""
+        feature = Feature(CAPABILITY_FEATURE)
+
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            PlainCapabilityFeatureGroup: {CapabilityFwA, CapabilityFwB},
+        }
+
+        identified = IdentifyFeatureGroupClass(
+            feature=feature,
+            accessible_plugins=accessible_plugins,
+            links=None,
+            data_access_collection=None,
+        )
+
+        feature_group_class, compute_frameworks = identified.get()
+        assert feature_group_class is PlainCapabilityFeatureGroup
+        assert compute_frameworks == {CapabilityFwA, CapabilityFwB}, (
+            f"Default behaviour must keep all declared frameworks; got {compute_frameworks}"
+        )
+
+        # The hook must exist on the base class and default to True for any framework.
+        assert FeatureGroup.supports_compute_framework(CAPABILITY_FEATURE, feature.options, CapabilityFwA) is True
+        assert FeatureGroup.supports_compute_framework(CAPABILITY_FEATURE, feature.options, CapabilityFwB) is True
+
+    def test_route_around_unsupported_framework_without_pin(self) -> None:
+        """Without a pin, an unsupported framework is dropped, the supported one kept."""
+        feature = Feature(CAPABILITY_FEATURE)
+
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            RejectBCapabilityFeatureGroup: {CapabilityFwA, CapabilityFwB},
+        }
+
+        identified = IdentifyFeatureGroupClass(
+            feature=feature,
+            accessible_plugins=accessible_plugins,
+            links=None,
+            data_access_collection=None,
+        )
+
+        feature_group_class, compute_frameworks = identified.get()
+        assert feature_group_class is RejectBCapabilityFeatureGroup
+        assert compute_frameworks == {CapabilityFwA}, (
+            f"Unsupported CapabilityFwB must be narrowed out, leaving only CapabilityFwA; got {compute_frameworks}"
+        )
+
+    def test_distinguishable_error_when_pinned_to_unsupported_framework(self) -> None:
+        """Pinning to the unsupported framework yields a dedicated, distinguishable error."""
+        feature = Feature(CAPABILITY_FEATURE)
+        feature._set_compute_frameworks({CapabilityFwB})
+
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            RejectBCapabilityFeatureGroup: {CapabilityFwA, CapabilityFwB},
+        }
+
+        with pytest.raises(ValueError) as exc_info:
+            IdentifyFeatureGroupClass(
+                feature=feature,
+                accessible_plugins=accessible_plugins,
+                links=None,
+                data_access_collection=None,
+            )
+
+        error_message = str(exc_info.value)
+        lowered = error_message.lower()
+
+        assert "unsupported" in lowered or "not supported" in lowered, (
+            f"Capability error must signal an unsupported framework, but got: {error_message}"
+        )
+        assert CapabilityFwB.get_class_name() in error_message, (
+            f"Error must name the unsupported framework '{CapabilityFwB.get_class_name()}', but got: {error_message}"
+        )
+        assert CapabilityFwA.get_class_name() in error_message, (
+            f"Error must name the supported framework '{CapabilityFwA.get_class_name()}', but got: {error_message}"
+        )
+        assert "Did you mean" not in error_message, (
+            f"Capability error must skip the fuzzy suggestion path, but got: {error_message}"
+        )
+
+    def test_all_frameworks_reject_operation(self) -> None:
+        """When every framework rejects the op, a graceful error names the feature."""
+        feature = Feature(CAPABILITY_FEATURE)
+
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            RejectAllCapabilityFeatureGroup: {CapabilityFwA, CapabilityFwB},
+        }
+
+        with pytest.raises(ValueError) as exc_info:
+            IdentifyFeatureGroupClass(
+                feature=feature,
+                accessible_plugins=accessible_plugins,
+                links=None,
+                data_access_collection=None,
+            )
+
+        error_message = str(exc_info.value)
+        lowered = error_message.lower()
+
+        assert CAPABILITY_FEATURE in error_message, f"Error must mention the feature name, but got: {error_message}"
+        assert "unsupported" in lowered or "not supported" in lowered, (
+            f"Error must signal that the framework(s) are unsupported, but got: {error_message}"
+        )
+        assert CapabilityFwA.get_class_name() in error_message, (
+            f"Error must name rejected framework '{CapabilityFwA.get_class_name()}', but got: {error_message}"
+        )
+        assert CapabilityFwB.get_class_name() in error_message, (
+            f"Error must name rejected framework '{CapabilityFwB.get_class_name()}', but got: {error_message}"
+        )
+
+    def test_capability_error_distinguishable_from_unknown_feature(self) -> None:
+        """The capability error is clearly different from the unknown-feature error."""
+        # Genuinely unknown feature -> classic resolution error.
+        unknown_feature = Feature("totally_unknown_capability_feature_xyz")
+        unknown_accessible: FeatureGroupEnvironmentMapping = {
+            RejectAllCapabilityFeatureGroup: {CapabilityFwA, CapabilityFwB},
+        }
+
+        with pytest.raises(ValueError) as unknown_exc:
+            IdentifyFeatureGroupClass(
+                feature=unknown_feature,
+                accessible_plugins=unknown_accessible,
+                links=None,
+                data_access_collection=None,
+            )
+        unknown_message = str(unknown_exc.value)
+        assert "No feature groups found" in unknown_message, (
+            f"Unknown feature must keep the classic error, but got: {unknown_message}"
+        )
+
+        # Capability rejection -> distinct, dedicated error.
+        pinned_feature = Feature(CAPABILITY_FEATURE)
+        pinned_feature._set_compute_frameworks({CapabilityFwB})
+        capability_accessible: FeatureGroupEnvironmentMapping = {
+            RejectBCapabilityFeatureGroup: {CapabilityFwA, CapabilityFwB},
+        }
+
+        with pytest.raises(ValueError) as capability_exc:
+            IdentifyFeatureGroupClass(
+                feature=pinned_feature,
+                accessible_plugins=capability_accessible,
+                links=None,
+                data_access_collection=None,
+            )
+        capability_message = str(capability_exc.value)
+        lowered = capability_message.lower()
+
+        assert "unsupported" in lowered or "not supported" in lowered, (
+            f"Capability error must signal an unsupported framework, but got: {capability_message}"
+        )
+        assert "No feature groups found for feature name" not in capability_message, (
+            f"Capability error must be distinguishable from the unknown-feature error, but got: {capability_message}"
+        )


### PR DESCRIPTION
Closes #482.

## Problem

Core gave a FeatureGroup no sanctioned way to say "this operation is unsupported on this compute framework" at match time. Plugin authors either omitted a backend class entirely or accepted the match and raised a generic error at compute time. That made "operation X exists but is unsupported on your framework" indistinguishable from "operation X does not exist", and every plugin reinvented the rejection + message (see the registry's `data_operations/errors.py`, mloda-registry#236).

## Change

- **New hook** `FeatureGroup.supports_compute_framework(feature_name, options, compute_framework) -> bool` (default `True`), arg order mirroring `match_feature_group_criteria`. Unlike the static `compute_framework_rule` (a class-level set), this is evaluated per feature at match time, so it can reject an operation on one backend while allowing it on others. Per-backend subclasses only reason about their own framework; nobody needs to enumerate all CFWs.
- **Matcher wiring** in `identify_feature_group.py`: `_filter_loop` narrows the candidate framework set per feature via the hook. If another framework can run the op, the matcher routes around the rejected one silently. If the only candidate is rejected (e.g. the user pinned the feature to it), resolution fails with a dedicated, distinguishable error that names the unsupported and supported frameworks, and skips the fuzzy "Did you mean" suggestion path.
- **"Supported on" list** is computed from each criteria-matched group's `compute_framework_definition()` ∩ `is_available()`, so the message names every *installed* backend that can run the op regardless of what this run enabled, and never suggests an uninstalled one.
- **`resolve_feature()` is capability-aware** (scope extension): `ResolvedFeature` gains `supported_compute_frameworks` / `unsupported_compute_frameworks` (evaluated under default options, since the inspector has no caller `Options`), and a feature that matches a group but is unsupported on every installed framework resolves to `feature_group=None` with a capability error instead of appearing runnable. The supported/rejected split is shared with the engine error builder via `split_frameworks_by_capability()` so the inspector and the engine cannot drift.
- **Docs**: documented in the compute-framework integration guide so registry plugins can drop their bespoke rejection code.

Default `True` means existing FeatureGroups are unaffected.

## Definition of done

- [x] Sanctioned mechanism for a FeatureGroup to declare an op unsupported on a framework, evaluated at match time.
- [x] Matcher routes around it and surfaces an actionable, distinguishable error ("supported on ...; not on ...").
- [x] Documented in the compute-framework integration guide.
- [x] (extended) `resolve_feature` reflects the same capability info.

## Tests

- `tests/test_core/test_prepare/test_compute_framework_capability.py` — resolver-unit cases: default-True/no-regression, route-around without pin, distinguishable error when pinned, all-frameworks-reject, distinguishability from unknown-feature, and installed-not-enabled "supported on" reporting.
- `tests/test_core/test_api/test_capability_run_all.py` — end-to-end `mlodaAPI.run_all` lock: pinned-to-rejected raises the distinguishable error; no-pin routes around to Pandas and computes.
- `tests/test_core/test_api/test_resolve_feature.py` — capability-aware `resolve_feature` (new fields, split reporting, all-rejected gate).

## Verification

Run against the project's `.tox/python310` interpreter (the local `.venv` was unavailable):
- `pytest tests/test_core` -> 1347 passed
- `mypy --strict --ignore-missing-imports .` -> no issues in 682 source files
- `ruff format --check` / `ruff check` -> clean
- docs test for the edited guide -> passed

Full `tox` is the authoritative gate; CI runs the matrix on this PR.

Out of scope intentionally: a separate ComputeFramework-side capability surface and capability tokens (the issue says "FeatureGroup or ComputeFramework"; the FeatureGroup hook owns op semantics).
