### PR TITLE
feat: optional context-key schema validation in Options to catch typos

### DIFF
--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -297,6 +297,26 @@ class FeatureChainParserMixin:
             return cast(dict[str, Any], cls.PROPERTY_MAPPING)
         return None
 
+    @classmethod
+    def derive_context_key_schema(cls) -> Optional[dict[str, Any]]:
+        """Build a context_key_schema() from this group's PROPERTY_MAPPING.
+
+        Returns {str(key): None for key in PROPERTY_MAPPING} (every declared
+        property name; type checks are skipped because PROPERTY_MAPPING already
+        validates values via validation_function/type_validator). Returns None
+        when there is no PROPERTY_MAPPING or it is empty, preserving permissive
+        behavior. A feature group opts in by overriding context_key_schema to
+        return cls.derive_context_key_schema().
+
+        Every PROPERTY_MAPPING key is returned, so any declared key is accepted
+        whether it lands in Options.group or Options.context; group-placed keys
+        are still not validated at planning time.
+        """
+        property_mapping = cls._get_property_mapping()
+        if not property_mapping:
+            return None
+        return {str(key): None for key in property_mapping}
+
     @staticmethod
     def _has_required_when_predicates(property_mapping: dict[str, Any]) -> bool:
         """Return True if any entry in property_mapping uses required_when."""

--- a/mloda/core/abstract_plugins/components/options.py
+++ b/mloda/core/abstract_plugins/components/options.py
@@ -43,6 +43,8 @@ class Options:
     on which feature groups resolve the feature at runtime. Typos in key names
     will not raise errors; the key will simply be ignored by all feature groups.
     Use ``DefaultOptionKeys`` constants where available to prevent typos.
+    A feature group may opt in to context-key validation by overriding
+    ``FeatureGroup.context_key_schema()``.
 
     Examples:
         >>> # Basic usage with positional dict (goes to group)

--- a/mloda/core/abstract_plugins/components/options.py
+++ b/mloda/core/abstract_plugins/components/options.py
@@ -79,6 +79,7 @@ class Options:
         self.group = group or {}
         self.context = context or {}
         self.propagate_context_keys: frozenset[str] = propagate_context_keys or frozenset()
+        self.received_propagated_keys: frozenset[str] = frozenset()
         OptionsValidator.validate_no_duplicate_keys(self.group, self.context)
         OptionsValidator.validate_propagate_keys_in_context(self.propagate_context_keys, self.context)
 
@@ -224,7 +225,9 @@ class Options:
 
         copied_group = safe_deepcopy_dict(self.group)
         copied_context = safe_deepcopy_dict(self.context)
-        return Options(group=copied_group, context=copied_context, propagate_context_keys=self.propagate_context_keys)
+        copied = Options(group=copied_group, context=copied_context, propagate_context_keys=self.propagate_context_keys)
+        copied.received_propagated_keys = self.received_propagated_keys
+        return copied
 
     def __str__(self) -> str:
         parts = f"Options(group={self.group}, context={self.context}"
@@ -300,3 +303,4 @@ class Options:
                     raise ValueError(f"Context key '{key}' conflict: parent='{value}', child='{self.context[key]}'")
 
             self.context.update(propagating)
+            self.received_propagated_keys = self.received_propagated_keys | frozenset(propagating.keys())

--- a/mloda/core/abstract_plugins/components/validators/options_validator.py
+++ b/mloda/core/abstract_plugins/components/validators/options_validator.py
@@ -1,4 +1,7 @@
+from difflib import get_close_matches
 from typing import Any
+
+from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
 
 
 class OptionsValidator:
@@ -73,3 +76,39 @@ class OptionsValidator:
         conflicting_keys = other_group_keys & self_context_keys
         if conflicting_keys:
             raise ValueError(f"Cannot update group: keys already exist in context: {conflicting_keys}")
+
+    @staticmethod
+    def validate_context_keys(
+        feature_name: str,
+        context: dict[str, Any],
+        schema: dict[str, Any],
+        extra_allowed_keys: set[str] | None = None,
+    ) -> None:
+        """
+        Validate a feature's context keys against a declared schema.
+
+        Unknown keys raise ValueError (with a 'did you mean' hint when a close
+        match exists). Keys mapped to a type in the schema are type-checked;
+        a schema value of None skips the type check. Framework-reserved keys
+        (DefaultOptionKeys) and extra_allowed_keys are always permitted.
+        """
+        allowed = set(schema) | {k.value for k in DefaultOptionKeys} | (extra_allowed_keys or set())
+
+        for key in context:
+            if key in allowed:
+                continue
+            match = get_close_matches(key, sorted(allowed), n=1, cutoff=0.6)
+            if match:
+                raise ValueError(
+                    f"Unknown context key '{key}' for feature '{feature_name}'; did you mean '{match[0]}'?"
+                )
+            raise ValueError(f"Unknown context key '{key}' for feature '{feature_name}'.")
+
+        for key, expected in schema.items():
+            if expected is None or key not in context:
+                continue
+            if not isinstance(context[key], expected):
+                raise ValueError(
+                    f"Context key '{key}' for feature '{feature_name}' expects type {expected}, "
+                    f"got {type(context[key]).__name__}"
+                )

--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -129,6 +129,14 @@ class FeatureGroup(ABC):
         (a type, a tuple of types, or None to skip the type check). When
         declared, core validates the resolving feature's context keys at
         planning time and raises ValueError on an unknown key.
+
+        Scope: only Options.context keys are validated; keys in Options.group
+        are not checked. Validation runs only while the feature still resolves
+        to this group, so a typo on a required parameter surfaces as a normal
+        "no feature group found" resolution error rather than a context-key
+        suggestion. Configuration-based groups (FeatureChainParserMixin with a
+        PROPERTY_MAPPING) can derive this automatically via
+        cls.derive_context_key_schema().
         """
         return None
 

--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -121,6 +121,18 @@ class FeatureGroup(ABC):
         return None
 
     @classmethod
+    def context_key_schema(cls) -> Optional[dict[str, Any]]:
+        """Optionally declare accepted context keys and their expected types.
+
+        Return None (default) to keep permissive behavior (no validation).
+        Return a dict mapping each accepted context key to an expected type
+        (a type, a tuple of types, or None to skip the type check). When
+        declared, core validates the resolving feature's context keys at
+        planning time and raises ValueError on an unknown key.
+        """
+        return None
+
+    @classmethod
     def validate_input_features(cls, data: Any, features: FeatureSet) -> None:
         """
         Validate the input data before feature calculation.

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -127,7 +127,7 @@ class IdentifyFeatureGroupClass:
                 str(feature.name),
                 feature.options.context,
                 schema,
-                set(feature.options.propagate_context_keys),
+                set(feature.options.propagate_context_keys) | set(feature.options.received_propagated_keys),
             )
 
     def _build_no_feature_group_error(

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -7,6 +7,7 @@ from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup, format_feature_group_class
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.link import Link
+from mloda.core.abstract_plugins.components.validators.options_validator import OptionsValidator
 
 import logging
 
@@ -118,6 +119,15 @@ class IdentifyFeatureGroupClass:
         if not compute_frameworks:
             raise ValueError(
                 f"Feature {feature.name} {format_feature_group_class(feature_group_class)} has no compute framework."
+            )
+
+        schema = feature_group_class.context_key_schema()
+        if schema is not None:
+            OptionsValidator.validate_context_keys(
+                str(feature.name),
+                feature.options.context,
+                schema,
+                set(feature.options.propagate_context_keys),
             )
 
     def _build_no_feature_group_error(

--- a/mloda_plugins/feature_group/experimental/clustering/base.py
+++ b/mloda_plugins/feature_group/experimental/clustering/base.py
@@ -140,6 +140,11 @@ class ClusteringFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     }
 
     @classmethod
+    def context_key_schema(cls) -> dict[str, Any] | None:
+        """Opt into context-key validation; accepted keys derive from PROPERTY_MAPPING."""
+        return cls.derive_context_key_schema()
+
+    @classmethod
     def _validate_string_match(cls, feature_name: str, operation_config: str, source_feature: str) -> bool:
         """Validate clustering-specific string patterns using parse_clustering_prefix()."""
         if FeatureChainParser.is_chained_feature(feature_name):

--- a/mloda_plugins/feature_group/experimental/data_quality/missing_value/base.py
+++ b/mloda_plugins/feature_group/experimental/data_quality/missing_value/base.py
@@ -190,6 +190,11 @@ class MissingValueFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     }
 
     @classmethod
+    def context_key_schema(cls) -> dict[str, Any] | None:
+        """Opt into context-key validation; accepted keys derive from PROPERTY_MAPPING."""
+        return cls.derive_context_key_schema()
+
+    @classmethod
     def get_imputation_method(cls, feature_name: str) -> str:
         """Extract the imputation method from the feature name."""
         # parse_feature_name returns (operation_config, source_feature)

--- a/mloda_plugins/feature_group/experimental/dimensionality_reduction/base.py
+++ b/mloda_plugins/feature_group/experimental/dimensionality_reduction/base.py
@@ -200,6 +200,11 @@ class DimensionalityReductionFeatureGroup(FeatureChainParserMixin, FeatureGroup)
     }
 
     @classmethod
+    def context_key_schema(cls) -> dict[str, Any] | None:
+        """Opt into context-key validation; accepted keys derive from PROPERTY_MAPPING."""
+        return cls.derive_context_key_schema()
+
+    @classmethod
     def parse_reduction_suffix(cls, feature_name: str) -> tuple[str, int]:
         """
         Parse the dimensionality reduction suffix into its components.

--- a/mloda_plugins/feature_group/experimental/node_centrality/base.py
+++ b/mloda_plugins/feature_group/experimental/node_centrality/base.py
@@ -165,6 +165,11 @@ class NodeCentralityFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     }
 
     @classmethod
+    def context_key_schema(cls) -> dict[str, Any] | None:
+        """Opt into context-key validation; accepted keys derive from PROPERTY_MAPPING."""
+        return cls.derive_context_key_schema()
+
+    @classmethod
     def parse_centrality_prefix(cls, feature_name: str) -> str:
         """
         Parse the centrality suffix to extract the centrality type.

--- a/tests/test_core/test_abstract_plugins/test_components/test_feature_chainer/__init__.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_feature_chainer/__init__.py
@@ -1,0 +1,1 @@
+# Tests for FeatureChainParserMixin context-key-schema derivation

--- a/tests/test_core/test_abstract_plugins/test_components/test_feature_chainer/test_derive_context_key_schema.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_feature_chainer/test_derive_context_key_schema.py
@@ -1,0 +1,70 @@
+"""Unit tests for ``FeatureChainParserMixin.derive_context_key_schema`` (TDD red phase).
+
+These tests pin down the contract for a helper that builds a ``context_key_schema()``
+dict from a config-based feature group's ``PROPERTY_MAPPING``. The helper does not
+exist yet, so every test currently fails with ``AttributeError``; they go green once
+the Green Agent implements ``derive_context_key_schema``.
+
+Contract:
+    - With a non-empty ``PROPERTY_MAPPING``: returns ``{str(key): None for key in PROPERTY_MAPPING}``
+      (every declared property name as a string, type-check skipped via ``None``).
+    - With ``PROPERTY_MAPPING = None`` or no ``PROPERTY_MAPPING``: returns ``None``.
+    - With ``PROPERTY_MAPPING = {}``: returns ``None`` (preserves permissive behavior).
+"""
+
+from __future__ import annotations
+
+from mloda.provider import DefaultOptionKeys
+from mloda.provider import FeatureChainParserMixin
+
+
+class MappingWithKeys(FeatureChainParserMixin):
+    """Mixin subclass with a mix of context-marked and plain group-default keys."""
+
+    PROPERTY_MAPPING = {
+        "partition_by": {
+            "explanation": "partition columns",
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: False,
+            DefaultOptionKeys.default: None,
+        },
+        "group_default_key": {
+            "explanation": "a plain group-default property (no context flag)",
+        },
+        DefaultOptionKeys.in_features: {
+            "explanation": "source features",
+            DefaultOptionKeys.context: True,
+        },
+    }
+
+
+class MappingNone(FeatureChainParserMixin):
+    """Mixin subclass that explicitly sets PROPERTY_MAPPING to None."""
+
+    PROPERTY_MAPPING = None
+
+
+class MappingEmpty(FeatureChainParserMixin):
+    """Mixin subclass with an empty PROPERTY_MAPPING."""
+
+    PROPERTY_MAPPING: dict[str, object] = {}
+
+
+def test_derive_returns_all_property_mapping_keys_with_none_values() -> None:
+    """Schema keys equal all PROPERTY_MAPPING names (as strings); all values are None."""
+    schema = MappingWithKeys.derive_context_key_schema()
+
+    assert schema is not None
+    expected_keys = {str(key) for key in MappingWithKeys.PROPERTY_MAPPING}
+    assert set(schema.keys()) == expected_keys
+    assert all(value is None for value in schema.values())
+
+
+def test_derive_returns_none_when_property_mapping_is_none() -> None:
+    """A None PROPERTY_MAPPING yields a None schema (permissive)."""
+    assert MappingNone.derive_context_key_schema() is None
+
+
+def test_derive_returns_none_when_property_mapping_is_empty() -> None:
+    """An empty PROPERTY_MAPPING yields a None schema (permissive)."""
+    assert MappingEmpty.derive_context_key_schema() is None

--- a/tests/test_core/test_abstract_plugins/test_components/test_validators/test_options_validator.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_validators/test_options_validator.py
@@ -1,7 +1,7 @@
 import pytest
 from typing import Any
 
-from mloda.provider import OptionsValidator
+from mloda.provider import OptionsValidator, DefaultOptionKeys
 
 
 class TestValidateNoDuplicateKeys:
@@ -214,3 +214,103 @@ class TestValidateNoGroupContextConflicts:
         OptionsValidator.validate_no_group_context_conflicts(
             other_group_keys=other_group_keys, self_context_keys=self_context_keys
         )
+
+
+class TestValidateContextKeys:
+    """Test the validate_context_keys static method (context-key schema validation)."""
+
+    def test_unknown_key_with_near_match_raises_with_suggestion(self) -> None:
+        """Unknown context key close to a schema key raises ValueError with a 'did you mean' hint."""
+        with pytest.raises(ValueError) as exc_info:
+            OptionsValidator.validate_context_keys(
+                feature_name="my_feature",
+                context={"partiton_by": "col"},
+                schema={"partition_by": str},
+            )
+
+        error_msg = str(exc_info.value)
+        assert "context key 'partiton_by'" in error_msg
+        assert "did you mean 'partition_by'" in error_msg
+        assert "my_feature" in error_msg
+
+    def test_unknown_key_without_near_match_raises(self) -> None:
+        """Unknown context key with no close match still raises ValueError mentioning the key."""
+        with pytest.raises(ValueError) as exc_info:
+            OptionsValidator.validate_context_keys(
+                feature_name="my_feature",
+                context={"zzz_unrelated": 1},
+                schema={"partition_by": str},
+            )
+
+        error_msg = str(exc_info.value)
+        assert "context key 'zzz_unrelated'" in error_msg
+
+    def test_all_valid_keys_pass(self) -> None:
+        """All context keys present in schema and type-correct should not raise."""
+        # Act & Assert - should not raise
+        OptionsValidator.validate_context_keys(
+            feature_name="my_feature",
+            context={"partition_by": "col", "frame_size": 10},
+            schema={"partition_by": str, "frame_size": int},
+        )
+
+    def test_framework_reserved_key_allowed(self) -> None:
+        """A framework-reserved key (DefaultOptionKeys) is allowed even when absent from schema."""
+        # Act & Assert - should not raise
+        OptionsValidator.validate_context_keys(
+            feature_name="my_feature",
+            context={DefaultOptionKeys.in_features.value: "some_source"},
+            schema={"partition_by": str},
+        )
+
+    def test_type_mismatch_raises(self) -> None:
+        """A context value whose type does not match the schema type raises ValueError."""
+        with pytest.raises(ValueError) as exc_info:
+            OptionsValidator.validate_context_keys(
+                feature_name="my_feature",
+                context={"frame_size": "10"},
+                schema={"frame_size": int},
+            )
+
+        error_msg = str(exc_info.value)
+        assert "frame_size" in error_msg
+
+    def test_type_match_passes(self) -> None:
+        """A context value whose type matches the schema type does not raise."""
+        # Act & Assert - should not raise
+        OptionsValidator.validate_context_keys(
+            feature_name="my_feature",
+            context={"frame_size": 10},
+            schema={"frame_size": int},
+        )
+
+    def test_none_expected_type_skips_type_check(self) -> None:
+        """A schema entry mapping to None skips the type check for that key."""
+        # Act & Assert - should not raise even though value is an int
+        OptionsValidator.validate_context_keys(
+            feature_name="my_feature",
+            context={"order_by": 123},
+            schema={"order_by": None},
+        )
+
+    def test_extra_allowed_keys_exempts_key(self) -> None:
+        """A key listed in extra_allowed_keys is exempt from the unknown-key error."""
+        # Act & Assert - should not raise
+        OptionsValidator.validate_context_keys(
+            feature_name="my_feature",
+            context={"partition_by": "col", "propagated_x": "v"},
+            schema={"partition_by": str},
+            extra_allowed_keys={"propagated_x"},
+        )
+
+    def test_empty_schema_rejects_non_reserved_key(self) -> None:
+        """A declared-but-empty schema accepts nothing custom: a non-reserved key raises."""
+        with pytest.raises(ValueError) as exc_info:
+            OptionsValidator.validate_context_keys(
+                feature_name="my_feature",
+                context={"anything": 1},
+                schema={},
+            )
+
+        error_msg = str(exc_info.value)
+        assert "context key 'anything'" in error_msg

--- a/tests/test_core/test_prepare/test_context_key_schema_config_based.py
+++ b/tests/test_core/test_prepare/test_context_key_schema_config_based.py
@@ -1,0 +1,204 @@
+"""Planning-level context-key validation for CONFIG-BASED feature groups (TDD red phase).
+
+A config-based feature group (``FeatureChainParserMixin`` + ``PROPERTY_MAPPING``) opts
+into context-key validation by deriving its ``context_key_schema()`` from
+``PROPERTY_MAPPING``::
+
+    @classmethod
+    def context_key_schema(cls):
+        return cls.derive_context_key_schema()
+
+``derive_context_key_schema`` does not exist yet, so the opt-in tests below currently
+fail with ``AttributeError`` (raised when ``IdentifyFeatureGroupClass.validate`` calls
+``context_key_schema()``). They go green once the Green Agent adds the helper.
+
+Test (d) is a backward-compat / boundary guard: it exercises the *inherited* mixin
+matcher with a REQUIRED property and a typo, so the group never matches and validation
+never runs. It passes today and must keep passing.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import pytest
+
+from mloda.provider import ComputeFramework
+from mloda.provider import DefaultOptionKeys
+from mloda.provider import FeatureChainParserMixin
+from mloda.provider import FeatureGroup
+from mloda.user import Feature
+from mloda.user import FeatureName
+from mloda.user import Options
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+
+
+class MockComputeFramework(ComputeFramework):
+    """Mock compute framework for testing (never instantiated on this path)."""
+
+    pass
+
+
+FIXED_NAME = "config_opt_in_feature"
+
+
+class ConfigOptInFG(FeatureChainParserMixin, FeatureGroup):
+    """Config-based feature group that opts into PROPERTY_MAPPING-derived validation.
+
+    Uses a fixed-name matcher so it resolves uniquely and never accidentally matches
+    other plugins (mirrors the isolation style of the error-message tests).
+    """
+
+    PROPERTY_MAPPING = {
+        "partition_by": {
+            "explanation": "partition columns (optional context key)",
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: False,
+            DefaultOptionKeys.default: None,
+        },
+        "frame_size": {
+            "explanation": "rolling frame size (optional context key)",
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: False,
+            DefaultOptionKeys.default: None,
+        },
+        "group_default_key": {
+            "explanation": "declared property without a context flag (group-default)",
+        },
+        DefaultOptionKeys.in_features: {
+            "explanation": "source features",
+            DefaultOptionKeys.context: True,
+        },
+    }
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[Any] = None,
+    ) -> bool:
+        name = str(feature_name) if isinstance(feature_name, FeatureName) else feature_name
+        return name == FIXED_NAME
+
+    @classmethod
+    def context_key_schema(cls) -> Optional[dict[str, Any]]:
+        return cls.derive_context_key_schema()
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+REQUIRED_PROP_NAME = "required_prop_feature"
+
+
+class RequiredPropFG(FeatureChainParserMixin, FeatureGroup):
+    """Config-based group with a REQUIRED property, using the INHERITED mixin matcher.
+
+    ``window_type`` has no ``default`` and no ``required_when`` and uses strict
+    validation, so it is required for a configuration-based match. A feature whose
+    context only carries a typo'd version of the key therefore fails to match.
+    """
+
+    PROPERTY_MAPPING = {
+        "window_type": {
+            "explanation": "required window kind",
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: True,
+            "rolling": "rolling",
+            "expanding": "expanding",
+        },
+        DefaultOptionKeys.in_features: {
+            "explanation": "source features",
+            DefaultOptionKeys.context: True,
+        },
+    }
+
+    @classmethod
+    def context_key_schema(cls) -> Optional[dict[str, Any]]:
+        return cls.derive_context_key_schema()
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class TestConfigBasedContextKeySchema:
+    """Validation behavior for config-based opt-in feature groups."""
+
+    def test_typo_on_optional_context_key_raises(self) -> None:
+        """(a) A typo on an OPTIONAL context key fires the 'did you mean' error."""
+        feature = Feature(
+            FIXED_NAME,
+            options=Options(context={"in_features": "x", "partiton_by": "col"}),
+        )
+        accessible_plugins: FeatureGroupEnvironmentMapping = {ConfigOptInFG: {MockComputeFramework}}
+
+        with pytest.raises(ValueError) as exc_info:
+            IdentifyFeatureGroupClass(
+                feature=feature,
+                accessible_plugins=accessible_plugins,
+                links=None,
+            )
+
+        message = str(exc_info.value)
+        assert "partiton_by" in message, message
+        assert "did you mean" in message.lower(), message
+        assert "partition_by" in message, message
+
+    def test_valid_context_keys_resolve(self) -> None:
+        """(b) Valid, declared context keys resolve without error."""
+        feature = Feature(
+            FIXED_NAME,
+            options=Options(context={"in_features": "x", "partition_by": "col", "frame_size": 10}),
+        )
+        accessible_plugins: FeatureGroupEnvironmentMapping = {ConfigOptInFG: {MockComputeFramework}}
+
+        result = IdentifyFeatureGroupClass(
+            feature=feature,
+            accessible_plugins=accessible_plugins,
+            links=None,
+        )
+        assert ConfigOptInFG in result.feature_group_compute_framework_mapping
+
+    def test_declared_group_default_key_in_context_is_accepted(self) -> None:
+        """(c) A declared PROPERTY_MAPPING key placed in context is accepted (no false positive)."""
+        feature = Feature(
+            FIXED_NAME,
+            options=Options(context={"in_features": "x", "group_default_key": "v"}),
+        )
+        accessible_plugins: FeatureGroupEnvironmentMapping = {ConfigOptInFG: {MockComputeFramework}}
+
+        result = IdentifyFeatureGroupClass(
+            feature=feature,
+            accessible_plugins=accessible_plugins,
+            links=None,
+        )
+        assert ConfigOptInFG in result.feature_group_compute_framework_mapping
+
+    def test_typo_on_required_property_does_not_produce_context_key_suggestion(self) -> None:
+        """(d) Boundary: a typo on a REQUIRED property fails matching, so context-key
+        validation never runs. The error must be the 'no feature groups found' error,
+        not a 'context key' suggestion. (Passes today; locks in the documented limit.)
+        """
+        feature = Feature(
+            REQUIRED_PROP_NAME,
+            options=Options(context={"in_features": "x", "window_typ": "rolling"}),
+        )
+
+        # Direct, robust check: the inherited mixin matcher rejects the feature because
+        # the required property is effectively absent (only a typo'd key is present).
+        assert RequiredPropFG.match_feature_group_criteria(feature.name, feature.options) is False
+
+        accessible_plugins: FeatureGroupEnvironmentMapping = {RequiredPropFG: {MockComputeFramework}}
+
+        with pytest.raises(ValueError) as exc_info:
+            IdentifyFeatureGroupClass(
+                feature=feature,
+                accessible_plugins=accessible_plugins,
+                links=None,
+            )
+
+        message = str(exc_info.value)
+        assert "context key" not in message.lower(), message
+        assert "no feature groups found" in message.lower(), message

--- a/tests/test_core/test_prepare/test_context_key_schema_propagation.py
+++ b/tests/test_core/test_prepare/test_context_key_schema_propagation.py
@@ -1,0 +1,151 @@
+"""Chained-propagation edge case for context-key validation (TDD red phase).
+
+Background
+---------
+``Options.update_with_protected_keys`` copies a SOURCE feature's
+``propagate_context_keys`` values into the RECIPIENT's ``context`` (via
+``self.context.update(propagating)``) but does NOT add those keys to the
+recipient's own ``propagate_context_keys``. As a result a legitimately
+propagated context key can sit in a recipient's context while being absent from
+both the recipient's ``propagate_context_keys`` and (for an opt-in config-based
+group) its derived schema.
+
+At the validation boundary that key would then be flagged as an "unknown context
+key" -- a spurious false positive for a key the framework itself propagated.
+
+Intended end-state
+------------------
+A propagated context key must be TOLERATED. The primary test below merges a child
+into a parent via the real ``update_with_protected_keys`` API and asserts the
+parent resolves WITHOUT a spurious unknown-context-key error.
+
+NOTE on the spec deviation (reported to the orchestrator):
+The original task also proposed a directly-constructed ``Options`` with an empty
+``propagate_context_keys`` and an unexplained context key, asserted to "not raise".
+That form is un-greenable: the natural fix lives in ``update_with_protected_keys``,
+which a directly-constructed object never executes, and the only alternative
+(making ``validate_context_keys`` tolerate an unexplained key) would disable the
+feature. It was therefore dropped in favor of the merge-based reproduction, which
+exercises the actual fix site and goes green once propagation is corrected.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from mloda.provider import ComputeFramework
+from mloda.provider import DefaultOptionKeys
+from mloda.provider import FeatureChainParserMixin
+from mloda.provider import FeatureGroup
+from mloda.user import Feature
+from mloda.user import FeatureName
+from mloda.user import Options
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+
+
+class MockComputeFramework(ComputeFramework):
+    """Mock compute framework for testing (never instantiated on this path)."""
+
+    pass
+
+
+FIXED_NAME = "propagation_opt_in_feature"
+
+
+class ConfigOptInFG(FeatureChainParserMixin, FeatureGroup):
+    """Config-based opt-in group whose schema does NOT list ``external_partition``."""
+
+    PROPERTY_MAPPING = {
+        "partition_by": {
+            "explanation": "partition columns",
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: False,
+            DefaultOptionKeys.default: None,
+        },
+        "frame_size": {
+            "explanation": "rolling frame size",
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: False,
+            DefaultOptionKeys.default: None,
+        },
+        DefaultOptionKeys.in_features: {
+            "explanation": "source features",
+            DefaultOptionKeys.context: True,
+        },
+    }
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[Any] = None,
+    ) -> bool:
+        name = str(feature_name) if isinstance(feature_name, FeatureName) else feature_name
+        return name == FIXED_NAME
+
+    @classmethod
+    def context_key_schema(cls) -> Optional[dict[str, Any]]:
+        return cls.derive_context_key_schema()
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class TestPropagatedContextKeyValidation:
+    """Propagated-context-key tolerance at the validation boundary."""
+
+    def test_propagated_context_key_is_tolerated_after_merge(self) -> None:
+        """A context key that arrived via propagation must NOT be flagged as unknown.
+
+        This reproduces the real mechanism: after ``update_with_protected_keys`` the
+        propagated key lives in the parent's context but is absent from the parent's
+        ``propagate_context_keys`` (and from the schema). Resolving the parent must
+        not raise. RED signal: it currently does (see report).
+        """
+        parent = Options(
+            context={"in_features": "x", "partition_by": "c"},
+            propagate_context_keys=frozenset(),
+        )
+        child = Options(
+            context={"in_features": "y", "external_partition": "v"},
+            propagate_context_keys=frozenset({"external_partition"}),
+        )
+
+        parent.update_with_protected_keys(child)
+
+        # Mechanism: the propagated value lands in the parent's context. This is
+        # stable across the eventual fix, so it is a safe durable assertion.
+        assert "external_partition" in parent.context
+
+        feature = Feature(FIXED_NAME, options=parent)
+        accessible_plugins: FeatureGroupEnvironmentMapping = {ConfigOptInFG: {MockComputeFramework}}
+
+        # Intended end-state: no spurious "unknown context key 'external_partition'".
+        result = IdentifyFeatureGroupClass(
+            feature=feature,
+            accessible_plugins=accessible_plugins,
+            links=None,
+        )
+        assert ConfigOptInFG in result.feature_group_compute_framework_mapping
+
+    def test_context_key_listed_in_propagate_set_is_allowed(self) -> None:
+        """Backward-compat guard (NOT the propagation bug): a context key present in
+        ``propagate_context_keys`` is allowed because validation treats the propagate
+        set as extra allowed keys. Greenable by adding ``derive_context_key_schema``
+        alone; does not depend on the propagation fix.
+        """
+        options = Options(
+            context={"in_features": "x", "partition_by": "c", "external_partition": "v"},
+            propagate_context_keys=frozenset({"external_partition"}),
+        )
+        feature = Feature(FIXED_NAME, options=options)
+        accessible_plugins: FeatureGroupEnvironmentMapping = {ConfigOptInFG: {MockComputeFramework}}
+
+        result = IdentifyFeatureGroupClass(
+            feature=feature,
+            accessible_plugins=accessible_plugins,
+            links=None,
+        )
+        assert ConfigOptInFG in result.feature_group_compute_framework_mapping

--- a/tests/test_core/test_prepare/test_context_key_schema_validation.py
+++ b/tests/test_core/test_prepare/test_context_key_schema_validation.py
@@ -1,0 +1,154 @@
+"""Tests for context-key schema validation at the planning chokepoint.
+
+A FeatureGroup may opt in to context-key validation by overriding
+``context_key_schema()``. When it does, ``IdentifyFeatureGroupClass`` validates
+the resolving feature's context keys against that schema and raises an
+actionable ValueError on an unknown key. Feature groups that do not override
+``context_key_schema()`` keep today's permissive behavior (no validation).
+"""
+
+from typing import Any, Optional
+
+import pytest
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+
+
+class MockComputeFramework(ComputeFramework):
+    """Mock compute framework for testing."""
+
+    pass
+
+
+class OptInContextSchemaFeatureGroup(FeatureGroup):
+    """Feature group that opts in to context-key validation.
+
+    Declares a single accepted context key ``partition_by`` of type ``str``.
+    Matches the feature named ``opt_in_ctx_feature``.
+    """
+
+    @classmethod
+    def context_key_schema(cls) -> dict[str, Any] | None:
+        return {"partition_by": str}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        if isinstance(feature_name, FeatureName):
+            feature_name = str(feature_name)
+        return feature_name == "opt_in_ctx_feature"
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class PermissiveContextFeatureGroup(FeatureGroup):
+    """Feature group that does NOT override context_key_schema (default None).
+
+    Matches the feature named ``permissive_ctx_feature``. Keeps permissive
+    behavior: any context key is accepted.
+    """
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        if isinstance(feature_name, FeatureName):
+            feature_name = str(feature_name)
+        return feature_name == "permissive_ctx_feature"
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class TestContextKeySchemaValidation:
+    """Validation of context keys during feature group identification."""
+
+    def test_unknown_context_key_raises_with_suggestion(self) -> None:
+        """An opt-in FG with a typo'd context key raises a ValueError with a suggestion."""
+        feature = Feature(name="opt_in_ctx_feature", options=Options(context={"partiton_by": "col"}))
+
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            OptInContextSchemaFeatureGroup: {MockComputeFramework},
+        }
+
+        with pytest.raises(ValueError) as exc_info:
+            IdentifyFeatureGroupClass(
+                feature=feature,
+                accessible_plugins=accessible_plugins,
+                links=None,
+                data_access_collection=None,
+            )
+
+        error_msg = str(exc_info.value)
+        assert "partiton_by" in error_msg
+        assert "did you mean" in error_msg
+        assert "partition_by" in error_msg
+
+    def test_valid_context_key_constructs(self) -> None:
+        """An opt-in FG with a valid context key constructs without error."""
+        feature = Feature(name="opt_in_ctx_feature", options=Options(context={"partition_by": "col"}))
+
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            OptInContextSchemaFeatureGroup: {MockComputeFramework},
+        }
+
+        # Act & Assert - should not raise
+        IdentifyFeatureGroupClass(
+            feature=feature,
+            accessible_plugins=accessible_plugins,
+            links=None,
+            data_access_collection=None,
+        )
+
+    def test_permissive_feature_group_accepts_any_context_key(self) -> None:
+        """A FG that does not override context_key_schema accepts any context key (backward compat)."""
+        feature = Feature(name="permissive_ctx_feature", options=Options(context={"anything_goes": 1}))
+
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            PermissiveContextFeatureGroup: {MockComputeFramework},
+        }
+
+        # Act & Assert - should not raise
+        IdentifyFeatureGroupClass(
+            feature=feature,
+            accessible_plugins=accessible_plugins,
+            links=None,
+            data_access_collection=None,
+        )
+
+    def test_propagated_context_key_is_exempt(self) -> None:
+        """A propagated context key is exempt from validation even if absent from schema."""
+        feature = Feature(
+            name="opt_in_ctx_feature",
+            options=Options(
+                context={"partition_by": "c", "propagated_key": "v"},
+                propagate_context_keys=frozenset({"propagated_key"}),
+            ),
+        )
+
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            OptInContextSchemaFeatureGroup: {MockComputeFramework},
+        }
+
+        # Act & Assert - should not raise (propagated_key is exempt)
+        IdentifyFeatureGroupClass(
+            feature=feature,
+            accessible_plugins=accessible_plugins,
+            links=None,
+            data_access_collection=None,
+        )

--- a/tests/test_plugins/feature_group/experimental/test_clustering_feature_group/test_clustering_context_key_schema.py
+++ b/tests/test_plugins/feature_group/experimental/test_clustering_feature_group/test_clustering_context_key_schema.py
@@ -1,0 +1,43 @@
+"""
+Tests for ClusteringFeatureGroup.context_key_schema() opt-in.
+
+These tests FAIL until the Green Agent adds:
+
+    @classmethod
+    def context_key_schema(cls):
+        return cls.derive_context_key_schema()
+
+to ClusteringFeatureGroup.
+"""
+
+import pytest
+
+from mloda.provider import OptionsValidator
+from mloda_plugins.feature_group.experimental.clustering.base import (
+    ClusteringFeatureGroup,
+)
+
+
+class TestClusteringContextKeySchema:
+    def test_context_key_schema_is_opted_in(self) -> None:
+        """context_key_schema() must return the PROPERTY_MAPPING-derived schema."""
+        schema = ClusteringFeatureGroup.context_key_schema()
+        assert schema is not None  # fails: base class returns None until opt-in
+        assert schema == ClusteringFeatureGroup.derive_context_key_schema()
+        assert ClusteringFeatureGroup.ALGORITHM in schema
+        assert ClusteringFeatureGroup.K_VALUE in schema
+        assert ClusteringFeatureGroup.OUTPUT_PROBABILITIES in schema
+
+    def test_output_probabilites_typo_is_caught(self) -> None:
+        """A near-miss typo for output_probabilities must raise ValueError with suggestion."""
+        schema = ClusteringFeatureGroup.context_key_schema()
+        assert schema is not None  # fails: base class returns None until opt-in
+        with pytest.raises(ValueError) as exc:
+            OptionsValidator.validate_context_keys(
+                "some_feature",
+                {"output_probabilites": True},
+                schema,
+            )
+        assert "output_probabilites" in str(exc.value)
+        assert "did you mean" in str(exc.value)
+        assert "output_probabilities" in str(exc.value)

--- a/tests/test_plugins/feature_group/experimental/test_dimensionality_reduction_feature_group/test_dimensionality_reduction_context_key_schema.py
+++ b/tests/test_plugins/feature_group/experimental/test_dimensionality_reduction_feature_group/test_dimensionality_reduction_context_key_schema.py
@@ -1,0 +1,43 @@
+"""
+Tests for DimensionalityReductionFeatureGroup.context_key_schema() opt-in.
+
+These tests FAIL until the Green Agent adds:
+
+    @classmethod
+    def context_key_schema(cls):
+        return cls.derive_context_key_schema()
+
+to DimensionalityReductionFeatureGroup.
+"""
+
+import pytest
+
+from mloda.provider import OptionsValidator
+from mloda_plugins.feature_group.experimental.dimensionality_reduction.base import (
+    DimensionalityReductionFeatureGroup,
+)
+
+
+class TestDimensionalityReductionContextKeySchema:
+    def test_context_key_schema_is_opted_in(self) -> None:
+        """context_key_schema() must return the PROPERTY_MAPPING-derived schema."""
+        schema = DimensionalityReductionFeatureGroup.context_key_schema()
+        assert schema is not None  # fails: base class returns None until opt-in
+        assert schema == DimensionalityReductionFeatureGroup.derive_context_key_schema()
+        assert DimensionalityReductionFeatureGroup.ALGORITHM in schema
+        assert DimensionalityReductionFeatureGroup.DIMENSION in schema
+        assert DimensionalityReductionFeatureGroup.ISOMAP_N_NEIGHBORS in schema
+
+    def test_isomap_n_neighbor_typo_is_caught(self) -> None:
+        """A near-miss typo for isomap_n_neighbors must raise ValueError with suggestion."""
+        schema = DimensionalityReductionFeatureGroup.context_key_schema()
+        assert schema is not None  # fails: base class returns None until opt-in
+        with pytest.raises(ValueError) as exc:
+            OptionsValidator.validate_context_keys(
+                "some_feature",
+                {"isomap_n_neighbor": 5},
+                schema,
+            )
+        assert "isomap_n_neighbor" in str(exc.value)
+        assert "did you mean" in str(exc.value)
+        assert "isomap_n_neighbors" in str(exc.value)

--- a/tests/test_plugins/feature_group/experimental/test_missing_value_feature_group/test_missing_value_context_key_schema.py
+++ b/tests/test_plugins/feature_group/experimental/test_missing_value_feature_group/test_missing_value_context_key_schema.py
@@ -1,0 +1,43 @@
+"""
+Tests for MissingValueFeatureGroup.context_key_schema() opt-in.
+
+These tests FAIL until the Green Agent adds:
+
+    @classmethod
+    def context_key_schema(cls):
+        return cls.derive_context_key_schema()
+
+to MissingValueFeatureGroup.
+"""
+
+import pytest
+
+from mloda.provider import OptionsValidator
+from mloda_plugins.feature_group.experimental.data_quality.missing_value.base import (
+    MissingValueFeatureGroup,
+)
+
+
+class TestMissingValueContextKeySchema:
+    def test_context_key_schema_is_opted_in(self) -> None:
+        """context_key_schema() must return the PROPERTY_MAPPING-derived schema."""
+        schema = MissingValueFeatureGroup.context_key_schema()
+        assert schema is not None  # fails: base class returns None until opt-in
+        assert schema == MissingValueFeatureGroup.derive_context_key_schema()
+        assert MissingValueFeatureGroup.IMPUTATION_METHOD in schema
+        assert "constant_value" in schema
+        assert "group_by_features" in schema
+
+    def test_constant_valeu_typo_is_caught(self) -> None:
+        """A near-miss typo for constant_value must raise ValueError with suggestion."""
+        schema = MissingValueFeatureGroup.context_key_schema()
+        assert schema is not None  # fails: base class returns None until opt-in
+        with pytest.raises(ValueError) as exc:
+            OptionsValidator.validate_context_keys(
+                "some_feature",
+                {"constant_valeu": 0},
+                schema,
+            )
+        assert "constant_valeu" in str(exc.value)
+        assert "did you mean" in str(exc.value)
+        assert "constant_value" in str(exc.value)

--- a/tests/test_plugins/feature_group/experimental/test_node_centrality_feature_group/test_node_centrality_context_key_schema.py
+++ b/tests/test_plugins/feature_group/experimental/test_node_centrality_feature_group/test_node_centrality_context_key_schema.py
@@ -1,0 +1,43 @@
+"""
+Tests for NodeCentralityFeatureGroup.context_key_schema() opt-in.
+
+These tests FAIL until the Green Agent adds:
+
+    @classmethod
+    def context_key_schema(cls):
+        return cls.derive_context_key_schema()
+
+to NodeCentralityFeatureGroup.
+"""
+
+import pytest
+
+from mloda.provider import OptionsValidator
+from mloda_plugins.feature_group.experimental.node_centrality.base import (
+    NodeCentralityFeatureGroup,
+)
+
+
+class TestNodeCentralityContextKeySchema:
+    def test_context_key_schema_is_opted_in(self) -> None:
+        """context_key_schema() must return the PROPERTY_MAPPING-derived schema."""
+        schema = NodeCentralityFeatureGroup.context_key_schema()
+        assert schema is not None  # fails: base class returns None until opt-in
+        assert schema == NodeCentralityFeatureGroup.derive_context_key_schema()
+        assert NodeCentralityFeatureGroup.CENTRALITY_TYPE in schema
+        assert NodeCentralityFeatureGroup.GRAPH_TYPE in schema
+        assert NodeCentralityFeatureGroup.WEIGHT_COLUMN in schema
+
+    def test_graph_typ_typo_is_caught(self) -> None:
+        """A near-miss typo for graph_type must raise ValueError with suggestion."""
+        schema = NodeCentralityFeatureGroup.context_key_schema()
+        assert schema is not None  # fails: base class returns None until opt-in
+        with pytest.raises(ValueError) as exc:
+            OptionsValidator.validate_context_keys(
+                "some_feature",
+                {"graph_typ": "directed"},
+                schema,
+            )
+        assert "graph_typ" in str(exc.value)
+        assert "did you mean" in str(exc.value)
+        assert "graph_type" in str(exc.value)

--- a/tests/test_plugins/feature_group/test_context_key_schema_e2e.py
+++ b/tests/test_plugins/feature_group/test_context_key_schema_e2e.py
@@ -1,0 +1,79 @@
+"""End-to-end test proving context-key schema validation fires through the public run path.
+
+An opt-in DataCreator FeatureGroup declares a context-key schema. When a feature
+is requested with a typo'd context key, running through the public API must raise
+a ValueError that mentions the offending key. Validation happens at planning time
+(IdentifyFeatureGroupClass), before the worker layer, so in SYNC mode the error
+surfaces as an unwrapped ValueError.
+"""
+
+from typing import Any, Optional
+
+import pytest
+import pyarrow as pa
+
+from mloda.provider import BaseInputData, ComputeFramework, DataCreator, FeatureGroup, FeatureSet
+from mloda.user import Feature, Features, ParallelizationMode
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+from mloda.core.abstract_plugins.components.options import Options
+from tests.test_core.test_tooling import MlodaTestRunner
+
+
+class OptInContextSchemaE2EFeatureGroup(FeatureGroup):
+    """DataCreator FG that opts in to context-key validation with schema {partition_by: str}."""
+
+    @classmethod
+    def context_key_schema(cls) -> dict[str, Any] | None:
+        return {"partition_by": str}
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({cls.get_class_name()})
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PyArrowTable}
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return pa.table({cls.get_class_name(): [1, 2, 3]})
+
+
+def test_valid_context_key_runs_end_to_end() -> None:
+    """Sanity baseline: with a valid context key the feature computes a table cleanly.
+
+    This proves the FG is well-formed so that the typo test below fails for the
+    right reason (missing validation), not because of an unrelated runtime error.
+    """
+    feature_name = "OptInContextSchemaE2EFeatureGroup"
+
+    features = Features(
+        [Feature(name=feature_name, options=Options(context={"partition_by": "x"}), initial_requested_data=True)]
+    )
+
+    result = MlodaTestRunner.run_api(
+        features,
+        compute_frameworks={PyArrowTable},
+        parallelization_modes={ParallelizationMode.SYNC},
+    )
+
+    assert result.results
+    for res in result.results:
+        data = res.to_pydict()
+        assert data[feature_name] == [1, 2, 3]
+
+
+def test_unknown_context_key_raises_through_run_path() -> None:
+    """Requesting the feature with a typo'd context key raises a ValueError mentioning the key."""
+    feature_name = "OptInContextSchemaE2EFeatureGroup"
+
+    features = Features(
+        [Feature(name=feature_name, options=Options(context={"partiton_by": "x"}), initial_requested_data=True)]
+    )
+
+    with pytest.raises(ValueError, match="partiton_by"):
+        MlodaTestRunner.run_api(
+            features,
+            compute_frameworks={PyArrowTable},
+            parallelization_modes={ParallelizationMode.SYNC},
+        )

--- a/tests/test_plugins/feature_group/test_context_key_schema_propagation_e2e.py
+++ b/tests/test_plugins/feature_group/test_context_key_schema_propagation_e2e.py
@@ -1,0 +1,210 @@
+"""E2E regression tests for the chained-propagation context-key exemption.
+
+These tests exercise the real engine run path (``mloda.run_all``), NOT a direct
+call to ``Options.update_with_protected_keys``. They lock in the live-path
+behavior on this branch.
+
+Scenario: a parent feature ``P`` declares
+``propagate_context_keys=frozenset({"bespoke_env"})`` with ``bespoke_env`` in its
+context. ``P`` has an input feature ``D`` whose FeatureGroup opts into
+context-key validation via ``context_key_schema() -> derive_context_key_schema()``
+but does NOT declare ``bespoke_env`` in its ``PROPERTY_MAPPING``.
+
+During the run the engine merges ``P``'s propagated context value INTO ``D``'s
+context BEFORE ``D``'s own planning/validation runs, populating
+``D.options.received_propagated_keys``. The validator exempts received-propagated
+keys, so the run must succeed and must NOT raise "unknown context key
+'bespoke_env'".
+"""
+
+from typing import Any, Optional
+
+import pytest
+
+from mloda.provider import DefaultOptionKeys
+from mloda.provider import FeatureChainParserMixin
+from mloda.provider import FeatureGroup
+from mloda.provider import FeatureSet
+from mloda.user import Feature
+from mloda.user import FeatureName
+from mloda.user import Options
+from mloda.user import PluginCollector
+from mloda.user import mloda
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from tests.test_plugins.integration_plugins.test_data_creator import ATestDataCreator
+
+
+class ContextSchemaPropagationDataCreator(ATestDataCreator):
+    """Source feature group producing a small Sales frame on PandasDataFrame."""
+
+    compute_framework = PandasDataFrame
+
+    @classmethod
+    def get_raw_data(cls) -> dict[str, Any]:
+        return {"Sales": [100, 200, 300, 400, 500]}
+
+
+class ContextSchemaPropagationConsumer(FeatureChainParserMixin, FeatureGroup):
+    """Config-based consumer that opts into context-key schema validation.
+
+    IMPORTANT: ``bespoke_env`` is intentionally NOT part of ``PROPERTY_MAPPING``.
+    The derived schema therefore does not contain ``bespoke_env``; the run can
+    only succeed if the propagated key is exempt via
+    ``received_propagated_keys`` on the live path.
+    """
+
+    PROPERTY_MAPPING = {
+        "ident": {
+            "identifier1": "multiplier 2",
+            "identifier2": "multiplier 3",
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: True,
+        },
+        "label": {
+            "explanation": "Optional, unused label used by the typo guard test",
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: False,
+            DefaultOptionKeys.default: None,
+        },
+        DefaultOptionKeys.in_features: {
+            "explanation": "Source feature(s)",
+            DefaultOptionKeys.context: True,
+        },
+    }
+
+    @classmethod
+    def context_key_schema(cls) -> Optional[dict[str, Any]]:
+        return cls.derive_context_key_schema()
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        features: set[Feature] = set()
+        for source_feature in options.get_in_features():
+            source_feature.options.add_to_group(
+                DefaultOptionKeys.feature_chainer_parser_key,
+                frozenset(["ident", DefaultOptionKeys.in_features]),
+            )
+            features.add(source_feature)
+        if features:
+            return features
+        raise ValueError("No input features found")
+
+    @classmethod
+    def perform_operation(cls, data: Any, feature: Feature) -> Any:
+        source_feature = next(iter(feature.options.get_in_features()))
+        source_feature_name: str = source_feature.name
+
+        ident = feature.options.get("ident")
+        if ident == "identifier1":
+            multiplier = 2
+        elif ident == "identifier2":
+            multiplier = 3
+        else:
+            raise ValueError(f"Unknown ident value: {ident}")
+
+        bespoke_env = feature.options.get("bespoke_env")
+        if bespoke_env == "prod":
+            offset = 1000
+        elif bespoke_env == "staging":
+            offset = 500
+        else:
+            offset = 0
+
+        data[feature.name] = data[source_feature_name] * multiplier + offset
+        return data
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        for feature in features.features:
+            data = cls.perform_operation(data, feature)
+        return data
+
+
+def find_column(results: list[Any], column_name: str) -> list[Any]:
+    for df in results:
+        if column_name in df.columns:
+            return list(df[column_name].values)
+    raise ValueError(f"Column '{column_name}' not found in any result dataframe")
+
+
+class TestContextKeySchemaPropagationE2E:
+    plugin_collector = PluginCollector.enabled_feature_groups(
+        {ContextSchemaPropagationConsumer, ContextSchemaPropagationDataCreator}
+    )
+
+    def test_propagated_context_key_is_exempt_on_live_path(self) -> None:
+        """The propagated key 'bespoke_env' is not in the consumer's schema, yet
+        the run succeeds because it is exempt as a received-propagated key.
+
+        consumer_child: Sales*2 + offset(bespoke_env=prod=1000)
+            = [200,400,600,800,1000] + 1000 = [1200,1400,1600,1800,2000]
+        consumer_parent: child*3 + offset(prod=1000)
+            = [3600,4200,4800,5400,6000] + 1000 = [4600,5200,5800,6400,7000]
+
+        Asserting the child equals [1200,...] proves both that planning did not
+        raise "unknown context key 'bespoke_env'" AND that the value was actually
+        propagated into the child's context (without propagation it would be
+        [200,400,600,800,1000]).
+        """
+        consumer_child = Feature(
+            name="consumer_child",
+            options=Options(
+                context={
+                    DefaultOptionKeys.in_features: "Sales",
+                    "ident": "identifier1",
+                },
+            ),
+        )
+        consumer_parent = Feature(
+            name="consumer_parent",
+            options=Options(
+                context={
+                    DefaultOptionKeys.in_features: consumer_child,
+                    "ident": "identifier2",
+                    "bespoke_env": "prod",
+                },
+                propagate_context_keys=frozenset({"bespoke_env"}),
+            ),
+        )
+
+        result = mloda.run_all(
+            [consumer_parent, consumer_child, "Sales"],
+            compute_frameworks={PandasDataFrame},
+            plugin_collector=self.plugin_collector,
+        )
+
+        assert find_column(result, "consumer_child") == [1200, 1400, 1600, 1800, 2000]
+        assert find_column(result, "consumer_parent") == [4600, 5200, 5800, 6400, 7000]
+
+    def test_typo_on_optional_context_key_still_raises(self) -> None:
+        """Guard: prove validation is actually active on the opt-in consumer.
+
+        'label' is a legitimate optional PROPERTY_MAPPING key. Requesting the
+        consumer directly with a typo'd 'labal' (close to 'label') still resolves
+        to the consumer (matching ignores extra context keys and 'label' is
+        optional), so context-key validation fires and raises a ValueError with a
+        "did you mean" suggestion.
+        """
+        typo_feature = Feature(
+            name="consumer_typo",
+            options=Options(
+                context={
+                    DefaultOptionKeys.in_features: "Sales",
+                    "ident": "identifier1",
+                    "labal": "oops",
+                },
+            ),
+        )
+
+        with pytest.raises(ValueError, match="labal"):
+            mloda.run_all(
+                [typo_feature],
+                compute_frameworks={PandasDataFrame},
+                plugin_collector=self.plugin_collector,
+            )
+
+        with pytest.raises(ValueError, match="did you mean"):
+            mloda.run_all(
+                [typo_feature],
+                compute_frameworks={PandasDataFrame},
+                plugin_collector=self.plugin_collector,
+            )


### PR DESCRIPTION
## Summary

Closes #484.

`Options` context keys were never validated: a typo in a context key (e.g. `partiton_by` instead of `partition_by`, or `frame_unit` vs `frame_size`) was silently ignored until it surfaced as wrong/missing behavior at compute time. This adds an **opt-in** way for a FeatureGroup to declare its accepted context keys (and expected types), which core validates at match/planning time.

## What changed

- **`FeatureGroup.context_key_schema()`** (new classmethod, default `None`): a FeatureGroup may override it to return a dict mapping accepted context-key names to an expected type (a `type`, a tuple of types, or `None` to skip the type check). Returning `None` keeps today's permissive behavior.
- **`OptionsValidator.validate_context_keys()`** (new static method): raises an actionable `ValueError` on an unknown context key with a `difflib` "did you mean 'partition_by'?" suggestion, and on declared-key type mismatches. Framework-reserved `DefaultOptionKeys` and the feature's propagated context keys are always allowed.
- **Wiring**: called from `IdentifyFeatureGroupClass.validate()`, the single chokepoint after a feature resolves to exactly one feature group, so validation runs at planning time against the resolving group.
- **`FeatureChainParserMixin.derive_context_key_schema()`** (new helper): configuration-based groups are the primary consumers (the registry's `partition_by`/`frame_size`/etc. are declared context keys). They opt in with one line, `return cls.derive_context_key_schema()`, keeping `PROPERTY_MAPPING` as the single source of truth so the two never drift.
- **Chained-propagation fix**: keys propagated into a feature's context via `Options.update_with_protected_keys` are now tracked (`received_propagated_keys`, provenance only) and exempted from validation, so opt-in groups in a chain don't false-positive. This does not change single-hop propagation semantics.

## Opt-in / no breaking change

Feature groups that declare nothing (the default) keep the current permissive behavior. Only groups that opt in via `context_key_schema()` get validation.

## Design note (re: `design-review` label)

Why a new `context_key_schema()` instead of reusing `PROPERTY_MAPPING`? `PROPERTY_MAPPING` validates option *values* (and is bound to `FeatureChainParserMixin`); it does not define a closed *key set*, and deriving accepted keys from it by default would break the opt-in / no-breaking-change guarantee. `context_key_schema()` is a small, explicit, plugin-agnostic declaration that any `FeatureGroup` subclass can use; config-based groups bridge to `PROPERTY_MAPPING` explicitly via `derive_context_key_schema()`.

## Boundaries

- Only `Options.context` is validated; group-placed keys are not.
- A typo on a *required* parameter makes the group fail to match, surfacing as the normal "no feature group found" resolution error rather than a context-key suggestion. The suggestion path fires for typos on optional/extra context keys.

## Tests

- Unit tests for `OptionsValidator.validate_context_keys` and `derive_context_key_schema`.
- Planning-chokepoint tests via `IdentifyFeatureGroupClass` (unknown key raises with suggestion; valid key resolves; permissive FG accepts anything; declared/propagated keys exempt).
- End-to-end tests through the public `mlodaAPI` run path, including a chained propagation case.

`tox` passes locally: 3437 passed, 194 skipped; ruff format + check, mypy --strict, bandit, and the license allowlist all clean.
