### PR TITLE
docs: fix grammar and spelling in docs, docstrings, and comments

### DIFF
--- a/docs/docs/in_depth/access-feature-data.md
+++ b/docs/docs/in_depth/access-feature-data.md
@@ -14,7 +14,7 @@ These methods ensure efficient data management while maintaining flexibility and
 
 #### DataAccessCollection - global data access
 
-The DataAccessCollection is designed to control the access to data of any kind. The main purpose of this class is to organize and simplify interactions with these different data elements, making it easier to work to ingest data of various form into the framework. It provides as an interface for accessing and storing of data on a global level.
+The DataAccessCollection is designed to control the access to data of any kind. The main purpose of this class is to organize and simplify interactions with these different data elements, making it easier to work to ingest data of various forms into the framework. It serves as an interface for accessing and storing of data on a global level.
 
 The DataAccessCollection can only be added via **mlodaAPI**.
 

--- a/docs/docs/in_depth/artifacts.md
+++ b/docs/docs/in_depth/artifacts.md
@@ -1,6 +1,6 @@
 # Artifacts
 
-Artifacts are a crucial part of the mloda, enabling the storage and retrieval of intermediate results feature engineering processes.
+Artifacts are a crucial part of the mloda, enabling the storage and retrieval of intermediate results in feature engineering processes.
 Example use cases are embeddings, Feature Matrices, Model Checkpoints and more.
 
 ## Overview

--- a/docs/docs/in_depth/filter_data.md
+++ b/docs/docs/in_depth/filter_data.md
@@ -12,7 +12,7 @@ That however means that a data project typically contains multiple filters. For 
 
 #### FilterType
 
-This class is supposed to created similarity in the framework and by framework users.
+This class is supposed to create similarity in the framework and by framework users.
 
 ``` python
 class FilterType(Enum):
@@ -26,7 +26,7 @@ class FilterType(Enum):
 
 #### GlobalFilter
 
-The GlobalFilter provides methods to add filters to the collection. The prefered way to use the GlobalFilter is by using the following functions.
+The GlobalFilter provides methods to add filters to the collection. The preferred way to use the GlobalFilter is by using the following functions.
 
 **add_filter**: Adds a single filter to the GlobalFilter object.
 

--- a/docs/docs/in_depth/framework-connection-object.md
+++ b/docs/docs/in_depth/framework-connection-object.md
@@ -187,7 +187,7 @@ return framework_connection_object.from_other_format(data)
    ```
    ValueError: A DuckDB connection object is required for this transformation.
    ```
-   **Solution**: Ensure you're providing a connection object when using stateful frameworks. Currently, parent features are not receiving the connection details automatic. Thus, you might need to give them a second time to root features!
+   **Solution**: Ensure you're providing a connection object when using stateful frameworks. Currently, parent features are not receiving the connection details automatically. Thus, you might need to give them a second time to root features!
 
 ## Summary
 

--- a/docs/docs/in_depth/join_data.md
+++ b/docs/docs/in_depth/join_data.md
@@ -8,7 +8,7 @@ Combining datasets from various feature groups is crucial for building comprehen
 -   **Multiple Links on the Same Compute Framework**: Joining a single base FG to multiple right-side FGs (same class, subclasses, or distinct) all within the same compute framework.
 
 
-_**If we have a feature, which is dependent on a aforementioned setup,**_
+_**If we have a feature, which is dependent on an aforementioned setup,**_
 
 -   we need to define a Link,
 -   and the ComputeFramework must support the according merge!

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -53,9 +53,9 @@ mloda addresses common challenges in data and feature engineering by leveraging 
 #### Plugins
   - Feature Groups: **Define feature dependencies**, such as creating a composite label based on features e.g. user activity, purchase history, and support interactions. Once defined, only the label needs to be requested, as dependencies are resolved automatically, simplifying processing. [Learn more here.](chapter1/feature-groups.md)
 
-  - Compute Frameworks: Defines the **technology stack**, like Spark or Pandas, along with support for different storage engines such as Parquet, Delta Lake, or PostgreSQL, to execute feature transformations and computations, ensuring efficient processing at scale. [Learn more here.](chapter1/compute-frameworks.md)
+  - Compute Frameworks: Define the **technology stack**, like Spark or Pandas, along with support for different storage engines such as Parquet, Delta Lake, or PostgreSQL, to execute feature transformations and computations, ensuring efficient processing at scale. [Learn more here.](chapter1/compute-frameworks.md)
 
-  - Extenders: Automates **metadata extraction processes**, helping you enhance data governance, compliance, and traceability, such as analyzing how often features are used by models or analysts, or understanding where the data is coming from. [Learn more here.](chapter1/extender.md)
+  - Extenders: Automate **metadata extraction processes**, helping you enhance data governance, compliance, and traceability, such as analyzing how often features are used by models or analysts, or understanding where the data is coming from. [Learn more here.](chapter1/extender.md)
 
 #### Core
   - Core Engine: **Handles dependencies between features and computations** by coordinating linking, joining, filtering, and ordering operations to ensure optimized data processing. For example, in customer segmentation, the core engine would link and filter different data sources, such as demographics, purchasing history, and online behavior, to create relevant features.

--- a/mloda/core/abstract_plugins/components/input_data/base_input_data.py
+++ b/mloda/core/abstract_plugins/components/input_data/base_input_data.py
@@ -136,7 +136,7 @@ class BaseInputData(ABC):
     @classmethod
     def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
         """
-        This funtion should be implemented in final child classes, which use scoped data access.
+        This function should be implemented in final child classes, which use scoped data access.
         """
         raise NotImplementedError
 

--- a/mloda/core/abstract_plugins/components/merge/base_merge_engine.py
+++ b/mloda/core/abstract_plugins/components/merge/base_merge_engine.py
@@ -28,7 +28,7 @@ class BaseMergeEngine(ABC):
     def check_import(self) -> None:
         """
         Convenience method to check if the necessary imports are available. This is important for ensuring that not
-        installed modules dont break the framework.
+        installed modules don't break the framework.
 
         This gets called in the final merge.
 

--- a/mloda/core/abstract_plugins/compute_framework.py
+++ b/mloda/core/abstract_plugins/compute_framework.py
@@ -36,7 +36,7 @@ class ComputeFramework(ABC):
 
     A compute framework must be in the namespace of the python project and must inherit from this class.
     This way, we can run feature computation on multiple frameworks.
-    Usecases:
+    Use cases:
     - Online and Offline computation
     - Testing
     - Migrations from one framework to another
@@ -48,8 +48,8 @@ class ComputeFramework(ABC):
     2) feature group definition - compute frameworks that can be used for the feature group
     3) from api request side - limits compute frameworks which can be used
 
-    Of course, for migrations, we have allow multiple definitions of the same feature group on different compute frameworks.
-    This usecase however is currently not supported, as one could just run the module twice and compare the result datasets for now.
+    Of course, for migrations, we allow multiple definitions of the same feature group on different compute frameworks.
+    This use case, however, is currently not supported, as one could just run the module twice and compare the result datasets for now.
     """
 
     def __init__(
@@ -59,7 +59,7 @@ class ComputeFramework(ABC):
         uuid: UUID = uuid4(),
         function_extender: Optional[set[Extender]] = None,
     ) -> None:
-        """This class is initialized step execution."""
+        """This class is initialized for step execution."""
         self.mode = mode
         self.data: Any = None
         self.children_if_root = children_if_root
@@ -113,7 +113,7 @@ class ComputeFramework(ABC):
         and thus, defined by the compute framework abstraction.
 
         If you wish not to transform the data, you can leave this.
-        This is not relevant if you stay in one compute framework as you don t need to switch it.
+        This is not relevant if you stay in one compute framework as you don't need to switch it.
         """
 
         transformed_data = self.apply_compute_framework_transformer(data)
@@ -543,7 +543,7 @@ class ComputeFramework(ABC):
     def validate_expected_framework(self, location: Optional[str] = None) -> None:
         """
         Validates that the data is in the expected framework.
-        Only touch is if your framework supports multiple data frameworks.
+        Only touch this if your framework supports multiple data frameworks.
         """
         if self.expected_data_framework() is None:
             return

--- a/mloda/core/abstract_plugins/function_extender.py
+++ b/mloda/core/abstract_plugins/function_extender.py
@@ -12,7 +12,7 @@ class ExtenderHook(Enum):
 
 class Extender(ABC):
     """
-    - Automated Metadata harvestor connector
+    - Automated Metadata harvester connector
     - Messaging Integration ( email )
     - Automation Tools
     - data lineage mapping
@@ -22,7 +22,7 @@ class Extender(ABC):
     - metadata capture
     - Event logging
     - metrics on feature calculation
-    - visibility / observibility
+    - visibility / observability
     - Performance
     """
 

--- a/mloda/core/abstract_plugins/plugin_loader/plugin_loader.py
+++ b/mloda/core/abstract_plugins/plugin_loader/plugin_loader.py
@@ -46,7 +46,7 @@ class PluginLoader:
 
         The PluginLoader is responsible for loading plugins from a specific package and its subpackages.
 
-        You can chose from:
+        You can choose from:
         - load_all_plugins
         - load_group
         - load_matching

--- a/mloda/core/core/engine.py
+++ b/mloda/core/core/engine.py
@@ -355,7 +355,7 @@ class Engine:
 
     def set_compute_framework(self, feature: Feature, compute_frameworks: set[type[ComputeFramework]]) -> Feature:
         """
-        This function leads to that the feature has always a compute framework set!
+        This function ensures that the feature always has a compute framework set!
         """
         if feature.compute_frameworks:
             if feature.get_compute_framework() not in compute_frameworks:

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -95,7 +95,7 @@ class GlobalFilter:
                 continue
             if self.compute_framework(_filter, feat) is False:
                 continue
-            # we don t check links, because this is not necessary as this is covered by the feature and feature group before
+            # we don't check links, because this is not necessary as this is covered by the feature and feature group before
 
             matched_filters.add(_filter)
         return matched_filters

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -436,7 +436,7 @@ class ExecutionPlan:
 
         children_uuids = self.reduce_children_to_one_level(children_uuids, graph)
 
-        # This gets the parent ids of the joinstep, which needs to be calulated before the link.
+        # This gets the parent ids of the joinstep, which needs to be calculated before the link.
         required_uuids: set[UUID] = set()
         for uuid in children_uuids:
             required_uuids.update(graph.parent_to_children_mapping[uuid])
@@ -453,7 +453,7 @@ class ExecutionPlan:
                 right_framework_uuids.add(uuid)
 
         # The order shows which items should be added first.
-        # Thus, we need to make sure that higher orderered links are calculated first.
+        # Thus, we need to make sure that higher ordered links are calculated first.
         for k, v in link_trekker.order.items():
             if link.uuid in v:
                 required_uuids.add(k)

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -100,7 +100,7 @@ class IdentifyFeatureGroupClass:
         if links is None:
             return True
 
-        # Validate that atleast one index is supported by the feature group
+        # Validate that at least one index is supported by the feature group
         for link in links:
             if feature_group.supports_index(link.left_index):
                 return True

--- a/mloda_plugins/feature_group/experimental/llm/llm_api/request_loop.py
+++ b/mloda_plugins/feature_group/experimental/llm/llm_api/request_loop.py
@@ -27,10 +27,10 @@ class RequestLoop(LLMBaseRequest):
     A feature group that interacts with LLMs via a request loop.
     It works by sending requests as long as tools are called.
 
-    If the `project_meta_data` option is set to True, the feature group requires that the requested of the
+    If the `project_meta_data` option is set to True, the feature group requires that the requester of the
     feature GeminiRequestLoop set the link between SourceInputFeatureComposite and one of the other feature groups.
 
-    The specific SourceInputFeatureComposite depends on your projects access, thus we don t know it here.
+    The specific SourceInputFeatureComposite depends on your project's access, thus we don't know it here.
     If you encounter this feature and want an automatic link setting, we could develop this.
     However, it was deprioritized due to the complexity of the feature.
 

--- a/mloda_plugins/feature_group/input_data/read_db.py
+++ b/mloda_plugins/feature_group/input_data/read_db.py
@@ -26,7 +26,7 @@ class ReadDB(BaseInputData):
 
     @classmethod
     def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
-        """This function should be implemented from child classes."""
+        """This function should be implemented by child classes."""
         raise NotImplementedError
 
     @classmethod

--- a/mloda_plugins/feature_group/input_data/read_file.py
+++ b/mloda_plugins/feature_group/input_data/read_file.py
@@ -54,7 +54,7 @@ class ReadFile(BaseInputData):
     @classmethod
     def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
         """
-        This function should be implemented from child classes.
+        This function should be implemented by child classes.
         """
         raise NotImplementedError
 


### PR DESCRIPTION
## Summary

Fixes objective grammar, spelling, and punctuation mistakes in prose only: docs, README-level pages, docstrings, and comments. No code, log strings, exception messages, or behavior are touched.

## Changes

28 fixes across 18 files. Examples:

- `docs/` — "Defines/Automates" → "Define/Automate" (plural subject agreement), "prefered" → "preferred", "a aforementioned" → "an aforementioned", "automatic" → "automatically", missing prepositions.
- docstrings/comments — "Usecases" → "Use cases", "we have allow" → "we allow", "harvestor" → "harvester", "observibility" → "observability", "funtion" → "function", "calulated" → "calculated", "orderered" → "ordered", "atleast" → "at least", "chose" → "choose", missing apostrophes in contractions (`don t` → `don't`), "implemented from" → "implemented by".

Style rewrites and rephrasings were deliberately excluded; only objective errors are fixed.

## Verification

- `ruff format --check` and `ruff check`: pass on all changed files.
- Prose-only changes; no behavior affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
