### PR TITLE
refactor: deduplicate reader load() and reuse _matches_discriminator

### DIFF
--- a/mloda/core/abstract_plugins/components/input_data/base_input_data.py
+++ b/mloda/core/abstract_plugins/components/input_data/base_input_data.py
@@ -127,11 +127,25 @@ class BaseInputData(ABC):
             )
         options.add_to_group("BaseInputData", (cls_to_be_added, matched_data_access))
 
-    def load(self, features: FeatureSet) -> Any:
-        """
-        This class should be implemented in intermediary child classes, which use scoped data access.
-        """
+    def init_reader(self, options: Optional[Options]) -> tuple["BaseInputData", Any]:
+        """Subclasses that load via a reader implement this to resolve (reader, data_access)."""
         raise NotImplementedError
+
+    def load(self, features: FeatureSet) -> Any:
+        _options = None
+        for feature in features.features:
+            if _options:
+                if _options != feature.options:
+                    raise ValueError("All features must have the same options.")
+            _options = feature.options
+
+        reader, data_access = self.init_reader(_options)
+        data = reader.load_data(data_access, features)
+
+        if data is None:
+            raise ValueError(f"Loading data failed for feature {features.get_name_of_one_feature()}.")
+
+        return data
 
     @classmethod
     def load_data(cls, data_access: Any, features: FeatureSet) -> Any:

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -873,11 +873,7 @@ class ExecutionPlan:
                 )
             )
 
-        for k, v in graph.nodes[uuid].feature.options.items():
-            for _k, _v in pointer_dict.items():
-                if k == _k and v == _v:
-                    return True
-        return False
+        return self._matches_discriminator(pointer_dict, graph, uuid)
 
     def find_feature_uuids(
         self, parents: set[UUID], local_feature_set_collection: list[set[UUID]]

--- a/mloda_plugins/feature_group/input_data/read_db.py
+++ b/mloda_plugins/feature_group/input_data/read_db.py
@@ -67,23 +67,6 @@ class ReadDB(BaseInputData):
         reader, data_access = reader_data_access
         return reader(), data_access
 
-    def load(self, features: FeatureSet) -> Any:
-        _options = None
-        for feature in features.features:
-            if _options:
-                if _options != feature.options:
-                    raise ValueError("All features must have the same options.")
-            _options = feature.options
-
-        reader, data_access = self.init_reader(_options)
-
-        data = reader.load_data(data_access, features)
-
-        if data is None:
-            raise ValueError(f"Loading data failed for feature {features.get_name_of_one_feature()}.")
-
-        return data
-
     @classmethod
     def match_subclass_data_access(cls, data_access: Any, feature_names: list[str], options: Options) -> Any:
         data_accesses: list[Any] = []

--- a/mloda_plugins/feature_group/input_data/read_document.py
+++ b/mloda_plugins/feature_group/input_data/read_document.py
@@ -37,23 +37,6 @@ class ReadDocument(BaseInputData):
     def suffix(cls) -> tuple[str, ...]:
         raise NotImplementedError
 
-    def load(self, features: FeatureSet) -> Any:
-        _options = None
-
-        for feature in features.features:
-            if _options:
-                if _options != feature.options:
-                    raise ValueError("All features must have the same options.")
-            _options = feature.options
-
-        reader, data_access = self.init_reader(_options)
-        data = reader.load_data(data_access, features)
-
-        if data is None:
-            raise ValueError(f"Loading data failed for feature {features.get_name_of_one_feature()}.")
-
-        return data
-
     def init_reader(self, options: Optional[Options]) -> tuple["ReadDocument", Any]:
         if options is None:
             raise ValueError("Options were not set.")

--- a/mloda_plugins/feature_group/input_data/read_file.py
+++ b/mloda_plugins/feature_group/input_data/read_file.py
@@ -66,23 +66,6 @@ class ReadFile(BaseInputData):
     def get_column_names(cls, file_name: str) -> list[str]:
         raise NotImplementedError
 
-    def load(self, features: FeatureSet) -> Any:
-        _options = None
-
-        for feature in features.features:
-            if _options:
-                if _options != feature.options:
-                    raise ValueError("All features must have the same options.")
-            _options = feature.options
-
-        reader, data_access = self.init_reader(_options)
-        data = reader.load_data(data_access, features)
-
-        if data is None:
-            raise ValueError(f"Loading data failed for feature {features.get_name_of_one_feature()}.")
-
-        return data
-
     def init_reader(self, options: Optional[Options]) -> tuple["ReadFile", Any]:
         if options is None:
             raise ValueError(


### PR DESCRIPTION
## Summary

Removes two pieces of true copy-paste duplication by reusing existing abstractions. No behavior change.

Addresses #495 (a focused, low-risk subset; the issue tracks the remaining candidates).

## Changes

1. **`BaseInputData.load()` lift** — `ReadFile`, `ReadDB`, and `ReadDocument` each defined a byte-identical `load()` (~15 lines). The body is engine-agnostic: it validates uniform options, calls the subclass `init_reader()`, then `reader.load_data()`. Moved the shared implementation up to `BaseInputData.load()` (the base already declared `load()` as a `NotImplementedError` stub) and added a small `init_reader()` stub on the base so it stays `mypy --strict` clean. The three overrides are deleted. `DataCreator`/`ApiInputData` never have `load()` invoked (it is only called on the readers), so their behavior is unchanged.

2. **`check_pointer` reuses `_matches_discriminator`** — `ExecutionPlan.check_pointer` reimplemented inline the exact double-loop that the sibling helper `_matches_discriminator()` already provides. Replaced the 5-line block with a single call. The helper was a clear missed-refactor: introduced to DRY this loop but never wired into this call site.

Net: 5 files, +19 / −60.

## Verification

- `ruff format --check` and `ruff check`: pass.
- `mypy --strict --ignore-missing-imports` on all touched files: pass (override-covariant tuple returns accepted).
- Targeted tests (`input_data`, `read_file`, `read_db`, `read_document`, `execution_plan`, `discriminator`): 203 passed, 2 skipped.

## Notes

The larger duplication candidates from the audit (the 6-backend `do_max_filter` skeleton, the `_extract_*_and_source_feature` mixin, pyarrow transformer base) are intentionally deferred to follow-ups in #495 because they carry higher type-surface / error-message-unification risk and deserve their own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
