### PR TITLE
refactor: remove dead code (#494)

### DIFF
--- a/mloda/core/abstract_plugins/components/feature.py
+++ b/mloda/core/abstract_plugins/components/feature.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import copy
 from typing import Any, Optional
-from uuid import UUID, uuid4
+from uuid import uuid4
 from mloda.core.abstract_plugins.components.data_types import DataType
 
 from mloda.core.abstract_plugins.components.domain import Domain
@@ -242,16 +242,6 @@ class Feature:
                 compute_framework_options, get_all_subclasses(ComputeFramework), "options"
             )
         return None
-
-    def _set_uuid(self, uuid: UUID) -> Feature:
-        # use only for testing
-        self.uuid = uuid
-        return self
-
-    def _set_compute_frameworks(self, compute_frameworks: set[type[ComputeFramework]]) -> Feature:
-        # use only for testing
-        self.compute_frameworks = compute_frameworks
-        return self
 
     def get_compute_framework(self) -> type[ComputeFramework]:
         FeatureValidator.validate_compute_frameworks_resolved(self.compute_frameworks, str(self.name))

--- a/mloda/core/abstract_plugins/components/feature_set.py
+++ b/mloda/core/abstract_plugins/components/feature_set.py
@@ -104,10 +104,6 @@ class FeatureSet:
         FeatureSetValidator.validate_equal_options(self.features)
         return self.options.get(key)
 
-    def validate_equal_options(self) -> None:
-        """Checks if all features have the same options."""
-        FeatureSetValidator.validate_equal_options(self.features)
-
     def get_initial_requested_features(self) -> set[FeatureName]:
         return {feature.name for feature in self.features if feature.initial_requested_data}
 
@@ -122,6 +118,3 @@ class FeatureSet:
         FeatureSetValidator.validate_filters_not_set(self.filters)
         FeatureSetValidator.validate_filters_is_set_type(single_filters)
         self.filters = single_filters
-
-    def get_artifact(self, config: Options) -> Any:
-        return None

--- a/mloda/core/abstract_plugins/compute_framework.py
+++ b/mloda/core/abstract_plugins/compute_framework.py
@@ -569,11 +569,6 @@ class ComputeFramework(ABC):
     def add_already_calculated_children_and_drop_if_possible(
         self, children: set[UUID], location: Optional[str] = None
     ) -> bool | frozenset[UUID]:
-        # if len(self.object_ids) > 1:
-        #    if location is None:
-        #        raise ValueError("Location is not set")
-        #    self.drop_data(set(self.object_ids[:-1]), location)
-
         self.already_calculated_children_tracker.update(children)
 
         if self.children_if_root.issubset(self.already_calculated_children_tracker):

--- a/mloda/core/core/cfw_manager.py
+++ b/mloda/core/core/cfw_manager.py
@@ -197,10 +197,6 @@ class CfwManager:
         """Retrieves the exception information."""
         return self.exc_info
 
-    def get_compute_frameworks(self) -> dict[UUID, tuple[str, set[UUID]]]:
-        """Retrieves the dictionary of compute frameworks."""
-        return self.compute_frameworks
-
     def get_function_extender(self) -> Optional[set[Extender]]:
         """Retrieves the optional set of function extenders."""
         return self.function_extender

--- a/mloda/core/runtime/data_lifecycle_manager.py
+++ b/mloda/core/runtime/data_lifecycle_manager.py
@@ -73,16 +73,6 @@ class DataLifecycleManager:
         else:
             cfw.drop_last_data(None)
 
-    def track_flyway_datasets(self, cfw_uuid: UUID, datasets: set[UUID]) -> None:
-        """
-        Stores flyway datasets for a CFW UUID for later dropping.
-
-        Args:
-            cfw_uuid: The UUID of the CFW.
-            datasets: Set of dataset UUIDs to track for dropping.
-        """
-        self.track_data_to_drop[cfw_uuid] = datasets
-
     def add_to_result_data_collection(
         self, cfw: ComputeFramework, features: FeatureSet, step_uuid: UUID, location: Optional[str] = None
     ) -> None:

--- a/mloda_plugins/compute_framework/base_implementations/pandas/dataframe.py
+++ b/mloda_plugins/compute_framework/base_implementations/pandas/dataframe.py
@@ -84,12 +84,6 @@ class PandasDataFrame(ComputeFramework):
             raise ImportError("Pandas is not installed. To be able to use this framework, please install pandas.")
         return pd.Series
 
-    @classmethod
-    def pd_merge(cls) -> Any:
-        if pd is None:
-            raise ImportError("Pandas is not installed. To be able to use this framework, please install pandas.")
-        return pd.merge
-
     def transform(
         self,
         data: Any,

--- a/mloda_plugins/compute_framework/base_implementations/spark/spark_merge_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/spark/spark_merge_engine.py
@@ -133,23 +133,3 @@ class SparkMergeEngine(BaseMergeEngine):
             join_condition = left_data[left_idx] == right_data[right_idx]
 
         return left_data.join(right_data, join_condition, join_type)
-
-    def _handle_column_conflicts(
-        self, left_data: Any, right_data: Any, left_index: Index, right_index: Index
-    ) -> tuple[Any, Any]:
-        """Handle column name conflicts by renaming columns in right DataFrame."""
-        left_columns = set(left_data.columns)
-        right_columns = set(right_data.columns)
-
-        # Find conflicting columns (excluding join keys)
-        left_idx = left_index.index[0]
-        right_idx = right_index.index[0]
-
-        conflicts = (left_columns & right_columns) - {left_idx, right_idx}
-
-        if conflicts:
-            # Rename conflicting columns in right DataFrame
-            for col in conflicts:
-                right_data = right_data.withColumnRenamed(col, f"{col}_right")
-
-        return left_data, right_data

--- a/mloda_plugins/feature_group/experimental/aggregated_feature_group/base.py
+++ b/mloda_plugins/feature_group/experimental/aggregated_feature_group/base.py
@@ -159,13 +159,6 @@ class AggregatedFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         return aggregation_type in cls.AGGREGATION_TYPES
 
     @classmethod
-    def _raise_unsupported_aggregation_type(cls, aggregation_type: str) -> bool:
-        """
-        Raise an error for unsupported aggregation type.
-        """
-        raise ValueError(f"Unsupported aggregation type: {aggregation_type}")
-
-    @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
         """
         Perform aggregations.

--- a/mloda_plugins/feature_group/experimental/geo_distance/base.py
+++ b/mloda_plugins/feature_group/experimental/geo_distance/base.py
@@ -181,11 +181,6 @@ class GeoDistanceFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         return point_parts[0], point_parts[1]
 
     @classmethod
-    def _supports_distance_type(cls, distance_type: str) -> bool:
-        """Check if this feature group supports the given distance type."""
-        return distance_type in cls.DISTANCE_TYPES
-
-    @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
         """
         Calculate distances between point features.

--- a/mloda_plugins/feature_group/experimental/llm/cli_features/refactor_git_cached.py
+++ b/mloda_plugins/feature_group/experimental/llm/cli_features/refactor_git_cached.py
@@ -11,7 +11,6 @@ from mloda.provider import DataCreator
 from mloda.provider import ComputeFramework
 from mloda.user import mloda
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
-from mloda_plugins.feature_group.experimental.llm.llm_api.claude import ClaudeRequestLoop
 from mloda_plugins.feature_group.experimental.llm.llm_api.gemini import GeminiRequestLoop
 from mloda_plugins.feature_group.experimental.llm.llm_file_selector import LLMFileSelector
 from mloda_plugins.feature_group.experimental.llm.tools.available.adjust_file_tool import AdjustFileTool
@@ -56,7 +55,6 @@ class RunRefactorDiffCached:
         # check if tests are passing
         previous = ""
         actual_git_diff = self.get_tool_output_by_feature_group_(DiffFeatureGroup)
-        single_code_smell, previous, actual_git_diff
         for i in range(20):
             previous = self.fix_code_smell(i, split_files, single_code_smell, previous, actual_git_diff)
             if "AnalysisComplete" in previous:
@@ -122,10 +120,8 @@ class RunRefactorDiffCached:
         tool_collection.add_tool(ReadFileTool.get_class_name())
         tool_collection.add_tool(CreateFileTool.get_class_name())
 
-        expensive_model = ClaudeRequestLoop.get_class_name()
         expensive_model = RunRefactorGeminiRequestLoop.get_class_name()
 
-        model = "claude-3-haiku-20240307"
         model = "gemini-2.0-flash-exp"
 
         feature = Feature(

--- a/mloda_plugins/feature_group/experimental/llm/llm_api/request_loop.py
+++ b/mloda_plugins/feature_group/experimental/llm/llm_api/request_loop.py
@@ -51,7 +51,7 @@ class RequestLoop(LLMBaseRequest):
 
     @classmethod
     def api(cls) -> Any:
-        NotImplementedError
+        raise NotImplementedError
 
     def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         features = SourceInputFeatureComposite.input_features(options, feature_name) or set()

--- a/mloda_plugins/feature_group/experimental/sklearn/sklearn_artifact.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/sklearn_artifact.py
@@ -4,7 +4,6 @@ Artifact for storing fitted scikit-learn transformers and estimators.
 
 import json
 import base64
-import hashlib
 import logging
 import tempfile
 from pathlib import Path
@@ -114,62 +113,6 @@ class SklearnArtifact(BaseArtifact):
                 artifact[key] = value
 
         return artifact
-
-    @classmethod
-    def _get_artifact_file_path(cls, features: FeatureSet) -> Path:
-        """
-        Generate a file path for storing the artifact.
-
-        Args:
-            features: The feature set
-
-        Returns:
-            Path object for the artifact file
-        """
-        if features.name_of_one_feature is None:
-            raise ValueError("Feature name is required for artifact storage")
-
-        # Get storage path from options or use default temp directory
-        storage_path = None
-
-        options = cls.get_singular_option_from_options(features)
-
-        if options:
-            storage_path = options.get("artifact_storage_path")
-
-        if storage_path is None:
-            storage_path = tempfile.gettempdir()
-
-        # Create a unique filename based on feature name and configuration
-        feature_name = str(features.name_of_one_feature)
-
-        # Create a hash of the feature configuration for uniqueness
-        # Exclude artifact-related keys to ensure consistent hashing
-        config_data = {}
-        if options:
-            config_data = {
-                k: v for k, v in options.items() if not k.startswith(feature_name) and k != "artifact_storage_path"
-            }
-
-        # Convert non-serializable objects for hashing
-        serializable_config = {}
-        for k, v in config_data.items():
-            if isinstance(v, frozenset):
-                # Convert frozenset to sorted list for consistent hashing
-                serializable_config[k] = sorted(list(v))
-            else:
-                serializable_config[k] = v
-
-        config_str = json.dumps(serializable_config, sort_keys=True)
-        config_hash = hashlib.md5(config_str.encode(), usedforsecurity=False).hexdigest()[:8]
-
-        filename = f"sklearn_artifact_{feature_name}_{config_hash}.joblib"
-
-        # Ensure the directory exists
-        storage_dir = Path(storage_path)
-        storage_dir.mkdir(parents=True, exist_ok=True)
-
-        return storage_dir / filename
 
     @classmethod
     def custom_saver(cls, features: FeatureSet, artifact: Any) -> Optional[Any]:
@@ -325,38 +268,3 @@ class SklearnArtifact(BaseArtifact):
             if not isinstance(features.save_artifact, dict):
                 features.save_artifact = {}
             features.save_artifact[artifact_key] = artifact_data
-
-    @classmethod
-    def check_artifact_exists(cls, features: FeatureSet, artifact_key: str) -> bool:
-        """
-        Helper method to check if a specific artifact exists.
-
-        Args:
-            features: The feature set
-            artifact_key: The artifact key to check
-
-        Returns:
-            True if the artifact exists, False otherwise
-        """
-        if features.artifact_to_load:
-            artifacts = cls.custom_loader(features)
-            return artifacts is not None and artifact_key in artifacts
-        return False
-
-    @classmethod
-    def validate_artifact_key_exists(cls, features: FeatureSet, artifact_key: str) -> None:
-        """
-        Helper method to validate that an artifact key exists, raising an error if not.
-
-        Args:
-            features: The feature set
-            artifact_key: The artifact key to validate
-
-        Raises:
-            ValueError: If the artifact key is not found
-        """
-        if features.artifact_to_load:
-            artifacts = cls.custom_loader(features)
-            if artifacts is None or artifact_key not in artifacts:
-                available_keys = list(artifacts.keys()) if artifacts else []
-                raise ValueError(f"Artifact not found for key '{artifact_key}'. Available artifacts: {available_keys}")

--- a/tests/test_core/test_prepare/test_compute_framework_capability.py
+++ b/tests/test_core/test_prepare/test_compute_framework_capability.py
@@ -234,7 +234,7 @@ class TestComputeFrameworkCapabilityHook:
     def test_distinguishable_error_when_pinned_to_unsupported_framework(self) -> None:
         """Pinning to the unsupported framework yields a dedicated, distinguishable error."""
         feature = Feature(CAPABILITY_FEATURE)
-        feature._set_compute_frameworks({CapabilityFwB})
+        feature.compute_frameworks = {CapabilityFwB}
 
         accessible_plugins: FeatureGroupEnvironmentMapping = {
             RejectBCapabilityFeatureGroup: {CapabilityFwA, CapabilityFwB},
@@ -316,7 +316,7 @@ class TestComputeFrameworkCapabilityHook:
 
         # Capability rejection -> distinct, dedicated error.
         pinned_feature = Feature(CAPABILITY_FEATURE)
-        pinned_feature._set_compute_frameworks({CapabilityFwB})
+        pinned_feature.compute_frameworks = {CapabilityFwB}
         capability_accessible: FeatureGroupEnvironmentMapping = {
             RejectBCapabilityFeatureGroup: {CapabilityFwA, CapabilityFwB},
         }
@@ -348,7 +348,7 @@ class TestComputeFrameworkCapabilityHook:
         (its accessible_plugins value is an empty set). It must still show up as supported.
         """
         feature = Feature(CAPABILITY_FEATURE)
-        feature._set_compute_frameworks({CapabilityFwB})
+        feature.compute_frameworks = {CapabilityFwB}
 
         # FwA declared by PandasLikeFG but NOT enabled (empty set); FwB enabled for SqliteLikeFG.
         accessible_plugins: FeatureGroupEnvironmentMapping = {

--- a/tests/test_core/test_runtime/test_data_lifecycle_manager.py
+++ b/tests/test_core/test_runtime/test_data_lifecycle_manager.py
@@ -189,44 +189,6 @@ class TestDataLifecycleManagerDropCfwData:
             manager.drop_cfw_data(cfw_uuid, cfw_collection)
 
 
-class TestDataLifecycleManagerTrackFlywayDatasets:
-    """Test tracking flyway datasets for data dropping."""
-
-    def test_track_flyway_datasets_stores_datasets_for_cfw(self) -> None:
-        """Should store flyway datasets for a CFW UUID."""
-        manager = DataLifecycleManager()
-        cfw_uuid = uuid4()
-        dataset_uuid1 = uuid4()
-        dataset_uuid2 = uuid4()
-        datasets = {dataset_uuid1, dataset_uuid2}
-
-        manager.track_flyway_datasets(cfw_uuid, datasets)
-
-        assert manager.track_data_to_drop[cfw_uuid] == datasets
-
-    def test_track_flyway_datasets_overwrites_existing_tracking(self) -> None:
-        """Should overwrite existing tracking for a CFW UUID."""
-        manager = DataLifecycleManager()
-        cfw_uuid = uuid4()
-        old_dataset = uuid4()
-        new_dataset1 = uuid4()
-        new_dataset2 = uuid4()
-
-        manager.track_data_to_drop[cfw_uuid] = {old_dataset}
-        manager.track_flyway_datasets(cfw_uuid, {new_dataset1, new_dataset2})
-
-        assert manager.track_data_to_drop[cfw_uuid] == {new_dataset1, new_dataset2}
-
-    def test_track_flyway_datasets_handles_empty_set(self) -> None:
-        """Should handle empty set of datasets."""
-        manager = DataLifecycleManager()
-        cfw_uuid = uuid4()
-
-        manager.track_flyway_datasets(cfw_uuid, set())
-
-        assert manager.track_data_to_drop[cfw_uuid] == set()
-
-
 class TestDataLifecycleManagerAddToResultDataCollection:
     """Test adding result data to the collection."""
 
@@ -511,8 +473,8 @@ class TestDataLifecycleManagerIntegration:
         manager.add_to_result_data_collection(mock_cfw2, features2, step_uuid2)
 
         # Track data to drop
-        manager.track_flyway_datasets(cfw_uuid1, {step_uuid1})
-        manager.track_flyway_datasets(cfw_uuid2, {step_uuid2})
+        manager.track_data_to_drop[cfw_uuid1] = {step_uuid1}
+        manager.track_data_to_drop[cfw_uuid2] = {step_uuid2}
 
         # Drop data for finished CFWs
         finished_ids = {step_uuid1, step_uuid2}

--- a/tests/test_core/test_setup/test_graph_builder.py
+++ b/tests/test_core/test_setup/test_graph_builder.py
@@ -73,13 +73,16 @@ class TestGraphBuildGraph:
         feature_link_parents[uuid.UUID(int=4)] = {uuid.UUID(int=3)}
 
         feature_group_collection: dict[type[FeatureGroup], set[Feature]] = defaultdict(set)
-        f0, f1, f2, f3, f4 = (
-            Feature("GraphFeature2")._set_uuid(uuid.UUID(int=0)),
-            Feature("GraphFeature3")._set_uuid(uuid.UUID(int=1)),
-            Feature("GraphFeature4")._set_uuid(uuid.UUID(int=2)),
-            Feature("GraphFeature6")._set_uuid(uuid.UUID(int=3)),
-            Feature("GraphFeature5")._set_uuid(uuid.UUID(int=4)),
-        )
+        f0 = Feature("GraphFeature2")
+        f0.uuid = uuid.UUID(int=0)
+        f1 = Feature("GraphFeature3")
+        f1.uuid = uuid.UUID(int=1)
+        f2 = Feature("GraphFeature4")
+        f2.uuid = uuid.UUID(int=2)
+        f3 = Feature("GraphFeature6")
+        f3.uuid = uuid.UUID(int=3)
+        f4 = Feature("GraphFeature5")
+        f4.uuid = uuid.UUID(int=4)
         feature_group_collection[BaseTestFeatureGroup1] = {f0, f1, f2, f3, f4}
 
         build_graph = BuildGraph(feature_link_parents, feature_group_collection)

--- a/tests/test_core/test_setup/test_link_resolver.py
+++ b/tests/test_core/test_setup/test_link_resolver.py
@@ -32,15 +32,27 @@ uuid_1, uuid_2, uuid_3, uuid_4, uuid_5, uuid_6, uuid_7 = (
 
 class TestResolveGraph:
     def create_graph(self) -> Graph:
-        f1, f2, f3, f4, f5, f6, f7 = (
-            Feature("GraphFeature1")._set_uuid(uuid_1)._set_compute_frameworks({BaseTestComputeFramework1}),
-            Feature("GraphFeature2")._set_uuid(uuid_2)._set_compute_frameworks({BaseTestComputeFramework1}),
-            Feature("GraphFeature3")._set_uuid(uuid_3)._set_compute_frameworks({BaseTestComputeFramework1}),
-            Feature("GraphFeature4")._set_uuid(uuid_4)._set_compute_frameworks({BaseTestComputeFramework2}),
-            Feature("GraphFeature5")._set_uuid(uuid_5)._set_compute_frameworks({BaseTestComputeFramework3}),
-            Feature("GraphFeature6")._set_uuid(uuid_6)._set_compute_frameworks({BaseTestComputeFramework1}),
-            Feature("GraphFeature7")._set_uuid(uuid_7)._set_compute_frameworks({BaseTestComputeFramework1}),
-        )
+        f1 = Feature("GraphFeature1")
+        f1.uuid = uuid_1
+        f1.compute_frameworks = {BaseTestComputeFramework1}
+        f2 = Feature("GraphFeature2")
+        f2.uuid = uuid_2
+        f2.compute_frameworks = {BaseTestComputeFramework1}
+        f3 = Feature("GraphFeature3")
+        f3.uuid = uuid_3
+        f3.compute_frameworks = {BaseTestComputeFramework1}
+        f4 = Feature("GraphFeature4")
+        f4.uuid = uuid_4
+        f4.compute_frameworks = {BaseTestComputeFramework2}
+        f5 = Feature("GraphFeature5")
+        f5.uuid = uuid_5
+        f5.compute_frameworks = {BaseTestComputeFramework3}
+        f6 = Feature("GraphFeature6")
+        f6.uuid = uuid_6
+        f6.compute_frameworks = {BaseTestComputeFramework1}
+        f7 = Feature("GraphFeature7")
+        f7.uuid = uuid_7
+        f7.compute_frameworks = {BaseTestComputeFramework1}
 
         graph = Graph()
 

--- a/tests/test_plugins/compute_framework/base_implementations/spark/test_spark_merge_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/spark/test_spark_merge_engine.py
@@ -166,23 +166,3 @@ class TestSparkMergeEngine:
 
         with pytest.raises(ValueError, match="MultiIndex is not yet implemented"):
             merge_engine._join_logic("inner", left_data, right_data, multi_idx, idx)
-
-    def test_handle_column_conflicts(self, spark_session: Any) -> None:
-        """Test column conflict handling."""
-        # Create data with conflicting column names
-        left_data_conflict = spark_session.createDataFrame(
-            [{"idx": 1, "common_col": "left_a"}, {"idx": 3, "common_col": "left_b"}]
-        )
-        right_data_conflict = spark_session.createDataFrame(
-            [{"idx": 1, "common_col": "right_x"}, {"idx": 2, "common_col": "right_z"}]
-        )
-        idx = Index(("idx",))
-
-        merge_engine = SparkMergeEngine(spark_session)
-        left_result, right_result = merge_engine._handle_column_conflicts(
-            left_data_conflict, right_data_conflict, idx, idx
-        )
-
-        # Check that conflicting columns in right DataFrame are renamed
-        assert "common_col_right" in right_result.columns
-        assert "common_col" in left_result.columns

--- a/tests/test_plugins/compute_framework/test_method_decorators.py
+++ b/tests/test_plugins/compute_framework/test_method_decorators.py
@@ -70,12 +70,6 @@ class TestPandasDataFrameClassMethods:
         assert inspect.ismethod(method), "pd_series should be a classmethod (bound method on class)"
         assert method.__self__ is PandasDataFrame, "pd_series should be bound to the PandasDataFrame class"
 
-    def test_pd_merge_is_classmethod(self) -> None:
-        """Verify pd_merge is a classmethod by checking it's bound when accessed from the class."""
-        method = getattr(PandasDataFrame, "pd_merge")
-        assert inspect.ismethod(method), "pd_merge should be a classmethod (bound method on class)"
-        assert method.__self__ is PandasDataFrame, "pd_merge should be bound to the PandasDataFrame class"
-
     def test_methods_callable_on_class(self) -> None:
         """Verify methods can be called on the class."""
         # These should work without instantiation
@@ -83,7 +77,6 @@ class TestPandasDataFrameClassMethods:
 
         assert PandasDataFrame.pd_dataframe() == pd.DataFrame
         assert PandasDataFrame.pd_series() == pd.Series
-        assert PandasDataFrame.pd_merge() == pd.merge
 
     def test_methods_callable_on_instance(self) -> None:
         """Verify methods can be called on instances."""
@@ -94,7 +87,6 @@ class TestPandasDataFrameClassMethods:
         instance = PandasDataFrame(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
         assert instance.pd_dataframe() == pd.DataFrame
         assert instance.pd_series() == pd.Series
-        assert instance.pd_merge() == pd.merge
 
 
 class TestPandasMergeEngineClassMethods:

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ setenv =
     PYTHONWARNINGS=ignore::UserWarning:piplicenses.spdx
     WRITE_THIRD_PARTY_LICENSES={env:TOX_WRITE_THIRD_PARTY_LICENSES:false}
     SKIP_POLARS_INSTALLATION_TEST={env:SKIP_POLARS_INSTALLATION_TEST:false}
-    EXPECTED_SKIP_COUNT = {env:EXPECTED_SKIP_COUNT:194}
+    EXPECTED_SKIP_COUNT = {env:EXPECTED_SKIP_COUNT:193}
     CHECK_SKIP_COUNT = {env:CHECK_SKIP_COUNT:1}
     TOX_LOCK_PATH = {env:TOX_LOCK_PATH:/tmp/mloda-tox.lock}
 commands = sh -c "set -- pytest -n {env:PYTEST_WORKERS:8} --timeout=10 -m 'not notebooks' {env:DEACTIVATE_NOTEBOOK_AND_DOC_TESTS:--ignore=tests/test_documentation}; if [ -n \"$TOX_LOCK_PATH\" ] && command -v flock >/dev/null 2>&1; then [ -e \"$TOX_LOCK_PATH\" ] || (umask 0 && : > \"$TOX_LOCK_PATH\") 2>/dev/null; if [ -w \"$TOX_LOCK_PATH\" ]; then exec flock \"$TOX_LOCK_PATH\" \"$@\"; fi; fi; exec \"$@\""


### PR DESCRIPTION
## Summary

Implements the dead-code removals from #494. Each candidate was re-verified before removal by grepping the symbol name and its string form (getattr / dynamic dispatch) across **all** sibling repos in the workspace (mloda-registry, mvp/*, demo/*, plugin-template), not just this repo, to confirm no external or production consumer depends on it.

## High confidence (zero references anywhere)

- `FeatureSet.get_artifact` (unconditional `return None`) and `FeatureSet.validate_equal_options` (unused instance wrapper)
- `CfwManager.get_compute_frameworks`
- `AggregatedFeatureGroup._raise_unsupported_aggregation_type`
- `GeoDistanceFeatureGroup._supports_distance_type`
- `SklearnArtifact._get_artifact_file_path`, `check_artifact_exists`, `validate_artifact_key_exists` (+ now-unused `hashlib` import)
- dead assignments (`expensive_model`, `model`) and a no-op bare-tuple statement in `refactor_git_cached.py` (+ now-unused `ClaudeRequestLoop` import)
- commented-out `if len(self.object_ids) > 1:` block in `ComputeFramework.add_already_calculated_children_and_drop_if_possible`

**Fixed (latent bug):** `RequestLoop.api` constructed `NotImplementedError` without raising it, silently returning `None`. Now `raise NotImplementedError`.

## Medium confidence (test-only; call sites adjusted)

These existed only to be exercised by tests, with no production path. Removed, with their test call sites inlined to set state directly:

- `DataLifecycleManager.track_flyway_datasets` (production assigns `track_data_to_drop` directly)
- `Feature._set_uuid` / `Feature._set_compute_frameworks` (testing-only helpers; the unrelated `PreFilterPlugins._set_compute_frameworks` is kept)
- `SparkMergeEngine._handle_column_conflicts` (off all merge paths)
- `PandasDataFrame.pd_merge` (duplicate of the live `PandasMergeEngine.pd_merge`)

`EXPECTED_SKIP_COUNT` decremented 194 -> 193 (the removed Spark test was skip-collected when PySpark is absent).

Low-confidence items from the issue (public accessor getters with deliberate test coverage) are intentionally left in place, as the issue specifies.

## Definition of done
- [x] All high-confidence items removed (`request_loop.py` fixed by adding `raise`)
- [x] Medium-confidence items removed with their test call sites adjusted
- [x] No new unused imports left behind
- [x] `tox` passes (3428 passed, 193 skipped; ruff format + check, pip-licenses, mypy --strict, bandit all green)

Closes #494