### PR TITLE
refactor: deduplicate copy-paste code into shared helpers/mixins (#495)

### DIFF
--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -46,6 +46,7 @@ group). Return values use truthy/falsy semantics: any falsy return (``False``,
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from typing import Any, Optional, cast
 
 from mloda.core.abstract_plugins.components.feature import Feature
@@ -380,6 +381,30 @@ class FeatureChainParserMixin:
         # Configuration-based fallback using get_in_features()
         in_features_set = feature.options.get_in_features()
         return [f.name for f in in_features_set]
+
+    @classmethod
+    def _extract_operation_and_source_feature(
+        cls, feature: Feature, extract_fn: Callable[[Feature], Any], label: str
+    ) -> tuple[Any, str]:
+        """
+        Extract an operation parameter and the primary source feature name from a feature.
+
+        Args:
+            feature: The feature to extract parameters from
+            extract_fn: Callable that returns the operation-specific value (or None if not found)
+            label: Human-readable noun used in the error message when extraction fails
+
+        Returns:
+            Tuple of (operation_value, source_feature_name)
+
+        Raises:
+            ValueError: If the operation value cannot be extracted
+        """
+        source_features = cls._extract_source_features(feature)
+        operation = extract_fn(feature)
+        if operation is None:
+            raise ValueError(f"Could not extract {label} from: {feature.name}")
+        return operation, source_features[0]
 
     @classmethod
     def _resolve_operation(

--- a/mloda/core/abstract_plugins/components/input_data/base_input_data.py
+++ b/mloda/core/abstract_plugins/components/input_data/base_input_data.py
@@ -127,11 +127,24 @@ class BaseInputData(ABC):
             )
         options.add_to_group("BaseInputData", (cls_to_be_added, matched_data_access))
 
-    def load(self, features: FeatureSet) -> Any:
-        """
-        This class should be implemented in intermediary child classes, which use scoped data access.
-        """
+    def init_reader(self, options: Optional[Options]) -> tuple["BaseInputData", Any]:
         raise NotImplementedError
+
+    def load(self, features: FeatureSet) -> Any:
+        _options = None
+        for feature in features.features:
+            if _options:
+                if _options != feature.options:
+                    raise ValueError("All features must have the same options.")
+            _options = feature.options
+
+        reader, data_access = self.init_reader(_options)
+        data = reader.load_data(data_access, features)
+
+        if data is None:
+            raise ValueError(f"Loading data failed for feature {features.get_name_of_one_feature()}.")
+
+        return data
 
     @classmethod
     def load_data(cls, data_access: Any, features: FeatureSet) -> Any:

--- a/mloda/core/filter/filter_engine.py
+++ b/mloda/core/filter/filter_engine.py
@@ -65,6 +65,46 @@ class BaseFilterEngine(ABC):
 
     @classmethod
     def do_max_filter(cls, data: Any, filter_feature: SingleFilter) -> Any:
+        column_name = filter_feature.name
+
+        # Check if this is a complex parameter with max/max_exclusive or a simple one with value
+        has_max = filter_feature.parameter.max_value is not None
+        has_value = filter_feature.parameter.value is not None
+
+        if has_max:
+            # Complex parameter - use get_min_max_operator
+            min_parameter, max_parameter, max_operator = cls.get_min_max_operator(filter_feature)
+
+            if min_parameter is not None:
+                raise ValueError(
+                    f"Filter parameter {filter_feature.parameter} not supported as max filter: {filter_feature.name}"
+                )
+
+            if max_parameter is None:
+                raise ValueError(
+                    f"Filter parameter {filter_feature.parameter} is None although expected: {filter_feature.name}"
+                )
+
+            if max_operator is True:
+                return cls._apply_max_exclusive_filter(data, column_name, max_parameter)
+            return cls._apply_max_inclusive_filter(data, column_name, max_parameter)
+        elif has_value:
+            # Simple parameter - extract the value
+            value = filter_feature.parameter.value
+            if value is None:
+                raise ValueError(f"Filter parameter 'value' not found in {filter_feature.parameter}")
+            return cls._apply_max_inclusive_filter(data, column_name, value)
+        else:
+            raise ValueError(f"No valid filter parameter found in {filter_feature.parameter}")
+
+    @classmethod
+    def _apply_max_exclusive_filter(cls, data: Any, column_name: str, threshold: Any) -> Any:
+        """Keep rows where column_name < threshold."""
+        raise NotImplementedError
+
+    @classmethod
+    def _apply_max_inclusive_filter(cls, data: Any, column_name: str, threshold: Any) -> Any:
+        """Keep rows where column_name <= threshold."""
         raise NotImplementedError
 
     @classmethod

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -873,11 +873,7 @@ class ExecutionPlan:
                 )
             )
 
-        for k, v in graph.nodes[uuid].feature.options.items():
-            for _k, _v in pointer_dict.items():
-                if k == _k and v == _v:
-                    return True
-        return False
+        return self._matches_discriminator(pointer_dict, graph, uuid)
 
     def find_feature_uuids(
         self, parents: set[UUID], local_feature_set_collection: list[set[UUID]]

--- a/mloda_plugins/compute_framework/base_implementations/pandas/pandas_filter_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/pandas/pandas_filter_engine.py
@@ -29,37 +29,12 @@ class PandasFilterEngine(BaseFilterEngine):
         return data[data[filter_feature.name] >= value]
 
     @classmethod
-    def do_max_filter(cls, data: Any, filter_feature: SingleFilter) -> Any:
-        # Check if this is a complex parameter with max/max_exclusive or a simple one with value
-        has_max = filter_feature.parameter.max_value is not None
-        has_value = filter_feature.parameter.value is not None
+    def _apply_max_exclusive_filter(cls, data: Any, column_name: str, threshold: Any) -> Any:
+        return data[data[column_name] < threshold]
 
-        if has_max:
-            # Complex parameter - use get_min_max_operator
-            min_parameter, max_parameter, max_operator = cls.get_min_max_operator(filter_feature)
-
-            if min_parameter is not None:
-                raise ValueError(
-                    f"Filter parameter {filter_feature.parameter} not supported as max filter: {filter_feature.name}"
-                )
-
-            if max_parameter is None:
-                raise ValueError(
-                    f"Filter parameter {filter_feature.parameter} is None although expected: {filter_feature.name}"
-                )
-
-            if max_operator is True:
-                return data[data[filter_feature.name] < max_parameter]
-            else:
-                return data[data[filter_feature.name] <= max_parameter]
-        elif has_value:
-            # Simple parameter - extract the value
-            value = filter_feature.parameter.value
-            if value is None:
-                raise ValueError(f"Filter parameter 'value' not found in {filter_feature.parameter}")
-            return data[data[filter_feature.name] <= value]
-        else:
-            raise ValueError(f"No valid filter parameter found in {filter_feature.parameter}")
+    @classmethod
+    def _apply_max_inclusive_filter(cls, data: Any, column_name: str, threshold: Any) -> Any:
+        return data[data[column_name] <= threshold]
 
     @classmethod
     def do_equal_filter(cls, data: Any, filter_feature: SingleFilter) -> Any:

--- a/mloda_plugins/compute_framework/base_implementations/polars/polars_filter_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/polars/polars_filter_engine.py
@@ -45,41 +45,12 @@ class PolarsFilterEngine(BaseFilterEngine):
         return data.filter(pl.col(column_name) >= value)
 
     @classmethod
-    def do_max_filter(cls, data: Any, filter_feature: SingleFilter) -> Any:
-        column_name = filter_feature.name
+    def _apply_max_exclusive_filter(cls, data: Any, column_name: str, threshold: Any) -> Any:
+        return data.filter(pl.col(column_name) < threshold)
 
-        # Check if this is a complex parameter with max/max_exclusive or a simple one with value
-        has_max = filter_feature.parameter.max_value is not None
-        has_value = filter_feature.parameter.value is not None
-
-        if has_max:
-            # Complex parameter - use get_min_max_operator
-            min_parameter, max_parameter, max_operator = cls.get_min_max_operator(filter_feature)
-
-            if min_parameter is not None:
-                raise ValueError(
-                    f"Filter parameter {filter_feature.parameter} not supported as max filter: {filter_feature.name}"
-                )
-
-            if max_parameter is None:
-                raise ValueError(
-                    f"Filter parameter {filter_feature.parameter} is None although expected: {filter_feature.name}"
-                )
-
-            if max_operator is True:
-                return data.filter(pl.col(column_name) < max_parameter)
-            else:
-                return data.filter(pl.col(column_name) <= max_parameter)
-        elif has_value:
-            # Simple parameter - extract the value
-            value = filter_feature.parameter.value
-
-            if value is None:
-                raise ValueError(f"Filter parameter 'value' not found in {filter_feature.parameter}")
-
-            return data.filter(pl.col(column_name) <= value)
-        else:
-            raise ValueError(f"No valid filter parameter found in {filter_feature.parameter}")
+    @classmethod
+    def _apply_max_inclusive_filter(cls, data: Any, column_name: str, threshold: Any) -> Any:
+        return data.filter(pl.col(column_name) <= threshold)
 
     @classmethod
     def do_equal_filter(cls, data: Any, filter_feature: SingleFilter) -> Any:

--- a/mloda_plugins/compute_framework/base_implementations/pyarrow/pyarrow_filter_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/pyarrow/pyarrow_filter_engine.py
@@ -48,45 +48,14 @@ class PyArrowFilterEngine(BaseFilterEngine):
         return data.filter(mask)
 
     @classmethod
-    def do_max_filter(cls, data: Any, filter_feature: SingleFilter) -> Any:
-        column_name = filter_feature.name
+    def _apply_max_exclusive_filter(cls, data: Any, column_name: str, threshold: Any) -> Any:
+        mask = pc.less(data[column_name], threshold)
+        return data.filter(mask)
 
-        # Check if this is a complex parameter with max/max_exclusive or a simple one with value
-        has_max = filter_feature.parameter.max_value is not None
-        has_value = filter_feature.parameter.value is not None
-
-        if has_max:
-            # Complex parameter - use get_min_max_operator
-            min_parameter, max_parameter, max_operator = cls.get_min_max_operator(filter_feature)
-
-            if min_parameter is not None:
-                raise ValueError(
-                    f"Filter parameter {filter_feature.parameter} not supported as max filter: {filter_feature.name}"
-                )
-
-            if max_parameter is None:
-                raise ValueError(
-                    f"Filter parameter {filter_feature.parameter} is None although expected: {filter_feature.name}"
-                )
-
-            if max_operator is True:
-                mask = pc.less(data[column_name], max_parameter)
-            else:
-                mask = pc.less_equal(data[column_name], max_parameter)
-
-            return data.filter(mask)
-        elif has_value:
-            # Simple parameter - extract the value
-            value = filter_feature.parameter.value
-
-            if value is None:
-                raise ValueError(f"Filter parameter 'value' not found in {filter_feature.parameter}")
-
-            # Simple max filter
-            mask = pc.less_equal(data[column_name], value)
-            return data.filter(mask)
-        else:
-            raise ValueError(f"No valid filter parameter found in {filter_feature.parameter}")
+    @classmethod
+    def _apply_max_inclusive_filter(cls, data: Any, column_name: str, threshold: Any) -> Any:
+        mask = pc.less_equal(data[column_name], threshold)
+        return data.filter(mask)
 
     @classmethod
     def do_equal_filter(cls, data: Any, filter_feature: SingleFilter) -> Any:

--- a/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_filter_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_filter_engine.py
@@ -54,48 +54,12 @@ class PythonDictFilterEngine(BaseFilterEngine):
         return [row for row in data if row.get(column_name) is not None and row.get(column_name) >= value]
 
     @classmethod
-    def do_max_filter(cls, data: Any, filter_feature: SingleFilter) -> Any:
-        column_name = filter_feature.name
+    def _apply_max_exclusive_filter(cls, data: Any, column_name: str, threshold: Any) -> Any:
+        return [row for row in data if row.get(column_name) is not None and row.get(column_name) < threshold]
 
-        # Check if this is a complex parameter with max/max_exclusive or a simple one with value
-
-        has_max = filter_feature.parameter.max_value is not None
-
-        has_value = filter_feature.parameter.value is not None
-
-        if has_max:
-            # Complex parameter - use get_min_max_operator
-            min_parameter, max_parameter, max_operator = cls.get_min_max_operator(filter_feature)
-
-            if min_parameter is not None:
-                raise ValueError(
-                    f"Filter parameter {filter_feature.parameter} not supported as max filter: {filter_feature.name}"
-                )
-
-            if max_parameter is None:
-                raise ValueError(
-                    f"Filter parameter {filter_feature.parameter} is None although expected: {filter_feature.name}"
-                )
-
-            if max_operator is True:
-                return [
-                    row for row in data if row.get(column_name) is not None and row.get(column_name) < max_parameter
-                ]
-            else:
-                return [
-                    row for row in data if row.get(column_name) is not None and row.get(column_name) <= max_parameter
-                ]
-        elif has_value:
-            # Simple parameter - extract the value
-
-            value = filter_feature.parameter.value
-
-            if value is None:
-                raise ValueError(f"Filter parameter 'value' not found in {filter_feature.parameter}")
-
-            return [row for row in data if row.get(column_name) is not None and row.get(column_name) <= value]
-        else:
-            raise ValueError(f"No valid filter parameter found in {filter_feature.parameter}")
+    @classmethod
+    def _apply_max_inclusive_filter(cls, data: Any, column_name: str, threshold: Any) -> Any:
+        return [row for row in data if row.get(column_name) is not None and row.get(column_name) <= threshold]
 
     @classmethod
     def do_equal_filter(cls, data: Any, filter_feature: SingleFilter) -> Any:

--- a/mloda_plugins/compute_framework/base_implementations/spark/spark_filter_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/spark/spark_filter_engine.py
@@ -46,46 +46,12 @@ class SparkFilterEngine(BaseFilterEngine):
         return data.filter(F.col(column_name) >= value)
 
     @classmethod
-    def do_max_filter(cls, data: Any, filter_feature: SingleFilter) -> Any:
-        column_name = filter_feature.name
+    def _apply_max_exclusive_filter(cls, data: Any, column_name: str, threshold: Any) -> Any:
+        return data.filter(F.col(column_name) < threshold)
 
-        # Check if this is a complex parameter with max/max_exclusive or a simple one with value
-
-        has_max = filter_feature.parameter.max_value is not None
-
-        has_value = filter_feature.parameter.value is not None
-
-        if has_max:
-            # Complex parameter - use get_min_max_operator
-            min_parameter, max_parameter, max_operator = cls.get_min_max_operator(filter_feature)
-
-            if min_parameter is not None:
-                raise ValueError(
-                    f"Filter parameter {filter_feature.parameter} not supported as max filter: {filter_feature.name}"
-                )
-
-            if max_parameter is None:
-                raise ValueError(
-                    f"Filter parameter {filter_feature.parameter} is None although expected: {filter_feature.name}"
-                )
-
-            if max_operator is True:
-                condition = F.col(column_name) < max_parameter
-            else:
-                condition = F.col(column_name) <= max_parameter
-        elif has_value:
-            # Simple parameter - extract the value
-
-            value = filter_feature.parameter.value
-
-            if value is None:
-                raise ValueError(f"Filter parameter 'value' not found in {filter_feature.parameter}")
-
-            condition = F.col(column_name) <= value
-        else:
-            raise ValueError(f"No valid filter parameter found in {filter_feature.parameter}")
-
-        return data.filter(condition)
+    @classmethod
+    def _apply_max_inclusive_filter(cls, data: Any, column_name: str, threshold: Any) -> Any:
+        return data.filter(F.col(column_name) <= threshold)
 
     @classmethod
     def do_equal_filter(cls, data: Any, filter_feature: SingleFilter) -> Any:

--- a/mloda_plugins/compute_framework/base_implementations/sql/sql_base_filter_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/sql/sql_base_filter_engine.py
@@ -58,42 +58,14 @@ class SqlBaseFilterEngine(BaseFilterEngine):
         return cls._apply_filter(data, condition, (value,))
 
     @classmethod
-    def do_max_filter(cls, data: Any, filter_feature: SingleFilter) -> Any:
-        column_name = filter_feature.name
+    def _apply_max_exclusive_filter(cls, data: Any, column_name: str, threshold: Any) -> Any:
+        condition = f"{quote_ident(column_name)} < ?"
+        return cls._apply_filter(data, condition, (threshold,))
 
-        has_max = filter_feature.parameter.max_value is not None
-        has_value = filter_feature.parameter.value is not None
-
-        if has_max:
-            min_parameter, max_parameter, max_operator = cls.get_min_max_operator(filter_feature)
-
-            if min_parameter is not None:
-                raise ValueError(
-                    f"Filter parameter {filter_feature.parameter} not supported as max filter: {filter_feature.name}"
-                )
-
-            if max_parameter is None:
-                raise ValueError(
-                    f"Filter parameter {filter_feature.parameter} is None although expected: {filter_feature.name}"
-                )
-
-            if max_operator is True:
-                condition = f"{quote_ident(column_name)} < ?"
-            else:
-                condition = f"{quote_ident(column_name)} <= ?"
-            params: tuple[Any, ...] = (max_parameter,)
-        elif has_value:
-            value = filter_feature.parameter.value
-
-            if value is None:
-                raise ValueError(f"Filter parameter 'value' not found in {filter_feature.parameter}")
-
-            condition = f"{quote_ident(column_name)} <= ?"
-            params = (value,)
-        else:
-            raise ValueError(f"No valid filter parameter found in {filter_feature.parameter}")
-
-        return cls._apply_filter(data, condition, params)
+    @classmethod
+    def _apply_max_inclusive_filter(cls, data: Any, column_name: str, threshold: Any) -> Any:
+        condition = f"{quote_ident(column_name)} <= ?"
+        return cls._apply_filter(data, condition, (threshold,))
 
     @classmethod
     def do_equal_filter(cls, data: Any, filter_feature: SingleFilter) -> Any:

--- a/mloda_plugins/feature_group/experimental/aggregated_feature_group/base.py
+++ b/mloda_plugins/feature_group/experimental/aggregated_feature_group/base.py
@@ -142,16 +142,9 @@ class AggregatedFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         Raises:
             ValueError: If parameters cannot be extracted
         """
-        # Use the mixin method to extract source features
-        source_features = cls._extract_source_features(feature)
-
-        # Extract aggregation type
-        aggregation_type = cls._resolve_operation(feature, cls.AGGREGATION_TYPE)
-
-        if aggregation_type is None:
-            raise ValueError(f"Could not extract aggregation type from: {feature.name}")
-
-        return aggregation_type, source_features[0]
+        return cls._extract_operation_and_source_feature(
+            feature, lambda f: cls._resolve_operation(f, cls.AGGREGATION_TYPE), "aggregation type"
+        )
 
     @classmethod
     def _supports_aggregation_type(cls, aggregation_type: str) -> bool:

--- a/mloda_plugins/feature_group/experimental/data_quality/missing_value/base.py
+++ b/mloda_plugins/feature_group/experimental/data_quality/missing_value/base.py
@@ -259,13 +259,7 @@ class MissingValueFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         Raises:
             ValueError: If parameters cannot be extracted
         """
-        source_features = cls._extract_source_features(feature)
-        imputation_method = cls._extract_imputation_method(feature)
-
-        if imputation_method is None:
-            raise ValueError(f"Could not extract imputation method from: {feature.name}")
-
-        return imputation_method, source_features[0]
+        return cls._extract_operation_and_source_feature(feature, cls._extract_imputation_method, "imputation method")
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:

--- a/mloda_plugins/feature_group/experimental/forecasting/base.py
+++ b/mloda_plugins/feature_group/experimental/forecasting/base.py
@@ -167,27 +167,6 @@ class ForecastingFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featu
         """
         return ForecastingArtifact
 
-    @classmethod
-    def get_reference_time_column(cls, options: Optional[Options] = None) -> str:
-        """
-        Get the reference time column name from options or use the default.
-
-        Args:
-            options: Optional Options object that may contain a custom reference time column name
-
-        Returns:
-            The reference time column name to use
-        """
-        reference_time_key = DefaultOptionKeys.reference_time
-        if options and options.get(reference_time_key):
-            reference_time = options.get(reference_time_key)
-            if not isinstance(reference_time, str):
-                raise ValueError(
-                    f"Invalid reference_time option: {reference_time}. Must be string. Is: {type(reference_time)}."
-                )
-            return reference_time
-        return DefaultOptionKeys.reference_time
-
     def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
         """Extract source feature and time filter feature from either configuration-based options or string parsing."""
 

--- a/mloda_plugins/feature_group/experimental/forecasting/base.py
+++ b/mloda_plugins/feature_group/experimental/forecasting/base.py
@@ -15,9 +15,10 @@ from mloda.user import FeatureName
 from mloda.user import Options
 from mloda.provider import DefaultOptionKeys
 from mloda_plugins.feature_group.experimental.forecasting.forecasting_artifact import ForecastingArtifact
+from mloda_plugins.feature_group.experimental.time_reference_mixin import TimeReferenceMixin
 
 
-class ForecastingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+class ForecastingFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, FeatureGroup):
     """
     Base class for all forecasting feature groups.
 
@@ -115,17 +116,6 @@ class ForecastingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         "knn": "K-Nearest Neighbors Regression",
     }
 
-    # Define supported time units (same as TimeWindowFeatureGroup)
-    TIME_UNITS = {
-        "second": "Seconds",
-        "minute": "Minutes",
-        "hour": "Hours",
-        "day": "Days",
-        "week": "Weeks",
-        "month": "Months",
-        "year": "Years",
-    }
-
     # Define the prefix pattern for this feature group
     PREFIX_PATTERN = r".*__([\w]+)_forecast_(\d+)([\w]+)$"
 
@@ -149,7 +139,7 @@ class ForecastingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             ),
         },
         TIME_UNIT: {
-            **TIME_UNITS,
+            **TimeReferenceMixin.TIME_UNITS,
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
         },

--- a/mloda_plugins/feature_group/experimental/node_centrality/base.py
+++ b/mloda_plugins/feature_group/experimental/node_centrality/base.py
@@ -262,11 +262,7 @@ class NodeCentralityFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         Raises:
             ValueError: If parameters cannot be extracted
         """
-        source_features = cls._extract_source_features(feature)
-        centrality_type = cls._extract_centrality_type(feature)
-        if centrality_type is None:
-            raise ValueError(f"Could not extract centrality type from: {feature.name}")
-        return centrality_type, source_features[0]
+        return cls._extract_operation_and_source_feature(feature, cls._extract_centrality_type, "centrality type")
 
     @classmethod
     def _extract_centrality_type(cls, feature: Feature) -> Optional[str]:

--- a/mloda_plugins/feature_group/experimental/sklearn/encoding/base.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/encoding/base.py
@@ -297,11 +297,7 @@ class EncodingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         Raises:
             ValueError: If parameters cannot be extracted
         """
-        source_features = cls._extract_source_features(feature)
-        encoder_type = cls._extract_encoder_type(feature)
-        if encoder_type is None:
-            raise ValueError(f"Could not extract encoder type from: {feature.name}")
-        return encoder_type, source_features[0]
+        return cls._extract_operation_and_source_feature(feature, cls._extract_encoder_type, "encoder type")
 
     @classmethod
     def _extract_encoder_type(cls, feature: Feature) -> Optional[str]:

--- a/mloda_plugins/feature_group/experimental/sklearn/scaling/base.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/scaling/base.py
@@ -185,11 +185,7 @@ class ScalingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         Raises:
             ValueError: If parameters cannot be extracted
         """
-        source_features = cls._extract_source_features(feature)
-        scaler_type = cls._extract_scaler_type(feature)
-        if scaler_type is None:
-            raise ValueError(f"Could not extract scaler type from: {feature.name}")
-        return scaler_type, source_features[0]
+        return cls._extract_operation_and_source_feature(feature, cls._extract_scaler_type, "scaler type")
 
     @classmethod
     def _extract_scaler_type(cls, feature: Feature) -> Optional[str]:

--- a/mloda_plugins/feature_group/experimental/text_cleaning/base.py
+++ b/mloda_plugins/feature_group/experimental/text_cleaning/base.py
@@ -137,11 +137,7 @@ class TextCleaningFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         Raises:
             ValueError: If parameters cannot be extracted
         """
-        source_features = cls._extract_source_features(feature)
-        operations = cls._extract_cleaning_operations(feature)
-        if operations is None:
-            raise ValueError(f"Could not extract operations from: {feature.name}")
-        return operations, source_features[0]
+        return cls._extract_operation_and_source_feature(feature, cls._extract_cleaning_operations, "operations")
 
     @classmethod
     def _extract_cleaning_operations(cls, feature: Feature) -> Optional[tuple[Any, Any]]:

--- a/mloda_plugins/feature_group/experimental/time_reference_mixin.py
+++ b/mloda_plugins/feature_group/experimental/time_reference_mixin.py
@@ -1,0 +1,43 @@
+"""Shared time-reference helpers for time-based feature groups."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from mloda.user import Options
+from mloda.provider import DefaultOptionKeys
+
+
+class TimeReferenceMixin:
+    """Provides the reference-time column resolver and time-unit mapping shared by time-based feature groups."""
+
+    TIME_UNITS = {
+        "second": "Seconds",
+        "minute": "Minutes",
+        "hour": "Hours",
+        "day": "Days",
+        "week": "Weeks",
+        "month": "Months",
+        "year": "Years",
+    }
+
+    @classmethod
+    def get_reference_time_column(cls, options: Optional[Options] = None) -> str:
+        """
+        Get the reference time column name from options or use the default.
+
+        Args:
+            options: Optional Options object that may contain a custom reference time column name
+
+        Returns:
+            The reference time column name to use
+        """
+        reference_time_key = DefaultOptionKeys.reference_time
+        if options and options.get(reference_time_key):
+            reference_time = options.get(reference_time_key)
+            if not isinstance(reference_time, str):
+                raise ValueError(
+                    f"Invalid reference_time option: {reference_time}. Must be string. Is: {type(reference_time)}."
+                )
+            return reference_time
+        return DefaultOptionKeys.reference_time

--- a/mloda_plugins/feature_group/experimental/time_window/base.py
+++ b/mloda_plugins/feature_group/experimental/time_window/base.py
@@ -17,9 +17,10 @@ from mloda.user import FeatureName
 from mloda.provider import FeatureSet
 from mloda.user import Options
 from mloda.provider import DefaultOptionKeys
+from mloda_plugins.feature_group.experimental.time_reference_mixin import TimeReferenceMixin
 
 
-class TimeWindowFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+class TimeWindowFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, FeatureGroup):
     """
     Base class for all time window feature groups.
 
@@ -75,27 +76,6 @@ class TimeWindowFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     WINDOW_SIZE = "window_size"
     TIME_UNIT = "time_unit"
 
-    @classmethod
-    def get_reference_time_column(cls, options: Optional[Options] = None) -> str:
-        """
-        Get the reference time column name from options or use the default.
-
-        Args:
-            options: Optional Options object that may contain a custom reference time column name
-
-        Returns:
-            The reference time column name to use
-        """
-        reference_time_key = DefaultOptionKeys.reference_time
-        if options and options.get(reference_time_key):
-            reference_time = options.get(reference_time_key)
-            if not isinstance(reference_time, str):
-                raise ValueError(
-                    f"Invalid reference_time option: {reference_time}. Must be string. Is: {type(reference_time)}."
-                )
-            return reference_time
-        return DefaultOptionKeys.reference_time
-
     # Define supported window functions
     WINDOW_FUNCTIONS = {
         "sum": "Sum of values in window",
@@ -109,17 +89,6 @@ class TimeWindowFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         "median": "Median value in window",
         "first": "First value in window",
         "last": "Last value in window",
-    }
-
-    # Define supported time units
-    TIME_UNITS = {
-        "second": "Seconds",
-        "minute": "Minutes",
-        "hour": "Hours",
-        "day": "Days",
-        "week": "Weeks",
-        "month": "Months",
-        "year": "Years",
     }
 
     # Define PROPERTY_MAPPING for the new unified parser approach
@@ -141,7 +110,7 @@ class TimeWindowFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         },
         # Time unit parameter (context parameter)
         TIME_UNIT: {
-            **TIME_UNITS,  # Reference existing TIME_UNITS dict
+            **TimeReferenceMixin.TIME_UNITS,  # Reference shared TIME_UNITS dict
             DefaultOptionKeys.context: True,  # Mark as context parameter
             DefaultOptionKeys.strict_validation: True,  # Enable strict validation
         },

--- a/mloda_plugins/feature_group/input_data/read_db.py
+++ b/mloda_plugins/feature_group/input_data/read_db.py
@@ -67,23 +67,6 @@ class ReadDB(BaseInputData):
         reader, data_access = reader_data_access
         return reader(), data_access
 
-    def load(self, features: FeatureSet) -> Any:
-        _options = None
-        for feature in features.features:
-            if _options:
-                if _options != feature.options:
-                    raise ValueError("All features must have the same options.")
-            _options = feature.options
-
-        reader, data_access = self.init_reader(_options)
-
-        data = reader.load_data(data_access, features)
-
-        if data is None:
-            raise ValueError(f"Loading data failed for feature {features.get_name_of_one_feature()}.")
-
-        return data
-
     @classmethod
     def match_subclass_data_access(cls, data_access: Any, feature_names: list[str], options: Options) -> Any:
         data_accesses: list[Any] = []

--- a/mloda_plugins/feature_group/input_data/read_document.py
+++ b/mloda_plugins/feature_group/input_data/read_document.py
@@ -37,23 +37,6 @@ class ReadDocument(BaseInputData):
     def suffix(cls) -> tuple[str, ...]:
         raise NotImplementedError
 
-    def load(self, features: FeatureSet) -> Any:
-        _options = None
-
-        for feature in features.features:
-            if _options:
-                if _options != feature.options:
-                    raise ValueError("All features must have the same options.")
-            _options = feature.options
-
-        reader, data_access = self.init_reader(_options)
-        data = reader.load_data(data_access, features)
-
-        if data is None:
-            raise ValueError(f"Loading data failed for feature {features.get_name_of_one_feature()}.")
-
-        return data
-
     def init_reader(self, options: Optional[Options]) -> tuple["ReadDocument", Any]:
         if options is None:
             raise ValueError("Options were not set.")

--- a/mloda_plugins/feature_group/input_data/read_file.py
+++ b/mloda_plugins/feature_group/input_data/read_file.py
@@ -66,23 +66,6 @@ class ReadFile(BaseInputData):
     def get_column_names(cls, file_name: str) -> list[str]:
         raise NotImplementedError
 
-    def load(self, features: FeatureSet) -> Any:
-        _options = None
-
-        for feature in features.features:
-            if _options:
-                if _options != feature.options:
-                    raise ValueError("All features must have the same options.")
-            _options = feature.options
-
-        reader, data_access = self.init_reader(_options)
-        data = reader.load_data(data_access, features)
-
-        if data is None:
-            raise ValueError(f"Loading data failed for feature {features.get_name_of_one_feature()}.")
-
-        return data
-
     def init_reader(self, options: Optional[Options]) -> tuple["ReadFile", Any]:
         if options is None:
             raise ValueError(


### PR DESCRIPTION
Part of #495 (the remaining high- and medium-confidence rows are intentionally left for follow-up PRs; the issue stays open to track them).

Collapses the high-value, low-risk copy-paste targets from the audit in #495 into shared helpers/mixins. Pure refactor: no behavior change, existing tests cover all sites, `tox` passes (3432 passed, 194 skipped; mypy --strict, ruff, bandit, licenses all green).

## Changes (the five "start with" targets)

| Target | Before | After |
|--------|--------|-------|
| `execution_plan.py: check_pointer` | inline copy of the options-matching loop | calls existing `_matches_discriminator(...)` |
| input_data `load()` | identical body in `read_file` / `read_db` / `read_document` | lifted to `BaseInputData.load()`; `init_reader` declared on the base |
| `TimeReferenceMixin` | `get_reference_time_column` + `TIME_UNITS` duplicated verbatim in time_window & forecasting | new `TimeReferenceMixin` in `feature_group/experimental/` |
| `_extract_*_and_source_feature` | six near-identical bodies | `FeatureChainParserMixin._extract_operation_and_source_feature(feature, extract_fn, label)` |
| `do_max_filter` skeleton | validation/branching duplicated across 6 filter engines | skeleton in `BaseFilterEngine.do_max_filter`; each backend overrides two one-line leaf helpers |

Net ~240 fewer lines. Error-message text and all branch semantics are preserved exactly (the `_extract_*` helper reproduces each original error noun via its `label` argument; the `do_max_filter` simple-value branch reuses the inclusive leaf, which matched its prior path byte-for-byte on every backend).

The remaining medium-confidence items and the rest of the high-confidence table in #495 are intentionally left for follow-up PRs, per the issue's "start with" definition of done.

## Notes
- Iceberg's `do_max_filter` (its own `NotImplementedError` override) is untouched; sqlite/duckdb inherit the SQL leaf helpers.
- `**TIME_UNITS` references inside `PROPERTY_MAPPING` class bodies were updated to `**TimeReferenceMixin.TIME_UNITS` (a bare name cannot resolve through inheritance at class-definition time; same dict, behavior-preserving).