### PR TITLE
refactor: remove verified dead code

### DIFF
--- a/mloda/core/abstract_plugins/components/feature_set.py
+++ b/mloda/core/abstract_plugins/components/feature_set.py
@@ -104,10 +104,6 @@ class FeatureSet:
         FeatureSetValidator.validate_equal_options(self.features)
         return self.options.get(key)
 
-    def validate_equal_options(self) -> None:
-        """Checks if all features have the same options."""
-        FeatureSetValidator.validate_equal_options(self.features)
-
     def get_initial_requested_features(self) -> set[FeatureName]:
         return {feature.name for feature in self.features if feature.initial_requested_data}
 
@@ -122,6 +118,3 @@ class FeatureSet:
         FeatureSetValidator.validate_filters_not_set(self.filters)
         FeatureSetValidator.validate_filters_is_set_type(single_filters)
         self.filters = single_filters
-
-    def get_artifact(self, config: Options) -> Any:
-        return None

--- a/mloda/core/abstract_plugins/compute_framework.py
+++ b/mloda/core/abstract_plugins/compute_framework.py
@@ -569,11 +569,6 @@ class ComputeFramework(ABC):
     def add_already_calculated_children_and_drop_if_possible(
         self, children: set[UUID], location: Optional[str] = None
     ) -> bool | frozenset[UUID]:
-        # if len(self.object_ids) > 1:
-        #    if location is None:
-        #        raise ValueError("Location is not set")
-        #    self.drop_data(set(self.object_ids[:-1]), location)
-
         self.already_calculated_children_tracker.update(children)
 
         if self.children_if_root.issubset(self.already_calculated_children_tracker):

--- a/mloda/core/core/cfw_manager.py
+++ b/mloda/core/core/cfw_manager.py
@@ -197,10 +197,6 @@ class CfwManager:
         """Retrieves the exception information."""
         return self.exc_info
 
-    def get_compute_frameworks(self) -> dict[UUID, tuple[str, set[UUID]]]:
-        """Retrieves the dictionary of compute frameworks."""
-        return self.compute_frameworks
-
     def get_function_extender(self) -> Optional[set[Extender]]:
         """Retrieves the optional set of function extenders."""
         return self.function_extender

--- a/mloda_plugins/feature_group/experimental/aggregated_feature_group/base.py
+++ b/mloda_plugins/feature_group/experimental/aggregated_feature_group/base.py
@@ -159,13 +159,6 @@ class AggregatedFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         return aggregation_type in cls.AGGREGATION_TYPES
 
     @classmethod
-    def _raise_unsupported_aggregation_type(cls, aggregation_type: str) -> bool:
-        """
-        Raise an error for unsupported aggregation type.
-        """
-        raise ValueError(f"Unsupported aggregation type: {aggregation_type}")
-
-    @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
         """
         Perform aggregations.

--- a/mloda_plugins/feature_group/experimental/geo_distance/base.py
+++ b/mloda_plugins/feature_group/experimental/geo_distance/base.py
@@ -181,11 +181,6 @@ class GeoDistanceFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         return point_parts[0], point_parts[1]
 
     @classmethod
-    def _supports_distance_type(cls, distance_type: str) -> bool:
-        """Check if this feature group supports the given distance type."""
-        return distance_type in cls.DISTANCE_TYPES
-
-    @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
         """
         Calculate distances between point features.

--- a/mloda_plugins/feature_group/experimental/llm/cli_features/refactor_git_cached.py
+++ b/mloda_plugins/feature_group/experimental/llm/cli_features/refactor_git_cached.py
@@ -11,7 +11,6 @@ from mloda.provider import DataCreator
 from mloda.provider import ComputeFramework
 from mloda.user import mloda
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
-from mloda_plugins.feature_group.experimental.llm.llm_api.claude import ClaudeRequestLoop
 from mloda_plugins.feature_group.experimental.llm.llm_api.gemini import GeminiRequestLoop
 from mloda_plugins.feature_group.experimental.llm.llm_file_selector import LLMFileSelector
 from mloda_plugins.feature_group.experimental.llm.tools.available.adjust_file_tool import AdjustFileTool
@@ -56,7 +55,6 @@ class RunRefactorDiffCached:
         # check if tests are passing
         previous = ""
         actual_git_diff = self.get_tool_output_by_feature_group_(DiffFeatureGroup)
-        single_code_smell, previous, actual_git_diff
         for i in range(20):
             previous = self.fix_code_smell(i, split_files, single_code_smell, previous, actual_git_diff)
             if "AnalysisComplete" in previous:
@@ -122,10 +120,8 @@ class RunRefactorDiffCached:
         tool_collection.add_tool(ReadFileTool.get_class_name())
         tool_collection.add_tool(CreateFileTool.get_class_name())
 
-        expensive_model = ClaudeRequestLoop.get_class_name()
         expensive_model = RunRefactorGeminiRequestLoop.get_class_name()
 
-        model = "claude-3-haiku-20240307"
         model = "gemini-2.0-flash-exp"
 
         feature = Feature(

--- a/mloda_plugins/feature_group/experimental/llm/llm_api/request_loop.py
+++ b/mloda_plugins/feature_group/experimental/llm/llm_api/request_loop.py
@@ -51,7 +51,7 @@ class RequestLoop(LLMBaseRequest):
 
     @classmethod
     def api(cls) -> Any:
-        NotImplementedError
+        raise NotImplementedError
 
     def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         features = SourceInputFeatureComposite.input_features(options, feature_name) or set()

--- a/mloda_plugins/feature_group/experimental/sklearn/sklearn_artifact.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/sklearn_artifact.py
@@ -4,7 +4,6 @@ Artifact for storing fitted scikit-learn transformers and estimators.
 
 import json
 import base64
-import hashlib
 import logging
 import tempfile
 from pathlib import Path
@@ -114,62 +113,6 @@ class SklearnArtifact(BaseArtifact):
                 artifact[key] = value
 
         return artifact
-
-    @classmethod
-    def _get_artifact_file_path(cls, features: FeatureSet) -> Path:
-        """
-        Generate a file path for storing the artifact.
-
-        Args:
-            features: The feature set
-
-        Returns:
-            Path object for the artifact file
-        """
-        if features.name_of_one_feature is None:
-            raise ValueError("Feature name is required for artifact storage")
-
-        # Get storage path from options or use default temp directory
-        storage_path = None
-
-        options = cls.get_singular_option_from_options(features)
-
-        if options:
-            storage_path = options.get("artifact_storage_path")
-
-        if storage_path is None:
-            storage_path = tempfile.gettempdir()
-
-        # Create a unique filename based on feature name and configuration
-        feature_name = str(features.name_of_one_feature)
-
-        # Create a hash of the feature configuration for uniqueness
-        # Exclude artifact-related keys to ensure consistent hashing
-        config_data = {}
-        if options:
-            config_data = {
-                k: v for k, v in options.items() if not k.startswith(feature_name) and k != "artifact_storage_path"
-            }
-
-        # Convert non-serializable objects for hashing
-        serializable_config = {}
-        for k, v in config_data.items():
-            if isinstance(v, frozenset):
-                # Convert frozenset to sorted list for consistent hashing
-                serializable_config[k] = sorted(list(v))
-            else:
-                serializable_config[k] = v
-
-        config_str = json.dumps(serializable_config, sort_keys=True)
-        config_hash = hashlib.md5(config_str.encode(), usedforsecurity=False).hexdigest()[:8]
-
-        filename = f"sklearn_artifact_{feature_name}_{config_hash}.joblib"
-
-        # Ensure the directory exists
-        storage_dir = Path(storage_path)
-        storage_dir.mkdir(parents=True, exist_ok=True)
-
-        return storage_dir / filename
 
     @classmethod
     def custom_saver(cls, features: FeatureSet, artifact: Any) -> Optional[Any]:
@@ -325,38 +268,3 @@ class SklearnArtifact(BaseArtifact):
             if not isinstance(features.save_artifact, dict):
                 features.save_artifact = {}
             features.save_artifact[artifact_key] = artifact_data
-
-    @classmethod
-    def check_artifact_exists(cls, features: FeatureSet, artifact_key: str) -> bool:
-        """
-        Helper method to check if a specific artifact exists.
-
-        Args:
-            features: The feature set
-            artifact_key: The artifact key to check
-
-        Returns:
-            True if the artifact exists, False otherwise
-        """
-        if features.artifact_to_load:
-            artifacts = cls.custom_loader(features)
-            return artifacts is not None and artifact_key in artifacts
-        return False
-
-    @classmethod
-    def validate_artifact_key_exists(cls, features: FeatureSet, artifact_key: str) -> None:
-        """
-        Helper method to validate that an artifact key exists, raising an error if not.
-
-        Args:
-            features: The feature set
-            artifact_key: The artifact key to validate
-
-        Raises:
-            ValueError: If the artifact key is not found
-        """
-        if features.artifact_to_load:
-            artifacts = cls.custom_loader(features)
-            if artifacts is None or artifact_key not in artifacts:
-                available_keys = list(artifacts.keys()) if artifacts else []
-                raise ValueError(f"Artifact not found for key '{artifact_key}'. Available artifacts: {available_keys}")


### PR DESCRIPTION
## Summary

Removes verified, high-confidence dead code: unreferenced methods, dead assignments, a no-op expression, an unused import, and a commented-out block. One related latent-bug fix (a bare `NotImplementedError` made into a `raise`).

Closes #494.

## Changes (8 files, +1 / −125)

| File | Removed |
|------|---------|
| `mloda/core/abstract_plugins/components/feature_set.py` | unused instance methods `validate_equal_options` (the `FeatureSetValidator` static method it wrapped is kept) and `get_artifact` (`return None`) |
| `mloda/core/core/cfw_manager.py` | unreferenced `get_compute_frameworks` |
| `mloda/core/abstract_plugins/compute_framework.py` | 4-line commented-out block in `add_already_calculated_children_and_drop_if_possible` |
| `mloda_plugins/feature_group/experimental/aggregated_feature_group/base.py` | unreachable `_raise_unsupported_aggregation_type` (`calculate_feature` raises inline instead) |
| `mloda_plugins/feature_group/experimental/sklearn/sklearn_artifact.py` | unreferenced `_get_artifact_file_path`, `check_artifact_exists`, `validate_artifact_key_exists` + now-unused `import hashlib` |
| `mloda_plugins/feature_group/experimental/geo_distance/base.py` | unreferenced `_supports_distance_type` |
| `mloda_plugins/feature_group/experimental/llm/cli_features/refactor_git_cached.py` | no-op tuple expression; two dead (immediately-overwritten) assignments; the now-unused `ClaudeRequestLoop` import |
| `mloda_plugins/feature_group/experimental/llm/llm_api/request_loop.py` | `NotImplementedError` → `raise NotImplementedError` in the abstract `api()` stub (subclasses always override, so the base path is unreachable) |

Each symbol was re-grepped (name + string form) across `mloda/`, `mloda_plugins/`, `tests/`, `docs/`, and example notebooks immediately before removal: zero references.

## Reviewer note

`check_artifact_exists` and `validate_artifact_key_exists` are *public* classmethods with zero references in this repo, undocumented, and not in any `__all__`. They were removed as dead. If a downstream `mloda-registry` plugin relies on them (not searchable from here), flag it and I'll keep them.

Medium/low-confidence candidates (test-only scaffolding and public accessor getters) were intentionally left in place and are documented in #494 for separate discussion.

## Verification

- `ruff check` / `ruff format --check`: pass.
- `mypy --strict --ignore-missing-imports` on full `mloda` + `mloda_plugins`: pass (274 files).
- `pytest` across touched areas (`sklearn`, `artifact`, `aggregated`, `geo_distance`, `feature_set`, `cfw`, `compute_framework`, `request_loop`, `llm`): 1611 passed, 194 skipped. The only failure is `test_notebook_runs[...]`, which fails identically for unrelated notebooks on clean `main` in this sandbox (a multiprocessing/notebook-runner infra limitation); it is expected to pass in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
