### PR TITLE
docs: update tests badge count in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Documentation](https://img.shields.io/badge/docs-github.io-blue.svg)](https://mloda-ai.github.io/mloda/)
 [![PyPI version](https://badge.fury.io/py/mloda.svg)](https://badge.fury.io/py/mloda)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/mloda-ai/mloda/blob/main/LICENSE)
-[![Tests](https://img.shields.io/badge/tests-1500%2B-green.svg)](https://github.com/mloda-ai/mloda)
+[![Tests](https://img.shields.io/badge/tests-2800%2B-green.svg)](https://github.com/mloda-ai/mloda)
 
 > **Declarative data access for AI agents. Describe what you need - mloda delivers it.**
 


### PR DESCRIPTION
Updates the Tests badge in the README from `1500+` to `2800+` to reflect the current test count (2829 test function definitions, more when parametrized).