### PR TITLE
docs: drop version-pinned note from data-type-enforcement

### DIFF
--- a/docs/docs/in_depth/data-type-enforcement.md
+++ b/docs/docs/in_depth/data-type-enforcement.md
@@ -66,13 +66,6 @@ fail to determine a type, return `None` for that case rather than letting it rai
 
 ## Validation Behavior
 
-!!! note "Changed in 0.7.0"
-    Type validation now runs on **all** bundled compute frameworks through a uniform
-    `_extract_column_data_type` hook. In 0.6.x, type extraction relied on a single
-    PyArrow-schema path, so typed features running on frameworks that did not expose that
-    schema were silently left unvalidated. After upgrading, those features may raise a
-    `DataTypeMismatchError` for the first time where validation previously did nothing.
-
 ### Default (Lenient) Mode
 
 By default, validation allows compatible type conversions within categories:


### PR DESCRIPTION
## Summary

Removes the `!!! note "Changed in 0.7.0"` admonition from `docs/docs/in_depth/data-type-enforcement.md`.

It was the only version-specific note in the entire `docs/docs/` tree, which is inconsistent with the rest of the documentation: conceptual docs describe current behavior rather than serve as a changelog (release notes already cover version history).

The fact it conveyed (type validation runs across all bundled compute frameworks via `_extract_column_data_type`) is already documented by the surrounding **Validation Behavior** section, so no information is lost.

## Notes

The note was factually accurate (the change did ship in 0.7.0), so this is an editorial/consistency cleanup, not a correctness fix.