### PR TITLE
feat: typed Credential slot and early mis-wrap error for DataAccessCollection credentials

### DIFF
--- a/docs/docs/in_depth/access-feature-data.md
+++ b/docs/docs/in_depth/access-feature-data.md
@@ -30,6 +30,7 @@ When the collection holds more than one resource of the same kind, you can name 
 You can apply these options like so:
 
 ``` python
+from mloda.user import Credential, DataAccessCollection
 
 data_access = DataAccessCollection()
 

--- a/docs/docs/in_depth/access-feature-data.md
+++ b/docs/docs/in_depth/access-feature-data.md
@@ -22,7 +22,7 @@ A DAC holds resources of four kinds:
 
 1.  **Files:** the exact location of files, e.g. `path/folder/text.txt`.
 2.  **Folders:** directories where files are located, e.g. `path/folder/`.
-3.  **Credentials:** dicts with the information needed to reach a data source, e.g. `{host: example.com, password: example}`.
+3.  **Credentials:** the information needed to reach a data source, expressed as a typed `Credential` (recommended) or a plain dict, e.g. `Credential(host="example.com", password="example")`.
 4.  **Connections:** already-initialized connection objects (database connections, Spark sessions, Iceberg catalogs, etc.).
 
 When the collection holds more than one resource of the same kind, you can name them with stable handles and disambiguate per feature via `Options(context={"data_access_handle": "..."})`. See [Named Data Access Handles](named-data-access-handles.md) for the full naming model, the resolution rule, and the available error shapes; for the simple single-source cases below, naming is optional.
@@ -36,7 +36,7 @@ data_access = DataAccessCollection()
 # Add file paths, folder paths, credentials, and connection objects
 data_access.add_file('path/to/folder/text.txt')
 data_access.add_folder('path/to/folder/')
-data_access.add_credentials({'host': 'example.com', 'password': 'example'})
+data_access.add_credentials(Credential(host='example.com', password='example'))
 data_access.add_connection('InitializedDBConnection')
 
 mloda.run_all(

--- a/docs/docs/in_depth/named-data-access-handles.md
+++ b/docs/docs/in_depth/named-data-access-handles.md
@@ -57,6 +57,7 @@ You only need to name resources when there are multiple sources of the same kind
 DataAccessCollection(files={"/data/tx.parquet"})       # set or list
 DataAccessCollection(connections={duckdb_conn})        # set
 DataAccessCollection(folders={"/data/raw"})            # set
+DataAccessCollection(credentials=Credential(host="h")) # typed single credential (recommended)
 DataAccessCollection(credentials=[{"host": "h"}])      # list (dicts are unhashable)
 ```
 
@@ -73,6 +74,43 @@ Naming is only required when:
 
 - Two or more resources of the same kind match the same consumer (then you must set `data_access_handle` to pick one), or
 - You use `column_to_file` and prefer to reference files by name rather than path (both work, see below).
+
+## Typed credentials: `Credential`
+
+Credentials are the one kind where the named form and the value itself look identical, because a credential *is* a dict. These two lines differ only in brackets but mean completely different things:
+
+``` py
+credentials={"sqlite": "/data/x.db"}    # named form: handle "sqlite" -> credential "/data/x.db"
+credentials=[{"sqlite": "/data/x.db"}]  # one credential whose mapping is {"sqlite": "/data/x.db"}
+```
+
+The first shape is almost never what you mean: it registers the string `"/data/x.db"` as the credential, which then fails every connector's `is_valid_credentials` check. The typed `Credential` class removes the ambiguity, so the meaning comes from the type instead of the nesting depth:
+
+``` py
+from mloda.user import Credential, DataAccessCollection
+
+DataAccessCollection(credentials=Credential(sqlite="/data/x.db"))       # kwargs form
+DataAccessCollection(credentials=Credential({"sqlite": "/data/x.db"}))  # dict form
+DataAccessCollection(credentials=[Credential(sqlite="/a.db"), {"pg": {"host": "h"}}])
+DataAccessCollection(credentials={"pg-prod": Credential(host="h")})     # named form
+dac.add_credentials(Credential(host="h"))                               # mutators too
+```
+
+`Credential` is unwrapped to a plain dict at registration time, so feature groups and `is_valid_credentials` implementations keep receiving plain dicts. Nothing changes downstream.
+
+Two safety behaviors come with it:
+
+- **Early mis-wrap error.** Passing a bare dict whose values are not mappings (the mis-wrap shape above) now raises `ValueError` at construction time, naming the offending handle and showing the three correct alternatives, instead of failing silently later during matcher selection.
+- **Redacted repr.** `repr(Credential(password="hunter2"))` prints `Credential(password='***')`. Keys stay visible, values never reach logs or tracebacks.
+
+### Why a typed class: four kinds of users
+
+The design serves four user groups that hit credentials differently:
+
+1. **Notebook users** (one data source) write the obvious shape from an example. For them the bare dict either has to work or fail loudly at construction; `Credential(sqlite="/data/x.db")` gives them a form with no nesting decision to get wrong, and the early error catches the legacy shape.
+2. **Production users** (multiple sources) live in the named-handle registry and disambiguate per feature via `data_access_handle`. For them `Credential` keeps the registry values homogeneous, so ambiguity errors and `handles()` introspection stay trustworthy.
+3. **Plugin authors** implement `is_valid_credentials` and previously had to isinstance-juggle whatever leaked through (including bare strings from mis-wrapped input). The framework now normalizes at the boundary: whatever the end user typed, the plugin receives a plain dict.
+4. **Ops and data stewards** care about what is in the credential, not its shape. The resolver's ambiguity errors print candidate values; the redacting `repr` keeps passwords out of those messages, out of logs, and out of stack traces.
 
 ## Resolution rule
 
@@ -176,6 +214,7 @@ Named handles collapse that bug class to one invariant: *if the registry has mor
 - **"Handle 'X' not found for kind 'K'. Available handles of kind 'K': [...]"**: you set `data_access_handle='X'` but the DAC has no resource of that kind named `X`. Check the spelling or register it.
 - **"Handle 'X' is registered under kind 'K1', but kind 'K2' was requested"**: you set `data_access_handle='X'`, but the registry has `X` under a different kind. A connection consumer cannot bind to a file handle even if the names match.
 - **"Ambiguous resolve for kind 'K': N candidates [...]; set 'data_access_handle' in Options to disambiguate"**: more than one entry of the requested kind matched. Set `data_access_handle` on the feature's `Options` to pick one, or remove the extras from the DAC.
+- **"credentials value for handle 'X' is not a mapping"**: you passed a bare `{connector_id: slot}` dict as `credentials`, which the named form reads as `{handle: credential}`. Use `credentials=Credential(...)`, the list form `credentials=[{...}]`, or the named form `{handle: {connector_id: slot}}`. See [Typed credentials](#typed-credentials-credential).
 
 ## Related
 

--- a/docs/docs/in_depth/named-data-access-handles.md
+++ b/docs/docs/in_depth/named-data-access-handles.md
@@ -49,19 +49,19 @@ assert dac.handles() == {
 }
 ```
 
-## Naming is optional
+## Accepted input shapes and why each exists
 
-You only need to name resources when there are multiple sources of the same kind that the resolver cannot tell apart. In the simple single-source case, pass bare values:
+Every kind accepts more than one input shape. Each shape earned its place at a different point in the API's history; pick by intent:
 
-``` py
-DataAccessCollection(files={"/data/tx.parquet"})       # set or list
-DataAccessCollection(connections={duckdb_conn})        # set
-DataAccessCollection(folders={"/data/raw"})            # set
-DataAccessCollection(credentials=Credential(host="h")) # typed single credential (recommended)
-DataAccessCollection(credentials=[{"host": "h"}])      # list (dicts are unhashable)
-```
+| Shape | Example | Use when | Why it exists |
+|-------|---------|----------|---------------|
+| Named dict `{handle: value}` | `files={"tx": "/data/tx.csv"}` | Several sources of one kind | Stable handles make resolution deterministic and per-feature addressable via `data_access_handle` ([#443](https://github.com/mloda-ai/mloda/issues/443)) |
+| Bare `set` / `list` | `files={"/data/tx.csv"}` | One source of a kind | Entries get internal auto-handles you never reference; naming a single source was pure boilerplate ([#449](https://github.com/mloda-ai/mloda/pull/449)) |
+| Typed `Credential(...)` | `credentials=Credential(sqlite="/x.db")` | Any credential (recommended) | A credential is itself a dict, so the bare dict shape collides with the named form; the type removes the nesting ambiguity ([#511](https://github.com/mloda-ai/mloda/issues/511)) |
+| `list` of credential dicts | `credentials=[{"host": "h"}]` | Several unnamed credentials | Credentials have no `set` form because dicts are unhashable |
+| `HashableDict` credential values | `credentials=[HashableDict({...})]` | Existing pre-0.7 call sites only | Before 0.7.0 credentials were force-wrapped in `HashableDict`; still accepted so those call sites keep working. New code should pass `Credential` or plain dicts here (`HashableDict` itself is not deprecated; it remains required where hashability matters, e.g. `Options` group values) |
 
-The same shape applies to the mutators:
+The named/auto split applies to the mutators as well:
 
 ``` py
 dac.add_file("/data/tx.parquet")                       # auto-named

--- a/docs/docs/in_depth/named-data-access-handles.md
+++ b/docs/docs/in_depth/named-data-access-handles.md
@@ -101,7 +101,7 @@ dac.add_credentials(Credential(host="h"))                               # mutato
 Two safety behaviors come with it:
 
 - **Early mis-wrap error.** Passing a bare dict whose values are not mappings (the mis-wrap shape above) now raises `ValueError` at construction time, naming the offending handle and showing the three correct alternatives, instead of failing silently later during matcher selection.
-- **Redacted repr.** `repr(Credential(password="hunter2"))` prints `Credential(password='***')`. Keys stay visible, values never reach logs or tracebacks.
+- **Redacted error output.** `repr(Credential(password="hunter2"))` prints `Credential(password='***')`, and the resolver's ambiguity error renders credential candidates with keys visible and values replaced by `***`. Note that the registered credential itself is a plain dict, so code that prints `dac.credentials` directly still sees raw values.
 
 ### Why a typed class: four kinds of users
 
@@ -110,7 +110,7 @@ The design serves four user groups that hit credentials differently:
 1. **Notebook users** (one data source) write the obvious shape from an example. For them the bare dict either has to work or fail loudly at construction; `Credential(sqlite="/data/x.db")` gives them a form with no nesting decision to get wrong, and the early error catches the legacy shape.
 2. **Production users** (multiple sources) live in the named-handle registry and disambiguate per feature via `data_access_handle`. For them `Credential` keeps the registry values homogeneous, so ambiguity errors and `handles()` introspection stay trustworthy.
 3. **Plugin authors** implement `is_valid_credentials` and previously had to isinstance-juggle whatever leaked through (including bare strings from mis-wrapped input). The framework now normalizes at the boundary: whatever the end user typed, the plugin receives a plain dict.
-4. **Ops and data stewards** care about what is in the credential, not its shape. The resolver's ambiguity errors print candidate values; the redacting `repr` keeps passwords out of those messages, out of logs, and out of stack traces.
+4. **Ops and data stewards** care about what is in the credential, not its shape. The resolver's ambiguity errors print candidate values, so credential candidates are rendered with redacted values (keys only), keeping passwords out of those messages and the logs that capture them.
 
 ## Resolution rule
 

--- a/mloda/core/abstract_plugins/components/credential.py
+++ b/mloda/core/abstract_plugins/components/credential.py
@@ -26,7 +26,7 @@ class Credential:
 
     @property
     def data(self) -> dict[str, Any]:
-        """Return a copy of the credential mapping."""
+        """Return a shallow copy of the credential mapping."""
         return dict(self._data)
 
     def __repr__(self) -> str:

--- a/mloda/core/abstract_plugins/components/credential.py
+++ b/mloda/core/abstract_plugins/components/credential.py
@@ -1,0 +1,34 @@
+"""Typed credential slot for ``DataAccessCollection`` (issue #511).
+
+Wraps exactly one credential mapping so a single credential dict can no longer
+be mistaken for a ``{handle: value}`` registry. One type serves four user
+groups: notebook users get a constructor with no nesting to get wrong, multi-
+source production users keep a homogeneous handle registry, plugin authors
+keep receiving plain dicts (the wrapper is unwrapped at registration), and ops
+users get a value-redacting ``repr`` that keeps secrets out of logs and
+tracebacks. Full rationale: docs/docs/in_depth/named-data-access-handles.md.
+"""
+
+from typing import Any
+
+
+class Credential:
+    """One credential mapping built from a dict, keyword fields, or both."""
+
+    def __init__(self, mapping: dict[str, Any] | None = None, /, **fields: Any) -> None:
+        if mapping is not None and not isinstance(mapping, dict):
+            raise TypeError(f"Credential expects a dict/mapping, got {type(mapping).__name__}.")
+        merged = dict(mapping or {})
+        merged.update(fields)
+        if not merged:
+            raise ValueError("Credential requires at least one field.")
+        self._data: dict[str, Any] = merged
+
+    @property
+    def data(self) -> dict[str, Any]:
+        """Return a copy of the credential mapping."""
+        return dict(self._data)
+
+    def __repr__(self) -> str:
+        redacted = ", ".join(f"{key}='***'" for key in self._data)
+        return f"Credential({redacted})"

--- a/mloda/core/abstract_plugins/components/data_access_collection.py
+++ b/mloda/core/abstract_plugins/components/data_access_collection.py
@@ -65,7 +65,11 @@ class DataAccessCollection:
         if isinstance(credentials, Credential):
             return [credentials.data]
         if isinstance(credentials, dict):
-            return {handle: cls._validated_credential_value(handle, value) for handle, value in credentials.items()}
+            context_keys = tuple(credentials.keys())
+            return {
+                handle: cls._validated_credential_value(handle, value, context_keys)
+                for handle, value in credentials.items()
+            }
         return [cls._unwrap_credential(entry) for entry in credentials]
 
     @staticmethod
@@ -75,15 +79,16 @@ class DataAccessCollection:
         return value
 
     @classmethod
-    def _validated_credential_value(cls, handle: str, value: Any) -> Any:
+    def _validated_credential_value(cls, handle: str, value: Any, context_keys: tuple[str, ...] | None = None) -> Any:
         unwrapped = cls._unwrap_credential(value)
         if isinstance(unwrapped, (dict, HashableDict)):
             return unwrapped
+        fields = ", ".join(f"'{key}': ..." for key in (context_keys if context_keys is not None else (handle,)))
         raise ValueError(
             f"credentials value for handle '{handle}' is not a mapping. A bare dict is read as "
             f"{{handle: credential}}, so a single credential must be wrapped: use the list form "
-            f"credentials=[{{'{handle}': ...}}], the typed form credentials=Credential({handle}=...), "
-            f"or the named form credentials={{'my-db': {{'{handle}': ...}}}}."
+            f"credentials=[{{{fields}}}], the typed form credentials=Credential({{{fields}}}), "
+            f"or the named form credentials={{'my-db': {{{fields}}}}}."
         )
 
     @staticmethod
@@ -249,7 +254,10 @@ class DataAccessCollection:
         candidate_handles = [h for h, _ in matches]
         all_auto = all(h in self._auto_handles for h in candidate_handles)
         if all_auto:
-            bullets = "\n".join(f"  - {v}" for _, v in matches)
+            if kind == "credentials":
+                bullets = "\n".join(f"  - {self._redacted_credential(v)}" for _, v in matches)
+            else:
+                bullets = "\n".join(f"  - {v}" for _, v in matches)
             raise ValueError(
                 f"Ambiguous resolve for kind '{kind}': {len(matches)} matches:\n"
                 f"{bullets}\n"
@@ -260,3 +268,11 @@ class DataAccessCollection:
             f"Ambiguous resolve for kind '{kind}': {len(matches)} candidates {candidate_handles}; "
             f"set 'data_access_handle' in Options to disambiguate."
         )
+
+    @staticmethod
+    def _redacted_credential(value: Any) -> str:
+        if isinstance(value, HashableDict):
+            value = value.data
+        if isinstance(value, dict):
+            return "{" + ", ".join(f"'{key}': '***'" for key in value) + "}"
+        return "'***'"

--- a/mloda/core/abstract_plugins/components/data_access_collection.py
+++ b/mloda/core/abstract_plugins/components/data_access_collection.py
@@ -1,5 +1,8 @@
 from typing import Any, Callable
 
+from mloda.core.abstract_plugins.components.credential import Credential
+from mloda.core.abstract_plugins.components.hashable_dict import HashableDict
+
 
 _KIND_TO_ATTR: dict[str, str] = {
     "connection": "connections",
@@ -23,7 +26,7 @@ class DataAccessCollection:
         connections: dict[str, Any] | set[Any] | list[Any] | None = None,
         files: dict[str, str] | set[str] | list[str] | None = None,
         folders: dict[str, str] | set[str] | list[str] | None = None,
-        credentials: dict[str, Any] | list[Any] | None = None,
+        credentials: dict[str, Any] | list[Any] | Credential | None = None,
         column_to_file: dict[str, str] | None = None,
     ) -> None:
         """Build the collection from named or auto-named resources.
@@ -34,6 +37,8 @@ class DataAccessCollection:
         (paths are normalized to their handle).
         """
         self._auto_handles: set[str] = set()
+
+        credentials = self._normalize_credentials(credentials)
 
         # Start with user-supplied dict entries; collect non-dict inputs for a second pass
         # so that auto-handle numbering can dodge every user-supplied handle (across all kinds).
@@ -50,6 +55,36 @@ class DataAccessCollection:
         self._assign_auto_handles("credentials", self.credentials, credentials)
 
         self.column_to_file: dict[str, str] | None = self._normalize_column_to_file(column_to_file)
+
+    @classmethod
+    def _normalize_credentials(
+        cls, credentials: dict[str, Any] | list[Any] | Credential | None
+    ) -> dict[str, Any] | list[Any] | None:
+        if credentials is None:
+            return None
+        if isinstance(credentials, Credential):
+            return [credentials.data]
+        if isinstance(credentials, dict):
+            return {handle: cls._validated_credential_value(handle, value) for handle, value in credentials.items()}
+        return [cls._unwrap_credential(entry) for entry in credentials]
+
+    @staticmethod
+    def _unwrap_credential(value: Any) -> Any:
+        if isinstance(value, Credential):
+            return value.data
+        return value
+
+    @classmethod
+    def _validated_credential_value(cls, handle: str, value: Any) -> Any:
+        unwrapped = cls._unwrap_credential(value)
+        if isinstance(unwrapped, (dict, HashableDict)):
+            return unwrapped
+        raise ValueError(
+            f"credentials value for handle '{handle}' is not a mapping. A bare dict is read as "
+            f"{{handle: credential}}, so a single credential must be wrapped: use the list form "
+            f"credentials=[{{'{handle}': ...}}], the typed form credentials=Credential({handle}=...), "
+            f"or the named form credentials={{'my-db': {{'{handle}': ...}}}}."
+        )
 
     @staticmethod
     def _copy_if_dict(value: Any) -> dict[str, Any]:
@@ -135,7 +170,7 @@ class DataAccessCollection:
         """Register credentials. ``add_credentials(value)`` auto-names them; ``add_credentials(handle, value)`` names them."""
         handle, value = self._resolve_mutator_args("credentials", args)
         self._reject_duplicate(handle)
-        self.credentials[handle] = value
+        self.credentials[handle] = self._validated_credential_value(handle, value)
 
     def _resolve_mutator_args(self, kind: str, args: tuple[Any, ...]) -> tuple[str, Any]:
         if len(args) == 1:

--- a/mloda/core/abstract_plugins/components/data_access_collection.py
+++ b/mloda/core/abstract_plugins/components/data_access_collection.py
@@ -31,8 +31,22 @@ class DataAccessCollection:
     ) -> None:
         """Build the collection from named or auto-named resources.
 
-        Each resource kind accepts a ``dict[handle, value]`` to register named
-        resources, or a ``set``/``list`` whose entries get auto-assigned handles.
+        Accepted shapes, by intent:
+          * ``dict[handle, value]``: named resources, for multi-source setups
+            where a consumer is pointed at one entry via
+            ``Options(data_access_handle=...)``.
+          * ``set`` / ``list`` of bare values: single-source convenience;
+            entries get internal auto-handles the user never references.
+          * ``credentials`` additionally accepts a single ``Credential`` (or
+            ``Credential`` entries in the list/dict forms). A credential is
+            itself a dict, so the bare ``{connector_id: slot}`` shape would be
+            read as ``{handle: value}``; the typed form removes that ambiguity
+            and is unwrapped to a plain dict at registration. Named-form
+            credential values must be mappings (``dict``, ``HashableDict``, or
+            ``Credential``); anything else raises an early mis-wrap
+            ``ValueError``. ``HashableDict`` stays accepted for pre-0.7 call
+            sites. Credentials have no ``set`` form (dicts are unhashable).
+
         ``column_to_file`` maps a column to either a file handle or a file path
         (paths are normalized to their handle).
         """

--- a/mloda/user/__init__.py
+++ b/mloda/user/__init__.py
@@ -19,6 +19,7 @@ from mloda.core.filter.filter_type_enum import FilterType
 
 # Data access
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.credential import Credential
 
 # Types
 from mloda.core.abstract_plugins.components.data_types import DataType
@@ -63,6 +64,7 @@ __all__ = [
     "FilterType",
     # Data access
     "DataAccessCollection",
+    "Credential",
     # Types
     "DataType",
     "ParallelizationMode",

--- a/mloda_plugins/feature_group/input_data/read_dbs/sqlite.py
+++ b/mloda_plugins/feature_group/input_data/read_dbs/sqlite.py
@@ -116,8 +116,8 @@ class SQLITEReader(ReadDB):
     ```python
     from mloda.user import Credential, DataAccessCollection
 
-    # Typed form (recommended). A list of plain dicts is also accepted,
-    # as is HashableDict for backwards compatibility.
+    # Typed form (recommended). A list of plain dicts is also accepted, as is
+    # HashableDict, for compatibility with pre-0.7 credential call sites.
     data_access = DataAccessCollection(
         credentials=Credential(sqlite="/data/analytics.db")
     )

--- a/mloda_plugins/feature_group/input_data/read_dbs/sqlite.py
+++ b/mloda_plugins/feature_group/input_data/read_dbs/sqlite.py
@@ -114,11 +114,12 @@ class SQLITEReader(ReadDB):
     ### Using DataAccessCollection
 
     ```python
-    from mloda.user import DataAccessCollection
+    from mloda.user import Credential, DataAccessCollection
 
-    # Plain dicts are accepted; HashableDict is also accepted for backwards compatibility.
+    # Typed form (recommended). A list of plain dicts is also accepted,
+    # as is HashableDict for backwards compatibility.
     data_access = DataAccessCollection(
-        credentials=[{"sqlite": "/data/analytics.db"}]
+        credentials=Credential(sqlite="/data/analytics.db")
     )
 
     # Features will automatically use the configured database

--- a/tests/test_core/test_abstract_plugins/test_components/test_credential.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_credential.py
@@ -138,6 +138,18 @@ class TestDataAccessCollectionUnwrapsCredential:
         assert dac.credentials == {"named": {"sqlite": "/a.db"}}
         assert type(dac.credentials["named"]) is dict
 
+    def test_dict_positional_credential_registers_one_auto_named_plain_dict(self) -> None:
+        """Dict-positional form Credential({...}) flows through the collection like the kwargs form."""
+        dac = DataAccessCollection(credentials=Credential({"sqlite": "/data/x.db"}))
+        resolved = dac.resolve("credentials")
+        assert type(resolved) is dict
+        assert resolved == {"sqlite": "/data/x.db"}
+        registered = dac.handles()
+        assert len(registered) == 1
+        (handle, kind) = next(iter(registered.items()))
+        assert kind == "credentials"
+        assert handle.startswith("_auto_credentials_")
+
 
 class TestNamedFormRejectsNonMappingValues:
     """Cycle 2 of issue #511: the named form ``{handle: value}`` requires mapping values.
@@ -198,3 +210,83 @@ class TestNamedFormAcceptsMappingValues:
         dac = DataAccessCollection()
         dac.add_credentials("h", {"sqlite": "/x.db"})
         assert dac.credentials == {"h": {"sqlite": "/x.db"}}
+
+
+class TestResolveAmbiguityRedactsCredentialValues:
+    """Cycle 3, Finding A (security): the all-auto ambiguity error in ``resolve()``
+    must not print stored credential values verbatim.
+
+    For kind 'credentials' the candidate listing must redact values (keys stay
+    visible, values replaced, e.g. with '***'). Other kinds keep showing values.
+    """
+
+    def test_two_auto_credentials_ambiguity_redacts_secret_values(self) -> None:
+        dac = DataAccessCollection(
+            credentials=[
+                Credential(host="db1", password="hunter2"),  # nosec B106
+                Credential(host="db2", password="swordfish"),  # nosec B106
+            ]
+        )
+        with pytest.raises(ValueError) as excinfo:
+            dac.resolve("credentials")
+        msg = str(excinfo.value)
+        assert "hunter2" not in msg
+        assert "swordfish" not in msg
+        assert "host" in msg
+        assert "password" in msg
+        assert "data_access_handle" in msg
+
+    def test_hashable_dict_credentials_ambiguity_redacts_values_but_shows_keys(self) -> None:
+        dac = DataAccessCollection(
+            credentials=[
+                HashableDict({"token": "secret-a"}),  # nosec B105
+                HashableDict({"token": "secret-b"}),  # nosec B105
+            ]
+        )
+        with pytest.raises(ValueError) as excinfo:
+            dac.resolve("credentials")
+        msg = str(excinfo.value)
+        assert "secret-a" not in msg
+        assert "secret-b" not in msg
+        assert "token" in msg
+
+    def test_auto_named_files_ambiguity_still_shows_values(self) -> None:
+        """Guardrail: redaction is credentials-only; file paths stay visible in the listing."""
+        dac = DataAccessCollection(files=["/data/a.csv", "/data/b.csv"])
+        with pytest.raises(ValueError) as excinfo:
+            dac.resolve("file")
+        msg = str(excinfo.value)
+        assert "/data/a.csv" in msg
+
+
+class TestMisWrapErrorSuggestionsAreSafeAndComplete:
+    """Cycle 3, Finding B: the named-form mis-wrap ValueError must build its
+    suggestions from ALL keys of the offending input, never include the
+    offending values (they may be secrets), and use the dict-positional form
+    ``Credential({...})`` so the suggestion stays valid Python for any key.
+    """
+
+    def test_multi_field_suggestion_lists_all_keys_and_uses_dict_positional_form(self) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            DataAccessCollection(credentials={"host": "h", "port": 5432})
+        msg = str(excinfo.value)
+        assert "host" in msg
+        assert "port" in msg
+        assert "Credential({" in msg
+        # Offending values must not be echoed back ('h' alone is untestable as a
+        # substring because 'host' contains it; the numeric value is unambiguous).
+        assert "5432" not in msg
+
+    def test_non_identifier_handle_never_yields_invalid_kwargs_suggestion(self) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            DataAccessCollection(credentials={"pg-prod": "dsn-string"})
+        msg = str(excinfo.value)
+        assert "pg-prod" in msg
+        assert "Credential({" in msg
+        assert "Credential(pg-prod=" not in msg
+
+    def test_secret_value_never_appears_in_mis_wrap_error(self) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            DataAccessCollection(credentials={"pg-prod": "dsn-string"})
+        msg = str(excinfo.value)
+        assert "dsn-string" not in msg

--- a/tests/test_core/test_abstract_plugins/test_components/test_credential.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_credential.py
@@ -1,0 +1,200 @@
+"""Contract tests for the typed ``Credential`` class (cycle 1, issue #511).
+
+``Credential`` wraps exactly one credential mapping so that
+``DataAccessCollection(credentials=...)`` can no longer mistake a single
+credential dict for a ``{handle: value}`` registry.
+"""
+
+import pytest
+
+from mloda.core.abstract_plugins.components.credential import Credential
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.hashable_dict import HashableDict
+
+
+class TestCredentialConstruction:
+    """Constructor accepts a mapping, kwargs, or both; ``.data`` exposes the merged dict."""
+
+    def test_positional_mapping_is_stored(self) -> None:
+        cred = Credential({"sqlite": "/data/x.db"})
+        assert cred.data == {"sqlite": "/data/x.db"}
+
+    def test_kwargs_form_is_equivalent_to_mapping(self) -> None:
+        cred = Credential(sqlite="/data/x.db")
+        assert cred.data == {"sqlite": "/data/x.db"}
+
+    def test_mixed_mapping_and_kwargs_merge_with_kwargs_winning(self) -> None:
+        """Mapping and kwargs merge with dict() semantics: kwargs override mapping keys."""
+        cred = Credential({"a": 1}, b=2)
+        assert cred.data == {"a": 1, "b": 2}
+        overridden = Credential({"a": 1}, a=3)
+        assert overridden.data == {"a": 3}
+
+
+class TestCredentialRejectsBadInput:
+    """Non-mapping positional input and empty credentials are rejected loudly."""
+
+    def test_string_positional_raises_type_error_mentioning_mapping(self) -> None:
+        with pytest.raises(TypeError, match="(?i)dict|mapping"):
+            Credential("oops")  # type: ignore[arg-type]
+
+    def test_list_of_pairs_positional_raises_type_error(self) -> None:
+        with pytest.raises(TypeError, match="(?i)dict|mapping"):
+            Credential([("a", 1)])  # type: ignore[arg-type]
+
+    def test_no_arguments_raises_value_error_mentioning_at_least_one_field(self) -> None:
+        with pytest.raises(ValueError, match="(?i)at least one"):
+            Credential()
+
+    def test_empty_mapping_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="(?i)at least one"):
+            Credential({})
+
+
+class TestCredentialDataIsDefensiveCopy:
+    """``.data`` hands out a copy; neither side can mutate the stored credential."""
+
+    def test_mutating_returned_dict_does_not_affect_subsequent_access(self) -> None:
+        cred = Credential(sqlite="/data/x.db")
+        leaked = cred.data
+        leaked["sqlite"] = "/tampered.db"
+        leaked["extra"] = "injected"
+        assert cred.data == {"sqlite": "/data/x.db"}
+
+    def test_mutating_original_constructor_dict_does_not_affect_data(self) -> None:
+        original = {"sqlite": "/data/x.db"}
+        cred = Credential(original)
+        original["sqlite"] = "/tampered.db"
+        original["extra"] = "injected"
+        assert cred.data == {"sqlite": "/data/x.db"}
+
+
+class TestCredentialReprRedactsValues:
+    """``repr()`` must never leak secret values; it shows keys with redacted values."""
+
+    def test_repr_shows_class_and_keys_but_redacts_values(self) -> None:
+        rendered = repr(Credential(sqlite="/secret/path.db"))
+        assert "Credential" in rendered
+        assert "sqlite" in rendered
+        assert "/secret/path.db" not in rendered
+        assert "***" in rendered
+
+
+class TestCredentialPublicSurface:
+    """``Credential`` is part of the public ``mloda.user`` API."""
+
+    def test_importable_from_mloda_user(self) -> None:
+        from mloda.user import Credential as UserCredential
+
+        assert UserCredential is Credential
+
+    def test_listed_in_mloda_user_all(self) -> None:
+        import mloda.user
+
+        assert "Credential" in mloda.user.__all__
+
+
+class TestDataAccessCollectionUnwrapsCredential:
+    """DataAccessCollection unwraps Credential at registration time.
+
+    Downstream consumers keep seeing plain dicts, never Credential instances.
+    """
+
+    def test_single_credential_registers_one_auto_named_plain_dict(self) -> None:
+        dac = DataAccessCollection(credentials=Credential(sqlite="/data/x.db"))
+        resolved = dac.resolve("credentials")
+        assert type(resolved) is dict
+        assert resolved == {"sqlite": "/data/x.db"}
+        registered = dac.handles()
+        assert len(registered) == 1
+        (handle, kind) = next(iter(registered.items()))
+        assert kind == "credentials"
+        assert handle.startswith("_auto_credentials_")
+
+    def test_list_mixing_credential_and_plain_dict_registers_two_plain_dicts(self) -> None:
+        dac = DataAccessCollection(credentials=[Credential(sqlite="/a.db"), {"pg": {"host": "h"}}])
+        assert len(dac.credentials) == 2
+        for value in dac.credentials.values():
+            assert type(value) is dict
+        assert list(dac.credentials.values()) == [{"sqlite": "/a.db"}, {"pg": {"host": "h"}}]
+
+    def test_named_form_with_credential_value_stores_plain_dict(self) -> None:
+        dac = DataAccessCollection(credentials={"prod": Credential(sqlite="/a.db")})
+        assert dac.credentials["prod"] == {"sqlite": "/a.db"}
+        assert type(dac.credentials["prod"]) is dict
+
+    def test_add_credentials_single_arg_unwraps_credential(self) -> None:
+        dac = DataAccessCollection()
+        dac.add_credentials(Credential(sqlite="/a.db"))
+        assert len(dac.credentials) == 1
+        (only_handle,) = dac.credentials.keys()
+        assert only_handle.startswith("_auto_credentials_")
+        assert dac.credentials[only_handle] == {"sqlite": "/a.db"}
+        assert type(dac.credentials[only_handle]) is dict
+
+    def test_add_credentials_two_arg_unwraps_credential(self) -> None:
+        dac = DataAccessCollection()
+        dac.add_credentials("named", Credential(sqlite="/a.db"))
+        assert dac.credentials == {"named": {"sqlite": "/a.db"}}
+        assert type(dac.credentials["named"]) is dict
+
+
+class TestNamedFormRejectsNonMappingValues:
+    """Cycle 2 of issue #511: the named form ``{handle: value}`` requires mapping values.
+
+    A non-mapping value means the caller almost certainly mis-wrapped a single
+    credential, e.g. ``credentials={"sqlite": "/data/x.db"}`` where the whole dict
+    was meant to BE the credential. This must fail loudly at construction time
+    instead of silently never matching later in matcher selection.
+    """
+
+    def test_single_field_mis_wrap_raises_value_error_naming_handle(self) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            DataAccessCollection(credentials={"sqlite": "/data/x.db"})
+        msg = str(excinfo.value)
+        assert "sqlite" in msg
+        assert "mapping" in msg.lower()
+
+    def test_error_message_points_to_all_three_correct_alternatives(self) -> None:
+        """The message must offer the list form, the typed form, and the named-with-mapping form."""
+        with pytest.raises(ValueError) as excinfo:
+            DataAccessCollection(credentials={"sqlite": "/data/x.db"})
+        msg = str(excinfo.value)
+        assert "Credential" in msg
+        assert "[" in msg
+        assert "list" in msg.lower()
+        assert "{" in msg
+
+    def test_multi_field_mis_wrap_raises_value_error(self) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            DataAccessCollection(credentials={"host": "h", "port": 5432})
+        msg = str(excinfo.value)
+        assert ("host" in msg) or ("port" in msg)
+        assert "mapping" in msg.lower()
+
+    def test_add_credentials_two_arg_non_mapping_value_raises_value_error(self) -> None:
+        dac = DataAccessCollection()
+        with pytest.raises(ValueError) as excinfo:
+            dac.add_credentials("h", "/data/x.db")
+        msg = str(excinfo.value)
+        assert "mapping" in msg.lower()
+        assert "Credential" in msg
+
+
+class TestNamedFormAcceptsMappingValues:
+    """Legitimate named-form values (plain dict, HashableDict, Credential) keep working."""
+
+    def test_plain_dict_value_does_not_raise_and_is_stored_as_is(self) -> None:
+        dac = DataAccessCollection(credentials={"pg-prod": {"host": "h"}})
+        assert dac.credentials == {"pg-prod": {"host": "h"}}
+        assert type(dac.credentials["pg-prod"]) is dict
+
+    def test_hashable_dict_value_does_not_raise_and_is_stored_as_is(self) -> None:
+        inner = HashableDict({"sqlite": "/x.db"})
+        dac = DataAccessCollection(credentials={"db": inner})
+        assert dac.credentials["db"] is inner
+
+    def test_add_credentials_two_arg_mapping_value_still_works(self) -> None:
+        dac = DataAccessCollection()
+        dac.add_credentials("h", {"sqlite": "/x.db"})
+        assert dac.credentials == {"h": {"sqlite": "/x.db"}}

--- a/tests/test_plugins/feature_group/input_data/test_data_access_handle_hint.py
+++ b/tests/test_plugins/feature_group/input_data/test_data_access_handle_hint.py
@@ -15,9 +15,11 @@ from typing import Any
 
 import pytest
 
+from mloda.core.abstract_plugins.components.credential import Credential
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.user import Options
 from mloda_plugins.feature_group.input_data.read_db import ReadDB
+from mloda_plugins.feature_group.input_data.read_dbs.sqlite import SQLITEReader
 from mloda_plugins.feature_group.input_data.read_document import ReadDocument
 from mloda_plugins.feature_group.input_data.read_file import ReadFile
 
@@ -206,6 +208,25 @@ class TestReadDBHint:
         resolved = _AlwaysValidCredsDB.match_subclass_data_access(dac, feature_names=["any"], options=Options())
         assert isinstance(resolved, dict)
         assert resolved.get("db_path") == str(db_a)
+
+
+# ----------------------------------------------------------------------------
+# Typed Credential through the real SQLITEReader matcher (issue #511 pin).
+# ----------------------------------------------------------------------------
+
+
+class TestSqliteReaderMatchesTypedCredential:
+    """Regression pin: a typed ``Credential`` flows end-to-end through the
+    ReadDB matcher path and is matched as a plain credentials dict, never None.
+    """
+
+    def test_credential_kwarg_form_is_matched_by_sqlite_reader(self, two_sqlite_dbs: tuple[Path, Path]) -> None:
+        db_a, _ = two_sqlite_dbs
+        dac = DataAccessCollection(credentials=Credential(sqlite=str(db_a)))
+        resolved = SQLITEReader.match_subclass_data_access(dac, feature_names=["id"], options=Options())
+        assert resolved is not None
+        assert isinstance(resolved, dict)
+        assert resolved[SQLITEReader.db_path()] == str(db_a)
 
 
 # Sanity check that fixtures are isolated (parallel-safety smoke).


### PR DESCRIPTION
## Summary

Closes #511.

A bare `credentials={connector_id: slot}` dict is read by `DataAccessCollection` as a `{handle: value}` registry, so the inner slot silently failed `is_valid_credentials` and matcher selection. This PR makes the correct shape expressible through a type and makes the wrong shape fail loudly at construction.

## Changes

- New public `Credential` class (`from mloda.user import Credential`): wraps exactly one credential mapping, accepts dict form `Credential({'sqlite': '/x.db'})` and kwargs form `Credential(sqlite='/x.db')`, validates non-empty mapping at construction, and has a value-redacting `repr`.
- `DataAccessCollection` unwraps `Credential` to a plain dict in every credential entry path (single value, list entries, named dict values, both `add_credentials` arities), so plugins keep receiving plain dicts.
- Early actionable `ValueError` when a named-form credential value is not a mapping (the mis-wrap shape). The message names the offending handle, preserves all keys in its suggestions, never echoes values, and shows the three correct forms.
- Resolver hardening from review: the all-auto ambiguity error in `resolve()` now renders credential candidates with redacted values (keys only); other kinds are unchanged.
- Docs: typed-credential section in the named-data-access-handles guide including the design rationale for four user groups (notebook users, multi-source production users, plugin authors, ops/data stewards), updated examples in access-feature-data and the SQLITEReader docstring.

## Behavior change

Named-form credentials with non-mapping values (e.g. `credentials={'prod': 'dsn-string'}`) previously registered silently and now raise the mis-wrap `ValueError`. This is intentional: that shape is indistinguishable from the bug this PR fixes. String-valued credentials remain expressible via the list form.

## Review

Two independent deep reviews (Claude Opus agent and codex) were run on the diff; both flagged the credential-value leak in the resolver ambiguity error, fixed in the second commit. Remaining findings were doc-accuracy and error-message-quality items, all applied; the suggestion to keep `Credential` wrappers stored instead of unwrapping was rejected to keep the plugin-facing contract (plain dicts) unchanged.

## Testing

Developed via Red/Green TDD cycles; `tox` green (3453 passed, 193 skipped, ruff, pip-licenses, mypy --strict, bandit).