### PR TITLE
fix: terminate spawn workers in join_all and split artifact test

### DIFF
--- a/mloda/core/runtime/worker_manager.py
+++ b/mloda/core/runtime/worker_manager.py
@@ -89,7 +89,7 @@ class WorkerManager:
         failed = False
         for task in self.tasks:
             try:
-                if isinstance(task, multiprocessing.Process):
+                if isinstance(task, BaseProcess):
                     task.terminate()
                 task.join()
             except Exception as e:

--- a/tests/test_core/test_artifacts/test_artifacts.py
+++ b/tests/test_core/test_artifacts/test_artifacts.py
@@ -69,12 +69,15 @@ class TestBaseArtifacts:
     def get_features(self, feature_list: list[str], options: dict[str, Any] = {}) -> Features:
         return Features([Feature(name=f_name, options=options, initial_requested_data=True) for f_name in feature_list])
 
-    def test_basic_artifact_feature(self, modes: set[ParallelizationMode], flight_server: Any) -> None:
+    def test_basic_artifact_feature_save(self, modes: set[ParallelizationMode], flight_server: Any) -> None:
         _features = "BaseTestArtifactFeature"
 
         features = self.get_features([_features])
         result = MlodaTestRunner.run_api(features, parallelization_modes=modes, flight_server=flight_server)
         assert result.artifacts == {"BaseTestArtifactFeature": "DummyArtifact"}
+
+    def test_basic_artifact_feature_load(self, modes: set[ParallelizationMode], flight_server: Any) -> None:
+        _features = "BaseTestArtifactFeature"
 
         features = self.get_features([_features], options={"BaseTestArtifactFeature": "DummyArtifact"})
         result = MlodaTestRunner.run_api(features, parallelization_modes=modes, flight_server=flight_server)

--- a/tests/test_core/test_runtime/test_worker_manager.py
+++ b/tests/test_core/test_runtime/test_worker_manager.py
@@ -19,6 +19,16 @@ def _noop_target(*args: Any, **kwargs: Any) -> None:
     return None
 
 
+def _loop_forever_target(command_queue: Any, result_queue: Any) -> None:
+    """Picklable worker target that never exits on its own.
+
+    Module-level so it pickles under the spawn context. create_worker_process
+    prepends command_queue and result_queue to the args it passes to the target.
+    """
+    while True:
+        time.sleep(0.1)
+
+
 class TestWorkerManagerInit:
     """Test WorkerManager initialization."""
 
@@ -433,6 +443,37 @@ class TestWorkerManagerJoinAll:
         # Second process should still be joined despite first failure
         mock_process2.terminate.assert_called_once()
         mock_process2.join.assert_called_once()
+
+    @pytest.mark.timeout(30)
+    def test_join_all_terminates_real_spawn_worker_process(self) -> None:
+        """join_all should terminate a real spawn-context worker and return promptly.
+
+        create_worker_process builds workers from the spawn context, so they are
+        multiprocessing.context.SpawnProcess instances, which subclass BaseProcess
+        and are NOT instances of multiprocessing.Process. join_all's isinstance
+        check therefore never calls terminate() on real workers, and join() blocks
+        forever on a worker that does not exit on its own (GitHub issue #514).
+        """
+        manager = WorkerManager()
+        process, _, _ = manager.create_worker_process(cfw_uuid=uuid4(), target=_loop_forever_target, args=())
+
+        join_thread = threading.Thread(target=manager.join_all, daemon=True)
+        join_thread.start()
+        try:
+            deadline = time.time() + 5.0
+            while join_thread.is_alive() and time.time() < deadline:
+                join_thread.join(timeout=0.1)
+
+            assert not join_thread.is_alive(), "join_all() did not terminate the spawn worker process; it hung"
+        finally:
+            # Never leak the worker or hang the suite: kill it directly so the
+            # daemon join_all thread can finish its blocking join().
+            process.terminate()
+            process.join(timeout=5)
+            if process.is_alive():
+                process.kill()
+                process.join(timeout=5)
+            join_thread.join(timeout=1.0)
 
 
 class TestWorkerManagerIntegration:

--- a/tests/test_core/test_tooling/mloda_test_runner.py
+++ b/tests/test_core/test_tooling/mloda_test_runner.py
@@ -259,9 +259,6 @@ PARALLELIZATION_MODES_ALL = pytest.mark.parametrize(
     [
         ({ParallelizationMode.SYNC}),
         ({ParallelizationMode.THREADING}),
-        # MULTIPROCESSING spawns worker processes plus a flight server; under
-        # `pytest -n 8` load, process spawn/join latency alone can eat most of
-        # the global 10s budget and flake. Give only this variant more room.
-        pytest.param({ParallelizationMode.MULTIPROCESSING}, marks=pytest.mark.timeout(30)),
+        ({ParallelizationMode.MULTIPROCESSING}),
     ],
 )

--- a/tests/test_core/test_tooling/mloda_test_runner.py
+++ b/tests/test_core/test_tooling/mloda_test_runner.py
@@ -259,6 +259,9 @@ PARALLELIZATION_MODES_ALL = pytest.mark.parametrize(
     [
         ({ParallelizationMode.SYNC}),
         ({ParallelizationMode.THREADING}),
-        ({ParallelizationMode.MULTIPROCESSING}),
+        # MULTIPROCESSING spawns worker processes plus a flight server; under
+        # `pytest -n 8` load, process spawn/join latency alone can eat most of
+        # the global 10s budget and flake. Give only this variant more room.
+        pytest.param({ParallelizationMode.MULTIPROCESSING}, marks=pytest.mark.timeout(30)),
     ],
 )


### PR DESCRIPTION
## Summary

Fixes the intermittent timeout of the MULTIPROCESSING parametrization of the artifact test under full-suite `pytest -n 8` load (#514). The earlier approach on this branch (a per-parametrization 30s timeout mark) treated a symptom and is reverted; the flake had two real causes, both fixed here.

## Cause 1: join_all never terminated spawn workers (unbounded hang)

`WorkerManager.join_all` is documented to terminate processes before joining, but guarded with `isinstance(task, multiprocessing.Process)`. Workers are created from the spawn context, and `SpawnProcess` subclasses `multiprocessing.process.BaseProcess` directly, so the check was always False: `terminate()` was dead code and `join()` blocked indefinitely on any worker that had not exited on its own. Workers only exit when a drop command returns True (the parent never sends STOP), so a missed or slow drop turned into the unbounded `os.waitpid` hang at `run.py:271` from the issue report.

Fix: check `isinstance(task, BaseProcess)`. A regression test creates a real spawn worker stuck in an infinite loop and asserts `join_all()` returns. Terminating at finalize time is safe: step results are uploaded to the flight server before the worker reports completion, and artifacts are read from the manager before `join()`.

## Cause 2: the test ran two MP lifecycles in one 10s budget

`test_basic_artifact_feature` performed two independent `run_api` lifecycles (save artifact, then load artifact via hardcoded options). In MULTIPROCESSING mode each lifecycle spawns a manager process and a worker process that re-import the package: about 3.4s each, 6.8s combined in isolation, leaving no headroom under `-n 8` contention. This reproduced even with cause 1 fixed (timeout landing in the bounded `manager.shutdown()` path, meaning budget exhaustion rather than a hang).

Fix: split into `test_basic_artifact_feature_save` and `test_basic_artifact_feature_load`. The load run never consumed the save run's output, so coverage and assertions are identical while each test gets its own 10s budget (about 3.1s and 2.7s in isolation).

## Validation

- Three consecutive full `tox` runs green: 3431 passed, 159 skipped; ruff format/check, license allowlist, `mypy --strict`, bandit all pass.
- New regression test fails on the old code (join_all hangs) and passes with the fix.
- The global 10s timeout is unchanged, per the issue's definition of done.

Closes #514
