### PR TITLE
feat!: drop HashableDict acceptance from the credentials path

### DIFF
--- a/docs/docs/in_depth/named-data-access-handles.md
+++ b/docs/docs/in_depth/named-data-access-handles.md
@@ -59,7 +59,6 @@ Every kind accepts more than one input shape. Each shape earned its place at a d
 | Bare `set` / `list` | `files={"/data/tx.csv"}` | One source of a kind | Entries get internal auto-handles you never reference; naming a single source was pure boilerplate ([#449](https://github.com/mloda-ai/mloda/pull/449)) |
 | Typed `Credential(...)` | `credentials=Credential(sqlite="/x.db")` | Any credential (recommended) | A credential is itself a dict, so the bare dict shape collides with the named form; the type removes the nesting ambiguity ([#511](https://github.com/mloda-ai/mloda/issues/511)) |
 | `list` of credential dicts | `credentials=[{"host": "h"}]` | Several unnamed credentials | Credentials have no `set` form because dicts are unhashable |
-| `HashableDict` credential values | `credentials=[HashableDict({...})]` | Existing pre-0.7 call sites only | Before 0.7.0 credentials were force-wrapped in `HashableDict`; still accepted so those call sites keep working. New code should pass `Credential` or plain dicts here (`HashableDict` itself is not deprecated; it remains required where hashability matters, e.g. `Options` group values) |
 
 The named/auto split applies to the mutators as well:
 
@@ -215,6 +214,7 @@ Named handles collapse that bug class to one invariant: *if the registry has mor
 - **"Handle 'X' is registered under kind 'K1', but kind 'K2' was requested"**: you set `data_access_handle='X'`, but the registry has `X` under a different kind. A connection consumer cannot bind to a file handle even if the names match.
 - **"Ambiguous resolve for kind 'K': N candidates [...]; set 'data_access_handle' in Options to disambiguate"**: more than one entry of the requested kind matched. Set `data_access_handle` on the feature's `Options` to pick one, or remove the extras from the DAC.
 - **"credentials value for handle 'X' is not a mapping"**: you passed a bare `{connector_id: slot}` dict as `credentials`, which the named form reads as `{handle: credential}`. Use `credentials=Credential(...)`, the list form `credentials=[{...}]`, or the named form `{handle: {connector_id: slot}}`. See [Typed credentials](#typed-credentials-credential).
+- **"HashableDict is no longer accepted as a credential value"**: pre-0.7 call sites wrapped credentials in `HashableDict`. The credentials path no longer accepts it; pass `Credential(...)` or a plain dict instead. `HashableDict` is not removed from the library: it still backs hashability-required internals (for example `Options` hashing and `ApiInputDataCollection`). It is simply no longer unwrapped anywhere on the database credential / data-access path, so the `Options(group={"BaseInputData": (Reader, ...)})` route also expects a plain dict now.
 
 ## Related
 

--- a/mloda/core/abstract_plugins/components/data_access_collection.py
+++ b/mloda/core/abstract_plugins/components/data_access_collection.py
@@ -42,10 +42,12 @@ class DataAccessCollection:
             itself a dict, so the bare ``{connector_id: slot}`` shape would be
             read as ``{handle: value}``; the typed form removes that ambiguity
             and is unwrapped to a plain dict at registration. Named-form
-            credential values must be mappings (``dict``, ``HashableDict``, or
-            ``Credential``); anything else raises an early mis-wrap
-            ``ValueError``. ``HashableDict`` stays accepted for pre-0.7 call
-            sites. Credentials have no ``set`` form (dicts are unhashable).
+            credential values must be mappings (``dict`` or ``Credential``);
+            anything else raises an early mis-wrap ``ValueError``.
+            ``HashableDict`` is no longer accepted on the credentials path; the
+            class itself stays for hashability-required internals (e.g. ``Options``
+            hashing, ``ApiInputDataCollection``). Credentials have no ``set``
+            form (dicts are unhashable).
 
         ``column_to_file`` maps a column to either a file handle or a file path
         (paths are normalized to their handle).
@@ -89,13 +91,20 @@ class DataAccessCollection:
     @staticmethod
     def _unwrap_credential(value: Any) -> Any:
         if isinstance(value, Credential):
-            return value.data
+            value = value.data
+        if isinstance(value, HashableDict):
+            raise ValueError(
+                "HashableDict is no longer accepted as a credential value. "
+                "Pass Credential({...}) or a plain dict instead. "
+                "(HashableDict itself is not removed; it stays for hashability-required "
+                "internals such as Options hashing.)"
+            )
         return value
 
     @classmethod
     def _validated_credential_value(cls, handle: str, value: Any, context_keys: tuple[str, ...] | None = None) -> Any:
         unwrapped = cls._unwrap_credential(value)
-        if isinstance(unwrapped, (dict, HashableDict)):
+        if isinstance(unwrapped, dict):
             return unwrapped
         fields = ", ".join(f"'{key}': ..." for key in (context_keys if context_keys is not None else (handle,)))
         raise ValueError(
@@ -285,8 +294,6 @@ class DataAccessCollection:
 
     @staticmethod
     def _redacted_credential(value: Any) -> str:
-        if isinstance(value, HashableDict):
-            value = value.data
         if isinstance(value, dict):
             return "{" + ", ".join(f"'{key}': '***'" for key in value) + "}"
         return "'***'"

--- a/mloda_plugins/feature_group/input_data/read_db.py
+++ b/mloda_plugins/feature_group/input_data/read_db.py
@@ -1,6 +1,6 @@
 from typing import Any, Optional
 from mloda.user import DataAccessCollection
-from mloda.provider import FeatureSet, HashableDict, BaseInputData
+from mloda.provider import FeatureSet, BaseInputData
 from mloda.user import Options
 
 
@@ -61,7 +61,7 @@ class ReadDB(BaseInputData):
         if reader_data_access is None:
             raise ValueError(
                 f"'BaseInputData' key is missing or None in the provided Options for {self.__class__.__name__}. "
-                f"Set options with Options(group={{'BaseInputData': (ReaderClass, HashableDict({{...}}))}})."
+                f"Set options with Options(group={{'BaseInputData': (ReaderClass, {{...}})}})."
             )
 
         reader, data_access = reader_data_access
@@ -78,7 +78,7 @@ class ReadDB(BaseInputData):
             creds = data_access.resolve("credentials", hint=hint)
             if creds:
                 data_accesses.append(creds)
-        elif isinstance(data_access, (HashableDict, dict)):
+        elif isinstance(data_access, dict):
             data_accesses.append(data_access)
 
         if not data_accesses:

--- a/mloda_plugins/feature_group/input_data/read_dbs/sqlite.py
+++ b/mloda_plugins/feature_group/input_data/read_dbs/sqlite.py
@@ -4,7 +4,7 @@ from typing import Any
 import pyarrow as pa
 import sqlite3
 
-from mloda.provider import FeatureSet, HashableDict
+from mloda.provider import FeatureSet
 from mloda.user import DataType
 from mloda.user import Options
 from mloda_plugins.feature_group.input_data.read_db import ReadDB
@@ -116,8 +116,7 @@ class SQLITEReader(ReadDB):
     ```python
     from mloda.user import Credential, DataAccessCollection
 
-    # Typed form (recommended). A list of plain dicts is also accepted, as is
-    # HashableDict, for compatibility with pre-0.7 credential call sites.
+    # Typed form (recommended). A list of plain dicts is also accepted.
     data_access = DataAccessCollection(
         credentials=Credential(sqlite="/data/analytics.db")
     )
@@ -160,14 +159,10 @@ class SQLITEReader(ReadDB):
 
     @classmethod
     def connect(cls, credentials: Any) -> Any:
-        if isinstance(credentials, HashableDict):
-            data = credentials.data
-        elif isinstance(credentials, dict):
+        if isinstance(credentials, dict):
             data = credentials
         else:
-            raise ValueError(
-                f"Credentials for {cls.__name__} must be a dict (or HashableDict). Got {type(credentials).__name__}."
-            )
+            raise ValueError(f"Credentials for {cls.__name__} must be a dict. Got {type(credentials).__name__}.")
         return sqlite3.connect(data[cls.db_path()])
 
     @classmethod
@@ -200,9 +195,7 @@ class SQLITEReader(ReadDB):
     def is_valid_credentials(cls, credentials: Any) -> bool:
         """Checks if the given dictionary is a valid credentials object."""
 
-        if isinstance(credentials, HashableDict):
-            db_path = credentials.data.get(cls.db_path(), None)
-        elif isinstance(credentials, dict):
+        if isinstance(credentials, dict):
             db_path = credentials.get(cls.db_path(), None)
         else:
             db_path = None
@@ -254,16 +247,8 @@ class SQLITEReader(ReadDB):
         return False
 
     @classmethod
-    def _credentials_data(cls, data_access: Any) -> dict[str, Any]:
-        if isinstance(data_access, HashableDict):
-            inner: dict[str, Any] = data_access.data
-            return inner
-        plain: dict[str, Any] = data_access
-        return plain
-
-    @classmethod
     def set_table_name(cls, data_access: Any, table_name: str) -> None:
-        data = cls._credentials_data(data_access)
+        data = data_access
         if data.get("table_name"):
             if data["table_name"] != table_name:
                 raise ValueError(f"Table name is already set to {data['table_name']} and not {table_name}.")
@@ -275,4 +260,4 @@ class SQLITEReader(ReadDB):
     def get_table(cls, options: Options | None) -> Any:
         if options is None:
             raise ValueError("Options were not set.")
-        return cls._credentials_data(options.get("BaseInputData")[1])["table_name"]
+        return options.get("BaseInputData")[1]["table_name"]

--- a/tests/test_core/test_abstract_plugins/test_components/test_credential.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_credential.py
@@ -194,22 +194,62 @@ class TestNamedFormRejectsNonMappingValues:
 
 
 class TestNamedFormAcceptsMappingValues:
-    """Legitimate named-form values (plain dict, HashableDict, Credential) keep working."""
+    """Legitimate named-form mapping values (plain dict, Credential) keep working."""
 
     def test_plain_dict_value_does_not_raise_and_is_stored_as_is(self) -> None:
         dac = DataAccessCollection(credentials={"pg-prod": {"host": "h"}})
         assert dac.credentials == {"pg-prod": {"host": "h"}}
         assert type(dac.credentials["pg-prod"]) is dict
 
-    def test_hashable_dict_value_does_not_raise_and_is_stored_as_is(self) -> None:
-        inner = HashableDict({"sqlite": "/x.db"})
-        dac = DataAccessCollection(credentials={"db": inner})
-        assert dac.credentials["db"] is inner
-
     def test_add_credentials_two_arg_mapping_value_still_works(self) -> None:
         dac = DataAccessCollection()
         dac.add_credentials("h", {"sqlite": "/x.db"})
         assert dac.credentials == {"h": {"sqlite": "/x.db"}}
+
+
+class TestCredentialsPathRejectsHashableDict:
+    """Issue #519: HashableDict is rejected as a credential VALUE on every entry path.
+
+    Before 0.7.0 ``DataAccessCollection`` force-wrapped credentials in HashableDict,
+    so readers grew isinstance branches for it. With the typed ``Credential`` class in
+    place, HashableDict on the credentials path is now a migration error. HashableDict
+    itself stays valid for Options group values; only the credentials path rejects it.
+
+    The migration ValueError must name ``Credential`` and ``dict`` (the supported
+    replacements), mention ``HashableDict`` (what was rejected), and never echo the
+    secret value.
+    """
+
+    SECRET = "/secret/credential/path.db"  # nosec B105
+
+    def _assert_migration_error(self, msg: str) -> None:
+        lowered = msg.lower()
+        assert "hashabledict" in lowered
+        assert "credential" in lowered
+        assert "dict" in lowered
+        assert self.SECRET not in msg
+
+    def test_named_form_rejects_hashable_dict_value(self) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            DataAccessCollection(credentials={"db": HashableDict({"sqlite": self.SECRET})})
+        self._assert_migration_error(str(excinfo.value))
+
+    def test_list_form_rejects_hashable_dict_value(self) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            DataAccessCollection(credentials=[HashableDict({"sqlite": self.SECRET})])
+        self._assert_migration_error(str(excinfo.value))
+
+    def test_add_credentials_single_arg_rejects_hashable_dict(self) -> None:
+        dac = DataAccessCollection()
+        with pytest.raises(ValueError) as excinfo:
+            dac.add_credentials(HashableDict({"sqlite": self.SECRET}))
+        self._assert_migration_error(str(excinfo.value))
+
+    def test_add_credentials_two_arg_rejects_hashable_dict_value(self) -> None:
+        dac = DataAccessCollection()
+        with pytest.raises(ValueError) as excinfo:
+            dac.add_credentials("named", HashableDict({"sqlite": self.SECRET}))
+        self._assert_migration_error(str(excinfo.value))
 
 
 class TestResolveAmbiguityRedactsCredentialValues:
@@ -235,20 +275,6 @@ class TestResolveAmbiguityRedactsCredentialValues:
         assert "host" in msg
         assert "password" in msg
         assert "data_access_handle" in msg
-
-    def test_hashable_dict_credentials_ambiguity_redacts_values_but_shows_keys(self) -> None:
-        dac = DataAccessCollection(
-            credentials=[
-                HashableDict({"token": "secret-a"}),  # nosec B105
-                HashableDict({"token": "secret-b"}),  # nosec B105
-            ]
-        )
-        with pytest.raises(ValueError) as excinfo:
-            dac.resolve("credentials")
-        msg = str(excinfo.value)
-        assert "secret-a" not in msg
-        assert "secret-b" not in msg
-        assert "token" in msg
 
     def test_auto_named_files_ambiguity_still_shows_values(self) -> None:
         """Guardrail: redaction is credentials-only; file paths stay visible in the listing."""

--- a/tests/test_plugins/feature_group/input_data/test_read_dbs/test_read_db_multiprocessing.py
+++ b/tests/test_plugins/feature_group/input_data/test_read_dbs/test_read_db_multiprocessing.py
@@ -1,10 +1,10 @@
 """Regression coverage for SQLITEReader credentials in a DataAccessCollection under
 ParallelizationMode.MULTIPROCESSING.
 
-SQLITEReader.is_valid_credentials and SQLITEReader.connect accept both a plain dict
-and the legacy HashableDict wrapping. Both forms must produce rows end-to-end through
-``mloda.run_all`` under MULTIPROCESSING. The HashableDict variant remains as a
-backwards-compat regression so the optional acceptor branch stays exercised.
+A plain dict credential must produce rows end-to-end through ``mloda.run_all`` under
+MULTIPROCESSING. HashableDict is no longer accepted on the credentials path (issue
+#519): passing it as a credential value is rejected at construction time with a
+migration error pointing to ``Credential`` / plain dict.
 
 Reference: https://github.com/mloda-ai/mloda/pull/449
 """
@@ -12,6 +12,8 @@ Reference: https://github.com/mloda-ai/mloda/pull/449
 import sqlite3
 from pathlib import Path
 from typing import Any
+
+import pytest
 
 from mloda.provider import HashableDict
 from mloda.user import DataAccessCollection
@@ -35,23 +37,13 @@ class TestSqliteCredentialsUnderMultiprocessing:
         conn.commit()
         conn.close()
 
-    def test_hashable_dict_credentials_work_under_multiprocessing(self, tmp_path: Path, flight_server: Any) -> None:
-        """Backwards-compat: the legacy HashableDict-wrapped pattern still produces rows under MULTIPROCESSING."""
+    def test_hashable_dict_credentials_rejected(self, tmp_path: Path) -> None:
+        """A HashableDict credential value is rejected at construction with a migration error."""
         db_path = tmp_path / "mp_hashable.sqlite"
-        self._seed_db(db_path)
 
-        result = mloda.run_all(
-            ["name", "id"],
-            compute_frameworks=["PyArrowTable"],
-            parallelization_modes={ParallelizationMode.MULTIPROCESSING},
-            flight_server=flight_server,
-            data_access_collection=DataAccessCollection(
-                credentials=[HashableDict({SQLITEReader.db_path(): str(db_path)})]
-            ),
-            plugin_collector=PluginCollector.enabled_feature_groups({DBInputDataTestFeatureGroup}),
-        )
-
-        assert "name" in result[0].to_pydict()
+        with pytest.raises(ValueError) as excinfo:
+            DataAccessCollection(credentials=[HashableDict({SQLITEReader.db_path(): str(db_path)})])
+        assert "credential" in str(excinfo.value).lower()
 
     def test_plain_dict_credentials_under_multiprocessing(self, tmp_path: Path, flight_server: Any) -> None:
         """An unwrapped plain dict is now accepted and produces rows end-to-end under MULTIPROCESSING."""

--- a/tests/test_plugins/feature_group/input_data/test_read_dbs/test_sqlite.py
+++ b/tests/test_plugins/feature_group/input_data/test_read_dbs/test_sqlite.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 import pyarrow as pa
 
 from mloda.user import Feature
-from mloda.provider import FeatureSet, HashableDict
+from mloda.provider import FeatureSet
 from mloda_plugins.feature_group.input_data.read_dbs.sqlite import SQLITEReader
 
 
@@ -56,9 +56,8 @@ class TestSQLITEReader:
 
     @pytest.fixture(scope="class")
     def valid_credentials(self, temp_sqlite_db: Any) -> Any:
-        # Backwards-compat regression: keep one HashableDict-wrapped fixture so the legacy
-        # acceptor branch in SQLITEReader.connect / is_valid_credentials stays exercised.
-        return HashableDict({"sqlite": temp_sqlite_db})
+        # Credentials flow through SQLITEReader.connect / is_valid_credentials as plain dicts.
+        return {"sqlite": temp_sqlite_db}
 
     @pytest.fixture(scope="class")
     def invalid_credentials(self) -> Any:
@@ -124,6 +123,6 @@ class TestSQLITEReader:
             SQLITEReader.get_table(None)
 
     def test_get_table_missing_table_name(self) -> None:
-        options = MockOptions(("BaseInputData", HashableDict({})))
+        options = MockOptions(("BaseInputData", {}))
         with pytest.raises(KeyError, match="'table_name'"):
             SQLITEReader.get_table(options)  # type: ignore


### PR DESCRIPTION
Closes #519. Lands on top of #516 (typed `Credential`), now merged to main.

## What

Drops the pre-0.7 `HashableDict` acceptance from the credentials path now that the typed `Credential` class provides a migration target. `HashableDict` force-wrapping of credentials predates 0.7.0; the readers grew isinstance branches for it that are now pure carry cost.

`HashableDict` itself stays in the library: it still backs hashability-required internals (`Options` hashing via `_make_hashable`, `ApiInputDataCollection.get_column_names`) and remains exported from `mloda.provider`. This change only touches the credentials / DB-reader data-access path.

## Changes

- `DataAccessCollection`: reject `HashableDict` as a credential value with a migration `ValueError` (points to `Credential(...)` or a plain dict). The rejection lives in `_unwrap_credential`, the single chokepoint shared by the named-dict form, the list form, and `add_credentials`. `_validated_credential_value` simplifies to a plain-dict check; `_redacted_credential` drops its now-dead `HashableDict` branch (stored credentials are always plain dicts now).
- `read_db.py` / `sqlite.py`: remove the `HashableDict` isinstance branches in `match_subclass_data_access`, `connect`, `is_valid_credentials`, and the inlined `_credentials_data`; drop the stale `HashableDict({...})` advice from the `init_reader` error message; drop the now-unused imports.
- Docs: remove the `HashableDict` credentials row from the shapes table in `named-data-access-handles.md` and add a common-error entry for the rejection.

## Breaking change

Passing a `HashableDict` as a credential value to `DataAccessCollection` (or `add_credentials`) now raises `ValueError`. Migrate to `Credential(...)` or a plain dict. The `Options(group={"BaseInputData": (Reader, ...)})` route now also expects a plain dict (plain dicts hash fine via `_make_hashable`).

## Tests

- Compat-pinning tests updated to the new behavior; an explicit `TestCredentialsPathRejectsHashableDict` pins the migration error across all entry forms, asserting no secret value leaks into the message.
- Full suite green. One unrelated multiprocessing artifact test (`test_basic_artifact_feature[modes2]`) is flaky under the 10s/`-n 8` timeout and passes in isolation and at `--timeout=30`; it touches no credential code.

## Reviews

Two independent deep reviews (Claude Opus + codex). Opus: ship. Codex flagged the `Options(group=...)` HashableDict route behavior change, which is the intended scope of #519; its valid kernel (overpromising migration text) was addressed by tightening the message and docs wording.

## Registry follow-up

mloda-registry plugins must be audited for `HashableDict` credential usage before this releases. A registry issue tracks this and is marked blocked for the next release. (Link added as a comment.)