### PR TITLE
fix: normalize DuckDB session timezone to UTC at framework chokepoint

### DIFF
--- a/attribution/ATTRIBUTION.md
+++ b/attribution/ATTRIBUTION.md
@@ -6,33 +6,28 @@
 | annotated-types                        | 0.7.0           | MIT License                                        |
 | ast_serialize                          | 0.5.0           | MIT                                                |
 | asttokens                              | 3.0.1           | Apache 2.0                                         |
-| attrs                                  | 26.1.0          | MIT                                                |
 | bandit                                 | 1.9.4           | Apache-2.0                                         |
 | cachetools                             | 6.2.6           | MIT                                                |
-| certifi                                | 2026.4.22       | Mozilla Public License 2.0 (MPL 2.0)               |
+| certifi                                | 2026.5.20       | Mozilla Public License 2.0 (MPL 2.0)               |
 | charset-normalizer                     | 3.4.7           | MIT                                                |
-| click                                  | 8.4.0           | BSD-3-Clause                                       |
+| click                                  | 8.4.1           | BSD-3-Clause                                       |
 | comm                                   | 0.2.3           | BSD License                                        |
 | cyclonedx-python-lib                   | 11.7.0          | Apache Software License                            |
-| debugpy                                | 1.8.20          | MIT License                                        |
+| debugpy                                | 1.8.21          | MIT License                                        |
 | decorator                              | 5.3.1           | BSD-2-Clause                                       |
 | defusedxml                             | 0.7.1           | Python Software Foundation License                 |
-| duckdb                                 | 1.5.2           | MIT License                                        |
+| duckdb                                 | 1.5.3           | MIT License                                        |
 | execnet                                | 2.1.2           | MIT License                                        |
 | executing                              | 2.2.1           | MIT License                                        |
-| fastjsonschema                         | 2.21.2          | BSD License                                        |
 | filelock                               | 3.29.0          | MIT License                                        |
 | fsspec                                 | 2026.4.0        | BSD-3-Clause                                       |
-| idna                                   | 3.15            | BSD-3-Clause                                       |
-| importlib_metadata                     | 8.7.1           | Apache-2.0                                         |
+| idna                                   | 3.18            | BSD-3-Clause                                       |
 | iniconfig                              | 2.3.0           | MIT                                                |
 | ipykernel                              | 7.2.0           | BSD-3-Clause                                       |
-| ipython                                | 9.13.0          | BSD-3-Clause                                       |
+| ipython                                | 9.14.0          | BSD-3-Clause                                       |
 | ipython_pygments_lexers                | 1.1.1           | BSD License                                        |
 | jedi                                   | 0.20.0          | MIT License                                        |
 | joblib                                 | 1.5.3           | BSD-3-Clause                                       |
-| jsonschema                             | 4.26.0          | MIT                                                |
-| jsonschema-specifications              | 2025.9.1        | MIT                                                |
 | jupyter_client                         | 8.8.0           | BSD License                                        |
 | jupyter_core                           | 5.9.1           | BSD-3-Clause                                       |
 | librt                                  | 0.11.0          | MIT                                                |
@@ -40,23 +35,22 @@
 | matplotlib-inline                      | 0.2.2           | BSD-3-Clause                                       |
 | mdurl                                  | 0.1.2           | MIT License                                        |
 | mktestdocs                             | 0.2.5           | MIT                                                |
-| mloda                                  | 0.6.3           | Apache-2.0                                         |
+| mloda                                  | 0.8.0           | Apache-2.0                                         |
 | mmh3                                   | 5.2.1           | MIT License                                        |
 | msgpack                                | 1.1.2           | Apache-2.0                                         |
 | mypy                                   | 2.1.0           | MIT                                                |
 | mypy_extensions                        | 1.1.0           | MIT                                                |
-| nbclient                               | 0.10.4          | BSD License                                        |
-| nbformat                               | 5.10.4          | BSD License                                        |
+| narwhals                               | 2.22.0          | MIT                                                |
 | nest-asyncio                           | 1.6.0           | BSD License                                        |
 | nltk                                   | 3.9.4           | Apache Software License                            |
 | numpy                                  | 2.4.6           | BSD-3-Clause AND 0BSD AND MIT AND Zlib AND CC0-1.0 |
-| opentelemetry-api                      | 1.42.0          | Apache-2.0                                         |
-| opentelemetry-instrumentation          | 0.63b0          | Apache Software License                            |
-| opentelemetry-instrumentation-logging  | 0.63b0          | Apache Software License                            |
-| opentelemetry-instrumentation-requests | 0.63b0          | Apache Software License                            |
-| opentelemetry-sdk                      | 1.42.0          | Apache-2.0                                         |
-| opentelemetry-semantic-conventions     | 0.63b0          | Apache-2.0                                         |
-| opentelemetry-util-http                | 0.63b0          | Apache Software License                            |
+| opentelemetry-api                      | 1.42.1          | Apache-2.0                                         |
+| opentelemetry-instrumentation          | 0.63b1          | Apache Software License                            |
+| opentelemetry-instrumentation-logging  | 0.63b1          | Apache Software License                            |
+| opentelemetry-instrumentation-requests | 0.63b1          | Apache Software License                            |
+| opentelemetry-sdk                      | 1.42.1          | Apache-2.0                                         |
+| opentelemetry-semantic-conventions     | 0.63b1          | Apache-2.0                                         |
+| opentelemetry-util-http                | 0.63b1          | Apache Software License                            |
 | packageurl-python                      | 0.17.6          | MIT License                                        |
 | packaging                              | 26.2            | Apache-2.0 OR BSD-2-Clause                         |
 | pandas                                 | 3.0.3           | BSD License                                        |
@@ -67,10 +61,10 @@
 | pip-api                                | 0.0.34          | Apache Software License                            |
 | pip-requirements-parser                | 32.0.1          | MIT                                                |
 | pip_audit                              | 2.10.0          | Apache Software License                            |
-| platformdirs                           | 4.9.6           | MIT License                                        |
+| platformdirs                           | 4.10.0          | MIT License                                        |
 | pluggy                                 | 1.6.0           | MIT License                                        |
-| polars                                 | 1.40.1          | MIT License                                        |
-| polars-runtime-32                      | 1.40.1          | MIT License                                        |
+| polars                                 | 1.41.2          | MIT License                                        |
+| polars-runtime-32                      | 1.41.2          | MIT License                                        |
 | prompt_toolkit                         | 3.0.52          | BSD License                                        |
 | psutil                                 | 7.2.2           | BSD-3-Clause                                       |
 | ptyprocess                             | 0.7.0           | ISC License (ISCL)                                 |
@@ -88,13 +82,11 @@
 | pytest-xdist                           | 3.8.0           | MIT                                                |
 | python-dateutil                        | 2.9.0.post0     | Apache Software License; BSD License               |
 | pyzmq                                  | 27.1.0          | BSD License                                        |
-| referencing                            | 0.37.0          | MIT                                                |
 | regex                                  | 2026.5.9        | Apache-2.0 AND CNRI-Python                         |
 | requests                               | 2.34.2          | Apache Software License                            |
 | rich                                   | 14.3.4          | MIT License                                        |
-| rpds-py                                | 0.30.0          | MIT                                                |
-| ruff                                   | 0.15.13         | MIT                                                |
-| scikit-learn                           | 1.8.0           | BSD-3-Clause                                       |
+| ruff                                   | 0.15.15         | MIT                                                |
+| scikit-learn                           | 1.9.0           | BSD-3-Clause                                       |
 | scipy                                  | 1.17.1          | BSD License                                        |
 | six                                    | 1.17.0          | MIT License                                        |
 | sortedcontainers                       | 2.4.0           | Apache Software License                            |
@@ -102,11 +94,10 @@
 | stevedore                              | 5.8.0           | Apache-2.0                                         |
 | strictyaml                             | 1.7.3           | MIT License                                        |
 | tenacity                               | 9.1.4           | Apache Software License                            |
-| testbook                               | 0.4.2           | BSD License                                        |
 | threadpoolctl                          | 3.6.0           | BSD License                                        |
 | tomli                                  | 2.4.1           | MIT                                                |
 | tomli_w                                | 1.2.0           | MIT License                                        |
-| tornado                                | 6.5.5           | Apache Software License                            |
+| tornado                                | 6.5.6           | Apache Software License                            |
 | tqdm                                   | 4.67.3          | MPL-2.0 AND MIT                                    |
 | traitlets                              | 5.15.0          | BSD License                                        |
 | typeguard                              | 4.5.2           | MIT                                                |
@@ -117,6 +108,5 @@
 | typing-inspection                      | 0.4.2           | MIT                                                |
 | typing_extensions                      | 4.15.0          | PSF-2.0                                            |
 | urllib3                                | 2.7.0           | MIT                                                |
-| wrapt                                  | 2.1.2           | BSD-2-Clause                                       |
-| zipp                                   | 3.23.1          | MIT                                                |
+| wrapt                                  | 2.2.1           | BSD-2-Clause                                       |
 | zstandard                              | 0.25.0          | BSD-3-Clause                                       |

--- a/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_framework.py
@@ -52,7 +52,16 @@ class DuckDBFramework(ComputeFramework):
     """
 
     def set_framework_connection_object(self, framework_connection_object: Optional[Any] = None) -> None:
-        """Use given DuckDB connection."""
+        """Use given DuckDB connection.
+
+        Pins the DuckDB session timezone to UTC on first assignment so that timestamp
+        operations (DATE_TRUNC, time_bucket, EPOCH, ...) are deterministic regardless of
+        the incoming connection's preset TimeZone. This is a global set-and-leave, not a
+        save/restore: DuckdbRelation is lazy and the SQL only materializes at
+        to_arrow_table(), long after this method returns, so restoring the zone here would
+        revert it before any relation materializes. The zone persists for the connection's
+        lifetime under the framework, so it only needs to be set once at first assignment.
+        """
         if duckdb is None:
             raise ImportError("DuckDB is not installed. To be able to use this framework, please install duckdb.")
         if framework_connection_object is None:
@@ -64,6 +73,7 @@ class DuckDBFramework(ComputeFramework):
                 raise ValueError("A different connection is already set. Cannot replace an existing connection.")
             return
         self.framework_connection_object = framework_connection_object
+        self.framework_connection_object.execute("SET TimeZone='UTC'")
 
     @classmethod
     def _connection_matches(cls, conn: Any) -> bool:

--- a/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_framework.py
@@ -72,8 +72,8 @@ class DuckDBFramework(ComputeFramework):
             if self.framework_connection_object is not framework_connection_object:
                 raise ValueError("A different connection is already set. Cannot replace an existing connection.")
             return
+        framework_connection_object.execute("SET TimeZone='UTC'")
         self.framework_connection_object = framework_connection_object
-        self.framework_connection_object.execute("SET TimeZone='UTC'")
 
     @classmethod
     def _connection_matches(cls, conn: Any) -> bool:

--- a/tests/test_plugins/compute_framework/base_implementations/duckdb/conftest.py
+++ b/tests/test_plugins/compute_framework/base_implementations/duckdb/conftest.py
@@ -36,3 +36,31 @@ def connection() -> Any:
     conn = duckdb.connect()
     yield conn
     conn.close()
+
+
+# Non-UTC session timezones used to surface DATE_TRUNC / time_bucket drift (issues #522/#523).
+# - America/New_York: whole-hour offset (UTC-5), catches day-granularity DATE_TRUNC drift.
+# - Asia/Kolkata: fractional offset (UTC+5:30), catches sub-hour drift whole-hour zones miss.
+NON_UTC_ZONES = ["America/New_York", "Asia/Kolkata"]
+
+
+@pytest.fixture(params=NON_UTC_ZONES)
+def non_utc_zone(request: Any) -> str:
+    """Expose the parametrized non-UTC session timezone string."""
+    return str(request.param)
+
+
+@pytest.fixture
+def non_utc_connection(non_utc_zone: str) -> Any:
+    """Create a DuckDB connection whose session timezone is preset to a non-UTC zone.
+
+    The zone is set via ``SET TimeZone`` BEFORE yielding so that any framework
+    consuming this connection inherits a non-UTC session timezone, mirroring a
+    user-supplied connection that was configured for a local timezone.
+    """
+    if not DUCKDB_AVAILABLE:
+        pytest.skip("DuckDB is not installed")
+    conn = duckdb.connect()
+    conn.execute(f"SET TimeZone='{non_utc_zone}'")
+    yield conn
+    conn.close()

--- a/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_framework.py
+++ b/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_framework.py
@@ -1,4 +1,5 @@
 import os
+from datetime import datetime, timezone
 from typing import Any, Optional
 import pytest
 from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framework import DuckDBFramework
@@ -110,6 +111,71 @@ class TestDuckDBFrameworkComputeFramework:
         arrow = result.to_arrow_table()
         assert arrow.column("col_a").to_pylist() == [1, 2, 3]
         assert arrow.column("col_c").to_pylist() == [7, 8, 9]
+
+
+@pytest.mark.skipif(duckdb is None, reason="DuckDB is not installed. Skipping this test.")
+class TestDuckDBFrameworkSessionTimezone:
+    """Timestamp flooring must be UTC-based regardless of the connection's preset session timezone.
+
+    DuckDB's ``DATE_TRUNC`` on a ``TIMESTAMPTZ`` operates in the connection's session
+    timezone. ``set_framework_connection_object`` is the contract chokepoint: after a
+    user-supplied connection is handed to the framework, flooring a known UTC instant to
+    the day must yield the UTC-floored instant, NOT the local-midnight instant of whatever
+    timezone the connection happened to be preset to (issues #522/#523).
+
+    The chosen instant ``2023-01-01 02:00:00+00`` floors (to day) to:
+      - UTC:                 2023-01-01 00:00:00+00  (expected)
+      - America/New_York:    2022-12-31 05:00:00+00  (leaked-tz bug)
+      - Asia/Kolkata:        2022-12-31 18:30:00+00  (leaked-tz bug)
+    so the bug is unambiguously visible as a wrong absolute instant.
+    """
+
+    # A UTC instant a couple of hours past midnight: still 2023-01-01 in UTC, but rolls
+    # back to the previous day once a negative-offset session tz leaks in.
+    KNOWN_INSTANT = datetime(2023, 1, 1, 2, 0, 0, tzinfo=timezone.utc)
+    EXPECTED_UTC_DAY_FLOOR = datetime(2023, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+    @pytest.fixture
+    def duckdb_framework(self) -> DuckDBFramework:
+        return DuckDBFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
+
+    def _timestamptz_relation(self, framework: DuckDBFramework, instant: datetime) -> DuckdbRelation:
+        """Build a single-row TIMESTAMPTZ relation on the framework's connection."""
+        conn = framework.get_framework_connection_object()
+        arrow_table = pa.table({"ts": pa.array([instant], type=pa.timestamp("us", tz="UTC"))})
+        return DuckdbRelation.from_arrow(conn, arrow_table)
+
+    @staticmethod
+    def _floored_instant(relation: DuckdbRelation) -> datetime:
+        """Force lazy materialization and return the floored instant normalized to UTC."""
+        arrow_result = relation.to_arrow_table()
+        value = arrow_result.column("ts").to_pylist()[0]
+        assert isinstance(value, datetime)
+        return value.astimezone(timezone.utc)
+
+    def test_date_trunc_day_floor_is_utc_via_project(
+        self, duckdb_framework: DuckDBFramework, non_utc_connection: Any, non_utc_zone: str
+    ) -> None:
+        """DATE_TRUNC day-flooring via the project() API must ignore the preset session tz."""
+        duckdb_framework.set_framework_connection_object(non_utc_connection)
+        relation = self._timestamptz_relation(duckdb_framework, self.KNOWN_INSTANT)
+        floored = relation.project('DATE_TRUNC(\'day\', "ts") AS "ts"')
+        result = self._floored_instant(floored)
+        assert result == self.EXPECTED_UTC_DAY_FLOOR, (
+            f"Day floor leaked session timezone {non_utc_zone!r}: expected {self.EXPECTED_UTC_DAY_FLOOR}, got {result}"
+        )
+
+    def test_date_trunc_day_floor_is_utc_via_query(
+        self, duckdb_framework: DuckDBFramework, non_utc_connection: Any, non_utc_zone: str
+    ) -> None:
+        """DATE_TRUNC day-flooring via the query() API must ignore the preset session tz."""
+        duckdb_framework.set_framework_connection_object(non_utc_connection)
+        relation = self._timestamptz_relation(duckdb_framework, self.KNOWN_INSTANT)
+        floored = relation.query("ts_rel", 'SELECT DATE_TRUNC(\'day\', "ts") AS "ts" FROM ts_rel')
+        result = self._floored_instant(floored)
+        assert result == self.EXPECTED_UTC_DAY_FLOOR, (
+            f"Day floor leaked session timezone {non_utc_zone!r}: expected {self.EXPECTED_UTC_DAY_FLOOR}, got {result}"
+        )
 
 
 @pytest.mark.skipif(duckdb is None, reason="DuckDB is not installed. Skipping this test.")

--- a/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_framework.py
+++ b/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_framework.py
@@ -128,12 +128,28 @@ class TestDuckDBFrameworkSessionTimezone:
       - America/New_York:    2022-12-31 05:00:00+00  (leaked-tz bug)
       - Asia/Kolkata:        2022-12-31 18:30:00+00  (leaked-tz bug)
     so the bug is unambiguously visible as a wrong absolute instant.
+
+    Day-granularity flooring alone is not enough to exercise the fractional (:30) offset:
+    a whole-hour zone already yields the wrong day, so Asia/Kolkata's half-hour adds no
+    distinct discriminating power there. The sub-day (hour) test below closes that gap.
+    The chosen sub-day instant ``2023-01-01 06:42:00+00`` floors (to hour) to:
+      - UTC:                 2023-01-01 06:00:00+00  (expected)
+      - America/New_York:    2023-01-01 06:00:00+00  (whole-hour offset: no drift at hour granularity)
+      - Asia/Kolkata:        2023-01-01 06:30:00+00  (+5:30 fractional offset: drifts by exactly 30 min)
+    so only the fractional zone produces a wrong instant, proving the :30 offset is what
+    genuinely discriminates at sub-hour granularity.
     """
 
     # A UTC instant a couple of hours past midnight: still 2023-01-01 in UTC, but rolls
     # back to the previous day once a negative-offset session tz leaks in.
     KNOWN_INSTANT = datetime(2023, 1, 1, 2, 0, 0, tzinfo=timezone.utc)
     EXPECTED_UTC_DAY_FLOOR = datetime(2023, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+    # A mid-hour UTC instant: hour-flooring stays on 2023-01-01 06:00:00+00 in UTC and for
+    # whole-hour zones, but a +5:30 session tz leaking in lands the hour boundary at the
+    # :30 mark (06:30:00+00), a wrong absolute instant differing by the fractional offset.
+    KNOWN_INSTANT_SUBDAY = datetime(2023, 1, 1, 6, 42, 0, tzinfo=timezone.utc)
+    EXPECTED_UTC_HOUR_FLOOR = datetime(2023, 1, 1, 6, 0, 0, tzinfo=timezone.utc)
 
     @pytest.fixture
     def duckdb_framework(self) -> DuckDBFramework:
@@ -142,8 +158,19 @@ class TestDuckDBFrameworkSessionTimezone:
     def _timestamptz_relation(self, framework: DuckDBFramework, instant: datetime) -> DuckdbRelation:
         """Build a single-row TIMESTAMPTZ relation on the framework's connection."""
         conn = framework.get_framework_connection_object()
-        arrow_table = pa.table({"ts": pa.array([instant], type=pa.timestamp("us", tz="UTC"))})
-        return DuckdbRelation.from_arrow(conn, arrow_table)
+        # pa.array with a tz-typed timestamp interprets naive datetimes as already in that tz;
+        # tz-aware datetimes are rejected on some PyArrow builds across the 3.10-3.14 matrix,
+        # hence the .replace(tzinfo=None). The stored absolute instant is unchanged.
+        naive_utc = instant.replace(tzinfo=None)
+        arrow_table = pa.table({"ts": pa.array([naive_utc], type=pa.timestamp("us", tz="UTC"))})
+        relation = DuckdbRelation.from_arrow(conn, arrow_table)
+        # Guard: a future arrow/duckdb mapping must not silently produce a naive TIMESTAMP,
+        # which would make DATE_TRUNC stop depending on session tz and pass without the bug.
+        ts_type = relation.types[relation.columns.index("ts")]
+        assert "TIMESTAMP WITH TIME ZONE" in str(ts_type).upper(), (
+            f"Expected 'ts' to be a TIMESTAMPTZ column, got {ts_type!r}"
+        )
+        return relation
 
     @staticmethod
     def _floored_instant(relation: DuckdbRelation) -> datetime:
@@ -175,6 +202,25 @@ class TestDuckDBFrameworkSessionTimezone:
         result = self._floored_instant(floored)
         assert result == self.EXPECTED_UTC_DAY_FLOOR, (
             f"Day floor leaked session timezone {non_utc_zone!r}: expected {self.EXPECTED_UTC_DAY_FLOOR}, got {result}"
+        )
+
+    def test_date_trunc_hour_floor_is_utc_via_project(
+        self, duckdb_framework: DuckDBFramework, non_utc_connection: Any, non_utc_zone: str
+    ) -> None:
+        """Sub-day (hour) flooring must ignore the preset session tz.
+
+        Day-granularity flooring is already wrong for any whole-hour zone, so it cannot
+        isolate the fractional (+5:30) offset. Hour-flooring 2023-01-01 06:42:00+00 stays
+        at 06:00:00+00 under UTC and whole-hour zones, but a leaked +5:30 session tz would
+        floor to 06:30:00+00, so Asia/Kolkata genuinely discriminates the bug here.
+        """
+        duckdb_framework.set_framework_connection_object(non_utc_connection)
+        relation = self._timestamptz_relation(duckdb_framework, self.KNOWN_INSTANT_SUBDAY)
+        floored = relation.project('DATE_TRUNC(\'hour\', "ts") AS "ts"')
+        result = self._floored_instant(floored)
+        assert result == self.EXPECTED_UTC_HOUR_FLOOR, (
+            f"Hour floor leaked session timezone {non_utc_zone!r}: "
+            f"expected {self.EXPECTED_UTC_HOUR_FLOOR}, got {result}"
         )
 
 


### PR DESCRIPTION
## Summary

`DuckDBFramework` accepted a user-supplied DuckDB connection but never normalized its session timezone. DuckDB's `DATE_TRUNC` / `time_bucket` / `EPOCH` operate in the connection's session timezone, so timestamp flooring silently produced different results depending on the connection's preset `TimeZone`. This already caused two downstream regressions (`mloda-registry` #238 and #265) that were invisible in CI because CI runners are UTC.

This establishes a UTC session-timezone contract at the single chokepoint where a connection enters the framework, and adds non-UTC test coverage so the regression class surfaces in core CI.

Closes #522
Closes #523

## The fix (#522)

`set_framework_connection_object` now pins the DuckDB session timezone to UTC once, on first assignment:

- It is a **global set-and-leave**, not a save/restore. `DuckdbRelation` is lazy: the floor SQL only materializes at `to_arrow_table()`, long after the setter returns, so restoring the zone in the setter would revert it before any relation materializes. The decision is recorded in the method docstring.
- The `SET TimeZone='UTC'` runs **before** the connection is stored, so a failed pin never leaves a half-adopted connection that the "different connection is already set" guard would then permanently reject.

## The test coverage (#523)

A parametrized `non_utc_connection` fixture presets the session timezone before handing the connection to the framework, over:

- `America/New_York` (whole-hour, UTC-5): catches day-granularity `DATE_TRUNC` drift.
- `Asia/Kolkata` (fractional, UTC+5:30): catches sub-hour drift whole-hour zones miss.

Tests floor known UTC instants through the framework and assert the result is UTC-based regardless of the preset zone:

- Day floor of `2023-01-01 02:00:00+00` -> `2023-01-01 00:00:00+00` (would leak to the previous day under either non-UTC zone).
- Hour floor of `2023-01-01 06:42:00+00` -> `2023-01-01 06:00:00+00` (Kolkata's +5:30 would land it at `06:30:00+00`, so the fractional offset genuinely discriminates at sub-day granularity).
- The column is asserted to be `TIMESTAMP WITH TIME ZONE`, and the array is built from a naive UTC datetime to stay portable across the PyArrow versions in the 3.10-3.14 matrix.

## Validation

- `tox` passes locally: full suite (3467 passed, 159 skipped), ruff format/check, license allowlist, `mypy --strict`, bandit.
- Two independent deep reviews (Claude Opus + codex) gated the change; their findings (connection adoption ordering, PyArrow tz-aware construction, fractional-offset coverage, column-type hardening) are folded in.