### PR TITLE
test: extract reusable run_all policy-conformance base (#521)

### DIFF
--- a/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_allow_empty_result_run_all.py
+++ b/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_allow_empty_result_run_all.py
@@ -8,6 +8,8 @@ from typing import Any, Optional
 
 import pytest
 
+from mloda.user import ParallelizationMode
+
 from tests.test_plugins.compute_framework.test_tooling.empty_result_run_all_test_base import (
     EmptyResultRunAllTestBase,
 )
@@ -43,3 +45,13 @@ class TestDuckDBAllowEmptyResultRunAll(EmptyResultRunAllTestBase):
         """Close the DuckDB connection opened by get_connection, if any."""
         if hasattr(self, "_connection"):
             self._connection.close()
+
+    @pytest.mark.parametrize("mode", [ParallelizationMode.SYNC])
+    def test_empty_result_default(self, mode: ParallelizationMode, flight_server: Any) -> None:
+        """DuckDBFramework only supports SYNC; run the inherited default case SYNC only."""
+        self._run_default_case(mode, flight_server)
+
+    @pytest.mark.parametrize("mode", [ParallelizationMode.SYNC])
+    def test_empty_result_allowed_succeeds(self, mode: ParallelizationMode, flight_server: Any) -> None:
+        """DuckDBFramework only supports SYNC; run the inherited allowed case SYNC only."""
+        self._run_allowed_case(mode, flight_server)

--- a/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_allow_empty_result_run_all.py
+++ b/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_allow_empty_result_run_all.py
@@ -25,8 +25,8 @@ from tests.test_plugins.compute_framework.test_tooling.empty_result_run_all_test
     _ENABLED_DEFAULT,
     EmptyResultRunAllTestBase,
     _EmptyResultMatchData,
-    _records_from_frame,
 )
+from tests.test_plugins.compute_framework.test_tooling.policy_run_all_test_base import records_from_frame
 
 
 class TestPythonDictAllowEmptyResultRunAll(EmptyResultRunAllTestBase):
@@ -68,7 +68,7 @@ def test_empty_result_allowed_succeeds_multiprocessing(flight_server: Any) -> No
     ``allow_empty_result()`` True succeeds) but runs with
     ``ParallelizationMode.MULTIPROCESSING``: the zero-row result must round-trip
     through the flight server upload from the process worker and come back as one
-    result with zero rows. ``_records_from_frame`` keeps the row-count assertion
+    result with zero rows. ``records_from_frame`` keeps the row-count assertion
     tolerant of the wire format (PyArrow table or list of row dicts).
     """
     result = mloda.run_all(
@@ -80,7 +80,7 @@ def test_empty_result_allowed_succeeds_multiprocessing(flight_server: Any) -> No
     )
 
     assert len(result) == 1
-    assert len(_records_from_frame(result[0])) == 0
+    assert len(records_from_frame(result[0])) == 0
 
 
 class EmptyResultNoneAllowedFeatureGroup(FeatureGroup, _EmptyResultMatchData):

--- a/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_allow_empty_result_run_all.py
+++ b/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_allow_empty_result_run_all.py
@@ -10,6 +10,8 @@ from typing import Any, Optional
 
 import pytest
 
+from mloda.user import ParallelizationMode
+
 from tests.test_plugins.compute_framework.test_tooling.empty_result_run_all_test_base import (
     EmptyResultRunAllTestBase,
 )
@@ -43,3 +45,13 @@ class TestSqliteAllowEmptyResultRunAll(EmptyResultRunAllTestBase):
         """Close the sqlite3 connection opened by get_connection, if any."""
         if hasattr(self, "_connection"):
             self._connection.close()
+
+    @pytest.mark.parametrize("mode", [ParallelizationMode.SYNC])
+    def test_empty_result_default(self, mode: ParallelizationMode, flight_server: Any) -> None:
+        """SqliteFramework only supports SYNC; run the inherited default case SYNC only."""
+        self._run_default_case(mode, flight_server)
+
+    @pytest.mark.parametrize("mode", [ParallelizationMode.SYNC])
+    def test_empty_result_allowed_succeeds(self, mode: ParallelizationMode, flight_server: Any) -> None:
+        """SqliteFramework only supports SYNC; run the inherited allowed case SYNC only."""
+        self._run_allowed_case(mode, flight_server)

--- a/tests/test_plugins/compute_framework/test_tooling/POLICY_CONFORMANCE.md
+++ b/tests/test_plugins/compute_framework/test_tooling/POLICY_CONFORMANCE.md
@@ -1,0 +1,28 @@
+# Policy conformance is mandatory
+
+Every new FeatureGroup-level policy flag (anything in the spirit of
+`allow_empty_result()`: a class method on `FeatureGroup` that changes how the pipeline
+treats a result) MUST ship a `run_all`-driven conformance suite.
+
+## What "conformance suite" means
+
+Build it on `PolicyRunAllTestBase` (see `policy_run_all_test_base.py`). The suite must:
+
+- exercise the flag END-TO-END through `mloda.run_all`, not in isolation;
+- cover ALL built-in compute frameworks (PyArrow, Pandas, Polars, DuckDB, SQLite,
+  PythonDict, Spark, Iceberg) via per-framework subclasses;
+- cover at least SYNC plus one worker-based parallelization mode (e.g. THREADING);
+- express each case as a `PolicySuccess` or `PolicyRaises` expectation.
+
+## Template
+
+- `policy_run_all_test_base.py` is the generic base.
+- `empty_result_run_all_test_base.py` is the canonical first consumer; copy its shape.
+
+## Why this bar exists
+
+`allow_empty_result()` had THREE enforcement surfaces. The third one, in
+`DataLifecycleManager.get_result_data`, shipped broken. Unit tests against the first two
+surfaces all passed. The defect was only caught because the full pipeline runs for every
+framework and every parallelization mode through `run_all`. A policy flag that is not
+driven through the whole pipeline, on every framework, is not actually verified.

--- a/tests/test_plugins/compute_framework/test_tooling/empty_result_run_all_test_base.py
+++ b/tests/test_plugins/compute_framework/test_tooling/empty_result_run_all_test_base.py
@@ -1,6 +1,7 @@
 """
 Shared base for the FeatureGroup-declared ``allow_empty_result`` policy, driven
-end-to-end through the public API ``mloda.run_all``.
+end-to-end through the public API ``mloda.run_all``. It is the canonical first consumer
+of the generic ``PolicyRunAllTestBase``.
 
 A feature computation must return a SCHEMA-BEARING result: at least one column. Rows are
 optional. The guard in ``ComputeFramework.run_validate_output_features`` fires only for
@@ -34,7 +35,6 @@ FeatureGroup.
 This module is intentionally NOT collected as tests (no ``Test`` prefix).
 """
 
-from abc import ABC, abstractmethod
 from typing import Any, Optional
 
 import pytest
@@ -46,51 +46,16 @@ from mloda.provider import FeatureGroup
 from mloda.provider import FeatureSet
 from mloda.provider import MatchData
 from mloda.user import DataAccessCollection
-from mloda.user import Feature
 from mloda.user import Options
 from mloda.user import ParallelizationMode
 from mloda.user import PluginCollector
-from mloda.user import mloda
 
-import logging
-
-logger = logging.getLogger(__name__)
-
-try:
-    import polars as pl
-except ImportError:
-    logger.warning("Polars is not installed. Some tests will be skipped.")
-    pl = None  # type: ignore[assignment]
-
-try:
-    import pyarrow as pa
-except ImportError:
-    logger.warning("PyArrow is not installed. Some tests will be skipped.")
-    pa = None  # type: ignore[assignment]
-
-
-def _records_from_frame(data: Any) -> list[dict[str, Any]]:
-    """Extract native frame rows to plain Python row dicts across backends.
-
-    Mirrors ``AsofRunAllTestBase._records_from_frame`` so the empty-result assertion is
-    framework-agnostic: a zero-row result is simply ``len(_records_from_frame(result)) == 0``.
-    """
-    records: list[dict[str, Any]]
-    if pl is not None and isinstance(data, pl.LazyFrame):
-        records = data.collect().to_dicts()
-    elif pl is not None and isinstance(data, pl.DataFrame):
-        records = data.to_dicts()
-    elif pa is not None and isinstance(data, pa.Table):
-        records = data.to_pylist()
-    elif isinstance(data, list):
-        records = data
-    elif hasattr(data, "to_dicts"):
-        records = data.to_dicts()
-    elif hasattr(data, "to_dict"):
-        records = data.to_dict("records")
-    else:
-        records = data.df().to_dict("records")
-    return records
+from tests.test_plugins.compute_framework.test_tooling.policy_run_all_test_base import (
+    PolicyRaises,
+    PolicyRunAllTestBase,
+    PolicySuccess,
+    records_from_frame,
+)
 
 
 class _EmptyResultMatchData(MatchData):
@@ -216,7 +181,13 @@ _ENABLED_SCHEMALESS_ALLOWED = PluginCollector.enabled_feature_groups({EmptyResul
 _ENABLED_NONE = PluginCollector.enabled_feature_groups({EmptyResultNoneFeatureGroup})
 
 
-class EmptyResultRunAllTestBase(ABC):
+def _assert_single_empty_result(result: list[Any]) -> None:
+    """A run_all result that is exactly one schema-bearing frame with zero rows."""
+    assert len(result) == 1
+    assert len(records_from_frame(result[0])) == 0
+
+
+class EmptyResultRunAllTestBase(PolicyRunAllTestBase):
     """Drives the ``allow_empty_result`` policy end-to-end through ``run_all``.
 
     Subclasses implement ``compute_framework_name`` and, for connection-backed frameworks,
@@ -224,10 +195,8 @@ class EmptyResultRunAllTestBase(ABC):
     """
 
     @classmethod
-    @abstractmethod
-    def compute_framework_name(cls) -> str:
-        """Return the compute framework name string for ``compute_frameworks=[...]``."""
-        pass
+    def connection_keyed_feature_groups(cls) -> set[type[FeatureGroup]]:
+        return {EmptyResultDefaultFeatureGroup, EmptyResultAllowedFeatureGroup}
 
     @classmethod
     def default_empty_is_schemaless(cls) -> bool:
@@ -239,71 +208,40 @@ class EmptyResultRunAllTestBase(ABC):
         """
         return False
 
-    def get_connection(self) -> Optional[Any]:
-        """Return a framework connection object, or None when none is needed."""
-        return None
+    def _run_default_case(self, mode: ParallelizationMode, flight_server: Any) -> None:
+        if self.default_empty_is_schemaless():
+            expectation: PolicySuccess | PolicyRaises = PolicyRaises(match_substring=EmptyResultError.__name__)
+        else:
+            expectation = PolicySuccess(assert_result=_assert_single_empty_result)
 
-    def _feature_and_dac(self, feature_name: str) -> tuple[Feature, Optional[DataAccessCollection]]:
-        conn = self.get_connection()
-        if conn is not None:
-            feature = Feature(
-                name=feature_name,
-                options={
-                    EmptyResultDefaultFeatureGroup.get_class_name(): conn,
-                    EmptyResultAllowedFeatureGroup.get_class_name(): conn,
-                },
-            )
-            return feature, DataAccessCollection(connections={conn})
-        return Feature(name=feature_name), None
+        self.assert_policy_case(
+            feature_name="empty_result_default_col",
+            plugin_collector=_ENABLED_DEFAULT,
+            expectation=expectation,
+            mode=mode,
+            flight_server=flight_server,
+        )
 
-    def test_empty_result_default(self, flight_server: Any) -> None:
+    def _run_allowed_case(self, mode: ParallelizationMode, flight_server: Any) -> None:
+        self.assert_policy_case(
+            feature_name="empty_result_allowed_col",
+            plugin_collector=_ENABLED_ALLOWED,
+            expectation=PolicySuccess(assert_result=_assert_single_empty_result),
+            mode=mode,
+            flight_server=flight_server,
+        )
+
+    @pytest.mark.parametrize("mode", [ParallelizationMode.SYNC, ParallelizationMode.THREADING])
+    def test_empty_result_default(self, mode: ParallelizationMode, flight_server: Any) -> None:
         """Default (not-allowed) FG requested as a final feature.
 
         Schema-bearing frameworks return a schema-bearing zero-row result (state C) and
         SUCCEED. python_dict drops the schema (state B) and raises ``EmptyResultError``.
+        SYNC-only frameworks (DuckDB / SQLite) override these methods to run SYNC only.
         """
-        feature, dac = self._feature_and_dac("empty_result_default_col")
+        self._run_default_case(mode, flight_server)
 
-        if self.default_empty_is_schemaless():
-            # run_all wraps the framework-raised EmptyResultError in a plain Exception, so we
-            # assert on the type NAME surfaced in the wrapped message (stable across the
-            # green-phase message change) rather than the exception class or its text.
-            with pytest.raises(Exception) as excinfo:
-                mloda.run_all(
-                    [feature],
-                    compute_frameworks=[self.compute_framework_name()],
-                    plugin_collector=_ENABLED_DEFAULT,
-                    parallelization_modes={ParallelizationMode.SYNC},
-                    flight_server=flight_server,
-                    data_access_collection=dac,
-                )
-            assert EmptyResultError.__name__ in str(excinfo.value)
-            return
-
-        result = mloda.run_all(
-            [feature],
-            compute_frameworks=[self.compute_framework_name()],
-            plugin_collector=_ENABLED_DEFAULT,
-            parallelization_modes={ParallelizationMode.SYNC},
-            flight_server=flight_server,
-            data_access_collection=dac,
-        )
-
-        assert len(result) == 1
-        assert len(_records_from_frame(result[0])) == 0
-
-    def test_empty_result_allowed_succeeds(self, flight_server: Any) -> None:
+    @pytest.mark.parametrize("mode", [ParallelizationMode.SYNC, ParallelizationMode.THREADING])
+    def test_empty_result_allowed_succeeds(self, mode: ParallelizationMode, flight_server: Any) -> None:
         """A FeatureGroup that overrides allow_empty_result()->True succeeds with an empty result."""
-        feature, dac = self._feature_and_dac("empty_result_allowed_col")
-
-        result = mloda.run_all(
-            [feature],
-            compute_frameworks=[self.compute_framework_name()],
-            plugin_collector=_ENABLED_ALLOWED,
-            parallelization_modes={ParallelizationMode.SYNC},
-            flight_server=flight_server,
-            data_access_collection=dac,
-        )
-
-        assert len(result) == 1
-        assert len(_records_from_frame(result[0])) == 0
+        self._run_allowed_case(mode, flight_server)

--- a/tests/test_plugins/compute_framework/test_tooling/policy_run_all_test_base.py
+++ b/tests/test_plugins/compute_framework/test_tooling/policy_run_all_test_base.py
@@ -1,0 +1,148 @@
+"""Generic policy-conformance tooling for FeatureGroup-level policy flags.
+
+Drives any FeatureGroup-declared policy flag (such as ``allow_empty_result()``) end-to-end
+through the public API ``mloda.run_all``, across every built-in compute framework and at
+least one worker-based parallelization mode. A policy case is expressed as an expectation:
+either ``PolicySuccess`` (run_all returns results that satisfy an assertion) or
+``PolicyRaises`` (run_all raises an Exception whose message contains a substring).
+
+This module is intentionally NOT collected as tests (no ``Test`` prefix). It is the shared
+base that concrete per-framework conformance suites build on.
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Callable, Optional
+
+import pytest
+
+from mloda.provider import FeatureGroup
+from mloda.user import DataAccessCollection
+from mloda.user import Feature
+from mloda.user import ParallelizationMode
+from mloda.user import PluginCollector
+from mloda.user import mloda
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+try:
+    import polars as pl
+except ImportError:
+    logger.warning("Polars is not installed. Some tests will be skipped.")
+    pl = None  # type: ignore[assignment]
+
+try:
+    import pyarrow as pa
+except ImportError:
+    logger.warning("PyArrow is not installed. Some tests will be skipped.")
+    pa = None  # type: ignore[assignment]
+
+
+def records_from_frame(data: Any) -> list[dict[str, Any]]:
+    """Extract native frame rows to plain Python row dicts across backends.
+
+    Framework-agnostic: a zero-row result is simply ``len(records_from_frame(result)) == 0``.
+    """
+    records: list[dict[str, Any]]
+    if pl is not None and isinstance(data, pl.LazyFrame):
+        records = data.collect().to_dicts()
+    elif pl is not None and isinstance(data, pl.DataFrame):
+        records = data.to_dicts()
+    elif pa is not None and isinstance(data, pa.Table):
+        records = data.to_pylist()
+    elif isinstance(data, list):
+        records = data
+    elif hasattr(data, "to_dicts"):
+        records = data.to_dicts()
+    elif hasattr(data, "to_dict"):
+        records = data.to_dict("records")
+    else:
+        records = data.df().to_dict("records")
+    return records
+
+
+@dataclass(frozen=True)
+class PolicySuccess:
+    """run_all returns results; ``assert_result`` is called on them."""
+
+    assert_result: Callable[[list[Any]], None]
+
+
+@dataclass(frozen=True)
+class PolicyRaises:
+    """run_all raises an Exception whose ``str()`` contains ``match_substring``."""
+
+    match_substring: str
+
+
+PolicyExpectation = PolicySuccess | PolicyRaises
+
+
+class PolicyRunAllTestBase(ABC):
+    """Drives a FeatureGroup-level policy end-to-end through ``run_all``.
+
+    Subclasses implement ``compute_framework_name`` and, for connection-backed frameworks,
+    ``get_connection`` plus ``connection_keyed_feature_groups``.
+    """
+
+    @classmethod
+    @abstractmethod
+    def compute_framework_name(cls) -> str:
+        """Return the compute framework name string for ``compute_frameworks=[...]``."""
+        pass
+
+    def get_connection(self) -> Optional[Any]:
+        """Return a framework connection object, or None when none is needed."""
+        return None
+
+    @classmethod
+    def connection_keyed_feature_groups(cls) -> set[type[FeatureGroup]]:
+        """FeatureGroup classes whose ``get_class_name()`` keys the connection in options."""
+        return set()
+
+    def _feature_and_dac(self, feature_name: str) -> tuple[Feature, Optional[DataAccessCollection]]:
+        conn = self.get_connection()
+        if conn is not None:
+            feature = Feature(
+                name=feature_name,
+                options={fg.get_class_name(): conn for fg in self.connection_keyed_feature_groups()},
+            )
+            return feature, DataAccessCollection(connections={conn})
+        return Feature(name=feature_name), None
+
+    def assert_policy_case(
+        self,
+        *,
+        feature_name: str,
+        plugin_collector: PluginCollector,
+        expectation: PolicyExpectation,
+        mode: ParallelizationMode,
+        flight_server: Any,
+    ) -> Optional[list[Any]]:
+        feature, dac = self._feature_and_dac(feature_name)
+
+        if isinstance(expectation, PolicyRaises):
+            with pytest.raises(Exception) as excinfo:
+                mloda.run_all(
+                    [feature],
+                    compute_frameworks=[self.compute_framework_name()],
+                    plugin_collector=plugin_collector,
+                    parallelization_modes={mode},
+                    flight_server=flight_server,
+                    data_access_collection=dac,
+                )
+            assert expectation.match_substring in str(excinfo.value)
+            return None
+
+        result = mloda.run_all(
+            [feature],
+            compute_frameworks=[self.compute_framework_name()],
+            plugin_collector=plugin_collector,
+            parallelization_modes={mode},
+            flight_server=flight_server,
+            data_access_collection=dac,
+        )
+        expectation.assert_result(result)
+        return result

--- a/tests/test_plugins/compute_framework/test_tooling/test_policy_run_all_test_base.py
+++ b/tests/test_plugins/compute_framework/test_tooling/test_policy_run_all_test_base.py
@@ -1,0 +1,84 @@
+"""Contract tests for the generic ``PolicyRunAllTestBase`` (issue #521).
+
+Pins the public API of the generic policy run_all base directly, independently of the
+``allow_empty_result`` consumer: the base must drive any FeatureGroup-level policy flag
+end-to-end through ``mloda.run_all``. These tests reuse the existing empty-result fixtures
+and exercise both the success and raises expectations, in SYNC and in a worker-based
+(THREADING) parallelization mode.
+"""
+
+from typing import Any
+
+from mloda.core.abstract_plugins.compute_framework import EmptyResultError
+from mloda.user import ParallelizationMode
+
+from tests.test_plugins.compute_framework.test_tooling.empty_result_run_all_test_base import (
+    _ENABLED_ALLOWED,
+    _ENABLED_DEFAULT,
+)
+from tests.test_plugins.compute_framework.test_tooling.policy_run_all_test_base import (
+    PolicyRaises,
+    PolicyRunAllTestBase,
+    PolicySuccess,
+    records_from_frame,
+)
+
+
+class _PythonDictPolicyConformance(PolicyRunAllTestBase):
+    """Concrete subclass for python_dict; no ``Test`` prefix so pytest does not collect it."""
+
+    @classmethod
+    def compute_framework_name(cls) -> str:
+        return "PythonDictFramework"
+
+
+def _assert_single_empty(result: list[Any]) -> None:
+    assert len(result) == 1
+    assert len(records_from_frame(result[0])) == 0
+
+
+def test_policy_base_drives_success_case(flight_server: Any) -> None:
+    """A policy success expectation returns a schema-bearing zero-row result."""
+    conformance = _PythonDictPolicyConformance()
+
+    result = conformance.assert_policy_case(
+        feature_name="empty_result_allowed_col",
+        plugin_collector=_ENABLED_ALLOWED,
+        expectation=PolicySuccess(assert_result=_assert_single_empty),
+        mode=ParallelizationMode.SYNC,
+        flight_server=flight_server,
+    )
+
+    assert result is not None
+    _assert_single_empty(result)
+
+
+def test_policy_base_drives_raises_case(flight_server: Any) -> None:
+    """A policy raises expectation: python_dict default empty result is schema-less and raises."""
+    conformance = _PythonDictPolicyConformance()
+
+    result = conformance.assert_policy_case(
+        feature_name="empty_result_default_col",
+        plugin_collector=_ENABLED_DEFAULT,
+        expectation=PolicyRaises(match_substring=EmptyResultError.__name__),
+        mode=ParallelizationMode.SYNC,
+        flight_server=flight_server,
+    )
+
+    assert result is None
+
+
+def test_policy_base_drives_worker_mode(flight_server: Any) -> None:
+    """The same success case under THREADING proves the worker-based path is covered."""
+    conformance = _PythonDictPolicyConformance()
+
+    result = conformance.assert_policy_case(
+        feature_name="empty_result_allowed_col",
+        plugin_collector=_ENABLED_ALLOWED,
+        expectation=PolicySuccess(assert_result=_assert_single_empty),
+        mode=ParallelizationMode.THREADING,
+        flight_server=flight_server,
+    )
+
+    assert result is not None
+    _assert_single_empty(result)

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ setenv =
     PYTHONWARNINGS=ignore::UserWarning:piplicenses.spdx
     WRITE_THIRD_PARTY_LICENSES={env:TOX_WRITE_THIRD_PARTY_LICENSES:false}
     SKIP_POLARS_INSTALLATION_TEST={env:SKIP_POLARS_INSTALLATION_TEST:false}
-    EXPECTED_SKIP_COUNT = {env:EXPECTED_SKIP_COUNT:163}
+    EXPECTED_SKIP_COUNT = {env:EXPECTED_SKIP_COUNT:165}
     CHECK_SKIP_COUNT = {env:CHECK_SKIP_COUNT:1}
     TOX_LOCK_PATH = {env:TOX_LOCK_PATH:/tmp/mloda-tox.lock}
 commands = sh -c "set -- pytest -n {env:PYTEST_WORKERS:8} --timeout=10 -m 'not notebooks' {env:DEACTIVATE_NOTEBOOK_AND_DOC_TESTS:--ignore=tests/test_documentation}; if [ -n \"$TOX_LOCK_PATH\" ] && command -v flock >/dev/null 2>&1; then [ -e \"$TOX_LOCK_PATH\" ] || (umask 0 && : > \"$TOX_LOCK_PATH\") 2>/dev/null; if [ -w \"$TOX_LOCK_PATH\" ]; then exec flock \"$TOX_LOCK_PATH\" \"$@\"; fi; fi; exec \"$@\""


### PR DESCRIPTION
## Summary

Closes #521. FeatureGroup-level policy flags (the existing `allow_empty_result()`) had no single enforcement surface, and the only thing that caught a broken enforcement site was an end-to-end, `run_all`-driven test base. This extracts that pattern into generic, reusable test tooling so any future policy flag gets cheap conformance coverage.

## What changed

- **New `policy_run_all_test_base.py`** (shared test tooling): a generic `PolicyRunAllTestBase` that drives any FeatureGroup-level policy end-to-end through `mloda.run_all`. A case is expressed as a `PolicySuccess` (returns results, runs an assertion) or `PolicyRaises` (raises with a message substring) expectation. Handles connection threading via `connection_keyed_feature_groups()` and a single `assert_policy_case(...)` driver. The framework-agnostic `records_from_frame` helper lives here.
- **`empty_result_run_all_test_base.py`** is now the first consumer: it subclasses `PolicyRunAllTestBase` and parametrizes both policy cases over SYNC plus the worker-based THREADING mode.
- **DuckDB / SQLite subclasses** run SYNC only, because those frameworks declare `supported_parallelization_modes() == {SYNC}` (matching the existing asof-base precedent). All other built-in frameworks exercise SYNC and THREADING.
- **`POLICY_CONFORMANCE.md`**: a maintainer note requiring a `run_all`-driven conformance suite, on this base, for every new FeatureGroup-level policy flag.
- **`tox.ini`**: `EXPECTED_SKIP_COUNT` 163 -> 165 for the two added skipped Spark instances (Spark is class-skipped; its two methods become four under the SYNC + THREADING parametrization).

## Definition of done

- [x] A reusable `run_all`-driven conformance base exists in shared test tooling and `EmptyResultRunAllTestBase` consumes it.
- [x] Tooling covers all built-in compute frameworks and at least SYNC plus one worker-based parallelization mode (THREADING).
- [x] A maintainer-visible note documents that new FeatureGroup-level policy flags require a conformance suite based on it.

## Validation

Full `tox` is green (`pytest -n 2`, ruff format + check, license allowlist, `mypy --strict`, bandit): `3540 passed, 165 skipped`, skip-count gate enabled.