### PR TITLE
feat: clear error for non-ordered as-of time columns across merge engines

### DIFF
--- a/docs/docs/in_depth/join_data.md
+++ b/docs/docs/in_depth/join_data.md
@@ -93,6 +93,10 @@ Cross-backend caveats to be aware of:
     by-keys/time columns, `pandas`/`pyarrow` keep both with `_x`/`_y` suffixes, whereas the
     SQL/`polars`/`python_dict` backends keep the left column and drop the right one. Rename
     conflicting columns upstream if you need both.
+-   **Time-column dtype.** As-of time columns must be ordered (datetime, numeric, or timedelta). A
+    non-ordered column (e.g. ISO-date strings / object dtype) raises a clear `ValueError` naming the
+    column; cast it to a real datetime or numeric before joining. This is enforced uniformly across
+    all backends inside the merge engine at run time.
 -   **Ties.** When two right rows share the identical boundary timestamp within a by-key, the chosen
     row is backend-defined (each engine applies its own internal tie rule). `python_dict`,
     `sqlite`, and `spark` resolve ties deterministically (smallest surviving right column values

--- a/mloda/core/abstract_plugins/components/merge/base_merge_engine.py
+++ b/mloda/core/abstract_plugins/components/merge/base_merge_engine.py
@@ -66,6 +66,33 @@ class BaseMergeEngine(ABC):
     ) -> Any:
         raise ValueError(f"JoinType asof is not yet implemented in {self.__class__.__name__}")
 
+    def validate_asof_time_columns(self, left_data: Any, right_data: Any, asof_config: AsOfJoinConfig) -> None:
+        """Guard that as-of time columns are ordered (datetime / numeric / timedelta).
+
+        Raises a clear ValueError naming the offending column instead of letting the
+        backend surface a cryptic low-level dtype error. This is the seam that opt-in
+        coercion (issue #513) will build on.
+        """
+        for data, column, side in (
+            (left_data, asof_config.left_time_column, "left"),
+            (right_data, asof_config.right_time_column, "right"),
+        ):
+            if not self._asof_time_column_is_ordered(data, column):
+                raise ValueError(
+                    f"As-of {side} time column '{column}' must be datetime, numeric, or timedelta, "
+                    f"but is a non-ordered (e.g. string/object) dtype; cast it before joining."
+                )
+
+    def _asof_time_column_is_ordered(self, data: Any, column: str) -> bool:
+        """Return True if `column` in `data` has an ordered (datetime/numeric/timedelta) dtype.
+
+        Overridden per engine with framework-native dtype detection. Default raises so an
+        asof-capable engine cannot silently skip the guard.
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__} must implement _asof_time_column_is_ordered for as-of joins."
+        )
+
     @final
     def merge(self, left_data: Any, right_data: Any, link: Link) -> Any:
         self.check_import()

--- a/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_merge_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_merge_engine.py
@@ -91,21 +91,10 @@ class DuckDBMergeEngine(SqlBaseMergeEngine):
 
     def _asof_time_column_is_ordered(self, data: Any, column: str) -> bool:
         idx = data.columns.index(column)
-        dtype_str = str(data.types[idx]).upper()
-        ordered = (
-            "INT",
-            "DECIMAL",
-            "DOUBLE",
-            "FLOAT",
-            "REAL",
-            "NUMERIC",
-            "HUGEINT",
-            "DATE",
-            "TIME",
-            "TIMESTAMP",
-            "INTERVAL",
-        )
-        return any(k in dtype_str for k in ordered)
+        t = data.types[idx]
+        dtype_id = getattr(t, "id", str(t)).lower()
+        ordered = ("int", "decimal", "float", "double", "real", "numeric", "date", "time", "interval")
+        return any(k in dtype_id for k in ordered)
 
     def _set_alias(self, data: Any, alias: str) -> Any:
         return data.set_alias(alias)

--- a/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_merge_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_merge_engine.py
@@ -37,6 +37,7 @@ class DuckDBMergeEngine(SqlBaseMergeEngine):
         right_index: Index,
         asof_config: AsOfJoinConfig,
     ) -> Any:
+        self.validate_asof_time_columns(left_data, right_data, asof_config)
         if self.framework_connection is None:
             raise ValueError("Framework connection not set. SQL merge engine requires a connection from the framework.")
         if asof_config.direction == "nearest":
@@ -87,6 +88,24 @@ class DuckDBMergeEngine(SqlBaseMergeEngine):
         final_proj += [f"{quote_ident(rmap[c])} AS {quote_ident(c)}" for c in right_extra]
         result = picked.project(", ".join(final_proj))
         return DuckdbRelation(self.framework_connection, result)
+
+    def _asof_time_column_is_ordered(self, data: Any, column: str) -> bool:
+        idx = data.columns.index(column)
+        dtype_str = str(data.types[idx]).upper()
+        ordered = (
+            "INT",
+            "DECIMAL",
+            "DOUBLE",
+            "FLOAT",
+            "REAL",
+            "NUMERIC",
+            "HUGEINT",
+            "DATE",
+            "TIME",
+            "TIMESTAMP",
+            "INTERVAL",
+        )
+        return any(k in dtype_str for k in ordered)
 
     def _set_alias(self, data: Any, alias: str) -> Any:
         return data.set_alias(alias)

--- a/mloda_plugins/compute_framework/base_implementations/pandas/pandas_merge_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/pandas/pandas_merge_engine.py
@@ -7,8 +7,10 @@ from mloda.provider import BaseMergeEngine
 
 try:
     import pandas as pd
+    import pandas.api.types as pdt
 except ImportError:
     pd = None
+    pdt = None
 
 
 class PandasMergeEngine(BaseMergeEngine):
@@ -43,6 +45,7 @@ class PandasMergeEngine(BaseMergeEngine):
         right_index: Index,
         asof_config: AsOfJoinConfig,
     ) -> Any:
+        self.validate_asof_time_columns(left_data, right_data, asof_config)
         by_left = list(left_index.index)
         by_right = list(right_index.index)
         lt, rt = asof_config.left_time_column, asof_config.right_time_column
@@ -62,6 +65,12 @@ class PandasMergeEngine(BaseMergeEngine):
             left_by=by_left,
             right_by=by_right,
             **kwargs,
+        )
+
+    def _asof_time_column_is_ordered(self, data: Any, column: str) -> bool:
+        dtype = data[column].dtype
+        return bool(
+            pdt.is_numeric_dtype(dtype) or pdt.is_datetime64_any_dtype(dtype) or pdt.is_timedelta64_dtype(dtype)
         )
 
     def join_logic(

--- a/mloda_plugins/compute_framework/base_implementations/pandas/pandas_merge_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/pandas/pandas_merge_engine.py
@@ -70,7 +70,8 @@ class PandasMergeEngine(BaseMergeEngine):
     def _asof_time_column_is_ordered(self, data: Any, column: str) -> bool:
         dtype = data[column].dtype
         return bool(
-            pdt.is_numeric_dtype(dtype) or pdt.is_datetime64_any_dtype(dtype) or pdt.is_timedelta64_dtype(dtype)
+            (pdt.is_numeric_dtype(dtype) or pdt.is_datetime64_any_dtype(dtype) or pdt.is_timedelta64_dtype(dtype))
+            and not pdt.is_bool_dtype(dtype)
         )
 
     def join_logic(

--- a/mloda_plugins/compute_framework/base_implementations/polars/polars_merge_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/polars/polars_merge_engine.py
@@ -43,6 +43,7 @@ class PolarsMergeEngine(BaseMergeEngine):
         right_index: Index,
         asof_config: AsOfJoinConfig,
     ) -> Any:
+        self.validate_asof_time_columns(left_data, right_data, asof_config)
         by_left = list(left_index.index)
         by_right = list(right_index.index)
         lt, rt = asof_config.left_time_column, asof_config.right_time_column
@@ -75,6 +76,10 @@ class PolarsMergeEngine(BaseMergeEngine):
         present = self.get_column_names(result)
         result = result.select([c for c in desired if c in present])
         return result
+
+    def _asof_time_column_is_ordered(self, data: Any, column: str) -> bool:
+        dtype = data.collect_schema()[column]
+        return bool(dtype.is_numeric() or dtype.is_temporal())
 
     def get_column_names(self, data: Any) -> list[str]:
         """Get column names from data. Override in subclasses for different data types."""

--- a/mloda_plugins/compute_framework/base_implementations/pyarrow/pyarrow_merge_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/pyarrow/pyarrow_merge_engine.py
@@ -7,7 +7,10 @@ from mloda.core.abstract_plugins.components.link import AsOfJoinConfig
 from mloda.user import Index
 from mloda.user import JoinType
 from mloda.provider import BaseMergeEngine
-from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import pick_helper_column_name
+from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import (
+    is_ordered_arrow_type,
+    pick_helper_column_name,
+)
 
 
 class PyArrowMergeEngine(BaseMergeEngine):
@@ -79,6 +82,7 @@ class PyArrowMergeEngine(BaseMergeEngine):
         right_index: Index,
         asof_config: AsOfJoinConfig,
     ) -> Any:
+        self.validate_asof_time_columns(left_data, right_data, asof_config)
         if asof_config.direction == "nearest":
             raise ValueError(f"{self.__class__.__name__} asof does not support direction='nearest'.")
 
@@ -150,6 +154,10 @@ class PyArrowMergeEngine(BaseMergeEngine):
             result = result.rename_columns(new_names)
 
         return result
+
+    def _asof_time_column_is_ordered(self, data: Any, column: str) -> bool:
+        t = data.schema.field(column).type
+        return is_ordered_arrow_type(t)
 
     def join_logic(
         self, join_type: str, left_data: Any, right_data: Any, left_index: Index, right_index: Index, jointype: JoinType

--- a/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_merge_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_merge_engine.py
@@ -86,7 +86,8 @@ class PythonDictMergeEngine(BaseMergeEngine):
             v = row.get(column)
             if v is None:
                 continue
-            return isinstance(v, (int, float, datetime, date, timedelta)) and not isinstance(v, bool)
+            if isinstance(v, bool) or not isinstance(v, (int, float, datetime, date, timedelta)):
+                return False
         return True
 
     @staticmethod

--- a/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_merge_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_merge_engine.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import date, datetime, timedelta
 from typing import Any
 from mloda.core.abstract_plugins.components.link import AsOfJoinConfig
 from mloda.provider import BaseMergeEngine
@@ -45,6 +45,7 @@ class PythonDictMergeEngine(BaseMergeEngine):
         right_index: Index,
         asof_config: AsOfJoinConfig,
     ) -> Any:
+        self.validate_asof_time_columns(left_data, right_data, asof_config)
         left_by = list(left_index.index)
         right_by = list(right_index.index)
         lt, rt = asof_config.left_time_column, asof_config.right_time_column
@@ -79,6 +80,14 @@ class PythonDictMergeEngine(BaseMergeEngine):
             result.append(merged)
 
         return result
+
+    def _asof_time_column_is_ordered(self, data: Any, column: str) -> bool:
+        for row in data:
+            v = row.get(column)
+            if v is None:
+                continue
+            return isinstance(v, (int, float, datetime, date, timedelta)) and not isinstance(v, bool)
+        return True
 
     @staticmethod
     def _select_asof_match(

--- a/mloda_plugins/compute_framework/base_implementations/spark/spark_merge_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/spark/spark_merge_engine.py
@@ -53,6 +53,7 @@ class SparkMergeEngine(BaseMergeEngine):
                 f"{self.__class__.__name__} ASOF does not support a timedelta tolerance; provide a numeric "
                 "tolerance (e.g. epoch seconds matching the time column)."
             )
+        self.validate_asof_time_columns(left_data, right_data, asof_config)
         self.check_import()
         if asof_config.direction == "nearest":
             raise ValueError("SparkMergeEngine asof does not support direction='nearest'.")
@@ -112,6 +113,24 @@ class SparkMergeEngine(BaseMergeEngine):
         select_list = [F.col(c) for c in left_cols]
         select_list += [F.col(f"{prefix}{c}").alias(c) for c in right_keep]
         return ranked.select(*select_list)
+
+    def _asof_time_column_is_ordered(self, data: Any, column: str) -> bool:
+        dtype = dict(data.dtypes)[column]
+        ordered_prefixes = (
+            "tinyint",
+            "smallint",
+            "int",
+            "bigint",
+            "long",
+            "short",
+            "float",
+            "double",
+            "decimal",
+            "timestamp",
+            "date",
+            "interval",
+        )
+        return any(dtype.startswith(p) for p in ordered_prefixes)
 
     def _join_logic(
         self, join_type: str, left_data: Any, right_data: Any, left_index: Index, right_index: Index

--- a/mloda_plugins/compute_framework/base_implementations/spark/spark_merge_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/spark/spark_merge_engine.py
@@ -121,8 +121,6 @@ class SparkMergeEngine(BaseMergeEngine):
             "smallint",
             "int",
             "bigint",
-            "long",
-            "short",
             "float",
             "double",
             "decimal",

--- a/mloda_plugins/compute_framework/base_implementations/sql/sql_utils.py
+++ b/mloda_plugins/compute_framework/base_implementations/sql/sql_utils.py
@@ -13,7 +13,17 @@ SQL injection prevention follows two layers:
 
 import math
 from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import pyarrow as pa
+
+
+def is_ordered_arrow_type(t: "pa.DataType") -> bool:
+    """Return True if a pyarrow DataType is ordered (integer/float/decimal/temporal)."""
+    import pyarrow as pa
+
+    return bool(pa.types.is_integer(t) or pa.types.is_floating(t) or pa.types.is_decimal(t) or pa.types.is_temporal(t))
 
 
 def quote_ident(name: str) -> str:

--- a/mloda_plugins/compute_framework/base_implementations/sqlite/sqlite_merge_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/sqlite/sqlite_merge_engine.py
@@ -5,7 +5,7 @@ from typing import Any
 from mloda.core.abstract_plugins.components.index.index import Index
 from mloda.core.abstract_plugins.components.link import AsOfJoinConfig
 from mloda_plugins.compute_framework.base_implementations.sql.sql_base_merge_engine import SqlBaseMergeEngine
-from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import quote_ident
+from mloda_plugins.compute_framework.base_implementations.sql.sql_utils import is_ordered_arrow_type, quote_ident
 from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_relation import SqliteRelation, _next_table_name
 
 
@@ -28,6 +28,7 @@ class SqliteMergeEngine(SqlBaseMergeEngine):
         right_index: Index,
         asof_config: AsOfJoinConfig,
     ) -> Any:
+        self.validate_asof_time_columns(left_data, right_data, asof_config)
         if self.framework_connection is None:
             raise ValueError("Framework connection not set. SQL merge engine requires a connection from the framework.")
         if asof_config.direction == "nearest":
@@ -88,6 +89,10 @@ class SqliteMergeEngine(SqlBaseMergeEngine):
             f") WHERE {rn} = 1"
         )
         return self._execute_sql(sql)
+
+    def _asof_time_column_is_ordered(self, data: Any, column: str) -> bool:
+        idx = data.columns.index(column)
+        return is_ordered_arrow_type(data.types[idx])
 
     def _execute_sql(self, sql: str) -> Any:
         if self.framework_connection is None:

--- a/tests/test_plugins/compute_framework/base_implementations/pandas/test_pandas_asof_merge_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/pandas/test_pandas_asof_merge_engine.py
@@ -94,6 +94,18 @@ class TestPandasAsofMergeEngine(AsofMergeEngineTestBase):
         assert rows[pd.Timestamp("2021-01-01 00:00:10")] == 7
         assert rows[pd.Timestamp("2021-01-01 00:01:42")] is None
 
+    def test_boolean_time_column_raises_value_error(self) -> None:
+        """A boolean time column is not orderable for an as-of join. pandas would otherwise pass
+        it via is_numeric_dtype; the guard must reject it consistently with the other engines and
+        raise a clear ValueError naming the column."""
+        left = pd.DataFrame({"k": [1], "t": [True], "lv": [1]})
+        right = pd.DataFrame({"k": [1], "t": [False], "rv": [7]})
+
+        engine = PandasMergeEngine()
+        cfg = AsOfJoinConfig(left_time_column="t", right_time_column="t")
+        with pytest.raises(ValueError, match=r"'t'.*(datetime|numeric)"):
+            engine.merge_asof(left, right, Index(("k",)), Index(("k",)), cfg)
+
     def test_config_and_factories_accept_timedelta_tolerance(self) -> None:
         """AsOfJoinConfig, Link.asof and Link.asof_on accept a timedelta tolerance and carry it
         through unchanged (type-widening characterization)."""

--- a/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_asof_merge_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_asof_merge_engine.py
@@ -56,6 +56,18 @@ class TestPythonDictAsofMergeEngine(AsofMergeEngineTestBase):
         assert len(result) == 1
         assert result[0]["rv"] == "A"
 
+    def test_mixed_time_column_raises_value_error(self) -> None:
+        """A heterogeneous time column (int then str) is not orderable. The guard must scan all
+        non-null values, not just the first, and raise a clear ValueError naming the column
+        instead of letting a raw comparison TypeError surface later."""
+        left = [{"k": "a", "t": 1, "lv": 1}, {"k": "a", "t": "2025-06-01", "lv": 2}]
+        right = [{"k": "a", "t": 1, "rv": 1.0}]
+
+        engine = PythonDictMergeEngine()
+        cfg = AsOfJoinConfig(left_time_column="t", right_time_column="t")
+        with pytest.raises(ValueError, match=r"'t'.*(datetime|numeric)"):
+            engine.merge_asof(left, right, Index(("k",)), Index(("k",)), cfg)
+
     def test_tie_breaks_ascending_and_is_order_independent(self) -> None:
         """
         Tie determinism: two right rows share the identical boundary timestamp within a

--- a/tests/test_plugins/compute_framework/test_tooling/asof/asof_merge_engine_test_base.py
+++ b/tests/test_plugins/compute_framework/test_tooling/asof/asof_merge_engine_test_base.py
@@ -219,10 +219,10 @@ class AsofMergeEngineTestBase(ABC):
         """A non-ordered (string/object) time column must raise a clear ValueError.
 
         Forwarding ISO-date strings straight to the backend yields a cryptic error
-        (e.g. pandas' "both sides must have numeric dtype"). The intended behavior is
-        a uniform ValueError that names the offending time column ('t') and states
-        the datetime/numeric/timedelta requirement. This guard does not exist yet, so
-        the test fails for every engine that inherits this base class.
+        (e.g. pandas' "both sides must have numeric dtype"). The guard instead raises a
+        uniform ValueError that names the offending time column ('t') and states the
+        datetime/numeric/timedelta requirement, consistently across every engine that
+        inherits this base class.
         """
         left_data = self.convert_dict_to_framework([{"k": "a", "t": "2025-06-01", "lv": 1}])
         right_data = self.convert_dict_to_framework([{"k": "a", "t": "2025-05-01", "rv": 1.0}])
@@ -232,10 +232,9 @@ class AsofMergeEngineTestBase(ABC):
         connection = self.get_connection()
         engine = self.merge_engine_class()(connection) if connection else self.merge_engine_class()()
 
-        # Require the quoted column name 't' AND the requirement wording. This is
-        # deliberately stricter than a bare ``t.*(datetime|numeric)`` regex: pandas'
-        # current cryptic MergeError ("...both sides must have numeric dtype") is itself
-        # a ValueError and would accidentally satisfy a loose pattern, masking the
-        # missing guard. The clear message must name the column, so we match on "'t'".
+        # Require the quoted column name 't' AND the requirement wording. A bare
+        # ``t.*(datetime|numeric)`` regex would be too loose: pandas' low-level MergeError
+        # ("...both sides must have numeric dtype") is itself a ValueError and would satisfy
+        # it. The clear guard message names the column, so we match on "'t'".
         with pytest.raises(ValueError, match=r"'t'.*(datetime|numeric)"):
             engine.merge_asof(left_data, right_data, Index(("k",)), Index(("k",)), cfg)

--- a/tests/test_plugins/compute_framework/test_tooling/asof/asof_merge_engine_test_base.py
+++ b/tests/test_plugins/compute_framework/test_tooling/asof/asof_merge_engine_test_base.py
@@ -11,6 +11,8 @@ from abc import ABC, abstractmethod
 from collections import Counter
 from typing import Any, Optional
 
+import pytest
+
 from mloda.user import Index
 from mloda.provider import BaseMergeEngine
 from mloda.core.abstract_plugins.components.link import AsOfJoinConfig
@@ -212,3 +214,28 @@ class AsofMergeEngineTestBase(ABC):
 
         offending = [str(w.message) for w in recorded if "Sortedness" in str(w.message)]
         assert not offending, f"Unexpected 'Sortedness' warning(s) emitted: {offending}"
+
+    def test_string_time_column_raises_clear_error(self) -> None:
+        """A non-ordered (string/object) time column must raise a clear ValueError.
+
+        Forwarding ISO-date strings straight to the backend yields a cryptic error
+        (e.g. pandas' "both sides must have numeric dtype"). The intended behavior is
+        a uniform ValueError that names the offending time column ('t') and states
+        the datetime/numeric/timedelta requirement. This guard does not exist yet, so
+        the test fails for every engine that inherits this base class.
+        """
+        left_data = self.convert_dict_to_framework([{"k": "a", "t": "2025-06-01", "lv": 1}])
+        right_data = self.convert_dict_to_framework([{"k": "a", "t": "2025-05-01", "rv": 1.0}])
+
+        cfg = AsOfJoinConfig(left_time_column="t", right_time_column="t")
+
+        connection = self.get_connection()
+        engine = self.merge_engine_class()(connection) if connection else self.merge_engine_class()()
+
+        # Require the quoted column name 't' AND the requirement wording. This is
+        # deliberately stricter than a bare ``t.*(datetime|numeric)`` regex: pandas'
+        # current cryptic MergeError ("...both sides must have numeric dtype") is itself
+        # a ValueError and would accidentally satisfy a loose pattern, masking the
+        # missing guard. The clear message must name the column, so we match on "'t'".
+        with pytest.raises(ValueError, match=r"'t'.*(datetime|numeric)"):
+            engine.merge_asof(left_data, right_data, Index(("k",)), Index(("k",)), cfg)


### PR DESCRIPTION
## Summary

Closes #509.

`merge_asof` in every compute-framework merge engine forwarded the configured time columns straight to the backend (e.g. `pd.merge_asof`). When a time column held non-ordered values (an ISO-date **string** / object dtype), the backend raised a cryptic low-level error such as `MergeError: both sides must have numeric dtype` that never named the real cause, the as-of time column.

This adds a strict-default guard that raises a clear, uniform `ValueError` naming the offending column and stating the datetime/numeric/timedelta requirement, consistently across all merge engines.

## Design

- `BaseMergeEngine.validate_asof_time_columns(left_data, right_data, asof_config)`: concrete seam that checks both time columns and raises a uniform, column-naming `ValueError`. This is the hook that opt-in coercion (#513) builds on.
- `BaseMergeEngine._asof_time_column_is_ordered(data, column) -> bool`: overridable predicate (default raises `NotImplementedError` so an as-of-capable engine cannot silently skip the guard).
- Every engine's `merge_asof` calls the guard first and implements the predicate with framework-native dtype detection:
  - pandas: `pandas.api.types` (numeric/datetime64/timedelta64, bool excluded)
  - polars eager + lazy: `collect_schema()` + `is_numeric()`/`is_temporal()`
  - pyarrow + sqlite: shared `is_ordered_arrow_type` helper on the Arrow type
  - duckdb: classified on the DuckDB dtype `.id` (so composite types like `INTEGER[]`/`STRUCT` are correctly rejected)
  - spark: `df.dtypes` type-string prefixes
  - python_dict: value sampling across all non-null values (bool excluded)

## Tests

- One shared test in `AsofMergeEngineTestBase` asserts a string time column raises a clear `ValueError` naming the column. It runs against every engine subclass (pandas, polars eager/lazy, pyarrow, duckdb, sqlite, python_dict).
- pandas: a boolean time column is rejected (cross-engine consistency).
- python_dict: a mixed int/string time column is rejected (would otherwise crash later with a raw `TypeError`).

## Docs

Added a "Time-column dtype" caveat to the ASOF section of `docs/docs/in_depth/join_data.md`.

## Notes

- Missing-time-column errors are left as-is (out of scope here; this issue targets non-ordered dtypes). Worth a follow-up if a uniform "column not found" message is wanted.
- `tox` passes (pytest, ruff format, ruff check, license allowlist, mypy --strict, bandit).
