### PR TITLE
feat!: enforce PROPERTY_MAPPING declared defaults are honored or required

### DIFF
--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -104,6 +104,51 @@ must be pure functions with no side effects.
 }
 ```
 
+### Declared Defaults Must Be Honored
+
+When a key uses `strict_validation: True`, a declared `default` must be a value the
+key actually accepts. mloda enforces this at class-definition time: defining a
+`FeatureGroup` subclass whose `PROPERTY_MAPPING` declares a strict default outside
+the accepted set (or one that fails the key's `validation_function`) raises
+`ValueError` immediately, naming the class, the key, the declared default, and the
+accepted values.
+
+This closes a silent gap: option validation only inspects keys present in the
+`Options` object, so omitting the key applies the default without revalidating it.
+Without the invariant, a subclass that narrows a key's accepted values to exclude
+the inherited default would validate successfully when the key is omitted, then run
+under a default it does not honor.
+
+``` python
+# Rejected at class definition: "mul" is not in the accepted set.
+PROPERTY_MAPPING = {
+    "operation_type": {
+        "add": "Addition",
+        "sub": "Subtraction",
+        DefaultOptionKeys.strict_validation: True,
+        DefaultOptionKeys.default: "mul",  # ValueError: not an accepted value
+    },
+}
+```
+
+To resolve a rejection, pick one of:
+
+- **Add the default to the accepted values** so it is honored.
+- **Remove the default**, which makes the key required by omission. A key with no
+  declared default (and no `required_when`) is unconditionally required, so it can
+  never silently run under an unhonored default.
+
+`required_when` does NOT exempt a key from this check. A `required_when` predicate
+expresses a *conditional* requirement: when the predicate returns `False` and the
+key is omitted, the declared default is still applied. A default outside the
+accepted set would therefore still slip through on that branch, so it is rejected
+regardless of `required_when`.
+
+A `default` of `None` is always legal: it is the conventional "unset" sentinel and
+is exempt from the check even under `strict_validation: True`. The check is also a
+no-op when `strict_validation` is `False`, where listed values are illustrative
+rather than enforced.
+
 ## Usage in Feature Groups
 
 ``` python

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -208,6 +208,67 @@ class FeatureChainParser:
         return property_value
 
     @classmethod
+    def validate_property_mapping_defaults(cls, owner_name: str, property_mapping: dict[str, Any] | None) -> None:
+        """Validate declared PROPERTY_MAPPING defaults at class-definition time.
+
+        For every key whose spec is a dict and declares a non-``None``
+        ``DefaultOptionKeys.default`` under strict validation, the declared default
+        must be in the accepted set or pass the key's ``validation_function``.
+        A ``validation_function`` that itself errors when called with the default is
+        reported as having raised (with the original exception chained as the cause),
+        which is distinct from the function running and rejecting the default.
+        ``DefaultOptionKeys.required_when`` does NOT exempt this check: it is a
+        conditional requirement, so the default still applies on the predicate-false
+        branch. The remedies are to add the default to the accepted values or to
+        remove the default (a key with no default is required).
+        """
+        if property_mapping is None:
+            return
+
+        def _message(key: str, default: Any, detail: str) -> str:
+            return (
+                f"{owner_name}.PROPERTY_MAPPING['{key}'] declares default {default!r}, "
+                f"but {detail} under strict_validation. "
+                f"Add the default to the accepted values, or remove the default "
+                f"(a key with no default is required)."
+            )
+
+        for key, spec in property_mapping.items():
+            if not isinstance(spec, dict):
+                continue
+            if DefaultOptionKeys.default not in spec:
+                continue
+
+            default = spec[DefaultOptionKeys.default]
+            if default is None:
+                continue
+
+            validation_function = cls._get_validation_function(spec)
+            if validation_function is not None:
+                if not cls._is_strict_validation(spec):
+                    continue
+                try:
+                    verdict = validation_function(default)
+                except Exception as exc:
+                    raise ValueError(
+                        _message(
+                            key, default, "the key's validation_function raised an error when called with that default"
+                        )
+                    ) from exc
+                if not verdict:
+                    raise ValueError(
+                        _message(key, default, "that default is rejected by the key's validation_function")
+                    )
+                continue
+
+            extracted = cls._extract_property_values(spec)
+            try:
+                cls._validate_property_value(default, extracted, key, spec)
+            except (ValueError, TypeError) as exc:
+                detail = f"that default is not one of the accepted values {sorted(extracted, key=repr)}"
+                raise ValueError(_message(key, default, detail)) from exc
+
+    @classmethod
     def _process_found_property_value(
         cls, found_property_value: Any, property_value: Any, property_name: str, original_property_config: Any
     ) -> set[str]:

--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -10,6 +10,7 @@ from mloda.core.abstract_plugins.components.data_types import DataType
 
 from mloda.core.abstract_plugins.components.domain import Domain
 from mloda.core.abstract_plugins.components.base_feature_group_version import BaseFeatureGroupVersion
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.input_data.api.api_input_data import ApiInputData
 from mloda.core.abstract_plugins.components.input_data.base_input_data import BaseInputData
@@ -75,6 +76,10 @@ class FeatureGroup(ABC):
     ``DefaultOptionKeys.strict_validation``, etc.), and optional validators.
     See ``docs/in_depth/property-mapping.md`` for the full specification.
     """
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        FeatureChainParser.validate_property_mapping_defaults(cls.__name__, cls.PROPERTY_MAPPING)
 
     def __init__(self) -> None:
         pass

--- a/tests/test_core/test_abstract_plugins/test_property_mapping_default_invariant.py
+++ b/tests/test_core/test_abstract_plugins/test_property_mapping_default_invariant.py
@@ -1,0 +1,538 @@
+"""Tests for the class-definition-time PROPERTY_MAPPING default invariant (issue #520).
+
+At class definition time, for every PROPERTY_MAPPING key whose spec is a dict and
+declares a non-``None`` ``DefaultOptionKeys.default``, the declared default must be
+honored by the key's own strict-validation rules (be in the accepted set or pass the
+``validation_function``). Otherwise defining the FeatureGroup subclass must raise
+``ValueError`` immediately.
+
+``DefaultOptionKeys.required_when`` is NOT an escape hatch: it expresses a conditional
+requirement, so when its predicate is False (or it is non-callable) and the key is
+omitted, the bad default would still apply silently. The only sound way to mark a key
+required is to declare NO default; mloda treats a key with no default and no
+``required_when`` as unconditionally required.
+"""
+
+from __future__ import annotations
+
+import gc
+from typing import Any
+
+import pytest
+
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import (
+    FeatureChainParserMixin,
+)
+from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+from mloda.core.abstract_plugins.components.utils import get_all_subclasses
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.provider import DefaultOptionKeys
+
+
+@pytest.fixture(autouse=True)
+def _no_feature_group_registry_pollution() -> Any:
+    """Guarantee this module never leaks throwaway FeatureGroup subclasses.
+
+    The tests below define FeatureGroup subclasses to exercise
+    ``FeatureGroup.__init_subclass__``. Those class objects sit in reference
+    cycles, so they linger in ``FeatureGroup.__subclasses__()`` until a GC cycle
+    runs. While they linger, other tests that enumerate feature groups via
+    ``get_all_subclasses(FeatureGroup)`` trip over them. After each test we force
+    a collection to reclaim the now-unreferenced classes and assert that none of
+    this module's classes remain registered, pinning the no-pollution contract.
+    """
+    yield
+    gc.collect()
+    gc.collect()
+    leaked = [c for c in get_all_subclasses(FeatureGroup) if c.__module__ == __name__]
+    assert not leaked, f"Leaked FeatureGroup subclasses from {__name__}: {[c.__name__ for c in leaked]}"
+
+
+def _never_required(options: Any) -> bool:
+    """Conditional-requirement predicate that is never satisfied.
+
+    With such a predicate the key is not required, so a bad default would still
+    apply silently when the key is omitted: ``required_when`` must therefore not
+    exempt a strict, non-None default from the invariant.
+    """
+    return False
+
+
+class TestStrictEnumeratedDefaultInvariant:
+    """Strict validation with an enumerated accepted set."""
+
+    def test_rejects_strict_default_outside_accepted_set(self) -> None:
+        """A strict key whose default is not in the accepted set must reject at class definition."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class BadDefaultFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PREFIX_PATTERN = r".*__([\w]+)_op$"
+                PROPERTY_MAPPING = {
+                    "operation_type": {
+                        "add": "Addition",
+                        "sub": "Subtraction",
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: True,
+                        DefaultOptionKeys.default: "mul",
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        assert "BadDefaultFeatureGroup" in message
+        assert "operation_type" in message
+        assert "mul" in message
+        assert "add" in message
+        assert "sub" in message
+
+    def test_accepts_strict_default_in_accepted_set(self) -> None:
+        """A strict key whose default is in the accepted set defines without error."""
+
+        class GoodDefaultFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+            PREFIX_PATTERN = r".*__([\w]+)_op$"
+            PROPERTY_MAPPING = {
+                "operation_type": {
+                    "add": "Addition",
+                    "sub": "Subtraction",
+                    DefaultOptionKeys.context: True,
+                    DefaultOptionKeys.strict_validation: True,
+                    DefaultOptionKeys.default: "add",
+                }
+            }
+
+            @classmethod
+            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                return data
+
+        assert GoodDefaultFeatureGroup.PROPERTY_MAPPING["operation_type"][DefaultOptionKeys.default] == "add"
+
+    def test_required_when_does_not_rescue_strict_bad_default(self) -> None:
+        """``required_when`` must not exempt a strict default outside the accepted set.
+
+        ``required_when`` is a conditional requirement: when its predicate is False
+        and the key is omitted, the bad default still applies silently, reopening the
+        exact bug the invariant closes. So a strict, non-None default outside the
+        accepted set must reject at class definition even with ``required_when`` set.
+        """
+        with pytest.raises(ValueError) as exc_info:
+
+            class RequiredWhenBadDefaultFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PREFIX_PATTERN = r".*__([\w]+)_op$"
+                PROPERTY_MAPPING = {
+                    "operation_type": {
+                        "add": "Addition",
+                        "sub": "Subtraction",
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: True,
+                        DefaultOptionKeys.default: "mul",
+                        DefaultOptionKeys.required_when: _never_required,
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        assert "RequiredWhenBadDefaultFeatureGroup" in message
+        assert "operation_type" in message
+        assert "mul" in message
+
+    def test_accepts_none_default_under_strict_validation(self) -> None:
+        """A ``None`` default is the unset/optional sentinel and is always legal.
+
+        Even when the key is strictly validated against an enumerated accepted set
+        that does not include ``None`` (mirroring real plugins such as
+        ``SklearnPipelineFeatureGroup.pipeline_name``), defining the FeatureGroup
+        subclass must not raise.
+        """
+
+        class NoneDefaultFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+            PREFIX_PATTERN = r".*__([\w]+)_op$"
+            PROPERTY_MAPPING = {
+                "operation_type": {
+                    "feature_engineering": "Feature engineering step",
+                    "scaling": "Scaling step",
+                    DefaultOptionKeys.context: True,
+                    DefaultOptionKeys.strict_validation: True,
+                    DefaultOptionKeys.default: None,
+                }
+            }
+
+            @classmethod
+            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                return data
+
+        assert NoneDefaultFeatureGroup.PROPERTY_MAPPING["operation_type"][DefaultOptionKeys.default] is None
+
+    def test_no_op_for_non_strict_spec(self) -> None:
+        """When strict_validation is False, the listed values are illustrative; any default is fine."""
+
+        class NonStrictFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+            PREFIX_PATTERN = r".*__([\w]+)_op$"
+            PROPERTY_MAPPING = {
+                "operation_type": {
+                    "add": "Addition",
+                    "sub": "Subtraction",
+                    DefaultOptionKeys.context: True,
+                    DefaultOptionKeys.strict_validation: False,
+                    DefaultOptionKeys.default: "mul",
+                }
+            }
+
+            @classmethod
+            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                return data
+
+        assert NonStrictFeatureGroup.PROPERTY_MAPPING["operation_type"][DefaultOptionKeys.default] == "mul"
+
+    def test_rejects_empty_accepted_set_under_strict_validation(self) -> None:
+        """A strict key with no enumerated values and no validation_function rejects a default.
+
+        Without any accepted values and without a ``validation_function``, the
+        declared default can never be honored, so defining the FeatureGroup subclass
+        must raise ``ValueError``.
+        """
+        with pytest.raises(ValueError) as exc_info:
+
+            class EmptyAcceptedSetFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PREFIX_PATTERN = r".*__([\w]+)_op$"
+                PROPERTY_MAPPING = {
+                    "operation_type": {
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: True,
+                        DefaultOptionKeys.default: "x",
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        assert "EmptyAcceptedSetFeatureGroup" in message
+        assert "operation_type" in message
+
+    def test_unhashable_default_reports_clear_error(self) -> None:
+        """An unhashable strict default surfaces as ``ValueError``, not a bare ``TypeError``.
+
+        The membership check ``default not in accepted`` raises ``TypeError`` for an
+        unhashable default (e.g. a list). The invariant must translate that into a
+        clear ``ValueError`` naming the class and key rather than leaking the
+        ``TypeError``.
+        """
+        with pytest.raises(ValueError) as exc_info:
+
+            class UnhashableDefaultFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PREFIX_PATTERN = r".*__([\w]+)_op$"
+                PROPERTY_MAPPING = {
+                    "operation_type": {
+                        "add": "Addition",
+                        "sub": "Subtraction",
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: True,
+                        DefaultOptionKeys.default: ["mul"],
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        assert "UnhashableDefaultFeatureGroup" in message
+        assert "operation_type" in message
+
+
+class TestStrictValidationFunctionDefaultInvariant:
+    """Strict validation driven by a validation_function callable."""
+
+    def test_rejects_default_failing_validation_function(self) -> None:
+        """A strict key whose default fails its validation_function must reject at class definition."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class BadFnDefaultFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PREFIX_PATTERN = r".*__([\w]+)_op$"
+                PROPERTY_MAPPING = {
+                    "operation_type": {
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: True,
+                        DefaultOptionKeys.validation_function: lambda v: v in {"x", "y"},
+                        DefaultOptionKeys.default: "z",
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        assert "BadFnDefaultFeatureGroup" in message
+        assert "operation_type" in message
+        assert "z" in message
+
+    def test_accepts_default_passing_validation_function(self) -> None:
+        """A strict key whose default passes its validation_function defines without error."""
+
+        class GoodFnDefaultFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+            PREFIX_PATTERN = r".*__([\w]+)_op$"
+            PROPERTY_MAPPING = {
+                "operation_type": {
+                    DefaultOptionKeys.context: True,
+                    DefaultOptionKeys.strict_validation: True,
+                    DefaultOptionKeys.validation_function: lambda v: v in {"x", "y"},
+                    DefaultOptionKeys.default: "x",
+                }
+            }
+
+            @classmethod
+            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                return data
+
+        assert GoodFnDefaultFeatureGroup.PROPERTY_MAPPING["operation_type"][DefaultOptionKeys.default] == "x"
+
+
+class TestNoDefaultDeclared:
+    """When no default is declared, the invariant performs no check."""
+
+    def test_strict_key_without_default_defines_without_error(self) -> None:
+        """A strict, narrowed key with no default declared (required by omission) is accepted."""
+
+        class NoDefaultFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+            PREFIX_PATTERN = r".*__([\w]+)_op$"
+            PROPERTY_MAPPING = {
+                "operation_type": {
+                    "add": "Addition",
+                    "sub": "Subtraction",
+                    DefaultOptionKeys.context: True,
+                    DefaultOptionKeys.strict_validation: True,
+                }
+            }
+
+            @classmethod
+            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                return data
+
+        assert DefaultOptionKeys.default not in NoDefaultFeatureGroup.PROPERTY_MAPPING["operation_type"]
+
+
+class TestDefaultInvariantErrorMessaging:
+    """The ValueError raised by the invariant must give accurate, actionable advice.
+
+    The two legal remedies for a strict default outside the accepted set are: add the
+    default to the accepted values, or remove the default. ``required_when`` is NOT a
+    remedy (its predicate being False still lets the bad default apply silently), so
+    the message must never advise it. The message must also distinguish a default that
+    was genuinely rejected by a working validation_function from a validation_function
+    that itself errored when called.
+    """
+
+    def test_message_advises_only_the_two_legal_remedies(self) -> None:
+        """The message for a strict out-of-set default advises exactly the legal remedies.
+
+        It must advise adding the default to the accepted values and removing the
+        default, and must NOT advise ``required_when``: a False predicate plus an
+        omitted key still applies the bad default silently, so suggesting it would
+        steer users back into the very bug the invariant closes.
+        """
+        with pytest.raises(ValueError) as exc_info:
+
+            class RemedyAdviceFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PREFIX_PATTERN = r".*__([\w]+)_op$"
+                PROPERTY_MAPPING = {
+                    "operation_type": {
+                        "add": "Addition",
+                        "sub": "Subtraction",
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: True,
+                        DefaultOptionKeys.default: "mul",
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        # Drop the ExceptionInfo before asserting: when an assert fails, pytest's
+        # report retains this frame, and via the captured traceback the throwaway
+        # class would stay alive and trip the no-pollution fixture.
+        del exc_info
+        assert "accepted values" in message
+        assert "remove the default" in message
+        assert "required_when" not in message
+
+    def test_message_renders_accepted_values_without_nested_quoting(self) -> None:
+        """Accepted values render as plain reprs, not repr-of-repr.
+
+        The accepted set for the key below must appear as ``['add', 'sub']`` in the
+        message, not as ``["'add'", "'sub'"]`` (stringifying each value before
+        repr-ing the list double-quotes every entry and obscures the actual values).
+        """
+        with pytest.raises(ValueError) as exc_info:
+
+            class ValueRenderingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PREFIX_PATTERN = r".*__([\w]+)_op$"
+                PROPERTY_MAPPING = {
+                    "operation_type": {
+                        "add": "Addition",
+                        "sub": "Subtraction",
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: True,
+                        DefaultOptionKeys.default: "mul",
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        # Drop the ExceptionInfo before asserting (see remedy-advice test above).
+        del exc_info
+        assert "['add', 'sub']" in message
+
+    def test_buggy_validation_function_reported_as_raised_not_rejected(self) -> None:
+        """A validation_function that errors when called is reported as having raised.
+
+        ``lambda: True`` takes no arguments, so calling it with the default raises
+        ``TypeError``. That is a bug in the plugin's validation_function, not a
+        verdict on the default, so the invariant must still surface a ``ValueError``
+        at class definition, must say the validation_function raised (not that the
+        default was "rejected by" it), and must chain the original ``TypeError`` as
+        the cause.
+        """
+        with pytest.raises(ValueError) as exc_info:
+
+            class BuggyFnFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PREFIX_PATTERN = r".*__([\w]+)_op$"
+                PROPERTY_MAPPING = {
+                    "operation_type": {
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: True,
+                        DefaultOptionKeys.validation_function: lambda: True,
+                        DefaultOptionKeys.default: "x",
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        cause_is_type_error = isinstance(exc_info.value.__cause__, TypeError)
+        # Drop the ExceptionInfo before asserting (see remedy-advice test above).
+        del exc_info
+        assert "BuggyFnFeatureGroup" in message
+        assert "operation_type" in message
+        assert "rejected by" not in message
+        assert "raised" in message
+        assert cause_is_type_error, "expected the original TypeError chained as __cause__"
+
+    def test_genuine_rejection_still_labeled_as_rejection(self) -> None:
+        """A working validation_function that returns False is still reported as a rejection.
+
+        Distinguishing a buggy validation_function (it raised) must not erase the
+        rejection wording for the genuine case: a callable that runs and returns
+        False has rejected the default, and the message must say so.
+        """
+        with pytest.raises(ValueError) as exc_info:
+
+            class RejectingFnFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PREFIX_PATTERN = r".*__([\w]+)_op$"
+                PROPERTY_MAPPING = {
+                    "operation_type": {
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: True,
+                        DefaultOptionKeys.validation_function: lambda v: False,
+                        DefaultOptionKeys.default: "x",
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        # Drop the ExceptionInfo before asserting (see remedy-advice test above).
+        del exc_info
+        assert "RejectingFnFeatureGroup" in message
+        assert "operation_type" in message
+        assert "rejected by the key's validation_function" in message
+
+    def test_validation_function_raising_attribute_error_reports_raised(self) -> None:
+        """A validation_function raising ``AttributeError`` surfaces as the curated ``ValueError``.
+
+        ``lambda v: v.startswith("a")`` crashes with ``AttributeError`` for the
+        non-string default ``5``. That is a bug in the plugin's validation_function,
+        not a verdict on the default, so the invariant must still surface a
+        ``ValueError`` at class definition naming the class and key, must say the
+        validation_function raised (not that the default was "rejected by" it), and
+        must chain the original ``AttributeError`` as the cause. The raw
+        ``AttributeError`` must never escape class definition.
+        """
+        with pytest.raises(ValueError) as exc_info:
+
+            class AttributeErrorFnFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PREFIX_PATTERN = r".*__([\w]+)_op$"
+                PROPERTY_MAPPING = {
+                    "operation_type": {
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: True,
+                        DefaultOptionKeys.validation_function: lambda v: v.startswith("a"),
+                        DefaultOptionKeys.default: 5,
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        cause_is_attribute_error = isinstance(exc_info.value.__cause__, AttributeError)
+        # Drop the ExceptionInfo before asserting (see remedy-advice test above).
+        del exc_info
+        assert "AttributeErrorFnFeatureGroup" in message
+        assert "operation_type" in message
+        assert "raised" in message
+        assert "rejected by" not in message
+        assert cause_is_attribute_error, "expected the original AttributeError chained as __cause__"
+
+    def test_validation_function_raising_value_error_reports_raised(self) -> None:
+        """A validation_function raising ``ValueError`` internally is reported as having raised.
+
+        ``lambda v: int(v) > 0`` crashes with ``ValueError`` for the default
+        ``"abc"``: the function never returned a verdict, it errored. The invariant
+        must not misreport this as the default being "rejected by" the
+        validation_function; it must say the validation_function raised and chain
+        the original ``ValueError`` as the cause.
+        """
+        with pytest.raises(ValueError) as exc_info:
+
+            class ValueErrorFnFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PREFIX_PATTERN = r".*__([\w]+)_op$"
+                PROPERTY_MAPPING = {
+                    "operation_type": {
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: True,
+                        DefaultOptionKeys.validation_function: lambda v: int(v) > 0,
+                        DefaultOptionKeys.default: "abc",
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        cause_is_value_error = isinstance(exc_info.value.__cause__, ValueError)
+        # Drop the ExceptionInfo before asserting (see remedy-advice test above).
+        del exc_info
+        assert "ValueErrorFnFeatureGroup" in message
+        assert "operation_type" in message
+        assert "raised" in message
+        assert "rejected by" not in message
+        assert cause_is_value_error, "expected the original ValueError chained as __cause__"


### PR DESCRIPTION
## Summary

Closes #520. Adds a class-definition-time invariant so a `FeatureGroup` cannot silently run under a `PROPERTY_MAPPING` default it does not honor.

Previously, option validation only inspected keys *present* in `Options`. A subclass that narrowed a key's accepted values (via `strict_validation`) to exclude the inherited `DefaultOptionKeys.default` would validate successfully whenever the key was omitted, then run under a default it would have rejected if supplied explicitly. The concrete downstream bug: a cursor-paginating connector narrowed `pagination_style` to `cursor` while the family default stayed `none`; a slot omitting the key validated, served page 1, then rejected its own continuation cursor.

## What changed

- **`FeatureGroup.__init_subclass__`** now validates declared defaults at class-definition time. For every `PROPERTY_MAPPING` key that declares a `default` under `strict_validation: True`, the default must be one of the key's accepted values (enumerated set) or pass its `validation_function`. Otherwise defining the class raises `ValueError` naming the class, key, declared default, and accepted values.
- The check lives in `FeatureChainParser.validate_property_mapping_defaults` and reuses the existing `_extract_property_values` and `_validate_property_value` helpers for the enumerated-set path. It is a **no-op when `strict_validation` is `False`** (listed values are illustrative there).
- A **`None` default** is always legal: it is the conventional "unset" sentinel (e.g. `SklearnPipelineFeatureGroup.pipeline_name`).
- To make a strict, narrowed key required instead of defaulted, **declare no default** (a key with no default is unconditionally required). `required_when` does **not** exempt the check: it is a conditional requirement, so the default still applies when the predicate is false. The error message advises only the two legal remedies (add the default to the accepted values, or remove the default).
- **`validation_function` failures are fully shielded.** The invariant calls the function directly and distinguishes by construction: a function that runs and returns falsy is reported as having *rejected* the default; a function that raises any exception when called (wrong arity, `AttributeError`, internal `ValueError` from `int(...)`, etc.) is reported as having *raised*, with the original exception chained as `__cause__`. No raw exception leaks out of class definition.

## Design notes

The escape mechanism is deliberately "no default" rather than a `required_when` exemption. `required_when` is conditional; exempting it would reopen the exact silent-default path on the predicate-false branch. This mirrors the unconditional-required semantics of the downstream reference implementation.

The error path is robust to unhashable or mixed-type accepted values (it reports a clear `ValueError` rather than leaking a bare `TypeError`), and accepted values render as plain reprs (e.g. `['add', 'sub']`).

## BREAKING CHANGE

Defining a `FeatureGroup` subclass whose `PROPERTY_MAPPING` declares a strict default outside its accepted values now raises `ValueError` at class definition (import time). Previously such classes imported silently and misbehaved at runtime. Affected plugins must add the default to the accepted values or remove the default.

## Tests

`tests/test_core/test_abstract_plugins/test_property_mapping_default_invariant.py` (16 tests) covers: strict default outside the accepted set (rejected), default in set (accepted), `None` sentinel under strict validation (accepted), non-strict no-op, `validation_function` default rejected/accepted, empty accepted set (rejected), unhashable default reports a clear error, `required_when` does not rescue a bad default, no-default = required (accepted), the error-message contract (only the two legal remedies advised, no `required_when` advice, plain-repr value rendering), and raised-vs-rejected reporting for buggy validation_functions (`TypeError` from wrong arity, `AttributeError`, internal `ValueError`, each chained as `__cause__`). An autouse fixture forces GC and asserts the throwaway `FeatureGroup` subclasses do not leak into the global registry.

`docs/docs/in_depth/property-mapping.md` documents the invariant.

The full tox gate passes (pytest -n 8, ruff format, ruff check, license check, mypy --strict, bandit).
