### PR TITLE
feat: plugin registry with tri-state strict mode

### DIFF
--- a/docs/docs/in_depth/plugin_registry.md
+++ b/docs/docs/in_depth/plugin_registry.md
@@ -1,0 +1,131 @@
+# Plugin Registry
+
+The plugin registry is an explicit catalog of FeatureGroup, ComputeFramework, and Extender classes, keyed by a string name (default: `"module:qualname"`). The [PluginLoader](plugin-loader.md) feeds it automatically: every plugin class defined in a loaded module is registered with provenance `source="loader"`; manual registrations carry `source="manual"`. Registries are plain instances, and the engine and catalog APIs use the process-global default, `PluginRegistry.default()`.
+
+## Registered vs Ad-Hoc Classes
+
+Two kinds of plugin classes exist at runtime:
+
+- **Registered**: classes defined in modules loaded by `PluginLoader`, plus anything registered manually via `register()`.
+- **Ad-hoc**: any other subclass, for example a notebook cell, a test double, or a class in a module that was imported but not loaded.
+
+Registration is additive. Defining a subclass and importing its module keeps working exactly as before:
+
+- **Catalog APIs**: `list_registered()` reports only registered classes. The `get_*_docs()` functions keep walking all subclasses by default and accept `registered_only=True` to restrict the result to the registry.
+- **Engine resolution**: while strict mode is `"off"` or `"warn"` (see below), the engine resolves registered plugins plus local ad-hoc subclasses. Only `"strict"` filters resolution to registered FeatureGroups.
+
+```python
+from mloda.provider import FeatureGroup
+from mloda.user import PluginLoader, list_registered
+
+PluginLoader.all()
+
+registered = list_registered(FeatureGroup)
+assert registered
+
+class AdHocFeatureGroup(FeatureGroup):
+    """Defined locally, for example in a notebook cell; never auto-registered."""
+
+assert AdHocFeatureGroup not in list_registered(FeatureGroup)
+```
+
+## Contract Tests over Registered Plugins
+
+`list_registered()` returns the classes of one plugin base type, sorted by registry key. That makes project-wide contract tests a simple loop: load your plugins, then assert a property on every registered class.
+
+```python
+from mloda.provider import FeatureGroup
+from mloda.user import PluginLoader, list_registered
+
+PluginLoader.all()
+
+for fg in list_registered(FeatureGroup):
+    name = fg.get_class_name()
+    assert isinstance(name, str)
+    assert name
+```
+
+Replace the assertion with whatever your project requires of every plugin: a docstring, a naming convention, a version scheme.
+
+## Manual Registration (Notebooks, Third-Party Packages)
+
+Classes that do not live in loaded plugin modules opt in with `register()`. Registering the same class twice is a no-op. Registering a *different* class under an already taken key raises `PluginRegistryCollisionError`; this happens when a notebook cell that defines a class is edited and re-run, because the re-run creates a new class object under the same key. Pass `replace=True` to accept the newest definition. `unregister()` removes an entry by key.
+
+```python
+from mloda.provider import FeatureGroup
+from mloda.user import PluginRegistry, register
+from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistryCollisionError
+
+class MyFeatureGroup(FeatureGroup):
+    """First definition."""
+
+key = register(MyFeatureGroup)
+assert PluginRegistry.default().get(key) is MyFeatureGroup
+
+class MyFeatureGroup(FeatureGroup):
+    """Edited and re-run, as in a notebook cell: a new class under the same key."""
+
+try:
+    register(MyFeatureGroup)
+    raise AssertionError("expected a collision")
+except PluginRegistryCollisionError:
+    pass
+
+register(MyFeatureGroup, replace=True)
+assert PluginRegistry.default().get(key) is MyFeatureGroup
+
+PluginRegistry.default().unregister(key)
+```
+
+`register()` also accepts `name=` for a custom key, for example `register(MyFeatureGroup, name="my_pkg:MyFeatureGroup")`.
+
+## Strict Mode
+
+Strict mode controls how the engine treats unregistered FeatureGroups during resolution. It is tri-state:
+
+- `"off"` (default): resolution behaves as before; the registry is informational.
+- `"warn"`: resolution is unchanged, but every unregistered FeatureGroup is logged with a warning naming the class.
+- `"strict"`: resolution only considers FeatureGroups registered in the default registry; unregistered ad-hoc classes are filtered out.
+
+Set it per run on the `PluginCollector` you pass into the API (`plugin_collector=` keyword):
+
+```python
+from mloda.user import PluginCollector
+
+plugin_collector = PluginCollector().set_strict_mode("warn")
+```
+
+Or process-wide via the environment variable, which also applies when no `PluginCollector` is passed:
+
+```bash
+export MLODA_PLUGIN_REGISTRY_STRICT=warn
+```
+
+An explicit `set_strict_mode()` overrides the environment variable; invalid values raise a `ValueError`.
+
+Recommended rollout for deployments: stay on `"off"`, switch CI or staging to `"warn"` and watch the logs for "not registered" warnings, then move to `"strict"` once they are gone. This repository's own CI (tox) runs with `MLODA_PLUGIN_REGISTRY_STRICT=warn`.
+
+## Test Isolation for Plugin Authors
+
+Manual registrations mutate the process-global default registry, so tests can leak state into each other. mloda ships a pytest fixture that snapshots the default registry before each test and restores it afterwards. Re-export it from your `conftest.py`:
+
+```python title="conftest.py"
+from mloda.core.abstract_plugins.plugin_registry.fixtures import isolated_plugin_registry
+
+__all__ = ["isolated_plugin_registry"]
+```
+
+Then request it in tests that register plugins:
+
+```python title="test_my_plugin.py"
+def test_my_feature_group_registration(isolated_plugin_registry):
+    key = isolated_plugin_registry.register(MyFeatureGroup)
+    assert isolated_plugin_registry.get(key) is MyFeatureGroup
+```
+
+The fixture yields `PluginRegistry.default()`, so registrations made through it (or through plain `register()`) are rolled back on teardown.
+
+## Related Documentation
+
+- [Plugin Loader](plugin-loader.md)
+- [Discover Plugins](discover-plugins.md)

--- a/docs/docs/in_depth/plugin_registry.md
+++ b/docs/docs/in_depth/plugin_registry.md
@@ -6,7 +6,7 @@ The plugin registry is an explicit catalog of FeatureGroup, ComputeFramework, an
 
 Two kinds of plugin classes exist at runtime:
 
-- **Registered**: classes defined in modules loaded by `PluginLoader`, plus anything registered manually via `register()`.
+- **Registered**: classes defined in modules loaded by `PluginLoader`, plus anything registered manually via `register_plugin()`.
 - **Ad-hoc**: any other subclass, for example a notebook cell, a test double, or a class in a module that was imported but not loaded.
 
 Registration is additive. Defining a subclass and importing its module keeps working exactly as before:
@@ -49,37 +49,37 @@ Replace the assertion with whatever your project requires of every plugin: a doc
 
 ## Manual Registration (Notebooks, Third-Party Packages)
 
-Classes that do not live in loaded plugin modules opt in with `register()`. Registering the same class twice is a no-op. Registering a *different* class under an already taken key raises `PluginRegistryCollisionError`; this happens when a notebook cell that defines a class is edited and re-run, because the re-run creates a new class object under the same key. Pass `replace=True` to accept the newest definition. `unregister()` removes an entry by key.
+Classes that do not live in loaded plugin modules opt in with `register_plugin()`. Registering the same class twice is a no-op. Registering a *different* class under an already taken key raises `PluginRegistryCollisionError`; this happens when a notebook cell that defines a class is edited and re-run, because the re-run creates a new class object under the same key. Pass `replace=True` to accept the newest definition. `unregister()` removes an entry by key.
 
 ```python
 from mloda.provider import FeatureGroup
-from mloda.user import PluginRegistry, register
-from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistryCollisionError
+from mloda.steward import PluginRegistry
+from mloda.user import PluginRegistryCollisionError, register_plugin
 
 class MyFeatureGroup(FeatureGroup):
     """First definition."""
 
-key = register(MyFeatureGroup)
+key = register_plugin(MyFeatureGroup)
 assert PluginRegistry.default().get(key) is MyFeatureGroup
 
 class MyFeatureGroup(FeatureGroup):
     """Edited and re-run, as in a notebook cell: a new class under the same key."""
 
 try:
-    register(MyFeatureGroup)
+    register_plugin(MyFeatureGroup)
     raise AssertionError("expected a collision")
 except PluginRegistryCollisionError:
     pass
 
-register(MyFeatureGroup, replace=True)
+register_plugin(MyFeatureGroup, replace=True)
 assert PluginRegistry.default().get(key) is MyFeatureGroup
 
 PluginRegistry.default().unregister(key)
 ```
 
-`register()` also accepts `name=` for a custom key, for example `register(MyFeatureGroup, name="my_pkg:MyFeatureGroup")`.
+`register_plugin()` also accepts `name=` for a custom key, for example `register_plugin(MyFeatureGroup, name="my_pkg:MyFeatureGroup")`. A class holds exactly one key: registering an already registered class under a second key raises `PluginRegistryCollisionError` naming the existing key; rename by unregistering the existing key first.
 
-The registry does not watch `importlib.reload()`: reloading a module creates new class objects while the registry keeps the old ones, so strict mode and `registered_only=True` would treat the reloaded classes as unregistered. After a reload, re-run the `PluginLoader` scope that covers the module (loading is idempotent and re-registers) or call `register(..., replace=True)` for the affected classes.
+The registry does not watch `importlib.reload()`: reloading a module creates new class objects while the registry keeps the old ones, so strict mode and `registered_only=True` would treat the reloaded classes as unregistered. After a reload, re-run the `PluginLoader` scope that covers the module (loading is idempotent and re-registers) or call `register_plugin(..., replace=True)` for the affected classes.
 
 ## Strict Mode
 
@@ -109,7 +109,7 @@ Three behavioral notes:
 
 - Strict mode governs engine resolution only. The catalog APIs (`get_*_docs()`, `list_registered()`) never consult strict mode: the docs functions keep walking all subclasses unless you pass `registered_only=True`, so in strict mode the catalog can show plugins the engine will not resolve. Pass `registered_only=True` to keep catalog and engine views consistent.
 - In `"warn"` mode, each unregistered class is reported once per process, not once per run, so long-running services do not repeat identical warnings forever.
-- In `"strict"` mode, FeatureGroups explicitly enabled on the `PluginCollector` but missing from the registry are dropped with a warning naming them; if strict filtering removes every FeatureGroup, the run fails with an error that points to `register()` and the environment variable.
+- In `"strict"` mode, FeatureGroups explicitly enabled on the `PluginCollector` but missing from the registry are dropped with a warning naming them; if strict filtering removes every FeatureGroup, the run fails with an error that points to `register_plugin()` and the environment variable.
 
 Recommended rollout for deployments: stay on `"off"`, switch CI or staging to `"warn"` and watch the logs for "not registered" warnings, then move to `"strict"` once they are gone. This repository's own CI (tox) runs with `MLODA_PLUGIN_REGISTRY_STRICT=warn`.
 
@@ -133,7 +133,7 @@ def test_my_feature_group_registration(isolated_plugin_registry):
     assert isolated_plugin_registry.get(key) is MyFeatureGroup
 ```
 
-The fixture yields `PluginRegistry.default()`, so registrations made through it (or through plain `register()`) are rolled back on teardown.
+The fixture yields `PluginRegistry.default()`, so registrations made through it (or through plain `register_plugin()`) are rolled back on teardown.
 
 ## Related Documentation
 

--- a/docs/docs/in_depth/plugin_registry.md
+++ b/docs/docs/in_depth/plugin_registry.md
@@ -1,6 +1,6 @@
 # Plugin Registry
 
-The plugin registry is an explicit catalog of FeatureGroup, ComputeFramework, and Extender classes, keyed by a string name (default: `"module:qualname"`). The [PluginLoader](plugin-loader.md) feeds it automatically: every plugin class defined in a loaded module is registered with provenance `source="loader"`; manual registrations carry `source="manual"`. Registries are plain instances, and the engine and catalog APIs use the process-global default, `PluginRegistry.default()`.
+The plugin registry is an explicit catalog of FeatureGroup, ComputeFramework, and Extender classes, keyed by a string name (default: `"module:qualname"`). The [PluginLoader](plugin-loader.md) feeds it automatically: every concrete plugin class defined in a loaded module is registered with provenance `source="loader"`; manual registrations carry `source="manual"`. Abstract classes (`inspect.isabstract`) are infrastructure, never plugins: the loader skips them, and strict and warn modes ignore them. Registries are plain instances, and the engine and catalog APIs use the process-global default, `PluginRegistry.default()`.
 
 ## Registered vs Ad-Hoc Classes
 
@@ -78,6 +78,8 @@ PluginRegistry.default().unregister(key)
 ```
 
 `register()` also accepts `name=` for a custom key, for example `register(MyFeatureGroup, name="my_pkg:MyFeatureGroup")`.
+
+The registry does not watch `importlib.reload()`: reloading a module creates new class objects while the registry keeps the old ones, so strict mode and `registered_only=True` would treat the reloaded classes as unregistered. After a reload, re-run the `PluginLoader` scope that covers the module (loading is idempotent and re-registers) or call `register(..., replace=True)` for the affected classes.
 
 ## Strict Mode
 

--- a/docs/docs/in_depth/plugin_registry.md
+++ b/docs/docs/in_depth/plugin_registry.md
@@ -101,9 +101,17 @@ Or process-wide via the environment variable, which also applies when no `Plugin
 export MLODA_PLUGIN_REGISTRY_STRICT=warn
 ```
 
-An explicit `set_strict_mode()` overrides the environment variable; invalid values raise a `ValueError`.
+An explicit `set_strict_mode()` overrides the environment variable; invalid values raise a `ValueError`. Environment variable values are case-insensitive (`WARN` works); `set_strict_mode()` accepts only the exact lowercase values.
+
+Three behavioral notes:
+
+- Strict mode governs engine resolution only. The catalog APIs (`get_*_docs()`, `list_registered()`) never consult strict mode: the docs functions keep walking all subclasses unless you pass `registered_only=True`, so in strict mode the catalog can show plugins the engine will not resolve. Pass `registered_only=True` to keep catalog and engine views consistent.
+- In `"warn"` mode, each unregistered class is reported once per process, not once per run, so long-running services do not repeat identical warnings forever.
+- In `"strict"` mode, FeatureGroups explicitly enabled on the `PluginCollector` but missing from the registry are dropped with a warning naming them; if strict filtering removes every FeatureGroup, the run fails with an error that points to `register()` and the environment variable.
 
 Recommended rollout for deployments: stay on `"off"`, switch CI or staging to `"warn"` and watch the logs for "not registered" warnings, then move to `"strict"` once they are gone. This repository's own CI (tox) runs with `MLODA_PLUGIN_REGISTRY_STRICT=warn`.
+
+Strict mode currently covers FeatureGroup resolution only: ComputeFrameworks and Extenders are registered and enumerable, but not yet enforced during resolution.
 
 ## Test Isolation for Plugin Authors
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -44,6 +44,7 @@ nav:
     - Plugin System:
       - Discover Plugins: in_depth/discover-plugins.md
       - Plugin Loader: in_depth/plugin-loader.md
+      - Plugin Registry: in_depth/plugin_registry.md
     - Data Type Enforcement: in_depth/data-type-enforcement.md
     - Troubleshooting:
       - Feature Group Resolution Errors: in_depth/troubleshooting/feature-group-resolution-errors.md

--- a/mloda/core/abstract_plugins/components/plugin_option/plugin_collector.py
+++ b/mloda/core/abstract_plugins/components/plugin_option/plugin_collector.py
@@ -8,7 +8,7 @@ VALID_STRICT_MODES = ("off", "warn", "strict")
 
 def strict_mode_from_env() -> str:
     """Read the strict mode from the environment, defaulting to "off"."""
-    mode = os.environ.get(STRICT_MODE_ENV_VAR, "off")
+    mode = os.environ.get(STRICT_MODE_ENV_VAR, "off").lower()
     _validate_strict_mode(mode)
     return mode
 

--- a/mloda/core/abstract_plugins/components/plugin_option/plugin_collector.py
+++ b/mloda/core/abstract_plugins/components/plugin_option/plugin_collector.py
@@ -1,4 +1,21 @@
+import os
+
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
+
+STRICT_MODE_ENV_VAR = "MLODA_PLUGIN_REGISTRY_STRICT"
+VALID_STRICT_MODES = ("off", "warn", "strict")
+
+
+def strict_mode_from_env() -> str:
+    """Read the strict mode from the environment, defaulting to "off"."""
+    mode = os.environ.get(STRICT_MODE_ENV_VAR, "off")
+    _validate_strict_mode(mode)
+    return mode
+
+
+def _validate_strict_mode(mode: str) -> None:
+    if mode not in VALID_STRICT_MODES:
+        raise ValueError(f"Invalid strict mode {mode!r}. Valid modes are: {', '.join(VALID_STRICT_MODES)}.")
 
 
 class PluginCollector:
@@ -21,10 +38,17 @@ class PluginCollector:
         self.disabled_feature_group_classes: set[type[FeatureGroup]] = set()
         self.enabled_feature_group_classes: set[type[FeatureGroup]] = set()
         self.allow_redefinition: bool = False
+        self.strict_mode: str = strict_mode_from_env()
 
     def set_allow_redefinition(self, allow: bool = True) -> "PluginCollector":
         """Allow keeping the most recently defined class when duplicates differ in source."""
         self.allow_redefinition = allow
+        return self
+
+    def set_strict_mode(self, mode: str) -> "PluginCollector":
+        """Set the registry strict mode: "off", "warn", or "strict"."""
+        _validate_strict_mode(mode)
+        self.strict_mode = mode
         return self
 
     def add_disabled_feature_group_classes(self, feature_group_cls: set[type[FeatureGroup]]) -> None:

--- a/mloda/core/abstract_plugins/plugin_loader/plugin_loader.py
+++ b/mloda/core/abstract_plugins/plugin_loader/plugin_loader.py
@@ -6,6 +6,8 @@ import logging
 from types import ModuleType
 from typing import ClassVar, Optional
 
+from mloda.core.abstract_plugins.plugin_registry.plugin_registry import register_module_plugins
+
 logger = logging.getLogger(__name__)
 
 # Missing modules NOT in this set are treated as genuine errors and re-raised; the set is intentionally
@@ -118,8 +120,10 @@ class PluginLoader:
         """Internal function to load a plugin."""
         full_module_name = f"{self.base_package}.{module_path}"
         if full_module_name in sys.modules:
-            self.plugins[full_module_name] = sys.modules[full_module_name]
+            cached_module = sys.modules[full_module_name]
+            self.plugins[full_module_name] = cached_module
             self._add_plugin_to_graph(full_module_name)
+            register_module_plugins(cached_module, source="loader")
             return
 
         try:
@@ -135,6 +139,7 @@ class PluginLoader:
 
         self.plugins[full_module_name] = module
         self._add_plugin_to_graph(full_module_name)
+        register_module_plugins(module, source="loader")
 
     def load_all_plugins(self) -> None:
         """Load all groups (top-level folders) and their plugins."""

--- a/mloda/core/abstract_plugins/plugin_registry/fixtures.py
+++ b/mloda/core/abstract_plugins/plugin_registry/fixtures.py
@@ -1,0 +1,18 @@
+"""Pytest fixture helpers for isolating the process-global plugin registry."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistry
+
+
+@pytest.fixture
+def isolated_plugin_registry() -> Iterator[PluginRegistry]:
+    """Snapshot the default registry, yield it, and restore the snapshot on teardown."""
+    registry = PluginRegistry.default()
+    snapshot = registry.snapshot()
+    yield registry
+    registry.restore(snapshot)

--- a/mloda/core/abstract_plugins/plugin_registry/plugin_registry.py
+++ b/mloda/core/abstract_plugins/plugin_registry/plugin_registry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import threading
 from dataclasses import dataclass
 from types import ModuleType
@@ -134,6 +135,8 @@ def register_module_plugins(module: ModuleType, *, source: str = "loader") -> li
         if not isinstance(obj, type) or obj in _PLUGIN_BASE_TYPES:
             continue
         if not issubclass(obj, _PLUGIN_BASE_TYPES) or obj.__module__ != module.__name__:
+            continue
+        if inspect.isabstract(obj):
             continue
         keys.append(registry.register(obj, source=source, replace=True))
     return keys

--- a/mloda/core/abstract_plugins/plugin_registry/plugin_registry.py
+++ b/mloda/core/abstract_plugins/plugin_registry/plugin_registry.py
@@ -78,13 +78,23 @@ class PluginRegistry:
         return entry.cls if entry is not None else None
 
     def get_entry(self, name: str) -> PluginRegistryEntry:
-        return self._entries[name]
+        entry = self._entries.get(name)
+        if entry is None:
+            raise ValueError(f"No plugin registered under key '{name}'.")
+        return entry
 
     def is_registered(self, cls: type[Any]) -> bool:
         return any(entry.cls is cls for entry in self._entries.values())
 
     def list_registered(self, plugin_type: type[Any]) -> list[type[Any]]:
-        return [entry.cls for key, entry in sorted(self._entries.items()) if entry.plugin_type is plugin_type]
+        result: list[type[Any]] = []
+        seen: set[type[Any]] = set()
+        for _key, entry in sorted(self._entries.items()):
+            if entry.plugin_type is not plugin_type or entry.cls in seen:
+                continue
+            seen.add(entry.cls)
+            result.append(entry.cls)
+        return result
 
     def snapshot(self) -> PluginRegistrySnapshot:
         return dict(self._entries)
@@ -104,7 +114,10 @@ def register(cls: type[Any], *, name: str | None = None, source: str = "manual",
 
 
 def register_module_plugins(module: ModuleType, *, source: str = "loader") -> list[str]:
-    """Register all plugin classes defined in a module into the default registry."""
+    """Register all plugin classes defined in a module into the default registry.
+
+    Last-write-wins (replace=True) so importlib.reload updates entries; provenance may flip to "loader".
+    """
     registry = PluginRegistry.default()
     keys: list[str] = []
     for obj in vars(module).values():

--- a/mloda/core/abstract_plugins/plugin_registry/plugin_registry.py
+++ b/mloda/core/abstract_plugins/plugin_registry/plugin_registry.py
@@ -39,6 +39,7 @@ def _resolve_plugin_type(cls: type[Any]) -> type[Any]:
 
 class PluginRegistry:
     def __init__(self) -> None:
+        # Only default() lazy init is locked; registration is expected single-threaded at import/startup time.
         self._entries: dict[str, PluginRegistryEntry] = {}
 
     @classmethod

--- a/mloda/core/abstract_plugins/plugin_registry/plugin_registry.py
+++ b/mloda/core/abstract_plugins/plugin_registry/plugin_registry.py
@@ -56,6 +56,12 @@ class PluginRegistry:
     ) -> str:
         plugin_type = _resolve_plugin_type(cls)
         key = name if name is not None else f"{cls.__module__}:{cls.__qualname__}"
+        existing_key = next((k for k, entry in self._entries.items() if entry.cls is cls), None)
+        if existing_key is not None and existing_key != key:
+            raise PluginRegistryCollisionError(
+                f"{cls!r} is already registered under key '{existing_key}'; a class holds exactly one key. "
+                f"To rename, unregister('{existing_key}') first, then register under the new key."
+            )
         existing = self._entries.get(key)
         if existing is not None and not replace:
             if existing.cls is cls:
@@ -120,7 +126,7 @@ _default: PluginRegistry | None = None
 _default_lock = threading.Lock()
 
 
-def register(cls: type[Any], *, name: str | None = None, source: str = "manual", replace: bool = False) -> str:
+def register_plugin(cls: type[Any], *, name: str | None = None, source: str = "manual", replace: bool = False) -> str:
     return PluginRegistry.default().register(cls, name=name, source=source, replace=replace)
 
 

--- a/mloda/core/abstract_plugins/plugin_registry/plugin_registry.py
+++ b/mloda/core/abstract_plugins/plugin_registry/plugin_registry.py
@@ -1,0 +1,102 @@
+"""Explicit plugin registry for FeatureGroup, ComputeFramework, and Extender classes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.abstract_plugins.function_extender import Extender
+
+_PLUGIN_BASE_TYPES: tuple[type[Any], ...] = (FeatureGroup, ComputeFramework, Extender)
+
+
+class PluginRegistryCollisionError(ValueError):
+    """Raised when a different class is registered under an already taken key."""
+
+
+@dataclass(frozen=True)
+class PluginRegistryEntry:
+    cls: type[Any]
+    name: str
+    plugin_type: type[Any]
+    source_module: str
+    source: str
+
+
+PluginRegistrySnapshot = dict[str, PluginRegistryEntry]
+
+
+def _resolve_plugin_type(cls: type[Any]) -> type[Any]:
+    for base in _PLUGIN_BASE_TYPES:
+        if isinstance(cls, type) and issubclass(cls, base):
+            return base
+    raise ValueError(f"{cls!r} is not a subclass of FeatureGroup, ComputeFramework, or Extender.")
+
+
+class PluginRegistry:
+    def __init__(self) -> None:
+        self._entries: dict[str, PluginRegistryEntry] = {}
+
+    @classmethod
+    def default(cls) -> PluginRegistry:
+        global _default
+        if _default is None:
+            _default = cls()
+        return _default
+
+    def register(
+        self, cls: type[Any], *, name: str | None = None, source: str = "manual", replace: bool = False
+    ) -> str:
+        plugin_type = _resolve_plugin_type(cls)
+        key = name if name is not None else f"{cls.__module__}:{cls.__qualname__}"
+        existing = self._entries.get(key)
+        if existing is not None and not replace:
+            if existing.cls is cls:
+                return key
+            raise PluginRegistryCollisionError(
+                f"Key '{key}' is already registered to {existing.cls!r}; cannot register {cls!r}."
+            )
+        self._entries[key] = PluginRegistryEntry(
+            cls=cls,
+            name=key,
+            plugin_type=plugin_type,
+            source_module=cls.__module__,
+            source=source,
+        )
+        return key
+
+    def unregister(self, name: str) -> None:
+        if name not in self._entries:
+            raise ValueError(f"No plugin registered under key '{name}'.")
+        del self._entries[name]
+
+    def get(self, name: str) -> type[Any] | None:
+        entry = self._entries.get(name)
+        return entry.cls if entry is not None else None
+
+    def get_entry(self, name: str) -> PluginRegistryEntry:
+        return self._entries[name]
+
+    def is_registered(self, cls: type[Any]) -> bool:
+        return any(entry.cls is cls for entry in self._entries.values())
+
+    def list_registered(self, plugin_type: type[Any]) -> list[type[Any]]:
+        return [entry.cls for key, entry in sorted(self._entries.items()) if entry.plugin_type is plugin_type]
+
+    def snapshot(self) -> PluginRegistrySnapshot:
+        return dict(self._entries)
+
+    def restore(self, snapshot: PluginRegistrySnapshot) -> None:
+        self._entries = dict(snapshot)
+
+    def clear(self) -> None:
+        self._entries.clear()
+
+
+_default: PluginRegistry | None = None
+
+
+def register(cls: type[Any], *, name: str | None = None, source: str = "manual", replace: bool = False) -> str:
+    return PluginRegistry.default().register(cls, name=name, source=source, replace=replace)

--- a/mloda/core/abstract_plugins/plugin_registry/plugin_registry.py
+++ b/mloda/core/abstract_plugins/plugin_registry/plugin_registry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 from dataclasses import dataclass
 from types import ModuleType
 from typing import Any
@@ -43,8 +44,9 @@ class PluginRegistry:
     @classmethod
     def default(cls) -> PluginRegistry:
         global _default
-        if _default is None:
-            _default = cls()
+        with _default_lock:
+            if _default is None:
+                _default = cls()
         return _default
 
     def register(
@@ -57,7 +59,8 @@ class PluginRegistry:
             if existing.cls is cls:
                 return key
             raise PluginRegistryCollisionError(
-                f"Key '{key}' is already registered to {existing.cls!r}; cannot register {cls!r}."
+                f"Key '{key}' is already registered to {existing.cls!r}; cannot register {cls!r}. "
+                "Pass replace=True to replace the existing entry."
             )
         self._entries[key] = PluginRegistryEntry(
             cls=cls,
@@ -87,6 +90,11 @@ class PluginRegistry:
         return any(entry.cls is cls for entry in self._entries.values())
 
     def list_registered(self, plugin_type: type[Any]) -> list[type[Any]]:
+        if plugin_type not in _PLUGIN_BASE_TYPES:
+            raise ValueError(
+                f"{plugin_type!r} is not a valid plugin base type. "
+                "Valid types are: FeatureGroup, ComputeFramework, Extender."
+            )
         result: list[type[Any]] = []
         seen: set[type[Any]] = set()
         for _key, entry in sorted(self._entries.items()):
@@ -107,6 +115,7 @@ class PluginRegistry:
 
 
 _default: PluginRegistry | None = None
+_default_lock = threading.Lock()
 
 
 def register(cls: type[Any], *, name: str | None = None, source: str = "manual", replace: bool = False) -> str:

--- a/mloda/core/abstract_plugins/plugin_registry/plugin_registry.py
+++ b/mloda/core/abstract_plugins/plugin_registry/plugin_registry.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from types import ModuleType
 from typing import Any
 
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
@@ -100,3 +101,16 @@ _default: PluginRegistry | None = None
 
 def register(cls: type[Any], *, name: str | None = None, source: str = "manual", replace: bool = False) -> str:
     return PluginRegistry.default().register(cls, name=name, source=source, replace=replace)
+
+
+def register_module_plugins(module: ModuleType, *, source: str = "loader") -> list[str]:
+    """Register all plugin classes defined in a module into the default registry."""
+    registry = PluginRegistry.default()
+    keys: list[str] = []
+    for obj in vars(module).values():
+        if not isinstance(obj, type) or obj in _PLUGIN_BASE_TYPES:
+            continue
+        if not issubclass(obj, _PLUGIN_BASE_TYPES) or obj.__module__ != module.__name__:
+            continue
+        keys.append(registry.register(obj, source=source, replace=True))
+    return keys

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -63,8 +63,8 @@ def get_feature_group_docs(
     allow_redefinition = plugin_collector.allow_redefinition if plugin_collector is not None else False
     all_feature_groups: set[type[FeatureGroup]] = get_all_subclasses(FeatureGroup)
     if registered_only:
-        registry = PluginRegistry.default()
-        all_feature_groups = {fg for fg in all_feature_groups if registry.is_registered(fg)}
+        registered = {entry.cls for entry in PluginRegistry.default().snapshot().values()}
+        all_feature_groups = {fg for fg in all_feature_groups if fg in registered}
     if plugin_collector is not None:
         all_feature_groups = {fg for fg in all_feature_groups if plugin_collector.applicable_feature_group_class(fg)}
     all_feature_groups = dedup_feature_group_subclasses(all_feature_groups, allow_redefinition=allow_redefinition)
@@ -134,8 +134,8 @@ def get_compute_framework_docs(
     """
     all_compute_frameworks = get_all_subclasses(ComputeFramework)
     if registered_only:
-        registry = PluginRegistry.default()
-        all_compute_frameworks = {cfw for cfw in all_compute_frameworks if registry.is_registered(cfw)}
+        registered = {entry.cls for entry in PluginRegistry.default().snapshot().values()}
+        all_compute_frameworks = {cfw for cfw in all_compute_frameworks if cfw in registered}
     results = []
 
     for cfw_class in all_compute_frameworks:
@@ -210,8 +210,8 @@ def get_extender_docs(
     """
     all_extenders = get_all_subclasses(Extender)
     if registered_only:
-        registry = PluginRegistry.default()
-        all_extenders = {ext for ext in all_extenders if registry.is_registered(ext)}
+        registered = {entry.cls for entry in PluginRegistry.default().snapshot().values()}
+        all_extenders = {ext for ext in all_extenders if ext in registered}
     results = []
 
     for ext_class in all_extenders:

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -15,18 +15,24 @@ Example:
     docs = get_feature_group_docs()
 """
 
-from typing import Optional
+from typing import Any, Optional
 
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
 from mloda.core.abstract_plugins.components.utils import get_all_subclasses
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.function_extender import Extender
+from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistry
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.api.plugin_info import ComputeFrameworkInfo, ExtenderInfo, FeatureGroupInfo, ResolvedFeature
 from mloda.core.prepare.accessible_plugins import dedup_feature_group_subclasses
 from mloda.core.prepare.identify_feature_group import split_frameworks_by_capability
+
+
+def list_registered(plugin_type: type[Any]) -> list[type[Any]]:
+    """Return the default-registry classes for a plugin base type, sorted by registry key."""
+    return PluginRegistry.default().list_registered(plugin_type)
 
 
 def get_feature_group_docs(
@@ -35,6 +41,7 @@ def get_feature_group_docs(
     compute_framework: Optional[str | type[ComputeFramework]] = None,
     version_contains: Optional[str] = None,
     plugin_collector: Optional[PluginCollector] = None,
+    registered_only: bool = False,
 ) -> list[FeatureGroupInfo]:
     """
     Get documentation for feature groups with optional filtering.
@@ -48,12 +55,16 @@ def get_feature_group_docs(
         compute_framework: Filter by compute framework name or class.
         version_contains: Filter by version substring.
         plugin_collector: Filter using plugin collector's applicability check.
+        registered_only: If True, only document classes registered in the default registry.
 
     Returns:
         List of FeatureGroupInfo objects sorted by name.
     """
     allow_redefinition = plugin_collector.allow_redefinition if plugin_collector is not None else False
     all_feature_groups: set[type[FeatureGroup]] = get_all_subclasses(FeatureGroup)
+    if registered_only:
+        registry = PluginRegistry.default()
+        all_feature_groups = {fg for fg in all_feature_groups if registry.is_registered(fg)}
     if plugin_collector is not None:
         all_feature_groups = {fg for fg in all_feature_groups if plugin_collector.applicable_feature_group_class(fg)}
     all_feature_groups = dedup_feature_group_subclasses(all_feature_groups, allow_redefinition=allow_redefinition)
@@ -104,6 +115,7 @@ def get_compute_framework_docs(
     name: Optional[str] = None,
     search: Optional[str] = None,
     available_only: bool = True,
+    registered_only: bool = False,
 ) -> list[ComputeFrameworkInfo]:
     """
     Get documentation for compute frameworks with optional filtering.
@@ -115,11 +127,15 @@ def get_compute_framework_docs(
         name: Filter by compute framework name (case-insensitive partial match).
         search: Search in compute framework description (case-insensitive partial match).
         available_only: If True, only return available frameworks (default True).
+        registered_only: If True, only document classes registered in the default registry.
 
     Returns:
         List of ComputeFrameworkInfo objects sorted by name.
     """
     all_compute_frameworks = get_all_subclasses(ComputeFramework)
+    if registered_only:
+        registry = PluginRegistry.default()
+        all_compute_frameworks = {cfw for cfw in all_compute_frameworks if registry.is_registered(cfw)}
     results = []
 
     for cfw_class in all_compute_frameworks:
@@ -175,6 +191,7 @@ def get_extender_docs(
     name: Optional[str] = None,
     search: Optional[str] = None,
     wraps: Optional[str] = None,
+    registered_only: bool = False,
 ) -> list[ExtenderInfo]:
     """
     Get documentation for extenders with optional filtering.
@@ -186,11 +203,15 @@ def get_extender_docs(
         name: Filter by extender name (case-insensitive partial match).
         search: Search in extender description (case-insensitive partial match).
         wraps: Filter by wrapped function type (case-insensitive exact match).
+        registered_only: If True, only document classes registered in the default registry.
 
     Returns:
         List of ExtenderInfo objects sorted by name.
     """
     all_extenders = get_all_subclasses(Extender)
+    if registered_only:
+        registry = PluginRegistry.default()
+        all_extenders = {ext for ext in all_extenders if registry.is_registered(ext)}
     results = []
 
     for ext_class in all_extenders:

--- a/mloda/core/prepare/accessible_plugins.py
+++ b/mloda/core/prepare/accessible_plugins.py
@@ -18,6 +18,8 @@ from mloda.core.abstract_plugins.components.utils import get_all_subclasses
 
 logger = logging.getLogger(__name__)
 
+_warned_unregistered: set[str] = set()
+
 
 FeatureGroupEnvironmentMapping = dict[type[FeatureGroup], set[type[ComputeFramework]]]
 
@@ -245,15 +247,39 @@ class PreFilterPlugins:
             registered = {entry.cls for entry in PluginRegistry.default().snapshot().values()}
 
         if strict_mode == "strict":
+            before_strict = accessible_feature_groups
             accessible_feature_groups = {fg for fg in accessible_feature_groups if fg in registered}
+            if plugin_collector is not None:
+                dropped_enabled = sorted(
+                    fg.__name__
+                    for fg in before_strict - accessible_feature_groups
+                    if fg in plugin_collector.enabled_feature_group_classes
+                )
+                if dropped_enabled:
+                    logger.warning(
+                        "Explicitly enabled FeatureGroups were dropped by strict mode because they are "
+                        "not registered in the plugin registry: %s.",
+                        ", ".join(dropped_enabled),
+                    )
+            if before_strict and not accessible_feature_groups:
+                raise ValueError(
+                    "Strict mode filtered out all FeatureGroups: none of the accessible FeatureGroups "
+                    "are registered in the plugin registry. Register them via mloda.user.register() or "
+                    "relax MLODA_PLUGIN_REGISTRY_STRICT to disable strict mode."
+                )
 
         accessible_feature_groups = dedup_feature_group_subclasses(
             accessible_feature_groups, allow_redefinition=allow_redefinition
         )
 
         if strict_mode == "warn":
-            unregistered = sorted(fg.__name__ for fg in accessible_feature_groups if fg not in registered)
+            unregistered = sorted(
+                fg.__name__
+                for fg in accessible_feature_groups
+                if fg not in registered and fg.__name__ not in _warned_unregistered
+            )
             if unregistered:
+                _warned_unregistered.update(unregistered)
                 logger.warning(
                     "FeatureGroups not registered in the plugin registry: %s.",
                     ", ".join(unregistered),

--- a/mloda/core/prepare/accessible_plugins.py
+++ b/mloda/core/prepare/accessible_plugins.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import logging
 import sys
 from copy import deepcopy
@@ -248,7 +249,9 @@ class PreFilterPlugins:
 
         if strict_mode == "strict":
             before_strict = accessible_feature_groups
-            accessible_feature_groups = {fg for fg in accessible_feature_groups if fg in registered}
+            accessible_feature_groups = {
+                fg for fg in accessible_feature_groups if fg in registered or inspect.isabstract(fg)
+            }
             if plugin_collector is not None:
                 dropped_enabled = sorted(
                     f"{fg.__module__}:{fg.__qualname__}"
@@ -261,7 +264,9 @@ class PreFilterPlugins:
                         "not registered in the plugin registry: %s.",
                         ", ".join(dropped_enabled),
                     )
-            if before_strict and not accessible_feature_groups:
+            had_concrete = any(not inspect.isabstract(fg) for fg in before_strict)
+            has_concrete = any(not inspect.isabstract(fg) for fg in accessible_feature_groups)
+            if had_concrete and not has_concrete:
                 raise ValueError(
                     "Strict mode filtered out all FeatureGroups: none of the accessible FeatureGroups "
                     "are registered in the plugin registry. Register them via mloda.user.register() or "
@@ -276,7 +281,9 @@ class PreFilterPlugins:
             unregistered = sorted(
                 f"{fg.__module__}:{fg.__qualname__}"
                 for fg in accessible_feature_groups
-                if fg not in registered and f"{fg.__module__}:{fg.__qualname__}" not in _warned_unregistered
+                if fg not in registered
+                and not inspect.isabstract(fg)
+                and f"{fg.__module__}:{fg.__qualname__}" not in _warned_unregistered
             )
             if unregistered:
                 _warned_unregistered.update(unregistered)

--- a/mloda/core/prepare/accessible_plugins.py
+++ b/mloda/core/prepare/accessible_plugins.py
@@ -6,7 +6,11 @@ from copy import deepcopy
 from typing import Optional, cast
 
 from mloda.core.abstract_plugins.components.base_feature_group_version import BaseFeatureGroupVersion
-from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
+from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import (
+    PluginCollector,
+    strict_mode_from_env,
+)
+from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistry
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.abstract_plugins.components.utils import get_all_subclasses
@@ -237,6 +241,16 @@ class PreFilterPlugins:
         accessible_feature_groups = dedup_feature_group_subclasses(
             accessible_feature_groups, allow_redefinition=allow_redefinition
         )
+
+        strict_mode = plugin_collector.strict_mode if plugin_collector is not None else strict_mode_from_env()
+        if strict_mode != "off":
+            registry = PluginRegistry.default()
+            if strict_mode == "strict":
+                accessible_feature_groups = {fg for fg in accessible_feature_groups if registry.is_registered(fg)}
+            else:
+                for fg in accessible_feature_groups:
+                    if not registry.is_registered(fg):
+                        logger.warning("FeatureGroup %s is not registered in the plugin registry.", fg.__name__)
 
         if len(accessible_feature_groups) == 0:
             raise ValueError("No feature groups are loaded. Did you call PluginLoader.all()?")

--- a/mloda/core/prepare/accessible_plugins.py
+++ b/mloda/core/prepare/accessible_plugins.py
@@ -251,7 +251,7 @@ class PreFilterPlugins:
             accessible_feature_groups = {fg for fg in accessible_feature_groups if fg in registered}
             if plugin_collector is not None:
                 dropped_enabled = sorted(
-                    fg.__name__
+                    f"{fg.__module__}:{fg.__qualname__}"
                     for fg in before_strict - accessible_feature_groups
                     if fg in plugin_collector.enabled_feature_group_classes
                 )
@@ -274,9 +274,9 @@ class PreFilterPlugins:
 
         if strict_mode == "warn":
             unregistered = sorted(
-                fg.__name__
+                f"{fg.__module__}:{fg.__qualname__}"
                 for fg in accessible_feature_groups
-                if fg not in registered and fg.__name__ not in _warned_unregistered
+                if fg not in registered and f"{fg.__module__}:{fg.__qualname__}" not in _warned_unregistered
             )
             if unregistered:
                 _warned_unregistered.update(unregistered)

--- a/mloda/core/prepare/accessible_plugins.py
+++ b/mloda/core/prepare/accessible_plugins.py
@@ -269,7 +269,7 @@ class PreFilterPlugins:
             if had_concrete and not has_concrete:
                 raise ValueError(
                     "Strict mode filtered out all FeatureGroups: none of the accessible FeatureGroups "
-                    "are registered in the plugin registry. Register them via mloda.user.register() or "
+                    "are registered in the plugin registry. Register them via mloda.user.register_plugin() or "
                     "relax MLODA_PLUGIN_REGISTRY_STRICT to disable strict mode."
                 )
 

--- a/mloda/core/prepare/accessible_plugins.py
+++ b/mloda/core/prepare/accessible_plugins.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import sys
 from copy import deepcopy
-from typing import Optional, cast
+from typing import Any, Optional, cast
 
 from mloda.core.abstract_plugins.components.base_feature_group_version import BaseFeatureGroupVersion
 from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import (
@@ -238,19 +238,26 @@ class PreFilterPlugins:
                     accessible_feature_groups.remove(accessible_fg)
 
         allow_redefinition = plugin_collector.allow_redefinition if plugin_collector is not None else False
+        strict_mode = plugin_collector.strict_mode if plugin_collector is not None else strict_mode_from_env()
+
+        registered: set[type[Any]] = set()
+        if strict_mode != "off":
+            registered = {entry.cls for entry in PluginRegistry.default().snapshot().values()}
+
+        if strict_mode == "strict":
+            accessible_feature_groups = {fg for fg in accessible_feature_groups if fg in registered}
+
         accessible_feature_groups = dedup_feature_group_subclasses(
             accessible_feature_groups, allow_redefinition=allow_redefinition
         )
 
-        strict_mode = plugin_collector.strict_mode if plugin_collector is not None else strict_mode_from_env()
-        if strict_mode != "off":
-            registry = PluginRegistry.default()
-            if strict_mode == "strict":
-                accessible_feature_groups = {fg for fg in accessible_feature_groups if registry.is_registered(fg)}
-            else:
-                for fg in accessible_feature_groups:
-                    if not registry.is_registered(fg):
-                        logger.warning("FeatureGroup %s is not registered in the plugin registry.", fg.__name__)
+        if strict_mode == "warn":
+            unregistered = sorted(fg.__name__ for fg in accessible_feature_groups if fg not in registered)
+            if unregistered:
+                logger.warning(
+                    "FeatureGroups not registered in the plugin registry: %s.",
+                    ", ".join(unregistered),
+                )
 
         if len(accessible_feature_groups) == 0:
             raise ValueError("No feature groups are loaded. Did you call PluginLoader.all()?")

--- a/mloda/provider/__init__.py
+++ b/mloda/provider/__init__.py
@@ -72,6 +72,12 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
 from mloda.core.abstract_plugins.components.framework_transformer.base_transformer import BaseTransformer
 from mloda.core.abstract_plugins.components.framework_transformer.cfw_transformer import ComputeFrameworkTransformer
 
+# Plugin registry
+from mloda.core.abstract_plugins.plugin_registry.plugin_registry import (
+    PluginRegistryCollisionError,
+    register_plugin,
+)
+
 # Engines
 from mloda.core.filter.filter_engine import BaseFilterEngine
 from mloda.core.abstract_plugins.components.mask.base_mask_engine import BaseMaskEngine
@@ -119,6 +125,9 @@ __all__ = [
     # Transformers
     "BaseTransformer",
     "ComputeFrameworkTransformer",
+    # Plugin registry
+    "PluginRegistryCollisionError",
+    "register_plugin",
     # Engines
     "BaseFilterEngine",
     "BaseMaskEngine",

--- a/mloda/steward/__init__.py
+++ b/mloda/steward/__init__.py
@@ -16,6 +16,9 @@ from mloda.core.abstract_plugins.function_extender import (
     ExtenderHook,
 )
 
+# Plugin registry administration
+from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistry
+
 __all__ = [
     # Plugin inspection
     "FeatureGroupInfo",
@@ -31,4 +34,6 @@ __all__ = [
     # Function extenders
     "Extender",
     "ExtenderHook",
+    # Plugin registry administration
+    "PluginRegistry",
 ]

--- a/mloda/steward/__init__.py
+++ b/mloda/steward/__init__.py
@@ -6,6 +6,7 @@ from mloda.core.api.plugin_docs import (
     get_feature_group_docs,
     get_compute_framework_docs,
     get_extender_docs,
+    list_registered,
     resolve_feature,
 )
 
@@ -25,6 +26,7 @@ __all__ = [
     "get_feature_group_docs",
     "get_compute_framework_docs",
     "get_extender_docs",
+    "list_registered",
     "resolve_feature",
     # Function extenders
     "Extender",

--- a/mloda/user/__init__.py
+++ b/mloda/user/__init__.py
@@ -30,7 +30,10 @@ from mloda.core.abstract_plugins.plugin_loader.plugin_loader import PluginLoader
 from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
 
 # Plugin registry
-from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistry, register
+from mloda.core.abstract_plugins.plugin_registry.plugin_registry import (
+    PluginRegistryCollisionError,
+    register_plugin,
+)
 
 # Config loading
 from mloda.core.api.feature_config.loader import load_features_from_config
@@ -76,8 +79,8 @@ __all__ = [
     "PluginLoader",
     "PluginCollector",
     # Plugin registry
-    "PluginRegistry",
-    "register",
+    "PluginRegistryCollisionError",
+    "register_plugin",
     # Streaming API
     "stream_all",
     # Config loading

--- a/mloda/user/__init__.py
+++ b/mloda/user/__init__.py
@@ -29,6 +29,9 @@ from mloda.core.abstract_plugins.components.parallelization_modes import Paralle
 from mloda.core.abstract_plugins.plugin_loader.plugin_loader import PluginLoader
 from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
 
+# Plugin registry
+from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistry, register
+
 # Config loading
 from mloda.core.api.feature_config.loader import load_features_from_config
 
@@ -37,6 +40,7 @@ from mloda.core.api.plugin_docs import (
     get_feature_group_docs,
     get_compute_framework_docs,
     get_extender_docs,
+    list_registered,
     resolve_feature,
 )
 
@@ -71,6 +75,9 @@ __all__ = [
     # Plugin discovery
     "PluginLoader",
     "PluginCollector",
+    # Plugin registry
+    "PluginRegistry",
+    "register",
     # Streaming API
     "stream_all",
     # Config loading
@@ -79,5 +86,6 @@ __all__ = [
     "get_feature_group_docs",
     "get_compute_framework_docs",
     "get_extender_docs",
+    "list_registered",
     "resolve_feature",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,16 +3,29 @@ from typing import Any
 import pytest
 
 from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistry
+from mloda.core.prepare import accessible_plugins
 from mloda.core.runtime.flight.runner_flight_server import ParallelRunnerFlightServer
+
+
+def _clear_warned_unregistered() -> None:
+    """Clear the warn-mode once-per-process dedup set if the implementation provides it."""
+    warned = getattr(accessible_plugins, "_warned_unregistered", None)
+    if warned is not None:
+        warned.clear()
 
 
 @pytest.fixture(autouse=True)
 def restore_default_plugin_registry() -> Any:
-    """Snapshot and restore the default plugin registry around every test."""
+    """Snapshot and restore the default plugin registry around every test.
+
+    Also clears the warn-mode dedup set so warn-mode tests stay independent.
+    """
     registry = PluginRegistry.default()
     snapshot = registry.snapshot()
+    _clear_warned_unregistered()
     yield
     registry.restore(snapshot)
+    _clear_warned_unregistered()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,17 @@ import os
 from typing import Any
 import pytest
 
+from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistry
 from mloda.core.runtime.flight.runner_flight_server import ParallelRunnerFlightServer
+
+
+@pytest.fixture(autouse=True)
+def restore_default_plugin_registry() -> Any:
+    """Snapshot and restore the default plugin registry around every test."""
+    registry = PluginRegistry.default()
+    snapshot = registry.snapshot()
+    yield
+    registry.restore(snapshot)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_docs_enumeration.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_docs_enumeration.py
@@ -1,7 +1,8 @@
 """Tests for the registry-backed enumeration/docs rebuild (issue #526, work item 4).
 
 Contract: the registry becomes a first-class enumeration source next to the
-__subclasses__() walk. mloda.user exports PluginRegistry and register. A new
+__subclasses__() walk. mloda.user exports register_plugin but not PluginRegistry;
+PluginRegistry is a steward concern and lives in mloda.steward. A
 list_registered(plugin_type) lives in mloda.core.api.plugin_docs and is
 re-exported from mloda.user and mloda.steward; it returns the default-registry
 classes for a plugin base type, sorted by registry key. The docs functions gain
@@ -21,7 +22,7 @@ from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.abstract_plugins.function_extender import Extender, ExtenderHook
 from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistry
-from mloda.core.abstract_plugins.plugin_registry.plugin_registry import register as registry_register
+from mloda.core.abstract_plugins.plugin_registry.plugin_registry import register_plugin as registry_register
 from mloda.core.api.plugin_docs import (
     get_compute_framework_docs,
     get_extender_docs,
@@ -30,14 +31,18 @@ from mloda.core.api.plugin_docs import (
 
 
 class TestPublicRegistryExports:
-    def test_user_exports_plugin_registry_and_register(self) -> None:
-        from mloda.user import PluginRegistry as user_plugin_registry
-        from mloda.user import register as user_register
+    def test_user_exports_register_plugin_but_not_plugin_registry(self) -> None:
+        from mloda.user import register_plugin as user_register_plugin
 
-        assert user_plugin_registry is PluginRegistry
-        assert user_register is registry_register
-        assert "PluginRegistry" in mloda.user.__all__
-        assert "register" in mloda.user.__all__
+        assert user_register_plugin is registry_register
+        assert "register_plugin" in mloda.user.__all__
+        assert "register" not in mloda.user.__all__, "the old 'register' name must be gone from mloda.user"
+        assert "PluginRegistry" not in mloda.user.__all__, "PluginRegistry is a steward export, not a user one"
+        assert not hasattr(mloda.user, "PluginRegistry")
+
+    def test_steward_exports_plugin_registry(self) -> None:
+        assert getattr(mloda.steward, "PluginRegistry") is PluginRegistry
+        assert "PluginRegistry" in mloda.steward.__all__
 
 
 class TestListRegisteredDocsApi:

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_docs_enumeration.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_docs_enumeration.py
@@ -1,4 +1,4 @@
-"""Failing tests for the registry-backed enumeration/docs rebuild (issue #526, work item 4).
+"""Tests for the registry-backed enumeration/docs rebuild (issue #526, work item 4).
 
 Contract: the registry becomes a first-class enumeration source next to the
 __subclasses__() walk. mloda.user exports PluginRegistry and register. A new
@@ -29,7 +29,6 @@ from mloda.core.api.plugin_docs import (
 )
 
 
-# Fails today: PluginRegistry and register are not exported from mloda.user.
 class TestPublicRegistryExports:
     def test_user_exports_plugin_registry_and_register(self) -> None:
         from mloda.user import PluginRegistry as user_plugin_registry
@@ -41,7 +40,6 @@ class TestPublicRegistryExports:
         assert "register" in mloda.user.__all__
 
 
-# Fails today: list_registered does not exist in mloda.core.api.plugin_docs.
 class TestListRegisteredDocsApi:
     def test_list_registered_returns_registry_contents_for_base_type(self) -> None:
         from mloda.core.api.plugin_docs import list_registered
@@ -86,7 +84,6 @@ class TestListRegisteredDocsApi:
         assert "list_registered" in mloda.steward.__all__
 
 
-# Fails today: the docs functions do not accept a registered_only keyword.
 class TestRegisteredOnlyDocsFiltering:
     def test_feature_group_docs_registered_only_filters_to_registry(self) -> None:
         registry = PluginRegistry.default()

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_docs_enumeration.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_docs_enumeration.py
@@ -1,0 +1,190 @@
+"""Failing tests for the registry-backed enumeration/docs rebuild (issue #526, work item 4).
+
+Contract: the registry becomes a first-class enumeration source next to the
+__subclasses__() walk. mloda.user exports PluginRegistry and register. A new
+list_registered(plugin_type) lives in mloda.core.api.plugin_docs and is
+re-exported from mloda.user and mloda.steward; it returns the default-registry
+classes for a plugin base type, sorted by registry key. The docs functions gain
+a registered_only keyword (default False) that restricts output to registered
+classes. Default-mode docs remain the union of registry and subclass walk, with
+no duplicate entries.
+
+The autouse conftest fixture restores the default registry around every test,
+so clearing it inside a test is safe.
+"""
+
+from typing import Any
+
+import mloda.steward
+import mloda.user
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.abstract_plugins.function_extender import Extender, ExtenderHook
+from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistry
+from mloda.core.abstract_plugins.plugin_registry.plugin_registry import register as registry_register
+from mloda.core.api.plugin_docs import (
+    get_compute_framework_docs,
+    get_extender_docs,
+    get_feature_group_docs,
+)
+
+
+# Fails today: PluginRegistry and register are not exported from mloda.user.
+class TestPublicRegistryExports:
+    def test_user_exports_plugin_registry_and_register(self) -> None:
+        from mloda.user import PluginRegistry as user_plugin_registry
+        from mloda.user import register as user_register
+
+        assert user_plugin_registry is PluginRegistry
+        assert user_register is registry_register
+        assert "PluginRegistry" in mloda.user.__all__
+        assert "register" in mloda.user.__all__
+
+
+# Fails today: list_registered does not exist in mloda.core.api.plugin_docs.
+class TestListRegisteredDocsApi:
+    def test_list_registered_returns_registry_contents_for_base_type(self) -> None:
+        from mloda.core.api.plugin_docs import list_registered
+
+        registry = PluginRegistry.default()
+        registry.clear()
+
+        class _DocsEnumListedFG(FeatureGroup):
+            """Local feature group registered for enumeration."""
+
+        registry_register(_DocsEnumListedFG)
+
+        assert list_registered(FeatureGroup) == [_DocsEnumListedFG]
+        assert list_registered(ComputeFramework) == []
+        assert list_registered(Extender) == []
+
+    def test_list_registered_sorted_by_registry_key(self) -> None:
+        from mloda.core.api.plugin_docs import list_registered
+
+        registry = PluginRegistry.default()
+        registry.clear()
+
+        class _DocsEnumZzFG(FeatureGroup):
+            """Sorts after the Aa double by registry key."""
+
+        class _DocsEnumAaFG(FeatureGroup):
+            """Sorts before the Zz double by registry key."""
+
+        registry_register(_DocsEnumZzFG)
+        registry_register(_DocsEnumAaFG)
+
+        assert list_registered(FeatureGroup) == [_DocsEnumAaFG, _DocsEnumZzFG], (
+            "list_registered must sort by registry key, not by registration order"
+        )
+
+    def test_list_registered_reexported_from_user_and_steward(self) -> None:
+        from mloda.core.api.plugin_docs import list_registered
+
+        assert getattr(mloda.user, "list_registered") is list_registered
+        assert getattr(mloda.steward, "list_registered") is list_registered
+        assert "list_registered" in mloda.user.__all__
+        assert "list_registered" in mloda.steward.__all__
+
+
+# Fails today: the docs functions do not accept a registered_only keyword.
+class TestRegisteredOnlyDocsFiltering:
+    def test_feature_group_docs_registered_only_filters_to_registry(self) -> None:
+        registry = PluginRegistry.default()
+        registry.clear()
+
+        class _DocsEnumRegOnlyFG(FeatureGroup):
+            """Registered-only filtering test double for feature group docs."""
+
+        before = [fg.name for fg in get_feature_group_docs(registered_only=True)]
+        assert "_DocsEnumRegOnlyFG" not in before, (
+            "registered_only=True must hide subclass-walk classes that are not in the registry"
+        )
+
+        registry_register(_DocsEnumRegOnlyFG)
+        after = [fg.name for fg in get_feature_group_docs(registered_only=True)]
+        assert "_DocsEnumRegOnlyFG" in after, "registered_only=True must document registered classes"
+
+    def test_feature_group_docs_registered_only_defaults_to_false(self) -> None:
+        registry = PluginRegistry.default()
+        registry.clear()
+
+        default_names = [fg.name for fg in get_feature_group_docs()]
+        explicit_names = [fg.name for fg in get_feature_group_docs(registered_only=False)]
+        assert default_names == explicit_names
+
+    def test_compute_framework_docs_registered_only_filters_to_registry(self) -> None:
+        registry = PluginRegistry.default()
+        registry.clear()
+
+        class _DocsEnumRegOnlyCFW(ComputeFramework):
+            """Registered-only filtering test double for compute framework docs."""
+
+        before = [cfw.name for cfw in get_compute_framework_docs(registered_only=True, available_only=False)]
+        assert "_DocsEnumRegOnlyCFW" not in before
+
+        registry_register(_DocsEnumRegOnlyCFW)
+        after = [cfw.name for cfw in get_compute_framework_docs(registered_only=True, available_only=False)]
+        assert "_DocsEnumRegOnlyCFW" in after
+
+    def test_extender_docs_registered_only_filters_to_registry(self) -> None:
+        registry = PluginRegistry.default()
+        registry.clear()
+
+        class _DocsEnumRegOnlyExtender(Extender):
+            """Registered-only filtering test double for extender docs."""
+
+            def wraps(self) -> set[ExtenderHook]:
+                return set()
+
+            def __call__(self, func: Any, *args: Any, **kwargs: Any) -> Any:
+                return func(*args, **kwargs)
+
+        before = [ext.name for ext in get_extender_docs(registered_only=True)]
+        assert "_DocsEnumRegOnlyExtender" not in before
+
+        registry_register(_DocsEnumRegOnlyExtender)
+        after = [ext.name for ext in get_extender_docs(registered_only=True)]
+        assert "_DocsEnumRegOnlyExtender" in after
+
+
+# Non-regression guard: default-mode docs keep the subclass-walk fallback.
+class TestDocsFallbackNonRegression:
+    def test_unregistered_local_fg_still_documented(self) -> None:
+        registry = PluginRegistry.default()
+        registry.clear()
+
+        class _DocsEnumFallbackFG(FeatureGroup):
+            """Unregistered local feature group; the subclass walk must still find it."""
+
+        names = [fg.name for fg in get_feature_group_docs()]
+        assert "_DocsEnumFallbackFG" in names
+
+    def test_default_docs_are_union_of_registry_and_subclass_walk(self) -> None:
+        registry = PluginRegistry.default()
+        registry.clear()
+
+        class _DocsEnumUnionRegisteredFG(FeatureGroup):
+            """Registered half of the union test pair."""
+
+        class _DocsEnumUnionUnregisteredFG(FeatureGroup):
+            """Unregistered half of the union test pair."""
+
+        registry_register(_DocsEnumUnionRegisteredFG)
+
+        names = [fg.name for fg in get_feature_group_docs()]
+        assert "_DocsEnumUnionRegisteredFG" in names
+        assert "_DocsEnumUnionUnregisteredFG" in names
+
+    def test_registered_and_walkable_fg_listed_exactly_once(self) -> None:
+        registry = PluginRegistry.default()
+        registry.clear()
+
+        class _DocsEnumOnceFG(FeatureGroup):
+            """Both registered and subclass-walk reachable; must be documented once."""
+
+        registry_register(_DocsEnumOnceFG)
+
+        names = [fg.name for fg in get_feature_group_docs()]
+        assert names.count("_DocsEnumOnceFG") == 1, (
+            "a class that is both registered and subclass-reachable must not be documented twice"
+        )

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_loader_registration.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_loader_registration.py
@@ -24,8 +24,8 @@ from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.abstract_plugins.function_extender import Extender
 from mloda.core.abstract_plugins.plugin_registry.plugin_registry import (
     PluginRegistry,
-    register,
     register_module_plugins,
+    register_plugin,
 )
 from mloda.user import PluginLoader
 
@@ -194,8 +194,8 @@ class TestLoaderIgnoresTransientSubclasses:
             "ad-hoc subclasses defined outside loaded plugin modules must stay out of the registry"
         )
 
-        key = register(_AdHocFeatureGroup)
-        assert registry.is_registered(_AdHocFeatureGroup), "explicit register() must opt a class in"
+        key = register_plugin(_AdHocFeatureGroup)
+        assert registry.is_registered(_AdHocFeatureGroup), "explicit register_plugin() must opt a class in"
         assert registry.get_entry(key).source == "manual"
 
         assert registry.is_registered(_python_dict_framework_cls()), (

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_loader_registration.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_loader_registration.py
@@ -1,4 +1,4 @@
-"""Failing tests for the loader -> registry discovery funnel (issue #526, work item 3).
+"""Tests for the loader -> registry discovery funnel (issue #526, work item 3).
 
 Contract: PluginLoader loads feed the default PluginRegistry. Every FeatureGroup,
 ComputeFramework, or Extender subclass DEFINED in a loaded module (cls.__module__

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_loader_registration.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_loader_registration.py
@@ -1,24 +1,32 @@
 """Tests for the loader -> registry discovery funnel (issue #526, work item 3).
 
-Contract: PluginLoader loads feed the default PluginRegistry. Every FeatureGroup,
-ComputeFramework, or Extender subclass DEFINED in a loaded module (cls.__module__
-equals the loaded module name) is registered exactly once under its defining module,
-with source="loader". Registration is idempotent, happens on the sys.modules cache
-path too (import-order and import-history independent), and never picks up ad-hoc
-subclasses defined outside loaded plugin modules.
+Contract: PluginLoader loads feed the default PluginRegistry. Every non-abstract
+FeatureGroup, ComputeFramework, or Extender subclass DEFINED in a loaded module
+(cls.__module__ equals the loaded module name) is registered exactly once under its
+defining module, with source="loader". Abstract classes (inspect.isabstract) are
+infrastructure, never plugins, and stay out. Registration is idempotent, happens on
+the sys.modules cache path too (import-order and import-history independent), and
+never picks up ad-hoc subclasses defined outside loaded plugin modules.
 
-All scopes used here import without optional dependencies (python_dict and sqlite).
-The autouse conftest fixture restores the default registry around every test, so
-clearing it inside a test is safe.
+All scopes used here import without optional dependencies (python_dict, sqlite,
+and text_cleaning). The autouse conftest fixture restores the default registry
+around every test, so clearing it inside a test is safe.
 """
 
+import inspect
 import sys
+import types
+from abc import abstractmethod
 from typing import Any
 
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.abstract_plugins.function_extender import Extender
-from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistry, register
+from mloda.core.abstract_plugins.plugin_registry.plugin_registry import (
+    PluginRegistry,
+    register,
+    register_module_plugins,
+)
 from mloda.user import PluginLoader
 
 PYTHON_DICT_FRAMEWORK_MODULE = "mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework"
@@ -192,4 +200,82 @@ class TestLoaderIgnoresTransientSubclasses:
 
         assert registry.is_registered(_python_dict_framework_cls()), (
             "loader-run plugins must be registered while ad-hoc subclasses are not"
+        )
+
+
+class TestLoaderRegistrationSkipsAbstractClasses:
+    """Abstract helper base classes are infrastructure, never plugins; they must not auto-register."""
+
+    def test_register_module_plugins_skips_abstract_classes(self) -> None:
+        registry = PluginRegistry.default()
+        registry.clear()
+
+        module = types.ModuleType("fake_registry_abstract_mod")
+
+        class _AbstractHelperBaseFG(FeatureGroup):
+            @abstractmethod
+            def _abstract_registry_probe_hook(self) -> None: ...
+
+            @classmethod
+            def match_feature_group_criteria(
+                cls,
+                feature_name: Any,
+                options: Any,
+                data_access_collection: Any = None,
+            ) -> bool:
+                # Inert for other tests' feature resolution in this worker; the default
+                # matching falls back to cls(), which raises TypeError on abstract classes.
+                return False
+
+        class _ConcreteLeafProbeFG(FeatureGroup):
+            @classmethod
+            def match_feature_group_criteria(
+                cls,
+                feature_name: Any,
+                options: Any,
+                data_access_collection: Any = None,
+            ) -> bool:
+                return False
+
+        _AbstractHelperBaseFG.__module__ = module.__name__
+        _ConcreteLeafProbeFG.__module__ = module.__name__
+        setattr(module, "_AbstractHelperBaseFG", _AbstractHelperBaseFG)
+        setattr(module, "_ConcreteLeafProbeFG", _ConcreteLeafProbeFG)
+
+        assert inspect.isabstract(_AbstractHelperBaseFG), "sanity: the helper base double is abstract"
+        assert not inspect.isabstract(_ConcreteLeafProbeFG), "sanity: the leaf double is concrete"
+
+        register_module_plugins(module)
+
+        assert registry.is_registered(_ConcreteLeafProbeFG), (
+            "concrete plugin classes defined in a loaded module must be registered"
+        )
+        assert not registry.is_registered(_AbstractHelperBaseFG), (
+            "abstract helper base classes must not be auto-registered by register_module_plugins"
+        )
+
+    def test_loaded_scope_registers_concrete_classes_but_not_abstract_bases(self) -> None:
+        """End to end through PluginLoader: the text_cleaning scope is dependency-free and its
+        base module defines an inspect.isabstract helper base."""
+        registry = PluginRegistry.default()
+        registry.clear()
+
+        loader = PluginLoader()
+        loader.load_matching("feature_group", "text_cleaning/*")
+
+        from mloda_plugins.feature_group.experimental.text_cleaning.base import TextCleaningFeatureGroup
+        from mloda_plugins.feature_group.experimental.text_cleaning.python_dict import (
+            PythonDictTextCleaningFeatureGroup,
+        )
+
+        assert inspect.isabstract(TextCleaningFeatureGroup), "sanity: the scope's base class is abstract"
+        assert not inspect.isabstract(PythonDictTextCleaningFeatureGroup), "sanity: the scope has a concrete class"
+
+        registered_feature_groups = registry.list_registered(FeatureGroup)
+        assert PythonDictTextCleaningFeatureGroup in registered_feature_groups, (
+            "loading a scope must register its concrete plugin classes"
+        )
+        assert TextCleaningFeatureGroup not in registered_feature_groups, (
+            "loading a scope must not register its abstract helper base class; abstract classes "
+            "pollute list_registered(), registered-only docs, and strict resolution"
         )

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_loader_registration.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_loader_registration.py
@@ -13,6 +13,7 @@ and text_cleaning). The autouse conftest fixture restores the default registry
 around every test, so clearing it inside a test is safe.
 """
 
+import gc
 import inspect
 import sys
 import types
@@ -242,17 +243,29 @@ class TestLoaderRegistrationSkipsAbstractClasses:
         setattr(module, "_AbstractHelperBaseFG", _AbstractHelperBaseFG)
         setattr(module, "_ConcreteLeafProbeFG", _ConcreteLeafProbeFG)
 
-        assert inspect.isabstract(_AbstractHelperBaseFG), "sanity: the helper base double is abstract"
-        assert not inspect.isabstract(_ConcreteLeafProbeFG), "sanity: the leaf double is concrete"
+        try:
+            assert inspect.isabstract(_AbstractHelperBaseFG), "sanity: the helper base double is abstract"
+            assert not inspect.isabstract(_ConcreteLeafProbeFG), "sanity: the leaf double is concrete"
 
-        register_module_plugins(module)
+            register_module_plugins(module)
 
-        assert registry.is_registered(_ConcreteLeafProbeFG), (
-            "concrete plugin classes defined in a loaded module must be registered"
-        )
-        assert not registry.is_registered(_AbstractHelperBaseFG), (
-            "abstract helper base classes must not be auto-registered by register_module_plugins"
-        )
+            assert registry.is_registered(_ConcreteLeafProbeFG), (
+                "concrete plugin classes defined in a loaded module must be registered"
+            )
+            assert not registry.is_registered(_AbstractHelperBaseFG), (
+                "abstract helper base classes must not be auto-registered by register_module_plugins"
+            )
+        finally:
+            # Drop every strong ref to the fake-module doubles so they cannot poison
+            # other tests in this worker via FeatureGroup.__subclasses__(): their fake
+            # __module__ has no importable file, so version()/class_source_hash raises
+            # TypeError for them. The conftest fixture restores the registry snapshot
+            # after the test, so clearing the loader-registered entry here is safe.
+            registry.clear()
+            delattr(module, "_AbstractHelperBaseFG")
+            delattr(module, "_ConcreteLeafProbeFG")
+            del _AbstractHelperBaseFG, _ConcreteLeafProbeFG, module
+            gc.collect()
 
     def test_loaded_scope_registers_concrete_classes_but_not_abstract_bases(self) -> None:
         """End to end through PluginLoader: the text_cleaning scope is dependency-free and its

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_loader_registration.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_loader_registration.py
@@ -1,0 +1,195 @@
+"""Failing tests for the loader -> registry discovery funnel (issue #526, work item 3).
+
+Contract: PluginLoader loads feed the default PluginRegistry. Every FeatureGroup,
+ComputeFramework, or Extender subclass DEFINED in a loaded module (cls.__module__
+equals the loaded module name) is registered exactly once under its defining module,
+with source="loader". Registration is idempotent, happens on the sys.modules cache
+path too (import-order and import-history independent), and never picks up ad-hoc
+subclasses defined outside loaded plugin modules.
+
+All scopes used here import without optional dependencies (python_dict and sqlite).
+The autouse conftest fixture restores the default registry around every test, so
+clearing it inside a test is safe.
+"""
+
+import sys
+from typing import Any
+
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.abstract_plugins.function_extender import Extender
+from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistry, register
+from mloda.user import PluginLoader
+
+PYTHON_DICT_FRAMEWORK_MODULE = "mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework"
+
+_PLUGIN_BASE_TYPES: tuple[type[Any], ...] = (FeatureGroup, ComputeFramework, Extender)
+
+
+def _default_key(cls: type[Any]) -> str:
+    return f"{cls.__module__}:{cls.__qualname__}"
+
+
+def _python_dict_framework_cls() -> type[Any]:
+    from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
+        PythonDictFramework,
+    )
+
+    return PythonDictFramework
+
+
+def _sqlite_framework_cls() -> type[Any]:
+    from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_framework import SqliteFramework
+
+    return SqliteFramework
+
+
+def _load_python_dict_compute_scope() -> PluginLoader:
+    """Small, dependency-free scope: the python_dict compute framework files only."""
+    loader = PluginLoader()
+    loader.load_matching("compute_framework", "*python_dict*")
+    return loader
+
+
+class TestLoaderRegistersLoadedPlugins:
+    def test_loader_registers_classes_defined_in_loaded_modules(self) -> None:
+        registry = PluginRegistry.default()
+        registry.clear()
+
+        _load_python_dict_compute_scope()
+
+        python_dict_framework = _python_dict_framework_cls()
+        assert registry.is_registered(python_dict_framework), (
+            "PluginLoader.load_matching must register plugin classes defined in loaded modules "
+            "in the default PluginRegistry"
+        )
+
+        module = sys.modules[PYTHON_DICT_FRAMEWORK_MODULE]
+        defined_plugin_classes = [
+            obj
+            for obj in vars(module).values()
+            if isinstance(obj, type) and issubclass(obj, _PLUGIN_BASE_TYPES) and obj.__module__ == module.__name__
+        ]
+        assert defined_plugin_classes, "sanity: the loaded module defines at least one plugin class"
+        for cls in defined_plugin_classes:
+            assert registry.is_registered(cls), f"{cls!r} is defined in a loaded module but is not registered"
+
+    def test_loader_entries_carry_loader_provenance(self) -> None:
+        registry = PluginRegistry.default()
+        registry.clear()
+
+        _load_python_dict_compute_scope()
+
+        python_dict_framework = _python_dict_framework_cls()
+        key = _default_key(python_dict_framework)
+        assert key in registry.snapshot(), f"loader must register '{key}' in the default registry"
+
+        entry = registry.get_entry(key)
+        assert entry.cls is python_dict_framework
+        assert entry.source == "loader"
+        assert entry.source_module == python_dict_framework.__module__
+
+
+class TestLoaderRegistrationKeying:
+    def test_imported_classes_register_once_under_their_defining_module(self) -> None:
+        """A class imported into other loaded modules must not get a second entry there.
+
+        Both mloda_plugins.feature_group.experimental.text_cleaning.python_dict and
+        mloda_plugins.feature_group.experimental.data_quality.missing_value.python_dict
+        import PythonDictFramework; only the defining module produces an entry.
+        """
+        registry = PluginRegistry.default()
+        registry.clear()
+
+        loader = PluginLoader()
+        loader.load_matching("compute_framework", "*python_dict*")
+        loader.load_matching("feature_group", "*python_dict*")
+
+        python_dict_framework = _python_dict_framework_cls()
+        entries = registry.snapshot()
+        keys_for_class = [key for key, entry in entries.items() if entry.cls is python_dict_framework]
+        assert keys_for_class == [_default_key(python_dict_framework)], (
+            "PythonDictFramework must be registered exactly once, keyed by its own defining module, "
+            f"got keys: {keys_for_class}"
+        )
+
+        for entry in entries.values():
+            assert entry.source_module == entry.cls.__module__
+            assert entry.name == _default_key(entry.cls)
+
+
+class TestLoaderRegistrationIdempotency:
+    def test_repeated_load_registers_nothing_new(self) -> None:
+        registry = PluginRegistry.default()
+        registry.clear()
+
+        _load_python_dict_compute_scope()
+        first_snapshot = registry.snapshot()
+        assert first_snapshot, "loader run must populate the cleared default registry"
+
+        _load_python_dict_compute_scope()
+        assert registry.snapshot() == first_snapshot, "loading the same scope twice must not add or change entries"
+
+    def test_load_of_already_imported_modules_reregisters(self) -> None:
+        """Registration must also happen on the sys.modules cache path of _load_plugin."""
+        registry = PluginRegistry.default()
+        registry.clear()
+
+        _load_python_dict_compute_scope()
+        first_snapshot = registry.snapshot()
+        assert first_snapshot, "loader run must populate the cleared default registry"
+        assert PYTHON_DICT_FRAMEWORK_MODULE in sys.modules, "sanity: module is cached in sys.modules"
+
+        registry.clear()
+        _load_python_dict_compute_scope()
+
+        python_dict_framework = _python_dict_framework_cls()
+        assert registry.is_registered(python_dict_framework), (
+            "loading a scope whose modules are already in sys.modules must still register the plugin classes"
+        )
+        assert registry.snapshot() == first_snapshot
+
+
+class TestLoaderRegistrationOrderIndependence:
+    def test_load_order_does_not_change_registry_contents(self) -> None:
+        registry = PluginRegistry.default()
+
+        registry.clear()
+        loader_ab = PluginLoader()
+        loader_ab.load_matching("compute_framework", "*python_dict*")
+        loader_ab.load_matching("compute_framework", "*sqlite*")
+        result_ab = registry.list_registered(ComputeFramework)
+
+        registry.clear()
+        loader_ba = PluginLoader()
+        loader_ba.load_matching("compute_framework", "*sqlite*")
+        loader_ba.load_matching("compute_framework", "*python_dict*")
+        result_ba = registry.list_registered(ComputeFramework)
+
+        assert result_ab, "loading two compute framework scopes must register compute frameworks"
+        assert _python_dict_framework_cls() in result_ab
+        assert _sqlite_framework_cls() in result_ab
+        assert result_ab == result_ba, "registry contents must not depend on load order"
+
+
+class TestLoaderIgnoresTransientSubclasses:
+    def test_local_subclass_stays_out_but_explicit_register_opts_in(self) -> None:
+        registry = PluginRegistry.default()
+        registry.clear()
+
+        class _AdHocFeatureGroup(FeatureGroup):
+            """Simulates a test double or notebook-cell class; must never auto-register."""
+
+        _load_python_dict_compute_scope()
+
+        assert not registry.is_registered(_AdHocFeatureGroup), (
+            "ad-hoc subclasses defined outside loaded plugin modules must stay out of the registry"
+        )
+
+        key = register(_AdHocFeatureGroup)
+        assert registry.is_registered(_AdHocFeatureGroup), "explicit register() must opt a class in"
+        assert registry.get_entry(key).source == "manual"
+
+        assert registry.is_registered(_python_dict_framework_cls()), (
+            "loader-run plugins must be registered while ad-hoc subclasses are not"
+        )

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_persona_exports.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_persona_exports.py
@@ -1,0 +1,72 @@
+"""Persona-export matrix for the plugin registry public API (pre-merge tightening).
+
+Contract: the module-level registration function is named register_plugin.
+mloda.user exports register_plugin, list_registered, and PluginRegistryCollisionError,
+but NOT PluginRegistry. mloda.provider exports register_plugin and
+PluginRegistryCollisionError. mloda.steward exports PluginRegistry and
+list_registered. Every export is the identical object from its core module
+and is listed in the namespace's __all__.
+"""
+
+from types import ModuleType
+
+import pytest
+
+import mloda.core.abstract_plugins.plugin_registry.plugin_registry as core_registry
+import mloda.core.api.plugin_docs as plugin_docs
+import mloda.provider
+import mloda.steward
+import mloda.user
+
+_NAMESPACES: dict[str, ModuleType] = {
+    "user": mloda.user,
+    "provider": mloda.provider,
+    "steward": mloda.steward,
+}
+
+_SOURCES: dict[str, ModuleType] = {
+    "core_registry": core_registry,
+    "plugin_docs": plugin_docs,
+}
+
+# (namespace, symbol, source module holding the canonical object)
+EXPORT_MATRIX: list[tuple[str, str, str]] = [
+    ("user", "register_plugin", "core_registry"),
+    ("user", "list_registered", "plugin_docs"),
+    ("user", "PluginRegistryCollisionError", "core_registry"),
+    ("provider", "register_plugin", "core_registry"),
+    ("provider", "PluginRegistryCollisionError", "core_registry"),
+    ("steward", "PluginRegistry", "core_registry"),
+    ("steward", "list_registered", "plugin_docs"),
+]
+
+_MATRIX_IDS = [f"{namespace}-{symbol}" for namespace, symbol, _source in EXPORT_MATRIX]
+
+
+class TestPersonaExportMatrix:
+    @pytest.mark.parametrize(("namespace_name", "symbol", "source_name"), EXPORT_MATRIX, ids=_MATRIX_IDS)
+    def test_symbol_listed_in_namespace_all(self, namespace_name: str, symbol: str, source_name: str) -> None:
+        namespace = _NAMESPACES[namespace_name]
+        assert symbol in namespace.__all__, f"mloda.{namespace_name} must list '{symbol}' in __all__"
+
+    @pytest.mark.parametrize(("namespace_name", "symbol", "source_name"), EXPORT_MATRIX, ids=_MATRIX_IDS)
+    def test_symbol_is_identical_to_core_object(self, namespace_name: str, symbol: str, source_name: str) -> None:
+        namespace = _NAMESPACES[namespace_name]
+        source = _SOURCES[source_name]
+        assert hasattr(source, symbol), f"{source.__name__} must define '{symbol}'"
+        assert hasattr(namespace, symbol), f"mloda.{namespace_name} must expose '{symbol}'"
+        assert getattr(namespace, symbol) is getattr(source, symbol), (
+            f"mloda.{namespace_name}.{symbol} must be the identical object from {source.__name__}"
+        )
+
+
+class TestUserDoesNotExportPluginRegistry:
+    def test_plugin_registry_absent_from_user_all(self) -> None:
+        assert "PluginRegistry" not in mloda.user.__all__, (
+            "mloda.user must not list PluginRegistry in __all__; it moves to mloda.steward"
+        )
+
+    def test_plugin_registry_not_a_user_attribute(self) -> None:
+        assert not hasattr(mloda.user, "PluginRegistry"), (
+            "mloda.user must not expose a PluginRegistry attribute; stewards use mloda.steward.PluginRegistry"
+        )

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_plugin_registry.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_plugin_registry.py
@@ -148,6 +148,12 @@ class TestPluginRegistryLookup:
         with pytest.raises(ValueError):
             reg.unregister("does_not_exist")
 
+    def test_get_entry_unknown_key_raises_value_error(self) -> None:
+        """get_entry on an unknown key must raise ValueError, not a bare KeyError."""
+        reg = PluginRegistry()
+        with pytest.raises(ValueError):
+            reg.get_entry("nope:Missing")
+
     def test_is_registered_true_for_registered_class(self) -> None:
         reg = PluginRegistry()
         reg.register(_RegistryTestFGA, name="any_key")
@@ -204,6 +210,17 @@ class TestPluginRegistryListRegistered:
         result = reg.list_registered(FeatureGroup)
         assert isinstance(result, list)
         assert result == [_RegistryTestFGA, _RegistryTestFGB]
+
+    def test_list_registered_dedupes_class_registered_under_multiple_keys(self) -> None:
+        """A class registered under several keys must appear exactly once in list_registered."""
+        reg = PluginRegistry()
+        reg.register(_RegistryTestFGA)
+        reg.register(_RegistryTestFGA, name="alias")
+        result = reg.list_registered(FeatureGroup)
+        assert _RegistryTestFGA in result
+        assert result.count(_RegistryTestFGA) == 1, (
+            f"list_registered must dedupe by class identity, got {result.count(_RegistryTestFGA)} occurrences"
+        )
 
     def test_list_registered_is_registration_order_independent(self) -> None:
         reg_ab = PluginRegistry()

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_plugin_registry.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_plugin_registry.py
@@ -1,0 +1,258 @@
+"""Tests for the explicit plugin registry core (issue #526, work item 1).
+
+Defines the contract for PluginRegistry: instance and process-global default,
+register/unregister/get, collision handling, replace, type filtering,
+snapshot/restore, and the module-level register() convenience.
+"""
+
+from collections.abc import Iterator
+
+import pytest
+
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.abstract_plugins.function_extender import Extender
+from mloda.core.abstract_plugins.plugin_registry.plugin_registry import (
+    PluginRegistry,
+    PluginRegistryCollisionError,
+    register,
+)
+
+
+class _RegistryTestFGA(FeatureGroup):
+    pass
+
+
+class _RegistryTestFGB(FeatureGroup):
+    pass
+
+
+class _RegistryTestCF(ComputeFramework):
+    pass
+
+
+class _RegistryTestExtender(Extender):
+    pass
+
+
+class _RegistryTestNotAPlugin:
+    pass
+
+
+def _default_key(cls: type) -> str:
+    return f"{cls.__module__}:{cls.__qualname__}"
+
+
+@pytest.fixture
+def default_registry_guard() -> Iterator[PluginRegistry]:
+    """Snapshot the process-global default registry and restore it on teardown."""
+    reg = PluginRegistry.default()
+    snap = reg.snapshot()
+    yield reg
+    reg.restore(snap)
+
+
+class TestPluginRegistryInstances:
+    def test_instantiable(self) -> None:
+        reg = PluginRegistry()
+        assert isinstance(reg, PluginRegistry)
+
+    def test_instances_have_independent_state(self) -> None:
+        reg1 = PluginRegistry()
+        reg2 = PluginRegistry()
+        key = reg1.register(_RegistryTestFGA)
+        assert reg1.get(key) is _RegistryTestFGA
+        assert reg2.get(key) is None
+
+    def test_default_returns_same_instance(self) -> None:
+        assert PluginRegistry.default() is PluginRegistry.default()
+
+    def test_default_is_not_a_fresh_instance(self) -> None:
+        assert PluginRegistry.default() is not PluginRegistry()
+
+
+class TestPluginRegistryRegister:
+    def test_register_returns_default_key(self) -> None:
+        reg = PluginRegistry()
+        key = reg.register(_RegistryTestFGA)
+        assert key == _default_key(_RegistryTestFGA)
+
+    def test_register_with_name_overrides_key(self) -> None:
+        reg = PluginRegistry()
+        key = reg.register(_RegistryTestFGA, name="custom")
+        assert key == "custom"
+        assert reg.get("custom") is _RegistryTestFGA
+
+    def test_register_source_defaults_to_manual(self) -> None:
+        reg = PluginRegistry()
+        key = reg.register(_RegistryTestFGA)
+        assert reg.get_entry(key).source == "manual"
+
+    def test_register_records_source(self) -> None:
+        reg = PluginRegistry()
+        key = reg.register(_RegistryTestFGA, source="entry_point")
+        assert reg.get_entry(key).source == "entry_point"
+
+    def test_register_non_plugin_class_raises_value_error(self) -> None:
+        reg = PluginRegistry()
+        with pytest.raises(ValueError):
+            reg.register(_RegistryTestNotAPlugin)
+
+    def test_register_same_class_twice_is_noop(self) -> None:
+        reg = PluginRegistry()
+        key1 = reg.register(_RegistryTestFGA)
+        key2 = reg.register(_RegistryTestFGA)
+        assert key1 == key2
+        assert reg.list_registered(FeatureGroup) == [_RegistryTestFGA]
+
+
+class TestPluginRegistryCollision:
+    def test_collision_error_is_value_error_subclass(self) -> None:
+        assert issubclass(PluginRegistryCollisionError, ValueError)
+
+    def test_different_class_same_key_raises_collision_error(self) -> None:
+        reg = PluginRegistry()
+        reg.register(_RegistryTestFGA, name="dup_key")
+        with pytest.raises(PluginRegistryCollisionError) as exc_info:
+            reg.register(_RegistryTestFGB, name="dup_key")
+        assert "dup_key" in str(exc_info.value)
+
+    def test_collision_keeps_original_entry(self) -> None:
+        reg = PluginRegistry()
+        reg.register(_RegistryTestFGA, name="dup_key")
+        with pytest.raises(PluginRegistryCollisionError):
+            reg.register(_RegistryTestFGB, name="dup_key")
+        assert reg.get("dup_key") is _RegistryTestFGA
+
+    def test_replace_true_replaces_entry(self) -> None:
+        reg = PluginRegistry()
+        reg.register(_RegistryTestFGA, name="replace_key")
+        key = reg.register(_RegistryTestFGB, name="replace_key", replace=True)
+        assert key == "replace_key"
+        assert reg.get("replace_key") is _RegistryTestFGB
+
+
+class TestPluginRegistryLookup:
+    def test_get_unknown_key_returns_none(self) -> None:
+        reg = PluginRegistry()
+        assert reg.get("does_not_exist") is None
+
+    def test_unregister_removes_entry(self) -> None:
+        reg = PluginRegistry()
+        key = reg.register(_RegistryTestFGA)
+        reg.unregister(key)
+        assert reg.get(key) is None
+
+    def test_unregister_unknown_key_raises_value_error(self) -> None:
+        reg = PluginRegistry()
+        with pytest.raises(ValueError):
+            reg.unregister("does_not_exist")
+
+    def test_is_registered_true_for_registered_class(self) -> None:
+        reg = PluginRegistry()
+        reg.register(_RegistryTestFGA, name="any_key")
+        assert reg.is_registered(_RegistryTestFGA) is True
+
+    def test_is_registered_false_for_unregistered_class(self) -> None:
+        reg = PluginRegistry()
+        reg.register(_RegistryTestFGA)
+        assert reg.is_registered(_RegistryTestFGB) is False
+
+    def test_is_registered_false_after_unregister(self) -> None:
+        reg = PluginRegistry()
+        key = reg.register(_RegistryTestFGA)
+        reg.unregister(key)
+        assert reg.is_registered(_RegistryTestFGA) is False
+
+
+class TestPluginRegistryEntry:
+    def test_get_entry_attributes(self) -> None:
+        reg = PluginRegistry()
+        key = reg.register(_RegistryTestFGA)
+        entry = reg.get_entry(key)
+        assert entry.cls is _RegistryTestFGA
+        assert entry.name == key
+        assert entry.plugin_type is FeatureGroup
+        assert entry.source_module == _RegistryTestFGA.__module__
+        assert entry.source == "manual"
+
+    def test_get_entry_plugin_type_compute_framework(self) -> None:
+        reg = PluginRegistry()
+        key = reg.register(_RegistryTestCF)
+        assert reg.get_entry(key).plugin_type is ComputeFramework
+
+    def test_get_entry_plugin_type_extender(self) -> None:
+        reg = PluginRegistry()
+        key = reg.register(_RegistryTestExtender)
+        assert reg.get_entry(key).plugin_type is Extender
+
+
+class TestPluginRegistryListRegistered:
+    def test_list_registered_filters_by_plugin_type(self) -> None:
+        reg = PluginRegistry()
+        reg.register(_RegistryTestFGA)
+        reg.register(_RegistryTestCF)
+        reg.register(_RegistryTestExtender)
+        assert reg.list_registered(FeatureGroup) == [_RegistryTestFGA]
+        assert reg.list_registered(ComputeFramework) == [_RegistryTestCF]
+        assert reg.list_registered(Extender) == [_RegistryTestExtender]
+
+    def test_list_registered_returns_list_sorted_by_key(self) -> None:
+        reg = PluginRegistry()
+        reg.register(_RegistryTestFGB, name="z_key")
+        reg.register(_RegistryTestFGA, name="a_key")
+        result = reg.list_registered(FeatureGroup)
+        assert isinstance(result, list)
+        assert result == [_RegistryTestFGA, _RegistryTestFGB]
+
+    def test_list_registered_is_registration_order_independent(self) -> None:
+        reg_ab = PluginRegistry()
+        reg_ab.register(_RegistryTestFGA)
+        reg_ab.register(_RegistryTestFGB)
+        reg_ba = PluginRegistry()
+        reg_ba.register(_RegistryTestFGB)
+        reg_ba.register(_RegistryTestFGA)
+        assert reg_ab.list_registered(FeatureGroup) == reg_ba.list_registered(FeatureGroup)
+
+
+class TestPluginRegistrySnapshotRestore:
+    def test_restore_removes_entries_added_after_snapshot(self) -> None:
+        reg = PluginRegistry()
+        reg.register(_RegistryTestFGA)
+        snap = reg.snapshot()
+        key_b = reg.register(_RegistryTestFGB)
+        reg.restore(snap)
+        assert reg.get(key_b) is None
+        assert reg.is_registered(_RegistryTestFGB) is False
+
+    def test_restore_brings_back_entries_removed_after_snapshot(self) -> None:
+        reg = PluginRegistry()
+        key_a = reg.register(_RegistryTestFGA)
+        snap = reg.snapshot()
+        reg.unregister(key_a)
+        reg.restore(snap)
+        assert reg.get(key_a) is _RegistryTestFGA
+
+    def test_clear_empties_registry(self) -> None:
+        reg = PluginRegistry()
+        key = reg.register(_RegistryTestFGA)
+        reg.register(_RegistryTestCF)
+        reg.clear()
+        assert reg.get(key) is None
+        assert reg.list_registered(FeatureGroup) == []
+        assert reg.list_registered(ComputeFramework) == []
+
+
+class TestModuleLevelRegister:
+    def test_register_writes_into_default_registry(self, default_registry_guard: PluginRegistry) -> None:
+        key = register(_RegistryTestFGA)
+        assert key == _default_key(_RegistryTestFGA)
+        assert default_registry_guard.get(key) is _RegistryTestFGA
+        assert PluginRegistry.default().get(key) is _RegistryTestFGA
+
+    def test_register_accepts_same_keyword_arguments(self, default_registry_guard: PluginRegistry) -> None:
+        key = register(_RegistryTestFGB, name="module_level_custom", source="notebook")
+        assert key == "module_level_custom"
+        entry = default_registry_guard.get_entry("module_level_custom")
+        assert entry.cls is _RegistryTestFGB
+        assert entry.source == "notebook"

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_plugin_registry.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_plugin_registry.py
@@ -2,7 +2,8 @@
 
 Defines the contract for PluginRegistry: instance and process-global default,
 register/unregister/get, collision handling, replace, type filtering,
-snapshot/restore, and the module-level register() convenience.
+snapshot/restore, the one-key-per-class invariant, and the module-level
+register_plugin() convenience.
 """
 
 import threading
@@ -17,7 +18,7 @@ from mloda.core.abstract_plugins.function_extender import Extender
 from mloda.core.abstract_plugins.plugin_registry.plugin_registry import (
     PluginRegistry,
     PluginRegistryCollisionError,
-    register,
+    register_plugin,
 )
 
 
@@ -142,6 +143,51 @@ class TestPluginRegistryCollision:
         assert reg.get("replace_key") is _RegistryTestFGB
 
 
+class TestOneKeyPerClassInvariant:
+    """A class holds exactly one registry key; aliasing the same class under a second key must raise."""
+
+    def test_register_same_class_under_second_key_raises(self) -> None:
+        reg = PluginRegistry()
+        default_key = reg.register(_RegistryTestFGA)
+        with pytest.raises(PluginRegistryCollisionError) as exc_info:
+            reg.register(_RegistryTestFGA, name="alias")
+        assert default_key in str(exc_info.value), "the one-key-per-class collision message must name the existing key"
+
+    def test_register_default_key_after_custom_key_raises(self) -> None:
+        reg = PluginRegistry()
+        reg.register(_RegistryTestFGA, name="custom")
+        with pytest.raises(PluginRegistryCollisionError) as exc_info:
+            reg.register(_RegistryTestFGA)
+        assert "custom" in str(exc_info.value), "the one-key-per-class collision message must name the existing key"
+
+    def test_second_key_collision_keeps_only_original_entry(self) -> None:
+        reg = PluginRegistry()
+        default_key = reg.register(_RegistryTestFGA)
+        with pytest.raises(PluginRegistryCollisionError):
+            reg.register(_RegistryTestFGA, name="alias")
+        assert reg.get(default_key) is _RegistryTestFGA
+        assert reg.get("alias") is None
+
+    def test_replace_true_does_not_bypass_different_key_collision(self) -> None:
+        """replace=True only resolves same-key-different-class; a second key for the same class still raises."""
+        reg = PluginRegistry()
+        default_key = reg.register(_RegistryTestFGA)
+        with pytest.raises(PluginRegistryCollisionError) as exc_info:
+            reg.register(_RegistryTestFGA, name="alias", replace=True)
+        assert default_key in str(exc_info.value)
+        assert reg.get("alias") is None
+
+    def test_rename_via_unregister_then_register_succeeds(self) -> None:
+        """The legitimate rename path: unregister the existing key, then register under the new name."""
+        reg = PluginRegistry()
+        reg.register(_RegistryTestFGA, name="old_name")
+        reg.unregister("old_name")
+        key = reg.register(_RegistryTestFGA, name="new_name")
+        assert key == "new_name"
+        assert reg.get("new_name") is _RegistryTestFGA
+        assert reg.get("old_name") is None
+
+
 class TestPluginRegistryLookup:
     def test_get_unknown_key_returns_none(self) -> None:
         reg = PluginRegistry()
@@ -221,16 +267,14 @@ class TestPluginRegistryListRegistered:
         assert isinstance(result, list)
         assert result == [_RegistryTestFGA, _RegistryTestFGB]
 
-    def test_list_registered_dedupes_class_registered_under_multiple_keys(self) -> None:
-        """A class registered under several keys must appear exactly once in list_registered."""
+    def test_list_registered_lists_class_once_after_rejected_alias_attempt(self) -> None:
+        """Aliasing now raises, so the class stays listed exactly once under its original key."""
         reg = PluginRegistry()
         reg.register(_RegistryTestFGA)
-        reg.register(_RegistryTestFGA, name="alias")
+        with pytest.raises(PluginRegistryCollisionError):
+            reg.register(_RegistryTestFGA, name="alias")
         result = reg.list_registered(FeatureGroup)
-        assert _RegistryTestFGA in result
-        assert result.count(_RegistryTestFGA) == 1, (
-            f"list_registered must dedupe by class identity, got {result.count(_RegistryTestFGA)} occurrences"
-        )
+        assert result == [_RegistryTestFGA]
 
     def test_list_registered_is_registration_order_independent(self) -> None:
         reg_ab = PluginRegistry()
@@ -335,16 +379,23 @@ class TestPluginRegistrySnapshotRestore:
         assert reg.list_registered(ComputeFramework) == []
 
 
-class TestModuleLevelRegister:
-    def test_register_writes_into_default_registry(self, default_registry_guard: PluginRegistry) -> None:
-        key = register(_RegistryTestFGA)
+class TestModuleLevelRegisterPlugin:
+    def test_register_plugin_writes_into_default_registry(self, default_registry_guard: PluginRegistry) -> None:
+        key = register_plugin(_RegistryTestFGA)
         assert key == _default_key(_RegistryTestFGA)
         assert default_registry_guard.get(key) is _RegistryTestFGA
         assert PluginRegistry.default().get(key) is _RegistryTestFGA
 
-    def test_register_accepts_same_keyword_arguments(self, default_registry_guard: PluginRegistry) -> None:
-        key = register(_RegistryTestFGB, name="module_level_custom", source="notebook")
+    def test_register_plugin_accepts_same_keyword_arguments(self, default_registry_guard: PluginRegistry) -> None:
+        key = register_plugin(_RegistryTestFGB, name="module_level_custom", source="notebook")
         assert key == "module_level_custom"
         entry = default_registry_guard.get_entry("module_level_custom")
         assert entry.cls is _RegistryTestFGB
         assert entry.source == "notebook"
+
+    def test_old_register_name_removed_from_core_module(self) -> None:
+        """The convenience function is renamed to register_plugin; the old name must be gone."""
+        assert not hasattr(plugin_registry_module, "register"), (
+            "mloda.core.abstract_plugins.plugin_registry.plugin_registry must not expose 'register'; "
+            "the module-level convenience function is named register_plugin"
+        )

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_plugin_registry.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_plugin_registry.py
@@ -5,10 +5,12 @@ register/unregister/get, collision handling, replace, type filtering,
 snapshot/restore, and the module-level register() convenience.
 """
 
+import threading
 from collections.abc import Iterator
 
 import pytest
 
+import mloda.core.abstract_plugins.plugin_registry.plugin_registry as plugin_registry_module
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.abstract_plugins.function_extender import Extender
@@ -124,6 +126,14 @@ class TestPluginRegistryCollision:
             reg.register(_RegistryTestFGB, name="dup_key")
         assert reg.get("dup_key") is _RegistryTestFGA
 
+    def test_collision_error_message_teaches_replace_flag(self) -> None:
+        """The collision message must tell users how to opt into replacement."""
+        reg = PluginRegistry()
+        reg.register(_RegistryTestFGA, name="dup_key")
+        with pytest.raises(PluginRegistryCollisionError) as exc_info:
+            reg.register(_RegistryTestFGB, name="dup_key")
+        assert "replace=True" in str(exc_info.value), "collision error must mention replace=True so users learn the fix"
+
     def test_replace_true_replaces_entry(self) -> None:
         reg = PluginRegistry()
         reg.register(_RegistryTestFGA, name="replace_key")
@@ -230,6 +240,71 @@ class TestPluginRegistryListRegistered:
         reg_ba.register(_RegistryTestFGB)
         reg_ba.register(_RegistryTestFGA)
         assert reg_ab.list_registered(FeatureGroup) == reg_ba.list_registered(FeatureGroup)
+
+    def test_list_registered_rejects_concrete_subclass(self) -> None:
+        """A concrete subclass is not a valid plugin base type; silence would hide the bug."""
+        reg = PluginRegistry()
+        with pytest.raises(ValueError) as exc_info:
+            reg.list_registered(_RegistryTestFGA)
+        message = str(exc_info.value)
+        assert "FeatureGroup" in message
+        assert "ComputeFramework" in message
+        assert "Extender" in message
+
+    def test_list_registered_rejects_non_plugin_type(self) -> None:
+        reg = PluginRegistry()
+        with pytest.raises(ValueError) as exc_info:
+            reg.list_registered(int)
+        message = str(exc_info.value)
+        assert "FeatureGroup" in message
+        assert "ComputeFramework" in message
+        assert "Extender" in message
+
+    def test_list_registered_accepts_exact_base_types(self) -> None:
+        """The three exact plugin base types must keep working, even on an empty registry."""
+        reg = PluginRegistry()
+        assert reg.list_registered(FeatureGroup) == []
+        assert reg.list_registered(ComputeFramework) == []
+        assert reg.list_registered(Extender) == []
+
+    def test_module_level_list_registered_wrapper_rejects_non_plugin_type(self) -> None:
+        from mloda.core.api.plugin_docs import list_registered
+
+        with pytest.raises(ValueError):
+            list_registered(int)
+
+
+class TestPluginRegistryDefaultThreadSafety:
+    def test_default_lazy_init_is_thread_safe(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """default() lazy init must be guarded by a module-level lock and return one instance.
+
+        The lock-existence assertion makes this test fail deterministically before
+        the implementation lands; the threaded part pins the observable contract.
+        """
+        lock = getattr(plugin_registry_module, "_default_lock", None)
+        assert lock is not None, "plugin_registry must expose a module-level _default_lock for default()"
+        assert isinstance(lock, type(threading.Lock())), "_default_lock must be a threading lock"
+
+        monkeypatch.setattr(plugin_registry_module, "_default", None)
+        thread_count = 16
+        barrier = threading.Barrier(thread_count)
+        results: list[PluginRegistry] = []
+
+        def _call_default() -> None:
+            barrier.wait()
+            results.append(PluginRegistry.default())
+
+        threads = [threading.Thread(target=_call_default) for _ in range(thread_count)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert len(results) == thread_count
+        first = results[0]
+        assert all(result is first for result in results), (
+            "all threads racing default() must observe the same registry instance"
+        )
 
 
 class TestPluginRegistrySnapshotRestore:

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_registry_fixture.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_registry_fixture.py
@@ -1,0 +1,49 @@
+"""Tests for the isolated_plugin_registry pytest fixture (issue #526, work item 2).
+
+The fixture snapshots PluginRegistry.default(), yields it, and restores the
+snapshot on teardown so tests cannot leak registrations into each other.
+"""
+
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.abstract_plugins.plugin_registry.fixtures import isolated_plugin_registry
+from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistry
+
+
+class _FixtureThrowawayFG(FeatureGroup):
+    pass
+
+
+class _FixtureSmokeFG(FeatureGroup):
+    pass
+
+
+def test_isolated_plugin_registry_is_a_pytest_fixture() -> None:
+    # pytest >= 8.4 exposes _fixture_function_marker on the FixtureFunctionDefinition,
+    # older pytest set _pytestfixturefunction on the function itself.
+    assert hasattr(isolated_plugin_registry, "_fixture_function_marker") or hasattr(
+        isolated_plugin_registry, "_pytestfixturefunction"
+    )
+    assert hasattr(isolated_plugin_registry, "__wrapped__")
+
+
+def test_isolated_plugin_registry_yields_default_and_restores_on_teardown() -> None:
+    default = PluginRegistry.default()
+    snap = default.snapshot()
+    try:
+        wrapped = getattr(isolated_plugin_registry, "__wrapped__")
+        gen = wrapped()
+        reg = next(gen)
+        assert reg is PluginRegistry.default()
+        key = reg.register(_FixtureThrowawayFG, name="_registry_fixture_throwaway")
+        assert reg.get(key) is _FixtureThrowawayFG
+        next(gen, None)
+        assert PluginRegistry.default().get(key) is None
+        assert PluginRegistry.default().is_registered(_FixtureThrowawayFG) is False
+    finally:
+        default.restore(snap)
+
+
+def test_isolated_plugin_registry_smoke_usage(isolated_plugin_registry: PluginRegistry) -> None:
+    key = isolated_plugin_registry.register(_FixtureSmokeFG, name="_registry_fixture_smoke")
+    assert isolated_plugin_registry.get(key) is _FixtureSmokeFG
+    assert isolated_plugin_registry is PluginRegistry.default()

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_strict_mode.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_strict_mode.py
@@ -15,11 +15,13 @@ env writes go through monkeypatch only.
 """
 
 import gc
+import inspect
 import linecache
 import logging
 import sys
 import textwrap
-from typing import cast
+from abc import abstractmethod
+from typing import Any, cast
 
 import pytest
 
@@ -55,6 +57,27 @@ class _StrictEnabledUnregisteredFG(FeatureGroup):
 
 class _StrictEnabledRegisteredFG(FeatureGroup):
     """Local double passed as enabled and registered, so strict resolution does not end empty."""
+
+
+class _StrictAbstractInfraFG(FeatureGroup):
+    """Abstract local double, never registered; strict and warn must treat it as infrastructure.
+
+    match_feature_group_criteria is overridden to False because the default falls back to
+    cls(), which raises TypeError on abstract classes. Real abstract bases override matching
+    too; this keeps the double inert for other tests' feature resolution in this worker.
+    """
+
+    @abstractmethod
+    def _strict_abstract_infra_hook(self) -> None: ...
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: Any,
+        options: Any,
+        data_access_collection: Any = None,
+    ) -> bool:
+        return False
 
 
 def _cfws() -> set[type[ComputeFramework]]:
@@ -341,6 +364,49 @@ class TestEngineStrictModeWarn:
         )
         assert "warn_dedup_fake_module_b:WarnDedupSameNameFG" in message, (
             "warn mode must report BOTH same-name classes from different modules, not collapse them on bare __name__"
+        )
+
+
+class TestEngineStrictModeAbstractClasses:
+    """Abstract classes never auto-register (they are infrastructure, not plugins), so strict and
+    warn modes must leave them alone instead of filtering or flagging them as unregistered."""
+
+    def test_strict_mode_keeps_unregistered_abstract_classes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        assert inspect.isabstract(_StrictAbstractInfraFG), "sanity: the local double is abstract"
+
+        monkeypatch.delenv(ENV_VAR, raising=False)
+        off_accessible = PreFilterPlugins(_cfws(), PluginCollector()).get_accessible_plugins()
+        assert _StrictAbstractInfraFG in off_accessible, "sanity: off mode resolves abstract subclasses"
+
+        register(_StrictRegisteredFG)
+        collector = PluginCollector().set_strict_mode("strict")
+        accessible = PreFilterPlugins(_cfws(), collector).get_accessible_plugins()
+        assert _StrictAbstractInfraFG in accessible, (
+            "strict mode must not filter abstract infrastructure classes (parity with off mode); "
+            "abstract classes cannot be loader-registered, so filtering them breaks resolution"
+        )
+        assert _StrictUnregisteredFG not in accessible, (
+            "sanity: strict mode still filters concrete unregistered classes"
+        )
+
+    def test_warn_mode_does_not_name_abstract_classes(self, caplog: pytest.LogCaptureFixture) -> None:
+        assert inspect.isabstract(_StrictAbstractInfraFG), "sanity: the local double is abstract"
+
+        collector = PluginCollector().set_strict_mode("warn")
+        with caplog.at_level(logging.WARNING):
+            PreFilterPlugins(_cfws(), collector)
+        message = " ".join(
+            rec.getMessage()
+            for rec in caplog.records
+            if rec.name == "mloda.core.prepare.accessible_plugins" and "not registered" in rec.getMessage()
+        )
+        assert _StrictUnregisteredFG.__name__ in message, (
+            "sanity: the aggregated warning still names concrete unregistered classes"
+        )
+        abstract_identifier = f"{_StrictAbstractInfraFG.__module__}:{_StrictAbstractInfraFG.__qualname__}"
+        assert abstract_identifier not in message, (
+            "warn mode must not name abstract infrastructure classes as unregistered plugins; "
+            "they cannot be registered, so warning about them is pure noise"
         )
 
 

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_strict_mode.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_strict_mode.py
@@ -1,4 +1,4 @@
-"""Failing tests for the tri-state strict parameter (issue #526, work item 5).
+"""Tests for the tri-state strict parameter (issue #526, work item 5).
 
 Contract: PluginCollector carries a strict_mode of "off", "warn", or "strict",
 defaulting from the MLODA_PLUGIN_REGISTRY_STRICT env var ("off" when unset,
@@ -26,7 +26,7 @@ import pytest
 from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
-from mloda.core.abstract_plugins.plugin_registry.plugin_registry import register
+from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistry, register
 from mloda.core.prepare.accessible_plugins import PreFilterPlugins, RedefinitionConflictError
 from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
 
@@ -47,6 +47,14 @@ class _StrictRegisteredFG(FeatureGroup):
 
 class _StrictConflictBystanderFG(FeatureGroup):
     """Local double registered alongside an unregistered redefinition conflict."""
+
+
+class _StrictEnabledUnregisteredFG(FeatureGroup):
+    """Local double passed as enabled but never registered; strict mode must drop it loudly."""
+
+
+class _StrictEnabledRegisteredFG(FeatureGroup):
+    """Local double passed as enabled and registered, so strict resolution does not end empty."""
 
 
 def _cfws() -> set[type[ComputeFramework]]:
@@ -117,6 +125,17 @@ class TestEnvVarDefault:
         collector = PluginCollector().set_strict_mode("off")
         assert collector.strict_mode == "off"
 
+    @pytest.mark.parametrize(("raw", "normalized"), [("WARN", "warn"), ("Strict", "strict")])
+    def test_env_var_value_is_case_insensitive(
+        self, monkeypatch: pytest.MonkeyPatch, raw: str, normalized: str
+    ) -> None:
+        """The env var is user input, so casing must be normalized to lowercase.
+
+        set_strict_mode() stays exact-match; only the env var path normalizes.
+        """
+        monkeypatch.setenv(ENV_VAR, raw)
+        assert PluginCollector().strict_mode == normalized
+
 
 class TestEngineStrictModeOff:
     def test_off_mode_keeps_unregistered_feature_group(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -179,6 +198,48 @@ class TestEngineStrictModeStrict:
         )
 
 
+class TestEngineStrictModeEmptyResult:
+    def test_strict_empty_result_error_mentions_strict_mode_and_fix(self) -> None:
+        """With strict mode on and an empty registry, the error must teach the strict-mode fix.
+
+        At least one accessible FeatureGroup subclass exists (this module's doubles),
+        so the empty result is caused by strict filtering, not by missing plugins.
+        The generic "Did you call PluginLoader.all()?" hint would mislead here.
+        """
+        PluginRegistry.default().clear()
+        collector = PluginCollector().set_strict_mode("strict")
+        with pytest.raises(ValueError) as exc_info:
+            PreFilterPlugins(_cfws(), collector)
+        message = str(exc_info.value)
+        assert "strict" in message, "empty-result error under strict mode must mention strict mode"
+        assert "register" in message, "empty-result error under strict mode must say how to fix it"
+        assert "PluginLoader.all" not in message, (
+            "strict-mode empty result must not blame plugin loading when subclasses exist"
+        )
+
+
+class TestEngineStrictModeEnabledButUnregistered:
+    def test_strict_mode_warns_when_enabled_class_is_dropped(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Explicitly enabled but unregistered classes silently vanish today; that must warn."""
+        register(_StrictEnabledRegisteredFG)
+        collector = PluginCollector().set_strict_mode("strict")
+        collector.add_enabled_feature_group_classes({_StrictEnabledUnregisteredFG, _StrictEnabledRegisteredFG})
+        with caplog.at_level(logging.WARNING):
+            accessible = PreFilterPlugins(_cfws(), collector).get_accessible_plugins()
+        assert _StrictEnabledRegisteredFG in accessible
+        assert _StrictEnabledUnregisteredFG not in accessible
+        matching = [
+            record
+            for record in caplog.records
+            if _StrictEnabledUnregisteredFG.__name__ in record.getMessage()
+            and "enabled" in record.getMessage()
+            and "not registered" in record.getMessage()
+        ]
+        assert matching, (
+            "strict mode must warn that an explicitly enabled class was dropped because it is not registered"
+        )
+
+
 class TestEngineStrictModeWarn:
     def test_warn_mode_resolution_matches_off_mode(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv(ENV_VAR, raising=False)
@@ -218,6 +279,28 @@ class TestEngineStrictModeWarn:
         assert _StrictUnregisteredFG.__name__ in message
         assert _StrictUnregisteredFG2.__name__ in message
         assert "not registered" in message
+
+    def test_warn_mode_warns_once_per_process_for_already_warned_classes(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Two constructions in a row must emit the aggregated warning only once.
+
+        Contract: accessible_plugins keeps a module-level set _warned_unregistered of
+        already-warned class names; the second construction finds every name already
+        warned and stays silent. The autouse conftest fixture clears the set per test,
+        so the per-construction warn tests above stay independent.
+        """
+        with caplog.at_level(logging.WARNING):
+            PreFilterPlugins(_cfws(), PluginCollector().set_strict_mode("warn"))
+            PreFilterPlugins(_cfws(), PluginCollector().set_strict_mode("warn"))
+        records = [
+            rec
+            for rec in caplog.records
+            if rec.name == "mloda.core.prepare.accessible_plugins" and "not registered" in rec.getMessage()
+        ]
+        assert len(records) == 1, (
+            f"warn mode must deduplicate already-warned class names per process, got {len(records)} records"
+        )
 
 
 class TestEnvWithoutCollector:

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_strict_mode.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_strict_mode.py
@@ -14,7 +14,12 @@ global counts. Registry writes are restored by the autouse conftest fixture;
 env writes go through monkeypatch only.
 """
 
+import gc
+import linecache
 import logging
+import sys
+import textwrap
+from typing import cast
 
 import pytest
 
@@ -22,7 +27,7 @@ from mloda.core.abstract_plugins.components.plugin_option.plugin_collector impor
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.abstract_plugins.plugin_registry.plugin_registry import register
-from mloda.core.prepare.accessible_plugins import PreFilterPlugins
+from mloda.core.prepare.accessible_plugins import PreFilterPlugins, RedefinitionConflictError
 from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
 
 ENV_VAR = "MLODA_PLUGIN_REGISTRY_STRICT"
@@ -32,12 +37,48 @@ class _StrictUnregisteredFG(FeatureGroup):
     """Local double that is never registered in the default registry."""
 
 
+class _StrictUnregisteredFG2(FeatureGroup):
+    """Second local double that is never registered, for warn-aggregation tests."""
+
+
 class _StrictRegisteredFG(FeatureGroup):
     """Local double that tests register explicitly in the default registry."""
 
 
+class _StrictConflictBystanderFG(FeatureGroup):
+    """Local double registered alongside an unregistered redefinition conflict."""
+
+
 def _cfws() -> set[type[ComputeFramework]]:
     return {PythonDictFramework}
+
+
+def _exec_fg_in_main(class_name: str, body: str, cell_label: str) -> type[FeatureGroup]:
+    """Exec a FeatureGroup subclass into ``__main__`` with linecache-backed source.
+
+    Mirrors the proven Jupyter-cell recipe from
+    tests/test_core/test_prepare/test_feature_group_dedup.py so
+    ``inspect.getsource`` works for the exec'd class.
+    """
+    main_mod = sys.modules["__main__"]
+    src = textwrap.dedent(body)
+    filename = f"<{cell_label}>"
+    linecache.cache[filename] = (len(src), None, src.splitlines(keepends=True), filename)
+    exec(compile(src, filename, "exec"), main_mod.__dict__)  # nosec B102
+    return cast(type[FeatureGroup], main_mod.__dict__[class_name])
+
+
+def _make_fg_source(class_name: str, feature_name: str, extra_body: str = "") -> str:
+    """Build FeatureGroup subclass source for exec into ``__main__``."""
+    return f"""
+from mloda.core.abstract_plugins.feature_group import FeatureGroup as _FG_BASE_
+
+class {class_name}(_FG_BASE_):
+    @classmethod
+    def feature_names_supported(cls):
+        return {{"{feature_name}"}}
+{extra_body}
+"""
 
 
 class TestSetStrictModeApi:
@@ -94,6 +135,51 @@ class TestEngineStrictModeStrict:
         assert _StrictUnregisteredFG not in accessible
 
 
+    def test_strict_filter_runs_before_dedup_so_unregistered_conflicts_cannot_poison(self) -> None:
+        """An unregistered same-name different-source pair must not break strict resolution.
+
+        Strict mode must filter unregistered classes BEFORE dedup runs, so a stale
+        redefinition conflict among unregistered classes never reaches dedup.
+        """
+        qualname = "StrictFG_RedConflictPair"
+        feature_name = "strict_red_conflict_feature_unique_xyz"
+        v1 = _exec_fg_in_main(qualname, _make_fg_source(qualname, feature_name), "cell-strict-red-v1")
+        v2 = _exec_fg_in_main(
+            qualname,
+            _make_fg_source(qualname, feature_name, extra_body="    def extra_method(self):\n        return 42\n"),
+            "cell-strict-red-v2",
+        )
+        assert v1 is not v2, "sanity: two distinct class objects with the same (module, qualname)"
+
+        register(_StrictConflictBystanderFG)
+        collector = PluginCollector().set_strict_mode("strict")
+
+        accessible = None
+        conflict_error = ""
+        try:
+            accessible = PreFilterPlugins(_cfws(), collector).get_accessible_plugins()
+        except RedefinitionConflictError as exc:
+            conflict_error = str(exc)
+        finally:
+            # Drop every strong ref to the conflicting pair so it cannot poison
+            # other tests in this worker process via FeatureGroup.__subclasses__().
+            sys.modules["__main__"].__dict__.pop(qualname, None)
+            linecache.cache.pop("<cell-strict-red-v1>", None)
+            linecache.cache.pop("<cell-strict-red-v2>", None)
+            del v1, v2
+            gc.collect()
+
+        if accessible is None:
+            pytest.fail(
+                "strict mode must filter unregistered classes before dedup; "
+                f"got RedefinitionConflictError: {conflict_error}"
+            )
+        assert _StrictConflictBystanderFG in accessible
+        assert not any(fg.__qualname__ == qualname for fg in accessible), (
+            "unregistered conflicting classes must not appear in strict accessible plugins"
+        )
+
+
 class TestEngineStrictModeWarn:
     def test_warn_mode_resolution_matches_off_mode(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv(ENV_VAR, raising=False)
@@ -113,6 +199,26 @@ class TestEngineStrictModeWarn:
             if _StrictUnregisteredFG.__name__ in record.getMessage() and "not registered" in record.getMessage()
         ]
         assert matching, "warn mode must log a warning naming the unregistered class and saying 'not registered'"
+
+    def test_warn_mode_aggregates_all_unregistered_classes_into_one_record(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """One PreFilterPlugins construction must emit exactly ONE warning record.
+
+        The single aggregated record names every unregistered class instead of
+        emitting one record per class.
+        """
+        collector = PluginCollector().set_strict_mode("warn")
+        with caplog.at_level(logging.WARNING):
+            PreFilterPlugins(_cfws(), collector)
+        records = [rec for rec in caplog.records if rec.name == "mloda.core.prepare.accessible_plugins"]
+        assert len(records) == 1, (
+            f"warn mode must aggregate unregistered classes into one record per construction, got {len(records)}"
+        )
+        message = records[0].getMessage()
+        assert _StrictUnregisteredFG.__name__ in message
+        assert _StrictUnregisteredFG2.__name__ in message
+        assert "not registered" in message
 
 
 class TestEnvWithoutCollector:

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_strict_mode.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_strict_mode.py
@@ -28,7 +28,7 @@ import pytest
 from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
-from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistry, register
+from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistry, register_plugin
 from mloda.core.prepare.accessible_plugins import PreFilterPlugins, RedefinitionConflictError
 from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
 
@@ -170,7 +170,7 @@ class TestEngineStrictModeOff:
 
 class TestEngineStrictModeStrict:
     def test_strict_mode_keeps_only_registered_feature_groups(self) -> None:
-        register(_StrictRegisteredFG)
+        register_plugin(_StrictRegisteredFG)
         collector = PluginCollector().set_strict_mode("strict")
         accessible = PreFilterPlugins(_cfws(), collector).get_accessible_plugins()
         assert _StrictRegisteredFG in accessible
@@ -192,7 +192,7 @@ class TestEngineStrictModeStrict:
         )
         assert v1 is not v2, "sanity: two distinct class objects with the same (module, qualname)"
 
-        register(_StrictConflictBystanderFG)
+        register_plugin(_StrictConflictBystanderFG)
         collector = PluginCollector().set_strict_mode("strict")
 
         accessible = None
@@ -244,7 +244,7 @@ class TestEngineStrictModeEmptyResult:
 class TestEngineStrictModeEnabledButUnregistered:
     def test_strict_mode_warns_when_enabled_class_is_dropped(self, caplog: pytest.LogCaptureFixture) -> None:
         """Explicitly enabled but unregistered classes silently vanish today; that must warn."""
-        register(_StrictEnabledRegisteredFG)
+        register_plugin(_StrictEnabledRegisteredFG)
         collector = PluginCollector().set_strict_mode("strict")
         collector.add_enabled_feature_group_classes({_StrictEnabledUnregisteredFG, _StrictEnabledRegisteredFG})
         with caplog.at_level(logging.WARNING):
@@ -378,7 +378,7 @@ class TestEngineStrictModeAbstractClasses:
         off_accessible = PreFilterPlugins(_cfws(), PluginCollector()).get_accessible_plugins()
         assert _StrictAbstractInfraFG in off_accessible, "sanity: off mode resolves abstract subclasses"
 
-        register(_StrictRegisteredFG)
+        register_plugin(_StrictRegisteredFG)
         collector = PluginCollector().set_strict_mode("strict")
         accessible = PreFilterPlugins(_cfws(), collector).get_accessible_plugins()
         assert _StrictAbstractInfraFG in accessible, (
@@ -413,7 +413,7 @@ class TestEngineStrictModeAbstractClasses:
 class TestEnvWithoutCollector:
     def test_env_strict_applies_without_collector(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv(ENV_VAR, "strict")
-        register(_StrictRegisteredFG)
+        register_plugin(_StrictRegisteredFG)
         accessible = PreFilterPlugins(_cfws(), None).get_accessible_plugins()
         assert _StrictRegisteredFG in accessible
         assert _StrictUnregisteredFG not in accessible

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_strict_mode.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_strict_mode.py
@@ -134,7 +134,6 @@ class TestEngineStrictModeStrict:
         assert _StrictRegisteredFG in accessible
         assert _StrictUnregisteredFG not in accessible
 
-
     def test_strict_filter_runs_before_dedup_so_unregistered_conflicts_cannot_poison(self) -> None:
         """An unregistered same-name different-source pair must not break strict resolution.
 

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_strict_mode.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_strict_mode.py
@@ -342,22 +342,25 @@ class TestEngineStrictModeWarn:
             type[FeatureGroup],
             type("WarnDedupSameNameFG", (FeatureGroup,), {"__module__": "warn_dedup_fake_module_b"}),
         )
-        assert fg_a is not fg_b, "sanity: two distinct class objects sharing __name__"
+        try:
+            assert fg_a is not fg_b, "sanity: two distinct class objects sharing __name__"
 
-        collector = PluginCollector().set_strict_mode("warn")
-        with caplog.at_level(logging.WARNING):
-            PreFilterPlugins(_cfws(), collector)
-        records = [
-            rec
-            for rec in caplog.records
-            if rec.name == "mloda.core.prepare.accessible_plugins" and "not registered" in rec.getMessage()
-        ]
-        message = " ".join(rec.getMessage() for rec in records)
-
-        # Drop strong refs before asserting so a failure cannot leak the classes
-        # into FeatureGroup.__subclasses__() for other tests in this worker.
-        del fg_a, fg_b
-        gc.collect()
+            collector = PluginCollector().set_strict_mode("warn")
+            with caplog.at_level(logging.WARNING):
+                PreFilterPlugins(_cfws(), collector)
+            records = [
+                rec
+                for rec in caplog.records
+                if rec.name == "mloda.core.prepare.accessible_plugins" and "not registered" in rec.getMessage()
+            ]
+            message = " ".join(rec.getMessage() for rec in records)
+        finally:
+            # Drop strong refs even when an assertion fails or PreFilterPlugins raises,
+            # so the fake-module classes cannot leak into FeatureGroup.__subclasses__()
+            # for other tests in this worker. caplog records hold only strings, so the
+            # message assertions below stay valid after the classes are collected.
+            del fg_a, fg_b
+            gc.collect()
 
         assert "warn_dedup_fake_module_a:WarnDedupSameNameFG" in message, (
             "warn mode must report unregistered classes with module-qualified identifiers"

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_strict_mode.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_strict_mode.py
@@ -1,0 +1,130 @@
+"""Failing tests for the tri-state strict parameter (issue #526, work item 5).
+
+Contract: PluginCollector carries a strict_mode of "off", "warn", or "strict",
+defaulting from the MLODA_PLUGIN_REGISTRY_STRICT env var ("off" when unset,
+ValueError on invalid values). PreFilterPlugins consults the mode during
+resolution: "strict" keeps only FeatureGroups registered in the default
+PluginRegistry, "warn" keeps everything but logs unregistered classes,
+"off" keeps today's behavior. The engine honors the env var even when no
+PluginCollector is passed.
+
+Parallel-safety: other tests define many FeatureGroup subclasses, so all
+assertions are membership or absence of this module's own doubles, never
+global counts. Registry writes are restored by the autouse conftest fixture;
+env writes go through monkeypatch only.
+"""
+
+import logging
+
+import pytest
+
+from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.abstract_plugins.plugin_registry.plugin_registry import register
+from mloda.core.prepare.accessible_plugins import PreFilterPlugins
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
+
+ENV_VAR = "MLODA_PLUGIN_REGISTRY_STRICT"
+
+
+class _StrictUnregisteredFG(FeatureGroup):
+    """Local double that is never registered in the default registry."""
+
+
+class _StrictRegisteredFG(FeatureGroup):
+    """Local double that tests register explicitly in the default registry."""
+
+
+def _cfws() -> set[type[ComputeFramework]]:
+    return {PythonDictFramework}
+
+
+class TestSetStrictModeApi:
+    def test_set_strict_mode_is_chainable(self) -> None:
+        collector = PluginCollector()
+        assert collector.set_strict_mode("warn") is collector
+
+    @pytest.mark.parametrize("mode", ["off", "warn", "strict"])
+    def test_set_strict_mode_accepts_valid_values(self, mode: str) -> None:
+        collector = PluginCollector().set_strict_mode(mode)
+        assert collector.strict_mode == mode
+
+    @pytest.mark.parametrize("mode", ["on", "OFF", "Strict", "", "true", "1"])
+    def test_set_strict_mode_rejects_invalid_values(self, mode: str) -> None:
+        with pytest.raises(ValueError):
+            PluginCollector().set_strict_mode(mode)
+
+    def test_default_is_off_when_env_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(ENV_VAR, raising=False)
+        assert PluginCollector().strict_mode == "off"
+
+
+class TestEnvVarDefault:
+    @pytest.mark.parametrize("mode", ["warn", "strict"])
+    def test_env_var_sets_default_mode(self, monkeypatch: pytest.MonkeyPatch, mode: str) -> None:
+        monkeypatch.setenv(ENV_VAR, mode)
+        assert PluginCollector().strict_mode == mode
+
+    def test_invalid_env_value_raises_loudly(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(ENV_VAR, "bogus")
+        with pytest.raises(ValueError):
+            PluginCollector()
+
+    def test_explicit_set_strict_mode_overrides_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(ENV_VAR, "strict")
+        collector = PluginCollector().set_strict_mode("off")
+        assert collector.strict_mode == "off"
+
+
+class TestEngineStrictModeOff:
+    def test_off_mode_keeps_unregistered_feature_group(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Non-regression guard: today's behavior, unregistered subclasses stay accessible.
+        monkeypatch.delenv(ENV_VAR, raising=False)
+        accessible = PreFilterPlugins(_cfws(), PluginCollector()).get_accessible_plugins()
+        assert _StrictUnregisteredFG in accessible
+
+
+class TestEngineStrictModeStrict:
+    def test_strict_mode_keeps_only_registered_feature_groups(self) -> None:
+        register(_StrictRegisteredFG)
+        collector = PluginCollector().set_strict_mode("strict")
+        accessible = PreFilterPlugins(_cfws(), collector).get_accessible_plugins()
+        assert _StrictRegisteredFG in accessible
+        assert _StrictUnregisteredFG not in accessible
+
+
+class TestEngineStrictModeWarn:
+    def test_warn_mode_resolution_matches_off_mode(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(ENV_VAR, raising=False)
+        off_accessible = PreFilterPlugins(_cfws(), PluginCollector()).get_accessible_plugins()
+        warn_collector = PluginCollector().set_strict_mode("warn")
+        warn_accessible = PreFilterPlugins(_cfws(), warn_collector).get_accessible_plugins()
+        assert _StrictUnregisteredFG in warn_accessible
+        assert set(warn_accessible.keys()) == set(off_accessible.keys())
+
+    def test_warn_mode_logs_unregistered_class(self, caplog: pytest.LogCaptureFixture) -> None:
+        collector = PluginCollector().set_strict_mode("warn")
+        with caplog.at_level(logging.WARNING):
+            PreFilterPlugins(_cfws(), collector)
+        matching = [
+            record
+            for record in caplog.records
+            if _StrictUnregisteredFG.__name__ in record.getMessage() and "not registered" in record.getMessage()
+        ]
+        assert matching, "warn mode must log a warning naming the unregistered class and saying 'not registered'"
+
+
+class TestEnvWithoutCollector:
+    def test_env_strict_applies_without_collector(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(ENV_VAR, "strict")
+        register(_StrictRegisteredFG)
+        accessible = PreFilterPlugins(_cfws(), None).get_accessible_plugins()
+        assert _StrictRegisteredFG in accessible
+        assert _StrictUnregisteredFG not in accessible
+
+    def test_env_unset_keeps_unregistered_without_collector(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Non-regression guard: today's behavior without collector and without env var.
+        monkeypatch.delenv(ENV_VAR, raising=False)
+        accessible = PreFilterPlugins(_cfws(), None).get_accessible_plugins()
+        assert _StrictUnregisteredFG in accessible

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_strict_mode.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_strict_mode.py
@@ -302,6 +302,47 @@ class TestEngineStrictModeWarn:
             f"warn mode must deduplicate already-warned class names per process, got {len(records)} records"
         )
 
+    def test_warn_mode_reports_same_name_classes_from_different_modules_separately(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Warn-mode dedup and reporting must key on module-qualified names, not bare __name__.
+
+        Two DISTINCT unregistered FeatureGroup classes that share __name__ but live in
+        different modules must BOTH appear in the aggregated warning, identified as
+        f"{module}:{qualname}". Keying on bare __name__ collapses them into one identity.
+        """
+        fg_a = cast(
+            type[FeatureGroup],
+            type("WarnDedupSameNameFG", (FeatureGroup,), {"__module__": "warn_dedup_fake_module_a"}),
+        )
+        fg_b = cast(
+            type[FeatureGroup],
+            type("WarnDedupSameNameFG", (FeatureGroup,), {"__module__": "warn_dedup_fake_module_b"}),
+        )
+        assert fg_a is not fg_b, "sanity: two distinct class objects sharing __name__"
+
+        collector = PluginCollector().set_strict_mode("warn")
+        with caplog.at_level(logging.WARNING):
+            PreFilterPlugins(_cfws(), collector)
+        records = [
+            rec
+            for rec in caplog.records
+            if rec.name == "mloda.core.prepare.accessible_plugins" and "not registered" in rec.getMessage()
+        ]
+        message = " ".join(rec.getMessage() for rec in records)
+
+        # Drop strong refs before asserting so a failure cannot leak the classes
+        # into FeatureGroup.__subclasses__() for other tests in this worker.
+        del fg_a, fg_b
+        gc.collect()
+
+        assert "warn_dedup_fake_module_a:WarnDedupSameNameFG" in message, (
+            "warn mode must report unregistered classes with module-qualified identifiers"
+        )
+        assert "warn_dedup_fake_module_b:WarnDedupSameNameFG" in message, (
+            "warn mode must report BOTH same-name classes from different modules, not collapse them on bare __name__"
+        )
+
 
 class TestEnvWithoutCollector:
     def test_env_strict_applies_without_collector(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_strict_mode_e2e.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_strict_mode_e2e.py
@@ -1,0 +1,56 @@
+"""End-to-end strict mode run through the real ``mloda.run_all`` path.
+
+A strict-mode run must succeed when everything it needs is registered: the
+PluginLoader funnel registers the loaded compute framework plugins, and the
+locally defined root FeatureGroup is registered explicitly. Mirrors the minimal
+DataCreator recipe of tests/test_core/test_api/test_capability_run_all.py on
+PythonDictFramework only, so the test never skips and stays fast.
+
+Parallel-safety: assertions are membership-based and the feature name is unique
+to this module; the autouse conftest fixture restores the default registry.
+"""
+
+from typing import Any, Optional
+
+from mloda.provider import BaseInputData, DataCreator, FeatureGroup, FeatureSet
+from mloda.user import Feature, PluginCollector, PluginLoader, mloda, register
+
+FEAT = "strict_e2e_run_all_feature_unique_xyz"
+
+
+class StrictE2ERunAllFeatureGroup(FeatureGroup):
+    """Root feature group producing one columnar feature for the strict e2e run."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({FEAT})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {FEAT: [1, 2, 3]}
+
+
+def _column_values(frame: Any) -> list[Any]:
+    """Extract the FEAT column tolerant of columnar dict or list-of-row-dicts results."""
+    if isinstance(frame, dict):
+        return list(frame[FEAT])
+    return [row[FEAT] for row in frame]
+
+
+class TestStrictModeEndToEnd:
+    def test_strict_run_all_succeeds_with_registered_plugins(self) -> None:
+        # Non-regression guard for strict e2e.
+        loader = PluginLoader()
+        loader.load_matching("compute_framework", "*python_dict*")
+        register(StrictE2ERunAllFeatureGroup)
+
+        collector = PluginCollector().set_strict_mode("strict")
+        result = mloda.run_all(
+            [Feature(FEAT)],
+            compute_frameworks=["PythonDictFramework"],
+            plugin_collector=collector,
+        )
+
+        assert isinstance(result, list)
+        assert len(result) == 1, f"Expected exactly one result frame, got: {result}"
+        assert _column_values(result[0]) == [1, 2, 3]

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_strict_mode_e2e.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_strict_mode_e2e.py
@@ -13,7 +13,7 @@ to this module; the autouse conftest fixture restores the default registry.
 from typing import Any, Optional
 
 from mloda.provider import BaseInputData, DataCreator, FeatureGroup, FeatureSet
-from mloda.user import Feature, PluginCollector, PluginLoader, mloda, register
+from mloda.user import Feature, PluginCollector, PluginLoader, mloda, register_plugin
 
 FEAT = "strict_e2e_run_all_feature_unique_xyz"
 
@@ -42,7 +42,7 @@ class TestStrictModeEndToEnd:
         # Non-regression guard for strict e2e.
         loader = PluginLoader()
         loader.load_matching("compute_framework", "*python_dict*")
-        register(StrictE2ERunAllFeatureGroup)
+        register_plugin(StrictE2ERunAllFeatureGroup)
 
         collector = PluginCollector().set_strict_mode("strict")
         result = mloda.run_all(

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,7 @@ setenv =
     EXPECTED_SKIP_COUNT = {env:EXPECTED_SKIP_COUNT:163}
     CHECK_SKIP_COUNT = {env:CHECK_SKIP_COUNT:1}
     TOX_LOCK_PATH = {env:TOX_LOCK_PATH:/tmp/mloda-tox.lock}
+    MLODA_PLUGIN_REGISTRY_STRICT = {env:MLODA_PLUGIN_REGISTRY_STRICT:warn}
 commands = sh -c "set -- pytest -n {env:PYTEST_WORKERS:8} --timeout=10 -m 'not notebooks' {env:DEACTIVATE_NOTEBOOK_AND_DOC_TESTS:--ignore=tests/test_documentation}; if [ -n \"$TOX_LOCK_PATH\" ] && command -v flock >/dev/null 2>&1; then [ -e \"$TOX_LOCK_PATH\" ] || (umask 0 && : > \"$TOX_LOCK_PATH\") 2>/dev/null; if [ -w \"$TOX_LOCK_PATH\" ]; then exec flock \"$TOX_LOCK_PATH\" \"$@\"; fi; fi; exec \"$@\""
            ruff format --check --line-length 120 .
            ruff check --line-length 120 .


### PR DESCRIPTION
Resolves #526 (and with it #512).

## What

Adds a first-class plugin registry with an explicit `register()` funnel and a tri-state strict mode, keeping today's "subclass + import = usable" behavior as the default.

- **Registry core**: `PluginRegistry`, instantiable with a process-global `PluginRegistry.default()` (thread-safe lazy init). Entries keyed by qualified string name (`module:qualname`, overridable via `name=`), storing the class plus provenance (`source_module`, `loader` vs `manual`). One key per class: registering an already registered class under a second key raises, naming the existing key (rename path: unregister, then register). Conflicting redefinition raises `PluginRegistryCollisionError` whose message teaches `replace=True` for the Jupyter re-run case; first-class `unregister(name)`, `snapshot()`/`restore()`, `clear()`. `list_registered` raises `ValueError` for non-base plugin types instead of returning an empty list.
- **Persona exports** (capability matrix, pinned by a contract test): `mloda.user` gets `register_plugin`, `list_registered`, `PluginRegistryCollisionError`; `mloda.provider` gets `register_plugin`, `PluginRegistryCollisionError`; `mloda.steward` gets `PluginRegistry` (provenance via `get_entry`/`snapshot`, curation via `unregister`/`clear`/`restore`) and `list_registered`. The module-level registration function is named `register_plugin` (the `PluginRegistry.register` method keeps its name; a free function without a receiver needs the noun).
- **Test isolation**: shipped `isolated_plugin_registry` pytest fixture plus an autouse snapshot/restore fixture in this repo's `tests/conftest.py`.
- **Discovery funnel**: `PluginLoader._load_plugin()` registers concrete FeatureGroup/ComputeFramework/Extender classes defined in each loaded module, on both the fresh-import and the `sys.modules` cache path, so registration is import-order independent and reload-idempotent (loader path is last-write-wins, following the pytest idempotent-loading precedent). Abstract classes (`inspect.isabstract`) are infrastructure, never plugins: the loader skips them and strict/warn enforcement ignores them. Public module-level `register()` for notebooks and third-party packages. A plain `importlib.reload()` is not watched; docs describe the recovery path (re-run the loader scope or `register(replace=True)`).
- **Enumeration API**: `list_registered(plugin_type)` (deduped by class identity, sorted by key) exported from `mloda.user` and `mloda.steward`; `get_feature_group_docs` / `get_compute_framework_docs` / `get_extender_docs` gain `registered_only=`. The catalog functions do not consult strict mode: they keep the `__subclasses__()` walk by default, and `registered_only=True` is the explicit opt-in to registry-only output (documented, so catalog and engine views can be kept consistent under strict).
- **Strict mode, tri-state**: `off` (default, unchanged behavior), `warn` (resolution unchanged; one aggregated warning per process per unregistered FeatureGroup, keyed by `module:qualname` so same-named classes in different modules are reported separately), `strict` (engine resolves only registered concrete FeatureGroups; the registry filter runs before `dedup_feature_group_subclasses`, so unregistered redefinition conflicts cannot poison strict resolution). Strict mode raises a strict-specific error when it filters out every concrete FeatureGroup (instead of the misleading "Did you call PluginLoader.all()?" hint) and warns when explicitly enabled FeatureGroups are dropped as unregistered. Set per run via `PluginCollector().set_strict_mode(...)` or process-wide via `MLODA_PLUGIN_REGISTRY_STRICT` (case-insensitive); invalid values fail loudly. This repo's CI now runs in `warn` (tox setenv).
- **Docs**: new in-depth page with the drive-all-registered-plugins contract-test example, registry vs ad-hoc semantics, strict-mode scope notes (engine-only, FeatureGroups-only for now), and a staged strict-mode rollout note (mktestdocs-verified code blocks).

## Scope notes

- Strict mode covers FeatureGroup resolution (the `PreFilterPlugins`/`PluginCollector` machinery per the issue). Extending registry enforcement to ComputeFrameworks/Extenders is follow-up material together with entry-points discovery and the governance allowlist.
- `dedup_feature_group_subclasses` stays in place for the engine path.
- Registration is expected single-threaded at import/startup; only `default()` lazy init is locked.

## Verification

- 117 registry tests: enumeration by type, import-order independence, pollution (transient test doubles and abstract bases stay out; Jupyter redefinition replaces), collision raises, strict excludes unregistered, warn logs once per process, loader provenance, fixture isolation, thread-safe default, case-insensitive env, plus an end-to-end strict `run_all`.
- Full `tox` green locally: 3619 passed / 163 skipped, ruff format + check, pip-licenses, `mypy --strict`, bandit.
- Three independent deep reviews (two before the first push; one Claude Opus + one codex round after). Accepted findings fixed in this branch: strict-before-dedup ordering, enumeration dedup, aggregated warn logging, `get_entry` error consistency, hot-path set lookups, strict-aware empty-result error, dropped-enabled warning, replace=True guidance in the collision error, loud `list_registered`, thread-safe `default()`, once-per-process warn dedup keyed by `module:qualname`, case-insensitive env values, abstract classes excluded from registration and enforcement, reload recovery docs. A final pre-release tightening pass (everything that would be breaking to change after semantic-release ships it): persona-export capability matrix, one-key-per-class invariant, and the `register_plugin` rename.
