### PR TITLE
fix: make compute framework test modules self-contained

### DIFF
--- a/tests/test_core/test_abstract_plugins/test_n_result_columns.py
+++ b/tests/test_core/test_abstract_plugins/test_n_result_columns.py
@@ -7,6 +7,7 @@ from mloda.user import Options
 from mloda.user import mloda
 
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable  # noqa: F401
 
 
 class NFeatureNameBase(FeatureGroup):

--- a/tests/test_core/test_abstract_plugins/test_set_feature_name.py
+++ b/tests/test_core/test_abstract_plugins/test_set_feature_name.py
@@ -7,6 +7,8 @@ from mloda.provider import FeatureSet
 from mloda.user import Options
 from mloda.user import mloda
 
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable  # noqa: F401
+
 
 class ATestSetFeatureNameBase(FeatureGroup):
     @classmethod

--- a/tests/test_core/test_index/test_add_index.py
+++ b/tests/test_core/test_index/test_add_index.py
@@ -22,6 +22,7 @@ from mloda.user import Index
 from mloda.user import Link, JoinSpec
 from mloda.user import Options
 from mloda.user import mloda
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable  # noqa: F401
 from tests.test_plugins.feature_group.input_data.test_classes.test_input_classes import (
     DBInputDataTestFeatureGroup,
 )

--- a/tests/test_core/test_plugin_collector/test_plugin_collector.py
+++ b/tests/test_core/test_plugin_collector/test_plugin_collector.py
@@ -5,6 +5,7 @@ import pytest
 from mloda.provider import FeatureGroup
 from mloda.user import PluginCollector
 from mloda.user import mloda
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable  # noqa: F401
 from tests.test_plugins.feature_group.input_data.test_input_data import InputDataTestFeatureGroup
 
 

--- a/tests/test_plugins/compute_framework/test_multi_link_same_cfw.py
+++ b/tests/test_plugins/compute_framework/test_multi_link_same_cfw.py
@@ -15,6 +15,8 @@ from mloda.user import ParallelizationMode
 from mloda.user import PluginCollector
 from mloda.user import mloda
 
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame  # noqa: F401
+
 
 # === Scenario 1: Same class used 3x with different feature names per batch ===
 

--- a/tests/test_plugins/compute_framework/test_non_root_merges_one_cfw.py
+++ b/tests/test_plugins/compute_framework/test_non_root_merges_one_cfw.py
@@ -15,6 +15,8 @@ from mloda.user import ParallelizationMode
 from mloda.user import PluginCollector
 from mloda.user import mloda
 
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame  # noqa: F401
+
 
 class NonRootJoinTestFeature(FeatureGroup):
     @classmethod

--- a/tests/test_plugins/feature_group/input_data/test_input_data.py
+++ b/tests/test_plugins/feature_group/input_data/test_input_data.py
@@ -8,6 +8,9 @@ from mloda.provider import BaseInputData
 from mloda.provider import DataCreator
 from mloda.user import mloda
 
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable  # noqa: F401
+from tests.test_core.test_integration.test_core.test_runner_one_compute_framework import SumFeature  # noqa: F401
+
 
 class InputDataTestFeatureGroup(FeatureGroup):
     @classmethod

--- a/tests/test_plugins/feature_group/input_data/test_read_files/test_read_file.py
+++ b/tests/test_plugins/feature_group/input_data/test_read_files/test_read_file.py
@@ -22,6 +22,7 @@ from mloda.provider import FeatureSet
 from mloda.user import Options
 from mloda.user import PluginCollector
 from mloda.user import mloda
+from tests.test_core.test_integration.test_core.test_runner_one_compute_framework import SumFeature  # noqa: F401
 
 
 class OverwrittenReadCsvInputDataTestFeatureGroup(ReadFileFeature):


### PR DESCRIPTION
## Summary
Fixes #532.

Eight test modules depended on import side effects from other collected test modules: seven requested compute frameworks by string name (PyArrowTable or PandasDataFrame) without importing the class, and two used the sum_of_ feature without importing SumFeature. They passed in the full suite but failed standalone, making them sensitive to collection scope and pytest-xdist worker distribution.

## Changes
- Add side-effect imports (with noqa: F401) of the requested compute framework class to:
  - tests/test_core/test_abstract_plugins/test_n_result_columns.py (the test from the issue)
  - tests/test_core/test_abstract_plugins/test_set_feature_name.py
  - tests/test_core/test_index/test_add_index.py
  - tests/test_core/test_plugin_collector/test_plugin_collector.py
  - tests/test_plugins/feature_group/input_data/test_input_data.py
  - tests/test_plugins/compute_framework/test_multi_link_same_cfw.py
  - tests/test_plugins/compute_framework/test_non_root_merges_one_cfw.py
- Add the SumFeature import to test_input_data.py and test_read_files/test_read_file.py, mirroring the existing pattern in test_read.py and test_read_db.py.

## Verification
- Each touched module now passes standalone (pytest <file>).
- Full tox gate passes (3688 passed, 165 skipped; ruff, mypy --strict, bandit, license check all green).
- Sweep per the issue's optional hardening: all other test modules using string compute_frameworks were run standalone; no remaining failures.