### PR TITLE
fix: make get_feature_group_docs robust against exotic runtime FeatureGroup subclasses

### DIFF
--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -26,7 +26,7 @@ from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRe
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.api.plugin_info import ComputeFrameworkInfo, ExtenderInfo, FeatureGroupInfo, ResolvedFeature
-from mloda.core.prepare.accessible_plugins import dedup_feature_group_subclasses
+from mloda.core.prepare.accessible_plugins import RedefinitionConflictError, dedup_feature_group_subclasses
 from mloda.core.prepare.identify_feature_group import split_frameworks_by_capability
 
 
@@ -46,13 +46,11 @@ def _safe_version(fg_class: type[FeatureGroup]) -> str:
 def _dedup_degrading_on_conflict(
     feature_groups: set[type[FeatureGroup]], allow_redefinition: bool
 ) -> set[type[FeatureGroup]]:
-    """Dedup feature groups, keeping all conflicting versions instead of raising on redefinition."""
+    """Dedup feature groups, collapsing each redefinition conflict to its live class instead of raising."""
     try:
         return dedup_feature_group_subclasses(feature_groups, allow_redefinition=allow_redefinition)
-    except ValueError as exc:
-        conflicts: set[type[FeatureGroup]] = set(getattr(exc, "conflicts", []))
-        survivors = dedup_feature_group_subclasses(feature_groups - conflicts, allow_redefinition=allow_redefinition)
-        return survivors | conflicts
+    except RedefinitionConflictError:
+        return dedup_feature_group_subclasses(feature_groups, allow_redefinition=True)
 
 
 def get_feature_group_docs(
@@ -69,8 +67,9 @@ def get_feature_group_docs(
     Returns the current state of loaded feature groups. Ensure plugins are loaded
     before calling this function (e.g., via PluginLoader.all()).
 
-    Returns gracefully on redefinition conflicts (all conflicting versions are
-    documented) and reports "unavailable" as version for classes whose source
+    Returns gracefully on redefinition conflicts: instead of raising, each
+    conflicting class is documented as its most recently defined (live)
+    version. Reports "unavailable" as version for classes whose source
     cannot be introspected.
 
     Args:

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -35,6 +35,26 @@ def list_registered(plugin_type: type[Any]) -> list[type[Any]]:
     return PluginRegistry.default().list_registered(plugin_type)
 
 
+def _safe_version(fg_class: type[FeatureGroup]) -> str:
+    """Return the feature group version or "unavailable" if source introspection fails."""
+    try:
+        return fg_class.version()
+    except (OSError, TypeError):
+        return "unavailable"
+
+
+def _dedup_degrading_on_conflict(
+    feature_groups: set[type[FeatureGroup]], allow_redefinition: bool
+) -> set[type[FeatureGroup]]:
+    """Dedup feature groups, keeping all conflicting versions instead of raising on redefinition."""
+    try:
+        return dedup_feature_group_subclasses(feature_groups, allow_redefinition=allow_redefinition)
+    except ValueError as exc:
+        conflicts: set[type[FeatureGroup]] = set(getattr(exc, "conflicts", []))
+        survivors = dedup_feature_group_subclasses(feature_groups - conflicts, allow_redefinition=allow_redefinition)
+        return survivors | conflicts
+
+
 def get_feature_group_docs(
     name: Optional[str] = None,
     search: Optional[str] = None,
@@ -48,6 +68,10 @@ def get_feature_group_docs(
 
     Returns the current state of loaded feature groups. Ensure plugins are loaded
     before calling this function (e.g., via PluginLoader.all()).
+
+    Returns gracefully on redefinition conflicts (all conflicting versions are
+    documented) and reports "unavailable" as version for classes whose source
+    cannot be introspected.
 
     Args:
         name: Filter by feature group name (case-insensitive partial match).
@@ -67,7 +91,7 @@ def get_feature_group_docs(
         all_feature_groups = {fg for fg in all_feature_groups if fg in registered}
     if plugin_collector is not None:
         all_feature_groups = {fg for fg in all_feature_groups if plugin_collector.applicable_feature_group_class(fg)}
-    all_feature_groups = dedup_feature_group_subclasses(all_feature_groups, allow_redefinition=allow_redefinition)
+    all_feature_groups = _dedup_degrading_on_conflict(all_feature_groups, allow_redefinition=allow_redefinition)
     results = []
 
     for fg_class in all_feature_groups:
@@ -76,7 +100,7 @@ def get_feature_group_docs(
 
         fg_name = fg_class.get_class_name()
         description = fg_class.description()
-        version = fg_class.version()
+        version = _safe_version(fg_class)
         module = fg_class.__module__
         compute_frameworks = [cfw.__name__ for cfw in fg_class.compute_framework_definition()]
         supported_feature_names = fg_class.feature_names_supported()

--- a/tests/test_core/test_prepare/test_feature_group_dedup.py
+++ b/tests/test_core/test_prepare/test_feature_group_dedup.py
@@ -13,9 +13,11 @@ exec'd classes (mirroring how IPython sets up ``<ipython-input-N-...>`` entries)
 
 from __future__ import annotations
 
+import gc
 import linecache
 import sys
 import textwrap
+import types
 from typing import Any, cast
 
 import pytest
@@ -59,6 +61,27 @@ def _exec_fg_in_main(class_name: str, body: str, cell_label: str) -> type[Featur
     code_obj = compile(src, filename, "exec")
     exec(code_obj, main_mod.__dict__)  # nosec B102
     cls = main_mod.__dict__[class_name]
+    return cast(type[FeatureGroup], cls)
+
+
+def _exec_fg_in_module(class_name: str, body: str, cell_label: str, module: types.ModuleType) -> type[FeatureGroup]:
+    """Exec a FeatureGroup subclass into a synthetic real module, registering source in linecache.
+
+    Mirrors ``_exec_fg_in_main`` but targets a caller-provided module object (which the
+    caller has inserted into ``sys.modules``), simulating an ``importlib.reload`` flow
+    in a real (non-``__main__``) module. ``types.ModuleType`` sets ``__name__``
+    automatically, and exec'd class definitions pick up ``__module__`` from the
+    globals' ``__name__``, so the exec'd class reports the synthetic module as its
+    ``__module__``. Source is registered in ``linecache`` under a distinct synthetic
+    filename so source hashes resolve via the linecache AST fallback.
+    """
+    src = textwrap.dedent(body)
+    filename = f"<{cell_label}>"
+    src_lines = src.splitlines(keepends=True)
+    linecache.cache[filename] = (len(src), None, src_lines, filename)
+    code_obj = compile(src, filename, "exec")
+    exec(code_obj, module.__dict__)  # nosec B102
+    cls = module.__dict__[class_name]
     return cast(type[FeatureGroup], cls)
 
 
@@ -833,17 +856,18 @@ def test_get_feature_group_docs_annotates_unintrospectable_class_with_unavailabl
     unintrospectable class is annotated with ``version == "unavailable"`` (not
     skipped), and all other classes are still documented.
 
-    NOTE: this class persists in ``FeatureGroup.__subclasses__()`` for the whole
-    session via ``_REF_STORE``, so its module name and class name are unique and it
-    deliberately does NOT define ``feature_names_supported`` (the base default is
-    an empty set), so it cannot match any other test's feature names.
+    NOTE: this class is held only via a LOCAL reference (enough to keep it alive in
+    ``FeatureGroup.__subclasses__()`` during the call). It is deliberately NOT
+    appended to ``_REF_STORE``: that would permanently leak a non-``__main__``
+    class into every later ``get_feature_group_docs()`` result on the same xdist
+    worker. After the assertions the local ref is deleted and ``gc.collect()`` runs
+    so the class is unregistered from ``__subclasses__``.
     """
     fake_module = "some_fake_module_name_xyz_19"
     fake_cls = cast(
         type[FeatureGroup],
         type("MyFG_Test19_FakeModule", (FeatureGroup,), {"__module__": fake_module}),
     )
-    _REF_STORE.append(fake_cls)
 
     result = get_feature_group_docs()
 
@@ -866,6 +890,11 @@ def test_get_feature_group_docs_annotates_unintrospectable_class_with_unavailabl
 
     other_entries = [item for item in result if item.module != fake_module]
     assert len(other_entries) > 0, "the rest of the catalog must still be documented alongside the annotated class"
+
+    # Cleanup: drop the only strong ref and collect so the fake class vanishes
+    # from FeatureGroup.__subclasses__() and cannot leak into later tests.
+    del fake_cls
+    gc.collect()
 
 
 # ---------------------------------------------------------------------------
@@ -897,3 +926,72 @@ def test_get_feature_group_docs_redef_conflict_does_not_leak_main_classes() -> N
     assert all(item.module != "__main__" for item in result), (
         "conflicting __main__ classes must not leak into the documented catalog"
     )
+
+
+# ---------------------------------------------------------------------------
+# Case 21: redef conflict in a REAL module collapses to the live class
+# ---------------------------------------------------------------------------
+def test_get_feature_group_docs_reload_conflict_collapses_to_live_class() -> None:
+    """A redefinition conflict in a real (non-``__main__``) module (the
+    ``importlib.reload`` flow) must NOT surface both the stale and the live
+    version of the class in the docs output. ``get_feature_group_docs`` is a
+    "current state" catalog: on a redefinition conflict it must collapse each
+    conflicting group to the most recently defined live class (the behavior of
+    dedup with ``allow_redefinition=True``), so exactly ONE entry per
+    conflicting class appears, and it is the live version.
+
+    Today's graceful-degradation path unions ALL conflicting classes back into
+    the result, so this test fails with TWO entries for the synthetic module
+    (stale v1 plus live v2) instead of one.
+
+    Cleanup runs BEFORE the assertions: a red failure must not leave the
+    conflicting classes live in a real module in ``sys.modules``, or every
+    later dedup on the same xdist worker would see the conflict.
+    """
+    module_name = "fake_reload_mod_case21"
+    qualname = "MyFG_Case21_Reload"
+    feature_name = "case21_feature_unique_xyz"
+
+    mod = types.ModuleType(module_name)
+    sys.modules[module_name] = mod
+
+    src_v1 = _make_fg_source(qualname, feature_name)
+    src_v2 = _make_fg_source(
+        qualname,
+        feature_name,
+        extra_body="    def extra_method(self):\n        return 21\n",
+    )
+
+    # Local refs only (NOT _REF_STORE): these non-__main__ classes must vanish
+    # from FeatureGroup.__subclasses__() at the end of this test.
+    v1 = _exec_fg_in_module(qualname, src_v1, "reload-case21-v1", mod)
+    v2 = _exec_fg_in_module(qualname, src_v2, "reload-case21-v2", mod)
+
+    # Sanity: this is a genuine conflict scenario; the latest version is live
+    # in the module (exec rebinding) and the source hashes differ.
+    assert getattr(mod, qualname) is v2, "v2 must be the live class bound in the synthetic module"
+    v1_version = v1.version()
+    v2_version = v2.version()
+    assert v1_version != v2_version, "the two versions must have differing source hashes for a real conflict"
+
+    result = get_feature_group_docs()
+
+    # Snapshot plain data, then clean up so the assertions below cannot leak
+    # the live-module conflict into later tests on this worker.
+    entry_versions = [item.version for item in result if item.module == module_name]
+
+    sys.modules.pop(module_name, None)
+    del mod
+    del v1
+    del v2
+    gc.collect()
+
+    assert len(entry_versions) == 1, (
+        f"a redefinition conflict must collapse to the live class: expected exactly one "
+        f"docs entry for module {module_name!r}, got {len(entry_versions)}: {entry_versions}"
+    )
+    assert entry_versions[0] == v2_version, (
+        f"the single documented entry must be the live (most recent) version; "
+        f"expected {v2_version!r}, got {entry_versions[0]!r}"
+    )
+    assert entry_versions[0] != v1_version, "the stale (pre-reload) version must not be the documented entry"

--- a/tests/test_core/test_prepare/test_feature_group_dedup.py
+++ b/tests/test_core/test_prepare/test_feature_group_dedup.py
@@ -25,7 +25,7 @@ from mloda.core.abstract_plugins.components.utils import get_all_subclasses
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.api.plugin_docs import get_feature_group_docs, resolve_feature
-from mloda.core.api.plugin_info import ResolvedFeature
+from mloda.core.api.plugin_info import FeatureGroupInfo, ResolvedFeature
 from mloda.core.prepare.accessible_plugins import PreFilterPlugins, dedup_feature_group_subclasses
 
 
@@ -317,6 +317,21 @@ class MockCFW(ComputeFramework):
     @staticmethod
     def is_available() -> bool:
         return True
+
+
+# ---------------------------------------------------------------------------
+# Module-level catalog anchor for the get_feature_group_docs graceful-degradation
+# tests (cases 13, 19, 20). It lives in this test module (NOT __main__) and has
+# real source on disk, so it is always documentable. This guarantees the "rest
+# of the catalog" is non-empty even when this file runs in isolation, where no
+# other non-__main__ FeatureGroup subclasses are imported.
+# ---------------------------------------------------------------------------
+class DocsCatalogAnchorFG(FeatureGroup):
+    """Anchor feature group guaranteeing a non-empty documentable catalog in this module."""
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return {"docs_catalog_anchor_feature_unique_xyz"}
 
 
 # ---------------------------------------------------------------------------
@@ -621,13 +636,15 @@ def test_get_feature_group_docs_with_allow_redefinition_does_not_raise() -> None
 
 
 # ---------------------------------------------------------------------------
-# Case 13: get_feature_group_docs raises ValueError on conflict without flag
+# Case 13: get_feature_group_docs degrades gracefully on conflict without flag
 # ---------------------------------------------------------------------------
-def test_get_feature_group_docs_raises_on_redef_conflict_without_flag() -> None:
-    """Without the ``allow_redefinition`` flag, ``get_feature_group_docs`` must
-    propagate the dedup ``ValueError`` so users see the same diagnostic they get
-    from the other call sites. This is the discriminating test that locks in the
-    dedup wiring at ``plugin_docs.py`` — removing the call would make this fail.
+def test_get_feature_group_docs_degrades_gracefully_on_redef_conflict_without_flag() -> None:
+    """Without the ``allow_redefinition`` flag, a Jupyter-style different-source
+    redefinition must NOT crash ``get_feature_group_docs``. The docs API is a
+    read-only introspection entry point and mirrors ``resolve_feature`` (which
+    catches the dedup ``ValueError`` instead of propagating it): it must degrade
+    gracefully, returning a list of ``FeatureGroupInfo`` and still documenting
+    the rest of the catalog despite the conflicting ``__main__`` classes.
     """
     qualname = "MyFG_Test13_Docs"
     feature_name = "case13_feature_unique_xyz"
@@ -642,12 +659,13 @@ def test_get_feature_group_docs_raises_on_redef_conflict_without_flag() -> None:
     v2 = _exec_fg_in_main(qualname, src_v2, "cell-test13-v2")
     _REF_STORE.extend([v1, v2])
 
-    with pytest.raises(ValueError) as exc_info:
-        get_feature_group_docs()
+    result = get_feature_group_docs()
 
-    msg = str(exc_info.value)
-    assert "FeatureGroup redefined" in msg, f"Expected 'FeatureGroup redefined' in error, got: {msg}"
-    assert "set_allow_redefinition" in msg, f"Expected 'set_allow_redefinition' in error, got: {msg}"
+    assert isinstance(result, list), f"get_feature_group_docs must not raise on a redef conflict, got {type(result)}"
+    assert all(isinstance(item, FeatureGroupInfo) for item in result), (
+        f"all items must be FeatureGroupInfo, got: {[type(i).__name__ for i in result]}"
+    )
+    assert len(result) > 0, "the rest of the catalog must still be documented despite the conflict"
 
 
 # ---------------------------------------------------------------------------
@@ -800,4 +818,82 @@ def test_class_source_hash_fallback_extracts_class_local_segment(monkeypatch: py
     assert h1 == h2, (
         "Fallback must extract only the class-local source segment so "
         f"identical class bodies hash identically; got {h1[:16]}... vs {h2[:16]}..."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Case 19: get_feature_group_docs annotates unintrospectable classes
+# ---------------------------------------------------------------------------
+def test_get_feature_group_docs_annotates_unintrospectable_class_with_unavailable_version() -> None:
+    """A FeatureGroup subclass built at runtime via ``type(...)`` with a fake
+    ``__module__`` has no importable source file, so ``fg_class.version()`` raises
+    ``TypeError`` (from ``inspect.getsource`` inside
+    ``BaseFeatureGroupVersion.class_source_hash``). ``get_feature_group_docs`` must
+    degrade gracefully instead of crashing the whole catalog call: the
+    unintrospectable class is annotated with ``version == "unavailable"`` (not
+    skipped), and all other classes are still documented.
+
+    NOTE: this class persists in ``FeatureGroup.__subclasses__()`` for the whole
+    session via ``_REF_STORE``, so its module name and class name are unique and it
+    deliberately does NOT define ``feature_names_supported`` (the base default is
+    an empty set), so it cannot match any other test's feature names.
+    """
+    fake_module = "some_fake_module_name_xyz_19"
+    fake_cls = cast(
+        type[FeatureGroup],
+        type("MyFG_Test19_FakeModule", (FeatureGroup,), {"__module__": fake_module}),
+    )
+    _REF_STORE.append(fake_cls)
+
+    result = get_feature_group_docs()
+
+    assert isinstance(result, list), (
+        f"get_feature_group_docs must not raise on an unintrospectable class, got {type(result)}"
+    )
+    assert all(isinstance(item, FeatureGroupInfo) for item in result), (
+        f"all items must be FeatureGroupInfo, got: {[type(i).__name__ for i in result]}"
+    )
+
+    fake_entries = [item for item in result if item.module == fake_module]
+    assert len(fake_entries) == 1, (
+        f"the unintrospectable class must be documented (annotate, not skip); "
+        f"expected exactly one entry for module {fake_module!r}, got: {fake_entries}"
+    )
+    assert fake_entries[0].name == "MyFG_Test19_FakeModule"
+    assert fake_entries[0].version == "unavailable", (
+        f"version must be 'unavailable' when source introspection fails, got: {fake_entries[0].version!r}"
+    )
+
+    other_entries = [item for item in result if item.module != fake_module]
+    assert len(other_entries) > 0, "the rest of the catalog must still be documented alongside the annotated class"
+
+
+# ---------------------------------------------------------------------------
+# Case 20: graceful redef handling must not leak __main__ classes into output
+# ---------------------------------------------------------------------------
+def test_get_feature_group_docs_redef_conflict_does_not_leak_main_classes() -> None:
+    """Graceful degradation on a redefinition conflict must not change the output
+    contract of ``get_feature_group_docs``: classes living in ``__main__``
+    (including the conflicting redefinitions themselves) stay filtered from the
+    documented catalog. Without any collector, the call returns a list and no
+    entry has ``module == "__main__"``.
+    """
+    qualname = "MyFG_Test20_Docs"
+    feature_name = "case20_feature_unique_xyz"
+    src_v1 = _make_fg_source(qualname, feature_name)
+    src_v2 = _make_fg_source(
+        qualname,
+        feature_name,
+        extra_body="    def extra_method(self):\n        return 20\n",
+    )
+
+    v1 = _exec_fg_in_main(qualname, src_v1, "cell-test20-v1")
+    v2 = _exec_fg_in_main(qualname, src_v2, "cell-test20-v2")
+    _REF_STORE.extend([v1, v2])
+
+    result = get_feature_group_docs()
+
+    assert isinstance(result, list), f"get_feature_group_docs must not raise on a redef conflict, got {type(result)}"
+    assert all(item.module != "__main__" for item in result), (
+        "conflicting __main__ classes must not leak into the documented catalog"
     )


### PR DESCRIPTION
## Summary
Closes #533.

`get_feature_group_docs()` crashed on runtime-created FeatureGroup subclasses in two ways. Both now degrade gracefully, consistent with `resolve_feature()`:

1. Redefinition conflicts (same module and qualname, different source) no longer raise `RedefinitionConflictError` from the docs path. On conflict, dedup is re-run with `allow_redefinition=True`, so each conflicting group collapses deterministically to its most recently defined live class and the rest of the catalog stays documented. Conflicts in `__main__` (the Jupyter case) remain filtered from the output as before.
2. Classes whose source cannot be introspected (e.g. built via `type()` with a synthetic `__module__`) no longer crash the whole call with `TypeError` from `inspect.getsource`. They are documented with `version="unavailable"` instead, mirroring the existing `expected_data_framework="unavailable"` pattern in `get_compute_framework_docs`.

## Changes
- `mloda/core/api/plugin_docs.py`: `_dedup_degrading_on_conflict` (catches `RedefinitionConflictError` specifically, unrelated `ValueError`s still propagate) and `_safe_version` (narrow `OSError`/`TypeError` guard); docstring updated.
- `tests/test_core/test_prepare/test_feature_group_dedup.py`: Case 13 rewritten to pin the graceful contract (it previously locked in the raise), plus new cases for the fake-module class (`version == "unavailable"`), no `__main__` leakage after a conflict, and a reload-style conflict in a real module collapsing to exactly one live entry. Runtime-created test classes are cleaned up via `gc.collect()` so they do not leak into other tests on the same xdist worker.

## Review pass
The change went through two independent reviews. Accepted findings: collapse non-`__main__` reload conflicts to the live class instead of documenting stale duplicates (was the initial implementation), catch the specific conflict error instead of bare `ValueError`, fix a test-only catalog leak, and tighten the docstring. No findings were dismissed.

## Testing
Full `tox` gate green: 3691 passed, 165 skipped, ruff format/check, license allowlist, mypy --strict, bandit.