### PR TITLE
[NEEDS ARCH REVIEW] feat: per-feature scoping to a specific feature group

### DIFF
--- a/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
+++ b/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
@@ -55,7 +55,7 @@ two sources that both declare a join key like `subject_token`), disabling one of
 not an option: you need both enabled, but a single request for the shared column is
 ambiguous. Scope the feature to the source it should come from:
 
-```python
+``` python
 from mloda.user import Feature
 
 # By class name
@@ -82,7 +82,7 @@ share a read with its sibling features. The parameter form leaves options untouc
 The scope matches on the class name only. Two feature group classes that share the same
 class name in different modules still collide and raise "Multiple feature groups found".
 
-```python
+``` python
 class NewestClaimPerSubject(FeatureGroup):
     def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return {

--- a/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
+++ b/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
@@ -74,6 +74,14 @@ derived feature group's `input_features`, which is the typical place you need it
 derived feature group reading a subset of one source's columns can pull in the shared
 join key from that same source.
 
+Prefer the `feature_group` parameter over the options form. The options form keeps the
+`feature_group` key inside the feature's options, which feeds into feature grouping and
+into the options the resolved feature group receives, so a scoped feature may no longer
+share a read with its sibling features. The parameter form leaves options untouched.
+
+The scope matches on the class name only. Two feature group classes that share the same
+class name in different modules still collide and raise "Multiple feature groups found".
+
 ```python
 class NewestClaimPerSubject(FeatureGroup):
     def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:

--- a/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
+++ b/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
@@ -48,6 +48,42 @@ def get_domain(cls):
     return "sales"  # Makes this FG only handle 'sales' domain features
 ```
 
+#### 4. Scope the feature to a specific feature group
+
+When two different feature group classes legitimately share a column name (for example,
+two sources that both declare a join key like `subject_token`), disabling one of them is
+not an option: you need both enabled, but a single request for the shared column is
+ambiguous. Scope the feature to the source it should come from:
+
+```python
+from mloda.user import Feature
+
+# By class name
+Feature("subject_token", feature_group="ClaimsReader")
+
+# By class object
+Feature("subject_token", feature_group=ClaimsReader)
+
+# Or via options
+Feature("subject_token", options={"feature_group": "ClaimsReader"})
+```
+
+The feature then resolves only against the named feature group class, so the
+"Multiple feature groups found" collision does not occur. This also works inside a
+derived feature group's `input_features`, which is the typical place you need it: a
+derived feature group reading a subset of one source's columns can pull in the shared
+join key from that same source.
+
+```python
+class NewestClaimPerSubject(FeatureGroup):
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        return {
+            Feature("claim_date"),
+            Feature("dx_code"),
+            Feature("subject_token", feature_group=ClaimsReader),
+        }
+```
+
 ## FeatureGroup Redefinition Errors
 
 ### The Problem

--- a/mloda/core/abstract_plugins/components/feature.py
+++ b/mloda/core/abstract_plugins/components/feature.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import copy
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 from uuid import uuid4
 from mloda.core.abstract_plugins.components.data_types import DataType
 
@@ -14,6 +14,9 @@ from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.components.utils import get_all_subclasses
 from mloda.core.abstract_plugins.components.validators.feature_validator import FeatureValidator
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+
+if TYPE_CHECKING:
+    from mloda.core.abstract_plugins.feature_group import FeatureGroup
 
 
 class Feature:
@@ -28,6 +31,7 @@ class Feature:
         initial_requested_data (bool): Whether the data was initially requested.
         link (Optional[Link]): The link associated with the feature.
         index (Optional[Index]): The index associated with the feature.
+        feature_group_class_name (Optional[str]): Scopes resolution to a single feature group class.
 
     Quick start (recommended progression)::
 
@@ -75,12 +79,16 @@ class Feature:
         initial_requested_data: bool = False,
         link: Optional[Link] = None,
         index: Optional[Index] = None,
+        feature_group: str | type[FeatureGroup] | None = None,
     ):
         if options is None:
             options = {}
         self.name = FeatureName(name) if isinstance(name, str) else name
         self.options = Options(options) if isinstance(options, dict) else options
         self.domain = self._set_domain(domain, self.options.get("domain"))
+        self.feature_group_class_name = self._set_feature_group_class_name(
+            feature_group, self.options.get("feature_group")
+        )
 
         cf = self._set_compute_framework(compute_framework, self.options.get("compute_framework"))
         self.compute_frameworks = {cf} if cf else None
@@ -175,6 +183,7 @@ class Feature:
             and self.options == other.options
             and self.options.context == other.options.context
             and self.domain == other.domain
+            and self.feature_group_class_name == other.feature_group_class_name
             and self.compute_frameworks == other.compute_frameworks
             and self.data_type == other.data_type
             and self.child_options == other.child_options
@@ -198,7 +207,17 @@ class Feature:
                 if isinstance(val, Feature):
                     child_options.group[DefaultOptionKeys.in_features] = val.name
 
-        return hash((self.name, self.options, self.domain, compute_frameworks_hashable, self.data_type, child_options))
+        return hash(
+            (
+                self.name,
+                self.options,
+                self.domain,
+                self.feature_group_class_name,
+                compute_frameworks_hashable,
+                self.data_type,
+                child_options,
+            )
+        )
 
     def is_different_data_type(self, other: Feature) -> bool:
         return self.name == other.name and self.data_type != other.data_type
@@ -229,6 +248,18 @@ class Feature:
         elif domain_options:
             return Domain(domain_options)
         return None
+
+    def _set_feature_group_class_name(
+        self,
+        feature_group: str | type[FeatureGroup] | None,
+        feature_group_options: str | type[FeatureGroup] | None,
+    ) -> str | None:
+        resolved = feature_group if feature_group is not None else feature_group_options
+        if resolved is None:
+            return None
+        if isinstance(resolved, str):
+            return resolved
+        return resolved.get_class_name()
 
     def _set_compute_framework(
         self, compute_framework: Optional[str], compute_framework_options: Optional[str]

--- a/mloda/core/abstract_plugins/components/feature.py
+++ b/mloda/core/abstract_plugins/components/feature.py
@@ -254,12 +254,17 @@ class Feature:
         feature_group: str | type[FeatureGroup] | None,
         feature_group_options: str | type[FeatureGroup] | None,
     ) -> str | None:
-        resolved = feature_group if feature_group is not None else feature_group_options
-        if resolved is None:
+        resolved = feature_group if feature_group else feature_group_options
+        if not resolved:
             return None
         if isinstance(resolved, str):
             return resolved
-        return resolved.get_class_name()
+        if isinstance(resolved, type) and hasattr(resolved, "get_class_name"):
+            return resolved.get_class_name()
+        raise TypeError(
+            f"feature_group must be a feature group class name string or a FeatureGroup class, "
+            f"got {type(resolved).__name__}"
+        )
 
     def _set_compute_framework(
         self, compute_framework: Optional[str], compute_framework_options: Optional[str]

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -71,6 +71,9 @@ class IdentifyFeatureGroupClass:
             if not self._filter_feature_group_by_domain(feature_group, feature):
                 continue
 
+            if not self._filter_feature_group_by_scope(feature_group, feature):
+                continue
+
             self._criteria_matched_feature_groups.add(feature_group)
 
             supported_frameworks = {
@@ -120,6 +123,12 @@ class IdentifyFeatureGroupClass:
 
     def _filter_feature_group_by_domain(self, feature_group: type[FeatureGroup], feature: Feature) -> bool:
         return not feature.domain or feature_group.get_domain() == feature.domain
+
+    def _filter_feature_group_by_scope(self, feature_group: type[FeatureGroup], feature: Feature) -> bool:
+        return (
+            feature.feature_group_class_name is None
+            or feature_group.get_class_name() == feature.feature_group_class_name
+        )
 
     def _filter_feature_group_by_framework(
         self,
@@ -184,6 +193,8 @@ class IdentifyFeatureGroupClass:
 
         feature_name = str(feature.name)
         msg = f"No feature groups found for feature name: '{feature_name}'."
+        if feature.feature_group_class_name is not None:
+            msg += f" Scoped to feature group '{feature.feature_group_class_name}'."
 
         if not accessible_plugins:
             msg += "\nNo plugins are loaded. Did you call PluginLoader.all()?"

--- a/tests/test_core/test_prepare/test_identify_feature_group_scoping.py
+++ b/tests/test_core/test_prepare/test_identify_feature_group_scoping.py
@@ -1,0 +1,319 @@
+"""RED-phase tests for per-feature feature-group scoping (GitHub issue #508).
+
+A derived feature group that reads a subset of one source's columns cannot
+obtain the shared join key (e.g. ``subject_token``) when two enabled sources
+both declare that column: requesting it by name raises
+``ValueError: Multiple feature groups found for feature 'subject_token'``.
+
+Target behavior:
+  * ``Feature`` gains an optional ``feature_group`` constructor parameter,
+    accepting a feature group class name string or the feature group class
+    itself, stored as ``feature_group_class_name`` (``str | None``), with an
+    ``options.get("feature_group")`` fallback (mirroring ``domain``).
+  * ``feature_group_class_name`` participates in ``Feature.__eq__`` and
+    ``Feature.__hash__`` (like ``domain``).
+  * ``IdentifyFeatureGroupClass._filter_loop`` filters candidate feature
+    groups by that scope BEFORE the "Multiple feature groups found"
+    validation, so a scoped feature resolves uniquely.
+  * A scope matching nothing raises the existing "No feature groups found"
+    ValueError, and its message mentions the requested scope name.
+
+PART A exercises ``IdentifyFeatureGroupClass`` directly.
+PART B drives the issue's definition-of-done scenario through
+``mloda.run_all``.
+"""
+
+from typing import Any
+
+import pytest
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+from mloda.provider import BaseInputData
+from mloda.provider import DataCreator
+from mloda.provider import FeatureGroup
+from mloda.provider import FeatureSet
+from mloda.user import Feature
+from mloda.user import FeatureName
+from mloda.user import Options
+from mloda.user import ParallelizationMode
+from mloda.user import PluginCollector
+from mloda.user import mloda
+
+# Importing the framework registers it as a ComputeFramework subclass, so
+# ``compute_frameworks=["PandasDataFrame"]`` resolves even when this module
+# runs in isolation.
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import (  # noqa: F401
+    PandasDataFrame,
+)
+
+
+class MockComputeFramework(ComputeFramework):
+    """Mock compute framework for direct IdentifyFeatureGroupClass tests."""
+
+    pass
+
+
+# ============================================================================
+# PART A - direct resolution scoping via IdentifyFeatureGroupClass
+# ============================================================================
+class ScopingSubjectTokenSourceA(FeatureGroup):
+    """First source feature group declaring the shared 'subject_token' column."""
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        if isinstance(feature_name, FeatureName):
+            feature_name = str(feature_name)
+        return feature_name in {"subject_token", "scoping_value_a"}
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return {"subject_token", "scoping_value_a"}
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        return None
+
+
+class ScopingSubjectTokenSourceB(FeatureGroup):
+    """Second source feature group also declaring the shared 'subject_token' column."""
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        if isinstance(feature_name, FeatureName):
+            feature_name = str(feature_name)
+        return feature_name in {"subject_token", "scoping_value_b"}
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return {"subject_token", "scoping_value_b"}
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        return None
+
+
+def _resolve_with_both_sources(feature: Feature) -> IdentifyFeatureGroupClass:
+    accessible_plugins: FeatureGroupEnvironmentMapping = {
+        ScopingSubjectTokenSourceA: {MockComputeFramework},
+        ScopingSubjectTokenSourceB: {MockComputeFramework},
+    }
+    return IdentifyFeatureGroupClass(
+        feature=feature,
+        accessible_plugins=accessible_plugins,
+        links=None,
+        data_access_collection=None,
+    )
+
+
+class TestFeatureGroupScopeResolution:
+    """Resolution scoping via the new Feature ``feature_group`` parameter."""
+
+    def test_unscoped_shared_column_raises_multiple_found(self) -> None:
+        """Characterization test: this is the CURRENT behavior and must stay.
+
+        An unscoped feature whose name is declared by two enabled feature
+        groups is ambiguous and raises 'Multiple feature groups found'.
+        """
+        feature = Feature("subject_token")
+
+        with pytest.raises(ValueError, match="Multiple feature groups found"):
+            _resolve_with_both_sources(feature)
+
+    def test_scope_by_class_name_string_resolves_uniquely(self) -> None:
+        """A feature scoped via a class name string resolves to exactly that class."""
+        feature = Feature("subject_token", feature_group="ScopingSubjectTokenSourceA")
+
+        resolved = _resolve_with_both_sources(feature)
+
+        feature_group_class, compute_frameworks = resolved.get()
+        assert feature_group_class is ScopingSubjectTokenSourceA
+        assert compute_frameworks == {MockComputeFramework}
+
+    def test_scope_by_class_object_resolves_uniquely(self) -> None:
+        """A feature scoped via the feature group class itself resolves to that class.
+
+        The class is stored by its resolved name string.
+        """
+        feature = Feature("subject_token", feature_group=ScopingSubjectTokenSourceA)
+
+        assert feature.feature_group_class_name == "ScopingSubjectTokenSourceA"
+
+        resolved = _resolve_with_both_sources(feature)
+
+        feature_group_class, _ = resolved.get()
+        assert feature_group_class is ScopingSubjectTokenSourceA
+
+    def test_scope_via_options_resolves_uniquely(self) -> None:
+        """The scope can also be provided via options, mirroring 'domain'."""
+        feature = Feature("subject_token", options={"feature_group": "ScopingSubjectTokenSourceB"})
+
+        assert feature.feature_group_class_name == "ScopingSubjectTokenSourceB"
+
+        resolved = _resolve_with_both_sources(feature)
+
+        feature_group_class, _ = resolved.get()
+        assert feature_group_class is ScopingSubjectTokenSourceB
+
+    def test_scope_matching_nothing_raises_with_scope_name_in_message(self) -> None:
+        """A scope matching no candidate raises 'No feature groups found' naming the scope."""
+        feature = Feature("subject_token", feature_group="CompletelyUnknownScopedFeatureGroup")
+
+        with pytest.raises(ValueError, match="No feature groups found") as exc_info:
+            _resolve_with_both_sources(feature)
+
+        assert "CompletelyUnknownScopedFeatureGroup" in str(exc_info.value)
+
+
+class TestFeatureEqualityWithScope:
+    """``feature_group_class_name`` participates in Feature equality and hash."""
+
+    def test_different_scopes_are_not_equal_and_hash_differently(self) -> None:
+        scoped_to_a = Feature("subject_token", feature_group="ScopingSubjectTokenSourceA")
+        scoped_to_b = Feature("subject_token", feature_group="ScopingSubjectTokenSourceB")
+
+        assert scoped_to_a != scoped_to_b
+        assert hash(scoped_to_a) != hash(scoped_to_b)
+
+    def test_scoped_and_unscoped_are_not_equal(self) -> None:
+        scoped = Feature("subject_token", feature_group="ScopingSubjectTokenSourceA")
+        unscoped = Feature("subject_token")
+
+        assert scoped != unscoped
+
+    def test_same_scope_is_equal_and_hashes_equally(self) -> None:
+        first = Feature("subject_token", feature_group="ScopingSubjectTokenSourceA")
+        second = Feature("subject_token", feature_group="ScopingSubjectTokenSourceA")
+
+        assert first == second
+        assert hash(first) == hash(second)
+
+
+# ============================================================================
+# PART B - integration through mloda.run_all (issue #508 definition of done)
+# ============================================================================
+# Two enabled sources both produce the shared join key 'subject_token'.
+#   source A: subject_token = [s1, s2, s1, s2], scoping_value_a = [10, 5, 30, 7]
+#   source B: subject_token = [s1, s2],         scoping_value_b = [1, 2]
+# The derived feature group reads 'scoping_value_a' AND the shared
+# 'subject_token' from source A, computing the max value per subject:
+#   s1 -> 30, s2 -> 7   encoded as ["s1|30", "s2|7"]
+class ScopingRunSourceA(FeatureGroup):
+    """Source A: emits the shared 'subject_token' key and 'scoping_value_a'."""
+
+    @classmethod
+    def input_data(cls) -> BaseInputData | None:
+        return DataCreator(supports_features={"subject_token", "scoping_value_a"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {
+            "subject_token": ["s1", "s2", "s1", "s2"],
+            "scoping_value_a": [10, 5, 30, 7],
+        }
+
+
+class ScopingRunSourceB(FeatureGroup):
+    """Source B: also emits the shared 'subject_token' key, plus 'scoping_value_b'."""
+
+    @classmethod
+    def input_data(cls) -> BaseInputData | None:
+        return DataCreator(supports_features={"subject_token", "scoping_value_b"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {
+            "subject_token": ["s1", "s2"],
+            "scoping_value_b": [1, 2],
+        }
+
+
+class ScopingMaxValuePerSubject(FeatureGroup):
+    """Derived FG reading source A columns; the shared key is scoped to source A."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        return {
+            Feature(name="scoping_value_a"),
+            Feature(name="subject_token", feature_group=ScopingRunSourceA),
+        }
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        maxima: dict[str, int] = {}
+        for token, value in zip(data["subject_token"], data["scoping_value_a"]):
+            if token not in maxima or value > maxima[token]:
+                maxima[token] = value
+        return {cls.get_class_name(): sorted(f"{token}|{value}" for token, value in maxima.items())}
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return {cls.get_class_name()}
+
+
+class ScopingUnscopedMaxValuePerSubject(FeatureGroup):
+    """Derived FG requesting the shared key WITHOUT a scope: stays ambiguous."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        return {
+            Feature(name="scoping_value_a"),
+            Feature(name="subject_token"),
+        }
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {cls.get_class_name(): []}
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return {cls.get_class_name()}
+
+
+_ENABLED_SCOPED = PluginCollector.enabled_feature_groups(
+    {ScopingRunSourceA, ScopingRunSourceB, ScopingMaxValuePerSubject}
+)
+_ENABLED_UNSCOPED = PluginCollector.enabled_feature_groups(
+    {ScopingRunSourceA, ScopingRunSourceB, ScopingUnscopedMaxValuePerSubject}
+)
+
+
+class TestScopedSharedColumnRunAll:
+    """Issue #508 definition of done, driven through mloda.run_all."""
+
+    def test_unscoped_shared_column_raises_multiple_found(self, flight_server: Any) -> None:
+        """Characterization test: without a scope the shared key stays ambiguous.
+
+        This must keep raising 'Multiple feature groups found' even after the
+        fix, because no per-feature scope is given.
+        """
+        with pytest.raises(ValueError, match="Multiple feature groups found"):
+            mloda.run_all(
+                [Feature(name=ScopingUnscopedMaxValuePerSubject.get_class_name())],
+                compute_frameworks=["PandasDataFrame"],
+                plugin_collector=_ENABLED_UNSCOPED,
+                flight_server=flight_server,
+                parallelization_modes={ParallelizationMode.SYNC},
+            )
+
+    def test_scoped_shared_column_computes_per_subject(self, flight_server: Any) -> None:
+        """Scoping the shared key to source A resolves it and computes per subject."""
+        result = mloda.run_all(
+            [Feature(name=ScopingMaxValuePerSubject.get_class_name())],
+            compute_frameworks=["PandasDataFrame"],
+            plugin_collector=_ENABLED_SCOPED,
+            flight_server=flight_server,
+            parallelization_modes={ParallelizationMode.SYNC},
+        )
+
+        assert len(result) == 1
+        values = sorted(str(v) for v in result[0][ScopingMaxValuePerSubject.get_class_name()])
+        assert values == ["s1|30", "s2|7"]

--- a/tests/test_core/test_prepare/test_identify_feature_group_scoping.py
+++ b/tests/test_core/test_prepare/test_identify_feature_group_scoping.py
@@ -199,6 +199,32 @@ class TestFeatureEqualityWithScope:
         assert hash(first) == hash(second)
 
 
+class TestEmptyStringScopeNormalization:
+    """An empty-string scope means 'no scope', mirroring ``Feature(domain="")``."""
+
+    def test_empty_string_parameter_normalizes_to_none(self) -> None:
+        feature = Feature("x", feature_group="")
+
+        assert feature.feature_group_class_name is None
+
+    def test_empty_string_in_options_normalizes_to_none(self) -> None:
+        feature = Feature("x", options={"feature_group": ""})
+
+        assert feature.feature_group_class_name is None
+
+
+class TestInvalidScopeTypeRaisesTypeError:
+    """A scope that is neither a string nor a feature group class raises a clear TypeError."""
+
+    def test_int_scope_raises_type_error_mentioning_feature_group(self) -> None:
+        with pytest.raises(TypeError, match="feature_group"):
+            Feature("x", feature_group=123)  # type: ignore[arg-type]
+
+    def test_arbitrary_instance_scope_raises_type_error_mentioning_feature_group(self) -> None:
+        with pytest.raises(TypeError, match="feature_group"):
+            Feature("x", feature_group=object())  # type: ignore[arg-type]
+
+
 # ============================================================================
 # PART B - integration through mloda.run_all (issue #508 definition of done)
 # ============================================================================


### PR DESCRIPTION
Closes #508.

## Problem

A derived feature group reading a subset of one source's columns could not obtain a shared join key such as subject_token. Readers return only explicitly requested columns, and requesting the key by name raised 'ValueError: Multiple feature groups found' when more than one enabled source declares it.

## Change

Feature gains an optional feature_group scope that restricts resolution to the named feature group class (issue option 2, mirroring the Link discriminator precedent):

- Feature("subject_token", feature_group="ClaimsReader"), feature_group=ClaimsReader (class object), or options={"feature_group": "ClaimsReader"}.
- The scope participates in Feature equality and hash (like domain) but not in similarity hashes, so a scoped key feature still shares a read with its sibling columns.
- IdentifyFeatureGroupClass filters candidates by the scope before validation; the no-match error reports the scope name.
- Empty-string scopes normalize to no scope; invalid scope types raise a clear TypeError.
- Troubleshooting guide documents the cross-class shared-key case, recommends the parameter form, and notes that scoping matches on class name only.

## Tests

14 new tests: unit coverage of resolution scoping (string, class object, options form, no-match error, equality/hash, empty-string normalization, invalid types) plus an integration test matching the issue's definition of done (two enabled sources sharing subject_token; a derived feature group on one source produces a correctly keyed per-subject frame via run_all). Full tox gate passes.

## Review

Two independent deep reviews ran against the diff; accepted findings (empty-string scope handling, invalid-type error, documentation caveats) are fixed in the follow-up commit. Storing full class identity instead of the class name was considered and rejected to stay consistent with the codebase's name-based class identification.