### PR TITLE
fix: validate inspect.getsource text defines the class in class_source_hash

### DIFF
--- a/mloda/core/abstract_plugins/components/base_feature_group_version.py
+++ b/mloda/core/abstract_plugins/components/base_feature_group_version.py
@@ -5,6 +5,7 @@ import importlib.metadata
 import inspect
 import linecache
 import hashlib
+import textwrap
 from typing import Any
 from abc import ABC
 
@@ -26,6 +27,11 @@ class BaseFeatureGroupVersion(ABC):
         """
         Returns a SHA-256 hash of the target class's source code.
 
+        Text returned by ``inspect.getsource`` is validated: it must actually
+        define the target class (Python 3.13+ can return unrelated file content
+        for exec-defined classes via ``__firstlineno__``). Invalid text is
+        treated like a getsource failure.
+
         Falls back to a linecache-based lookup via the class's methods'
         ``__code__.co_filename`` when ``inspect.getsource`` cannot resolve the
         class (common for classes defined in long-lived namespaces such as
@@ -45,6 +51,15 @@ class BaseFeatureGroupVersion(ABC):
             if fallback is None:
                 raise
             source = fallback
+        else:
+            if not _source_defines_class(source, target_class.__name__):
+                fallback = _linecache_source_for_class(target_class)
+                if fallback is None:
+                    raise OSError(
+                        f"inspect.getsource returned text that does not define {target_class.__name__!r} "
+                        "and no linecache fallback was available"
+                    )
+                source = fallback
         return hashlib.sha256(source.encode("utf-8")).hexdigest()
 
     @classmethod
@@ -72,6 +87,25 @@ class BaseFeatureGroupVersion(ABC):
             raise ValueError(f"target_class must be a subclass of FeatureGroup: {target_class}")
 
         return f"{cls.mloda_version()}-{cls.module_name(target_class)}-{cls.class_source_hash(target_class)}"
+
+
+def _source_defines_class(source: str, class_name: str) -> bool:
+    """Returns True when the source text contains a ``ClassDef`` named ``class_name``.
+
+    On Python 3.13+, ``inspect.getsource`` slices lines out of whatever file the
+    class's module resolves to (via ``__firstlineno__``), so it can succeed with
+    text that does not define the class at all. The text is dedented before
+    parsing because nested classes come back indented; a ``SyntaxError`` counts
+    as not defining the class.
+    """
+    try:
+        tree = ast.parse(textwrap.dedent(source))
+    except SyntaxError:
+        return False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            return True
+    return False
 
 
 def _linecache_source_for_class(target_class: type[Any]) -> str | None:

--- a/mloda/core/abstract_plugins/components/base_feature_group_version.py
+++ b/mloda/core/abstract_plugins/components/base_feature_group_version.py
@@ -5,7 +5,6 @@ import importlib.metadata
 import inspect
 import linecache
 import hashlib
-import textwrap
 from typing import Any
 from abc import ABC
 
@@ -94,14 +93,23 @@ def _source_defines_class(source: str, class_name: str) -> bool:
 
     On Python 3.13+, ``inspect.getsource`` slices lines out of whatever file the
     class's module resolves to (via ``__firstlineno__``), so it can succeed with
-    text that does not define the class at all. The text is dedented before
-    parsing because nested classes come back indented; a ``SyntaxError`` counts
-    as not defining the class.
+    text that does not define the class at all.
+
+    Nested classes come back indented, so the text is parsed twice: first as-is
+    (top-level classes), then wrapped in an ``if True:`` block so the indented
+    text becomes a valid block body. ``textwrap.dedent`` is NOT used here: it
+    computes the common indent over all nonblank lines including lines inside
+    string literals, so a flush-left line inside a multiline string makes dedent
+    a no-op and the still-indented text would be wrongly rejected. If neither
+    parse succeeds, the source does not define the class.
     """
     try:
-        tree = ast.parse(textwrap.dedent(source))
+        tree = ast.parse(source)
     except SyntaxError:
-        return False
+        try:
+            tree = ast.parse("if True:\n" + source)
+        except SyntaxError:
+            return False
     for node in ast.walk(tree):
         if isinstance(node, ast.ClassDef) and node.name == class_name:
             return True

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_docs_enumeration.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_docs_enumeration.py
@@ -14,7 +14,10 @@ The autouse conftest fixture restores the default registry around every test,
 so clearing it inside a test is safe.
 """
 
+import gc
 from typing import Any
+
+import pytest
 
 import mloda.steward
 import mloda.user
@@ -28,6 +31,19 @@ from mloda.core.api.plugin_docs import (
     get_extender_docs,
     get_feature_group_docs,
 )
+
+
+@pytest.fixture(autouse=True)
+def _reap_pending_dead_plugin_classes() -> None:
+    """Collect dead test-local plugin classes before each test.
+
+    Plugin docs enumeration walks live __subclasses__() registries. Local plugin
+    classes from earlier tests on the same worker stay visible there until a gc
+    pass runs, so a pass landing between two enumeration calls inside one test
+    changes the result mid-test. Collecting up front makes enumeration stable
+    for the duration of each test.
+    """
+    gc.collect()
 
 
 class TestPublicRegistryExports:

--- a/tests/test_core/test_api/test_plugin_docs.py
+++ b/tests/test_core/test_api/test_plugin_docs.py
@@ -1,3 +1,5 @@
+import gc
+
 import pytest
 from mloda.core.api.plugin_info import (
     FeatureGroupInfo,
@@ -16,6 +18,19 @@ from mloda.user import PluginLoader
 def load_plugins() -> None:
     """Load all plugins before running tests in this module."""
     PluginLoader.all()
+
+
+@pytest.fixture(autouse=True)
+def _reap_pending_dead_plugin_classes() -> None:
+    """Collect dead test-local plugin classes before each test.
+
+    Plugin docs enumeration walks live __subclasses__() registries. Local plugin
+    classes from earlier tests on the same worker stay visible there until a gc
+    pass runs, so a pass landing between two enumeration calls inside one test
+    changes the result mid-test. Collecting up front makes enumeration stable
+    for the duration of each test.
+    """
+    gc.collect()
 
 
 class TestFeatureGroupInfo:

--- a/tests/test_core/test_prepare/test_feature_group_dedup.py
+++ b/tests/test_core/test_prepare/test_feature_group_dedup.py
@@ -995,3 +995,155 @@ def test_get_feature_group_docs_reload_conflict_collapses_to_live_class() -> Non
         f"expected {v2_version!r}, got {entry_versions[0]!r}"
     )
     assert entry_versions[0] != v1_version, "the stale (pre-reload) version must not be the documented entry"
+
+
+# ---------------------------------------------------------------------------
+# Cases 22-24 (issue 540): class_source_hash must reject getsource text that
+# does not define the target class. On Python 3.13+, inspect.getsource slices
+# lines out of whatever file the class's module resolves to (via
+# __firstlineno__), so for exec-defined __main__ classes it can SUCCEED with
+# text that does not contain the class at all. These tests monkeypatch
+# inspect.getsource to succeed with wrong text so they fail on ALL versions.
+# ---------------------------------------------------------------------------
+def test_class_source_hash_rejects_getsource_text_not_defining_class(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``class_source_hash`` must not hash ``inspect.getsource`` output that does
+    not define the target class.
+
+    Simulates the Python 3.13+ ``__firstlineno__`` failure mode: ``getsource``
+    SUCCEEDS but returns text from an unrelated file (e.g. ``pytest/__main__.py``)
+    that never defines the class. Two genuinely different exec-defined versions
+    of the same class then get IDENTICAL meaningless hashes and dedup silently
+    collapses them instead of raising a redefinition conflict.
+
+    Today this FAILS: the same bogus text is hashed for both versions, so the
+    hashes are equal. After the fix, the bogus text is rejected (no ``ClassDef``
+    named after the class in its AST) and the linecache AST fallback extracts
+    the real, differing class segments, so the hashes differ.
+    """
+    import inspect
+
+    from mloda.core.abstract_plugins.components.base_feature_group_version import BaseFeatureGroupVersion
+
+    qualname = "MyFG_BogusSrc22"
+    feature_name = "case22_feature_unique_xyz"
+    src_v1 = _make_fg_source(qualname, feature_name)
+    src_v2 = _make_fg_source(
+        qualname,
+        feature_name,
+        extra_body="    def extra_method(self):\n        return 22\n",
+    )
+
+    v1 = _exec_fg_in_main(qualname, src_v1, "cell-bogus-src22-v1")
+    v2 = _exec_fg_in_main(qualname, src_v2, "cell-bogus-src22-v2")
+    _REF_STORE.extend([v1, v2])
+
+    def wrong_getsource(obj: Any) -> str:
+        # Valid Python, but it does NOT define the target class.
+        return "import sys\n\nx = 1\n"
+
+    monkeypatch.setattr(inspect, "getsource", wrong_getsource)
+
+    h1 = BaseFeatureGroupVersion.class_source_hash(v1)
+    h2 = BaseFeatureGroupVersion.class_source_hash(v2)
+
+    assert h1 != h2, (
+        "Different class sources must produce different hashes even when "
+        "inspect.getsource succeeds with text that does not define the class "
+        f"(both hashed to {h1[:16]}...)"
+    )
+
+
+def test_class_source_hash_getsource_wrong_text_identical_bodies_hash_equal(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When ``inspect.getsource`` succeeds with wrong text, the fallback must
+    extract only the class-local segment, so byte-identical class bodies hash
+    identically even when surrounding cell content differs.
+
+    The monkeypatched ``getsource`` returns DIFFERENT unrelated text per call
+    (mirroring distinct slices of an unrelated file per version). Today this
+    FAILS: the two wrong texts are hashed directly, so the hashes differ for
+    identical class bodies. After the fix, both texts are rejected and the
+    linecache AST fallback extracts the identical class segments.
+    """
+    import inspect
+
+    from mloda.core.abstract_plugins.components.base_feature_group_version import BaseFeatureGroupVersion
+
+    qualname = "MyFG_BogusSrc23"
+
+    class_body = textwrap.dedent(
+        f"""
+        class {qualname}(_FG_):
+            @classmethod
+            def feature_names_supported(cls):
+                return {{"case23_feature_unique_xyz"}}
+        """
+    )
+
+    cell_v1 = (
+        f"from mloda.core.abstract_plugins.feature_group import FeatureGroup as _FG_\n\nunrelated_var = 1\n{class_body}"
+    )
+    cell_v2 = (
+        "from mloda.core.abstract_plugins.feature_group import FeatureGroup as _FG_\n"
+        "\n"
+        "unrelated_var = 99\n"
+        f"{class_body}"
+    )
+
+    v1 = _exec_fg_in_main(qualname, cell_v1, "cell-bogus-src23-v1")
+    _REF_STORE.append(v1)
+    v2 = _exec_fg_in_main(qualname, cell_v2, "cell-bogus-src23-v2")
+    _REF_STORE.append(v2)
+
+    call_count = [0]
+
+    def wrong_getsource(obj: Any) -> str:
+        # Different unrelated text per call, never defining the class.
+        call_count[0] += 1
+        return f"import sys\n\nbogus_marker_{call_count[0]} = {call_count[0]}\n"
+
+    monkeypatch.setattr(inspect, "getsource", wrong_getsource)
+
+    h1 = BaseFeatureGroupVersion.class_source_hash(v1)
+    h2 = BaseFeatureGroupVersion.class_source_hash(v2)
+
+    assert h1 == h2, (
+        "Identical class bodies must hash identically even when inspect.getsource "
+        "succeeds with differing text that does not define the class; "
+        f"got {h1[:16]}... vs {h2[:16]}..."
+    )
+
+
+def test_class_source_hash_getsource_wrong_text_no_fallback_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When ``inspect.getsource`` succeeds with text that does not define the
+    class AND no linecache fallback is available, ``class_source_hash`` must
+    raise ``OSError`` instead of silently hashing the wrong text.
+
+    The class is built via ``type(...)`` so its only ``__code__``-bearing method
+    points at this real test file (not a synthetic ``<...>`` filename), making
+    ``_linecache_source_for_class`` return ``None``. Today this FAILS with
+    DID NOT RAISE: the bogus text is hashed and returned.
+    """
+    import inspect
+
+    from mloda.core.abstract_plugins.components.base_feature_group_version import BaseFeatureGroupVersion
+
+    qualname = "MyFG_BogusSrc24"
+    feature_name = "case24_feature_unique_xyz"
+
+    # __module__ = "__main__" mirrors a Jupyter factory pattern and keeps the
+    # class out of get_feature_group_docs results in later tests on this worker.
+    body: dict[str, Any] = {
+        "feature_names_supported": classmethod(lambda cls: {feature_name}),
+        "__module__": "__main__",
+    }
+    dyn_cls = cast(type[FeatureGroup], type(qualname, (FeatureGroup,), body))
+    _REF_STORE.append(dyn_cls)
+
+    def wrong_getsource(obj: Any) -> str:
+        # Succeeds, but the text does not define the class.
+        return "import sys\n\nx = 1\n"
+
+    monkeypatch.setattr(inspect, "getsource", wrong_getsource)
+
+    with pytest.raises(OSError):
+        BaseFeatureGroupVersion.class_source_hash(dyn_cls)

--- a/tests/test_core/test_prepare/test_feature_group_dedup.py
+++ b/tests/test_core/test_prepare/test_feature_group_dedup.py
@@ -1147,3 +1147,57 @@ def test_class_source_hash_getsource_wrong_text_no_fallback_raises(monkeypatch: 
 
     with pytest.raises(OSError):
         BaseFeatureGroupVersion.class_source_hash(dyn_cls)
+
+
+# ---------------------------------------------------------------------------
+# Case 25 (regression): nested class with a flush-left multiline string must
+# be accepted by the getsource validation, not rejected.
+# ---------------------------------------------------------------------------
+def test_class_source_hash_accepts_nested_class_with_flush_left_multiline_string() -> None:
+    """A function-local FeatureGroup subclass whose body contains a triple-quoted
+    multiline string with a flush-left (column 0) line must hash the legitimate
+    ``inspect.getsource`` text.
+
+    ``_source_defines_class`` validates getsource output via
+    ``ast.parse(textwrap.dedent(source))``. ``textwrap.dedent`` computes the
+    common indent over ALL nonblank lines, including lines INSIDE string
+    literals, so a flush-left line inside the multiline string makes dedent a
+    no-op. The still-indented nested-class source then raises
+    ``IndentationError`` (a ``SyntaxError`` subclass) in ``ast.parse``,
+    validation returns False, ``_linecache_source_for_class`` returns None for
+    real on-disk files, and ``class_source_hash`` raises ``OSError`` for a
+    perfectly valid class that hashed fine before the validation was added.
+
+    Cleanup: the class is held only via a LOCAL reference (NOT ``_REF_STORE``)
+    and is deleted plus ``gc.collect()``'d at the end so it does not leak into
+    other tests' ``FeatureGroup.__subclasses__()`` views.
+    """
+    import hashlib
+    import inspect
+
+    from mloda.core.abstract_plugins.components.base_feature_group_version import BaseFeatureGroupVersion
+
+    class MyFG_NestedFlushLeft25(FeatureGroup):
+        DOC_TEMPLATE = """
+case25 flush-left line at column zero
+"""
+
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {"case25_feature_unique_xyz"}
+
+    source = inspect.getsource(MyFG_NestedFlushLeft25)
+    expected = hashlib.sha256(source.encode("utf-8")).hexdigest()
+
+    h = BaseFeatureGroupVersion.class_source_hash(MyFG_NestedFlushLeft25)
+
+    assert h == expected, (
+        "class_source_hash must accept the legitimate getsource text of a nested "
+        "class containing a flush-left multiline string; "
+        f"expected {expected[:16]}..., got {h[:16]}..."
+    )
+
+    # Cleanup: drop the only strong ref and collect so the nested class vanishes
+    # from FeatureGroup.__subclasses__() and cannot leak into later tests.
+    del MyFG_NestedFlushLeft25
+    gc.collect()


### PR DESCRIPTION
## Summary

Fixes #540.

On Python 3.13+, `inspect.getsource` can succeed via the new `__firstlineno__` attribute while slicing a file that does not contain the target class (exec-defined classes whose module resolves to an unrelated real file, for example `__main__` under single-process pytest). `class_source_hash` then hashed meaningless identical text for genuinely different redefinitions, so `dedup_feature_group_subclasses` silently collapsed conflicting versions instead of raising. The dedup suite passed under `pytest -n 8` (xdist workers have a non-file `__main__`) but failed single-process on 3.13+.

## Changes

- `class_source_hash` now AST-validates that the text returned by `inspect.getsource` defines a `ClassDef` matching the target class name; otherwise it falls through to the existing linecache/AST fallback and raises `OSError` when no fallback source is available (callers already map `OSError` to preserve-group / "unavailable").
- The validation parses the raw source first and retries wrapped in a synthetic block for indented nested-class source. `textwrap.dedent` is deliberately not used: it counts indentation of lines inside string literals, so a flush-left line in a multiline string would make valid nested-class source unparseable (found by review, covered by a test).
- Regression tests cover the 3.13+ path on all supported versions by monkeypatching `inspect.getsource` to succeed with wrong text: differing sources must hash differently, identical class bodies must hash identically, and wrong text without a fallback must raise `OSError`.
- Test-only stabilization: the plugin docs tests compare consecutive `get_feature_group_docs()` enumerations, which flake when a gc pass collects pending-dead test classes between calls (reproduced on main as well; this change adds allocations during `version()` and makes the window more likely to hit). A module-level autouse `gc.collect()` fixture in the two affected test modules makes enumeration stable per test. Verified with 8 consecutive full-suite `-n 8` runs, all green.

## Validation

- `tests/test_core/test_prepare/test_feature_group_dedup.py` passes both single-process and under `-n 8` on Python 3.14 (previously 2 failures single-process).
- Full `tox` gate green (pytest, ruff format/check, licenses, mypy --strict, bandit).
- Reviewed independently by two deep review passes; the one accepted finding (dedent vs flush-left multiline strings) is fixed and covered by a dedicated test.