### PR TITLE
feat: entry-point plugin discovery and governance allowlist

### DIFF
--- a/attribution/ATTRIBUTION.md
+++ b/attribution/ATTRIBUTION.md
@@ -12,14 +12,14 @@
 | charset-normalizer                     | 3.4.7           | MIT                                                |
 | click                                  | 8.4.1           | BSD-3-Clause                                       |
 | comm                                   | 0.2.3           | BSD License                                        |
-| cyclonedx-python-lib                   | 11.7.0          | Apache Software License                            |
+| cyclonedx-python-lib                   | 11.8.0          | Apache Software License                            |
 | debugpy                                | 1.8.21          | MIT License                                        |
 | decorator                              | 5.3.1           | BSD-2-Clause                                       |
 | defusedxml                             | 0.7.1           | Python Software Foundation License                 |
 | duckdb                                 | 1.5.3           | MIT License                                        |
 | execnet                                | 2.1.2           | MIT License                                        |
 | executing                              | 2.2.1           | MIT License                                        |
-| filelock                               | 3.29.0          | MIT License                                        |
+| filelock                               | 3.29.1          | MIT License                                        |
 | fsspec                                 | 2026.4.0        | BSD-3-Clause                                       |
 | idna                                   | 3.18            | BSD-3-Clause                                       |
 | iniconfig                              | 2.3.0           | MIT                                                |
@@ -99,7 +99,7 @@
 | tomli_w                                | 1.2.0           | MIT License                                        |
 | tornado                                | 6.5.6           | Apache Software License                            |
 | tqdm                                   | 4.67.3          | MPL-2.0 AND MIT                                    |
-| traitlets                              | 5.15.0          | BSD License                                        |
+| traitlets                              | 5.15.1          | BSD License                                        |
 | typeguard                              | 4.5.2           | MIT                                                |
 | types-PyYAML                           | 6.0.12.20260518 | Apache-2.0                                         |
 | types-requests                         | 2.33.0.20260518 | Apache-2.0                                         |

--- a/docs/docs/in_depth/plugin-loader.md
+++ b/docs/docs/in_depth/plugin-loader.md
@@ -1,6 +1,6 @@
 # PluginLoader
 
-The PluginLoader dynamically loads and manages plugins from the `mloda_plugins` package.
+The PluginLoader dynamically loads and manages plugins from the `mloda_plugins` package, and discovers plugins shipped by separately installed packages via [entry points](#entry-points).
 
 ## Quick Start
 
@@ -18,7 +18,7 @@ loader.load_group("feature_group")
 ## Main Methods
 
 ### `PluginLoader.all()`
-Creates a loader and loads all available plugins.
+Creates a loader, loads all bundled plugins, then folds in installed [entry points](#entry-points).
 
 ### `load_group(group_name: str)`
 Loads all plugins from a specific group folder, including nested subdirectories. Supports slash-separated paths for subdirectories (e.g. `"feature_group/input_data/read_files"`).
@@ -28,6 +28,9 @@ Loads only files within a group whose filename matches a glob pattern (e.g. `"*t
 
 ### `load_all_plugins()`
 Loads all plugin groups.
+
+### `load_entry_points(group: str | None = None)`
+Discovers plugins from installed packages that declare [entry points](#entry-points). Pass a group name to restrict discovery to one group; `None` loads all three. Returns the sorted list of registry keys it registered.
 
 ### `disable_auto_load(group: str)`
 Prevents a group from being auto-loaded lazily. Call this before any plugin discovery if you want full control over what is loaded.
@@ -58,3 +61,59 @@ graph = loader.display_plugin_graph()
 ```
 
 Plugins are automatically discovered from `.py` files in these directories.
+
+## Entry Points
+
+Separately installed packages publish plugins through three entry-point groups, one per plugin base type:
+
+- `mloda.feature_groups` for FeatureGroup classes
+- `mloda.compute_frameworks` for ComputeFramework classes
+- `mloda.extenders` for Extender classes
+
+### Manifest Convention
+
+A package declares one entry per group it ships plugins for. The entry points at a module attribute, the manifest: a plain sequence of plugin classes. The entry-point name (`my-pkg` below) is a package label only, never a registry key; registered classes keep the usual `module:qualname` keys.
+
+```toml title="pyproject.toml"
+[project.entry-points."mloda.feature_groups"]
+my-pkg = "my_pkg.manifest:FEATURE_GROUPS"
+
+[project.entry-points."mloda.compute_frameworks"]
+my-pkg = "my_pkg.manifest:COMPUTE_FRAMEWORKS"
+```
+
+The manifest module lists the concrete classes explicitly:
+
+```python title="my_pkg/manifest.py"
+from mloda.provider import FeatureGroup
+
+class CustomerChurnFeatureGroup(FeatureGroup):
+    """Shipped by my-pkg; registers under its module:qualname key."""
+
+FEATURE_GROUPS = [CustomerChurnFeatureGroup]
+```
+
+### Loading
+
+Discovery is lazy: installing a package does nothing by itself. Manifests are imported and registered only when `load_entry_points()` runs, either directly or as the final step of `PluginLoader.all()`. Discovered classes register into the default registry with provenance `source="entry_point"` (see [Plugin Registry](plugin_registry.md)).
+
+```python
+from mloda.user import PluginLoader
+
+loader = PluginLoader()
+
+# All three groups; returns the sorted registry keys that were registered.
+keys = loader.load_entry_points()
+assert keys == sorted(keys)
+
+# One group only; unknown group names raise ValueError.
+fg_keys = loader.load_entry_points(group="mloda.feature_groups")
+```
+
+### Behavior Notes
+
+- **Validation is loud.** A manifest that is not a sequence of classes, or that contains classes of the wrong base type for its group, raises `TypeError` naming the entry point.
+- **Abstract classes are skipped** silently; manifests may list a shared abstract base alongside its concrete subclasses.
+- **Collisions raise.** If a different class already holds a manifest class's `module:qualname` key, loading raises `PluginRegistryCollisionError`. Loading the same manifests twice is idempotent.
+- **Missing optional dependencies skip.** If importing a manifest fails on a module listed in `OPTIONAL_PLUGIN_DEPENDENCIES` (pandas, polars, duckdb, ...), only that entry point is skipped; any other `ModuleNotFoundError` is re-raised.
+- **Policies apply.** Entry-point registrations denied by an installed [plugin policy](plugin_registry.md#governance) are skipped with one warning per key.

--- a/docs/docs/in_depth/plugin-loader.md
+++ b/docs/docs/in_depth/plugin-loader.md
@@ -30,7 +30,7 @@ Loads only files within a group whose filename matches a glob pattern (e.g. `"*t
 Loads all plugin groups.
 
 ### `load_entry_points(group: str | None = None)`
-Discovers plugins from installed packages that declare [entry points](#entry-points). Pass a group name to restrict discovery to one group; `None` loads all three. Returns the sorted list of registry keys it registered.
+Discovers plugins from installed packages that declare [entry points](#entry-points). Pass a group name to restrict discovery to one group; `None` loads all three. Returns the sorted, deduplicated list of registry keys it registered.
 
 ### `disable_auto_load(group: str)`
 Prevents a group from being auto-loaded lazily. Call this before any plugin discovery if you want full control over what is loaded.
@@ -102,9 +102,9 @@ from mloda.user import PluginLoader
 
 loader = PluginLoader()
 
-# All three groups; returns the sorted registry keys that were registered.
+# All three groups; returns the sorted, deduplicated registry keys that were registered.
 keys = loader.load_entry_points()
-assert keys == sorted(keys)
+assert keys == sorted(set(keys))
 
 # One group only; unknown group names raise ValueError.
 fg_keys = loader.load_entry_points(group="mloda.feature_groups")
@@ -112,8 +112,8 @@ fg_keys = loader.load_entry_points(group="mloda.feature_groups")
 
 ### Behavior Notes
 
-- **Validation is loud.** A manifest that is not a sequence of classes, or that contains classes of the wrong base type for its group, raises `TypeError` naming the entry point.
+- **Validation is loud, by design.** A malformed entry point fails discovery with an error instead of being skipped: a manifest that is not a list or tuple of plugin classes, or that contains classes of the wrong base type for its group, raises `TypeError` naming the entry point.
 - **Abstract classes are skipped** silently; manifests may list a shared abstract base alongside its concrete subclasses.
 - **Collisions raise.** If a different class already holds a manifest class's `module:qualname` key, loading raises `PluginRegistryCollisionError`. Loading the same manifests twice is idempotent.
 - **Missing optional dependencies skip.** If importing a manifest fails on a module listed in `OPTIONAL_PLUGIN_DEPENDENCIES` (pandas, polars, duckdb, ...), only that entry point is skipped; any other `ModuleNotFoundError` is re-raised.
-- **Policies apply.** Entry-point registrations denied by an installed [plugin policy](plugin_registry.md#governance) are skipped with one warning per key.
+- **Policies apply, after import.** A registration denied by an installed [plugin policy](plugin_registry.md#governance) raises inside `register()`; the loader catches the denial, skips the class, leaves its key out of the returned list, and logs one warning per denied key per registry instance. The policy gates registration only, not import: the manifest module is imported before the policy applies, so installing a package implies trusting its import side effects.

--- a/docs/docs/in_depth/plugin_registry.md
+++ b/docs/docs/in_depth/plugin_registry.md
@@ -1,6 +1,6 @@
 # Plugin Registry
 
-The plugin registry is an explicit catalog of FeatureGroup, ComputeFramework, and Extender classes, keyed by a string name (default: `"module:qualname"`). The [PluginLoader](plugin-loader.md) feeds it automatically: every concrete plugin class defined in a loaded module is registered with provenance `source="loader"`; manual registrations carry `source="manual"`. Abstract classes (`inspect.isabstract`) are infrastructure, never plugins: the loader skips them, and strict and warn modes ignore them. Registries are plain instances, and the engine and catalog APIs use the process-global default, `PluginRegistry.default()`.
+The plugin registry is an explicit catalog of FeatureGroup, ComputeFramework, and Extender classes, keyed by a string name (default: `"module:qualname"`). The [PluginLoader](plugin-loader.md) feeds it automatically: every concrete plugin class defined in a loaded module is registered with provenance `source="loader"`, manual registrations carry `source="manual"`, and classes discovered from installed [entry-point manifests](plugin-loader.md#entry-points) carry `source="entry_point"`. Provenance is the `PluginSource` enum on each entry (`get_entry(key).source`); `register()` accepts the enum or its string value and rejects anything else with a `ValueError`. Abstract classes (`inspect.isabstract`) are infrastructure, never plugins: the loader skips them, and strict and warn modes ignore them. Registries are plain instances, and the engine and catalog APIs use the process-global default, `PluginRegistry.default()`.
 
 ## Registered vs Ad-Hoc Classes
 
@@ -83,7 +83,7 @@ The registry does not watch `importlib.reload()`: reloading a module creates new
 
 ## Strict Mode
 
-Strict mode controls how the engine treats unregistered FeatureGroups during resolution. It is tri-state:
+Strict mode controls how the engine treats unregistered plugins during resolution. It is tri-state:
 
 - `"off"` (default): resolution behaves as before; the registry is informational.
 - `"warn"`: resolution is unchanged, but every unregistered FeatureGroup is logged with a warning naming the class.
@@ -111,21 +111,99 @@ Three behavioral notes:
 - In `"warn"` mode, each unregistered class is reported once per process, not once per run, so long-running services do not repeat identical warnings forever.
 - In `"strict"` mode, FeatureGroups explicitly enabled on the `PluginCollector` but missing from the registry are dropped with a warning naming them; if strict filtering removes every FeatureGroup, the run fails with an error that points to `register_plugin()` and the environment variable.
 
-Recommended rollout for deployments: stay on `"off"`, switch CI or staging to `"warn"` and watch the logs for "not registered" warnings, then move to `"strict"` once they are gone. This repository's own CI (tox) runs with `MLODA_PLUGIN_REGISTRY_STRICT=warn`.
+Strict mode covers all three plugin kinds:
 
-Strict mode currently covers FeatureGroup resolution only: ComputeFrameworks and Extenders are registered and enumerable, but not yet enforced during resolution.
+- **FeatureGroups**: resolution filtering as described above; this behavior is unchanged.
+- **ComputeFrameworks**: requested frameworks must be registered; under `"strict"` unregistered ones are dropped (the run fails if none survive). Frameworks bundled in `mloda_plugins` ship with mloda and are exempt as infrastructure, like abstract classes.
+- **Extenders**: function-extender instances passed into the runner must have registered classes; under `"strict"` unregistered ones are dropped with a warning naming them, under `"warn"` they are logged once per process.
+
+Recommended rollout for deployments: stay on `"off"`, switch CI or staging to `"warn"` and watch the logs for "not registered" warnings, then move to `"strict"` once they are gone. Packages that declare [entry points](plugin-loader.md#entry-points) register automatically, so the usual path is: add entry-point manifests to your installed plugin packages, watch the warn logs go quiet, then ramp to strict. This repository's own CI (tox) runs with `MLODA_PLUGIN_REGISTRY_STRICT=warn`.
+
+## Governance
+
+Stewards can install a `PluginPolicy` on a registry to control what may register. All governance symbols (`PluginPolicy`, `ApprovalStatus`, `PluginPolicyViolationError`, `PluginRegistry`) are exported from `mloda.steward`.
+
+### Plugin Policy
+
+`PluginPolicy` is a frozen dataclass evaluated deny-first on every registration: `denied_keys` first, then `denied_module_prefixes`, then the allowlist (`allowed_keys` admits individual keys; `allowed_module_prefixes`, when not `None`, requires the class module to match a prefix), then `require_approval`. `allows(key, module, approval)` exposes the decision directly.
+
+Enforcement depends on provenance: a denied *manual* registration raises `PluginPolicyViolationError`; denied loader and entry-point registrations are skipped with one warning per key, so an installed policy never breaks `PluginLoader.all()`.
+
+```python
+from mloda.provider import FeatureGroup
+from mloda.steward import ApprovalStatus, PluginPolicy, PluginRegistry
+
+class GovernedFeatureGroup(FeatureGroup):
+    """Allowed below via its canonical module prefix."""
+
+registry = PluginRegistry()
+policy = PluginPolicy(allowed_module_prefixes=(GovernedFeatureGroup.__module__,))
+registry.set_policy(policy)
+
+# Outside the allowlist: allows() is False, and a manual register()
+# of such a class would raise PluginPolicyViolationError.
+assert not policy.allows("acme.plugins:Alien", "acme.plugins", ApprovalStatus.UNREVIEWED)
+
+# Inside the allowlist: registration succeeds.
+key = registry.register(GovernedFeatureGroup)
+assert registry.get(key) is GovernedFeatureGroup
+```
+
+`set_policy(None)` removes the policy; the installed policy is readable via the `policy` property.
+
+### Approval Metadata
+
+Every entry carries an `owner` (default `None`) and an `ApprovalStatus` (`unreviewed`, `approved`, `rejected`; default `unreviewed`). `register()` accepts `owner=` and `approval=`, and `set_approval()` updates an existing entry. A policy with `require_approval=True` admits only plugins registered as approved.
+
+```python
+from mloda.provider import FeatureGroup
+from mloda.steward import ApprovalStatus, PluginPolicy, PluginRegistry
+
+class ReviewedFeatureGroup(FeatureGroup):
+    """Registered pre-approved by the data platform team."""
+
+registry = PluginRegistry()
+registry.set_policy(PluginPolicy(require_approval=True))
+
+key = registry.register(ReviewedFeatureGroup, owner="data-platform", approval="approved")
+entry = registry.get_entry(key)
+assert entry.owner == "data-platform"
+assert entry.approval is ApprovalStatus.APPROVED
+
+# Enforcement is registration-time only: rejecting later does not evict the entry.
+registry.set_approval(key, "rejected")
+assert registry.get(key) is ReviewedFeatureGroup
+
+# The steward removes it explicitly.
+registry.unregister(key)
+assert registry.get(key) is None
+```
+
+### Registration-Time Enforcement
+
+A policy is checked only when `register()` runs. Installing or tightening a policy later does not evict entries that are already registered: audit them via `snapshot()` and remove offenders with `unregister()`. The same applies to approval: `set_approval(key, "rejected")` records the decision but keeps the entry until the steward unregisters it.
+
+### Dual-Import Caveat
+
+A module importable under two paths (for example `my_pkg.churn` via the installed package and `churn` via a stray `sys.path` entry) produces two distinct class objects and therefore two registry keys. A key-based allowlist cannot tell them apart. Allowlist by canonical module prefix (`allowed_module_prefixes=("my_pkg.",)`) so only classes imported under the canonical path register.
+
+### Registry Injection
+
+By default the engine consults `PluginRegistry.default()`. Multi-tenant processes can give each run its own registry via `PluginCollector().set_registry()`; strict and warn modes then consult the injected registry instead of the process-global default.
+
+```python
+from mloda.steward import PluginRegistry
+from mloda.user import PluginCollector
+
+tenant_registry = PluginRegistry()
+plugin_collector = PluginCollector().set_strict_mode("strict").set_registry(tenant_registry)
+```
+
+Pass the collector into the API via the `plugin_collector=` keyword, as with strict mode.
 
 ## Test Isolation for Plugin Authors
 
-Manual registrations mutate the process-global default registry, so tests can leak state into each other. mloda ships a pytest fixture that snapshots the default registry before each test and restores it afterwards. Re-export it from your `conftest.py`:
-
-```python title="conftest.py"
-from mloda.core.abstract_plugins.plugin_registry.fixtures import isolated_plugin_registry
-
-__all__ = ["isolated_plugin_registry"]
-```
-
-Then request it in tests that register plugins:
+Manual registrations mutate the process-global default registry, so tests can leak state into each other. mloda ships a pytest plugin (registered through the `pytest11` entry point in its packaging) that provides the `isolated_plugin_registry` fixture: it snapshots the default registry before each test and restores it afterwards. Any project with mloda installed gets the fixture automatically; no `conftest.py` re-export is needed. Request it in tests that register plugins:
 
 ```python title="test_my_plugin.py"
 def test_my_feature_group_registration(isolated_plugin_registry):

--- a/docs/docs/in_depth/plugin_registry.md
+++ b/docs/docs/in_depth/plugin_registry.md
@@ -127,7 +127,9 @@ Stewards can install a `PluginPolicy` on a registry to control what may register
 
 `PluginPolicy` is a frozen dataclass evaluated deny-first on every registration: `denied_keys` first, then `denied_module_prefixes`, then the allowlist (`allowed_keys` admits individual keys; `allowed_module_prefixes`, when not `None`, requires the class module to match a prefix), then `require_approval`. `allows(key, module, approval)` exposes the decision directly.
 
-Enforcement depends on provenance: a denied *manual* registration raises `PluginPolicyViolationError`; denied loader and entry-point registrations are skipped with one warning per key, so an installed policy never breaks `PluginLoader.all()`.
+Module-prefix matching is boundary-aware on both the denied and allowed sides: the prefix `"acme.plugins"` matches the module `acme.plugins` itself and submodules such as `acme.plugins.churn`, but never a sibling like `acme.plugins_evil`. The trailing-dot form `"acme.plugins."` matches submodules only. For `allowed_module_prefixes`, `None` (the default) leaves modules unrestricted, while the empty tuple `()` denies everything that is not in `allowed_keys`.
+
+Enforcement is uniform across provenance: a denied `register()` raises `PluginPolicyViolationError` naming the would-be key, whether the source is manual, loader, or entry-point. The discovery funnels (the loader's module scans and entry-point loading) catch that denial themselves: they skip the denied class, leave it out of their returned keys, and log one warning per denied key per registry instance, so an installed policy never breaks `PluginLoader.all()`.
 
 ```python
 from mloda.provider import FeatureGroup
@@ -140,8 +142,8 @@ registry = PluginRegistry()
 policy = PluginPolicy(allowed_module_prefixes=(GovernedFeatureGroup.__module__,))
 registry.set_policy(policy)
 
-# Outside the allowlist: allows() is False, and a manual register()
-# of such a class would raise PluginPolicyViolationError.
+# Outside the allowlist: allows() is False, and register() of such a
+# class raises PluginPolicyViolationError, regardless of source.
 assert not policy.allows("acme.plugins:Alien", "acme.plugins", ApprovalStatus.UNREVIEWED)
 
 # Inside the allowlist: registration succeeds.
@@ -183,6 +185,8 @@ assert registry.get(key) is None
 
 A policy is checked only when `register()` runs. Installing or tightening a policy later does not evict entries that are already registered: audit them via `snapshot()` and remove offenders with `unregister()`. The same applies to approval: `set_approval(key, "rejected")` records the decision but keeps the entry until the steward unregisters it.
 
+The policy gates registration only, not import: `PluginLoader.all()` imports entry-point manifest modules before the policy applies, so installing a package implies trusting its import side effects. A policy keeps denied plugins out of the registry; it is not a sandbox for untrusted code.
+
 ### Dual-Import Caveat
 
 A module importable under two paths (for example `my_pkg.churn` via the installed package and `churn` via a stray `sys.path` entry) produces two distinct class objects and therefore two registry keys. A key-based allowlist cannot tell them apart. Allowlist by canonical module prefix (`allowed_module_prefixes=("my_pkg.",)`) so only classes imported under the canonical path register.
@@ -203,7 +207,7 @@ Pass the collector into the API via the `plugin_collector=` keyword, as with str
 
 ## Test Isolation for Plugin Authors
 
-Manual registrations mutate the process-global default registry, so tests can leak state into each other. mloda ships a pytest plugin (registered through the `pytest11` entry point in its packaging) that provides the `isolated_plugin_registry` fixture: it snapshots the default registry before each test and restores it afterwards. Any project with mloda installed gets the fixture automatically; no `conftest.py` re-export is needed. Request it in tests that register plugins:
+Manual registrations mutate the process-global default registry, so tests can leak state into each other. mloda ships a pytest plugin (registered through the `pytest11` entry point in its packaging) that provides the `isolated_plugin_registry` fixture: it snapshots the default registry and its installed policy before each test and restores both afterwards, also resetting the policy-denial warning dedup. Any project with mloda installed gets the fixture automatically; no `conftest.py` re-export is needed. Request it in tests that register plugins:
 
 ```python title="test_my_plugin.py"
 def test_my_feature_group_registration(isolated_plugin_registry):

--- a/mloda/core/abstract_plugins/components/plugin_option/plugin_collector.py
+++ b/mloda/core/abstract_plugins/components/plugin_option/plugin_collector.py
@@ -1,6 +1,10 @@
 import os
+from typing import TYPE_CHECKING
 
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
+
+if TYPE_CHECKING:
+    from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistry
 
 STRICT_MODE_ENV_VAR = "MLODA_PLUGIN_REGISTRY_STRICT"
 VALID_STRICT_MODES = ("off", "warn", "strict")
@@ -39,6 +43,7 @@ class PluginCollector:
         self.enabled_feature_group_classes: set[type[FeatureGroup]] = set()
         self.allow_redefinition: bool = False
         self.strict_mode: str = strict_mode_from_env()
+        self.registry: "PluginRegistry | None" = None
 
     def set_allow_redefinition(self, allow: bool = True) -> "PluginCollector":
         """Allow keeping the most recently defined class when duplicates differ in source."""
@@ -49,6 +54,11 @@ class PluginCollector:
         """Set the registry strict mode: "off", "warn", or "strict"."""
         _validate_strict_mode(mode)
         self.strict_mode = mode
+        return self
+
+    def set_registry(self, registry: "PluginRegistry") -> "PluginCollector":
+        """Inject the plugin registry consulted by strict and warn modes."""
+        self.registry = registry
         return self
 
     def add_disabled_feature_group_classes(self, feature_group_cls: set[type[FeatureGroup]]) -> None:

--- a/mloda/core/abstract_plugins/plugin_loader/plugin_loader.py
+++ b/mloda/core/abstract_plugins/plugin_loader/plugin_loader.py
@@ -12,10 +12,12 @@ from typing import Any, ClassVar, Optional
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.abstract_plugins.function_extender import Extender
+from mloda.core.abstract_plugins.plugin_registry.plugin_policy import PluginPolicyViolationError
 from mloda.core.abstract_plugins.plugin_registry.plugin_registry import (
     PluginRegistry,
     PluginSource,
     register_module_plugins,
+    warn_policy_denied,
 )
 
 logger = logging.getLogger(__name__)
@@ -114,12 +116,14 @@ class PluginLoader:
                         continue
                     raise
                 keys.extend(self._register_manifest(entry_point.name, group_name, base_type, manifest))
-        return sorted(keys)
+        return sorted(set(keys))
 
     def _register_manifest(self, label: str, group_name: str, base_type: type[Any], manifest: Any) -> list[str]:
         """Validate a manifest sequence and register its concrete classes."""
         if isinstance(manifest, (str, bytes)) or not isinstance(manifest, Sequence):
-            raise TypeError(f"Entry point '{label}' must resolve to a sequence of plugin classes, got {manifest!r}.")
+            raise TypeError(
+                f"Entry point '{label}' must resolve to a list or tuple of plugin classes, got {manifest!r}."
+            )
         registry = PluginRegistry.default()
         keys: list[str] = []
         for cls in manifest:
@@ -132,9 +136,12 @@ class PluginLoader:
                 )
             if inspect.isabstract(cls):
                 continue
-            key = registry.register(cls, source=PluginSource.ENTRY_POINT, replace=False)
-            if key is not None:
-                keys.append(key)
+            try:
+                key = registry.register(cls, source=PluginSource.ENTRY_POINT, replace=False)
+            except PluginPolicyViolationError:
+                warn_policy_denied(registry, f"{cls.__module__}:{cls.__qualname__}")
+                continue
+            keys.append(key)
         return keys
 
     def __repr__(self) -> str:

--- a/mloda/core/abstract_plugins/plugin_loader/plugin_loader.py
+++ b/mloda/core/abstract_plugins/plugin_loader/plugin_loader.py
@@ -132,7 +132,9 @@ class PluginLoader:
                 )
             if inspect.isabstract(cls):
                 continue
-            keys.append(registry.register(cls, source=PluginSource.ENTRY_POINT, replace=False))
+            key = registry.register(cls, source=PluginSource.ENTRY_POINT, replace=False)
+            if key is not None:
+                keys.append(key)
         return keys
 
     def __repr__(self) -> str:

--- a/mloda/core/abstract_plugins/plugin_loader/plugin_loader.py
+++ b/mloda/core/abstract_plugins/plugin_loader/plugin_loader.py
@@ -1,12 +1,22 @@
 import importlib
+import importlib.metadata
+import inspect
 import sys
+from collections.abc import Sequence
 from pathlib import Path
 
 import logging
 from types import ModuleType
-from typing import ClassVar, Optional
+from typing import Any, ClassVar, Optional
 
-from mloda.core.abstract_plugins.plugin_registry.plugin_registry import register_module_plugins
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.abstract_plugins.function_extender import Extender
+from mloda.core.abstract_plugins.plugin_registry.plugin_registry import (
+    PluginRegistry,
+    PluginSource,
+    register_module_plugins,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +43,12 @@ OPTIONAL_PLUGIN_DEPENDENCIES: frozenset[str] = frozenset(
         "yaml",
     }
 )
+
+ENTRY_POINT_GROUPS: dict[str, type[Any]] = {
+    "mloda.feature_groups": FeatureGroup,
+    "mloda.compute_frameworks": ComputeFramework,
+    "mloda.extenders": Extender,
+}
 
 
 class PluginLoader:
@@ -74,7 +90,50 @@ class PluginLoader:
     def all() -> "PluginLoader":
         plugin_loader = PluginLoader()
         plugin_loader.load_all_plugins()
+        plugin_loader.load_entry_points()
         return plugin_loader
+
+    def load_entry_points(self, group: str | None = None) -> list[str]:
+        """Discover installed entry-point manifests and register their plugin classes."""
+        if group is not None and group not in ENTRY_POINT_GROUPS:
+            valid = ", ".join(ENTRY_POINT_GROUPS)
+            raise ValueError(f"Unknown entry-point group '{group}'. Valid groups are: {valid}.")
+        groups = [group] if group is not None else list(ENTRY_POINT_GROUPS)
+        keys: list[str] = []
+        for group_name in groups:
+            base_type = ENTRY_POINT_GROUPS[group_name]
+            for entry_point in importlib.metadata.entry_points(group=group_name):
+                try:
+                    manifest = entry_point.load()
+                except ModuleNotFoundError as e:
+                    root = e.name.split(".")[0] if e.name else None
+                    if root in OPTIONAL_PLUGIN_DEPENDENCIES:
+                        logger.debug(
+                            "Skipping entry point %s: missing optional dependency %s", entry_point.name, e.name
+                        )
+                        continue
+                    raise
+                keys.extend(self._register_manifest(entry_point.name, group_name, base_type, manifest))
+        return sorted(keys)
+
+    def _register_manifest(self, label: str, group_name: str, base_type: type[Any], manifest: Any) -> list[str]:
+        """Validate a manifest sequence and register its concrete classes."""
+        if isinstance(manifest, (str, bytes)) or not isinstance(manifest, Sequence):
+            raise TypeError(f"Entry point '{label}' must resolve to a sequence of plugin classes, got {manifest!r}.")
+        registry = PluginRegistry.default()
+        keys: list[str] = []
+        for cls in manifest:
+            if not isinstance(cls, type):
+                raise TypeError(f"Entry point '{label}' manifest contains a non-class item: {cls!r}.")
+            if not issubclass(cls, base_type):
+                raise TypeError(
+                    f"Entry-point group '{group_name}' requires subclasses of {base_type.__name__}; "
+                    f"got {cls.__qualname__}."
+                )
+            if inspect.isabstract(cls):
+                continue
+            keys.append(registry.register(cls, source=PluginSource.ENTRY_POINT, replace=False))
+        return keys
 
     def __repr__(self) -> str:
         return f"PluginLoader plugins: {self.plugins}"

--- a/mloda/core/abstract_plugins/plugin_registry/fixtures.py
+++ b/mloda/core/abstract_plugins/plugin_registry/fixtures.py
@@ -11,8 +11,11 @@ from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRe
 
 @pytest.fixture
 def isolated_plugin_registry() -> Iterator[PluginRegistry]:
-    """Snapshot the default registry, yield it, and restore the snapshot on teardown."""
+    """Snapshot the default registry and policy, yield it, and restore both on teardown."""
     registry = PluginRegistry.default()
     snapshot = registry.snapshot()
+    policy = registry.policy
     yield registry
     registry.restore(snapshot)
+    registry.set_policy(policy)
+    registry._policy_warned_keys.clear()

--- a/mloda/core/abstract_plugins/plugin_registry/plugin_policy.py
+++ b/mloda/core/abstract_plugins/plugin_registry/plugin_policy.py
@@ -1,0 +1,44 @@
+"""Deployment-scoped governance policy for plugin registration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class ApprovalStatus(str, Enum):
+    """Review state of a registered plugin."""
+
+    UNREVIEWED = "unreviewed"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+
+
+class PluginPolicyViolationError(Exception):
+    """Raised when a manual registration violates the installed plugin policy."""
+
+
+@dataclass(frozen=True)
+class PluginPolicy:
+    """Deny-first registration policy evaluated per (key, module, approval)."""
+
+    allowed_module_prefixes: tuple[str, ...] | None = None
+    denied_module_prefixes: tuple[str, ...] = ()
+    allowed_keys: tuple[str, ...] = ()
+    denied_keys: tuple[str, ...] = ()
+    require_approval: bool = False
+
+    def allows(self, key: str, module: str, approval: ApprovalStatus) -> bool:
+        """Return True if the plugin may register under this policy."""
+        if key in self.denied_keys:
+            return False
+        if any(module.startswith(prefix) for prefix in self.denied_module_prefixes):
+            return False
+        if key not in self.allowed_keys:
+            if self.allowed_module_prefixes is not None and not any(
+                module.startswith(prefix) for prefix in self.allowed_module_prefixes
+            ):
+                return False
+        if self.require_approval and approval is not ApprovalStatus.APPROVED:
+            return False
+        return True

--- a/mloda/core/abstract_plugins/plugin_registry/plugin_policy.py
+++ b/mloda/core/abstract_plugins/plugin_registry/plugin_policy.py
@@ -15,7 +15,14 @@ class ApprovalStatus(str, Enum):
 
 
 class PluginPolicyViolationError(Exception):
-    """Raised when a manual registration violates the installed plugin policy."""
+    """Raised when a registration violates the installed plugin policy."""
+
+
+def _module_matches_prefix(module: str, prefix: str) -> bool:
+    """Boundary-aware match: "p" matches "p" and "p.sub"; "p." matches submodules only."""
+    if prefix.endswith("."):
+        return module.startswith(prefix)
+    return module == prefix or module.startswith(prefix + ".")
 
 
 @dataclass(frozen=True)
@@ -32,11 +39,11 @@ class PluginPolicy:
         """Return True if the plugin may register under this policy."""
         if key in self.denied_keys:
             return False
-        if any(module.startswith(prefix) for prefix in self.denied_module_prefixes):
+        if any(_module_matches_prefix(module, prefix) for prefix in self.denied_module_prefixes):
             return False
         if key not in self.allowed_keys:
             if self.allowed_module_prefixes is not None and not any(
-                module.startswith(prefix) for prefix in self.allowed_module_prefixes
+                _module_matches_prefix(module, prefix) for prefix in self.allowed_module_prefixes
             ):
                 return False
         if self.require_approval and approval is not ApprovalStatus.APPROVED:

--- a/mloda/core/abstract_plugins/plugin_registry/plugin_registry.py
+++ b/mloda/core/abstract_plugins/plugin_registry/plugin_registry.py
@@ -25,6 +25,13 @@ logger = logging.getLogger(__name__)
 _PLUGIN_BASE_TYPES: tuple[type[Any], ...] = (FeatureGroup, ComputeFramework, Extender)
 
 
+class _Unset:
+    """Sentinel type marking an argument as not passed."""
+
+
+_UNSET = _Unset()
+
+
 class PluginRegistryCollisionError(ValueError):
     """Raised when a different class is registered under an already taken key."""
 
@@ -107,32 +114,37 @@ class PluginRegistry:
         name: str | None = None,
         source: PluginSource | str = PluginSource.MANUAL,
         replace: bool = False,
-        owner: str | None = None,
-        approval: ApprovalStatus | str = ApprovalStatus.UNREVIEWED,
-    ) -> str | None:
+        owner: str | _Unset | None = _UNSET,
+        approval: ApprovalStatus | str | _Unset = _UNSET,
+    ) -> str:
         normalized_source = _normalize_source(source)
-        normalized_approval = _normalize_approval(approval)
+        explicit_approval = None if isinstance(approval, _Unset) else _normalize_approval(approval)
         plugin_type = _resolve_plugin_type(cls)
         key = name if name is not None else f"{cls.__module__}:{cls.__qualname__}"
-        if self._policy is not None and not self._policy.allows(key, cls.__module__, normalized_approval):
-            if normalized_source is PluginSource.MANUAL:
-                raise PluginPolicyViolationError(f"Plugin '{key}' is denied by the installed plugin policy.")
-            if key not in self._policy_warned_keys:
-                self._policy_warned_keys.add(key)
-                logger.warning("Plugin '%s' was denied by the installed plugin policy and not registered.", key)
-            return None
+        previous = self._entries.get(key)
+        carried = previous if previous is not None and previous.cls is cls else None
+        effective_owner: str | None
+        if isinstance(owner, _Unset):
+            effective_owner = carried.owner if carried is not None else None
+        else:
+            effective_owner = owner
+        if explicit_approval is not None:
+            effective_approval = explicit_approval
+        else:
+            effective_approval = carried.approval if carried is not None else ApprovalStatus.UNREVIEWED
+        if self._policy is not None and not self._policy.allows(key, cls.__module__, effective_approval):
+            raise PluginPolicyViolationError(f"Plugin '{key}' is denied by the installed plugin policy.")
         existing_key = next((k for k, entry in self._entries.items() if entry.cls is cls), None)
         if existing_key is not None and existing_key != key:
             raise PluginRegistryCollisionError(
                 f"{cls!r} is already registered under key '{existing_key}'; a class holds exactly one key. "
                 f"To rename, unregister('{existing_key}') first, then register under the new key."
             )
-        existing = self._entries.get(key)
-        if existing is not None and not replace:
-            if existing.cls is cls:
+        if previous is not None and not replace:
+            if previous.cls is cls:
                 return key
             raise PluginRegistryCollisionError(
-                f"Key '{key}' is already registered to {existing.cls!r}; cannot register {cls!r}. "
+                f"Key '{key}' is already registered to {previous.cls!r}; cannot register {cls!r}. "
                 "Pass replace=True to replace the existing entry."
             )
         self._entries[key] = PluginRegistryEntry(
@@ -141,8 +153,8 @@ class PluginRegistry:
             plugin_type=plugin_type,
             source_module=cls.__module__,
             source=normalized_source,
-            owner=owner,
-            approval=normalized_approval,
+            owner=effective_owner,
+            approval=effective_approval,
         )
         return key
 
@@ -208,18 +220,27 @@ def register_plugin(
     name: str | None = None,
     source: PluginSource | str = PluginSource.MANUAL,
     replace: bool = False,
-    owner: str | None = None,
-    approval: ApprovalStatus | str = ApprovalStatus.UNREVIEWED,
-) -> str | None:
+    owner: str | _Unset | None = _UNSET,
+    approval: ApprovalStatus | str | _Unset = _UNSET,
+) -> str:
     return PluginRegistry.default().register(
         cls, name=name, source=source, replace=replace, owner=owner, approval=approval
     )
+
+
+def warn_policy_denied(registry: PluginRegistry, key: str) -> None:
+    """Log one WARNING per policy-denied key per registry instance."""
+    if key in registry._policy_warned_keys:
+        return
+    registry._policy_warned_keys.add(key)
+    logger.warning("Plugin '%s' was denied by the installed plugin policy and not registered.", key)
 
 
 def register_module_plugins(module: ModuleType, *, source: PluginSource | str = PluginSource.LOADER) -> list[str]:
     """Register all plugin classes defined in a module into the default registry.
 
     Last-write-wins (replace=True) so importlib.reload updates entries; provenance may flip to "loader".
+    Policy-denied classes are skipped with one warning per denied key per registry instance.
     """
     registry = PluginRegistry.default()
     keys: list[str] = []
@@ -230,7 +251,10 @@ def register_module_plugins(module: ModuleType, *, source: PluginSource | str = 
             continue
         if inspect.isabstract(obj):
             continue
-        key = registry.register(obj, source=source, replace=True)
-        if key is not None:
-            keys.append(key)
+        try:
+            key = registry.register(obj, source=source, replace=True)
+        except PluginPolicyViolationError:
+            warn_policy_denied(registry, f"{obj.__module__}:{obj.__qualname__}")
+            continue
+        keys.append(key)
     return keys

--- a/mloda/core/abstract_plugins/plugin_registry/plugin_registry.py
+++ b/mloda/core/abstract_plugins/plugin_registry/plugin_registry.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import inspect
 import threading
 from dataclasses import dataclass
+from enum import Enum
 from types import ModuleType
 from typing import Any
 
@@ -19,13 +20,31 @@ class PluginRegistryCollisionError(ValueError):
     """Raised when a different class is registered under an already taken key."""
 
 
+class PluginSource(str, Enum):
+    """Provenance of a registry entry."""
+
+    MANUAL = "manual"
+    LOADER = "loader"
+    ENTRY_POINT = "entry_point"
+
+
+def _normalize_source(source: PluginSource | str) -> PluginSource:
+    if isinstance(source, PluginSource):
+        return source
+    members = {member.value: member for member in PluginSource}
+    if source not in members:
+        valid = ", ".join(member.value for member in PluginSource)
+        raise ValueError(f"Invalid plugin source {source!r}. Valid values are: {valid}.")
+    return members[source]
+
+
 @dataclass(frozen=True)
 class PluginRegistryEntry:
     cls: type[Any]
     name: str
     plugin_type: type[Any]
     source_module: str
-    source: str
+    source: PluginSource
 
 
 PluginRegistrySnapshot = dict[str, PluginRegistryEntry]
@@ -52,8 +71,14 @@ class PluginRegistry:
         return _default
 
     def register(
-        self, cls: type[Any], *, name: str | None = None, source: str = "manual", replace: bool = False
+        self,
+        cls: type[Any],
+        *,
+        name: str | None = None,
+        source: PluginSource | str = PluginSource.MANUAL,
+        replace: bool = False,
     ) -> str:
+        normalized_source = _normalize_source(source)
         plugin_type = _resolve_plugin_type(cls)
         key = name if name is not None else f"{cls.__module__}:{cls.__qualname__}"
         existing_key = next((k for k, entry in self._entries.items() if entry.cls is cls), None)
@@ -75,7 +100,7 @@ class PluginRegistry:
             name=key,
             plugin_type=plugin_type,
             source_module=cls.__module__,
-            source=source,
+            source=normalized_source,
         )
         return key
 
@@ -112,6 +137,9 @@ class PluginRegistry:
             result.append(entry.cls)
         return result
 
+    def registered_classes(self) -> set[type[Any]]:
+        return {entry.cls for entry in self._entries.values()}
+
     def snapshot(self) -> PluginRegistrySnapshot:
         return dict(self._entries)
 
@@ -126,11 +154,13 @@ _default: PluginRegistry | None = None
 _default_lock = threading.Lock()
 
 
-def register_plugin(cls: type[Any], *, name: str | None = None, source: str = "manual", replace: bool = False) -> str:
+def register_plugin(
+    cls: type[Any], *, name: str | None = None, source: PluginSource | str = PluginSource.MANUAL, replace: bool = False
+) -> str:
     return PluginRegistry.default().register(cls, name=name, source=source, replace=replace)
 
 
-def register_module_plugins(module: ModuleType, *, source: str = "loader") -> list[str]:
+def register_module_plugins(module: ModuleType, *, source: PluginSource | str = PluginSource.LOADER) -> list[str]:
     """Register all plugin classes defined in a module into the default registry.
 
     Last-write-wins (replace=True) so importlib.reload updates entries; provenance may flip to "loader".

--- a/mloda/core/abstract_plugins/plugin_registry/plugin_registry.py
+++ b/mloda/core/abstract_plugins/plugin_registry/plugin_registry.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import dataclasses
 import inspect
+import logging
 import threading
 from dataclasses import dataclass
 from enum import Enum
@@ -12,6 +14,13 @@ from typing import Any
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.abstract_plugins.function_extender import Extender
+from mloda.core.abstract_plugins.plugin_registry.plugin_policy import (
+    ApprovalStatus,
+    PluginPolicy,
+    PluginPolicyViolationError,
+)
+
+logger = logging.getLogger(__name__)
 
 _PLUGIN_BASE_TYPES: tuple[type[Any], ...] = (FeatureGroup, ComputeFramework, Extender)
 
@@ -38,6 +47,16 @@ def _normalize_source(source: PluginSource | str) -> PluginSource:
     return members[source]
 
 
+def _normalize_approval(approval: ApprovalStatus | str) -> ApprovalStatus:
+    if isinstance(approval, ApprovalStatus):
+        return approval
+    members = {member.value: member for member in ApprovalStatus}
+    if approval not in members:
+        valid = ", ".join(member.value for member in ApprovalStatus)
+        raise ValueError(f"Invalid approval status {approval!r}. Valid values are: {valid}.")
+    return members[approval]
+
+
 @dataclass(frozen=True)
 class PluginRegistryEntry:
     cls: type[Any]
@@ -45,6 +64,8 @@ class PluginRegistryEntry:
     plugin_type: type[Any]
     source_module: str
     source: PluginSource
+    owner: str | None = None
+    approval: ApprovalStatus = ApprovalStatus.UNREVIEWED
 
 
 PluginRegistrySnapshot = dict[str, PluginRegistryEntry]
@@ -61,6 +82,8 @@ class PluginRegistry:
     def __init__(self) -> None:
         # Only default() lazy init is locked; registration is expected single-threaded at import/startup time.
         self._entries: dict[str, PluginRegistryEntry] = {}
+        self._policy: PluginPolicy | None = None
+        self._policy_warned_keys: set[str] = set()
 
     @classmethod
     def default(cls) -> PluginRegistry:
@@ -70,6 +93,13 @@ class PluginRegistry:
                 _default = cls()
         return _default
 
+    @property
+    def policy(self) -> PluginPolicy | None:
+        return self._policy
+
+    def set_policy(self, policy: PluginPolicy | None) -> None:
+        self._policy = policy
+
     def register(
         self,
         cls: type[Any],
@@ -77,10 +107,20 @@ class PluginRegistry:
         name: str | None = None,
         source: PluginSource | str = PluginSource.MANUAL,
         replace: bool = False,
-    ) -> str:
+        owner: str | None = None,
+        approval: ApprovalStatus | str = ApprovalStatus.UNREVIEWED,
+    ) -> str | None:
         normalized_source = _normalize_source(source)
+        normalized_approval = _normalize_approval(approval)
         plugin_type = _resolve_plugin_type(cls)
         key = name if name is not None else f"{cls.__module__}:{cls.__qualname__}"
+        if self._policy is not None and not self._policy.allows(key, cls.__module__, normalized_approval):
+            if normalized_source is PluginSource.MANUAL:
+                raise PluginPolicyViolationError(f"Plugin '{key}' is denied by the installed plugin policy.")
+            if key not in self._policy_warned_keys:
+                self._policy_warned_keys.add(key)
+                logger.warning("Plugin '%s' was denied by the installed plugin policy and not registered.", key)
+            return None
         existing_key = next((k for k, entry in self._entries.items() if entry.cls is cls), None)
         if existing_key is not None and existing_key != key:
             raise PluginRegistryCollisionError(
@@ -101,8 +141,16 @@ class PluginRegistry:
             plugin_type=plugin_type,
             source_module=cls.__module__,
             source=normalized_source,
+            owner=owner,
+            approval=normalized_approval,
         )
         return key
+
+    def set_approval(self, name: str, approval: ApprovalStatus | str, owner: str | None = None) -> None:
+        normalized_approval = _normalize_approval(approval)
+        entry = self.get_entry(name)
+        new_owner = owner if owner is not None else entry.owner
+        self._entries[name] = dataclasses.replace(entry, approval=normalized_approval, owner=new_owner)
 
     def unregister(self, name: str) -> None:
         if name not in self._entries:
@@ -155,9 +203,17 @@ _default_lock = threading.Lock()
 
 
 def register_plugin(
-    cls: type[Any], *, name: str | None = None, source: PluginSource | str = PluginSource.MANUAL, replace: bool = False
-) -> str:
-    return PluginRegistry.default().register(cls, name=name, source=source, replace=replace)
+    cls: type[Any],
+    *,
+    name: str | None = None,
+    source: PluginSource | str = PluginSource.MANUAL,
+    replace: bool = False,
+    owner: str | None = None,
+    approval: ApprovalStatus | str = ApprovalStatus.UNREVIEWED,
+) -> str | None:
+    return PluginRegistry.default().register(
+        cls, name=name, source=source, replace=replace, owner=owner, approval=approval
+    )
 
 
 def register_module_plugins(module: ModuleType, *, source: PluginSource | str = PluginSource.LOADER) -> list[str]:
@@ -174,5 +230,7 @@ def register_module_plugins(module: ModuleType, *, source: PluginSource | str = 
             continue
         if inspect.isabstract(obj):
             continue
-        keys.append(registry.register(obj, source=source, replace=True))
+        key = registry.register(obj, source=source, replace=True)
+        if key is not None:
+            keys.append(key)
     return keys

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -86,7 +86,7 @@ def get_feature_group_docs(
     allow_redefinition = plugin_collector.allow_redefinition if plugin_collector is not None else False
     all_feature_groups: set[type[FeatureGroup]] = get_all_subclasses(FeatureGroup)
     if registered_only:
-        registered = {entry.cls for entry in PluginRegistry.default().snapshot().values()}
+        registered = PluginRegistry.default().registered_classes()
         all_feature_groups = {fg for fg in all_feature_groups if fg in registered}
     if plugin_collector is not None:
         all_feature_groups = {fg for fg in all_feature_groups if plugin_collector.applicable_feature_group_class(fg)}
@@ -157,7 +157,7 @@ def get_compute_framework_docs(
     """
     all_compute_frameworks = get_all_subclasses(ComputeFramework)
     if registered_only:
-        registered = {entry.cls for entry in PluginRegistry.default().snapshot().values()}
+        registered = PluginRegistry.default().registered_classes()
         all_compute_frameworks = {cfw for cfw in all_compute_frameworks if cfw in registered}
     results = []
 
@@ -233,7 +233,7 @@ def get_extender_docs(
     """
     all_extenders = get_all_subclasses(Extender)
     if registered_only:
-        registered = {entry.cls for entry in PluginRegistry.default().snapshot().values()}
+        registered = PluginRegistry.default().registered_classes()
         all_extenders = {ext for ext in all_extenders if ext in registered}
     results = []
 

--- a/mloda/core/api/request.py
+++ b/mloda/core/api/request.py
@@ -7,6 +7,7 @@ from mloda.core.abstract_plugins.components.input_data.api.api_input_data_collec
 from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
 from mloda.core.core.engine import Engine
 from mloda.core.api.prepare.setup_compute_framework import SetupComputeFramework
+from mloda.core.prepare.accessible_plugins import filter_extenders_by_strict_mode
 from mloda.core.filter.global_filter import GlobalFilter
 from mloda.core.runtime.run import ExecutionOrchestrator
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
@@ -332,7 +333,8 @@ class mlodaAPI:
         api_data: Optional[dict[str, Any]],
         artifacts: Optional[dict[str, Any]] = None,
     ) -> None:
-        """Enters the runner context."""
+        """Enters the runner context with strict-mode-filtered extenders."""
+        function_extender = filter_extenders_by_strict_mode(function_extender, self.plugin_collector)
         runner.__enter__(parallelization_modes, function_extender, api_data, artifacts)
 
     def _exit_runner_context(self, runner: ExecutionOrchestrator) -> None:

--- a/mloda/core/prepare/accessible_plugins.py
+++ b/mloda/core/prepare/accessible_plugins.py
@@ -14,6 +14,7 @@ from mloda.core.abstract_plugins.components.plugin_option.plugin_collector impor
 from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistry
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.abstract_plugins.function_extender import Extender
 from mloda.core.abstract_plugins.components.utils import get_all_subclasses
 
 
@@ -23,6 +24,49 @@ _warned_unregistered: set[str] = set()
 
 
 FeatureGroupEnvironmentMapping = dict[type[FeatureGroup], set[type[ComputeFramework]]]
+
+
+def registry_for(plugin_collector: PluginCollector | None) -> PluginRegistry:
+    """Return the collector's injected registry when set, else the default registry."""
+    if plugin_collector is not None and plugin_collector.registry is not None:
+        return plugin_collector.registry
+    return PluginRegistry.default()
+
+
+def _is_bundled_plugin(cls: type[Any]) -> bool:
+    """True for classes shipped in the bundled plugin distribution (mloda_plugins)."""
+    return cls.__module__.split(".", 1)[0] == "mloda_plugins"
+
+
+def filter_extenders_by_strict_mode(
+    extenders: set[Extender] | None,
+    plugin_collector: PluginCollector | None,
+) -> set[Extender] | None:
+    """Filter function-extender instances by the registry strict mode."""
+    if extenders is None:
+        return extenders
+
+    strict_mode = plugin_collector.strict_mode if plugin_collector is not None else strict_mode_from_env()
+    if strict_mode == "off":
+        return extenders
+
+    registered = registry_for(plugin_collector).registered_classes()
+    unregistered = {extender for extender in extenders if type(extender) not in registered}
+    unregistered_names = sorted({f"{type(e).__module__}:{type(e).__qualname__}" for e in unregistered})
+
+    if strict_mode == "warn":
+        new_names = [name for name in unregistered_names if name not in _warned_unregistered]
+        if new_names:
+            _warned_unregistered.update(new_names)
+            logger.warning("Extenders not registered in the plugin registry: %s.", ", ".join(new_names))
+        return extenders
+
+    if unregistered:
+        logger.warning(
+            "Strict mode dropped Extenders not registered in the plugin registry: %s.",
+            ", ".join(unregistered_names),
+        )
+    return extenders - unregistered
 
 
 class RedefinitionConflictError(ValueError):
@@ -223,7 +267,7 @@ class PreFilterPlugins:
         plugin_collector: Optional[PluginCollector] = None,
     ) -> None:
         feature_groups = self._set_feature_groups(plugin_collector)
-        compute_frameworks = self._set_compute_frameworks(compute_frameworks)
+        compute_frameworks = self._set_compute_frameworks(compute_frameworks, plugin_collector)
 
         self.accessible_plugins = self.resolve_feature_group_compute_framework_limitations(
             feature_groups, compute_frameworks
@@ -245,7 +289,7 @@ class PreFilterPlugins:
 
         registered: set[type[Any]] = set()
         if strict_mode != "off":
-            registered = PluginRegistry.default().registered_classes()
+            registered = registry_for(plugin_collector).registered_classes()
 
         if strict_mode == "strict":
             before_strict = accessible_feature_groups
@@ -299,8 +343,40 @@ class PreFilterPlugins:
     def _set_compute_frameworks(
         self,
         compute_frameworks: set[type[ComputeFramework]],
+        plugin_collector: Optional[PluginCollector] = None,
     ) -> set[type[ComputeFramework]]:
-        return compute_frameworks.intersection(self.get_cfw_subclasses())
+        compute_frameworks = compute_frameworks.intersection(self.get_cfw_subclasses())
+
+        strict_mode = plugin_collector.strict_mode if plugin_collector is not None else strict_mode_from_env()
+        if strict_mode == "off":
+            return compute_frameworks
+
+        registered = registry_for(plugin_collector).registered_classes()
+        # Bundled plugin frameworks ship with mloda, like abstract classes: never filtered or flagged.
+        unregistered = {
+            cfw
+            for cfw in compute_frameworks
+            if cfw not in registered and not inspect.isabstract(cfw) and not _is_bundled_plugin(cfw)
+        }
+        unregistered_names = sorted(f"{cfw.__module__}:{cfw.__qualname__}" for cfw in unregistered)
+
+        if strict_mode == "warn":
+            new_names = [name for name in unregistered_names if name not in _warned_unregistered]
+            if new_names:
+                _warned_unregistered.update(new_names)
+                logger.warning("ComputeFrameworks not registered in the plugin registry: %s.", ", ".join(new_names))
+            return compute_frameworks
+
+        surviving = compute_frameworks - unregistered
+        had_concrete = any(not inspect.isabstract(cfw) for cfw in compute_frameworks)
+        has_concrete = any(not inspect.isabstract(cfw) for cfw in surviving)
+        if had_concrete and not has_concrete:
+            raise ValueError(
+                "Strict mode filtered out all ComputeFrameworks: none of the requested ComputeFrameworks "
+                "are registered in the plugin registry. Register them via mloda.user.register_plugin() or "
+                "relax MLODA_PLUGIN_REGISTRY_STRICT to disable strict mode."
+            )
+        return surviving
 
     def resolve_feature_group_compute_framework_limitations(
         self, feature_groups: set[type[FeatureGroup]], compute_frameworks: set[type[ComputeFramework]]

--- a/mloda/core/prepare/accessible_plugins.py
+++ b/mloda/core/prepare/accessible_plugins.py
@@ -245,7 +245,7 @@ class PreFilterPlugins:
 
         registered: set[type[Any]] = set()
         if strict_mode != "off":
-            registered = {entry.cls for entry in PluginRegistry.default().snapshot().values()}
+            registered = PluginRegistry.default().registered_classes()
 
         if strict_mode == "strict":
             before_strict = accessible_feature_groups

--- a/mloda/steward/__init__.py
+++ b/mloda/steward/__init__.py
@@ -19,6 +19,13 @@ from mloda.core.abstract_plugins.function_extender import (
 # Plugin registry administration
 from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistry
 
+# Plugin governance
+from mloda.core.abstract_plugins.plugin_registry.plugin_policy import (
+    ApprovalStatus,
+    PluginPolicy,
+    PluginPolicyViolationError,
+)
+
 __all__ = [
     # Plugin inspection
     "FeatureGroupInfo",
@@ -36,4 +43,8 @@ __all__ = [
     "ExtenderHook",
     # Plugin registry administration
     "PluginRegistry",
+    # Plugin governance
+    "ApprovalStatus",
+    "PluginPolicy",
+    "PluginPolicyViolationError",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,9 @@ all = [
     "mloda[docs]",
 ]
 
+[project.entry-points.pytest11]
+mloda = "mloda.core.abstract_plugins.plugin_registry.fixtures"
+
 [project.urls]
 "Bug Tracker" = "https://github.com/mloda-ai/mloda/issues"
 "Documentation" = "https://mloda-ai.github.io/mloda/"

--- a/tests/test_core/test_abstract_plugins/test_plugin_loader/test_entry_points.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_loader/test_entry_points.py
@@ -6,8 +6,11 @@ Contract under test:
 - PluginLoader.load_entry_points(group=None) discovers installed distributions' entry points via
   importlib.metadata, loads each manifest attribute (a sequence of plugin classes), registers the
   classes into PluginRegistry.default() with source=PluginSource.ENTRY_POINT under module:qualname
-  keys, and returns the sorted list of registered keys. The entry-point NAME is a label, never a key.
-- Validation is loud (non-sequence manifests, wrong base types), abstract classes are skipped,
+  keys, and returns the sorted, DEDUPLICATED list of registered keys (a manifest listing the same
+  class twice yields its key once). The entry-point NAME is a label, never a key.
+- Validation is loud (a non-sequence manifest raises an error naming the entry-point label and
+  saying a list or tuple of plugin classes is expected; wrong base types raise naming group and
+  class), abstract classes are skipped,
   missing optional dependencies skip only the affected entry point, key conflicts raise
   PluginRegistryCollisionError, double loads are idempotent, and PluginLoader.all() folds
   entry points in after the mloda_plugins scan.
@@ -313,21 +316,36 @@ class TestLoadEntryPointsGroupFilter:
 
 
 class TestLoadEntryPointsValidation:
-    @pytest.mark.parametrize(
-        ("slug", "manifest_value"),
-        [
-            ("int", "42"),
-            ("strings", '["not_a_class"]'),
-        ],
-    )
-    def test_manifest_not_a_sequence_of_classes_raises_naming_entry_point(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, slug: str, manifest_value: str
+    def test_non_sequence_manifest_error_names_label_and_expects_list_or_tuple(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        pkg = f"eptest_badmanifest_{slug}_pkg"
+        pkg = "eptest_badmanifest_int_pkg"
         _build_distribution(
             tmp_path,
             pkg,
-            f"FEATURE_GROUPS = {manifest_value}\n",
+            "FEATURE_GROUPS = 42\n",
+            f"""
+            [mloda.feature_groups]
+            broken_label = {pkg}.manifest:FEATURE_GROUPS
+            """,
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+
+        with pytest.raises((TypeError, ValueError)) as exc_info:
+            PluginLoader().load_entry_points()
+        message = str(exc_info.value)
+        assert "broken_label" in message, "the error must name the entry-point label"
+        assert "list" in message, "the error must say a list or tuple of plugin classes is expected"
+        assert "tuple" in message, "the error must say a list or tuple of plugin classes is expected"
+
+    def test_manifest_with_non_class_items_raises_naming_entry_point(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pkg = "eptest_badmanifest_strings_pkg"
+        _build_distribution(
+            tmp_path,
+            pkg,
+            'FEATURE_GROUPS = ["not_a_class"]\n',
             f"""
             [mloda.feature_groups]
             broken_label = {pkg}.manifest:FEATURE_GROUPS
@@ -487,6 +505,42 @@ class TestLoadEntryPointsIdempotencyAndCollisions:
         with pytest.raises(PluginRegistryCollisionError):
             PluginLoader().load_entry_points()
         assert PluginRegistry.default().get(conflicting_key) is _PreexistingConflictFG
+
+
+_DUP_FG_MANIFEST = """
+    from mloda.core.abstract_plugins.feature_group import FeatureGroup
+
+
+    class DupEpFeatureGroup(FeatureGroup):
+        pass
+
+
+    FEATURE_GROUPS = [DupEpFeatureGroup, DupEpFeatureGroup]
+"""
+
+
+class TestLoadEntryPointsDeduplication:
+    def test_manifest_listing_same_class_twice_yields_key_once(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pkg = "eptest_dupclass_pkg"
+        _build_distribution(
+            tmp_path,
+            pkg,
+            _DUP_FG_MANIFEST,
+            f"""
+            [mloda.feature_groups]
+            demo = {pkg}.manifest:FEATURE_GROUPS
+            """,
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+
+        keys = PluginLoader().load_entry_points()
+
+        expected_key = f"{pkg}.manifest:DupEpFeatureGroup"
+        assert keys.count(expected_key) == 1, "a class listed twice in one manifest must yield its key once"
+        assert keys == sorted(set(keys)), "load_entry_points must return a sorted, deduplicated key list"
+        assert PluginRegistry.default().get_entry(expected_key).cls is _manifest_class(pkg, "DupEpFeatureGroup")
 
 
 class TestEntryPointNameIsLabelOnly:

--- a/tests/test_core/test_abstract_plugins/test_plugin_loader/test_entry_points.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_loader/test_entry_points.py
@@ -1,0 +1,538 @@
+"""Tests for entry-point based plugin discovery (PluginLoader.load_entry_points).
+
+Contract under test:
+- ENTRY_POINT_GROUPS maps "mloda.feature_groups" / "mloda.compute_frameworks" / "mloda.extenders"
+  to FeatureGroup / ComputeFramework / Extender.
+- PluginLoader.load_entry_points(group=None) discovers installed distributions' entry points via
+  importlib.metadata, loads each manifest attribute (a sequence of plugin classes), registers the
+  classes into PluginRegistry.default() with source=PluginSource.ENTRY_POINT under module:qualname
+  keys, and returns the sorted list of registered keys. The entry-point NAME is a label, never a key.
+- Validation is loud (non-sequence manifests, wrong base types), abstract classes are skipped,
+  missing optional dependencies skip only the affected entry point, key conflicts raise
+  PluginRegistryCollisionError, double loads are idempotent, and PluginLoader.all() folds
+  entry points in after the mloda_plugins scan.
+
+Each test builds real on-disk distributions (package + dist-info) in tmp_path with a unique
+package name, so importlib.metadata discovery is exercised for real and tests stay xdist-safe.
+"""
+
+import importlib
+import textwrap
+from pathlib import Path
+
+import pytest
+
+import mloda.core.abstract_plugins.plugin_loader.plugin_loader as plugin_loader_module
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.abstract_plugins.function_extender import Extender
+from mloda.core.abstract_plugins.plugin_registry.plugin_registry import (
+    PluginRegistry,
+    PluginRegistryCollisionError,
+    PluginSource,
+    register_plugin,
+)
+from mloda.user import PluginLoader
+
+FEATURE_GROUPS_GROUP = "mloda.feature_groups"
+COMPUTE_FRAMEWORKS_GROUP = "mloda.compute_frameworks"
+EXTENDERS_GROUP = "mloda.extenders"
+
+
+def _build_distribution(base_dir: Path, pkg_name: str, manifest_source: str, entry_points_txt: str) -> None:
+    """Create a real on-disk distribution: importable package plus dist-info metadata.
+
+    With base_dir on sys.path, importlib.metadata discovers the dist-info (entry_points.txt)
+    and the package itself is importable. No wheel building required.
+    """
+    pkg_dir = base_dir / pkg_name
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text("")
+    (pkg_dir / "manifest.py").write_text(textwrap.dedent(manifest_source))
+    dist_info = base_dir / f"{pkg_name}-1.0.0.dist-info"
+    dist_info.mkdir()
+    metadata = f"Metadata-Version: 2.1\nName: {pkg_name.replace('_', '-')}\nVersion: 1.0.0\n"
+    (dist_info / "METADATA").write_text(metadata)
+    (dist_info / "entry_points.txt").write_text(textwrap.dedent(entry_points_txt))
+    importlib.invalidate_caches()
+
+
+def _manifest_class(pkg_name: str, class_name: str) -> type:
+    """Import the fake package's manifest module and return one of its plugin classes."""
+    module = importlib.import_module(f"{pkg_name}.manifest")
+    cls = getattr(module, class_name)
+    assert isinstance(cls, type)
+    return cls
+
+
+_FG_MANIFEST = """
+    from mloda.core.abstract_plugins.feature_group import FeatureGroup
+
+
+    class EpFeatureGroup(FeatureGroup):
+        pass
+
+
+    FEATURE_GROUPS = [EpFeatureGroup]
+"""
+
+_TWO_FG_MANIFEST = """
+    from mloda.core.abstract_plugins.feature_group import FeatureGroup
+
+
+    class ZebraEpFeatureGroup(FeatureGroup):
+        pass
+
+
+    class AlphaEpFeatureGroup(FeatureGroup):
+        pass
+
+
+    FEATURE_GROUPS = [ZebraEpFeatureGroup, AlphaEpFeatureGroup]
+"""
+
+_TRIPLE_MANIFEST = """
+    from typing import Any
+
+    from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+    from mloda.core.abstract_plugins.feature_group import FeatureGroup
+    from mloda.core.abstract_plugins.function_extender import Extender, ExtenderHook
+
+
+    class EpFeatureGroup(FeatureGroup):
+        pass
+
+
+    class EpComputeFramework(ComputeFramework):
+        pass
+
+
+    class EpExtender(Extender):
+        def wraps(self) -> set[ExtenderHook]:
+            return set()
+
+        def __call__(self, func: Any, *args: Any, **kwargs: Any) -> Any:
+            return func
+
+
+    FEATURE_GROUPS = [EpFeatureGroup]
+    COMPUTE_FRAMEWORKS = [EpComputeFramework]
+    EXTENDERS = [EpExtender]
+"""
+
+_ABSTRACT_MANIFEST = """
+    from abc import abstractmethod
+    from typing import Any
+
+    from mloda.core.abstract_plugins.feature_group import FeatureGroup
+
+
+    class AbstractEpFeatureGroup(FeatureGroup):
+        @abstractmethod
+        def _ep_probe(self) -> None: ...
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls, feature_name: Any, options: Any, data_access_collection: Any = None
+        ) -> bool:
+            # Inert for other tests' feature resolution in this worker; the default
+            # matching falls back to cls(), which raises TypeError on abstract classes.
+            return False
+
+
+    class ConcreteEpFeatureGroup(AbstractEpFeatureGroup):
+        def _ep_probe(self) -> None:
+            return None
+
+
+    FEATURE_GROUPS = [AbstractEpFeatureGroup, ConcreteEpFeatureGroup]
+"""
+
+_OPTIONAL_DEP_MANIFEST = """
+    import eptest_fake_optional_dep
+
+    from mloda.core.abstract_plugins.feature_group import FeatureGroup
+
+
+    class EpOptionalDepFeatureGroup(FeatureGroup):
+        pass
+
+
+    FEATURE_GROUPS = [EpOptionalDepFeatureGroup]
+"""
+
+_HARD_DEP_MANIFEST = """
+    import eptest_missing_hard_dep
+
+    from mloda.core.abstract_plugins.feature_group import FeatureGroup
+
+
+    class EpHardDepFeatureGroup(FeatureGroup):
+        pass
+
+
+    FEATURE_GROUPS = [EpHardDepFeatureGroup]
+"""
+
+
+class _PreexistingConflictFG(FeatureGroup):
+    """Registered manually under an entry-point class's key to force a collision."""
+
+
+class TestEntryPointGroupsConstant:
+    def test_entry_point_groups_maps_groups_to_base_types(self) -> None:
+        groups = plugin_loader_module.ENTRY_POINT_GROUPS
+        assert groups == {
+            FEATURE_GROUPS_GROUP: FeatureGroup,
+            COMPUTE_FRAMEWORKS_GROUP: ComputeFramework,
+            EXTENDERS_GROUP: Extender,
+        }
+
+
+class TestLoadEntryPointsDiscovery:
+    def test_registers_class_with_module_qualname_key_and_entry_point_provenance(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pkg = "eptest_discovery_pkg"
+        _build_distribution(
+            tmp_path,
+            pkg,
+            _FG_MANIFEST,
+            f"""
+            [mloda.feature_groups]
+            demo = {pkg}.manifest:FEATURE_GROUPS
+            """,
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+
+        loader = PluginLoader()
+        keys = loader.load_entry_points()
+
+        expected_key = f"{pkg}.manifest:EpFeatureGroup"
+        assert expected_key in keys
+        entry = PluginRegistry.default().get_entry(expected_key)
+        assert entry.cls is _manifest_class(pkg, "EpFeatureGroup")
+        assert entry.source == PluginSource.ENTRY_POINT
+        assert entry.plugin_type is FeatureGroup
+
+    def test_returns_sorted_list_of_registered_keys(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        pkg = "eptest_sortedkeys_pkg"
+        _build_distribution(
+            tmp_path,
+            pkg,
+            _TWO_FG_MANIFEST,
+            f"""
+            [mloda.feature_groups]
+            demo = {pkg}.manifest:FEATURE_GROUPS
+            """,
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+
+        keys = PluginLoader().load_entry_points()
+
+        assert keys == sorted(keys)
+        expected = sorted(
+            [
+                f"{pkg}.manifest:AlphaEpFeatureGroup",
+                f"{pkg}.manifest:ZebraEpFeatureGroup",
+            ]
+        )
+        assert [key for key in keys if key.startswith(f"{pkg}.")] == expected
+
+    def test_registers_all_three_plugin_kinds(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        pkg = "eptest_kinds_pkg"
+        _build_distribution(
+            tmp_path,
+            pkg,
+            _TRIPLE_MANIFEST,
+            f"""
+            [mloda.feature_groups]
+            main = {pkg}.manifest:FEATURE_GROUPS
+
+            [mloda.compute_frameworks]
+            main = {pkg}.manifest:COMPUTE_FRAMEWORKS
+
+            [mloda.extenders]
+            main = {pkg}.manifest:EXTENDERS
+            """,
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+
+        PluginLoader().load_entry_points()
+
+        registry = PluginRegistry.default()
+        for class_name, base_type in [
+            ("EpFeatureGroup", FeatureGroup),
+            ("EpComputeFramework", ComputeFramework),
+            ("EpExtender", Extender),
+        ]:
+            entry = registry.get_entry(f"{pkg}.manifest:{class_name}")
+            assert entry.cls is _manifest_class(pkg, class_name)
+            assert entry.plugin_type is base_type
+            assert entry.source == PluginSource.ENTRY_POINT
+
+
+class TestLoadEntryPointsGroupFilter:
+    def test_specific_group_loads_only_that_group(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        pkg = "eptest_groupfilter_pkg"
+        _build_distribution(
+            tmp_path,
+            pkg,
+            _TRIPLE_MANIFEST,
+            f"""
+            [mloda.feature_groups]
+            main = {pkg}.manifest:FEATURE_GROUPS
+
+            [mloda.compute_frameworks]
+            main = {pkg}.manifest:COMPUTE_FRAMEWORKS
+
+            [mloda.extenders]
+            main = {pkg}.manifest:EXTENDERS
+            """,
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+
+        keys = PluginLoader().load_entry_points(group=COMPUTE_FRAMEWORKS_GROUP)
+
+        registry = PluginRegistry.default()
+        cf_key = f"{pkg}.manifest:EpComputeFramework"
+        assert [key for key in keys if key.startswith(f"{pkg}.")] == [cf_key]
+        assert registry.get_entry(cf_key).cls is _manifest_class(pkg, "EpComputeFramework")
+        assert not registry.is_registered(_manifest_class(pkg, "EpFeatureGroup"))
+        assert not registry.is_registered(_manifest_class(pkg, "EpExtender"))
+
+    def test_unknown_group_raises_value_error_listing_valid_groups(self) -> None:
+        loader = PluginLoader()
+        with pytest.raises(ValueError) as exc_info:
+            loader.load_entry_points(group="mloda.bogus_group")
+        message = str(exc_info.value)
+        assert "mloda.bogus_group" in message
+        assert FEATURE_GROUPS_GROUP in message
+        assert COMPUTE_FRAMEWORKS_GROUP in message
+        assert EXTENDERS_GROUP in message
+
+
+class TestLoadEntryPointsValidation:
+    @pytest.mark.parametrize(
+        ("slug", "manifest_value"),
+        [
+            ("int", "42"),
+            ("strings", '["not_a_class"]'),
+        ],
+    )
+    def test_manifest_not_a_sequence_of_classes_raises_naming_entry_point(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, slug: str, manifest_value: str
+    ) -> None:
+        pkg = f"eptest_badmanifest_{slug}_pkg"
+        _build_distribution(
+            tmp_path,
+            pkg,
+            f"FEATURE_GROUPS = {manifest_value}\n",
+            f"""
+            [mloda.feature_groups]
+            broken_label = {pkg}.manifest:FEATURE_GROUPS
+            """,
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+
+        with pytest.raises((TypeError, ValueError)) as exc_info:
+            PluginLoader().load_entry_points()
+        assert "broken_label" in str(exc_info.value)
+
+    def test_wrong_base_type_for_group_raises_naming_group_and_class(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pkg = "eptest_wrongbase_pkg"
+        _build_distribution(
+            tmp_path,
+            pkg,
+            _TRIPLE_MANIFEST,
+            f"""
+            [mloda.feature_groups]
+            wrong = {pkg}.manifest:EXTENDERS
+            """,
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+
+        with pytest.raises((TypeError, ValueError)) as exc_info:
+            PluginLoader().load_entry_points()
+        message = str(exc_info.value)
+        assert FEATURE_GROUPS_GROUP in message
+        assert "EpExtender" in message
+
+    def test_abstract_classes_in_manifest_are_skipped_silently(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pkg = "eptest_abstract_pkg"
+        _build_distribution(
+            tmp_path,
+            pkg,
+            _ABSTRACT_MANIFEST,
+            f"""
+            [mloda.feature_groups]
+            demo = {pkg}.manifest:FEATURE_GROUPS
+            """,
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+
+        keys = PluginLoader().load_entry_points()
+
+        registry = PluginRegistry.default()
+        assert registry.is_registered(_manifest_class(pkg, "ConcreteEpFeatureGroup"))
+        assert not registry.is_registered(_manifest_class(pkg, "AbstractEpFeatureGroup"))
+        assert [key for key in keys if key.startswith(f"{pkg}.")] == [f"{pkg}.manifest:ConcreteEpFeatureGroup"]
+
+
+class TestLoadEntryPointsMissingDependencies:
+    def test_missing_optional_dependency_skips_entry_point_but_loads_others(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        broken_pkg = "eptest_optdep_broken_pkg"
+        good_pkg = "eptest_optdep_good_pkg"
+        _build_distribution(
+            tmp_path,
+            broken_pkg,
+            _OPTIONAL_DEP_MANIFEST,
+            f"""
+            [mloda.feature_groups]
+            broken = {broken_pkg}.manifest:FEATURE_GROUPS
+            """,
+        )
+        _build_distribution(
+            tmp_path,
+            good_pkg,
+            _FG_MANIFEST,
+            f"""
+            [mloda.feature_groups]
+            good = {good_pkg}.manifest:FEATURE_GROUPS
+            """,
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+        monkeypatch.setattr(
+            plugin_loader_module,
+            "OPTIONAL_PLUGIN_DEPENDENCIES",
+            plugin_loader_module.OPTIONAL_PLUGIN_DEPENDENCIES | frozenset({"eptest_fake_optional_dep"}),
+        )
+
+        keys = PluginLoader().load_entry_points()
+
+        registry = PluginRegistry.default()
+        good_key = f"{good_pkg}.manifest:EpFeatureGroup"
+        assert good_key in keys
+        assert registry.get_entry(good_key).source == PluginSource.ENTRY_POINT
+        assert not any(key.startswith(f"{broken_pkg}.") for key in keys)
+        assert registry.get(f"{broken_pkg}.manifest:EpOptionalDepFeatureGroup") is None
+
+    def test_missing_non_optional_dependency_propagates(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        pkg = "eptest_harddep_pkg"
+        _build_distribution(
+            tmp_path,
+            pkg,
+            _HARD_DEP_MANIFEST,
+            f"""
+            [mloda.feature_groups]
+            hard = {pkg}.manifest:FEATURE_GROUPS
+            """,
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+
+        with pytest.raises(ModuleNotFoundError):
+            PluginLoader().load_entry_points()
+
+
+class TestLoadEntryPointsIdempotencyAndCollisions:
+    def test_double_load_registers_nothing_new_and_raises_nothing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pkg = "eptest_idempotent_pkg"
+        _build_distribution(
+            tmp_path,
+            pkg,
+            _FG_MANIFEST,
+            f"""
+            [mloda.feature_groups]
+            demo = {pkg}.manifest:FEATURE_GROUPS
+            """,
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+
+        loader = PluginLoader()
+        loader.load_entry_points()
+        registry = PluginRegistry.default()
+        first_snapshot = registry.snapshot()
+        assert f"{pkg}.manifest:EpFeatureGroup" in first_snapshot
+
+        loader.load_entry_points()
+
+        assert registry.snapshot() == first_snapshot
+
+    def test_different_class_already_under_key_raises_collision_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pkg = "eptest_collision_pkg"
+        _build_distribution(
+            tmp_path,
+            pkg,
+            _FG_MANIFEST,
+            f"""
+            [mloda.feature_groups]
+            demo = {pkg}.manifest:FEATURE_GROUPS
+            """,
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+
+        conflicting_key = f"{pkg}.manifest:EpFeatureGroup"
+        register_plugin(_PreexistingConflictFG, name=conflicting_key)
+
+        with pytest.raises(PluginRegistryCollisionError):
+            PluginLoader().load_entry_points()
+        assert PluginRegistry.default().get(conflicting_key) is _PreexistingConflictFG
+
+
+class TestEntryPointNameIsLabelOnly:
+    def test_two_labels_for_same_manifest_register_class_once_under_module_qualname(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pkg = "eptest_labels_pkg"
+        _build_distribution(
+            tmp_path,
+            pkg,
+            _FG_MANIFEST,
+            f"""
+            [mloda.feature_groups]
+            label_one = {pkg}.manifest:FEATURE_GROUPS
+            label_two = {pkg}.manifest:FEATURE_GROUPS
+            """,
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+
+        PluginLoader().load_entry_points()
+
+        registry = PluginRegistry.default()
+        cls = _manifest_class(pkg, "EpFeatureGroup")
+        keys_for_class = [key for key, entry in registry.snapshot().items() if entry.cls is cls]
+        assert keys_for_class == [f"{pkg}.manifest:EpFeatureGroup"]
+        assert registry.get("label_one") is None
+        assert registry.get("label_two") is None
+
+
+class TestPluginLoaderAllLoadsEntryPoints:
+    def test_all_folds_in_entry_points_after_module_scan(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        pkg = "eptest_all_pkg"
+        _build_distribution(
+            tmp_path,
+            pkg,
+            _FG_MANIFEST,
+            f"""
+            [mloda.feature_groups]
+            demo = {pkg}.manifest:FEATURE_GROUPS
+            """,
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+
+        PluginLoader.all()
+
+        registry = PluginRegistry.default()
+        key = f"{pkg}.manifest:EpFeatureGroup"
+        assert registry.is_registered(_manifest_class(pkg, "EpFeatureGroup"))
+        assert registry.get_entry(key).source == PluginSource.ENTRY_POINT

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_persona_exports.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_persona_exports.py
@@ -3,17 +3,18 @@
 Contract: the module-level registration function is named register_plugin.
 mloda.user exports register_plugin, list_registered, and PluginRegistryCollisionError,
 but NOT PluginRegistry. mloda.provider exports register_plugin and
-PluginRegistryCollisionError. mloda.steward exports PluginRegistry and
-list_registered. Every export is the identical object from its core module
-and is listed in the namespace's __all__.
+PluginRegistryCollisionError. mloda.steward exports PluginRegistry,
+list_registered, and the governance objects PluginPolicy, ApprovalStatus, and
+PluginPolicyViolationError. Every export is the identical object from its core
+module and is listed in the namespace's __all__. Governance objects are
+steward-only: mloda.user and mloda.provider gain nothing.
 """
 
+import importlib
 from types import ModuleType
 
 import pytest
 
-import mloda.core.abstract_plugins.plugin_registry.plugin_registry as core_registry
-import mloda.core.api.plugin_docs as plugin_docs
 import mloda.provider
 import mloda.steward
 import mloda.user
@@ -24,10 +25,17 @@ _NAMESPACES: dict[str, ModuleType] = {
     "steward": mloda.steward,
 }
 
-_SOURCES: dict[str, ModuleType] = {
-    "core_registry": core_registry,
-    "plugin_docs": plugin_docs,
+# Source modules are resolved lazily so a missing source module fails only its own matrix rows.
+_SOURCE_MODULES: dict[str, str] = {
+    "core_registry": "mloda.core.abstract_plugins.plugin_registry.plugin_registry",
+    "plugin_docs": "mloda.core.api.plugin_docs",
+    "core_policy": "mloda.core.abstract_plugins.plugin_registry.plugin_policy",
 }
+
+
+def _source_module(source_name: str) -> ModuleType:
+    return importlib.import_module(_SOURCE_MODULES[source_name])
+
 
 # (namespace, symbol, source module holding the canonical object)
 EXPORT_MATRIX: list[tuple[str, str, str]] = [
@@ -38,9 +46,14 @@ EXPORT_MATRIX: list[tuple[str, str, str]] = [
     ("provider", "PluginRegistryCollisionError", "core_registry"),
     ("steward", "PluginRegistry", "core_registry"),
     ("steward", "list_registered", "plugin_docs"),
+    ("steward", "PluginPolicy", "core_policy"),
+    ("steward", "ApprovalStatus", "core_policy"),
+    ("steward", "PluginPolicyViolationError", "core_policy"),
 ]
 
 _MATRIX_IDS = [f"{namespace}-{symbol}" for namespace, symbol, _source in EXPORT_MATRIX]
+
+_GOVERNANCE_SYMBOLS = ["PluginPolicy", "ApprovalStatus", "PluginPolicyViolationError"]
 
 
 class TestPersonaExportMatrix:
@@ -52,7 +65,7 @@ class TestPersonaExportMatrix:
     @pytest.mark.parametrize(("namespace_name", "symbol", "source_name"), EXPORT_MATRIX, ids=_MATRIX_IDS)
     def test_symbol_is_identical_to_core_object(self, namespace_name: str, symbol: str, source_name: str) -> None:
         namespace = _NAMESPACES[namespace_name]
-        source = _SOURCES[source_name]
+        source = _source_module(source_name)
         assert hasattr(source, symbol), f"{source.__name__} must define '{symbol}'"
         assert hasattr(namespace, symbol), f"mloda.{namespace_name} must expose '{symbol}'"
         assert getattr(namespace, symbol) is getattr(source, symbol), (
@@ -70,3 +83,12 @@ class TestUserDoesNotExportPluginRegistry:
         assert not hasattr(mloda.user, "PluginRegistry"), (
             "mloda.user must not expose a PluginRegistry attribute; stewards use mloda.steward.PluginRegistry"
         )
+
+
+class TestGovernanceExportsAreStewardOnly:
+    @pytest.mark.parametrize("symbol", _GOVERNANCE_SYMBOLS)
+    def test_governance_symbol_absent_from_user_and_provider(self, symbol: str) -> None:
+        for namespace_name in ("user", "provider"):
+            namespace = _NAMESPACES[namespace_name]
+            assert symbol not in namespace.__all__, f"mloda.{namespace_name} must not list '{symbol}' in __all__"
+            assert not hasattr(namespace, symbol), f"mloda.{namespace_name} must not expose '{symbol}'"

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_plugin_policy.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_plugin_policy.py
@@ -1,0 +1,86 @@
+"""Tests for the deployment-scoped governance policy value object (PluginPolicy).
+
+Contract: mloda.core.abstract_plugins.plugin_registry.plugin_policy defines
+ApprovalStatus (a str enum: unreviewed/approved/rejected), the
+PluginPolicyViolationError exception, and the frozen dataclass PluginPolicy.
+PluginPolicy.allows(key, module, approval) evaluates deny-first:
+1) key in denied_keys, 2) module under denied_module_prefixes, 3) key in
+allowed_keys bypasses the module-prefix constraint but NOT require_approval,
+4) allowed_module_prefixes (None = unrestricted, () = nothing passes),
+5) require_approval admits only ApprovalStatus.APPROVED.
+"""
+
+import dataclasses
+
+import pytest
+
+from mloda.core.abstract_plugins.plugin_registry.plugin_policy import (
+    ApprovalStatus,
+    PluginPolicy,
+    PluginPolicyViolationError,
+)
+
+
+class TestPolicyModuleContract:
+    def test_approval_status_is_str_enum_with_expected_values(self) -> None:
+        assert issubclass(ApprovalStatus, str)
+        assert ApprovalStatus.UNREVIEWED.value == "unreviewed"
+        assert ApprovalStatus.APPROVED.value == "approved"
+        assert ApprovalStatus.REJECTED.value == "rejected"
+        assert ApprovalStatus.APPROVED == "approved"
+
+    def test_violation_error_is_exception_subclass(self) -> None:
+        assert issubclass(PluginPolicyViolationError, Exception)
+
+    def test_policy_defaults_and_frozenness(self) -> None:
+        policy = PluginPolicy()
+        assert policy.allowed_module_prefixes is None
+        assert policy.denied_module_prefixes == ()
+        assert policy.allowed_keys == ()
+        assert policy.denied_keys == ()
+        assert policy.require_approval is False
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            setattr(policy, "require_approval", True)
+
+
+class TestPolicyAllows:
+    def test_default_policy_allows_any_key_module_and_approval(self) -> None:
+        policy = PluginPolicy()
+        assert policy.allows("any_pkg.mod:Cls", "any_pkg.mod", ApprovalStatus.UNREVIEWED) is True
+        assert policy.allows("any_pkg.mod:Cls", "any_pkg.mod", ApprovalStatus.REJECTED) is True
+
+    def test_denied_keys_deny_and_win_over_allowed_keys(self) -> None:
+        policy = PluginPolicy(denied_keys=("pkg.mod:Bad",), allowed_keys=("pkg.mod:Bad",))
+        assert policy.allows("pkg.mod:Bad", "pkg.mod", ApprovalStatus.APPROVED) is False
+        assert policy.allows("pkg.mod:Good", "pkg.mod", ApprovalStatus.APPROVED) is True
+
+    def test_denied_module_prefixes_deny_and_win_over_allowed_keys(self) -> None:
+        policy = PluginPolicy(denied_module_prefixes=("evil_pkg",), allowed_keys=("evil_pkg.mod:Cls",))
+        assert policy.allows("evil_pkg.mod:Cls", "evil_pkg.mod", ApprovalStatus.APPROVED) is False
+        assert policy.allows("good_pkg.mod:Cls", "good_pkg.mod", ApprovalStatus.APPROVED) is True
+
+    def test_allowed_module_prefixes_gate_modules(self) -> None:
+        policy = PluginPolicy(allowed_module_prefixes=("mloda_plugins", "trusted_pkg"))
+        assert policy.allows("trusted_pkg.mod:Cls", "trusted_pkg.mod", ApprovalStatus.UNREVIEWED) is True
+        assert policy.allows("mloda_plugins.x:Cls", "mloda_plugins.x", ApprovalStatus.UNREVIEWED) is True
+        assert policy.allows("outside_pkg.mod:Cls", "outside_pkg.mod", ApprovalStatus.UNREVIEWED) is False
+        empty = PluginPolicy(allowed_module_prefixes=())
+        assert empty.allows("any_pkg.mod:Cls", "any_pkg.mod", ApprovalStatus.APPROVED) is False
+
+    def test_allowed_keys_bypass_module_prefix_but_not_require_approval(self) -> None:
+        bypass = PluginPolicy(allowed_module_prefixes=("trusted_pkg",), allowed_keys=("outside_pkg.mod:Special",))
+        assert bypass.allows("outside_pkg.mod:Special", "outside_pkg.mod", ApprovalStatus.UNREVIEWED) is True
+        assert bypass.allows("outside_pkg.mod:Other", "outside_pkg.mod", ApprovalStatus.UNREVIEWED) is False
+        strict = PluginPolicy(
+            allowed_module_prefixes=("trusted_pkg",),
+            allowed_keys=("outside_pkg.mod:Special",),
+            require_approval=True,
+        )
+        assert strict.allows("outside_pkg.mod:Special", "outside_pkg.mod", ApprovalStatus.UNREVIEWED) is False
+        assert strict.allows("outside_pkg.mod:Special", "outside_pkg.mod", ApprovalStatus.APPROVED) is True
+
+    def test_require_approval_only_admits_approved(self) -> None:
+        policy = PluginPolicy(require_approval=True)
+        assert policy.allows("pkg.mod:Cls", "pkg.mod", ApprovalStatus.APPROVED) is True
+        assert policy.allows("pkg.mod:Cls", "pkg.mod", ApprovalStatus.UNREVIEWED) is False
+        assert policy.allows("pkg.mod:Cls", "pkg.mod", ApprovalStatus.REJECTED) is False

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_plugin_policy.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_plugin_policy.py
@@ -8,6 +8,12 @@ PluginPolicy.allows(key, module, approval) evaluates deny-first:
 allowed_keys bypasses the module-prefix constraint but NOT require_approval,
 4) allowed_module_prefixes (None = unrestricted, () = nothing passes),
 5) require_approval admits only ApprovalStatus.APPROVED.
+
+Module-prefix matching is boundary-aware on both the denied and allowed
+sides: prefix "acme.plugins" matches the module "acme.plugins" itself and
+any submodule "acme.plugins.sub", but never a sibling like
+"acme.plugins_evil". The trailing-dot form "acme.plugins." matches only
+submodules: "acme.plugins.sub" yes, "acme.plugins" and "acme.plugins_evil" no.
 """
 
 import dataclasses
@@ -27,7 +33,7 @@ class TestPolicyModuleContract:
         assert ApprovalStatus.UNREVIEWED.value == "unreviewed"
         assert ApprovalStatus.APPROVED.value == "approved"
         assert ApprovalStatus.REJECTED.value == "rejected"
-        assert ApprovalStatus.APPROVED == "approved"
+        assert ApprovalStatus("approved") is ApprovalStatus.APPROVED
 
     def test_violation_error_is_exception_subclass(self) -> None:
         assert issubclass(PluginPolicyViolationError, Exception)
@@ -84,3 +90,29 @@ class TestPolicyAllows:
         assert policy.allows("pkg.mod:Cls", "pkg.mod", ApprovalStatus.APPROVED) is True
         assert policy.allows("pkg.mod:Cls", "pkg.mod", ApprovalStatus.UNREVIEWED) is False
         assert policy.allows("pkg.mod:Cls", "pkg.mod", ApprovalStatus.REJECTED) is False
+
+
+class TestPolicyPrefixBoundaryMatching:
+    def test_denied_prefix_matches_exact_module_and_submodules_but_not_siblings(self) -> None:
+        policy = PluginPolicy(denied_module_prefixes=("acme.plugins",))
+        assert policy.allows("k:Cls", "acme.plugins", ApprovalStatus.APPROVED) is False
+        assert policy.allows("k:Cls", "acme.plugins.sub", ApprovalStatus.APPROVED) is False
+        assert policy.allows("k:Cls", "acme.plugins_evil", ApprovalStatus.APPROVED) is True
+
+    def test_denied_prefix_trailing_dot_matches_submodules_only(self) -> None:
+        policy = PluginPolicy(denied_module_prefixes=("acme.plugins.",))
+        assert policy.allows("k:Cls", "acme.plugins.sub", ApprovalStatus.APPROVED) is False
+        assert policy.allows("k:Cls", "acme.plugins", ApprovalStatus.APPROVED) is True
+        assert policy.allows("k:Cls", "acme.plugins_evil", ApprovalStatus.APPROVED) is True
+
+    def test_allowed_prefix_matches_exact_module_and_submodules_but_not_siblings(self) -> None:
+        policy = PluginPolicy(allowed_module_prefixes=("acme.plugins",))
+        assert policy.allows("k:Cls", "acme.plugins", ApprovalStatus.UNREVIEWED) is True
+        assert policy.allows("k:Cls", "acme.plugins.sub", ApprovalStatus.UNREVIEWED) is True
+        assert policy.allows("k:Cls", "acme.plugins_evil", ApprovalStatus.UNREVIEWED) is False
+
+    def test_allowed_prefix_trailing_dot_matches_submodules_only(self) -> None:
+        policy = PluginPolicy(allowed_module_prefixes=("acme.plugins.",))
+        assert policy.allows("k:Cls", "acme.plugins.sub", ApprovalStatus.UNREVIEWED) is True
+        assert policy.allows("k:Cls", "acme.plugins", ApprovalStatus.UNREVIEWED) is False
+        assert policy.allows("k:Cls", "acme.plugins_evil", ApprovalStatus.UNREVIEWED) is False

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_plugin_registry.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_plugin_registry.py
@@ -387,11 +387,11 @@ class TestModuleLevelRegisterPlugin:
         assert PluginRegistry.default().get(key) is _RegistryTestFGA
 
     def test_register_plugin_accepts_same_keyword_arguments(self, default_registry_guard: PluginRegistry) -> None:
-        key = register_plugin(_RegistryTestFGB, name="module_level_custom", source="notebook")
+        key = register_plugin(_RegistryTestFGB, name="module_level_custom", source="loader")
         assert key == "module_level_custom"
         entry = default_registry_guard.get_entry("module_level_custom")
         assert entry.cls is _RegistryTestFGB
-        assert entry.source == "notebook"
+        assert entry.source == "loader"
 
     def test_old_register_name_removed_from_core_module(self) -> None:
         """The convenience function is renamed to register_plugin; the old name must be gone."""

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_plugin_source.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_plugin_source.py
@@ -37,13 +37,13 @@ class TestPluginSourceEnum:
         assert issubclass(PluginSource, enum.Enum)
 
     def test_plugin_source_members_and_values(self) -> None:
-        assert PluginSource.MANUAL == "manual"
-        assert PluginSource.LOADER == "loader"
-        assert PluginSource.ENTRY_POINT == "entry_point"
+        assert PluginSource.MANUAL.value == "manual"
+        assert PluginSource.LOADER.value == "loader"
+        assert PluginSource.ENTRY_POINT.value == "entry_point"
 
     def test_plugin_source_keeps_string_comparisons_working(self) -> None:
         """Existing call sites compare entry.source against bare strings; str subclassing keeps that True."""
-        assert PluginSource.LOADER == "loader"
+        assert PluginSource.LOADER.value == "loader"
         assert isinstance(PluginSource.LOADER, str)
 
 
@@ -100,4 +100,4 @@ class TestRegisterModulePluginsProvenance:
         for key in keys:
             entry = registry.get_entry(key)
             assert entry.source is PluginSource.LOADER
-            assert entry.source == "loader", "loader provenance must keep comparing equal to the bare string"
+            assert entry.source.value == "loader", "loader provenance must keep the bare string value"

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_plugin_source.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_plugin_source.py
@@ -1,0 +1,103 @@
+"""Tests for the PluginSource provenance enum.
+
+Contract: PluginSource is a public str-subclassing enum (MANUAL="manual",
+LOADER="loader", ENTRY_POINT="entry_point"). PluginRegistry.register()
+normalizes plain strings to enum members, stores PluginSource.MANUAL by
+default, and rejects unknown sources with a ValueError that lists the valid
+values. register_module_plugins keeps stamping loader provenance, now as
+PluginSource.LOADER.
+"""
+
+import enum
+import importlib
+
+import pytest
+
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.abstract_plugins.plugin_registry.plugin_registry import (
+    PluginRegistry,
+    PluginSource,
+    register_module_plugins,
+)
+
+PYTHON_DICT_FRAMEWORK_MODULE = "mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework"
+
+
+class _SourceTestFGA(FeatureGroup):
+    pass
+
+
+class _SourceTestFGB(FeatureGroup):
+    pass
+
+
+class TestPluginSourceEnum:
+    def test_plugin_source_is_str_enum(self) -> None:
+        assert issubclass(PluginSource, str)
+        assert issubclass(PluginSource, enum.Enum)
+
+    def test_plugin_source_members_and_values(self) -> None:
+        assert PluginSource.MANUAL == "manual"
+        assert PluginSource.LOADER == "loader"
+        assert PluginSource.ENTRY_POINT == "entry_point"
+
+    def test_plugin_source_keeps_string_comparisons_working(self) -> None:
+        """Existing call sites compare entry.source against bare strings; str subclassing keeps that True."""
+        assert PluginSource.LOADER == "loader"
+        assert isinstance(PluginSource.LOADER, str)
+
+
+class TestRegisterSourceNormalization:
+    def test_register_default_source_is_manual_enum_member(self) -> None:
+        reg = PluginRegistry()
+        key = reg.register(_SourceTestFGA)
+        entry = reg.get_entry(key)
+        assert entry.source is PluginSource.MANUAL
+
+    def test_register_plain_string_is_normalized_to_enum_member(self) -> None:
+        reg = PluginRegistry()
+        key = reg.register(_SourceTestFGA, source="loader")
+        entry = reg.get_entry(key)
+        assert entry.source is PluginSource.LOADER
+        assert isinstance(entry.source, PluginSource), "a plain-string source must be stored as a PluginSource member"
+
+    def test_register_enum_member_is_stored_as_is(self) -> None:
+        reg = PluginRegistry()
+        key = reg.register(_SourceTestFGA, source=PluginSource.ENTRY_POINT)
+        assert reg.get_entry(key).source is PluginSource.ENTRY_POINT
+
+    def test_register_unknown_source_raises_value_error(self) -> None:
+        reg = PluginRegistry()
+        with pytest.raises(ValueError):
+            reg.register(_SourceTestFGB, source="invented")
+
+    def test_register_unknown_source_error_lists_valid_values(self) -> None:
+        reg = PluginRegistry()
+        with pytest.raises(ValueError) as exc_info:
+            reg.register(_SourceTestFGB, source="invented")
+        message = str(exc_info.value)
+        assert "manual" in message
+        assert "loader" in message
+        assert "entry_point" in message
+
+    def test_register_unknown_source_does_not_register_the_class(self) -> None:
+        reg = PluginRegistry()
+        with pytest.raises(ValueError):
+            reg.register(_SourceTestFGB, source="invented")
+        assert reg.is_registered(_SourceTestFGB) is False
+
+
+class TestRegisterModulePluginsProvenance:
+    def test_register_module_plugins_stamps_loader_enum_member(self) -> None:
+        """The loader funnel keeps working; its entries now carry PluginSource.LOADER."""
+        registry = PluginRegistry.default()
+        registry.clear()
+
+        module = importlib.import_module(PYTHON_DICT_FRAMEWORK_MODULE)
+        keys = register_module_plugins(module)
+        assert keys, "sanity: the python_dict framework module defines at least one plugin class"
+
+        for key in keys:
+            entry = registry.get_entry(key)
+            assert entry.source is PluginSource.LOADER
+            assert entry.source == "loader", "loader provenance must keep comparing equal to the bare string"

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_policy_enforcement.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_policy_enforcement.py
@@ -4,14 +4,20 @@ Contract: PluginRegistry.set_policy installs a deployment-scoped PluginPolicy,
 exposed via the read-only `policy` property (default None = allow everything).
 register() evaluates the policy after source normalization and before any state
 mutation, against the would-be key, cls.__module__, and the approval being
-registered. Denied manual registrations raise PluginPolicyViolationError naming
-the key; denied loader/entry_point registrations register nothing, return None,
-and warn once per key per registry instance. Entries carry owner/approval
-metadata (approval strings normalized like source; invalid values raise
-ValueError listing the valid ones). set_approval updates existing entries and
-raises the get_entry error type for unknown names. The discovery funnels
-(register_module_plugins, PluginLoader.load_entry_points) exclude denied
-classes from their returned key lists without error.
+registered. A denied registration always raises PluginPolicyViolationError
+naming the would-be key, regardless of source (manual, loader, entry_point);
+otherwise register() returns the key string (never None). The discovery
+funnels (register_module_plugins, PluginLoader.load_entry_points) catch the
+denial themselves: they skip denied classes, exclude them from their returned
+key lists, and log one WARNING per denied key per registry instance (a second
+funnel call for the same denied key logs nothing new). Entries carry
+owner/approval metadata (approval strings normalized like source; invalid
+values raise ValueError listing the valid ones). Benign re-registration
+(replace=True, same class and key) with default owner/approval keeps the
+existing entry's governance metadata; an explicit owner or approval updates
+it; replacing with a different class resets it to defaults (owner None,
+UNREVIEWED). set_approval updates existing entries and raises the get_entry
+error type for unknown names.
 """
 
 import gc
@@ -53,6 +59,10 @@ class _PolicyEnfFGC(FeatureGroup):
 
 
 class _PolicyEnfFGD(FeatureGroup):
+    pass
+
+
+class _PolicyEnfFGE(FeatureGroup):
     pass
 
 
@@ -121,29 +131,25 @@ class TestPolicyDenialBySource:
         with pytest.raises(ValueError, match="bogus_source"):
             reg.register(_PolicyEnfFGA, source="bogus_source")
 
-    def test_loader_denied_returns_none_and_warns_once_per_key(self, caplog: pytest.LogCaptureFixture) -> None:
+    def test_loader_denied_raises_naming_key_and_mutates_nothing(self) -> None:
         reg = PluginRegistry()
-        denied_a = _key(_PolicyEnfFGA)
-        denied_b = _key(_PolicyEnfFGB)
-        reg.set_policy(PluginPolicy(denied_keys=(denied_a, denied_b)))
-        with caplog.at_level(logging.WARNING):
-            assert reg.register(_PolicyEnfFGA, source="loader") is None
-            assert len(_warning_messages(caplog, denied_a)) == 1
-            assert reg.register(_PolicyEnfFGA, source="loader") is None
-            assert len(_warning_messages(caplog, denied_a)) == 1, "second denial of the same key must not warn again"
-            assert reg.register(_PolicyEnfFGB, source="loader") is None
-            assert len(_warning_messages(caplog, denied_b)) == 1, "a different denied key warns on its own"
+        denied = _key(_PolicyEnfFGA)
+        reg.set_policy(PluginPolicy(denied_keys=(denied,)))
+        with pytest.raises(PluginPolicyViolationError) as exc_info:
+            reg.register(_PolicyEnfFGA, source="loader")
+        assert denied in str(exc_info.value)
         assert not reg.is_registered(_PolicyEnfFGA)
-        assert not reg.is_registered(_PolicyEnfFGB)
+        assert reg.snapshot() == {}
 
-    def test_entry_point_denied_returns_none_and_warns(self, caplog: pytest.LogCaptureFixture) -> None:
+    def test_entry_point_denied_raises_naming_key_and_mutates_nothing(self) -> None:
         reg = PluginRegistry()
         denied = _key(_PolicyEnfFGC)
         reg.set_policy(PluginPolicy(denied_keys=(denied,)))
-        with caplog.at_level(logging.WARNING):
-            assert reg.register(_PolicyEnfFGC, source=PluginSource.ENTRY_POINT) is None
-        assert len(_warning_messages(caplog, denied)) == 1
+        with pytest.raises(PluginPolicyViolationError) as exc_info:
+            reg.register(_PolicyEnfFGC, source=PluginSource.ENTRY_POINT)
+        assert denied in str(exc_info.value)
         assert reg.get(denied) is None
+        assert reg.snapshot() == {}
 
 
 class TestApprovalMetadata:
@@ -222,9 +228,66 @@ class TestModuleLevelRegisterPluginForwarding:
         assert entry.owner == "carol"
         assert entry.approval is ApprovalStatus.APPROVED
 
+    @pytest.mark.parametrize("source", [PluginSource.MANUAL, "loader", PluginSource.ENTRY_POINT])
+    def test_register_plugin_denied_raises_for_every_source(
+        self, source: PluginSource | str, default_registry_policy_guard: PluginRegistry
+    ) -> None:
+        registry = default_registry_policy_guard
+        denied = _key(_PolicyEnfFGE)
+        registry.set_policy(PluginPolicy(denied_keys=(denied,)))
+        with pytest.raises(PluginPolicyViolationError) as exc_info:
+            register_plugin(_PolicyEnfFGE, source=source)
+        assert denied in str(exc_info.value)
+        assert not registry.is_registered(_PolicyEnfFGE)
+
+
+class TestReplacePreservesGovernanceMetadata:
+    def test_replace_same_class_with_defaults_keeps_owner_and_approval(self) -> None:
+        reg = PluginRegistry()
+        reg.register(_PolicyEnfFGA, owner="alice", approval=ApprovalStatus.APPROVED)
+        reg.register(_PolicyEnfFGA, replace=True)
+        entry = reg.get_entry(_key(_PolicyEnfFGA))
+        assert entry.owner == "alice"
+        assert entry.approval is ApprovalStatus.APPROVED
+
+    def test_replace_same_class_explicit_owner_updates_owner_and_keeps_approval(self) -> None:
+        reg = PluginRegistry()
+        reg.register(_PolicyEnfFGA, owner="alice", approval=ApprovalStatus.APPROVED)
+        reg.register(_PolicyEnfFGA, replace=True, owner="bob")
+        entry = reg.get_entry(_key(_PolicyEnfFGA))
+        assert entry.owner == "bob"
+        assert entry.approval is ApprovalStatus.APPROVED
+
+    def test_replace_same_class_explicit_approval_updates_approval_and_keeps_owner(self) -> None:
+        reg = PluginRegistry()
+        reg.register(_PolicyEnfFGA, owner="alice", approval=ApprovalStatus.APPROVED)
+        reg.register(_PolicyEnfFGA, replace=True, approval="rejected")
+        entry = reg.get_entry(_key(_PolicyEnfFGA))
+        assert entry.approval is ApprovalStatus.REJECTED
+        assert entry.owner == "alice"
+
+    def test_replace_same_class_under_explicit_key_keeps_metadata(self) -> None:
+        reg = PluginRegistry()
+        reg.register(_PolicyEnfFGA, name="governed_meta_key", owner="alice", approval="approved")
+        reg.register(_PolicyEnfFGA, name="governed_meta_key", replace=True)
+        entry = reg.get_entry("governed_meta_key")
+        assert entry.owner == "alice"
+        assert entry.approval is ApprovalStatus.APPROVED
+
+    def test_replace_with_different_class_resets_metadata_to_defaults(self) -> None:
+        reg = PluginRegistry()
+        reg.register(_PolicyEnfFGA, name="governed_shared_key", owner="alice", approval=ApprovalStatus.APPROVED)
+        reg.register(_PolicyEnfFGB, name="governed_shared_key", replace=True)
+        entry = reg.get_entry("governed_shared_key")
+        assert entry.cls is _PolicyEnfFGB
+        assert entry.owner is None
+        assert entry.approval is ApprovalStatus.UNREVIEWED
+
 
 class TestRegisterModulePluginsSkipsDenied:
-    def test_register_module_plugins_excludes_denied(self, default_registry_policy_guard: PluginRegistry) -> None:
+    def test_register_module_plugins_excludes_denied_and_warns_once(
+        self, caplog: pytest.LogCaptureFixture, default_registry_policy_guard: PluginRegistry
+    ) -> None:
         registry = default_registry_policy_guard
         module = types.ModuleType("policy_gate_fake_mod")
 
@@ -251,12 +314,21 @@ class TestRegisterModulePluginsSkipsDenied:
         denied_key = f"{module.__name__}:{_ModDeniedFG.__qualname__}"
         try:
             registry.set_policy(PluginPolicy(denied_keys=(denied_key,)))
-            keys = register_module_plugins(module)
+            with caplog.at_level(logging.WARNING):
+                keys = register_module_plugins(module)
             assert all(isinstance(key, str) for key in keys), "denied classes must not surface as None results"
             assert allowed_key in keys
             assert denied_key not in keys
             assert registry.is_registered(_ModAllowedFG)
             assert not registry.is_registered(_ModDeniedFG)
+            assert len(_warning_messages(caplog, denied_key)) == 1, "the funnel warns once for a denied key"
+            with caplog.at_level(logging.WARNING):
+                keys_again = register_module_plugins(module)
+            assert denied_key not in keys_again
+            assert allowed_key in keys_again
+            assert len(_warning_messages(caplog, denied_key)) == 1, (
+                "a second funnel call for the same denied key must not warn again on the same registry instance"
+            )
         finally:
             # Drop every strong ref to the fake-module doubles so they cannot poison
             # other tests in this worker via FeatureGroup.__subclasses__(); the autouse
@@ -299,8 +371,12 @@ def _build_distribution(base_dir: Path, pkg_name: str, manifest_source: str, ent
 
 
 class TestLoadEntryPointsSkipsDenied:
-    def test_load_entry_points_excludes_denied(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, default_registry_policy_guard: PluginRegistry
+    def test_load_entry_points_excludes_denied_and_warns_once(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+        default_registry_policy_guard: PluginRegistry,
     ) -> None:
         pkg = "eptest_policy_denied_pkg"
         _build_distribution(
@@ -318,13 +394,23 @@ class TestLoadEntryPointsSkipsDenied:
         registry = default_registry_policy_guard
         registry.set_policy(PluginPolicy(denied_keys=(denied_key,)))
 
-        keys = PluginLoader().load_entry_points()
+        with caplog.at_level(logging.WARNING):
+            keys = PluginLoader().load_entry_points()
 
         assert allowed_key in keys
         assert denied_key not in keys
         assert all(isinstance(key, str) for key in keys), "denied classes must not surface as None results"
         assert registry.get(denied_key) is None
         assert registry.get_entry(allowed_key).source == PluginSource.ENTRY_POINT
+        assert len(_warning_messages(caplog, denied_key)) == 1, "the funnel warns once for a denied key"
+
+        with caplog.at_level(logging.WARNING):
+            keys_again = PluginLoader().load_entry_points()
+
+        assert denied_key not in keys_again
+        assert len(_warning_messages(caplog, denied_key)) == 1, (
+            "a second funnel call for the same denied key must not warn again on the same registry instance"
+        )
 
 
 class TestDualImportAwareness:
@@ -353,7 +439,9 @@ class TestDualImportAwareness:
 
             governed.set_policy(PluginPolicy(allowed_module_prefixes=(canonical_module,)))
             assert governed.register(_DualCanonicalFG) == canonical_key
-            assert governed.register(_DualAliasFG, source="loader") is None
+            with pytest.raises(PluginPolicyViolationError) as exc_info:
+                governed.register(_DualAliasFG, source="loader")
+            assert alias_key in str(exc_info.value)
             assert governed.is_registered(_DualCanonicalFG)
             assert not governed.is_registered(_DualAliasFG)
         finally:

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_policy_enforcement.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_policy_enforcement.py
@@ -1,0 +1,363 @@
+"""Registration-time governance enforcement and approval metadata.
+
+Contract: PluginRegistry.set_policy installs a deployment-scoped PluginPolicy,
+exposed via the read-only `policy` property (default None = allow everything).
+register() evaluates the policy after source normalization and before any state
+mutation, against the would-be key, cls.__module__, and the approval being
+registered. Denied manual registrations raise PluginPolicyViolationError naming
+the key; denied loader/entry_point registrations register nothing, return None,
+and warn once per key per registry instance. Entries carry owner/approval
+metadata (approval strings normalized like source; invalid values raise
+ValueError listing the valid ones). set_approval updates existing entries and
+raises the get_entry error type for unknown names. The discovery funnels
+(register_module_plugins, PluginLoader.load_entry_points) exclude denied
+classes from their returned key lists without error.
+"""
+
+import gc
+import importlib
+import logging
+import textwrap
+import types
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.abstract_plugins.plugin_registry.plugin_policy import (
+    ApprovalStatus,
+    PluginPolicy,
+    PluginPolicyViolationError,
+)
+from mloda.core.abstract_plugins.plugin_registry.plugin_registry import (
+    PluginRegistry,
+    PluginSource,
+    register_module_plugins,
+    register_plugin,
+)
+from mloda.user import PluginLoader
+
+
+class _PolicyEnfFGA(FeatureGroup):
+    pass
+
+
+class _PolicyEnfFGB(FeatureGroup):
+    pass
+
+
+class _PolicyEnfFGC(FeatureGroup):
+    pass
+
+
+class _PolicyEnfFGD(FeatureGroup):
+    pass
+
+
+class _DualCanonicalFG(FeatureGroup):
+    pass
+
+
+def _key(cls: type[Any]) -> str:
+    return f"{cls.__module__}:{cls.__qualname__}"
+
+
+def _warning_messages(caplog: pytest.LogCaptureFixture, key: str) -> list[str]:
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno >= logging.WARNING and key in record.getMessage()
+    ]
+
+
+@pytest.fixture
+def default_registry_policy_guard() -> Iterator[PluginRegistry]:
+    """Hand out the default registry and reset its policy on teardown.
+
+    The autouse conftest fixture restores the entries snapshot; the policy is
+    separate state and must be cleared explicitly.
+    """
+    registry = PluginRegistry.default()
+    yield registry
+    registry.set_policy(None)
+
+
+class TestSetPolicy:
+    def test_policy_property_defaults_to_none_and_roundtrips(self) -> None:
+        reg = PluginRegistry()
+        assert reg.policy is None
+        policy = PluginPolicy(require_approval=True)
+        reg.set_policy(policy)
+        assert reg.policy is policy
+        reg.set_policy(None)
+        assert reg.policy is None
+        with pytest.raises(AttributeError):
+            setattr(reg, "policy", policy)
+
+    def test_no_policy_allows_every_source(self) -> None:
+        reg = PluginRegistry()
+        assert reg.register(_PolicyEnfFGA) == _key(_PolicyEnfFGA)
+        assert reg.register(_PolicyEnfFGB, source="loader") == _key(_PolicyEnfFGB)
+        assert reg.register(_PolicyEnfFGC, source=PluginSource.ENTRY_POINT) == _key(_PolicyEnfFGC)
+
+
+class TestPolicyDenialBySource:
+    def test_manual_denied_raises_naming_key_and_mutates_nothing(self) -> None:
+        reg = PluginRegistry()
+        reg.set_policy(PluginPolicy(denied_keys=("governed_custom_key",)))
+        with pytest.raises(PluginPolicyViolationError) as exc_info:
+            reg.register(_PolicyEnfFGA, name="governed_custom_key")
+        assert "governed_custom_key" in str(exc_info.value)
+        assert reg.get("governed_custom_key") is None
+        assert not reg.is_registered(_PolicyEnfFGA)
+        assert reg.snapshot() == {}
+
+    def test_invalid_source_string_raises_value_error_before_policy(self) -> None:
+        """Enforcement runs after source normalization, so a bogus source wins over the policy."""
+        reg = PluginRegistry()
+        reg.set_policy(PluginPolicy(denied_keys=(_key(_PolicyEnfFGA),)))
+        with pytest.raises(ValueError, match="bogus_source"):
+            reg.register(_PolicyEnfFGA, source="bogus_source")
+
+    def test_loader_denied_returns_none_and_warns_once_per_key(self, caplog: pytest.LogCaptureFixture) -> None:
+        reg = PluginRegistry()
+        denied_a = _key(_PolicyEnfFGA)
+        denied_b = _key(_PolicyEnfFGB)
+        reg.set_policy(PluginPolicy(denied_keys=(denied_a, denied_b)))
+        with caplog.at_level(logging.WARNING):
+            assert reg.register(_PolicyEnfFGA, source="loader") is None
+            assert len(_warning_messages(caplog, denied_a)) == 1
+            assert reg.register(_PolicyEnfFGA, source="loader") is None
+            assert len(_warning_messages(caplog, denied_a)) == 1, "second denial of the same key must not warn again"
+            assert reg.register(_PolicyEnfFGB, source="loader") is None
+            assert len(_warning_messages(caplog, denied_b)) == 1, "a different denied key warns on its own"
+        assert not reg.is_registered(_PolicyEnfFGA)
+        assert not reg.is_registered(_PolicyEnfFGB)
+
+    def test_entry_point_denied_returns_none_and_warns(self, caplog: pytest.LogCaptureFixture) -> None:
+        reg = PluginRegistry()
+        denied = _key(_PolicyEnfFGC)
+        reg.set_policy(PluginPolicy(denied_keys=(denied,)))
+        with caplog.at_level(logging.WARNING):
+            assert reg.register(_PolicyEnfFGC, source=PluginSource.ENTRY_POINT) is None
+        assert len(_warning_messages(caplog, denied)) == 1
+        assert reg.get(denied) is None
+
+
+class TestApprovalMetadata:
+    def test_entry_owner_and_approval_defaults(self) -> None:
+        reg = PluginRegistry()
+        key = reg.register(_PolicyEnfFGA)
+        assert key is not None
+        entry = reg.get_entry(key)
+        assert entry.owner is None
+        assert entry.approval is ApprovalStatus.UNREVIEWED
+
+    def test_register_stores_owner_and_normalizes_approval(self) -> None:
+        reg = PluginRegistry()
+        key_a = reg.register(_PolicyEnfFGA, owner="alice", approval=ApprovalStatus.APPROVED)
+        assert key_a is not None
+        entry_a = reg.get_entry(key_a)
+        assert entry_a.owner == "alice"
+        assert entry_a.approval is ApprovalStatus.APPROVED
+        key_b = reg.register(_PolicyEnfFGB, approval="rejected")
+        assert key_b is not None
+        assert reg.get_entry(key_b).approval is ApprovalStatus.REJECTED
+
+    def test_register_invalid_approval_string_raises_listing_valid_values(self) -> None:
+        reg = PluginRegistry()
+        with pytest.raises(ValueError) as exc_info:
+            reg.register(_PolicyEnfFGA, approval="bogus_approval")
+        message = str(exc_info.value)
+        assert "bogus_approval" in message
+        for valid in ("unreviewed", "approved", "rejected"):
+            assert valid in message, f"the error must list the valid approval value '{valid}'"
+        assert not reg.is_registered(_PolicyEnfFGA)
+
+    def test_require_approval_policy_blocks_unapproved_and_admits_approved(self) -> None:
+        reg = PluginRegistry()
+        reg.set_policy(PluginPolicy(require_approval=True))
+        with pytest.raises(PluginPolicyViolationError):
+            reg.register(_PolicyEnfFGA)
+        assert not reg.is_registered(_PolicyEnfFGA)
+        key = reg.register(_PolicyEnfFGB, approval=ApprovalStatus.APPROVED)
+        assert key == _key(_PolicyEnfFGB)
+        assert reg.get_entry(_key(_PolicyEnfFGB)).approval is ApprovalStatus.APPROVED
+
+
+class TestSetApproval:
+    def test_set_approval_updates_approval_and_owner(self) -> None:
+        reg = PluginRegistry()
+        key = reg.register(_PolicyEnfFGA, owner="alice")
+        assert key is not None
+        reg.set_approval(key, ApprovalStatus.APPROVED, owner="bob")
+        entry = reg.get_entry(key)
+        assert entry.approval is ApprovalStatus.APPROVED
+        assert entry.owner == "bob"
+        assert entry.cls is _PolicyEnfFGA
+        assert entry.name == key
+
+    def test_set_approval_normalizes_string_and_keeps_owner_when_omitted(self) -> None:
+        reg = PluginRegistry()
+        key = reg.register(_PolicyEnfFGA, owner="alice")
+        assert key is not None
+        reg.set_approval(key, "rejected")
+        entry = reg.get_entry(key)
+        assert entry.approval is ApprovalStatus.REJECTED
+        assert entry.owner == "alice"
+
+    def test_set_approval_unknown_name_raises_value_error(self) -> None:
+        reg = PluginRegistry()
+        with pytest.raises(ValueError):
+            reg.set_approval("nope:Missing", ApprovalStatus.APPROVED)
+
+
+class TestModuleLevelRegisterPluginForwarding:
+    def test_register_plugin_forwards_owner_and_approval(self) -> None:
+        key = register_plugin(_PolicyEnfFGD, owner="carol", approval="approved")
+        assert key is not None
+        entry = PluginRegistry.default().get_entry(key)
+        assert entry.owner == "carol"
+        assert entry.approval is ApprovalStatus.APPROVED
+
+
+class TestRegisterModulePluginsSkipsDenied:
+    def test_register_module_plugins_excludes_denied(self, default_registry_policy_guard: PluginRegistry) -> None:
+        registry = default_registry_policy_guard
+        module = types.ModuleType("policy_gate_fake_mod")
+
+        class _ModAllowedFG(FeatureGroup):
+            @classmethod
+            def match_feature_group_criteria(
+                cls, feature_name: Any, options: Any, data_access_collection: Any = None
+            ) -> bool:
+                # Inert for other tests' feature resolution in this worker.
+                return False
+
+        class _ModDeniedFG(FeatureGroup):
+            @classmethod
+            def match_feature_group_criteria(
+                cls, feature_name: Any, options: Any, data_access_collection: Any = None
+            ) -> bool:
+                return False
+
+        _ModAllowedFG.__module__ = module.__name__
+        _ModDeniedFG.__module__ = module.__name__
+        setattr(module, "_ModAllowedFG", _ModAllowedFG)
+        setattr(module, "_ModDeniedFG", _ModDeniedFG)
+        allowed_key = f"{module.__name__}:{_ModAllowedFG.__qualname__}"
+        denied_key = f"{module.__name__}:{_ModDeniedFG.__qualname__}"
+        try:
+            registry.set_policy(PluginPolicy(denied_keys=(denied_key,)))
+            keys = register_module_plugins(module)
+            assert all(isinstance(key, str) for key in keys), "denied classes must not surface as None results"
+            assert allowed_key in keys
+            assert denied_key not in keys
+            assert registry.is_registered(_ModAllowedFG)
+            assert not registry.is_registered(_ModDeniedFG)
+        finally:
+            # Drop every strong ref to the fake-module doubles so they cannot poison
+            # other tests in this worker via FeatureGroup.__subclasses__(); the autouse
+            # conftest fixture restores the registry snapshot after the test.
+            registry.clear()
+            delattr(module, "_ModAllowedFG")
+            delattr(module, "_ModDeniedFG")
+            del _ModAllowedFG, _ModDeniedFG, module
+            gc.collect()
+
+
+_POLICY_EP_MANIFEST = """
+    from mloda.core.abstract_plugins.feature_group import FeatureGroup
+
+
+    class AllowedEpPolicyFeatureGroup(FeatureGroup):
+        pass
+
+
+    class DeniedEpPolicyFeatureGroup(FeatureGroup):
+        pass
+
+
+    FEATURE_GROUPS = [AllowedEpPolicyFeatureGroup, DeniedEpPolicyFeatureGroup]
+"""
+
+
+def _build_distribution(base_dir: Path, pkg_name: str, manifest_source: str, entry_points_txt: str) -> None:
+    """Create a real on-disk distribution: importable package plus dist-info metadata."""
+    pkg_dir = base_dir / pkg_name
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text("")
+    (pkg_dir / "manifest.py").write_text(textwrap.dedent(manifest_source))
+    dist_info = base_dir / f"{pkg_name}-1.0.0.dist-info"
+    dist_info.mkdir()
+    metadata = f"Metadata-Version: 2.1\nName: {pkg_name.replace('_', '-')}\nVersion: 1.0.0\n"
+    (dist_info / "METADATA").write_text(metadata)
+    (dist_info / "entry_points.txt").write_text(textwrap.dedent(entry_points_txt))
+    importlib.invalidate_caches()
+
+
+class TestLoadEntryPointsSkipsDenied:
+    def test_load_entry_points_excludes_denied(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, default_registry_policy_guard: PluginRegistry
+    ) -> None:
+        pkg = "eptest_policy_denied_pkg"
+        _build_distribution(
+            tmp_path,
+            pkg,
+            _POLICY_EP_MANIFEST,
+            f"""
+            [mloda.feature_groups]
+            demo = {pkg}.manifest:FEATURE_GROUPS
+            """,
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+        allowed_key = f"{pkg}.manifest:AllowedEpPolicyFeatureGroup"
+        denied_key = f"{pkg}.manifest:DeniedEpPolicyFeatureGroup"
+        registry = default_registry_policy_guard
+        registry.set_policy(PluginPolicy(denied_keys=(denied_key,)))
+
+        keys = PluginLoader().load_entry_points()
+
+        assert allowed_key in keys
+        assert denied_key not in keys
+        assert all(isinstance(key, str) for key in keys), "denied classes must not surface as None results"
+        assert registry.get(denied_key) is None
+        assert registry.get_entry(allowed_key).source == PluginSource.ENTRY_POINT
+
+
+class TestDualImportAwareness:
+    def test_alias_module_path_gets_distinct_key_and_policy_allows_only_canonical(self) -> None:
+        """Two class objects for "the same" plugin under two module paths are two keys;
+        an allowed_module_prefixes policy covering only the canonical path splits them."""
+        canonical_module = _DualCanonicalFG.__module__
+        unrestricted = PluginRegistry()
+        governed = PluginRegistry()
+
+        class _DualAliasFG(FeatureGroup):
+            @classmethod
+            def match_feature_group_criteria(
+                cls, feature_name: Any, options: Any, data_access_collection: Any = None
+            ) -> bool:
+                # Inert for other tests' feature resolution in this worker.
+                return False
+
+        _DualAliasFG.__module__ = "dual_import_alias_pkg.shadowed_manifest"
+        try:
+            canonical_key = unrestricted.register(_DualCanonicalFG)
+            alias_key = unrestricted.register(_DualAliasFG)
+            assert canonical_key is not None
+            assert alias_key is not None
+            assert canonical_key != alias_key, "dual-imported class objects must get two distinct keys"
+
+            governed.set_policy(PluginPolicy(allowed_module_prefixes=(canonical_module,)))
+            assert governed.register(_DualCanonicalFG) == canonical_key
+            assert governed.register(_DualAliasFG, source="loader") is None
+            assert governed.is_registered(_DualCanonicalFG)
+            assert not governed.is_registered(_DualAliasFG)
+        finally:
+            unrestricted.clear()
+            governed.clear()
+            del _DualAliasFG
+            gc.collect()

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_pytest11_entry_point.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_pytest11_entry_point.py
@@ -1,0 +1,42 @@
+"""Tests that the plugin-registry fixtures module ships as a pytest11 entry point."""
+
+from __future__ import annotations
+
+import sys
+from importlib import metadata
+from pathlib import Path
+from typing import Any
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
+
+
+_PYPROJECT = Path(__file__).parents[4] / "pyproject.toml"
+_PLUGIN_MODULE = "mloda.core.abstract_plugins.plugin_registry.fixtures"
+
+
+def test_pyproject_declares_pytest11_entry_point() -> None:
+    """pyproject.toml declares a pytest11 entry point named mloda pointing at the fixtures module."""
+    with open(_PYPROJECT, "rb") as fh:
+        data: dict[str, Any] = tomllib.load(fh)
+    entry_points = data["project"].get("entry-points", {})
+    assert "pytest11" in entry_points, f"No pytest11 entry-point group in pyproject.toml. Got: {list(entry_points)}"
+    assert entry_points["pytest11"].get("mloda") == _PLUGIN_MODULE
+
+
+def test_installed_distribution_exposes_pytest11_entry_point() -> None:
+    """The installed mloda distribution exposes the pytest11 entry point in its metadata."""
+    eps = metadata.entry_points(group="pytest11", name="mloda")
+    assert eps, "Installed mloda distribution exposes no pytest11 entry point named mloda"
+    (ep,) = eps
+    assert ep.value == _PLUGIN_MODULE
+
+
+def test_fixtures_module_provides_pytest_fixture() -> None:
+    """The fixtures module defines isolated_plugin_registry as a pytest fixture."""
+    module = __import__(_PLUGIN_MODULE, fromlist=["isolated_plugin_registry"])
+    fixture = module.isolated_plugin_registry
+    is_fixture = hasattr(fixture, "_fixture_function_marker") or hasattr(fixture, "_pytestfixturefunction")
+    assert is_fixture, "isolated_plugin_registry is not wrapped by pytest.fixture"

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_registered_classes.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_registered_classes.py
@@ -1,0 +1,93 @@
+"""Tests for PluginRegistry.registered_classes().
+
+Contract: registered_classes() returns a fresh set[type[Any]] of all
+registered classes; empty registry yields an empty set, each class appears
+exactly once, and mutating the returned set never touches registry state.
+"""
+
+from typing import Any
+
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.abstract_plugins.function_extender import Extender
+from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistry
+
+
+class _RegisteredClassesFGA(FeatureGroup):
+    pass
+
+
+class _RegisteredClassesFGB(FeatureGroup):
+    pass
+
+
+class _RegisteredClassesFGC(FeatureGroup):
+    pass
+
+
+class _RegisteredClassesCF(ComputeFramework):
+    pass
+
+
+class _RegisteredClassesExtender(Extender):
+    pass
+
+
+class TestRegisteredClasses:
+    def test_empty_registry_returns_empty_set(self) -> None:
+        reg = PluginRegistry()
+        result = reg.registered_classes()
+        assert isinstance(result, set)
+        assert result == set()
+
+    def test_returns_exactly_the_registered_classes(self) -> None:
+        reg = PluginRegistry()
+        reg.register(_RegisteredClassesFGA)
+        reg.register(_RegisteredClassesFGB)
+        reg.register(_RegisteredClassesFGC)
+        assert reg.registered_classes() == {
+            _RegisteredClassesFGA,
+            _RegisteredClassesFGB,
+            _RegisteredClassesFGC,
+        }
+
+    def test_includes_all_plugin_base_types(self) -> None:
+        reg = PluginRegistry()
+        reg.register(_RegisteredClassesFGA)
+        reg.register(_RegisteredClassesCF)
+        reg.register(_RegisteredClassesExtender)
+        assert reg.registered_classes() == {
+            _RegisteredClassesFGA,
+            _RegisteredClassesCF,
+            _RegisteredClassesExtender,
+        }
+
+    def test_class_appears_exactly_once(self) -> None:
+        reg = PluginRegistry()
+        reg.register(_RegisteredClassesFGA)
+        reg.register(_RegisteredClassesFGA)
+        result = reg.registered_classes()
+        assert result == {_RegisteredClassesFGA}
+        assert len(result) == 1
+
+    def test_unregister_removes_class_from_result(self) -> None:
+        reg = PluginRegistry()
+        key = reg.register(_RegisteredClassesFGA)
+        reg.register(_RegisteredClassesFGB)
+        reg.unregister(key)
+        assert reg.registered_classes() == {_RegisteredClassesFGB}
+
+    def test_mutating_returned_set_does_not_affect_registry(self) -> None:
+        reg = PluginRegistry()
+        reg.register(_RegisteredClassesFGA)
+        first: set[type[Any]] = reg.registered_classes()
+        first.clear()
+        first.add(_RegisteredClassesFGB)
+        assert reg.registered_classes() == {_RegisteredClassesFGA}
+        assert reg.is_registered(_RegisteredClassesFGA) is True
+        assert reg.is_registered(_RegisteredClassesFGB) is False
+
+    def test_returns_a_fresh_set_each_call(self) -> None:
+        reg = PluginRegistry()
+        reg.register(_RegisteredClassesFGA)
+        assert reg.registered_classes() is not reg.registered_classes()

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_registry_fixture.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_registry_fixture.py
@@ -1,12 +1,23 @@
 """Tests for the isolated_plugin_registry pytest fixture (issue #526, work item 2).
 
 The fixture snapshots PluginRegistry.default(), yields it, and restores the
-snapshot on teardown so tests cannot leak registrations into each other.
+snapshot on teardown so tests cannot leak registrations into each other. It
+also restores governance state: a policy set during the test is reverted to
+the pre-test policy on teardown, and the per-instance policy-denial warning
+dedup state is reset so the same denied key can warn again afterwards.
 """
+
+import gc
+import logging
+import types
+from typing import Any
+
+import pytest
 
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.abstract_plugins.plugin_registry.fixtures import isolated_plugin_registry
-from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistry
+from mloda.core.abstract_plugins.plugin_registry.plugin_policy import PluginPolicy
+from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistry, register_module_plugins
 
 
 class _FixtureThrowawayFG(FeatureGroup):
@@ -47,3 +58,80 @@ def test_isolated_plugin_registry_smoke_usage(isolated_plugin_registry: PluginRe
     key = isolated_plugin_registry.register(_FixtureSmokeFG, name="_registry_fixture_smoke")
     assert isolated_plugin_registry.get(key) is _FixtureSmokeFG
     assert isolated_plugin_registry is PluginRegistry.default()
+
+
+def _denial_warnings(caplog: pytest.LogCaptureFixture, key: str) -> list[str]:
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno >= logging.WARNING and key in record.getMessage()
+    ]
+
+
+def test_isolated_plugin_registry_restores_pre_test_policy_on_teardown() -> None:
+    default = PluginRegistry.default()
+    original_policy = default.policy
+    snap = default.snapshot()
+    pre_test_policy = PluginPolicy(denied_keys=("_registry_fixture_pre_test_denied",))
+    try:
+        default.set_policy(pre_test_policy)
+        wrapped = getattr(isolated_plugin_registry, "__wrapped__")
+        gen = wrapped()
+        reg = next(gen)
+        in_test_policy = PluginPolicy(require_approval=True)
+        reg.set_policy(in_test_policy)
+        assert reg.policy is in_test_policy
+        next(gen, None)
+        assert PluginRegistry.default().policy is pre_test_policy
+    finally:
+        default.set_policy(original_policy)
+        default.restore(snap)
+
+
+def test_isolated_plugin_registry_resets_policy_denial_warn_dedup_on_teardown(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    default = PluginRegistry.default()
+    original_policy = default.policy
+    snap = default.snapshot()
+    module = types.ModuleType("registry_fixture_dedup_fake_mod")
+
+    class _FixtureDedupDeniedFG(FeatureGroup):
+        @classmethod
+        def match_feature_group_criteria(
+            cls, feature_name: Any, options: Any, data_access_collection: Any = None
+        ) -> bool:
+            # Inert for other tests' feature resolution in this worker.
+            return False
+
+    _FixtureDedupDeniedFG.__module__ = module.__name__
+    setattr(module, "_FixtureDedupDeniedFG", _FixtureDedupDeniedFG)
+    denied_key = f"{module.__name__}:{_FixtureDedupDeniedFG.__qualname__}"
+    denying_policy = PluginPolicy(denied_keys=(denied_key,))
+    wrapped = getattr(isolated_plugin_registry, "__wrapped__")
+    try:
+        gen = wrapped()
+        reg = next(gen)
+        reg.set_policy(denying_policy)
+        with caplog.at_level(logging.WARNING):
+            keys = register_module_plugins(module)
+        assert denied_key not in keys
+        assert len(_denial_warnings(caplog, denied_key)) == 1
+        next(gen, None)
+
+        gen_again = wrapped()
+        reg_again = next(gen_again)
+        reg_again.set_policy(denying_policy)
+        with caplog.at_level(logging.WARNING):
+            keys_again = register_module_plugins(module)
+        assert denied_key not in keys_again
+        assert len(_denial_warnings(caplog, denied_key)) == 2, (
+            "fixture teardown must reset the warn dedup so the same denied key warns again"
+        )
+        next(gen_again, None)
+    finally:
+        default.set_policy(original_policy)
+        default.restore(snap)
+        delattr(module, "_FixtureDedupDeniedFG")
+        del _FixtureDedupDeniedFG, module
+        gc.collect()

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_registry_injection.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_registry_injection.py
@@ -1,0 +1,109 @@
+"""Tests for registry instance injection via PluginCollector (issue #526, cycle 5).
+
+Contract: PluginCollector gains ``set_registry(registry)`` (chainable, like
+``set_strict_mode``) and a ``registry`` attribute defaulting to ``None``.
+``mloda.core.prepare.accessible_plugins`` gains ``registry_for(plugin_collector)``
+returning the collector's injected registry when set, else
+``PluginRegistry.default()``. PreFilterPlugins strict/warn checks consult the
+injected registry instead of hard-coding the default one.
+
+All tests are written to FAIL until the feature exists. Registry writes to the
+default registry are restored by the autouse conftest fixture; injected
+registries are fresh local instances, so the tests stay xdist parallel-safe.
+"""
+
+import logging
+
+import pytest
+
+from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistry, register_plugin
+from mloda.core.prepare.accessible_plugins import PreFilterPlugins
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
+
+
+class _InjectionInjectedOnlyFG(FeatureGroup):
+    """Local double registered ONLY in a fresh injected registry, never in the default one."""
+
+
+class _InjectionDefaultOnlyFG(FeatureGroup):
+    """Local double registered ONLY in the default registry."""
+
+
+def _cfws() -> set[type[ComputeFramework]]:
+    return {PythonDictFramework}
+
+
+def _qualid(cls: type) -> str:
+    return f"{cls.__module__}:{cls.__qualname__}"
+
+
+class TestSetRegistryApi:
+    def test_registry_attribute_defaults_to_none(self) -> None:
+        assert PluginCollector().registry is None
+
+    def test_set_registry_is_chainable_and_stores_the_instance(self) -> None:
+        fresh = PluginRegistry()
+        collector = PluginCollector()
+        assert collector.set_registry(fresh) is collector
+        assert collector.registry is fresh
+
+
+class TestRegistryFor:
+    def test_registry_for_returns_default_without_injection(self) -> None:
+        from mloda.core.prepare.accessible_plugins import registry_for
+
+        assert registry_for(None) is PluginRegistry.default()
+        assert registry_for(PluginCollector()) is PluginRegistry.default()
+
+    def test_registry_for_returns_injected_registry(self) -> None:
+        from mloda.core.prepare.accessible_plugins import registry_for
+
+        fresh = PluginRegistry()
+        collector = PluginCollector().set_registry(fresh)
+        assert registry_for(collector) is fresh
+
+
+class TestStrictModeConsultsInjectedRegistry:
+    def test_strict_keeps_injected_only_fg_and_drops_default_only_fg(self) -> None:
+        """The injected registry, not the hard-coded default, decides strict survival.
+
+        With the old hard-coding of PluginRegistry.default(), the outcome would be
+        exactly inverted: the default-only class would survive and the
+        injected-only class would be dropped.
+        """
+        fresh = PluginRegistry()
+        fresh.register(_InjectionInjectedOnlyFG)
+        register_plugin(_InjectionDefaultOnlyFG)
+
+        collector = PluginCollector().set_strict_mode("strict").set_registry(fresh)
+        accessible = PreFilterPlugins(_cfws(), collector).get_accessible_plugins()
+
+        assert _InjectionInjectedOnlyFG in accessible, (
+            "a FeatureGroup registered in the injected registry must survive strict filtering"
+        )
+        assert _InjectionDefaultOnlyFG not in accessible, (
+            "a FeatureGroup registered only in the default registry must be dropped when "
+            "a different registry is injected via the PluginCollector"
+        )
+
+    def test_warn_mode_consults_injected_registry(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Warn mode must not flag a class that IS registered in the injected registry."""
+        fresh = PluginRegistry()
+        fresh.register(_InjectionInjectedOnlyFG)
+
+        collector = PluginCollector().set_strict_mode("warn").set_registry(fresh)
+        with caplog.at_level(logging.WARNING):
+            PreFilterPlugins(_cfws(), collector)
+
+        message = " ".join(
+            rec.getMessage() for rec in caplog.records if rec.name == "mloda.core.prepare.accessible_plugins"
+        )
+        assert _qualid(_InjectionInjectedOnlyFG) not in message, (
+            "warn mode must consult the injected registry; a class registered there is not unregistered"
+        )
+        assert _qualid(_InjectionDefaultOnlyFG) in message, (
+            "sanity: a class registered nowhere relevant must still be flagged by warn mode"
+        )

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_strict_mode_compute_frameworks.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_strict_mode_compute_frameworks.py
@@ -1,0 +1,183 @@
+"""Tests for tri-state strict mode on ComputeFrameworks (issue #526, cycle 5).
+
+Contract: PreFilterPlugins._set_compute_frameworks mirrors the FeatureGroup
+tri-state. "off" keeps today's behavior (intersection with available
+subclasses). "strict" keeps only registered (or abstract) ComputeFramework
+classes, raising a ValueError that names ComputeFrameworks and how to
+register when every concrete framework from the pre-filter set is dropped.
+"warn" filters nothing but emits ONE aggregated WARNING per process per
+unregistered concrete framework, keyed module:qualname and deduplicated via
+the existing _warned_unregistered set (cleared per test by conftest).
+Registry lookups go through the injected registry (registry_for), not a
+hard-coded PluginRegistry.default().
+
+All tests are written to FAIL until the feature exists. Assertions are
+membership-only on this module's local doubles, so the tests stay xdist
+parallel-safe.
+"""
+
+import inspect
+import logging
+from abc import abstractmethod
+
+import pytest
+
+from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistry, register_plugin
+from mloda.core.prepare.accessible_plugins import PreFilterPlugins
+
+
+class _CfwStrictObserverFG(FeatureGroup):
+    """Local observer: compute_framework_rule is None, so its accessible mapping
+    value equals exactly the set of ComputeFrameworks that survived filtering."""
+
+
+class _CfwStrictRegistered(ComputeFramework):
+    """Local concrete framework that tests register explicitly."""
+
+
+class _CfwStrictUnregisteredA(ComputeFramework):
+    """Local concrete framework that is never registered."""
+
+
+class _CfwStrictUnregisteredB(ComputeFramework):
+    """Second never-registered concrete framework, for aggregation tests."""
+
+
+class _CfwStrictInjectedOnly(ComputeFramework):
+    """Local concrete framework registered ONLY in a fresh injected registry."""
+
+
+class _CfwStrictAbstractInfra(ComputeFramework):
+    """Abstract local framework; strict and warn must treat it as infrastructure."""
+
+    @abstractmethod
+    def _cfw_strict_abstract_infra_hook(self) -> None: ...
+
+
+def _qualid(cls: type) -> str:
+    return f"{cls.__module__}:{cls.__qualname__}"
+
+
+def _cfw_records(caplog: pytest.LogCaptureFixture, cls: type[ComputeFramework]) -> list[str]:
+    """Messages from the accessible_plugins logger that name the given framework."""
+    return [
+        rec.getMessage()
+        for rec in caplog.records
+        if rec.name == "mloda.core.prepare.accessible_plugins" and _qualid(cls) in rec.getMessage()
+    ]
+
+
+class TestCfwStrictModeOff:
+    def test_off_mode_keeps_unregistered_cfw_regardless_of_injected_registry(self) -> None:
+        """Off mode never filters by registration, even with an (empty) injected registry."""
+        collector = PluginCollector().set_strict_mode("off").set_registry(PluginRegistry())
+        accessible = PreFilterPlugins({_CfwStrictUnregisteredA}, collector).get_accessible_plugins()
+        assert _CfwStrictUnregisteredA in accessible[_CfwStrictObserverFG]
+
+
+class TestCfwStrictModeStrict:
+    def test_strict_keeps_registered_and_drops_unregistered_cfws(self) -> None:
+        register_plugin(_CfwStrictObserverFG)
+        register_plugin(_CfwStrictRegistered)
+        collector = PluginCollector().set_strict_mode("strict")
+
+        accessible = PreFilterPlugins({_CfwStrictRegistered, _CfwStrictUnregisteredA}, collector)
+        surviving = accessible.get_accessible_plugins()[_CfwStrictObserverFG]
+
+        assert _CfwStrictRegistered in surviving
+        assert _CfwStrictUnregisteredA not in surviving, (
+            "strict mode must drop concrete ComputeFrameworks that are not registered"
+        )
+
+    def test_strict_keeps_unregistered_abstract_cfws(self) -> None:
+        assert inspect.isabstract(_CfwStrictAbstractInfra), "sanity: the local double is abstract"
+
+        register_plugin(_CfwStrictObserverFG)
+        register_plugin(_CfwStrictRegistered)
+        collector = PluginCollector().set_strict_mode("strict")
+
+        cfws: set[type[ComputeFramework]] = {_CfwStrictRegistered, _CfwStrictAbstractInfra, _CfwStrictUnregisteredA}
+        surviving = PreFilterPlugins(cfws, collector).get_accessible_plugins()[_CfwStrictObserverFG]
+
+        assert _CfwStrictAbstractInfra in surviving, (
+            "abstract ComputeFrameworks are infrastructure and must survive strict mode unregistered"
+        )
+        assert _CfwStrictUnregisteredA not in surviving, (
+            "sanity: strict mode still drops concrete unregistered ComputeFrameworks"
+        )
+
+    def test_strict_dropping_all_concrete_cfws_raises_with_fix_hint(self) -> None:
+        register_plugin(_CfwStrictObserverFG)
+        collector = PluginCollector().set_strict_mode("strict")
+
+        with pytest.raises(ValueError) as exc_info:
+            PreFilterPlugins({_CfwStrictUnregisteredA, _CfwStrictUnregisteredB}, collector)
+
+        message = str(exc_info.value)
+        assert "ComputeFramework" in message, "the empty-result error must name ComputeFrameworks"
+        assert "register" in message, "the empty-result error must say how to fix it (registration)"
+
+    def test_strict_consults_injected_registry_for_cfws(self) -> None:
+        """Frameworks registered only in the injected registry survive; the default registry is ignored."""
+        fresh = PluginRegistry()
+        fresh.register(_CfwStrictObserverFG)
+        fresh.register(_CfwStrictInjectedOnly)
+        register_plugin(_CfwStrictRegistered)  # default registry only: must NOT count
+
+        collector = PluginCollector().set_strict_mode("strict").set_registry(fresh)
+        cfws: set[type[ComputeFramework]] = {_CfwStrictInjectedOnly, _CfwStrictRegistered}
+        surviving = PreFilterPlugins(cfws, collector).get_accessible_plugins()[_CfwStrictObserverFG]
+
+        assert _CfwStrictInjectedOnly in surviving
+        assert _CfwStrictRegistered not in surviving, (
+            "a ComputeFramework registered only in the default registry must be dropped "
+            "when a different registry is injected"
+        )
+
+
+class TestCfwStrictModeWarn:
+    def test_warn_keeps_unregistered_cfw_and_logs_qualified_name(self, caplog: pytest.LogCaptureFixture) -> None:
+        register_plugin(_CfwStrictRegistered)
+        collector = PluginCollector().set_strict_mode("warn")
+
+        cfws: set[type[ComputeFramework]] = {_CfwStrictRegistered, _CfwStrictAbstractInfra, _CfwStrictUnregisteredA}
+        with caplog.at_level(logging.WARNING):
+            surviving = PreFilterPlugins(cfws, collector).get_accessible_plugins()[_CfwStrictObserverFG]
+
+        assert _CfwStrictUnregisteredA in surviving, "warn mode must not filter ComputeFrameworks"
+        assert _cfw_records(caplog, _CfwStrictUnregisteredA), (
+            "warn mode must log a WARNING naming the unregistered framework as module:qualname"
+        )
+        assert not _cfw_records(caplog, _CfwStrictRegistered), "warn mode must not name registered ComputeFrameworks"
+        assert not _cfw_records(caplog, _CfwStrictAbstractInfra), (
+            "warn mode must not name abstract infrastructure ComputeFrameworks"
+        )
+
+    def test_warn_aggregates_per_construction_and_once_per_process(self, caplog: pytest.LogCaptureFixture) -> None:
+        """First construction emits ONE aggregated record naming both unregistered
+        frameworks; a second construction stays silent (per-process dedup via
+        _warned_unregistered, cleared between tests by conftest)."""
+        collector = PluginCollector().set_strict_mode("warn")
+        cfws: set[type[ComputeFramework]] = {_CfwStrictUnregisteredA, _CfwStrictUnregisteredB}
+
+        with caplog.at_level(logging.WARNING):
+            PreFilterPlugins(cfws, collector)
+            PreFilterPlugins(cfws, collector)
+
+        records = [
+            rec.getMessage()
+            for rec in caplog.records
+            if rec.name == "mloda.core.prepare.accessible_plugins"
+            and (
+                _qualid(_CfwStrictUnregisteredA) in rec.getMessage()
+                or _qualid(_CfwStrictUnregisteredB) in rec.getMessage()
+            )
+        ]
+        assert len(records) == 1, (
+            f"warn mode must emit one aggregated record per process for unregistered frameworks, got {len(records)}"
+        )
+        assert _qualid(_CfwStrictUnregisteredA) in records[0]
+        assert _qualid(_CfwStrictUnregisteredB) in records[0]

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_strict_mode_extenders.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_strict_mode_extenders.py
@@ -1,0 +1,204 @@
+"""Tests for tri-state strict mode on Extender instances (issue #526, cycle 5).
+
+Contract: mloda.core.prepare.accessible_plugins gains
+``filter_extenders_by_strict_mode(extenders, plugin_collector)``:
+
+- off (or ``extenders is None``): returned unchanged.
+- warn: returned unchanged; one aggregated WARNING per process per
+  unregistered extender CLASS (module:qualname keyed, reusing the existing
+  _warned_unregistered dedup set, cleared per test by conftest).
+- strict: instances whose class is not registered in the injected-or-default
+  registry are dropped with a WARNING listing the dropped classes; registered
+  instances survive; dropping every instance yields an empty set, no raise.
+
+mlodaAPI wires the helper at the seam where ``self.plugin_collector`` and
+``function_extender`` meet: ``_enter_runner_context`` must hand the runner the
+FILTERED set under strict mode.
+
+The helper is imported inside each test so every test fails with a precise
+ImportError until the Green agent implements it; the integration test fails
+on the unfiltered set instead. All doubles are local, keeping xdist
+parallel-safety.
+"""
+
+import logging
+from typing import Any, Optional, cast
+
+import pytest
+
+from mloda.core.abstract_plugins.components.parallelization_modes import ParallelizationMode
+from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
+from mloda.core.abstract_plugins.function_extender import Extender, ExtenderHook
+from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistry, register_plugin
+from mloda.core.api.request import mlodaAPI
+from mloda.core.runtime.run import ExecutionOrchestrator
+
+
+class _ExtStrictRegistered(Extender):
+    """Local double whose class tests register explicitly."""
+
+    def wraps(self) -> set[ExtenderHook]:
+        return {ExtenderHook.FEATURE_GROUP_CALCULATE_FEATURE}
+
+    def __call__(self, func: Any, *args: Any, **kwargs: Any) -> Any:
+        return func(*args, **kwargs)
+
+
+class _ExtStrictUnregisteredA(Extender):
+    """Local double whose class is never registered."""
+
+    def wraps(self) -> set[ExtenderHook]:
+        return {ExtenderHook.FEATURE_GROUP_CALCULATE_FEATURE}
+
+    def __call__(self, func: Any, *args: Any, **kwargs: Any) -> Any:
+        return func(*args, **kwargs)
+
+
+class _ExtStrictUnregisteredB(Extender):
+    """Second never-registered local double, for aggregation tests."""
+
+    def wraps(self) -> set[ExtenderHook]:
+        return {ExtenderHook.VALIDATE_INPUT_FEATURE}
+
+    def __call__(self, func: Any, *args: Any, **kwargs: Any) -> Any:
+        return func(*args, **kwargs)
+
+
+class _ExtStrictInjectedOnly(Extender):
+    """Local double registered ONLY in a fresh injected registry."""
+
+    def wraps(self) -> set[ExtenderHook]:
+        return {ExtenderHook.VALIDATE_OUTPUT_FEATURE}
+
+    def __call__(self, func: Any, *args: Any, **kwargs: Any) -> Any:
+        return func(*args, **kwargs)
+
+
+def _qualid(cls: type) -> str:
+    return f"{cls.__module__}:{cls.__qualname__}"
+
+
+def _messages_naming(caplog: pytest.LogCaptureFixture, cls: type) -> list[str]:
+    return [rec.getMessage() for rec in caplog.records if _qualid(cls) in rec.getMessage()]
+
+
+class TestFilterExtendersOffAndNone:
+    def test_none_and_off_mode_pass_through_unchanged(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from mloda.core.prepare.accessible_plugins import filter_extenders_by_strict_mode
+
+        monkeypatch.delenv("MLODA_PLUGIN_REGISTRY_STRICT", raising=False)
+        collector = PluginCollector().set_strict_mode("strict")
+        assert filter_extenders_by_strict_mode(None, collector) is None
+
+        unregistered = _ExtStrictUnregisteredA()
+        extenders: set[Extender] = {unregistered}
+        off_collector = PluginCollector().set_strict_mode("off")
+        assert filter_extenders_by_strict_mode(extenders, off_collector) == extenders
+        # No collector: strict mode comes from the env (off when unset).
+        assert filter_extenders_by_strict_mode(extenders, None) == extenders
+
+
+class TestFilterExtendersWarn:
+    def test_warn_returns_unchanged_logs_once_per_process(self, caplog: pytest.LogCaptureFixture) -> None:
+        from mloda.core.prepare.accessible_plugins import filter_extenders_by_strict_mode
+
+        register_plugin(_ExtStrictRegistered)
+        registered = _ExtStrictRegistered()
+        unregistered = _ExtStrictUnregisteredA()
+        extenders: set[Extender] = {registered, unregistered}
+        collector = PluginCollector().set_strict_mode("warn")
+
+        with caplog.at_level(logging.WARNING):
+            first = filter_extenders_by_strict_mode(extenders, collector)
+            second = filter_extenders_by_strict_mode(extenders, collector)
+
+        assert first == extenders, "warn mode must not drop extender instances"
+        assert second == extenders
+        naming = _messages_naming(caplog, _ExtStrictUnregisteredA)
+        assert len(naming) == 1, (
+            f"warn mode must warn exactly once per process per unregistered extender class, got {len(naming)}"
+        )
+        assert "not registered" in naming[0]
+        assert not _messages_naming(caplog, _ExtStrictRegistered), "warn mode must not name registered extender classes"
+
+
+class TestFilterExtendersStrict:
+    def test_strict_drops_unregistered_keeps_registered_and_warns(self, caplog: pytest.LogCaptureFixture) -> None:
+        from mloda.core.prepare.accessible_plugins import filter_extenders_by_strict_mode
+
+        register_plugin(_ExtStrictRegistered)
+        registered = _ExtStrictRegistered()
+        unregistered = _ExtStrictUnregisteredA()
+        collector = PluginCollector().set_strict_mode("strict")
+
+        with caplog.at_level(logging.WARNING):
+            result = filter_extenders_by_strict_mode({registered, unregistered}, collector)
+
+        assert result == {registered}, "strict mode must keep registered and drop unregistered extender instances"
+        assert _messages_naming(caplog, _ExtStrictUnregisteredA), (
+            "strict mode must warn with the dropped classes as module:qualname"
+        )
+
+    def test_strict_dropping_all_yields_empty_set_without_raising(self) -> None:
+        from mloda.core.prepare.accessible_plugins import filter_extenders_by_strict_mode
+
+        extenders: set[Extender] = {_ExtStrictUnregisteredA(), _ExtStrictUnregisteredB()}
+        collector = PluginCollector().set_strict_mode("strict")
+        assert filter_extenders_by_strict_mode(extenders, collector) == set()
+
+    def test_strict_consults_injected_registry(self) -> None:
+        from mloda.core.prepare.accessible_plugins import filter_extenders_by_strict_mode
+
+        fresh = PluginRegistry()
+        fresh.register(_ExtStrictInjectedOnly)
+        register_plugin(_ExtStrictRegistered)  # default registry only: must NOT count
+
+        injected_only = _ExtStrictInjectedOnly()
+        default_only = _ExtStrictRegistered()
+        collector = PluginCollector().set_strict_mode("strict").set_registry(fresh)
+
+        result = filter_extenders_by_strict_mode({injected_only, default_only}, collector)
+        assert result == {injected_only}, (
+            "strict mode must consult the injected registry: only the class registered there survives"
+        )
+
+
+class _RecordingRunner:
+    """Stand-in for ExecutionOrchestrator that records what __enter__ receives."""
+
+    def __init__(self) -> None:
+        self.received_extenders: Optional[set[Extender]] = None
+
+    def __enter__(
+        self,
+        parallelization_modes: Optional[set[ParallelizationMode]] = None,
+        function_extender: Optional[set[Extender]] = None,
+        api_data: Optional[dict[str, Any]] = None,
+        artifacts: Optional[dict[str, Any]] = None,
+    ) -> None:
+        self.received_extenders = function_extender
+
+
+class TestRequestWiring:
+    def test_runner_receives_filtered_extenders_under_strict_mode(self) -> None:
+        """mlodaAPI._enter_runner_context is the seam where self.plugin_collector and
+        function_extender meet; under strict mode the runner must receive the
+        FILTERED set, not the raw one."""
+        register_plugin(_ExtStrictRegistered)
+        registered = _ExtStrictRegistered()
+        unregistered = _ExtStrictUnregisteredA()
+
+        api = mlodaAPI.__new__(mlodaAPI)
+        api.plugin_collector = PluginCollector().set_strict_mode("strict")
+
+        recorder = _RecordingRunner()
+        api._enter_runner_context(
+            cast(ExecutionOrchestrator, recorder),
+            {ParallelizationMode.SYNC},
+            {registered, unregistered},
+            None,
+        )
+
+        assert recorder.received_extenders == {registered}, (
+            "the runner must receive the strict-filtered extender set, not the raw one passed to the API"
+        )


### PR DESCRIPTION
Resolves #545 and #546. Follow-up to #526 / #531; unblocks mloda-ai/mloda-registry#271 once released.

## What

### Entry-point discovery (#545)

- `ENTRY_POINT_GROUPS`: `mloda.feature_groups`, `mloda.compute_frameworks`, `mloda.extenders`.
- `PluginLoader.load_entry_points(group=None)` discovers installed distributions via `importlib.metadata` and is folded into `PluginLoader.all()`. Discovery is lazy: nothing happens at `import mloda` time.
- Manifest-object convention (dbt style): one entry per package per group, whose value points at a module attribute holding a list or tuple of plugin classes. The entry-point name is a package label only; plugin identity stays with the registry key (`module:qualname`).
- Validation is loud: non-sequence manifests and wrong base types raise naming the entry point; key conflicts raise `PluginRegistryCollisionError` (never silent replace); abstract classes are skipped. Missing optional dependencies reuse the `OPTIONAL_PLUGIN_DEPENDENCIES` skip. Everything funnels through `register()` with `PluginSource.ENTRY_POINT` provenance, so strict mode and governance apply uniformly.
- `isolated_plugin_registry` ships as a `pytest11` entry point: downstream plugin packages get the fixture without conftest re-exports. The fixture now also restores the governance policy and warn-dedup state.

### Governance (#546)

- `PluginPolicy` (steward-exported, frozen dataclass): deployment-scoped allow/deny by key and module prefix plus `require_approval`, attached per registry instance via `set_policy()`, evaluated inside `register()` before any mutation. Denial raises `PluginPolicyViolationError` for every source; the loader and entry-point funnels catch it, skip the plugin, and warn once per key per registry instance. Prefix matching is module-boundary aware (`acme.plugins` does not admit `acme.plugins_evil`). The policy gates registration, not import.
- Approval metadata on entries: `owner` and `ApprovalStatus` (unreviewed, approved, rejected), settable at registration and via `set_approval()`. Benign re-registration (same class, same key) preserves steward-set metadata; replacing with a different class resets it.
- Provenance `source` constrained to the `PluginSource` enum (manual, loader, entry_point); unknown values raise.
- Strict mode now also covers ComputeFramework resolution (bundled `mloda_plugins` frameworks stay exempt as infrastructure) and function extenders handed to the runner, mirroring the FeatureGroup tri-state semantics.
- Registry instance injection: `PluginCollector().set_registry(...)`; the engine consults the injected registry instead of hard-coding `PluginRegistry.default()`, completing instance scoping for multi-tenant processes.
- `registered_classes()` accessor replaces the `snapshot()` dict copies on the engine and docs paths.

## Decisions

- CI stays in `warn` mode; ramp to `strict` is deferred until registry packages declare entry points end to end (mloda-ai/mloda-registry#271).
- `mloda.provider` still does not export `list_registered` (revisit on provider feedback); pinned by the persona-export contract test, which now also pins the steward-only governance exports.
- A malformed entry point fails discovery loudly by design (the silent-deactivation failure mode is the thing this avoids); documented.
- Registration stays single-threaded at import/startup per the existing registry contract.

## Verification

- Full `tox` green locally (pytest -n 8, ruff format and check, pip-licenses, mypy --strict, bandit).
- End to end in a clean venv: a synthetic wheel declaring `mloda.feature_groups` is discovered by `PluginLoader.all()` without any manual import (provenance `entry_point`, correct key); `load_entry_points()` alone finds it without the bundled scan; the pytest11 fixture arrives in a project with no conftest; a denying policy blocks the same wheel with one warning and no exception.
- Two independent deep reviews (Claude Opus and codex). Accepted and fixed: stable `str` return on `register()`/`register_plugin()` with raise-always denial semantics and funnel-side catch (also resolves 25 strict-mypy errors in typed callers), boundary-aware policy prefix matching, snapshot/restore coverage of governance state in the shipped fixture, metadata preservation across loader re-registration, deduplicated `load_entry_points()` keys, clearer manifest error wording, doc notes (policy gates registration not import, `allowed_module_prefixes=()` semantics, loud failure behavior). Rejected with rationale: continue-on-error discovery (loudness is the design), registry-wide locking (single-threaded registration contract unchanged), policy-after-idempotency reorder (registration-time enforcement is the documented semantic).
