### PR TITLE
docs: clarify mypy dev-loop scope, exclude build/, note agent session root

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,7 @@
 - **Orchestration Only**: Coordinate Test-Driven Development cycles between specialized agents
 - **No Code Implementation**: NEVER write implementation code or tests directly
 - **Agent Delegation**: Use Red Agent for test writing, Green Agent for implementation
+- **Session root**: `.claude/agents/red-agent.md` and `.claude/agents/green-agent.md` are only auto-loaded when Claude Code's session is rooted at this repository. If working from a parent or workspace directory, start a session inside the clone (`cd code/mloda && claude`) so the agents are available natively.
 
 ## TDD Workflow
 
@@ -79,6 +80,12 @@ source .venv/bin/activate
 - **Supply chain**: `[tool.uv] exclude-newer = "7 days"` in `pyproject.toml` defers new dependency releases by 7 days. Do not edit this without a reason.
 - **Licenses**: dependencies must satisfy the allowlist in `tox.ini` (Apache-2.0, BSD, MIT, MPL-2.0, PSF, ISC, LGPLv2+). Adding a dependency with a non-listed license fails tox.
 - **Commits**: use [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, `docs:`, `test:`, `refactor:`, `minor:`). semantic-release computes the next version. This project deviates from the standard: the minor version (middle number) bumps only on `minor:` commits; `feat:` is treated as a patch bump.
+
+### mypy iteration notes
+
+- `mypy --strict --ignore-missing-imports .` (what tox runs) checks `tests/` as well as `mloda/` and `mloda_plugins/`. Running `mypy mloda/` locally will miss test-tree type errors that block the tox gate. `tox` (or `tox -e python310`) is the only trustworthy mypy invocation.
+- A stray `pip build` creates a `build/` directory. mypy picks it up and reports spurious errors. Clean it with `rm -rf build/` before running tox. The `[tool.mypy]` exclude list in `pyproject.toml` now includes `build/` to prevent this.
+- Running `mypy --strict .` in the dev venv (outside tox) may surface pyspark-related errors that tox's isolated env does not see; ignore those when iterating inside tox.
 
 ## Issue Creation
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,8 +84,8 @@ source .venv/bin/activate
 ### mypy iteration notes
 
 - `mypy --strict --ignore-missing-imports .` (what tox runs) checks `tests/` as well as `mloda/` and `mloda_plugins/`. Running `mypy mloda/` locally will miss test-tree type errors that block the tox gate. `tox` (or `tox -e python310`) is the only trustworthy mypy invocation.
-- A stray `pip build` creates a `build/` directory. mypy picks it up and reports spurious errors. Clean it with `rm -rf build/` before running tox. The `[tool.mypy]` exclude list in `pyproject.toml` now includes `build/` to prevent this.
-- Running `mypy --strict .` in the dev venv (outside tox) may surface pyspark-related errors that tox's isolated env does not see; ignore those when iterating inside tox.
+- A stray local build (`python -m build` or `pip wheel .`) creates a `build/` directory. mypy picks it up and reports spurious errors. Clean it with `rm -rf build/` before running tox. The `[tool.mypy]` exclude list in `pyproject.toml` includes `build/` to prevent this at the gate.
+- Running `mypy --strict .` in the dev venv (outside tox) may surface pyspark-related errors that tox's isolated env does not see; trust the tox run as the source of truth.
 
 ## Issue Creation
 

--- a/attribution/ATTRIBUTION.md
+++ b/attribution/ATTRIBUTION.md
@@ -85,7 +85,7 @@
 | regex                                  | 2026.5.9        | Apache-2.0 AND CNRI-Python                         |
 | requests                               | 2.34.2          | Apache Software License                            |
 | rich                                   | 14.3.4          | MIT License                                        |
-| ruff                                   | 0.15.15         | MIT                                                |
+| ruff                                   | 0.15.16         | MIT                                                |
 | scikit-learn                           | 1.9.0           | BSD-3-Clause                                       |
 | scipy                                  | 1.17.1          | BSD License                                        |
 | six                                    | 1.17.0          | MIT License                                        |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,10 +134,12 @@ skips = [
 explicit_package_bases = true
 namespace_packages = true
 # marimo notebooks are unannotated reactive cells; validated by execution, not mypy.
+# build/ is excluded so a stray `pip build` artifact does not break the gate.
 exclude = [
     'docs/docs/examples/base_usage\.py$',
     'docs/docs/examples/sklearn_integration_basic\.py$',
     'docs/docs/examples/mloda_basics/\d.*\.py$',
+    '^build/',
 ]
 
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,7 @@ skips = [
 explicit_package_bases = true
 namespace_packages = true
 # marimo notebooks are unannotated reactive cells; validated by execution, not mypy.
-# build/ is excluded so a stray `pip build` artifact does not break the gate.
+# build/ is excluded so a stray local build artifact does not break the gate.
 exclude = [
     'docs/docs/examples/base_usage\.py$',
     'docs/docs/examples/sklearn_integration_basic\.py$',


### PR DESCRIPTION
## Summary

- `CLAUDE.md`: adds a `mypy iteration notes` subsection under Project Practices clarifying that `mypy --strict .` (what tox runs) covers `tests/` too; running `mypy mloda/` locally misses test-tree type errors. Documents that tox is the only trustworthy gate-parity invocation, and that a stray `pip build` artifact in `build/` will cause spurious errors.
- `CLAUDE.md`: adds a note that `.claude/agents/red-agent.md` and `.claude/agents/green-agent.md` are only auto-loaded when the Claude Code session is rooted inside this repo.
- `pyproject.toml`: adds `^build/` to `[tool.mypy]` exclude so a stray `pip build` artifact does not break the mypy gate.

## Test plan

- [x] `tox -e python310` passes (3695 passed, 165 skipped, mypy clean)
- [x] No code changes; doc and config only