### PR TITLE
Fix standalone documentation checks

### DIFF
--- a/docs/docs/in_depth/data-quality.md
+++ b/docs/docs/in_depth/data-quality.md
@@ -21,9 +21,20 @@ Example: Input Feature Validation Using Custom Validators
 ```python
 from typing import Any, Optional, Set
 from mloda.user import mloda
-from mloda.provider import FeatureGroup, FeatureSet
+from mloda.provider import BaseInputData, DataCreator, FeatureGroup, FeatureSet
 from mloda.user import Options, FeatureName, Feature
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+
+
+class BaseValidateInputFeaturesBase(FeatureGroup):
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({cls.get_class_name()})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {cls.get_class_name(): [1, 2]}
 
 
 class DocSimpleValidateInputFeatures(FeatureGroup):
@@ -46,10 +57,12 @@ class DocSimpleValidateInputFeatures(FeatureGroup):
 As we run it, it will return an error.
 
 ``` python
-results = mloda.run_all(
-            ["DocSimpleValidateInputFeatures"], {PyArrowTable}
-        )
-ValueError: Data should have 3 elements
+try:
+    results = mloda.run_all(
+                ["DocSimpleValidateInputFeatures"], {PyArrowTable}
+            )
+except ValueError as exc:
+    assert "Data should have 3 elements" in str(exc)
 ```
 
 ###### Loading a validator based on BaseValidator

--- a/docs/docs/in_depth/data-type-enforcement.md
+++ b/docs/docs/in_depth/data-type-enforcement.md
@@ -7,6 +7,7 @@ mloda supports optional data type declarations on Features, enabling runtime val
 Use typed constructors to declare the expected data type:
 
 ```python
+from typing import Any, Optional
 from mloda.user import Feature
 
 # Typed features - will be validated at runtime
@@ -120,7 +121,6 @@ The contract:
 A custom framework imports `DataType` from the public API:
 
 ```python
-from typing import Any, Optional
 from mloda.user import DataType
 from mloda.provider import ComputeFramework
 


### PR DESCRIPTION
## Summary
- Make `data-quality.md` self-contained by defining the base input feature used by the validation example.
- Assert the intended validation failure instead of letting the docs test abort on an uncaught exception.
- Move typing imports in `data-type-enforcement.md` before the first signature-only example so full Markdown execution passes.

## Tests
- `.venv/bin/python -m pytest "tests/test_documentation/test_documentation.py::test_files_good[docs/docs/in_depth/data-quality.md]"`
- `.venv/bin/python -m pytest tests/test_documentation/test_documentation.py::test_files_good -q`
- `.venv/bin/python -m pytest tests/test_documentation/test_documentation.py -q`
- `git diff --check`

Fixes #552
