### PR TITLE
fix: steward doc calls list all frameworks by default; case-insensitive compute_framework filter (#537)

### DIFF
--- a/docs/docs/in_depth/discover-plugins.md
+++ b/docs/docs/in_depth/discover-plugins.md
@@ -57,11 +57,11 @@ Get documentation for compute frameworks:
 ``` python
 from mloda.steward import get_compute_framework_docs
 
-# Get all available frameworks
+# List every framework (is_available flags whether each is importable)
 frameworks = get_compute_framework_docs()
 
-# Include unavailable frameworks
-all_frameworks = get_compute_framework_docs(available_only=False)
+# Filter to importable frameworks only
+available_frameworks = get_compute_framework_docs(available_only=True)
 ```
 
 ## Inspecting Extenders

--- a/docs/docs/in_depth/mloda-api.md
+++ b/docs/docs/in_depth/mloda-api.md
@@ -157,18 +157,18 @@ Get documentation for compute frameworks with optional filtering.
 ``` python
 from mloda.steward import get_compute_framework_docs
 
-# Get all available frameworks
+# List every framework (is_available flags whether each is importable)
 frameworks = get_compute_framework_docs()
 
-# Include unavailable frameworks
-all_frameworks = get_compute_framework_docs(available_only=False)
+# Only frameworks whose backing library is importable
+available_frameworks = get_compute_framework_docs(available_only=True)
 ```
 
 **Parameters:**
 
 - **name** (`str`, optional): Filter by name (case-insensitive partial match).
 - **search** (`str`, optional): Search in description (case-insensitive partial match).
-- **available_only** (`bool`, default `True`): Only return available frameworks.
+- **available_only** (`bool`, default `False`): By default all frameworks are listed (with `is_available` as the flag); set `available_only=True` to filter to importable frameworks only.
 
 **Returns:** `List[ComputeFrameworkInfo]` sorted by name.
 

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -149,7 +149,8 @@ def get_compute_framework_docs(
     Args:
         name: Filter by compute framework name (case-insensitive partial match).
         search: Search in compute framework description (case-insensitive partial match).
-        available_only: If True, only return importable frameworks; by default all frameworks are listed with is_available as the flag (default False).
+        available_only: If True, only return importable frameworks. By default (False) all frameworks
+            are listed, with is_available as the flag indicating importability.
         registered_only: If True, only document classes registered in the default registry.
 
     Returns:

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -75,7 +75,7 @@ def get_feature_group_docs(
     Args:
         name: Filter by feature group name (case-insensitive partial match).
         search: Search in feature group description (case-insensitive partial match).
-        compute_framework: Filter by compute framework name or class.
+        compute_framework: Filter by compute framework name or class (case-insensitive match).
         version_contains: Filter by version substring.
         plugin_collector: Filter using plugin collector's applicability check.
         registered_only: If True, only document classes registered in the default registry.
@@ -113,7 +113,7 @@ def get_feature_group_docs(
 
         if compute_framework is not None:
             cfw_name = compute_framework if isinstance(compute_framework, str) else compute_framework.__name__
-            if cfw_name not in compute_frameworks:
+            if cfw_name.lower() not in {c.lower() for c in compute_frameworks}:
                 continue
 
         if version_contains is not None and version_contains not in version:
@@ -137,7 +137,7 @@ def get_feature_group_docs(
 def get_compute_framework_docs(
     name: Optional[str] = None,
     search: Optional[str] = None,
-    available_only: bool = True,
+    available_only: bool = False,
     registered_only: bool = False,
 ) -> list[ComputeFrameworkInfo]:
     """
@@ -149,7 +149,7 @@ def get_compute_framework_docs(
     Args:
         name: Filter by compute framework name (case-insensitive partial match).
         search: Search in compute framework description (case-insensitive partial match).
-        available_only: If True, only return available frameworks (default True).
+        available_only: If True, only return importable frameworks; by default all frameworks are listed with is_available as the flag (default False).
         registered_only: If True, only document classes registered in the default registry.
 
     Returns:

--- a/tests/test_core/test_api/test_plugin_docs.py
+++ b/tests/test_core/test_api/test_plugin_docs.py
@@ -219,14 +219,16 @@ class TestGetFeatureGroupDocs:
                 break
         assert canonical_name is not None, "Need a feature group with at least one compute framework"
 
-        canonical_filtered = get_feature_group_docs(compute_framework=canonical_name)
-        assert len(canonical_filtered) >= 1, "Canonical-case filter should match at least one feature group"
+        # Derive the expected match count from the single unfiltered enumeration
+        # above, so we do not pay for an extra canonical-case enumeration here.
+        expected = sum(1 for fg in all_results if canonical_name.lower() in {c.lower() for c in fg.compute_frameworks})
+        assert expected >= 1, "Canonical framework should match at least one feature group"
 
         lower_filtered = get_feature_group_docs(compute_framework=canonical_name.lower())
         upper_filtered = get_feature_group_docs(compute_framework=canonical_name.upper())
 
-        assert len(lower_filtered) == len(canonical_filtered)
-        assert len(upper_filtered) == len(canonical_filtered)
+        assert len(lower_filtered) == expected
+        assert len(upper_filtered) == expected
 
 
 class TestGetComputeFrameworkDocs:
@@ -344,7 +346,7 @@ class TestGetComputeFrameworkDocs:
             assert len(filtered_lower) >= 1
 
     def test_get_compute_framework_docs_available_only_true_filters_correctly(self) -> None:
-        """Test that available_only=True (default) filters to only available frameworks."""
+        """Test that available_only=True filters to only available frameworks."""
         result = get_compute_framework_docs(available_only=True)
         # All results should have is_available=True
         for cfw_info in result:

--- a/tests/test_core/test_api/test_plugin_docs.py
+++ b/tests/test_core/test_api/test_plugin_docs.py
@@ -1,4 +1,5 @@
 import gc
+import inspect
 
 import pytest
 from mloda.core.api.plugin_info import (
@@ -201,6 +202,32 @@ class TestGetFeatureGroupDocs:
             assert len(filtered_lower) == len(filtered_upper)
             assert len(filtered_lower) >= 1
 
+    def test_get_feature_group_docs_compute_framework_filter_case_insensitive(self) -> None:
+        """Test that the compute_framework filter matches the framework name case-insensitively.
+
+        Issue #537 requirement 2: the compute_framework filter compares names
+        case-sensitively, so a casing mismatch wrongly returns an empty list.
+        """
+        all_results = get_feature_group_docs()
+        assert len(all_results) > 0, "Need at least one feature group for filtering"
+
+        # Pick a real framework name that at least one feature group supports.
+        canonical_name: str | None = None
+        for fg in all_results:
+            if len(fg.compute_frameworks) > 0:
+                canonical_name = fg.compute_frameworks[0]
+                break
+        assert canonical_name is not None, "Need a feature group with at least one compute framework"
+
+        canonical_filtered = get_feature_group_docs(compute_framework=canonical_name)
+        assert len(canonical_filtered) >= 1, "Canonical-case filter should match at least one feature group"
+
+        lower_filtered = get_feature_group_docs(compute_framework=canonical_name.lower())
+        upper_filtered = get_feature_group_docs(compute_framework=canonical_name.upper())
+
+        assert len(lower_filtered) == len(canonical_filtered)
+        assert len(upper_filtered) == len(canonical_filtered)
+
 
 class TestGetComputeFrameworkDocs:
     def test_get_compute_framework_docs_returns_list(self) -> None:
@@ -330,6 +357,26 @@ class TestGetComputeFrameworkDocs:
 
         # available_only=False should return same or more frameworks than available_only=True
         assert len(all_results) >= len(available_only_results)
+
+    def test_get_compute_framework_docs_available_only_default_lists_all(self) -> None:
+        """Test that the default call does not filter by availability.
+
+        Issue #537 requirement 1: the default should be available_only=False so a
+        bare doc call lists ALL frameworks (with is_available as a flag) rather
+        than silently dropping frameworks whose backing library is not importable.
+
+        The behavioral set-equality assertion below only diverges when some
+        framework is unavailable, which is not guaranteed in every environment
+        (e.g. an all-extras venv has every backing library installed). The
+        signature-default assertion encodes the requirement deterministically:
+        the default must be available_only=False.
+        """
+        default_value = inspect.signature(get_compute_framework_docs).parameters["available_only"].default
+        assert default_value is False, "Default of available_only should be False so a bare call lists all frameworks"
+
+        default_names = {cfw.name for cfw in get_compute_framework_docs()}
+        all_names = {cfw.name for cfw in get_compute_framework_docs(available_only=False)}
+        assert default_names == all_names
 
 
 class TestGetExtenderDocs:


### PR DESCRIPTION
## What

Two `plugin_docs` ergonomics fixes from issue #537, both in `mloda/core/api/plugin_docs.py`.

1. **`get_compute_framework_docs` now defaults `available_only=False`.** A bare introspection/catalog call previously dropped every framework whose backing library is not importable, so in a bare environment a steward consumer saw a silently-truncated list that looked correct. The call now lists every framework with `is_available` as the flag; pass `available_only=True` to opt into filtering to importable frameworks.

2. **`get_feature_group_docs(compute_framework=...)` now matches case-insensitively.** A casing mismatch previously returned an empty list, indistinguishable from "no groups support this framework".

Both changes let a steward consumer (e.g. mloda-portal) drop its two workarounds: passing `available_only=False`, and canonicalizing the framework-name case before filtering.

## Definition of done

- [x] Doc calls list unavailable frameworks by default (with `is_available` flagging availability)
- [x] Framework-name filtering is case-insensitive
- [x] Consumers can drop both workarounds

## Tests

- New `test_get_compute_framework_docs_available_only_default_lists_all` pins the default to `False` (deterministic, environment-independent: an all-extras venv has no unavailable frameworks, so a pure set-equality assertion alone would be a false green).
- New `test_get_feature_group_docs_compute_framework_filter_case_insensitive` asserts lower- and upper-cased framework names return the same matches as the canonical name.
- Docs (`mloda-api.md`, `discover-plugins.md`) updated so examples and the parameter reference reflect the new default.

## Compatibility note

Flipping the public `available_only` default is an intentional behavior change per the issue: existing callers relying on the old default will now also see unavailable frameworks (each flagged via `is_available`). No internal callers depend on the old default. Committed as `fix:` (patch under this repo's semantic-release).

`tox` is green (3845 passed, 167 skipped; ruff format/check, mypy --strict, pip-licenses, bandit all clean).
