### PR TITLE
feat: explicit allowed_values field and property_spec builder for PROPERTY_MAPPING

### DIFF
--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -45,7 +45,13 @@ widen an allowed set), declare it under `DefaultOptionKeys.allowed_values`:
 
 When `allowed_values` is present the parser uses it directly and ignores any
 other non-flag keys. `allowed_values` may be a mapping of value to one-line
-docstring, or a plain iterable of values.
+docstring, or a re-iterable collection of values (list, tuple, set). Do not
+pass a one-shot iterator (e.g. a generator) in a hand-written spec: the parser
+iterates the value space more than once, so an exhausted iterator would behave
+like an empty set. (`property_spec` materializes iterables for you.)
+
+`allowed_values` and `explanation` are reserved key names. A spec cannot use
+either as a literal accepted value; both are recovered as metadata, not values.
 
 ### Builder: `property_spec`
 

--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -24,6 +24,49 @@ PROPERTY_MAPPING = {
 }
 ```
 
+In this flattened form, the allowed values share one dict namespace with the
+metadata flag keys. The parser recovers the value space by subtracting the
+reserved metadata keys (`RESERVED_PROPERTY_KEYS`: `explanation`, `allowed_values`,
+`default`, `context`, `group`, `strict_validation`, `validation_function`,
+`required_when`, `type_validator`). The flattened form stays fully supported.
+
+## Recommended: explicit `allowed_values`
+
+To keep the value space separate from the flags (so a doc-only key can never
+widen an allowed set), declare it under `DefaultOptionKeys.allowed_values`:
+
+``` python
+"operation_type": {
+    DefaultOptionKeys.allowed_values: {"add": "Addition", "sub": "Subtraction"},
+    DefaultOptionKeys.context: True,
+    DefaultOptionKeys.strict_validation: True,
+}
+```
+
+When `allowed_values` is present the parser uses it directly and ignores any
+other non-flag keys. `allowed_values` may be a mapping of value to one-line
+docstring, or a plain iterable of values.
+
+### Builder: `property_spec`
+
+`property_spec` builds the same dict and validates its invariants at
+construction (strict needs a non-empty `allowed_values`; `allowed_values`
+without strict is rejected as a no-op; a strict `default` must be in the
+allowed set). The contract stays a plain dict, so this is optional sugar:
+
+``` python
+from mloda.provider import property_spec
+
+PROPERTY_MAPPING = {
+    "operation_type": property_spec(
+        "Arithmetic operation",
+        strict=True,
+        allowed_values={"add": "Addition", "sub": "Subtraction"},
+        default="add",
+    ),
+}
+```
+
 ## Parameter Classification
 
 ``` python

--- a/mloda/core/abstract_plugins/components/default_options_key.py
+++ b/mloda/core/abstract_plugins/components/default_options_key.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Any
 
 
 class DefaultOptionKeys(str, Enum):
@@ -24,6 +25,7 @@ class DefaultOptionKeys(str, Enum):
     feature_chainer_parser_key = "feature_chainer_parser_key"
     reference_time = "reference_time"
     time_travel = "time_travel"
+    allowed_values = "allowed_values"
     default = "default"
     context = "context"
     group = "group"
@@ -39,3 +41,21 @@ class DefaultOptionKeys(str, Enum):
 
     def __format__(self, format_spec: str) -> str:
         return self.value.__format__(format_spec)
+
+
+# Single source of truth for spec-internal metadata keys in a PROPERTY_MAPPING entry.
+# ``FeatureChainParser._extract_property_values`` subtracts this set to recover a spec's
+# legacy flattened value space, so a new doc-only key cannot silently widen an allowed set.
+RESERVED_PROPERTY_KEYS: frozenset[Any] = frozenset(
+    {
+        "explanation",
+        DefaultOptionKeys.allowed_values,
+        DefaultOptionKeys.default,
+        DefaultOptionKeys.context,
+        DefaultOptionKeys.group,
+        DefaultOptionKeys.strict_validation,
+        DefaultOptionKeys.validation_function,
+        DefaultOptionKeys.required_when,
+        DefaultOptionKeys.type_validator,
+    }
+)

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -10,7 +10,7 @@ from typing import Any, Optional
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
-from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys, RESERVED_PROPERTY_KEYS
 
 # Separator constants for feature name parsing
 CHAIN_SEPARATOR = "__"  # Separates chained transformations (source→suffix)
@@ -190,21 +190,16 @@ class FeatureChainParser:
 
     @classmethod
     def _extract_property_values(cls, property_value: Any) -> Any:
-        """Extract property values, removing metadata keys."""
+        """Extract a spec's declared value space.
+
+        Prefers an explicit ``DefaultOptionKeys.allowed_values`` field; otherwise
+        falls back to the legacy flattened form (all entries minus the reserved
+        metadata keys).
+        """
         if isinstance(property_value, dict):
-            # Remove metadata keys, keep only the actual valid values
-            metadata_keys = {
-                # Plain string metadata key used for human-readable documentation
-                "explanation",
-                DefaultOptionKeys.default,
-                DefaultOptionKeys.context,
-                DefaultOptionKeys.group,
-                DefaultOptionKeys.strict_validation,
-                DefaultOptionKeys.validation_function,
-                DefaultOptionKeys.required_when,
-                DefaultOptionKeys.type_validator,
-            }
-            return {k: v for k, v in property_value.items() if k not in metadata_keys}
+            if DefaultOptionKeys.allowed_values in property_value:
+                return property_value[DefaultOptionKeys.allowed_values]
+            return {k: v for k, v in property_value.items() if k not in RESERVED_PROPERTY_KEYS}
         return property_value
 
     @classmethod

--- a/mloda/core/abstract_plugins/components/feature_chainer/property_spec.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/property_spec.py
@@ -41,5 +41,6 @@ def property_spec(
         spec[DefaultOptionKeys.allowed_values] = allowed_values
     spec[DefaultOptionKeys.context] = context
     spec[DefaultOptionKeys.strict_validation] = strict
-    spec[DefaultOptionKeys.default] = default
+    if default is not None:
+        spec[DefaultOptionKeys.default] = default
     return spec

--- a/mloda/core/abstract_plugins/components/feature_chainer/property_spec.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/property_spec.py
@@ -1,0 +1,45 @@
+"""Authoring helper that builds a conventional PROPERTY_MAPPING spec dict.
+
+The contract stays a plain dict; this only changes authoring, validating the
+invariants up front instead of relying on hand-written spec dicts.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+
+
+def property_spec(
+    explanation: str,
+    *,
+    strict: bool = False,
+    allowed_values: Mapping[Any, str] | Iterable[Any] | None = None,
+    default: Any = None,
+    context: bool = True,
+) -> dict[str, Any]:
+    if allowed_values is not None and not isinstance(allowed_values, Mapping):
+        allowed_values = tuple(allowed_values)
+
+    if strict and not allowed_values:
+        raise ValueError(f"property_spec({explanation!r}): strict=True needs a non-empty allowed_values.")
+
+    if not strict and allowed_values is not None:
+        raise ValueError(f"property_spec({explanation!r}): allowed_values is never enforced without strict=True.")
+
+    if strict and default is not None and allowed_values is not None:
+        accepted = set(allowed_values.keys()) if isinstance(allowed_values, Mapping) else set(allowed_values)
+        if default not in accepted:
+            raise ValueError(
+                f"property_spec({explanation!r}): default {default!r} is not in the accepted set {accepted}."
+            )
+
+    spec: dict[str, Any] = {"explanation": explanation}
+    if allowed_values is not None:
+        spec[DefaultOptionKeys.allowed_values] = allowed_values
+    spec[DefaultOptionKeys.context] = context
+    spec[DefaultOptionKeys.strict_validation] = strict
+    spec[DefaultOptionKeys.default] = default
+    return spec

--- a/mloda/provider/__init__.py
+++ b/mloda/provider/__init__.py
@@ -67,6 +67,7 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
     INPUT_SEPARATOR,
 )
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
+from mloda.core.abstract_plugins.components.feature_chainer.property_spec import property_spec
 
 # Transformers
 from mloda.core.abstract_plugins.components.framework_transformer.base_transformer import BaseTransformer
@@ -122,6 +123,7 @@ __all__ = [
     "COLUMN_SEPARATOR",
     "INPUT_SEPARATOR",
     "FeatureChainParserMixin",
+    "property_spec",
     # Transformers
     "BaseTransformer",
     "ComputeFrameworkTransformer",

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_allowed_values.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_allowed_values.py
@@ -1,0 +1,237 @@
+"""Tests for the allowed_values-aware PROPERTY_MAPPING extractor/validator (issue #543).
+
+PROPERTY_MAPPING specs historically conflated allowed-value->docstring entries,
+``DefaultOptionKeys`` flag keys, and a magic plain-string ``"explanation"`` doc key
+in one namespace. ``FeatureChainParser._extract_property_values`` recovered the
+allowed-value set by subtracting a hardcoded blocklist. This module pins the
+additive, backward-compatible improvement:
+
+* a single ``RESERVED_PROPERTY_KEYS`` frozenset is the one source of truth for
+  spec-internal metadata keys,
+* a new ``DefaultOptionKeys.allowed_values`` member lets authors declare the
+  allowed-value mapping explicitly,
+* ``_extract_property_values`` honors ``allowed_values`` when present and falls
+  back to the legacy flattened form otherwise, so both membership validation and
+  the class-definition default invariant follow automatically.
+
+Reject semantics: ``match_configuration_feature_chain_parser`` raises ``ValueError``
+for a strict value outside the accepted set (verified against the existing parser),
+so rejection is asserted via ``pytest.raises(ValueError)``.
+"""
+
+from __future__ import annotations
+
+import gc
+from typing import Any
+
+import pytest
+
+from mloda.core.abstract_plugins.components.default_options_key import (
+    DefaultOptionKeys,
+    RESERVED_PROPERTY_KEYS,
+)
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import (
+    FeatureChainParser,
+)
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import (
+    FeatureChainParserMixin,
+)
+from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.components.utils import get_all_subclasses
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+
+
+@pytest.fixture(autouse=True)
+def _no_feature_group_registry_pollution() -> Any:
+    """Guarantee this module never leaks throwaway FeatureGroup subclasses.
+
+    Copied from ``test_property_mapping_default_invariant.py``: tests below define
+    FeatureGroup subclasses to exercise ``FeatureGroup.__init_subclass__``. Those
+    class objects sit in reference cycles, so we force a collection after each test
+    and assert that none of this module's classes remain registered.
+    """
+    yield
+    gc.collect()
+    gc.collect()
+    leaked = [c for c in get_all_subclasses(FeatureGroup) if c.__module__ == __name__]
+    assert not leaked, f"Leaked FeatureGroup subclasses from {__name__}: {[c.__name__ for c in leaked]}"
+
+
+class TestReservedPropertyKeys:
+    """``RESERVED_PROPERTY_KEYS`` is the single source of truth for metadata keys."""
+
+    def test_reserved_property_keys_importable_and_complete(self) -> None:
+        """The frozenset is importable and contains every spec-internal metadata key."""
+        assert isinstance(RESERVED_PROPERTY_KEYS, frozenset)
+        for member in (
+            DefaultOptionKeys.default,
+            DefaultOptionKeys.context,
+            DefaultOptionKeys.group,
+            DefaultOptionKeys.strict_validation,
+            DefaultOptionKeys.validation_function,
+            DefaultOptionKeys.required_when,
+            DefaultOptionKeys.type_validator,
+            DefaultOptionKeys.allowed_values,
+        ):
+            assert member in RESERVED_PROPERTY_KEYS
+        assert "explanation" in RESERVED_PROPERTY_KEYS
+
+    def test_allowed_values_enum_member_exists(self) -> None:
+        """``DefaultOptionKeys.allowed_values`` exists and stringifies to ``allowed_values``."""
+        assert str(DefaultOptionKeys.allowed_values) == "allowed_values"
+        assert DefaultOptionKeys.allowed_values.value == "allowed_values"
+
+
+class TestStrictMembershipViaAllowedValues:
+    """Strict membership flows through the explicit ``allowed_values`` field."""
+
+    def test_allowed_values_field_accepts_and_rejects(self) -> None:
+        """A spec using ``allowed_values`` accepts members and rejects non-members."""
+
+        class AllowedValuesFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+            PREFIX_PATTERN = r".*__([\w]+)_op$"
+            PROPERTY_MAPPING = {
+                "operation_type": {
+                    DefaultOptionKeys.allowed_values: {"add": "Addition", "sub": "Subtraction"},
+                    DefaultOptionKeys.context: True,
+                    DefaultOptionKeys.strict_validation: True,
+                }
+            }
+
+            @classmethod
+            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                return data
+
+        property_mapping = AllowedValuesFeatureGroup.PROPERTY_MAPPING
+
+        assert (
+            FeatureChainParser.match_configuration_feature_chain_parser(
+                "any_feature", Options(context={"operation_type": "add"}), property_mapping
+            )
+            is True
+        )
+        with pytest.raises(ValueError, match="mul"):
+            FeatureChainParser.match_configuration_feature_chain_parser(
+                "any_feature", Options(context={"operation_type": "mul"}), property_mapping
+            )
+
+    def test_legacy_flattened_form_still_validates(self) -> None:
+        """An equivalent legacy spec (top-level entries) gives the same accept/reject results."""
+
+        class LegacyFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+            PREFIX_PATTERN = r".*__([\w]+)_op$"
+            PROPERTY_MAPPING = {
+                "operation_type": {
+                    "add": "Addition",
+                    "sub": "Subtraction",
+                    DefaultOptionKeys.context: True,
+                    DefaultOptionKeys.strict_validation: True,
+                }
+            }
+
+            @classmethod
+            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                return data
+
+        property_mapping = LegacyFeatureGroup.PROPERTY_MAPPING
+
+        assert (
+            FeatureChainParser.match_configuration_feature_chain_parser(
+                "any_feature", Options(context={"operation_type": "add"}), property_mapping
+            )
+            is True
+        )
+        with pytest.raises(ValueError, match="mul"):
+            FeatureChainParser.match_configuration_feature_chain_parser(
+                "any_feature", Options(context={"operation_type": "mul"}), property_mapping
+            )
+
+
+class TestClassDefinitionDefaultInvariantHonorsAllowedValues:
+    """The class-definition default invariant reads accepted values from ``allowed_values``."""
+
+    def test_rejects_strict_default_outside_allowed_values(self) -> None:
+        """A strict default outside the ``allowed_values`` set rejects at class definition."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class BadAllowedValuesDefault(FeatureChainParserMixin, FeatureGroup):
+                PREFIX_PATTERN = r".*__([\w]+)_op$"
+                PROPERTY_MAPPING = {
+                    "operation_type": {
+                        DefaultOptionKeys.allowed_values: {"add": "Addition", "sub": "Subtraction"},
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: True,
+                        DefaultOptionKeys.default: "mul",
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "BadAllowedValuesDefault" in message
+        assert "operation_type" in message
+        assert "mul" in message
+        assert "add" in message
+        assert "sub" in message
+
+    def test_accepts_strict_default_in_allowed_values(self) -> None:
+        """A strict default inside the ``allowed_values`` set defines without error."""
+
+        class GoodAllowedValuesDefault(FeatureChainParserMixin, FeatureGroup):
+            PREFIX_PATTERN = r".*__([\w]+)_op$"
+            PROPERTY_MAPPING = {
+                "operation_type": {
+                    DefaultOptionKeys.allowed_values: {"add": "Addition", "sub": "Subtraction"},
+                    DefaultOptionKeys.context: True,
+                    DefaultOptionKeys.strict_validation: True,
+                    DefaultOptionKeys.default: "add",
+                }
+            }
+
+            @classmethod
+            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                return data
+
+        assert GoodAllowedValuesDefault.PROPERTY_MAPPING["operation_type"][DefaultOptionKeys.default] == "add"
+
+
+class TestNoSilentWidening:
+    """An extra top-level doc key is never promoted to an allowed value."""
+
+    def test_extra_doc_key_not_treated_as_allowed_value(self) -> None:
+        """When ``allowed_values`` is present, extraction returns exactly that mapping."""
+        spec = {
+            DefaultOptionKeys.allowed_values: {"add": "Addition"},
+            "explanation": "operation_type chooses the arithmetic operation",
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: True,
+        }
+
+        extracted = FeatureChainParser._extract_property_values(spec)
+        assert extracted == {"add": "Addition"}
+
+    def test_doc_key_name_rejected_by_strict_validation(self) -> None:
+        """The doc key name (``explanation``) is not a member, so strict validation rejects it."""
+        property_mapping = {
+            "operation_type": {
+                DefaultOptionKeys.allowed_values: {"add": "Addition"},
+                "explanation": "operation_type chooses the arithmetic operation",
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: True,
+            }
+        }
+
+        assert (
+            FeatureChainParser.match_configuration_feature_chain_parser(
+                "any_feature", Options(context={"operation_type": "add"}), property_mapping
+            )
+            is True
+        )
+        with pytest.raises(ValueError, match="explanation"):
+            FeatureChainParser.match_configuration_feature_chain_parser(
+                "any_feature", Options(context={"operation_type": "explanation"}), property_mapping
+            )

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_spec_builder.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_spec_builder.py
@@ -149,3 +149,63 @@ class TestPropertySpecRoundTrip:
             FeatureChainParser.match_configuration_feature_chain_parser(
                 "any_feature", Options(context={"operation_type": "mul"}), property_mapping
             )
+
+
+class TestPropertySpecDefaultOmission:
+    """A builder call with no default must NOT emit a spurious ``default`` key.
+
+    The parser's ``_can_skip_required_check`` treats the mere PRESENCE of the
+    ``default`` key as "this option is optional". Emitting ``default=None``
+    therefore silently makes an otherwise-required strict property optional.
+    The fix is for ``property_spec`` to emit the ``default`` key only when the
+    caller passes a non-``None`` default.
+    """
+
+    def test_builder_without_default_omits_default_key(self) -> None:
+        """No default argument -> the spec carries no ``default`` key at all."""
+        spec = property_spec("op", strict=True, allowed_values={"add": "Addition", "sub": "Subtraction"})
+
+        assert DefaultOptionKeys.default not in spec
+
+    def test_builder_without_default_makes_strict_property_required(self) -> None:
+        """A defaultless strict property is REQUIRED: absent option -> no match.
+
+        With the spurious ``default`` key the parser wrongly skips the required
+        check, so an absent option matches. After the fix the option is required,
+        so an absent option yields False while a present, valid option yields True.
+        """
+
+        class RequiredOpFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+            PREFIX_PATTERN = r".*__([\w]+)_op$"
+            PROPERTY_MAPPING = {
+                "operation_type": property_spec(
+                    "op",
+                    strict=True,
+                    allowed_values={"add": "Addition", "sub": "Subtraction"},
+                )
+            }
+
+            @classmethod
+            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                return data
+
+        property_mapping = RequiredOpFeatureGroup.PROPERTY_MAPPING
+
+        assert (
+            FeatureChainParser.match_configuration_feature_chain_parser(
+                "any_feature", Options(context={}), property_mapping
+            )
+            is False
+        )
+        assert (
+            FeatureChainParser.match_configuration_feature_chain_parser(
+                "any_feature", Options(context={"operation_type": "add"}), property_mapping
+            )
+            is True
+        )
+
+    def test_builder_with_explicit_default_keeps_default_key(self) -> None:
+        """An explicit, valid default is preserved (we did not over-correct)."""
+        spec = property_spec("op", strict=True, allowed_values={"add": "Addition"}, default="add")
+
+        assert spec[DefaultOptionKeys.default] == "add"

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_spec_builder.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_spec_builder.py
@@ -1,0 +1,151 @@
+"""Tests for the ``property_spec`` authoring helper (issue #543).
+
+``property_spec`` builds a conventional PROPERTY_MAPPING entry from explicit
+arguments, validating the invariants that previously had to be enforced by hand:
+
+* ``strict=True`` requires a non-empty ``allowed_values`` (a strict enum with no
+  value space rejects everything),
+* ``allowed_values`` without ``strict`` is a silent no-op and is rejected,
+* a strict, non-``None`` ``default`` must be within the allowed set,
+* a one-shot iterable for ``allowed_values`` is materialized so it survives reuse.
+"""
+
+from __future__ import annotations
+
+import gc
+from typing import Any
+
+import pytest
+
+from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import (
+    FeatureChainParser,
+)
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import (
+    FeatureChainParserMixin,
+)
+from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.components.utils import get_all_subclasses
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.provider import property_spec
+
+
+@pytest.fixture(autouse=True)
+def _no_feature_group_registry_pollution() -> Any:
+    """Guarantee this module never leaks throwaway FeatureGroup subclasses.
+
+    Copied from ``test_property_mapping_default_invariant.py``. The round-trip test
+    defines a FeatureGroup subclass; this fixture forces a collection afterwards
+    and asserts none of this module's classes linger in the registry.
+    """
+    yield
+    gc.collect()
+    gc.collect()
+    leaked = [c for c in get_all_subclasses(FeatureGroup) if c.__module__ == __name__]
+    assert not leaked, f"Leaked FeatureGroup subclasses from {__name__}: {[c.__name__ for c in leaked]}"
+
+
+class TestPropertySpecImport:
+    """The helper is exported from the public provider surface."""
+
+    def test_property_spec_importable_from_provider(self) -> None:
+        """``from mloda.provider import property_spec`` works."""
+        from mloda.provider import property_spec as imported
+
+        assert callable(imported)
+
+
+class TestPropertySpecEmission:
+    """A valid call emits a conventional spec dict."""
+
+    def test_emits_conventional_spec_dict(self) -> None:
+        """All conventional keys are present with the expected values."""
+        spec = property_spec("desc", strict=True, allowed_values={"add": "Addition"}, default="add")
+
+        assert spec["explanation"] == "desc"
+        assert spec[DefaultOptionKeys.allowed_values] == {"add": "Addition"}
+        assert spec[DefaultOptionKeys.strict_validation] is True
+        assert spec[DefaultOptionKeys.context] is True
+        assert spec[DefaultOptionKeys.default] == "add"
+
+
+class TestPropertySpecInvariants:
+    """Invalid combinations raise ``ValueError``."""
+
+    def test_strict_without_allowed_values_raises(self) -> None:
+        """``strict=True`` with no value space rejects everything, so it is illegal."""
+        with pytest.raises(ValueError):
+            property_spec("d", strict=True)
+
+    def test_allowed_values_without_strict_raises(self) -> None:
+        """``allowed_values`` is never enforced without ``strict`` (silent no-op), so it is rejected."""
+        with pytest.raises(ValueError):
+            property_spec("d", allowed_values={"a": "A"})
+
+    def test_strict_default_outside_allowed_set_raises(self) -> None:
+        """A strict, non-``None`` default must be within the allowed set."""
+        with pytest.raises(ValueError):
+            property_spec("d", strict=True, allowed_values={"add": "A"}, default="mul")
+
+    def test_strict_default_none_is_exempt(self) -> None:
+        """An omitted/``None`` default is always legal under strict validation."""
+        spec = property_spec("d", strict=True, allowed_values={"add": "A"})
+
+        assert spec[DefaultOptionKeys.allowed_values] == {"add": "A"}
+
+
+class TestPropertySpecIterableAllowedValues:
+    """``allowed_values`` may be a plain iterable, and one-shot iterables are materialized."""
+
+    def test_plain_iterable_accepted(self) -> None:
+        """A tuple of allowed values is accepted with strict validation."""
+        spec = property_spec("d", strict=True, allowed_values=("add", "sub"), default="add")
+
+        emitted = spec[DefaultOptionKeys.allowed_values]
+        assert set(emitted) == {"add", "sub"}
+
+    def test_one_shot_generator_is_materialized(self) -> None:
+        """A generator must be materialized so the emitted allowed_values is re-iterable."""
+        spec = property_spec("d", strict=True, allowed_values=(x for x in ("add", "sub")), default="add")
+
+        emitted = spec[DefaultOptionKeys.allowed_values]
+        first = list(emitted)
+        second = list(emitted)
+        assert first == second
+        assert set(first) == {"add", "sub"}
+
+
+class TestPropertySpecRoundTrip:
+    """A spec built by the helper drives membership validation end to end."""
+
+    def test_round_trip_through_property_mapping(self) -> None:
+        """The built entry defines without error and accepts/rejects via the parser."""
+
+        class RoundTripFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+            PREFIX_PATTERN = r".*__([\w]+)_op$"
+            PROPERTY_MAPPING = {
+                "operation_type": property_spec(
+                    "op",
+                    strict=True,
+                    allowed_values={"add": "Addition", "sub": "Subtraction"},
+                    default="add",
+                )
+            }
+
+            @classmethod
+            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                return data
+
+        property_mapping = RoundTripFeatureGroup.PROPERTY_MAPPING
+
+        assert (
+            FeatureChainParser.match_configuration_feature_chain_parser(
+                "any_feature", Options(context={"operation_type": "add"}), property_mapping
+            )
+            is True
+        )
+        with pytest.raises(ValueError, match="mul"):
+            FeatureChainParser.match_configuration_feature_chain_parser(
+                "any_feature", Options(context={"operation_type": "mul"}), property_mapping
+            )

--- a/tests/test_plugins/feature_group/experimental/test_property_mapping_consistency.py
+++ b/tests/test_plugins/feature_group/experimental/test_property_mapping_consistency.py
@@ -2,6 +2,7 @@ from typing import Any
 
 import pytest
 
+from mloda.core.abstract_plugins.components.default_options_key import RESERVED_PROPERTY_KEYS
 from mloda.provider import DefaultOptionKeys
 from mloda_plugins.feature_group.experimental.aggregated_feature_group.base import AggregatedFeatureGroup
 from mloda_plugins.feature_group.experimental.clustering.base import ClusteringFeatureGroup
@@ -31,17 +32,11 @@ ALL_PLUGINS: list[type[Any]] = [
     TimeWindowFeatureGroup,
 ]
 
-METADATA_KEYS: tuple[Any, ...] = (
-    DefaultOptionKeys.context,
-    DefaultOptionKeys.default,
-    DefaultOptionKeys.strict_validation,
-    DefaultOptionKeys.validation_function,
-    DefaultOptionKeys.required_when,
-    DefaultOptionKeys.type_validator,
-    DefaultOptionKeys.in_features,
-    DefaultOptionKeys.group,
-    "explanation",
-)
+# Derive from the single source of truth so this set can never drift again.
+# ``in_features`` is intentionally NOT in RESERVED_PROPERTY_KEYS (it is a property
+# NAME, not a spec-internal metadata flag), but the consistency tests still treat
+# it as metadata, so add it here.
+METADATA_KEYS: frozenset[Any] = RESERVED_PROPERTY_KEYS | {DefaultOptionKeys.in_features}
 
 DOK_VALUES: list[str] = [dok.value for dok in DefaultOptionKeys]
 


### PR DESCRIPTION
Part of #543 (the analysis ticket, kept open to track downstream follow-ups: mloda-ai/open-kgo#29 and mloda-ai/mloda-registry#275). This implements that ticket's recommendation: an additive, backward-compatible change.

## Problem

A `PROPERTY_MAPPING` spec dict conflates three things in one namespace: allowed-value to docstring entries, `DefaultOptionKeys` metadata flags, and a plain string `"explanation"` doc key. The parser recovered the value space by subtracting a hardcoded blocklist that literally contained `"explanation"`, so a future doc-only key could silently widen an allowed set. Downstream (open-kgo) reinvented a compensating builder and a divergent nested schema.

## Change (recommendation from the #543 analysis)

1. `DefaultOptionKeys.allowed_values` plus a single `RESERVED_PROPERTY_KEYS` frozenset: the one source of truth for spec-internal metadata keys.
2. `_extract_property_values` prefers an explicit `allowed_values` field; otherwise falls back to the legacy flattened form minus `RESERVED_PROPERTY_KEYS` (the inline blocklist and its magic string are gone). Membership validation and the class-definition default invariant flow through this function, so both honor `allowed_values` automatically.
3. Optional `property_spec()` authoring helper (exported from `mloda.provider`) that validates its strict / allowed_values / default invariants at construction and emits the conventional dict. The contract stays `dict[str, Any]`.
4. Docs updated; the consistency test now derives its metadata-key set from `RESERVED_PROPERTY_KEYS`.

The flattened form stays fully supported. No shipped plugin or doc requires migration. The explicit field also matches the schema open-kgo already adopted, so it can drop its private accessor.

## Notes

- `allowed_values` and `explanation` are reserved value names (documented). A hand-written `allowed_values` must be a re-iterable collection, not a one-shot generator; `property_spec` materializes for you.
- `property_spec` emits the `default` key only when a non-None default is given, so a builder-authored strict property with no default stays required (a presence-only `default` would otherwise make it skippable).

## Testing

`tox` is green: 3863 passed, 167 skipped, ruff format/check, license allowlist, `mypy --strict`, and bandit all pass. New tests cover allowed_values strict membership and defaults, legacy-form parity, no-silent-widening, the builder invariants and round trip, and the required-property regression. The change was gated by two independent deep reviews before merge.
