### PR TITLE
fix: make data-quality doc input-validation self-contained (#552)

### DIFF
--- a/docs/docs/in_depth/data-quality.md
+++ b/docs/docs/in_depth/data-quality.md
@@ -21,9 +21,19 @@ Example: Input Feature Validation Using Custom Validators
 ```python
 from typing import Any, Optional, Set
 from mloda.user import mloda
-from mloda.provider import FeatureGroup, FeatureSet
+from mloda.provider import BaseInputData, DataCreator, FeatureGroup, FeatureSet
 from mloda.user import Options, FeatureName, Feature
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+
+
+class DocBaseValidateInputFeaturesBase(FeatureGroup):
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({cls.get_class_name()})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {cls.get_class_name(): [1, 2, 3]}
 
 
 class DocSimpleValidateInputFeatures(FeatureGroup):
@@ -33,13 +43,13 @@ class DocSimpleValidateInputFeatures(FeatureGroup):
         return {cls.get_class_name(): [1, 2, 3]}
 
     def input_features(self, options: Options, feature_name: FeatureName) -> Optional[Set[Feature]]:
-        return {Feature(name="BaseValidateInputFeaturesBase", options=options)}
+        return {Feature(name="DocBaseValidateInputFeaturesBase", options=options)}
 
     @classmethod
     def validate_input_features(cls, data: Any, features: FeatureSet) -> None:
         """This function is a naive implementation of a validator."""
 
-        if len(data["BaseValidateInputFeaturesBase"]) != 3:
+        if len(data["DocBaseValidateInputFeaturesBase"]) != 3:
             raise ValueError("Data should have 3 elements")
 ```
 
@@ -68,7 +78,7 @@ class DocCustomValidateInputFeatures(DocSimpleValidateInputFeatures):
         """This function should be used to validate the input data."""
 
         validation_rules = {
-            "BaseValidateInputFeaturesBase": Column(int, Check.in_range(1, 2)),
+            "DocBaseValidateInputFeaturesBase": Column(int, Check.in_range(1, 2)),
         }
 
         # Loading from feature config


### PR DESCRIPTION
## Summary

Fixes #552. `tests/test_documentation/test_documentation.py::test_files_good[docs/docs/in_depth/data-quality.md]` failed when run standalone with:

```
ValueError: No feature groups found for feature name: 'BaseValidateInputFeaturesBase'.
```

### Root cause

The doc's input-validation section referenced a FeatureGroup named `BaseValidateInputFeaturesBase` by string. That class is defined only in a test module (`tests/test_plugins/integration_plugins/test_validate_features/test_validate_input_features.py`), so it is registered globally only when the full test suite is collected in the same process. Run in isolation, the plugin is absent and resolution fails. The snippet was also not runnable for a user copy-pasting it, for the same reason.

### Fix

The doc's output-validation section is already self-contained: it defines `DocBaseValidateOutputFeaturesBase` as a `DataCreator` root group. This mirrors that for the input section:

- Add a self-contained `DocBaseValidateInputFeaturesBase` root group (`DataCreator` + `calculate_feature -> [1, 2, 3]`) to the first code block, plus the `BaseInputData, DataCreator` imports it needs.
- Point the three references (`input_features`, `validate_input_features`, and the pandera `validation_rules` key) at the new name.

A distinct `Doc`-prefixed name is used deliberately so it does not collide with the test module's `BaseValidateInputFeaturesBase` during a full run (mloda raises "Multiple feature groups found" if two registered groups share a feature name). No `from tests.` import is introduced, so `test_no_test_imports_in_docs` stays green.

### Verification

- Standalone: `test_files_good[docs/docs/in_depth/data-quality.md]` passes.
- Full `test_documentation.py` module: 140 passed (no collision).
- Full `tox -e python314` gate: 4008 passed, ruff/mypy/bandit clean.