### PR TITLE
feat: per-feature FeatureGroup resolution scope (identity-safe alternative to #547)

### DIFF
--- a/attribution/ATTRIBUTION.md
+++ b/attribution/ATTRIBUTION.md
@@ -8,27 +8,27 @@
 | asttokens                              | 3.0.1           | Apache 2.0                                         |
 | bandit                                 | 1.9.4           | Apache-2.0                                         |
 | cachetools                             | 6.2.6           | MIT                                                |
-| certifi                                | 2026.5.20       | Mozilla Public License 2.0 (MPL 2.0)               |
+| certifi                                | 2026.6.17       | Mozilla Public License 2.0 (MPL 2.0)               |
 | charset-normalizer                     | 3.4.7           | MIT                                                |
-| click                                  | 8.4.1           | BSD-3-Clause                                       |
+| click                                  | 8.4.2           | BSD-3-Clause                                       |
 | comm                                   | 0.2.3           | BSD License                                        |
-| cyclonedx-python-lib                   | 11.8.0          | Apache Software License                            |
+| cyclonedx-python-lib                   | 11.11.0         | Apache Software License                            |
 | debugpy                                | 1.8.21          | MIT License                                        |
 | decorator                              | 5.3.1           | BSD-2-Clause                                       |
 | defusedxml                             | 0.7.1           | Python Software Foundation License                 |
-| duckdb                                 | 1.5.3           | MIT License                                        |
+| duckdb                                 | 1.5.4           | MIT License                                        |
 | execnet                                | 2.1.2           | MIT License                                        |
 | executing                              | 2.2.1           | MIT License                                        |
-| filelock                               | 3.29.1          | MIT License                                        |
-| fsspec                                 | 2026.4.0        | BSD-3-Clause                                       |
+| filelock                               | 3.29.4          | MIT License                                        |
+| fsspec                                 | 2026.6.0        | BSD-3-Clause                                       |
 | idna                                   | 3.18            | BSD-3-Clause                                       |
 | iniconfig                              | 2.3.0           | MIT                                                |
-| ipykernel                              | 7.2.0           | BSD-3-Clause                                       |
-| ipython                                | 9.14.0          | BSD-3-Clause                                       |
+| ipykernel                              | 7.3.0           | BSD-3-Clause                                       |
+| ipython                                | 9.14.1          | BSD-3-Clause                                       |
 | ipython_pygments_lexers                | 1.1.1           | BSD License                                        |
 | jedi                                   | 0.20.0          | MIT License                                        |
 | joblib                                 | 1.5.3           | BSD-3-Clause                                       |
-| jupyter_client                         | 8.8.0           | BSD License                                        |
+| jupyter_client                         | 8.9.1           | BSD License                                        |
 | jupyter_core                           | 5.9.1           | BSD-3-Clause                                       |
 | librt                                  | 0.11.0          | MIT                                                |
 | markdown-it-py                         | 4.2.0           | MIT License                                        |
@@ -37,34 +37,34 @@
 | mktestdocs                             | 0.2.5           | MIT                                                |
 | mloda                                  | 0.8.0           | Apache-2.0                                         |
 | mmh3                                   | 5.2.1           | MIT License                                        |
-| msgpack                                | 1.1.2           | Apache-2.0                                         |
+| msgpack                                | 1.2.1           | Apache-2.0                                         |
 | mypy                                   | 2.1.0           | MIT                                                |
 | mypy_extensions                        | 1.1.0           | MIT                                                |
-| narwhals                               | 2.22.0          | MIT                                                |
-| nest-asyncio                           | 1.6.0           | BSD License                                        |
+| narwhals                               | 2.22.1          | MIT                                                |
+| nest-asyncio2                          | 1.7.2           | BSD License                                        |
 | nltk                                   | 3.9.4           | Apache Software License                            |
-| numpy                                  | 2.4.6           | BSD-3-Clause AND 0BSD AND MIT AND Zlib AND CC0-1.0 |
-| opentelemetry-api                      | 1.42.1          | Apache-2.0                                         |
-| opentelemetry-instrumentation          | 0.63b1          | Apache Software License                            |
-| opentelemetry-instrumentation-logging  | 0.63b1          | Apache Software License                            |
-| opentelemetry-instrumentation-requests | 0.63b1          | Apache Software License                            |
-| opentelemetry-sdk                      | 1.42.1          | Apache-2.0                                         |
-| opentelemetry-semantic-conventions     | 0.63b1          | Apache-2.0                                         |
-| opentelemetry-util-http                | 0.63b1          | Apache Software License                            |
+| numpy                                  | 2.5.0           | BSD-3-Clause AND 0BSD AND MIT AND Zlib AND CC0-1.0 |
+| opentelemetry-api                      | 1.43.0          | Apache-2.0                                         |
+| opentelemetry-instrumentation          | 0.64b0          | Apache Software License                            |
+| opentelemetry-instrumentation-logging  | 0.64b0          | Apache Software License                            |
+| opentelemetry-instrumentation-requests | 0.64b0          | Apache Software License                            |
+| opentelemetry-sdk                      | 1.43.0          | Apache-2.0                                         |
+| opentelemetry-semantic-conventions     | 0.64b0          | Apache-2.0                                         |
+| opentelemetry-util-http                | 0.64b0          | Apache Software License                            |
 | packageurl-python                      | 0.17.6          | MIT License                                        |
 | packaging                              | 26.2            | Apache-2.0 OR BSD-2-Clause                         |
 | pandas                                 | 3.0.3           | BSD License                                        |
-| pandera                                | 0.31.1          | MIT License                                        |
+| pandera                                | 0.32.0          | MIT License                                        |
 | parso                                  | 0.8.7           | MIT License                                        |
 | pathspec                               | 1.1.1           | Mozilla Public License 2.0 (MPL 2.0)               |
 | pexpect                                | 4.9.0           | ISC License (ISCL)                                 |
 | pip-api                                | 0.0.34          | Apache Software License                            |
 | pip-requirements-parser                | 32.0.1          | MIT                                                |
-| pip_audit                              | 2.10.0          | Apache Software License                            |
+| pip_audit                              | 2.10.1          | Apache Software License                            |
 | platformdirs                           | 4.10.0          | MIT License                                        |
 | pluggy                                 | 1.6.0           | MIT License                                        |
-| polars                                 | 1.41.2          | MIT License                                        |
-| polars-runtime-32                      | 1.41.2          | MIT License                                        |
+| polars                                 | 1.42.0          | MIT License                                        |
+| polars-runtime-32                      | 1.42.0          | MIT License                                        |
 | prompt_toolkit                         | 3.0.52          | BSD License                                        |
 | psutil                                 | 7.2.2           | BSD-3-Clause                                       |
 | ptyprocess                             | 0.7.0           | ISC License (ISCL)                                 |
@@ -76,8 +76,8 @@
 | pyiceberg                              | 0.11.1          | Apache-2.0                                         |
 | pyparsing                              | 3.3.2           | MIT                                                |
 | pyroaring                              | 1.1.0           | MIT License                                        |
-| pytest                                 | 9.0.3           | MIT                                                |
-| pytest-order                           | 1.4.0           | MIT                                                |
+| pytest                                 | 9.1.1           | MIT                                                |
+| pytest-order                           | 1.5.0           | MIT                                                |
 | pytest-timeout                         | 2.4.0           | DFSG approved; MIT License                         |
 | pytest-xdist                           | 3.8.0           | MIT                                                |
 | python-dateutil                        | 2.9.0.post0     | Apache Software License; BSD License               |
@@ -85,9 +85,9 @@
 | regex                                  | 2026.5.9        | Apache-2.0 AND CNRI-Python                         |
 | requests                               | 2.34.2          | Apache Software License                            |
 | rich                                   | 14.3.4          | MIT License                                        |
-| ruff                                   | 0.15.16         | MIT                                                |
+| ruff                                   | 0.15.19         | MIT                                                |
 | scikit-learn                           | 1.9.0           | BSD-3-Clause                                       |
-| scipy                                  | 1.17.1          | BSD License                                        |
+| scipy                                  | 1.18.0          | BSD License                                        |
 | six                                    | 1.17.0          | MIT License                                        |
 | sortedcontainers                       | 2.4.0           | Apache Software License                            |
 | stack-data                             | 0.6.3           | MIT License                                        |
@@ -97,8 +97,8 @@
 | threadpoolctl                          | 3.6.0           | BSD License                                        |
 | tomli                                  | 2.4.1           | MIT                                                |
 | tomli_w                                | 1.2.0           | MIT License                                        |
-| tornado                                | 6.5.6           | Apache Software License                            |
-| tqdm                                   | 4.67.3          | MPL-2.0 AND MIT                                    |
+| tornado                                | 6.5.7           | Apache Software License                            |
+| tqdm                                   | 4.68.3          | MPL-2.0 AND MIT                                    |
 | traitlets                              | 5.15.1          | BSD License                                        |
 | typeguard                              | 4.5.2           | MIT                                                |
 | types-PyYAML                           | 6.0.12.20260518 | Apache-2.0                                         |
@@ -108,5 +108,5 @@
 | typing-inspection                      | 0.4.2           | MIT                                                |
 | typing_extensions                      | 4.15.0          | PSF-2.0                                            |
 | urllib3                                | 2.7.0           | MIT                                                |
-| wrapt                                  | 2.2.1           | BSD-2-Clause                                       |
+| wrapt                                  | 2.2.2           | BSD-2-Clause                                       |
 | zstandard                              | 0.25.0          | BSD-3-Clause                                       |

--- a/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
+++ b/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
@@ -48,6 +48,22 @@ def get_domain(cls):
     return "sales"  # Makes this FG only handle 'sales' domain features
 ```
 
+#### 4. Scope a feature to one source (shared keys across sources)
+When two enabled sources declare the same column (for example a shared join key), requesting that column by bare name is ambiguous. Scope the request to one source. The scope is resolution-only and does not affect feature identity.
+
+``` python
+# RECOMMENDED: class object, collision-proof
+Feature("subject_token", feature_group=ClaimsReader)
+
+# class-name string form
+Feature("subject_token", feature_group="ClaimsReader")
+```
+
+Caveats:
+
+- The string form matches the exact class name only: it does not match subclasses, and two classes with the same name in different modules stay ambiguous. The class-object form matches the class and its registered subclasses, preferring the most specific subclass, so prefer the class object.
+- The scope is resolution-only and excluded from Feature identity, so two requests for the same column name scoped to different sources compare equal. Requesting both in one features list raises `ValueError: Duplicate feature setup: <name>` rather than silently dropping one, so you are told, not surprised. Inside a single `input_features()` returning a set literal, a second same-name feature with a different scope is silently deduplicated by the Python set itself before the engine ever sees it, so never scope the same name twice within one feature group. To read the same column from two sources side by side, give them distinct derived feature names.
+
 ## FeatureGroup Redefinition Errors
 
 ### The Problem

--- a/mloda/core/abstract_plugins/components/feature.py
+++ b/mloda/core/abstract_plugins/components/feature.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import copy
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 from uuid import uuid4
 from mloda.core.abstract_plugins.components.data_types import DataType
+
+if TYPE_CHECKING:
+    from mloda.core.abstract_plugins.feature_group import FeatureGroup
 
 from mloda.core.abstract_plugins.components.domain import Domain
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
@@ -28,6 +31,7 @@ class Feature:
         initial_requested_data (bool): Whether the data was initially requested.
         link (Optional[Link]): The link associated with the feature.
         index (Optional[Index]): The index associated with the feature.
+        feature_group_scope (str | type[FeatureGroup] | None): Resolution-only scope; excluded from identity.
 
     Quick start (recommended progression)::
 
@@ -75,6 +79,7 @@ class Feature:
         initial_requested_data: bool = False,
         link: Optional[Link] = None,
         index: Optional[Index] = None,
+        feature_group: str | type[FeatureGroup] | None = None,
     ):
         if options is None:
             options = {}
@@ -107,65 +112,151 @@ class Feature:
         self.link = link
         self.index = index  # Index is a feature currently only used for append/union features.
 
-    @classmethod
-    def not_typed(cls, name: str | FeatureName, options: Optional[dict[str, Any]] = None) -> Feature:
-        if options is None:
-            options = {}
-        name = FeatureName(name) if isinstance(name, str) else name
-        return cls(name=name, options=options)
+        # feature_group_scope is resolution-only metadata, excluded from equality and hash like link/index.
+        self.feature_group_scope = self._set_feature_group_scope(feature_group)
+
+    def _set_feature_group_scope(
+        self, feature_group: str | type[FeatureGroup] | None
+    ) -> str | type[FeatureGroup] | None:
+        if feature_group is None:
+            return None
+        if isinstance(feature_group, str):
+            stripped = feature_group.strip()
+            return stripped or None
+        from mloda.core.abstract_plugins.feature_group import FeatureGroup
+
+        if feature_group is FeatureGroup:
+            raise TypeError("feature_group cannot be the root FeatureGroup base class; a concrete subclass is required")
+        if isinstance(feature_group, type) and issubclass(feature_group, FeatureGroup):
+            return feature_group
+        raise TypeError(
+            f"feature_group must be a FeatureGroup subclass, a class-name string, or None, "
+            f"got {type(feature_group).__name__}"
+        )
 
     @classmethod
-    def str_of(cls, name: str | FeatureName, options: Optional[dict[str, Any]] = None) -> Feature:
-        return cls._typed_of(name, DataType.STRING, options)
-
-    @classmethod
-    def int32_of(cls, name: str | FeatureName, options: Optional[dict[str, Any]] = None) -> Feature:
-        return cls._typed_of(name, DataType.INT32, options)
-
-    @classmethod
-    def int64_of(cls, name: str | FeatureName, options: Optional[dict[str, Any]] = None) -> "Feature":
-        return cls._typed_of(name, DataType.INT64, options)
-
-    @classmethod
-    def float_of(cls, name: str | FeatureName, options: Optional[dict[str, Any]] = None) -> "Feature":
-        return cls._typed_of(name, DataType.FLOAT, options)
-
-    @classmethod
-    def double_of(cls, name: str | FeatureName, options: Optional[dict[str, Any]] = None) -> "Feature":
-        return cls._typed_of(name, DataType.DOUBLE, options)
-
-    @classmethod
-    def boolean_of(cls, name: str | FeatureName, options: Optional[dict[str, Any]] = None) -> "Feature":
-        return cls._typed_of(name, DataType.BOOLEAN, options)
-
-    @classmethod
-    def binary_of(cls, name: str | FeatureName, options: Optional[dict[str, Any]] = None) -> "Feature":
-        return cls._typed_of(name, DataType.BINARY, options)
-
-    @classmethod
-    def date_of(cls, name: str | FeatureName, options: Optional[dict[str, Any]] = None) -> "Feature":
-        return cls._typed_of(name, DataType.DATE, options)
-
-    @classmethod
-    def timestamp_millis_of(cls, name: str | FeatureName, options: Optional[dict[str, Any]] = None) -> "Feature":
-        return cls._typed_of(name, DataType.TIMESTAMP_MILLIS, options)
-
-    @classmethod
-    def timestamp_micros_of(cls, name: str | FeatureName, options: Optional[dict[str, Any]] = None) -> "Feature":
-        return cls._typed_of(name, DataType.TIMESTAMP_MICROS, options)
-
-    @classmethod
-    def decimal_of(cls, name: str | FeatureName, options: Optional[dict[str, Any]] = None) -> "Feature":
-        return cls._typed_of(name, DataType.DECIMAL, options)
-
-    @classmethod
-    def _typed_of(
-        cls, name: str | FeatureName, data_type: DataType, options: Optional[dict[str, Any]] = None
+    def not_typed(
+        cls,
+        name: str | FeatureName,
+        options: Optional[dict[str, Any]] = None,
+        feature_group: str | type[FeatureGroup] | None = None,
     ) -> Feature:
         if options is None:
             options = {}
         name = FeatureName(name) if isinstance(name, str) else name
-        return cls(name=name, data_type=data_type, options=options)
+        return cls(name=name, options=options, feature_group=feature_group)
+
+    @classmethod
+    def str_of(
+        cls,
+        name: str | FeatureName,
+        options: Optional[dict[str, Any]] = None,
+        feature_group: str | type[FeatureGroup] | None = None,
+    ) -> Feature:
+        return cls._typed_of(name, DataType.STRING, options, feature_group)
+
+    @classmethod
+    def int32_of(
+        cls,
+        name: str | FeatureName,
+        options: Optional[dict[str, Any]] = None,
+        feature_group: str | type[FeatureGroup] | None = None,
+    ) -> Feature:
+        return cls._typed_of(name, DataType.INT32, options, feature_group)
+
+    @classmethod
+    def int64_of(
+        cls,
+        name: str | FeatureName,
+        options: Optional[dict[str, Any]] = None,
+        feature_group: str | type[FeatureGroup] | None = None,
+    ) -> "Feature":
+        return cls._typed_of(name, DataType.INT64, options, feature_group)
+
+    @classmethod
+    def float_of(
+        cls,
+        name: str | FeatureName,
+        options: Optional[dict[str, Any]] = None,
+        feature_group: str | type[FeatureGroup] | None = None,
+    ) -> "Feature":
+        return cls._typed_of(name, DataType.FLOAT, options, feature_group)
+
+    @classmethod
+    def double_of(
+        cls,
+        name: str | FeatureName,
+        options: Optional[dict[str, Any]] = None,
+        feature_group: str | type[FeatureGroup] | None = None,
+    ) -> "Feature":
+        return cls._typed_of(name, DataType.DOUBLE, options, feature_group)
+
+    @classmethod
+    def boolean_of(
+        cls,
+        name: str | FeatureName,
+        options: Optional[dict[str, Any]] = None,
+        feature_group: str | type[FeatureGroup] | None = None,
+    ) -> "Feature":
+        return cls._typed_of(name, DataType.BOOLEAN, options, feature_group)
+
+    @classmethod
+    def binary_of(
+        cls,
+        name: str | FeatureName,
+        options: Optional[dict[str, Any]] = None,
+        feature_group: str | type[FeatureGroup] | None = None,
+    ) -> "Feature":
+        return cls._typed_of(name, DataType.BINARY, options, feature_group)
+
+    @classmethod
+    def date_of(
+        cls,
+        name: str | FeatureName,
+        options: Optional[dict[str, Any]] = None,
+        feature_group: str | type[FeatureGroup] | None = None,
+    ) -> "Feature":
+        return cls._typed_of(name, DataType.DATE, options, feature_group)
+
+    @classmethod
+    def timestamp_millis_of(
+        cls,
+        name: str | FeatureName,
+        options: Optional[dict[str, Any]] = None,
+        feature_group: str | type[FeatureGroup] | None = None,
+    ) -> "Feature":
+        return cls._typed_of(name, DataType.TIMESTAMP_MILLIS, options, feature_group)
+
+    @classmethod
+    def timestamp_micros_of(
+        cls,
+        name: str | FeatureName,
+        options: Optional[dict[str, Any]] = None,
+        feature_group: str | type[FeatureGroup] | None = None,
+    ) -> "Feature":
+        return cls._typed_of(name, DataType.TIMESTAMP_MICROS, options, feature_group)
+
+    @classmethod
+    def decimal_of(
+        cls,
+        name: str | FeatureName,
+        options: Optional[dict[str, Any]] = None,
+        feature_group: str | type[FeatureGroup] | None = None,
+    ) -> "Feature":
+        return cls._typed_of(name, DataType.DECIMAL, options, feature_group)
+
+    @classmethod
+    def _typed_of(
+        cls,
+        name: str | FeatureName,
+        data_type: DataType,
+        options: Optional[dict[str, Any]] = None,
+        feature_group: str | type[FeatureGroup] | None = None,
+    ) -> Feature:
+        if options is None:
+            options = {}
+        name = FeatureName(name) if isinstance(name, str) else name
+        return cls(name=name, data_type=data_type, options=options, feature_group=feature_group)
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, Feature):

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -40,6 +40,15 @@ def split_frameworks_by_capability(
     return supported, rejected
 
 
+def _scope_callout(feature: Feature) -> str | None:
+    """Render the shared scope callout, or None when the feature is unscoped."""
+    scope = feature.feature_group_scope
+    if scope is None:
+        return None
+    scope_name = scope.get_class_name() if isinstance(scope, type) else scope
+    return f"Scoped to feature group: '{scope_name}'."
+
+
 class IdentifyFeatureGroupClass:
     def __init__(
         self,
@@ -69,6 +78,9 @@ class IdentifyFeatureGroupClass:
                 continue
 
             if not self._filter_feature_group_by_domain(feature_group, feature):
+                continue
+
+            if not self._filter_feature_group_by_scope(feature_group, feature):
                 continue
 
             self._criteria_matched_feature_groups.add(feature_group)
@@ -121,6 +133,14 @@ class IdentifyFeatureGroupClass:
     def _filter_feature_group_by_domain(self, feature_group: type[FeatureGroup], feature: Feature) -> bool:
         return not feature.domain or feature_group.get_domain() == feature.domain
 
+    def _filter_feature_group_by_scope(self, feature_group: type[FeatureGroup], feature: Feature) -> bool:
+        scope = feature.feature_group_scope
+        if scope is None:
+            return True
+        if isinstance(scope, type):
+            return issubclass(feature_group, scope)
+        return feature_group.get_class_name() == scope
+
     def _filter_feature_group_by_framework(
         self,
         compute_frameworks: set[type[ComputeFramework]],
@@ -145,9 +165,13 @@ class IdentifyFeatureGroupClass:
         if len(feature_group) > 1:
             from mloda.core.abstract_plugins.feature_group import format_feature_group_classes
 
+            scope_callout = _scope_callout(feature)
+            scope_line = f"{scope_callout}\n" if scope_callout else ""
+
             raise ValueError(
                 f"Multiple feature groups found for feature '{feature.name}':\n"
                 f"{format_feature_group_classes(feature_group.keys(), include_domain=True)}\n"
+                f"{scope_line}"
                 "For troubleshooting guide, see: https://mloda-ai.github.io/mloda/in_depth/troubleshooting/feature-group-resolution-errors/"
             )
 
@@ -178,12 +202,19 @@ class IdentifyFeatureGroupClass:
     def _build_no_feature_group_error(
         self, feature: Feature, accessible_plugins: FeatureGroupEnvironmentMapping
     ) -> str:
+        scope_callout = _scope_callout(feature)
+
         capability_message = self._capability_rejection_message(feature)
         if capability_message is not None:
+            if scope_callout:
+                return f"{capability_message} {scope_callout}"
             return capability_message
 
         feature_name = str(feature.name)
         msg = f"No feature groups found for feature name: '{feature_name}'."
+
+        if scope_callout:
+            msg += f" {scope_callout}"
 
         if not accessible_plugins:
             msg += "\nNo plugins are loaded. Did you call PluginLoader.all()?"

--- a/tests/test_core/test_abstract_plugins/test_components/test_feature_group_scope.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_feature_group_scope.py
@@ -1,0 +1,317 @@
+"""Tests for the per-feature FeatureGroup resolution scope (issue #508).
+
+These tests specify a new OPTIONAL, RESOLUTION-ONLY scope on ``Feature``:
+
+    Feature("subject_token", feature_group=SomeFeatureGroup)
+    Feature("subject_token", feature_group="SomeFeatureGroup")
+
+The scope is stored on ``feature.feature_group_scope`` and is EXCLUDED from
+identity (``__eq__``/``__hash__``/``similarity_hash``), exactly like
+``Feature.link`` and ``Feature.index`` already are. It only influences which
+feature group a feature resolves to, never how features are grouped/batched.
+
+The resolution behaviour itself is covered in
+tests/test_core/test_prepare/test_feature_group_scope_resolution.py.
+"""
+
+import copy
+
+import pytest
+
+from mloda.provider import FeatureGroup
+from mloda.user import Feature
+from mloda.user import Features
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+
+
+class _ScopeDummyFeatureGroup(FeatureGroup):
+    """Concrete FeatureGroup used only as a scope target in these tests."""
+
+
+class _OtherScopeDummyFeatureGroup(FeatureGroup):
+    """A second concrete FeatureGroup, distinct from the first."""
+
+
+class _NotAFeatureGroup:
+    """A non-FeatureGroup class that nonetheless exposes get_class_name().
+
+    ComputeFramework and several other mloda base classes also expose a
+    ``get_class_name`` classmethod, so a mere ``hasattr(x, "get_class_name")``
+    guard is not sufficient to prove ``x`` is a FeatureGroup subclass.
+    """
+
+    @classmethod
+    def get_class_name(cls) -> str:
+        return "X"
+
+
+# ---------------------------------------------------------------------------
+# Constructor contract
+# ---------------------------------------------------------------------------
+
+
+def test_scope_defaults_to_none() -> None:
+    """Without the new keyword, feature_group_scope is None."""
+    feature = Feature("subject_token")
+    assert feature.feature_group_scope is None
+
+
+def test_scope_stores_string() -> None:
+    """A string scope is stored verbatim on feature_group_scope."""
+    feature = Feature("subject_token", feature_group="SomeSource")
+    assert feature.feature_group_scope == "SomeSource"
+
+
+def test_scope_stores_class_object_as_is() -> None:
+    """A FeatureGroup class scope is stored AS-IS (not converted to a string)."""
+    feature = Feature("subject_token", feature_group=_ScopeDummyFeatureGroup)
+    assert feature.feature_group_scope is _ScopeDummyFeatureGroup
+
+
+def test_scope_none_is_none() -> None:
+    """Passing None explicitly keeps feature_group_scope as None."""
+    feature = Feature("subject_token", feature_group=None)
+    assert feature.feature_group_scope is None
+
+
+def test_scope_empty_string_is_none() -> None:
+    """An empty string scope normalises to None."""
+    feature = Feature("subject_token", feature_group="")
+    assert feature.feature_group_scope is None
+
+
+def test_scope_invalid_int_raises_typeerror() -> None:
+    """An int scope raises TypeError mentioning feature_group (not a kwarg error)."""
+    with pytest.raises(TypeError) as exc_info:
+        Feature("subject_token", feature_group=123)  # type: ignore[arg-type]
+    message = str(exc_info.value)
+    assert "feature_group" in message
+    # Guard against a false pass while the kwarg does not yet exist: the current
+    # "unexpected keyword argument 'feature_group'" TypeError must NOT satisfy this.
+    assert "unexpected keyword" not in message
+
+
+def test_scope_invalid_object_raises_typeerror() -> None:
+    """An arbitrary object instance scope raises TypeError mentioning feature_group."""
+    with pytest.raises(TypeError) as exc_info:
+        Feature("subject_token", feature_group=object())  # type: ignore[arg-type]
+    message = str(exc_info.value)
+    assert "feature_group" in message
+    assert "unexpected keyword" not in message
+
+
+def test_options_dict_does_not_set_scope() -> None:
+    """There is NO options fallback: options={'feature_group': ...} must not set the scope."""
+    feature = Feature("subject_token", options={"feature_group": "SomeSource"})
+    assert feature.feature_group_scope is None
+
+
+def test_constructor_scope_does_not_pollute_options() -> None:
+    """The constructor scope value must not leak into options.group or options.context."""
+    feature = Feature("subject_token", feature_group="SomeSource")
+    assert "feature_group" not in feature.options.group
+    assert "feature_group" not in feature.options.context
+
+
+# ---------------------------------------------------------------------------
+# Identity invariants: scope is excluded from equality / hash / similarity
+# ---------------------------------------------------------------------------
+
+
+def test_scoped_equals_unscoped() -> None:
+    """A scoped feature equals an otherwise-identical unscoped feature."""
+    scoped = Feature("subject_token", feature_group=_ScopeDummyFeatureGroup)
+    unscoped = Feature("subject_token")
+    assert scoped == unscoped
+
+
+def test_scoped_hash_equals_unscoped() -> None:
+    """A scoped feature hashes equal to an otherwise-identical unscoped feature."""
+    scoped = Feature("subject_token", feature_group=_ScopeDummyFeatureGroup)
+    unscoped = Feature("subject_token")
+    assert hash(scoped) == hash(unscoped)
+
+
+def test_different_scopes_are_equal() -> None:
+    """Two features scoped to different feature groups are still equal and hash equal."""
+    scoped_a = Feature("subject_token", feature_group=_ScopeDummyFeatureGroup)
+    scoped_b = Feature("subject_token", feature_group=_OtherScopeDummyFeatureGroup)
+    assert scoped_a == scoped_b
+    assert hash(scoped_a) == hash(scoped_b)
+
+
+def test_similarity_hash_identical_scoped_vs_unscoped() -> None:
+    """similarity_hash must be identical so read-batching is unaffected by scope."""
+    scoped = Feature("subject_token", feature_group=_ScopeDummyFeatureGroup)
+    unscoped = Feature("subject_token")
+    assert scoped.similarity_hash() == unscoped.similarity_hash()
+
+
+def test_scoped_and_unscoped_collapse_in_set() -> None:
+    """A scoped and an otherwise-identical unscoped feature collapse to ONE set element."""
+    collection = {
+        Feature("subject_token", feature_group=_ScopeDummyFeatureGroup),
+        Feature("subject_token"),
+    }
+    assert len(collection) == 1
+
+
+# ---------------------------------------------------------------------------
+# Constructor guard: only FeatureGroup subclasses (or names) are valid scopes
+# ---------------------------------------------------------------------------
+
+
+def test_scope_compute_framework_class_raises_typeerror() -> None:
+    """A ComputeFramework subclass must be rejected, not silently accepted.
+
+    ComputeFramework exposes get_class_name(), so a hasattr-based guard wrongly
+    treats it as a valid FeatureGroup scope. The scope must reject any class that
+    is not a FeatureGroup subclass, with a TypeError naming feature_group.
+    """
+    with pytest.raises(TypeError) as exc_info:
+        Feature("x", feature_group=PandasDataFrame)  # type: ignore[arg-type]
+    message = str(exc_info.value)
+    assert "feature_group" in message
+    assert "unexpected keyword" not in message
+
+
+def test_scope_non_feature_group_class_raises_typeerror() -> None:
+    """An unrelated class exposing get_class_name() must be rejected.
+
+    Guards against the hasattr(x, "get_class_name") shortcut: presence of that
+    method does not make a class a FeatureGroup subclass.
+    """
+    with pytest.raises(TypeError) as exc_info:
+        Feature("x", feature_group=_NotAFeatureGroup)  # type: ignore[arg-type]
+    message = str(exc_info.value)
+    assert "feature_group" in message
+    assert "unexpected keyword" not in message
+
+
+# ---------------------------------------------------------------------------
+# deepcopy characterization: class-object scope survives the engine copy path
+# ---------------------------------------------------------------------------
+
+
+def test_class_scope_survives_deepcopy() -> None:
+    """A class-object scope survives copy.deepcopy and preserves identity.
+
+    Characterization/guard test for the engine's deepcopy path: deepcopying a
+    Feature must keep the same FeatureGroup class object as the scope (classes
+    deepcopy to themselves) while equality/hash stay independent of the scope.
+    """
+    f = Feature("subject_token", feature_group=_ScopeDummyFeatureGroup)
+    g = copy.deepcopy(f)
+
+    assert g.feature_group_scope is f.feature_group_scope
+    assert g.feature_group_scope is _ScopeDummyFeatureGroup
+    assert g == f
+    assert hash(g) == hash(f)
+
+
+# ---------------------------------------------------------------------------
+# Duplicate guard: scope is excluded from identity, so same-name features with
+# different scopes collide inside a single Features request (issue #508).
+# ---------------------------------------------------------------------------
+
+
+def test_same_name_two_class_scopes_in_one_request_raise_duplicate() -> None:
+    """Two same-name features with different class scopes are equal, so Features rejects them.
+
+    The scope is excluded from identity, so both features compare equal and
+    check_duplicate_feature raises "Duplicate feature setup" for the name.
+    """
+    with pytest.raises(ValueError, match="Duplicate feature setup"):
+        Features(
+            [
+                Feature("subject_token", feature_group=_ScopeDummyFeatureGroup),
+                Feature("subject_token", feature_group=_OtherScopeDummyFeatureGroup),
+            ]
+        )
+
+
+def test_same_name_two_string_scopes_in_one_request_raise_duplicate() -> None:
+    """Two same-name features with different string scopes still collide as duplicates."""
+    with pytest.raises(ValueError, match="Duplicate feature setup"):
+        Features(
+            [
+                Feature("subject_token", feature_group="A"),
+                Feature("subject_token", feature_group="B"),
+            ]
+        )
+
+
+def test_same_name_scoped_and_unscoped_in_one_request_raise_duplicate() -> None:
+    """A scoped and an otherwise-identical unscoped feature collide as duplicates."""
+    with pytest.raises(ValueError, match="Duplicate feature setup"):
+        Features(
+            [
+                Feature("subject_token", feature_group=_ScopeDummyFeatureGroup),
+                Feature("subject_token"),
+            ]
+        )
+
+
+# ---------------------------------------------------------------------------
+# Root-base rejection: the abstract FeatureGroup root class is not a scope
+# ---------------------------------------------------------------------------
+
+
+def test_scope_root_feature_group_class_raises_typeerror() -> None:
+    """Scoping to the abstract root FeatureGroup class must be rejected.
+
+    The root class can never be a concrete resolution target; accepting it
+    silently produces a scope that matches everything (with issubclass
+    semantics) or nothing (with identity semantics). It must raise a TypeError
+    naming feature_group at construction time.
+    """
+    with pytest.raises(TypeError) as exc_info:
+        Feature("x", feature_group=FeatureGroup)
+    message = str(exc_info.value)
+    assert "feature_group" in message
+    assert "unexpected keyword" not in message
+
+
+# ---------------------------------------------------------------------------
+# String normalization: whitespace-only scopes collapse to None
+# ---------------------------------------------------------------------------
+
+
+def test_scope_whitespace_only_string_is_none() -> None:
+    """A whitespace-only string scope normalises to None, like the empty string."""
+    feature = Feature("x", feature_group="   ")
+    assert feature.feature_group_scope is None
+
+
+def test_scope_padded_string_is_stored_stripped() -> None:
+    """A class-name string scope with surrounding whitespace is stored STRIPPED.
+
+    Resolution compares the scope against get_class_name() results, which never
+    carry padding, so ' SomeSource ' stored verbatim could never match anything.
+    The constructor must normalise it to 'SomeSource'.
+    """
+    feature = Feature("subject_token", feature_group=" SomeSource ")
+    assert feature.feature_group_scope == "SomeSource"
+
+
+# ---------------------------------------------------------------------------
+# Typed helpers forward the scope to the constructor
+# ---------------------------------------------------------------------------
+
+
+def test_int32_of_forwards_class_scope() -> None:
+    """Feature.int32_of forwards a class-object scope to feature_group_scope."""
+    feature = Feature.int32_of("subject_token", feature_group=_ScopeDummyFeatureGroup)
+    assert feature.feature_group_scope is _ScopeDummyFeatureGroup
+
+
+def test_str_of_forwards_string_scope() -> None:
+    """Feature.str_of forwards a string scope to feature_group_scope."""
+    feature = Feature.str_of("subject_token", feature_group="SomeSource")
+    assert feature.feature_group_scope == "SomeSource"
+
+
+def test_not_typed_forwards_class_scope() -> None:
+    """Feature.not_typed forwards a class-object scope to feature_group_scope."""
+    feature = Feature.not_typed("subject_token", feature_group=_ScopeDummyFeatureGroup)
+    assert feature.feature_group_scope is _ScopeDummyFeatureGroup

--- a/tests/test_core/test_prepare/test_feature_group_scope_resolution.py
+++ b/tests/test_core/test_prepare/test_feature_group_scope_resolution.py
@@ -1,0 +1,410 @@
+"""Resolution-scope tests for IdentifyFeatureGroupClass (issue #508).
+
+Two source feature groups (A and B) both match the shared feature name
+"subject_token". Requesting it unscoped is ambiguous ("Multiple feature groups
+found"). The new per-feature scope disambiguates resolution to a single source,
+by class identity or by class-name string, without changing feature identity.
+
+Follows the construction conventions in test_identify_feature_group_error_message.py.
+"""
+
+from typing import Optional
+
+import pytest
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+
+
+class MockComputeFramework(ComputeFramework):
+    """Mock compute framework for testing."""
+
+
+class ScopeSourceA(FeatureGroup):
+    """Source A: matches the shared "subject_token" plus its own "scoping_value_a"."""
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return {"subject_token", "scoping_value_a"}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        name = str(feature_name)
+        return name in {"subject_token", "scoping_value_a"}
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class ScopeSourceB(FeatureGroup):
+    """Source B: matches the shared "subject_token" plus its own "scoping_value_b"."""
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return {"subject_token", "scoping_value_b"}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        name = str(feature_name)
+        return name in {"subject_token", "scoping_value_b"}
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class InaccessibleScopeSource(FeatureGroup):
+    """A FeatureGroup that matches "subject_token" but is never added to accessible_plugins."""
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return {"subject_token"}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == "subject_token"
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class _DupNameBase(FeatureGroup):
+    """Base for two feature groups that will share the identical class name."""
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return {"subject_token"}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == "subject_token"
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+def _both_sources() -> FeatureGroupEnvironmentMapping:
+    return {
+        ScopeSourceA: {MockComputeFramework},
+        ScopeSourceB: {MockComputeFramework},
+    }
+
+
+def test_unscoped_shared_name_is_ambiguous() -> None:
+    """Characterization: unscoped "subject_token" with A and B both accessible is ambiguous."""
+    feature = Feature("subject_token")
+
+    with pytest.raises(ValueError, match="Multiple feature groups found"):
+        IdentifyFeatureGroupClass(
+            feature=feature,
+            accessible_plugins=_both_sources(),
+            links=None,
+            data_access_collection=None,
+        )
+
+
+def test_scope_class_resolves_uniquely_by_identity() -> None:
+    """A class-object scope resolves uniquely to that class (matched by identity)."""
+    feature = Feature("subject_token", feature_group=ScopeSourceA)
+
+    identifier = IdentifyFeatureGroupClass(
+        feature=feature,
+        accessible_plugins=_both_sources(),
+        links=None,
+        data_access_collection=None,
+    )
+    resolved_feature_group, _compute_frameworks = identifier.get()
+    assert resolved_feature_group is ScopeSourceA
+
+
+def test_scope_string_resolves_uniquely_by_class_name() -> None:
+    """A class-name string scope resolves uniquely to the matching class."""
+    feature = Feature("subject_token", feature_group=ScopeSourceA.get_class_name())
+
+    identifier = IdentifyFeatureGroupClass(
+        feature=feature,
+        accessible_plugins=_both_sources(),
+        links=None,
+        data_access_collection=None,
+    )
+    resolved_feature_group, _compute_frameworks = identifier.get()
+    assert resolved_feature_group is ScopeSourceA
+
+
+def test_unknown_scope_raises_no_feature_groups_found() -> None:
+    """A scope naming no accessible feature group raises 'No feature groups found'."""
+    feature = Feature("subject_token", feature_group="CompletelyUnknownScope")
+
+    with pytest.raises(ValueError, match="No feature groups found") as exc_info:
+        IdentifyFeatureGroupClass(
+            feature=feature,
+            accessible_plugins=_both_sources(),
+            links=None,
+            data_access_collection=None,
+        )
+    assert "CompletelyUnknownScope" in str(exc_info.value)
+
+
+def test_class_scope_pointing_at_inaccessible_group_raises_no_feature_groups_found() -> None:
+    """A class-object scope for a FeatureGroup absent from accessible_plugins raises no-match.
+
+    The class matches the feature name but is not registered, so scope filtering
+    eliminates every accessible candidate. The error must be 'No feature groups
+    found' and name the scoped class so the missing registration is debuggable.
+    """
+    feature = Feature("subject_token", feature_group=InaccessibleScopeSource)
+
+    with pytest.raises(ValueError, match="No feature groups found") as exc_info:
+        IdentifyFeatureGroupClass(
+            feature=feature,
+            accessible_plugins=_both_sources(),
+            links=None,
+            data_access_collection=None,
+        )
+    assert InaccessibleScopeSource.get_class_name() in str(exc_info.value)
+
+
+def test_string_scope_name_collision_reports_scope_in_multiple_found() -> None:
+    """A string scope that matches two identically-named groups must name the scope.
+
+    Two distinct FeatureGroup classes share the class name 'DupNameSource' and
+    both match 'subject_token'. A string scope of 'DupNameSource' therefore stays
+    ambiguous. The 'Multiple feature groups found' diagnostics must explicitly
+    call out the requested scope (as the no-match branch already does), so the
+    string-name collision is debuggable rather than looking like a plain
+    unscoped ambiguity.
+    """
+    dup_a = type("DupNameSource", (_DupNameBase,), {})
+    dup_b = type("DupNameSource", (_DupNameBase,), {})
+    accessible_plugins: FeatureGroupEnvironmentMapping = {
+        dup_a: {MockComputeFramework},
+        dup_b: {MockComputeFramework},
+    }
+
+    feature = Feature("subject_token", feature_group="DupNameSource")
+
+    with pytest.raises(ValueError, match="Multiple feature groups found") as exc_info:
+        IdentifyFeatureGroupClass(
+            feature=feature,
+            accessible_plugins=accessible_plugins,
+            links=None,
+            data_access_collection=None,
+        )
+    message = str(exc_info.value)
+    assert "Scoped to feature group: 'DupNameSource'" in message
+
+
+# ---------------------------------------------------------------------------
+# issubclass matching for class-object scopes
+# ---------------------------------------------------------------------------
+
+
+class ScopeSourceASub(ScopeSourceA):
+    """Subclass of ScopeSourceA; inherits its name matching."""
+
+
+def test_base_class_scope_resolves_to_accessible_subclass() -> None:
+    """A base-class scope matches subclasses of the scoped class.
+
+    Only the subclass ScopeSourceASub is accessible. Scoping to its base
+    ScopeSourceA must resolve to the subclass (issubclass matching) instead of
+    raising 'No feature groups found'. ScopeSourceB stays filtered out because
+    it is unrelated to the scope.
+    """
+    feature = Feature("subject_token", feature_group=ScopeSourceA)
+    accessible_plugins: FeatureGroupEnvironmentMapping = {
+        ScopeSourceASub: {MockComputeFramework},
+        ScopeSourceB: {MockComputeFramework},
+    }
+
+    identifier = IdentifyFeatureGroupClass(
+        feature=feature,
+        accessible_plugins=accessible_plugins,
+        links=None,
+        data_access_collection=None,
+    )
+    resolved_feature_group, _compute_frameworks = identifier.get()
+    assert resolved_feature_group is ScopeSourceASub
+
+
+def test_base_class_scope_prefers_subclass_when_both_accessible() -> None:
+    """With base AND subclass accessible, a base-class scope resolves to the subclass.
+
+    issubclass matching keeps both candidates in the scope filter; the existing
+    filter_subclasses preference (same compute-framework set) then drops the
+    base in favour of the subclass. Resolving to the base is wrong.
+    """
+    feature = Feature("subject_token", feature_group=ScopeSourceA)
+    accessible_plugins: FeatureGroupEnvironmentMapping = {
+        ScopeSourceA: {MockComputeFramework},
+        ScopeSourceASub: {MockComputeFramework},
+    }
+
+    identifier = IdentifyFeatureGroupClass(
+        feature=feature,
+        accessible_plugins=accessible_plugins,
+        links=None,
+        data_access_collection=None,
+    )
+    resolved_feature_group, _compute_frameworks = identifier.get()
+    assert resolved_feature_group is ScopeSourceASub
+
+
+# ---------------------------------------------------------------------------
+# Capability-rejection error names the scope
+# ---------------------------------------------------------------------------
+
+
+class ScopedCapabilityFw(ComputeFramework):
+    """Compute framework rejected by RejectAllScopedSource at match time."""
+
+
+class RejectAllScopedSource(FeatureGroup):
+    """Matches "subject_token" but declares every compute framework unsupported."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {ScopedCapabilityFw}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == "subject_token"
+
+    @classmethod
+    def supports_compute_framework(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        compute_framework: type[ComputeFramework],
+    ) -> bool:
+        return False
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+def test_capability_rejection_error_names_the_scope() -> None:
+    """When every framework of the scoped group is capability-rejected, the error names the scope.
+
+    The scoped group matches the feature name, but supports_compute_framework
+    rejects all of its frameworks, so the no-match error takes the capability
+    branch. That message must still call out the requested scope, otherwise the
+    scoped request looks like a plain capability failure.
+    """
+    feature = Feature("subject_token", feature_group=RejectAllScopedSource)
+    accessible_plugins: FeatureGroupEnvironmentMapping = {
+        RejectAllScopedSource: {ScopedCapabilityFw},
+    }
+
+    with pytest.raises(ValueError) as exc_info:
+        IdentifyFeatureGroupClass(
+            feature=feature,
+            accessible_plugins=accessible_plugins,
+            links=None,
+            data_access_collection=None,
+        )
+    message = str(exc_info.value)
+    # Prove the capability branch was taken (guards against a fixture bug).
+    assert "Unsupported compute framework" in message
+    assert "Scoped to feature group: 'RejectAllScopedSource'" in message
+
+
+# ---------------------------------------------------------------------------
+# Ambiguous-error message ordering: scope callout before the trailing URL
+# ---------------------------------------------------------------------------
+
+
+def test_scoped_ambiguity_callout_precedes_troubleshooting_url() -> None:
+    """In the scoped 'Multiple feature groups found' error, the URL stays last.
+
+    The scope callout must appear BEFORE the troubleshooting URL, and the
+    message's last line must end with the URL so terminals auto-link it.
+    Appending the callout after the URL breaks both.
+    """
+    dup_a = type("DupNameSource", (_DupNameBase,), {})
+    dup_b = type("DupNameSource", (_DupNameBase,), {})
+    accessible_plugins: FeatureGroupEnvironmentMapping = {
+        dup_a: {MockComputeFramework},
+        dup_b: {MockComputeFramework},
+    }
+
+    feature = Feature("subject_token", feature_group="DupNameSource")
+
+    with pytest.raises(ValueError, match="Multiple feature groups found") as exc_info:
+        IdentifyFeatureGroupClass(
+            feature=feature,
+            accessible_plugins=accessible_plugins,
+            links=None,
+            data_access_collection=None,
+        )
+    message = str(exc_info.value)
+    url = "https://mloda-ai.github.io/mloda/in_depth/troubleshooting/feature-group-resolution-errors/"
+    assert "Scoped to feature group: 'DupNameSource'" in message
+    assert message.index("Scoped to feature group:") < message.index(url), (
+        f"Scope callout must precede the troubleshooting URL, but got: {message}"
+    )
+    assert message.splitlines()[-1].endswith(url), (
+        f"The message's last line must end with the troubleshooting URL, but got: {message}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# String-form scopes match the exact class name only (no subclass matching)
+# ---------------------------------------------------------------------------
+
+
+def test_base_class_name_string_scope_does_not_match_subclass() -> None:
+    """Pinning test: a STRING scope matches the exact class name only, never subclasses.
+
+    This pins the INTENDED asymmetry between the two scope forms: a class-object
+    scope uses issubclass matching (see
+    test_base_class_scope_resolves_to_accessible_subclass), while the string form
+    'ScopeSourceA' compares against get_class_name() exactly. With only the
+    subclass ScopeSourceASub accessible, the base-name string scope therefore
+    matches nothing and raises 'No feature groups found', naming the scope.
+
+    This is a characterization test of current behaviour; it may already pass.
+    """
+    feature = Feature("subject_token", feature_group=ScopeSourceA.get_class_name())
+    accessible_plugins: FeatureGroupEnvironmentMapping = {
+        ScopeSourceASub: {MockComputeFramework},
+    }
+
+    with pytest.raises(ValueError, match="No feature groups found") as exc_info:
+        IdentifyFeatureGroupClass(
+            feature=feature,
+            accessible_plugins=accessible_plugins,
+            links=None,
+            data_access_collection=None,
+        )
+    assert ScopeSourceA.get_class_name() in str(exc_info.value)

--- a/tests/test_plugins/compute_framework/test_per_feature_fg_scope_integration.py
+++ b/tests/test_plugins/compute_framework/test_per_feature_fg_scope_integration.py
@@ -1,0 +1,335 @@
+"""End-to-end scope test through mloda.run_all (issue #508 definition of done).
+
+A derived feature group needs a shared join key ("subject_token") that TWO
+enabled sources both declare. Requesting it by bare name is ambiguous. Scoping
+the request to one source (Feature("subject_token", feature_group=SourceA))
+resolves it uniquely, so the derived feature group can compute its result.
+"""
+
+from typing import Any, Optional
+
+import pytest
+
+from mloda.provider import BaseInputData
+from mloda.provider import DataCreator
+from mloda.provider import FeatureGroup
+from mloda.provider import FeatureSet
+from mloda.user import Feature
+from mloda.user import FeatureName
+from mloda.user import Options
+from mloda.user import ParallelizationMode
+from mloda.user import PluginCollector
+from mloda.user import mloda
+
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame  # noqa: F401
+
+
+class Source508A(FeatureGroup):
+    """Source A: provides the shared "subject_token" plus "scoping_value_a"."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={"subject_token", "scoping_value_a"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {
+            "subject_token": ["s1", "s2", "s1", "s2"],
+            "scoping_value_a": [10, 5, 30, 7],
+        }
+
+
+class Source508B(FeatureGroup):
+    """Source B: also provides the shared "subject_token" plus "scoping_value_b"."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={"subject_token", "scoping_value_b"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {
+            "subject_token": ["s1", "s2"],
+            "scoping_value_b": [1, 2],
+        }
+
+
+class Derived508Scoped(FeatureGroup):
+    """Derived FG: reads scoping_value_a and subject_token scoped to Source A."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return {
+            Feature("scoping_value_a"),
+            Feature("subject_token", feature_group=Source508A),
+        }
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        grouped = data.groupby("subject_token")["scoping_value_a"].max()
+        result = sorted(f"{key}|{value}" for key, value in grouped.items())
+        return {cls.get_class_name(): result}
+
+
+class Derived508Unscoped(FeatureGroup):
+    """Derived FG requesting subject_token WITHOUT scope (ambiguous by design)."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return {
+            Feature("scoping_value_a"),
+            Feature("subject_token"),
+        }
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        grouped = data.groupby("subject_token")["scoping_value_a"].max()
+        result = sorted(f"{key}|{value}" for key, value in grouped.items())
+        return {cls.get_class_name(): result}
+
+
+def test_scoped_derived_feature_resolves_and_computes(flight_server: Any) -> None:
+    """Scoping subject_token to Source A lets the derived FG compute per-token maxima."""
+    feature = Feature(name=Derived508Scoped.get_class_name())
+
+    result = mloda.run_all(
+        [feature],
+        compute_frameworks=["PandasDataFrame"],
+        plugin_collector=PluginCollector.enabled_feature_groups({Source508A, Source508B, Derived508Scoped}),
+        flight_server=flight_server,
+        parallelization_modes={ParallelizationMode.SYNC},
+    )
+
+    values: list[str] = []
+    for res in result:
+        values = list(res[Derived508Scoped.get_class_name()].values)
+
+    assert values == ["s1|30", "s2|7"]
+
+
+def test_unscoped_derived_feature_is_ambiguous(flight_server: Any) -> None:
+    """Characterization: without scope, subject_token still raises 'Multiple feature groups found'."""
+    feature = Feature(name=Derived508Unscoped.get_class_name())
+
+    with pytest.raises(ValueError, match="Multiple feature groups found"):
+        mloda.run_all(
+            [feature],
+            compute_frameworks=["PandasDataFrame"],
+            plugin_collector=PluginCollector.enabled_feature_groups({Source508A, Source508B, Derived508Unscoped}),
+            flight_server=flight_server,
+            parallelization_modes={ParallelizationMode.SYNC},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Behavior B: a scoped join key rides along in the same source read as its
+# sibling columns rather than triggering a second computation of the source.
+# ---------------------------------------------------------------------------
+
+
+class Source508CounterA(FeatureGroup):
+    """Source A with a class-level call counter, providing subject_token + counter_value_a."""
+
+    calls = 0
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={"subject_token", "counter_value_a"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        cls.calls += 1
+        return {
+            "subject_token": ["s1", "s2", "s1", "s2"],
+            "counter_value_a": [10, 5, 30, 7],
+        }
+
+
+class Source508CounterB(FeatureGroup):
+    """Source B, providing the shared subject_token plus counter_value_b (creates ambiguity)."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={"subject_token", "counter_value_b"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {
+            "subject_token": ["s1", "s2"],
+            "counter_value_b": [1, 2],
+        }
+
+
+class Derived508CounterScoped(FeatureGroup):
+    """Derived FG: reads counter_value_a and subject_token scoped to Source A."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return {
+            Feature("counter_value_a"),
+            Feature("subject_token", feature_group=Source508CounterA),
+        }
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        grouped = data.groupby("subject_token")["counter_value_a"].max()
+        result = sorted(f"{key}|{value}" for key, value in grouped.items())
+        return {cls.get_class_name(): result}
+
+
+def test_scoped_key_shares_read_with_siblings(flight_server: Any) -> None:
+    """The scoped join key batches into the SAME source read as its sibling column.
+
+    counter_value_a and the subject_token scoped to Source A both resolve to
+    Source A. Because scope is excluded from the similarity hash, they share a
+    single read: Source A's calculate_feature runs exactly once, not twice.
+    """
+    Source508CounterA.calls = 0
+
+    feature = Feature(name=Derived508CounterScoped.get_class_name())
+
+    result = mloda.run_all(
+        [feature],
+        compute_frameworks=["PandasDataFrame"],
+        plugin_collector=PluginCollector.enabled_feature_groups(
+            {Source508CounterA, Source508CounterB, Derived508CounterScoped}
+        ),
+        flight_server=flight_server,
+        parallelization_modes={ParallelizationMode.SYNC},
+    )
+
+    values: list[str] = []
+    for res in result:
+        values = list(res[Derived508CounterScoped.get_class_name()].values)
+
+    assert values == ["s1|30", "s2|7"]
+    assert Source508CounterA.calls == 1
+
+
+# ---------------------------------------------------------------------------
+# Behavior C: same-name-different-scope keys in DIFFERENT derived feature groups
+# resolve independently to their own source without colliding.
+# ---------------------------------------------------------------------------
+
+
+class Source508IndepA(FeatureGroup):
+    """Source A: provides subject_token plus value_a."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={"subject_token", "value_a"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {
+            "subject_token": ["s1", "s2", "s1", "s2"],
+            "value_a": [10, 5, 30, 7],
+        }
+
+
+class Source508IndepB(FeatureGroup):
+    """Source B: provides subject_token plus value_b."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={"subject_token", "value_b"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {
+            "subject_token": ["s1", "s2", "s1", "s2"],
+            "value_b": [100, 200, 300, 400],
+        }
+
+
+class Derived508IndepA(FeatureGroup):
+    """Derived FG A: reads value_a and subject_token scoped to Source A."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return {
+            Feature("value_a"),
+            Feature("subject_token", feature_group=Source508IndepA),
+        }
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        grouped = data.groupby("subject_token")["value_a"].max()
+        result = sorted(f"{key}|{value}" for key, value in grouped.items())
+        return {cls.get_class_name(): result}
+
+
+class Derived508IndepB(FeatureGroup):
+    """Derived FG B: reads value_b and subject_token scoped to Source B."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return {
+            Feature("value_b"),
+            Feature("subject_token", feature_group=Source508IndepB),
+        }
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        grouped = data.groupby("subject_token")["value_b"].max()
+        result = sorted(f"{key}|{value}" for key, value in grouped.items())
+        return {cls.get_class_name(): result}
+
+
+def _column_from_result(result: Any, column: str) -> list[Any]:
+    for res in result:
+        if column in res:
+            return list(res[column].values)
+    return []
+
+
+def test_two_derived_fgs_scope_same_key_to_different_sources(flight_server: Any) -> None:
+    """Two derived FGs scope the same-name key to different sources and resolve independently.
+
+    FG_A pulls subject_token from Source A (alongside value_a); FG_B pulls the
+    same-named subject_token from Source B (alongside value_b). Requested together
+    in one run, each computes correctly from its own source, proving that
+    same-name/different-scope features in different FGs do not collide.
+    """
+    features: list[Feature | str] = [
+        Feature(name=Derived508IndepA.get_class_name()),
+        Feature(name=Derived508IndepB.get_class_name()),
+    ]
+
+    result = mloda.run_all(
+        features,
+        compute_frameworks=["PandasDataFrame"],
+        plugin_collector=PluginCollector.enabled_feature_groups(
+            {Source508IndepA, Source508IndepB, Derived508IndepA, Derived508IndepB}
+        ),
+        flight_server=flight_server,
+        parallelization_modes={ParallelizationMode.SYNC},
+    )
+
+    values_a = _column_from_result(result, Derived508IndepA.get_class_name())
+    values_b = _column_from_result(result, Derived508IndepB.get_class_name())
+
+    assert values_a == ["s1|30", "s2|7"]
+    assert values_b == ["s1|300", "s2|400"]
+
+
+# ---------------------------------------------------------------------------
+# Behavior A at the real entry path: two same-name features with different
+# scopes in a single top-level request are rejected as duplicates.
+# ---------------------------------------------------------------------------
+
+
+def test_same_name_two_scopes_top_level_request_raises(flight_server: Any) -> None:
+    """Two same-name/different-scope features in one top-level request are rejected.
+
+    Scope is excluded from identity, so the two features compare equal and the
+    request-level Features validation raises "Duplicate feature setup".
+    """
+    features: list[Feature | str] = [
+        Feature("subject_token", feature_group=Source508A),
+        Feature("subject_token", feature_group=Source508B),
+    ]
+
+    with pytest.raises(ValueError, match="Duplicate feature setup"):
+        mloda.run_all(
+            features,
+            compute_frameworks=["PandasDataFrame"],
+            plugin_collector=PluginCollector.enabled_feature_groups({Source508A, Source508B}),
+            flight_server=flight_server,
+            parallelization_modes={ParallelizationMode.SYNC},
+        )


### PR DESCRIPTION
Closes #508. Alternative to #547 that keeps the scope out of `Feature` identity.

## Problem

A derived feature group reading a subset of one source's columns cannot obtain a shared join key (e.g. `subject_token`) when more than one enabled source declares that column: requesting it by name raises `ValueError: Multiple feature groups found`.

## Approach: resolution-only scope, excluded from identity

`Feature` gains an optional `feature_group` scope that restricts resolution to one feature group class:

```python
Feature("subject_token", feature_group=ClaimsReader)      # class object (recommended, collision-proof)
Feature("subject_token", feature_group="ClaimsReader")    # class-name string
```

The scope is stored as `feature_group_scope` and is deliberately **excluded from `__eq__`, `__hash__`, and `similarity_hash`**, mirroring the existing `link`/`index` attributes. Consequences:

- Scoped and unscoped features stay equal and hash equal, so the scope does not fragment feature identity across the pipeline, and read batching is unaffected (a scoped key still shares a read with its sibling columns).
- No identity/batching asymmetry to reason about: the scope is uniformly absent from every hash and only consulted at resolution time (`IdentifyFeatureGroupClass`, per-feature, before any set/dict use), so it cannot be silently lost before it does its job.
- The scope is settable only via the constructor parameter, never through `options`, so it does not leak into the resolved feature group's options.

`IdentifyFeatureGroupClass` filters candidates by the scope before the multiple-match check: a class scope matches by identity (collision-proof), a string scope by class name. Unmatched and still-ambiguous scopes name the requested scope in the error message.

## Relationship to #547

This is a rework of #547. #547 added the scope to `Feature.__eq__`/`__hash__` (but not `similarity_hash`), which made scoped and unscoped features distinct in every set/dict and introduced an identity-vs-batching asymmetry, and routed one form through `options` (leaking into the resolved FG's options and batching). This PR avoids all of that by treating the scope as resolution-only metadata.

Known tradeoff (documented in the troubleshooting guide): because the scope is out of identity, requesting the same column name scoped to two different sources in one request collapses to one feature. Side-by-side multi-source comparison is out of scope for #508.

## Tests

New unit tests (Feature identity invariants, scope validation/TypeError, deepcopy survival) and resolution tests (class-object and string scoping, no-match and ambiguous diagnostics), plus an integration test through `mloda.run_all` matching the issue's definition of done. Full `tox` gate passes (pytest, ruff, mypy --strict, bandit, licenses).

## Review

Two independent deep reviews (a fresh Opus agent and codex) ran against the diff. Accepted findings (precise FeatureGroup-subclass validation, scope naming in the ambiguous-match error, added tests, docs) are folded into the second commit.
