### PR TITLE
feat: add Link.star star-join builder for shared-index joins (#571)

### DIFF
--- a/docs/docs/in_depth/join_data.md
+++ b/docs/docs/in_depth/join_data.md
@@ -190,6 +190,35 @@ Available `_on` methods: `inner_on`, `left_on`, `right_on`, `outer_on`, `append_
 
 **Note:** Explicit `JoinSpec` (Option 1 above) works regardless of whether the feature group defines `index_columns()`. The engine automatically injects the join columns specified in the `JoinSpec` into that feature group's feature set. The `_on` shorthand requires `index_columns()`.
 
+#### Star Joins (Link.star)
+
+When several feature groups share one row-index column and all join back to a single hub, `Link.star` builds the whole set of links in one call instead of a hand-rolled loop of `Link.inner(...)`:
+
+```python
+from mloda.user import Link, JoinType
+
+# First feature group is the hub; every remaining group is a spoke joined to it
+# on the shared index column. Returns a set of Links.
+links = Link.star(HubFG, SpokeAFG, SpokeBFG, index_column="row_id")
+
+# Equivalent to building, by hand:
+#   Link.inner(JoinSpec(HubFG, Index(("row_id",))), JoinSpec(SpokeAFG, Index(("row_id",))))
+#   Link.inner(JoinSpec(HubFG, Index(("row_id",))), JoinSpec(SpokeBFG, Index(("row_id",))))
+```
+
+- **`index_column`** is keyword-only and accepts a `str`, a `tuple[str, ...]` (multi-column), or an explicit `Index`. It is normalized once and reused on both sides of every link, so all three forms are equivalent.
+- **`jointype`** is keyword-only and defaults to `JoinType.INNER`. It accepts a `JoinType` or its string form and must be one of `inner`, `left`, or `outer`; the same type is applied to every spoke:
+
+```python
+links = Link.star(HubFG, SpokeAFG, SpokeBFG, index_column="row_id", jointype=JoinType.LEFT)
+```
+
+- `right`, `append`, and `union` are rejected with a `ValueError` (a star anchors on the hub, so they do not fit); `asof` joins need `Link.asof(...)`.
+- At least two feature groups are required (a hub plus one spoke), and the hub class cannot also appear as a spoke. Duplicate spokes collapse in the returned set.
+- **Scope:** `Link.star` targets joins between distinct feature-group classes and does not carry discriminators, so it cannot disambiguate multiple same-class nodes. For same-class self-joins, use `Link.inner` with discriminators (see below).
+
+The returned set is passed straight to `mlodaAPI` like any other link set.
+
 #### Same-Class Joins with Discriminators
 
 When joining a feature group with itself (or two nodes of the same class loading different data sources), you need to distinguish between the left and right instances using **discriminators**.

--- a/docs/docs/in_depth/join_data.md
+++ b/docs/docs/in_depth/join_data.md
@@ -196,6 +196,17 @@ When several feature groups share one row-index column and all join back to a si
 
 ```python
 from mloda.user import Link, JoinType
+from mloda.provider import FeatureGroup
+
+# A hub feature group and two spokes that share the "row_id" column:
+class HubFG(FeatureGroup):
+    pass
+
+class SpokeAFG(FeatureGroup):
+    pass
+
+class SpokeBFG(FeatureGroup):
+    pass
 
 # First feature group is the hub; every remaining group is a spoke joined to it
 # on the shared index column. Returns a set of Links.

--- a/mloda/core/abstract_plugins/components/link.py
+++ b/mloda/core/abstract_plugins/components/link.py
@@ -176,6 +176,12 @@ class Link:
         The _on methods require feature groups to have index_columns() defined.
         Use left_index/right_index to select which index when multiple are available.
 
+        **Star factory** - joins every spoke to a shared-index hub:
+            - Link.star(HubFG, SpokeAFG, SpokeBFG, index_column="row_id")
+
+        The first feature group is the hub; each remaining group is joined to it with
+        an INNER join on the shared index. Returns a set of Links.
+
         **ASOF factories** - point-in-time / as-of joins:
             - Link.asof(left_joinspec, right_joinspec, left_time_column=..., right_time_column=...)
             - Link.asof_on(LeftFG, RightFG, left_time_column=..., right_time_column=...)
@@ -362,6 +368,28 @@ class Link:
         return cls._from_feature_groups(
             JoinType.INNER, left, right, left_index, right_index, left_discriminator, right_discriminator
         )
+
+    @classmethod
+    def star(
+        cls,
+        *feature_groups: type[Any],
+        index_column: Index | tuple[str, ...] | str,
+    ) -> set["Link"]:
+        """Create INNER links joining every spoke to a shared-index hub.
+
+        The first feature group is the hub; each remaining group is joined to it on the
+        shared index. Returns a set of INNER Links (duplicate spokes collapse in the set).
+        Targets joins between distinct feature-group classes and does not support
+        left/right discriminators, so it cannot disambiguate multiple same-class nodes
+        (use ``Link.inner`` with discriminators for that).
+        """
+        if len(feature_groups) < 2:
+            raise ValueError("Link.star needs at least two feature groups: a hub plus at least one spoke.")
+
+        # coerce/validate index_column (str/tuple/Index) into a shared Index reused on both sides
+        idx = JoinSpec(feature_groups[0], index_column).index
+        hub = feature_groups[0]
+        return {cls.inner(JoinSpec(hub, idx), JoinSpec(spoke, idx)) for spoke in feature_groups[1:]}
 
     @classmethod
     def left_on(

--- a/mloda/core/abstract_plugins/components/link.py
+++ b/mloda/core/abstract_plugins/components/link.py
@@ -4,7 +4,7 @@ from dataclasses import FrozenInstanceError, dataclass
 from datetime import timedelta
 from enum import Enum
 from uuid import uuid4
-from typing import Any, Literal, Optional
+from typing import Any, ClassVar, Literal, Optional
 
 
 from mloda.core.abstract_plugins.components.index.index import Index
@@ -178,9 +178,11 @@ class Link:
 
         **Star factory** - joins every spoke to a shared-index hub:
             - Link.star(HubFG, SpokeAFG, SpokeBFG, index_column="row_id")
+            - Link.star(HubFG, SpokeAFG, index_column="row_id", jointype=JoinType.LEFT)
 
-        The first feature group is the hub; each remaining group is joined to it with
-        an INNER join on the shared index. Returns a set of Links.
+        The first feature group is the hub; each remaining group is joined to it on the
+        shared index. The optional ``jointype`` (inner/left/outer, default inner) sets the
+        join type for every spoke. Returns a set of Links.
 
         **ASOF factories** - point-in-time / as-of joins:
             - Link.asof(left_joinspec, right_joinspec, left_time_column=..., right_time_column=...)
@@ -236,6 +238,9 @@ class Link:
         3. **Most specific wins**: Among valid matches, the link closest in the
            inheritance hierarchy is selected.
     """
+
+    # Join types Link.star supports: the hub anchors every spoke, so only these three apply.
+    _STAR_JOIN_TYPES: ClassVar[frozenset[JoinType]] = frozenset({JoinType.INNER, JoinType.LEFT, JoinType.OUTER})
 
     def __init__(
         self,
@@ -374,22 +379,40 @@ class Link:
         cls,
         *feature_groups: type[Any],
         index_column: Index | tuple[str, ...] | str,
+        jointype: JoinType | str = JoinType.INNER,
     ) -> set["Link"]:
-        """Create INNER links joining every spoke to a shared-index hub.
+        """Create links joining every spoke to a shared-index hub.
 
         The first feature group is the hub; each remaining group is joined to it on the
-        shared index. Returns a set of INNER Links (duplicate spokes collapse in the set).
+        shared index using ``jointype`` (default inner). Returns a set of Links (duplicate
+        spokes collapse in the set). ``jointype`` may be a ``JoinType`` or its string form
+        and must be one of inner, left, or outer; right/append/union are not supported for
+        star joins and asof needs ``Link.asof``.
         Targets joins between distinct feature-group classes and does not support
         left/right discriminators, so it cannot disambiguate multiple same-class nodes
-        (use ``Link.inner`` with discriminators for that).
+        (use ``Link.inner`` with discriminators for that). The hub class cannot also
+        appear as a spoke; spokes must be distinct classes from the hub.
         """
         if len(feature_groups) < 2:
             raise ValueError("Link.star needs at least two feature groups: a hub plus at least one spoke.")
 
-        # coerce/validate index_column (str/tuple/Index) into a shared Index reused on both sides
-        idx = JoinSpec(feature_groups[0], index_column).index
         hub = feature_groups[0]
-        return {cls.inner(JoinSpec(hub, idx), JoinSpec(spoke, idx)) for spoke in feature_groups[1:]}
+        if any(spoke is hub for spoke in feature_groups[1:]):
+            raise ValueError(
+                "Link.star cannot join the hub feature group to itself: the hub class "
+                f"{hub.__name__} also appears as a spoke. Star joins target distinct feature-group classes."
+            )
+
+        jointype = JoinType(jointype) if isinstance(jointype, str) else jointype
+        if jointype not in cls._STAR_JOIN_TYPES:
+            raise ValueError(
+                f"Link.star supports only inner, left, or outer joins, got {getattr(jointype, 'value', jointype)}. "
+                "right/append/union are not supported for star joins; use Link.asof for asof joins."
+            )
+
+        # coerce/validate index_column (str/tuple/Index) into a shared Index reused on both sides
+        idx = JoinSpec(hub, index_column).index
+        return {cls(jointype, JoinSpec(hub, idx), JoinSpec(spoke, idx)) for spoke in feature_groups[1:]}
 
     @classmethod
     def left_on(

--- a/tests/test_core/test_integration/test_core/test_runner_join_multiple_compute_framework.py
+++ b/tests/test_core/test_integration/test_core/test_runner_join_multiple_compute_framework.py
@@ -303,14 +303,7 @@ class TestEngineMultipleJoinCfw:
     def test_runner_join_multiple_cfw2_join_to_same_base(
         self, modes: set[ParallelizationMode], flight_server: Any
     ) -> None:
-        idx = Index(
-            ("idx",),
-        )
-
-        left = JoinSpec(JoinCfwTest1, idx)
-        right_1 = JoinSpec(JoinCfwTest2, idx)
-        right_2 = JoinSpec(JoinCfwTest3, idx)
-        links = {Link("inner", left, right_1), Link("inner", left, right_2)}
+        links = Link.star(JoinCfwTest1, JoinCfwTest2, JoinCfwTest3, index_column="idx")
 
         self.base_join_runner(modes, flight_server, links)
 

--- a/tests/test_core/test_setup/test_link_star.py
+++ b/tests/test_core/test_setup/test_link_star.py
@@ -150,3 +150,103 @@ class TestLinkStar:
         """Test Link.star raises ValueError when no feature groups are provided."""
         with pytest.raises(ValueError):
             Link.star(index_column="row_id")
+
+
+# ============================================================================
+# Test Link.star jointype Parameter
+# ============================================================================
+class TestLinkStarJoinType:
+    """Test the keyword-only jointype parameter on Link.star."""
+
+    def test_star_left_yields_left_links(self) -> None:
+        """Test jointype=JoinType.LEFT yields LEFT links: hub left, spoke right, shared index."""
+        links = Link.star(HubFG, SpokeAFG, index_column="row_id", jointype=JoinType.LEFT)
+
+        assert len(links) == 1
+        link = next(iter(links))
+        assert link.jointype == JoinType.LEFT
+        assert link.left_feature_group is HubFG
+        assert link.right_feature_group is SpokeAFG
+        assert link.left_index == ROW_INDEX
+        assert link.right_index == ROW_INDEX
+
+    def test_star_left_string_form_yields_left_links(self) -> None:
+        """Test the string form jointype="left" yields LEFT links."""
+        links = Link.star(HubFG, SpokeAFG, index_column="row_id", jointype="left")
+
+        assert len(links) == 1
+        link = next(iter(links))
+        assert link.jointype == JoinType.LEFT
+
+    def test_star_outer_yields_outer_links(self) -> None:
+        """Test jointype=JoinType.OUTER yields OUTER links."""
+        links = Link.star(HubFG, SpokeAFG, index_column="row_id", jointype=JoinType.OUTER)
+
+        assert len(links) == 1
+        link = next(iter(links))
+        assert link.jointype == JoinType.OUTER
+        assert link.left_feature_group is HubFG
+        assert link.right_feature_group is SpokeAFG
+
+    def test_star_string_and_enum_forms_are_equivalent(self) -> None:
+        """Test the string and enum forms of jointype produce equal link sets."""
+        links_str = Link.star(HubFG, SpokeAFG, index_column="row_id", jointype="left")
+        links_enum = Link.star(HubFG, SpokeAFG, index_column="row_id", jointype=JoinType.LEFT)
+
+        assert links_str == links_enum
+
+    def test_star_multi_spoke_left_returns_two_left_links(self) -> None:
+        """Test jointype=JoinType.LEFT with two spokes returns two LEFT links anchored on the hub."""
+        links = Link.star(HubFG, SpokeAFG, SpokeBFG, index_column="row_id", jointype=JoinType.LEFT)
+
+        assert len(links) == 2
+        for link in links:
+            assert link.jointype == JoinType.LEFT
+            assert link.left_feature_group is HubFG
+
+        spokes = {link.right_feature_group for link in links}
+        assert spokes == {SpokeAFG, SpokeBFG}
+
+    def test_star_right_jointype_raises_value_error(self) -> None:
+        """Test jointype=JoinType.RIGHT is rejected: a star join anchors on the hub."""
+        with pytest.raises(ValueError):
+            Link.star(HubFG, SpokeAFG, index_column="row_id", jointype=JoinType.RIGHT)
+
+    def test_star_append_jointype_raises_value_error(self) -> None:
+        """Test jointype=JoinType.APPEND is rejected for star joins."""
+        with pytest.raises(ValueError):
+            Link.star(HubFG, SpokeAFG, index_column="row_id", jointype=JoinType.APPEND)
+
+    def test_star_union_jointype_raises_value_error(self) -> None:
+        """Test jointype=JoinType.UNION is rejected for star joins."""
+        with pytest.raises(ValueError):
+            Link.star(HubFG, SpokeAFG, index_column="row_id", jointype=JoinType.UNION)
+
+    def test_star_asof_jointype_raises_value_error(self) -> None:
+        """Test jointype=JoinType.ASOF is rejected for star joins."""
+        with pytest.raises(ValueError):
+            Link.star(HubFG, SpokeAFG, index_column="row_id", jointype=JoinType.ASOF)
+
+    def test_star_invalid_jointype_string_raises_value_error(self) -> None:
+        """Test an unknown jointype string is rejected (JoinType("banana") raises ValueError)."""
+        with pytest.raises(ValueError):
+            Link.star(HubFG, SpokeAFG, index_column="row_id", jointype="banana")
+
+    def test_star_right_string_form_raises_value_error(self) -> None:
+        """Test the string form "right" is rejected: it converts to JoinType.RIGHT then fails the allowed set."""
+        with pytest.raises(ValueError):
+            Link.star(HubFG, SpokeAFG, index_column="row_id", jointype="right")
+
+    def test_star_rejection_message_names_allowed_set(self) -> None:
+        """Test the rejection message names the allowed set of join types."""
+        with pytest.raises(ValueError, match="only inner, left, or outer"):
+            Link.star(HubFG, SpokeAFG, index_column="row_id", jointype=JoinType.RIGHT)
+
+    def test_star_hub_as_spoke_raises_value_error(self) -> None:
+        """Test the hub class cannot also be a spoke: a star cannot self-join the hub.
+
+        Self-joining a class requires left/right discriminators to disambiguate the two
+        same-class nodes, which Link.star does not support, so this must be rejected.
+        """
+        with pytest.raises(ValueError, match="hub"):
+            Link.star(HubFG, HubFG, index_column="row_id")

--- a/tests/test_core/test_setup/test_link_star.py
+++ b/tests/test_core/test_setup/test_link_star.py
@@ -1,0 +1,152 @@
+"""
+Test Link.star Factory Method
+
+Tests for the Link.star star-join builder that joins every feature group to a
+shared row-index column, replacing hand-rolled loops of the shape:
+
+    links = set()
+    idx = Index((ROW_INDEX_COLUMN,))
+    base_group = feature_groups[0]
+    for other_group in feature_groups[1:]:
+        links.add(Link.inner(JoinSpec(base_group, idx), JoinSpec(other_group, idx)))
+
+Usage:
+    # Star-join three feature groups on a shared row-index column:
+    Link.star(HubFG, SpokeAFG, SpokeBFG, index_column="row_id")
+
+The first feature group is the hub; every remaining group is joined to it with an
+INNER join on the shared index. Returns a set of Links.
+
+See Also:
+    - GitHub Issue #571: Star-join builder Link.star
+"""
+
+from typing import Any, Optional
+
+import pytest
+
+from mloda.provider import FeatureGroup
+from mloda.user import FeatureName
+from mloda.user import Index
+from mloda.user import JoinSpec, JoinType, Link
+from mloda.user import Options
+
+
+# ============================================================================
+# Mock Feature Groups for Testing
+# ============================================================================
+class HubFG(FeatureGroup):
+    """Hub feature group for star-join testing."""
+
+    def input_features(self, _options: Options, _feature_name: FeatureName) -> Optional[set[Any]]:
+        return None
+
+
+class SpokeAFG(FeatureGroup):
+    """First spoke feature group for star-join testing."""
+
+    def input_features(self, _options: Options, _feature_name: FeatureName) -> Optional[set[Any]]:
+        return None
+
+
+class SpokeBFG(FeatureGroup):
+    """Second spoke feature group for star-join testing."""
+
+    def input_features(self, _options: Options, _feature_name: FeatureName) -> Optional[set[Any]]:
+        return None
+
+
+ROW_INDEX = Index(("row_id",))
+
+
+# ============================================================================
+# Test Link.star Method
+# ============================================================================
+class TestLinkStar:
+    """Test Link.star star-join builder."""
+
+    def test_star_default_three_groups_returns_two_links(self) -> None:
+        """Test Link.star with three groups returns two INNER links from the hub."""
+        links = Link.star(HubFG, SpokeAFG, SpokeBFG, index_column="row_id")
+
+        assert isinstance(links, set)
+        assert len(links) == 2
+
+        # Every link is an INNER join from the hub to a spoke, on the shared index.
+        for link in links:
+            assert link.jointype == JoinType.INNER
+            assert link.left_feature_group is HubFG
+            assert link.left_index == ROW_INDEX
+            assert link.right_index == ROW_INDEX
+
+        spokes = {link.right_feature_group for link in links}
+        assert spokes == {SpokeAFG, SpokeBFG}
+
+    def test_star_single_spoke_returns_one_link(self) -> None:
+        """Test Link.star with two groups returns a single hub-to-spoke INNER link."""
+        links = Link.star(HubFG, SpokeAFG, index_column="row_id")
+
+        assert isinstance(links, set)
+        assert len(links) == 1
+
+        link = next(iter(links))
+        assert link.jointype == JoinType.INNER
+        assert link.left_feature_group is HubFG
+        assert link.right_feature_group is SpokeAFG
+        assert link.left_index == ROW_INDEX
+        assert link.right_index == ROW_INDEX
+
+    def test_star_accepts_str_tuple_and_index_equivalently(self) -> None:
+        """Test index_column accepts str, tuple, or Index and produces equivalent links."""
+        links_str = Link.star(HubFG, SpokeAFG, index_column="row_id")
+        links_tuple = Link.star(HubFG, SpokeAFG, index_column=("row_id",))
+        links_index = Link.star(HubFG, SpokeAFG, index_column=Index(("row_id",)))
+
+        assert links_str == links_tuple
+        assert links_tuple == links_index
+
+    def test_star_dedupes_duplicate_spokes(self) -> None:
+        """Test Link.star dedupes a repeated spoke into a single link (set semantics)."""
+        links = Link.star(HubFG, SpokeAFG, SpokeAFG, index_column="row_id")
+
+        assert len(links) == 1
+        link = next(iter(links))
+        assert link.left_feature_group is HubFG
+        assert link.right_feature_group is SpokeAFG
+
+    def test_star_equivalent_to_manual_inner_construction(self) -> None:
+        """Test Link.star produces a link equal to manual Link.inner construction."""
+        links = Link.star(HubFG, SpokeAFG, index_column="row_id")
+
+        manual = Link.inner(
+            JoinSpec(HubFG, Index(("row_id",))),
+            JoinSpec(SpokeAFG, Index(("row_id",))),
+        )
+
+        assert next(iter(links)) == manual
+
+    def test_star_with_multi_column_tuple_index(self) -> None:
+        """Test Link.star with a multi-column tuple index yields a multi-column index on both sides."""
+        links = Link.star(HubFG, SpokeAFG, index_column=("row_id", "region"))
+
+        assert len(links) == 1
+        link = next(iter(links))
+        multi_index = Index(("row_id", "region"))
+        assert link.left_index == multi_index
+        assert link.right_index == multi_index
+        assert link.left_index.is_multi_index() is True
+
+    def test_star_raises_value_error_on_empty_index_column(self) -> None:
+        """Test Link.star raises ValueError on an empty index column string."""
+        with pytest.raises(ValueError, match="empty"):
+            Link.star(HubFG, SpokeAFG, index_column="")
+
+    def test_star_raises_value_error_with_single_group(self) -> None:
+        """Test Link.star raises ValueError when only a hub is provided (no spokes)."""
+        with pytest.raises(ValueError):
+            Link.star(HubFG, index_column="row_id")
+
+    def test_star_raises_value_error_with_no_groups(self) -> None:
+        """Test Link.star raises ValueError when no feature groups are provided."""
+        with pytest.raises(ValueError):
+            Link.star(index_column="row_id")

--- a/tests/test_plugins/compute_framework/test_link_star_integration.py
+++ b/tests/test_plugins/compute_framework/test_link_star_integration.py
@@ -1,0 +1,351 @@
+"""End-to-end integration coverage for ``Link.star`` through the real mloda engine.
+
+These tests build a genuine star topology (one hub feature group plus multiple
+spoke feature groups, all sharing a single ``"row_id"`` index column) and run the
+result through ``mloda.run_all`` on the pandas compute framework. Unlike the unit
+tests for ``Link.star`` (which only inspect the returned ``Link`` set), these
+exercise the joins the engine actually performs and assert on concrete joined
+cell values.
+"""
+
+from typing import Any, Optional
+
+from mloda.provider import FeatureGroup, FeatureSet, BaseInputData, DataCreator
+from mloda.user import Feature, FeatureName, Index, Link, JoinSpec, JoinType, Options, PluginCollector, mloda
+
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame  # noqa: F401
+
+
+# === Fully-matching star topology (all FGs expose row_id [1, 2, 3]) ===
+
+
+class StarHubFG(FeatureGroup):
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={"row_id", "hub_value"})
+
+    @classmethod
+    def index_columns(cls) -> Optional[list[Index]]:
+        return [Index(("row_id",))]
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {"row_id": [1, 2, 3], "hub_value": ["h1", "h2", "h3"]}
+
+
+class StarSpokeAFG(FeatureGroup):
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={"row_id", "spoke_a_value"})
+
+    @classmethod
+    def index_columns(cls) -> Optional[list[Index]]:
+        return [Index(("row_id",))]
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {"row_id": [1, 2, 3], "spoke_a_value": [10, 20, 30]}
+
+
+class StarSpokeBFG(FeatureGroup):
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={"row_id", "spoke_b_value"})
+
+    @classmethod
+    def index_columns(cls) -> Optional[list[Index]]:
+        return [Index(("row_id",))]
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {"row_id": [1, 2, 3], "spoke_b_value": ["x", "y", "z"]}
+
+
+class StarConsumerFG(FeatureGroup):
+    """Downstream consumer that combines the hub column with both spoke columns.
+
+    Requesting all three features forces the engine to materialise the star join
+    before this group runs, so the merged frame is what ``calculate_feature`` sees.
+    """
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return {
+            Feature(name="hub_value"),
+            Feature(name="spoke_a_value"),
+            Feature(name="spoke_b_value"),
+        }
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        data[cls.get_class_name()] = (
+            data["hub_value"] + "|" + data["spoke_a_value"].astype(str) + "|" + data["spoke_b_value"]
+        )
+        return data
+
+
+# === Partial star topology (spoke B is missing row_id 3) to observe LEFT vs INNER ===
+
+
+class StarLeftHubFG(FeatureGroup):
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={"row_id", "left_hub_value"})
+
+    @classmethod
+    def index_columns(cls) -> Optional[list[Index]]:
+        return [Index(("row_id",))]
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {"row_id": [1, 2, 3], "left_hub_value": ["h1", "h2", "h3"]}
+
+
+class StarLeftSpokeAFG(FeatureGroup):
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={"row_id", "left_spoke_a_value"})
+
+    @classmethod
+    def index_columns(cls) -> Optional[list[Index]]:
+        return [Index(("row_id",))]
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {"row_id": [1, 2, 3], "left_spoke_a_value": [10, 20, 30]}
+
+
+class StarLeftSpokeBFG(FeatureGroup):
+    """Spoke B is intentionally missing row_id 3 so INNER drops it and LEFT keeps it."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={"row_id", "left_spoke_b_value"})
+
+    @classmethod
+    def index_columns(cls) -> Optional[list[Index]]:
+        return [Index(("row_id",))]
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {"row_id": [1, 2], "left_spoke_b_value": ["x", "y"]}
+
+
+class StarLeftConsumerFG(FeatureGroup):
+    """Consumer for the partial topology.
+
+    It requests all three features (so both spoke joins run) but only combines the
+    always-present hub and spoke-A columns, avoiding NaN concatenation on the row
+    that spoke B does not supply.
+    """
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return {
+            Feature(name="left_hub_value"),
+            Feature(name="left_spoke_a_value"),
+            Feature(name="left_spoke_b_value"),
+        }
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        data[cls.get_class_name()] = data["left_hub_value"] + "|" + data["left_spoke_a_value"].astype(str)
+        return data
+
+
+# === Outer star topology (spoke has a row_id the hub lacks) to observe OUTER vs INNER ===
+
+
+class StarOuterHubFG(FeatureGroup):
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={"row_id", "outer_hub_value"})
+
+    @classmethod
+    def index_columns(cls) -> Optional[list[Index]]:
+        return [Index(("row_id",))]
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {"row_id": [1, 2, 3], "outer_hub_value": ["h1", "h2", "h3"]}
+
+
+class StarOuterSpokeAFG(FeatureGroup):
+    """Spoke carries row_id 4 (which the hub lacks) and lacks row_id 1 (which the hub has)."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={"row_id", "outer_spoke_a_value"})
+
+    @classmethod
+    def index_columns(cls) -> Optional[list[Index]]:
+        return [Index(("row_id",))]
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {"row_id": [2, 3, 4], "outer_spoke_a_value": [20, 30, 40]}
+
+
+class StarOuterConsumerFG(FeatureGroup):
+    """Consumer for the outer topology.
+
+    It requests both features (so the join runs) but only passes the join key
+    ``row_id`` through, so no possibly-null column is string-concatenated.
+    """
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return {
+            Feature(name="outer_hub_value"),
+            Feature(name="outer_spoke_a_value"),
+        }
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        data[cls.get_class_name()] = data["row_id"]
+        return data
+
+
+class TestLinkStarIntegration:
+    def test_default_inner_star_end_to_end(self, flight_server: Any) -> None:
+        """Default inner ``Link.star`` produces a 3-row merged frame with exact combined values."""
+        links = Link.star(StarHubFG, StarSpokeAFG, StarSpokeBFG, index_column="row_id")
+
+        result = mloda.run_all(
+            [Feature(name=StarConsumerFG.get_class_name())],
+            links=links,
+            compute_frameworks=["PandasDataFrame"],
+            plugin_collector=PluginCollector.enabled_feature_groups(
+                {StarHubFG, StarSpokeAFG, StarSpokeBFG, StarConsumerFG}
+            ),
+            flight_server=flight_server,
+        )
+
+        assert len(result) == 1
+        res = result[0]
+        assert len(res) == 3
+        column = StarConsumerFG.get_class_name()
+        assert column in res.columns
+        assert set(res[column].values) == {"h1|10|x", "h2|20|y", "h3|30|z"}
+
+    def test_star_matches_manual_inner_links(self, flight_server: Any) -> None:
+        """``Link.star`` is a faithful drop-in for a hand-built loop of ``Link.inner`` links."""
+        star_links = Link.star(StarHubFG, StarSpokeAFG, StarSpokeBFG, index_column="row_id")
+        manual_links = {
+            Link.inner(JoinSpec(StarHubFG, Index(("row_id",))), JoinSpec(StarSpokeAFG, Index(("row_id",)))),
+            Link.inner(JoinSpec(StarHubFG, Index(("row_id",))), JoinSpec(StarSpokeBFG, Index(("row_id",)))),
+        }
+
+        collector = PluginCollector.enabled_feature_groups({StarHubFG, StarSpokeAFG, StarSpokeBFG, StarConsumerFG})
+        column = StarConsumerFG.get_class_name()
+
+        star_result = mloda.run_all(
+            [Feature(name=column)],
+            links=star_links,
+            compute_frameworks=["PandasDataFrame"],
+            plugin_collector=collector,
+            flight_server=flight_server,
+        )
+        manual_result = mloda.run_all(
+            [Feature(name=column)],
+            links=manual_links,
+            compute_frameworks=["PandasDataFrame"],
+            plugin_collector=collector,
+            flight_server=flight_server,
+        )
+
+        assert len(star_result) == 1
+        assert len(manual_result) == 1
+        star_values = sorted(star_result[0][column].values)
+        manual_values = sorted(manual_result[0][column].values)
+        assert star_values == manual_values
+        assert star_values == ["h1|10|x", "h2|20|y", "h3|30|z"]
+
+    def test_left_star_preserves_hub_rows(self, flight_server: Any) -> None:
+        """A LEFT ``Link.star`` keeps every hub row while an inner star drops the unmatched one."""
+        left_links = Link.star(
+            StarLeftHubFG,
+            StarLeftSpokeAFG,
+            StarLeftSpokeBFG,
+            index_column="row_id",
+            jointype=JoinType.LEFT,
+        )
+        inner_links = Link.star(
+            StarLeftHubFG,
+            StarLeftSpokeAFG,
+            StarLeftSpokeBFG,
+            index_column="row_id",
+        )
+
+        collector = PluginCollector.enabled_feature_groups(
+            {StarLeftHubFG, StarLeftSpokeAFG, StarLeftSpokeBFG, StarLeftConsumerFG}
+        )
+        column = StarLeftConsumerFG.get_class_name()
+
+        left_result = mloda.run_all(
+            [Feature(name=column)],
+            links=left_links,
+            compute_frameworks=["PandasDataFrame"],
+            plugin_collector=collector,
+            flight_server=flight_server,
+        )
+        inner_result = mloda.run_all(
+            [Feature(name=column)],
+            links=inner_links,
+            compute_frameworks=["PandasDataFrame"],
+            plugin_collector=collector,
+            flight_server=flight_server,
+        )
+
+        assert len(left_result) == 1
+        left_res = left_result[0]
+        # LEFT star keeps all three hub rows (row_id 3 has no spoke-B match).
+        assert len(left_res) == 3
+        assert set(left_res[column].values) == {"h1|10", "h2|20", "h3|30"}
+
+        # INNER star on the same data drops the unmatched hub row: observable contrast.
+        assert len(inner_result) == 1
+        inner_res = inner_result[0]
+        assert len(inner_res) == 2
+        assert set(inner_res[column].values) == {"h1|10", "h2|20"}
+
+    def test_outer_star_keeps_unmatched_spoke_row(self, flight_server: Any) -> None:
+        """An OUTER ``Link.star`` keeps the spoke row_id the hub lacks; an inner star drops it."""
+        outer_links = Link.star(
+            StarOuterHubFG,
+            StarOuterSpokeAFG,
+            index_column="row_id",
+            jointype=JoinType.OUTER,
+        )
+        inner_links = Link.star(
+            StarOuterHubFG,
+            StarOuterSpokeAFG,
+            index_column="row_id",
+        )
+
+        collector = PluginCollector.enabled_feature_groups({StarOuterHubFG, StarOuterSpokeAFG, StarOuterConsumerFG})
+        column = StarOuterConsumerFG.get_class_name()
+
+        outer_result = mloda.run_all(
+            [Feature(name=column)],
+            links=outer_links,
+            compute_frameworks=["PandasDataFrame"],
+            plugin_collector=collector,
+            flight_server=flight_server,
+        )
+        inner_result = mloda.run_all(
+            [Feature(name=column)],
+            links=inner_links,
+            compute_frameworks=["PandasDataFrame"],
+            plugin_collector=collector,
+            flight_server=flight_server,
+        )
+
+        # OUTER keeps the full union of row_ids: hub-only (1), matched (2, 3) and spoke-only (4).
+        assert len(outer_result) == 1
+        outer_ids = {int(v) for v in outer_result[0][column].values}
+        assert outer_ids == {1, 2, 3, 4}
+        assert 4 in outer_ids
+
+        # INNER keeps only the matched row_ids, dropping the spoke-only row 4: observable contrast.
+        assert len(inner_result) == 1
+        inner_ids = {int(v) for v in inner_result[0][column].values}
+        assert inner_ids == {2, 3}
+        assert 4 not in inner_ids


### PR DESCRIPTION
## Summary

Adds `Link.star(*feature_groups, index_column=...)` to mloda core, a builder for the star-join topology (join every feature group to a shared row-index column). This replaces the hand-rolled loop reinvented 6+ times in mvp-cwa:

```python
# before
links = set()
idx = Index((ROW_INDEX_COLUMN,))
base_group = feature_groups[0]
for other_group in feature_groups[1:]:
    links.add(Link.inner(JoinSpec(base_group, idx), JoinSpec(other_group, idx)))

# after
links = Link.star(base_group, *other_groups, index_column=ROW_INDEX_COLUMN)
```

Closes #571 (part of umbrella #566).

## Behavior

- First feature group is the hub; every remaining group is inner-joined to it on the shared index. Returns a `set[Link]`.
- `index_column` is keyword-only and accepts `str`, `tuple[str, ...]`, or `Index`; it is normalized once and reused on both sides of every link, so all three forms are equivalent.
- Duplicate spokes collapse in the returned set (via `Link.__eq__`/`__hash__`).
- Raises `ValueError` when fewer than two feature groups are supplied (a star needs a hub plus at least one spoke).
- Scope: targets joins between distinct feature-group classes. Same-class node disambiguation via discriminators is intentionally out of scope; use `Link.inner` with discriminators for that.

## Tests

New `tests/test_core/test_setup/test_link_star.py` (9 tests): 3-group star, single spoke, str/tuple/Index equivalence, multi-column tuple index, dedup of duplicate spokes, equivalence to manual `Link.inner` construction, empty index raises, and `< 2` groups raises.

## Validation

`tox` passes locally: 3874 passed, 167 skipped, plus ruff format/check, mypy --strict, pip-licenses, and bandit all green.

## Review

Built via TDD (red/green) and gated by two independent deep reviews (Claude Opus and codex). No blocking findings. Accepted improvements: added multi-column and empty-index coverage tests, and documented the distinct-class scope limitation. Codex suggested forwarding discriminators for same-class nodes; deferred as out of scope for this issue's motivating cases.