### PR TITLE
feat: result serialization helpers (to_json_records/to_csv) for run_all output (#573)

### DIFF
--- a/mloda/core/api/request.py
+++ b/mloda/core/api/request.py
@@ -174,9 +174,13 @@ class mlodaAPI:
         )
 
     @staticmethod
-    def to_framework(result: Any, framework: "str | type[ComputeFramework]") -> Any:
+    def to_framework(
+        result: Any,
+        framework: "str | type[ComputeFramework]",
+        framework_connection_object: Any = None,
+    ) -> Any:
         """Convert a single ``run_all`` result to the native object of the target framework."""
-        return _to_framework(result, framework)
+        return _to_framework(result, framework, framework_connection_object)
 
     @staticmethod
     def to_records(result: Any) -> list[dict[str, Any]]:

--- a/mloda/core/api/request.py
+++ b/mloda/core/api/request.py
@@ -167,6 +167,20 @@ class mlodaAPI:
             function_extender=function_extender,
         )
 
+    @staticmethod
+    def to_json_records(result: Any) -> list[dict[str, Any]]:
+        """Serialize a single ``run_all`` result to a list of row dicts."""
+        from mloda.core.api.result_serializer import to_json_records
+
+        return to_json_records(result)
+
+    @staticmethod
+    def to_csv(result: Any) -> str:
+        """Serialize a single ``run_all`` result to a CSV string."""
+        from mloda.core.api.result_serializer import to_csv
+
+        return to_csv(result)
+
     @classmethod
     def stream_all(
         cls,

--- a/mloda/core/api/request.py
+++ b/mloda/core/api/request.py
@@ -7,6 +7,7 @@ from mloda.core.abstract_plugins.components.input_data.api.api_input_data_collec
 from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
 from mloda.core.core.engine import Engine
 from mloda.core.api.prepare.setup_compute_framework import SetupComputeFramework
+from mloda.core.api.result_serializer import to_csv as _to_csv, to_json_records as _to_json_records
 from mloda.core.prepare.accessible_plugins import filter_extenders_by_strict_mode
 from mloda.core.filter.global_filter import GlobalFilter
 from mloda.core.runtime.run import ExecutionOrchestrator
@@ -170,16 +171,12 @@ class mlodaAPI:
     @staticmethod
     def to_json_records(result: Any) -> list[dict[str, Any]]:
         """Serialize a single ``run_all`` result to a list of row dicts."""
-        from mloda.core.api.result_serializer import to_json_records
-
-        return to_json_records(result)
+        return _to_json_records(result)
 
     @staticmethod
     def to_csv(result: Any) -> str:
         """Serialize a single ``run_all`` result to a CSV string."""
-        from mloda.core.api.result_serializer import to_csv
-
-        return to_csv(result)
+        return _to_csv(result)
 
     @classmethod
     def stream_all(

--- a/mloda/core/api/request.py
+++ b/mloda/core/api/request.py
@@ -7,7 +7,12 @@ from mloda.core.abstract_plugins.components.input_data.api.api_input_data_collec
 from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
 from mloda.core.core.engine import Engine
 from mloda.core.api.prepare.setup_compute_framework import SetupComputeFramework
-from mloda.core.api.result_serializer import to_csv as _to_csv, to_json_records as _to_json_records
+from mloda.core.api.result_serializer import (
+    to_framework as _to_framework,
+    to_records as _to_records,
+    to_arrow as _to_arrow,
+    to_csv as _to_csv,
+)
 from mloda.core.prepare.accessible_plugins import filter_extenders_by_strict_mode
 from mloda.core.filter.global_filter import GlobalFilter
 from mloda.core.runtime.run import ExecutionOrchestrator
@@ -169,9 +174,19 @@ class mlodaAPI:
         )
 
     @staticmethod
-    def to_json_records(result: Any) -> list[dict[str, Any]]:
+    def to_framework(result: Any, framework: "str | type[ComputeFramework]") -> Any:
+        """Convert a single ``run_all`` result to the native object of the target framework."""
+        return _to_framework(result, framework)
+
+    @staticmethod
+    def to_records(result: Any) -> list[dict[str, Any]]:
         """Serialize a single ``run_all`` result to a list of row dicts."""
-        return _to_json_records(result)
+        return _to_records(result)
+
+    @staticmethod
+    def to_arrow(result: Any) -> Any:
+        """Serialize a single ``run_all`` result to a pyarrow Table."""
+        return _to_arrow(result)
 
     @staticmethod
     def to_csv(result: Any) -> str:

--- a/mloda/core/api/result_serializer.py
+++ b/mloda/core/api/result_serializer.py
@@ -66,11 +66,18 @@ def _rows_to_csv(fieldnames: list[str], rows: list[dict[str, Any]]) -> str:
     return buf.getvalue()
 
 
+def _normalize_records(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Rewrite records to the UNION of all keys, filling missing keys with ``None``."""
+    fieldnames = _record_union_fieldnames(records)
+    return [{name: rec.get(name) for name in fieldnames} for rec in records]
+
+
 def _load_compute_frameworks() -> None:
     from mloda.core.abstract_plugins.plugin_loader.plugin_loader import PluginLoader
 
     if "compute_framework" not in PluginLoader._disabled_groups:
         PluginLoader().load_group("compute_framework")
+    PluginLoader().load_entry_points()
 
 
 def _resolve_framework(framework: str | type[ComputeFramework]) -> type[ComputeFramework]:
@@ -93,7 +100,11 @@ def _resolve_framework(framework: str | type[ComputeFramework]) -> type[ComputeF
     )
 
 
-def to_framework(result: Any, framework: str | type[ComputeFramework]) -> Any:
+def to_framework(
+    result: Any,
+    framework: str | type[ComputeFramework],
+    framework_connection_object: Any = None,
+) -> Any:
     """Convert a single run_all result into the native object of the target compute framework."""
     if isinstance(result, list) and not _is_record_list(result):
         raise _ambiguous_list_error()
@@ -108,12 +119,15 @@ def to_framework(result: Any, framework: str | type[ComputeFramework]) -> Any:
     if source_type == target_type:
         return result
 
+    data = result
+    if _is_record_list(result):
+        data = _normalize_records(result)
+
     transformer = ComputeFrameworkTransformer()
     chain = transformer.get_transformation_chain(source_type, target_type)
     if chain is None:
         raise ValueError(f"No transformation path found from {source_type} to {target_type}.")
 
-    data = result
     current_fw = source_type
     for i, transformer_cls in enumerate(chain):
         if i == len(chain) - 1:
@@ -129,7 +143,7 @@ def to_framework(result: Any, framework: str | type[ComputeFramework]) -> Any:
                     f"Could not determine intermediate target for transformer {transformer_cls} from {current_fw}."
                 )
 
-        data = transformer_cls.transform(current_fw, step_target, data, None)
+        data = transformer_cls.transform(current_fw, step_target, data, framework_connection_object)
         current_fw = step_target
 
     return data

--- a/mloda/core/api/result_serializer.py
+++ b/mloda/core/api/result_serializer.py
@@ -77,7 +77,6 @@ def _load_compute_frameworks() -> None:
 
     if "compute_framework" not in PluginLoader._disabled_groups:
         PluginLoader().load_group("compute_framework")
-    PluginLoader().load_entry_points()
 
 
 def _resolve_framework(framework: str | type[ComputeFramework]) -> type[ComputeFramework]:

--- a/mloda/core/api/result_serializer.py
+++ b/mloda/core/api/result_serializer.py
@@ -5,21 +5,23 @@ Each ``result`` is a SINGLE compute-framework object (one element of the
 python_dict result (``list[dict]``).
 
 Notes:
-- Record-list (python_dict) results serialize with the stdlib only. Framework
-  objects (pandas, polars, pyarrow Table, ...) go through the pyarrow hub, so
-  pyarrow is required for non-python_dict framework results.
-- ``to_json_records`` values are Python natives produced by the compute
-  framework and may include non-JSON-primitive types (e.g. ``datetime``) for
-  such columns, mirroring pandas' ``to_dict("records")``.
+- Conversions dispatch through mloda's compute-framework registry. Only
+  python_dict record-list CSV output stays pyarrow-free; all other framework
+  conversions go through the pyarrow hub, so pyarrow is required for
+  non-python_dict framework results.
+- Record values are Python natives produced by the target compute framework and
+  may include non-JSON-primitive types (e.g. ``datetime``) for such columns.
 """
 
 import csv
 import io
 from typing import Any
 
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.components.framework_transformer.cfw_transformer import (
     ComputeFrameworkTransformer,
 )
+from mloda.core.abstract_plugins.components.utils import get_all_subclasses
 
 try:
     import pyarrow as pa
@@ -64,41 +66,93 @@ def _rows_to_csv(fieldnames: list[str], rows: list[dict[str, Any]]) -> str:
     return buf.getvalue()
 
 
-def _framework_to_pyarrow_table(result: Any) -> "pa.Table":
-    _require_pyarrow()
+def _load_compute_frameworks() -> None:
+    from mloda.core.abstract_plugins.plugin_loader.plugin_loader import PluginLoader
 
-    if isinstance(result, pa.Table):
-        return result
-
-    from_framework = type(result)
-    chain = ComputeFrameworkTransformer().get_transformation_chain(from_framework, pa.Table)
-
-    if chain is None:
-        raise ValueError(f"No transformation path found from {from_framework} to pyarrow.Table.")
-    if len(chain) != 1:
-        raise ValueError(
-            f"Unexpected multi-step transformation chain from {from_framework} to pyarrow.Table; "
-            "a direct transformer was expected."
-        )
-
-    return chain[0].transform(from_framework, pa.Table, result, None)
+    if "compute_framework" not in PluginLoader._disabled_groups:
+        PluginLoader().load_group("compute_framework")
 
 
-def to_json_records(result: Any) -> list[dict[str, Any]]:
-    if isinstance(result, list):
-        if _is_record_list(result):
-            return list(result)
+def _resolve_framework(framework: str | type[ComputeFramework]) -> type[ComputeFramework]:
+    if isinstance(framework, type) and issubclass(framework, ComputeFramework):
+        return framework
+
+    for cls in get_all_subclasses(ComputeFramework):
+        if cls.get_class_name() == framework:
+            return cls
+
+    _load_compute_frameworks()
+    sub_classes = get_all_subclasses(ComputeFramework)
+    for cls in sub_classes:
+        if cls.get_class_name() == framework:
+            return cls
+
+    available_names = sorted(cls.get_class_name() for cls in sub_classes)
+    raise ValueError(
+        f"No compute framework named '{framework}' found in available compute frameworks: {available_names}."
+    )
+
+
+def to_framework(result: Any, framework: str | type[ComputeFramework]) -> Any:
+    """Convert a single run_all result into the native object of the target compute framework."""
+    if isinstance(result, list) and not _is_record_list(result):
         raise _ambiguous_list_error()
 
-    records: list[dict[str, Any]] = _framework_to_pyarrow_table(result).to_pylist()
+    target_cls = _resolve_framework(framework)
+
+    target_type = target_cls.expected_data_framework()
+    if target_type is None:
+        raise ValueError(f"Compute framework '{target_cls.get_class_name()}' does not declare a native data type.")
+
+    source_type = type(result)
+    if source_type == target_type:
+        return result
+
+    transformer = ComputeFrameworkTransformer()
+    chain = transformer.get_transformation_chain(source_type, target_type)
+    if chain is None:
+        raise ValueError(f"No transformation path found from {source_type} to {target_type}.")
+
+    data = result
+    current_fw = source_type
+    for i, transformer_cls in enumerate(chain):
+        if i == len(chain) - 1:
+            step_target = target_type
+        else:
+            step_target = None
+            for (src, dst), trans in transformer.transformer_map.items():
+                if trans == transformer_cls and src == current_fw:
+                    step_target = dst
+                    break
+            if step_target is None:
+                raise ValueError(
+                    f"Could not determine intermediate target for transformer {transformer_cls} from {current_fw}."
+                )
+
+        data = transformer_cls.transform(current_fw, step_target, data, None)
+        current_fw = step_target
+
+    return data
+
+
+def to_records(result: Any) -> list[dict[str, Any]]:
+    """Serialize a single ``run_all`` result to a list of row dicts (python_dict native)."""
+    records: list[dict[str, Any]] = to_framework(result, "PythonDictFramework")
     return records
 
 
+def to_arrow(result: Any) -> "pa.Table":
+    """Serialize a single ``run_all`` result to a pyarrow Table."""
+    _require_pyarrow()
+    return to_framework(result, "PyArrowTable")
+
+
 def to_csv(result: Any) -> str:
+    """Serialize a single ``run_all`` result to a CSV string."""
     if isinstance(result, list):
         if _is_record_list(result):
             return _rows_to_csv(_record_union_fieldnames(result), result)
         raise _ambiguous_list_error()
 
-    table = _framework_to_pyarrow_table(result)
+    table = to_arrow(result)
     return _rows_to_csv(table.column_names, table.to_pylist())

--- a/mloda/core/api/result_serializer.py
+++ b/mloda/core/api/result_serializer.py
@@ -5,8 +5,11 @@ Each ``result`` is a SINGLE compute-framework object (one element of the
 python_dict result (``list[dict]``).
 
 Notes:
-- Conversions dispatch through mloda's compute-framework registry. Only
-  python_dict record-list CSV output stays pyarrow-free; all other framework
+- Conversions rely on mloda's compute-framework transformer registry. Names are
+  resolved only against ALREADY-LOADED frameworks; no plugin auto-loading is
+  triggered. ``to_framework`` therefore requires the named framework to be
+  imported first, exactly as you would before passing it to ``run_all``.
+- Only python_dict record-list CSV output stays pyarrow-free; all other framework
   conversions go through the pyarrow hub, so pyarrow is required for
   non-python_dict framework results.
 - Record values are Python natives produced by the target compute framework and
@@ -72,22 +75,10 @@ def _normalize_records(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return [{name: rec.get(name) for name in fieldnames} for rec in records]
 
 
-def _load_compute_frameworks() -> None:
-    from mloda.core.abstract_plugins.plugin_loader.plugin_loader import PluginLoader
-
-    if "compute_framework" not in PluginLoader._disabled_groups:
-        PluginLoader().load_group("compute_framework")
-
-
 def _resolve_framework(framework: str | type[ComputeFramework]) -> type[ComputeFramework]:
     if isinstance(framework, type) and issubclass(framework, ComputeFramework):
         return framework
 
-    for cls in get_all_subclasses(ComputeFramework):
-        if cls.get_class_name() == framework:
-            return cls
-
-    _load_compute_frameworks()
     sub_classes = get_all_subclasses(ComputeFramework)
     for cls in sub_classes:
         if cls.get_class_name() == framework:
@@ -95,24 +86,14 @@ def _resolve_framework(framework: str | type[ComputeFramework]) -> type[ComputeF
 
     available_names = sorted(cls.get_class_name() for cls in sub_classes)
     raise ValueError(
-        f"No compute framework named '{framework}' found in available compute frameworks: {available_names}."
+        f"No compute framework named '{framework}' found in loaded compute frameworks: {available_names}. "
+        "Import the framework module (as you would before passing it to run_all)."
     )
 
 
-def to_framework(
-    result: Any,
-    framework: str | type[ComputeFramework],
-    framework_connection_object: Any = None,
-) -> Any:
-    """Convert a single run_all result into the native object of the target compute framework."""
+def _convert(result: Any, target_type: Any, framework_connection_object: Any = None) -> Any:
     if isinstance(result, list) and not _is_record_list(result):
         raise _ambiguous_list_error()
-
-    target_cls = _resolve_framework(framework)
-
-    target_type = target_cls.expected_data_framework()
-    if target_type is None:
-        raise ValueError(f"Compute framework '{target_cls.get_class_name()}' does not declare a native data type.")
 
     source_type = type(result)
     if source_type == target_type:
@@ -148,16 +129,31 @@ def to_framework(
     return data
 
 
+def to_framework(
+    result: Any,
+    framework: str | type[ComputeFramework],
+    framework_connection_object: Any = None,
+) -> Any:
+    """Convert a single run_all result into the native object of the target compute framework."""
+    target_cls = _resolve_framework(framework)
+
+    target_type = target_cls.expected_data_framework()
+    if target_type is None:
+        raise ValueError(f"Compute framework '{target_cls.get_class_name()}' does not declare a native data type.")
+
+    return _convert(result, target_type, framework_connection_object)
+
+
 def to_records(result: Any) -> list[dict[str, Any]]:
     """Serialize a single ``run_all`` result to a list of row dicts (python_dict native)."""
-    records: list[dict[str, Any]] = to_framework(result, "PythonDictFramework")
+    records: list[dict[str, Any]] = _convert(result, list)
     return records
 
 
 def to_arrow(result: Any) -> "pa.Table":
     """Serialize a single ``run_all`` result to a pyarrow Table."""
     _require_pyarrow()
-    return to_framework(result, "PyArrowTable")
+    return _convert(result, pa.Table)
 
 
 def to_csv(result: Any) -> str:
@@ -167,5 +163,6 @@ def to_csv(result: Any) -> str:
             return _rows_to_csv(_record_union_fieldnames(result), result)
         raise _ambiguous_list_error()
 
-    table = to_arrow(result)
+    _require_pyarrow()
+    table = _convert(result, pa.Table)
     return _rows_to_csv(table.column_names, table.to_pylist())

--- a/mloda/core/api/result_serializer.py
+++ b/mloda/core/api/result_serializer.py
@@ -3,6 +3,14 @@
 Each ``result`` is a SINGLE compute-framework object (one element of the
 ``run_all`` list), e.g. a ``pd.DataFrame``, ``pa.Table``, polars DataFrame, or a
 python_dict result (``list[dict]``).
+
+Notes:
+- Record-list (python_dict) results serialize with the stdlib only. Framework
+  objects (pandas, polars, pyarrow Table, ...) go through the pyarrow hub, so
+  pyarrow is required for non-python_dict framework results.
+- ``to_json_records`` values are Python natives produced by the compute
+  framework and may include non-JSON-primitive types (e.g. ``datetime``) for
+  such columns, mirroring pandas' ``to_dict("records")``.
 """
 
 import csv
@@ -29,62 +37,68 @@ def _is_record_list(result: Any) -> bool:
     return isinstance(result, list) and (len(result) == 0 or all(isinstance(item, dict) for item in result))
 
 
-def _to_pyarrow_table(result: Any) -> "pa.Table":
+def _ambiguous_list_error() -> ValueError:
+    return ValueError(
+        "Expected a single run_all result object, got a list whose elements are not all dicts. "
+        "Pass a single result element, e.g. results[0], not the whole run_all() list."
+    )
+
+
+def _record_union_fieldnames(records: list[dict[str, Any]]) -> list[str]:
+    """Union of all keys across all records, preserving first-seen order."""
+    fieldnames: list[str] = []
+    seen: set[str] = set()
+    for record in records:
+        for key in record:
+            if key not in seen:
+                seen.add(key)
+                fieldnames.append(key)
+    return fieldnames
+
+
+def _rows_to_csv(fieldnames: list[str], rows: list[dict[str, Any]]) -> str:
+    buf = io.StringIO()
+    writer = csv.DictWriter(buf, fieldnames=fieldnames, lineterminator="\n", extrasaction="ignore")
+    writer.writeheader()
+    writer.writerows(rows)
+    return buf.getvalue()
+
+
+def _framework_to_pyarrow_table(result: Any) -> "pa.Table":
     _require_pyarrow()
 
     if isinstance(result, pa.Table):
         return result
 
-    if _is_record_list(result):
-        return pa.Table.from_pylist(result)
-
-    transformer = ComputeFrameworkTransformer()
     from_framework = type(result)
-    chain = transformer.get_transformation_chain(from_framework, pa.Table)
+    chain = ComputeFrameworkTransformer().get_transformation_chain(from_framework, pa.Table)
 
     if chain is None:
         raise ValueError(f"No transformation path found from {from_framework} to pyarrow.Table.")
+    if len(chain) != 1:
+        raise ValueError(
+            f"Unexpected multi-step transformation chain from {from_framework} to pyarrow.Table; "
+            "a direct transformer was expected."
+        )
 
-    data = result
-    current_fw = from_framework
-    for i, transformer_cls in enumerate(chain):
-        if i == len(chain) - 1:
-            target_fw = pa.Table
-        else:
-            for (src, dst), trans in transformer.transformer_map.items():
-                if trans == transformer_cls and src == current_fw:
-                    target_fw = dst
-                    break
-        data = transformer_cls.transform(current_fw, target_fw, data, None)
-        current_fw = target_fw
-
-    return data
+    return chain[0].transform(from_framework, pa.Table, result, None)
 
 
 def to_json_records(result: Any) -> list[dict[str, Any]]:
     if isinstance(result, list):
         if _is_record_list(result):
             return list(result)
-        raise ValueError(
-            f"Expected a single run_all result object, got a list of {type(result[0])}. "
-            "Pass a single result element, e.g. results[0], not the whole run_all() list."
-        )
+        raise _ambiguous_list_error()
 
-    table = _to_pyarrow_table(result)
-    records: list[dict[str, Any]] = table.to_pylist()
+    records: list[dict[str, Any]] = _framework_to_pyarrow_table(result).to_pylist()
     return records
 
 
 def to_csv(result: Any) -> str:
-    if isinstance(result, list) and not _is_record_list(result):
-        raise ValueError(
-            f"Expected a single run_all result object, got a list of {type(result[0])}. "
-            "Pass a single result element, e.g. results[0], not the whole run_all() list."
-        )
+    if isinstance(result, list):
+        if _is_record_list(result):
+            return _rows_to_csv(_record_union_fieldnames(result), result)
+        raise _ambiguous_list_error()
 
-    table = _to_pyarrow_table(result)
-    buf = io.StringIO()
-    writer = csv.DictWriter(buf, fieldnames=table.column_names, lineterminator="\n")
-    writer.writeheader()
-    writer.writerows(table.to_pylist())
-    return buf.getvalue()
+    table = _framework_to_pyarrow_table(result)
+    return _rows_to_csv(table.column_names, table.to_pylist())

--- a/mloda/core/api/result_serializer.py
+++ b/mloda/core/api/result_serializer.py
@@ -106,6 +106,15 @@ def _convert(result: Any, target_type: Any, framework_connection_object: Any = N
     transformer = ComputeFrameworkTransformer()
     chain = transformer.get_transformation_chain(source_type, target_type)
     if chain is None:
+        # The transformer registry may be only partially populated (its auto-load
+        # is skipped once any transformer is registered). Force-load the transformer
+        # plugins (transformers only, not frameworks) and retry once.
+        from mloda.core.abstract_plugins.plugin_loader.plugin_loader import PluginLoader
+
+        PluginLoader().load_matching("compute_framework", "*transformer*")
+        transformer = ComputeFrameworkTransformer()
+        chain = transformer.get_transformation_chain(source_type, target_type)
+    if chain is None:
         raise ValueError(f"No transformation path found from {source_type} to {target_type}.")
 
     current_fw = source_type
@@ -145,8 +154,15 @@ def to_framework(
 
 
 def to_records(result: Any) -> list[dict[str, Any]]:
-    """Serialize a single ``run_all`` result to a list of row dicts (python_dict native)."""
-    records: list[dict[str, Any]] = _convert(result, list)
+    """Serialize a single ``run_all`` result to a list of row dicts.
+
+    A python_dict result (``list[dict]``) is returned as-is (no pyarrow). Any
+    other framework object is routed through the pyarrow hub, which only needs
+    that object's own transformer (loaded by the run that produced it).
+    """
+    if _is_record_list(result):
+        return list(result)
+    records: list[dict[str, Any]] = to_arrow(result).to_pylist()
     return records
 
 

--- a/mloda/core/api/result_serializer.py
+++ b/mloda/core/api/result_serializer.py
@@ -1,0 +1,90 @@
+"""Framework-aware serialization helpers for ``mlodaAPI.run_all`` results (issue #573).
+
+Each ``result`` is a SINGLE compute-framework object (one element of the
+``run_all`` list), e.g. a ``pd.DataFrame``, ``pa.Table``, polars DataFrame, or a
+python_dict result (``list[dict]``).
+"""
+
+import csv
+import io
+from typing import Any
+
+from mloda.core.abstract_plugins.components.framework_transformer.cfw_transformer import (
+    ComputeFrameworkTransformer,
+)
+
+try:
+    import pyarrow as pa
+except ImportError:
+    pa = None  # type: ignore[assignment]
+
+
+def _require_pyarrow() -> None:
+    if pa is None:
+        raise ImportError("pyarrow is required for this operation. Install it with: pip install 'mloda[pyarrow]'")
+
+
+def _is_record_list(result: Any) -> bool:
+    """A python_dict result is an empty list or a list where every element is a dict."""
+    return isinstance(result, list) and (len(result) == 0 or all(isinstance(item, dict) for item in result))
+
+
+def _to_pyarrow_table(result: Any) -> "pa.Table":
+    _require_pyarrow()
+
+    if isinstance(result, pa.Table):
+        return result
+
+    if _is_record_list(result):
+        return pa.Table.from_pylist(result)
+
+    transformer = ComputeFrameworkTransformer()
+    from_framework = type(result)
+    chain = transformer.get_transformation_chain(from_framework, pa.Table)
+
+    if chain is None:
+        raise ValueError(f"No transformation path found from {from_framework} to pyarrow.Table.")
+
+    data = result
+    current_fw = from_framework
+    for i, transformer_cls in enumerate(chain):
+        if i == len(chain) - 1:
+            target_fw = pa.Table
+        else:
+            for (src, dst), trans in transformer.transformer_map.items():
+                if trans == transformer_cls and src == current_fw:
+                    target_fw = dst
+                    break
+        data = transformer_cls.transform(current_fw, target_fw, data, None)
+        current_fw = target_fw
+
+    return data
+
+
+def to_json_records(result: Any) -> list[dict[str, Any]]:
+    if isinstance(result, list):
+        if _is_record_list(result):
+            return list(result)
+        raise ValueError(
+            f"Expected a single run_all result object, got a list of {type(result[0])}. "
+            "Pass a single result element, e.g. results[0], not the whole run_all() list."
+        )
+
+    table = _to_pyarrow_table(result)
+    records: list[dict[str, Any]] = table.to_pylist()
+    return records
+
+
+def to_csv(result: Any) -> str:
+    if isinstance(result, list) and not _is_record_list(result):
+        raise ValueError(
+            f"Expected a single run_all result object, got a list of {type(result[0])}. "
+            "Pass a single result element, e.g. results[0], not the whole run_all() list."
+        )
+
+    table = _to_pyarrow_table(result)
+    buf = io.StringIO()
+    writer = csv.DictWriter(buf, fieldnames=table.column_names, lineterminator="\n")
+    writer.writeheader()
+    writer.writerows(table.to_pylist())
+    return buf.getvalue()

--- a/tests/test_core/test_api/test_result_serializer.py
+++ b/tests/test_core/test_api/test_result_serializer.py
@@ -40,6 +40,7 @@ from mloda_plugins.compute_framework.base_implementations.pandas.dataframe impor
 from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
     PythonDictFramework,  # noqa: F401
 )
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable  # noqa: F401
 
 
 FEAT = "ResultSerializerFeature"

--- a/tests/test_core/test_api/test_result_serializer.py
+++ b/tests/test_core/test_api/test_result_serializer.py
@@ -1,0 +1,157 @@
+"""RED-phase tests for the result serialization helpers (issue #573).
+
+These tests define the contract for two framework-aware serialization helpers
+exposed as ``@staticmethod`` on ``mlodaAPI`` (aliased as ``mloda`` in
+``mloda.user``):
+
+- ``mloda.to_json_records(result) -> list[dict[str, Any]]``
+- ``mloda.to_csv(result) -> str``
+
+``result`` is a SINGLE compute-framework object (one element of the
+``run_all`` list), not the whole list.
+
+They use only the always-installed frameworks (pandas, python_dict, pyarrow)
+so they never skip (which would break the tox EXPECTED_SKIP_COUNT). The tests
+are expected to FAIL until the helpers are implemented.
+"""
+
+from typing import Any, Optional
+
+import pandas as pd
+import pyarrow as pa
+
+from mloda.provider import FeatureGroup, FeatureSet, DataCreator, BaseInputData
+from mloda.user import Feature, mloda
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame  # noqa: F401
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
+    PythonDictFramework,  # noqa: F401
+)
+
+
+FEAT = "ResultSerializerFeature"
+PY_DICT_FEAT = "ResultSerializerPyDictFeature"
+
+
+class ResultSerializerFeatureGroup(FeatureGroup):
+    """Root feature group producing a small deterministic frame.
+
+    Declared module-level so it registers as a discoverable FeatureGroup. It
+    produces a single root feature via ``DataCreator`` and returns a pandas
+    DataFrame; the engine converts to the pinned framework as needed.
+    """
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({FEAT})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return pd.DataFrame({FEAT: [1, 2, 3]})
+
+
+class ResultSerializerPyDictFeatureGroup(FeatureGroup):
+    """Root feature group producing python_dict-native columnar data.
+
+    Returns a columnar dict which ``PythonDictFramework`` converts to a
+    row-based ``list[dict]`` natively, so no cross-framework (pandas -> list)
+    engine conversion is required.
+    """
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({PY_DICT_FEAT})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {PY_DICT_FEAT: [1, 2, 3]}
+
+
+class TestToJsonRecordsPandas:
+    """``to_json_records`` on a pandas ``run_all`` result."""
+
+    def test_pandas_result_to_json_records(self) -> None:
+        results = mloda.run_all([Feature(FEAT)], compute_frameworks=["PandasDataFrame"])
+        assert isinstance(results, list) and len(results) == 1
+        assert isinstance(results[0], pd.DataFrame)
+
+        records = mloda.to_json_records(results[0])
+        assert records == [{FEAT: 1}, {FEAT: 2}, {FEAT: 3}]
+
+
+class TestToCsvPandas:
+    """``to_csv`` on a pandas ``run_all`` result."""
+
+    def test_pandas_result_to_csv(self) -> None:
+        results = mloda.run_all([Feature(FEAT)], compute_frameworks=["PandasDataFrame"])
+        csv_str = mloda.to_csv(results[0])
+
+        assert isinstance(csv_str, str)
+        lines = [line for line in csv_str.splitlines() if line != ""]
+        assert lines[0] == FEAT, f"First line must be the header, got: {lines[0]!r}"
+        assert lines[1:] == ["1", "2", "3"], f"Rows must be the column values, got: {lines[1:]!r}"
+
+
+class TestToJsonRecordsPythonDict:
+    """``to_json_records`` on a python_dict ``run_all`` result.
+
+    Uses a python_dict-native feature group so the engine exercises
+    ``PythonDictFramework`` without any cross-framework conversion.
+    """
+
+    def test_python_dict_result_to_json_records(self) -> None:
+        results = mloda.run_all([Feature(PY_DICT_FEAT)], compute_frameworks=["PythonDictFramework"])
+        assert isinstance(results, list) and len(results) == 1
+        assert isinstance(results[0], list)
+
+        records = mloda.to_json_records(results[0])
+        assert records == [{PY_DICT_FEAT: 1}, {PY_DICT_FEAT: 2}, {PY_DICT_FEAT: 3}]
+
+
+class TestToCsvPythonDict:
+    """``to_csv`` on a python_dict ``run_all`` result.
+
+    Uses a python_dict-native feature group so the engine exercises
+    ``PythonDictFramework`` without any cross-framework conversion.
+    """
+
+    def test_python_dict_result_to_csv(self) -> None:
+        results = mloda.run_all([Feature(PY_DICT_FEAT)], compute_frameworks=["PythonDictFramework"])
+        csv_str = mloda.to_csv(results[0])
+
+        assert isinstance(csv_str, str)
+        lines = [line for line in csv_str.splitlines() if line != ""]
+        assert lines[0] == PY_DICT_FEAT, f"First line must be the header, got: {lines[0]!r}"
+        assert lines[1:] == ["1", "2", "3"], f"Rows must be the column values, got: {lines[1:]!r}"
+
+
+class TestPyarrowTableDirectly:
+    """Both helpers accept a ``pa.Table`` passed directly."""
+
+    def test_pyarrow_table_to_json_records(self) -> None:
+        table = pa.table({"a": [1, 2], "b": ["x", "y"]})
+        records = mloda.to_json_records(table)
+        assert records == [{"a": 1, "b": "x"}, {"a": 2, "b": "y"}]
+
+    def test_pyarrow_table_to_csv(self) -> None:
+        table = pa.table({"a": [1, 2], "b": ["x", "y"]})
+        csv_str = mloda.to_csv(table)
+
+        assert isinstance(csv_str, str)
+        lines = [line for line in csv_str.splitlines() if line != ""]
+        assert lines[0] == "a,b", f"First line must be the header, got: {lines[0]!r}"
+        assert lines[1:] == ["1,x", "2,y"], f"Rows must match the table values, got: {lines[1:]!r}"
+
+
+class TestAmbiguousListRaises:
+    """Passing the whole ``run_all`` list (non-dict elements) is a caller error."""
+
+    def test_list_of_dataframes_raises_value_error(self) -> None:
+        whole_output = [pd.DataFrame({FEAT: [1, 2, 3]})]
+
+        import pytest
+
+        with pytest.raises(ValueError):
+            mloda.to_json_records(whole_output)
+
+        with pytest.raises(ValueError):
+            mloda.to_csv(whole_output)

--- a/tests/test_core/test_api/test_result_serializer.py
+++ b/tests/test_core/test_api/test_result_serializer.py
@@ -309,3 +309,45 @@ class TestAmbiguousListRaises:
 
         with pytest.raises(ValueError):
             mloda.to_csv(whole_output)
+
+
+class TestToFrameworkSparseRecords:
+    """Sparse ``list[dict]`` converted to a DIFFERENT framework unions keys.
+
+    Matches ``to_csv`` behavior: the target frame carries the UNION of keys
+    across all records, with missing values represented as null.
+    """
+
+    def test_sparse_records_to_pandas_unions_columns(self) -> None:
+        records = [{"a": 1}, {"b": 2}]
+        df = mloda.to_framework(records, "PandasDataFrame")
+
+        assert isinstance(df, pd.DataFrame)
+        assert set(df.columns) == {"a", "b"}
+        assert len(df) == 2
+        assert df.loc[0, "a"] == 1
+        assert df.loc[1, "b"] == 2
+
+    def test_sparse_records_to_arrow_unions_columns(self) -> None:
+        records = [{"a": 1}, {"b": 2}]
+        table = mloda.to_arrow(records)
+
+        assert isinstance(table, pa.Table)
+        assert set(table.column_names) == {"a", "b"}
+
+        rows = table.to_pylist()
+        assert len(rows) == 2
+        assert rows[0] == {"a": 1, "b": None}
+        assert rows[1] == {"a": None, "b": 2}
+
+
+class TestToFrameworkConnectionArg:
+    """``to_framework`` accepts an optional ``framework_connection_object``."""
+
+    def test_to_framework_accepts_connection_kwarg(self) -> None:
+        table = pa.table({"a": [1, 2]})
+        result = mloda.to_framework(table, "PyArrowTable", framework_connection_object=None)
+
+        assert isinstance(result, pa.Table)
+        assert result.column_names == table.column_names
+        assert result.to_pylist() == table.to_pylist()

--- a/tests/test_core/test_api/test_result_serializer.py
+++ b/tests/test_core/test_api/test_result_serializer.py
@@ -1,11 +1,23 @@
 """RED-phase tests for the result serialization helpers (issue #573).
 
-These tests define the contract for two framework-aware serialization helpers
+These tests define the contract for framework-aware serialization helpers
 exposed as ``@staticmethod`` on ``mlodaAPI`` (aliased as ``mloda`` in
-``mloda.user``):
+``mloda.user``). The core primitive dispatches through mloda's dynamic
+compute-framework registry:
 
-- ``mloda.to_json_records(result) -> list[dict[str, Any]]``
-- ``mloda.to_csv(result) -> str``
+- ``mloda.to_framework(result, framework) -> Any`` converts a single
+  ``run_all`` result object into the NATIVE object of the target compute
+  framework. ``framework`` is either the framework's class-name string
+  (e.g. ``"PandasDataFrame"``, ``"PyArrowTable"``, ``"PythonDictFramework"``)
+  resolved via the registry, or a ``ComputeFramework`` subclass.
+
+Thin sugar helpers build on it:
+
+- ``mloda.to_records(result) -> list[dict[str, Any]]`` ==
+  ``to_framework(result, "PythonDictFramework")``.
+- ``mloda.to_arrow(result) -> pa.Table`` ==
+  ``to_framework(result, "PyArrowTable")``.
+- ``mloda.to_csv(result) -> str`` (unchanged behavior).
 
 ``result`` is a SINGLE compute-framework object (one element of the
 ``run_all`` list), not the whole list.
@@ -24,7 +36,7 @@ import pyarrow as pa
 
 from mloda.provider import FeatureGroup, FeatureSet, DataCreator, BaseInputData
 from mloda.user import Feature, mloda
-from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame  # noqa: F401
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
     PythonDictFramework,  # noqa: F401
 )
@@ -68,15 +80,15 @@ class ResultSerializerPyDictFeatureGroup(FeatureGroup):
         return {PY_DICT_FEAT: [1, 2, 3]}
 
 
-class TestToJsonRecordsPandas:
-    """``to_json_records`` on a pandas ``run_all`` result."""
+class TestToRecordsPandas:
+    """``to_records`` on a pandas ``run_all`` result."""
 
-    def test_pandas_result_to_json_records(self) -> None:
+    def test_pandas_result_to_records(self) -> None:
         results = mloda.run_all([Feature(FEAT)], compute_frameworks=["PandasDataFrame"])
         assert isinstance(results, list) and len(results) == 1
         assert isinstance(results[0], pd.DataFrame)
 
-        records = mloda.to_json_records(results[0])
+        records = mloda.to_records(results[0])
         assert records == [{FEAT: 1}, {FEAT: 2}, {FEAT: 3}]
 
 
@@ -93,19 +105,19 @@ class TestToCsvPandas:
         assert lines[1:] == ["1", "2", "3"], f"Rows must be the column values, got: {lines[1:]!r}"
 
 
-class TestToJsonRecordsPythonDict:
-    """``to_json_records`` on a python_dict ``run_all`` result.
+class TestToRecordsPythonDict:
+    """``to_records`` on a python_dict ``run_all`` result.
 
     Uses a python_dict-native feature group so the engine exercises
     ``PythonDictFramework`` without any cross-framework conversion.
     """
 
-    def test_python_dict_result_to_json_records(self) -> None:
+    def test_python_dict_result_to_records(self) -> None:
         results = mloda.run_all([Feature(PY_DICT_FEAT)], compute_frameworks=["PythonDictFramework"])
         assert isinstance(results, list) and len(results) == 1
         assert isinstance(results[0], list)
 
-        records = mloda.to_json_records(results[0])
+        records = mloda.to_records(results[0])
         assert records == [{PY_DICT_FEAT: 1}, {PY_DICT_FEAT: 2}, {PY_DICT_FEAT: 3}]
 
 
@@ -129,9 +141,9 @@ class TestToCsvPythonDict:
 class TestPyarrowTableDirectly:
     """Both helpers accept a ``pa.Table`` passed directly."""
 
-    def test_pyarrow_table_to_json_records(self) -> None:
+    def test_pyarrow_table_to_records(self) -> None:
         table = pa.table({"a": [1, 2], "b": ["x", "y"]})
-        records = mloda.to_json_records(table)
+        records = mloda.to_records(table)
         assert records == [{"a": 1, "b": "x"}, {"a": 2, "b": "y"}]
 
     def test_pyarrow_table_to_csv(self) -> None:
@@ -144,6 +156,71 @@ class TestPyarrowTableDirectly:
         assert lines[1:] == ["1,x", "2,y"], f"Rows must match the table values, got: {lines[1:]!r}"
 
 
+class TestToFramework:
+    """``to_framework`` dispatches through the compute-framework registry."""
+
+    def test_to_framework_pandas_result_to_python_dict(self) -> None:
+        results = mloda.run_all([Feature(FEAT)], compute_frameworks=["PandasDataFrame"])
+        assert isinstance(results[0], pd.DataFrame)
+
+        records = mloda.to_framework(results[0], "PythonDictFramework")
+        assert isinstance(records, list)
+        assert records == [{FEAT: 1}, {FEAT: 2}, {FEAT: 3}]
+
+    def test_to_framework_record_list_to_pyarrow(self) -> None:
+        records = [{"a": 1, "b": "x"}, {"a": 2, "b": "y"}]
+        table = mloda.to_framework(records, "PyArrowTable")
+        assert isinstance(table, pa.Table)
+        assert table.to_pylist() == records
+
+    def test_to_framework_pyarrow_to_pandas(self) -> None:
+        table = pa.table({"a": [1, 2], "b": ["x", "y"]})
+        df = mloda.to_framework(table, "PandasDataFrame")
+        assert isinstance(df, pd.DataFrame)
+        assert df.to_dict("records") == [{"a": 1, "b": "x"}, {"a": 2, "b": "y"}]
+
+    def test_to_framework_identity(self) -> None:
+        table = pa.table({"a": [1, 2], "b": ["x", "y"]})
+        result = mloda.to_framework(table, "PyArrowTable")
+        assert isinstance(result, pa.Table)
+        assert result.column_names == table.column_names
+        assert result.to_pylist() == table.to_pylist()
+
+    def test_to_framework_accepts_class(self) -> None:
+        table = pa.table({"a": [1, 2], "b": ["x", "y"]})
+        df = mloda.to_framework(table, PandasDataFrame)
+        assert isinstance(df, pd.DataFrame)
+        assert df.to_dict("records") == [{"a": 1, "b": "x"}, {"a": 2, "b": "y"}]
+
+    def test_to_framework_unknown_name_raises(self) -> None:
+        table = pa.table({"a": [1, 2]})
+
+        import pytest
+
+        with pytest.raises(ValueError) as exc_info:
+            mloda.to_framework(table, "NotARealFramework")
+
+        message = str(exc_info.value)
+        assert "PandasDataFrame" in message or "PyArrowTable" in message
+
+
+class TestToArrow:
+    """``to_arrow`` is sugar for ``to_framework(result, "PyArrowTable")``."""
+
+    def test_to_arrow_identity(self) -> None:
+        table = pa.table({"a": [1]})
+        result = mloda.to_arrow(table)
+        assert isinstance(result, pa.Table)
+        assert result.column_names == table.column_names
+        assert result.to_pylist() == table.to_pylist()
+
+    def test_to_arrow_from_pandas(self) -> None:
+        results = mloda.run_all([Feature(FEAT)], compute_frameworks=["PandasDataFrame"])
+        table = mloda.to_arrow(results[0])
+        assert isinstance(table, pa.Table)
+        assert table.to_pylist() == [{FEAT: 1}, {FEAT: 2}, {FEAT: 3}]
+
+
 class TestSparsePythonDictRecords:
     """python_dict ``list[dict]`` results with sparse keys keep all columns.
 
@@ -152,9 +229,9 @@ class TestSparsePythonDictRecords:
     become empty CSV cells.
     """
 
-    def test_sparse_records_to_json_records_unchanged(self) -> None:
+    def test_sparse_records_to_records_unchanged(self) -> None:
         records = [{"a": 1}, {"b": 2}]
-        assert mloda.to_json_records(records) == [{"a": 1}, {"b": 2}]
+        assert mloda.to_records(records) == [{"a": 1}, {"b": 2}]
 
     def test_sparse_records_to_csv_keeps_all_columns(self) -> None:
         records = [{"a": 1}, {"b": 2}]
@@ -171,9 +248,9 @@ class TestSparsePythonDictRecords:
 class TestFloatsAndNullsPyarrow:
     """Floats and nulls via a ``pa.Table`` serialize cleanly."""
 
-    def test_floats_and_nulls_to_json_records(self) -> None:
+    def test_floats_and_nulls_to_records(self) -> None:
         table = pa.table({"a": [1.5, None], "b": ["x", None]})
-        assert mloda.to_json_records(table) == [{"a": 1.5, "b": "x"}, {"a": None, "b": None}]
+        assert mloda.to_records(table) == [{"a": 1.5, "b": "x"}, {"a": None, "b": None}]
 
     def test_floats_and_nulls_to_csv(self) -> None:
         table = pa.table({"a": [1.5, None], "b": ["x", None]})
@@ -206,9 +283,9 @@ class TestCsvEscaping:
 class TestEmptyTableWithSchema:
     """An empty ``pa.Table`` that still carries a schema yields header-only CSV."""
 
-    def test_empty_table_to_json_records(self) -> None:
+    def test_empty_table_to_records(self) -> None:
         table = pa.table({"a": pa.array([], type=pa.int64()), "b": pa.array([], type=pa.string())})
-        assert mloda.to_json_records(table) == []
+        assert mloda.to_records(table) == []
 
     def test_empty_table_to_csv_header_only(self) -> None:
         table = pa.table({"a": pa.array([], type=pa.int64()), "b": pa.array([], type=pa.string())})
@@ -228,7 +305,7 @@ class TestAmbiguousListRaises:
         import pytest
 
         with pytest.raises(ValueError):
-            mloda.to_json_records(whole_output)
+            mloda.to_records(whole_output)
 
         with pytest.raises(ValueError):
             mloda.to_csv(whole_output)

--- a/tests/test_core/test_api/test_result_serializer.py
+++ b/tests/test_core/test_api/test_result_serializer.py
@@ -15,6 +15,8 @@ so they never skip (which would break the tox EXPECTED_SKIP_COUNT). The tests
 are expected to FAIL until the helpers are implemented.
 """
 
+import csv
+import io
 from typing import Any, Optional
 
 import pandas as pd
@@ -140,6 +142,81 @@ class TestPyarrowTableDirectly:
         lines = [line for line in csv_str.splitlines() if line != ""]
         assert lines[0] == "a,b", f"First line must be the header, got: {lines[0]!r}"
         assert lines[1:] == ["1,x", "2,y"], f"Rows must match the table values, got: {lines[1:]!r}"
+
+
+class TestSparsePythonDictRecords:
+    """python_dict ``list[dict]`` results with sparse keys keep all columns.
+
+    The KEY regression: ``to_csv`` must emit the UNION of keys across all
+    records, not just the keys present in the first record. Missing values
+    become empty CSV cells.
+    """
+
+    def test_sparse_records_to_json_records_unchanged(self) -> None:
+        records = [{"a": 1}, {"b": 2}]
+        assert mloda.to_json_records(records) == [{"a": 1}, {"b": 2}]
+
+    def test_sparse_records_to_csv_keeps_all_columns(self) -> None:
+        records = [{"a": 1}, {"b": 2}]
+        csv_str = mloda.to_csv(records)
+
+        lines = [line for line in csv_str.splitlines() if line != ""]
+        header = lines[0]
+        assert set(header.split(",")) == {"a", "b"}, f"Header must be union of keys, got: {header!r}"
+
+        parsed = list(csv.DictReader(io.StringIO(csv_str)))
+        assert parsed == [{"a": "1", "b": ""}, {"a": "", "b": "2"}]
+
+
+class TestFloatsAndNullsPyarrow:
+    """Floats and nulls via a ``pa.Table`` serialize cleanly."""
+
+    def test_floats_and_nulls_to_json_records(self) -> None:
+        table = pa.table({"a": [1.5, None], "b": ["x", None]})
+        assert mloda.to_json_records(table) == [{"a": 1.5, "b": "x"}, {"a": None, "b": None}]
+
+    def test_floats_and_nulls_to_csv(self) -> None:
+        table = pa.table({"a": [1.5, None], "b": ["x", None]})
+        csv_str = mloda.to_csv(table)
+
+        lines = [line for line in csv_str.splitlines() if line != ""]
+        assert lines[0] == "a,b", f"First line must be the header, got: {lines[0]!r}"
+
+        parsed = list(csv.DictReader(io.StringIO(csv_str)))
+        assert parsed == [{"a": "1.5", "b": "x"}, {"a": "", "b": ""}]
+
+
+class TestCsvEscaping:
+    """Values containing commas, quotes, and newlines round-trip correctly."""
+
+    def test_special_characters_round_trip(self) -> None:
+        records = [
+            {"a": "x,y", "b": 'he said "hi"'},
+            {"a": "line1\nline2", "b": "plain"},
+        ]
+        csv_str = mloda.to_csv(records)
+
+        parsed = list(csv.DictReader(io.StringIO(csv_str)))
+        assert parsed == [
+            {"a": "x,y", "b": 'he said "hi"'},
+            {"a": "line1\nline2", "b": "plain"},
+        ]
+
+
+class TestEmptyTableWithSchema:
+    """An empty ``pa.Table`` that still carries a schema yields header-only CSV."""
+
+    def test_empty_table_to_json_records(self) -> None:
+        table = pa.table({"a": pa.array([], type=pa.int64()), "b": pa.array([], type=pa.string())})
+        assert mloda.to_json_records(table) == []
+
+    def test_empty_table_to_csv_header_only(self) -> None:
+        table = pa.table({"a": pa.array([], type=pa.int64()), "b": pa.array([], type=pa.string())})
+        csv_str = mloda.to_csv(table)
+
+        lines = [line for line in csv_str.splitlines() if line != ""]
+        assert len(lines) == 1, f"Empty table must yield header-only CSV, got: {lines!r}"
+        assert set(lines[0].split(",")) == {"a", "b"}
 
 
 class TestAmbiguousListRaises:


### PR DESCRIPTION
## Summary

Closes #573. Adds framework-aware serialization helpers for `mlodaAPI.run_all` output so MCP servers and agent-tool integrations stop hand-rolling `to_dict("records")` / `to_csv()` packaging.

Exposed as staticmethods on `mlodaAPI` (aliased `mloda`):

- `mloda.to_json_records(result) -> list[dict[str, Any]]`
- `mloda.to_csv(result) -> str`

`result` is a single `run_all` result element (e.g. `results[0]`), which may be a pandas DataFrame, pyarrow Table, polars DataFrame, or a python_dict result (`list[dict]`).

## Approach

- Framework objects (pandas, polars, pyarrow Table, ...) are converted to a `pa.Table` via the existing `ComputeFrameworkTransformer` hub, then serialized. Going through pyarrow yields clean JSON-native scalars (python `int`/`float`/`None`/`str`), which matters for feeding results to LLM tool calls via `json.dumps`.
- A python_dict result (`list[dict]`) is serialized with the stdlib only (no pyarrow): `to_json_records` returns the records, `to_csv` writes them over the union of all record keys.
- CSV writing is unified (stdlib `csv.DictWriter`, header, QUOTE_MINIMAL, `\n` terminator), so formatting is identical across frameworks and the header is preserved for empty-with-schema tables.
- Passing the whole `run_all` list (elements that are not all dicts) raises a clear `ValueError` guiding the caller to pass a single element.

## Tests

New `tests/test_core/test_api/test_result_serializer.py`: end-to-end through `run_all` for pandas and python_dict, direct pyarrow Table input, floats/nulls, CSV special-char escaping (round-trip), empty-with-schema tables, sparse records (union of keys, no dropped columns), and the ambiguous-list error. Only always-installed frameworks are used, so the tox skip count is unchanged.

## Validation

Full `tox` passes: pytest (`3879 passed, 167 skipped`), `ruff format --check`, `ruff check`, license allowlist, `mypy --strict`, and `bandit` all green.

## Review

Went through two independent deep reviews (Claude Opus and codex). Key fix from that pass: `to_csv` on a python_dict result previously routed through `pa.Table.from_pylist`, which inferred the schema from the first record only (silently dropping columns) and needlessly required pyarrow. That is now stdlib-based with a union of keys.