### PR TITLE
minor: columnar native representation for PythonDict, retire allow_empty_result

### DIFF
--- a/docs/docs/chapter1/compute-frameworks.md
+++ b/docs/docs/chapter1/compute-frameworks.md
@@ -132,7 +132,7 @@ In this case, the feature group ExampleB will only run on the PyArrowTable frame
 | **DuckDBFramework** | DuckDB Relations | SQL interface, fast analytics, OLAP queries | Analytical workloads, SQL-based transformations, data warehousing | duckdb |
 | **IcebergFramework** | Apache Iceberg Tables | Schema evolution, time travel, data lake management | Data lake scenarios, versioned datasets, large-scale analytics | pyiceberg, pyarrow |
 | **SparkFramework** | Apache Spark DataFrames | Distributed processing, scalability, fault tolerance | Big data, distributed computing, production clusters | pyspark, Java 8+ |
-| **PythonDictFramework** | List[Dict[str, Any]] | Zero dependencies, simple, lightweight | Minimal environments, education, prototyping | None (Python stdlib only) |
+| **PythonDictFramework** | dict[str, list[Any]] (columnar) | Zero dependencies, simple, lightweight | Minimal environments, education, prototyping | None (Python stdlib only) |
 
 ##### Automatic Dependency Detection
 
@@ -156,8 +156,10 @@ result = mloda.run_all(
     [feature],
     data_access_collection=data_access_collection
 )
-result[0]  # Returns List[Dict[str, Any]]
+result[0]  # Returns dict[str, list[Any]] (columnar)
 ```
+
+A feature group running on PythonDictFramework may also return row-wise data as a list of dicts; it is normalized to the columnar form, and all rows must have identical keys.
 
 Example using Polars frameworks:
 ``` python

--- a/docs/docs/chapter1/feature-groups.md
+++ b/docs/docs/chapter1/feature-groups.md
@@ -81,7 +81,7 @@ For more in-depth information about feature groups, check out these advanced top
 - [Data Type Enforcement](../in_depth/data-type-enforcement.md) - Runtime validation of declared feature data types
 - [Filter Handling in FeatureGroups](../in_depth/filter_data.md#handling-filters-in-a-featuregroup) - Row elimination and `final_filters()`
 - [Mask Engine](../in_depth/mask_engine.md) - Inline masking with `features.mask_engine`
-- [Empty Result Handling](../in_depth/compute-framework-integration.md#allowing-empty-results) - Zero rows is always valid; `allow_empty_result` opts into schema-less empty results
+- [Empty Result Handling](../in_depth/compute-framework-integration.md#empty-results) - Zero rows is always valid; a zero-column (schema-less) result raises `EmptyResultError`
 
 #### 6. Discovering Feature Groups
 

--- a/docs/docs/in_depth/compute-framework-integration.md
+++ b/docs/docs/in_depth/compute-framework-integration.md
@@ -57,7 +57,7 @@ inspector does not know the caller's `Options`), and a feature that matches a
 group but is unsupported on every installed framework resolves to
 `feature_group=None` with a capability error rather than appearing runnable.
 
-### Allowing Empty Results
+### Empty Results
 
 The contract is: a **final** requested feature must return a *schema-bearing*
 result, meaning at least one column. **Zero rows is a valid result; zero columns
@@ -91,44 +91,23 @@ columns for a zero-row frame.
 There is one representational caveat. The schema-bearing frameworks (PyArrow,
 Pandas, Polars, DuckDB, SQLite, Spark, Iceberg) carry their schema as metadata
 even at zero rows, so a zero-row result keeps its columns and passes. The
-PythonDict framework represents data as `list[dict]`, where the schema lives in
-each row's keys, so its only empty value is `[]`, which has no columns. A
-PythonDict result that is empty is therefore always treated as schema-less and
-must opt in via `allow_empty_result()` (see below) to be accepted. One
-consequence: on any schema-less result on any framework (PythonDict's empty
-list, or a zero-column frame from an opted-in feature group), column selection
-returns the result as is, so a misspelled requested column on schema-less data
-does not produce a "column not found" error.
-
-#### Opting in to empty results
-
-Override `allow_empty_result` on a feature group to declare that a schema-less
-empty result is a legitimate outcome for that group:
-
-``` python
-class KnowledgeGraphFeatureGroup(FeatureGroup):
-    @classmethod
-    def allow_empty_result(cls) -> bool:
-        """Zero matches is a valid answer for graph traversals."""
-        return True
-```
-
-When `allow_empty_result()` returns `True`, the result flows through to the
-caller unchanged regardless of schema: result selection passes a schema-less
-result through unchanged on every framework, never trying to match requested
-column names against an empty column set. Typical use cases include knowledge
-graphs, search, agent memory, and authorization filters, especially on the
-PythonDict framework where an empty match cannot carry a schema.
+PythonDict framework represents data as a columnar `dict[str, list]`, where the
+schema is the set of keys and is present even at zero rows: `{"col": []}` is a
+valid schema-bearing zero-row frame, while `{}` (zero columns) is the only
+schema-less value. Emptiness is judged purely on schema presence, with no
+opt-in: a zero-column result raises `EmptyResultError` uniformly on every
+framework. One consequence: on a schema-less result (a zero-column frame),
+column selection returns the result as is, so a misspelled requested column on
+schema-less data does not produce a "column not found" error.
 
 #### Filter column validation
 
 `_validate_filter_columns` skips its column-presence and dtype checks only when
-the data is a schema-less empty result (in practice PythonDict's empty list),
-regardless of the `allow_empty_result()` policy. Filtering an empty result is a
-no-op, so neither the column check nor row elimination has anything to do.
-Judging whether emptiness is acceptable belongs solely to the output guard
-above. Data on which the framework cannot see columns but that is not an empty
-result still fails the missing-filter-column check loudly.
+the data is the schema-less empty result (in practice PythonDict's `{}`).
+Filtering an empty result is a no-op, so neither the column check nor row
+elimination has anything to do. Data on which the framework cannot see columns
+but that is not an empty result still fails the missing-filter-column check
+loudly.
 
 ### Framework-Specific Implementations
 

--- a/docs/docs/in_depth/data-quality.md
+++ b/docs/docs/in_depth/data-quality.md
@@ -270,18 +270,17 @@ For more details on artifacts, refer to the [artifact documentation](artifacts.m
 
 `run_validate_output_features` runs a schema-presence check **before** data-type
 enforcement and before the custom `validate_output_features` hook. If the result
-carries no schema (zero columns) and `allow_empty_result()` is `False` (the
-default), it raises `EmptyResultError` immediately. A zero-*row* result with a
-valid schema is not an error and flows through normally. As a consequence, custom
-output validators are not reached on a schema-less result unless the feature
-group has opted in by returning `True` from `allow_empty_result()`.
+carries no schema (zero columns), it raises `EmptyResultError` immediately. A
+zero-*row* result with a valid schema is not an error and flows through normally.
+As a consequence, custom output validators are not reached on a schema-less
+result.
 
 This ordering ensures that schema-level validators never receive a column-less
 result they were not designed to handle, and that the error message is clear and
 actionable rather than a downstream type error.
 
-For details on opting in and the underlying schema-presence gate, see
-[Allowing Empty Results](compute-framework-integration.md#allowing-empty-results).
+For details on the underlying schema-presence gate, see
+[Empty Results](compute-framework-integration.md#empty-results).
 
 #### Conclusion
 

--- a/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
+++ b/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
@@ -111,13 +111,14 @@ EmptyResultError: Result carries no schema (no columns): MyFeatureGroup. ...
 ```
 
 This error fires when a **final** requested feature group returns a result with
-*no schema* (zero columns) and `allow_empty_result()` is `False` (the default).
-Note that **zero rows is not an error**: a well-typed frame with the right
-columns and no rows is a valid result and passes through. Only a result that
-carries no columns at all is rejected.
+*no schema* (zero columns). There is no opt-in or opt-out: the rule applies
+uniformly on every compute framework. Note that **zero rows is not an error**: a
+well-typed frame with the right columns and no rows is a valid result and
+passes through. Only a result that carries no columns at all is rejected.
 
-In practice you hit this on the PythonDict framework, whose empty value (`[]`)
-cannot carry a schema, or when a feature genuinely produces a column-less result.
+On the PythonDict framework, whose native representation is a columnar
+`dict[str, list]`, the schema is the set of keys: `{"col": []}` carries a
+schema, while `{}` (zero columns) is the only schema-less value and raises.
 
 If the schema-less result is genuine (a bug, missing data, wrong filter), this
 error is correct behavior: it protects callers from silently receiving output
@@ -125,35 +126,36 @@ they cannot interpret.
 
 ### When to fix it
 
-Override `allow_empty_result` only when a schema-less empty result is a
-legitimate answer for your domain, for example: graph traversals that may find no
-path, search queries that may match nothing, authorization filters that may deny
-all rows, or agent memory that may have no relevant entries. This is most often
-needed on the PythonDict framework.
+If an empty result is a legitimate answer for your domain, for example: graph
+traversals that may find no path, search queries that may match nothing,
+authorization filters that may deny all rows, or agent memory that may have no
+relevant entries, return a *schema-bearing* empty result: keep the columns and
+drop the rows. On PythonDict that is a dict with empty column lists; on the
+other frameworks it is an empty typed table or frame with the right columns.
 
 ``` python
 class MyFeatureGroup(FeatureGroup):
     @classmethod
-    def allow_empty_result(cls) -> bool:
-        return True
+    def calculate_feature(cls, data, features):
+        ...
+        return {"my_feature": []}  # schema-bearing, zero rows: valid
 ```
 
-With the override in place, empty data flows through to the caller without
-raising. The public import `from mloda.provider import EmptyResultError` (a
-`ValueError` subclass) supports a typed `except` when you invoke framework or
-plugin code directly. When calling `mloda.run_all`, worker errors are wrapped
-in a generic `Exception` whose message embeds the original traceback, so match
-on the `EmptyResultError` name in the raised exception's message instead.
+A schema-bearing empty result flows through to the caller without raising. The
+public import `from mloda.provider import EmptyResultError` (a `ValueError`
+subclass) supports a typed `except` when you invoke framework or plugin code
+directly. When calling `mloda.run_all`, worker errors are wrapped in a generic
+`Exception` whose message embeds the original traceback, so match on the
+`EmptyResultError` name in the raised exception's message instead.
 
 ### Intermediates are exempt
 
 The check applies only to features that were explicitly requested by the caller.
 Intermediate feature groups, meaning those whose output feeds another feature
-group rather than the final result, are never subject to `EmptyResultError`,
-even if `allow_empty_result()` is `False`.
+group rather than the final result, are never subject to `EmptyResultError`.
 
 For full details on how the guard works and the schema-presence gate, see
-[Allowing Empty Results](../compute-framework-integration.md#allowing-empty-results).
+[Empty Results](../compute-framework-integration.md#empty-results).
 
 ## Related Documentation
 

--- a/mloda/core/abstract_plugins/compute_framework.py
+++ b/mloda/core/abstract_plugins/compute_framework.py
@@ -29,8 +29,8 @@ def _require_pyarrow() -> None:
 
 
 class EmptyResultError(ValueError):
-    """Raised when a final requested feature's result carries no schema (zero columns)
-    while allow_empty_result() is False; zero rows with a schema is valid."""
+    """Raised when a final requested feature's result carries no schema (zero columns);
+    zero rows with a schema is valid."""
 
 
 class ComputeFramework(ABC):
@@ -125,6 +125,14 @@ class ComputeFramework(ABC):
         if transformed_data is not None:
             return transformed_data
         return data
+
+    def validate_native_data(self, data: Any) -> None:
+        """Hook: validate that an already-native result satisfies the framework's contract.
+
+        Called when transform() is skipped because the result is already the expected type.
+        Default no-op; frameworks whose native type is too loose to be self-validating override it.
+        """
+        return None
 
     @final
     def apply_compute_framework_transformer(self, data: Any) -> Any:
@@ -237,16 +245,21 @@ class ComputeFramework(ABC):
         features = self.set_filter_engine(features)
         features = self.set_mask_engine(features)
         data = self.run_calculate_feature(feature_group, features)
-        data = self.run_final_filter(data, features, feature_group)
 
         names = features.get_all_names()
 
         if not isinstance(data, self.expected_data_framework()):
             # if data is not in the expected data framework, we need to transform it and for this, we may need the framework connection object
             self.set_framework_connection_object(features.get_options_key(feature_group.get_class_name()))
-            self.data = self.transform(data, names)
+            data = self.transform(data, names)
         else:
-            self.data = data
+            # already the native type: transform is skipped, so enforce the framework's
+            # native-representation contract here before it is stored / filtered.
+            self.validate_native_data(data)
+
+        # filter runs on the normalized native representation, not the raw FG output
+        data = self.run_final_filter(data, features, feature_group)
+        self.data = data
 
         self.set_column_names()
 
@@ -529,15 +542,10 @@ class ComputeFramework(ABC):
         if self.data is None:
             return
 
-        if (
-            features.get_initial_requested_features()
-            and not feature_group.allow_empty_result()
-            and not self.column_names
-        ):
+        if features.get_initial_requested_features() and not self.column_names:
             raise EmptyResultError(
                 f"Result carries no schema (no columns): {feature_group.get_class_name()}. "
-                "A feature must return a schema; zero rows is a valid result, zero columns is not. "
-                "If a schema-less empty result is legitimate, override allow_empty_result() to return True."
+                "A feature must return a schema; zero rows is a valid result, zero columns is not."
             )
 
         from mloda.core.abstract_plugins.components.validators.datatype_validator import DataTypeValidator

--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -467,18 +467,6 @@ class FeatureGroup(ABC):
         return rule
 
     @classmethod
-    def allow_empty_result(cls) -> bool:
-        """Whether a SCHEMA-LESS empty result (no columns) is a valid outcome for this feature group.
-
-        Zero rows with a schema is always valid and never needs this flag. Returns False
-        by default: a final requested result that carries no schema raises EmptyResultError.
-        Non-tabular domains whose queries can legitimately match nothing (knowledge graphs,
-        search, memory, authz filters) override this to return True; in practice this matters
-        on frameworks whose empty representation cannot carry a schema (PythonDict's ``[]``).
-        """
-        return False
-
-    @classmethod
     def supports_compute_framework(
         cls,
         feature_name: FeatureName | str,

--- a/mloda/core/runtime/data_lifecycle_manager.py
+++ b/mloda/core/runtime/data_lifecycle_manager.py
@@ -126,8 +126,8 @@ class DataLifecycleManager:
             )
 
         # A result with no visible columns has already been judged by the empty-result guard in
-        # run_validate_output_features: it only reaches here when the FeatureGroup opted in via
-        # allow_empty_result, or for PythonDict's schema-less empties. Selecting named columns from
+        # run_validate_output_features: a truly column-less result raises there, so anything that
+        # reaches here with no columns is a schema-less pass-through. Selecting named columns from
         # a schema-less result is meaningless and must not raise; the caller receives it unchanged.
         if not cfw._extract_column_names(data):
             return data

--- a/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_filter_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_filter_engine.py
@@ -1,20 +1,37 @@
 import re
-from typing import Any
+from typing import Any, Callable, cast
 from mloda.provider import BaseFilterEngine
 from mloda.user import SingleFilter
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils import rows_to_columnar
 
 
 class PythonDictFilterEngine(BaseFilterEngine):
     """
-    Filter engine for PythonDict framework using List[Dict[str, Any]] data structure.
+    Filter engine for PythonDict framework using a COLUMNAR ``dict[str, list[Any]]``.
 
-    Implements filtering operations using list comprehensions and Python built-in functions.
+    Each filter computes a keep-index list over the target column, then slices every
+    column by those indices. A missing column or the schema-less ``{}`` is handled
+    without crashing (yields an empty keep set / passes through).
     """
 
     @classmethod
     def final_filters(cls) -> bool:
         """Filters are applied after the feature calculation."""
         return True
+
+    @staticmethod
+    def _to_columnar(data: Any) -> dict[str, list[Any]]:
+        """Normalize a row-wise ``list[dict]`` to columnar. Columnar dict input passes through."""
+        if isinstance(data, list):
+            return rows_to_columnar(data)
+        return cast(dict[str, list[Any]], data)
+
+    @classmethod
+    def _apply_keep(cls, data: Any, column_name: str, predicate: Callable[[Any], bool]) -> Any:
+        data = cls._to_columnar(data)
+        column = data.get(column_name, [])
+        keep = [i for i, value in enumerate(column) if predicate(value)]
+        return {c: [data[c][i] for i in keep] for c in data}
 
     @classmethod
     def do_range_filter(cls, data: Any, filter_feature: SingleFilter) -> Any:
@@ -26,86 +43,61 @@ class PythonDictFilterEngine(BaseFilterEngine):
         column_name = filter_feature.name
 
         if max_operator is True:
-            # Exclusive max
-            return [
-                row
-                for row in data
-                if row.get(column_name) is not None and min_parameter <= row.get(column_name) < max_parameter
-            ]
-        else:
-            # Inclusive max
-            return [
-                row
-                for row in data
-                if row.get(column_name) is not None and min_parameter <= row.get(column_name) <= max_parameter
-            ]
+            return cls._apply_keep(data, column_name, lambda v: v is not None and min_parameter <= v < max_parameter)
+        return cls._apply_keep(data, column_name, lambda v: v is not None and min_parameter <= v <= max_parameter)
 
     @classmethod
     def do_min_filter(cls, data: Any, filter_feature: SingleFilter) -> Any:
         column_name = filter_feature.name
 
-        # Extract the value from the parameter
-
         value = filter_feature.parameter.value
 
         if value is None:
             raise ValueError(f"Filter parameter 'value' not found in {filter_feature.parameter}")
 
-        return [row for row in data if row.get(column_name) is not None and row.get(column_name) >= value]
+        return cls._apply_keep(data, column_name, lambda v: v is not None and v >= value)
 
     @classmethod
     def _apply_max_exclusive_filter(cls, data: Any, column_name: str, threshold: Any) -> Any:
-        return [row for row in data if row.get(column_name) is not None and row.get(column_name) < threshold]
+        return cls._apply_keep(data, column_name, lambda v: v is not None and v < threshold)
 
     @classmethod
     def _apply_max_inclusive_filter(cls, data: Any, column_name: str, threshold: Any) -> Any:
-        return [row for row in data if row.get(column_name) is not None and row.get(column_name) <= threshold]
+        return cls._apply_keep(data, column_name, lambda v: v is not None and v <= threshold)
 
     @classmethod
     def do_equal_filter(cls, data: Any, filter_feature: SingleFilter) -> Any:
         column_name = filter_feature.name
 
-        # Extract the value from the parameter
-
         value = filter_feature.parameter.value
 
         if value is None:
             raise ValueError(f"Filter parameter 'value' not found in {filter_feature.parameter}")
 
-        return [row for row in data if row.get(column_name) == value]
+        return cls._apply_keep(data, column_name, lambda v: v == value)
 
     @classmethod
     def do_regex_filter(cls, data: Any, filter_feature: SingleFilter) -> Any:
         column_name = filter_feature.name
 
-        # Extract the value from the parameter
-
         value = filter_feature.parameter.value
 
         if value is None:
             raise ValueError(f"Filter parameter 'value' not found in {filter_feature.parameter}")
 
-        # Compile regex pattern for efficiency
         compiled_pattern = re.compile(value)
 
-        return [
-            row
-            for row in data
-            if row.get(column_name) is not None and compiled_pattern.match(str(row.get(column_name)))
-        ]
+        return cls._apply_keep(data, column_name, lambda v: v is not None and bool(compiled_pattern.match(str(v))))
 
     @classmethod
     def do_categorical_inclusion_filter(cls, data: Any, filter_feature: SingleFilter) -> Any:
         column_name = filter_feature.name
-
-        # Extract the values from the parameter
 
         values = filter_feature.parameter.values
 
         if values is None:
             raise ValueError(f"Filter parameter 'values' not found in {filter_feature.parameter}")
 
-        # Convert to set for faster lookup
         allowed_set = set(values) if isinstance(values, (list, tuple)) else {values}
 
-        return [row for row in data if row.get(column_name) in allowed_set]
+        return cls._apply_keep(data, column_name, lambda v: v in allowed_set)

--- a/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_framework.py
@@ -15,29 +15,35 @@ from mloda_plugins.compute_framework.base_implementations.python_dict.python_dic
 from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_mask_engine import (
     PythonDictMaskEngine,
 )
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils import rows_to_columnar
 
 
 class PythonDictFramework(ComputeFramework):
     """
     PythonDict Compute Framework
 
-    Uses List[Dict[str, Any]] as the data structure for tabular data.
+    Uses a COLUMNAR ``dict[str, list[Any]]`` as the data structure for tabular data.
     This framework provides a simple, dependency-free implementation using
     native Python data structures.
 
     Data Structure:
-        List[Dict[str, Any]] - Each dict represents a row, keys are column names
+        dict[str, list[Any]] - Each key is a column name, each value is that column's
+        list of cell values. All value-lists share one length (= the row count). The
+        schema is the set of keys, present even at zero rows.
 
     Example:
-        [
-            {"col1": 1, "col2": "a"},
-            {"col1": 2, "col2": "b"}
-        ]
+        {
+            "col1": [1, 2],
+            "col2": ["a", "b"],
+        }
+
+    ``{"a": []}`` is a valid schema-bearing zero-row frame (one known column). ``{}`` is
+    the only schema-less value (zero columns).
     """
 
     @classmethod
     def expected_data_framework(cls) -> Any:
-        return list
+        return dict
 
     @classmethod
     def merge_engine(cls) -> type[BaseMergeEngine]:
@@ -45,49 +51,51 @@ class PythonDictFramework(ComputeFramework):
 
     def select_data_by_column_names(
         self,
-        data: list[dict[str, Any]],
+        data: dict[str, list[Any]],
         selected_feature_names: set[FeatureName],
         column_ordering: Optional[str] = None,
-    ) -> list[dict[str, Any]]:
+    ) -> dict[str, list[Any]]:
         if not data:
-            return []
-
-        # Get all unique column names from all rows
-        column_names: set[str] = set()
-        for row in data:
-            column_names.update(row.keys())
+            return {}
 
         _selected_feature_names = self.identify_naming_convention(
-            selected_feature_names, column_names, ordering=column_ordering
+            selected_feature_names, set(data.keys()), ordering=column_ordering
         )
 
-        return [{k: record.get(k) for k in _selected_feature_names if k in record} for record in data]
+        # Copy the column lists so mutating the selection cannot mutate framework internals.
+        return {k: list(data[k]) for k in _selected_feature_names if k in data}
 
     def _extract_column_names(self, data: Any) -> set[str]:
-        all_columns: set[str] = set()
-        for row in data:
-            if isinstance(row, dict):
-                all_columns.update(row.keys())
-        return all_columns
+        if isinstance(data, dict):
+            return set(data.keys())
+        # Row-wise list[dict] (still an accepted pre-transform shape): columns are the keys.
+        if isinstance(data, list) and data and isinstance(data[0], dict):
+            return set(data[0].keys())
+        return set()
 
     def _is_schemaless_empty(self, data: Any) -> bool:
-        """``[]`` and ``{}`` are PythonDict's representational empties; ``transform``
-        collapses both to ``[]``. None is excluded: ``transform`` rejects None as an
-        unsupported type, so filter validation never sees a None result path.
+        """Only the empty dict ``{}`` (zero columns) is schema-less. A zero-row but
+        column-bearing frame such as ``{"a": []}`` carries a schema and is NOT schema-less.
         """
-        return isinstance(data, (list, dict)) and not data
+        return isinstance(data, dict) and not data
+
+    @staticmethod
+    def _column_values(data: Any, column_name: str) -> list[Any]:
+        """Return the values of ``column_name`` for either columnar dict or row-wise list[dict]."""
+        if isinstance(data, list):
+            return [row.get(column_name) for row in data if isinstance(row, dict)]
+        return data.get(column_name, [])  # type: ignore[no-any-return]
 
     def _extract_column_dtype(self, data: Any, column_name: str) -> str | None:
-        for row in data:
-            if isinstance(row, dict) and column_name in row and row[column_name] is not None:
-                return type(row[column_name]).__name__
+        for value in self._column_values(data, column_name):
+            if value is not None:
+                return type(value).__name__
         return None
 
     def _extract_column_data_type(self, data: Any, column_name: str) -> Optional[DataType]:
-        for row in data:
-            if not isinstance(row, dict) or column_name not in row or row[column_name] is None:
+        for val in self._column_values(data, column_name):
+            if val is None:
                 continue
-            val = row[column_name]
             if isinstance(val, bool):
                 return DataType.BOOLEAN
             if isinstance(val, int):
@@ -107,62 +115,68 @@ class PythonDictFramework(ComputeFramework):
             return None
         return None
 
-    def transform(self, data: Any, feature_names: set[str]) -> list[dict[str, Any]]:
+    @staticmethod
+    def _validate_columnar_dict(data: dict[str, Any]) -> None:
+        """Enforce the columnar contract on a dict: every value is a list and all value-lists
+        share one length. ``{}`` is schema-less and always valid. Shared by ``transform`` and
+        ``validate_native_data`` so both agree on what a valid columnar frame is.
         """
-        Transforms data to the PythonDict framework format.
+        if not data:
+            return
+
+        if not all(isinstance(v, list) for v in data.values()):
+            raise ValueError(
+                f"Columnar dict values must all be lists (rows must arrive as a list of dicts). Got: {data}"
+            )
+
+        lengths = {len(v) for v in data.values()}
+        if len(lengths) > 1:
+            raise ValueError(f"All columns must have the same length. Got column lengths {lengths}.")
+
+    def validate_native_data(self, data: Any) -> None:
+        """Enforce the columnar contract when a dict result bypasses ``transform``.
+
+        A scalar/mixed dict such as ``{"a": 1}`` is the expected framework type (``dict``) and
+        would otherwise be stored without validation. This raises the same ``ValueError``
+        ``transform`` raises for a malformed columnar dict.
+        """
+        if isinstance(data, dict):
+            self._validate_columnar_dict(data)
+
+    def transform(self, data: Any, feature_names: set[str]) -> dict[str, list[Any]]:
+        """
+        Transforms data to the COLUMNAR PythonDict framework format.
 
         Args:
             data: Input data to transform
             feature_names: Set of feature names being processed
 
         Returns:
-            List[Dict]: Data in PythonDict format
+            dict[str, list[Any]]: Data in columnar PythonDict format
 
         Raises:
             ValueError: If data type is not supported
         """
 
-        # Only the representational empties [] and {} short-circuit. None is a missing
-        # return value (state A), not an empty result, and falls through to the
-        # unsupported-type rejection below, regardless of allow_empty_result().
-        if isinstance(data, (list, dict)) and not data:
-            return []
+        # The representational empties [] and {} normalize to the schema-less {}. None is a
+        # missing return value (state A), not an empty result, and falls through to the
+        # unsupported-type rejection below.
+        if isinstance(data, list) and not data:
+            return {}
+        if isinstance(data, dict) and not data:
+            return {}
 
         transformed_data = self.apply_compute_framework_transformer(data)
         if transformed_data is not None:
             return transformed_data  # type: ignore[no-any-return]
 
         if isinstance(data, dict):
-            """Initial data: Transform columnar dict to row-based list of dicts"""
-            if all(isinstance(v, list) for v in data.values()):
-                # Columnar format: {"col1": [1,2], "col2": [3,4]}
-                # Convert to: [{"col1":1,"col2":3}, {"col1":2,"col2":4}]
-
-                # Get the length from the first column
-                first_key = next(iter(data.keys()))
-                length = len(data[first_key])
-
-                # Verify all columns have the same length
-                for key, values in data.items():
-                    if len(values) != length:
-                        raise ValueError(
-                            f"All columns must have the same length. Column '{key}' has length {len(values)}, expected {length}"
-                        )
-
-                return [{key: data[key][i] for key in data.keys()} for i in range(length)]
-            else:
-                # Single row dict: {"col1": 1, "col2": 2} -> [{"col1": 1, "col2": 2}]
-                return [data]
+            self._validate_columnar_dict(data)
+            return data
 
         if isinstance(data, list):
-            """Data is already in list format"""
-
-            # Verify it's a list of dicts
-            for i, item in enumerate(data):
-                if not isinstance(item, dict):
-                    raise ValueError(f"Expected list of dictionaries, but item at index {i} is {type(item)}")
-
-            return data
+            # List of row dicts -> pivot to columnar. Keys must be homogeneous across rows.
+            return rows_to_columnar(data)
 
         raise ValueError(f"Data type {type(data)} is not supported by {self.__class__.__name__}")
 

--- a/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_mask_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_mask_engine.py
@@ -1,42 +1,58 @@
-from typing import Any
+from typing import Any, Callable
 
 from mloda.core.abstract_plugins.components.mask.base_mask_engine import BaseMaskEngine
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils import row_count
 
 
 class PythonDictMaskEngine(BaseMaskEngine):
+    """Mask engine for the columnar ``dict[str, list[Any]]`` data of the PythonDict framework.
+
+    A mask over a column absent from the data is all-False at row-count length: a missing
+    column never matches, regardless of the compared value.
+    """
+
     @classmethod
     def supported_data_type(cls) -> type[Any]:
-        return list
+        return dict
 
     @classmethod
     def all_true(cls, data: Any) -> list[Any]:
-        return [True] * len(data)
+        return [True] * row_count(data)
 
     @classmethod
     def combine(cls, mask1: Any, mask2: Any) -> list[Any]:
         return [a and b for a, b in zip(mask1, mask2)]
 
     @classmethod
+    def _mask(cls, data: dict[str, list[Any]], column: str, predicate: Callable[[Any], bool]) -> list[Any]:
+        """Apply ``predicate`` per value; a missing column yields all-False at row-count length,
+        so it never matches (even ``None`` comparisons) and ``combine``'s ``zip`` cannot truncate.
+        """
+        if column not in data:
+            return [False] * row_count(data)
+        return [predicate(v) for v in data[column]]
+
+    @classmethod
     def equal(cls, data: Any, column: str, value: Any) -> list[Any]:
-        return [row.get(column) == value for row in data]
+        return cls._mask(data, column, lambda v: v == value)
 
     @classmethod
     def greater_equal(cls, data: Any, column: str, value: Any) -> list[Any]:
-        return [row.get(column) is not None and row.get(column) >= value for row in data]
+        return cls._mask(data, column, lambda v: v is not None and v >= value)
 
     @classmethod
     def less_equal(cls, data: Any, column: str, value: Any) -> list[Any]:
-        return [row.get(column) is not None and row.get(column) <= value for row in data]
+        return cls._mask(data, column, lambda v: v is not None and v <= value)
 
     @classmethod
     def less_than(cls, data: Any, column: str, value: Any) -> list[Any]:
-        return [row.get(column) is not None and row.get(column) < value for row in data]
+        return cls._mask(data, column, lambda v: v is not None and v < value)
 
     @classmethod
     def greater_than(cls, data: Any, column: str, value: Any) -> list[Any]:
-        return [row.get(column) is not None and row.get(column) > value for row in data]
+        return cls._mask(data, column, lambda v: v is not None and v > value)
 
     @classmethod
     def is_in(cls, data: Any, column: str, values: Any) -> list[Any]:
         allowed = set(values) if isinstance(values, (list, tuple)) else {values}
-        return [row.get(column) in allowed for row in data]
+        return cls._mask(data, column, lambda v: v in allowed)

--- a/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_merge_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_merge_engine.py
@@ -4,13 +4,15 @@ from mloda.core.abstract_plugins.components.link import AsOfJoinConfig
 from mloda.provider import BaseMergeEngine
 from mloda.user import Index
 from mloda.user import JoinType
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils import row_count
 
 
 class PythonDictMergeEngine(BaseMergeEngine):
     """
-    Merge engine for PythonDict framework using List[Dict[str, Any]] data structure.
+    Merge engine for PythonDict framework using a COLUMNAR ``dict[str, list[Any]]``.
 
-    Implements hash-based joins using dictionary lookups.
+    Joins are computed over row-index views built from the columnar data and produce
+    columnar dicts with the union of columns; the absent side is null-filled with ``None``.
     """
 
     def check_import(self) -> None:
@@ -18,6 +20,27 @@ class PythonDictMergeEngine(BaseMergeEngine):
         No external dependencies required for PythonDict framework.
         """
         pass
+
+    # -- columnar helpers ----------------------------------------------------
+
+    @classmethod
+    def _to_rows(cls, data: dict[str, list[Any]]) -> list[dict[str, Any]]:
+        n = row_count(data)
+        return [{col: data[col][i] for col in data} for i in range(n)]
+
+    @staticmethod
+    def _to_columnar(rows: list[dict[str, Any]], columns: list[str]) -> dict[str, list[Any]]:
+        # None-fills missing keys because join outputs are ragged by design.
+        return {col: [row.get(col) for row in rows] for col in columns}
+
+    @staticmethod
+    def _ordered_columns(*column_groups: Any) -> list[str]:
+        ordered: list[str] = []
+        for group in column_groups:
+            for col in group:
+                if col not in ordered:
+                    ordered.append(col)
+        return ordered
 
     def merge_inner(self, left_data: Any, right_data: Any, left_index: Index, right_index: Index) -> Any:
         return self.join_logic("inner", left_data, right_data, left_index, right_index, JoinType.INNER)
@@ -32,7 +55,10 @@ class PythonDictMergeEngine(BaseMergeEngine):
         return self.join_logic("outer", left_data, right_data, left_index, right_index, JoinType.OUTER)
 
     def merge_append(self, left_data: Any, right_data: Any, left_index: Index, right_index: Index) -> Any:
-        return left_data + right_data
+        columns = self._ordered_columns(left_data.keys(), right_data.keys())
+        left_rows = self._to_rows(left_data)
+        right_rows = self._to_rows(right_data)
+        return self._to_columnar(left_rows + right_rows, columns)
 
     def merge_union(self, left_data: Any, right_data: Any, left_index: Index, right_index: Index) -> Any:
         return self.join_logic("union", left_data, right_data, left_index, right_index, JoinType.UNION)
@@ -53,22 +79,20 @@ class PythonDictMergeEngine(BaseMergeEngine):
         allow_exact = asof_config.allow_exact_matches
         tolerance = asof_config.tolerance
 
+        left_rows = self._to_rows(left_data)
+        right_rows = self._to_rows(right_data)
+
         right_by_groups: dict[tuple[Any, ...], list[dict[str, Any]]] = {}
-        for r in right_data:
+        for r in right_rows:
             key = tuple(r.get(col) for col in right_by)
             right_by_groups.setdefault(key, []).append(r)
 
-        left_keys = set()
-        for left in left_data:
-            left_keys.update(left.keys())
-        right_extra_cols = []
-        for r in right_data:
-            for col in r.keys():
-                if col not in left_keys and col not in right_extra_cols:
-                    right_extra_cols.append(col)
+        left_keys = set(left_data.keys())
+        right_extra_cols = [col for col in right_data.keys() if col not in left_keys]
+        out_columns = self._ordered_columns(left_data.keys(), right_extra_cols)
 
-        result = []
-        for left in left_data:
+        result_rows = []
+        for left in left_rows:
             key = tuple(left.get(col) for col in left_by)
             left_time = left.get(lt)
             match = self._select_asof_match(
@@ -77,38 +101,40 @@ class PythonDictMergeEngine(BaseMergeEngine):
             merged = {**left}
             for col in right_extra_cols:
                 merged[col] = match.get(col) if match is not None else None
-            result.append(merged)
+            result_rows.append(merged)
 
-        return result
+        return self._to_columnar(result_rows, out_columns)
 
     def _coerce_asof_time_column(self, data: Any, column: str) -> Any:
-        coerced: list[dict[str, Any]] = []
+        column_values = data.get(column, [])
+        new_column: list[Any] = []
         parsed_values: list[datetime] = []
-        for row in data:
-            new_row = dict(row)
-            v = row.get(column)
-            if v is not None:
-                if not isinstance(v, str):
-                    raise ValueError(
-                        f"Cannot coerce as-of time column '{column}': expected ISO-8601 string or None, "
-                        f"got {type(v).__name__}."
-                    )
-                # Python 3.10's fromisoformat rejects a trailing 'Z'; normalize it to '+00:00'.
-                parse_input = v[:-1] + "+00:00" if v.endswith("Z") else v
-                new_row[column] = datetime.fromisoformat(parse_input)
-                parsed_values.append(new_row[column])
-            coerced.append(new_row)
+        for v in column_values:
+            if v is None:
+                new_column.append(None)
+                continue
+            if not isinstance(v, str):
+                raise ValueError(
+                    f"Cannot coerce as-of time column '{column}': expected ISO-8601 string or None, "
+                    f"got {type(v).__name__}."
+                )
+            # Python 3.10's fromisoformat rejects a trailing 'Z'; normalize it to '+00:00'.
+            parse_input = v[:-1] + "+00:00" if v.endswith("Z") else v
+            parsed = datetime.fromisoformat(parse_input)
+            new_column.append(parsed)
+            parsed_values.append(parsed)
         has_naive = any(p.tzinfo is None for p in parsed_values)
         has_aware = any(p.tzinfo is not None for p in parsed_values)
         if has_naive and has_aware:
             raise ValueError(
                 f"Cannot coerce as-of time column '{column}': mixed tz-naive and tz-aware values are not allowed."
             )
+        coerced = dict(data)
+        coerced[column] = new_column
         return coerced
 
     def _asof_time_column_is_ordered(self, data: Any, column: str) -> bool:
-        for row in data:
-            v = row.get(column)
+        for v in data.get(column, []):
             if v is None:
                 continue
             if isinstance(v, bool) or not isinstance(v, (int, float, datetime, date, timedelta)):
@@ -173,14 +199,14 @@ class PythonDictMergeEngine(BaseMergeEngine):
 
         Args:
             join_type: Type of join ("inner", "left", "right", "outer", "union")
-            left_data: Left dataset as List[Dict]
-            right_data: Right dataset as List[Dict]
+            left_data: Left dataset as a columnar dict
+            right_data: Right dataset as a columnar dict
             left_index: Index object containing left join columns
             right_index: Index object containing right join columns
             jointype: JoinType enum value
 
         Returns:
-            List[Dict]: Joined result
+            dict[str, list[Any]]: Joined result as a columnar dict
         """
         left_cols = left_index.index
         right_cols = right_index.index
@@ -202,102 +228,91 @@ class PythonDictMergeEngine(BaseMergeEngine):
         self, left_data: Any, right_data: Any, left_cols: tuple[str, ...], right_cols: tuple[str, ...]
     ) -> Any:
         """Performs inner join."""
-        right_index_map = {tuple(r.get(col) for col in right_cols): r for r in right_data}
+        left_rows = self._to_rows(left_data)
+        right_rows = self._to_rows(right_data)
+        right_index_map = {tuple(r.get(col) for col in right_cols): r for r in right_rows}
 
+        out_columns = self._ordered_columns(left_data.keys(), right_data.keys())
         result = []
-        for left in left_data:
+        for left in left_rows:
             key = tuple(left.get(col) for col in left_cols)
             if key in right_index_map:
-                merged = {**left, **right_index_map[key]}
-                result.append(merged)
+                result.append({**left, **right_index_map[key]})
 
-        return result
+        return self._to_columnar(result, out_columns)
 
     def _left_join(
         self, left_data: Any, right_data: Any, left_cols: tuple[str, ...], right_cols: tuple[str, ...]
     ) -> Any:
         """Performs left join."""
-        right_index_map = {tuple(r.get(col) for col in right_cols): r for r in right_data}
+        left_rows = self._to_rows(left_data)
+        right_rows = self._to_rows(right_data)
+        right_index_map = {tuple(r.get(col) for col in right_cols): r for r in right_rows}
 
-        # Get right columns for null filling
-        right_columns = set()
-        for r in right_data:
-            right_columns.update(r.keys())
-        right_columns = right_columns - set(right_cols)
-
-        left_columns = set()
-        for left in left_data:
-            left_columns.update(left.keys())
-        right_columns = right_columns - left_columns
+        out_columns = self._ordered_columns(left_data.keys(), right_data.keys())
+        right_columns = [col for col in right_data.keys() if col not in set(right_cols) and col not in left_data]
 
         result = []
-        for left in left_data:
+        for left in left_rows:
             key = tuple(left.get(col) for col in left_cols)
             if key in right_index_map:
-                merged = {**left, **right_index_map[key]}
-                result.append(merged)
+                result.append({**left, **right_index_map[key]})
             else:
                 merged = {**left}
                 for col in right_columns:
                     merged[col] = None
                 result.append(merged)
 
-        return result
+        return self._to_columnar(result, out_columns)
 
     def _right_join(
         self, left_data: Any, right_data: Any, left_cols: tuple[str, ...], right_cols: tuple[str, ...]
     ) -> Any:
         """Performs right join."""
-        left_index_map = {tuple(left.get(col) for col in left_cols): left for left in left_data}
+        left_rows = self._to_rows(left_data)
+        right_rows = self._to_rows(right_data)
+        left_index_map = {tuple(left.get(col) for col in left_cols): left for left in left_rows}
 
-        # Get left columns for null filling
-        left_columns = set()
-        for left in left_data:
-            left_columns.update(left.keys())
-        left_columns = left_columns - set(left_cols)
-
-        right_columns = set()
-        for r in right_data:
-            right_columns.update(r.keys())
-        left_columns = left_columns - right_columns
+        out_columns = self._ordered_columns(right_data.keys(), left_data.keys())
+        left_columns = [col for col in left_data.keys() if col not in set(left_cols) and col not in right_data]
 
         result = []
-        for r in right_data:
+        for r in right_rows:
             key = tuple(r.get(col) for col in right_cols)
             if key in left_index_map:
-                merged = {**left_index_map[key], **r}
-                result.append(merged)
+                result.append({**left_index_map[key], **r})
             else:
                 merged = {**r}
                 for col in left_columns:
                     merged[col] = None
                 result.append(merged)
 
-        return result
+        return self._to_columnar(result, out_columns)
 
     def _outer_join(
         self, left_data: Any, right_data: Any, left_cols: tuple[str, ...], right_cols: tuple[str, ...]
     ) -> Any:
         """Performs outer join."""
-        left_index_map = {tuple(left.get(col) for col in left_cols): left for left in left_data}
-        right_index_map = {tuple(r.get(col) for col in right_cols): r for r in right_data}
+        left_rows = self._to_rows(left_data)
+        right_rows = self._to_rows(right_data)
+        left_index_map = {tuple(left.get(col) for col in left_cols): left for left in left_rows}
+        right_index_map = {tuple(r.get(col) for col in right_cols): r for r in right_rows}
 
-        all_keys = set(left_index_map.keys()) | set(right_index_map.keys())
+        all_keys = list(left_index_map.keys())
+        for key in right_index_map.keys():
+            if key not in left_index_map:
+                all_keys.append(key)
 
-        # Get all column names
-        left_columns = set()
-        right_columns = set()
-        for left in left_data:
-            left_columns.update(left.keys())
-        for r in right_data:
-            right_columns.update(r.keys())
+        left_columns = list(left_data.keys())
+        right_columns = list(right_data.keys())
+        out_columns = self._ordered_columns(left_columns, right_columns)
 
         result = []
         for key in all_keys:
             left_row = left_index_map.get(key, {})
             right_row = right_index_map.get(key, {})
 
-            merged = {}
+            merged: dict[str, Any] = {}
 
             # Start with the key values
             if left_cols == right_cols:
@@ -311,39 +326,39 @@ class PythonDictMergeEngine(BaseMergeEngine):
                     for i, col in enumerate(right_cols):
                         merged[col] = key[i]
 
-            # Add left columns (excluding join columns)
             for col in left_columns:
                 if col not in left_cols:
                     merged[col] = left_row.get(col)
 
-            # Add right columns (excluding join columns)
             for col in right_columns:
                 if col not in right_cols:
                     merged[col] = right_row.get(col)
 
             result.append(merged)
 
-        return result
+        return self._to_columnar(result, out_columns)
 
     def _union_join(
         self, left_data: Any, right_data: Any, left_cols: tuple[str, ...], right_cols: tuple[str, ...]
     ) -> Any:
         """Performs union (removes duplicates based on join columns)."""
+        left_rows = self._to_rows(left_data)
+        right_rows = self._to_rows(right_data)
+        out_columns = self._ordered_columns(left_data.keys(), right_data.keys())
+
         seen_keys: set[Any] = set()
         result = []
 
-        # Add left rows
-        for row in left_data:
+        for row in left_rows:
             key = tuple(row.get(col) for col in left_cols)
             if key not in seen_keys:
                 seen_keys.add(key)
                 result.append(row)
 
-        # Add right rows that haven't been seen
-        for row in right_data:
+        for row in right_rows:
             key = tuple(row.get(col) for col in right_cols)
             if key not in seen_keys:
                 seen_keys.add(key)
                 result.append(row)
 
-        return result
+        return self._to_columnar(result, out_columns)

--- a/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_pyarrow_transformer.py
+++ b/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_pyarrow_transformer.py
@@ -10,16 +10,16 @@ except ImportError:
 
 class PythonDictPyArrowTransformer(BaseTransformer):
     """
-    Transformer for converting between PythonDict (List[Dict]) and PyArrow Table.
+    Transformer for converting between PythonDict (columnar dict) and PyArrow Table.
 
-    This transformer handles bidirectional conversion between List[Dict[str, Any]]
+    This transformer handles bidirectional conversion between ``dict[str, list[Any]]``
     and PyArrow Table data structures, using PyArrow's built-in methods for
     efficient conversion.
     """
 
     @classmethod
     def framework(cls) -> Any:
-        return list
+        return dict
 
     @classmethod
     def other_framework(cls) -> Any:
@@ -38,10 +38,10 @@ class PythonDictPyArrowTransformer(BaseTransformer):
     @classmethod
     def transform_fw_to_other_fw(cls, data: Any) -> Any:
         """
-        Transform a List[Dict] to a PyArrow Table.
+        Transform a columnar dict to a PyArrow Table.
 
         Args:
-            data: List[Dict[str, Any]] representing tabular data
+            data: ``dict[str, list[Any]]`` representing tabular data
 
         Returns:
             pa.Table: PyArrow Table representation of the data
@@ -49,48 +49,23 @@ class PythonDictPyArrowTransformer(BaseTransformer):
         if pa is None:
             raise ImportError("PyArrow is not installed. To be able to use this transformer, please install pyarrow.")
 
-        if not isinstance(data, list):
-            raise ValueError(f"Expected list, got {type(data)}")
+        if not isinstance(data, dict):
+            raise ValueError(f"Expected dict, got {type(data)}")
 
-        if not data:
-            # Handle empty list case
-            return pa.table({})
-
-        # Verify all items are dictionaries and have consistent schema
-        if data:
-            # First check that the first item is a dict before accessing .keys()
-            if not isinstance(data[0], dict):
-                raise ValueError(f"Expected dict at index 0, got {type(data[0])}")
-
-            first_keys = set(data[0].keys())
-            for i, item in enumerate(data):
-                if not isinstance(item, dict):
-                    raise ValueError(f"Expected dict at index {i}, got {type(item)}")
-
-                item_keys = set(item.keys())
-                if item_keys != first_keys:
-                    missing_keys = first_keys - item_keys
-                    extra_keys = item_keys - first_keys
-                    error_msg = f"Inconsistent schema at index {i}."
-                    if missing_keys:
-                        error_msg += f" Missing keys: {missing_keys}."
-                    if extra_keys:
-                        error_msg += f" Extra keys: {extra_keys}."
-                    raise ValueError(error_msg)
-
-        # Use PyArrow's from_pylist method for efficient conversion
-        return pa.Table.from_pylist(data)
+        # A columnar dict of columns maps directly onto a PyArrow table. An empty column
+        # ``{"col": []}`` yields a 0-row table that keeps the column name; ``{}`` -> empty table.
+        return pa.table(data)
 
     @classmethod
     def transform_other_fw_to_fw(cls, data: Any, framework_connection_object: Optional[Any] = None) -> Any:
         """
-        Transform a PyArrow Table to a List[Dict].
+        Transform a PyArrow Table to a columnar dict.
 
         Args:
             data: pa.Table representing tabular data
 
         Returns:
-            List[Dict[str, Any]]: List of dictionaries representation of the data
+            dict[str, list[Any]]: columnar dict representation of the data
         """
         if pa is None:
             raise ImportError("PyArrow is not installed. To be able to use this transformer, please install pyarrow.")
@@ -98,5 +73,5 @@ class PythonDictPyArrowTransformer(BaseTransformer):
         if not isinstance(data, pa.Table):
             raise ValueError(f"Expected pa.Table, got {type(data)}")
 
-        # Use PyArrow's to_pylist method for efficient conversion
-        return data.to_pylist()
+        # Use PyArrow's to_pydict method: columnar dict, schema preserved even at zero rows.
+        return data.to_pydict()

--- a/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_utils.py
+++ b/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_utils.py
@@ -1,0 +1,28 @@
+"""Shared helpers for the PythonDict framework's columnar ``dict[str, list[Any]]`` data."""
+
+from typing import Any
+
+
+def row_count(data: dict[str, list[Any]]) -> int:
+    """Number of rows in a columnar dict: length of the first column, 0 for the empty dict."""
+    for column in data.values():
+        return len(column)
+    return 0
+
+
+def rows_to_columnar(rows: list[dict[str, Any]]) -> dict[str, list[Any]]:
+    """Pivot row-wise ``list[dict]`` to columnar. Keys must be homogeneous across rows."""
+    if not rows:
+        return {}
+
+    for i, item in enumerate(rows):
+        if not isinstance(item, dict):
+            raise ValueError(f"Expected list of dictionaries, but item at index {i} is {type(item)}")
+
+    first_keys = list(rows[0].keys())
+    first_keys_set = set(first_keys)
+    for i, item in enumerate(rows):
+        if set(item.keys()) != first_keys_set:
+            raise ValueError(f"Inconsistent row keys at index {i}: expected {first_keys_set}, got {set(item.keys())}.")
+
+    return {key: [row[key] for row in rows] for key in first_keys}

--- a/mloda_plugins/feature_group/experimental/data_quality/missing_value/python_dict.py
+++ b/mloda_plugins/feature_group/experimental/data_quality/missing_value/python_dict.py
@@ -11,6 +11,7 @@ from typing import Any, Optional
 from mloda.provider import ComputeFramework
 
 from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils import row_count
 from mloda_plugins.feature_group.experimental.data_quality.missing_value.base import MissingValueFeatureGroup
 
 
@@ -18,8 +19,8 @@ class PythonDictMissingValueFeatureGroup(MissingValueFeatureGroup):
     """
     PythonDict implementation for missing value imputation feature groups.
 
-    This implementation uses pure Python operations on List[Dict[str, Any]] data structures
-    to perform missing value imputation without external dependencies.
+    This implementation uses pure Python operations on columnar ``dict[str, list[Any]]``
+    data structures to perform missing value imputation without external dependencies.
     """
 
     @classmethod
@@ -27,18 +28,12 @@ class PythonDictMissingValueFeatureGroup(MissingValueFeatureGroup):
         return {PythonDictFramework}
 
     @classmethod
-    def _get_available_columns(cls, data: list[dict[str, Any]]) -> set[str]:
+    def _get_available_columns(cls, data: dict[str, list[Any]]) -> set[str]:
         """Get the set of available column names from the data."""
-        if not data:
-            return set()
-        # Collect all keys from all dictionaries
-        all_keys: set[str] = set()
-        for row in data:
-            all_keys.update(row.keys())
-        return all_keys
+        return set(data.keys())
 
     @classmethod
-    def _check_source_features_exist(cls, data: list[dict[str, Any]], feature_names: list[str]) -> None:
+    def _check_source_features_exist(cls, data: dict[str, list[Any]], feature_names: list[str]) -> None:
         """Check if the resolved source features exist in the data."""
         if not data:
             raise ValueError("Data cannot be empty")
@@ -55,21 +50,20 @@ class PythonDictMissingValueFeatureGroup(MissingValueFeatureGroup):
 
     @classmethod
     def _add_result_to_data(
-        cls, data: list[dict[str, Any]], feature_name: str, result: list[Any]
-    ) -> list[dict[str, Any]]:
+        cls, data: dict[str, list[Any]], feature_name: str, result: list[Any]
+    ) -> dict[str, list[Any]]:
         """Add the result to the data."""
-        if len(result) != len(data):
-            raise ValueError(f"Result length {len(result)} does not match data length {len(data)}")
+        if len(result) != row_count(data):
+            raise ValueError(f"Result length {len(result)} does not match data length {row_count(data)}")
 
-        for i, row in enumerate(data):
-            row[feature_name] = result[i]
+        data[feature_name] = list(result)
 
         return data
 
     @classmethod
     def _perform_imputation(
         cls,
-        data: list[dict[str, Any]],
+        data: dict[str, list[Any]],
         imputation_method: str,
         in_features: list[str],
         constant_value: Optional[Any] = None,
@@ -96,7 +90,7 @@ class PythonDictMissingValueFeatureGroup(MissingValueFeatureGroup):
         if len(in_features) == 1:
             source_feature = in_features[0]
             # Extract the source feature values
-            source_values = [row.get(source_feature) for row in data]
+            source_values = list(data.get(source_feature, []))
 
             # If there are no missing values, return the original values
             if not any(value is None for value in source_values):
@@ -127,8 +121,8 @@ class PythonDictMissingValueFeatureGroup(MissingValueFeatureGroup):
             # Multi-column case: impute across columns (row-wise)
             # For multi-column features, we compute imputation values across columns for each row
             result = []
-            for row in data:
-                row_values = [row.get(col) for col in in_features]
+            for i in range(row_count(data)):
+                row_values = [data[col][i] if col in data else None for col in in_features]
 
                 if imputation_method == "mean":
                     non_null = [v for v in row_values if v is not None]
@@ -162,7 +156,7 @@ class PythonDictMissingValueFeatureGroup(MissingValueFeatureGroup):
     @classmethod
     def _perform_grouped_imputation(
         cls,
-        data: list[dict[str, Any]],
+        data: dict[str, list[Any]],
         imputation_method: str,
         in_features: str,  # Note: grouped imputation only supports single column
         constant_value: Optional[Any],
@@ -183,14 +177,14 @@ class PythonDictMissingValueFeatureGroup(MissingValueFeatureGroup):
         """
         # Create groups based on group_by_features
         groups: dict[tuple[Any, ...], list[int]] = {}
-        for i, row in enumerate(data):
-            group_key = tuple(row.get(feature) for feature in group_by_features)
+        for i in range(row_count(data)):
+            group_key = tuple(data[feature][i] if feature in data else None for feature in group_by_features)
             if group_key not in groups:
                 groups[group_key] = []
             groups[group_key].append(i)
 
         # Initialize result with original values
-        result = [row.get(in_features) for row in data]
+        result = list(data.get(in_features, []))
 
         if imputation_method == "constant":
             # Constant imputation is the same regardless of groups

--- a/mloda_plugins/feature_group/experimental/text_cleaning/python_dict.py
+++ b/mloda_plugins/feature_group/experimental/text_cleaning/python_dict.py
@@ -12,6 +12,7 @@ from typing import Any
 from mloda.provider import ComputeFramework
 
 from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils import row_count
 from mloda_plugins.feature_group.experimental.text_cleaning.base import TextCleaningFeatureGroup
 
 # Optional NLTK support - gracefully handle if not available
@@ -30,8 +31,9 @@ class PythonDictTextCleaningFeatureGroup(TextCleaningFeatureGroup):
     """
     PythonDict implementation for text cleaning feature groups.
 
-    This implementation uses pure Python operations on List[Dict[str, Any]] data structures
-    to perform text cleaning operations without external dependencies (except optional NLTK).
+    This implementation uses pure Python operations on columnar ``dict[str, list[Any]]``
+    data structures to perform text cleaning operations without external dependencies
+    (except optional NLTK).
     """
 
     @classmethod
@@ -39,13 +41,11 @@ class PythonDictTextCleaningFeatureGroup(TextCleaningFeatureGroup):
         return {PythonDictFramework}
 
     @classmethod
-    def _check_source_features_exist(cls, data: list[dict[str, Any]], feature_names: list[str]) -> None:
+    def _check_source_features_exist(cls, data: dict[str, list[Any]], feature_names: list[str]) -> None:
         if not data:
             raise ValueError("Data cannot be empty")
 
-        available_features: set[str] = set()
-        for row in data:
-            available_features.update(row.keys())
+        available_features = set(data.keys())
         missing_features = [f for f in feature_names if f not in available_features]
         if missing_features:
             raise ValueError(
@@ -54,45 +54,44 @@ class PythonDictTextCleaningFeatureGroup(TextCleaningFeatureGroup):
             )
 
     @classmethod
-    def _get_source_text(cls, data: list[dict[str, Any]], feature_name: str) -> list[str]:
+    def _get_source_text(cls, data: dict[str, list[Any]], feature_name: str) -> list[str]:
         """
         Get the source text from the data.
 
         Args:
-            data: The List[Dict] data structure
+            data: The columnar dict data structure
             feature_name: The name of the feature to get
 
         Returns:
             The source text as a list of strings
         """
         # Convert to string if not already and handle None values
-        return [str(row.get(feature_name, "")) if row.get(feature_name) is not None else "" for row in data]
+        return [str(value) if value is not None else "" for value in data.get(feature_name, [])]
 
     @classmethod
     def _add_result_to_data(
-        cls, data: list[dict[str, Any]], feature_name: str, result: list[str]
-    ) -> list[dict[str, Any]]:
+        cls, data: dict[str, list[Any]], feature_name: str, result: list[str]
+    ) -> dict[str, list[Any]]:
         """
         Add the cleaning result to the data.
 
         Args:
-            data: The List[Dict] data structure
+            data: The columnar dict data structure
             feature_name: The name of the feature to add
             result: The cleaning result as a list of strings
 
         Returns:
             The updated data with the cleaning result added
         """
-        if len(result) != len(data):
-            raise ValueError(f"Result length {len(result)} does not match data length {len(data)}")
+        if len(result) != row_count(data):
+            raise ValueError(f"Result length {len(result)} does not match data length {row_count(data)}")
 
-        for i, row in enumerate(data):
-            row[feature_name] = result[i]
+        data[feature_name] = list(result)
 
         return data
 
     @classmethod
-    def _apply_operation(cls, data: list[dict[str, Any]], text: list[str], operation: str) -> list[str]:
+    def _apply_operation(cls, data: dict[str, list[Any]], text: list[str], operation: str) -> list[str]:
         """
         Apply a cleaning operation to the text.
 

--- a/tests/test_core/test_abstract_plugins/test_column_ordering.py
+++ b/tests/test_core/test_abstract_plugins/test_column_ordering.py
@@ -307,11 +307,11 @@ class TestComputeFrameworksColumnOrdering:
 
     def test_python_dict_accepts_column_ordering(self) -> None:
         cfw = PythonDictFramework(ParallelizationMode.SYNC, frozenset(), uuid4())
-        # PythonDictFramework expects List[Dict] format (rows)
-        data = [{"Z": 1, "A": 2, "M": 3}]
+        # PythonDictFramework expects a columnar dict format
+        data = {"Z": [1], "A": [2], "M": [3]}
         features = {FeatureName("Z"), FeatureName("A"), FeatureName("M")}
         result = cfw.select_data_by_column_names(data, features, column_ordering="alphabetical")
-        assert list(result[0].keys()) == ["A", "M", "Z"]
+        assert list(result.keys()) == ["A", "M", "Z"]
 
 
 # --- End-to-End Test Features ---

--- a/tests/test_core/test_setup/test_polymorphic_link_resolution.py
+++ b/tests/test_core/test_setup/test_polymorphic_link_resolution.py
@@ -105,10 +105,9 @@ class AssemblerWithConcreteLinks(FeatureGroup):
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-        # Extract from joined data
-        row = data[0] if isinstance(data, list) else data
-        a = row.get(BaseFeatureGroupA.FEATURE_NAME, "MISSING_A")
-        b = row.get(BaseFeatureGroupB.FEATURE_NAME, "MISSING_B")
+        # Extract the first row from the joined columnar data
+        a = data.get(BaseFeatureGroupA.FEATURE_NAME, ["MISSING_A"])[0]
+        b = data.get(BaseFeatureGroupB.FEATURE_NAME, ["MISSING_B"])[0]
         return {cls.FEATURE_NAME: [f"a={a}, b={b}"]}
 
 
@@ -137,10 +136,9 @@ class AssemblerWithPolymorphicLinks(FeatureGroup):
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-        # Extract from joined data
-        row = data[0] if isinstance(data, list) else data
-        a = row.get(BaseFeatureGroupA.FEATURE_NAME, "MISSING_A")
-        b = row.get(BaseFeatureGroupB.FEATURE_NAME, "MISSING_B")
+        # Extract the first row from the joined columnar data
+        a = data.get(BaseFeatureGroupA.FEATURE_NAME, ["MISSING_A"])[0]
+        b = data.get(BaseFeatureGroupB.FEATURE_NAME, ["MISSING_B"])[0]
         return {cls.FEATURE_NAME: [f"a={a}, b={b}"]}
 
 
@@ -172,7 +170,7 @@ class TestPolymorphicLinkResolution:
             ),
         )
 
-        result = results[0][0][AssemblerWithConcreteLinks.FEATURE_NAME]
+        result = results[0][AssemblerWithConcreteLinks.FEATURE_NAME][0]
         assert result == "a=value_a, b=value_b", f"Got: {result}"
 
     def test_polymorphic_links_resolve_correctly(self) -> None:
@@ -187,7 +185,7 @@ class TestPolymorphicLinkResolution:
             ),
         )
 
-        result = results[0][0][AssemblerWithPolymorphicLinks.FEATURE_NAME]
+        result = results[0][AssemblerWithPolymorphicLinks.FEATURE_NAME][0]
         assert result == "a=value_a, b=value_b", f"Got: {result}"
 
 
@@ -222,10 +220,9 @@ class AssemblerWithMixedLink(FeatureGroup):
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-        # Extract from joined data
-        row = data[0] if isinstance(data, list) else data
-        a = row.get(BaseFeatureGroupA.FEATURE_NAME, "MISSING_A")
-        query = row.get("user_query", "MISSING_QUERY")
+        # Extract the first row from the joined columnar data
+        a = data.get(BaseFeatureGroupA.FEATURE_NAME, ["MISSING_A"])[0]
+        query = data.get("user_query", ["MISSING_QUERY"])[0]
         return {cls.FEATURE_NAME: [f"a={a}, query={query}"]}
 
 
@@ -245,5 +242,5 @@ class TestAsymmetricPolymorphicLinkResolution:
             ),
         )
 
-        result = results[0][0][AssemblerWithMixedLink.FEATURE_NAME]
+        result = results[0][AssemblerWithMixedLink.FEATURE_NAME][0]
         assert result == "a=value_a, query=test query", f"Got: {result}"

--- a/tests/test_plugins/compute_framework/base_implementations/filter_engine_test_mixin.py
+++ b/tests/test_plugins/compute_framework/base_implementations/filter_engine_test_mixin.py
@@ -53,6 +53,15 @@ class FilterEngineTestMixin:
         """
         raise NotImplementedError
 
+    def result_row_count(self, result: Any) -> int:
+        """Return the number of rows in a filter result.
+
+        Defaults to ``len(result)`` (correct for row-shaped frames: pandas, polars,
+        pyarrow). Columnar frameworks (PythonDict's ``dict[str, list]``) override this,
+        since ``len`` on a columnar dict counts columns, not rows.
+        """
+        return len(result)
+
     def _assert_values_equal(self, actual: list[Any], expected: list[Any]) -> None:
         """Assert values are equal regardless of order."""
         assert sorted(actual) == sorted(expected)
@@ -66,7 +75,7 @@ class FilterEngineTestMixin:
 
         result = filter_engine.do_range_filter(sample_data, single_filter)
 
-        assert len(result) == 3
+        assert self.result_row_count(result) == 3
         self._assert_values_equal(self.get_column_values(result, "age"), [30, 35, 40])
         self._assert_values_equal(self.get_column_values(result, "id"), [2, 3, 4])
 
@@ -79,7 +88,7 @@ class FilterEngineTestMixin:
 
         result = filter_engine.do_range_filter(sample_data, single_filter)
 
-        assert len(result) == 2
+        assert self.result_row_count(result) == 2
         self._assert_values_equal(self.get_column_values(result, "age"), [30, 35])
         self._assert_values_equal(self.get_column_values(result, "id"), [2, 3])
 
@@ -92,7 +101,7 @@ class FilterEngineTestMixin:
 
         result = filter_engine.do_min_filter(sample_data, single_filter)
 
-        assert len(result) == 2
+        assert self.result_row_count(result) == 2
         self._assert_values_equal(self.get_column_values(result, "age"), [40, 45])
         self._assert_values_equal(self.get_column_values(result, "id"), [4, 5])
 
@@ -105,7 +114,7 @@ class FilterEngineTestMixin:
 
         result = filter_engine.do_max_filter(sample_data, single_filter)
 
-        assert len(result) == 2
+        assert self.result_row_count(result) == 2
         self._assert_values_equal(self.get_column_values(result, "age"), [25, 30])
         self._assert_values_equal(self.get_column_values(result, "id"), [1, 2])
 
@@ -118,7 +127,7 @@ class FilterEngineTestMixin:
 
         result = filter_engine.do_max_filter(sample_data, single_filter)
 
-        assert len(result) == 2
+        assert self.result_row_count(result) == 2
         self._assert_values_equal(self.get_column_values(result, "age"), [25, 30])
         self._assert_values_equal(self.get_column_values(result, "id"), [1, 2])
 
@@ -131,7 +140,7 @@ class FilterEngineTestMixin:
 
         result = filter_engine.do_equal_filter(sample_data, single_filter)
 
-        assert len(result) == 1
+        assert self.result_row_count(result) == 1
         assert self.get_column_values(result, "age")[0] == 35
         assert self.get_column_values(result, "id")[0] == 3
 
@@ -144,7 +153,7 @@ class FilterEngineTestMixin:
 
         result = filter_engine.do_regex_filter(sample_data, single_filter)
 
-        assert len(result) == 1
+        assert self.result_row_count(result) == 1
         assert self.get_column_values(result, "name")[0] == "Alice"
         assert self.get_column_values(result, "id")[0] == 1
 
@@ -157,7 +166,7 @@ class FilterEngineTestMixin:
 
         result = filter_engine.do_categorical_inclusion_filter(sample_data, single_filter)
 
-        assert len(result) == 4
+        assert self.result_row_count(result) == 4
         assert set(self.get_column_values(result, "category")) == {"A", "B"}
         assert set(self.get_column_values(result, "id")) == {1, 2, 3, 5}
 
@@ -180,7 +189,7 @@ class FilterEngineTestMixin:
 
         result = filter_engine.apply_filters(sample_data, feature_set)
 
-        assert len(result) == 1
+        assert self.result_row_count(result) == 1
         assert self.get_column_values(result, "age")[0] == 35
         assert self.get_column_values(result, "category")[0] == "A"
         assert self.get_column_values(result, "id")[0] == 3

--- a/tests/test_plugins/compute_framework/base_implementations/pandas/test_pandas_allow_empty_result_run_all.py
+++ b/tests/test_plugins/compute_framework/base_implementations/pandas/test_pandas_allow_empty_result_run_all.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import pytest
 
+from mloda.core.abstract_plugins.compute_framework import EmptyResultError
 from mloda.user import Feature
 from mloda.user import ParallelizationMode
 from mloda.user import mloda
@@ -51,24 +52,21 @@ def test_empty_result_none_raises_pandas(flight_server: Any) -> None:
         )
 
 
-def test_zero_column_allowed_succeeds_pandas(flight_server: Any) -> None:
-    """An opted-in FG returning ``{}`` (zero columns) must succeed end-to-end on pandas.
+def test_zero_column_raises_pandas(flight_server: Any) -> None:
+    """A FG returning ``{}`` (zero columns) raises ``EmptyResultError`` end-to-end on pandas.
 
-    The output guard accepts the schema-less result because ``allow_empty_result()`` is
-    True; result selection must then pass the zero-column frame through unchanged instead
-    of trying (and failing) to match feature names against an empty column set. The caller
-    receives exactly one result that carries zero columns.
+    With ``allow_empty_result`` retired, a schema-less result is never legitimate: the
+    output guard raises for the zero-column frame. ``run_all`` re-wraps the framework error,
+    so the assertion targets the type NAME in the wrapped message.
     """
     feature = Feature(name="empty_result_schemaless_col")
 
-    result = mloda.run_all(
-        [feature],
-        compute_frameworks=["PandasDataFrame"],
-        plugin_collector=_ENABLED_SCHEMALESS_ALLOWED,
-        parallelization_modes={ParallelizationMode.SYNC},
-        flight_server=flight_server,
-    )
-
-    assert len(result) == 1
-    # Tolerant zero-column check: pandas DataFrame and pa.Table both expose .columns.
-    assert len(result[0].columns) == 0
+    with pytest.raises(Exception) as excinfo:
+        mloda.run_all(
+            [feature],
+            compute_frameworks=["PandasDataFrame"],
+            plugin_collector=_ENABLED_SCHEMALESS_ALLOWED,
+            parallelization_modes={ParallelizationMode.SYNC},
+            flight_server=flight_server,
+        )
+    assert EmptyResultError.__name__ in str(excinfo.value)

--- a/tests/test_plugins/compute_framework/base_implementations/pyarrow/test_pyarrow_allow_empty_result_run_all.py
+++ b/tests/test_plugins/compute_framework/base_implementations/pyarrow/test_pyarrow_allow_empty_result_run_all.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import pytest
 
+from mloda.core.abstract_plugins.compute_framework import EmptyResultError
 from mloda.user import Feature
 from mloda.user import ParallelizationMode
 from mloda.user import mloda
@@ -37,23 +38,21 @@ class TestPyArrowAllowEmptyResultRunAll(EmptyResultRunAllTestBase):
 
 
 @pytest.mark.skipif(pa is None, reason="PyArrow is not installed. Skipping this test.")
-def test_zero_column_allowed_succeeds_pyarrow(flight_server: Any) -> None:
-    """An opted-in FG returning ``{}`` (zero columns) must succeed end-to-end on PyArrow.
+def test_zero_column_raises_pyarrow(flight_server: Any) -> None:
+    """A FG returning ``{}`` (zero columns) raises ``EmptyResultError`` end-to-end on PyArrow.
 
-    The output guard accepts the schema-less result because ``allow_empty_result()`` is
-    True; result selection must then pass the zero-column table through unchanged instead
-    of trying (and failing) to match feature names against an empty column set. The caller
-    receives exactly one result: a ``pa.Table`` with zero columns.
+    With ``allow_empty_result`` retired, a schema-less result is never legitimate: the
+    output guard raises for the zero-column table. ``run_all`` re-wraps the framework error,
+    so the assertion targets the type NAME in the wrapped message.
     """
     feature = Feature(name="empty_result_schemaless_col")
 
-    result = mloda.run_all(
-        [feature],
-        compute_frameworks=["PyArrowTable"],
-        plugin_collector=_ENABLED_SCHEMALESS_ALLOWED,
-        parallelization_modes={ParallelizationMode.SYNC},
-        flight_server=flight_server,
-    )
-
-    assert len(result) == 1
-    assert result[0].num_columns == 0
+    with pytest.raises(Exception) as excinfo:
+        mloda.run_all(
+            [feature],
+            compute_frameworks=["PyArrowTable"],
+            plugin_collector=_ENABLED_SCHEMALESS_ALLOWED,
+            parallelization_modes={ParallelizationMode.SYNC},
+            flight_server=flight_server,
+        )
+    assert EmptyResultError.__name__ in str(excinfo.value)

--- a/tests/test_plugins/compute_framework/base_implementations/pyarrow/test_pyarrow_table.py
+++ b/tests/test_plugins/compute_framework/base_implementations/pyarrow/test_pyarrow_table.py
@@ -140,14 +140,10 @@ class TestPyArrowEmptyResult(EmptyResultFrameworkTestMixin):
 class _FakeGuardFeatureGroup:
     """Minimal FeatureGroup stand-in for the empty-result guard.
 
-    ``run_validate_output_features`` reads ``allow_empty_result()`` (False so the guard
-    is armed), ``get_class_name()`` for the error message, and finally calls
-    ``validate_output_features`` (no-op). Mirrors ``_FakeFeatureGroup`` in the
-    python_dict policy test file.
+    ``run_validate_output_features`` uses ``get_class_name()`` for the error message and
+    finally calls ``validate_output_features`` (no-op). The guard now keys purely on schema
+    presence (zero columns), so there is no opt-in flag to declare.
     """
-
-    def allow_empty_result(self) -> bool:
-        return False
 
     def get_class_name(self) -> str:
         return "FakeGuardFeatureGroup"

--- a/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_allow_empty_result.py
+++ b/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_allow_empty_result.py
@@ -1,22 +1,17 @@
-"""Unit tests for the FeatureGroup-declared ``allow_empty_result`` policy.
+"""Unit tests for the empty-result policy on the COLUMNAR PythonDict framework.
 
-- ``PythonDictFramework.select_data_by_column_names`` is unconditionally
-  empty-safe: on empty rows it returns ``[]``. It only propagates emptiness,
-  it never judges it. (``transform`` emptiness is covered in
-  ``test_python_dict_framework.py``.)
-- The empty short-circuit triggers only on empty rows, never on missing columns:
-  non-empty data with an absent requested column still raises ``ValueError``.
+- ``PythonDictFramework.select_data_by_column_names`` is unconditionally empty-safe:
+  on the schema-less ``{}`` it returns ``{}``. It only propagates emptiness, it never
+  judges it. (``transform`` emptiness is covered in ``test_python_dict_framework.py``
+  and ``test_python_dict_columnar_contract.py``.)
+- The empty short-circuit triggers only on the schema-less ``{}``, never on missing
+  columns: non-empty data with an absent requested column still raises ``ValueError``.
 - ``ComputeFramework._extract_column_names(data)`` reports schema presence;
-  ``PythonDictFramework`` returns the union of row keys (empty set for ``[]``).
-- ``_validate_filter_columns`` skips the column-presence check ONLY for a
-  schema-less EMPTY result, as judged by the framework-owned hook
-  ``_is_schemaless_empty(data)`` (for PythonDict: ``[]`` and ``{}``, both of
-  which ``transform`` collapses to ``[]``), regardless of
-  ``allow_empty_result()``: emptiness judgement belongs solely to the output
-  guard, and ``apply_filters([])`` is ``[]``. Any other data on which the
-  framework sees no columns (filters run BEFORE transform, so raw pre-transform
-  objects such as a columnar dict reach the validator) still raises, as does
-  non-empty row data missing a filter column.
+  ``PythonDictFramework`` returns the columnar dict's keys (empty set only for ``{}``).
+- ``_validate_filter_columns`` skips the column-presence check ONLY for the framework's
+  schema-less EMPTY result, as judged by the framework-owned hook ``_is_schemaless_empty``
+  (for PythonDict: only ``{}``). Any other data on which the framework sees the filter
+  column missing still raises.
 - ``EmptyResultError`` is a ``ValueError`` subclass and part of the public
   ``mloda.provider`` API.
 """
@@ -61,18 +56,7 @@ class _FakeFeaturesWithFilter:
 
 
 class _FakeFeatureGroup:
-    """Minimal stand-in for a FeatureGroup exposing the ``allow_empty_result`` policy.
-
-    ``_validate_filter_columns`` reads ``feature_group.allow_empty_result()`` to decide
-    whether to skip validation on zero-row data, and ``feature_group.get_class_name()``
-    for error messages.
-    """
-
-    def __init__(self, allow_empty: bool) -> None:
-        self._allow_empty = allow_empty
-
-    def allow_empty_result(self) -> bool:
-        return self._allow_empty
+    """Minimal stand-in for a FeatureGroup exposing ``get_class_name`` for error messages."""
 
     def get_class_name(self) -> str:
         return "FakeFeatureGroup"
@@ -82,106 +66,62 @@ def _framework() -> PythonDictFramework:
     return PythonDictFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
 
 
-class TestPythonDictAllowEmptyResultPolicy:
-    """The framework propagates emptiness unconditionally; the FG declares the policy."""
+class TestPythonDictEmptyResultPolicy:
+    """The framework propagates emptiness unconditionally; the guard judges it elsewhere."""
 
-    def test_select_empty_data_returns_empty_list(self) -> None:
-        """select on empty rows returns [] unconditionally."""
-        result = _framework().select_data_by_column_names([], {FeatureName("col1")})
-        assert result == []
+    def test_select_empty_data_returns_empty_dict(self) -> None:
+        """select on the schema-less ``{}`` returns ``{}`` unconditionally."""
+        result = _framework().select_data_by_column_names({}, {FeatureName("col1")})
+        assert result == {}
 
     def test_select_missing_column_still_raises(self) -> None:
         """Non-empty data with an absent requested column still raises ValueError.
 
-        The empty short-circuit must trigger only on empty ROWS, not on missing
-        columns. With non-empty rows, identify_naming_convention raises a plain
+        The empty short-circuit must trigger only on the schema-less ``{}``, not on a
+        missing column. With a present schema, identify_naming_convention raises a plain
         ValueError ('No columns found ...').
         """
         with pytest.raises(ValueError, match="No columns found"):
-            _framework().select_data_by_column_names([{"a": 1}], {FeatureName("missing")})
-
-    def test_validate_filter_columns_empty_data_allow_empty_does_not_raise(self) -> None:
-        """The skip is driven by the data being a schema-less empty list, not by the policy.
-
-        The applicable filter targets a column 'age' that is absent (the data is
-        the schema-less empty list ``[]``). Validation returns early because the
-        data is an empty list; ``allow_empty_result()`` being True is irrelevant
-        to the skip. Together with the default-policy twin test below, this pins
-        policy-independence of the skip.
-        """
-        single_filter = SingleFilter("age", FilterType.MIN, {"value": 30})
-        features = _FakeFeaturesWithFilter([single_filter])
-        feature_group = _FakeFeatureGroup(allow_empty=True)
-
-        # Must not raise.
-        _framework()._validate_filter_columns([], features, feature_group)
-
-    def test_validate_filter_columns_empty_data_default_does_not_raise(self) -> None:
-        """The skip is driven by the data being a schema-less empty list, not by the policy.
-
-        Emptiness judgement belongs solely to the output guard, and
-        ``apply_filters([])`` is ``[]``. Even with ``feature_group.allow_empty_result()``
-        False, the schema-less empty list ``[]`` must not trigger the column-presence
-        check: the ``allow_empty_result`` policy is irrelevant to the skip. Together
-        with the allow-empty twin test above, this pins policy-independence of the skip.
-        """
-        single_filter = SingleFilter("age", FilterType.MIN, {"value": 30})
-        features = _FakeFeaturesWithFilter([single_filter])
-        feature_group = _FakeFeatureGroup(allow_empty=False)
-
-        # Must not raise.
-        _framework()._validate_filter_columns([], features, feature_group)
+            _framework().select_data_by_column_names({"a": [1]}, {FeatureName("missing")})
 
     def test_validate_filter_columns_empty_dict_does_not_raise(self) -> None:
-        """The schema-less-empty skip must cover BOTH of PythonDict's empty forms.
+        """The skip is driven by the data being the schema-less ``{}``.
 
-        Filters run BEFORE transform, so the validator can receive the raw empty
-        dict ``{}`` exactly as ``calculate_feature`` returned it. ``transform``
-        treats ``{}`` as empty and collapses it to ``[]``, so ``{}`` is the same
-        representational empty as ``[]`` and must get the same skip; the policy
-        (``allow_empty_result()`` False here) stays irrelevant to the skip, as in
-        the ``[]`` twin tests above. A list-only skip wrongly raises 'missing
-        filter column' on ``{}``.
+        The applicable filter targets a column 'age' that is absent (the data is the
+        schema-less ``{}``). Validation returns early because the data is schema-less.
         """
         single_filter = SingleFilter("age", FilterType.MIN, {"value": 30})
         features = _FakeFeaturesWithFilter([single_filter])
-        feature_group = _FakeFeatureGroup(allow_empty=False)
+        feature_group = _FakeFeatureGroup()
 
         # Must not raise.
         _framework()._validate_filter_columns({}, features, feature_group)
 
     def test_validate_filter_columns_non_empty_data_missing_column_raises(self) -> None:
-        """Non-empty data missing the filter column still raises, regardless of the policy.
+        """Non-empty data missing the filter column still raises.
 
-        The schema-less skip applies only to zero-column data. With a present schema
-        that lacks the filter column 'age', the 'missing filter column' error must
-        fire even though ``allow_empty_result()`` is False.
+        The schema-less skip applies only to the zero-column ``{}``. With a present schema
+        that lacks the filter column 'age', the 'missing filter column' error must fire.
         """
         single_filter = SingleFilter("age", FilterType.MIN, {"value": 30})
         features = _FakeFeaturesWithFilter([single_filter])
-        feature_group = _FakeFeatureGroup(allow_empty=False)
-
-        with pytest.raises(ValueError, match="missing filter column"):
-            _framework()._validate_filter_columns([{"other": 1}], features, feature_group)
-
-    def test_validate_filter_columns_columnar_dict_missing_column_raises(self) -> None:
-        """Raw pre-transform data the framework sees no columns on must still raise.
-
-        Filters run BEFORE transform (run_calculation), so the validator can receive
-        a raw NON-empty object the framework cannot read columns from: PythonDict's
-        ``_extract_column_names`` only reads list-of-dict rows and returns an empty
-        set for the columnar dict ``{"other": [1]}``. The skip applies ONLY to a
-        schema-less empty result (``isinstance(data, list) and not data``); for any
-        other no-columns-visible data, silently skipping hands raw data to the filter
-        engine, which crashes confusingly. The loud 'missing filter column' ValueError
-        must fire instead, regardless of ``allow_empty_result()``.
-        """
-        single_filter = SingleFilter("age", FilterType.MIN, {"value": 30})
-        features = _FakeFeaturesWithFilter([single_filter])
-        feature_group = _FakeFeatureGroup(allow_empty=False)
+        feature_group = _FakeFeatureGroup()
 
         with pytest.raises(ValueError, match="missing filter column"):
             _framework()._validate_filter_columns({"other": [1]}, features, feature_group)
+
+    def test_validate_filter_columns_zero_row_schema_missing_column_raises(self) -> None:
+        """A schema-bearing zero-row frame missing the filter column still raises.
+
+        ``{"other": []}`` carries a schema (one column) and is NOT the schema-less empty,
+        so the loud 'missing filter column' ValueError fires for the absent 'age' column.
+        """
+        single_filter = SingleFilter("age", FilterType.MIN, {"value": 30})
+        features = _FakeFeaturesWithFilter([single_filter])
+        feature_group = _FakeFeatureGroup()
+
+        with pytest.raises(ValueError, match="missing filter column"):
+            _framework()._validate_filter_columns({"other": []}, features, feature_group)
 
     def test_empty_result_error_is_value_error_subclass(self) -> None:
         """EmptyResultError remains a subclass of ValueError."""
@@ -207,43 +147,39 @@ class TestIsSchemalessEmptyHook:
     """Pins the ``_is_schemaless_empty(data) -> bool`` hook on ComputeFramework.
 
     The filter-column skip in ``_validate_filter_columns`` must be driven by a
-    framework-owned predicate instead of a hardcoded ``isinstance(data, list)``
-    check: only the framework knows which raw objects are its representational
-    empties. PythonDict has two (``[]`` and ``{}``, both collapsed by
-    ``transform``); every other value, including falsy non-container garbage,
-    is NOT an empty result. The base-class default returns False so schema-less
-    data on other frameworks keeps failing the loud filter-column check.
+    framework-owned predicate. Under the columnar model PythonDict has exactly one
+    representational schema-less empty: ``{}`` (zero columns). Everything else, including
+    a schema-bearing zero-row frame ``{"a": []}`` and falsy non-container garbage, is NOT a
+    schema-less empty. The base-class default returns False.
     """
 
-    def test_python_dict_empty_list_is_schemaless_empty(self) -> None:
-        """``[]`` is PythonDict's canonical empty form: True."""
-        assert _framework()._is_schemaless_empty([]) is True
-
     def test_python_dict_empty_dict_is_schemaless_empty(self) -> None:
-        """``{}`` is also empty for PythonDict (transform collapses it to ``[]``): True."""
+        """``{}`` is PythonDict's only schema-less empty form: True."""
         assert _framework()._is_schemaless_empty({}) is True
 
+    def test_python_dict_zero_row_column_is_not_schemaless_empty(self) -> None:
+        """``{"a": []}`` carries a schema (one column) and is not schema-less: False."""
+        assert _framework()._is_schemaless_empty({"a": []}) is False
+
     def test_python_dict_non_empty_data_is_not_schemaless_empty(self) -> None:
-        """Non-empty row data carries a schema and is not empty: False."""
-        assert _framework()._is_schemaless_empty([{"a": 1}]) is False
+        """Non-empty columnar data carries a schema and is not empty: False."""
+        assert _framework()._is_schemaless_empty({"a": [1]}) is False
+
+    def test_python_dict_empty_list_is_not_schemaless_empty(self) -> None:
+        """Only ``{}`` is schema-less; a bare ``[]`` is not the native empty: False."""
+        assert _framework()._is_schemaless_empty([]) is False
 
     @pytest.mark.parametrize("garbage", [0, False, ""])
     def test_python_dict_falsy_non_container_values_are_not_schemaless_empty(self, garbage: Any) -> None:
-        """Falsy non-container values are unsupported garbage, not empty results: False.
-
-        A naive ``not data`` predicate would wrongly classify ``0``, ``False`` and
-        ``""`` as empty and silently skip validation; they must instead keep
-        flowing into the loud failure paths.
-        """
+        """Falsy non-container values are unsupported garbage, not empty results: False."""
         assert _framework()._is_schemaless_empty(garbage) is False
 
     def test_base_class_default_is_false_even_for_schemaless_data(self) -> None:
         """The base-class default returns False, even for zero-column data.
 
-        Only PythonDict's representational empties get the skip. A zero-column
-        Arrow table is schema-less (``_extract_column_names`` yields an empty
-        set) but PyArrowTable does not override the hook, so the loud
-        filter-column check must still fire for it.
+        Only PythonDict's representational empty gets the skip. A zero-column Arrow table is
+        schema-less (``_extract_column_names`` yields an empty set) but PyArrowTable does not
+        override the hook, so the loud filter-column check must still fire for it.
         """
         pyarrow_framework = PyArrowTable(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
         assert pyarrow_framework._is_schemaless_empty(pa.table({})) is False
@@ -252,12 +188,12 @@ class TestIsSchemalessEmptyHook:
 class TestPythonDictEmptyResult(EmptyResultFrameworkTestMixin):
     """Test PythonDictFramework schema detection via the shared mixin.
 
-    PythonDict's native data is a list of row dicts: empty is ``[]`` (no schema, state B),
-    non-empty is a one-row list. ``empty_data_carries_schema`` is False so the mixin asserts
-    ``_extract_column_names([])`` yields an empty set.
+    PythonDict's native data is a columnar dict. A schema-bearing zero-row frame keeps its
+    columns (``{"a": []}`` -> ``{"a"}``), so ``empty_data_carries_schema`` is True, matching
+    every other backend.
     """
 
-    empty_data_carries_schema = False
+    empty_data_carries_schema = True
 
     @pytest.fixture
     def framework_instance(self) -> Any:
@@ -265,8 +201,8 @@ class TestPythonDictEmptyResult(EmptyResultFrameworkTestMixin):
 
     @pytest.fixture
     def empty_data(self) -> Any:
-        return []
+        return {"a": []}
 
     @pytest.fixture
     def non_empty_data(self) -> Any:
-        return [{"a": 1}]
+        return {"a": [1]}

--- a/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_allow_empty_result_run_all.py
+++ b/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_allow_empty_result_run_all.py
@@ -1,17 +1,17 @@
-"""End-to-end ``allow_empty_result`` policy test for PythonDict.
+"""End-to-end empty-result policy test for PythonDict.
 
 Consumes the shared EmptyResultRunAllTestBase. PythonDict is selected by name; no
 connection is required. The shared empty-producing FeatureGroups emit a columnar dict
-with one empty column. Unlike schema-bearing frameworks, ``PythonDictFramework.transform``
-collapses ``{"col": []}`` to ``[]``, dropping the schema: the default (not-allowed) FG
-therefore yields a schema-less result (state B) and must RAISE, not succeed.
+with one empty column. Under the columnar model ``PythonDictFramework.transform`` keeps
+``{"col": []}`` (schema-bearing zero rows), so the default FG SUCCEEDS like every other
+backend. A zero-column ``{}`` result raises ``EmptyResultError`` (the ``allow_empty_result``
+opt-in is retired).
 """
 
 from typing import Any, Optional
 
 import pytest
 
-from mloda.core.abstract_plugins.compute_framework import EmptyResultError
 from mloda.provider import BaseInputData
 from mloda.provider import DataCreator
 from mloda.provider import FeatureGroup
@@ -30,46 +30,40 @@ from tests.test_plugins.compute_framework.test_tooling.policy_run_all_test_base 
 
 
 class TestPythonDictAllowEmptyResultRunAll(EmptyResultRunAllTestBase):
-    """Drives the allow_empty_result policy end-to-end through run_all on PythonDict."""
+    """Drives the empty-result policy end-to-end through run_all on PythonDict."""
 
     @classmethod
     def compute_framework_name(cls) -> str:
         return "PythonDictFramework"
 
-    @classmethod
-    def default_empty_is_schemaless(cls) -> bool:
-        # transform collapses {"col": []} to [], so the default empty result has no schema.
-        return True
 
+def test_empty_result_default_succeeds_threading(flight_server: Any) -> None:
+    """A schema-bearing zero-row default result survives the THREADING worker channel.
 
-def test_empty_result_default_raises_threading(flight_server: Any) -> None:
-    """The EmptyResultError survives the THREADING worker error channel.
-
-    Mirrors the base's default test (state B raises on PythonDict) but runs with
-    ``ParallelizationMode.THREADING`` instead of SYNC, pinning that the framework-raised
-    error propagates out of the thread worker. As in the base, run_all wraps the error,
-    so the assertion targets the type NAME in the wrapped message.
+    Mirrors the base's default test (state C succeeds under the columnar model) but runs
+    with ``ParallelizationMode.THREADING`` instead of SYNC, pinning that the zero-row
+    columnar result propagates out of the thread worker as one result with zero rows.
     """
-    with pytest.raises(Exception) as excinfo:
-        mloda.run_all(
-            [Feature(name="empty_result_default_col")],
-            compute_frameworks=["PythonDictFramework"],
-            plugin_collector=_ENABLED_DEFAULT,
-            parallelization_modes={ParallelizationMode.THREADING},
-            flight_server=flight_server,
-        )
-    assert EmptyResultError.__name__ in str(excinfo.value)
+    result = mloda.run_all(
+        [Feature(name="empty_result_default_col")],
+        compute_frameworks=["PythonDictFramework"],
+        plugin_collector=_ENABLED_DEFAULT,
+        parallelization_modes={ParallelizationMode.THREADING},
+        flight_server=flight_server,
+    )
+
+    assert len(result) == 1
+    assert len(records_from_frame(result[0])) == 0
 
 
 def test_empty_result_allowed_succeeds_multiprocessing(flight_server: Any) -> None:
-    """The allow-empty success path survives the flight-server upload in MULTIPROCESSING.
+    """The empty success path survives the flight-server upload in MULTIPROCESSING.
 
-    Mirrors the base's ``test_empty_result_allowed_succeeds`` (state B with
-    ``allow_empty_result()`` True succeeds) but runs with
-    ``ParallelizationMode.MULTIPROCESSING``: the zero-row result must round-trip
-    through the flight server upload from the process worker and come back as one
-    result with zero rows. ``records_from_frame`` keeps the row-count assertion
-    tolerant of the wire format (PyArrow table or list of row dicts).
+    Mirrors the base's ``test_empty_result_allowed_succeeds`` (schema-bearing zero-row
+    result succeeds) but runs with ``ParallelizationMode.MULTIPROCESSING``: the zero-row
+    result must round-trip through the flight server upload from the process worker and
+    come back as one result with zero rows. ``records_from_frame`` keeps the row-count
+    assertion tolerant of the wire format (PyArrow table or columnar dict).
     """
     result = mloda.run_all(
         [Feature(name="empty_result_allowed_col")],
@@ -84,15 +78,11 @@ def test_empty_result_allowed_succeeds_multiprocessing(flight_server: Any) -> No
 
 
 class EmptyResultNoneAllowedFeatureGroup(FeatureGroup, _EmptyResultMatchData):
-    """Root FG whose ``calculate_feature`` returns ``None`` (state A) AND opts into empty results.
+    """Root FG whose ``calculate_feature`` returns ``None`` (state A).
 
-    Module-local on purpose: it pins that the ``allow_empty_result`` opt-in covers only
-    representational empties (``[]`` / ``{}``), never a missing result.
+    Module-local on purpose: it pins that a MISSING result is rejected upstream in
+    ``transform`` (never legitimized as an empty result).
     """
-
-    @classmethod
-    def allow_empty_result(cls) -> bool:
-        return True
 
     @classmethod
     def input_data(cls) -> Optional[BaseInputData]:
@@ -111,16 +101,15 @@ class EmptyResultNoneAllowedFeatureGroup(FeatureGroup, _EmptyResultMatchData):
 _ENABLED_NONE_ALLOWED = PluginCollector.enabled_feature_groups({EmptyResultNoneAllowedFeatureGroup})
 
 
-def test_empty_result_none_raises_python_dict_even_when_allowed(flight_server: Any) -> None:
-    """State A live test: a ``None`` result raises on PythonDict even with the opt-in.
+def test_empty_result_none_raises_python_dict(flight_server: Any) -> None:
+    """State A live test: a ``None`` result raises on PythonDict.
 
-    ``allow_empty_result()`` legitimizes EMPTY results, not MISSING ones. PythonDict's
-    ``transform`` must reject ``None`` like every schema-bearing framework does
-    (``ValueError: Data type <class 'NoneType'> is not supported by PythonDictFramework``)
-    instead of converting it to ``[]`` and letting the opt-in turn the run into a silent
-    success. ``run_all`` re-wraps the framework error as a plain ``Exception`` whose
-    message embeds that text (repr-escaped, so the inner quotes around ``NoneType`` carry
-    backslashes), which the ``match`` below pins.
+    A MISSING result is not an empty one. PythonDict's ``transform`` must reject ``None``
+    like every schema-bearing framework does (``ValueError: Data type <class 'NoneType'>
+    is not supported by PythonDictFramework``) instead of converting it to ``{}`` and
+    turning the run into a silent success. ``run_all`` re-wraps the framework error as a
+    plain ``Exception`` whose message embeds that text (repr-escaped, so the inner quotes
+    around ``NoneType`` carry backslashes), which the ``match`` below pins.
     """
     feature = Feature(name="empty_result_none_allowed_col")
 

--- a/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_asof_merge_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_asof_merge_engine.py
@@ -1,9 +1,8 @@
 """
 Tests for PythonDictMergeEngine.merge_asof (point-in-time / as-of join).
 
-Consumes the shared AsofMergeEngineTestBase. PythonDict's native format is
-list[dict], so conversion is a passthrough; the DataConverter still routes
-through PyArrow for other frameworks, so PyArrow must be available.
+Consumes the shared AsofMergeEngineTestBase. PythonDict's native format is a
+columnar dict; the DataConverter routes through PyArrow, so PyArrow must be available.
 """
 
 from typing import Any, Optional
@@ -39,29 +38,29 @@ class TestPythonDictAsofMergeEngine(AsofMergeEngineTestBase):
 
     @classmethod
     def framework_type(cls) -> type[Any]:
-        return list
+        return dict
 
     def get_connection(self) -> Optional[Any]:
         return None
 
     def test_nearest_direction(self) -> None:
         """Vector F: PythonDict supports 'nearest' -> closer right row (t=8, gap 2) matched."""
-        left = [{"k": 1, "t": 10, "lv": 100}]
-        right = [{"k": 1, "t": 8, "rv": "A"}, {"k": 1, "t": 15, "rv": "B"}]
+        left = {"k": [1], "t": [10], "lv": [100]}
+        right = {"k": [1, 1], "t": [8, 15], "rv": ["A", "B"]}
 
         engine = PythonDictMergeEngine()
         cfg = AsOfJoinConfig(left_time_column="t", right_time_column="t", direction="nearest")
         result = engine.merge_asof(left, right, Index(("k",)), Index(("k",)), cfg)
 
-        assert len(result) == 1
-        assert result[0]["rv"] == "A"
+        assert len(result["rv"]) == 1
+        assert result["rv"][0] == "A"
 
     def test_mixed_time_column_raises_value_error(self) -> None:
         """A heterogeneous time column (int then str) is not orderable. The guard must scan all
         non-null values, not just the first, and raise a clear ValueError naming the column
         instead of letting a raw comparison TypeError surface later."""
-        left = [{"k": "a", "t": 1, "lv": 1}, {"k": "a", "t": "2025-06-01", "lv": 2}]
-        right = [{"k": "a", "t": 1, "rv": 1.0}]
+        left = {"k": ["a", "a"], "t": [1, "2025-06-01"], "lv": [1, 2]}
+        right = {"k": ["a"], "t": [1], "rv": [1.0]}
 
         engine = PythonDictMergeEngine()
         cfg = AsOfJoinConfig(left_time_column="t", right_time_column="t")
@@ -79,9 +78,9 @@ class TestPythonDictAsofMergeEngine(AsofMergeEngineTestBase):
         default True): {k:1, t:10, rv:5} and {k:1, t:10, rv:2}. Expected exactly one row with
         rv==2 regardless of which order the tied right rows are supplied in.
         """
-        left = [{"k": 1, "t": 10, "lv": 1}]
-        right_a = [{"k": 1, "t": 10, "rv": 5}, {"k": 1, "t": 10, "rv": 2}]
-        right_b = [{"k": 1, "t": 10, "rv": 2}, {"k": 1, "t": 10, "rv": 5}]
+        left = {"k": [1], "t": [10], "lv": [1]}
+        right_a = {"k": [1, 1], "t": [10, 10], "rv": [5, 2]}
+        right_b = {"k": [1, 1], "t": [10, 10], "rv": [2, 5]}
 
         cfg = AsOfJoinConfig(
             left_time_column="t",
@@ -91,24 +90,25 @@ class TestPythonDictAsofMergeEngine(AsofMergeEngineTestBase):
         )
 
         result_a = PythonDictMergeEngine().merge_asof(left, right_a, Index(("k",)), Index(("k",)), cfg)
-        assert len(result_a) == 1
-        assert result_a[0]["rv"] == 2
+        assert len(result_a["rv"]) == 1
+        assert result_a["rv"][0] == 2
 
         # Order-independence: reversed right input must yield the identical winner.
         result_b = PythonDictMergeEngine().merge_asof(left, right_b, Index(("k",)), Index(("k",)), cfg)
-        assert len(result_b) == 1
-        assert result_b[0]["rv"] == 2
+        assert len(result_b["rv"]) == 1
+        assert result_b["rv"][0] == 2
 
     def test_coerce_z_suffix_utc_strings_join(self) -> None:
         """datetime.fromisoformat on Python 3.10 rejects a trailing 'Z'. The engine must
         normalize 'Z' to '+00:00' before parsing so Z-suffixed UTC strings coerce on every
         supported interpreter. All values are tz-aware, so no mixed-tz error: the join
         succeeds with one row matching the earlier right row (rv == 1.0)."""
-        left = [{"k": "a", "t": "2025-06-03T00:00:00Z", "lv": 1}]
-        right = [
-            {"k": "a", "t": "2025-06-01T00:00:00Z", "rv": 1.0},
-            {"k": "a", "t": "2025-06-04T00:00:00Z", "rv": 2.0},
-        ]
+        left = {"k": ["a"], "t": ["2025-06-03T00:00:00Z"], "lv": [1]}
+        right = {
+            "k": ["a", "a"],
+            "t": ["2025-06-01T00:00:00Z", "2025-06-04T00:00:00Z"],
+            "rv": [1.0, 2.0],
+        }
 
         engine = PythonDictMergeEngine()
         cfg = AsOfJoinConfig(
@@ -119,18 +119,19 @@ class TestPythonDictAsofMergeEngine(AsofMergeEngineTestBase):
         )
         result = engine.merge_asof(left, right, Index(("k",)), Index(("k",)), cfg)
 
-        assert len(result) == 1
-        assert result[0]["rv"] == 1.0
+        assert len(result["rv"]) == 1
+        assert result["rv"][0] == 1.0
 
     def test_coerce_mixed_tz_naive_and_aware_raises(self) -> None:
         """Coercion of a column mixing tz-aware and tz-naive ISO strings must raise ValueError:
         datetime.fromisoformat parses both, but naive and aware datetimes are not mutually
         orderable, so the engine must reject the mix explicitly instead of failing later."""
-        left = [
-            {"k": "a", "t": "2025-06-01T00:00:00+00:00", "lv": 1},
-            {"k": "a", "t": "2025-06-01T01:00:00", "lv": 2},
-        ]
-        right = [{"k": "a", "t": "2025-05-01T00:00:00", "rv": 1.0}]
+        left = {
+            "k": ["a", "a"],
+            "t": ["2025-06-01T00:00:00+00:00", "2025-06-01T01:00:00"],
+            "lv": [1, 2],
+        }
+        right = {"k": ["a"], "t": ["2025-05-01T00:00:00"], "rv": [1.0]}
 
         engine = PythonDictMergeEngine()
         cfg = AsOfJoinConfig(

--- a/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_columnar_contract.py
+++ b/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_columnar_contract.py
@@ -1,0 +1,279 @@
+"""Red-phase contract tests for the COLUMNAR PythonDict compute framework.
+
+These tests pin the NEW native representation of ``PythonDictFramework``: a columnar
+dict ``{"col": [v0, v1, ...]}`` where each top-level key is a column name and each value
+is that column's list of cell values, all value-lists sharing one length (= row count).
+
+They are expected to FAIL against the current row-wise (``list[dict]``) implementation and
+to PASS once the columnar behavior is implemented. Contract points pinned (1-8) mirror the
+task specification, plus the retirement of ``FeatureGroup.allow_empty_result()``.
+
+Not to be confused with the legacy ``test_python_dict_framework.py`` which still encodes the
+row-wise contract; that module is superseded by this one under the columnar model.
+"""
+
+from typing import Any, Optional
+
+import pytest
+
+from mloda.core.abstract_plugins.components.data_types import DataType
+from mloda.core.abstract_plugins.compute_framework import EmptyResultError
+from mloda.provider import BaseInputData
+from mloda.provider import DataCreator
+from mloda.provider import FeatureGroup
+from mloda.provider import FeatureSet
+from mloda.user import Feature
+from mloda.user import FeatureName
+from mloda.user import ParallelizationMode
+from mloda.user import PluginCollector
+from mloda.user import mloda
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
+from tests.test_plugins.compute_framework.test_tooling.empty_result_run_all_test_base import (
+    _EmptyResultMatchData,
+)
+
+
+def _framework() -> PythonDictFramework:
+    return PythonDictFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
+
+
+# ---------------------------------------------------------------------------
+# Point 3: expected_data_framework() must return dict (was list)
+# ---------------------------------------------------------------------------
+class TestExpectedDataFramework:
+    def test_expected_data_framework_is_dict(self) -> None:
+        """The native container type is ``dict`` (columnar), no longer ``list``."""
+        assert PythonDictFramework.expected_data_framework() is dict
+
+
+# ---------------------------------------------------------------------------
+# Point 4: transform() normalizes accepted inputs to columnar storage
+# ---------------------------------------------------------------------------
+class TestTransformColumnar:
+    def test_columnar_dict_passthrough(self) -> None:
+        """A columnar dict with equal-length list values is returned as-is."""
+        data = {"a": [1, 2], "b": ["x", "y"]}
+        assert _framework().transform(data, set()) == {"a": [1, 2], "b": ["x", "y"]}
+
+    def test_list_of_row_dicts_becomes_columnar(self) -> None:
+        """A list of row dicts pivots into a columnar dict."""
+        data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
+        assert _framework().transform(data, set()) == {"a": [1, 3], "b": [2, 4]}
+
+    def test_single_row_list_becomes_columnar(self) -> None:
+        """A single-element list of a row dict becomes a one-row columnar dict."""
+        assert _framework().transform([{"a": 1}], set()) == {"a": [1]}
+
+    def test_empty_list_becomes_empty_dict(self) -> None:
+        """An empty list has no schema and normalizes to the schema-less ``{}``."""
+        assert _framework().transform([], set()) == {}
+
+    def test_empty_dict_passthrough(self) -> None:
+        """``{}`` (zero columns) is already the schema-less empty; returned as ``{}``."""
+        assert _framework().transform({}, set()) == {}
+
+    def test_zero_row_columnar_dict_passthrough(self) -> None:
+        """A columnar dict with an empty column keeps its schema (one known column)."""
+        assert _framework().transform({"a": []}, set()) == {"a": []}
+
+    def test_columnar_dict_unequal_lengths_raises(self) -> None:
+        """Value-lists of differing length are invalid columnar input."""
+        with pytest.raises(ValueError):
+            _framework().transform({"a": [1, 2], "b": [3]}, set())
+
+    def test_dict_with_non_list_values_raises(self) -> None:
+        """A dict whose values are not lists is not columnar and is rejected.
+
+        Single-row dicts are no longer special-cased under the columnar model.
+        """
+        with pytest.raises(ValueError):
+            _framework().transform({"a": 1, "b": 2}, set())
+
+    def test_none_raises(self) -> None:
+        """``None`` is a missing result, not an empty one: unsupported type."""
+        with pytest.raises(ValueError, match="Data type .* is not supported"):
+            _framework().transform(None, set())
+
+    def test_int_raises(self) -> None:
+        """A bare int is an unsupported type."""
+        with pytest.raises(ValueError, match="Data type .* is not supported"):
+            _framework().transform(5, set())
+
+
+# ---------------------------------------------------------------------------
+# Points 2 & 5: schema = top-level keys, present even at zero rows
+# ---------------------------------------------------------------------------
+class TestExtractColumnNames:
+    def test_multi_column_zero_rows(self) -> None:
+        """Zero-row columnar dict still exposes all its column names."""
+        assert _framework()._extract_column_names({"a": [], "b": []}) == {"a", "b"}
+
+    def test_populated_columns(self) -> None:
+        assert _framework()._extract_column_names({"a": [1, 2], "b": [3, 4]}) == {"a", "b"}
+
+    def test_single_empty_column_is_schema_bearing(self) -> None:
+        """``{"col_a": []}`` is a valid schema-bearing empty (one known column)."""
+        assert _framework()._extract_column_names({"col_a": []}) == {"col_a"}
+
+    def test_empty_dict_has_no_columns(self) -> None:
+        assert _framework()._extract_column_names({}) == set()
+
+
+# ---------------------------------------------------------------------------
+# Point 6: _is_schemaless_empty is True ONLY for {}
+# ---------------------------------------------------------------------------
+class TestIsSchemalessEmpty:
+    def test_empty_dict_is_schemaless(self) -> None:
+        """``{}`` (zero columns) is the only schema-less value."""
+        assert _framework()._is_schemaless_empty({}) is True
+
+    def test_single_empty_column_is_not_schemaless(self) -> None:
+        """``{"a": []}`` carries a schema (one column) and is NOT schema-less."""
+        assert _framework()._is_schemaless_empty({"a": []}) is False
+
+    def test_populated_columnar_is_not_schemaless(self) -> None:
+        assert _framework()._is_schemaless_empty({"a": [1, 2]}) is False
+
+    def test_empty_list_is_not_schemaless(self) -> None:
+        """Only ``{}`` is schema-less; a bare ``[]`` is not the native empty."""
+        assert _framework()._is_schemaless_empty([]) is False
+
+
+# ---------------------------------------------------------------------------
+# Point 7: column dtype / data-type read the column list
+# ---------------------------------------------------------------------------
+class TestExtractColumnTypes:
+    def test_data_type_int(self) -> None:
+        assert _framework()._extract_column_data_type({"i": [1, 2, 3]}, "i") == DataType.INT64
+
+    def test_data_type_string(self) -> None:
+        assert _framework()._extract_column_data_type({"s": ["a", "b"]}, "s") == DataType.STRING
+
+    def test_data_type_float(self) -> None:
+        assert _framework()._extract_column_data_type({"f": [1.0, 2.0]}, "f") == DataType.DOUBLE
+
+    def test_data_type_bool(self) -> None:
+        assert _framework()._extract_column_data_type({"b": [True, False]}, "b") == DataType.BOOLEAN
+
+    def test_data_type_first_non_none_wins(self) -> None:
+        """The first non-None value in the column list determines the type."""
+        assert _framework()._extract_column_data_type({"i": [None, 2, 3]}, "i") == DataType.INT64
+
+    def test_data_type_all_none_is_unknown(self) -> None:
+        """An all-None column yields an unknown (None) data type."""
+        assert _framework()._extract_column_data_type({"i": [None, None]}, "i") is None
+
+    def test_data_type_empty_column_is_unknown_but_present(self) -> None:
+        """An empty column has an unknown type yet still counts as a present column."""
+        fw = _framework()
+        assert fw._extract_column_data_type({"i": []}, "i") is None
+        assert "i" in fw._extract_column_names({"i": []})
+
+    def test_dtype_int(self) -> None:
+        assert _framework()._extract_column_dtype({"i": [1, 2]}, "i") == "int"
+
+    def test_dtype_string(self) -> None:
+        assert _framework()._extract_column_dtype({"s": ["a"]}, "s") == "str"
+
+    def test_dtype_first_non_none_wins(self) -> None:
+        assert _framework()._extract_column_dtype({"i": [None, 7]}, "i") == "int"
+
+    def test_dtype_all_none_is_none(self) -> None:
+        assert _framework()._extract_column_dtype({"i": [None, None]}, "i") is None
+
+
+# ---------------------------------------------------------------------------
+# Point 8: select_data_by_column_names operates columnar
+# ---------------------------------------------------------------------------
+class TestSelectColumnar:
+    def test_select_subset_preserves_rows(self) -> None:
+        """Selection returns a columnar dict of only the requested columns."""
+        data = {"a": [1, 2], "b": [3, 4], "c": [5, 6]}
+        result = _framework().select_data_by_column_names(data, {FeatureName("a"), FeatureName("b")})
+        assert result == {"a": [1, 2], "b": [3, 4]}
+
+    def test_select_empty_dict_returns_empty_dict(self) -> None:
+        """Selecting from ``{}`` yields ``{}``."""
+        result = _framework().select_data_by_column_names({}, {FeatureName("a")})
+        assert result == {}
+
+    def test_select_zero_row_columns_kept(self) -> None:
+        """Selecting a present-but-empty column keeps the column at zero rows."""
+        result = _framework().select_data_by_column_names({"a": [], "b": []}, {FeatureName("a")})
+        assert result == {"a": []}
+
+
+# ---------------------------------------------------------------------------
+# Retirement of FeatureGroup.allow_empty_result()
+# ---------------------------------------------------------------------------
+class TestAllowEmptyResultRetired:
+    def test_feature_group_has_no_allow_empty_result(self) -> None:
+        """``allow_empty_result`` is removed entirely from the FeatureGroup API."""
+        assert not hasattr(FeatureGroup, "allow_empty_result")
+
+
+class _ColumnarZeroRowFeatureGroup(FeatureGroup, _EmptyResultMatchData):
+    """Root FG returning a schema-bearing zero-row columnar dict, with NO opt-in flag."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={"columnar_zero_row_col"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {"columnar_zero_row_col": []}
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return {"columnar_zero_row_col"}
+
+
+class _ColumnarZeroColumnFeatureGroup(FeatureGroup, _EmptyResultMatchData):
+    """Root FG returning a schema-less ``{}`` (zero columns), with NO opt-in flag."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={"columnar_zero_column_col"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {}
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return {"columnar_zero_column_col"}
+
+
+_ENABLED_ZERO_ROW = PluginCollector.enabled_feature_groups({_ColumnarZeroRowFeatureGroup})
+_ENABLED_ZERO_COLUMN = PluginCollector.enabled_feature_groups({_ColumnarZeroColumnFeatureGroup})
+
+
+def test_zero_row_with_columns_succeeds_without_flag(flight_server: Any) -> None:
+    """A zero-row result WITH a column succeeds on PythonDict without any opt-in.
+
+    Under the columnar model ``transform`` keeps ``{"col": []}`` (schema-bearing), so the
+    output guard passes and the run returns the columnar dict with zero rows.
+    """
+    result = mloda.run_all(
+        [Feature(name="columnar_zero_row_col")],
+        compute_frameworks=["PythonDictFramework"],
+        plugin_collector=_ENABLED_ZERO_ROW,
+        parallelization_modes={ParallelizationMode.SYNC},
+        flight_server=flight_server,
+    )
+
+    assert len(result) == 1
+    assert result[0] == {"columnar_zero_row_col": []}
+
+
+def test_zero_column_result_raises_without_flag(flight_server: Any) -> None:
+    """A zero-column ``{}`` result raises ``EmptyResultError`` with NO opt-in."""
+    with pytest.raises(Exception) as excinfo:
+        mloda.run_all(
+            [Feature(name="columnar_zero_column_col")],
+            compute_frameworks=["PythonDictFramework"],
+            plugin_collector=_ENABLED_ZERO_COLUMN,
+            parallelization_modes={ParallelizationMode.SYNC},
+            flight_server=flight_server,
+        )
+    assert EmptyResultError.__name__ in str(excinfo.value)

--- a/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_filter_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_filter_engine.py
@@ -31,25 +31,30 @@ class TestPythonDictFilterEngine(FilterEngineTestMixin, TimeRangeFilterEngineTes
 
     @pytest.fixture
     def sample_data(self) -> Any:
-        """Create a sample list of dicts for testing."""
-        return [
-            {"id": 1, "age": 25, "name": "Alice", "category": "A"},
-            {"id": 2, "age": 30, "name": "Bob", "category": "B"},
-            {"id": 3, "age": 35, "name": "Charlie", "category": "A"},
-            {"id": 4, "age": 40, "name": "David", "category": "C"},
-            {"id": 5, "age": 45, "name": "Eve", "category": "B"},
-        ]
+        """Create a sample columnar dict for testing."""
+        return {
+            "id": [1, 2, 3, 4, 5],
+            "age": [25, 30, 35, 40, 45],
+            "name": ["Alice", "Bob", "Charlie", "David", "Eve"],
+            "category": ["A", "B", "A", "C", "B"],
+        }
+
+    def result_row_count(self, result: Any) -> int:
+        """A columnar dict's row count is the length of any of its columns."""
+        for column in result.values():
+            return len(column)
+        return 0
 
     def get_column_values(self, result: Any, column: str) -> list[Any]:
-        """Extract column values from list of dicts."""
-        return [row[column] for row in result]
+        """Extract column values from a columnar dict."""
+        return list(result[column])
 
     @pytest.fixture
     def sample_time_data(self) -> Any:
-        return [{"id": SAMPLE_IDS[i], "ts": SAMPLE_TIMESTAMPS[i]} for i in range(len(SAMPLE_IDS))]
+        return {"id": list(SAMPLE_IDS), "ts": list(SAMPLE_TIMESTAMPS)}
 
     def get_id_column_values(self, result: Any) -> list[int]:
-        return [row["id"] for row in result]
+        return list(result["id"])
 
     # Framework-specific tests below
 
@@ -62,6 +67,19 @@ class TestPythonDictFilterEngine(FilterEngineTestMixin, TimeRangeFilterEngineTes
 
         with pytest.raises(ValueError, match="Filter parameter 'value' not found"):
             PythonDictFilterEngine.do_min_filter(sample_data, single_filter)
+
+    def test_do_min_filter_rejects_min_key_fallback(self) -> None:
+        """``do_min_filter`` must accept ONLY the canonical ``{"value": ...}`` parameter key.
+
+        The pandas/pyarrow/polars filter engines raise when a min filter carries its
+        threshold under ``{"min": ...}``; PythonDict must behave identically instead of
+        silently falling back to ``parameter.min_value``.
+        """
+        data = {"x": [1, 2, 3]}
+        single_filter = SingleFilter(Feature("x"), FilterType.MIN, {"min": 2})
+
+        with pytest.raises(ValueError, match="Filter parameter 'value' not found"):
+            PythonDictFilterEngine.do_min_filter(data, single_filter)
 
     def test_do_equal_filter_missing_value(self, sample_data: Any) -> None:
         """Test equal filter with missing value parameter."""
@@ -95,7 +113,12 @@ class TestPythonDictFilterEngine(FilterEngineTestMixin, TimeRangeFilterEngineTes
 
     def test_filter_with_none_values(self, sample_data: Any) -> None:
         """Test filtering with None values in data."""
-        data_with_none = sample_data + [{"id": 6, "age": None, "name": "Frank", "category": "A"}]
+        data_with_none = {
+            "id": sample_data["id"] + [6],
+            "age": sample_data["age"] + [None],
+            "name": sample_data["name"] + ["Frank"],
+            "category": sample_data["category"] + ["A"],
+        }
 
         feature = Feature("age")
         filter_type = FilterType.MIN
@@ -104,7 +127,7 @@ class TestPythonDictFilterEngine(FilterEngineTestMixin, TimeRangeFilterEngineTes
 
         result = PythonDictFilterEngine.do_min_filter(data_with_none, single_filter)
 
-        assert len(result) == 4
-        ages = [row["age"] for row in result]
+        assert self.result_row_count(result) == 4
+        ages = list(result["age"])
         assert None not in ages
         assert ages == [30, 35, 40, 45]

--- a/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_framework.py
+++ b/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_framework.py
@@ -17,48 +17,40 @@ class TestPythonDictFramework:
     """Test suite for PythonDict compute framework."""
 
     def test_expected_data_framework(self) -> None:
-        assert PythonDictFramework.expected_data_framework() is list
+        assert PythonDictFramework.expected_data_framework() is dict
 
-    def test_transform_dict_to_list(self) -> None:
-        """Test transformation from columnar dict to list of dicts."""
+    def test_transform_columnar_dict_passthrough(self) -> None:
+        """A columnar dict with equal-length lists is returned as-is."""
         framework = PythonDictFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
 
-        # Test columnar dict transformation
         input_data = {"col1": [1, 2, 3], "col2": ["a", "b", "c"]}
-        expected = [{"col1": 1, "col2": "a"}, {"col1": 2, "col2": "b"}, {"col1": 3, "col2": "c"}]
 
         result = framework.transform(input_data, set())
-        assert result == expected
+        assert result == {"col1": [1, 2, 3], "col2": ["a", "b", "c"]}
 
-    def test_transform_single_dict(self) -> None:
-        """Test transformation from single dict to list of dicts."""
+    def test_transform_single_dict_raises(self) -> None:
+        """A single row dict (non-list values) is invalid columnar input and raises."""
         framework = PythonDictFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
 
-        # Test single dict transformation
-        input_data = {"col1": 1, "col2": "a"}
-        expected = [{"col1": 1, "col2": "a"}]
+        with pytest.raises(ValueError):
+            framework.transform({"col1": 1, "col2": "a"}, set())
 
-        result = framework.transform(input_data, set())
-        assert result == expected
-
-    def test_transform_list_passthrough(self) -> None:
-        """Test that list of dicts passes through unchanged."""
+    def test_transform_list_of_rows_becomes_columnar(self) -> None:
+        """A list of row dicts pivots into a columnar dict."""
         framework = PythonDictFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
 
-        # Test list passthrough
         input_data = [{"col1": 1, "col2": "a"}, {"col1": 2, "col2": "b"}]
 
         result = framework.transform(input_data, set())
-        assert result == input_data
+        assert result == {"col1": [1, 2], "col2": ["a", "b"]}
 
-    def test_transform_empty_data_returns_empty_list(self) -> None:
-        """The representational empties [] and {} are propagated as [] (the framework
-        never judges emptiness). None is NOT an empty: it raises, pinned by
-        ``test_transform_none_raises``."""
+    def test_transform_empty_data_returns_empty_dict(self) -> None:
+        """The representational empties [] and {} normalize to the schema-less {}.
+        None is NOT an empty: it raises, pinned by ``test_transform_none_raises``."""
         framework = PythonDictFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
 
-        assert framework.transform([], set()) == []
-        assert framework.transform({}, set()) == []
+        assert framework.transform([], set()) == {}
+        assert framework.transform({}, set()) == {}
 
     def test_transform_none_raises(self) -> None:
         """``None`` is a MISSING result (state A), not a representational empty.
@@ -93,31 +85,47 @@ class TestPythonDictFramework:
             framework.transform(falsy_value, set())
 
     def test_select_data_by_column_names(self) -> None:
-        """Test column selection functionality."""
+        """Test columnar column selection functionality."""
         framework = PythonDictFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
 
-        data = [{"col1": 1, "col2": "a", "col3": 10}, {"col1": 2, "col2": "b", "col3": 20}]
+        data: dict[str, list[Any]] = {"col1": [1, 2], "col2": ["a", "b"], "col3": [10, 20]}
 
         feature_names = {FeatureName("col1"), FeatureName("col2")}
 
         result = framework.select_data_by_column_names(data, feature_names)
-        expected = [{"col1": 1, "col2": "a"}, {"col1": 2, "col2": "b"}]
+        assert result == {"col1": [1, 2], "col2": ["a", "b"]}
 
-        assert result == expected
+    def test_select_data_by_column_names_does_not_alias_internal_state(self) -> None:
+        """Mutating the selection result must not mutate the framework's stored data.
 
-    def test_select_data_empty_returns_empty_list(self) -> None:
-        """Empty data is propagated as [] in column selection (no judgement)."""
+        ``select_data_by_column_names`` currently returns a dict whose column lists are
+        the SAME list objects held in ``framework.data``, so appending to the result
+        corrupts the framework's internal state. The selection must not alias them.
+        """
+        framework = PythonDictFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
+
+        framework.data = {"a": [1, 2], "b": [3, 4]}
+
+        result = framework.select_data_by_column_names(framework.data, {FeatureName("a")})
+        assert result == {"a": [1, 2]}
+
+        result["a"].append(99)
+
+        assert framework.data["a"] == [1, 2]
+
+    def test_select_data_empty_returns_empty_dict(self) -> None:
+        """Empty data ({}) is propagated as {} in column selection (no judgement)."""
         framework = PythonDictFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
 
         feature_names = {FeatureName("col1")}
 
-        assert framework.select_data_by_column_names([], feature_names) == []
+        assert framework.select_data_by_column_names({}, feature_names) == {}
 
     def test_set_column_names(self) -> None:
-        """Test setting column names from data."""
+        """Test setting column names from columnar data."""
         framework = PythonDictFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
 
-        framework.data = [{"col1": 1, "col2": "a"}, {"col1": 2, "col2": "b", "col3": 10}]
+        framework.data = {"col1": [1, 2], "col2": ["a", "b"], "col3": [None, 10]}
 
         framework.set_column_names()
 
@@ -125,10 +133,10 @@ class TestPythonDictFramework:
         assert framework.column_names == expected_columns
 
     def test_set_column_names_empty_data(self) -> None:
-        """Test that empty data produces an empty column set."""
+        """Test that the schema-less empty ({}) produces an empty column set."""
         framework = PythonDictFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
 
-        framework.data = []
+        framework.data = {}
         framework.set_column_names()
         assert framework.column_names == set()
 
@@ -160,11 +168,11 @@ class TestPythonDictDtypeExtraction(DtypeExtractionTestMixin):
 
     @pytest.fixture
     def dtype_sample_data(self) -> Any:
-        return [
-            {"int_col": 1, "str_col": "a", "float_col": 1.0},
-            {"int_col": 2, "str_col": "b", "float_col": 2.0},
-            {"int_col": 3, "str_col": "c", "float_col": 3.0},
-        ]
+        return {
+            "int_col": [1, 2, 3],
+            "str_col": ["a", "b", "c"],
+            "float_col": [1.0, 2.0, 3.0],
+        }
 
 
 class TestPythonDictDataTypeValidator(DataTypeValidatorFrameworkTestMixin):
@@ -182,7 +190,7 @@ class TestPythonDictDataTypeValidator(DataTypeValidatorFrameworkTestMixin):
         return PythonDictFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
 
     def from_arrow(self, table: pa.Table) -> Any:
-        return table.to_pylist()
+        return table.to_pydict()
 
     def test_int32_column_strict_int32_passes(self, framework_instance: Any, precision_sample_data: Any) -> None:
         pytest.skip("Python type.__name__ collapses int widths; the int32 column reports INT64, not INT32")

--- a/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_list_dict_filter_run_all.py
+++ b/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_list_dict_filter_run_all.py
@@ -1,0 +1,101 @@
+"""Regression tests: a PythonDict FeatureGroup returning row-wise ``list[dict]`` output
+combined with a final/global filter works.
+
+``ComputeFramework.run_calculation`` normalizes the feature output via
+``transform``/``validate_native_data`` BEFORE ``run_final_filter``, so the columnar filter
+engine and ``_validate_filter_columns`` always see a columnar ``dict[str, list[Any]]``.
+"""
+
+from typing import Any, Optional
+
+from mloda.provider import ComputeFramework, DataCreator, FeatureGroup, FeatureSet
+from mloda.provider import BaseInputData
+from mloda.user import Feature, Features, GlobalFilter, ParallelizationMode, PluginCollector
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
+    PythonDictFramework,
+)
+from tests.test_core.test_tooling import MlodaTestRunner
+
+
+class ListDictRootFeatureGroup(FeatureGroup):
+    """Root PythonDict FeatureGroup that returns ROW-WISE ``list[dict]`` output.
+
+    ``calculate_feature`` returns ``[{"x": .., "y": ..}, ...]``, a still-accepted transform
+    input. A filter on ``x`` works because the output is normalized to columnar first.
+    """
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({"x", "y"})
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PythonDictFramework}
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return [
+            {"x": 1, "y": 10},
+            {"x": 2, "y": 20},
+            {"x": 3, "y": 30},
+        ]
+
+
+_ENABLED_LIST_DICT = PluginCollector.enabled_feature_groups({ListDictRootFeatureGroup})
+
+
+def test_list_dict_output_with_filter_run_all(flight_server: Any) -> None:
+    """End-to-end: list[dict] FG output + min filter x >= 2 -> filtered columnar result."""
+    features = Features([Feature(name="x"), Feature(name="y")])
+
+    global_filter = GlobalFilter()
+    global_filter.add_filter("x", "min", {"value": 2})
+
+    result = MlodaTestRunner.run_api(
+        features,
+        compute_frameworks={PythonDictFramework},
+        parallelization_modes={ParallelizationMode.SYNC},
+        flight_server=flight_server,
+        global_filter=global_filter,
+        plugin_collector=_ENABLED_LIST_DICT,
+    )
+
+    assert len(result.results) == 1
+    assert result.results[0] == {"x": [2, 3], "y": [20, 30]}
+
+
+def test_validate_and_apply_filters_on_list_dict_does_not_raise() -> None:
+    """Focused: the framework filter path handles a row-wise ``list[dict]`` without raising.
+
+    ``_validate_filter_columns`` followed by ``filter_engine.apply_filters`` on a
+    ``list[dict]`` input normalizes to columnar and returns the rows with x >= 2.
+    """
+    from mloda.core.filter.single_filter import SingleFilter
+
+    fw = PythonDictFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
+
+    data: list[dict[str, Any]] = [
+        {"x": 1, "y": 10},
+        {"x": 2, "y": 20},
+        {"x": 3, "y": 30},
+    ]
+
+    single_filter = SingleFilter("x", "min", {"value": 2})
+
+    class _FeaturesStub:
+        filter_engine = PythonDictFramework.filter_engine()
+        filters = {single_filter}
+
+        @staticmethod
+        def get_all_names() -> set[str]:
+            return {"x", "y"}
+
+    features = _FeaturesStub()
+
+    # The filter path itself also normalizes row-wise input; this must NOT raise.
+    fw._validate_filter_columns(data, features, ListDictRootFeatureGroup)
+
+    filtered = features.filter_engine().apply_filters(data, features)
+
+    # After normalization + filtering, the columnar result keeps only x >= 2.
+    assert filtered == {"x": [2, 3], "y": [20, 30]}

--- a/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_malformed_result_run_all.py
+++ b/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_malformed_result_run_all.py
@@ -1,0 +1,111 @@
+"""Red-phase regression test for Defect 1 (P2): a malformed (scalar-valued) dict result
+must not bypass columnar validation.
+
+Under the columnar model ``PythonDictFramework.expected_data_framework()`` returns ``dict``.
+In ``ComputeFramework.run_calculation`` the ``transform`` step (which enforces the columnar
+contract: every value is a list, all equal length) is SKIPPED when the ``calculate_feature``
+result is already an instance of the expected framework type. A FeatureGroup that returns a
+non-columnar dict with SCALAR values, e.g. ``{"feat": 1}``, is therefore stored as native
+WITHOUT ever passing through ``transform``. This later corrupts joins / pyarrow upload.
+
+Desired behavior: such a result must be REJECTED with a clear error (``ValueError`` /
+``EmptyResultError`` surfaced as an ``Exception`` through the public ``run_all`` path), not
+silently accepted. ``transform`` already rejects ``{"a": 1, "b": 2}`` (see
+``test_python_dict_columnar_contract.py::TestTransformColumnar.test_dict_with_non_list_values_raises``);
+the run must enforce the same contract even when the framework short-circuits ``transform``.
+
+This test is expected to FAIL against the current implementation because ``{"feat": 1}`` is a
+``dict`` (the expected framework type), so ``transform`` is skipped and the malformed result is
+accepted and returned instead of raising.
+"""
+
+from typing import Any, Optional
+
+import pytest
+
+from mloda.provider import BaseInputData
+from mloda.provider import DataCreator
+from mloda.provider import FeatureGroup
+from mloda.provider import FeatureSet
+from mloda.user import Feature
+from mloda.user import ParallelizationMode
+from mloda.user import PluginCollector
+from mloda.user import mloda
+from tests.test_plugins.compute_framework.test_tooling.empty_result_run_all_test_base import (
+    _EmptyResultMatchData,
+)
+
+
+class _ScalarValuedResultFeatureGroup(FeatureGroup, _EmptyResultMatchData):
+    """Root FeatureGroup whose ``calculate_feature`` returns a scalar-valued dict.
+
+    ``{"scalar_result_col": 1}`` is NOT columnar: the value is a bare int, not a list. It
+    must be rejected the same way ``transform`` rejects ``{"a": 1, "b": 2}``.
+    """
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={"scalar_result_col"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        # Scalar value, not a list -> malformed columnar dict. Bypasses transform today.
+        return {"scalar_result_col": 1}
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return {"scalar_result_col"}
+
+
+class _MultiScalarValuedResultFeatureGroup(FeatureGroup, _EmptyResultMatchData):
+    """Root FeatureGroup returning a multi-column scalar-valued dict ``{"a": 1, "b": 2}``."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={"multi_scalar_result_col"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        # Both values scalar -> malformed columnar dict.
+        return {"multi_scalar_result_col": 1, "extra_scalar_col": 2}
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return {"multi_scalar_result_col"}
+
+
+_ENABLED_SCALAR = PluginCollector.enabled_feature_groups({_ScalarValuedResultFeatureGroup})
+_ENABLED_MULTI_SCALAR = PluginCollector.enabled_feature_groups({_MultiScalarValuedResultFeatureGroup})
+
+
+def test_scalar_valued_dict_result_is_rejected(flight_server: Any) -> None:
+    """A single-column scalar-valued dict result must raise through run_all, not be accepted.
+
+    Expected failure reason (Red): the current implementation SKIPS ``transform`` for a dict
+    result, so ``{"scalar_result_col": 1}`` is stored and returned as-is. ``run_all`` returns
+    one malformed result instead of raising, so ``pytest.raises`` is unsatisfied.
+    """
+    with pytest.raises(Exception):
+        mloda.run_all(
+            [Feature(name="scalar_result_col")],
+            compute_frameworks=["PythonDictFramework"],
+            plugin_collector=_ENABLED_SCALAR,
+            parallelization_modes={ParallelizationMode.SYNC},
+            flight_server=flight_server,
+        )
+
+
+def test_multi_column_scalar_valued_dict_result_is_rejected(flight_server: Any) -> None:
+    """A multi-column scalar-valued dict result must raise through run_all, not be accepted.
+
+    Expected failure reason (Red): same short-circuit as above; ``{"a": 1, "b": 2}`` bypasses
+    ``transform`` and is accepted, so no exception is raised.
+    """
+    with pytest.raises(Exception):
+        mloda.run_all(
+            [Feature(name="multi_scalar_result_col")],
+            compute_frameworks=["PythonDictFramework"],
+            plugin_collector=_ENABLED_MULTI_SCALAR,
+            parallelization_modes={ParallelizationMode.SYNC},
+            flight_server=flight_server,
+        )

--- a/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_mask_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_mask_engine.py
@@ -18,12 +18,83 @@ class TestPythonDictMaskEngine(MaskEngineTestMixin):
 
     @pytest.fixture
     def sample_data(self) -> Any:
-        return [
-            {"status": "active", "value": 10},
-            {"status": "inactive", "value": 20},
-            {"status": "active", "value": 30},
-            {"status": "inactive", "value": 40},
-        ]
+        return {
+            "status": ["active", "inactive", "active", "inactive"],
+            "value": [10, 20, 30, 40],
+        }
 
     def evaluate_mask(self, mask: Any, data: Any) -> list[bool]:
         return list(mask)
+
+
+class TestPythonDictMaskEngineMissingColumn:
+    """Red-phase regression tests for Defect 3 (Opus #1): a mask over a MISSING column must
+    return a row-count-length all-False mask, not a length-0 list.
+
+    ``PythonDictMaskEngine`` primitives read ``data.get(column, [])``. For a column NOT present
+    in the columnar data this yields ``[]``, so the mask has length 0 instead of the row count.
+    ``combine`` uses ``zip``, which silently truncates to the shorter operand, so
+    ``combine(all_true(data), equal(data, "missing", v))`` collapses an AND-combination to
+    ZERO rows even though every row should simply be excluded (all-False).
+
+    Desired behavior: a mask over a missing column is a list of length = row count, all False;
+    combining it with ``all_true`` preserves the row count.
+
+    These tests are expected to FAIL against the current implementation: the missing-column mask
+    is length 0 and the combined mask is length 0 (not 3).
+    """
+
+    @staticmethod
+    def _engine() -> type[PythonDictMaskEngine]:
+        return PythonDictMaskEngine
+
+    def test_equal_on_missing_column_is_row_length_all_false(self) -> None:
+        """``equal`` over a missing column returns length-3 all-False, not length-0."""
+        data = {"a": [1, 2, 3]}
+        mask = self._engine().equal(data, "missing_col", 1)
+        assert list(mask) == [False, False, False]
+
+    def test_greater_equal_on_missing_column_is_row_length_all_false(self) -> None:
+        """``greater_equal`` over a missing column returns length-3 all-False, not length-0."""
+        data = {"a": [1, 2, 3]}
+        mask = self._engine().greater_equal(data, "missing_col", 1)
+        assert list(mask) == [False, False, False]
+
+    def test_is_in_on_missing_column_is_row_length_all_false(self) -> None:
+        """``is_in`` over a missing column returns length-3 all-False, not length-0."""
+        data = {"a": [1, 2, 3]}
+        mask = self._engine().is_in(data, "missing_col", (1, 2))
+        assert list(mask) == [False, False, False]
+
+    def test_combine_all_true_with_missing_column_preserves_row_count(self) -> None:
+        """``combine(all_true(data), equal(data, "missing", v))`` keeps 3 rows (all False).
+
+        This is the corruption the defect describes: today ``zip`` truncates to the length-0
+        missing-column mask, collapsing the AND-combination to zero rows.
+        """
+        engine = self._engine()
+        data = {"a": [1, 2, 3]}
+        combined = engine.combine(engine.all_true(data), engine.equal(data, "missing_col", 1))
+        assert list(combined) == [False, False, False]
+
+
+class TestPythonDictMaskEngineMissingColumnNeverMatches:
+    """A mask over a MISSING column must never match, regardless of the compared value.
+
+    ``_column_or_nulls`` substitutes ``None`` placeholders for a missing column. A
+    ``None``/``[None]`` comparison value then matches those placeholders (``None == None``,
+    ``None in {None}``), so ``equal``/``is_in`` return all-True for a column that does not
+    exist. A missing column must yield an all-False mask even for ``None`` comparisons.
+    """
+
+    def test_equal_none_on_missing_column_is_all_false(self) -> None:
+        """``equal(data, "missing_col", None)`` returns all-False, not all-True."""
+        data = {"a": [1, 2, 3]}
+        mask = PythonDictMaskEngine.equal(data, "missing_col", None)
+        assert list(mask) == [False, False, False]
+
+    def test_is_in_none_on_missing_column_is_all_false(self) -> None:
+        """``is_in(data, "missing_col", [None])`` returns all-False, not all-True."""
+        data = {"a": [1, 2, 3]}
+        mask = PythonDictMaskEngine.is_in(data, "missing_col", [None])
+        assert list(mask) == [False, False, False]

--- a/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_merge_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_merge_engine.py
@@ -18,13 +18,13 @@ class TestPythonDictMergeEngine:
 
     @pytest.fixture
     def left_data(self) -> Any:
-        """Create sample left dataset."""
-        return [{"idx": 1, "col1": "a"}, {"idx": 3, "col1": "b"}]
+        """Create sample columnar left dataset."""
+        return {"idx": [1, 3], "col1": ["a", "b"]}
 
     @pytest.fixture
     def right_data(self) -> Any:
-        """Create sample right dataset."""
-        return [{"idx": 1, "col2": "x"}, {"idx": 2, "col2": "z"}]
+        """Create sample columnar right dataset."""
+        return {"idx": [1, 2], "col2": ["x", "z"]}
 
     def test_check_import(self) -> None:
         """Test that check_import passes without errors."""
@@ -36,59 +36,51 @@ class TestPythonDictMergeEngine:
         engine = PythonDictMergeEngine()
         result = engine.merge_inner(left_data, right_data, index_obj, index_obj)
 
-        expected = [{"idx": 1, "col1": "a", "col2": "x"}]
-        assert result == expected
+        assert result == {"idx": [1], "col1": ["a"], "col2": ["x"]}
 
     def test_merge_left(self, left_data: Any, right_data: Any, index_obj: Any) -> None:
         """Test left join."""
         engine = PythonDictMergeEngine()
         result = engine.merge_left(left_data, right_data, index_obj, index_obj)
 
-        expected = [{"idx": 1, "col1": "a", "col2": "x"}, {"idx": 3, "col1": "b", "col2": None}]
-        assert result == expected
+        assert result == {"idx": [1, 3], "col1": ["a", "b"], "col2": ["x", None]}
 
     def test_merge_right(self, left_data: Any, right_data: Any, index_obj: Any) -> None:
         """Test right join."""
         engine = PythonDictMergeEngine()
         result = engine.merge_right(left_data, right_data, index_obj, index_obj)
 
-        expected = [{"idx": 1, "col1": "a", "col2": "x"}, {"idx": 2, "col1": None, "col2": "z"}]
-        assert result == expected
+        assert result == {"idx": [1, 2], "col2": ["x", "z"], "col1": ["a", None]}
 
     def test_merge_full_outer(self, left_data: Any, right_data: Any, index_obj: Any) -> None:
         """Test outer join."""
         engine = PythonDictMergeEngine()
         result = engine.merge_full_outer(left_data, right_data, index_obj, index_obj)
 
-        # Sort by idx for consistent comparison
-        result_sorted = sorted(result, key=lambda x: x["idx"])
-        expected = [
-            {"idx": 1, "col1": "a", "col2": "x"},
-            {"idx": 2, "col1": None, "col2": "z"},
-            {"idx": 3, "col1": "b", "col2": None},
-        ]
-        assert result_sorted == expected
+        assert result == {"idx": [1, 3, 2], "col1": ["a", "b", None], "col2": ["x", None, "z"]}
 
     def test_merge_append(self, left_data: Any, right_data: Any, index_obj: Any) -> None:
-        """Test append operation."""
+        """Test append operation (column-wise concatenation with the union of columns)."""
         engine = PythonDictMergeEngine()
         result = engine.merge_append(left_data, right_data, index_obj, index_obj)
 
-        expected = left_data + right_data
-        assert result == expected
+        assert result == {
+            "idx": [1, 3, 1, 2],
+            "col1": ["a", "b", None, None],
+            "col2": [None, None, "x", "z"],
+        }
 
     def test_merge_union(self, left_data: Any, right_data: Any, index_obj: Any) -> None:
         """Test union operation (removes duplicates)."""
         engine = PythonDictMergeEngine()
         result = engine.merge_union(left_data, right_data, index_obj, index_obj)
 
-        expected = [{"idx": 1, "col1": "a"}, {"idx": 3, "col1": "b"}, {"idx": 2, "col2": "z"}]
-        assert result == expected
+        assert result == {"idx": [1, 3, 2], "col1": ["a", "b", None], "col2": [None, None, "z"]}
 
     def test_merge_with_different_join_columns(self) -> None:
         """Test merge with different column names for join."""
-        left_data = [{"left_id": 1, "col1": "a"}, {"left_id": 2, "col1": "b"}]
-        right_data = [{"right_id": 1, "col2": "x"}, {"right_id": 3, "col2": "z"}]
+        left_data = {"left_id": [1, 2], "col1": ["a", "b"]}
+        right_data = {"right_id": [1, 3], "col2": ["x", "z"]}
 
         left_index = Index(("left_id",))
         right_index = Index(("right_id",))
@@ -96,72 +88,68 @@ class TestPythonDictMergeEngine:
         engine = PythonDictMergeEngine()
         result = engine.merge_inner(left_data, right_data, left_index, right_index)
 
-        expected = [{"left_id": 1, "col1": "a", "right_id": 1, "col2": "x"}]
-        assert result == expected
+        assert result == {"left_id": [1], "col1": ["a"], "right_id": [1], "col2": ["x"]}
 
     def test_merge_with_empty_datasets(self, index_obj: Any) -> None:
-        """Test merge operations with empty datasets."""
+        """Test merge operations with empty datasets (schema-bearing zero-row frames)."""
         engine = PythonDictMergeEngine()
 
-        # Empty left
-        result = engine.merge_inner([], [{"idx": 1, "col": "a"}], index_obj, index_obj)
-        assert result == []
+        # Empty left carries its schema; the right side contributes its columns.
+        result = engine.merge_inner({"idx": [], "col1": []}, {"idx": [1], "col": ["a"]}, index_obj, index_obj)
+        assert result == {"idx": [], "col1": [], "col": []}
 
-        # Empty right
-        result = engine.merge_inner([{"idx": 1, "col": "a"}], [], index_obj, index_obj)
-        assert result == []
+        # Empty right.
+        result = engine.merge_inner({"idx": [1], "col": ["a"]}, {"idx": [], "col2": []}, index_obj, index_obj)
+        assert result == {"idx": [], "col": [], "col2": []}
 
-        # Both empty
-        result = engine.merge_inner([], [], index_obj, index_obj)
-        assert result == []
+        # Both empty.
+        result = engine.merge_inner({"idx": []}, {"idx": []}, index_obj, index_obj)
+        assert result == {"idx": []}
 
     def test_merge_with_complex_data(self) -> None:
         """Test merge with more complex data structures."""
-        left_data = [
-            {"id": 1, "name": "Alice", "age": 25},
-            {"id": 2, "name": "Bob", "age": 30},
-            {"id": 3, "name": "Charlie", "age": 35},
-        ]
+        left_data = {
+            "id": [1, 2, 3],
+            "name": ["Alice", "Bob", "Charlie"],
+            "age": [25, 30, 35],
+        }
 
-        right_data = [
-            {"id": 1, "city": "New York", "country": "USA"},
-            {"id": 2, "city": "London", "country": "UK"},
-            {"id": 4, "city": "Tokyo", "country": "Japan"},
-        ]
+        right_data = {
+            "id": [1, 2, 4],
+            "city": ["New York", "London", "Tokyo"],
+            "country": ["USA", "UK", "Japan"],
+        }
 
         index_obj = Index(("id",))
         engine = PythonDictMergeEngine()
 
-        # Test inner join
         result = engine.merge_inner(left_data, right_data, index_obj, index_obj)
-        expected = [
-            {"id": 1, "name": "Alice", "age": 25, "city": "New York", "country": "USA"},
-            {"id": 2, "name": "Bob", "age": 30, "city": "London", "country": "UK"},
-        ]
-        assert result == expected
+        assert result == {
+            "id": [1, 2],
+            "name": ["Alice", "Bob"],
+            "age": [25, 30],
+            "city": ["New York", "London"],
+            "country": ["USA", "UK"],
+        }
 
     def test_merge_with_none_values(self) -> None:
         """Test merge operations with None values in join columns."""
-        left_data = [{"id": 1, "col1": "a"}, {"id": None, "col1": "b"}]
-        right_data = [{"id": 1, "col2": "x"}, {"id": None, "col2": "y"}]
+        left_data = {"id": [1, None], "col1": ["a", "b"]}
+        right_data = {"id": [1, None], "col2": ["x", "y"]}
 
         index_obj = Index(("id",))
         engine = PythonDictMergeEngine()
 
         result = engine.merge_inner(left_data, right_data, index_obj, index_obj)
-        expected = [{"id": 1, "col1": "a", "col2": "x"}, {"id": None, "col1": "b", "col2": "y"}]
-        assert result == expected
+        assert result == {"id": [1, None], "col1": ["a", "b"], "col2": ["x", "y"]}
 
     def test_join_logic_integration(self, left_data: Any, right_data: Any, index_obj: Any) -> None:
         """Test that join_logic method works correctly."""
         engine = PythonDictMergeEngine()
 
-        # Test inner join through join_logic
         result = engine.join_logic("inner", left_data, right_data, index_obj, index_obj, JoinType.INNER)
-        expected = [{"idx": 1, "col1": "a", "col2": "x"}]
-        assert result == expected
+        assert result == {"idx": [1], "col1": ["a"], "col2": ["x"]}
 
-        # Test unsupported join type
         with pytest.raises(ValueError, match="Join type unsupported is not supported"):
             engine.join_logic("unsupported", left_data, right_data, index_obj, index_obj, JoinType.INNER)
 
@@ -169,14 +157,11 @@ class TestPythonDictMergeEngine:
         """Test the main merge method that dispatches to specific join types."""
         engine = PythonDictMergeEngine()
 
-        # Test all join types through the main merge method
         result = engine.merge(left_data, right_data, make_merge_link(JoinType.INNER, index_obj, index_obj))
-        expected = [{"idx": 1, "col1": "a", "col2": "x"}]
-        assert result == expected
+        assert result == {"idx": [1], "col1": ["a"], "col2": ["x"]}
 
         result = engine.merge(left_data, right_data, make_merge_link(JoinType.LEFT, index_obj, index_obj))
-        expected = [{"idx": 1, "col1": "a", "col2": "x"}, {"idx": 3, "col1": "b", "col2": None}]
-        assert result == expected
+        assert result == {"idx": [1, 3], "col1": ["a", "b"], "col2": ["x", None]}
 
 
 class TestPythonDictMergeEngineMultiIndex(MultiIndexMergeEngineTestBase):
@@ -189,8 +174,8 @@ class TestPythonDictMergeEngineMultiIndex(MultiIndexMergeEngineTestBase):
 
     @classmethod
     def framework_type(cls) -> type[Any]:
-        """Return list type (PythonDict uses List[Dict])."""
-        return list
+        """Return dict type (PythonDict uses a columnar dict)."""
+        return dict
 
     def get_connection(self) -> Optional[Any]:
         """PythonDict does not require a connection object."""

--- a/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_pyarrow_transformer.py
+++ b/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_pyarrow_transformer.py
@@ -15,16 +15,16 @@ from mloda_plugins.compute_framework.base_implementations.python_dict.python_dic
 
 @pytest.mark.skipif(not PYARROW_AVAILABLE, reason="PyArrow not available")
 class TestPythonDictPyArrowTransformer:
-    """Unit tests for the PythonDictPyArrowTransformer class."""
+    """Unit tests for the PythonDictPyArrowTransformer class (columnar dict <-> pa.Table)."""
 
     @pytest.fixture
     def sample_python_dict_data(self) -> Any:
-        """Create sample PythonDict data."""
-        return [
-            {"id": 1, "name": "Alice", "age": 25},
-            {"id": 2, "name": "Bob", "age": 30},
-            {"id": 3, "name": "Charlie", "age": 35},
-        ]
+        """Create sample columnar PythonDict data."""
+        return {
+            "id": [1, 2, 3],
+            "name": ["Alice", "Bob", "Charlie"],
+            "age": [25, 30, 35],
+        }
 
     @pytest.fixture
     def sample_pyarrow_data(self) -> Any:
@@ -33,7 +33,7 @@ class TestPythonDictPyArrowTransformer:
 
     def test_framework(self) -> None:
         """Test that framework returns correct type."""
-        assert PythonDictPyArrowTransformer.framework() is list
+        assert PythonDictPyArrowTransformer.framework() is dict
 
     def test_other_framework(self) -> None:
         """Test that other_framework returns correct type."""
@@ -48,7 +48,7 @@ class TestPythonDictPyArrowTransformer:
         PythonDictPyArrowTransformer.import_other_fw()  # Should not raise
 
     def test_transform_fw_to_other_fw(self, sample_python_dict_data: Any) -> None:
-        """Test transformation from PythonDict to PyArrow."""
+        """Test transformation from columnar PythonDict to PyArrow."""
         result = PythonDictPyArrowTransformer.transform_fw_to_other_fw(sample_python_dict_data)
 
         assert isinstance(result, pa.Table)
@@ -57,63 +57,50 @@ class TestPythonDictPyArrowTransformer:
         assert set(result.column_names) == {"id", "name", "age"}
 
         # Check data integrity
-        result_dict = result.to_pylist()
-        assert result_dict == sample_python_dict_data
+        assert result.to_pydict() == sample_python_dict_data
 
     def test_transform_other_fw_to_fw(self, sample_pyarrow_data: Any) -> None:
-        """Test transformation from PyArrow to PythonDict."""
+        """Test transformation from PyArrow to columnar PythonDict."""
         result = PythonDictPyArrowTransformer.transform_other_fw_to_fw(sample_pyarrow_data)
 
-        assert isinstance(result, list)
-        assert len(result) == 3
-        assert all(isinstance(row, dict) for row in result)
-
-        expected = [
-            {"id": 1, "name": "Alice", "age": 25},
-            {"id": 2, "name": "Bob", "age": 30},
-            {"id": 3, "name": "Charlie", "age": 35},
-        ]
-        assert result == expected
+        assert isinstance(result, dict)
+        assert result == {"id": [1, 2, 3], "name": ["Alice", "Bob", "Charlie"], "age": [25, 30, 35]}
 
     def test_roundtrip_transformation(self, sample_python_dict_data: Any) -> None:
         """Test that PythonDict -> PyArrow -> PythonDict preserves data."""
-        # Transform to PyArrow
         pyarrow_data = PythonDictPyArrowTransformer.transform_fw_to_other_fw(sample_python_dict_data)
-
-        # Transform back to PythonDict
         result = PythonDictPyArrowTransformer.transform_other_fw_to_fw(pyarrow_data)
 
-        # Should be identical to original
         assert result == sample_python_dict_data
 
-    def test_transform_empty_list(self) -> None:
-        """Test transformation of empty list."""
-        empty_list: list[dict[str, Any]] = []
-        result = PythonDictPyArrowTransformer.transform_fw_to_other_fw(empty_list)
+    def test_transform_empty_dict(self) -> None:
+        """Test transformation of the schema-less empty dict."""
+        result = PythonDictPyArrowTransformer.transform_fw_to_other_fw({})
 
         assert isinstance(result, pa.Table)
         assert result.num_rows == 0
         assert result.num_columns == 0
+
+    def test_transform_zero_row_column_keeps_schema(self) -> None:
+        """A zero-row column ``{"col": []}`` yields a 0-row table that keeps the column."""
+        result = PythonDictPyArrowTransformer.transform_fw_to_other_fw({"col": []})
+
+        assert isinstance(result, pa.Table)
+        assert result.num_rows == 0
+        assert result.column_names == ["col"]
 
     def test_transform_empty_table(self) -> None:
         """Test transformation of empty PyArrow table."""
         empty_table = pa.table({})
         result = PythonDictPyArrowTransformer.transform_other_fw_to_fw(empty_table)
 
-        assert isinstance(result, list)
-        assert len(result) == 0
+        assert isinstance(result, dict)
+        assert result == {}
 
     def test_transform_fw_to_other_fw_invalid_type(self) -> None:
         """Test that invalid input type raises error."""
-        with pytest.raises(ValueError, match="Expected list, got"):
+        with pytest.raises(ValueError, match="Expected dict, got"):
             PythonDictPyArrowTransformer.transform_fw_to_other_fw("invalid")
-
-    def test_transform_fw_to_other_fw_invalid_list_content(self) -> None:
-        """Test that list with non-dict items raises error."""
-        invalid_data = [{"id": 1}, "invalid", {"id": 3}]
-
-        with pytest.raises(ValueError, match="Expected dict at index 1, got"):
-            PythonDictPyArrowTransformer.transform_fw_to_other_fw(invalid_data)
 
     def test_transform_other_fw_to_fw_invalid_type(self) -> None:
         """Test that invalid PyArrow input type raises error."""
@@ -122,13 +109,13 @@ class TestPythonDictPyArrowTransformer:
 
     def test_transform_with_mixed_types(self) -> None:
         """Test transformation with mixed data types."""
-        mixed_data = [
-            {"id": 1, "name": "Alice", "score": 95.5, "active": True},
-            {"id": 2, "name": "Bob", "score": 87.2, "active": False},
-            {"id": 3, "name": "Charlie", "score": None, "active": True},
-        ]
+        mixed_data = {
+            "id": [1, 2, 3],
+            "name": ["Alice", "Bob", "Charlie"],
+            "score": [95.5, 87.2, None],
+            "active": [True, False, True],
+        }
 
-        # Transform to PyArrow and back
         pyarrow_data = PythonDictPyArrowTransformer.transform_fw_to_other_fw(mixed_data)
         result = PythonDictPyArrowTransformer.transform_other_fw_to_fw(pyarrow_data)
 
@@ -136,25 +123,15 @@ class TestPythonDictPyArrowTransformer:
 
     def test_transform_with_nested_structures(self) -> None:
         """Test transformation with nested data structures."""
-        nested_data = [
-            {"id": 1, "metadata": {"tags": ["python", "data"], "count": 5}},
-            {"id": 2, "metadata": {"tags": ["arrow", "table"], "count": 3}},
-        ]
+        nested_data = {
+            "id": [1, 2],
+            "metadata": [
+                {"tags": ["python", "data"], "count": 5},
+                {"tags": ["arrow", "table"], "count": 3},
+            ],
+        }
 
-        # Transform to PyArrow and back
         pyarrow_data = PythonDictPyArrowTransformer.transform_fw_to_other_fw(nested_data)
         result = PythonDictPyArrowTransformer.transform_other_fw_to_fw(pyarrow_data)
 
         assert result == nested_data
-
-    def test_transform_with_inconsistent_schemas(self) -> None:
-        """Test transformation with inconsistent column schemas should raise an error."""
-        inconsistent_data = [
-            {"id": 1, "name": "Alice", "age": 25},
-            {"id": 2, "name": "Bob"},  # Missing age
-            {"id": 3, "name": "Charlie", "age": 35, "city": "New York"},  # Extra column
-        ]
-
-        # Should raise an error due to inconsistent schema
-        with pytest.raises(ValueError, match="Inconsistent schema at index 1"):
-            PythonDictPyArrowTransformer.transform_fw_to_other_fw(inconsistent_data)

--- a/tests/test_plugins/compute_framework/test_tooling/POLICY_CONFORMANCE.md
+++ b/tests/test_plugins/compute_framework/test_tooling/POLICY_CONFORMANCE.md
@@ -1,7 +1,7 @@
 # Policy conformance is mandatory
 
-Every new FeatureGroup-level policy flag (anything in the spirit of
-`allow_empty_result()`: a class method on `FeatureGroup` that changes how the pipeline
+Every new pipeline-level result policy (anything in the spirit of the schema-based
+empty-result contract: a rule or FeatureGroup-level flag that changes how the pipeline
 treats a result) MUST ship a `run_all`-driven conformance suite.
 
 ## What "conformance suite" means
@@ -17,11 +17,13 @@ Build it on `PolicyRunAllTestBase` (see `policy_run_all_test_base.py`). The suit
 ## Template
 
 - `policy_run_all_test_base.py` is the generic base.
-- `empty_result_run_all_test_base.py` is the canonical first consumer; copy its shape.
+- `empty_result_run_all_test_base.py` is the canonical worked example: it validates the
+  schema-based empty-result contract (zero columns raise, zero rows succeed). Copy its shape.
 
 ## Why this bar exists
 
-`allow_empty_result()` had THREE enforcement surfaces. The third one, in
+The now-retired `allow_empty_result()` flag, the historical motivation for this bar,
+had THREE enforcement surfaces. The third one, in
 `DataLifecycleManager.get_result_data`, shipped broken. Unit tests against the first two
 surfaces all passed. The defect was only caught because the full pipeline runs for every
 framework and every parallelization mode through `run_all`. A policy flag that is not

--- a/tests/test_plugins/compute_framework/test_tooling/asof/asof_run_all_test_base.py
+++ b/tests/test_plugins/compute_framework/test_tooling/asof/asof_run_all_test_base.py
@@ -88,6 +88,13 @@ def _records_from_frame(data: Any) -> list[dict[str, Any]]:
         records = data.to_dicts()
     elif pa is not None and isinstance(data, pa.Table):
         records = data.to_pylist()
+    elif isinstance(data, dict):
+        # PythonDict columnar frame: {"col": [v0, v1, ...]}.
+        if not data:
+            records = []
+        else:
+            length = len(next(iter(data.values())))
+            records = [{k: data[k][i] for k in data} for i in range(length)]
     elif isinstance(data, list):
         records = data
     elif hasattr(data, "to_dicts"):

--- a/tests/test_plugins/compute_framework/test_tooling/empty_result_run_all_test_base.py
+++ b/tests/test_plugins/compute_framework/test_tooling/empty_result_run_all_test_base.py
@@ -1,12 +1,12 @@
 """
-Shared base for the FeatureGroup-declared ``allow_empty_result`` policy, driven
-end-to-end through the public API ``mloda.run_all``. It is the canonical first consumer
-of the generic ``PolicyRunAllTestBase``.
+Shared base for the schema-based empty-result contract, driven end-to-end through the
+public API ``mloda.run_all``. It is the canonical first consumer of the generic
+``PolicyRunAllTestBase``.
 
 A feature computation must return a SCHEMA-BEARING result: at least one column. Rows are
 optional. The guard in ``ComputeFramework.run_validate_output_features`` fires only for
-FINAL requested features when ``feature_group.allow_empty_result()`` is False, and raises
-``EmptyResultError`` for:
+FINAL requested features, with no per-FeatureGroup opt-in, and raises ``EmptyResultError``
+for:
 
 - State B: a schema-less result (zero columns, i.e. ``_extract_column_names`` returns an
   empty set).
@@ -20,17 +20,16 @@ PythonDictFramework``), so state A never reaches the guard on any backend.
 State C, a schema-bearing result with ZERO ROWS, MUST SUCCEED. This is the key behavior:
 a zero-row but column-bearing frame is a valid, well-typed empty result.
 
-Both empty-producing FeatureGroups emit a columnar dict with a single empty column.
-``transform`` turns this into a zero-row frame in every schema-bearing framework (PyArrow,
-Pandas, Polars, DuckDB, SQLite, Spark, Iceberg): the schema is carried as metadata even at
-zero rows, so these are state C and SUCCEED. For ``python_dict`` (``List[Dict[str, Any]]``)
-``transform`` collapses ``{"col": []}`` to ``[]``, which has no schema: that is state B and
-STILL RAISES (unless ``allow_empty_result()`` is True).
+Both zero-row FeatureGroups emit a columnar dict with a single empty column. ``transform``
+turns this into a zero-row frame in every framework: the schema-bearing frameworks (PyArrow,
+Pandas, Polars, DuckDB, SQLite, Spark, Iceberg) carry the schema as metadata even at zero
+rows, and ``python_dict`` (columnar ``dict[str, list]``) keeps ``{"col": []}`` as a
+schema-bearing zero-row frame. All of these are state C and SUCCEED. Only the schema-less
+``{}`` (zero columns) is state B and RAISES, uniformly on every backend.
 
 Subclasses implement only ``compute_framework_name`` (and, for connection-backed frameworks
-such as DuckDB / SQLite / Spark / Iceberg, ``get_connection``). The python_dict subclass also
-overrides ``default_empty_is_schemaless`` to opt into the "raises" expectation for the default
-FeatureGroup.
+such as DuckDB / SQLite / Spark / Iceberg, ``get_connection``). ``default_empty_is_schemaless``
+remains as an override point but is False for every built-in framework.
 
 This module is intentionally NOT collected as tests (no ``Test`` prefix).
 """
@@ -91,7 +90,7 @@ class _EmptyResultMatchData(MatchData):
 
 
 class EmptyResultDefaultFeatureGroup(FeatureGroup, _EmptyResultMatchData):
-    """Root FeatureGroup that yields zero rows and does NOT allow empty results."""
+    """Root FeatureGroup that yields a schema-bearing zero-row result under default behavior."""
 
     @classmethod
     def input_data(cls) -> Optional[BaseInputData]:
@@ -100,7 +99,7 @@ class EmptyResultDefaultFeatureGroup(FeatureGroup, _EmptyResultMatchData):
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
         # Columnar dict with one empty column -> zero rows after transform.
-        # Schema-bearing frameworks keep the column (state C); python_dict drops it (state B).
+        # Every framework keeps the column at zero rows (state C), including python_dict.
         return {"empty_result_default_col": []}
 
     @classmethod
@@ -109,11 +108,7 @@ class EmptyResultDefaultFeatureGroup(FeatureGroup, _EmptyResultMatchData):
 
 
 class EmptyResultAllowedFeatureGroup(FeatureGroup, _EmptyResultMatchData):
-    """Root FeatureGroup that yields zero rows and DECLARES empty results are allowed."""
-
-    @classmethod
-    def allow_empty_result(cls) -> bool:
-        return True
+    """Root FeatureGroup that yields a schema-bearing zero-row result (one empty column)."""
 
     @classmethod
     def input_data(cls) -> Optional[BaseInputData]:
@@ -130,19 +125,12 @@ class EmptyResultAllowedFeatureGroup(FeatureGroup, _EmptyResultMatchData):
 
 
 class EmptyResultSchemalessAllowedFeatureGroup(FeatureGroup, _EmptyResultMatchData):
-    """Root FeatureGroup that yields a ZERO-COLUMN result and DECLARES empty results are allowed.
+    """Root FeatureGroup that yields a ZERO-COLUMN (schema-less) ``{}`` result.
 
-    Unlike ``EmptyResultAllowedFeatureGroup`` (one empty column, schema-less only on
-    python_dict), the ``{}`` returned here is schema-less (state B) on EVERY framework:
-    ``transform`` produces a frame with zero columns. With ``allow_empty_result()`` True the
-    output guard accepts it, and the framework must hand the zero-column result through to
-    the caller unchanged (result selection has no columns to match against and must not
-    re-judge what the guard already accepted).
+    The ``{}`` returned here is schema-less (state B) on EVERY framework: ``transform``
+    produces a frame with zero columns. With ``allow_empty_result()`` retired, the output
+    guard now RAISES ``EmptyResultError`` for this result on every backend.
     """
-
-    @classmethod
-    def allow_empty_result(cls) -> bool:
-        return True
 
     @classmethod
     def input_data(cls) -> Optional[BaseInputData]:
@@ -150,7 +138,7 @@ class EmptyResultSchemalessAllowedFeatureGroup(FeatureGroup, _EmptyResultMatchDa
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-        # Zero columns -> schema-less (state B) in every framework, accepted via the opt-in.
+        # Zero columns -> schema-less (state B) in every framework, now always raises.
         return {}
 
     @classmethod
@@ -188,7 +176,7 @@ def _assert_single_empty_result(result: list[Any]) -> None:
 
 
 class EmptyResultRunAllTestBase(PolicyRunAllTestBase):
-    """Drives the ``allow_empty_result`` policy end-to-end through ``run_all``.
+    """Drives the schema-based empty-result contract end-to-end through ``run_all``.
 
     Subclasses implement ``compute_framework_name`` and, for connection-backed frameworks,
     ``get_connection`` (plus a ``teardown_method`` to close it).
@@ -202,9 +190,8 @@ class EmptyResultRunAllTestBase(PolicyRunAllTestBase):
     def default_empty_is_schemaless(cls) -> bool:
         """Whether the default FG's empty result is schema-less (state B) on this framework.
 
-        Schema-bearing frameworks keep the column at zero rows (state C -> success); the
-        python_dict subclass overrides this to True because ``transform`` collapses the
-        columnar dict to ``[]`` (state B -> raises).
+        Every backend now keeps the single empty column at zero rows (state C -> success),
+        including python_dict under the columnar model, so this returns False everywhere.
         """
         return False
 
@@ -233,15 +220,15 @@ class EmptyResultRunAllTestBase(PolicyRunAllTestBase):
 
     @pytest.mark.parametrize("mode", [ParallelizationMode.SYNC, ParallelizationMode.THREADING])
     def test_empty_result_default(self, mode: ParallelizationMode, flight_server: Any) -> None:
-        """Default (not-allowed) FG requested as a final feature.
+        """Default FG requested as a final feature.
 
-        Schema-bearing frameworks return a schema-bearing zero-row result (state C) and
-        SUCCEED. python_dict drops the schema (state B) and raises ``EmptyResultError``.
+        Every framework, python_dict included, returns a schema-bearing zero-row result
+        (state C) and SUCCEEDS.
         SYNC-only frameworks (DuckDB / SQLite) override these methods to run SYNC only.
         """
         self._run_default_case(mode, flight_server)
 
     @pytest.mark.parametrize("mode", [ParallelizationMode.SYNC, ParallelizationMode.THREADING])
     def test_empty_result_allowed_succeeds(self, mode: ParallelizationMode, flight_server: Any) -> None:
-        """A FeatureGroup that overrides allow_empty_result()->True succeeds with an empty result."""
+        """A FeatureGroup returning a schema-bearing zero-row result succeeds on every backend."""
         self._run_allowed_case(mode, flight_server)

--- a/tests/test_plugins/compute_framework/test_tooling/multi_index/test_data_converter.py
+++ b/tests/test_plugins/compute_framework/test_tooling/multi_index/test_data_converter.py
@@ -67,16 +67,16 @@ class DataConverter:
         if target_framework_type is list:
             return data
 
-        # Step 1: List[Dict] → PyArrow
-        try:
-            transformer_list_to_arrow = self.transformer.transformer_map[(list, pa.Table)]
-            arrow_data = transformer_list_to_arrow.transform(list, pa.Table, data, None)
-        except KeyError:
-            raise KeyError("No transformer found for list → PyArrow. Ensure PythonDictPyarrowTransformer is available.")
+        # Step 1: List[Dict] → PyArrow (built directly; the canonical test format is List[Dict])
+        arrow_data = pa.Table.from_pylist(data)
 
         # Special case: if target is PyArrow, we're done
         if target_framework_type == pa.Table:
             return arrow_data
+
+        # Special case: PythonDict is a COLUMNAR dict; PyArrow -> columnar dict
+        if target_framework_type is dict:
+            return arrow_data.to_pydict()
 
         # Step 2: PyArrow → Target Framework
         try:
@@ -111,8 +111,10 @@ class DataConverter:
             assert isinstance(data, list), "Expected list data"
             return data
 
-        # Special case: if source is PyArrow, skip the first step
-        if source_framework_type == pa.Table:
+        # Special case: PythonDict is a COLUMNAR dict; columnar dict -> PyArrow
+        if source_framework_type is dict:
+            arrow_data = pa.table(data)
+        elif source_framework_type == pa.Table:
             arrow_data = data
         else:
             # Step 1: Source Framework → PyArrow
@@ -125,10 +127,6 @@ class DataConverter:
                     f"Ensure the framework has a PyArrow transformer."
                 )
 
-        # Step 2: PyArrow → List[Dict]
-        try:
-            transformer_arrow_to_list = self.transformer.transformer_map[(pa.Table, list)]
-            result: list[dict[str, Any]] = transformer_arrow_to_list.transform(pa.Table, list, arrow_data, None)
-            return result
-        except KeyError:
-            raise KeyError("No transformer found for PyArrow → list. Ensure PythonDictPyarrowTransformer is available.")
+        # Step 2: PyArrow → List[Dict] (built directly; the canonical test format is List[Dict])
+        result: list[dict[str, Any]] = arrow_data.to_pylist()
+        return result

--- a/tests/test_plugins/compute_framework/test_tooling/policy_run_all_test_base.py
+++ b/tests/test_plugins/compute_framework/test_tooling/policy_run_all_test_base.py
@@ -1,6 +1,6 @@
 """Generic policy-conformance tooling for FeatureGroup-level policy flags.
 
-Drives any FeatureGroup-declared policy flag (such as ``allow_empty_result()``) end-to-end
+Drives any pipeline result policy (such as the schema-based empty-result contract) end-to-end
 through the public API ``mloda.run_all``, across every built-in compute framework and at
 least one worker-based parallelization mode. A policy case is expressed as an expectation:
 either ``PolicySuccess`` (run_all returns results that satisfy an assertion) or
@@ -52,6 +52,13 @@ def records_from_frame(data: Any) -> list[dict[str, Any]]:
         records = data.to_dicts()
     elif pa is not None and isinstance(data, pa.Table):
         records = data.to_pylist()
+    elif isinstance(data, dict):
+        # PythonDict columnar frame: {"col": [v0, v1, ...]}. Zero columns -> zero rows.
+        if not data:
+            records = []
+        else:
+            length = len(next(iter(data.values())))
+            records = [{k: data[k][i] for k in data} for i in range(length)]
     elif isinstance(data, list):
         records = data
     elif hasattr(data, "to_dicts"):

--- a/tests/test_plugins/compute_framework/test_tooling/test_policy_run_all_test_base.py
+++ b/tests/test_plugins/compute_framework/test_tooling/test_policy_run_all_test_base.py
@@ -1,8 +1,8 @@
 """Contract tests for the generic ``PolicyRunAllTestBase`` (issue #521).
 
 Pins the public API of the generic policy run_all base directly, independently of the
-``allow_empty_result`` consumer: the base must drive any FeatureGroup-level policy flag
-end-to-end through ``mloda.run_all``. These tests reuse the existing empty-result fixtures
+empty-result consumer: the base must drive any pipeline result policy end-to-end
+through ``mloda.run_all``. These tests reuse the existing empty-result fixtures
 and exercise both the success and raises expectations, in SYNC and in a worker-based
 (THREADING) parallelization mode.
 """
@@ -14,7 +14,7 @@ from mloda.user import ParallelizationMode
 
 from tests.test_plugins.compute_framework.test_tooling.empty_result_run_all_test_base import (
     _ENABLED_ALLOWED,
-    _ENABLED_DEFAULT,
+    _ENABLED_SCHEMALESS_ALLOWED,
 )
 from tests.test_plugins.compute_framework.test_tooling.policy_run_all_test_base import (
     PolicyRaises,
@@ -54,12 +54,12 @@ def test_policy_base_drives_success_case(flight_server: Any) -> None:
 
 
 def test_policy_base_drives_raises_case(flight_server: Any) -> None:
-    """A policy raises expectation: python_dict default empty result is schema-less and raises."""
+    """A policy raises expectation: a zero-column ``{}`` result is schema-less and raises."""
     conformance = _PythonDictPolicyConformance()
 
     result = conformance.assert_policy_case(
-        feature_name="empty_result_default_col",
-        plugin_collector=_ENABLED_DEFAULT,
+        feature_name="empty_result_schemaless_col",
+        plugin_collector=_ENABLED_SCHEMALESS_ALLOWED,
         expectation=PolicyRaises(match_substring=EmptyResultError.__name__),
         mode=ParallelizationMode.SYNC,
         flight_server=flight_server,

--- a/tests/test_plugins/feature_group/experimental/test_missing_value_feature_group/test_python_dict_missing_value_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/test_missing_value_feature_group/test_python_dict_missing_value_feature_group.py
@@ -40,36 +40,26 @@ class PythonDictMissingValueTestDataCreator(ATestDataCreator):
         }
 
     @classmethod
-    def transform_format_for_testing(cls, data: dict[str, Any]) -> list[dict[str, Any]]:
-        """Transform the data to PythonDict format (List[Dict[str, Any]])."""
-        # Convert columnar format to row-based format
-        if not data:
-            return []
-
-        # Get the length from the first column
-        first_key = next(iter(data.keys()))
-        length = len(data[first_key])
-
-        # Verify all columns have the same length
-        for key, values in data.items():
-            if len(values) != length:
-                raise ValueError(
-                    f"All columns must have the same length. Column '{key}' has length {len(values)}, expected {length}"
-                )
-
-        return [{key: data[key][i] for key in data.keys()} for i in range(length)]
+    def transform_format_for_testing(cls, data: dict[str, Any]) -> dict[str, Any]:
+        """PythonDict's native format is already columnar; return it unchanged."""
+        return data
 
 
 @pytest.fixture
-def sample_data_with_missing() -> list[dict[str, Any]]:
-    """Create sample PythonDict data with missing values for testing."""
-    return [
-        {"income": 50000, "age": 30, "category": "A", "temperature": 72.5, "group": "X"},
-        {"income": None, "age": 25, "category": None, "temperature": 68.3, "group": "Y"},
-        {"income": 75000, "age": None, "category": "B", "temperature": None, "group": "X"},
-        {"income": None, "age": 45, "category": "A", "temperature": None, "group": "Y"},
-        {"income": 60000, "age": None, "category": None, "temperature": 70.1, "group": "X"},
-    ]
+def sample_data_with_missing() -> dict[str, Any]:
+    """Create sample columnar PythonDict data with missing values for testing."""
+    return {
+        "income": [50000, None, 75000, None, 60000],
+        "age": [30, 25, None, 45, None],
+        "category": ["A", None, "B", "A", None],
+        "temperature": [72.5, 68.3, None, None, 70.1],
+        "group": ["X", "Y", "X", "Y", "X"],
+    }
+
+
+def _copy_columnar(data: dict[str, Any]) -> dict[str, Any]:
+    """Deep-copy a columnar dict so tests don't mutate the shared fixture."""
+    return {key: list(values) for key, values in data.items()}
 
 
 @pytest.fixture
@@ -122,7 +112,7 @@ class TestPythonDictMissingValueFeatureGroup:
         """Test compute_framework_rule method."""
         assert PythonDictMissingValueFeatureGroup.compute_framework_rule() == {PythonDictFramework}
 
-    def test_check_source_features_exist(self, sample_data_with_missing: list[dict[str, Any]]) -> None:
+    def test_check_source_features_exist(self, sample_data_with_missing: dict[str, Any]) -> None:
         """Test _check_source_features_exist method."""
         # Feature exists
         PythonDictMissingValueFeatureGroup._check_source_features_exist(sample_data_with_missing, ["income"])
@@ -133,24 +123,22 @@ class TestPythonDictMissingValueFeatureGroup:
 
         # Empty data
         with pytest.raises(ValueError, match="Data cannot be empty"):
-            PythonDictMissingValueFeatureGroup._check_source_features_exist([], ["income"])
+            PythonDictMissingValueFeatureGroup._check_source_features_exist({}, ["income"])
 
-    def test_add_result_to_data(self, sample_data_with_missing: list[dict[str, Any]]) -> None:
+    def test_add_result_to_data(self, sample_data_with_missing: dict[str, Any]) -> None:
         """Test _add_result_to_data method."""
         result = [1, 2, 3, 4, 5]
-        data_copy = [row.copy() for row in sample_data_with_missing]
+        data_copy = _copy_columnar(sample_data_with_missing)
 
         updated_data = PythonDictMissingValueFeatureGroup._add_result_to_data(data_copy, "test_feature", result)
 
-        assert len(updated_data) == len(sample_data_with_missing)
-        for i, row in enumerate(updated_data):
-            assert row["test_feature"] == result[i]
+        assert updated_data["test_feature"] == result
 
         # Test mismatched lengths
         with pytest.raises(ValueError, match="Result length 3 does not match data length 5"):
             PythonDictMissingValueFeatureGroup._add_result_to_data(data_copy, "test", [1, 2, 3])
 
-    def test_impute_mean(self, sample_data_with_missing: list[dict[str, Any]]) -> None:
+    def test_impute_mean(self, sample_data_with_missing: dict[str, Any]) -> None:
         """Test _impute_mean method."""
         values = [50000, None, 75000, None, 60000]
         result = PythonDictMissingValueFeatureGroup._impute_mean(values)
@@ -164,7 +152,7 @@ class TestPythonDictMissingValueFeatureGroup:
         assert result[2] == 75000
         assert result[4] == 60000
 
-    def test_impute_median(self, sample_data_with_missing: list[dict[str, Any]]) -> None:
+    def test_impute_median(self, sample_data_with_missing: dict[str, Any]) -> None:
         """Test _impute_median method."""
         values = [50000, None, 75000, None, 60000]
         result = PythonDictMissingValueFeatureGroup._impute_median(values)
@@ -177,7 +165,7 @@ class TestPythonDictMissingValueFeatureGroup:
         assert result[2] == 75000
         assert result[4] == 60000
 
-    def test_impute_mode(self, sample_data_with_missing: list[dict[str, Any]]) -> None:
+    def test_impute_mode(self, sample_data_with_missing: dict[str, Any]) -> None:
         """Test _impute_mode method."""
         values = ["A", None, "B", "A", None]
         result = PythonDictMissingValueFeatureGroup._impute_mode(values)
@@ -190,7 +178,7 @@ class TestPythonDictMissingValueFeatureGroup:
         assert result[2] == "B"
         assert result[3] == "A"
 
-    def test_impute_constant(self, sample_data_with_missing: list[dict[str, Any]]) -> None:
+    def test_impute_constant(self, sample_data_with_missing: dict[str, Any]) -> None:
         """Test _impute_constant method."""
         values = ["A", None, "B", None, "C"]
         result = PythonDictMissingValueFeatureGroup._impute_constant(values, "Unknown")
@@ -202,7 +190,7 @@ class TestPythonDictMissingValueFeatureGroup:
         assert result[2] == "B"
         assert result[4] == "C"
 
-    def test_impute_ffill(self, sample_data_with_missing: list[dict[str, Any]]) -> None:
+    def test_impute_ffill(self, sample_data_with_missing: dict[str, Any]) -> None:
         """Test _impute_ffill method."""
         values = [72.5, 68.3, None, None, 70.1]
         result = PythonDictMissingValueFeatureGroup._impute_ffill(values)
@@ -213,7 +201,7 @@ class TestPythonDictMissingValueFeatureGroup:
         assert result[3] == 68.3  # Forward filled
         assert result[4] == 70.1
 
-    def test_impute_bfill(self, sample_data_with_missing: list[dict[str, Any]]) -> None:
+    def test_impute_bfill(self, sample_data_with_missing: dict[str, Any]) -> None:
         """Test _impute_bfill method."""
         values = [72.5, 68.3, None, None, 70.1]
         result = PythonDictMissingValueFeatureGroup._impute_bfill(values)
@@ -224,7 +212,7 @@ class TestPythonDictMissingValueFeatureGroup:
         assert result[3] == 70.1  # Backward filled
         assert result[4] == 70.1
 
-    def test_perform_imputation_mean(self, sample_data_with_missing: list[dict[str, Any]]) -> None:
+    def test_perform_imputation_mean(self, sample_data_with_missing: dict[str, Any]) -> None:
         """Test _perform_imputation method with mean imputation."""
         result = PythonDictMissingValueFeatureGroup._perform_imputation(sample_data_with_missing, "mean", ["income"])
 
@@ -237,12 +225,12 @@ class TestPythonDictMissingValueFeatureGroup:
         assert result[2] == 75000
         assert result[4] == 60000
 
-    def test_perform_imputation_invalid(self, sample_data_with_missing: list[dict[str, Any]]) -> None:
+    def test_perform_imputation_invalid(self, sample_data_with_missing: dict[str, Any]) -> None:
         """Test _perform_imputation method with invalid imputation type."""
         with pytest.raises(ValueError, match="Unsupported imputation method: invalid"):
             PythonDictMissingValueFeatureGroup._perform_imputation(sample_data_with_missing, "invalid", ["income"])
 
-    def test_perform_grouped_imputation_mean(self, sample_data_with_missing: list[dict[str, Any]]) -> None:
+    def test_perform_grouped_imputation_mean(self, sample_data_with_missing: dict[str, Any]) -> None:
         """Test _perform_grouped_imputation method with mean imputation by group."""
         result = PythonDictMissingValueFeatureGroup._perform_grouped_imputation(
             sample_data_with_missing, "mean", "income", None, ["group"]
@@ -258,94 +246,95 @@ class TestPythonDictMissingValueFeatureGroup:
         assert abs(result[4] - 60000) < 0.1  # Original value
 
     def test_calculate_feature_single(
-        self, sample_data_with_missing: list[dict[str, Any]], feature_set_mean: FeatureSet
+        self, sample_data_with_missing: dict[str, Any], feature_set_mean: FeatureSet
     ) -> None:
         """Test calculate_feature method with a single imputation."""
-        data_copy = [row.copy() for row in sample_data_with_missing]
+        data_copy = _copy_columnar(sample_data_with_missing)
         result = PythonDictMissingValueFeatureGroup.calculate_feature(data_copy, feature_set_mean)
 
         # Check that the result contains the imputed feature
-        assert "income__mean_imputed" in result[0]
+        assert "income__mean_imputed" in result
         expected_mean = 61666.67
-        assert abs(result[1]["income__mean_imputed"] - expected_mean) < 0.1
-        assert abs(result[3]["income__mean_imputed"] - expected_mean) < 0.1
+        assert abs(result["income__mean_imputed"][1] - expected_mean) < 0.1
+        assert abs(result["income__mean_imputed"][3] - expected_mean) < 0.1
 
         # Check that the original data is preserved
-        assert "income" in result[0]
-        assert "age" in result[0]
-        assert "category" in result[0]
+        assert "income" in result
+        assert "age" in result
+        assert "category" in result
 
     def test_calculate_feature_multiple(
-        self, sample_data_with_missing: list[dict[str, Any]], feature_set_multiple: FeatureSet
+        self, sample_data_with_missing: dict[str, Any], feature_set_multiple: FeatureSet
     ) -> None:
         """Test calculate_feature method with multiple imputations."""
-        data_copy = [row.copy() for row in sample_data_with_missing]
+        data_copy = _copy_columnar(sample_data_with_missing)
         result = PythonDictMissingValueFeatureGroup.calculate_feature(data_copy, feature_set_multiple)
 
         # Check that all imputed features are present
-        assert "income__mean_imputed" in result[0]
-        assert "age__median_imputed" in result[0]
-        assert "category__mode_imputed" in result[0]
-        assert "temperature__ffill_imputed" in result[0]
+        assert "income__mean_imputed" in result
+        assert "age__median_imputed" in result
+        assert "category__mode_imputed" in result
+        assert "temperature__ffill_imputed" in result
 
         # Check some specific values
         expected_mean = 61666.67
-        assert abs(result[1]["income__mean_imputed"] - expected_mean) < 0.1
+        assert abs(result["income__mean_imputed"][1] - expected_mean) < 0.1
 
         # Median age of [30, 25, 45] = 30
-        assert result[2]["age__median_imputed"] == 30
-        assert result[4]["age__median_imputed"] == 30
+        assert result["age__median_imputed"][2] == 30
+        assert result["age__median_imputed"][4] == 30
 
         # Mode category of ["A", "B", "A"] = "A"
-        assert result[1]["category__mode_imputed"] == "A"
-        assert result[4]["category__mode_imputed"] == "A"
+        assert result["category__mode_imputed"][1] == "A"
+        assert result["category__mode_imputed"][4] == "A"
 
     def test_calculate_feature_constant(
-        self, sample_data_with_missing: list[dict[str, Any]], feature_set_constant: FeatureSet
+        self, sample_data_with_missing: dict[str, Any], feature_set_constant: FeatureSet
     ) -> None:
         """Test calculate_feature method with constant imputation."""
-        data_copy = [row.copy() for row in sample_data_with_missing]
+        data_copy = _copy_columnar(sample_data_with_missing)
         result = PythonDictMissingValueFeatureGroup.calculate_feature(data_copy, feature_set_constant)
 
         # Check that the result contains the imputed feature
-        assert "category__constant_imputed" in result[0]
-        assert result[1]["category__constant_imputed"] == "Unknown"
-        assert result[4]["category__constant_imputed"] == "Unknown"
+        assert "category__constant_imputed" in result
+        assert result["category__constant_imputed"][1] == "Unknown"
+        assert result["category__constant_imputed"][4] == "Unknown"
 
     def test_calculate_feature_grouped(
-        self, sample_data_with_missing: list[dict[str, Any]], feature_set_grouped: FeatureSet
+        self, sample_data_with_missing: dict[str, Any], feature_set_grouped: FeatureSet
     ) -> None:
         """Test calculate_feature method with grouped imputation."""
-        data_copy = [row.copy() for row in sample_data_with_missing]
+        data_copy = _copy_columnar(sample_data_with_missing)
         result = PythonDictMissingValueFeatureGroup.calculate_feature(data_copy, feature_set_grouped)
 
         # Check that the result contains the imputed feature
-        assert "income__mean_imputed" in result[0]
+        assert "income__mean_imputed" in result
 
         # Group X: [50000, 75000, 60000] -> mean = 61666.67
         # Group Y: [None, None] -> no mean, should get overall mean
         overall_mean = 61666.67
-        assert abs(result[0]["income__mean_imputed"] - 50000) < 0.1  # Original value
-        assert abs(result[1]["income__mean_imputed"] - overall_mean) < 0.1  # Imputed
-        assert abs(result[2]["income__mean_imputed"] - 75000) < 0.1  # Original value
-        assert abs(result[3]["income__mean_imputed"] - overall_mean) < 0.1  # Imputed
-        assert abs(result[4]["income__mean_imputed"] - 60000) < 0.1  # Original value
+        imputed = result["income__mean_imputed"]
+        assert abs(imputed[0] - 50000) < 0.1  # Original value
+        assert abs(imputed[1] - overall_mean) < 0.1  # Imputed
+        assert abs(imputed[2] - 75000) < 0.1  # Original value
+        assert abs(imputed[3] - overall_mean) < 0.1  # Imputed
+        assert abs(imputed[4] - 60000) < 0.1  # Original value
 
-    def test_calculate_feature_missing_source(self, sample_data_with_missing: list[dict[str, Any]]) -> None:
+    def test_calculate_feature_missing_source(self, sample_data_with_missing: dict[str, Any]) -> None:
         """Test calculate_feature method with missing source feature."""
         feature_set = FeatureSet()
         feature_set.add(Feature("missing__mean_imputed"))
 
-        data_copy = [row.copy() for row in sample_data_with_missing]
+        data_copy = _copy_columnar(sample_data_with_missing)
         with pytest.raises(ValueError, match="Source features not found in data"):
             PythonDictMissingValueFeatureGroup.calculate_feature(data_copy, feature_set)
 
-    def test_calculate_feature_constant_without_value(self, sample_data_with_missing: list[dict[str, Any]]) -> None:
+    def test_calculate_feature_constant_without_value(self, sample_data_with_missing: dict[str, Any]) -> None:
         """Test calculate_feature method with constant imputation but no constant value."""
         feature_set = FeatureSet()
         feature_set.add(Feature("category__constant_imputed"))
 
-        data_copy = [row.copy() for row in sample_data_with_missing]
+        data_copy = _copy_columnar(sample_data_with_missing)
         with pytest.raises(ValueError, match="Constant value must be provided for constant imputation method"):
             PythonDictMissingValueFeatureGroup.calculate_feature(data_copy, feature_set)
 

--- a/tests/test_plugins/feature_group/experimental/test_text_cleaning/test_text_cleaning_python_dict.py
+++ b/tests/test_plugins/feature_group/experimental/test_text_cleaning/test_text_cleaning_python_dict.py
@@ -52,39 +52,30 @@ class PythonDictTextCleaningTestDataCreator(ATestDataCreator):
         }
 
     @classmethod
-    def transform_format_for_testing(cls, data: dict[str, Any]) -> list[dict[str, Any]]:
-        """Transform the data to PythonDict format (List[Dict[str, Any]])."""
-        # Convert columnar format to row-based format
-        if not data:
-            return []
+    def transform_format_for_testing(cls, data: dict[str, Any]) -> dict[str, Any]:
+        """PythonDict's native format is already columnar; return it unchanged."""
+        return data
 
-        # Get the length from the first column
-        first_key = next(iter(data.keys()))
-        length = len(data[first_key])
 
-        # Verify all columns have the same length
-        for key, values in data.items():
-            if len(values) != length:
-                raise ValueError(
-                    f"All columns must have the same length. Column '{key}' has length {len(values)}, expected {length}"
-                )
-
-        return [{key: data[key][i] for key in data.keys()} for i in range(length)]
+def _copy_columnar(data: dict[str, Any]) -> dict[str, Any]:
+    """Deep-copy a columnar dict so tests don't mutate the shared fixture."""
+    return {key: list(values) for key, values in data.items()}
 
 
 class TestPythonDictTextCleaningFeatureGroup:
     """Tests for the PythonDictTextCleaningFeatureGroup implementation."""
 
     def setup_method(self) -> None:
-        """Set up test data."""
-        # Create test data
-        self.data = [
-            {"text": "Hello World!"},
-            {"text": "TESTING text normalization"},
-            {"text": "This is a test with punctuation, special chars, and extra   spaces."},
-            {"text": "Visit https://example.com or email test@example.com"},
-            {"text": "This contains stopwords like the and is and a"},
-        ]
+        """Set up columnar test data."""
+        self.data = {
+            "text": [
+                "Hello World!",
+                "TESTING text normalization",
+                "This is a test with punctuation, special chars, and extra   spaces.",
+                "Visit https://example.com or email test@example.com",
+                "This contains stopwords like the and is and a",
+            ]
+        }
 
     def test_compute_framework_rule(self) -> None:
         """Test compute_framework_rule method."""
@@ -103,33 +94,32 @@ class TestPythonDictTextCleaningFeatureGroup:
 
         # Empty data
         with pytest.raises(ValueError, match="Data cannot be empty"):
-            PythonDictTextCleaningFeatureGroup._check_source_features_exist([], ["text"])
+            PythonDictTextCleaningFeatureGroup._check_source_features_exist({}, ["text"])
 
     def test_get_source_text(self) -> None:
         """Test that the source text is correctly retrieved."""
         result = PythonDictTextCleaningFeatureGroup._get_source_text(self.data, "text")
 
         assert isinstance(result, list)
-        assert len(result) == len(self.data)
+        assert len(result) == len(self.data["text"])
         assert result[0] == "Hello World!"
         assert result[1] == "TESTING text normalization"
 
         # Test with None values
-        data_with_none: list[dict[str, Any]] = [{"text": "Hello"}, {"text": None}, {"text": "World"}]
+        data_with_none: dict[str, Any] = {"text": ["Hello", None, "World"]}
         result_with_none = PythonDictTextCleaningFeatureGroup._get_source_text(data_with_none, "text")
         assert result_with_none == ["Hello", "", "World"]
 
     def test_add_result_to_data(self) -> None:
         """Test that the result is correctly added to the data."""
         result = ["test1", "test2", "test3", "test4", "test5"]
-        data_copy = [row.copy() for row in self.data]
+        data_copy = _copy_columnar(self.data)
 
         updated_data = PythonDictTextCleaningFeatureGroup._add_result_to_data(data_copy, "new_column", result)
 
-        assert len(updated_data) == len(self.data)
-        assert "new_column" in updated_data[0]
-        assert updated_data[0]["new_column"] == "test1"
-        assert updated_data[4]["new_column"] == "test5"
+        assert "new_column" in updated_data
+        assert updated_data["new_column"][0] == "test1"
+        assert updated_data["new_column"][4] == "test5"
 
         # Test mismatched lengths
         with pytest.raises(ValueError, match="Result length 3 does not match data length 5"):
@@ -227,13 +217,13 @@ class TestPythonDictTextCleaningFeatureGroup:
         feature_set.add(feature)
 
         # Apply feature
-        data_copy = [row.copy() for row in self.data]
+        data_copy = _copy_columnar(self.data)
         result = PythonDictTextCleaningFeatureGroup.calculate_feature(data_copy, feature_set)
 
         # Check results
-        assert "text__cleaned_text" in result[0]
-        assert result[0]["text__cleaned_text"] == "hello world!"
-        assert result[1]["text__cleaned_text"] == "testing text normalization"
+        assert "text__cleaned_text" in result
+        assert result["text__cleaned_text"][0] == "hello world!"
+        assert result["text__cleaned_text"][1] == "testing text normalization"
 
     def test_calculate_feature_multiple_operations(self) -> None:
         """Test calculate_feature with multiple operations."""
@@ -254,14 +244,14 @@ class TestPythonDictTextCleaningFeatureGroup:
         feature_set.add(feature)
 
         # Apply feature
-        data_copy = [row.copy() for row in self.data]
+        data_copy = _copy_columnar(self.data)
         result = PythonDictTextCleaningFeatureGroup.calculate_feature(data_copy, feature_set)
 
         # Check results
-        assert "text__cleaned_text" in result[0]
-        assert result[0]["text__cleaned_text"] == "hello world"  # Lowercase and no punctuation
-        assert "," not in result[2]["text__cleaned_text"]  # No punctuation
-        assert "   " not in result[2]["text__cleaned_text"]  # No extra spaces
+        assert "text__cleaned_text" in result
+        assert result["text__cleaned_text"][0] == "hello world"  # Lowercase and no punctuation
+        assert "," not in result["text__cleaned_text"][2]  # No punctuation
+        assert "   " not in result["text__cleaned_text"][2]  # No extra spaces
 
     def test_calculate_feature_missing_source(self) -> None:
         """Test calculate_feature with a missing source feature."""
@@ -278,7 +268,7 @@ class TestPythonDictTextCleaningFeatureGroup:
         feature_set.add(feature)
 
         # Apply feature
-        data_copy = [row.copy() for row in self.data]
+        data_copy = _copy_columnar(self.data)
         with pytest.raises(ValueError) as excinfo:
             PythonDictTextCleaningFeatureGroup.calculate_feature(data_copy, feature_set)
 
@@ -299,7 +289,7 @@ class TestPythonDictTextCleaningFeatureGroup:
         feature_set.add(feature)
 
         # Apply feature
-        data_copy = [row.copy() for row in self.data]
+        data_copy = _copy_columnar(self.data)
         with pytest.raises(ValueError) as excinfo:
             PythonDictTextCleaningFeatureGroup.calculate_feature(data_copy, feature_set)
 
@@ -343,24 +333,22 @@ class TestTextCleaningPythonDictIntegration:
         # Validate that the text cleaning features are present
         assert len(result) == 2, "Expected 2 results: one for original data and one for cleaned features"
 
-        # Result is a list of dictionaries (PythonDict format)
-        data = result[1]  # Get the first result (which is the list of rows)
-        first_row = data[0]  # Get the first row
+        # Result is a columnar dict (PythonDict format)
+        data = result[1]
 
         # Check that cleaning was applied (text should be lowercase and without punctuation)
-        assert first_row["text__cleaned_text"] == "hello world"
-        assert "!" not in first_row["review__cleaned_text"]
-        assert first_row["review__cleaned_text"].islower()
+        assert data["text__cleaned_text"][0] == "hello world"
+        assert "!" not in data["review__cleaned_text"][0]
+        assert data["review__cleaned_text"][0].islower()
 
         # Check that cleaned features are present
-        assert "text__cleaned_text" in first_row
-        assert "review__cleaned_text" in first_row
-        assert "description__cleaned_text" in first_row
+        assert "text__cleaned_text" in data
+        assert "review__cleaned_text" in data
+        assert "description__cleaned_text" in data
 
         data = result[0]
-        first_row = data[0]
 
         # Check that original features are present
-        assert "text" in first_row
-        assert "review" in first_row
-        assert "description" in first_row
+        assert "text" in data
+        assert "review" in data
+        assert "description" in data

--- a/tests/test_plugins/feature_group/experimental/test_time_window_feature_group/test_global_filter_tz_aware_time_range.py
+++ b/tests/test_plugins/feature_group/experimental/test_time_window_feature_group/test_global_filter_tz_aware_time_range.py
@@ -180,13 +180,10 @@ def test_python_dict_tz_aware_time_range_filter() -> None:
 
         @classmethod
         def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-            return [
-                {
-                    "temperature": TEMPERATURES[i],
-                    DefaultOptionKeys.reference_time: TIMESTAMPS_UTC[i],
-                }
-                for i in range(len(TIMESTAMPS_UTC))
-            ]
+            return {
+                "temperature": list(TEMPERATURES),
+                DefaultOptionKeys.reference_time: list(TIMESTAMPS_UTC),
+            }
 
         @classmethod
         def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
@@ -204,17 +201,17 @@ def test_python_dict_tz_aware_time_range_filter() -> None:
         global_filter=global_filter,
     )
 
-    rows = None
+    frame = None
     for candidate in result:
-        if candidate and isinstance(candidate, list) and "temperature" in candidate[0]:
-            rows = candidate
+        if isinstance(candidate, dict) and "temperature" in candidate:
+            frame = candidate
             break
 
-    assert rows is not None, "python_dict result with temperature column not found"
+    assert frame is not None, "python_dict result with temperature column not found"
 
-    actual_temps = sorted(row["temperature"] for row in rows)
+    actual_temps = sorted(frame["temperature"])
     assert actual_temps == EXPECTED_TEMPERATURES
-    assert len(rows) == EXPECTED_ROW_COUNT
+    assert len(frame["temperature"]) == EXPECTED_ROW_COUNT
 
 
 @pytest.mark.skipif(pl is None, reason="Polars is not installed")


### PR DESCRIPTION
## What

Switch the PythonDict compute framework's native representation from row-wise `list[dict]` to columnar `dict[str, list]`, and retire `FeatureGroup.allow_empty_result()`.

Implements direction E from the analysis in #525 (follow-up to #492 / #497).

## Why

PythonDict stored the schema implicitly inside each row's keys, so an empty result `[]` carried no schema (zero columns). That made empty-result semantics backend-dependent: `{"col": []}` succeeds on PyArrow/Pandas/Polars/DuckDB/etc. (schema survives at zero rows) but collapsed to a schema-less `[]` on PythonDict, which is why `allow_empty_result()` existed as a PythonDict-specific escape hatch.

Columnar `dict[str, list]` keeps the schema in the top-level keys, present even at zero rows:

- `{"col": []}` is a valid, schema-bearing empty result (zero rows, one known column).
- `{}` is the only schema-less value (zero columns).

This makes empty-result semantics uniform across every backend, so `allow_empty_result()` is no longer needed and is removed. A zero-column `{}` result for a requested feature now raises `EmptyResultError` uniformly; a zero-row result with columns succeeds everywhere with no opt-in. The non-tabular domains that motivated the flag (knowledge graphs, search, memory, authz) now return schema-bearing empties without a subclass or flag.

## Changes

- Framework: `expected_data_framework()` returns `dict`; `transform`, extract helpers, and `select_data_by_column_names` are columnar; `_is_schemaless_empty` is true only for `{}`.
- PyArrow transformer: `pa.table(columnar)` / `to_pydict()`, so column names survive the Arrow Flight (multiprocessing) round trip at zero rows.
- Filter, mask, and merge engines rewritten columnar (all join types and asof).
- Core: `allow_empty_result()` removed from `FeatureGroup`; the output guard raises `EmptyResultError` on a zero-column final result with no opt-in.
- The two PythonDict plugin FeatureGroups (missing value, text cleaning) and the affected tests/docs updated to the columnar contract.

## Review fixes (round 1)

Two independent deep reviews (Claude Opus and codex) ran on the initial implementation. Accepted findings, all fixed and covered by regression tests:

- Normalize a FeatureGroup's output to the native representation before `run_final_filter`, so a PythonDict FG returning `list[dict]` plus a final filter no longer hits the columnar filter engine with row data.
- Add a `validate_native_data` hook (default no-op) for the path where `transform` is skipped because the result is already the native type; PythonDict overrides it to enforce the columnar contract, so a malformed dict like `{"a": 1}` raises instead of being stored and corrupting later joins / the pyarrow upload.
- Fix the mask engine so a mask over a missing column is a row-count-length all-False mask instead of a zero-length list (previously `combine` could silently truncate to zero rows).

## Review fixes (round 2)

A verified deep review of the branch surfaced eight findings; all accepted and fixed:

- `do_min_filter` accepts only the canonical `value` parameter again. The first version added a PythonDict-only fallback to the `min` key, which made the same filter spec succeed on PythonDict and raise on pandas/pyarrow/polars. No fallbacks: the spec `("min", {"value": 2})` is the one canonical form on every framework.
- Masks over a missing column are now unconditionally all-False at row-count length, closing the `equal(col, None)` / `is_in(col, [None])` hole where None placeholders matched None values and silently selected every row.
- `select_data_by_column_names` returns copied column lists, so a collected result can no longer alias (and mutate) the framework's live columns.
- New `python_dict_utils.py` with shared `row_count` and validated `rows_to_columnar` helpers replaces four private `_row_count` copies and the divergent row-to-columnar pivots; ragged `list[dict]` input now fails with the clear `Inconsistent row keys` ValueError everywhere instead of a raw KeyError in the filter engine. The merge engine keeps its own None-filling pivot because join outputs are ragged by design.
- Stale docs fixed: the troubleshooting guide no longer instructs overriding the removed `allow_empty_result()`; the `Allowing Empty Results` heading and its anchors were renamed; the test-tooling module docstrings and `POLICY_CONFORMANCE.md` now describe the schema-based contract; the red-phase docstrings in the list-dict filter regression tests were rewritten to describe the merged behavior.

## Breaking changes

Deliberate (accepted: small user base):

- PythonDict's native representation is now columnar `dict[str, list]` instead of `list[dict]`. Results from `run_all` for PythonDict features are columnar.
- `FeatureGroup.allow_empty_result()` is removed. Downstream plugins that overrode it should delete the override; empty-result behavior is now schema-based and uniform.
- Row-wise `list[dict]` FeatureGroup output is still auto-normalized to columnar, but only when every row has identical keys. Sparse rows such as `[{"a": 1, "b": 2}, {"a": 3}]` (previously tolerated via union-of-keys) now raise `ValueError: Inconsistent row keys at index 1`. Represent missing values explicitly as `None`.

## Versioning

The branch is squashed into a single `minor:` commit so semantic-release bumps the minor version (this repo bumps minor only on `minor:` commits; `feat:` is a patch).

## Testing

Full `tox` green: 3911 passed, 167 skipped, `ruff format --check`, `ruff check`, license allowlist, `mypy --strict`, and bandit all pass. The `run_all` policy-conformance harness (#521 / #528) validates empty-result behavior across all backends and parallelization modes.
