### PR TITLE
fix: import typing helpers before first annotated example in data-type-enforcement doc

### DIFF
--- a/docs/docs/in_depth/data-type-enforcement.md
+++ b/docs/docs/in_depth/data-type-enforcement.md
@@ -96,6 +96,8 @@ In strict mode, only exact type matches or standard widening conversions are all
 Enforcement is driven by a single override point on `ComputeFramework`:
 
 ```python
+from typing import Any, Optional
+
 def _extract_column_data_type(self, data: Any, column_name: str) -> Optional[DataType]:
     ...
 ```
@@ -120,7 +122,6 @@ The contract:
 A custom framework imports `DataType` from the public API:
 
 ```python
-from typing import Any, Optional
 from mloda.user import DataType
 from mloda.provider import ComputeFramework
 


### PR DESCRIPTION
## Summary
- `docs/docs/in_depth/data-type-enforcement.md` used `Any`/`Optional` in a signature-only example before the `typing` import that appeared later in the file.
- `mktestdocs` executes a doc's `python` code blocks cumulatively in file order, and annotations are evaluated eagerly on Python 3.10-3.13, so `tests/test_documentation/test_documentation.py::test_files_good[docs/docs/in_depth/data-type-enforcement.md]` raised `NameError: name 'Any' is not defined` on those versions.
- Move the import above its first use.

Related: this overlaps with the `data-type-enforcement.md` half of #553; the `data-quality.md` half of that PR is already covered by #567, so it isn't included here.

## Tests
- `pytest "tests/test_documentation/test_documentation.py::test_files_good[docs/docs/in_depth/data-type-enforcement.md]"` (Python 3.12): fails on current main without this change, passes with it
- `pytest tests/test_documentation/test_documentation.py -q`: 144 passed