### PR TITLE
fix: re-attribute data-type-enforcement doc import fix to original author

### DIFF
--- a/docs/docs/in_depth/data-type-enforcement.md
+++ b/docs/docs/in_depth/data-type-enforcement.md
@@ -7,6 +7,7 @@ mloda supports optional data type declarations on Features, enabling runtime val
 Use typed constructors to declare the expected data type:
 
 ```python
+from typing import Any, Optional
 from mloda.user import Feature
 
 # Typed features - will be validated at runtime
@@ -96,8 +97,6 @@ In strict mode, only exact type matches or standard widening conversions are all
 Enforcement is driven by a single override point on `ComputeFramework`:
 
 ```python
-from typing import Any, Optional
-
 def _extract_column_data_type(self, data: Any, column_name: str) -> Optional[DataType]:
     ...
 ```


### PR DESCRIPTION
## Summary
- #584 fixed the same `NameError` in `docs/docs/in_depth/data-type-enforcement.md` that @Ola-Yeenca had already correctly diagnosed and fixed in #553, just with the import placed at a different line.
- This PR reverts #584 and re-lands the fix using Ola Yeenca's original commit from #553 (cherry-picked, author preserved), so the fix is properly attributed to the person who found and fixed it first.
- The `data-quality.md` half of #553 is intentionally not included: it's already covered by #567 with a different (already-merged) approach, so that hunk is dropped to avoid reintroducing a stale duplicate.
- Net effect on `main` after merge: identical behavior to #584, only the import's line position within the file and the commit authorship differ.

## Tests
- `pytest tests/test_documentation/test_documentation.py -q` (Python 3.12): 144 passed
- `pytest "tests/test_documentation/test_documentation.py::test_files_good[docs/docs/in_depth/data-type-enforcement.md]"`: passed

Closes #553 (superseded, but the original diagnosis/fix is landed here).