### PR TITLE
fix: preserve original worker exception type in run_all

### DIFF
--- a/mloda/core/abstract_plugins/components/error_utils.py
+++ b/mloda/core/abstract_plugins/components/error_utils.py
@@ -1,6 +1,12 @@
 REPORT_URL = "https://github.com/mloda-ai/mloda/issues"
 
 
+class MlodaRunError(Exception):
+    """Raised by mlodaAPI when a worker step failed and the original exception
+    object could not be preserved (e.g. the internal critical error_out path,
+    or a non-picklable exception crossing a process boundary)."""
+
+
 def internal_invariant_error(
     invariant: str,
     actual_values: str = "",

--- a/mloda/core/core/cfw_manager.py
+++ b/mloda/core/core/cfw_manager.py
@@ -49,6 +49,7 @@ class CfwManager:
         self.error = False  # multiprocessing error flag
         self.msg: Any = None
         self.exc_info: Any = None
+        self.exception: Any = None
 
         self.uuid_column_names: dict[UUID, set[str]] = {}  # We only set this in case of TransformFrameworkStep
         self.uuid_flyway_datasets: dict[UUID, set[UUID]] = {}
@@ -179,15 +180,20 @@ class CfwManager:
         """Retrieves the set of parallelization modes."""
         return self.parallelization_modes
 
-    def set_error(self, msg: Any, exc_info: Any) -> None:
+    def set_error(self, msg: Any, exc_info: Any, exception: Any = None) -> None:
         """Sets an error message and exception information."""
         self.error = True
         self.msg = msg
         self.exc_info = exc_info
+        self.exception = exception
 
     def get_error(self) -> bool:
         """Retrieves the error flag."""
         return self.error
+
+    def get_error_exception(self) -> Any:
+        """Retrieves the original exception object, if captured."""
+        return self.exception
 
     def get_error_msg(self) -> Any:
         """Retrieves the error message."""

--- a/mloda/core/runtime/compute_framework_executor.py
+++ b/mloda/core/runtime/compute_framework_executor.py
@@ -265,7 +265,7 @@ class ComputeFrameworkExecutor:
             msg = f"{error_message}\nFull traceback:\n{traceback.format_exc()}"
             logging.error(msg)
             exc_info = traceback.format_exc()
-            self.cfw_register.set_error(msg, exc_info)
+            self.cfw_register.set_error(msg, exc_info, exception=e)
 
     def thread_execute_step(self, step: Any) -> None:
         """

--- a/mloda/core/runtime/run.py
+++ b/mloda/core/runtime/run.py
@@ -22,6 +22,7 @@ from mloda.core.core.step.feature_group_step import FeatureGroupStep
 from mloda.core.core.step.join_step import JoinStep
 from mloda.core.core.step.transform_frame_work_step import TransformFrameworkStep
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+from mloda.core.abstract_plugins.components.error_utils import MlodaRunError
 
 
 logger = logging.getLogger(__name__)
@@ -135,7 +136,10 @@ class ExecutionOrchestrator:
             error = self.cfw_register.get_error()
             if error:
                 logger.error(self.cfw_register.get_error_exc_info())
-                raise Exception(self.cfw_register.get_error_exc_info(), self.cfw_register.get_error_msg())
+                original = self.cfw_register.get_error_exception()
+                if isinstance(original, BaseException):
+                    raise original
+                raise MlodaRunError(self.cfw_register.get_error_msg())
             return False
         return True
 

--- a/mloda/core/runtime/worker/multiprocessing_worker.py
+++ b/mloda/core/runtime/worker/multiprocessing_worker.py
@@ -141,7 +141,13 @@ def worker(
             logging.error(msg)
             exc_info = traceback.format_exc()
             if cfw_register:
-                cfw_register.set_error(msg, exc_info, exception=e)
+                try:
+                    cfw_register.set_error(msg, exc_info, exception=e)
+                except Exception:
+                    # The exception object is not picklable across the manager
+                    # proxy; degrade to the string-only path (surfaces as MlodaRunError)
+                    # rather than let this raise and skip the STOP below (which would hang the run).
+                    cfw_register.set_error(msg, exc_info)
 
             _handle_stop_command(command_queue)
             break

--- a/mloda/core/runtime/worker/multiprocessing_worker.py
+++ b/mloda/core/runtime/worker/multiprocessing_worker.py
@@ -141,7 +141,7 @@ def worker(
             logging.error(msg)
             exc_info = traceback.format_exc()
             if cfw_register:
-                cfw_register.set_error(msg, exc_info)
+                cfw_register.set_error(msg, exc_info, exception=e)
 
             _handle_stop_command(command_queue)
             break

--- a/mloda/core/runtime/worker/thread_worker.py
+++ b/mloda/core/runtime/worker/thread_worker.py
@@ -16,5 +16,5 @@ def thread_worker(command: Any, cfw_register: Any, cfw: ComputeFramework, from_c
         error_message = f"An error occurred: {e}"
         msg = f"{error_message}\nFull traceback:\n{traceback.format_exc()}"
         exc_info = traceback.format_exc()
-        cfw_register.set_error(msg, exc_info)
-        raise Exception(msg, exc_info)
+        cfw_register.set_error(msg, exc_info, exception=e)
+        raise

--- a/tests/test_core/test_integration/test_core/test_datatype_enforcement.py
+++ b/tests/test_core/test_integration/test_core/test_datatype_enforcement.py
@@ -489,7 +489,7 @@ class TestStrictTypeEnforcementPropagation:
             )
         assert "INT32" in str(exc_info.value)
         assert "INT64" in str(exc_info.value)
-        assert "DataTypeMismatchError" in str(exc_info.value)
+        assert isinstance(exc_info.value, DataTypeMismatchError)
 
         # LENIENT MODE: Should pass because numeric types are interchangeable
         result = MlodaTestRunner.run_api(
@@ -551,4 +551,4 @@ class TestStrictTypeEnforcementPropagation:
         assert "BaseFG" in str(exc_info.value)
         assert "INT32" in str(exc_info.value)
         assert "INT64" in str(exc_info.value)
-        assert "DataTypeMismatchError" in str(exc_info.value)
+        assert isinstance(exc_info.value, DataTypeMismatchError)

--- a/tests/test_core/test_runtime/test_exception_preservation.py
+++ b/tests/test_core/test_runtime/test_exception_preservation.py
@@ -20,6 +20,7 @@ and because ``MlodaRunError`` does not yet exist.
 
 from __future__ import annotations
 
+import threading
 from typing import Any, Optional
 
 import pytest
@@ -230,3 +231,89 @@ def test_check_for_error_raises_mloda_run_error_when_no_exception_captured() -> 
 
     with pytest.raises(MlodaRunError):
         orchestrator._check_for_error()
+
+
+# --------------------------------------------------------------------------- #
+# 6. MULTIPROCESSING: picklable vs non-picklable worker exceptions (issue #563
+#    regression guard). In MULTIPROCESSING mode ``cfw_register`` is a
+#    ``multiprocessing.managers`` proxy, so ``set_error(exception=e)`` PICKLES
+#    the exception. A picklable exception type must survive (already works). A
+#    NON-picklable exception must NOT hang the orchestrator loop: the worker's
+#    except block must still send STOP so ``run_all`` raises promptly instead of
+#    freezing.
+# --------------------------------------------------------------------------- #
+
+
+class UnpicklableError(RuntimeError):
+    """A RuntimeError whose instance carries a non-picklable payload.
+
+    ``threading.Lock()`` cannot be pickled, so ``set_error(exception=self)`` on
+    the multiprocessing manager proxy fails to serialize this instance.
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.lock = threading.Lock()  # not picklable
+
+
+class UnpicklableErrorFeatureGroup(FeatureGroup):
+    """Root FG whose ``calculate_feature`` raises a non-picklable exception."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={"exc_unpicklable_col"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        raise UnpicklableError("boom")
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return {"exc_unpicklable_col"}
+
+
+_ENABLED_UNPICKLABLE = PluginCollector.enabled_feature_groups({UnpicklableErrorFeatureGroup})
+
+
+def test_multiprocessing_preserves_picklable_exception_type(flight_server: Any) -> None:
+    """MULTIPROCESSING ``run_all`` must surface the original ``ImportError`` type.
+
+    Regression guard: a PICKLABLE worker exception round-trips through the
+    ``multiprocessing.managers`` proxy in ``set_error(exception=e)`` and is
+    re-raised with its original type. This already passes today; it pins that
+    the forthcoming pickle-failure guard does not degrade the happy path.
+    """
+    with pytest.raises(ImportError, match="bm25s"):
+        mloda.run_all(
+            [Feature(name="exc_import_error_col")],
+            compute_frameworks=["PythonDictFramework"],
+            plugin_collector=_ENABLED_IMPORT_ERROR,
+            parallelization_modes={ParallelizationMode.MULTIPROCESSING},
+            flight_server=flight_server,
+        )
+
+
+@pytest.mark.timeout(15)
+def test_multiprocessing_unpicklable_exception_does_not_hang(flight_server: Any) -> None:
+    """A NON-picklable worker exception must not hang the orchestrator loop.
+
+    FAILS today: in MULTIPROCESSING mode ``cfw_register`` is a manager proxy, so
+    ``set_error(exception=e)`` tries to PICKLE the ``UnpicklableError`` instance
+    (it holds a ``threading.Lock``). Pickling raises inside the worker's except
+    block BEFORE STOP is sent, so the orchestrator loop never terminates and the
+    run HANGS. The ``@pytest.mark.timeout(15)`` turns that hang into a red
+    ``Failed`` state instead of freezing the suite.
+
+    The requirement: ``run_all`` must RAISE (any Exception) PROMPTLY. Once the
+    production guard degrades ``set_error(exception=e)`` to ``set_error(msg,
+    exc_info)`` on pickle failure, this surfaces as ``MlodaRunError`` and the
+    test passes without timing out.
+    """
+    with pytest.raises(Exception):
+        mloda.run_all(
+            [Feature(name="exc_unpicklable_col")],
+            compute_frameworks=["PythonDictFramework"],
+            plugin_collector=_ENABLED_UNPICKLABLE,
+            parallelization_modes={ParallelizationMode.MULTIPROCESSING},
+            flight_server=flight_server,
+        )

--- a/tests/test_core/test_runtime/test_exception_preservation.py
+++ b/tests/test_core/test_runtime/test_exception_preservation.py
@@ -1,0 +1,232 @@
+"""Failing tests for GitHub issue #563: preserve original exception type and cause.
+
+``mlodaAPI.run_all`` currently wraps any worker-step exception in a bare
+``Exception(exc_info, msg)`` (see ``mloda/core/runtime/run.py`` ->
+``ExecutionOrchestrator._check_for_error``). This drops the original exception
+TYPE and the ``__cause__`` chain, so a caller cannot write
+``except ImportError:`` / ``except ValueError:`` around ``run_all``.
+
+These tests define the intended behavior:
+
+* The specific stdlib / custom exception type raised inside ``calculate_feature``
+  must survive out of ``run_all`` (SYNC and THREADING).
+* The ``__cause__`` chain must be preserved.
+* A typed fallback ``MlodaRunError`` must exist and be raised when no original
+  exception object was captured (e.g. the internal ``error_out`` critical path).
+
+They FAIL today because ``run_all`` surfaces a bare ``Exception`` (wrong type)
+and because ``MlodaRunError`` does not yet exist.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import pytest
+
+from mloda.provider import BaseInputData
+from mloda.provider import DataCreator
+from mloda.provider import FeatureGroup
+from mloda.provider import FeatureSet
+from mloda.user import Feature
+from mloda.user import ParallelizationMode
+from mloda.user import PluginCollector
+from mloda.user import mloda
+
+# Importing the framework registers it as a ComputeFramework subclass so
+# ``compute_frameworks=["PythonDictFramework"]`` resolves during ``run_all``.
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (  # noqa: F401
+    PythonDictFramework,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Minimal root FeatureGroups whose calculate_feature raises a chosen error type
+# --------------------------------------------------------------------------- #
+
+
+class ImportErrorFeatureGroup(FeatureGroup):
+    """Root FG whose ``calculate_feature`` raises a stdlib ``ImportError``."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={"exc_import_error_col"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        raise ImportError("optional backend 'bm25s' missing")
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return {"exc_import_error_col"}
+
+
+class MyDomainError(ValueError):
+    """Custom domain error that is also a ``ValueError`` subclass."""
+
+
+class DomainErrorFeatureGroup(FeatureGroup):
+    """Root FG whose ``calculate_feature`` raises a ``ValueError`` subclass."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={"exc_domain_error_col"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        raise MyDomainError("domain rule violated")
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return {"exc_domain_error_col"}
+
+
+class CauseChainFeatureGroup(FeatureGroup):
+    """Root FG that raises ``ValueError`` from a ``KeyError`` (``__cause__`` chain)."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={"exc_cause_chain_col"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        raise ValueError("boom") from KeyError("root")
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return {"exc_cause_chain_col"}
+
+
+_ENABLED_IMPORT_ERROR = PluginCollector.enabled_feature_groups({ImportErrorFeatureGroup})
+_ENABLED_DOMAIN_ERROR = PluginCollector.enabled_feature_groups({DomainErrorFeatureGroup})
+_ENABLED_CAUSE_CHAIN = PluginCollector.enabled_feature_groups({CauseChainFeatureGroup})
+
+
+# --------------------------------------------------------------------------- #
+# 1. SYNC mode type preservation
+# --------------------------------------------------------------------------- #
+
+
+def test_sync_preserves_import_error_type() -> None:
+    """SYNC ``run_all`` must surface the original ``ImportError`` type, not a bare Exception.
+
+    FAILS today: ``_check_for_error`` raises a bare ``Exception`` so
+    ``pytest.raises(ImportError)`` does not match and the Exception propagates.
+    """
+    with pytest.raises(ImportError, match="bm25s"):
+        mloda.run_all(
+            [Feature(name="exc_import_error_col")],
+            compute_frameworks=["PythonDictFramework"],
+            plugin_collector=_ENABLED_IMPORT_ERROR,
+            parallelization_modes={ParallelizationMode.SYNC},
+        )
+
+
+# --------------------------------------------------------------------------- #
+# 2. THREADING mode type preservation
+# --------------------------------------------------------------------------- #
+
+
+def test_threading_preserves_import_error_type(flight_server: Any) -> None:
+    """THREADING ``run_all`` must surface the original ``ImportError`` type.
+
+    FAILS today: the worker error is re-wrapped as a bare ``Exception``.
+    """
+    with pytest.raises(ImportError, match="bm25s"):
+        mloda.run_all(
+            [Feature(name="exc_import_error_col")],
+            compute_frameworks=["PythonDictFramework"],
+            plugin_collector=_ENABLED_IMPORT_ERROR,
+            parallelization_modes={ParallelizationMode.THREADING},
+            flight_server=flight_server,
+        )
+
+
+# --------------------------------------------------------------------------- #
+# 3. Custom ValueError subclass -> the core "except ImportError works" repro
+# --------------------------------------------------------------------------- #
+
+
+def test_sync_preserves_valueerror_subclass() -> None:
+    """A ``ValueError`` subclass must survive so ``except ValueError`` also catches it.
+
+    FAILS today: a bare ``Exception`` is raised, which is not a ``MyDomainError``
+    nor a ``ValueError``.
+    """
+    with pytest.raises(MyDomainError) as excinfo:
+        mloda.run_all(
+            [Feature(name="exc_domain_error_col")],
+            compute_frameworks=["PythonDictFramework"],
+            plugin_collector=_ENABLED_DOMAIN_ERROR,
+            parallelization_modes={ParallelizationMode.SYNC},
+        )
+
+    # The whole point of the issue: broad `except ValueError` must catch it too.
+    assert isinstance(excinfo.value, ValueError)
+
+
+# --------------------------------------------------------------------------- #
+# 4. __cause__ chain preservation
+# --------------------------------------------------------------------------- #
+
+
+def test_sync_preserves_cause_chain() -> None:
+    """The surfaced exception must keep its ``__cause__`` (a ``KeyError`` here).
+
+    FAILS today: the original exception object (with its ``__cause__``) is
+    discarded; a bare ``Exception`` built from a traceback string is raised.
+    """
+    with pytest.raises(ValueError) as excinfo:
+        mloda.run_all(
+            [Feature(name="exc_cause_chain_col")],
+            compute_frameworks=["PythonDictFramework"],
+            plugin_collector=_ENABLED_CAUSE_CHAIN,
+            parallelization_modes={ParallelizationMode.SYNC},
+        )
+
+    assert isinstance(excinfo.value.__cause__, KeyError)
+
+
+# --------------------------------------------------------------------------- #
+# 5. MlodaRunError exists and is the typed fallback
+# --------------------------------------------------------------------------- #
+
+
+def test_mloda_run_error_exists_and_is_exception_subclass() -> None:
+    """``MlodaRunError`` must exist and be an ``Exception`` subclass.
+
+    FAILS today with ImportError: the class does not exist yet.
+    """
+    from mloda.core.abstract_plugins.components.error_utils import MlodaRunError
+
+    assert issubclass(MlodaRunError, Exception)
+
+
+def test_check_for_error_raises_mloda_run_error_when_no_exception_captured() -> None:
+    """``_check_for_error`` must raise the typed ``MlodaRunError`` fallback.
+
+    When a run reports an error but no original exception object was captured
+    (``get_error_exception()`` returns ``None`` -- e.g. the internal critical
+    ``error_out`` path), the loop must raise ``MlodaRunError`` rather than a bare
+    ``Exception``.
+
+    FAILS today with ImportError: ``MlodaRunError`` does not exist. Once it does,
+    this pins that the fallback branch raises the typed error.
+    """
+    from unittest.mock import MagicMock, Mock
+
+    from mloda.core.abstract_plugins.components.error_utils import MlodaRunError
+    from mloda.core.prepare.execution_plan import ExecutionPlan
+    from mloda.core.runtime.run import ExecutionOrchestrator
+
+    orchestrator = ExecutionOrchestrator(Mock(spec=ExecutionPlan))
+
+    cfw_register = MagicMock()
+    cfw_register.get_error.return_value = True
+    cfw_register.get_error_exception.return_value = None
+    cfw_register.get_error_msg.return_value = "critical error_out"
+    cfw_register.get_error_exc_info.return_value = "critical error_out"
+    orchestrator.cfw_register = cfw_register
+
+    with pytest.raises(MlodaRunError):
+        orchestrator._check_for_error()

--- a/tests/test_plugins/compute_framework/base_implementations/pandas/test_pandas_allow_empty_result_run_all.py
+++ b/tests/test_plugins/compute_framework/base_implementations/pandas/test_pandas_allow_empty_result_run_all.py
@@ -69,4 +69,4 @@ def test_zero_column_raises_pandas(flight_server: Any) -> None:
             parallelization_modes={ParallelizationMode.SYNC},
             flight_server=flight_server,
         )
-    assert EmptyResultError.__name__ in str(excinfo.value)
+    assert isinstance(excinfo.value, EmptyResultError)

--- a/tests/test_plugins/compute_framework/base_implementations/pyarrow/test_pyarrow_allow_empty_result_run_all.py
+++ b/tests/test_plugins/compute_framework/base_implementations/pyarrow/test_pyarrow_allow_empty_result_run_all.py
@@ -55,4 +55,4 @@ def test_zero_column_raises_pyarrow(flight_server: Any) -> None:
             parallelization_modes={ParallelizationMode.SYNC},
             flight_server=flight_server,
         )
-    assert EmptyResultError.__name__ in str(excinfo.value)
+    assert isinstance(excinfo.value, EmptyResultError)

--- a/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_columnar_contract.py
+++ b/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_columnar_contract.py
@@ -276,4 +276,4 @@ def test_zero_column_result_raises_without_flag(flight_server: Any) -> None:
             parallelization_modes={ParallelizationMode.SYNC},
             flight_server=flight_server,
         )
-    assert EmptyResultError.__name__ in str(excinfo.value)
+    assert isinstance(excinfo.value, EmptyResultError)

--- a/tests/test_plugins/compute_framework/test_tooling/empty_result_run_all_test_base.py
+++ b/tests/test_plugins/compute_framework/test_tooling/empty_result_run_all_test_base.py
@@ -38,7 +38,6 @@ from typing import Any, Optional
 
 import pytest
 
-from mloda.core.abstract_plugins.compute_framework import EmptyResultError
 from mloda.provider import BaseInputData
 from mloda.provider import DataCreator
 from mloda.provider import FeatureGroup
@@ -197,7 +196,7 @@ class EmptyResultRunAllTestBase(PolicyRunAllTestBase):
 
     def _run_default_case(self, mode: ParallelizationMode, flight_server: Any) -> None:
         if self.default_empty_is_schemaless():
-            expectation: PolicySuccess | PolicyRaises = PolicyRaises(match_substring=EmptyResultError.__name__)
+            expectation: PolicySuccess | PolicyRaises = PolicyRaises(match_substring="Result carries no schema")
         else:
             expectation = PolicySuccess(assert_result=_assert_single_empty_result)
 

--- a/tests/test_plugins/compute_framework/test_tooling/test_policy_run_all_test_base.py
+++ b/tests/test_plugins/compute_framework/test_tooling/test_policy_run_all_test_base.py
@@ -9,7 +9,6 @@ and exercise both the success and raises expectations, in SYNC and in a worker-b
 
 from typing import Any
 
-from mloda.core.abstract_plugins.compute_framework import EmptyResultError
 from mloda.user import ParallelizationMode
 
 from tests.test_plugins.compute_framework.test_tooling.empty_result_run_all_test_base import (
@@ -60,7 +59,7 @@ def test_policy_base_drives_raises_case(flight_server: Any) -> None:
     result = conformance.assert_policy_case(
         feature_name="empty_result_schemaless_col",
         plugin_collector=_ENABLED_SCHEMALESS_ALLOWED,
-        expectation=PolicyRaises(match_substring=EmptyResultError.__name__),
+        expectation=PolicyRaises(match_substring="Result carries no schema"),
         mode=ParallelizationMode.SYNC,
         flight_server=flight_server,
     )


### PR DESCRIPTION
## Summary

Fixes #563. `mlodaAPI.run_all` wrapped any failing worker-step exception in a bare `Exception(msg, exc_info)`, dropping the original exception type and `__cause__` chain. Callers could not `except ImportError:` / `except ValueError:` around a run, and had to pre-probe with `importlib.util.find_spec` to gate optional dependencies.

Now the original exception is carried across the worker boundary and re-raised, preserving its type and cause. When no original exception object is available, a new typed `MlodaRunError` is raised instead of a bare `Exception`.

## Changes

- `CfwManager.set_error(msg, exc_info, exception=None)` stores the original exception; `get_error_exception()` retrieves it. The new arg is keyword-only in practice, so existing positional callers/tests are unaffected.
- The three worker error paths (`sync_execute_step`, `thread_worker`, multiprocessing `worker`) pass `exception=e`. `thread_worker` now re-raises the original with a bare `raise`.
- `ExecutionOrchestrator._check_for_error` re-raises the captured `BaseException` (type + `__cause__` preserved for SYNC/THREADING; type + args for MULTIPROCESSING, where the traceback cannot cross the process boundary), else raises the typed `MlodaRunError`.
- New `MlodaRunError(Exception)` in `error_utils.py`.
- Multiprocessing safety: `CfwManager` is a manager proxy in MP mode, so `set_error(exception=e)` pickles `e`. A non-picklable worker exception (e.g. one holding a lock) is guarded at that cross-process boundary and degrades to the string-only path (surfaced as `MlodaRunError`), so the worker always signals STOP and the run fails promptly instead of hanging.

## Tests

New `tests/test_core/test_runtime/test_exception_preservation.py`: type preservation for SYNC, THREADING, and MULTIPROCESSING; `ValueError`-subclass and `__cause__` chain preservation; the `MlodaRunError` fallback; and a regression test that a non-picklable exception under MULTIPROCESSING raises promptly rather than hanging.

Existing assertions that matched an exception class name inside the old wrapped-traceback string were updated to `isinstance` checks (equivalent or stronger). Full `tox` is green (pytest, ruff, pip-licenses, mypy --strict, bandit).

## Review

Went through two independent deep reviews (a fresh Opus agent and codex). Both flagged the multiprocessing non-picklable-exception hang, which is fixed by the guard above and pinned by a regression test.