### PR TITLE
feat: document author-side option forwarding and add Options.forward_for_input_feature (#542)

### DIFF
--- a/docs/docs/in_depth/feature-chain-parser.md
+++ b/docs/docs/in_depth/feature-chain-parser.md
@@ -426,9 +426,11 @@ must forward that value explicitly on the child `Feature` it constructs.
 ### Why a bare `Feature(name)` can fail resolution
 
 The group auto-merge also copies the parent's own query-specific group keys (for
-example `query_text`, `top_k`) onto the child. The child's feature group matcher does
-not expect those keys, so resolution fails with `No feature groups found ...` and no
-hint about why:
+example `query_text`, `top_k`) onto the child. The child's matcher (its
+`match_feature_group_criteria` / `PROPERTY_MAPPING`) does not accept those extra keys,
+so resolution fails with `No feature groups found ...` and no hint about why. (Reserved
+keys such as `feature_chainer_parser_key` are ignored by matching, so it is only the
+parent's own query-specific keys that break the match.)
 
 ``` python
 def input_features(self, options: Options, feature_name: FeatureName) -> Optional[Set[Feature]]:
@@ -472,11 +474,14 @@ semantics it does not cover.
 
 ### Upstream feature deduplication
 
-Declaring the same source feature as an input of several parents does not compute it
-several times. The engine deduplicates identical upstream features, so requesting a
-source feature directly and via a parent's `input_features` still computes it once.
-Forwarding options as above does not change this: it keeps the child's group identity
-stable, which is what lets the engine recognize the shared feature.
+The engine deduplicates upstream features that share the same group identity. Declaring
+the same source feature as the input of several parents therefore computes it once,
+**provided those parents forward the same options to it**. Forwarded options become part
+of the child's group identity, so two parents that call `forward_for_input_feature` with
+identical arguments share a single computed feature, while a plain request of the same
+name (or one carrying different options) is a distinct identity and is computed
+separately. Keep the forwarded options identical across parents when you want them to
+share the computation.
 
 ## Multiple Result Columns with ~ Pattern
 

--- a/docs/docs/in_depth/feature-chain-parser.md
+++ b/docs/docs/in_depth/feature-chain-parser.md
@@ -402,6 +402,82 @@ PROPERTY_MAPPING = {
 }
 ```
 
+## Author-Side Option Forwarding for input_features
+
+The [Context Propagation](property-mapping.md#context-propagation) docs describe the
+**caller side**: context options stay local by default, and `propagate_context_keys`
+opts specific keys in. This section describes the **author side**: what happens to a
+feature group's own options when it declares an input feature.
+
+### The group-vs-context merge asymmetry
+
+When your `input_features()` returns a child `Feature`, the engine merges the parent
+feature's options into that child before resolving it:
+
+- **Group** parameters auto-merge from parent into the child input feature.
+- **Context** parameters do NOT auto-merge. They only reach a child when the caller
+  lists them in `propagate_context_keys`.
+
+A connector that needs an upstream selector (for example a `kg_backend` group option)
+to reach its input feature can rely on the group auto-merge. A connector that needs a
+**context** option to reach its input feature cannot rely on callers opting in, so it
+must forward that value explicitly on the child `Feature` it constructs.
+
+### Why a bare `Feature(name)` can fail resolution
+
+The group auto-merge also copies the parent's own query-specific group keys (for
+example `query_text`, `top_k`) onto the child. The child's feature group matcher does
+not expect those keys, so resolution fails with `No feature groups found ...` and no
+hint about why:
+
+``` python
+def input_features(self, options: Options, feature_name: FeatureName) -> Optional[Set[Feature]]:
+    return {Feature("knowledge_graph")}  # parent's query_text/top_k pollute this child -> no match
+```
+
+### Protecting keys with `forward_for_input_feature`
+
+To keep the parent's query-specific keys off the child, mark them as merge-protected.
+`Options.forward_for_input_feature(exclude=...)` builds options for a declared input
+feature that survive the auto-merge: it forwards the parent's non-excluded group
+parameters and marks the `exclude` keys (always together with `in_features`) as
+protected, so they are not copied onto the child.
+
+``` python
+def input_features(self, options: Options, feature_name: FeatureName) -> Optional[Set[Feature]]:
+    child_options = options.forward_for_input_feature(exclude={"query_text", "top_k"})
+    return {Feature("knowledge_graph", child_options)}
+```
+
+The shared `kg_backend` selector still flows to the child through the group
+auto-merge; `query_text` and `top_k` stay on the parent only. If the child needs a
+**context** value forwarded, set it explicitly on `child_options` before returning the
+feature, since context is never auto-merged.
+
+### The underlying mechanism
+
+`forward_for_input_feature` wraps `DefaultOptionKeys.feature_chainer_parser_key`, the
+key whose value is the set of option keys to protect during the parent-to-child merge.
+`in_features` is always protected. Setting this key by hand is the lower-level form of
+the same mechanism:
+
+``` python
+child_options = Options(
+    group={DefaultOptionKeys.feature_chainer_parser_key: frozenset({"query_text", "top_k"})}
+)
+```
+
+Prefer `forward_for_input_feature`; reach for the raw key only when you need protection
+semantics it does not cover.
+
+### Upstream feature deduplication
+
+Declaring the same source feature as an input of several parents does not compute it
+several times. The engine deduplicates identical upstream features, so requesting a
+source feature directly and via a parent's `input_features` still computes it once.
+Forwarding options as above does not change this: it keeps the child's group identity
+stable, which is what lets the engine recognize the shared feature.
+
 ## Multiple Result Columns with ~ Pattern
 
 Some feature groups produce multiple result columns from a single input feature. mloda provides utilities to work with these patterns seamlessly.

--- a/docs/docs/in_depth/feature-chain-parser.md
+++ b/docs/docs/in_depth/feature-chain-parser.md
@@ -428,9 +428,11 @@ must forward that value explicitly on the child `Feature` it constructs.
 The group auto-merge also copies the parent's own query-specific group keys (for
 example `query_text`, `top_k`) onto the child. The child's matcher (its
 `match_feature_group_criteria` / `PROPERTY_MAPPING`) does not accept those extra keys,
-so resolution fails with `No feature groups found ...` and no hint about why. (Reserved
-keys such as `feature_chainer_parser_key` are ignored by matching, so it is only the
-parent's own query-specific keys that break the match.)
+so resolution fails with `No feature groups found ...`. When a feature group would
+match the bare name but rejects it because of those extra group keys, the error names
+the offending keys and points to `forward_for_input_feature`. (Reserved keys such as
+`feature_chainer_parser_key` are ignored by matching, so it is only the parent's own
+query-specific keys that break the match.)
 
 ``` python
 def input_features(self, options: Options, feature_name: FeatureName) -> Optional[Set[Feature]]:

--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -291,3 +291,7 @@ Options(
 ```
 
 Only the specified keys propagate. Everything else stays local. Group propagation is unchanged.
+
+This is the caller side. For the author side (how a feature group's own options merge
+into an input feature it declares, and how to keep query-specific keys off that child),
+see [Author-Side Option Forwarding for input_features](feature-chain-parser.md#author-side-option-forwarding-for-input_features).

--- a/mloda/core/abstract_plugins/components/options.py
+++ b/mloda/core/abstract_plugins/components/options.py
@@ -308,15 +308,25 @@ class Options:
         (listed in ``exclude``) plus in_features are marked merge-protected via
         feature_chainer_parser_key so they do not flow onto and break the child's resolution.
 
+        The feature_chainer_parser_key itself is also protected, and any protected keys the parent
+        already carries under feature_chainer_parser_key are preserved. This lets nested
+        input_features chains compose without raising.
+
         Called on the PARENT's Options. Returns a NEW Options carrying the parent's group params
-        forward, except keys in ``exclude`` and except in_features. The parent's context is not
-        copied and the parent is not mutated.
+        forward, except the protected keys. The parent's context is not copied and the parent is
+        not mutated.
         """
-        excluded = frozenset(exclude or ())
-        new_group = {
-            key: value
-            for key, value in self.group.items()
-            if key not in excluded and key != DefaultOptionKeys.in_features
-        }
-        new_group[DefaultOptionKeys.feature_chainer_parser_key] = excluded | {DefaultOptionKeys.in_features}
+        if isinstance(exclude, str):
+            raise TypeError(
+                "forward_for_input_feature 'exclude' must be an iterable of keys, not a bare str "
+                "(a str would iterate into single characters)."
+            )
+        inherited = frozenset(self.get(DefaultOptionKeys.feature_chainer_parser_key) or ())
+        protected = (
+            frozenset(exclude or ())
+            | {DefaultOptionKeys.in_features, DefaultOptionKeys.feature_chainer_parser_key}
+            | inherited
+        )
+        new_group = {key: value for key, value in self.group.items() if key not in protected}
+        new_group[DefaultOptionKeys.feature_chainer_parser_key] = protected
         return Options(group=new_group)

--- a/mloda/core/abstract_plugins/components/options.py
+++ b/mloda/core/abstract_plugins/components/options.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Optional, TYPE_CHECKING, cast
+from typing import Any, Iterable, Optional, TYPE_CHECKING, cast
 from copy import deepcopy
 
 from mloda.core.abstract_plugins.components.hashable_dict import _make_hashable
@@ -298,3 +298,25 @@ class Options:
                     raise ValueError(f"Context key '{key}' conflict: parent='{value}', child='{self.context[key]}'")
 
             self.context.update(propagating)
+
+    def forward_for_input_feature(self, exclude: Optional[Iterable[str]] = None) -> "Options":
+        """
+        Build Options for a declared input feature that survives the parent->child group auto-merge.
+
+        When a FeatureGroup returns a declared input feature from input_features(), the engine
+        merges the parent feature's group options into that child. Parent query-specific keys
+        (listed in ``exclude``) plus in_features are marked merge-protected via
+        feature_chainer_parser_key so they do not flow onto and break the child's resolution.
+
+        Called on the PARENT's Options. Returns a NEW Options carrying the parent's group params
+        forward, except keys in ``exclude`` and except in_features. The parent's context is not
+        copied and the parent is not mutated.
+        """
+        excluded = frozenset(exclude or ())
+        new_group = {
+            key: value
+            for key, value in self.group.items()
+            if key not in excluded and key != DefaultOptionKeys.in_features
+        }
+        new_group[DefaultOptionKeys.feature_chainer_parser_key] = excluded | {DefaultOptionKeys.in_features}
+        return Options(group=new_group)

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -3,6 +3,7 @@ from typing import Iterable, Optional
 
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
@@ -61,6 +62,7 @@ class IdentifyFeatureGroupClass:
 
         feature_group = self._filter_loop(feature, accessible_plugins, links, data_access_collection)
 
+        self._data_access_collection = data_access_collection
         self.validate(feature_group, feature, accessible_plugins)
         self.feature_group_compute_framework_mapping = feature_group
 
@@ -199,6 +201,45 @@ class IdentifyFeatureGroupClass:
         msg += " Pin the feature to a supported compute framework or override supports_compute_framework."
         return msg
 
+    def _input_feature_forwarding_hint(
+        self, feature: Feature, accessible_plugins: FeatureGroupEnvironmentMapping
+    ) -> Optional[str]:
+        reserved = {DefaultOptionKeys.in_features, DefaultOptionKeys.feature_chainer_parser_key}
+        offending = sorted(str(k) for k in feature.options.group if k not in reserved)
+        if not offending:
+            return None
+
+        bare = Options(
+            context=dict(feature.options.context),
+            propagate_context_keys=feature.options.propagate_context_keys,
+        )
+
+        culprits: list[type[FeatureGroup]] = []
+        for feature_group in accessible_plugins:
+            if not self._filter_feature_group_by_domain(feature_group, feature):
+                continue
+            if not self._filter_feature_group_by_scope(feature_group, feature):
+                continue
+            accepts_bare = feature_group.match_feature_group_criteria(feature.name, bare, self._data_access_collection)
+            rejects_actual = not feature_group.match_feature_group_criteria(
+                feature.name, feature.options, self._data_access_collection
+            )
+            if accepts_bare and rejects_actual:
+                culprits.append(feature_group)
+
+        if not culprits:
+            return None
+
+        names = sorted(fg.get_class_name() for fg in culprits)
+        exclude_snippet = "{" + ", ".join(repr(k) for k in offending) + "}"
+        return (
+            f"Feature group(s) {names} match the name '{str(feature.name)}' but reject it because of "
+            f"extra group option(s) {offending}. These look like options merged from a parent feature. "
+            f"If '{str(feature.name)}' is a declared input feature, build it with "
+            f"Options.forward_for_input_feature(exclude={exclude_snippet}) so the parent's query-specific "
+            f"keys stay off it."
+        )
+
     def _build_no_feature_group_error(
         self, feature: Feature, accessible_plugins: FeatureGroupEnvironmentMapping
     ) -> str:
@@ -219,6 +260,10 @@ class IdentifyFeatureGroupClass:
         if not accessible_plugins:
             msg += "\nNo plugins are loaded. Did you call PluginLoader.all()?"
             return msg
+
+        forwarding_hint = self._input_feature_forwarding_hint(feature, accessible_plugins)
+        if forwarding_hint is not None:
+            msg += f"\n{forwarding_hint}"
 
         known_names: list[str] = []
         for fg_class in accessible_plugins:

--- a/tests/test_core/test_abstract_plugins/test_components/test_options.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_options.py
@@ -747,10 +747,15 @@ class TestForwardForInputFeature:
     feature_chainer_parser_key.
 
     CONTRACT (called on the PARENT's Options):
+    - If ``exclude`` is a bare ``str``, raise TypeError (it would otherwise
+      iterate into single characters). None and non-str iterables are fine.
+    - Let inherited = frozenset(self.get(feature_chainer_parser_key) or ()).
+    - protected = frozenset(exclude or ()) | {in_features,
+      feature_chainer_parser_key} | inherited.
     - Returns a NEW Options carrying the parent's group params forward, except
-      keys in ``exclude`` and except in_features.
-    - Sets feature_chainer_parser_key in the returned .group to
-      frozenset(exclude) | {in_features}.
+      every key in ``protected`` (so excluded keys, in_features,
+      feature_chainer_parser_key, and inherited keys are all dropped).
+    - Sets feature_chainer_parser_key in the returned .group to ``protected``.
     - The parent's context is NOT copied onto the returned Options.
     - Does not mutate the parent.
     """
@@ -791,7 +796,10 @@ class TestForwardForInputFeature:
 
         protected = result.group[DefaultOptionKeys.feature_chainer_parser_key]
         assert isinstance(protected, frozenset)
-        assert protected == frozenset({"query_text", "top_k"}) | {DefaultOptionKeys.in_features}
+        assert protected == frozenset({"query_text", "top_k"}) | {
+            DefaultOptionKeys.in_features,
+            DefaultOptionKeys.feature_chainer_parser_key,
+        }
 
     def test_exclude_none_protects_only_in_features_and_forwards_all(self) -> None:
         from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
@@ -803,9 +811,9 @@ class TestForwardForInputFeature:
         assert result.group["kg_backend"] == "neo4j"
         assert result.group["query_text"] == "hello"
         assert result.group["top_k"] == 5
-        # Only in_features protected
+        # in_features and feature_chainer_parser_key itself are protected
         protected = result.group[DefaultOptionKeys.feature_chainer_parser_key]
-        assert protected == frozenset({DefaultOptionKeys.in_features})
+        assert protected == frozenset({DefaultOptionKeys.in_features, DefaultOptionKeys.feature_chainer_parser_key})
 
     def test_exclude_accepts_list(self) -> None:
         from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
@@ -816,7 +824,10 @@ class TestForwardForInputFeature:
         assert "query_text" not in result.group
         assert "top_k" not in result.group
         protected = result.group[DefaultOptionKeys.feature_chainer_parser_key]
-        assert protected == frozenset({"query_text", "top_k"}) | {DefaultOptionKeys.in_features}
+        assert protected == frozenset({"query_text", "top_k"}) | {
+            DefaultOptionKeys.in_features,
+            DefaultOptionKeys.feature_chainer_parser_key,
+        }
 
     def test_exclude_accepts_frozenset(self) -> None:
         from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
@@ -826,7 +837,10 @@ class TestForwardForInputFeature:
 
         assert "query_text" not in result.group
         protected = result.group[DefaultOptionKeys.feature_chainer_parser_key]
-        assert protected == frozenset({"query_text"}) | {DefaultOptionKeys.in_features}
+        assert protected == frozenset({"query_text"}) | {
+            DefaultOptionKeys.in_features,
+            DefaultOptionKeys.feature_chainer_parser_key,
+        }
 
     def test_parent_context_not_copied(self) -> None:
         parent = Options(
@@ -884,3 +898,92 @@ class TestForwardForInputFeature:
         assert "top_k" not in child_feature.options.group
         # Shared group key still flows through
         assert child_feature.options.group["kg_backend"] == "neo4j"
+
+    def test_str_exclude_raises_type_error(self) -> None:
+        """A bare str exclude must raise TypeError, not silently protect characters."""
+        parent = Options(group={"kg_backend": "neo4j", "query_text": "hi"})
+        with pytest.raises(TypeError):
+            parent.forward_for_input_feature(exclude="query_text")
+
+    def test_preserves_inherited_protected_keys(self) -> None:
+        """
+        When the parent was itself produced by this helper (it already carries
+        feature_chainer_parser_key), the inherited protected keys must be
+        preserved and re-protected, not overwritten.
+        """
+        from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+
+        fcp = DefaultOptionKeys.feature_chainer_parser_key
+        in_features = DefaultOptionKeys.in_features
+
+        parent = Options(
+            group={
+                fcp: frozenset({"grand_key", in_features}),
+                "kg_backend": "neo4j",
+                "query_text": "hi",
+            }
+        )
+        result = parent.forward_for_input_feature(exclude={"query_text"})
+
+        protected = result.group[fcp]
+        assert protected == frozenset({"query_text", in_features, fcp, "grand_key"})
+        # Inherited + newly-excluded keys are dropped from the forwarded copy
+        assert "grand_key" not in result.group
+        assert "query_text" not in result.group
+        # Non-protected shared key still flows
+        assert result.group["kg_backend"] == "neo4j"
+
+    def test_nested_merge_does_not_raise(self) -> None:
+        """
+        Full nested chain: a parent that already carries an inherited protected
+        set must survive the real parent->child merge without a duplicate-key
+        ValueError, and grandparent protected keys must not leak onto the child.
+        """
+        from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+        from mloda.user import Feature, Features
+
+        fcp = DefaultOptionKeys.feature_chainer_parser_key
+        in_features = DefaultOptionKeys.in_features
+
+        parent_options = Options(
+            group={
+                fcp: frozenset({"grand_key", in_features}),
+                "kg_backend": "neo4j",
+                "query_text": "hi",
+                "grand_key": "grand_value",
+            }
+        )
+
+        child = Feature(
+            "knowledge_graph",
+            parent_options.forward_for_input_feature(exclude={"query_text"}),
+        )
+
+        Features([child]).merge_options(child.options, parent_options)
+
+        assert child.options.group["kg_backend"] == "neo4j"
+        assert "query_text" not in child.options.group
+        assert "grand_key" not in child.options.group
+
+    def test_exclude_containing_in_features(self) -> None:
+        """Passing in_features explicitly in exclude is harmless and does not error."""
+        from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+
+        fcp = DefaultOptionKeys.feature_chainer_parser_key
+        in_features = DefaultOptionKeys.in_features
+
+        parent = Options(group={"kg_backend": "neo4j"})
+        result = parent.forward_for_input_feature(exclude={in_features})
+
+        assert result.group[fcp] == frozenset({in_features, fcp})
+
+    def test_empty_parent_group(self) -> None:
+        """An empty parent forwards only the protected feature_chainer_parser_key entry."""
+        from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+
+        fcp = DefaultOptionKeys.feature_chainer_parser_key
+        in_features = DefaultOptionKeys.in_features
+
+        result = Options().forward_for_input_feature()
+
+        assert result.group == {fcp: frozenset({in_features, fcp})}

--- a/tests/test_core/test_abstract_plugins/test_components/test_options.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_options.py
@@ -732,3 +732,155 @@ class TestOptionsNestedStructureHashing:
         )
         result = hash(options)
         assert isinstance(result, int)
+
+
+class TestForwardForInputFeature:
+    """
+    Test suite for Options.forward_for_input_feature.
+
+    WHY THIS EXISTS:
+    When a FeatureGroup returns a declared input feature from input_features(),
+    the engine merges the PARENT feature's group options into that child input
+    feature. Parent query-specific group keys (e.g. query_text, top_k) then land
+    on the child and break its resolution. forward_for_input_feature formalizes
+    the workaround of marking those keys merge-protected via
+    feature_chainer_parser_key.
+
+    CONTRACT (called on the PARENT's Options):
+    - Returns a NEW Options carrying the parent's group params forward, except
+      keys in ``exclude`` and except in_features.
+    - Sets feature_chainer_parser_key in the returned .group to
+      frozenset(exclude) | {in_features}.
+    - The parent's context is NOT copied onto the returned Options.
+    - Does not mutate the parent.
+    """
+
+    def test_returns_new_options_instance(self) -> None:
+        parent = Options(group={"kg_backend": "neo4j"})
+        result = parent.forward_for_input_feature(exclude={"query_text", "top_k"})
+
+        assert isinstance(result, Options)
+        assert result is not parent
+
+    def test_forwards_group_keys_except_exclude_and_in_features(self) -> None:
+        from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+
+        parent = Options(
+            group={
+                "kg_backend": "neo4j",
+                "query_text": "hello",
+                "top_k": 5,
+                DefaultOptionKeys.in_features: "some_source",
+            }
+        )
+        result = parent.forward_for_input_feature(exclude={"query_text", "top_k"})
+
+        # Shared key forwarded
+        assert result.group["kg_backend"] == "neo4j"
+        # Excluded keys not forwarded
+        assert "query_text" not in result.group
+        assert "top_k" not in result.group
+        # in_features never forwarded
+        assert DefaultOptionKeys.in_features not in result.group
+
+    def test_sets_feature_chainer_parser_key_to_exclude_plus_in_features(self) -> None:
+        from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+
+        parent = Options(group={"kg_backend": "neo4j", "query_text": "hello", "top_k": 5})
+        result = parent.forward_for_input_feature(exclude={"query_text", "top_k"})
+
+        protected = result.group[DefaultOptionKeys.feature_chainer_parser_key]
+        assert isinstance(protected, frozenset)
+        assert protected == frozenset({"query_text", "top_k"}) | {DefaultOptionKeys.in_features}
+
+    def test_exclude_none_protects_only_in_features_and_forwards_all(self) -> None:
+        from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+
+        parent = Options(group={"kg_backend": "neo4j", "query_text": "hello", "top_k": 5})
+        result = parent.forward_for_input_feature()
+
+        # All group keys forwarded when exclude is None
+        assert result.group["kg_backend"] == "neo4j"
+        assert result.group["query_text"] == "hello"
+        assert result.group["top_k"] == 5
+        # Only in_features protected
+        protected = result.group[DefaultOptionKeys.feature_chainer_parser_key]
+        assert protected == frozenset({DefaultOptionKeys.in_features})
+
+    def test_exclude_accepts_list(self) -> None:
+        from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+
+        parent = Options(group={"kg_backend": "neo4j", "query_text": "hello", "top_k": 5})
+        result = parent.forward_for_input_feature(exclude=["query_text", "top_k"])
+
+        assert "query_text" not in result.group
+        assert "top_k" not in result.group
+        protected = result.group[DefaultOptionKeys.feature_chainer_parser_key]
+        assert protected == frozenset({"query_text", "top_k"}) | {DefaultOptionKeys.in_features}
+
+    def test_exclude_accepts_frozenset(self) -> None:
+        from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+
+        parent = Options(group={"kg_backend": "neo4j", "query_text": "hello"})
+        result = parent.forward_for_input_feature(exclude=frozenset({"query_text"}))
+
+        assert "query_text" not in result.group
+        protected = result.group[DefaultOptionKeys.feature_chainer_parser_key]
+        assert protected == frozenset({"query_text"}) | {DefaultOptionKeys.in_features}
+
+    def test_parent_context_not_copied(self) -> None:
+        parent = Options(
+            group={"kg_backend": "neo4j"},
+            context={"debug_mode": True, "trace_id": "abc"},
+        )
+        result = parent.forward_for_input_feature(exclude={"query_text"})
+
+        assert "debug_mode" not in result.context
+        assert "trace_id" not in result.context
+
+    def test_does_not_mutate_parent(self) -> None:
+        from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+
+        parent = Options(
+            group={"kg_backend": "neo4j", "query_text": "hello", "top_k": 5},
+            context={"debug_mode": True},
+        )
+        group_before = deepcopy(parent.group)
+        context_before = deepcopy(parent.context)
+
+        parent.forward_for_input_feature(exclude={"query_text", "top_k"})
+
+        assert parent.group == group_before
+        assert parent.context == context_before
+        # Parent should not gain the protection key
+        assert DefaultOptionKeys.feature_chainer_parser_key not in parent.group
+
+    def test_integration_through_real_merge_path(self) -> None:
+        """
+        Proof through the actual parent->child merge: excluded keys are protected
+        (do not flow to the child), while shared group keys still flow.
+        """
+        from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+        from mloda.user import Feature, Features
+
+        parent_options = Options(
+            group={
+                "kg_backend": "neo4j",
+                "query_text": "hello",
+                "top_k": 5,
+                DefaultOptionKeys.in_features: "parent_source",
+            }
+        )
+
+        child_feature = Feature(
+            "child_input",
+            parent_options.forward_for_input_feature(exclude={"query_text", "top_k"}),
+        )
+
+        Features([child_feature]).merge_options(child_feature.options, parent_options)
+
+        # Excluded / query-specific keys are protected -> not on the child
+        assert "query_text" not in child_feature.options.group
+        assert "top_k" not in child_feature.options.group
+        # Shared group key still flows through
+        assert child_feature.options.group["kg_backend"] == "neo4j"

--- a/tests/test_core/test_prepare/test_identify_feature_group_error_message.py
+++ b/tests/test_core/test_prepare/test_identify_feature_group_error_message.py
@@ -9,6 +9,7 @@ from typing import Optional
 import pytest
 
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
 from mloda.core.abstract_plugins.components.domain import Domain
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
@@ -456,4 +457,160 @@ class TestNoComputeFrameworkErrorMessageFormat:
         )
         assert expected_pattern in error_message, (
             f"Error message should contain formatted class '{expected_pattern}', but got: {error_message}"
+        )
+
+
+class KnowledgeGraphLikeFeatureGroup(FeatureGroup):
+    """Strict input-feature matcher: accepts the bare name 'knowledge_graph' but
+    rejects any feature that carries extra group options.
+
+    This mimics a knowledge-graph style feature group that is meant to be an
+    input feature. When a parent feature forwards its query-specific group
+    options onto this declared input feature, the extra group keys cause the
+    matcher to reject the feature entirely.
+    """
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        name = str(feature_name) if isinstance(feature_name, FeatureName) else feature_name
+        return name == "knowledge_graph" and not options.group
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class OtherNameFeatureGroup(FeatureGroup):
+    """Feature group that only matches a different name, used to keep some
+    plugins accessible while never matching the feature under test."""
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        name = str(feature_name) if isinstance(feature_name, FeatureName) else feature_name
+        return name == "some_other_feature"
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class TestInputFeatureForwardingHint:
+    """Tests for the 'forward_for_input_feature' hint in the no-feature-group error.
+
+    The hint should fire only when a feature fails to resolve BECAUSE its group
+    options carry keys the matcher rejects, and some accessible feature group
+    WOULD match the same bare feature name if the group options were empty.
+    """
+
+    def test_hint_names_offending_keys_and_helper(self) -> None:
+        feature = Feature("knowledge_graph", Options(group={"query_text": "hi", "top_k": 5}))
+
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            KnowledgeGraphLikeFeatureGroup: {MockComputeFramework},
+        }
+
+        with pytest.raises(ValueError) as exc_info:
+            IdentifyFeatureGroupClass(
+                feature=feature,
+                accessible_plugins=accessible_plugins,
+                links=None,
+                data_access_collection=None,
+            )
+
+        error_message = str(exc_info.value)
+
+        assert "forward_for_input_feature" in error_message, (
+            f"Error message should point to forward_for_input_feature, but got: {error_message}"
+        )
+        assert "query_text" in error_message, (
+            f"Error message should name offending key 'query_text', but got: {error_message}"
+        )
+        assert "top_k" in error_message, f"Error message should name offending key 'top_k', but got: {error_message}"
+        assert "KnowledgeGraphLikeFeatureGroup" in error_message, (
+            f"Error message should name culprit feature group, but got: {error_message}"
+        )
+
+    def test_no_hint_when_no_group_options(self) -> None:
+        feature = Feature("knowledge_graph")
+
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            OtherNameFeatureGroup: {MockComputeFramework},
+        }
+
+        with pytest.raises(ValueError) as exc_info:
+            IdentifyFeatureGroupClass(
+                feature=feature,
+                accessible_plugins=accessible_plugins,
+                links=None,
+                data_access_collection=None,
+            )
+
+        error_message = str(exc_info.value)
+
+        assert "forward_for_input_feature" not in error_message, (
+            f"Error message should NOT emit forwarding hint when no group options, but got: {error_message}"
+        )
+
+    def test_no_hint_when_no_feature_group_matches_bare_name(self) -> None:
+        feature = Feature("totally_unknown", Options(group={"query_text": "hi"}))
+
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            KnowledgeGraphLikeFeatureGroup: {MockComputeFramework},
+        }
+
+        with pytest.raises(ValueError) as exc_info:
+            IdentifyFeatureGroupClass(
+                feature=feature,
+                accessible_plugins=accessible_plugins,
+                links=None,
+                data_access_collection=None,
+            )
+
+        error_message = str(exc_info.value)
+
+        assert "forward_for_input_feature" not in error_message, (
+            f"Error message should NOT emit forwarding hint when no FG matches the bare name, but got: {error_message}"
+        )
+
+    def test_reserved_keys_not_listed_as_offending(self) -> None:
+        feature = Feature(
+            "knowledge_graph",
+            Options(
+                group={
+                    "query_text": "hi",
+                    DefaultOptionKeys.feature_chainer_parser_key: frozenset({"query_text"}),
+                }
+            ),
+        )
+
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            KnowledgeGraphLikeFeatureGroup: {MockComputeFramework},
+        }
+
+        with pytest.raises(ValueError) as exc_info:
+            IdentifyFeatureGroupClass(
+                feature=feature,
+                accessible_plugins=accessible_plugins,
+                links=None,
+                data_access_collection=None,
+            )
+
+        error_message = str(exc_info.value)
+
+        assert "forward_for_input_feature" in error_message, (
+            f"Error message should point to forward_for_input_feature, but got: {error_message}"
+        )
+        assert "query_text" in error_message, (
+            f"Error message should name offending key 'query_text', but got: {error_message}"
+        )
+        assert "feature_chainer_parser_key" not in error_message, (
+            f"Reserved key 'feature_chainer_parser_key' must NOT be listed as offending, but got: {error_message}"
         )


### PR DESCRIPTION
## Summary

Closes #542. Documents the plugin-author side of option forwarding for `input_features`, and adds the public helper the issue suggested.

When a FeatureGroup returns a declared input feature, the engine merges the parent feature's **group** options into that child, while **context** options never auto-merge (they only cross when the caller opts in with `propagate_context_keys`). The group auto-merge also copies the parent's own query-specific keys (`query_text`, `top_k`, ...) onto the child, so a bare `Feature(name)` input feature fails resolution with `No feature groups found ...`. Until now the only fix was hand-rolling `DefaultOptionKeys.feature_chainer_parser_key`, which reads like parser internals.

## Changes

- **New public helper** `Options.forward_for_input_feature(exclude=...)`: forwards the parent's non-excluded group parameters and marks the excluded keys (plus `in_features` and `feature_chainer_parser_key` itself) as merge-protected, so a declared input feature resolves cleanly. It preserves any protected keys the parent already carries, so nested `input_features` chains compose without conflict. Context is never copied, keeping the documented "context stays local" default intact. A bare `str` `exclude` is rejected with `TypeError`.
- **Docs**: new "Author-Side Option Forwarding for input_features" section in `feature-chain-parser.md` (group-vs-context asymmetry, the failure mode, the helper, the underlying `feature_chainer_parser_key` mechanism, and upstream deduplication), plus a cross-reference from the caller-side "Context Propagation" note in `property-mapping.md`.

## Testing

- New `TestForwardForInputFeature` suite covers the happy path, the real parent to child merge path, nested-chain preservation, the `str` guard, `exclude` containing `in_features`, and empty parent group.
- Full `tox` gate green: 4138+ passed, ruff format + check, `mypy --strict`, license allowlist, and bandit all pass.

## Review

Gated by two independent deep reviews (a fresh Claude Opus agent and codex). Both found the nested-chain composition bug (parent's `feature_chainer_parser_key` was overwritten, causing a conflicting-value `ValueError` on merge) and a docs deduplication overclaim; both are fixed here, with the fixes covered by new tests.
