### PR TITLE
feat: honor injected registry in get_feature_group_docs registered_only

### DIFF
--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -26,7 +26,11 @@ from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRe
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.api.plugin_info import ComputeFrameworkInfo, ExtenderInfo, FeatureGroupInfo, ResolvedFeature
-from mloda.core.prepare.accessible_plugins import RedefinitionConflictError, dedup_feature_group_subclasses
+from mloda.core.prepare.accessible_plugins import (
+    RedefinitionConflictError,
+    dedup_feature_group_subclasses,
+    registry_for,
+)
 from mloda.core.prepare.identify_feature_group import split_frameworks_by_capability
 
 
@@ -78,7 +82,7 @@ def get_feature_group_docs(
         compute_framework: Filter by compute framework name or class (case-insensitive match).
         version_contains: Filter by version substring.
         plugin_collector: Filter using plugin collector's applicability check.
-        registered_only: If True, only document classes registered in the default registry.
+        registered_only: If True, only document classes in the collector's injected registry, else the default registry.
 
     Returns:
         List of FeatureGroupInfo objects sorted by name.
@@ -86,7 +90,7 @@ def get_feature_group_docs(
     allow_redefinition = plugin_collector.allow_redefinition if plugin_collector is not None else False
     all_feature_groups: set[type[FeatureGroup]] = get_all_subclasses(FeatureGroup)
     if registered_only:
-        registered = PluginRegistry.default().registered_classes()
+        registered = registry_for(plugin_collector).registered_classes()
         all_feature_groups = {fg for fg in all_feature_groups if fg in registered}
     if plugin_collector is not None:
         all_feature_groups = {fg for fg in all_feature_groups if plugin_collector.applicable_feature_group_class(fg)}

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_docs_enumeration.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_docs_enumeration.py
@@ -26,6 +26,7 @@ from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.abstract_plugins.function_extender import Extender, ExtenderHook
 from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistry
 from mloda.core.abstract_plugins.plugin_registry.plugin_registry import register_plugin as registry_register
+from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
 from mloda.core.api.plugin_docs import (
     get_compute_framework_docs,
     get_extender_docs,
@@ -205,4 +206,53 @@ class TestDocsFallbackNonRegression:
         names = [fg.name for fg in get_feature_group_docs()]
         assert names.count("_DocsEnumOnceFG") == 1, (
             "a class that is both registered and subclass-reachable must not be documented twice"
+        )
+
+
+class TestRegisteredOnlyHonorsInjectedRegistry:
+    """registered_only=True must consult the collector's injected registry.
+
+    The engine path honors an injected registry via registry_for(plugin_collector),
+    falling back to the default registry only when none is injected. The docs path
+    must behave identically for multi-tenant instance scoping.
+    """
+
+    def test_registered_only_consults_injected_registry(self) -> None:
+        PluginRegistry.default().clear()
+
+        class _DocsEnumInjectedFG(FeatureGroup):
+            """Registered in the injected tenant registry only."""
+
+        class _DocsEnumDefaultOnlyFG(FeatureGroup):
+            """Registered in the default registry only."""
+
+        registry_register(_DocsEnumDefaultOnlyFG)
+
+        tenant = PluginRegistry()
+        tenant.register(_DocsEnumInjectedFG)
+
+        collector = PluginCollector().set_registry(tenant)
+        names = [fg.name for fg in get_feature_group_docs(plugin_collector=collector, registered_only=True)]
+
+        assert "_DocsEnumInjectedFG" in names, (
+            "registered_only=True must document classes in the collector's injected registry"
+        )
+        assert "_DocsEnumDefaultOnlyFG" not in names, (
+            "registered_only=True must consult the injected registry, not the default registry"
+        )
+
+    def test_registered_only_falls_back_to_default_without_injected_registry(self) -> None:
+        PluginRegistry.default().clear()
+
+        class _DocsEnumFallbackDefaultFG(FeatureGroup):
+            """Registered in the default registry; used with a collector that injects none."""
+
+        registry_register(_DocsEnumFallbackDefaultFG)
+
+        collector = PluginCollector()
+        assert collector.registry is None
+        names = [fg.name for fg in get_feature_group_docs(plugin_collector=collector, registered_only=True)]
+
+        assert "_DocsEnumFallbackDefaultFG" in names, (
+            "a collector without an injected registry must fall back to the default registry"
         )


### PR DESCRIPTION
## Summary

Closes the one residual gap in the governance allowlist / instance-scoping work tracked by #546. The bulk of #546 (policy object, approval metadata, `PluginSource` enum, strict mode for ComputeFrameworks and Extenders, registry injection via `PluginCollector`, `registered_classes()` accessor, dual-import handling, steward docs) already shipped in #531 and #550. This PR completes multi-tenant instance scoping on the docs path.

## Problem

`get_feature_group_docs()` accepts a `plugin_collector`, but when `registered_only=True` it filtered against `PluginRegistry.default()` and ignored a registry injected on the collector via `PluginCollector().set_registry(...)`. The engine path already honors the injected registry through `registry_for(plugin_collector)`; the docs path did not. A multi-tenant caller passing an injected registry saw the global registered set instead of the tenant's.

## Change

- `get_feature_group_docs`'s `registered_only` branch now resolves the registry via `registry_for(plugin_collector)`, which returns the collector's injected registry when set and falls back to `PluginRegistry.default()` otherwise. Behavior is unchanged for every existing caller that passes no collector (or a collector with no injected registry).
- `get_compute_framework_docs` and `get_extender_docs` take no `plugin_collector`, so there is no injected registry to honor; they are left unchanged.
- Updated the `registered_only` docstring line accordingly.

## Tests

Added `TestRegisteredOnlyHonorsInjectedRegistry` to `test_docs_enumeration.py`:
- `test_registered_only_consults_injected_registry`: a class registered only in the injected tenant registry is documented, and a class registered only in the default registry is excluded, proving the injected registry is consulted.
- `test_registered_only_falls_back_to_default_without_injected_registry`: a collector with no injected registry falls back to the default registry.

Both are parallel-safe (fresh tenant `PluginRegistry()` instance; the autouse conftest restores the default registry per test).

## Validation

`tox` is fully green: 4131 passed, 171 skipped, ruff format/check clean, mypy --strict clean, bandit clean. Two independent deep reviews (a fresh Opus agent and codex) found no correctness issues or regressions.