### PR TITLE
feat: expose feature-group/options introspection helpers on Extender

### DIFF
--- a/mloda/core/abstract_plugins/function_extender.py
+++ b/mloda/core/abstract_plugins/function_extender.py
@@ -53,16 +53,25 @@ class Extender(ABC):
 
     @staticmethod
     def feature_group_name(func: Any) -> str:
-        """Resolve the owning feature group class name of the hooked callable."""
-        unwrapped = inspect.unwrap(func)
-        if hasattr(unwrapped, "__self__"):
-            owner = unwrapped.__self__
+        """Resolve the owning feature group class name of the hooked callable.
+
+        Returns the string sentinel "unknown" (never None) when the owner cannot be resolved.
+        """
+
+        def owner_name(candidate: Any) -> str:
+            owner = candidate.__self__
             if isinstance(owner, type):
                 return str(owner.__name__)
             return str(owner.__class__.__name__)
+
+        if hasattr(func, "__self__"):
+            return owner_name(func)
+        unwrapped = inspect.unwrap(func)
+        if hasattr(unwrapped, "__self__"):
+            return owner_name(unwrapped)
         qualname = getattr(unwrapped, "__qualname__", "")
         parts = qualname.split(".")
-        if len(parts) >= 2:
+        if len(parts) >= 2 and parts[-2] != "<locals>":
             return str(parts[-2])
         return "unknown"
 

--- a/mloda/core/abstract_plugins/function_extender.py
+++ b/mloda/core/abstract_plugins/function_extender.py
@@ -1,7 +1,13 @@
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
+import functools
+import inspect
 import logging
+
+if TYPE_CHECKING:
+    from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+    from mloda.core.abstract_plugins.components.options import Options
 
 
 class ExtenderHook(Enum):
@@ -45,6 +51,47 @@ class Extender(ABC):
     def __call__(self, func: Any, *args: Any, **kwargs: Any) -> Any:
         pass
 
+    @staticmethod
+    def feature_group_name(func: Any) -> str:
+        """Resolve the owning feature group class name of the hooked callable."""
+        unwrapped = inspect.unwrap(func)
+        if hasattr(unwrapped, "__self__"):
+            owner = unwrapped.__self__
+            if isinstance(owner, type):
+                return str(owner.__name__)
+            return str(owner.__class__.__name__)
+        qualname = getattr(unwrapped, "__qualname__", "")
+        parts = qualname.split(".")
+        if len(parts) >= 2:
+            return str(parts[-2])
+        return "unknown"
+
+    @staticmethod
+    def feature_set(args: tuple[Any, ...]) -> "FeatureSet | None":
+        """Return the first FeatureSet in the hook args, else None."""
+        from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+
+        for arg in args:
+            if isinstance(arg, FeatureSet):
+                return arg
+        return None
+
+    @staticmethod
+    def feature_name(args: tuple[Any, ...]) -> str | None:
+        """Return the name of one feature from the FeatureSet in the hook args, else None."""
+        feature_set = Extender.feature_set(args)
+        if feature_set is None or feature_set.name_of_one_feature is None:
+            return None
+        return str(feature_set.name_of_one_feature)
+
+    @staticmethod
+    def feature_options(args: tuple[Any, ...]) -> "Options | None":
+        """Return the Options of the FeatureSet in the hook args, else None."""
+        feature_set = Extender.feature_set(args)
+        if feature_set is None:
+            return None
+        return feature_set.options
+
 
 class _CompositeExtender(Extender):
     """Internal class that chains multiple Extenders in priority order."""
@@ -63,6 +110,7 @@ class _CompositeExtender(Extender):
 
     def __call__(self, func: Any, *args: Any, **kwargs: Any) -> Any:
         def make_wrapper(ext: Extender, inner_func: Any) -> Any:
+            @functools.wraps(inner_func)
             def wrapper(*a: Any, **kw: Any) -> Any:
                 try:
                     return ext.__call__(inner_func, *a, **kw)

--- a/tests/test_plugins/extender/test_extender_introspection.py
+++ b/tests/test_plugins/extender/test_extender_introspection.py
@@ -1,0 +1,186 @@
+"""Tests for introspection helpers on the Extender base class (issue #572).
+
+These helpers let custom extenders (tracing/otel/lineage) resolve the feature
+group name, FeatureSet, feature name, and options from the hook invocation
+`extender(feature_group.calculate_feature, data, features)` without every
+plugin reimplementing bound-method introspection.
+"""
+
+import functools
+from typing import Any
+
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.function_extender import (
+    Extender,
+    ExtenderHook,
+    _CompositeExtender,
+)
+
+
+class SampleFeatureGroup:
+    """FeatureGroup-like class exposing calculate_feature as a classmethod, as core invokes it."""
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return data
+
+    def instance_method(self, data: Any, features: FeatureSet) -> Any:
+        return data
+
+    @staticmethod
+    def static_method(data: Any, features: FeatureSet) -> Any:
+        return data
+
+
+def top_level_function(data: Any, features: FeatureSet) -> Any:
+    return data
+
+
+class RecordingExtender(Extender):
+    """Extender that records the resolved feature group name on every call."""
+
+    def __init__(self, priority: int = 100) -> None:
+        self.priority = priority
+        self.seen_names: list[str] = []
+
+    def wraps(self) -> set[ExtenderHook]:
+        return {ExtenderHook.FEATURE_GROUP_CALCULATE_FEATURE}
+
+    def __call__(self, func: Any, *args: Any, **kwargs: Any) -> Any:
+        self.seen_names.append(self.feature_group_name(func))
+        return func(*args, **kwargs)
+
+
+def build_feature_set() -> FeatureSet:
+    return FeatureSet([Feature("some_feature", {"key": "value"})])
+
+
+def make_opaque_wrapper(inner: Any) -> Any:
+    """Wrap without functools.wraps: only __wrapped__ links back to the inner callable."""
+
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        return inner(*args, **kwargs)
+
+    wrapper.__wrapped__ = inner  # type: ignore[attr-defined]
+    return wrapper
+
+
+class TestFeatureGroupName:
+    """Extender.feature_group_name resolves the owning class name of the hooked callable."""
+
+    def test_bound_classmethod_returns_class_name(self) -> None:
+        assert Extender.feature_group_name(SampleFeatureGroup.calculate_feature) == "SampleFeatureGroup"
+
+    def test_bound_instance_method_returns_instance_class_name(self) -> None:
+        instance = SampleFeatureGroup()
+        assert Extender.feature_group_name(instance.instance_method) == "SampleFeatureGroup"
+
+    def test_unbound_function_with_dotted_qualname_returns_class_name(self) -> None:
+        unbound = SampleFeatureGroup.__dict__["instance_method"]
+        assert Extender.feature_group_name(unbound) == "SampleFeatureGroup"
+
+    def test_staticmethod_returns_class_name_from_qualname(self) -> None:
+        assert Extender.feature_group_name(SampleFeatureGroup.static_method) == "SampleFeatureGroup"
+
+    def test_top_level_function_returns_unknown(self) -> None:
+        assert Extender.feature_group_name(top_level_function) == "unknown"
+
+    def test_object_without_self_and_qualname_returns_unknown(self) -> None:
+        partial_func = functools.partial(top_level_function)
+        assert not hasattr(partial_func, "__qualname__")
+        assert not hasattr(partial_func, "__self__")
+        assert Extender.feature_group_name(partial_func) == "unknown"
+
+    def test_functools_wraps_wrapper_is_unwrapped_to_bound_classmethod(self) -> None:
+        @functools.wraps(SampleFeatureGroup.calculate_feature)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            return SampleFeatureGroup.calculate_feature(*args, **kwargs)
+
+        assert Extender.feature_group_name(wrapper) == "SampleFeatureGroup"
+
+    def test_opaque_wrapped_chain_is_unwrapped_before_inspection(self) -> None:
+        # No functools.wraps: the outer closures have useless qualnames, only
+        # the __wrapped__ chain leads back to the bound classmethod.
+        once = make_opaque_wrapper(SampleFeatureGroup.calculate_feature)
+        twice = make_opaque_wrapper(once)
+        assert Extender.feature_group_name(twice) == "SampleFeatureGroup"
+
+
+class TestFeatureSetHelper:
+    """Extender.feature_set finds the FeatureSet in hook args."""
+
+    def test_returns_feature_set_from_args(self) -> None:
+        feature_set = build_feature_set()
+        assert Extender.feature_set(({"col": [1]}, feature_set)) is feature_set
+
+    def test_returns_first_feature_set_when_multiple(self) -> None:
+        first = build_feature_set()
+        second = build_feature_set()
+        assert Extender.feature_set((first, second)) is first
+
+    def test_returns_none_when_no_feature_set_in_args(self) -> None:
+        assert Extender.feature_set(({"col": [1]}, "not_a_feature_set")) is None
+
+    def test_returns_none_for_empty_args(self) -> None:
+        assert Extender.feature_set(()) is None
+
+
+class TestFeatureNameHelper:
+    """Extender.feature_name resolves one feature name from the FeatureSet in hook args."""
+
+    def test_returns_feature_name_string(self) -> None:
+        feature_set = build_feature_set()
+        result = Extender.feature_name(({"col": [1]}, feature_set))
+        assert result == "some_feature"
+        assert isinstance(result, str)
+
+    def test_returns_none_when_no_feature_set_in_args(self) -> None:
+        assert Extender.feature_name(({"col": [1]},)) is None
+
+    def test_returns_none_for_empty_feature_set_without_raising(self) -> None:
+        empty_feature_set = FeatureSet()
+        assert Extender.feature_name(({"col": [1]}, empty_feature_set)) is None
+
+
+class TestFeatureOptionsHelper:
+    """Extender.feature_options resolves the Options of the FeatureSet in hook args."""
+
+    def test_returns_options_of_feature_set(self) -> None:
+        feature_set = build_feature_set()
+        result = Extender.feature_options(({"col": [1]}, feature_set))
+        assert isinstance(result, Options)
+        assert result.get("key") == "value"
+
+    def test_returns_none_when_no_feature_set_in_args(self) -> None:
+        assert Extender.feature_options(({"col": [1]},)) is None
+
+    def test_returns_none_when_options_not_set(self) -> None:
+        empty_feature_set = FeatureSet()
+        assert empty_feature_set.options is None
+        assert Extender.feature_options(({"col": [1]}, empty_feature_set)) is None
+
+
+class TestCompositeExtenderNamePropagation:
+    """Regression: every extender in a composite chain must see the real feature group name.
+
+    Today _CompositeExtender.make_wrapper hands all but the innermost extender an
+    anonymous `wrapper` closure, so name introspection breaks for the outer ones.
+    """
+
+    def test_all_extenders_in_chain_resolve_real_class_name(self) -> None:
+        ext_a = RecordingExtender(priority=10)
+        ext_b = RecordingExtender(priority=20)
+        composite = _CompositeExtender([ext_a, ext_b])
+
+        feature_set = build_feature_set()
+        result = composite(SampleFeatureGroup.calculate_feature, {"x": [1]}, feature_set)
+
+        assert result == {"x": [1]}
+        assert ext_a.seen_names == ["SampleFeatureGroup"], (
+            "First extender in the chain must resolve the real feature group class name"
+        )
+        assert ext_b.seen_names == ["SampleFeatureGroup"], (
+            "Second extender in the chain must resolve the real feature group class name"
+        )

--- a/tests/test_plugins/extender/test_extender_introspection.py
+++ b/tests/test_plugins/extender/test_extender_introspection.py
@@ -67,6 +67,28 @@ def make_opaque_wrapper(inner: Any) -> Any:
     return wrapper
 
 
+def make_bare_closure(inner: Any) -> Any:
+    """Wrap without functools.wraps and without __wrapped__: nothing links back to the inner callable."""
+
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        return inner(*args, **kwargs)
+
+    return wrapper
+
+
+def _unrelated_top_level(*args: Any, **kwargs: Any) -> Any:
+    return None
+
+
+class DecoratedFeatureGroup:
+    """FeatureGroup whose classmethod carries a __wrapped__ chain to an unrelated top-level function."""
+
+    @classmethod
+    @functools.wraps(_unrelated_top_level)
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return data
+
+
 class TestFeatureGroupName:
     """Extender.feature_group_name resolves the owning class name of the hooked callable."""
 
@@ -106,6 +128,18 @@ class TestFeatureGroupName:
         once = make_opaque_wrapper(SampleFeatureGroup.calculate_feature)
         twice = make_opaque_wrapper(once)
         assert Extender.feature_group_name(twice) == "SampleFeatureGroup"
+
+    def test_bare_closure_qualname_returns_unknown_not_locals(self) -> None:
+        # A bare closure has qualname `make_bare_closure.<locals>.wrapper`; the
+        # `<locals>` scope marker is not a feature group name, so the helper
+        # must fall back to the unresolved sentinel "unknown".
+        assert Extender.feature_group_name(make_bare_closure(top_level_function)) == "unknown"
+
+    def test_decorated_bound_classmethod_prefers_raw_self_over_wrapped_chain(self) -> None:
+        # The raw bound classmethod carries __self__ pointing at its owning
+        # class; that must win over the __wrapped__ chain leading to an
+        # unrelated top-level function.
+        assert Extender.feature_group_name(DecoratedFeatureGroup.calculate_feature) == "DecoratedFeatureGroup"
 
 
 class TestFeatureSetHelper:


### PR DESCRIPTION
## Summary

Closes #572.

Custom extenders (tracing, opentelemetry, lineage, config-capture) all reinvent bound-method introspection to pull the feature group name and options out of the wrapped call. This adds core-owned helpers on the `Extender` base class:

- `feature_group_name(func)`: resolves the owning feature group class name of the hooked callable (raw `__self__` first, then the `__wrapped__` chain, then a `__qualname__` fallback, with the string sentinel `"unknown"` when unresolvable).
- `feature_set(args)`: first `FeatureSet` in the hook args, else `None`.
- `feature_name(args)`: name of one feature from that `FeatureSet`, else `None` (never raises, also for empty sets).
- `feature_options(args)`: the `FeatureSet` options, else `None`.

It also fixes a latent bug this surfaced: `_CompositeExtender` chained extenders through bare closures, so with two or more extenders on the same hook every extender except the innermost received an anonymous wrapper and name introspection silently broke. `make_wrapper` now applies `functools.wraps(inner_func)`, and a regression test asserts that every extender in a chain resolves the real feature group class name.

## Review hardening

Two findings from independent deep review are fixed and pinned by tests:

- A bare closure without `functools.wraps` previously leaked the literal `<locals>` qualname segment as a feature group name; it now returns `"unknown"`.
- A bound classmethod decorated with `functools.wraps(<unrelated function>)` previously unwrapped past its owner and returned `"unknown"`; the raw callable's `__self__` now wins over the `__wrapped__` chain.

## Testing

- 21 new tests in `tests/test_plugins/extender/test_extender_introspection.py` (helper semantics, edge callables such as partials, lambdas, static methods, opaque wrapped chains, and the composite name-propagation regression).
- `tox` fully green (pytest, ruff format/check, pip-licenses, mypy --strict, bandit).
