### PR TITLE
feat: validation_function, required_when, type_validator passthroughs for property_spec (#536)

### DIFF
--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -81,6 +81,9 @@ when provided (an omitted passthrough leaves no key in the dict):
   `allowed_values`, it is only enforced under strict validation). With a
   `validation_function`, strict no longer needs `allowed_values`, and a
   declared `default` is checked through the function instead of by membership.
+  If the function raises when called with the default, the builder wraps it as
+  a `ValueError` with the original exception chained as `__cause__`, mirroring
+  core's class-definition check.
 - `required_when`: conditional-requirement predicate; callable-checked, no
   strict requirement.
 - `type_validator`: raw-value shape check; callable-checked, no strict

--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -56,9 +56,10 @@ either as a literal accepted value; both are recovered as metadata, not values.
 ### Builder: `property_spec`
 
 `property_spec` builds the same dict and validates its invariants at
-construction (strict needs a non-empty `allowed_values`; `allowed_values`
-without strict is rejected as a no-op; a strict `default` must be in the
-allowed set). The contract stays a plain dict, so this is optional sugar:
+construction (strict needs a non-empty `allowed_values` or a
+`validation_function`; `allowed_values` without strict is rejected as a no-op;
+a strict `default` must be in the allowed set). The contract stays a plain
+dict, so this is optional sugar:
 
 ``` python
 from mloda.provider import property_spec
@@ -72,6 +73,18 @@ PROPERTY_MAPPING = {
     ),
 }
 ```
+
+The builder also accepts three optional callable passthroughs, emitted only
+when provided (an omitted passthrough leaves no key in the dict):
+
+- `validation_function`: must be callable and requires `strict=True` (like
+  `allowed_values`, it is only enforced under strict validation). With a
+  `validation_function`, strict no longer needs `allowed_values`, and a
+  declared `default` is checked through the function instead of by membership.
+- `required_when`: conditional-requirement predicate; callable-checked, no
+  strict requirement.
+- `type_validator`: raw-value shape check; callable-checked, no strict
+  requirement.
 
 ## Parameter Classification
 

--- a/mloda/core/abstract_plugins/components/feature_chainer/property_spec.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/property_spec.py
@@ -6,7 +6,7 @@ invariants up front instead of relying on hand-written spec dicts.
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from typing import Any
 
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
@@ -19,26 +19,55 @@ def property_spec(
     allowed_values: Mapping[Any, str] | Iterable[Any] | None = None,
     default: Any = None,
     context: bool = True,
+    validation_function: Callable[..., Any] | None = None,
+    required_when: Callable[..., Any] | None = None,
+    type_validator: Callable[..., Any] | None = None,
 ) -> dict[str, Any]:
     if allowed_values is not None and not isinstance(allowed_values, Mapping):
         allowed_values = tuple(allowed_values)
 
-    if strict and not allowed_values:
-        raise ValueError(f"property_spec({explanation!r}): strict=True needs a non-empty allowed_values.")
+    if validation_function is not None and not callable(validation_function):
+        raise ValueError(f"property_spec({explanation!r}): validation_function must be callable.")
+
+    if required_when is not None and not callable(required_when):
+        raise ValueError(f"property_spec({explanation!r}): required_when must be callable.")
+
+    if type_validator is not None and not callable(type_validator):
+        raise ValueError(f"property_spec({explanation!r}): type_validator must be callable.")
+
+    if validation_function is not None and not strict:
+        raise ValueError(f"property_spec({explanation!r}): validation_function is never enforced without strict=True.")
+
+    if strict and not allowed_values and validation_function is None:
+        raise ValueError(
+            f"property_spec({explanation!r}): strict=True needs a non-empty allowed_values or a validation_function."
+        )
 
     if not strict and allowed_values is not None:
         raise ValueError(f"property_spec({explanation!r}): allowed_values is never enforced without strict=True.")
 
-    if strict and default is not None and allowed_values is not None:
-        accepted = set(allowed_values.keys()) if isinstance(allowed_values, Mapping) else set(allowed_values)
-        if default not in accepted:
-            raise ValueError(
-                f"property_spec({explanation!r}): default {default!r} is not in the accepted set {accepted}."
-            )
+    if strict and default is not None:
+        if validation_function is not None:
+            if not validation_function(default):
+                raise ValueError(
+                    f"property_spec({explanation!r}): default {default!r} is rejected by the validation_function."
+                )
+        elif allowed_values is not None:
+            accepted = set(allowed_values.keys()) if isinstance(allowed_values, Mapping) else set(allowed_values)
+            if default not in accepted:
+                raise ValueError(
+                    f"property_spec({explanation!r}): default {default!r} is not in the accepted set {accepted}."
+                )
 
     spec: dict[str, Any] = {"explanation": explanation}
     if allowed_values is not None:
         spec[DefaultOptionKeys.allowed_values] = allowed_values
+    if validation_function is not None:
+        spec[DefaultOptionKeys.validation_function] = validation_function
+    if required_when is not None:
+        spec[DefaultOptionKeys.required_when] = required_when
+    if type_validator is not None:
+        spec[DefaultOptionKeys.type_validator] = type_validator
     spec[DefaultOptionKeys.context] = context
     spec[DefaultOptionKeys.strict_validation] = strict
     if default is not None:

--- a/mloda/core/abstract_plugins/components/feature_chainer/property_spec.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/property_spec.py
@@ -38,7 +38,10 @@ def property_spec(
     if validation_function is not None and not strict:
         raise ValueError(f"property_spec({explanation!r}): validation_function is never enforced without strict=True.")
 
-    if strict and not allowed_values and validation_function is None:
+    if strict and allowed_values is not None and not allowed_values:
+        raise ValueError(f"property_spec({explanation!r}): an empty allowed_values would reject every value.")
+
+    if strict and allowed_values is None and validation_function is None:
         raise ValueError(
             f"property_spec({explanation!r}): strict=True needs a non-empty allowed_values or a validation_function."
         )
@@ -48,7 +51,13 @@ def property_spec(
 
     if strict and default is not None:
         if validation_function is not None:
-            if not validation_function(default):
+            try:
+                verdict = validation_function(default)
+            except Exception as exc:
+                raise ValueError(
+                    f"property_spec({explanation!r}): validation_function raised an error when called with default {default!r}."
+                ) from exc
+            if not verdict:
                 raise ValueError(
                     f"property_spec({explanation!r}): default {default!r} is rejected by the validation_function."
                 )

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_spec_builder.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_spec_builder.py
@@ -209,3 +209,192 @@ class TestPropertySpecDefaultOmission:
         spec = property_spec("op", strict=True, allowed_values={"add": "Addition"}, default="add")
 
         assert spec[DefaultOptionKeys.default] == "add"
+
+
+def _positive_int(value: Any) -> bool:
+    """Shared validator for the ``validation_function`` passthrough tests (issue #536)."""
+    return isinstance(value, int) and value > 0
+
+
+def _is_mul(value: Any) -> bool:
+    """Validator that only accepts the literal ``"mul"`` (issue #536)."""
+    return bool(value == "mul")
+
+
+def _always_required(options: Any) -> bool:
+    """``required_when`` predicate that always demands the option (issue #536)."""
+    return True
+
+
+def _is_list_of_strings(value: Any) -> bool:
+    """``type_validator`` accepting only a list of strings (issue #536)."""
+    return isinstance(value, list) and all(isinstance(item, str) for item in value)
+
+
+class TestPropertySpecValidationFunction:
+    """``validation_function`` passthrough (issue #536).
+
+    Core's ``_validate_property_value`` applies a spec's ``validation_function``
+    INSTEAD of the membership check under strict validation, so a strict spec with
+    a ``validation_function`` and no ``allowed_values`` is valid and meaningful
+    (see the ``window_size`` example in ``docs/docs/in_depth/property-mapping.md``).
+    Like ``allowed_values``, a ``validation_function`` is only enforced under
+    strict validation, so passing it without ``strict=True`` is a silent no-op
+    and is rejected.
+    """
+
+    def test_strict_with_validation_function_needs_no_allowed_values(self) -> None:
+        """``strict=True`` plus a ``validation_function`` needs no ``allowed_values``."""
+        spec = property_spec("d", strict=True, validation_function=_positive_int)
+
+        assert spec["explanation"] == "d"
+        assert spec[DefaultOptionKeys.validation_function] is _positive_int
+        assert spec[DefaultOptionKeys.strict_validation] is True
+        assert spec[DefaultOptionKeys.context] is True
+
+    def test_validation_function_without_strict_raises(self) -> None:
+        """A ``validation_function`` is never enforced without ``strict`` (silent no-op)."""
+        with pytest.raises(ValueError):
+            property_spec("d", validation_function=_positive_int)
+
+    def test_non_callable_validation_function_raises(self) -> None:
+        """A non-callable ``validation_function`` is rejected up front."""
+        not_callable: Any = "not callable"
+        with pytest.raises(ValueError):
+            property_spec("d", strict=True, validation_function=not_callable)
+
+
+class TestPropertySpecValidationFunctionDefault:
+    """Strict defaults are checked via the ``validation_function`` when present (issue #536).
+
+    Mirrors ``FeatureChainParser.validate_property_mapping_defaults``: when a spec
+    carries a ``validation_function``, the strict default check uses it, taking
+    precedence over membership in ``allowed_values``.
+    """
+
+    def test_strict_default_accepted_by_validation_function(self) -> None:
+        """A default the ``validation_function`` accepts is legal without ``allowed_values``."""
+        spec = property_spec("d", strict=True, validation_function=_positive_int, default=5)
+
+        assert spec[DefaultOptionKeys.default] == 5
+
+    def test_strict_default_rejected_by_validation_function_raises(self) -> None:
+        """A default the ``validation_function`` rejects is illegal."""
+        with pytest.raises(ValueError):
+            property_spec("d", strict=True, validation_function=_positive_int, default=-1)
+
+    def test_validation_function_takes_precedence_over_allowed_values(self) -> None:
+        """With both present, the default is checked via the ``validation_function``, not membership."""
+        spec = property_spec("d", strict=True, allowed_values={"add": "A"}, validation_function=_is_mul, default="mul")
+
+        assert spec[DefaultOptionKeys.default] == "mul"
+        assert spec[DefaultOptionKeys.allowed_values] == {"add": "A"}
+        assert spec[DefaultOptionKeys.validation_function] is _is_mul
+
+
+class TestPropertySpecRequiredWhen:
+    """``required_when`` passthrough (issue #536).
+
+    ``required_when`` is a conditional-requirement predicate, independent of
+    strict validation, so it is legal without ``strict=True``.
+    """
+
+    def test_required_when_emitted_without_strict(self) -> None:
+        """The predicate is emitted under ``DefaultOptionKeys.required_when`` without ``strict``."""
+        spec = property_spec("d", required_when=_always_required)
+
+        assert spec[DefaultOptionKeys.required_when] is _always_required
+        assert spec[DefaultOptionKeys.strict_validation] is False
+
+    def test_non_callable_required_when_raises(self) -> None:
+        """A non-callable ``required_when`` is rejected up front."""
+        not_callable: Any = "not callable"
+        with pytest.raises(ValueError):
+            property_spec("d", required_when=not_callable)
+
+
+class TestPropertySpecTypeValidator:
+    """``type_validator`` passthrough (issue #536).
+
+    ``type_validator`` checks the raw option value's shape before any list
+    unpacking and, unlike ``validation_function``, does not require strict
+    validation.
+    """
+
+    def test_type_validator_emitted_without_strict(self) -> None:
+        """The validator is emitted under ``DefaultOptionKeys.type_validator`` without ``strict``."""
+        spec = property_spec("d", type_validator=_is_list_of_strings)
+
+        assert spec[DefaultOptionKeys.type_validator] is _is_list_of_strings
+        assert spec[DefaultOptionKeys.strict_validation] is False
+
+    def test_non_callable_type_validator_raises(self) -> None:
+        """A non-callable ``type_validator`` is rejected up front."""
+        not_callable: Any = "not callable"
+        with pytest.raises(ValueError):
+            property_spec("d", type_validator=not_callable)
+
+
+class TestPropertySpecPassthroughOmission:
+    """Omitted passthroughs never appear in the emitted dict (issue #536).
+
+    Emitting ``None``-valued passthrough keys would change core behavior (e.g.
+    ``_can_skip_required_check`` keys off the mere PRESENCE of
+    ``required_when``), so an omitted passthrough must be absent, not ``None``.
+    """
+
+    def test_omitted_passthroughs_are_absent(self) -> None:
+        """Only explicitly passed passthrough keys are emitted; the rest are absent."""
+        plain = property_spec("d")
+        assert DefaultOptionKeys.validation_function not in plain
+        assert DefaultOptionKeys.required_when not in plain
+        assert DefaultOptionKeys.type_validator not in plain
+
+        with_required_when = property_spec("d", required_when=_always_required)
+        assert DefaultOptionKeys.validation_function not in with_required_when
+        assert DefaultOptionKeys.type_validator not in with_required_when
+
+        with_type_validator = property_spec("d", type_validator=_is_list_of_strings)
+        assert DefaultOptionKeys.validation_function not in with_type_validator
+        assert DefaultOptionKeys.required_when not in with_type_validator
+
+
+class TestPropertySpecValidationFunctionRoundTrip:
+    """A strict ``validation_function`` spec matches core semantics end to end (issue #536)."""
+
+    def test_class_definition_accepts_validation_function_default(self) -> None:
+        """The built entry defines without error and equals the hand-written dict.
+
+        Core's class-definition check (``validate_property_mapping_defaults``)
+        accepts a strict default via the ``validation_function``; the helper must
+        emit exactly the dict an author would hand-write for that spec.
+        """
+
+        class WindowFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+            PREFIX_PATTERN = r".*__([\w]+)_window$"
+            PROPERTY_MAPPING = {
+                "window_size": property_spec(
+                    "Size of time window",
+                    strict=True,
+                    validation_function=_positive_int,
+                    default=5,
+                )
+            }
+
+            @classmethod
+            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                return data
+
+        built = WindowFeatureGroup.PROPERTY_MAPPING["window_size"]
+
+        hand_written: dict[str, Any] = {
+            "explanation": "Size of time window",
+            DefaultOptionKeys.validation_function: _positive_int,
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: True,
+            DefaultOptionKeys.default: 5,
+        }
+        assert built == hand_written
+
+        FeatureChainParser.validate_property_mapping_defaults("Built", {"window_size": built})
+        FeatureChainParser.validate_property_mapping_defaults("HandWritten", {"window_size": hand_written})

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_spec_builder.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_spec_builder.py
@@ -231,6 +231,11 @@ def _is_list_of_strings(value: Any) -> bool:
     return isinstance(value, list) and all(isinstance(item, str) for item in value)
 
 
+def _boom(value: Any) -> bool:
+    """Validator that raises instead of returning a verdict (issue #536)."""
+    raise RuntimeError("boom")
+
+
 class TestPropertySpecValidationFunction:
     """``validation_function`` passthrough (issue #536).
 
@@ -398,3 +403,82 @@ class TestPropertySpecValidationFunctionRoundTrip:
 
         FeatureChainParser.validate_property_mapping_defaults("Built", {"window_size": built})
         FeatureChainParser.validate_property_mapping_defaults("HandWritten", {"window_size": hand_written})
+
+
+class TestPropertySpecRaisingValidationFunction:
+    """A ``validation_function`` that raises on the default is wrapped (issue #536).
+
+    Mirrors core's ``FeatureChainParser.validate_property_mapping_defaults``, which
+    distinguishes "the validation_function raised when called with the default"
+    from "the validation_function ran and rejected the default": both surface as
+    ``ValueError``, with the original exception chained as ``__cause__`` in the
+    raising case. The builder's strict-default check must behave the same way
+    instead of letting the author's exception propagate raw.
+    """
+
+    def test_raising_validation_function_wraps_as_value_error_with_cause(self) -> None:
+        """``_boom`` raising ``RuntimeError`` surfaces as ``ValueError`` with the original chained."""
+        with pytest.raises(ValueError) as exc_info:
+            property_spec("d", strict=True, validation_function=_boom, default=5)
+
+        assert isinstance(exc_info.value.__cause__, RuntimeError)
+
+
+class TestPropertySpecEmptyAllowedValues:
+    """An explicitly empty ``allowed_values`` is always an authoring mistake (issue #536).
+
+    Even when a ``validation_function`` is present (so the spec would still be
+    enforceable), an explicitly empty allowed set is dead configuration: core's
+    ``_extract_property_values`` would surface it as an empty accepted set. The
+    builder must reject it up front instead of silently emitting a dead, empty
+    ``allowed_values`` key.
+    """
+
+    def test_empty_allowed_values_with_validation_function_raises(self) -> None:
+        """``strict=True`` with ``allowed_values=[]`` raises even though a validator is present."""
+        with pytest.raises(ValueError):
+            property_spec("d", strict=True, validation_function=_positive_int, allowed_values=[])
+
+
+class TestPropertySpecPassthroughRegressionGuards:
+    """Regression guards from the second review round of the passthroughs (issue #536)."""
+
+    def test_falsy_non_none_default_is_still_validated(self) -> None:
+        """``default=0`` is falsy but not ``None``, so it must still be checked (and rejected)."""
+        with pytest.raises(ValueError):
+            property_spec("d", strict=True, validation_function=_positive_int, default=0)
+
+    def test_validation_function_precedence_also_rejects_allowed_member(self) -> None:
+        """With both present, a default IN ``allowed_values`` is still rejected by the validator."""
+        with pytest.raises(ValueError):
+            property_spec(
+                "d",
+                strict=True,
+                allowed_values={"add": "A"},
+                validation_function=_positive_int,
+                default="add",
+            )
+
+    def test_required_when_spec_equals_hand_written_dict(self) -> None:
+        """A ``required_when`` spec is exactly the dict an author would hand-write."""
+        built = property_spec("d", required_when=_always_required)
+
+        hand_written: dict[str, Any] = {
+            "explanation": "d",
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: False,
+            DefaultOptionKeys.required_when: _always_required,
+        }
+        assert built == hand_written
+
+    def test_type_validator_spec_equals_hand_written_dict(self) -> None:
+        """A ``type_validator`` spec is exactly the dict an author would hand-write."""
+        built = property_spec("d", type_validator=_is_list_of_strings)
+
+        hand_written: dict[str, Any] = {
+            "explanation": "d",
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: False,
+            DefaultOptionKeys.type_validator: _is_list_of_strings,
+        }
+        assert built == hand_written

--- a/tests/test_plugins/integration_plugins/chainer/test_property_spec_validation_e2e.py
+++ b/tests/test_plugins/integration_plugins/chainer/test_property_spec_validation_e2e.py
@@ -1,0 +1,179 @@
+"""End-to-end tests for the property_spec validation_function passthrough (issue #536).
+
+Demonstrates the user-facing story of PR feat/property-spec-passthroughs: a feature
+group author declares a "window_size" option via
+``property_spec(..., strict=True, validation_function=...)`` and gets two distinct
+validation moments for free:
+
+1. Planning time: an end-user request through the public mloda API with an invalid
+   window_size raises ValueError before any computation runs.
+2. Authoring time: ``property_spec`` itself rejects a declared default that fails
+   the validation_function, at the call site (class-definition time).
+
+The derived feature group uses FeatureChainParserMixin for input_features but
+overrides ``match_feature_group_criteria`` to call
+``FeatureChainParser.match_configuration_feature_chain_parser`` directly, following
+``test_list_valued_options_e2e.py``. The mixin's default match catches the
+validation ValueError and returns False (see
+``test_strict_validation_returns_false.py``), which would surface only as a generic
+"No feature groups found" error; the direct call preserves the actionable message
+naming the rejected option.
+"""
+
+from typing import Any, Optional
+
+import pandas as pd
+import pytest
+
+from mloda.provider import (
+    BaseInputData,
+    ComputeFramework,
+    DataCreator,
+    DefaultOptionKeys,
+    FeatureChainParser,
+    FeatureChainParserMixin,
+    FeatureGroup,
+    FeatureSet,
+    property_spec,
+)
+from mloda.user import Feature, FeatureName, Options, PluginCollector, mloda
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+
+# Records calculate_feature invocations so tests can assert that planning-time
+# rejection happens before any computation runs.
+CALCULATE_INVOCATIONS: list[str] = []
+
+
+def is_valid_window_size(value: Any) -> bool:
+    """Module-level validator (named function, not a lambda, for pickling safety)."""
+    return isinstance(value, int) and 0 < value <= 13
+
+
+class PropertySpecE2EDataCreator(FeatureGroup):
+    """Root data provider supplying a numeric base column."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({"property_spec_e2e_base"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        CALCULATE_INVOCATIONS.append(cls.__name__)
+        return pd.DataFrame({"property_spec_e2e_base": [1, 2, 3]})
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+
+class PropertySpecE2EWindowedFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+    """Derived feature group whose "window_size" option is guarded by property_spec.
+
+    The computation (base column + window_size) is intentionally trivial; the point
+    is the validation_function passthrough, not rolling-window logic.
+    """
+
+    PROPERTY_MAPPING = {
+        "window_size": property_spec(
+            "Size of the time window, at most 13",
+            strict=True,
+            validation_function=is_valid_window_size,
+        ),
+        DefaultOptionKeys.in_features: property_spec("Source feature to window over"),
+    }
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[Any] = None,
+    ) -> bool:
+        _name = str(feature_name) if isinstance(feature_name, FeatureName) else feature_name
+        return FeatureChainParser.match_configuration_feature_chain_parser(
+            _name,
+            options,
+            property_mapping=cls.PROPERTY_MAPPING,
+        )
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        CALCULATE_INVOCATIONS.append(cls.__name__)
+        for feature in features.features:
+            window_size = feature.options.get("window_size")
+            data[feature.name] = data["property_spec_e2e_base"] + window_size
+        return data
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+
+class TestPropertySpecValidationFunctionE2E:
+    """End-to-end coverage of the two validation moments enabled by property_spec."""
+
+    plugin_collector = PluginCollector.enabled_feature_groups(
+        {PropertySpecE2EDataCreator, PropertySpecE2EWindowedFeatureGroup}
+    )
+
+    def test_valid_window_size_runs_end_to_end(self) -> None:
+        """window_size=7 passes the validator; the run returns the computed column."""
+        feature = Feature(
+            name="property_spec_e2e_windowed",
+            options=Options(
+                context={
+                    DefaultOptionKeys.in_features: "property_spec_e2e_base",
+                    "window_size": 7,
+                },
+            ),
+        )
+
+        result = mloda.run_all(
+            [feature],
+            compute_frameworks={PandasDataFrame},
+            plugin_collector=self.plugin_collector,
+        )
+
+        assert len(result) >= 1
+
+        for df in result:
+            if "property_spec_e2e_windowed" in df.columns:
+                # base [1, 2, 3] + window_size 7
+                assert df["property_spec_e2e_windowed"].tolist() == [8, 9, 10]
+                assert PropertySpecE2EWindowedFeatureGroup.__name__ in CALCULATE_INVOCATIONS
+                return
+
+        raise AssertionError("property_spec_e2e_windowed not found in results")
+
+    def test_invalid_window_size_rejected_at_planning_time(self) -> None:
+        """window_size=14 fails the validator: ValueError before any computation runs."""
+        invocations_before = len(CALCULATE_INVOCATIONS)
+
+        feature = Feature(
+            name="property_spec_e2e_windowed_invalid",
+            options=Options(
+                context={
+                    DefaultOptionKeys.in_features: "property_spec_e2e_base",
+                    "window_size": 14,
+                },
+            ),
+        )
+
+        with pytest.raises(ValueError, match="window_size"):
+            mloda.run_all(
+                [feature],
+                compute_frameworks={PandasDataFrame},
+                plugin_collector=self.plugin_collector,
+            )
+
+        assert len(CALCULATE_INVOCATIONS) == invocations_before, "rejection must happen before any computation"
+
+    def test_author_side_default_rejected_at_call_site(self) -> None:
+        """A default rejected by the validation_function fails at the property_spec call."""
+        with pytest.raises(ValueError, match="default 14 is rejected by the validation_function"):
+            property_spec(
+                "Size of the time window, at most 13",
+                strict=True,
+                validation_function=is_valid_window_size,
+                default=14,
+            )


### PR DESCRIPTION
Closes #536.

## Status analysis

Most of #536 was already delivered by #562 (from analysis ticket #543): the `property_spec()` builder in core, the four construction-time invariants (strict needs a non-empty `allowed_values`; `allowed_values` without strict is rejected; a strict default must be in the allowed set; one-shot iterables are materialized), full raw-dict compatibility, docs, and tests. The frozen-dataclass form mentioned in the issue was resolved differently by design in #543: the contract stays a plain `dict[str, Any]`, emitted directly by the helper.

## What this PR adds (the remaining delta)

Optional passthroughs on `property_spec()` for the advanced spec keys core already supports, with construction-time validation:

- `validation_function`: must be callable and requires `strict=True` (core never enforces it non-strict, same rationale as the existing `allowed_values` rule). With a `validation_function`, `strict=True` no longer requires `allowed_values` (matching the documented `window_size` pattern), and a declared default is checked through the function instead of membership, mirroring `FeatureChainParser.validate_property_mapping_defaults`. A function that itself raises on the default is wrapped as a contextual `ValueError` with the original exception chained as `__cause__`, exactly as core does at class-definition time.
- `required_when` and `type_validator`: callable-checked passthroughs, no strict requirement, matching the mixin's enforcement.
- Omitted passthroughs leave no key in the emitted dict (presence of `required_when` matters to `_can_skip_required_check`).
- An explicitly empty `allowed_values` under strict is now rejected even when a `validation_function` is present, instead of emitting a dead empty key.

Docs: the Builder section of `docs/in_depth/property-mapping.md` documents the passthroughs and their invariants.

Tests: 18 new tests covering each rejected invariant, precedence on both the accept and reject side, falsy non-None defaults, the raised-vs-rejected distinction, passthrough omission, and hand-written-dict round-trip equality plus the class-definition check.

## Validation

- `tox` green: 4251 passed, 171 skipped; ruff format/check, license allowlist, `mypy --strict` (732 files), bandit all pass.
- Two independent deep reviews (Claude Opus and codex) ran against the diff; both flagged the unwrapped raising `validation_function`, one flagged the silently emitted empty `allowed_values`. Both fixed here. Note: the wrap uses a tight `try/except ... from exc`, matching the established pattern in `validate_property_mapping_defaults` for the same check.
