### PR TITLE
feat: fluent Results reading API for run_all (get_df, get_rows, get_values, get_one)

### DIFF
--- a/docs/docs/in_depth/access-feature-data.md
+++ b/docs/docs/in_depth/access-feature-data.md
@@ -360,6 +360,42 @@ AInputFeatureGroup
 
 As the input features can be fulfilled by **multiple other features**, we can have the same processes running in different environments, migrations and processes.
 
+#### Convenience helpers: run_one, run_all_as_dataframe, results_by_feature
+
+`run_all` returns a list with one result object per feature group, so reading a value requires knowing that nesting. Three helpers cover the common cases: use `run_one` for a single feature (it returns the rows as a flat list of dicts), `run_all_as_dataframe` for one horizontally concatenated DataFrame (pandas or polars; it raises `ValueError` on mismatched row counts or non-DataFrame frameworks), and `results_by_feature` to pick a `run_all` result by column name (multi-output columns like `feature~suffix` are also reachable via their base name; missing names raise `KeyError`).
+
+Reusing the feature groups from the previous example:
+
+```python
+from mloda.user import results_by_feature
+
+plugin_collector = PluginCollector.enabled_feature_groups({AInputFeatureGroup, AFeatureInputCreator})
+
+# Single feature: flat rows, no nesting to unpack
+rows = mloda.run_one("AFeatureInputCreator", compute_frameworks={PandasDataFrame}, plugin_collector=plugin_collector)
+print(rows)
+
+# All features combined into one wide DataFrame
+df = mloda.run_all_as_dataframe(
+    feature_list, compute_frameworks={PandasDataFrame}, plugin_collector=plugin_collector
+)
+print(sorted(df.columns))
+
+# Pick a result from a plain run_all output by column name
+by_name = results_by_feature(result)
+print(by_name["AInputFeatureGroup"])
+```
+
+Output:
+
+``` python
+[{'AFeatureInputCreator': 'TestValue5'}, {'AFeatureInputCreator': 'TestValue6'}]
+['AFeatureInputCreator', 'AInputFeatureGroup']
+   AInputFeatureGroup
+0                   2
+1                   2
+```
+
 #### Combining Data Sources with Links
 
 When input features come from different sources (e.g., ApiData and DataCreator), you can join them using Links. Create a `Link` in `input_features()` and attach it to a `Feature`:

--- a/docs/docs/in_depth/access-feature-data.md
+++ b/docs/docs/in_depth/access-feature-data.md
@@ -360,36 +360,34 @@ AInputFeatureGroup
 
 As the input features can be fulfilled by **multiple other features**, we can have the same processes running in different environments, migrations and processes.
 
-#### Convenience helpers: run_one, run_all_as_dataframe, results_by_feature
+#### Reading results: get_one, get_rows, get_values, get_df
 
-`run_all` returns a list with one result object per feature group, so reading a value requires knowing that nesting. Three helpers cover the common cases: use `run_one` for a single feature (it returns the rows as a flat list of dicts), `run_all_as_dataframe` for one horizontally concatenated DataFrame (pandas or polars; it raises `ValueError` on mismatched row counts or non-DataFrame frameworks), and `results_by_feature` to pick a `run_all` result by column name (multi-output columns like `feature~suffix` are also reachable via their base name; missing names raise `KeyError`).
+`run_all` returns a `Results` list with one result object per feature group. Its accessors read a value without knowing that nesting: `get_rows(name)` converts one feature's result to a flat list of row dicts, `get_values(name)` returns one column as a plain Python list, `get_df()` concatenates all results into one wide DataFrame (pandas or polars; it raises `ValueError` on mismatched row counts or non-DataFrame frameworks), and `get_one(name)` returns the raw result object containing that column. Multi-output columns like `feature~suffix` are also reachable via their base name; unknown names raise `ValueError`.
 
-Reusing the feature groups from the previous example:
+Reusing the `result` from the previous example:
 
 ```python
-from mloda.user import results_by_feature
-
-plugin_collector = PluginCollector.enabled_feature_groups({AInputFeatureGroup, AFeatureInputCreator})
-
-# Single feature: flat rows, no nesting to unpack
-rows = mloda.run_one("AFeatureInputCreator", compute_frameworks={PandasDataFrame}, plugin_collector=plugin_collector)
+# One feature's rows as flat dicts, no nesting to unpack
+rows = result.get_rows("AFeatureInputCreator")
 print(rows)
 
+# One column as a plain Python list
+values = result.get_values("AInputFeatureGroup")
+print(values)
+
 # All features combined into one wide DataFrame
-df = mloda.run_all_as_dataframe(
-    feature_list, compute_frameworks={PandasDataFrame}, plugin_collector=plugin_collector
-)
+df = result.get_df()
 print(sorted(df.columns))
 
-# Pick a result from a plain run_all output by column name
-by_name = results_by_feature(result)
-print(by_name["AInputFeatureGroup"])
+# The raw result object containing a column
+print(result.get_one("AInputFeatureGroup"))
 ```
 
 Output:
 
 ``` python
 [{'AFeatureInputCreator': 'TestValue5'}, {'AFeatureInputCreator': 'TestValue6'}]
+[2, 2]
 ['AFeatureInputCreator', 'AInputFeatureGroup']
    AInputFeatureGroup
 0                   2

--- a/mloda/core/api/request.py
+++ b/mloda/core/api/request.py
@@ -172,21 +172,26 @@ class mlodaAPI:
     def run_one(cls, feature: Feature | str, **run_all_kwargs: Any) -> list[dict[str, Any]]:
         """Run a single feature and return its result as a flat list of row dicts (issue #564).
 
-        Accepts the same keyword arguments as ``run_all``.
+        Accepts the same options as ``run_all``, but unlike ``run_all`` they must all be
+        passed as keyword arguments.
         """
         if not isinstance(feature, (Feature, str)):
             raise ValueError("run_one takes a single feature; use run_all for multiple features.")
         results = cls.run_all([feature], **run_all_kwargs)
         if len(results) != 1:
-            raise ValueError(f"run_one expected exactly one result, got {len(results)}.")
+            raise ValueError(
+                f"run_one expected exactly one result, got {len(results)}: the feature resolved "
+                "to multiple result groups. Use run_all instead."
+            )
         return _to_rows(results[0])
 
     @classmethod
     def run_all_as_dataframe(cls, features: Features | list[Feature | str], **run_all_kwargs: Any) -> Any:
         """Run like ``run_all`` and return one horizontally concatenated DataFrame (issue #568).
 
-        Accepts the same keyword arguments as ``run_all``. Raises ValueError on mismatched
-        row counts or when the results are not pandas/polars DataFrames.
+        Accepts the same options as ``run_all``, but unlike ``run_all`` they must all be
+        passed as keyword arguments. Raises ValueError on mismatched row counts or when
+        the results are not pandas/polars DataFrames.
         """
         return _concat_frames(cls.run_all(features, **run_all_kwargs))
 

--- a/mloda/core/api/request.py
+++ b/mloda/core/api/request.py
@@ -18,6 +18,7 @@ from mloda.core.abstract_plugins.components.feature_collection import Features
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.link import Link
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+from mloda.core.api.results import _concat_frames, _to_rows
 
 
 class mlodaAPI:
@@ -166,6 +167,28 @@ class mlodaAPI:
             flight_server=flight_server,
             function_extender=function_extender,
         )
+
+    @classmethod
+    def run_one(cls, feature: Feature | str, **run_all_kwargs: Any) -> list[dict[str, Any]]:
+        """Run a single feature and return its result as a flat list of row dicts (issue #564).
+
+        Accepts the same keyword arguments as ``run_all``.
+        """
+        if not isinstance(feature, (Feature, str)):
+            raise ValueError("run_one takes a single feature; use run_all for multiple features.")
+        results = cls.run_all([feature], **run_all_kwargs)
+        if len(results) != 1:
+            raise ValueError(f"run_one expected exactly one result, got {len(results)}.")
+        return _to_rows(results[0])
+
+    @classmethod
+    def run_all_as_dataframe(cls, features: Features | list[Feature | str], **run_all_kwargs: Any) -> Any:
+        """Run like ``run_all`` and return one horizontally concatenated DataFrame (issue #568).
+
+        Accepts the same keyword arguments as ``run_all``. Raises ValueError on mismatched
+        row counts or when the results are not pandas/polars DataFrames.
+        """
+        return _concat_frames(cls.run_all(features, **run_all_kwargs))
 
     @classmethod
     def stream_all(

--- a/mloda/core/api/request.py
+++ b/mloda/core/api/request.py
@@ -18,7 +18,7 @@ from mloda.core.abstract_plugins.components.feature_collection import Features
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.link import Link
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
-from mloda.core.api.results import _concat_frames, _to_rows
+from mloda.core.api.results import Results
 
 
 class mlodaAPI:
@@ -112,7 +112,7 @@ class mlodaAPI:
         copy_features: bool = True,
         strict_type_enforcement: bool = False,
         column_ordering: Optional[str] = None,
-    ) -> list[Any]:
+    ) -> Results:
         """
         Run feature computation in one step.
 
@@ -136,11 +136,13 @@ class mlodaAPI:
             strict_type_enforcement: If True, enforce strict type matching for typed features.
 
         Returns:
-            List of computed results, one per feature group in execution plan
-            order. Each element is a compute-framework object (e.g.
-            ``pd.DataFrame``, ``pa.Table``) containing only the columns for
-            the requested features resolved by that group. When all requested
-            features resolve to a single group, the list has one element.
+            Results list of computed results, one per feature group in
+            execution plan order. Each element is a compute-framework object
+            (e.g. ``pd.DataFrame``, ``pa.Table``) containing only the columns
+            for the requested features resolved by that group. When all
+            requested features resolve to a single group, the list has one
+            element. Use ``get_one``, ``get_rows``, ``get_values``, or
+            ``get_df`` to read results without knowing the element shape.
 
         Example:
             result = mloda.run_all(
@@ -167,33 +169,6 @@ class mlodaAPI:
             flight_server=flight_server,
             function_extender=function_extender,
         )
-
-    @classmethod
-    def run_one(cls, feature: Feature | str, **run_all_kwargs: Any) -> list[dict[str, Any]]:
-        """Run a single feature and return its result as a flat list of row dicts (issue #564).
-
-        Accepts the same options as ``run_all``, but unlike ``run_all`` they must all be
-        passed as keyword arguments.
-        """
-        if not isinstance(feature, (Feature, str)):
-            raise ValueError("run_one takes a single feature; use run_all for multiple features.")
-        results = cls.run_all([feature], **run_all_kwargs)
-        if len(results) != 1:
-            raise ValueError(
-                f"run_one expected exactly one result, got {len(results)}: the feature resolved "
-                "to multiple result groups. Use run_all instead."
-            )
-        return _to_rows(results[0])
-
-    @classmethod
-    def run_all_as_dataframe(cls, features: Features | list[Feature | str], **run_all_kwargs: Any) -> Any:
-        """Run like ``run_all`` and return one horizontally concatenated DataFrame (issue #568).
-
-        Accepts the same options as ``run_all``, but unlike ``run_all`` they must all be
-        passed as keyword arguments. Raises ValueError on mismatched row counts or when
-        the results are not pandas/polars DataFrames.
-        """
-        return _concat_frames(cls.run_all(features, **run_all_kwargs))
 
     @classmethod
     def stream_all(
@@ -281,7 +256,7 @@ class mlodaAPI:
         flight_server: Optional[Any] = None,
         function_extender: Optional[set[Extender]] = None,
         artifacts: Optional[dict[str, Any]] = None,
-    ) -> list[Any]:
+    ) -> Results:
         """Execute the prepared session and return results.
 
         Can be called multiple times on the same session with different ``api_data``
@@ -404,10 +379,10 @@ class mlodaAPI:
 
         return runner
 
-    def get_result(self) -> list[Any]:
+    def get_result(self) -> Results:
         if self.runner is None:
             raise ValueError("You need to run any run function beforehand.")
-        return self.runner.get_result()
+        return Results(self.runner.get_result())
 
     def get_artifacts(self) -> dict[str, Any]:
         if self.runner is None:

--- a/mloda/core/api/results.py
+++ b/mloda/core/api/results.py
@@ -1,32 +1,31 @@
-"""Public helpers for reading mlodaAPI.run_all output (issue #569)."""
+"""Fluent result list returned by mlodaAPI.run_all (issues #564, #568, #569)."""
 
 from typing import Any
 
 
-def results_by_feature(results: list[Any]) -> dict[str, Any]:
-    """Map each column name of each result element to the element itself.
+def _element_columns(element: Any) -> list[str]:
+    """List the column names of one result element."""
+    if isinstance(element, dict):
+        return list(element.keys())
+    if isinstance(element, list):
+        if element and not isinstance(element[0], dict):
+            raise ValueError(f"Unsupported result element type: list of {type(element[0]).__name__}")
+        return list(element[0].keys()) if element else []
+    if hasattr(element, "column_names"):
+        return list(element.column_names)
+    if hasattr(element, "columns"):
+        return list(element.columns)
+    raise ValueError(f"Unsupported result element type: {type(element).__name__}")
 
-    A multi-output column "feature~suffix" is also reachable via its base name "feature".
-    First occurrence wins on duplicate names. Looking up a missing name raises KeyError.
-    Caveat: a literal column name containing "~" also registers its base name, which can
-    shadow a same-named column from a later result.
+
+def _column_mapping(results: list[Any]) -> dict[str, Any]:
+    """Map each column name (and each multi-output base name before the first "~") to its element.
+
+    First occurrence wins on duplicate names.
     """
     mapping: dict[str, Any] = {}
     for element in results:
-        if isinstance(element, dict):
-            column_names = list(element.keys())
-        elif isinstance(element, list):
-            if element and not isinstance(element[0], dict):
-                raise ValueError(f"Unsupported result element type: list of {type(element[0]).__name__}")
-            column_names = list(element[0].keys()) if element else []
-        elif hasattr(element, "column_names"):
-            column_names = list(element.column_names)
-        elif hasattr(element, "columns"):
-            column_names = list(element.columns)
-        else:
-            raise ValueError(f"Unsupported result element type: {type(element).__name__}")
-
-        for column_name in column_names:
+        for column_name in _element_columns(element):
             if column_name not in mapping:
                 mapping[column_name] = element
             if "~" in column_name:
@@ -37,7 +36,7 @@ def results_by_feature(results: list[Any]) -> dict[str, Any]:
 
 
 def _to_rows(result: Any) -> list[dict[str, Any]]:
-    """Convert one run_all result element to a flat list of row dicts."""
+    """Convert one result element to a flat list of row dicts."""
     if isinstance(result, list):
         return list(result)
     if isinstance(result, dict):
@@ -68,7 +67,7 @@ def _to_rows(result: Any) -> list[dict[str, Any]]:
 
 
 def _concat_frames(results: list[Any]) -> Any:
-    """Horizontally combine run_all results into one pandas or polars DataFrame."""
+    """Horizontally combine result elements into one pandas or polars DataFrame."""
     elements = [
         element.collect()
         if type(element).__module__.split(".")[0] == "polars" and hasattr(element, "collect")
@@ -86,7 +85,7 @@ def _concat_frames(results: list[Any]) -> Any:
 
     if not frames:
         raise ValueError(
-            "run_all produced no DataFrame results; use results_by_feature or run_one "
+            "run_all produced no DataFrame results; use get_one, get_rows or get_values "
             "for non-DataFrame compute frameworks."
         )
     if non_frames:
@@ -119,3 +118,60 @@ def _concat_frames(results: list[Any]) -> Any:
     import polars as pl
 
     return pl.concat(deduped, how="horizontal")
+
+
+class Results(list[Any]):
+    """Result list of mlodaAPI.run_all: one element per resolving feature group (issues #564, #568, #569).
+
+    Accessors read results without knowing the element shape:
+
+    - get_one(name): the raw element containing a column (identity preserved)
+    - get_rows(name): one element converted to a flat list of row dicts
+    - get_values(name): one column as a plain Python list
+    - get_df(): all elements horizontally concatenated into one pandas or polars DataFrame
+
+    A multi-output column "feature~suffix" is also reachable via its base name "feature"
+    (split on the first "~"). First occurrence wins on duplicate names.
+    """
+
+    def get_one(self, name: str | None = None) -> Any:
+        """Return the element containing column ``name``; without a name, the sole element."""
+        if name is None:
+            if len(self) != 1:
+                raise ValueError(
+                    f"Expected exactly one result element, got {len(self)}; pass a feature name to get_one."
+                )
+            return self[0]
+        mapping = _column_mapping(self)
+        if name not in mapping:
+            raise ValueError(f"Unknown feature name '{name}'. Available names: {sorted(mapping)}.")
+        return mapping[name]
+
+    def get_rows(self, name: str | None = None) -> list[dict[str, Any]]:
+        """Return the element containing column ``name`` as a flat list of row dicts."""
+        return _to_rows(self.get_one(name))
+
+    def get_values(self, name: str) -> list[Any]:
+        """Return the column ``name`` as a plain Python list."""
+        element = self.get_one(name)
+        if name not in _element_columns(element):
+            raise ValueError(
+                f"'{name}' is not a column of the resolved element. "
+                f"Available columns: {sorted(_element_columns(element))}."
+            )
+        if isinstance(element, dict):
+            return list(element[name])
+        if isinstance(element, list):
+            return [row[name] for row in element]
+        column = element[name]
+        if hasattr(column, "to_pylist"):
+            return list(column.to_pylist())
+        if hasattr(column, "to_list"):
+            return list(column.to_list())
+        if hasattr(column, "tolist"):
+            return list(column.tolist())
+        return list(column)
+
+    def get_df(self) -> Any:
+        """Return all elements horizontally concatenated into one pandas or polars DataFrame."""
+        return _concat_frames(self)

--- a/mloda/core/api/results.py
+++ b/mloda/core/api/results.py
@@ -8,12 +8,16 @@ def results_by_feature(results: list[Any]) -> dict[str, Any]:
 
     A multi-output column "feature~suffix" is also reachable via its base name "feature".
     First occurrence wins on duplicate names. Looking up a missing name raises KeyError.
+    Caveat: a literal column name containing "~" also registers its base name, which can
+    shadow a same-named column from a later result.
     """
     mapping: dict[str, Any] = {}
     for element in results:
         if isinstance(element, dict):
             column_names = list(element.keys())
         elif isinstance(element, list):
+            if element and not isinstance(element[0], dict):
+                raise ValueError(f"Unsupported result element type: list of {type(element[0]).__name__}")
             column_names = list(element[0].keys()) if element else []
         elif hasattr(element, "column_names"):
             column_names = list(element.column_names)
@@ -35,8 +39,11 @@ def results_by_feature(results: list[Any]) -> dict[str, Any]:
 def _to_rows(result: Any) -> list[dict[str, Any]]:
     """Convert one run_all result element to a flat list of row dicts."""
     if isinstance(result, list):
-        return result
+        return list(result)
     if isinstance(result, dict):
+        column_lengths = {len(values) for values in result.values()}
+        if len(column_lengths) > 1:
+            raise ValueError(f"Columnar dict has mismatched column lengths: {sorted(column_lengths)}.")
         keys = list(result.keys())
         return [dict(zip(keys, values)) for values in zip(*result.values())]
     if hasattr(result, "to_pylist"):
@@ -48,21 +55,43 @@ def _to_rows(result: Any) -> list[dict[str, Any]]:
     if hasattr(result, "to_dict") and hasattr(result, "columns"):
         records_rows: list[dict[str, Any]] = result.to_dict("records")
         return records_rows
+    if hasattr(result, "collect"):
+        collected = result.collect()
+        if hasattr(collected, "to_dicts"):
+            collected_rows: list[dict[str, Any]] = collected.to_dicts()
+            return collected_rows
+        if isinstance(collected, list):
+            return [row.asDict() if hasattr(row, "asDict") else row for row in collected]
+    if hasattr(result, "df"):
+        return _to_rows(result.df())
     raise ValueError(f"Unsupported result element type: {type(result).__name__}")
 
 
 def _concat_frames(results: list[Any]) -> Any:
     """Horizontally combine run_all results into one pandas or polars DataFrame."""
-    frames = [
-        element
+    elements = [
+        element.collect()
+        if type(element).__module__.split(".")[0] == "polars" and hasattr(element, "collect")
+        else element
         for element in results
-        if type(element).__module__.split(".")[0] in ("pandas", "polars") and hasattr(element, "columns")
     ]
+
+    frames: list[Any] = []
+    non_frames: list[Any] = []
+    for element in elements:
+        if type(element).__module__.split(".")[0] in ("pandas", "polars") and hasattr(element, "columns"):
+            frames.append(element)
+        else:
+            non_frames.append(element)
+
     if not frames:
         raise ValueError(
             "run_all produced no DataFrame results; use results_by_feature or run_one "
             "for non-DataFrame compute frameworks."
         )
+    if non_frames:
+        non_frame_types = ", ".join(sorted({type(element).__name__ for element in non_frames}))
+        raise ValueError(f"run_all produced non-DataFrame results that cannot be concatenated: {non_frame_types}.")
     if len(frames) == 1:
         return frames[0]
 

--- a/mloda/core/api/results.py
+++ b/mloda/core/api/results.py
@@ -1,0 +1,92 @@
+"""Public helpers for reading mlodaAPI.run_all output (issue #569)."""
+
+from typing import Any
+
+
+def results_by_feature(results: list[Any]) -> dict[str, Any]:
+    """Map each column name of each result element to the element itself.
+
+    A multi-output column "feature~suffix" is also reachable via its base name "feature".
+    First occurrence wins on duplicate names. Looking up a missing name raises KeyError.
+    """
+    mapping: dict[str, Any] = {}
+    for element in results:
+        if isinstance(element, dict):
+            column_names = list(element.keys())
+        elif isinstance(element, list):
+            column_names = list(element[0].keys()) if element else []
+        elif hasattr(element, "column_names"):
+            column_names = list(element.column_names)
+        elif hasattr(element, "columns"):
+            column_names = list(element.columns)
+        else:
+            raise ValueError(f"Unsupported result element type: {type(element).__name__}")
+
+        for column_name in column_names:
+            if column_name not in mapping:
+                mapping[column_name] = element
+            if "~" in column_name:
+                base_name = column_name.split("~", 1)[0]
+                if base_name not in mapping:
+                    mapping[base_name] = element
+    return mapping
+
+
+def _to_rows(result: Any) -> list[dict[str, Any]]:
+    """Convert one run_all result element to a flat list of row dicts."""
+    if isinstance(result, list):
+        return result
+    if isinstance(result, dict):
+        keys = list(result.keys())
+        return [dict(zip(keys, values)) for values in zip(*result.values())]
+    if hasattr(result, "to_pylist"):
+        pylist_rows: list[dict[str, Any]] = result.to_pylist()
+        return pylist_rows
+    if hasattr(result, "to_dicts"):
+        dicts_rows: list[dict[str, Any]] = result.to_dicts()
+        return dicts_rows
+    if hasattr(result, "to_dict") and hasattr(result, "columns"):
+        records_rows: list[dict[str, Any]] = result.to_dict("records")
+        return records_rows
+    raise ValueError(f"Unsupported result element type: {type(result).__name__}")
+
+
+def _concat_frames(results: list[Any]) -> Any:
+    """Horizontally combine run_all results into one pandas or polars DataFrame."""
+    frames = [
+        element
+        for element in results
+        if type(element).__module__.split(".")[0] in ("pandas", "polars") and hasattr(element, "columns")
+    ]
+    if not frames:
+        raise ValueError(
+            "run_all produced no DataFrame results; use results_by_feature or run_one "
+            "for non-DataFrame compute frameworks."
+        )
+    if len(frames) == 1:
+        return frames[0]
+
+    packages = {type(frame).__module__.split(".")[0] for frame in frames}
+    if len(packages) > 1:
+        raise ValueError("Cannot concatenate mixed pandas and polars frames in one run.")
+
+    row_counts = {len(frame) for frame in frames}
+    if len(row_counts) > 1:
+        raise ValueError(f"Cannot concatenate frames with mismatched row counts: {sorted(row_counts)}.")
+
+    seen: set[str] = set()
+    deduped: list[Any] = []
+    for frame in frames:
+        keep = [column for column in frame.columns if column not in seen]
+        seen.update(frame.columns)
+        if not keep:
+            continue
+        deduped.append(frame if len(keep) == len(frame.columns) else frame[keep])
+
+    if packages == {"pandas"}:
+        import pandas as pd
+
+        return pd.concat(deduped, axis=1)
+    import polars as pl
+
+    return pl.concat(deduped, how="horizontal")

--- a/mloda/user/__init__.py
+++ b/mloda/user/__init__.py
@@ -36,7 +36,7 @@ from mloda.core.abstract_plugins.plugin_registry.plugin_registry import (
 )
 
 # Result reading
-from mloda.core.api.results import results_by_feature
+from mloda.core.api.results import Results
 
 # Config loading
 from mloda.core.api.feature_config.loader import load_features_from_config
@@ -87,7 +87,7 @@ __all__ = [
     # Streaming API
     "stream_all",
     # Result reading
-    "results_by_feature",
+    "Results",
     # Config loading
     "load_features_from_config",
     # Plugin documentation / discovery

--- a/mloda/user/__init__.py
+++ b/mloda/user/__init__.py
@@ -35,6 +35,9 @@ from mloda.core.abstract_plugins.plugin_registry.plugin_registry import (
     register_plugin,
 )
 
+# Result reading
+from mloda.core.api.results import results_by_feature
+
 # Config loading
 from mloda.core.api.feature_config.loader import load_features_from_config
 
@@ -83,6 +86,8 @@ __all__ = [
     "register_plugin",
     # Streaming API
     "stream_all",
+    # Result reading
+    "results_by_feature",
     # Config loading
     "load_features_from_config",
     # Plugin documentation / discovery

--- a/tests/test_core/test_abstract_plugins/test_sub_column_dependency.py
+++ b/tests/test_core/test_abstract_plugins/test_sub_column_dependency.py
@@ -343,11 +343,11 @@ class TestSubColumnIntegration:
             }
         )
 
-        df = mloda.run_all_as_dataframe(
+        df = mloda.run_all(
             ["sub_column_consumer_output"],
             compute_frameworks={PandasDataFrame},
             plugin_collector=plugin_collector,
-        )
+        ).get_df()
 
         assert "sub_column_consumer_output" in df.columns, "sub_column_consumer_output should be in the result"
 
@@ -409,11 +409,11 @@ class TestSubColumnIntegration:
             }
         )
 
-        df = mloda.run_all_as_dataframe(
+        df = mloda.run_all(
             ["validating_consumer_output"],
             compute_frameworks={PandasDataFrame},
             plugin_collector=plugin_collector,
-        )
+        ).get_df()
 
         expected = np.array([100, 200, 300, 400, 500])
         np.testing.assert_array_equal(
@@ -465,11 +465,11 @@ class TestSubColumnIntegration:
             }
         )
 
-        df = mloda.run_all_as_dataframe(
+        df = mloda.run_all(
             ["multi_sub_column_consumer_output"],
             compute_frameworks={PandasDataFrame},
             plugin_collector=plugin_collector,
-        )
+        ).get_df()
 
         assert "multi_sub_column_consumer_output" in df.columns
 
@@ -528,11 +528,11 @@ class TestSubColumnIntegration:
             }
         )
 
-        df = mloda.run_all_as_dataframe(
+        df = mloda.run_all(
             ["sub_column_consumer_output__value_doubled"],
             compute_frameworks={PandasDataFrame},
             plugin_collector=plugin_collector,
-        )
+        ).get_df()
 
         assert "sub_column_consumer_output__value_doubled" in df.columns
 
@@ -567,11 +567,11 @@ class TestSubColumnIntegration:
             }
         )
 
-        df = mloda.run_all_as_dataframe(
+        df = mloda.run_all(
             ["base_feature", "sub_column_consumer_output"],
             compute_frameworks={PandasDataFrame},
             plugin_collector=plugin_collector,
-        )
+        ).get_df()
 
         assert "base_feature~0" in df.columns, "base_feature~0 should be in result"
         assert "base_feature~1" in df.columns, "base_feature~1 should be in result"
@@ -663,11 +663,11 @@ class TestSubColumnIntegration:
             }
         )
 
-        df = mloda.run_all_as_dataframe(
+        df = mloda.run_all(
             ["second_consumer_output"],
             compute_frameworks={PandasDataFrame},
             plugin_collector=plugin_collector,
-        )
+        ).get_df()
 
         assert "second_consumer_output" in df.columns
 

--- a/tests/test_core/test_abstract_plugins/test_sub_column_dependency.py
+++ b/tests/test_core/test_abstract_plugins/test_sub_column_dependency.py
@@ -343,15 +343,11 @@ class TestSubColumnIntegration:
             }
         )
 
-        result = mloda.run_all(
+        df = mloda.run_all_as_dataframe(
             ["sub_column_consumer_output"],
             compute_frameworks={PandasDataFrame},
             plugin_collector=plugin_collector,
         )
-
-        assert len(result) >= 1, "Should return at least one result"
-
-        df = pd.concat(result, axis=1) if len(result) > 1 else result[0]
 
         assert "sub_column_consumer_output" in df.columns, "sub_column_consumer_output should be in the result"
 
@@ -413,15 +409,11 @@ class TestSubColumnIntegration:
             }
         )
 
-        result = mloda.run_all(
+        df = mloda.run_all_as_dataframe(
             ["validating_consumer_output"],
             compute_frameworks={PandasDataFrame},
             plugin_collector=plugin_collector,
         )
-
-        assert len(result) >= 1, "Should complete without error"
-
-        df = pd.concat(result, axis=1) if len(result) > 1 else result[0]
 
         expected = np.array([100, 200, 300, 400, 500])
         np.testing.assert_array_equal(
@@ -473,15 +465,11 @@ class TestSubColumnIntegration:
             }
         )
 
-        result = mloda.run_all(
+        df = mloda.run_all_as_dataframe(
             ["multi_sub_column_consumer_output"],
             compute_frameworks={PandasDataFrame},
             plugin_collector=plugin_collector,
         )
-
-        assert len(result) >= 1, "Should return at least one result"
-
-        df = pd.concat(result, axis=1) if len(result) > 1 else result[0]
 
         assert "multi_sub_column_consumer_output" in df.columns
 
@@ -540,15 +528,11 @@ class TestSubColumnIntegration:
             }
         )
 
-        result = mloda.run_all(
+        df = mloda.run_all_as_dataframe(
             ["sub_column_consumer_output__value_doubled"],
             compute_frameworks={PandasDataFrame},
             plugin_collector=plugin_collector,
         )
-
-        assert len(result) >= 1, "Should return at least one result"
-
-        df = pd.concat(result, axis=1) if len(result) > 1 else result[0]
 
         assert "sub_column_consumer_output__value_doubled" in df.columns
 
@@ -583,15 +567,11 @@ class TestSubColumnIntegration:
             }
         )
 
-        result = mloda.run_all(
+        df = mloda.run_all_as_dataframe(
             ["base_feature", "sub_column_consumer_output"],
             compute_frameworks={PandasDataFrame},
             plugin_collector=plugin_collector,
         )
-
-        assert len(result) >= 1, "Should return at least one result"
-
-        df = pd.concat(result, axis=1) if len(result) > 1 else result[0]
 
         assert "base_feature~0" in df.columns, "base_feature~0 should be in result"
         assert "base_feature~1" in df.columns, "base_feature~1 should be in result"
@@ -683,15 +663,11 @@ class TestSubColumnIntegration:
             }
         )
 
-        result = mloda.run_all(
+        df = mloda.run_all_as_dataframe(
             ["second_consumer_output"],
             compute_frameworks={PandasDataFrame},
             plugin_collector=plugin_collector,
         )
-
-        assert len(result) >= 1, "Should return at least one result"
-
-        df = pd.concat(result, axis=1) if len(result) > 1 else result[0]
 
         assert "second_consumer_output" in df.columns
 

--- a/tests/test_core/test_api/test_results.py
+++ b/tests/test_core/test_api/test_results.py
@@ -3,11 +3,15 @@
 from typing import Any
 
 import pandas as pd
-import polars as pl
 import pyarrow as pa
 import pytest
 
 from mloda.core.api.results import _concat_frames, _to_rows, results_by_feature
+
+try:
+    import polars as pl
+except ImportError:
+    pl = None  # type: ignore[assignment]
 
 
 class _SparkRowStub:
@@ -87,6 +91,7 @@ class TestResultsByFeatureColumnExtraction:
         assert mapping["col_a"] is element
         assert mapping["col_b"] is element
 
+    @pytest.mark.skipif(pl is None, reason="polars is not installed")
     def test_polars_dataframe_maps_columns_to_element(self) -> None:
         element = pl.DataFrame({"col_a": [1, 2], "col_b": [3, 4]})
         results: list[Any] = [element]
@@ -188,6 +193,7 @@ class TestToRows:
 
         assert rows == [{"col_a": 1, "col_b": 3}, {"col_a": 2, "col_b": 4}]
 
+    @pytest.mark.skipif(pl is None, reason="polars is not installed")
     def test_polars_dataframe_converts_to_dicts_rows(self) -> None:
         frame = pl.DataFrame({"col_a": [1, 2], "col_b": [3, 4]})
 
@@ -195,6 +201,7 @@ class TestToRows:
 
         assert rows == [{"col_a": 1, "col_b": 3}, {"col_a": 2, "col_b": 4}]
 
+    @pytest.mark.skipif(pl is None, reason="polars is not installed")
     def test_polars_lazyframe_collects_to_rows(self) -> None:
         lazy = pl.DataFrame({"col_a": [1, 2], "col_b": [3, 4]}).lazy()
 
@@ -262,6 +269,7 @@ class TestConcatFrames:
         assert list(combined["col_a"]) == [1, 2]
         assert list(combined["col_b"]) == [3, 4]
 
+    @pytest.mark.skipif(pl is None, reason="polars is not installed")
     def test_overlapping_columns_polars_keeps_first_frame_values(self) -> None:
         first = pl.DataFrame({"col_a": [1, 2], "shared": [10, 20]})
         second = pl.DataFrame({"shared": [99, 98], "col_b": [3, 4]})
@@ -282,6 +290,7 @@ class TestConcatFrames:
         assert list(combined.columns) == ["col_a", "col_b"]
         assert len(combined) == 0
 
+    @pytest.mark.skipif(pl is None, reason="polars is not installed")
     def test_polars_lazyframes_are_collected_and_concatenated(self) -> None:
         first = pl.DataFrame({"col_a": [1, 2]}).lazy()
         second = pl.DataFrame({"col_b": [3, 4]}).lazy()

--- a/tests/test_core/test_api/test_results.py
+++ b/tests/test_core/test_api/test_results.py
@@ -1,0 +1,141 @@
+"""Tests for results_by_feature, mapping run_all result elements by their column names."""
+
+from typing import Any
+
+import pandas as pd
+import polars as pl
+import pyarrow as pa
+import pytest
+
+from mloda.core.api.results import results_by_feature
+
+
+class TestResultsByFeatureColumnExtraction:
+    def test_columnar_dict_maps_keys_to_element(self) -> None:
+        element = {"col_a": [1, 2], "col_b": [3, 4]}
+        results: list[Any] = [element]
+
+        mapping = results_by_feature(results)
+
+        assert mapping["col_a"] is element
+        assert mapping["col_b"] is element
+
+    def test_list_of_row_dicts_maps_first_row_keys_to_element(self) -> None:
+        element = [{"col_a": 1, "col_b": 2}, {"col_a": 3, "col_b": 4}]
+        results: list[Any] = [element]
+
+        mapping = results_by_feature(results)
+
+        assert mapping["col_a"] is element
+        assert mapping["col_b"] is element
+
+    def test_empty_list_element_contributes_no_columns(self) -> None:
+        results: list[Any] = [[]]
+
+        mapping = results_by_feature(results)
+
+        assert mapping == {}
+
+    def test_pyarrow_table_maps_column_names_to_element(self) -> None:
+        element = pa.table({"col_a": [1, 2], "col_b": [3, 4]})
+        results: list[Any] = [element]
+
+        mapping = results_by_feature(results)
+
+        assert mapping["col_a"] is element
+        assert mapping["col_b"] is element
+
+    def test_pandas_dataframe_maps_columns_to_element(self) -> None:
+        element = pd.DataFrame({"col_a": [1, 2], "col_b": [3, 4]})
+        results: list[Any] = [element]
+
+        mapping = results_by_feature(results)
+
+        assert mapping["col_a"] is element
+        assert mapping["col_b"] is element
+
+    def test_polars_dataframe_maps_columns_to_element(self) -> None:
+        element = pl.DataFrame({"col_a": [1, 2], "col_b": [3, 4]})
+        results: list[Any] = [element]
+
+        mapping = results_by_feature(results)
+
+        assert mapping["col_a"] is element
+        assert mapping["col_b"] is element
+
+
+class TestResultsByFeatureMultiOutputNaming:
+    def test_tilde_column_registers_base_name_and_full_name(self) -> None:
+        element = pd.DataFrame({"heatmap~a": [1], "heatmap~b": [2]})
+        results: list[Any] = [element]
+
+        mapping = results_by_feature(results)
+
+        assert mapping["heatmap"] is element
+        assert mapping["heatmap~a"] is element
+        assert mapping["heatmap~b"] is element
+
+    def test_base_name_uses_text_before_first_tilde_only(self) -> None:
+        element = {"multi~x~y": [1]}
+        results: list[Any] = [element]
+
+        mapping = results_by_feature(results)
+
+        assert mapping["multi"] is element
+        assert mapping["multi~x~y"] is element
+        assert "multi~x" not in mapping
+
+
+class TestResultsByFeatureDuplicates:
+    def test_first_occurrence_wins_across_elements(self) -> None:
+        first = pd.DataFrame({"shared": [1]})
+        second = {"shared": [2], "other": [3]}
+        results: list[Any] = [first, second]
+
+        mapping = results_by_feature(results)
+
+        assert mapping["shared"] is first
+        assert mapping["other"] is second
+
+    def test_first_occurrence_wins_for_multi_output_base_name(self) -> None:
+        first = {"heatmap~a": [1]}
+        second = {"heatmap": [2]}
+        results: list[Any] = [first, second]
+
+        mapping = results_by_feature(results)
+
+        assert mapping["heatmap"] is first
+        assert mapping["heatmap~a"] is first
+
+
+class TestResultsByFeatureErrors:
+    def test_unsupported_element_type_raises_value_error_with_type_in_message(self) -> None:
+        results: list[Any] = [42]
+
+        with pytest.raises(ValueError, match="int"):
+            results_by_feature(results)
+
+    def test_absent_feature_name_raises_key_error(self) -> None:
+        results: list[Any] = [{"col_a": [1]}]
+
+        mapping = results_by_feature(results)
+
+        with pytest.raises(KeyError):
+            mapping["does_not_exist"]
+
+
+class TestResultsByFeatureReturnType:
+    def test_returns_plain_dict(self) -> None:
+        results: list[Any] = [{"col_a": [1]}]
+
+        mapping = results_by_feature(results)
+
+        assert type(mapping) is dict
+
+    def test_empty_results_list_returns_empty_dict(self) -> None:
+        results: list[Any] = []
+
+        mapping = results_by_feature(results)
+
+        assert mapping == {}
+        assert type(mapping) is dict

--- a/tests/test_core/test_api/test_results.py
+++ b/tests/test_core/test_api/test_results.py
@@ -1,4 +1,16 @@
-"""Tests for results_by_feature, _to_rows and _concat_frames (run_all result reading)."""
+"""Failing tests for the fluent ``Results`` list returned by run_all (issues #564/#568/#569).
+
+``Results`` is a ``list`` subclass living in ``mloda.core.api.results`` (also exported
+from ``mloda.user``). It replaces ``results_by_feature``/``run_one``/``run_all_as_dataframe``
+with four accessors on the result list itself:
+
+- ``get_one(name)``: the per-feature-group element containing a column (identity preserved)
+- ``get_rows(name)``: that element converted to a flat list of row dicts
+- ``get_values(name)``: one column as a plain Python list
+- ``get_df()``: all elements horizontally concatenated into ONE pandas/polars DataFrame
+
+The class does not exist yet; this module must fail at collection with ImportError.
+"""
 
 from typing import Any
 
@@ -6,7 +18,7 @@ import pandas as pd
 import pyarrow as pa
 import pytest
 
-from mloda.core.api.results import _concat_frames, _to_rows, results_by_feature
+from mloda.core.api.results import Results
 
 try:
     import polars as pl
@@ -47,222 +59,329 @@ class _RelationStub:
         return self._frame
 
 
-class TestResultsByFeatureColumnExtraction:
-    def test_columnar_dict_maps_keys_to_element(self) -> None:
+class TestGetOneColumnExtraction:
+    def test_columnar_dict_resolves_keys_to_element(self) -> None:
         element = {"col_a": [1, 2], "col_b": [3, 4]}
-        results: list[Any] = [element]
+        results = Results([element])
 
-        mapping = results_by_feature(results)
+        assert results.get_one("col_a") is element
+        assert results.get_one("col_b") is element
 
-        assert mapping["col_a"] is element
-        assert mapping["col_b"] is element
-
-    def test_list_of_row_dicts_maps_first_row_keys_to_element(self) -> None:
+    def test_list_of_row_dicts_resolves_first_row_keys_to_element(self) -> None:
         element = [{"col_a": 1, "col_b": 2}, {"col_a": 3, "col_b": 4}]
-        results: list[Any] = [element]
+        results = Results([element])
 
-        mapping = results_by_feature(results)
-
-        assert mapping["col_a"] is element
-        assert mapping["col_b"] is element
+        assert results.get_one("col_a") is element
+        assert results.get_one("col_b") is element
 
     def test_empty_list_element_contributes_no_columns(self) -> None:
-        results: list[Any] = [[]]
+        results = Results([[]])
 
-        mapping = results_by_feature(results)
+        with pytest.raises(ValueError):
+            results.get_one("col_a")
 
-        assert mapping == {}
-
-    def test_pyarrow_table_maps_column_names_to_element(self) -> None:
+    def test_pyarrow_table_resolves_column_names_to_element(self) -> None:
         element = pa.table({"col_a": [1, 2], "col_b": [3, 4]})
-        results: list[Any] = [element]
+        results = Results([element])
 
-        mapping = results_by_feature(results)
+        assert results.get_one("col_a") is element
+        assert results.get_one("col_b") is element
 
-        assert mapping["col_a"] is element
-        assert mapping["col_b"] is element
-
-    def test_pandas_dataframe_maps_columns_to_element(self) -> None:
+    def test_pandas_dataframe_resolves_columns_to_element(self) -> None:
         element = pd.DataFrame({"col_a": [1, 2], "col_b": [3, 4]})
-        results: list[Any] = [element]
+        results = Results([element])
 
-        mapping = results_by_feature(results)
-
-        assert mapping["col_a"] is element
-        assert mapping["col_b"] is element
+        assert results.get_one("col_a") is element
+        assert results.get_one("col_b") is element
 
     @pytest.mark.skipif(pl is None, reason="polars is not installed")
-    def test_polars_dataframe_maps_columns_to_element(self) -> None:
+    def test_polars_dataframe_resolves_columns_to_element(self) -> None:
         element = pl.DataFrame({"col_a": [1, 2], "col_b": [3, 4]})
-        results: list[Any] = [element]
+        results = Results([element])
 
-        mapping = results_by_feature(results)
+        assert results.get_one("col_a") is element
+        assert results.get_one("col_b") is element
 
-        assert mapping["col_a"] is element
-        assert mapping["col_b"] is element
+    def test_named_lookup_picks_the_containing_element_among_several(self) -> None:
+        first = {"col_a": [1]}
+        second = {"col_b": [2]}
+        results = Results([first, second])
+
+        assert results.get_one("col_a") is first
+        assert results.get_one("col_b") is second
 
 
-class TestResultsByFeatureMultiOutputNaming:
-    def test_tilde_column_registers_base_name_and_full_name(self) -> None:
+class TestGetOneWithoutName:
+    def test_single_element_is_returned_without_name(self) -> None:
+        element = {"col_a": [1]}
+        results = Results([element])
+
+        assert results.get_one() is element
+
+    def test_two_elements_without_name_raise_value_error_mentioning_count(self) -> None:
+        results = Results([{"col_a": [1]}, {"col_b": [2]}])
+
+        with pytest.raises(ValueError) as exc_info:
+            results.get_one()
+
+        assert "2" in str(exc_info.value)
+        assert "get_one" in str(exc_info.value)
+
+    def test_empty_results_without_name_raise_value_error(self) -> None:
+        results = Results([])
+
+        with pytest.raises(ValueError):
+            results.get_one()
+
+
+class TestGetOneMultiOutputNaming:
+    def test_tilde_column_resolves_base_name_and_full_name(self) -> None:
         element = pd.DataFrame({"heatmap~a": [1], "heatmap~b": [2]})
-        results: list[Any] = [element]
+        results = Results([element])
 
-        mapping = results_by_feature(results)
-
-        assert mapping["heatmap"] is element
-        assert mapping["heatmap~a"] is element
-        assert mapping["heatmap~b"] is element
+        assert results.get_one("heatmap") is element
+        assert results.get_one("heatmap~a") is element
+        assert results.get_one("heatmap~b") is element
 
     def test_base_name_uses_text_before_first_tilde_only(self) -> None:
         element = {"multi~x~y": [1]}
-        results: list[Any] = [element]
+        results = Results([element])
 
-        mapping = results_by_feature(results)
+        assert results.get_one("multi") is element
+        assert results.get_one("multi~x~y") is element
+        with pytest.raises(ValueError):
+            results.get_one("multi~x")
 
-        assert mapping["multi"] is element
-        assert mapping["multi~x~y"] is element
-        assert "multi~x" not in mapping
 
-
-class TestResultsByFeatureDuplicates:
+class TestGetOneDuplicates:
     def test_first_occurrence_wins_across_elements(self) -> None:
         first = pd.DataFrame({"shared": [1]})
         second = {"shared": [2], "other": [3]}
-        results: list[Any] = [first, second]
+        results = Results([first, second])
 
-        mapping = results_by_feature(results)
-
-        assert mapping["shared"] is first
-        assert mapping["other"] is second
+        assert results.get_one("shared") is first
+        assert results.get_one("other") is second
 
     def test_first_occurrence_wins_for_multi_output_base_name(self) -> None:
         first = {"heatmap~a": [1]}
         second = {"heatmap": [2]}
-        results: list[Any] = [first, second]
+        results = Results([first, second])
 
-        mapping = results_by_feature(results)
-
-        assert mapping["heatmap"] is first
-        assert mapping["heatmap~a"] is first
+        assert results.get_one("heatmap") is first
+        assert results.get_one("heatmap~a") is first
 
 
-class TestResultsByFeatureErrors:
+class TestGetOneErrors:
     def test_unsupported_element_type_raises_value_error_with_type_in_message(self) -> None:
-        results: list[Any] = [42]
+        results = Results([42])
 
         with pytest.raises(ValueError, match="int"):
-            results_by_feature(results)
+            results.get_one("col_a")
 
     def test_list_of_scalars_raises_value_error_with_type_in_message(self) -> None:
-        results: list[Any] = [[1, 2]]
+        results = Results([[1, 2]])
 
         with pytest.raises(ValueError, match="int"):
-            results_by_feature(results)
+            results.get_one("col_a")
 
-    def test_absent_feature_name_raises_key_error(self) -> None:
-        results: list[Any] = [{"col_a": [1]}]
+    def test_unknown_name_raises_value_error_listing_available_names(self) -> None:
+        results = Results([{"col_a": [1], "col_b": [2]}])
 
-        mapping = results_by_feature(results)
+        with pytest.raises(ValueError) as exc_info:
+            results.get_one("does_not_exist")
 
-        with pytest.raises(KeyError):
-            mapping["does_not_exist"]
-
-
-class TestResultsByFeatureReturnType:
-    def test_returns_plain_dict(self) -> None:
-        results: list[Any] = [{"col_a": [1]}]
-
-        mapping = results_by_feature(results)
-
-        assert type(mapping) is dict
-
-    def test_empty_results_list_returns_empty_dict(self) -> None:
-        results: list[Any] = []
-
-        mapping = results_by_feature(results)
-
-        assert mapping == {}
-        assert type(mapping) is dict
+        assert "col_a" in str(exc_info.value)
+        assert "col_b" in str(exc_info.value)
 
 
-class TestToRows:
+class TestGetRows:
+    def test_columnar_dict_zips_into_rows(self) -> None:
+        results = Results([{"col_a": [1, 2], "col_b": [3, 4]}])
+
+        rows = results.get_rows()
+
+        assert rows == [{"col_a": 1, "col_b": 3}, {"col_a": 2, "col_b": 4}]
+
     def test_pyarrow_table_converts_to_pylist_rows(self) -> None:
-        table = pa.table({"col_a": [1, 2], "col_b": [3, 4]})
+        results = Results([pa.table({"col_a": [1, 2], "col_b": [3, 4]})])
 
-        rows = _to_rows(table)
+        rows = results.get_rows()
+
+        assert rows == [{"col_a": 1, "col_b": 3}, {"col_a": 2, "col_b": 4}]
+
+    def test_pandas_dataframe_converts_to_records_rows(self) -> None:
+        results = Results([pd.DataFrame({"col_a": [1, 2], "col_b": [3, 4]})])
+
+        rows = results.get_rows()
 
         assert rows == [{"col_a": 1, "col_b": 3}, {"col_a": 2, "col_b": 4}]
 
     @pytest.mark.skipif(pl is None, reason="polars is not installed")
     def test_polars_dataframe_converts_to_dicts_rows(self) -> None:
-        frame = pl.DataFrame({"col_a": [1, 2], "col_b": [3, 4]})
+        results = Results([pl.DataFrame({"col_a": [1, 2], "col_b": [3, 4]})])
 
-        rows = _to_rows(frame)
+        rows = results.get_rows()
 
         assert rows == [{"col_a": 1, "col_b": 3}, {"col_a": 2, "col_b": 4}]
 
     @pytest.mark.skipif(pl is None, reason="polars is not installed")
     def test_polars_lazyframe_collects_to_rows(self) -> None:
-        lazy = pl.DataFrame({"col_a": [1, 2], "col_b": [3, 4]}).lazy()
+        results = Results([pl.DataFrame({"col_a": [1, 2], "col_b": [3, 4]}).lazy()])
 
-        rows = _to_rows(lazy)
+        rows = results.get_rows()
 
         assert rows == [{"col_a": 1, "col_b": 3}, {"col_a": 2, "col_b": 4}]
 
     def test_spark_like_object_collects_rows_via_as_dict(self) -> None:
-        stub = _SparkDataFrameStub([{"col_a": 1, "col_b": 3}, {"col_a": 2, "col_b": 4}])
+        results = Results([_SparkDataFrameStub([{"col_a": 1, "col_b": 3}, {"col_a": 2, "col_b": 4}])])
 
-        rows = _to_rows(stub)
+        rows = results.get_rows()
 
         assert rows == [{"col_a": 1, "col_b": 3}, {"col_a": 2, "col_b": 4}]
 
     def test_relation_like_object_converts_df_records(self) -> None:
-        stub = _RelationStub(pd.DataFrame({"col_a": [1, 2], "col_b": [3, 4]}))
+        results = Results([_RelationStub(pd.DataFrame({"col_a": [1, 2], "col_b": [3, 4]}))])
 
-        rows = _to_rows(stub)
+        rows = results.get_rows()
 
         assert rows == [{"col_a": 1, "col_b": 3}, {"col_a": 2, "col_b": 4}]
 
-    def test_list_input_returns_a_copy(self) -> None:
+    def test_list_element_returns_a_copy(self) -> None:
         source: list[dict[str, Any]] = [{"col_a": 1}, {"col_a": 2}]
+        results = Results([source])
 
-        rows = _to_rows(source)
+        rows = results.get_rows()
 
         assert rows == source
         assert rows is not source
         rows.append({"col_a": 3})
         assert source == [{"col_a": 1}, {"col_a": 2}]
 
+    def test_named_lookup_converts_the_containing_element(self) -> None:
+        results = Results([{"col_a": [1]}, {"col_b": [2]}])
+
+        rows = results.get_rows("col_b")
+
+        assert rows == [{"col_b": 2}]
+
     def test_ragged_columnar_dict_raises_value_error(self) -> None:
+        results = Results([{"col_a": [1, 2], "col_b": [1]}])
+
         with pytest.raises(ValueError):
-            _to_rows({"col_a": [1, 2], "col_b": [1]})
+            results.get_rows()
 
-    def test_unsupported_type_raises_value_error_with_type_in_message(self) -> None:
+    def test_unsupported_element_type_raises_value_error_with_type_in_message(self) -> None:
+        results = Results([42])
+
         with pytest.raises(ValueError, match="int"):
-            _to_rows(42)
+            results.get_rows()
 
 
-class TestConcatFrames:
-    def test_mixed_pandas_and_pyarrow_raises_value_error_naming_dropped_type(self) -> None:
-        results: list[Any] = [pd.DataFrame({"col_a": [1, 2]}), pa.table({"col_b": [3, 4]})]
+class TestGetValues:
+    def test_pandas_dataframe_column_returns_plain_list(self) -> None:
+        results = Results([pd.DataFrame({"col_a": [1, 2], "col_b": [3, 4]})])
+
+        values = results.get_values("col_a")
+
+        assert values == [1, 2]
+        assert type(values) is list
+
+    @pytest.mark.skipif(pl is None, reason="polars is not installed")
+    def test_polars_dataframe_column_returns_plain_list(self) -> None:
+        results = Results([pl.DataFrame({"col_a": [1, 2], "col_b": [3, 4]})])
+
+        values = results.get_values("col_a")
+
+        assert values == [1, 2]
+        assert type(values) is list
+
+    def test_pyarrow_table_column_returns_plain_list(self) -> None:
+        results = Results([pa.table({"col_a": [1, 2], "col_b": [3, 4]})])
+
+        values = results.get_values("col_a")
+
+        assert values == [1, 2]
+        assert type(values) is list
+
+    def test_columnar_dict_column_returns_plain_list(self) -> None:
+        results = Results([{"col_a": [1, 2], "col_b": [3, 4]}])
+
+        values = results.get_values("col_b")
+
+        assert values == [3, 4]
+        assert type(values) is list
+
+    def test_list_of_row_dicts_column_returns_plain_list(self) -> None:
+        results = Results([[{"col_a": 1, "col_b": 3}, {"col_a": 2, "col_b": 4}]])
+
+        values = results.get_values("col_a")
+
+        assert values == [1, 2]
+        assert type(values) is list
+
+    def test_unknown_name_raises_value_error_listing_available_names(self) -> None:
+        results = Results([{"col_a": [1], "col_b": [2]}])
 
         with pytest.raises(ValueError) as exc_info:
-            _concat_frames(results)
+            results.get_values("does_not_exist")
+
+        assert "col_a" in str(exc_info.value)
+        assert "col_b" in str(exc_info.value)
+
+    def test_multi_output_base_name_that_is_not_a_column_raises_value_error(self) -> None:
+        results = Results([{"multi~x": [1], "multi~y": [2]}])
+
+        with pytest.raises(ValueError):
+            results.get_values("multi")
+
+
+class TestGetDf:
+    def test_mixed_pandas_and_pyarrow_raises_value_error_naming_dropped_type(self) -> None:
+        results = Results([pd.DataFrame({"col_a": [1, 2]}), pa.table({"col_b": [3, 4]})])
+
+        with pytest.raises(ValueError) as exc_info:
+            results.get_df()
 
         assert "Table" in str(exc_info.value)
         assert "DataFrame" in str(exc_info.value)
 
     def test_mixed_pandas_and_columnar_dict_raises_value_error(self) -> None:
-        results: list[Any] = [pd.DataFrame({"col_a": [1, 2]}), {"col_b": [3, 4]}]
+        results = Results([pd.DataFrame({"col_a": [1, 2]}), {"col_b": [3, 4]}])
 
         with pytest.raises(ValueError):
-            _concat_frames(results)
+            results.get_df()
+
+    def test_only_non_dataframe_elements_raise_value_error_mentioning_dataframe(self) -> None:
+        results = Results([{"col_a": [1, 2]}])
+
+        with pytest.raises(ValueError, match="DataFrame"):
+            results.get_df()
+
+    @pytest.mark.skipif(pl is None, reason="polars is not installed")
+    def test_mixed_pandas_and_polars_raises_value_error(self) -> None:
+        results = Results([pd.DataFrame({"col_a": [1, 2]}), pl.DataFrame({"col_b": [3, 4]})])
+
+        with pytest.raises(ValueError):
+            results.get_df()
+
+    def test_row_count_mismatch_raises_value_error_mentioning_row(self) -> None:
+        results = Results([pd.DataFrame({"col_a": [1, 2, 3]}), pd.DataFrame({"col_b": [7, 8]})])
+
+        with pytest.raises(ValueError, match="row"):
+            results.get_df()
+
+    def test_single_frame_is_returned_as_is(self) -> None:
+        frame = pd.DataFrame({"col_a": [1, 2]})
+        results = Results([frame])
+
+        assert results.get_df() is frame
 
     def test_overlapping_columns_pandas_keeps_first_frame_values(self) -> None:
         first = pd.DataFrame({"col_a": [1, 2], "shared": [10, 20]})
         second = pd.DataFrame({"shared": [99, 98], "col_b": [3, 4]})
+        results = Results([first, second])
 
-        combined = _concat_frames([first, second])
+        combined = results.get_df()
 
         assert list(combined.columns).count("shared") == 1
         assert list(combined["shared"]) == [10, 20]
@@ -273,8 +392,9 @@ class TestConcatFrames:
     def test_overlapping_columns_polars_keeps_first_frame_values(self) -> None:
         first = pl.DataFrame({"col_a": [1, 2], "shared": [10, 20]})
         second = pl.DataFrame({"shared": [99, 98], "col_b": [3, 4]})
+        results = Results([first, second])
 
-        combined = _concat_frames([first, second])
+        combined = results.get_df()
 
         assert combined.columns.count("shared") == 1
         assert combined["shared"].to_list() == [10, 20]
@@ -284,8 +404,9 @@ class TestConcatFrames:
     def test_zero_row_frames_with_different_columns_concatenate(self) -> None:
         first = pd.DataFrame({"col_a": []})
         second = pd.DataFrame({"col_b": []})
+        results = Results([first, second])
 
-        combined = _concat_frames([first, second])
+        combined = results.get_df()
 
         assert list(combined.columns) == ["col_a", "col_b"]
         assert len(combined) == 0
@@ -294,10 +415,48 @@ class TestConcatFrames:
     def test_polars_lazyframes_are_collected_and_concatenated(self) -> None:
         first = pl.DataFrame({"col_a": [1, 2]}).lazy()
         second = pl.DataFrame({"col_b": [3, 4]}).lazy()
+        results = Results([first, second])
 
-        combined = _concat_frames([first, second])
+        combined = results.get_df()
 
         assert isinstance(combined, pl.DataFrame)
         assert combined.columns == ["col_a", "col_b"]
         assert combined["col_a"].to_list() == [1, 2]
         assert combined["col_b"].to_list() == [3, 4]
+
+
+class TestResultsIsAList:
+    def test_results_is_instance_of_list(self) -> None:
+        results = Results([{"col_a": [1]}])
+
+        assert isinstance(results, list)
+
+    def test_indexing_returns_the_original_elements(self) -> None:
+        first = {"col_a": [1]}
+        second = {"col_b": [2]}
+        results = Results([first, second])
+
+        assert results[0] is first
+        assert results[1] is second
+
+    def test_len_matches_element_count(self) -> None:
+        assert len(Results([{"col_a": [1]}, {"col_b": [2]}])) == 2
+        assert len(Results([])) == 0
+
+    def test_iteration_yields_elements_in_order(self) -> None:
+        first = {"col_a": [1]}
+        second = {"col_b": [2]}
+        results = Results([first, second])
+
+        assert [element for element in results] == [first, second]
+
+    def test_equality_with_plain_list(self) -> None:
+        elements: list[Any] = [{"col_a": [1]}, {"col_b": [2]}]
+
+        assert Results(elements) == elements
+        assert Results([]) == []
+
+    def test_results_is_exported_from_mloda_user(self) -> None:
+        from mloda.user import Results as UserResults
+
+        assert UserResults is Results

--- a/tests/test_core/test_api/test_results.py
+++ b/tests/test_core/test_api/test_results.py
@@ -1,4 +1,4 @@
-"""Tests for results_by_feature, mapping run_all result elements by their column names."""
+"""Tests for results_by_feature, _to_rows and _concat_frames (run_all result reading)."""
 
 from typing import Any
 
@@ -7,7 +7,40 @@ import polars as pl
 import pyarrow as pa
 import pytest
 
-from mloda.core.api.results import results_by_feature
+from mloda.core.api.results import _concat_frames, _to_rows, results_by_feature
+
+
+class _SparkRowStub:
+    """Mimics a pyspark Row: exposes asDict() only."""
+
+    def __init__(self, data: dict[str, Any]) -> None:
+        self._data = data
+
+    def asDict(self) -> dict[str, Any]:
+        return dict(self._data)
+
+
+class _SparkDataFrameStub:
+    """Mimics a pyspark DataFrame: collect() returning Row-like objects plus a toPandas attribute."""
+
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self._rows = rows
+
+    def collect(self) -> list[_SparkRowStub]:
+        return [_SparkRowStub(row) for row in self._rows]
+
+    def toPandas(self) -> Any:
+        return None
+
+
+class _RelationStub:
+    """Mimics a DuckDB/SQLite relation: df() only, no collect/to_pylist/to_dicts/to_dict."""
+
+    def __init__(self, frame: pd.DataFrame) -> None:
+        self._frame = frame
+
+    def df(self) -> pd.DataFrame:
+        return self._frame
 
 
 class TestResultsByFeatureColumnExtraction:
@@ -115,6 +148,12 @@ class TestResultsByFeatureErrors:
         with pytest.raises(ValueError, match="int"):
             results_by_feature(results)
 
+    def test_list_of_scalars_raises_value_error_with_type_in_message(self) -> None:
+        results: list[Any] = [[1, 2]]
+
+        with pytest.raises(ValueError, match="int"):
+            results_by_feature(results)
+
     def test_absent_feature_name_raises_key_error(self) -> None:
         results: list[Any] = [{"col_a": [1]}]
 
@@ -139,3 +178,117 @@ class TestResultsByFeatureReturnType:
 
         assert mapping == {}
         assert type(mapping) is dict
+
+
+class TestToRows:
+    def test_pyarrow_table_converts_to_pylist_rows(self) -> None:
+        table = pa.table({"col_a": [1, 2], "col_b": [3, 4]})
+
+        rows = _to_rows(table)
+
+        assert rows == [{"col_a": 1, "col_b": 3}, {"col_a": 2, "col_b": 4}]
+
+    def test_polars_dataframe_converts_to_dicts_rows(self) -> None:
+        frame = pl.DataFrame({"col_a": [1, 2], "col_b": [3, 4]})
+
+        rows = _to_rows(frame)
+
+        assert rows == [{"col_a": 1, "col_b": 3}, {"col_a": 2, "col_b": 4}]
+
+    def test_polars_lazyframe_collects_to_rows(self) -> None:
+        lazy = pl.DataFrame({"col_a": [1, 2], "col_b": [3, 4]}).lazy()
+
+        rows = _to_rows(lazy)
+
+        assert rows == [{"col_a": 1, "col_b": 3}, {"col_a": 2, "col_b": 4}]
+
+    def test_spark_like_object_collects_rows_via_as_dict(self) -> None:
+        stub = _SparkDataFrameStub([{"col_a": 1, "col_b": 3}, {"col_a": 2, "col_b": 4}])
+
+        rows = _to_rows(stub)
+
+        assert rows == [{"col_a": 1, "col_b": 3}, {"col_a": 2, "col_b": 4}]
+
+    def test_relation_like_object_converts_df_records(self) -> None:
+        stub = _RelationStub(pd.DataFrame({"col_a": [1, 2], "col_b": [3, 4]}))
+
+        rows = _to_rows(stub)
+
+        assert rows == [{"col_a": 1, "col_b": 3}, {"col_a": 2, "col_b": 4}]
+
+    def test_list_input_returns_a_copy(self) -> None:
+        source: list[dict[str, Any]] = [{"col_a": 1}, {"col_a": 2}]
+
+        rows = _to_rows(source)
+
+        assert rows == source
+        assert rows is not source
+        rows.append({"col_a": 3})
+        assert source == [{"col_a": 1}, {"col_a": 2}]
+
+    def test_ragged_columnar_dict_raises_value_error(self) -> None:
+        with pytest.raises(ValueError):
+            _to_rows({"col_a": [1, 2], "col_b": [1]})
+
+    def test_unsupported_type_raises_value_error_with_type_in_message(self) -> None:
+        with pytest.raises(ValueError, match="int"):
+            _to_rows(42)
+
+
+class TestConcatFrames:
+    def test_mixed_pandas_and_pyarrow_raises_value_error_naming_dropped_type(self) -> None:
+        results: list[Any] = [pd.DataFrame({"col_a": [1, 2]}), pa.table({"col_b": [3, 4]})]
+
+        with pytest.raises(ValueError) as exc_info:
+            _concat_frames(results)
+
+        assert "Table" in str(exc_info.value)
+        assert "DataFrame" in str(exc_info.value)
+
+    def test_mixed_pandas_and_columnar_dict_raises_value_error(self) -> None:
+        results: list[Any] = [pd.DataFrame({"col_a": [1, 2]}), {"col_b": [3, 4]}]
+
+        with pytest.raises(ValueError):
+            _concat_frames(results)
+
+    def test_overlapping_columns_pandas_keeps_first_frame_values(self) -> None:
+        first = pd.DataFrame({"col_a": [1, 2], "shared": [10, 20]})
+        second = pd.DataFrame({"shared": [99, 98], "col_b": [3, 4]})
+
+        combined = _concat_frames([first, second])
+
+        assert list(combined.columns).count("shared") == 1
+        assert list(combined["shared"]) == [10, 20]
+        assert list(combined["col_a"]) == [1, 2]
+        assert list(combined["col_b"]) == [3, 4]
+
+    def test_overlapping_columns_polars_keeps_first_frame_values(self) -> None:
+        first = pl.DataFrame({"col_a": [1, 2], "shared": [10, 20]})
+        second = pl.DataFrame({"shared": [99, 98], "col_b": [3, 4]})
+
+        combined = _concat_frames([first, second])
+
+        assert combined.columns.count("shared") == 1
+        assert combined["shared"].to_list() == [10, 20]
+        assert combined["col_a"].to_list() == [1, 2]
+        assert combined["col_b"].to_list() == [3, 4]
+
+    def test_zero_row_frames_with_different_columns_concatenate(self) -> None:
+        first = pd.DataFrame({"col_a": []})
+        second = pd.DataFrame({"col_b": []})
+
+        combined = _concat_frames([first, second])
+
+        assert list(combined.columns) == ["col_a", "col_b"]
+        assert len(combined) == 0
+
+    def test_polars_lazyframes_are_collected_and_concatenated(self) -> None:
+        first = pl.DataFrame({"col_a": [1, 2]}).lazy()
+        second = pl.DataFrame({"col_b": [3, 4]}).lazy()
+
+        combined = _concat_frames([first, second])
+
+        assert isinstance(combined, pl.DataFrame)
+        assert combined.columns == ["col_a", "col_b"]
+        assert combined["col_a"].to_list() == [1, 2]
+        assert combined["col_b"].to_list() == [3, 4]

--- a/tests/test_core/test_api/test_run_convenience.py
+++ b/tests/test_core/test_api/test_run_convenience.py
@@ -1,0 +1,231 @@
+"""Failing tests for the mlodaAPI convenience classmethods (issues #564 and #568).
+
+``mlodaAPI.run_one`` (issue #564): run a SINGLE feature and return a flat list of
+row dicts, regardless of the compute framework that produced the result.
+
+``mlodaAPI.run_all_as_dataframe`` (issue #568): run like ``run_all`` and concatenate
+the per-feature-group results horizontally into ONE DataFrame (pandas or polars).
+
+Both methods do not exist yet; every test in this module must fail with
+``AttributeError`` until the Green agent implements them.
+
+All FeatureGroups are module-local with unique ``rc564_`` / ``rc568_`` feature names
+and each run is pinned to its own ``PluginCollector`` so the tests stay deterministic
+and parallel-safe under pytest-xdist.
+"""
+
+from typing import Any, Optional
+
+import pandas as pd
+import polars as pl
+import pytest
+
+from mloda.provider import BaseInputData, DataCreator, FeatureGroup, FeatureSet
+from mloda.user import Feature, PluginCollector, mlodaAPI
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame  # noqa: F401
+from mloda_plugins.compute_framework.base_implementations.polars.dataframe import PolarsDataFrame  # noqa: F401
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (  # noqa: F401
+    PythonDictFramework,
+)
+
+
+class Rc564PandasFeatureGroup(FeatureGroup):
+    """Root FG producing a single pandas column for the run_one tests."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({"rc564_pandas_feature"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return pd.DataFrame({"rc564_pandas_feature": [1, 2]})
+
+
+class Rc564DictFeatureGroup(FeatureGroup):
+    """Root FG producing a single columnar-dict column for the run_one tests."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({"rc564_dict_feature"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {"rc564_dict_feature": [1, 2]}
+
+
+class Rc568PandasLeftFeatureGroup(FeatureGroup):
+    """First of two pandas FGs for the horizontal-concat tests (3 rows)."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({"rc568_pd_left"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return pd.DataFrame({"rc568_pd_left": [1, 2, 3]})
+
+
+class Rc568PandasRightFeatureGroup(FeatureGroup):
+    """Second of two pandas FGs for the horizontal-concat tests (3 rows)."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({"rc568_pd_right"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return pd.DataFrame({"rc568_pd_right": [10, 20, 30]})
+
+
+class Rc568PandasShortFeatureGroup(FeatureGroup):
+    """Pandas FG with a DIFFERENT row count (2 rows) to force a concat mismatch."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({"rc568_pd_short"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return pd.DataFrame({"rc568_pd_short": [7, 8]})
+
+
+class Rc568PolarsLeftFeatureGroup(FeatureGroup):
+    """First of two polars FGs for the horizontal-concat tests (3 rows)."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({"rc568_pl_left"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return pl.DataFrame({"rc568_pl_left": [1, 2, 3]})
+
+
+class Rc568PolarsRightFeatureGroup(FeatureGroup):
+    """Second of two polars FGs for the horizontal-concat tests (3 rows)."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({"rc568_pl_right"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return pl.DataFrame({"rc568_pl_right": [10, 20, 30]})
+
+
+class Rc568DictFeatureGroup(FeatureGroup):
+    """Columnar-dict FG proving run_all_as_dataframe rejects non-DataFrame results."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({"rc568_dict_feature"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {"rc568_dict_feature": [1, 2]}
+
+
+_RC564_PANDAS = PluginCollector.enabled_feature_groups({Rc564PandasFeatureGroup})
+_RC564_DICT = PluginCollector.enabled_feature_groups({Rc564DictFeatureGroup})
+_RC568_PANDAS_PAIR = PluginCollector.enabled_feature_groups({Rc568PandasLeftFeatureGroup, Rc568PandasRightFeatureGroup})
+_RC568_PANDAS_SINGLE = PluginCollector.enabled_feature_groups({Rc568PandasLeftFeatureGroup})
+_RC568_PANDAS_MISMATCH = PluginCollector.enabled_feature_groups(
+    {Rc568PandasLeftFeatureGroup, Rc568PandasShortFeatureGroup}
+)
+_RC568_POLARS_PAIR = PluginCollector.enabled_feature_groups({Rc568PolarsLeftFeatureGroup, Rc568PolarsRightFeatureGroup})
+_RC568_DICT = PluginCollector.enabled_feature_groups({Rc568DictFeatureGroup})
+
+
+class TestRunOne:
+    """Contract for ``mlodaAPI.run_one`` (issue #564)."""
+
+    def test_run_one_pandas_returns_flat_row_dicts(self) -> None:
+        """A pandas-backed single feature comes back as a flat list of row dicts."""
+        result = mlodaAPI.run_one(
+            Feature("rc564_pandas_feature"),
+            compute_frameworks=["PandasDataFrame"],
+            plugin_collector=_RC564_PANDAS,
+        )
+
+        assert result == [{"rc564_pandas_feature": 1}, {"rc564_pandas_feature": 2}]
+
+    def test_run_one_python_dict_returns_flat_row_dicts(self) -> None:
+        """A PythonDict-backed single feature (given as str) yields identical flat rows."""
+        result = mlodaAPI.run_one(
+            "rc564_dict_feature",
+            compute_frameworks=["PythonDictFramework"],
+            plugin_collector=_RC564_DICT,
+        )
+
+        assert result == [{"rc564_dict_feature": 1}, {"rc564_dict_feature": 2}]
+
+    def test_run_one_rejects_list_input(self) -> None:
+        """Passing a list instead of a single feature raises a clear ValueError."""
+        with pytest.raises(ValueError, match="single"):
+            mlodaAPI.run_one(
+                [Feature("rc564_pandas_feature")],  # type: ignore[arg-type]
+                compute_frameworks=["PandasDataFrame"],
+                plugin_collector=_RC564_PANDAS,
+            )
+
+
+class TestRunAllAsDataframe:
+    """Contract for ``mlodaAPI.run_all_as_dataframe`` (issue #568)."""
+
+    def test_pandas_two_groups_concat_into_one_frame(self) -> None:
+        """Two pandas feature-group results are horizontally concatenated into ONE frame."""
+        result = mlodaAPI.run_all_as_dataframe(
+            [Feature("rc568_pd_left"), Feature("rc568_pd_right")],
+            compute_frameworks=["PandasDataFrame"],
+            plugin_collector=_RC568_PANDAS_PAIR,
+        )
+
+        assert isinstance(result, pd.DataFrame)
+        assert {"rc568_pd_left", "rc568_pd_right"} <= set(result.columns)
+        assert len(result) == 3
+        assert list(result["rc568_pd_left"]) == [1, 2, 3]
+        assert list(result["rc568_pd_right"]) == [10, 20, 30]
+
+    def test_pandas_single_group_returns_single_frame(self) -> None:
+        """A single-group run returns that single frame with the requested column."""
+        result = mlodaAPI.run_all_as_dataframe(
+            [Feature("rc568_pd_left")],
+            compute_frameworks=["PandasDataFrame"],
+            plugin_collector=_RC568_PANDAS_SINGLE,
+        )
+
+        assert isinstance(result, pd.DataFrame)
+        assert "rc568_pd_left" in result.columns
+        assert list(result["rc568_pd_left"]) == [1, 2, 3]
+
+    def test_polars_two_groups_concat_into_one_frame(self) -> None:
+        """Two polars feature-group results are horizontally concatenated into ONE frame."""
+        result = mlodaAPI.run_all_as_dataframe(
+            [Feature("rc568_pl_left"), Feature("rc568_pl_right")],
+            compute_frameworks=["PolarsDataFrame"],
+            plugin_collector=_RC568_POLARS_PAIR,
+        )
+
+        assert isinstance(result, pl.DataFrame)
+        assert {"rc568_pl_left", "rc568_pl_right"} <= set(result.columns)
+        assert result.height == 3
+        assert result["rc568_pl_left"].to_list() == [1, 2, 3]
+        assert result["rc568_pl_right"].to_list() == [10, 20, 30]
+
+    def test_non_dataframe_results_raise_value_error(self) -> None:
+        """PythonDict columnar-dict results cannot be concatenated and raise ValueError."""
+        with pytest.raises(ValueError, match="DataFrame"):
+            mlodaAPI.run_all_as_dataframe(
+                [Feature("rc568_dict_feature")],
+                compute_frameworks=["PythonDictFramework"],
+                plugin_collector=_RC568_DICT,
+            )
+
+    def test_row_count_mismatch_raises_value_error(self) -> None:
+        """Two groups with different row counts (3 vs 2) raise ValueError on concat."""
+        with pytest.raises(ValueError, match="row"):
+            mlodaAPI.run_all_as_dataframe(
+                [Feature("rc568_pd_left"), Feature("rc568_pd_short")],
+                compute_frameworks=["PandasDataFrame"],
+                plugin_collector=_RC568_PANDAS_MISMATCH,
+            )

--- a/tests/test_core/test_api/test_run_convenience.py
+++ b/tests/test_core/test_api/test_run_convenience.py
@@ -1,13 +1,13 @@
-"""Failing tests for the mlodaAPI convenience classmethods (issues #564 and #568).
+"""Failing tests for the fluent Results returned by ``mlodaAPI.run_all`` (issues #564 and #568).
 
-``mlodaAPI.run_one`` (issue #564): run a SINGLE feature and return a flat list of
-row dicts, regardless of the compute framework that produced the result.
+``mlodaAPI.run_all`` must return a ``Results`` instance (a ``list`` subclass exported from
+``mloda.user``) whose accessors replace the removed ``run_one`` / ``run_all_as_dataframe``:
 
-``mlodaAPI.run_all_as_dataframe`` (issue #568): run like ``run_all`` and concatenate
-the per-feature-group results horizontally into ONE DataFrame (pandas or polars).
+- ``run_all(...).get_rows()``: one feature's result as a flat list of row dicts
+- ``run_all(...).get_values(name)``: one column as a plain Python list
+- ``run_all(...).get_df()``: all results horizontally concatenated into ONE DataFrame
 
-Both methods do not exist yet; every test in this module must fail with
-``AttributeError`` until the Green agent implements them.
+``Results`` does not exist yet; this module must fail at collection with ImportError.
 
 All FeatureGroups are module-local with unique ``rc564_`` / ``rc568_`` feature names
 and each run is pinned to its own ``PluginCollector`` so the tests stay deterministic
@@ -21,7 +21,7 @@ import pyarrow as pa
 import pytest
 
 from mloda.provider import BaseInputData, DataCreator, FeatureGroup, FeatureSet
-from mloda.user import Feature, PluginCollector, mlodaAPI
+from mloda.user import Feature, PluginCollector, Results, mlodaAPI
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame  # noqa: F401
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable  # noqa: F401
 from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (  # noqa: F401
@@ -37,7 +37,7 @@ except ImportError:
 
 
 class Rc564PandasFeatureGroup(FeatureGroup):
-    """Root FG producing a single pandas column for the run_one tests."""
+    """Root FG producing a single pandas column for the get_rows tests."""
 
     @classmethod
     def input_data(cls) -> Optional[BaseInputData]:
@@ -49,7 +49,7 @@ class Rc564PandasFeatureGroup(FeatureGroup):
 
 
 class Rc564DictFeatureGroup(FeatureGroup):
-    """Root FG producing a single columnar-dict column for the run_one tests."""
+    """Root FG producing a single columnar-dict column for the get_rows tests."""
 
     @classmethod
     def input_data(cls) -> Optional[BaseInputData]:
@@ -61,7 +61,7 @@ class Rc564DictFeatureGroup(FeatureGroup):
 
 
 class Rc564ArrowFeatureGroup(FeatureGroup):
-    """Root FG producing a single pyarrow column for the run_one tests."""
+    """Root FG producing a single pyarrow column for the get_rows tests."""
 
     @classmethod
     def input_data(cls) -> Optional[BaseInputData]:
@@ -73,7 +73,7 @@ class Rc564ArrowFeatureGroup(FeatureGroup):
 
 
 class Rc564PolarsFeatureGroup(FeatureGroup):
-    """Root FG producing a single polars column for the run_one tests."""
+    """Root FG producing a single polars column for the get_rows tests."""
 
     @classmethod
     def input_data(cls) -> Optional[BaseInputData]:
@@ -145,7 +145,7 @@ class Rc568PolarsRightFeatureGroup(FeatureGroup):
 
 
 class Rc568DictFeatureGroup(FeatureGroup):
-    """Columnar-dict FG proving run_all_as_dataframe rejects non-DataFrame results."""
+    """Columnar-dict FG proving get_df rejects non-DataFrame results."""
 
     @classmethod
     def input_data(cls) -> Optional[BaseInputData]:
@@ -169,70 +169,84 @@ _RC568_POLARS_PAIR = PluginCollector.enabled_feature_groups({Rc568PolarsLeftFeat
 _RC568_DICT = PluginCollector.enabled_feature_groups({Rc568DictFeatureGroup})
 
 
-class TestRunOne:
-    """Contract for ``mlodaAPI.run_one`` (issue #564)."""
+class TestRunAllReturnType:
+    """``mlodaAPI.run_all`` must return a fluent ``Results`` that is still a plain list."""
 
-    def test_run_one_pandas_returns_flat_row_dicts(self) -> None:
-        """A pandas-backed single feature comes back as a flat list of row dicts."""
-        result = mlodaAPI.run_one(
-            Feature("rc564_pandas_feature"),
+    def test_run_all_returns_results_instance_that_is_a_list(self) -> None:
+        result = mlodaAPI.run_all(
+            [Feature("rc568_pd_left")],
+            compute_frameworks=["PandasDataFrame"],
+            plugin_collector=_RC568_PANDAS_SINGLE,
+        )
+
+        assert isinstance(result, Results)
+        assert isinstance(result, list)
+
+
+class TestRunAllGetRows:
+    """``run_all(...).get_rows()`` yields flat row dicts for every compute framework."""
+
+    def test_pandas_result_returns_flat_row_dicts(self) -> None:
+        rows = mlodaAPI.run_all(
+            [Feature("rc564_pandas_feature")],
             compute_frameworks=["PandasDataFrame"],
             plugin_collector=_RC564_PANDAS,
-        )
+        ).get_rows()
 
-        assert result == [{"rc564_pandas_feature": 1}, {"rc564_pandas_feature": 2}]
+        assert rows == [{"rc564_pandas_feature": 1}, {"rc564_pandas_feature": 2}]
 
-    def test_run_one_python_dict_returns_flat_row_dicts(self) -> None:
-        """A PythonDict-backed single feature (given as str) yields identical flat rows."""
-        result = mlodaAPI.run_one(
-            "rc564_dict_feature",
+    def test_python_dict_result_returns_flat_row_dicts(self) -> None:
+        rows = mlodaAPI.run_all(
+            ["rc564_dict_feature"],
             compute_frameworks=["PythonDictFramework"],
             plugin_collector=_RC564_DICT,
-        )
+        ).get_rows()
 
-        assert result == [{"rc564_dict_feature": 1}, {"rc564_dict_feature": 2}]
+        assert rows == [{"rc564_dict_feature": 1}, {"rc564_dict_feature": 2}]
 
-    def test_run_one_pyarrow_returns_flat_row_dicts(self) -> None:
-        """A pyarrow-backed single feature comes back as a flat list of row dicts."""
-        result = mlodaAPI.run_one(
-            Feature("rc564_arrow_feature"),
+    def test_pyarrow_result_returns_flat_row_dicts(self) -> None:
+        rows = mlodaAPI.run_all(
+            [Feature("rc564_arrow_feature")],
             compute_frameworks=["PyArrowTable"],
             plugin_collector=_RC564_ARROW,
-        )
+        ).get_rows()
 
-        assert result == [{"rc564_arrow_feature": 1}, {"rc564_arrow_feature": 2}]
+        assert rows == [{"rc564_arrow_feature": 1}, {"rc564_arrow_feature": 2}]
 
     @pytest.mark.skipif(pl is None, reason="polars is not installed")
-    def test_run_one_polars_returns_flat_row_dicts(self) -> None:
-        """A polars-backed single feature comes back as a flat list of row dicts."""
-        result = mlodaAPI.run_one(
-            Feature("rc564_polars_feature"),
+    def test_polars_result_returns_flat_row_dicts(self) -> None:
+        rows = mlodaAPI.run_all(
+            [Feature("rc564_polars_feature")],
             compute_frameworks=["PolarsDataFrame"],
             plugin_collector=_RC564_POLARS,
-        )
+        ).get_rows()
 
-        assert result == [{"rc564_polars_feature": 1}, {"rc564_polars_feature": 2}]
-
-    def test_run_one_rejects_list_input(self) -> None:
-        """Passing a list instead of a single feature raises a clear ValueError."""
-        with pytest.raises(ValueError, match="single"):
-            mlodaAPI.run_one(
-                [Feature("rc564_pandas_feature")],  # type: ignore[arg-type]
-                compute_frameworks=["PandasDataFrame"],
-                plugin_collector=_RC564_PANDAS,
-            )
+        assert rows == [{"rc564_polars_feature": 1}, {"rc564_polars_feature": 2}]
 
 
-class TestRunAllAsDataframe:
-    """Contract for ``mlodaAPI.run_all_as_dataframe`` (issue #568)."""
+class TestRunAllGetValues:
+    """``run_all(...).get_values(name)`` yields one column as a plain Python list."""
+
+    def test_pandas_result_returns_plain_column_values(self) -> None:
+        values = mlodaAPI.run_all(
+            [Feature("rc568_pd_left")],
+            compute_frameworks=["PandasDataFrame"],
+            plugin_collector=_RC568_PANDAS_SINGLE,
+        ).get_values("rc568_pd_left")
+
+        assert values == [1, 2, 3]
+        assert type(values) is list
+
+
+class TestRunAllGetDf:
+    """``run_all(...).get_df()`` concatenates all results into ONE DataFrame."""
 
     def test_pandas_two_groups_concat_into_one_frame(self) -> None:
-        """Two pandas feature-group results are horizontally concatenated into ONE frame."""
-        result = mlodaAPI.run_all_as_dataframe(
+        result = mlodaAPI.run_all(
             [Feature("rc568_pd_left"), Feature("rc568_pd_right")],
             compute_frameworks=["PandasDataFrame"],
             plugin_collector=_RC568_PANDAS_PAIR,
-        )
+        ).get_df()
 
         assert isinstance(result, pd.DataFrame)
         assert {"rc568_pd_left", "rc568_pd_right"} <= set(result.columns)
@@ -241,12 +255,11 @@ class TestRunAllAsDataframe:
         assert list(result["rc568_pd_right"]) == [10, 20, 30]
 
     def test_pandas_single_group_returns_single_frame(self) -> None:
-        """A single-group run returns that single frame with the requested column."""
-        result = mlodaAPI.run_all_as_dataframe(
+        result = mlodaAPI.run_all(
             [Feature("rc568_pd_left")],
             compute_frameworks=["PandasDataFrame"],
             plugin_collector=_RC568_PANDAS_SINGLE,
-        )
+        ).get_df()
 
         assert isinstance(result, pd.DataFrame)
         assert "rc568_pd_left" in result.columns
@@ -254,12 +267,11 @@ class TestRunAllAsDataframe:
 
     @pytest.mark.skipif(pl is None, reason="polars is not installed")
     def test_polars_two_groups_concat_into_one_frame(self) -> None:
-        """Two polars feature-group results are horizontally concatenated into ONE frame."""
-        result = mlodaAPI.run_all_as_dataframe(
+        result = mlodaAPI.run_all(
             [Feature("rc568_pl_left"), Feature("rc568_pl_right")],
             compute_frameworks=["PolarsDataFrame"],
             plugin_collector=_RC568_POLARS_PAIR,
-        )
+        ).get_df()
 
         assert isinstance(result, pl.DataFrame)
         assert {"rc568_pl_left", "rc568_pl_right"} <= set(result.columns)
@@ -268,19 +280,21 @@ class TestRunAllAsDataframe:
         assert result["rc568_pl_right"].to_list() == [10, 20, 30]
 
     def test_non_dataframe_results_raise_value_error(self) -> None:
-        """PythonDict columnar-dict results cannot be concatenated and raise ValueError."""
+        results = mlodaAPI.run_all(
+            [Feature("rc568_dict_feature")],
+            compute_frameworks=["PythonDictFramework"],
+            plugin_collector=_RC568_DICT,
+        )
+
         with pytest.raises(ValueError, match="DataFrame"):
-            mlodaAPI.run_all_as_dataframe(
-                [Feature("rc568_dict_feature")],
-                compute_frameworks=["PythonDictFramework"],
-                plugin_collector=_RC568_DICT,
-            )
+            results.get_df()
 
     def test_row_count_mismatch_raises_value_error(self) -> None:
-        """Two groups with different row counts (3 vs 2) raise ValueError on concat."""
+        results = mlodaAPI.run_all(
+            [Feature("rc568_pd_left"), Feature("rc568_pd_short")],
+            compute_frameworks=["PandasDataFrame"],
+            plugin_collector=_RC568_PANDAS_MISMATCH,
+        )
+
         with pytest.raises(ValueError, match="row"):
-            mlodaAPI.run_all_as_dataframe(
-                [Feature("rc568_pd_left"), Feature("rc568_pd_short")],
-                compute_frameworks=["PandasDataFrame"],
-                plugin_collector=_RC568_PANDAS_MISMATCH,
-            )
+            results.get_df()

--- a/tests/test_core/test_api/test_run_convenience.py
+++ b/tests/test_core/test_api/test_run_convenience.py
@@ -18,12 +18,14 @@ from typing import Any, Optional
 
 import pandas as pd
 import polars as pl
+import pyarrow as pa
 import pytest
 
 from mloda.provider import BaseInputData, DataCreator, FeatureGroup, FeatureSet
 from mloda.user import Feature, PluginCollector, mlodaAPI
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame  # noqa: F401
 from mloda_plugins.compute_framework.base_implementations.polars.dataframe import PolarsDataFrame  # noqa: F401
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable  # noqa: F401
 from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (  # noqa: F401
     PythonDictFramework,
 )
@@ -51,6 +53,30 @@ class Rc564DictFeatureGroup(FeatureGroup):
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
         return {"rc564_dict_feature": [1, 2]}
+
+
+class Rc564ArrowFeatureGroup(FeatureGroup):
+    """Root FG producing a single pyarrow column for the run_one tests."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({"rc564_arrow_feature"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return pa.table({"rc564_arrow_feature": [1, 2]})
+
+
+class Rc564PolarsFeatureGroup(FeatureGroup):
+    """Root FG producing a single polars column for the run_one tests."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({"rc564_polars_feature"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return pl.DataFrame({"rc564_polars_feature": [1, 2]})
 
 
 class Rc568PandasLeftFeatureGroup(FeatureGroup):
@@ -127,6 +153,8 @@ class Rc568DictFeatureGroup(FeatureGroup):
 
 _RC564_PANDAS = PluginCollector.enabled_feature_groups({Rc564PandasFeatureGroup})
 _RC564_DICT = PluginCollector.enabled_feature_groups({Rc564DictFeatureGroup})
+_RC564_ARROW = PluginCollector.enabled_feature_groups({Rc564ArrowFeatureGroup})
+_RC564_POLARS = PluginCollector.enabled_feature_groups({Rc564PolarsFeatureGroup})
 _RC568_PANDAS_PAIR = PluginCollector.enabled_feature_groups({Rc568PandasLeftFeatureGroup, Rc568PandasRightFeatureGroup})
 _RC568_PANDAS_SINGLE = PluginCollector.enabled_feature_groups({Rc568PandasLeftFeatureGroup})
 _RC568_PANDAS_MISMATCH = PluginCollector.enabled_feature_groups(
@@ -158,6 +186,26 @@ class TestRunOne:
         )
 
         assert result == [{"rc564_dict_feature": 1}, {"rc564_dict_feature": 2}]
+
+    def test_run_one_pyarrow_returns_flat_row_dicts(self) -> None:
+        """A pyarrow-backed single feature comes back as a flat list of row dicts."""
+        result = mlodaAPI.run_one(
+            Feature("rc564_arrow_feature"),
+            compute_frameworks=["PyArrowTable"],
+            plugin_collector=_RC564_ARROW,
+        )
+
+        assert result == [{"rc564_arrow_feature": 1}, {"rc564_arrow_feature": 2}]
+
+    def test_run_one_polars_returns_flat_row_dicts(self) -> None:
+        """A polars-backed single feature comes back as a flat list of row dicts."""
+        result = mlodaAPI.run_one(
+            Feature("rc564_polars_feature"),
+            compute_frameworks=["PolarsDataFrame"],
+            plugin_collector=_RC564_POLARS,
+        )
+
+        assert result == [{"rc564_polars_feature": 1}, {"rc564_polars_feature": 2}]
 
     def test_run_one_rejects_list_input(self) -> None:
         """Passing a list instead of a single feature raises a clear ValueError."""

--- a/tests/test_core/test_api/test_run_convenience.py
+++ b/tests/test_core/test_api/test_run_convenience.py
@@ -17,18 +17,23 @@ and parallel-safe under pytest-xdist.
 from typing import Any, Optional
 
 import pandas as pd
-import polars as pl
 import pyarrow as pa
 import pytest
 
 from mloda.provider import BaseInputData, DataCreator, FeatureGroup, FeatureSet
 from mloda.user import Feature, PluginCollector, mlodaAPI
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame  # noqa: F401
-from mloda_plugins.compute_framework.base_implementations.polars.dataframe import PolarsDataFrame  # noqa: F401
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable  # noqa: F401
 from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (  # noqa: F401
     PythonDictFramework,
 )
+
+try:
+    import polars as pl
+    from mloda_plugins.compute_framework.base_implementations.polars.dataframe import PolarsDataFrame  # noqa: F401
+except ImportError:
+    pl = None  # type: ignore[assignment]
+    PolarsDataFrame = None  # type: ignore[assignment, misc]
 
 
 class Rc564PandasFeatureGroup(FeatureGroup):
@@ -197,6 +202,7 @@ class TestRunOne:
 
         assert result == [{"rc564_arrow_feature": 1}, {"rc564_arrow_feature": 2}]
 
+    @pytest.mark.skipif(pl is None, reason="polars is not installed")
     def test_run_one_polars_returns_flat_row_dicts(self) -> None:
         """A polars-backed single feature comes back as a flat list of row dicts."""
         result = mlodaAPI.run_one(
@@ -246,6 +252,7 @@ class TestRunAllAsDataframe:
         assert "rc568_pd_left" in result.columns
         assert list(result["rc568_pd_left"]) == [1, 2, 3]
 
+    @pytest.mark.skipif(pl is None, reason="polars is not installed")
     def test_polars_two_groups_concat_into_one_frame(self) -> None:
         """Two polars feature-group results are horizontally concatenated into ONE frame."""
         result = mlodaAPI.run_all_as_dataframe(

--- a/tests/test_core/test_filter/test_feature_group_final_filters.py
+++ b/tests/test_core/test_filter/test_feature_group_final_filters.py
@@ -28,7 +28,7 @@ import pyarrow.compute as pc
 from mloda.provider import BaseFilterEngine, ComputeFramework, DataCreator, FeatureGroup, FeatureSet
 from mloda.provider import BaseInputData
 from mloda_plugins.compute_framework.base_implementations.pyarrow.pyarrow_filter_engine import PyArrowFilterEngine
-from mloda.user import Feature, Features, GlobalFilter, ParallelizationMode
+from mloda.user import Feature, Features, GlobalFilter, ParallelizationMode, results_by_feature
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
 from tests.test_core.test_tooling import MlodaTestRunner, PARALLELIZATION_MODES_SYNC_THREADING
 
@@ -535,18 +535,12 @@ class TestFeatureGroupFinalFilters:
             global_filter=global_filter,
         )
 
-        results_by_feature = {}
-        for res in result.results:
-            data = res.to_pydict()
-            if inline_feature_name in data:
-                results_by_feature[inline_feature_name] = data[inline_feature_name]
-            if final_feature_name in data:
-                results_by_feature[final_feature_name] = data[final_feature_name]
+        mapping = results_by_feature(result.results)
 
         # Inline FeatureGroup preserves all 4 rows with masked aggregation
-        assert results_by_feature[inline_feature_name] == [10, 10, 30, 30]
+        assert mapping[inline_feature_name].to_pydict()[inline_feature_name] == [10, 10, 30, 30]
         # Regular FeatureGroup has non-matching rows eliminated by final filtering
-        assert results_by_feature[final_feature_name] == [10, 30]
+        assert mapping[final_feature_name].to_pydict()[final_feature_name] == [10, 30]
 
     def test_fg_skip_with_inline_engine(self, modes: set[ParallelizationMode], flight_server: Any) -> None:
         """FG=False, Engine=False. Both agree to skip final filtering. Rows preserved.

--- a/tests/test_core/test_filter/test_feature_group_final_filters.py
+++ b/tests/test_core/test_filter/test_feature_group_final_filters.py
@@ -28,7 +28,7 @@ import pyarrow.compute as pc
 from mloda.provider import BaseFilterEngine, ComputeFramework, DataCreator, FeatureGroup, FeatureSet
 from mloda.provider import BaseInputData
 from mloda_plugins.compute_framework.base_implementations.pyarrow.pyarrow_filter_engine import PyArrowFilterEngine
-from mloda.user import Feature, Features, GlobalFilter, ParallelizationMode, results_by_feature
+from mloda.user import Feature, Features, GlobalFilter, ParallelizationMode
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
 from tests.test_core.test_tooling import MlodaTestRunner, PARALLELIZATION_MODES_SYNC_THREADING
 
@@ -535,12 +535,10 @@ class TestFeatureGroupFinalFilters:
             global_filter=global_filter,
         )
 
-        mapping = results_by_feature(result.results)
-
         # Inline FeatureGroup preserves all 4 rows with masked aggregation
-        assert mapping[inline_feature_name].to_pydict()[inline_feature_name] == [10, 10, 30, 30]
+        assert result.results.get_values(inline_feature_name) == [10, 10, 30, 30]
         # Regular FeatureGroup has non-matching rows eliminated by final filtering
-        assert mapping[final_feature_name].to_pydict()[final_feature_name] == [10, 30]
+        assert result.results.get_values(final_feature_name) == [10, 30]
 
     def test_fg_skip_with_inline_engine(self, modes: set[ParallelizationMode], flight_server: Any) -> None:
         """FG=False, Engine=False. Both agree to skip final filtering. Rows preserved.

--- a/tests/test_core/test_tooling/mloda_test_runner.py
+++ b/tests/test_core/test_tooling/mloda_test_runner.py
@@ -28,6 +28,7 @@ from mloda.user import Features
 from mloda.user import Link
 from mloda.user import ParallelizationMode
 from mloda.user import PluginCollector
+from mloda.user import Results
 from mloda.provider import ComputeFramework
 from mloda.steward import Extender
 from mloda.user import mloda
@@ -42,7 +43,7 @@ from mloda_plugins.compute_framework.base_implementations.pyarrow.table import P
 class RunResult:
     """Container for test run results."""
 
-    results: list[Any] = field(default_factory=list)
+    results: Results = field(default_factory=Results)
     artifacts: dict[str, Any] = field(default_factory=dict)
     runner: Optional[ExecutionOrchestrator] = None
 

--- a/tests/test_plugins/compute_framework/test_per_feature_fg_scope_integration.py
+++ b/tests/test_plugins/compute_framework/test_per_feature_fg_scope_integration.py
@@ -20,6 +20,7 @@ from mloda.user import Options
 from mloda.user import ParallelizationMode
 from mloda.user import PluginCollector
 from mloda.user import mloda
+from mloda.user import results_by_feature
 
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame  # noqa: F401
 
@@ -98,9 +99,8 @@ def test_scoped_derived_feature_resolves_and_computes(flight_server: Any) -> Non
         parallelization_modes={ParallelizationMode.SYNC},
     )
 
-    values: list[str] = []
-    for res in result:
-        values = list(res[Derived508Scoped.get_class_name()].values)
+    col = Derived508Scoped.get_class_name()
+    values = list(results_by_feature(result)[col][col].values)
 
     assert values == ["s1|30", "s2|7"]
 
@@ -195,9 +195,8 @@ def test_scoped_key_shares_read_with_siblings(flight_server: Any) -> None:
         parallelization_modes={ParallelizationMode.SYNC},
     )
 
-    values: list[str] = []
-    for res in result:
-        values = list(res[Derived508CounterScoped.get_class_name()].values)
+    col = Derived508CounterScoped.get_class_name()
+    values = list(results_by_feature(result)[col][col].values)
 
     assert values == ["s1|30", "s2|7"]
     assert Source508CounterA.calls == 1
@@ -271,13 +270,6 @@ class Derived508IndepB(FeatureGroup):
         return {cls.get_class_name(): result}
 
 
-def _column_from_result(result: Any, column: str) -> list[Any]:
-    for res in result:
-        if column in res:
-            return list(res[column].values)
-    return []
-
-
 def test_two_derived_fgs_scope_same_key_to_different_sources(flight_server: Any) -> None:
     """Two derived FGs scope the same-name key to different sources and resolve independently.
 
@@ -301,8 +293,11 @@ def test_two_derived_fgs_scope_same_key_to_different_sources(flight_server: Any)
         parallelization_modes={ParallelizationMode.SYNC},
     )
 
-    values_a = _column_from_result(result, Derived508IndepA.get_class_name())
-    values_b = _column_from_result(result, Derived508IndepB.get_class_name())
+    mapping = results_by_feature(result)
+    col_a = Derived508IndepA.get_class_name()
+    col_b = Derived508IndepB.get_class_name()
+    values_a = list(mapping[col_a][col_a].values)
+    values_b = list(mapping[col_b][col_b].values)
 
     assert values_a == ["s1|30", "s2|7"]
     assert values_b == ["s1|300", "s2|400"]

--- a/tests/test_plugins/compute_framework/test_per_feature_fg_scope_integration.py
+++ b/tests/test_plugins/compute_framework/test_per_feature_fg_scope_integration.py
@@ -20,7 +20,6 @@ from mloda.user import Options
 from mloda.user import ParallelizationMode
 from mloda.user import PluginCollector
 from mloda.user import mloda
-from mloda.user import results_by_feature
 
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame  # noqa: F401
 
@@ -100,7 +99,7 @@ def test_scoped_derived_feature_resolves_and_computes(flight_server: Any) -> Non
     )
 
     col = Derived508Scoped.get_class_name()
-    values = list(results_by_feature(result)[col][col].values)
+    values = result.get_values(col)
 
     assert values == ["s1|30", "s2|7"]
 
@@ -196,7 +195,7 @@ def test_scoped_key_shares_read_with_siblings(flight_server: Any) -> None:
     )
 
     col = Derived508CounterScoped.get_class_name()
-    values = list(results_by_feature(result)[col][col].values)
+    values = result.get_values(col)
 
     assert values == ["s1|30", "s2|7"]
     assert Source508CounterA.calls == 1
@@ -293,11 +292,10 @@ def test_two_derived_fgs_scope_same_key_to_different_sources(flight_server: Any)
         parallelization_modes={ParallelizationMode.SYNC},
     )
 
-    mapping = results_by_feature(result)
     col_a = Derived508IndepA.get_class_name()
     col_b = Derived508IndepB.get_class_name()
-    values_a = list(mapping[col_a][col_a].values)
-    values_b = list(mapping[col_b][col_b].values)
+    values_a = result.get_values(col_a)
+    values_b = result.get_values(col_b)
 
     assert values_a == ["s1|30", "s2|7"]
     assert values_b == ["s1|300", "s2|400"]

--- a/tests/test_plugins/feature_group/experimental/test_combined_feature_groups/test_combined_integration.py
+++ b/tests/test_plugins/feature_group/experimental/test_combined_feature_groups/test_combined_integration.py
@@ -5,6 +5,7 @@ Integration tests for combined feature groups.
 from mloda.user import mloda
 from mloda.user import Feature
 from mloda.user import PluginCollector
+from mloda.user import results_by_feature
 
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
@@ -71,13 +72,9 @@ class TestCombinedFeatureGroupsPandas:
             plugin_collector=plugin_collector,
         )
 
-        for res in result:
-            if "price__mean_imputed__sum_7_day_window__max_aggr" in res.columns:
-                res_check = res["price__mean_imputed__sum_7_day_window__max_aggr"]
-
-        for res in result2:
-            if "price__mean_imputed__sum_7_day_window__max_aggr" in res.columns:
-                res2_check = res["price__mean_imputed__sum_7_day_window__max_aggr"]
+        col = "price__mean_imputed__sum_7_day_window__max_aggr"
+        res_check = results_by_feature(result)[col][col]
+        res2_check = results_by_feature(result2)[col][col]
 
         assert res_check.equals(res2_check)
 

--- a/tests/test_plugins/feature_group/experimental/test_combined_feature_groups/test_combined_integration.py
+++ b/tests/test_plugins/feature_group/experimental/test_combined_feature_groups/test_combined_integration.py
@@ -5,7 +5,6 @@ Integration tests for combined feature groups.
 from mloda.user import mloda
 from mloda.user import Feature
 from mloda.user import PluginCollector
-from mloda.user import results_by_feature
 
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
@@ -73,8 +72,8 @@ class TestCombinedFeatureGroupsPandas:
         )
 
         col = "price__mean_imputed__sum_7_day_window__max_aggr"
-        res_check = results_by_feature(result)[col][col]
-        res2_check = results_by_feature(result2)[col][col]
+        res_check = result.get_one(col)[col]
+        res2_check = result2.get_one(col)[col]
 
         assert res_check.equals(res2_check)
 


### PR DESCRIPTION
## Summary

`run_all` returns one compute-framework object per resolving feature group, so every downstream consumer hand-rolled result unwrapping, name lookup, and horizontal concat (audited across 13 demo/MVP repos in #566). This PR gives `run_all` a fluent reading API instead:

```python
results = mloda.run_all(features, compute_frameworks={PandasDataFrame})

df = results.get_df()             # one concatenated DataFrame
rows = results.get_rows("price")  # flat [{"price": 1.2}, ...]
vals = results.get_values("price")# [1.2, 3.4, ...] as a plain list
one = results.get_one("price")    # the raw result object containing "price"
```

- `run_all` (and `session.run()` / `get_result()`) now return `Results`, a `list` subclass, so all existing consumers keep working (indexing, iteration, `isinstance(r, list)`), closes #564, closes #568, closes #569
- `get_one` resolves multi-output columns (`feature~suffix`) via their base name; unknown names raise `ValueError` listing the available features
- `Results` is exported from `mloda.user` for typing

## Design

- One module, `mloda/core/api/results.py`. Reading is duck-typed (dict, list-of-rows, pyarrow `to_pylist`, polars `to_dicts` / lazy `collect`, pandas `to_dict("records")`, Spark-like `collect`/`asDict`, relation-like `df()`), keeping mloda core dependency-free. pandas/polars are imported only inside branches where an instance proves availability.
- Failure modes are loud: mismatched row counts, mixed pandas/polars, and non-DataFrame results in `get_df` all raise `ValueError` (no silent column loss); ragged columnar dicts raise instead of truncating.
- Existing tests that hand-rolled these patterns were migrated (`get_df` for concat-or-first sites, `get_values`/`get_one` for scan loops); tests that deliberately pin the raw per-group output shape were left untouched.

## Review

Two independent deep reviews (Claude Opus subagent and codex) ran on the initial helper implementation. Accepted and fixed: silent dropping of non-DataFrame elements in mixed runs, missing Spark/relation/LazyFrame row paths, list aliasing, ragged columnar dict truncation, error-type consistency. The API was then reshaped from standalone helpers (`run_one`, `run_all_as_dataframe`, `results_by_feature`) into this single fluent surface.

## Testing

- 50 unit tests for `Results` and 12 integration tests through `mlodaAPI` (pandas, polars, pyarrow, python_dict), plus a documented, mktestdocs-executed example in `access-feature-data.md`
- `tox` green: 4295 passed, 171 skipped, ruff, pip-licenses, mypy --strict, bandit; full CI matrix including the no-polars `core`/`installed` envs
