### PR TITLE
fix: unify catalog graceful-degradation policy and guard is_available() (#541)

### DIFF
--- a/docs/docs/in_depth/discover-plugins.md
+++ b/docs/docs/in_depth/discover-plugins.md
@@ -78,6 +78,64 @@ extenders = get_extender_docs()
 extenders = get_extender_docs(wraps="formula")
 ```
 
+## Graceful Degradation Policy
+
+The discovery functions above walk every live plugin subclass and introspect it.
+Plugins can be broken, exotic, or built at runtime (via `type()`, notebook
+re-execution, or `importlib.reload`), so introspecting one class can fail. The
+whole catalog surface follows one shared contract so that a single broken plugin
+never sinks an entire catalog call.
+
+Every failure a plugin can cause falls into one of three tiers:
+
+- **Annotate.** A single descriptive field cannot be read, but the class is still
+  a valid catalog entry. The entry is listed with a sentinel value and discovery
+  continues. Examples: `get_feature_group_docs` reports `version="unavailable"`
+  when source introspection fails (`_safe_version`); `get_compute_framework_docs`
+  reports `expected_data_framework="unavailable"`, `has_merge_engine=False`,
+  `has_filter_engine=False`, and `is_available=False` when the corresponding call
+  raises; `get_extender_docs` reports `wraps=[]` when the extender cannot be
+  instantiated. A framework that degrades to `is_available=False` is excluded by
+  `available_only=True`, exactly as a genuinely unavailable one would be.
+- **Skip.** An entry that is not meant to be documented is dropped silently:
+  classes defined in `__main__`, and the abstract bases (`get_extender_docs`
+  skips `Extender` and `_CompositeExtender` explicitly; the FeatureGroup and
+  ComputeFramework roots never appear because `get_all_subclasses` omits them).
+  Redefinition duplicates are collapsed rather than listed twice (see below).
+- **Propagate.** Errors that are not a single plugin's introspection fault are
+  left to surface: bad arguments to the discovery function itself, and failures
+  in mloda's own catalog machinery. These are bugs to fix, not conditions to
+  paper over.
+
+### Redefinition conflicts
+
+When the same `(module, qualname)` FeatureGroup is defined more than once with
+differing source (typical in notebooks and reload-heavy sessions), the catalog
+and resolution paths intentionally differ:
+
+- **`get_*_docs` degrade.** Documentation is a best-effort read-only view, so a
+  conflict collapses to the most recently defined (live) class and listing
+  continues. There is nothing to execute, so ambiguity is harmless.
+- **`resolve_feature` surfaces the conflict.** Resolution feeds execution, which
+  must be unambiguous to be safe, so it returns `feature_group=None` with the
+  conflict described in `error` and the conflicting classes that match the
+  requested feature name in `candidates` rather than silently picking one.
+
+### Shared helper
+
+The annotate tier is currently expressed as ad hoc `try/except Exception`
+blocks repeated per field in `get_compute_framework_docs`, alongside the
+narrower named guards `_safe_version` (in `plugin_docs.py`) and
+`_safe_class_source_hash` (one layer down in `accessible_plugins.py`), which
+catch only `(OSError, TypeError)`. A small
+shared safe-introspection helper (a per-field guard: call a thunk, return a
+caller-supplied fallback on failure) is worth extracting so the next catalog
+function or info field reaches for it instead of re-deriving the pattern. It
+should stay per-field (annotate the entry) rather than per-class (skip the whole
+entry), because the catalog's job is to list a degraded class, not hide it. That
+refactor is tracked as its own scoped follow-up; the unguarded `is_available()`
+call is fixed inline here so no known gap is left open in the meantime.
+
 ## Related Documentation
 
 - [Plugin Loader](plugin-loader.md)

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -174,7 +174,10 @@ def get_compute_framework_docs(
         description = (cfw_class.__doc__ or "").strip() or cfw_class.__name__
         module = cfw_class.__module__
 
-        is_available = cfw_class.is_available()
+        try:
+            is_available = cfw_class.is_available()
+        except Exception:  # nosec
+            is_available = False
 
         try:
             expected_data_framework = str(cfw_class.expected_data_framework())

--- a/tests/test_core/test_api/test_plugin_docs.py
+++ b/tests/test_core/test_api/test_plugin_docs.py
@@ -12,6 +12,7 @@ from mloda.core.api.plugin_docs import (
     get_compute_framework_docs,
     get_extender_docs,
 )
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.user import PluginLoader
 
 
@@ -379,6 +380,41 @@ class TestGetComputeFrameworkDocs:
         default_names = {cfw.name for cfw in get_compute_framework_docs()}
         all_names = {cfw.name for cfw in get_compute_framework_docs(available_only=False)}
         assert default_names == all_names
+
+    def test_get_compute_framework_docs_degrades_when_is_available_raises(self) -> None:
+        """A framework whose is_available() raises must degrade to unavailable, not sink the catalog.
+
+        The is_available() call at plugin_docs.py:177 runs outside any guard, so a live
+        ComputeFramework subclass whose availability probe raises currently propagates the
+        exception out of get_compute_framework_docs() (same shape as issue #533). The sibling
+        field reads (expected_data_framework, merge_engine, filter_engine) already fall back to
+        a sentinel on exception; is_available must degrade the same way: is_available=False.
+        """
+
+        class _DocsIsAvailableBoomCFW(ComputeFramework):
+            """Test double whose availability probe raises."""
+
+            @staticmethod
+            def is_available() -> bool:
+                raise RuntimeError("boom")
+
+        try:
+            # The broken class must not take the whole catalog call down.
+            results = get_compute_framework_docs(available_only=False)
+            assert len(results) > 0, "Broken framework must not sink the whole catalog"
+
+            by_name = {cfw.name: cfw for cfw in results}
+            assert "_DocsIsAvailableBoomCFW" in by_name, "Broken framework should still be documented"
+            # It degrades to unavailable, matching the sibling guards.
+            assert by_name["_DocsIsAvailableBoomCFW"].is_available is False
+
+            # available_only=True must exclude it because it degraded to unavailable.
+            available_names = {cfw.name for cfw in get_compute_framework_docs(available_only=True)}
+            assert "_DocsIsAvailableBoomCFW" not in available_names
+        finally:
+            # Reap the test-local subclass so sibling tests are unaffected (live __subclasses__).
+            del _DocsIsAvailableBoomCFW
+            gc.collect()
 
 
 class TestGetExtenderDocs:


### PR DESCRIPTION
Closes #541.

## What

Issue #541 is an analysis task: unify the graceful-degradation policy across the plugin discovery / resolution surface in `plugin_docs.py`, and decide the one concrete unguarded gap inline. This PR delivers all three DoD items.

### 1. Stated contract (docs)

Adds a "Graceful Degradation Policy" section to `docs/docs/in_depth/discover-plugins.md` describing one shared contract for the whole catalog surface, expressed as three tiers:

- **Annotate** a single unreadable field with a sentinel (`version="unavailable"`, `is_available=False`, `wraps=[]`, ...) and keep listing the class.
- **Skip** entries that are not meant to be documented (`__main__` classes, abstract bases, collapsed redefinition duplicates).
- **Propagate** failures that are not a single plugin's introspection fault (bad arguments, mloda's own machinery bugs).

It also documents the intentional asymmetry on redefinition conflicts: `get_*_docs` collapse to the live class (best-effort read-only view) while `resolve_feature` surfaces the conflict (resolution feeds execution and must be unambiguous).

### 2. Shared helper decision (docs)

Records that a small per-field safe-introspection helper is worth extracting (shape: call a thunk, return a caller-supplied fallback on failure; per-field annotate, not per-class skip), and that the broad refactor is a scoped follow-up rather than part of this analysis issue.

### 3. The one unguarded gap (code + test)

`get_compute_framework_docs` called `cfw_class.is_available()` outside any guard, so a runtime-created ComputeFramework whose `is_available()` raises would take down the whole catalog call (the #533 failure shape on a sibling function). Guarded it to degrade to `is_available=False`, exactly matching the three sibling field reads immediately below it, so the framework is listed as unavailable and excluded by `available_only=True`. Added a regression test that pins the behavior and reaps its throwaway subclass to stay parallel-safe.

## Testing

`tox` is fully green (4255 passed, ruff format + check, `mypy --strict`, bandit, license allowlist).

## Review

Two independent deep reviews (a fresh Claude Opus agent and codex) gated this PR. Codex found no issues; Opus found no blockers or majors and three doc-phrasing accuracy nits, all applied.
