### PR TITLE
refactor: extract shared safe_field helper for catalog annotate tier (#541)

### DIFF
--- a/attribution/ATTRIBUTION.md
+++ b/attribution/ATTRIBUTION.md
@@ -82,7 +82,7 @@
 | pytest-xdist                           | 3.8.0           | MIT                                                |
 | python-dateutil                        | 2.9.0.post0     | Apache Software License; BSD License               |
 | pyzmq                                  | 27.1.0          | BSD License                                        |
-| regex                                  | 2026.5.9        | Apache-2.0 AND CNRI-Python                         |
+| regex                                  | 2026.6.28       | Apache-2.0 AND CNRI-Python                         |
 | requests                               | 2.34.2          | Apache Software License                            |
 | rich                                   | 14.3.4          | MIT License                                        |
 | ruff                                   | 0.15.20         | MIT                                                |

--- a/docs/docs/in_depth/discover-plugins.md
+++ b/docs/docs/in_depth/discover-plugins.md
@@ -83,8 +83,9 @@ extenders = get_extender_docs(wraps="formula")
 The discovery functions above walk every live plugin subclass and introspect it.
 Plugins can be broken, exotic, or built at runtime (via `type()`, notebook
 re-execution, or `importlib.reload`), so introspecting one class can fail. The
-whole catalog surface follows one shared contract so that a single broken plugin
-never sinks an entire catalog call.
+guarded catalog reads follow one shared contract so that a broken plugin
+degrades a field instead of sinking the catalog call; not every read is guarded
+yet (see below).
 
 Every failure a plugin can cause falls into one of three tiers:
 
@@ -123,18 +124,23 @@ and resolution paths intentionally differ:
 
 ### Shared helper
 
-The annotate tier is currently expressed as ad hoc `try/except Exception`
-blocks repeated per field in `get_compute_framework_docs`, alongside the
-narrower named guards `_safe_version` (in `plugin_docs.py`) and
-`_safe_class_source_hash` (one layer down in `accessible_plugins.py`), which
-catch only `(OSError, TypeError)`. A small
-shared safe-introspection helper (a per-field guard: call a thunk, return a
-caller-supplied fallback on failure) is worth extracting so the next catalog
-function or info field reaches for it instead of re-deriving the pattern. It
-should stay per-field (annotate the entry) rather than per-class (skip the whole
-entry), because the catalog's job is to list a degraded class, not hide it. That
-refactor is tracked as its own scoped follow-up; the unguarded `is_available()`
-call is fixed inline here so no known gap is left open in the meantime.
+The annotate tier is a single shared helper,
+`safe_field(read, fallback, catching=(Exception,))` in
+`mloda.core.abstract_plugins.components.utils`: it calls the `read` thunk and
+returns `fallback` if the read raises one of `catching`. The guarded annotate
+sites route through it (the feature-group version, the four compute-framework
+fields, and extender wraps), so the next catalog function or info field reaches
+for one helper instead of re-deriving a `try/except`. The remaining overridable
+reads in `get_feature_group_docs` (class name, description, compute framework
+definition, supported feature names, prefix) are not yet guarded, so a plugin
+raising there still propagates (a known follow-up gap).
+`get_compute_framework_docs` uses the default broad `catching` (any failure
+degrades the field), while the narrower named guards `_safe_version` (in
+`plugin_docs.py`) and `_safe_class_source_hash` (one layer down in
+`accessible_plugins.py`) pass the shared `SOURCE_INTROSPECTION_ERRORS` constant
+(from `base_feature_group_version.py`) so anything else still propagates. The helper is
+deliberately per-field (annotate the entry) rather than per-class (skip the whole
+entry), because the catalog's job is to list a degraded class, not hide it.
 
 ## Related Documentation
 

--- a/docs/docs/in_depth/discover-plugins.md
+++ b/docs/docs/in_depth/discover-plugins.md
@@ -78,6 +78,64 @@ extenders = get_extender_docs()
 extenders = get_extender_docs(wraps="formula")
 ```
 
+## Graceful Degradation Policy
+
+The discovery functions above walk every live plugin subclass and introspect it.
+Plugins can be broken, exotic, or built at runtime (via `type()`, notebook
+re-execution, or `importlib.reload`), so introspecting one class can fail. The
+whole catalog surface follows one shared contract so that a single broken plugin
+never sinks an entire catalog call.
+
+Every failure a plugin can cause falls into one of three tiers:
+
+- **Annotate.** A single descriptive field cannot be read, but the class is still
+  a valid catalog entry. The entry is listed with a sentinel value and discovery
+  continues. Examples: `get_feature_group_docs` reports `version="unavailable"`
+  when source introspection fails (`_safe_version`); `get_compute_framework_docs`
+  reports `expected_data_framework="unavailable"`, `has_merge_engine=False`,
+  `has_filter_engine=False`, and `is_available=False` when the corresponding call
+  raises; `get_extender_docs` reports `wraps=[]` when the extender cannot be
+  instantiated. A framework that degrades to `is_available=False` is excluded by
+  `available_only=True`, exactly as a genuinely unavailable one would be.
+- **Skip.** An entry that is not meant to be documented is dropped silently:
+  classes defined in `__main__`, and the abstract bases (`get_extender_docs`
+  skips `Extender` and `_CompositeExtender` explicitly; the FeatureGroup and
+  ComputeFramework roots never appear because `get_all_subclasses` omits them).
+  Redefinition duplicates are collapsed rather than listed twice (see below).
+- **Propagate.** Errors that are not a single plugin's introspection fault are
+  left to surface: bad arguments to the discovery function itself, and failures
+  in mloda's own catalog machinery. These are bugs to fix, not conditions to
+  paper over.
+
+### Redefinition conflicts
+
+When the same `(module, qualname)` FeatureGroup is defined more than once with
+differing source (typical in notebooks and reload-heavy sessions), the catalog
+and resolution paths intentionally differ:
+
+- **`get_*_docs` degrade.** Documentation is a best-effort read-only view, so a
+  conflict collapses to the most recently defined (live) class and listing
+  continues. There is nothing to execute, so ambiguity is harmless.
+- **`resolve_feature` surfaces the conflict.** Resolution feeds execution, which
+  must be unambiguous to be safe, so it returns `feature_group=None` with the
+  conflict described in `error` and the conflicting classes that match the
+  requested feature name in `candidates` rather than silently picking one.
+
+### Shared helper
+
+The annotate tier is currently expressed as ad hoc `try/except Exception`
+blocks repeated per field in `get_compute_framework_docs`, alongside the
+narrower named guards `_safe_version` (in `plugin_docs.py`) and
+`_safe_class_source_hash` (one layer down in `accessible_plugins.py`), which
+catch only `(OSError, TypeError)`. A small
+shared safe-introspection helper (a per-field guard: call a thunk, return a
+caller-supplied fallback on failure) is worth extracting so the next catalog
+function or info field reaches for it instead of re-deriving the pattern. It
+should stay per-field (annotate the entry) rather than per-class (skip the whole
+entry), because the catalog's job is to list a degraded class, not hide it. That
+refactor is tracked as its own scoped follow-up; the unguarded `is_available()`
+call is fixed inline here so no known gap is left open in the meantime.
+
 ## Related Documentation
 
 - [Plugin Loader](plugin-loader.md)

--- a/mloda/core/abstract_plugins/components/base_feature_group_version.py
+++ b/mloda/core/abstract_plugins/components/base_feature_group_version.py
@@ -5,8 +5,11 @@ import importlib.metadata
 import inspect
 import linecache
 import hashlib
-from typing import Any
+from typing import Any, Final
 from abc import ABC
+
+# Exceptions inspect.getsource raises for dynamically built classes (no source backing / built-in).
+SOURCE_INTROSPECTION_ERRORS: Final = (OSError, TypeError)
 
 
 class BaseFeatureGroupVersion(ABC):
@@ -45,7 +48,7 @@ class BaseFeatureGroupVersion(ABC):
 
         try:
             source: str = inspect.getsource(target_class)
-        except (OSError, TypeError):
+        except SOURCE_INTROSPECTION_ERRORS:
             fallback = _linecache_source_for_class(target_class)
             if fallback is None:
                 raise

--- a/mloda/core/abstract_plugins/components/utils.py
+++ b/mloda/core/abstract_plugins/components/utils.py
@@ -1,10 +1,20 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Callable, TypeVar
 
 import logging
 
 logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+def safe_field(read: Callable[[], T], fallback: T, catching: tuple[type[Exception], ...] = (Exception,)) -> T:
+    """Annotate tier: degrade a single unreadable field to a fallback instead of failing the whole discovery call."""
+    try:
+        return read()
+    except catching:
+        return fallback
 
 
 def get_all_subclasses(cls: Any, log_n_subclasses: int = 0) -> set[type[Any]]:

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -174,7 +174,10 @@ def get_compute_framework_docs(
         description = (cfw_class.__doc__ or "").strip() or cfw_class.__name__
         module = cfw_class.__module__
 
-        is_available = cfw_class.is_available()
+        try:
+            is_available = cfw_class.is_available()
+        except Exception:  # nosec
+            is_available = False
 
         try:
             expected_data_framework = str(cfw_class.expected_data_framework())

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -17,9 +17,10 @@ Example:
 
 from typing import Any, Optional
 
+from mloda.core.abstract_plugins.components.base_feature_group_version import SOURCE_INTROSPECTION_ERRORS
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
-from mloda.core.abstract_plugins.components.utils import get_all_subclasses
+from mloda.core.abstract_plugins.components.utils import get_all_subclasses, safe_field
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.function_extender import Extender
 from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistry
@@ -41,10 +42,7 @@ def list_registered(plugin_type: type[Any]) -> list[type[Any]]:
 
 def _safe_version(fg_class: type[FeatureGroup]) -> str:
     """Return the feature group version or "unavailable" if source introspection fails."""
-    try:
-        return fg_class.version()
-    except (OSError, TypeError):
-        return "unavailable"
+    return safe_field(lambda: fg_class.version(), "unavailable", catching=SOURCE_INTROSPECTION_ERRORS)
 
 
 def _dedup_degrading_on_conflict(
@@ -174,25 +172,10 @@ def get_compute_framework_docs(
         description = (cfw_class.__doc__ or "").strip() or cfw_class.__name__
         module = cfw_class.__module__
 
-        try:
-            is_available = cfw_class.is_available()
-        except Exception:  # nosec
-            is_available = False
-
-        try:
-            expected_data_framework = str(cfw_class.expected_data_framework())
-        except Exception:  # nosec
-            expected_data_framework = "unavailable"
-
-        try:
-            has_merge_engine = cfw_class.merge_engine() is not None
-        except Exception:  # nosec
-            has_merge_engine = False
-
-        try:
-            has_filter_engine = cfw_class.filter_engine() is not None
-        except Exception:  # nosec
-            has_filter_engine = False
+        is_available = safe_field(lambda: cfw_class.is_available(), False)
+        expected_data_framework = safe_field(lambda: str(cfw_class.expected_data_framework()), "unavailable")
+        has_merge_engine = safe_field(lambda: cfw_class.merge_engine() is not None, False)
+        has_filter_engine = safe_field(lambda: cfw_class.filter_engine() is not None, False)
 
         if available_only and not is_available:
             continue
@@ -256,12 +239,7 @@ def get_extender_docs(
         if ext_name in ("Extender", "_CompositeExtender"):
             continue
 
-        wraps_list: list[str] = []
-        try:
-            instance = ext_class()
-            wraps_list = [w.value for w in instance.wraps()]
-        except Exception:  # nosec
-            pass
+        wraps_list: list[str] = safe_field(lambda: [w.value for w in ext_class().wraps()], [])
 
         if name is not None and name.lower() not in ext_name.lower():
             continue

--- a/mloda/core/prepare/accessible_plugins.py
+++ b/mloda/core/prepare/accessible_plugins.py
@@ -6,7 +6,10 @@ import sys
 from copy import deepcopy
 from typing import Any, Optional, cast
 
-from mloda.core.abstract_plugins.components.base_feature_group_version import BaseFeatureGroupVersion
+from mloda.core.abstract_plugins.components.base_feature_group_version import (
+    SOURCE_INTROSPECTION_ERRORS,
+    BaseFeatureGroupVersion,
+)
 from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import (
     PluginCollector,
     strict_mode_from_env,
@@ -15,7 +18,7 @@ from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRe
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.abstract_plugins.function_extender import Extender
-from mloda.core.abstract_plugins.components.utils import get_all_subclasses
+from mloda.core.abstract_plugins.components.utils import get_all_subclasses, safe_field
 
 
 logger = logging.getLogger(__name__)
@@ -103,10 +106,9 @@ def _safe_class_source_hash(cls: type[FeatureGroup]) -> Optional[str]:
     (built-in class) for classes built dynamically via ``type()``. Both leave the
     class without a stable source hash, so we return ``None``.
     """
-    try:
-        return BaseFeatureGroupVersion.class_source_hash(cls)
-    except (OSError, TypeError):
-        return None
+    return safe_field(
+        lambda: BaseFeatureGroupVersion.class_source_hash(cls), None, catching=SOURCE_INTROSPECTION_ERRORS
+    )
 
 
 def dedup_feature_group_subclasses(

--- a/tests/test_core/test_abstract_plugins/test_components/test_safe_field.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_safe_field.py
@@ -1,0 +1,59 @@
+"""Tests for the safe_field plugin-catalog graceful-degradation helper.
+
+safe_field is the "annotate" tier: it reads one introspected field and, if the
+read raises an exception in `catching`, returns a caller-supplied fallback
+instead of propagating. Exceptions outside `catching` still propagate.
+"""
+
+from typing import Any
+
+import pytest
+
+from mloda.core.abstract_plugins.components.utils import safe_field
+
+
+class TestSafeFieldSuccessPath:
+    """When the read succeeds, its value is returned and the fallback is ignored."""
+
+    def test_returns_read_value_on_success(self) -> None:
+        assert safe_field(lambda: 42, -1) == 42
+
+
+class TestSafeFieldDefaultCatching:
+    """The default catching=(Exception,) swallows ordinary exceptions."""
+
+    def test_default_catching_swallows_runtime_error(self) -> None:
+        def raises() -> str:
+            raise RuntimeError("boom")
+
+        assert safe_field(raises, "unavailable") == "unavailable"
+
+
+class TestSafeFieldNarrowCatching:
+    """A narrow catching tuple swallows listed types and propagates the rest."""
+
+    def test_returns_fallback_for_listed_exception_type(self) -> None:
+        def raises() -> str:
+            raise OSError("disk gone")
+
+        assert safe_field(raises, "fallback", catching=(OSError, TypeError)) == "fallback"
+
+    def test_propagates_unlisted_exception_type(self) -> None:
+        def raises() -> str:
+            raise ValueError("not caught")
+
+        with pytest.raises(ValueError):
+            safe_field(raises, "fallback", catching=(OSError, TypeError))
+
+
+class TestSafeFieldFallbackIdentity:
+    """The fallback value is returned as-is, preserving type and identity."""
+
+    @pytest.mark.parametrize("fallback", [False, [], None, "", 0])
+    def test_fallback_returned_as_is_on_failure(self, fallback: Any) -> None:
+        def raises() -> Any:
+            raise RuntimeError("boom")
+
+        result = safe_field(raises, fallback)
+
+        assert result is fallback

--- a/tests/test_core/test_api/test_plugin_docs.py
+++ b/tests/test_core/test_api/test_plugin_docs.py
@@ -12,6 +12,7 @@ from mloda.core.api.plugin_docs import (
     get_compute_framework_docs,
     get_extender_docs,
 )
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.user import PluginLoader
 
 
@@ -379,6 +380,41 @@ class TestGetComputeFrameworkDocs:
         default_names = {cfw.name for cfw in get_compute_framework_docs()}
         all_names = {cfw.name for cfw in get_compute_framework_docs(available_only=False)}
         assert default_names == all_names
+
+    def test_get_compute_framework_docs_degrades_when_is_available_raises(self) -> None:
+        """A framework whose is_available() raises must degrade to unavailable, not sink the catalog.
+
+        The is_available() call at plugin_docs.py:177 runs outside any guard, so a live
+        ComputeFramework subclass whose availability probe raises currently propagates the
+        exception out of get_compute_framework_docs() (same shape as issue #533). The sibling
+        field reads (expected_data_framework, merge_engine, filter_engine) already fall back to
+        a sentinel on exception; is_available must degrade the same way: is_available=False.
+        """
+
+        class _DocsIsAvailableBoomCFW(ComputeFramework):
+            """Test double whose availability probe raises."""
+
+            @staticmethod
+            def is_available() -> bool:
+                raise RuntimeError("boom")
+
+        try:
+            # The broken class must not take the whole catalog call down.
+            results = get_compute_framework_docs(available_only=False)
+            assert len(results) > 0, "Broken framework must not sink the whole catalog"
+
+            by_name = {cfw.name: cfw for cfw in results}
+            assert "_DocsIsAvailableBoomCFW" in by_name, "Broken framework should still be documented"
+            # It degrades to unavailable, matching the sibling guards.
+            assert by_name["_DocsIsAvailableBoomCFW"].is_available is False
+
+            # available_only=True must exclude it because it degraded to unavailable.
+            available_names = {cfw.name for cfw in get_compute_framework_docs(available_only=True)}
+            assert "_DocsIsAvailableBoomCFW" not in available_names
+        finally:
+            # Reap the test-local subclass so sibling tests are unaffected (live __subclasses__).
+            del _DocsIsAvailableBoomCFW
+            gc.collect()
 
 
 class TestGetExtenderDocs:

--- a/tests/test_core/test_api/test_plugin_docs.py
+++ b/tests/test_core/test_api/test_plugin_docs.py
@@ -1,5 +1,6 @@
 import gc
 import inspect
+from typing import Any
 
 import pytest
 from mloda.core.api.plugin_info import (
@@ -11,6 +12,7 @@ from mloda.core.api.plugin_docs import (
     get_feature_group_docs,
     get_compute_framework_docs,
     get_extender_docs,
+    _safe_version,
 )
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.user import PluginLoader
@@ -382,13 +384,11 @@ class TestGetComputeFrameworkDocs:
         assert default_names == all_names
 
     def test_get_compute_framework_docs_degrades_when_is_available_raises(self) -> None:
-        """A framework whose is_available() raises must degrade to unavailable, not sink the catalog.
+        """A framework whose is_available() raises must degrade to is_available=False, not sink the catalog.
 
-        The is_available() call at plugin_docs.py:177 runs outside any guard, so a live
-        ComputeFramework subclass whose availability probe raises currently propagates the
-        exception out of get_compute_framework_docs() (same shape as issue #533). The sibling
-        field reads (expected_data_framework, merge_engine, filter_engine) already fall back to
-        a sentinel on exception; is_available must degrade the same way: is_available=False.
+        Like the sibling field reads (expected_data_framework, merge_engine, filter_engine),
+        the availability probe routes through safe_field, and a degraded framework is excluded
+        by available_only=True exactly as a genuinely unavailable one would be (issue #533).
         """
 
         class _DocsIsAvailableBoomCFW(ComputeFramework):
@@ -415,6 +415,55 @@ class TestGetComputeFrameworkDocs:
             # Reap the test-local subclass so sibling tests are unaffected (live __subclasses__).
             del _DocsIsAvailableBoomCFW
             gc.collect()
+
+
+class TestSafeVersionGuard:
+    """Characterization tests pinning the narrow exception guard in ``_safe_version``.
+
+    ``_safe_version`` delegates to ``safe_field(..., catching=(OSError, TypeError))``.
+    The guard must stay narrow: only the listed types degrade to "unavailable";
+    every other exception (e.g. ``ValueError``) must propagate so unrelated bugs
+    are not silently swallowed. If a future edit drops the ``catching=`` argument,
+    the guard widens to ``except Exception`` and the ValueError case below flips
+    from raising to returning "unavailable", failing this test.
+    """
+
+    def test_safe_version_reraises_unlisted_exception(self) -> None:
+        """A ValueError from version() is NOT in (OSError, TypeError), so it propagates."""
+
+        class _StubFG:
+            @staticmethod
+            def version() -> str:
+                raise ValueError("unlisted exception must propagate")
+
+        with pytest.raises(ValueError):
+            _safe_version(_StubFG)  # type: ignore[arg-type]
+
+    def test_safe_version_degrades_on_listed_oserror(self) -> None:
+        """An OSError from version() IS listed, so it degrades to "unavailable"."""
+
+        class _StubFG:
+            @staticmethod
+            def version() -> str:
+                raise OSError("listed exception degrades")
+
+        assert _safe_version(_StubFG) == "unavailable"  # type: ignore[arg-type]
+
+    def test_safe_version_degrades_when_attribute_lookup_raises(self) -> None:
+        """A TypeError raised during the ``version`` attribute lookup itself degrades to "unavailable".
+
+        The annotate tier must keep the whole read inside the guard, including
+        attribute resolution, not just the ``version()`` call.
+        """
+
+        class _RaisingDescriptor:
+            def __get__(self, obj: Any, owner: type) -> Any:
+                raise TypeError("attribute lookup fails")
+
+        class _StubFG:
+            version = _RaisingDescriptor()
+
+        assert _safe_version(_StubFG) == "unavailable"  # type: ignore[arg-type]
 
 
 class TestGetExtenderDocs:

--- a/tests/test_core/test_prepare/test_feature_group_dedup.py
+++ b/tests/test_core/test_prepare/test_feature_group_dedup.py
@@ -28,7 +28,12 @@ from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.api.plugin_docs import get_feature_group_docs, resolve_feature
 from mloda.core.api.plugin_info import FeatureGroupInfo, ResolvedFeature
-from mloda.core.prepare.accessible_plugins import PreFilterPlugins, dedup_feature_group_subclasses
+from mloda.core.abstract_plugins.components.base_feature_group_version import BaseFeatureGroupVersion
+from mloda.core.prepare.accessible_plugins import (
+    PreFilterPlugins,
+    dedup_feature_group_subclasses,
+    _safe_class_source_hash,
+)
 
 
 # Module-level reference store. This simulates IPython's ``_oh``/``Out[N]`` history,
@@ -124,6 +129,38 @@ def _cleanup_main_module_attrs() -> Any:
 def _filter_by_qualname(classes: set[type[FeatureGroup]], qualname: str) -> set[type[FeatureGroup]]:
     """Filter a set of classes to those with a matching ``__qualname__``."""
     return {c for c in classes if c.__qualname__ == qualname}
+
+
+# ---------------------------------------------------------------------------
+# Characterization: _safe_class_source_hash keeps a NARROW exception guard.
+#
+# _safe_class_source_hash delegates to safe_field(..., catching=(OSError, TypeError)).
+# Only the listed types degrade to None; every other exception (e.g. ValueError)
+# must propagate so unrelated bugs are not silently swallowed. If a future edit
+# drops the catching= argument, the guard widens to except Exception and the
+# ValueError case below flips from raising to returning None, failing this test.
+# ---------------------------------------------------------------------------
+def test_safe_class_source_hash_reraises_unlisted_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A ValueError from class_source_hash is NOT in (OSError, TypeError), so it propagates."""
+
+    def _raise_value_error(target_class: Any) -> str:
+        raise ValueError("unlisted exception must propagate")
+
+    monkeypatch.setattr(BaseFeatureGroupVersion, "class_source_hash", _raise_value_error)
+
+    with pytest.raises(ValueError):
+        _safe_class_source_hash(DocsCatalogAnchorFG)
+
+
+def test_safe_class_source_hash_degrades_on_listed_oserror(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An OSError from class_source_hash IS listed, so it degrades to None."""
+
+    def _raise_os_error(target_class: Any) -> str:
+        raise OSError("listed exception degrades")
+
+    monkeypatch.setattr(BaseFeatureGroupVersion, "class_source_hash", _raise_os_error)
+
+    assert _safe_class_source_hash(DocsCatalogAnchorFG) is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Implements the shared safe-introspection helper that the "Graceful Degradation Policy" doc recommended (#541). Originally stacked on #604; that branch's commits are now part of this PR and it targets `main` directly.

## What

The catalog "annotate" tier (a single unreadable plugin field degrades to a sentinel instead of taking down the whole discovery call) was expressed as ad hoc `try/except` blocks repeated per field, plus the narrower named guards `_safe_version` and `_safe_class_source_hash`. This extracts one helper and routes every guarded annotate site through it.

- **New helper:** `safe_field(read, fallback, catching=(Exception,))` in `mloda/core/abstract_plugins/components/utils.py` (the lowest shared module, already home to `get_all_subclasses`, so no layering inversion). It calls the `read` thunk and returns `fallback` if the read raises one of `catching`; anything else propagates. `catching` is typed `tuple[type[Exception], ...]`, so `KeyboardInterrupt`/`SystemExit` can never be swallowed.
- **Applied to:** the four field reads in `get_compute_framework_docs` (default broad `catching`), the `get_extender_docs` wraps read, and the narrow guards `_safe_version` and `_safe_class_source_hash`.
- **Shared constant:** the narrow guards now pass `SOURCE_INTROSPECTION_ERRORS = (OSError, TypeError)`, defined next to `class_source_hash` where those exceptions originate, so the two call sites cannot drift.
- **Doc:** the "Graceful Degradation Policy" section of `discover-plugins.md` describes the helper and the broad-vs-narrow `catching` split, scoped to the reads that are actually guarded. The remaining overridable reads in `get_feature_group_docs` (class name, description, compute framework definition, supported feature names, prefix) are not yet guarded and are documented as a known follow-up gap.

## Behavior

Mostly behavior-preserving, with two deliberate changes, both covered by tests:

1. `is_available()` in `get_compute_framework_docs` was previously unguarded; a raising availability probe took down the whole catalog call (issue #533 shape). It now degrades to `is_available=False` like its sibling fields.
2. The whole read, including the attribute lookup, now sits inside the guard: `safe_field(lambda: fg_class.version(), ...)` instead of passing the bound attribute. A raising descriptor or `__getattribute__` override on `version` degrades to `"unavailable"` instead of propagating.

All fallback values and exception widths are otherwise identical at every site.

## Testing

- Unit tests for `safe_field` (success, default catching, narrow catching returns fallback, narrow catching propagates an unlisted type, fallback identity).
- Call-site characterization tests pinning that `_safe_version` and `_safe_class_source_hash` still propagate a non-`(OSError, TypeError)` exception, plus a regression test that a raising `version` attribute lookup degrades instead of propagating.
- Degradation test for a raising `is_available()` probe, including exclusion under `available_only=True`.
- `tox` gate green (pytest, ruff format + check, `mypy --strict`, bandit, license allowlist).

## Review

Gated by independent deep reviews (Claude and codex) in two rounds. Round one produced five findings, all fixed here: guard scope on attribute lookup, doc overclaim, stale test docstring, duplicated exception tuple, needless temp variable. Round two (fresh Claude Opus agent plus codex on the updated diff) found no blockers; its two minor suggestions (tighten the `catching` type, drop an unneeded `# nosec`) are applied.
