### PR TITLE
feat: lazy two-sided column-semantics seam for equi-join validation (#594)

### DIFF
--- a/mloda/core/abstract_plugins/components/merge/base_merge_engine.py
+++ b/mloda/core/abstract_plugins/components/merge/base_merge_engine.py
@@ -115,6 +115,10 @@ class BaseMergeEngine(ABC):
             f"to support timezone/ordered validation for joins."
         )
 
+    def _schema_maybe_temporal(self, data: Any, column: str) -> bool:
+        """Schema-only guess: could this column be temporal? Default True (never rule out)."""
+        return True
+
     def _coerce_asof_time_column(self, data: Any, column: str) -> Any:
         """Coerce an ISO-8601 string as-of time column to a temporal/numeric dtype.
 
@@ -158,8 +162,16 @@ class BaseMergeEngine(ABC):
         if len(left_cols) != len(right_cols):
             return
         contract = ComparisonContract(required=frozenset())
+        # require_compatible only fires for temporal-vs-temporal pairs, so skip a pair as soon
+        # as either side is known non-temporal (from schema, then from the left's semantics).
         for left_col, right_col in zip(left_cols, right_cols):
+            if not self._schema_maybe_temporal(left_data, left_col):
+                continue
+            if not self._schema_maybe_temporal(right_data, right_col):
+                continue
             left_sem = self._column_semantics(left_data, left_col)
+            if not left_sem.is_temporal:
+                continue
             right_sem = self._column_semantics(right_data, right_col)
             contract.require_compatible(left_sem, right_sem, left_col, right_col)
 

--- a/mloda_plugins/compute_framework/base_implementations/sqlite/sqlite_merge_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/sqlite/sqlite_merge_engine.py
@@ -116,6 +116,11 @@ class SqliteMergeEngine(SqlBaseMergeEngine):
                 )
         return super().validate_asof_time_columns(left_data, right_data, asof_config)
 
+    def _schema_maybe_temporal(self, data: Any, column: str) -> bool:
+        # Temporal only if a real temporal arrow type or a string (sqlite stores datetimes as TEXT).
+        arrow_type = data.types[data.columns.index(column)]
+        return bool(pa.types.is_temporal(arrow_type)) or sql_type_semantics.is_string_like_arrow_type(arrow_type)
+
     def _column_semantics(self, data: Any, column: str) -> ColumnSemantics:
         arrow_type = data.types[data.columns.index(column)]
         # Cost note: value-sampling runs one LIMIT 100 query per string-typed column during

--- a/tests/test_core/test_abstract_plugins/test_components/test_merge_engine/test_base_merge_engine_594.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_merge_engine/test_base_merge_engine_594.py
@@ -1,0 +1,46 @@
+"""Lazy two-sided column-semantics seam (issue #594)."""
+
+from typing import Any
+
+from mloda.core.abstract_plugins.components.contract.comparison_contract import ColumnSemantics
+from mloda.provider import BaseMergeEngine
+from mloda.user import Index
+
+
+class _RecordingMergeEngine(BaseMergeEngine):
+    provides_column_semantics = True
+
+    def __init__(self, framework_connection: Any | None = None) -> None:
+        super().__init__(framework_connection)
+        self.semantics_calls: list[tuple[Any, str]] = []
+
+    def _column_semantics(self, data: Any, column: str) -> ColumnSemantics:
+        self.semantics_calls.append((data, column))
+        return ColumnSemantics(is_ordered=False, is_temporal=False, is_numeric=False, unit=None, is_tz_aware=False)
+
+
+class _SchemaSkipMergeEngine(_RecordingMergeEngine):
+    def _schema_maybe_temporal(self, data: Any, column: str) -> bool:
+        return False
+
+
+class TestLazyTwoSidedColumnSemantics:
+    def test_left_non_temporal_short_circuits_right(self) -> None:
+        engine = _RecordingMergeEngine()
+        left_index = Index(("lk",))
+        right_index = Index(("rk",))
+
+        engine._validate_equi_join_time_columns("left", "right", left_index, right_index)
+
+        assert ("left", "lk") in engine.semantics_calls
+        assert ("right", "rk") not in engine.semantics_calls
+        assert len(engine.semantics_calls) == 1
+
+    def test_schema_maybe_temporal_false_skips_both_sides(self) -> None:
+        engine = _SchemaSkipMergeEngine()
+        left_index = Index(("lk",))
+        right_index = Index(("rk",))
+
+        engine._validate_equi_join_time_columns("left", "right", left_index, right_index)
+
+        assert engine.semantics_calls == []

--- a/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_lazy_column_semantics_594.py
+++ b/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_lazy_column_semantics_594.py
@@ -1,0 +1,84 @@
+"""Lazy sqlite column-semantics seam (issue #594)."""
+
+import logging
+import sqlite3
+from typing import Any
+
+import pytest
+
+import mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_merge_engine as sqlite_merge_engine_module
+from mloda.user import Index, JoinType
+from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_merge_engine import SqliteMergeEngine
+from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_relation import SqliteRelation
+from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_value_sample import (
+    sample_string_values as _real_sample_string_values,
+)
+from tests.test_plugins.compute_framework.test_tooling.merge_link import make_merge_link
+
+logger = logging.getLogger(__name__)
+
+try:
+    import pyarrow as pa
+except ImportError:
+    logger.warning("PyArrow is not installed. Some tests will be skipped.")
+    pa = None  # type: ignore[assignment]
+
+
+def _spy_on_sample_string_values(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Count sample_string_values calls by column, delegating to the real implementation."""
+    sampled_columns: list[str] = []
+
+    def spy(data: Any, column: str) -> list[Any]:
+        sampled_columns.append(column)
+        return _real_sample_string_values(data, column)
+
+    monkeypatch.setattr(sqlite_merge_engine_module, "sample_string_values", spy)
+    return sampled_columns
+
+
+@pytest.mark.skipif(pa is None, reason="PyArrow is not installed. Skipping this test.")
+class TestSqliteLazyColumnSemantics:
+    def test_string_vs_integer_equi_join_does_zero_sampling(
+        self, connection: sqlite3.Connection, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        left = SqliteRelation.from_dict(connection, {"lk": ["a", "b"], "lv": [1, 2]})
+        right = SqliteRelation.from_dict(connection, {"rk": [1, 2], "rv": [10, 20]})
+        sampled_columns = _spy_on_sample_string_values(monkeypatch)
+
+        engine = SqliteMergeEngine(connection)
+        link = make_merge_link(JoinType.INNER, Index(("lk",)), Index(("rk",)))
+        result = engine.merge(left, right, link)
+
+        assert result.df() is not None
+        assert sampled_columns == []
+
+    def test_string_vs_string_id_equi_join_samples_left_only(
+        self, connection: sqlite3.Connection, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        left = SqliteRelation.from_dict(connection, {"k": ["id_a", "id_b"], "lv": [1, 2]})
+        right = SqliteRelation.from_dict(connection, {"k": ["id_a", "id_c"], "rv": [10, 20]})
+        sampled_columns = _spy_on_sample_string_values(monkeypatch)
+
+        engine = SqliteMergeEngine(connection)
+        link = make_merge_link(JoinType.INNER, Index(("k",)), Index(("k",)))
+        result = engine.merge(left, right, link)
+
+        result_df = result.df()
+        assert len(result_df) == 1
+        assert result_df["k"].tolist() == ["id_a"]
+        assert len(sampled_columns) == 1
+
+    def test_iso_datetime_text_tz_mismatch_still_raises(self, connection: sqlite3.Connection) -> None:
+        left = SqliteRelation.from_dict(
+            connection,
+            {"k": ["2024-01-01T00:00:00+00:00", "2024-06-01T12:30:00+00:00"], "lv": [1, 2]},
+        )
+        right = SqliteRelation.from_dict(
+            connection,
+            {"k": ["2024-01-01T00:00:00", "2024-06-01T12:30:00"], "rv": [10, 20]},
+        )
+
+        engine = SqliteMergeEngine(connection)
+        link = make_merge_link(JoinType.INNER, Index(("k",)), Index(("k",)))
+        with pytest.raises(ValueError, match=r"(?i)time[ -]?zone"):
+            engine.merge(left, right, link)


### PR DESCRIPTION
Closes #594.

Makes the equi-join comparison-contract check (`_validate_equi_join_time_columns`) lazy so a key column is value-inspected only when it can change the guard's result. `require_compatible` no-ops unless both sides are temporal, so inspection that can't flip that is wasted (on sqlite: a SQL probe per string key, even for string-ID joins).

## Change
- **`base_merge_engine.py`**: new opt-in hook `_schema_maybe_temporal(data, column)`, default `True` (unchanged behavior for engines that don't override). The loop now skips the pair with zero inspection if either side is schema-provably non-temporal, and skips the right side when the left resolves non-temporal. Both are behavior-preserving.
- **`sqlite_merge_engine.py`**: overrides the hook to `True` only for temporal or string-like arrow types, so string-vs-int keys do zero sampling and string-vs-string sample the left only.

Filter engines and the as-of path are untouched; the defaulted hook keeps all other engines backward compatible.

## Tests
sqlite string-vs-int asserts zero samples; string-vs-string asserts left-only; ISO-TEXT tz mismatch still raises (#518/#588 intact); base-level tests cover both short-circuits. `tox` green.
