### PR TITLE
fix: isolate string-declared input feature Options from the consumer

### DIFF
--- a/mloda/core/abstract_plugins/components/feature_collection.py
+++ b/mloda/core/abstract_plugins/components/feature_collection.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from copy import deepcopy
 from typing import Generator, Optional
 from uuid import UUID
 from mloda.core.abstract_plugins.components.domain import Domain
@@ -44,8 +45,10 @@ class Features:
                 child_options = Options({})
 
             if isinstance(feature, str):
+                is_string = True
                 feature = Feature(name=feature, options=child_options, domain=self.parent_domain)
             else:
+                is_string = False
                 if feature.domain is None and self.parent_domain is not None:
                     feature.domain = Domain(self.parent_domain)
             if child_uuid:
@@ -53,6 +56,14 @@ class Features:
                 self.child_uuid = child_uuid
                 feature.child_options = child_options
                 self.merge_options(feature, child_options)
+                if is_string:
+                    # String-declared input features share the consumer's Options instance during the
+                    # merge (a self-merge no-op), so isolate the child here: deepcopy severs the shared
+                    # group/context containers so mutating a string child cannot leak into the consumer
+                    # or sibling string children. By-reference aliasing of forwarded values for
+                    # Feature-object children is tracked separately (#607); unpickleable values fall back
+                    # to a shallow copy in Options.__deepcopy__ and cannot be isolated.
+                    feature.options = deepcopy(feature.options)
 
             self.check_duplicate_feature(feature)
             self.collection.append(feature)

--- a/tests/test_core/test_abstract_plugins/test_components/test_string_child_options_isolation.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_string_child_options_isolation.py
@@ -1,0 +1,144 @@
+"""
+Tests for issue #602: copy Options for string-declared input features instead of
+sharing the consumer's instance.
+
+Today a bare-string input feature keeps the consumer's Options object (Feature stores
+the passed Options instance as-is, and Features.build_feature_collection reuses one
+child_options across the loop). The self-merge in Options.inherit_from then no-ops, so
+every string child aliases the consumer's group and context dicts. These tests pin the
+desired post-fix behavior: each string child owns a deep, independent copy of the
+consumer's options, so mutations never leak, while the forwarded values are preserved.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from mloda.user import Feature
+from mloda.user import Features
+from mloda.user import Options
+
+
+def _children(consumer: Options) -> dict[str, Feature]:
+    """Build a collection from two bare-string input features, keyed by name."""
+    features = Features(["alpha", "beta"], child_options=consumer, child_uuid=uuid4())
+    return {str(feature.name): feature for feature in features.collection}
+
+
+class TestStringChildOptionsIsolation:
+    """String-declared input features must own copies of the consumer's Options."""
+
+    def test_string_children_get_distinct_option_instances(self) -> None:
+        """Each string child's options is a fresh object, not the shared consumer instance."""
+        consumer = Options(group={"backend": "neo4j", "top_k": 5})
+
+        children = _children(consumer)
+        alpha, beta = children["alpha"], children["beta"]
+
+        assert alpha.options is not consumer
+        assert beta.options is not consumer
+        assert alpha.options is not beta.options
+
+    def test_top_level_group_mutation_does_not_leak(self) -> None:
+        """Mutating one child's top-level group value leaves consumer and sibling untouched."""
+        consumer = Options(group={"backend": "neo4j", "top_k": 5})
+
+        children = _children(consumer)
+        alpha, beta = children["alpha"], children["beta"]
+
+        alpha.options.group["backend"] = "MUTATED"
+
+        assert consumer.group["backend"] == "neo4j"
+        assert beta.options.group["backend"] == "neo4j"
+
+    def test_nested_group_mutation_does_not_leak(self) -> None:
+        """The sharper aliasing check: mutating a nested container in one child stays local."""
+        consumer = Options(group={"cfg": {"a": 1}})
+
+        children = _children(consumer)
+        alpha, beta = children["alpha"], children["beta"]
+
+        alpha.options.group["cfg"]["a"] = 999
+
+        assert consumer.group["cfg"]["a"] == 1
+        assert beta.options.group["cfg"]["a"] == 1
+
+    def test_top_level_context_mutation_does_not_leak(self) -> None:
+        """Mutating one child's top-level context value leaves consumer and sibling untouched."""
+        consumer = Options(group={"backend": "neo4j"}, context={"trace": "abc"})
+
+        children = _children(consumer)
+        alpha, beta = children["alpha"], children["beta"]
+
+        alpha.options.context["trace"] = "MUTATED"
+
+        assert consumer.context["trace"] == "abc"
+        assert beta.options.context["trace"] == "abc"
+
+    def test_nested_context_mutation_does_not_leak(self) -> None:
+        """The sharper aliasing check for context: nested mutation in one child stays local."""
+        consumer = Options(group={"backend": "neo4j"}, context={"cfg": {"a": 1}})
+
+        children = _children(consumer)
+        alpha, beta = children["alpha"], children["beta"]
+
+        alpha.options.context["cfg"]["a"] = 999
+
+        assert consumer.context["cfg"]["a"] == 1
+        assert beta.options.context["cfg"]["a"] == 1
+
+    def test_forwarded_group_and_context_values_are_preserved(self) -> None:
+        """The copy must not drop data: forwarded group and context values still reach the child."""
+        consumer = Options(group={"backend": "neo4j", "top_k": 5}, context={"trace": "abc"})
+
+        children = _children(consumer)
+        alpha = children["alpha"]
+
+        assert alpha.options.group["backend"] == "neo4j"
+        assert alpha.options.group["top_k"] == 5
+        assert alpha.options.context["trace"] == "abc"
+
+
+class TestStringChildBehaviorPreserved:
+    """String-declared input features must keep pre-fix self-merge behavior, not real forwarding.
+
+    Copying a string child's Options must not route it through the real forwarding merge in
+    Options.inherit_from. Pre-fix a string child was a self-merge no-op: no provenance was
+    recorded and consumer option values were never compared. These tests pin that behavior so
+    the forwarded-name-mismatch guard and dual-consumption warning do not newly fire on string
+    children, and so an identity-equality option value does not make the merge raise.
+    """
+
+    def test_string_child_provenance_stays_empty(self) -> None:
+        """A string child records no forwarding provenance (self-merge preserved)."""
+        consumer = Options(group={"backend": "neo4j", "top_k": 5})
+
+        alpha = _children(consumer)["alpha"]
+
+        assert alpha.options.inherited_group_keys == frozenset()
+        assert alpha.options.last_forwarded_group_keys == frozenset()
+
+    def test_string_child_does_not_raise_on_identity_equality_value(self) -> None:
+        """A consumer option value with identity-based __eq__ must not make the copy raise."""
+        consumer = Options(group={"payload": object()})
+
+        features = Features(["alpha"], child_options=consumer, child_uuid=uuid4())
+        children = {str(feature.name): feature for feature in features.collection}
+        alpha = children["alpha"]
+
+        assert "payload" in alpha.options.group
+
+    def test_forwarded_nested_context_is_isolated(self) -> None:
+        """Nested context forwarded via propagate_context_keys is preserved and copied per child."""
+        consumer = Options(context={"cfg": {"a": 1}}, propagate_context_keys=frozenset({"cfg"}))
+
+        children = _children(consumer)
+        alpha, beta = children["alpha"], children["beta"]
+
+        assert alpha.options.context["cfg"]["a"] == 1
+        assert beta.options.context["cfg"]["a"] == 1
+
+        alpha.options.context["cfg"]["a"] = 999
+
+        assert consumer.context["cfg"]["a"] == 1
+        assert beta.options.context["cfg"]["a"] == 1


### PR DESCRIPTION
## What

Isolates the `Options` of string-declared input features from the consumer. Fixes the aliasing described in #602.

`Features.build_feature_collection` wrapped a bare-string input feature as `Feature(name=feature, options=child_options)`, where `child_options` is the consumer's own `Options` instance (and is reused across loop iterations). Consumer and every sibling string child therefore shared one mutable options object, so mutating a string child's `group` or `context` wrote through to the consumer and its siblings.

## Approach

The string child keeps sharing the consumer instance during `merge_options`, so it still takes the existing `consumer is self` self-merge no-op: no forwarded-value comparison runs and its provenance fields (`inherited_group_keys`, `last_forwarded_group_keys`) stay empty, exactly as before. Isolation then comes from a single `deepcopy(feature.options)` after the merge, which severs the shared `group`/`context` containers.

This deliberately does not route string children through the real forwarding merge. Doing so would compare copied option values (raising spurious conflicts for values with identity-based or non-bool `__eq__`) and populate provenance (newly activating the forwarded-name-mismatch guard and dual-consumption warning for string children). Both were caught in review and avoided.

Net production change is small: one import, an `is_string` flag, and the commented post-merge copy. `Options` and the self-merge guard are untouched.

## Scope

- By-reference aliasing of forwarded values for `Feature`-object children is a separate concern, tracked by #607.
- Unpickleable option values fall back to a shallow copy in `Options.__deepcopy__` and cannot be isolated (documented in a code comment).
- `feature.child_options` still references the consumer by design (it feeds parent hashing and is deep-copied before mutation in `Feature.__build_hash__`); it is not the `feature.options` aliasing this issue targets.

## Tests

New `tests/test_core/test_abstract_plugins/test_components/test_string_child_options_isolation.py` pins:
- each string child gets a distinct `Options` instance (not the consumer's, not a sibling's);
- top-level and nested `group`/`context` mutations on one string child do not leak into the consumer or siblings;
- forwarded values are preserved;
- string-child provenance stays empty (guards do not newly fire);
- a consumer option value with identity-based equality does not cause a spurious conflict.

## Review

Two independent deep reviews (Claude Opus and codex) ran on the first cut. Both flagged that the initial approach (deep-copying at wrap time) routed string children through the real merge, causing spurious conflict raises on identity/non-bool `__eq__` values and flipping provenance-gated guards on. This PR is the revised approach that keeps the self-merge path and isolates only via the post-merge copy. Regression pins for both findings are included.

## Validation

`tox` is green: 4492 passed, 171 skipped, ruff format and check clean, license allowlist clean, `mypy --strict` clean, bandit clean.

Refs #602
