### PR TITLE
perf: cache group base_similarity_hash and short-circuit empty context split (#622)

### DIFF
--- a/mloda/core/abstract_plugins/components/feature.py
+++ b/mloda/core/abstract_plugins/components/feature.py
@@ -347,7 +347,13 @@ class Feature:
 
     def _split_context_hashable(self, split_keys: frozenset[str]) -> Any:
         """Order-independent view of this feature's context values for the split keys."""
-        return _make_hashable({key: self.options.context[key] for key in split_keys if key in self.options.context})
+        if not split_keys:
+            return ()
+        context = self.options.context
+        relevant = {key: context[key] for key in split_keys if key in context}
+        if not relevant:
+            return ()
+        return _make_hashable(relevant)
 
     def _grouping_hash(self, split_keys: frozenset[str] | None, include_data_type: bool) -> int:
         keys = self.options.inherited_context_keys if split_keys is None else split_keys

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -1100,21 +1100,23 @@ class ExecutionPlan:
                 f_hash = feature.similarity_hash(split_keys)
                 hash_collector[f_hash].add(feature)
 
-        # Second pass: assign None-typed features to existing groups with matching base hash
+        # Second pass: assign None-typed features to existing groups with matching base hash.
+        # Precompute each group representative's base hash once (O(groups)) and look up in O(1),
+        # preserving the first-match-in-insertion-order semantics of the original scan.
+        base_hash_to_group: dict[int, int] = {}
+        for existing_hash, group in hash_collector.items():
+            representative_base_hash = next(iter(group)).base_similarity_hash(split_keys)
+            base_hash_to_group.setdefault(representative_base_hash, existing_hash)
+
         for feature in none_typed_features:
             base_hash = feature.base_similarity_hash(split_keys)
-            assigned = False
-
-            # Find an existing group with matching base properties
-            for existing_hash, group in hash_collector.items():
-                any_feature = next(iter(group))
-                if any_feature.base_similarity_hash(split_keys) == base_hash:
-                    hash_collector[existing_hash].add(feature)
-                    assigned = True
-                    break
-
-            if not assigned:
-                # No matching typed group found, create a new group for this None-typed feature
+            matched_group = base_hash_to_group.get(base_hash)
+            if matched_group is not None:
+                hash_collector[matched_group].add(feature)
+            else:
+                # No matching typed group found; create a new group for this None-typed feature
+                # and register it so later None-typed features with the same base hash reuse it.
                 hash_collector[base_hash].add(feature)
+                base_hash_to_group[base_hash] = base_hash
 
         return hash_collector

--- a/tests/test_core/test_prepare/test_execution_plan_context_grouping.py
+++ b/tests/test_core/test_prepare/test_execution_plan_context_grouping.py
@@ -166,6 +166,95 @@ def test_plain_value_splits_from_inherited_value_when_key_is_a_split_key() -> No
     )
 
 
+def test_none_typed_joins_first_of_two_data_type_only_groups() -> None:
+    """Characterization pin for the O(1) reverse-map optimization (issue #622).
+
+    Two typed features sharing everything (name, options, compute framework, inherited
+    context) but differing ONLY in data_type form two distinct groups (data_type is part
+    of similarity_hash). A None-typed feature with the same base properties shares the
+    SAME base_similarity_hash as both typed groups, so the current code joins the FIRST
+    matching group in insertion order and breaks. The optimization must preserve this
+    first-match semantics: exactly 2 groups survive, one with 2 members, the other with 1.
+    """
+    typed_int = Feature(
+        "tenant_scoped_source",
+        options=_options_with_inherited_tenant("acme"),
+        data_type=DataType.INT32,
+    )
+    typed_float = Feature(
+        "tenant_scoped_source",
+        options=_options_with_inherited_tenant("acme"),
+        data_type=DataType.FLOAT,
+    )
+    none_typed = Feature(
+        "tenant_scoped_source",
+        options=_options_with_inherited_tenant("acme"),
+    )
+
+    groups = _group({typed_int, typed_float, none_typed})
+
+    assert len(groups) == 2, (
+        "Two typed features differing only in data_type must stay in distinct groups, and the "
+        f"None-typed feature must join one existing group rather than form its own. Got {len(groups)}: {groups}"
+    )
+
+    sizes = sorted(len(group) for group in groups.values())
+    assert sizes == [1, 2], (
+        "The None-typed feature must join exactly one of the two typed groups (first-match "
+        f"semantics), yielding group sizes [1, 2]. Got {sizes}: {groups}"
+    )
+
+    joined_group = next(group for group in groups.values() if none_typed in group)
+    assert len(joined_group) == 2 and (typed_int in joined_group) ^ (typed_float in joined_group), (
+        "The None-typed feature must join exactly one typed group, keeping the two typed features in separate groups."
+    )
+
+
+def test_two_none_typed_features_without_typed_group_share_one_group() -> None:
+    """Characterization pin (issue #622): a newly created None-typed group is reused.
+
+    When two None-typed features have identical base properties and there is NO matching
+    typed group, the first opens a new group keyed by its base hash and the second must
+    join that same group. Expect a single group holding both features.
+    """
+    none_typed_a = Feature(
+        "tenant_scoped_source",
+        options=_options_with_inherited_tenant("acme"),
+    )
+    none_typed_b = Feature(
+        "tenant_scoped_index",
+        options=_options_with_inherited_tenant("acme"),
+    )
+
+    groups = _group({none_typed_a, none_typed_b})
+
+    assert len(groups) == 1, (
+        "Two None-typed features with identical base properties and no typed group must share one "
+        f"group (the newly created None-typed group is reused). Got {len(groups)}: {groups}"
+    )
+    only_group = next(iter(groups.values()))
+    assert none_typed_a in only_group and none_typed_b in only_group
+
+
+def test_split_context_hashable_empty_cases_return_empty_tuple() -> None:
+    """Characterization pin (issue #622): the empty split-context canonicalizes to ().
+
+    The optimization introduces an empty-case short-circuit; this pins its expected value.
+    With EMPTY split_keys the result is the empty-tuple canonical value (), and for a feature
+    carrying context that contains NONE of the split keys the result is also ()."""
+    feature = Feature(
+        "tenant_scoped_source",
+        options=Options(group={"data_source": "prod"}, context={"tenant": "acme"}),
+    )
+
+    assert feature._split_context_hashable(frozenset()) == (), (
+        "Empty split_keys must canonicalize to the empty tuple ()."
+    )
+    assert feature._split_context_hashable(frozenset({"region"})) == (), (
+        "A feature carrying none of the split keys in its context must canonicalize to ()."
+    )
+
+
 def test_features_with_identical_inherited_context_share_one_group() -> None:
     """Regression pin: identical group options and identical inherited context still group together."""
     feature_a = Feature(


### PR DESCRIPTION
## Summary

Closes #622. Removes repeated work from the FeatureSet resolution hot path in `ExecutionPlan.group_features_by_compute_framework_and_options`, with no behavior change.

## Changes

1. **`mloda/core/prepare/execution_plan.py` (second/lenient pass).** The pass previously recomputed each group representative's `base_similarity_hash(split_keys)` for every None-typed feature, an O(features x groups) scan with no memoization. It now precomputes a `base_hash -> group` reverse map once (O(groups) build, O(1) lookup per feature). First-match-in-insertion-order semantics are preserved: typed groups are always inserted before None-typed groups, `dict.setdefault` keeps the first group per base hash, and newly created None-typed groups are registered so later features with the same base hash reuse them. The `else` branch that assigns a new group is only reached when the base hash is absent from the map, so it can never shadow a typed entry.

2. **`mloda/core/abstract_plugins/components/feature.py` (`_split_context_hashable`).** Short-circuits to the empty tuple `()` when `split_keys` is empty or the feature carries none of those keys, skipping the dict comprehension and `_make_hashable` allocation in the common case. This matches the previous `_make_hashable({}) == ()` result exactly, so grouping is unchanged.

## Tests

Characterization tests added to `tests/test_core/test_prepare/test_execution_plan_context_grouping.py` pin the invariants the optimization must preserve:
- None-typed feature joins the first of two typed groups that share a base hash but differ only in `data_type` (first-match order).
- Two None-typed features with no matching typed group collapse into one shared group (None-typed group reuse).
- `_split_context_hashable` returns `()` for empty `split_keys` and for a feature carrying none of the split keys (empty-case short-circuit).

## Validation

- Full `tox` green: 4491 passed, 171 skipped; ruff format/check, pip-licenses, `mypy --strict`, and bandit all pass.
- Two independent deep reviews (Claude Opus + codex) found no behavior change and no actionable bugs.