### PR TITLE
fix: make chained extender failures breaking by default (#593)

### DIFF
--- a/docs/docs/chapter1/extender.md
+++ b/docs/docs/chapter1/extender.md
@@ -62,6 +62,28 @@ With this simple extender, you can easily log and monitor the execution time of 
 
 When multiple extenders are provided, they are automatically chained and executed in priority order (lower values first).
 
-#### 4. Discovering Extenders
+#### 4. Error handling
+
+By default an exception raised inside an extender is **breaking**: it propagates and fails the feature calculation, just like a bug in any other code. This holds whether one extender or several are registered for a hook, so adding a second extender never changes the error semantics.
+
+An extender that is non-critical (for example observability or telemetry) can opt out by setting `raise_on_error = False`. When such an extender fails, the error is logged as a warning and the wrapped function still runs, so a failing extender cannot break the calculation:
+
+```python
+class MetricsExtender(Extender):
+    def __init__(self) -> None:
+        self.raise_on_error = False  # failures log a warning instead of breaking
+
+    def wraps(self) -> Set[ExtenderHook]:
+        return {ExtenderHook.FEATURE_GROUP_CALCULATE_FEATURE}
+
+    def __call__(self, func: Any, *args: Any, **kwargs: Any) -> Any:
+        result = func(*args, **kwargs)
+        record_metric(...)  # if this raises, the calculation still succeeds
+        return result
+```
+
+Only the extender's own failure is caught: an exception raised by the wrapped function (or by a downstream breaking extender) always propagates, and the wrapped function is never run twice. Concrete extenders can also expose the flag as a constructor argument (for example `OtelExtender(raise_on_error=True)`) to let callers opt back into breaking behavior.
+
+#### 5. Discovering Extenders
 
 To list all available extenders and their documentation, use the `get_extender_docs()` function from `mloda.steward`.

--- a/mloda/core/abstract_plugins/compute_framework.py
+++ b/mloda/core/abstract_plugins/compute_framework.py
@@ -10,6 +10,7 @@ from mloda.core.abstract_plugins.function_extender import (
     Extender,
     ExtenderHook,
     _CompositeExtender,
+    _invoke_extender,
 )
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.parallelization_modes import ParallelizationMode
@@ -642,7 +643,7 @@ class ComputeFramework(ABC):
         try:
             if extender is None:
                 return feature_group.calculate_feature(self.data, features)
-            return extender(feature_group.calculate_feature, self.data, features)
+            return _invoke_extender(extender, feature_group.calculate_feature, self.data, features)
         except KeyError as e:
             # Provide helpful error message for missing columns
             self._raise_helpful_missing_column_error(feature_group, e)

--- a/mloda/core/abstract_plugins/function_extender.py
+++ b/mloda/core/abstract_plugins/function_extender.py
@@ -10,6 +10,9 @@ if TYPE_CHECKING:
     from mloda.core.abstract_plugins.components.options import Options
 
 
+logger = logging.getLogger(__name__)
+
+
 class ExtenderHook(Enum):
     FEATURE_GROUP_CALCULATE_FEATURE = "feature_group_calculate_feature"
     VALIDATE_INPUT_FEATURE = "validate_input_feature"
@@ -42,6 +45,20 @@ class Extender(ABC):
     @priority.setter
     def priority(self, value: int) -> None:
         self._priority = value
+
+    @property
+    def raise_on_error(self) -> bool:
+        """Whether a failure in this extender breaks the calculation.
+
+        True (default) means a failure in this extender propagates and breaks the
+        calculation; False means the failure is logged as a warning and the wrapped
+        function is called instead.
+        """
+        return getattr(self, "_raise_on_error", True)
+
+    @raise_on_error.setter
+    def raise_on_error(self, value: bool) -> None:
+        self._raise_on_error = value
 
     @abstractmethod
     def wraps(self) -> set[ExtenderHook]:
@@ -121,11 +138,7 @@ class _CompositeExtender(Extender):
         def make_wrapper(ext: Extender, inner_func: Any) -> Any:
             @functools.wraps(inner_func)
             def wrapper(*a: Any, **kw: Any) -> Any:
-                try:
-                    return ext.__call__(inner_func, *a, **kw)
-                except Exception as e:
-                    logging.error(f"{ext.__class__.__name__} {ext.name if hasattr(ext, 'name') else ''} {str(e)}")
-                    return inner_func(*a, **kw)
+                return _invoke_extender(ext, inner_func, *a, **kw)
 
             return wrapper
 
@@ -133,3 +146,43 @@ class _CompositeExtender(Extender):
         for extender in reversed(self.extenders):
             wrapped_func = make_wrapper(extender, wrapped_func)
         return wrapped_func(*args, **kwargs)
+
+
+def _invoke_extender(ext: Extender, inner_func: Any, *args: Any, **kwargs: Any) -> Any:
+    """Invoke an extender around inner_func, scoping any warning-only fallback to the
+    extender's OWN code so inner-function failures propagate and inner never re-runs."""
+    # Breaking (default): call directly, everything propagates.
+    if ext.raise_on_error:
+        return ext.__call__(inner_func, *args, **kwargs)
+
+    # Warning-only: guard ONLY the extender's own code. Wrap inner_func so we can tell
+    # whether a raised exception came from inner_func (must propagate, never swallow,
+    # never re-run) versus the extender's own instrumentation (log + fall back).
+    sentinel = object()
+    state: dict[str, Any] = {"result": sentinel, "inner_raised": False}
+
+    @functools.wraps(inner_func)
+    def guarded_inner(*a: Any, **kw: Any) -> Any:
+        try:
+            result = inner_func(*a, **kw)
+        except BaseException:
+            state["inner_raised"] = True
+            raise
+        state["result"] = result
+        return result
+
+    try:
+        return ext.__call__(guarded_inner, *args, **kwargs)
+    except Exception as e:
+        if state["inner_raised"]:
+            # The failure came from the wrapped function / downstream chain, not this
+            # extender. Propagate unchanged; do not swallow, do not re-run.
+            raise
+        name = ext.name if hasattr(ext, "name") else ""
+        logger.warning(f"{ext.__class__.__name__} {name} {type(e).__name__}: {e}", exc_info=True)
+        if state["result"] is not sentinel:
+            # Inner already ran successfully; the extender failed afterwards.
+            # Return the already-computed result; do NOT re-run inner.
+            return state["result"]
+        # Extender failed before delegating; run inner exactly once as the fallback.
+        return inner_func(*args, **kwargs)

--- a/mloda_plugins/function_extender/base_implementations/otel/otel_extender.py
+++ b/mloda_plugins/function_extender/base_implementations/otel/otel_extender.py
@@ -13,8 +13,9 @@ except ImportError:
 
 
 class OtelExtender(Extender):
-    def __init__(self) -> None:
+    def __init__(self, raise_on_error: bool = False) -> None:
         self.wrapped: set[ExtenderHook] = set()
+        self.raise_on_error = raise_on_error
 
         if trace is None:
             return

--- a/tests/test_plugins/extender/test_composite_extender.py
+++ b/tests/test_plugins/extender/test_composite_extender.py
@@ -19,12 +19,26 @@ from mloda.provider import ComputeFramework
 
 
 class MockExtender(Extender):
-    """Mock extender for testing purposes."""
+    """Mock extender for testing purposes.
 
-    def __init__(self, name: str, priority: int = 100, should_fail: bool = False):
+    ``raise_on_error`` mirrors the new error contract: when True (default) an
+    extender failure must break the calculation; when False the extender opts
+    into warning-only behavior (log + fall back to the wrapped function).
+    """
+
+    def __init__(
+        self,
+        name: str,
+        priority: int = 100,
+        should_fail: bool = False,
+        raise_on_error: bool = True,
+    ):
         self.name = name
         self.priority = priority
         self.should_fail = should_fail
+        # Uses the base-class property/setter (same pattern as ``priority``)
+        # so the mock reports its opt-in via ``raise_on_error``.
+        self.raise_on_error = raise_on_error
         self.call_count = 0
 
     def wraps(self) -> set[ExtenderHook]:
@@ -36,6 +50,27 @@ class MockExtender(Extender):
             raise ValueError(f"MockExtender {self.name} intentionally failed")
         result = func(*args, **kwargs)
         return result
+
+
+class _PostFailExtender(Extender):
+    """Warning-only extender that delegates successfully, then fails in its OWN post-processing.
+
+    ``__call__`` runs the wrapped function first (so the inner result is already
+    computed) and only afterwards raises. The correct fallback must return the
+    already-computed inner result WITHOUT re-running the wrapped function.
+    """
+
+    def __init__(self, name: str, priority: int = 100) -> None:
+        self.name = name
+        self.priority = priority
+        self.raise_on_error = False
+
+    def wraps(self) -> set[ExtenderHook]:
+        return {ExtenderHook.FEATURE_GROUP_CALCULATE_FEATURE}
+
+    def __call__(self, func: Any, *args: Any, **kwargs: Any) -> Any:
+        func(*args, **kwargs)
+        raise ValueError("post boom")
 
 
 class TestExtenderPriority:
@@ -169,10 +204,15 @@ class TestExtenderErrorResilience:
     """Test that if one extender fails, the chain continues."""
 
     def test_continues_after_extender_failure(self) -> None:
-        """Test that if one extender raises an exception, remaining extenders still execute."""
+        """A WARNING-ONLY extender that fails must not break the chain.
+
+        Under the new contract, only extenders that opt out of breaking
+        (``raise_on_error=False``) fall back; the rest of the chain and the
+        wrapped function still execute.
+        """
 
         extender1 = MockExtender("first", priority=10)
-        extender2 = MockExtender("failing", priority=20, should_fail=True)
+        extender2 = MockExtender("failing", priority=20, should_fail=True, raise_on_error=False)
         extender3 = MockExtender("third", priority=30)
 
         composite = _CompositeExtender([extender1, extender2, extender3])
@@ -180,33 +220,31 @@ class TestExtenderErrorResilience:
         def test_func(x: int) -> int:
             return x * 2
 
-        # This will fail until _CompositeExtender handles exceptions gracefully
         result = composite(test_func, 5)
 
-        assert result == 10, "Function should still execute despite middle extender failure"
+        assert result == 10, "Function should still execute despite middle warning-only extender failure"
         assert extender1.call_count == 1, "First extender should execute"
         assert extender2.call_count == 1, "Failing extender should be attempted"
         assert extender3.call_count == 1, "Third extender should execute despite failure"
 
     def test_logs_error_when_extender_fails(self, caplog: Any) -> None:
-        """Test that extender failures are logged."""
+        """A warning-only extender failure is logged at WARNING level."""
 
         extender1 = MockExtender("first", priority=10)
-        extender2 = MockExtender("failing", priority=20, should_fail=True)
+        extender2 = MockExtender("failing", priority=20, should_fail=True, raise_on_error=False)
 
         composite = _CompositeExtender([extender1, extender2])
 
         def test_func(x: int) -> int:
             return x * 2
 
-        with caplog.at_level(logging.ERROR):
-            # This will fail until _CompositeExtender logs errors
+        with caplog.at_level(logging.WARNING):
             composite(test_func, 5)
 
-        # Check that error was logged
-        assert any("MockExtender failing intentionally failed" in record.message for record in caplog.records), (
-            "Extender failures should be logged"
-        )
+        assert any(
+            record.levelno == logging.WARNING and "MockExtender failing intentionally failed" in record.message
+            for record in caplog.records
+        ), "Warning-only extender failures should be logged at WARNING level and identify the failure"
 
     def test_original_function_error_propagates(self) -> None:
         """Test that errors from the original function are not caught."""
@@ -296,3 +334,302 @@ class TestGetFunctionExtenderWithComposite:
         result = compute_fw.get_function_extender(ExtenderHook.FEATURE_GROUP_CALCULATE_FEATURE)
 
         assert result is extender, "Single matching extender should be returned directly (backward compatibility)"
+
+
+class TestExtenderRaiseOnErrorProperty:
+    """Test the new ``raise_on_error`` property (mirrors the ``priority`` property)."""
+
+    def test_raise_on_error_default_true(self) -> None:
+        """raise_on_error defaults to True on a plain Extender subclass (breaking by default)."""
+
+        class PlainExtender(Extender):
+            def wraps(self) -> set[ExtenderHook]:
+                return {ExtenderHook.FEATURE_GROUP_CALCULATE_FEATURE}
+
+            def __call__(self, func: Any, *args: Any, **kwargs: Any) -> Any:
+                return func(*args, **kwargs)
+
+        extender = PlainExtender()
+        assert extender.raise_on_error is True, "Extenders must break by default (raise_on_error=True)"
+
+    def test_raise_on_error_settable_to_false(self) -> None:
+        """raise_on_error can be set to False to opt into warning-only behavior."""
+
+        class PlainExtender(Extender):
+            def wraps(self) -> set[ExtenderHook]:
+                return {ExtenderHook.FEATURE_GROUP_CALCULATE_FEATURE}
+
+            def __call__(self, func: Any, *args: Any, **kwargs: Any) -> Any:
+                return func(*args, **kwargs)
+
+        extender = PlainExtender()
+        extender.raise_on_error = False
+        assert extender.raise_on_error is False, "raise_on_error should be settable to False"
+
+
+class TestExtenderRaiseOnErrorContractComposite:
+    """Pin the new breaking-by-default error contract for the composite path."""
+
+    def test_default_extender_failure_re_raises(self) -> None:
+        """A DEFAULT (raise_on_error=True) extender that fails must re-raise, not swallow/fall back."""
+
+        failing = MockExtender("boom", priority=10, should_fail=True)  # raise_on_error defaults True
+        composite = _CompositeExtender([failing])
+
+        def test_func(x: int) -> int:
+            return x * 2
+
+        with pytest.raises(ValueError, match="MockExtender boom intentionally failed"):
+            composite(test_func, 5)
+
+    def test_default_extender_failure_does_not_call_fallback(self) -> None:
+        """A breaking extender failure must not silently run the wrapped function as a fallback."""
+
+        call_marker = {"func_calls": 0}
+
+        failing = MockExtender("boom", priority=10, should_fail=True)
+        composite = _CompositeExtender([failing])
+
+        def test_func(x: int) -> int:
+            call_marker["func_calls"] += 1
+            return x * 2
+
+        with pytest.raises(ValueError, match="MockExtender boom intentionally failed"):
+            composite(test_func, 5)
+
+        assert call_marker["func_calls"] == 0, "Breaking extender must not fall back to the wrapped function"
+
+    def test_adding_extender_does_not_change_error_semantics(self) -> None:
+        """SYMMETRY: a single breaking extender raises; adding a second breaking extender still raises."""
+
+        def test_func(x: int) -> int:
+            return x * 2
+
+        # Single breaking extender
+        single = _CompositeExtender([MockExtender("boom", priority=10, should_fail=True)])
+        with pytest.raises(ValueError, match="MockExtender boom intentionally failed"):
+            single(test_func, 5)
+
+        # Adding a second (non-failing) breaking extender must not change the semantics
+        composite = _CompositeExtender(
+            [
+                MockExtender("boom", priority=10, should_fail=True),
+                MockExtender("ok", priority=20),
+            ]
+        )
+        with pytest.raises(ValueError, match="MockExtender boom intentionally failed"):
+            composite(test_func, 5)
+
+    def test_warning_only_extender_falls_back_and_warns(self, caplog: Any) -> None:
+        """A warning-only (raise_on_error=False) extender that fails logs a warning and falls back."""
+
+        failing = MockExtender("soft", priority=10, should_fail=True, raise_on_error=False)
+        other = MockExtender("ok", priority=20)
+        composite = _CompositeExtender([failing, other])
+
+        def test_func(x: int) -> int:
+            return x * 2
+
+        with caplog.at_level(logging.WARNING):
+            result = composite(test_func, 5)
+
+        assert result == 10, "Warning-only extender failure should fall back to the wrapped function"
+        assert other.call_count == 1, "Remaining extenders should still execute"
+        assert any(
+            record.levelno == logging.WARNING and "MockExtender soft intentionally failed" in record.message
+            for record in caplog.records
+        ), "Warning-only failure should be logged at WARNING level"
+
+
+class _FakeFeatureGroup:
+    """Minimal feature group exercising the single-extender path of run_calculate_feature."""
+
+    def __init__(self) -> None:
+        self.calc_count = 0
+
+    def calculate_feature(self, data: Any, features: Any) -> Any:
+        self.calc_count += 1
+        return f"calculated:{data}"
+
+    def get_class_name(self) -> str:
+        return "FakeFeatureGroup"
+
+
+class _KeyErrorFeatureGroup:
+    """Feature group whose calculate_feature raises KeyError, counting invocations."""
+
+    def __init__(self) -> None:
+        self.calc_count = 0
+
+    def calculate_feature(self, data: Any, features: Any) -> Any:
+        self.calc_count += 1
+        raise KeyError("missing_col")
+
+    def get_class_name(self) -> str:
+        return "KeyErrorFeatureGroup"
+
+
+class _RuntimeErrorFeatureGroup:
+    """Feature group whose calculate_feature raises RuntimeError, counting invocations."""
+
+    def __init__(self) -> None:
+        self.calc_count = 0
+
+    def calculate_feature(self, data: Any, features: Any) -> Any:
+        self.calc_count += 1
+        raise RuntimeError("inner boom")
+
+    def get_class_name(self) -> str:
+        return "RuntimeErrorFeatureGroup"
+
+
+class TestWarningOnlyDoesNotSwallowInnerErrors:
+    """Pin that a warning-only extender only handles its OWN failures.
+
+    Exceptions raised by the inner function or a downstream breaking extender must
+    propagate unchanged, and the inner function must never be executed twice.
+    """
+
+    def test_warning_only_outer_does_not_swallow_breaking_inner(self, caplog: Any) -> None:
+        """COMPOSITE A: warning-only OUTER must let a breaking INNER extender's exception propagate.
+
+        The breaking extender (raise_on_error=True) runs inner to the warning-only
+        extender. When it raises, the outer warning-only fallback must NOT catch it,
+        must NOT re-run the breaking extender, and must NOT log a spurious warning.
+        """
+
+        base_calls = {"n": 0}
+
+        def base(x: int) -> int:
+            base_calls["n"] += 1
+            return x * 2
+
+        warn = MockExtender("warn", priority=10, raise_on_error=False)
+        breaking = MockExtender("boom", priority=20, should_fail=True, raise_on_error=True)
+        composite = _CompositeExtender([warn, breaking])
+
+        with caplog.at_level(logging.WARNING):
+            with pytest.raises(ValueError, match="MockExtender boom intentionally failed"):
+                composite(base, 5)
+
+        assert breaking.call_count == 1, (
+            "Breaking inner extender must run exactly once; the outer warning-only fallback must not re-run it"
+        )
+        assert base_calls["n"] == 0, "Base function must not run when the breaking extender raises before delegating"
+        assert not [r for r in caplog.records if r.levelno == logging.WARNING], (
+            "Warning-only outer extender must not log a spurious warning for the breaking inner extender's failure"
+        )
+
+    def test_warning_only_does_not_swallow_inner_function_error(self) -> None:
+        """COMPOSITE B: an inner-function exception through a warning-only extender propagates, single run."""
+
+        base_calls = {"n": 0}
+
+        def base() -> int:
+            base_calls["n"] += 1
+            raise RuntimeError("inner boom")
+
+        warn = MockExtender("warn", priority=10, raise_on_error=False)
+        composite = _CompositeExtender([warn])
+
+        with pytest.raises(RuntimeError, match="inner boom"):
+            composite(base)
+
+        assert base_calls["n"] == 1, (
+            "The inner function must run exactly once; the warning-only wrapper must not swallow and re-run it"
+        )
+
+    def test_warning_only_post_failure_returns_computed_result_without_rerun(self, caplog: Any) -> None:
+        """COMPOSITE C: extender fails AFTER inner ran, must return already-computed result, no double run."""
+
+        base_calls = {"n": 0}
+
+        def base(x: int) -> int:
+            base_calls["n"] += 1
+            return x * 3
+
+        post_fail = _PostFailExtender("posty", priority=10)
+        composite = _CompositeExtender([post_fail])
+
+        with caplog.at_level(logging.WARNING):
+            result = composite(base, 7)
+
+        assert result == 21, "Fallback must return the already-computed inner result"
+        assert base_calls["n"] == 1, (
+            "Inner function must run exactly once; no double execution after the extender's post-processing fails"
+        )
+        assert any(
+            r.levelno == logging.WARNING and "post boom" in r.message and "posty" in r.message for r in caplog.records
+        ), "The failing extender must be identified in a WARNING"
+
+
+class TestSingleExtenderPathHonorsRaiseOnError:
+    """The single-extender path (run_calculate_feature) must honor raise_on_error identically."""
+
+    @staticmethod
+    def _make_compute_framework(extenders: list[Extender]) -> Any:
+        cf = Mock(spec=ComputeFramework)
+        cf.data = "DATA"
+        cf.function_extender = extenders
+        cf.get_function_extender = ComputeFramework.get_function_extender.__get__(cf)
+        cf.run_calculate_feature = ComputeFramework.run_calculate_feature.__get__(cf)
+        cf._raise_helpful_missing_column_error = ComputeFramework._raise_helpful_missing_column_error.__get__(cf)
+        return cf
+
+    def test_single_default_extender_failure_propagates(self) -> None:
+        """A single DEFAULT extender that fails must propagate (symmetry with composite)."""
+
+        cf = self._make_compute_framework([MockExtender("boom", should_fail=True)])
+        fg = _FakeFeatureGroup()
+
+        with pytest.raises(ValueError, match="MockExtender boom intentionally failed"):
+            cf.run_calculate_feature(fg, "features")
+
+        assert fg.calc_count == 0, "Breaking extender must not fall back to calculate_feature"
+
+    def test_single_warning_only_extender_falls_back(self, caplog: Any) -> None:
+        """A single WARNING-ONLY extender that fails logs a warning and falls back to calculate_feature."""
+
+        cf = self._make_compute_framework([MockExtender("soft", should_fail=True, raise_on_error=False)])
+        fg = _FakeFeatureGroup()
+
+        with caplog.at_level(logging.WARNING):
+            result = cf.run_calculate_feature(fg, "features")
+
+        assert result == "calculated:DATA", "Warning-only extender should fall back to calculate_feature"
+        assert fg.calc_count == 1, "The wrapped calculate_feature should run exactly once as fallback"
+        assert any(
+            record.levelno == logging.WARNING and "MockExtender soft intentionally failed" in record.message
+            for record in caplog.records
+        ), "Warning-only failure should be logged at WARNING level on the single-extender path"
+
+    def test_single_warning_only_inner_keyerror_propagates_once(self) -> None:
+        """SINGLE D: an inner KeyError through a warning-only extender must not be swallowed/re-run.
+
+        The KeyError must propagate through the same handling a plain (no-extender)
+        KeyError would receive (the helpful ValueError), and calculate_feature must
+        run exactly once.
+        """
+
+        cf = self._make_compute_framework([MockExtender("soft", should_fail=False, raise_on_error=False)])
+        fg = _KeyErrorFeatureGroup()
+
+        with pytest.raises(ValueError, match="failed with a KeyError"):
+            cf.run_calculate_feature(fg, "features")
+
+        assert fg.calc_count == 1, (
+            "calculate_feature must run exactly once; the warning-only fallback must not re-run it on inner KeyError"
+        )
+
+    def test_single_warning_only_inner_runtime_error_propagates_once(self) -> None:
+        """SINGLE (analogue of B): an inner RuntimeError through a warning-only extender propagates, single run."""
+
+        cf = self._make_compute_framework([MockExtender("soft", should_fail=False, raise_on_error=False)])
+        fg = _RuntimeErrorFeatureGroup()
+
+        with pytest.raises(RuntimeError, match="inner boom"):
+            cf.run_calculate_feature(fg, "features")
+
+        assert fg.calc_count == 1, (
+            "calculate_feature must run exactly once on inner RuntimeError through a warning-only extender"
+        )

--- a/tests/test_plugins/extender/test_otel_extender.py
+++ b/tests/test_plugins/extender/test_otel_extender.py
@@ -1,6 +1,10 @@
+import logging
 from typing import Any
 from unittest.mock import patch
 
+import pytest
+
+from mloda.core.abstract_plugins.function_extender import _CompositeExtender
 from mloda.steward import ExtenderHook
 from mloda_plugins.function_extender.base_implementations.otel.otel_extender import OtelExtender
 
@@ -39,3 +43,66 @@ def test_otel_extender_call_still_works_when_trace_missing(caplog: Any) -> None:
         result = otel(func, 3, 4)
         assert result == 7
         assert "OtelExtender" in caplog.text
+
+
+def test_otel_extender_opts_into_warning_only() -> None:
+    """OtelExtender is observability-only: its failures must not break calculations."""
+    assert OtelExtender().raise_on_error is False
+
+
+def test_failing_otel_extender_falls_back_with_warning(caplog: Any) -> None:
+    """A failing OtelExtender must not propagate: it logs a warning and the inner result is returned.
+
+    The extender body is forced to fail (independent of the wrapped function) by making
+    its logger raise; the wrapped function itself succeeds, so the fallback returns its result.
+    """
+    otel = OtelExtender()
+    composite = _CompositeExtender([otel])
+
+    def func(x: int, y: int) -> int:
+        return x + y
+
+    with patch(
+        "mloda_plugins.function_extender.base_implementations.otel.otel_extender.logger.warning",
+        side_effect=RuntimeError("otel instrumentation boom"),
+    ):
+        with caplog.at_level(logging.WARNING):
+            result = composite(func, 3, 4)
+
+    assert result == 7, "Failing OtelExtender must fall back to the wrapped function result"
+    assert any(record.levelno == logging.WARNING and "OtelExtender" in record.message for record in caplog.records), (
+        "A failing warning-only OtelExtender should be logged at WARNING level"
+    )
+
+
+def test_otel_extender_constructor_raise_on_error_true() -> None:
+    """The constructor exposes raise_on_error so callers can opt into breaking behavior."""
+    assert OtelExtender(raise_on_error=True).raise_on_error is True
+
+
+def test_otel_extender_constructor_raise_on_error_false_explicit() -> None:
+    """Passing raise_on_error=False explicitly keeps warning-only behavior."""
+    assert OtelExtender(raise_on_error=False).raise_on_error is False
+
+
+def test_failing_otel_extender_propagates_when_raise_on_error_true(caplog: Any) -> None:
+    """With raise_on_error=True the extender's own failure must PROPAGATE, not fall back.
+
+    Same failure-injection technique as test_failing_otel_extender_falls_back_with_warning
+    (patch the otel module's logger.warning to raise), but the extender is constructed with
+    raise_on_error=True, so the composite call must re-raise the injected error rather than
+    returning the inner result.
+    """
+    otel = OtelExtender(raise_on_error=True)
+    composite = _CompositeExtender([otel])
+
+    def func(x: int, y: int) -> int:
+        return x + y
+
+    with patch(
+        "mloda_plugins.function_extender.base_implementations.otel.otel_extender.logger.warning",
+        side_effect=RuntimeError("otel instrumentation boom"),
+    ):
+        with caplog.at_level(logging.WARNING):
+            with pytest.raises(RuntimeError, match="otel instrumentation boom"):
+                composite(func, 3, 4)


### PR DESCRIPTION
## Problem

Fixes #593. `_CompositeExtender` swallowed every exception raised by a chained extender (logged at error level, fell back to the inner function), hiding real defects. It was also asymmetric: a single extender registered for a hook was called directly and raised loudly, but the same buggy extender was silenced as soon as a second extender was added.

## Decision (the error contract)

Extender failures are **breaking by default**. An extender may opt into **"warning only"** by declaring itself non-critical.

- New `Extender.raise_on_error` property (default `True`), mirroring the existing `priority` property. `True` propagates the failure and breaks the calculation; `False` logs a WARNING (with the exception type and traceback) and falls back to the wrapped function.
- Both the composite path (`_CompositeExtender`) and the single-extender path (`ComputeFramework.run_calculate_feature`) honor `raise_on_error` through one shared `_invoke_extender` helper, so adding a second extender no longer changes error semantics.
- `OtelExtender` opts into warning-only: observability must never break a feature calculation.

## Correctness of the warning-only fallback

The fallback is scoped to the extender's **own** code, not the inner function:

- An exception raised by the inner function (including a downstream breaking extender or a genuine missing-column `KeyError`) propagates unchanged and never triggers a warning-only swallow. A real `KeyError` still reaches the helpful missing-column error.
- The inner function runs **exactly once**: if it already ran, the fallback returns the computed result instead of re-invoking it (no double side effects).
- Only the warning-only extender's own instrumentation failure logs a WARNING and falls back.

## Tests

- Default-breaking contract: composite re-raises; single vs composite symmetry for breaking extenders.
- `raise_on_error` property defaults and settability.
- Warning-only opt-in falls back with a WARNING (composite and single paths, plus `OtelExtender`).
- Regression tests for the reviewed edge cases: warning-only outer + breaking inner propagates; inner-function errors (incl. `KeyError`) propagate and run once; failure after the inner call returns the computed result without re-running.

Full `tox` is green (4506 passed, mypy `--strict`, ruff, bandit, licenses).