### PR TITLE
fix!: unify string and object input-feature option forwarding

### DIFF
--- a/mloda/core/abstract_plugins/components/feature_collection.py
+++ b/mloda/core/abstract_plugins/components/feature_collection.py
@@ -44,7 +44,7 @@ class Features:
                 child_options = Options({})
 
             if isinstance(feature, str):
-                feature = Feature(name=feature, options=child_options, domain=self.parent_domain)
+                feature = Feature(name=feature, options=Options({}), domain=self.parent_domain)
             else:
                 if feature.domain is None and self.parent_domain is not None:
                     feature.domain = Domain(self.parent_domain)

--- a/mloda/core/abstract_plugins/components/options.py
+++ b/mloda/core/abstract_plugins/components/options.py
@@ -16,6 +16,49 @@ logger = logging.getLogger(__name__)
 NON_FORWARDED_KEYS: frozenset[str] = frozenset({DefaultOptionKeys.in_features})
 
 
+def _safe_deepcopy(value: Any, memo: dict[int, Any]) -> Any:
+    """Deep-copy a single value, falling back to sharing the value by reference when it cannot be
+    deep-copied for ANY reason (e.g. unpicklable objects, or values whose deepcopy raises under some
+    Python versions such as uuid.UUID on 3.14)."""
+    try:
+        return deepcopy(value, memo)
+    except Exception:
+        # If the value cannot be deep-copied for any reason, share it by reference.
+        return value
+
+
+def _isolate_forwarded_value(value: Any, memo: dict[int, Any]) -> Any:
+    """Copy the mutable-container spine so nested-container mutation cannot leak back to the
+    consumer, while sharing every non-container leaf (validators, models, handles, unpicklable
+    objects) by reference to preserve the identity the framework relies on for dedup, hashing,
+    and conflict detection. Custom container types (anything other than dict/list/set/tuple) are
+    shared by reference (documented limitation)."""
+    vid = id(value)
+    if vid in memo:
+        return memo[vid]
+    if isinstance(value, dict):
+        result: dict[Any, Any] = {}
+        memo[vid] = result
+        for k, v in value.items():
+            result[k] = _isolate_forwarded_value(v, memo)
+        return result
+    if isinstance(value, list):
+        result_list: list[Any] = []
+        memo[vid] = result_list
+        for v in value:
+            result_list.append(_isolate_forwarded_value(v, memo))
+        return result_list
+    if isinstance(value, set):
+        result_set = {_isolate_forwarded_value(v, memo) for v in value}
+        memo[vid] = result_set
+        return result_set
+    if isinstance(value, tuple):
+        result_tuple = tuple(_isolate_forwarded_value(v, memo) for v in value)
+        memo[vid] = result_tuple
+        return result_tuple
+    return value
+
+
 def validate_forwarding_directives(
     forward_group: frozenset[str] | bool | None, forward_group_exclude: frozenset[str]
 ) -> None:
@@ -229,14 +272,7 @@ class Options:
     def __deepcopy__(self, memo: dict[int, Any]) -> "Options":
         def safe_deepcopy_dict(d: dict[str, Any]) -> dict[str, Any]:
             """Safely deepcopy a dictionary, falling back to shallow copy for unpickleable objects."""
-            result = {}
-            for key, value in d.items():
-                try:
-                    result[key] = deepcopy(value, memo)
-                except (TypeError, AttributeError, RecursionError):
-                    # If the object cannot be pickled/deepcopied or causes recursion, use shallow copy
-                    result[key] = value
-            return result
+            return {key: _safe_deepcopy(value, memo) for key, value in d.items()}
 
         copied_group = safe_deepcopy_dict(self.group)
         copied_context = safe_deepcopy_dict(self.context)
@@ -285,9 +321,13 @@ class Options:
         Every key actually forwarded (including keys self already held with an equal value) is
         unioned into self.inherited_group_keys, so provenance accumulates across consumers.
 
-        A self-merge (string-declared input features share the consumer's Options instance) is a
-        complete no-op and preserves inherited_group_keys; it logs a warning when any non-default
-        directive is passed, because such directives have no effect.
+        Forwarded values are isolated by a container-spine copy as they are stored: the mutable
+        container spine (dict/list/set/tuple) is copied recursively so nested mutation on the child
+        never leaks back to the consumer or to a sibling input feature, while every non-container
+        leaf (validators, models, handles, unpicklable values) is shared by reference to preserve
+        the identity the framework relies on for dedup, hashing, and conflict detection. Custom
+        container types are shared by reference. Both string-declared and object input features run
+        this same merge.
 
         The optional ``owner`` (the input feature's name) only enriches the forwarding-conflict
         error message; it changes no behavior otherwise.
@@ -301,15 +341,14 @@ class Options:
                         or forward_group=False is combined with a non-empty forward_group_exclude.
         """
         if consumer is self:
-            if forward_group is not None or forward_group_exclude or inherit_context_keys:
-                logger.warning(
-                    "inherit_from directives have no effect on a child that shares the consumer's "
-                    "Options instance (string-declared input features share the instance by design): "
-                    f"forward_group={forward_group!r}, forward_group_exclude={forward_group_exclude!r}, "
-                    f"inherit_context_keys={inherit_context_keys!r} are ignored."
-                )
+            # A child that shares the consumer's own Options instance has nothing to forward; treat it
+            # as a no-op so a user/plugin passing the consumer's own Options does not self-copy values or
+            # stamp self-referential provenance. Bundled code never hits this (string children get a fresh
+            # Options); it is purely defensive.
             self.last_forwarded_group_keys = frozenset()
             return
+
+        memo: dict[int, Any] = {}
 
         excluded = NON_FORWARDED_KEYS
         validate_forwarding_directives(forward_group, forward_group_exclude)
@@ -343,7 +382,7 @@ class Options:
                     f"Keep the key off the child with forward_group_exclude={{'{key}'}}, an allowlist, "
                     "or forward_group=False."
                 )
-            self.add_to_group(key, consumer.group[key])
+            self.add_to_group(key, _isolate_forwarded_value(consumer.group[key], memo))
             inherited.add(key)
         self.inherited_group_keys = self.inherited_group_keys | frozenset(inherited)
         self.last_forwarded_group_keys = frozenset(inherited)
@@ -352,7 +391,7 @@ class Options:
         for key in inherit_context_keys:
             if key in excluded or key not in consumer.context:
                 continue
-            self.add_to_context(key, consumer.context[key])
+            self.add_to_context(key, _isolate_forwarded_value(consumer.context[key], memo))
             inherited_context.add(key)
 
         if consumer.propagate_context_keys and forward_group is not False:
@@ -366,7 +405,7 @@ class Options:
                 if key in self.context and self.context[key] != value:
                     raise ValueError(f"Context key '{key}' conflict: consumer='{value}', child='{self.context[key]}'")
 
-            self.context.update(propagating)
+            self.context.update({key: _isolate_forwarded_value(value, memo) for key, value in propagating.items()})
             inherited_context.update(propagating.keys())
 
         self.inherited_context_keys = self.inherited_context_keys | frozenset(inherited_context)

--- a/tests/test_core/test_abstract_plugins/test_components/test_options.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_options.py
@@ -1,7 +1,15 @@
+import copy
 from copy import deepcopy
 
 import pytest
 from mloda.user import Options
+
+
+class _RaisesOnDeepcopy:
+    """Value whose deep-copy raises, mimicking the Python 3.14 uuid.UUID KeyError('int')."""
+
+    def __deepcopy__(self, memo: dict[int, object]) -> "_RaisesOnDeepcopy":
+        raise KeyError("int")
 
 
 class TestOptions:
@@ -240,6 +248,22 @@ class TestPropagateContextKeys:
         o = Options(context={"k": "v"}, propagate_context_keys=frozenset({"k"}))
         o2 = deepcopy(o)
         assert o2.propagate_context_keys == frozenset({"k"})
+
+    def test_deepcopy_falls_back_to_reference_when_value_deepcopy_raises(self) -> None:
+        """A value whose deep-copy raises ANY exception must be shared by reference, and
+        copy.deepcopy(Options(...)) must never propagate that exception (Python 3.14 uuid.UUID
+        raises KeyError('int'), which _safe_deepcopy must swallow per-value)."""
+        sentinel = _RaisesOnDeepcopy()
+        opts = Options(group={"g": sentinel, "d": {"n": 1}}, context={"c": sentinel})
+
+        copied = copy.deepcopy(opts)
+
+        # Un-deep-copyable values fall back to being shared by reference.
+        assert copied.group["g"] is sentinel
+        assert copied.context["c"] is sentinel
+        # Sibling values in the same dict are still independently deep-copied (per-value fallback).
+        assert copied.group["d"] is not opts.group["d"]
+        assert copied.group["d"] == {"n": 1}
 
 
 class TestContextPropagationIntegration:

--- a/tests/test_core/test_abstract_plugins/test_components/test_options_inherit_from.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_options_inherit_from.py
@@ -1,6 +1,4 @@
-import logging
 from copy import deepcopy
-from typing import Any
 from uuid import uuid4
 
 import pytest
@@ -805,29 +803,6 @@ class TestLastForwardedGroupKeys:
 
         assert child.last_forwarded_group_keys == frozenset({"kg_backend"})
 
-    def test_self_merge_resets_last_forwarded_but_preserves_inherited(self) -> None:
-        """A self-merge RESETS last_forwarded to empty while PRESERVING inherited_group_keys."""
-        consumer = Options(group={"kg_backend": "neo4j"})
-        child = Options()
-        child.inherit_from(consumer)
-        assert child.last_forwarded_group_keys == frozenset({"kg_backend"})
-        assert child.inherited_group_keys == frozenset({"kg_backend"})
-
-        child.inherit_from(child)
-
-        assert child.last_forwarded_group_keys == frozenset()
-        assert child.inherited_group_keys == frozenset({"kg_backend"})
-
-    def test_self_merge_with_directives_also_resets_last_forwarded(self) -> None:
-        """A self-merge carrying directives is still a no-op that resets last_forwarded to empty."""
-        consumer = Options(group={"kg_backend": "neo4j"})
-        child = Options()
-        child.inherit_from(consumer)
-
-        child.inherit_from(child, forward_group=True)
-
-        assert child.last_forwarded_group_keys == frozenset()
-
     def test_deepcopy_preserves_last_forwarded_group_keys(self) -> None:
         """last_forwarded_group_keys survives Options.__deepcopy__."""
         consumer = Options(group={"kg_backend": "neo4j"})
@@ -839,127 +814,33 @@ class TestLastForwardedGroupKeys:
         assert copied.last_forwarded_group_keys == frozenset({"kg_backend"})
 
 
-class TestInheritFromSelfMerge:
+class TestInheritFromSelfMergeGuard:
     """
-    Test suite for the self-merge no-op contract.
+    Test suite for the self-merge defensive guard.
 
-    String-declared input features share the consumer's Options instance, so the
-    engine ends up calling options.inherit_from(options) with the SAME object as
-    self and consumer. That call must be a complete no-op (identity check):
-    group and context stay unchanged AND inherited_group_keys set by an EARLIER
-    real inherit is preserved, not reset to frozenset().
-    """
-
-    def test_self_merge_is_noop_and_preserves_inherited_group_keys(self) -> None:
-        """inherit_from(self) leaves group, context, and inherited_group_keys untouched."""
-        consumer = Options(group={"kg_backend": "neo4j", "top_k": 5})
-        child = Options(group={"own_key": "own_value"}, context={"trace_id": "abc"})
-
-        child.inherit_from(consumer)
-        assert child.inherited_group_keys == frozenset({"kg_backend", "top_k"})
-
-        group_before = deepcopy(child.group)
-        context_before = deepcopy(child.context)
-
-        child.inherit_from(child)
-
-        assert child.group == group_before
-        assert child.context == context_before
-        assert child.inherited_group_keys == frozenset({"kg_backend", "top_k"})
-
-    def test_self_merge_with_directives_is_still_noop(self) -> None:
-        """inherit_from(self, ...) with forwarding directives is also a complete no-op."""
-        consumer = Options(group={"kg_backend": "neo4j"})
-        child = Options(group={"own_key": "own_value"})
-
-        child.inherit_from(consumer)
-        assert child.inherited_group_keys == frozenset({"kg_backend"})
-
-        group_before = deepcopy(child.group)
-        context_before = deepcopy(child.context)
-
-        child.inherit_from(child, forward_group=True)
-
-        assert child.group == group_before
-        assert child.context == context_before
-        assert child.inherited_group_keys == frozenset({"kg_backend"})
-
-        child.inherit_from(child, forward_group_exclude=frozenset({"x"}))
-
-        assert child.group == group_before
-        assert child.context == context_before
-        assert child.inherited_group_keys == frozenset({"kg_backend"})
-
-
-class TestInheritFromSelfMergeDirectiveWarning:
-    """
-    Test suite for the self-merge directive warning.
-
-    String-declared input features share the consumer's Options instance, so
-    directives a plugin sets on such a child (forward_group, forward_group_exclude,
-    inherit_context_keys) silently do nothing today. The new contract: a self-merge
-    carrying any NON-DEFAULT directive logs a warning explaining the directives
-    have no effect because the child shares the consumer's Options instance. The
-    merge stays a complete no-op either way, and an all-default self-merge stays
-    silent.
+    ``opts.inherit_from(opts)`` (the consumer IS self) must be a no-op: it must
+    NOT deep-copy self's own values into itself, must NOT stamp self-referential
+    provenance, and must RESET last_forwarded_group_keys to frozenset() while
+    PRESERVING the accumulated inherited_group_keys.
     """
 
-    @pytest.mark.parametrize(
-        "directives",
-        [
-            pytest.param({"forward_group": True}, id="forward_group_true"),
-            pytest.param({"forward_group": False}, id="forward_group_false"),
-            pytest.param({"forward_group": frozenset({"x"})}, id="forward_group_allowlist"),
-            pytest.param({"forward_group_exclude": frozenset({"x"})}, id="forward_group_exclude"),
-            pytest.param({"inherit_context_keys": frozenset({"x"})}, id="inherit_context_keys"),
-        ],
-    )
-    def test_self_merge_with_nondefault_directive_logs_warning(
-        self, directives: dict[str, Any], caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """Each non-default directive on a self-merge emits a logger.warning saying
-        the directives have no effect (shared Options instance)."""
-        options = Options(group={"own_key": "own_value"}, context={"trace_id": "abc"})
+    def test_self_merge_is_noop_preserving_provenance_and_resetting_last_forwarded(self) -> None:
+        """A self-merge preserves inherited_group_keys, leaves values untouched, adds no
+        new keys, and resets last_forwarded_group_keys to an empty frozenset."""
+        opts = Options(group={"a": 1})
+        consumer = Options(group={"a": 1})
+        opts.inherit_from(consumer)
 
-        with caplog.at_level(logging.WARNING):
-            options.inherit_from(options, **directives)
+        assert opts.inherited_group_keys == frozenset({"a"})
 
-        warning_records = [record for record in caplog.records if record.levelno >= logging.WARNING]
-        assert len(warning_records) >= 1, f"Expected a warning for self-merge with directives {directives}, got none"
-        assert "no effect" in caplog.text
+        opts.inherit_from(opts)
 
-    def test_self_merge_with_nondefault_directive_stays_complete_noop(self, caplog: pytest.LogCaptureFixture) -> None:
-        """The warning does not change the contract: the self-merge remains a no-op."""
-        consumer = Options(group={"kg_backend": "neo4j"})
-        child = Options(group={"own_key": "own_value"}, context={"trace_id": "abc"})
-        child.inherit_from(consumer)
-
-        group_before = deepcopy(child.group)
-        context_before = deepcopy(child.context)
-        inherited_before = child.inherited_group_keys
-
-        with caplog.at_level(logging.WARNING):
-            child.inherit_from(child, forward_group=frozenset({"x"}))
-
-        assert child.group == group_before
-        assert child.context == context_before
-        assert child.inherited_group_keys == inherited_before
-
-    def test_self_merge_with_default_directives_is_silent(self, caplog: pytest.LogCaptureFixture) -> None:
-        """An all-default self-merge (the normal string-declared child path) logs nothing."""
-        options = Options(group={"own_key": "own_value"}, context={"trace_id": "abc"})
-
-        with caplog.at_level(logging.WARNING):
-            options.inherit_from(options)
-            options.inherit_from(
-                options,
-                forward_group=None,
-                forward_group_exclude=frozenset(),
-                inherit_context_keys=frozenset(),
-            )
-
-        warning_records = [record for record in caplog.records if record.levelno >= logging.WARNING]
-        assert warning_records == []
+        # Provenance preserved, no self-referential churn.
+        assert opts.inherited_group_keys == frozenset({"a"})
+        # Values untouched, no new keys introduced.
+        assert opts.group == {"a": 1}
+        # A self-merge forwards nothing this call.
+        assert opts.last_forwarded_group_keys == frozenset()
 
 
 class TestInheritContextKeys:

--- a/tests/test_core/test_abstract_plugins/test_components/test_string_child_options_isolation.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_string_child_options_isolation.py
@@ -1,0 +1,298 @@
+"""Unifying string-declared and object input-feature option forwarding.
+
+These tests pin the INTENDED behavior after the string/object forwarding paths
+are unified. Today a string-declared input feature is built with the consumer's
+own Options instance, so ``Options.inherit_from`` takes its ``consumer is self``
+self-merge no-op: string children alias the consumer's group/context dicts,
+record no provenance, and share nested value objects with the consumer and each
+other. Object children go through the real forwarding merge but forward nested
+values BY REFERENCE (issue #607).
+
+The unified contract these tests specify:
+
+1. A string-declared input feature owns its OWN Options instance, never the
+   consumer's and never shared with a sibling string child.
+2. A string child goes through the SAME real forwarding merge as an object
+   child, so it RECORDS provenance: ``inherited_group_keys`` equals the set of
+   forwarded consumer group keys and ``last_forwarded_group_keys`` is populated.
+   (Deliberate change: provenance is NO LONGER empty for string children.)
+3. Forwarded values are DEEP-copied, so mutating a forwarded value on a child
+   never leaks to the consumer or a sibling, including NESTED containers. This
+   isolation holds for BOTH string children and object children (the #607 fix,
+   applied uniformly).
+4. Forwarded group and context values are still preserved on the child.
+5. A consumer option whose value has identity-based ``__eq__`` (``object()``)
+   must not make ``inherit_from`` raise while constructing a string child.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from mloda.user import Feature
+from mloda.user import Features
+from mloda.user import Options
+
+
+def _string_children(consumer: Options, names: list[str]) -> dict[str, Feature]:
+    """Build a Features collection from string names and index children by name."""
+    features = Features(list(names), child_options=consumer, child_uuid=uuid4())
+    return {str(f.name): f for f in features.collection}
+
+
+# ---------------------------------------------------------------------------
+# 1. Distinct Options instances
+# ---------------------------------------------------------------------------
+
+
+def test_string_children_get_distinct_options_instances() -> None:
+    """Each string child owns its own Options, not the consumer and not a sibling's."""
+    consumer = Options(group={"gk": "gv"})
+
+    children = _string_children(consumer, ["alpha", "beta"])
+    alpha = children["alpha"]
+    beta = children["beta"]
+
+    assert alpha.options is not consumer
+    assert beta.options is not consumer
+    assert alpha.options is not beta.options
+
+
+# ---------------------------------------------------------------------------
+# 2. Top-level mutation isolation
+# ---------------------------------------------------------------------------
+
+
+def test_top_level_group_mutation_does_not_leak_to_consumer_or_sibling() -> None:
+    """Rebinding a forwarded top-level group key on one child leaves others untouched."""
+    consumer = Options(group={"gk": "gv"})
+
+    children = _string_children(consumer, ["alpha", "beta"])
+    alpha = children["alpha"]
+    beta = children["beta"]
+
+    alpha.options.group["gk"] = "mutated"
+
+    assert consumer.group["gk"] == "gv"
+    assert beta.options.group["gk"] == "gv"
+
+
+# ---------------------------------------------------------------------------
+# 3. Nested mutation isolation (the #607 fix on the string path)
+# ---------------------------------------------------------------------------
+
+
+def test_nested_group_mutation_does_not_leak_to_consumer_or_sibling() -> None:
+    """Mutating a forwarded NESTED group value on one child leaves others untouched."""
+    consumer = Options(group={"cfg": {"a": 1}})
+
+    children = _string_children(consumer, ["alpha", "beta"])
+    alpha = children["alpha"]
+    beta = children["beta"]
+
+    alpha.options.group["cfg"]["a"] = 999
+
+    assert consumer.group["cfg"]["a"] == 1
+    assert beta.options.group["cfg"]["a"] == 1
+
+
+def test_nested_context_mutation_does_not_leak_to_consumer_or_sibling() -> None:
+    """Mutating a forwarded NESTED context value on one child leaves others untouched."""
+    consumer = Options(
+        group={"gk": "gv"},
+        context={"cfg": {"a": 1}},
+        propagate_context_keys=frozenset({"cfg"}),
+    )
+
+    children = _string_children(consumer, ["alpha", "beta"])
+    alpha = children["alpha"]
+    beta = children["beta"]
+
+    alpha.options.context["cfg"]["a"] = 999
+
+    assert consumer.context["cfg"]["a"] == 1
+    assert beta.options.context["cfg"]["a"] == 1
+
+
+# ---------------------------------------------------------------------------
+# 4. Forwarded values preserved (as deep copies, not aliases)
+# ---------------------------------------------------------------------------
+
+
+def test_forwarded_group_and_context_values_preserved_as_deep_copies() -> None:
+    """Forwarded group/context values are kept on the child but are distinct objects."""
+    consumer = Options(
+        group={"gk": "gv", "cfg": {"a": 1}},
+        context={"ctx": {"b": 2}},
+        propagate_context_keys=frozenset({"ctx"}),
+    )
+
+    children = _string_children(consumer, ["alpha"])
+    alpha = children["alpha"]
+
+    assert alpha.options.group["gk"] == "gv"
+    assert alpha.options.group["cfg"] == {"a": 1}
+    assert alpha.options.context["ctx"] == {"b": 2}
+
+    assert alpha.options.group["cfg"] is not consumer.group["cfg"]
+    assert alpha.options.context["ctx"] is not consumer.context["ctx"]
+
+
+# ---------------------------------------------------------------------------
+# 5. Provenance populated for string children
+# ---------------------------------------------------------------------------
+
+
+def test_string_child_records_forwarding_provenance() -> None:
+    """A string child records the forwarded group keys in its provenance sets."""
+    consumer = Options(group={"gk": "gv", "cfg": {"a": 1}})
+
+    children = _string_children(consumer, ["alpha"])
+    alpha = children["alpha"]
+
+    assert alpha.options.inherited_group_keys == frozenset({"gk", "cfg"})
+    assert alpha.options.last_forwarded_group_keys == frozenset({"gk", "cfg"})
+
+
+# ---------------------------------------------------------------------------
+# 6. Identity-based __eq__ consumer value does not raise
+# ---------------------------------------------------------------------------
+
+
+def test_identity_eq_consumer_value_does_not_break_string_child() -> None:
+    """A consumer value with identity __eq__ (object()) forwards without raising,
+    and the TOP-LEVEL opaque value is SHARED by reference (identity preserved)."""
+    sentinel = object()
+    consumer = Options(group={"gk": "gv", "tok": sentinel})
+
+    children = _string_children(consumer, ["alpha"])
+    alpha = children["alpha"]
+
+    assert alpha.options is not consumer
+    assert "tok" in alpha.options.group
+    assert alpha.options.inherited_group_keys == frozenset({"gk", "tok"})
+    # A top-level opaque leaf must remain the SAME object on the child so identity
+    # (for models/validators/handles and Options dedup) is preserved.
+    assert alpha.options.group["tok"] is sentinel
+
+
+# ---------------------------------------------------------------------------
+# 8. Nested opaque-leaf identity preserved (container SPINE copied, leaves shared)
+# ---------------------------------------------------------------------------
+
+
+def test_nested_opaque_leaf_identity_preserved_while_spine_is_fresh() -> None:
+    """An opaque leaf nested inside a forwarded list AND dict stays the SAME object on
+    the child, while the mutable container spines around it are fresh copies."""
+    sentinel = object()
+    consumer = Options(group={"models": [sentinel], "wrap": {"m": sentinel}})
+
+    children = _string_children(consumer, ["alpha"])
+    alpha = children["alpha"]
+
+    # Leaves shared by reference: identity preserved through nested containers.
+    assert alpha.options.group["models"][0] is sentinel
+    assert alpha.options.group["wrap"]["m"] is sentinel
+
+    # Container spines are fresh, not aliases of the consumer's containers.
+    assert alpha.options.group["models"] is not consumer.group["models"]
+    assert alpha.options.group["wrap"] is not consumer.group["wrap"]
+
+
+# ---------------------------------------------------------------------------
+# 9. Nested container mutation still isolated (regression guard for the spine copy)
+# ---------------------------------------------------------------------------
+
+
+def test_nested_container_mutation_still_isolated_after_spine_copy() -> None:
+    """Mutating a forwarded nested container on one child does not leak to the consumer
+    or a sibling, even though nested leaves are shared by reference."""
+    consumer = Options(group={"models": [1, 2], "wrap": {"m": 0}})
+
+    children = _string_children(consumer, ["alpha", "beta"])
+    alpha = children["alpha"]
+    beta = children["beta"]
+
+    alpha.options.group["wrap"]["m2"] = 1
+    alpha.options.group["models"].append(999)
+
+    assert consumer.group["wrap"] == {"m": 0}
+    assert consumer.group["models"] == [1, 2]
+    assert beta.options.group["wrap"] == {"m": 0}
+    assert beta.options.group["models"] == [1, 2]
+
+
+# ---------------------------------------------------------------------------
+# 10. Dedup preserved: shared identity leaves keep siblings Options-equal
+# ---------------------------------------------------------------------------
+
+
+def test_dedup_preserved_for_siblings_sharing_identity_leaf() -> None:
+    """Two string children forwarding the SAME container-of-identity-objects from the
+    SAME consumer stay equal and hash-equal at the Options level (dedup preserved)."""
+    consumer = Options(group={"models": [object()]})
+
+    children = _string_children(consumer, ["alpha", "beta"])
+
+    assert children["alpha"].options == children["beta"].options
+    assert hash(children["alpha"].options) == hash(children["beta"].options)
+
+
+# ---------------------------------------------------------------------------
+# 11. Tuple-nested mutable container is isolated (spine copy recurses into tuples)
+# ---------------------------------------------------------------------------
+
+
+def test_tuple_nested_mutable_container_is_isolated() -> None:
+    """A mutable container nested inside a forwarded tuple is spine-copied, so mutating
+    it on the child does not leak back to the consumer."""
+    consumer = Options(group={"tup": ("a", [1, 2])})
+
+    children = _string_children(consumer, ["alpha"])
+    alpha = children["alpha"]
+
+    alpha.options.group["tup"][1].append(999)
+
+    assert consumer.group["tup"][1] == [1, 2]
+
+
+# ---------------------------------------------------------------------------
+# 12. Unpicklable leaf inside a container does not reopen the leak
+# ---------------------------------------------------------------------------
+
+
+def test_unpicklable_leaf_does_not_reopen_container_leak() -> None:
+    """A non-deepcopyable leaf (threading.Lock) inside a forwarded dict must not force
+    the whole container to be shared: the container spine is still copied (mutation
+    isolated) while the unpicklable leaf itself is shared by reference."""
+    import threading
+
+    lock = threading.Lock()
+    consumer = Options(group={"cfg": {"lock": lock, "a": 1}})
+
+    children = _string_children(consumer, ["alpha"])
+    alpha = children["alpha"]
+
+    alpha.options.group["cfg"]["a"] = 999
+
+    # Container spine copied: the write does not leak to the consumer.
+    assert consumer.group["cfg"]["a"] == 1
+    # The unpicklable leaf is shared by reference (identity preserved).
+    assert alpha.options.group["cfg"]["lock"] is consumer.group["cfg"]["lock"]
+
+
+# ---------------------------------------------------------------------------
+# 7. Object child nested isolation (#607 on the general path)
+# ---------------------------------------------------------------------------
+
+
+def test_object_child_nested_group_mutation_does_not_leak_to_consumer() -> None:
+    """A Feature-object child also deep-copies forwarded nested group values."""
+    consumer = Options(group={"cfg": {"a": 1}})
+
+    features = Features([Feature("alpha")], child_options=consumer, child_uuid=uuid4())
+    alpha = features.collection[0]
+
+    alpha.options.group["cfg"]["a"] = 999
+
+    assert consumer.group["cfg"]["a"] == 1


### PR DESCRIPTION
## Problem

mloda input features can be declared two ways: as a bare string name or as a `Feature` object. A consumer's `Options` are forwarded onto its input features, but the two declaration styles behaved differently:

- **String-declared** inputs were constructed with the consumer's own `Options` instance, so `Options.inherit_from` hit a self-merge no-op. They aliased the consumer's `group`/`context` dicts, recorded no forwarding provenance, and shared nested value objects with the consumer and every sibling.
- **Object-declared** inputs ran the real forwarding merge but forwarded values by reference, so nested mutation leaked back to the consumer (issue #607).

This asymmetry meant "does this input feature carry provenance / isolate its options" depended on whether you wrote `"name"` or `Feature("name")`, which is surprising and was the source of the earlier isolation patches.

## Change

Unify both declaration styles onto one path:

- String children now get their own fresh `Options({})` and run the **same** `inherit_from` merge as object children, so they record forwarding provenance (`inherited_group_keys` / `last_forwarded_group_keys`) like any other child.
- Forwarding now isolates the **mutable container spine** (`dict`/`list`/`set`/`tuple`, recursively, via a shared id-memo) so nested-container mutation cannot leak to the consumer or siblings, for both string and object children. Every **non-container leaf** (validators, models, handles, unpicklable values) is shared by reference, preserving the identity the framework relies on for dedup, hashing, and conflict detection.
- Removed the string-vs-object special-casing and the now-dead self-merge branch, then restored a minimal defensive no-op for the degenerate `consumer is self` case so a user/plugin passing the consumer's own `Options` does not self-copy or stamp self-referential provenance.

This closes #602 (string-child option isolation) and #607 (forwarded nested-value aliasing) with a single mechanism instead of two divergent ones.

## Breaking changes

- Name-declared input features now participate in forwarding provenance, so the dual-option-consumption warning and the forwarded-name-mismatch guard can fire on them, exactly as they already do for object children.
- Forwarded mutable containers are spine-copied, so a consumer relying on by-reference sharing of a forwarded `dict`/`list`/`set`/`tuple` no longer observes a child's nested mutations. (Opaque leaf objects are still shared by reference.)
- Forwarding is uniformly gated on the parent link (`child_uuid`); a bare `Features([...], child_options=X)` with no `child_uuid` no longer forwards to string children (it never did for object children).

## Tests / gate

New `test_string_child_options_isolation.py` pins the unified contract: distinct per-child Options, no top-level or nested leak (string and object), preserved forwarded values, populated provenance, nested opaque-leaf identity, sibling dedup of identity-leaf containers, tuple-nested isolation, unpicklable-leaf isolation, and the `object()` identity case. Obsolete self-merge tests were retired and one defensive-guard test added. Full `tox` green: 4494 passed, 171 skipped, `ruff format`/`ruff check`, `mypy --strict`, and `bandit` all pass.

## Review

Gated by two independent deep reviews (a fresh Claude Opus agent and codex). Both flagged that the first-cut whole-container deepcopy cloned nested opaque objects and broke identity/dedup; that is fixed here by the spine-copy policy.