### PR TITLE
minor: FeatureSet name accessors return sorted tuples (#613)

### DIFF
--- a/mloda/core/abstract_plugins/components/feature_set.py
+++ b/mloda/core/abstract_plugins/components/feature_set.py
@@ -73,8 +73,14 @@ class FeatureSet:
     def get_all_feature_ids(self) -> set[UUID]:
         return {feature.uuid for feature in self.features}
 
-    def get_all_names(self) -> set[str]:
-        return {feature.name for feature in self.features}
+    def get_all_names(self) -> tuple[str, ...]:
+        """Return the unique feature names as an alphabetically sorted tuple (deterministic order)."""
+        return tuple(sorted({feature.name for feature in self.features}))
+
+    def get_sorted_features(self) -> tuple[Feature, ...]:
+        """Return all features sorted by name: deterministic iteration order for callers
+        that materialize column or query order."""
+        return tuple(sorted(self.features, key=lambda feature: feature.name))
 
     def __str__(self) -> str:
         return f"{self.features}"
@@ -104,8 +110,8 @@ class FeatureSet:
         FeatureSetValidator.validate_equal_options(self.features)
         return self.options.get(key)
 
-    def get_initial_requested_features(self) -> set[FeatureName]:
-        return {feature.name for feature in self.features if feature.initial_requested_data}
+    def get_initial_requested_features(self) -> tuple[FeatureName, ...]:
+        return tuple(sorted({feature.name for feature in self.features if feature.initial_requested_data}))
 
     def get_name_of_one_feature(self) -> FeatureName:
         FeatureSetValidator.validate_feature_added(

--- a/mloda/core/abstract_plugins/compute_framework.py
+++ b/mloda/core/abstract_plugins/compute_framework.py
@@ -1,4 +1,5 @@
 from abc import ABC
+from collections.abc import Sequence
 from typing import Any, Optional, final
 from uuid import UUID, uuid4
 from mloda.core.abstract_plugins.components.data_types import DataType
@@ -110,7 +111,7 @@ class ComputeFramework(ABC):
     def transform(
         self,
         data: Any,
-        feature_names: set[str],
+        feature_names: Sequence[str],
     ) -> Any:
         """This function should be used to transform the data.
         The idea here is that we can transform the data to a common format.
@@ -150,7 +151,7 @@ class ComputeFramework(ABC):
         return None
 
     def select_data_by_column_names(
-        self, data: Any, selected_feature_names: set[FeatureName], column_ordering: Optional[str] = None
+        self, data: Any, selected_feature_names: Sequence[FeatureName], column_ordering: Optional[str] = None
     ) -> Any:
         """
         If you only want to store the requested features, implement this functionality depending on your framework.
@@ -770,7 +771,7 @@ Available join types:
     @final
     def identify_naming_convention(
         self,
-        selected_feature_names: set[FeatureName],
+        selected_feature_names: Sequence[FeatureName],
         column_names: set[str],
         ordering: Optional[str] = None,
     ) -> set[str] | list[str]:
@@ -781,7 +782,7 @@ Available join types:
         return multiple related columns using the naming convention 'feature_name~column_suffix'.
 
         Args:
-            selected_feature_names: A set of FeatureName objects representing the requested features
+            selected_feature_names: A sequence of FeatureName objects representing the requested features
             column_names: A set of strings representing the available column names in the data
             ordering: Optional ordering mode - None for Set, "alphabetical" or "request_order" for List
 
@@ -824,7 +825,7 @@ Available join types:
 
         # ordering == "request_order"
         result: list[str] = []
-        for feature in selected_feature_names:
+        for feature in dict.fromkeys(selected_feature_names):
             feature_name_str = str(feature)
             matching_cols = []
             for col in _selected_feature_names:

--- a/mloda/core/filter/filter_engine.py
+++ b/mloda/core/filter/filter_engine.py
@@ -31,7 +31,7 @@ class BaseFilterEngine(ABC):
         """
         if features.filters is None:
             return []
-        all_names = features.get_all_names()
+        all_names = set(features.get_all_names())
         return [sf for sf in features.filters if sf.filter_feature.name in all_names]
 
     @classmethod

--- a/mloda/core/runtime/data_lifecycle_manager.py
+++ b/mloda/core/runtime/data_lifecycle_manager.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from typing import Any, Generator, Optional
 from uuid import UUID
 
@@ -94,14 +95,14 @@ class DataLifecycleManager:
             self.result_data_collection[step_uuid] = result
 
     def get_result_data(
-        self, cfw: ComputeFramework, selected_feature_names: set[FeatureName], location: Optional[str] = None
+        self, cfw: ComputeFramework, selected_feature_names: Sequence[FeatureName], location: Optional[str] = None
     ) -> Any:
         """
         Gets result data from the compute framework.
 
         Args:
             cfw: The compute framework containing the data.
-            selected_feature_names: Set of feature names to select.
+            selected_feature_names: Sequence of feature names to select.
             location: Optional location string for remote data access.
 
         Returns:

--- a/mloda/core/runtime/run.py
+++ b/mloda/core/runtime/run.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import multiprocessing
 import threading
 import time
+from collections.abc import Sequence
 from typing import Any, Generator, Optional
 from uuid import UUID
 import logging
@@ -281,7 +282,7 @@ class ExecutionOrchestrator:
         self.data_lifecycle_manager.add_to_result_data_collection(cfw, features, step_uuid, self.location)
 
     def get_result_data(
-        self, cfw: ComputeFramework, selected_feature_names: set[FeatureName], location: Optional[str] = None
+        self, cfw: ComputeFramework, selected_feature_names: Sequence[FeatureName], location: Optional[str] = None
     ) -> Any:
         """
         Gets result data from the compute framework.

--- a/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_framework.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Sequence
 from typing import Any, Optional
 from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.provider import BaseMergeEngine
@@ -99,7 +100,7 @@ class DuckDBFramework(ComputeFramework):
         return DuckDBMergeEngine
 
     def select_data_by_column_names(
-        self, data: Any, selected_feature_names: set[FeatureName], column_ordering: Optional[str] = None
+        self, data: Any, selected_feature_names: Sequence[FeatureName], column_ordering: Optional[str] = None
     ) -> Any:
         """Materialize the final result as a PyArrow Table.
 
@@ -145,7 +146,7 @@ class DuckDBFramework(ComputeFramework):
     def transform(
         self,
         data: Any,
-        feature_names: set[str],
+        feature_names: Sequence[str],
     ) -> Any:
         transformed_data = self.apply_compute_framework_transformer(data)
         if transformed_data is not None:

--- a/mloda_plugins/compute_framework/base_implementations/iceberg/iceberg_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/iceberg/iceberg_framework.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from typing import Any, Optional
 from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.provider import BaseMergeEngine
@@ -108,14 +109,14 @@ class IcebergFramework(ComputeFramework):
         )
 
     def select_data_by_column_names(
-        self, data: Any, selected_feature_names: set[FeatureName], column_ordering: Optional[str] = None
+        self, data: Any, selected_feature_names: Sequence[FeatureName], column_ordering: Optional[str] = None
     ) -> Any:
         """
         Select specific columns from Iceberg table.
 
         Args:
             data: Iceberg table
-            selected_feature_names: Set of feature names to select
+            selected_feature_names: Sequence of feature names to select
             column_ordering: Optional column ordering strategy
 
         Returns:
@@ -181,13 +182,13 @@ class IcebergFramework(ComputeFramework):
             return DataType.DECIMAL
         return None
 
-    def transform(self, data: Any, feature_names: set[str]) -> Any:
+    def transform(self, data: Any, feature_names: Sequence[str]) -> Any:
         """
         Transform data to Iceberg table format.
 
         Args:
             data: Input data (dict, PyArrow table, etc.)
-            feature_names: Set of feature names
+            feature_names: Sequence of feature names
 
         Returns:
             Transformed data in Iceberg table format

--- a/mloda_plugins/compute_framework/base_implementations/pandas/dataframe.py
+++ b/mloda_plugins/compute_framework/base_implementations/pandas/dataframe.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from typing import Any, Optional
 from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.provider import BaseMergeEngine
@@ -34,7 +35,7 @@ class PandasDataFrame(ComputeFramework):
         return PandasMergeEngine
 
     def select_data_by_column_names(
-        self, data: Any, selected_feature_names: set[FeatureName], column_ordering: Optional[str] = None
+        self, data: Any, selected_feature_names: Sequence[FeatureName], column_ordering: Optional[str] = None
     ) -> Any:
         column_names = set(data.columns)
         _selected_feature_names = self.identify_naming_convention(
@@ -87,7 +88,7 @@ class PandasDataFrame(ComputeFramework):
     def transform(
         self,
         data: Any,
-        feature_names: set[str],
+        feature_names: Sequence[str],
     ) -> Any:
         transformed_data = self.apply_compute_framework_transformer(data)
         if transformed_data is not None:

--- a/mloda_plugins/compute_framework/base_implementations/polars/dataframe.py
+++ b/mloda_plugins/compute_framework/base_implementations/polars/dataframe.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from typing import Any, Optional
 from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.provider import BaseMergeEngine
@@ -34,7 +35,7 @@ class PolarsDataFrame(ComputeFramework):
         return PolarsMergeEngine
 
     def select_data_by_column_names(
-        self, data: Any, selected_feature_names: set[FeatureName], column_ordering: Optional[str] = None
+        self, data: Any, selected_feature_names: Sequence[FeatureName], column_ordering: Optional[str] = None
     ) -> Any:
         column_names = set(data.columns)
         _selected_feature_names = self.identify_naming_convention(
@@ -96,7 +97,7 @@ class PolarsDataFrame(ComputeFramework):
     def transform(
         self,
         data: Any,
-        feature_names: set[str],
+        feature_names: Sequence[str],
     ) -> Any:
         transformed_data = self.apply_compute_framework_transformer(data)
         if transformed_data is not None:

--- a/mloda_plugins/compute_framework/base_implementations/polars/lazy_dataframe.py
+++ b/mloda_plugins/compute_framework/base_implementations/polars/lazy_dataframe.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from typing import Any, Optional
 from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.user import FeatureName
@@ -35,7 +36,7 @@ class PolarsLazyDataFrame(PolarsDataFrame):
         return PolarsExprMaskEngine
 
     def select_data_by_column_names(
-        self, data: Any, selected_feature_names: set[FeatureName], column_ordering: Optional[str] = None
+        self, data: Any, selected_feature_names: Sequence[FeatureName], column_ordering: Optional[str] = None
     ) -> Any:
         column_names = set(data.collect_schema().names())
         _selected_feature_names = self.identify_naming_convention(
@@ -81,7 +82,7 @@ class PolarsLazyDataFrame(PolarsDataFrame):
     def transform(
         self,
         data: Any,
-        feature_names: set[str],
+        feature_names: Sequence[str],
     ) -> Any:
         transformed_data = self.apply_compute_framework_transformer(data)
         if transformed_data is not None:

--- a/mloda_plugins/compute_framework/base_implementations/pyarrow/table.py
+++ b/mloda_plugins/compute_framework/base_implementations/pyarrow/table.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from typing import Any, Optional
 from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.provider import BaseMergeEngine
@@ -47,7 +48,7 @@ class PyArrowTable(ComputeFramework):
         return PyArrowMaskEngine
 
     def select_data_by_column_names(
-        self, data: Any, selected_feature_names: set[FeatureName], column_ordering: Optional[str] = None
+        self, data: Any, selected_feature_names: Sequence[FeatureName], column_ordering: Optional[str] = None
     ) -> Any:
         column_names = set(data.schema.names)
         _selected_feature_names = self.identify_naming_convention(
@@ -71,7 +72,7 @@ class PyArrowTable(ComputeFramework):
     def transform(
         self,
         data: Any,
-        feature_names: set[str],
+        feature_names: Sequence[str],
     ) -> Any:
         transformed_data = self.apply_compute_framework_transformer(data)
         if transformed_data is not None:

--- a/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_framework.py
@@ -1,5 +1,6 @@
 import datetime
 import decimal
+from collections.abc import Sequence
 from typing import Any, Optional
 from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.provider import BaseMergeEngine
@@ -52,7 +53,7 @@ class PythonDictFramework(ComputeFramework):
     def select_data_by_column_names(
         self,
         data: dict[str, list[Any]],
-        selected_feature_names: set[FeatureName],
+        selected_feature_names: Sequence[FeatureName],
         column_ordering: Optional[str] = None,
     ) -> dict[str, list[Any]]:
         if not data:
@@ -143,13 +144,13 @@ class PythonDictFramework(ComputeFramework):
         if isinstance(data, dict):
             self._validate_columnar_dict(data)
 
-    def transform(self, data: Any, feature_names: set[str]) -> dict[str, list[Any]]:
+    def transform(self, data: Any, feature_names: Sequence[str]) -> dict[str, list[Any]]:
         """
         Transforms data to the COLUMNAR PythonDict framework format.
 
         Args:
             data: Input data to transform
-            feature_names: Set of feature names being processed
+            feature_names: Sequence of feature names being processed
 
         Returns:
             dict[str, list[Any]]: Data in columnar PythonDict format

--- a/mloda_plugins/compute_framework/base_implementations/spark/spark_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/spark/spark_framework.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Sequence
 from typing import Any, Optional
 from mloda.core.abstract_plugins.components.data_types import DataType
 from mloda.provider import BaseMergeEngine
@@ -78,7 +79,7 @@ class SparkFramework(ComputeFramework):
         return SparkMergeEngine
 
     def select_data_by_column_names(
-        self, data: Any, selected_feature_names: set[FeatureName], column_ordering: Optional[str] = None
+        self, data: Any, selected_feature_names: Sequence[FeatureName], column_ordering: Optional[str] = None
     ) -> Any:
         column_names = set(data.columns)
         _selected_feature_names = self.identify_naming_convention(
@@ -161,7 +162,7 @@ class SparkFramework(ComputeFramework):
     def transform(
         self,
         data: Any,
-        feature_names: set[str],
+        feature_names: Sequence[str],
     ) -> Any:
         transformed_data = self.apply_compute_framework_transformer(data)
         if transformed_data is not None:

--- a/mloda_plugins/compute_framework/base_implementations/sqlite/sqlite_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/sqlite/sqlite_framework.py
@@ -1,6 +1,7 @@
 import logging
 import re
 import sqlite3
+from collections.abc import Sequence
 from typing import Any, Optional
 
 from mloda.core.abstract_plugins.components.data_types import DataType
@@ -54,7 +55,7 @@ class SqliteFramework(ComputeFramework):
         return SqliteMergeEngine
 
     def select_data_by_column_names(
-        self, data: Any, selected_feature_names: set[FeatureName], column_ordering: Optional[str] = None
+        self, data: Any, selected_feature_names: Sequence[FeatureName], column_ordering: Optional[str] = None
     ) -> Any:
         column_names = set(data.columns)
         _selected_feature_names = self.identify_naming_convention(
@@ -82,7 +83,7 @@ class SqliteFramework(ComputeFramework):
     def transform(
         self,
         data: Any,
-        feature_names: set[str],
+        feature_names: Sequence[str],
     ) -> Any:
         transformed_data = self.apply_compute_framework_transformer(data)
         if transformed_data is not None:

--- a/mloda_plugins/feature_group/experimental/aggregated_feature_group/base.py
+++ b/mloda_plugins/feature_group/experimental/aggregated_feature_group/base.py
@@ -165,7 +165,7 @@ class AggregatedFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         Adds the aggregated results directly to the input data structure.
         """
         # Process each requested feature
-        for feature in features.features:
+        for feature in features.get_sorted_features():
             aggregation_type, source_feature_name = cls._extract_aggr_and_source_feature(feature)
 
             # Resolve multi-column features automatically

--- a/mloda_plugins/feature_group/experimental/clustering/base.py
+++ b/mloda_plugins/feature_group/experimental/clustering/base.py
@@ -287,7 +287,7 @@ class ClusteringFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         Adds the clustering results directly to the input data structure.
         """
         # Process each requested feature
-        for feature in features.features:
+        for feature in features.get_sorted_features():
             algorithm, k_value, source_features = cls._extract_algorithm_k_value_and_source_features(feature)
 
             # Resolve multi-column features automatically

--- a/mloda_plugins/feature_group/experimental/data_quality/missing_value/base.py
+++ b/mloda_plugins/feature_group/experimental/data_quality/missing_value/base.py
@@ -273,7 +273,7 @@ class MissingValueFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         """
 
         # Process each requested feature
-        for feature in features.features:
+        for feature in features.get_sorted_features():
             imputation_method, source_feature = cls._extract_imputation_method_and_source_feature(feature)
 
             # Resolve multi-column features automatically

--- a/mloda_plugins/feature_group/experimental/dimensionality_reduction/base.py
+++ b/mloda_plugins/feature_group/experimental/dimensionality_reduction/base.py
@@ -348,7 +348,7 @@ class DimensionalityReductionFeatureGroup(FeatureChainParserMixin, FeatureGroup)
         """
 
         # Process each requested feature
-        for feature in features.features:
+        for feature in features.get_sorted_features():
             algorithm, dimension, source_features, options = cls._extract_algorithm_dimension_and_source_features(
                 feature
             )

--- a/mloda_plugins/feature_group/experimental/forecasting/base.py
+++ b/mloda_plugins/feature_group/experimental/forecasting/base.py
@@ -287,7 +287,7 @@ class ForecastingFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featu
         """
 
         _options = None
-        for feature in features.features:
+        for feature in features.get_sorted_features():
             if _options:
                 if _options != feature.options:
                     raise ValueError("All features must have the same options.")
@@ -305,7 +305,7 @@ class ForecastingFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featu
         results: list[tuple[str, Any]] = []
 
         # Process each requested feature with the original clean data
-        for feature in features.features:
+        for feature in features.get_sorted_features():
             algorithm, horizon, time_unit, in_features = cls._extract_forecasting_parameters(feature)
 
             # Resolve multi-column features automatically

--- a/mloda_plugins/feature_group/experimental/geo_distance/base.py
+++ b/mloda_plugins/feature_group/experimental/geo_distance/base.py
@@ -191,7 +191,7 @@ class GeoDistanceFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         Adds the calculated distances directly to the input data structure.
         """
         # Process each requested feature
-        for feature in features.features:
+        for feature in features.get_sorted_features():
             distance_type, point1_feature, point2_feature = cls._extract_geo_distance_parameters(feature)
 
             cls._check_source_features_exist(data, [point1_feature, point2_feature])

--- a/mloda_plugins/feature_group/experimental/node_centrality/base.py
+++ b/mloda_plugins/feature_group/experimental/node_centrality/base.py
@@ -222,7 +222,7 @@ class NodeCentralityFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         Adds the centrality results directly to the input data structure.
         """
         # Process each feature
-        for feature in features.features:
+        for feature in features.get_sorted_features():
             centrality_type, source_feature_str = cls._extract_centrality_and_source_feature(feature)
 
             # Common parameter extraction (works for both approaches)

--- a/mloda_plugins/feature_group/experimental/sklearn/encoding/base.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/encoding/base.py
@@ -240,7 +240,7 @@ class EncodingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         Adds the encoding results directly to the input data structure.
         """
         # Process each requested feature
-        for feature in features.features:
+        for feature in features.get_sorted_features():
             encoder_type, source_feature = cls._extract_encoder_type_and_source_feature(feature)
 
             # Remove ~suffix if present (for OneHot column patterns like category~1)

--- a/mloda_plugins/feature_group/experimental/sklearn/pipeline/base.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/pipeline/base.py
@@ -202,7 +202,7 @@ class SklearnPipelineFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         Adds the pipeline results directly to the input data structure.
         """
         # Process each requested feature
-        for feature in features.features:
+        for feature in features.get_sorted_features():
             pipeline_name, source_features = cls._extract_pipeline_name_and_source_features(feature)
 
             # Check that all source features exist

--- a/mloda_plugins/feature_group/experimental/sklearn/scaling/base.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/scaling/base.py
@@ -132,7 +132,7 @@ class ScalingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         Adds the scaling results directly to the input data structure.
         """
         # Process each requested feature
-        for feature in features.features:
+        for feature in features.get_sorted_features():
             scaler_type, source_feature = cls._extract_scaler_type_and_source_feature(feature)
 
             # Check that source feature exists

--- a/mloda_plugins/feature_group/experimental/text_cleaning/base.py
+++ b/mloda_plugins/feature_group/experimental/text_cleaning/base.py
@@ -181,7 +181,7 @@ class TextCleaningFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         """
 
         # Process each requested feature
-        for feature in features.features:
+        for feature in features.get_sorted_features():
             operations, source_feature = cls._extract_operations_and_source_feature(feature)
 
             # Check if source feature exists

--- a/mloda_plugins/feature_group/experimental/time_window/base.py
+++ b/mloda_plugins/feature_group/experimental/time_window/base.py
@@ -308,7 +308,7 @@ class TimeWindowFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featur
         """
 
         _options = None
-        for feature in features.features:
+        for feature in features.get_sorted_features():
             if _options:
                 if _options != feature.options:
                     raise ValueError("All features must have the same options.")
@@ -321,7 +321,7 @@ class TimeWindowFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featur
         cls._check_reference_time_column_is_datetime(data, reference_time_column)
 
         # Process each requested feature
-        for feature in features.features:
+        for feature in features.get_sorted_features():
             window_function, window_size, time_unit, in_features = cls._extract_time_window_params_and_source_features(
                 feature
             )

--- a/mloda_plugins/feature_group/input_data/read_dbs/sqlite.py
+++ b/mloda_plugins/feature_group/input_data/read_dbs/sqlite.py
@@ -170,7 +170,7 @@ class SQLITEReader(ReadDB):
         query = "select "
 
         options = None
-        for feature in features.features:
+        for feature in features.get_sorted_features():
             query += f"{feature.name}, "
             options = feature.options
 

--- a/mloda_plugins/feature_group/input_data/read_files/feather.py
+++ b/mloda_plugins/feature_group/input_data/read_files/feather.py
@@ -113,4 +113,5 @@ class FeatherReader(ReadFile):
             raise ImportError(
                 "pyarrow is required to read Feather files. Install it with: pip install 'mloda[pyarrow]'"
             )
-        return pyarrow_feather.read_table(source=data_access, columns=list(features.get_all_names()))
+        columns = list(features.get_all_names())
+        return pyarrow_feather.read_table(source=data_access, columns=columns).select(columns)

--- a/mloda_plugins/feature_group/input_data/read_files/orc.py
+++ b/mloda_plugins/feature_group/input_data/read_files/orc.py
@@ -111,4 +111,5 @@ class OrcReader(ReadFile):
     def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
         if pyarrow_orc is None:
             raise ImportError("pyarrow is required to read ORC files. Install it with: pip install 'mloda[pyarrow]'")
-        return pyarrow_orc.read_table(source=data_access, columns=list(features.get_all_names()))
+        columns = list(features.get_all_names())
+        return pyarrow_orc.read_table(source=data_access, columns=columns).select(columns)

--- a/tests/test_core/test_abstract_plugins/test_column_ordering.py
+++ b/tests/test_core/test_abstract_plugins/test_column_ordering.py
@@ -94,14 +94,14 @@ class TestIdentifyNamingConvention:
 
     def test_default_returns_set(self) -> None:
         cfw = create_compute_framework()
-        result = cfw.identify_naming_convention({FeatureName("A"), FeatureName("B")}, {"A", "B", "C"})
+        result = cfw.identify_naming_convention([FeatureName("A"), FeatureName("B")], {"A", "B", "C"})
         assert isinstance(result, set)
         assert result == {"A", "B"}
 
     def test_alphabetical_returns_sorted_list(self) -> None:
         cfw = create_compute_framework()
         result = cfw.identify_naming_convention(
-            {FeatureName("Zebra"), FeatureName("Apple"), FeatureName("Mango")},
+            [FeatureName("Zebra"), FeatureName("Apple"), FeatureName("Mango")],
             {"Zebra", "Apple", "Mango"},
             ordering="alphabetical",
         )
@@ -110,14 +110,14 @@ class TestIdentifyNamingConvention:
     def test_alphabetical_with_sub_columns(self) -> None:
         cfw = create_compute_framework()
         result = cfw.identify_naming_convention(
-            {FeatureName("Temp")}, {"Temp~min", "Temp~max", "Temp~mean"}, ordering="alphabetical"
+            [FeatureName("Temp")], {"Temp~min", "Temp~max", "Temp~mean"}, ordering="alphabetical"
         )
         assert result == ["Temp~max", "Temp~mean", "Temp~min"]
 
     def test_request_order_returns_list(self) -> None:
         cfw = create_compute_framework()
         result = cfw.identify_naming_convention(
-            {FeatureName("A"), FeatureName("B")}, {"A", "B"}, ordering="request_order"
+            [FeatureName("A"), FeatureName("B")], {"A", "B"}, ordering="request_order"
         )
         assert isinstance(result, list)
         assert set(result) == {"A", "B"}
@@ -125,7 +125,7 @@ class TestIdentifyNamingConvention:
     def test_sub_columns_grouped_alphabetical(self) -> None:
         cfw = create_compute_framework()
         result = cfw.identify_naming_convention(
-            {FeatureName("Temp"), FeatureName("Hum")},
+            [FeatureName("Temp"), FeatureName("Hum")],
             {"Temp~mean", "Temp~max", "Hum~mean", "Hum~max"},
             ordering="alphabetical",
         )
@@ -134,7 +134,7 @@ class TestIdentifyNamingConvention:
     def test_invalid_ordering_raises(self) -> None:
         cfw = create_compute_framework()
         with pytest.raises(ValueError):
-            cfw.identify_naming_convention({FeatureName("A")}, {"A"}, ordering="invalid")
+            cfw.identify_naming_convention([FeatureName("A")], {"A"}, ordering="invalid")
 
 
 # --- API Parameter Tests ---
@@ -204,14 +204,14 @@ class TestColumnOrderingThreading:
         mock_cfw.data = {"col": [1, 2, 3]}
         mock_cfw.select_data_by_column_names.return_value = {"col": [1, 2, 3]}
 
-        dlm.get_result_data(mock_cfw, {FeatureName("col")})
+        dlm.get_result_data(mock_cfw, [FeatureName("col")])
         mock_cfw.select_data_by_column_names.assert_called_once_with(
-            mock_cfw.data, {FeatureName("col")}, column_ordering="alphabetical"
+            mock_cfw.data, [FeatureName("col")], column_ordering="alphabetical"
         )
 
     def test_compute_framework_select_accepts_column_ordering(self) -> None:
         cfw = create_compute_framework()
-        result = cfw.select_data_by_column_names({}, set(), column_ordering="alphabetical")
+        result = cfw.select_data_by_column_names({}, [], column_ordering="alphabetical")
         assert result == {}
 
 
@@ -259,14 +259,14 @@ class TestComputeFrameworksColumnOrdering:
     def test_pandas_accepts_column_ordering(self) -> None:
         cfw = PandasDataFrame(ParallelizationMode.SYNC, frozenset(), uuid4())
         data = pd.DataFrame({"Z": [1], "A": [2], "M": [3]})
-        features = {FeatureName("Z"), FeatureName("A"), FeatureName("M")}
+        features = [FeatureName("Z"), FeatureName("A"), FeatureName("M")]
         result = cfw.select_data_by_column_names(data, features, column_ordering="alphabetical")
         assert list(result.columns) == ["A", "M", "Z"]
 
     def test_pandas_request_order(self) -> None:
         cfw = PandasDataFrame(ParallelizationMode.SYNC, frozenset(), uuid4())
         data = pd.DataFrame({"Z": [1], "A": [2], "M": [3]})
-        features = {FeatureName("Z"), FeatureName("A"), FeatureName("M")}
+        features = [FeatureName("Z"), FeatureName("A"), FeatureName("M")]
         result = cfw.select_data_by_column_names(data, features, column_ordering="request_order")
         assert isinstance(result, pd.DataFrame)
         assert set(result.columns) == {"Z", "A", "M"}
@@ -274,7 +274,7 @@ class TestComputeFrameworksColumnOrdering:
     def test_pyarrow_accepts_column_ordering(self) -> None:
         cfw = PyArrowTable(ParallelizationMode.SYNC, frozenset(), uuid4())
         data = pa.table({"Z": [1], "A": [2], "M": [3]})
-        features = {FeatureName("Z"), FeatureName("A"), FeatureName("M")}
+        features = [FeatureName("Z"), FeatureName("A"), FeatureName("M")]
         result = cfw.select_data_by_column_names(data, features, column_ordering="alphabetical")
         assert result.column_names == ["A", "M", "Z"]
 
@@ -282,7 +282,7 @@ class TestComputeFrameworksColumnOrdering:
     def test_polars_accepts_column_ordering(self) -> None:
         cfw = PolarsDataFrame(ParallelizationMode.SYNC, frozenset(), uuid4())
         data = pl.DataFrame({"Z": [1], "A": [2], "M": [3]})
-        features = {FeatureName("Z"), FeatureName("A"), FeatureName("M")}
+        features = [FeatureName("Z"), FeatureName("A"), FeatureName("M")]
         result = cfw.select_data_by_column_names(data, features, column_ordering="alphabetical")
         assert result.columns == ["A", "M", "Z"]
 
@@ -290,7 +290,7 @@ class TestComputeFrameworksColumnOrdering:
     def test_polars_lazy_accepts_column_ordering(self) -> None:
         cfw = PolarsLazyDataFrame(ParallelizationMode.SYNC, frozenset(), uuid4())
         data = pl.DataFrame({"Z": [1], "A": [2], "M": [3]}).lazy()
-        features = {FeatureName("Z"), FeatureName("A"), FeatureName("M")}
+        features = [FeatureName("Z"), FeatureName("A"), FeatureName("M")]
         result = cfw.select_data_by_column_names(data, features, column_ordering="alphabetical")
         # PolarsLazyDataFrame.select_data_by_column_names() returns collected DataFrame
         assert result.columns == ["A", "M", "Z"]
@@ -301,7 +301,7 @@ class TestComputeFrameworksColumnOrdering:
         conn = duckdb.connect(":memory:")
         # DuckDB expects a DuckDBPyRelation
         data = conn.sql("SELECT 1 as Z, 2 as A, 3 as M")
-        features = {FeatureName("Z"), FeatureName("A"), FeatureName("M")}
+        features = [FeatureName("Z"), FeatureName("A"), FeatureName("M")]
         result = cfw.select_data_by_column_names(data, features, column_ordering="alphabetical")
         assert result.column_names == ["A", "M", "Z"]
 
@@ -309,7 +309,7 @@ class TestComputeFrameworksColumnOrdering:
         cfw = PythonDictFramework(ParallelizationMode.SYNC, frozenset(), uuid4())
         # PythonDictFramework expects a columnar dict format
         data = {"Z": [1], "A": [2], "M": [3]}
-        features = {FeatureName("Z"), FeatureName("A"), FeatureName("M")}
+        features = [FeatureName("Z"), FeatureName("A"), FeatureName("M")]
         result = cfw.select_data_by_column_names(data, features, column_ordering="alphabetical")
         assert list(result.keys()) == ["A", "M", "Z"]
 

--- a/tests/test_core/test_abstract_plugins/test_components/test_feature_set_ordering.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_feature_set_ordering.py
@@ -1,0 +1,69 @@
+"""Contract tests for deterministic, sorted-tuple name accessors on FeatureSet (#613 follow-up).
+
+These pin the NEW API:
+- get_all_names() -> tuple[str, ...] sorted alphabetically
+- get_initial_requested_features() -> tuple[FeatureName, ...] sorted alphabetically
+- get_sorted_features() -> tuple[Feature, ...] sorted by feature.name
+"""
+
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+
+
+class TestGetAllNamesSortedTuple:
+    def test_returns_alphabetically_sorted_names(self) -> None:
+        features = FeatureSet()
+        features.add(Feature("c_col"))
+        features.add(Feature("a_col"))
+        features.add(Feature("b_col"))
+
+        assert features.get_all_names() == ("a_col", "b_col", "c_col")
+
+    def test_returns_tuple(self) -> None:
+        features = FeatureSet()
+        features.add(Feature("c_col"))
+        features.add(Feature("a_col"))
+        features.add(Feature("b_col"))
+
+        assert isinstance(features.get_all_names(), tuple)
+
+
+class TestGetInitialRequestedFeaturesSortedTuple:
+    def test_returns_alphabetically_sorted_requested_names_only(self) -> None:
+        features = FeatureSet()
+        features.add(Feature("z_req", initial_requested_data=True))
+        features.add(Feature("m_req", initial_requested_data=True))
+        features.add(Feature("not_req"))
+
+        assert features.get_initial_requested_features() == (FeatureName("m_req"), FeatureName("z_req"))
+
+    def test_returns_tuple(self) -> None:
+        features = FeatureSet()
+        features.add(Feature("z_req", initial_requested_data=True))
+        features.add(Feature("m_req", initial_requested_data=True))
+        features.add(Feature("not_req"))
+
+        assert isinstance(features.get_initial_requested_features(), tuple)
+
+
+class TestGetSortedFeatures:
+    def test_returns_features_sorted_by_name(self) -> None:
+        features = FeatureSet()
+        features.add(Feature("c_col"))
+        features.add(Feature("a_col"))
+        features.add(Feature("b_col"))
+
+        sorted_features = features.get_sorted_features()
+
+        assert tuple(feature.name for feature in sorted_features) == ("a_col", "b_col", "c_col")
+
+    def test_returns_tuple_of_features(self) -> None:
+        features = FeatureSet()
+        features.add(Feature("b_col"))
+        features.add(Feature("a_col"))
+
+        sorted_features = features.get_sorted_features()
+
+        assert isinstance(sorted_features, tuple)
+        assert all(isinstance(feature, Feature) for feature in sorted_features)

--- a/tests/test_core/test_abstract_plugins/test_components/test_merge_engine/test_base_merge_engine.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_merge_engine/test_base_merge_engine.py
@@ -34,7 +34,7 @@ class AppendMergeTestFeature(FeatureGroup):
         if len(feature_name) != 1:
             raise ValueError(f"Test Failed: {feature_name}")
         else:
-            single_feature_name = feature_name.pop()
+            single_feature_name = feature_name[0]
         return {single_feature_name: [f"{single_feature_name}_value"]}
 
 

--- a/tests/test_core/test_abstract_plugins/test_sub_column_dependency.py
+++ b/tests/test_core/test_abstract_plugins/test_sub_column_dependency.py
@@ -218,7 +218,7 @@ class TestIdentifyNamingConventionForSubColumns:
         from uuid import uuid4
         from mloda.user import ParallelizationMode
 
-        selected_feature_names = {FeatureName("base~1")}
+        selected_feature_names = [FeatureName("base~1")]
         column_names = {"base~0", "base~1", "base~2", "other_column"}
 
         framework = PandasDataFrame(
@@ -243,7 +243,7 @@ class TestIdentifyNamingConventionForSubColumns:
         from uuid import uuid4
         from mloda.user import ParallelizationMode
 
-        selected_feature_names = {FeatureName("base")}
+        selected_feature_names = [FeatureName("base")]
         column_names = {"base~0", "base~1", "base~2", "other_column"}
 
         framework = PandasDataFrame(
@@ -299,7 +299,7 @@ class TestSubColumnErrorHandling:
         from uuid import uuid4
         from mloda.user import ParallelizationMode
 
-        selected_feature_names = {FeatureName("base~999")}
+        selected_feature_names = [FeatureName("base~999")]
         column_names = {"base~0", "base~1", "base~2"}
 
         framework = PandasDataFrame(

--- a/tests/test_core/test_runtime/test_data_lifecycle_manager.py
+++ b/tests/test_core/test_runtime/test_data_lifecycle_manager.py
@@ -292,7 +292,7 @@ class TestDataLifecycleManagerGetResultData:
         mock_cfw.select_data_by_column_names.return_value = selected_data
 
         feature_name = FeatureName("feature1")
-        selected_feature_names = {feature_name}
+        selected_feature_names = [feature_name]
 
         result = manager.get_result_data(mock_cfw, selected_feature_names)
 
@@ -318,7 +318,7 @@ class TestDataLifecycleManagerGetResultData:
         mock_cfw.select_data_by_column_names.return_value = selected_data
 
         feature_name = Mock(spec=FeatureName)
-        selected_feature_names = {feature_name}
+        selected_feature_names = [feature_name]
 
         with patch("mloda.core.runtime.data_lifecycle_manager.FlightServer") as mock_flight_server:
             mock_flight_server.download_table.return_value = downloaded_data
@@ -340,7 +340,7 @@ class TestDataLifecycleManagerGetResultData:
         mock_cfw.data = None
 
         feature_name = Mock(spec=FeatureName)
-        selected_feature_names = {feature_name}
+        selected_feature_names = [feature_name]
 
         with pytest.raises(NotImplementedError, match="Cannot retrieve result data"):
             manager.get_result_data(mock_cfw, selected_feature_names, location=None)

--- a/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_framework.py
+++ b/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_framework.py
@@ -82,7 +82,7 @@ class TestDuckDBFrameworkComputeFramework:
         self, duckdb_framework: DuckDBFramework, connection: Any, dict_data: dict[str, list[int]], expected_data: Any
     ) -> None:
         duckdb_framework.set_framework_connection_object(connection)
-        result = duckdb_framework.transform(dict_data, set())
+        result = duckdb_framework.transform(dict_data, [])
         result_df = result.df()
         expected_df = expected_data.df()
 
@@ -91,10 +91,10 @@ class TestDuckDBFrameworkComputeFramework:
 
     def test_transform_invalid_data(self, duckdb_framework: DuckDBFramework) -> None:
         with pytest.raises(ValueError):
-            duckdb_framework.transform(data=["a"], feature_names=set())
+            duckdb_framework.transform(data=["a"], feature_names=[])
 
     def test_select_data_by_column_names(self, duckdb_framework: DuckDBFramework, expected_data: Any) -> None:
-        data = duckdb_framework.select_data_by_column_names(expected_data, {FeatureName("column1")})
+        data = duckdb_framework.select_data_by_column_names(expected_data, [FeatureName("column1")])
         assert isinstance(data, pa.Table)
         assert "column1" in data.column_names
 
@@ -107,8 +107,8 @@ class TestDuckDBFrameworkComputeFramework:
     def test_transform_add_column_preserves_existing(self, duckdb_framework: DuckDBFramework, connection: Any) -> None:
         duckdb_framework.set_framework_connection_object(connection)
         dict_data = {"col_a": [1, 2, 3], "col_b": [4, 5, 6]}
-        duckdb_framework.data = duckdb_framework.transform(dict_data, set())
-        result = duckdb_framework.transform(data=[7, 8, 9], feature_names={"col_c"})
+        duckdb_framework.data = duckdb_framework.transform(dict_data, [])
+        result = duckdb_framework.transform(data=[7, 8, 9], feature_names=["col_c"])
         assert set(result.columns) == {"col_a", "col_b", "col_c"}
         assert len(result) == 3
         arrow = result.to_arrow_table()

--- a/tests/test_plugins/compute_framework/base_implementations/iceberg/test_iceberg_framework.py
+++ b/tests/test_plugins/compute_framework/base_implementations/iceberg/test_iceberg_framework.py
@@ -89,7 +89,7 @@ class TestIcebergFrameworkComputeFramework:
 
     def test_transform_dict_to_arrow(self) -> None:
         """Test transforming dict to PyArrow table (intermediate step for Iceberg)."""
-        result = self.iceberg_framework.transform(self.dict_data, set())
+        result = self.iceberg_framework.transform(self.dict_data, [])
         assert isinstance(result, pa.Table)
         assert result.column_names == ["column1", "column2"]
         assert result.to_pydict() == self.dict_data
@@ -97,13 +97,13 @@ class TestIcebergFrameworkComputeFramework:
     def test_transform_iceberg_table_passthrough(self) -> None:
         """Test that Iceberg tables pass through unchanged."""
         mock_iceberg_table = Mock(spec=IcebergTable)
-        result = self.iceberg_framework.transform(mock_iceberg_table, set())
+        result = self.iceberg_framework.transform(mock_iceberg_table, [])
         assert result is mock_iceberg_table
 
     def test_transform_invalid_data(self) -> None:
         """Test that invalid data types raise ValueError."""
         with pytest.raises(ValueError, match="Data type .* is not supported"):
-            self.iceberg_framework.transform(data=["invalid"], feature_names=set())
+            self.iceberg_framework.transform(data=["invalid"], feature_names=[])
 
     def test_set_framework_connection_object_catalog(self) -> None:
         """Test setting a catalog as framework connection object."""
@@ -128,7 +128,7 @@ class TestIcebergFrameworkComputeFramework:
     def test_select_data_by_column_names_non_iceberg(self) -> None:
         """Test that non-Iceberg data passes through unchanged."""
         data = "not_iceberg_table"
-        feature_names = {FeatureName("column1")}
+        feature_names = [FeatureName("column1")]
         result = self.iceberg_framework.select_data_by_column_names(data, feature_names)
         assert result is data
 

--- a/tests/test_plugins/compute_framework/base_implementations/pandas/test_pandas_dataframe.py
+++ b/tests/test_plugins/compute_framework/base_implementations/pandas/test_pandas_dataframe.py
@@ -44,24 +44,24 @@ class TestPandasDataFrameComputeFramework:
     def test_transform_dict_to_table(
         self, pd_dataframe: PandasDataFrame, dict_data: dict[str, list[int]], expected_data: Any
     ) -> None:
-        assert all(pd_dataframe.transform(dict_data, set()) == expected_data)
+        assert all(pd_dataframe.transform(dict_data, []) == expected_data)
 
     def test_transform_arrays(self) -> None:
         data = PandasDataFrame.pd_series()([1, 2, 3])
         _pdDf = PandasDataFrame(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
         _pdDf.set_data(PandasDataFrame.pd_dataframe().from_dict({"existing_column": [4, 5, 6]}))
 
-        data = _pdDf.transform(data=data, feature_names={"new_column"})
+        data = _pdDf.transform(data=data, feature_names=["new_column"])
         assert data.equals(
             PandasDataFrame.pd_dataframe().from_dict({"existing_column": [4, 5, 6], "new_column": [1, 2, 3]})
         )
 
     def test_transform_invalid_data(self, pd_dataframe: PandasDataFrame) -> None:
         with pytest.raises(ValueError):
-            pd_dataframe.transform(data=["a"], feature_names=set())
+            pd_dataframe.transform(data=["a"], feature_names=[])
 
     def test_select_data_by_column_names(self, pd_dataframe: PandasDataFrame, expected_data: Any) -> None:
-        data = pd_dataframe.select_data_by_column_names(expected_data, {FeatureName("column1")})
+        data = pd_dataframe.select_data_by_column_names(expected_data, [FeatureName("column1")])
         assert data.columns == ["column1"]
 
     def test_set_column_names(self, pd_dataframe: PandasDataFrame, expected_data: Any) -> None:
@@ -78,7 +78,7 @@ class TestPandasTransformList:
 
         data = [{"content": "hello world", "source": "/path/to/file.txt", "file_type": "text"}]
 
-        result = pdf.transform(data, {"content"})
+        result = pdf.transform(data, ["content"])
 
         assert isinstance(result, pd.DataFrame)
         assert len(result) == 1
@@ -95,7 +95,7 @@ class TestPandasTransformList:
             {"content": "second", "source": "/path/b.json", "file_type": "json"},
         ]
 
-        result = pdf.transform(data, {"content"})
+        result = pdf.transform(data, ["content"])
 
         assert isinstance(result, pd.DataFrame)
         assert len(result) == 2

--- a/tests/test_plugins/compute_framework/base_implementations/polars/test_polars_dataframe.py
+++ b/tests/test_plugins/compute_framework/base_implementations/polars/test_polars_dataframe.py
@@ -72,7 +72,7 @@ class TestPolarsDataFrameComputeFramework:
     def test_transform_dict_to_table(
         self, pl_dataframe: PolarsDataFrame, dict_data: dict[str, list[int]], expected_data: Any
     ) -> None:
-        result = pl_dataframe.transform(dict_data, set())
+        result = pl_dataframe.transform(dict_data, [])
         assert result.equals(expected_data)
 
     def test_transform_arrays(self) -> None:
@@ -80,16 +80,16 @@ class TestPolarsDataFrameComputeFramework:
         _plDf = PolarsDataFrame(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
         _plDf.set_data(PolarsDataFrame.pl_dataframe()({"existing_column": [4, 5, 6]}))
 
-        result = _plDf.transform(data=data, feature_names={"new_column"})
+        result = _plDf.transform(data=data, feature_names=["new_column"])
         expected = PolarsDataFrame.pl_dataframe()({"existing_column": [4, 5, 6], "new_column": [1, 2, 3]})
         assert result.equals(expected)
 
     def test_transform_invalid_data(self, pl_dataframe: PolarsDataFrame) -> None:
         with pytest.raises(ValueError):
-            pl_dataframe.transform(data=["a"], feature_names=set())
+            pl_dataframe.transform(data=["a"], feature_names=[])
 
     def test_select_data_by_column_names(self, pl_dataframe: PolarsDataFrame, expected_data: Any) -> None:
-        data = pl_dataframe.select_data_by_column_names(expected_data, {FeatureName("column1")})
+        data = pl_dataframe.select_data_by_column_names(expected_data, [FeatureName("column1")])
         assert data.columns == ["column1"]
 
     def test_set_column_names(self, pl_dataframe: PolarsDataFrame, expected_data: Any) -> None:

--- a/tests/test_plugins/compute_framework/base_implementations/polars/test_polars_lazy_dataframe.py
+++ b/tests/test_plugins/compute_framework/base_implementations/polars/test_polars_lazy_dataframe.py
@@ -52,7 +52,7 @@ class TestPolarsLazyDataFrameComputeFramework:
         assert self.lazy_df.expected_data_framework() == pl.LazyFrame
 
     def test_transform_dict_to_lazy_frame(self) -> None:
-        result = self.lazy_df.transform(self.dict_data, set())
+        result = self.lazy_df.transform(self.dict_data, [])
         assert isinstance(result, pl.LazyFrame)
         # Verify it's actually lazy (no execution yet) by checking schema
         assert set(result.collect_schema().names()) == {"column1", "column2"}
@@ -66,7 +66,7 @@ class TestPolarsLazyDataFrameComputeFramework:
         _lazy_df = PolarsLazyDataFrame(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
         _lazy_df.set_data(PolarsLazyDataFrame.pl_lazy_frame()({"existing_column": [4, 5, 6]}))
 
-        result = _lazy_df.transform(data=data, feature_names={"new_column"})
+        result = _lazy_df.transform(data=data, feature_names=["new_column"])
         assert isinstance(result, pl.LazyFrame)
 
         # Verify schema without executing
@@ -81,14 +81,14 @@ class TestPolarsLazyDataFrameComputeFramework:
     def test_transform_dataframe_to_lazy(self) -> None:
         """Test converting DataFrame to LazyFrame"""
         df = pl.DataFrame({"col": [1, 2, 3]})
-        result = self.lazy_df.transform(df, set())
+        result = self.lazy_df.transform(df, [])
         assert isinstance(result, pl.LazyFrame)
         # Verify schema
         assert set(result.collect_schema().names()) == {"col"}
 
     def test_transform_invalid_data(self) -> None:
         with pytest.raises(ValueError):
-            self.lazy_df.transform(data=["a"], feature_names=set())
+            self.lazy_df.transform(data=["a"], feature_names=[])
 
     def test_set_column_names(self) -> None:
         self.lazy_df.data = self.expected_lazy_data
@@ -158,11 +158,11 @@ class TestLazyEagerEquivalence:
 
         # Eager transformation
         eager_df = PolarsDataFrame(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
-        eager_result = eager_df.transform(self.dict_data, set())
+        eager_result = eager_df.transform(self.dict_data, [])
 
         # Lazy transformation
         lazy_df = PolarsLazyDataFrame(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
-        lazy_result = lazy_df.transform(self.dict_data, set())
+        lazy_result = lazy_df.transform(self.dict_data, [])
 
         # Compare collected lazy result with eager result
         assert lazy_result.collect().equals(eager_result)
@@ -174,7 +174,7 @@ class TestLazyEagerEquivalence:
         # Setup data
         df_data = pl.DataFrame(self.dict_data)
         lazy_data = df_data.lazy()
-        feature_names = {FeatureName("column1")}
+        feature_names = [FeatureName("column1")]
 
         # Eager selection
         eager_df = PolarsDataFrame(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
@@ -200,7 +200,7 @@ class TestLazyExecutionTiming:
         lazy_df = PolarsLazyDataFrame(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
 
         # Create lazy frame
-        result = lazy_df.transform(self.dict_data, set())
+        result = lazy_df.transform(self.dict_data, [])
 
         # Should be able to get schema without execution
         schema = result.collect_schema()

--- a/tests/test_plugins/compute_framework/base_implementations/pyarrow/test_pyarrow_table.py
+++ b/tests/test_plugins/compute_framework/base_implementations/pyarrow/test_pyarrow_table.py
@@ -44,7 +44,7 @@ class TestPyArrowTableComputeFramework:
     def test_transform_dict_to_table(
         self, pyarrow_table: PyArrowTable, dict_data: dict[str, list[int]], expected_data: Any
     ) -> None:
-        assert pyarrow_table.transform(dict_data, set()) == expected_data
+        assert pyarrow_table.transform(dict_data, []) == expected_data
 
     def test_transform_arrays(self) -> None:
         chunked_array = pa.chunked_array([pa.array([1, 2]), pa.array([3])])
@@ -54,15 +54,15 @@ class TestPyArrowTableComputeFramework:
             _pytable = PyArrowTable(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
             _pytable.set_data(pa.table({"existing_column": [4, 5, 6]}))
 
-            data = _pytable.transform(data=data, feature_names={"new_column"})
+            data = _pytable.transform(data=data, feature_names=["new_column"])
             assert data.equals(pa.table({"existing_column": [4, 5, 6], "new_column": [1, 2, 3]}))
 
     def test_transform_invalid_data(self, pyarrow_table: PyArrowTable) -> None:
         with pytest.raises(ValueError):
-            pyarrow_table.transform(data=["a"], feature_names=set())
+            pyarrow_table.transform(data=["a"], feature_names=[])
 
     def test_select_data_by_column_names(self, pyarrow_table: PyArrowTable, expected_data: Any) -> None:
-        data = pyarrow_table.select_data_by_column_names(expected_data, {FeatureName("column1")})
+        data = pyarrow_table.select_data_by_column_names(expected_data, [FeatureName("column1")])
         assert data.schema.names == ["column1"]
 
     def test_set_column_names(self, pyarrow_table: PyArrowTable, expected_data: Any) -> None:

--- a/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_allow_empty_result.py
+++ b/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_allow_empty_result.py
@@ -71,7 +71,7 @@ class TestPythonDictEmptyResultPolicy:
 
     def test_select_empty_data_returns_empty_dict(self) -> None:
         """select on the schema-less ``{}`` returns ``{}`` unconditionally."""
-        result = _framework().select_data_by_column_names({}, {FeatureName("col1")})
+        result = _framework().select_data_by_column_names({}, [FeatureName("col1")])
         assert result == {}
 
     def test_select_missing_column_still_raises(self) -> None:
@@ -82,7 +82,7 @@ class TestPythonDictEmptyResultPolicy:
         ValueError ('No columns found ...').
         """
         with pytest.raises(ValueError, match="No columns found"):
-            _framework().select_data_by_column_names({"a": [1]}, {FeatureName("missing")})
+            _framework().select_data_by_column_names({"a": [1]}, [FeatureName("missing")])
 
     def test_validate_filter_columns_empty_dict_does_not_raise(self) -> None:
         """The skip is driven by the data being the schema-less ``{}``.

--- a/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_columnar_contract.py
+++ b/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_columnar_contract.py
@@ -53,33 +53,33 @@ class TestTransformColumnar:
     def test_columnar_dict_passthrough(self) -> None:
         """A columnar dict with equal-length list values is returned as-is."""
         data = {"a": [1, 2], "b": ["x", "y"]}
-        assert _framework().transform(data, set()) == {"a": [1, 2], "b": ["x", "y"]}
+        assert _framework().transform(data, []) == {"a": [1, 2], "b": ["x", "y"]}
 
     def test_list_of_row_dicts_becomes_columnar(self) -> None:
         """A list of row dicts pivots into a columnar dict."""
         data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
-        assert _framework().transform(data, set()) == {"a": [1, 3], "b": [2, 4]}
+        assert _framework().transform(data, []) == {"a": [1, 3], "b": [2, 4]}
 
     def test_single_row_list_becomes_columnar(self) -> None:
         """A single-element list of a row dict becomes a one-row columnar dict."""
-        assert _framework().transform([{"a": 1}], set()) == {"a": [1]}
+        assert _framework().transform([{"a": 1}], []) == {"a": [1]}
 
     def test_empty_list_becomes_empty_dict(self) -> None:
         """An empty list has no schema and normalizes to the schema-less ``{}``."""
-        assert _framework().transform([], set()) == {}
+        assert _framework().transform([], []) == {}
 
     def test_empty_dict_passthrough(self) -> None:
         """``{}`` (zero columns) is already the schema-less empty; returned as ``{}``."""
-        assert _framework().transform({}, set()) == {}
+        assert _framework().transform({}, []) == {}
 
     def test_zero_row_columnar_dict_passthrough(self) -> None:
         """A columnar dict with an empty column keeps its schema (one known column)."""
-        assert _framework().transform({"a": []}, set()) == {"a": []}
+        assert _framework().transform({"a": []}, []) == {"a": []}
 
     def test_columnar_dict_unequal_lengths_raises(self) -> None:
         """Value-lists of differing length are invalid columnar input."""
         with pytest.raises(ValueError):
-            _framework().transform({"a": [1, 2], "b": [3]}, set())
+            _framework().transform({"a": [1, 2], "b": [3]}, [])
 
     def test_dict_with_non_list_values_raises(self) -> None:
         """A dict whose values are not lists is not columnar and is rejected.
@@ -87,17 +87,17 @@ class TestTransformColumnar:
         Single-row dicts are no longer special-cased under the columnar model.
         """
         with pytest.raises(ValueError):
-            _framework().transform({"a": 1, "b": 2}, set())
+            _framework().transform({"a": 1, "b": 2}, [])
 
     def test_none_raises(self) -> None:
         """``None`` is a missing result, not an empty one: unsupported type."""
         with pytest.raises(ValueError, match="Data type .* is not supported"):
-            _framework().transform(None, set())
+            _framework().transform(None, [])
 
     def test_int_raises(self) -> None:
         """A bare int is an unsupported type."""
         with pytest.raises(ValueError, match="Data type .* is not supported"):
-            _framework().transform(5, set())
+            _framework().transform(5, [])
 
 
 # ---------------------------------------------------------------------------
@@ -189,17 +189,17 @@ class TestSelectColumnar:
     def test_select_subset_preserves_rows(self) -> None:
         """Selection returns a columnar dict of only the requested columns."""
         data = {"a": [1, 2], "b": [3, 4], "c": [5, 6]}
-        result = _framework().select_data_by_column_names(data, {FeatureName("a"), FeatureName("b")})
+        result = _framework().select_data_by_column_names(data, [FeatureName("a"), FeatureName("b")])
         assert result == {"a": [1, 2], "b": [3, 4]}
 
     def test_select_empty_dict_returns_empty_dict(self) -> None:
         """Selecting from ``{}`` yields ``{}``."""
-        result = _framework().select_data_by_column_names({}, {FeatureName("a")})
+        result = _framework().select_data_by_column_names({}, [FeatureName("a")])
         assert result == {}
 
     def test_select_zero_row_columns_kept(self) -> None:
         """Selecting a present-but-empty column keeps the column at zero rows."""
-        result = _framework().select_data_by_column_names({"a": [], "b": []}, {FeatureName("a")})
+        result = _framework().select_data_by_column_names({"a": [], "b": []}, [FeatureName("a")])
         assert result == {"a": []}
 
 

--- a/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_framework.py
+++ b/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_framework.py
@@ -25,7 +25,7 @@ class TestPythonDictFramework:
 
         input_data = {"col1": [1, 2, 3], "col2": ["a", "b", "c"]}
 
-        result = framework.transform(input_data, set())
+        result = framework.transform(input_data, [])
         assert result == {"col1": [1, 2, 3], "col2": ["a", "b", "c"]}
 
     def test_transform_single_dict_raises(self) -> None:
@@ -33,7 +33,7 @@ class TestPythonDictFramework:
         framework = PythonDictFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
 
         with pytest.raises(ValueError):
-            framework.transform({"col1": 1, "col2": "a"}, set())
+            framework.transform({"col1": 1, "col2": "a"}, [])
 
     def test_transform_list_of_rows_becomes_columnar(self) -> None:
         """A list of row dicts pivots into a columnar dict."""
@@ -41,7 +41,7 @@ class TestPythonDictFramework:
 
         input_data = [{"col1": 1, "col2": "a"}, {"col1": 2, "col2": "b"}]
 
-        result = framework.transform(input_data, set())
+        result = framework.transform(input_data, [])
         assert result == {"col1": [1, 2], "col2": ["a", "b"]}
 
     def test_transform_empty_data_returns_empty_dict(self) -> None:
@@ -49,8 +49,8 @@ class TestPythonDictFramework:
         None is NOT an empty: it raises, pinned by ``test_transform_none_raises``."""
         framework = PythonDictFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
 
-        assert framework.transform([], set()) == {}
-        assert framework.transform({}, set()) == {}
+        assert framework.transform([], []) == {}
+        assert framework.transform({}, []) == {}
 
     def test_transform_none_raises(self) -> None:
         """``None`` is a MISSING result (state A), not a representational empty.
@@ -63,14 +63,14 @@ class TestPythonDictFramework:
         framework = PythonDictFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
 
         with pytest.raises(ValueError, match="Data type .* is not supported"):
-            framework.transform(None, set())
+            framework.transform(None, [])
 
     def test_transform_invalid_data(self) -> None:
         """Test that invalid data types raise errors."""
         framework = PythonDictFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
 
         with pytest.raises(ValueError, match="Data type .* is not supported"):
-            framework.transform("invalid", set())
+            framework.transform("invalid", [])
 
     @pytest.mark.parametrize("falsy_value", [0, False, ""])
     def test_transform_falsy_unsupported_data_raises(self, falsy_value: Any) -> None:
@@ -82,7 +82,7 @@ class TestPythonDictFramework:
         framework = PythonDictFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
 
         with pytest.raises(ValueError, match="Data type .* is not supported"):
-            framework.transform(falsy_value, set())
+            framework.transform(falsy_value, [])
 
     def test_select_data_by_column_names(self) -> None:
         """Test columnar column selection functionality."""
@@ -90,7 +90,7 @@ class TestPythonDictFramework:
 
         data: dict[str, list[Any]] = {"col1": [1, 2], "col2": ["a", "b"], "col3": [10, 20]}
 
-        feature_names = {FeatureName("col1"), FeatureName("col2")}
+        feature_names = [FeatureName("col1"), FeatureName("col2")]
 
         result = framework.select_data_by_column_names(data, feature_names)
         assert result == {"col1": [1, 2], "col2": ["a", "b"]}
@@ -106,7 +106,7 @@ class TestPythonDictFramework:
 
         framework.data = {"a": [1, 2], "b": [3, 4]}
 
-        result = framework.select_data_by_column_names(framework.data, {FeatureName("a")})
+        result = framework.select_data_by_column_names(framework.data, [FeatureName("a")])
         assert result == {"a": [1, 2]}
 
         result["a"].append(99)
@@ -117,7 +117,7 @@ class TestPythonDictFramework:
         """Empty data ({}) is propagated as {} in column selection (no judgement)."""
         framework = PythonDictFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
 
-        feature_names = {FeatureName("col1")}
+        feature_names = [FeatureName("col1")]
 
         assert framework.select_data_by_column_names({}, feature_names) == {}
 

--- a/tests/test_plugins/compute_framework/base_implementations/spark/test_spark_framework.py
+++ b/tests/test_plugins/compute_framework/base_implementations/spark/test_spark_framework.py
@@ -133,7 +133,7 @@ class TestSparkFrameworkComputeFramework:
         spark_framework.set_framework_connection_object(spark_session)
 
         dict_data = {"column1": [1, 2, 3], "column2": [4, 5, 6]}
-        result = spark_framework.transform(dict_data, set())
+        result = spark_framework.transform(dict_data, [])
         result_data = result.collect()
 
         expected_data = spark_session.createDataFrame(
@@ -150,7 +150,7 @@ class TestSparkFrameworkComputeFramework:
         spark_framework.set_framework_connection_object(spark_session)
 
         with pytest.raises(ValueError):
-            spark_framework.transform(data=["a"], feature_names=set())
+            spark_framework.transform(data=["a"], feature_names=[])
 
     def test_select_data_by_column_names(self, spark_session: Any) -> None:
         spark_framework = SparkFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
@@ -158,7 +158,7 @@ class TestSparkFrameworkComputeFramework:
         expected_data = spark_session.createDataFrame(
             [{"column1": 1, "column2": 4}, {"column1": 2, "column2": 5}, {"column1": 3, "column2": 6}]
         )
-        data = spark_framework.select_data_by_column_names(expected_data, {FeatureName("column1")})
+        data = spark_framework.select_data_by_column_names(expected_data, [FeatureName("column1")])
         assert data.columns == ["column1"]
 
     def test_set_column_names(self, spark_session: Any) -> None:
@@ -270,7 +270,7 @@ class TestSparkFrameworkComputeFramework:
         spark_framework = SparkFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
         spark_framework.set_framework_connection_object(spark_session)
 
-        result = spark_framework.transform({}, set())
+        result = spark_framework.transform({}, [])
         assert result is not None
         assert result.count() == 0
 
@@ -293,7 +293,7 @@ class TestSparkFrameworkComputeFramework:
         )
         spark_framework.data = existing
 
-        result = spark_framework.transform([10, 20, 30], {"new_feature"})
+        result = spark_framework.transform([10, 20, 30], ["new_feature"])
         rows = result.collect()
 
         by_other = {row["other"]: row for row in rows}

--- a/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_framework.py
+++ b/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_framework.py
@@ -41,7 +41,7 @@ class TestSqliteFrameworkBasics:
         fw = SqliteFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
         fw.set_framework_connection_object(connection)
         dict_data = {"column1": [1, 2, 3], "column2": [4, 5, 6]}
-        result = fw.transform(dict_data, set())
+        result = fw.transform(dict_data, [])
         assert isinstance(result, SqliteRelation)
         assert len(result) == 3
         assert set(result.columns) == {"column1", "column2"}
@@ -49,7 +49,7 @@ class TestSqliteFrameworkBasics:
     def test_transform_invalid_data(self) -> None:
         fw = SqliteFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
         with pytest.raises(ValueError):
-            fw.transform(data=["a"], feature_names=set())
+            fw.transform(data=["a"], feature_names=[])
 
     def test_select_data_by_column_names(self, connection: sqlite3.Connection) -> None:
         fw = SqliteFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
@@ -58,7 +58,7 @@ class TestSqliteFrameworkBasics:
         arrow = pa.Table.from_pydict({"column1": [1, 2, 3], "column2": [4, 5, 6]})
         data = SqliteRelation.from_arrow(connection, arrow)
 
-        result = fw.select_data_by_column_names(data, {FeatureName("column1")})
+        result = fw.select_data_by_column_names(data, [FeatureName("column1")])
         assert "column1" in result.columns
 
     def test_set_framework_connection_object_none_raises(self) -> None:
@@ -95,20 +95,20 @@ class TestSqliteFrameworkBasics:
         """transform() with a plain int raises ValueError."""
         fw = SqliteFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
         with pytest.raises(ValueError):
-            fw.transform(data=42, feature_names=set())
+            fw.transform(data=42, feature_names=[])
 
     def test_transform_dict_no_connection_raises(self) -> None:
         """transform() with dict but no connection set raises ValueError."""
         fw = SqliteFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
         with pytest.raises(ValueError, match="not set"):
-            fw.transform(data={"col": [1, 2]}, feature_names=set())
+            fw.transform(data={"col": [1, 2]}, feature_names=[])
 
     def test_transform_add_column_preserves_existing(self, connection: sqlite3.Connection) -> None:
         fw = SqliteFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
         fw.set_framework_connection_object(connection)
         dict_data = {"col_a": [1, 2, 3], "col_b": [4, 5, 6]}
-        fw.data = fw.transform(dict_data, set())
-        result = fw.transform(data=[7, 8, 9], feature_names={"col_c"})
+        fw.data = fw.transform(dict_data, [])
+        result = fw.transform(data=[7, 8, 9], feature_names=["col_c"])
         assert set(result.columns) == {"col_a", "col_b", "col_c"}
         assert len(result) == 3
         arrow = result.to_arrow_table()

--- a/tests/test_plugins/feature_group/input_data/test_read_dbs/test_sqlite.py
+++ b/tests/test_plugins/feature_group/input_data/test_read_dbs/test_sqlite.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import pyarrow as pa
 
 from mloda.user import Feature
+from mloda.user import Options
 from mloda.provider import FeatureSet
 from mloda_plugins.feature_group.input_data.read_dbs.sqlite import SQLITEReader
 
@@ -117,6 +118,28 @@ class TestSQLITEReader:
         )
         # Assert the result is the mocked table
         assert result == table
+
+    def test_build_query_columns_sorted(self) -> None:
+        """SELECT column order must be deterministic (alphabetically sorted), not
+        dependent on FeatureSet.features set iteration order / PYTHONHASHSEED (#613)."""
+        feature_set = FeatureSet()
+        # Deliberately non-alphabetical insertion order; six names so at least one
+        # PYTHONHASHSEED reorders the underlying set against the sorted expectation.
+        names = ["c_col", "a_col", "f_col", "b_col", "e_col", "d_col"]
+        for name in names:
+            feature_set.add(
+                Feature(
+                    name,
+                    options=Options(context={"BaseInputData": (SQLITEReader, {"table_name": "test_table"})}),
+                )
+            )
+
+        query = SQLITEReader.build_query(feature_set)
+
+        columns_part = query[len("select ") :].split(" from")[0]
+        columns = [col.strip() for col in columns_part.split(",")]
+
+        assert columns == sorted(names), f"build_query emitted columns {columns}, expected {sorted(names)}"
 
     def test_get_table_missing_options(self) -> None:
         with pytest.raises(ValueError, match="Options were not set."):

--- a/tests/test_plugins/feature_group/input_data/test_read_files/test_deterministic_column_order.py
+++ b/tests/test_plugins/feature_group/input_data/test_read_files/test_deterministic_column_order.py
@@ -1,0 +1,123 @@
+import json
+import shutil
+import tempfile
+from typing import Any
+
+import pyarrow as pa
+import pyarrow.feather as pyarrow_feather
+import pyarrow.orc as pyarrow_orc
+import pyarrow.parquet as pyarrow_parquet
+
+from mloda_plugins.feature_group.input_data.read_files.csv import CsvReader
+from mloda_plugins.feature_group.input_data.read_files.feather import FeatherReader
+from mloda_plugins.feature_group.input_data.read_files.json import JsonReader
+from mloda_plugins.feature_group.input_data.read_files.orc import OrcReader
+from mloda_plugins.feature_group.input_data.read_files.parquet import ParquetReader
+
+
+class FeatureSetStub:
+    """Mirrors FeatureSet.get_all_names() which returns an alphabetically sorted tuple."""
+
+    def __init__(self, columns: list[str]) -> None:
+        self.columns = columns
+
+    def get_all_names(self) -> tuple[str, ...]:
+        return tuple(sorted(self.columns))
+
+
+class TestDeterministicColumnOrder:
+    """The five read-files plugins must materialize get_all_names() (a sorted tuple) in a
+    deterministic, alphabetically sorted order so the output column order does not
+    depend on PYTHONHASHSEED."""
+
+    base_path: Any = None
+    physical_columns: Any = None
+    sorted_columns: Any = None
+    feather_file: Any = None
+    json_file: Any = None
+    csv_file: Any = None
+    orc_file: Any = None
+    parquet_file: Any = None
+
+    @classmethod
+    def setup_class(cls) -> None:
+        cls.base_path = tempfile.mkdtemp(prefix="arrow_order_test_")
+
+        # Non-alphabetical physical column order to expose ordering bugs.
+        cls.physical_columns = ["c1", "a1", "b1"]
+        cls.sorted_columns = sorted(cls.physical_columns)  # ["a1", "b1", "c1"]
+
+        table = pa.Table.from_pydict({"c1": [1, 2, 3], "a1": [4, 5, 6], "b1": [7, 8, 9]})
+
+        cls.feather_file = f"{cls.base_path}/test.feather"
+        pyarrow_feather.write_feather(table, cls.feather_file)
+
+        cls.json_file = f"{cls.base_path}/test.json"
+        with open(cls.json_file, "w") as f:
+            rows = [{col: table.column(col)[i].as_py() for col in cls.physical_columns} for i in range(table.num_rows)]
+            for row in rows:
+                f.write(json.dumps(row) + "\n")
+
+        cls.csv_file = f"{cls.base_path}/test.csv"
+        import pyarrow.csv as pyarrow_csv
+
+        pyarrow_csv.write_csv(table, cls.csv_file)
+
+        cls.orc_file = f"{cls.base_path}/test.orc"
+        with pa.OSFile(cls.orc_file, "wb") as f:
+            pyarrow_orc.write_table(table, f)
+
+        cls.parquet_file = f"{cls.base_path}/test.parquet"
+        pyarrow_parquet.write_table(table, cls.parquet_file)
+
+    @classmethod
+    def teardown_class(cls) -> None:
+        shutil.rmtree(cls.base_path, ignore_errors=True)
+
+    def test_column_order_is_sorted(self) -> None:
+        test_cases: list[tuple[Any, Any]] = [
+            (FeatherReader, self.feather_file),
+            (JsonReader, self.json_file),
+            (CsvReader, self.csv_file),
+            (OrcReader, self.orc_file),
+            (ParquetReader, self.parquet_file),
+        ]
+
+        features = FeatureSetStub(self.physical_columns)
+
+        for cls, path in test_cases:
+            result = cls.load_data(path, features)
+            assert result.column_names == self.sorted_columns, (
+                f"{cls.__name__} returned columns {result.column_names}, expected {self.sorted_columns}"
+            )
+
+    def _all_readers(self) -> list[tuple[Any, Any]]:
+        return [
+            (FeatherReader, self.feather_file),
+            (JsonReader, self.json_file),
+            (CsvReader, self.csv_file),
+            (OrcReader, self.orc_file),
+            (ParquetReader, self.parquet_file),
+        ]
+
+    def test_empty_feature_set_returns_zero_columns(self) -> None:
+        """An empty get_all_names() (empty tuple) must yield a zero-column table
+        without raising. Regression lock for the already-sorted readers."""
+        features = FeatureSetStub([])
+
+        for cls, path in self._all_readers():
+            result = cls.load_data(path, features)
+            assert result.column_names == [], (
+                f"{cls.__name__} returned columns {result.column_names}, expected [] for empty feature set"
+            )
+
+    def test_single_column_feature_set_returns_that_column(self) -> None:
+        """A single-column feature set must return exactly that one column.
+        Regression lock for the already-sorted readers."""
+        features = FeatureSetStub(["a1"])
+
+        for cls, path in self._all_readers():
+            result = cls.load_data(path, features)
+            assert result.column_names == ["a1"], (
+                f"{cls.__name__} returned columns {result.column_names}, expected ['a1']"
+            )


### PR DESCRIPTION
## Summary

Fixes #613 at the root. `FeatureSet.get_all_names()` returned an unordered `set[str]`, so any order-materializing caller (`list(...)`, per-feature compute loops, SQL projection building) had PYTHONHASHSEED-dependent output column order.

This PR evolved in two stages (kept as separate commits):

1. **Call-site fix**: sort at each `list(get_all_names())` site in the five file readers plus the SQLite query builder, with determinism tests.
2. **Root-cause fix (breaking)**: make the accessors deterministic by construction so no caller can reintroduce the bug.

## Breaking changes

- `FeatureSet.get_all_names()` returns an alphabetically sorted, deduplicated `tuple[str, ...]` (was `set[str]`).
- `FeatureSet.get_initial_requested_features()` returns a sorted, deduplicated `tuple[FeatureName, ...]` (was `set[FeatureName]`).
- `ComputeFramework.transform`, `select_data_by_column_names`, `identify_naming_convention` and `DataLifecycleManager.get_result_data` take `collections.abc.Sequence` parameters (were `set`). Plugin overrides typed with `set` parameters must update their signatures; callers doing set operations on accessor results must wrap them in `set(...)`.

## Additions

- `FeatureSet.get_sorted_features() -> tuple[Feature, ...]` (sorted by name): deterministic iteration for callers that materialize column or query order. The per-feature compute loops in all experimental feature group base classes (aggregation, time window, forecasting, clustering, sklearn encoding/scaling/pipeline, geo distance, node centrality, text cleaning, missing value, dimensionality reduction) and the SQLite `build_query` now use it, so their output column order is deterministic as well.
- `identify_naming_convention`'s `request_order` branch dedups via `dict.fromkeys(...)`, so duplicate names in a caller-supplied sequence cannot emit duplicate columns.

## Notes

- Feather and ORC keep an explicit re-`.select()`: pyarrow's `read_table(columns=...)` filters but returns physical file order for those formats (parquet honors the requested order; verified empirically).
- `column_ordering="request_order"` previously iterated a set, so it never actually reflected the request sequence (hash-seed arbitrary). It is now deterministic (alphabetical at the source). True request-order fidelity needs the user's ordered feature list plumbed from the API request to selection time, which is a separate follow-up.
- Filter engine wraps the tuple in `set(...)` to keep O(1) membership.

## Tests

- New `FeatureSet` ordering contract tests (sorted tuple returns, `get_sorted_features`).
- Deterministic column-order tests for all five file readers (including empty and single-column cases) and the SQLite query builder.
- Full `tox` green: 4501 passed, ruff format/check, pip-licenses, mypy --strict, bandit.

## Definition of done

- [x] `get_all_names()` returns a deterministically-ordered collection.
- [x] No `list(get_all_names())` call site relies on set iteration order.
