### PR TITLE
test: cover bare-string input features for dual-consumption warning and name-mismatch guard

### DIFF
--- a/tests/test_plugins/integration_plugins/test_dual_option_consumption_warning.py
+++ b/tests/test_plugins/integration_plugins/test_dual_option_consumption_warning.py
@@ -139,6 +139,25 @@ class DualWarn579ConsumerGroup(_DualWarn579ConsumerBase):
         return {Feature(SOURCE_NAME)}
 
 
+class DualWarn579StringConsumerGroup(_DualWarn579ConsumerBase):
+    """Consumer that declares the mode key but requests its child as a BARE STRING.
+
+    The unified forwarding path gives the bare-string child its own fresh Options and
+    runs the real inherit_from merge, so it records forwarding provenance exactly like
+    an object child and must trigger the same dual-consumption warning.
+    """
+
+    FEATURE_NAME = "dualwarn579_string_consumer"
+    PROPERTY_MAPPING = {
+        MODE_KEY: {
+            "explanation": "Execution mode consumed by the dualwarn579 string consumer group",
+        },
+    }
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Any]]:
+        return {SOURCE_NAME}
+
+
 class DualWarn579RepeatConsumerGroup(_DualWarn579ConsumerBase):
     """Consumer matching TWO feature names so one class can be requested twice in one run."""
 
@@ -509,3 +528,82 @@ class TestDualOptionConsumptionWarningForwardingAttribution:
         assert "DualWarn579SourceGroup" in message
         # The non-forwarding consumer B must NOT be warned.
         assert "DualWarn579SharedConsumerBGroup" not in message
+
+
+class TestDualOptionConsumptionWarningStringChild:
+    """
+    Pins the dual-consumption warning for the BARE-STRING input-feature path (#620).
+
+    A bare-string child (input_features returning {SOURCE_NAME}, not {Feature(...)})
+    now runs the real inherit_from merge on its own fresh Options and records the same
+    forwarding provenance as an object child. The dual-consumption warning must fire
+    for it exactly as it does for an object child.
+    """
+
+    def test_warning_fires_for_bare_string_input_feature(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A bare-string child that inherits a dual-declared key triggers exactly one WARNING."""
+        DualWarn579SourceGroup.reset_recording()
+
+        consumer = Feature(
+            DualWarn579StringConsumerGroup.FEATURE_NAME,
+            options=Options(group={MODE_KEY: "fast"}),
+        )
+        with caplog.at_level(logging.WARNING):
+            results = _run([consumer], {DualWarn579SourceGroup, DualWarn579StringConsumerGroup})
+
+        # The run itself must succeed for the requested consumer feature.
+        frame = _frame_with_column(results, DualWarn579StringConsumerGroup.FEATURE_NAME)
+        assert frame[DualWarn579StringConsumerGroup.FEATURE_NAME].tolist() == [2, 4, 6]
+
+        records = _mode_warning_records(caplog)
+        assert len(records) == 1, (
+            f"Expected exactly one WARNING mentioning '{MODE_KEY}', got {len(records)}: "
+            f"{[record.getMessage() for record in records]}"
+        )
+        message = records[0].getMessage()
+        assert "DualWarn579StringConsumerGroup" in message
+        assert "DualWarn579SourceGroup" in message
+        assert "forward_group_exclude" in message
+
+        # The warning plus this seen_options check are the proof that the bare-string
+        # child inherited the forwarded key: the mode key actually reached the upstream
+        # source (the [2, 4, 6] value alone comes from the consumer's OWN mode).
+        assert len(DualWarn579SourceGroup.seen_options) == 1
+        assert MODE_KEY in DualWarn579SourceGroup.seen_options[0]["group"]
+
+    def test_bare_string_child_warns_and_forwards_but_wrapped_feature_exclude_decouples(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A bare-string input feature carries no per-child opt-out: it warns and forwards
+        the dual-declared key to the upstream source. The documented decouple is wrapping
+        it as Feature(name, forward_group_exclude={...}), which then warns not at all and
+        withholds the key. Both behaviors are contrasted on the SAME upstream seen_options.
+        """
+        # Bare-string child: no per-child opt-out, so it warns AND forwards the key.
+        DualWarn579SourceGroup.reset_recording()
+        bare_consumer = Feature(
+            DualWarn579StringConsumerGroup.FEATURE_NAME,
+            options=Options(group={MODE_KEY: "fast"}),
+        )
+        with caplog.at_level(logging.WARNING):
+            _run([bare_consumer], {DualWarn579SourceGroup, DualWarn579StringConsumerGroup})
+
+        assert len(_mode_warning_records(caplog)) == 1
+        assert len(DualWarn579SourceGroup.seen_options) == 1
+        assert MODE_KEY in DualWarn579SourceGroup.seen_options[0]["group"]
+
+        # Wrapped child with forward_group_exclude: no warning AND the key is withheld.
+        caplog.clear()
+        DualWarn579SourceGroup.reset_recording()
+        wrapped_consumer = Feature(
+            DualWarn579ExcludeConsumerGroup.FEATURE_NAME,
+            options=Options(group={MODE_KEY: "fast"}),
+        )
+        with caplog.at_level(logging.WARNING):
+            _run([wrapped_consumer], {DualWarn579SourceGroup, DualWarn579ExcludeConsumerGroup})
+
+        assert _mode_warning_records(caplog) == []
+        assert len(DualWarn579SourceGroup.seen_options) == 1
+        upstream = DualWarn579SourceGroup.seen_options[0]
+        assert MODE_KEY not in upstream["group"]
+        assert MODE_KEY not in upstream["context"]

--- a/tests/test_plugins/integration_plugins/test_forwarded_name_mismatch_e2e.py
+++ b/tests/test_plugins/integration_plugins/test_forwarded_name_mismatch_e2e.py
@@ -40,6 +40,7 @@ SOURCE_NAME = "namemis579_source"
 OPERATION_KEY = "operation_namemis579"
 CHAINED_CHILD_NAME = f"{SOURCE_NAME}__sum_namemis579"
 CONSUMER_NAME = "namemis579_consumer"
+STRING_CONSUMER_NAME = "namemis579_string_consumer"
 
 
 class NameMis579SourceGroup(FeatureGroup):
@@ -125,6 +126,52 @@ class NameMis579ConsumerGroup(FeatureGroup):
         for feature in features.features:
             data[feature.name] = data[CHAINED_CHILD_NAME]
         return data
+
+
+class NameMis579StringConsumerGroup(FeatureGroup):
+    """Consumer requesting the chained child as a BARE STRING; forwards options by default.
+
+    On the unified forwarding path the bare-string child runs the real inherit_from
+    merge, so the forwarded operation key must trip the forwarded-name-mismatch guard
+    exactly like an object child does.
+    """
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: str | FeatureName,
+        options: Options,
+        data_access_collection: Any = None,
+    ) -> bool:
+        return str(feature_name) == STRING_CONSUMER_NAME
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Any]]:
+        return {CHAINED_CHILD_NAME}
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        for feature in features.features:
+            data[feature.name] = data[CHAINED_CHILD_NAME]
+        return data
+
+
+class TestForwardedNameMismatchStringChildEndToEnd:
+    def test_run_all_raises_on_forwarded_name_mismatch_for_bare_string_child(self) -> None:
+        """A group option contradicting the bare-string child's name-parsed value fails the run."""
+        consumer = Feature(STRING_CONSUMER_NAME, options=Options(group={OPERATION_KEY: "max"}))
+
+        with pytest.raises(ValueError, match=OPERATION_KEY):
+            mloda.run_all(
+                [consumer],
+                compute_frameworks={PandasDataFrame},
+                plugin_collector=PluginCollector.enabled_feature_groups(
+                    {NameMis579SourceGroup, NameMis579ChainedGroup, NameMis579StringConsumerGroup}
+                ),
+            )
 
 
 class TestForwardedNameMismatchEndToEnd:


### PR DESCRIPTION
## Summary

Closes #620. Adds integration test coverage proving the three provenance-keyed guards now fire on the **bare-string input-feature path**, which was previously untested (all prior cases used `Feature(...)` objects).

The unified string/object input-feature forwarding path (merged in `af1f78a`, "fix!: unify string and object input-feature option forwarding") gives a bare-string input feature (`input_features()` returning `{"name"}` instead of `{Feature("name")}`) its own fresh `Options` and runs the real `inherit_from` merge, so it records forwarding provenance (`inherited_group_keys` / `last_forwarded_group_keys`) exactly like an object child. The three guards that key off that provenance therefore now reach bare-string children. This PR pins that behavior with tests; no product source was changed.

## Coverage added

1. **Dual-option-consumption WARNING** (`test_dual_option_consumption_warning.py`): a bare-string child that inherits a key declared in both the consumer's and the resolved child's `PROPERTY_MAPPING` triggers exactly one warning, and the forwarded key is asserted to actually reach the upstream source (`seen_options`).
2. **Opt-out / decouple contract**: a bare string carries no per-child opt-out, so it warns and forwards; the documented decouple is wrapping it as `Feature(name, forward_group_exclude={...})`, which then warns not at all and withholds the key. Both behaviors are contrasted on the same upstream `seen_options`.
3. **Forwarded-name-mismatch guard** (`test_forwarded_name_mismatch_e2e.py`): a bare-string chained child whose forwarded value contradicts its name-parsed value raises `ValueError` during resolution.

## Validation

- `tox` green: 4516 passed, ruff format, ruff check, pip-licenses allowlist, `mypy --strict`, bandit.
- Two independent reviews (a fresh Claude Opus agent and codex). The Opus pass caught that the first draft of the decouple test duplicated an existing object-path test without exercising the string path; it was reworked into the string-vs-wrapped contrast described above. codex found no issues.

## Notes

- Bare-string `input_features` overrides are annotated `Optional[set[Any]]` (matching the existing pattern at `test_pandas_asof_merge_engine.py`) to keep the LSP override valid under `mypy --strict` without widening the base `Optional[set[Feature]]` signature.
