### PR TITLE
fix: cycle-safe Feature equality/hash for child_options (#608)

### DIFF
--- a/mloda/core/abstract_plugins/components/feature.py
+++ b/mloda/core/abstract_plugins/components/feature.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import copy
 from typing import TYPE_CHECKING, Any, Optional
 from uuid import uuid4
 from mloda.core.abstract_plugins.components.data_types import DataType
@@ -17,7 +16,6 @@ from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.components.options import Options, validate_forwarding_directives
 from mloda.core.abstract_plugins.components.utils import get_all_subclasses
 from mloda.core.abstract_plugins.components.validators.feature_validator import FeatureValidator
-from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
 
 
 class Feature:
@@ -108,6 +106,7 @@ class Feature:
                     f"got {type(data_type).__name__}"
                 )
 
+        # Engine-stamped consumer metadata; in equality/hash via cycle-safe _child_options_key (#608).
         self.child_options: Optional[Options] = None
 
         self.initial_requested_data = initial_requested_data
@@ -319,7 +318,7 @@ class Feature:
             and self.domain == other.domain
             and self.compute_frameworks == other.compute_frameworks
             and self.data_type == other.data_type
-            and self.child_options == other.child_options
+            and self._child_options_key() == other._child_options_key()
         )
 
     def __hash__(self) -> int:
@@ -327,20 +326,57 @@ class Feature:
             frozenset(self.compute_frameworks) if self.compute_frameworks is not None else None
         )
 
-        child_options = copy.deepcopy(self.child_options)
-        if child_options:
-            if child_options.get(DefaultOptionKeys.in_features):
-                val = child_options.get(DefaultOptionKeys.in_features)
+        return hash(
+            (
+                self.name,
+                self.options,
+                self.domain,
+                compute_frameworks_hashable,
+                self.data_type,
+                self._child_options_key(),
+            )
+        )
 
-                if isinstance(val, frozenset):
-                    for v in val:
-                        if isinstance(v, Feature):
-                            child_options.group[DefaultOptionKeys.in_features] = v.name
+    def _child_options_key(self) -> Any:
+        """Cycle-safe identity view of child_options for __eq__/__hash__ (#608).
 
-                if isinstance(val, Feature):
-                    child_options.group[DefaultOptionKeys.in_features] = val.name
+        child_options can hold features value-equal to self, so a deep compare recurses
+        forever. _reduce mirrors the Feature.__eq__/Options.__eq__ fields, with an id()
+        visited guard that collapses an already-seen feature to its name to terminate.
+        """
+        if self.child_options is None:
+            return None
+        return self._reduce(self.child_options.group, frozenset())
 
-        return hash((self.name, self.options, self.domain, compute_frameworks_hashable, self.data_type, child_options))
+    @staticmethod
+    def _reduce(value: Any, seen: frozenset[int]) -> Any:
+        if isinstance(value, Feature):
+            if id(value) in seen:
+                return ("feature", value.name)
+            seen = seen | {id(value)}
+            compute_frameworks = frozenset(value.compute_frameworks) if value.compute_frameworks is not None else None
+            child_group = Feature._reduce(value.child_options.group, seen) if value.child_options is not None else None
+            return (
+                "feature",
+                value.name,
+                Feature._reduce(value.options.group, seen),
+                Feature._reduce(value.options.context, seen),
+                value.domain,
+                compute_frameworks,
+                value.data_type,
+                child_group,
+            )
+        if isinstance(value, Options):
+            return ("options", Feature._reduce(value.group, seen))
+        if isinstance(value, dict):
+            return tuple(
+                sorted(((key, Feature._reduce(val, seen)) for key, val in value.items()), key=lambda kv: kv[0])
+            )
+        if isinstance(value, (frozenset, set)):
+            return frozenset(Feature._reduce(item, seen) for item in value)
+        if isinstance(value, (list, tuple)):
+            return tuple(Feature._reduce(item, seen) for item in value)
+        return _make_hashable(value)
 
     def is_different_data_type(self, other: Feature) -> bool:
         return self.name == other.name and self.data_type != other.data_type

--- a/tests/test_core/test_abstract_plugins/test_components/test_feature_eq_child_options_cycle.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_feature_eq_child_options_cycle.py
@@ -1,0 +1,109 @@
+"""Regression tests for #608: cyclic child_options must not recurse forever in Feature.__eq__/__hash__."""
+
+from __future__ import annotations
+
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+
+
+def _make_cyclic_feature(name: str) -> Feature:
+    """Build a feature whose child_options in_features frozenset holds a value-equal copy, closing the cycle."""
+    child = Feature(name)
+    nested = Feature(name)
+    child.child_options = Options(group={DefaultOptionKeys.in_features: frozenset({nested})})
+    nested.child_options = Options(group={DefaultOptionKeys.in_features: frozenset({child})})
+    return child
+
+
+def test_feature_eq_with_cyclic_child_options_terminates() -> None:
+    """Directly comparing two value-equal cyclic features must terminate, not recurse forever."""
+    child = _make_cyclic_feature("src")
+    other_child = _make_cyclic_feature("src")
+
+    assert (child == other_child) is True
+
+
+def test_feature_eq_cyclic_child_options_detects_inequality() -> None:
+    """Cyclic features with different names must compare unequal without recursing forever."""
+    child = _make_cyclic_feature("src")
+    different = _make_cyclic_feature("other")
+
+    assert (child == different) is False
+
+
+def test_feature_hash_with_cyclic_child_options_terminates() -> None:
+    """Hashing a cyclic feature must terminate and stay consistent with equality."""
+    child = _make_cyclic_feature("src")
+    other_child = _make_cyclic_feature("src")
+
+    assert hash(child) == hash(other_child)
+
+
+def test_cyclic_features_usable_as_set_and_dict_members() -> None:
+    """Value-equal cyclic features must collapse in a set and be usable as dict keys."""
+    child = _make_cyclic_feature("src")
+    other_child = _make_cyclic_feature("src")
+
+    collapsed = {child, other_child}
+    assert len(collapsed) == 1
+
+    mapping = {child: "value"}
+    assert mapping[other_child] == "value"
+
+
+def test_feature_eq_dict_nested_feature_cycle_terminates() -> None:
+    """A Feature hidden inside a nested dict in child_options must not cause RecursionError (GAP A)."""
+    child_a = Feature("child")
+    nested_a = Feature("child")
+    child_a.child_options = Options(group={"wrapper": {"src": nested_a}})
+    nested_a.child_options = Options(group={"wrapper": {"src": child_a}})
+
+    child_b = Feature("child")
+    nested_b = Feature("child")
+    child_b.child_options = Options(group={"wrapper": {"src": nested_b}})
+    nested_b.child_options = Options(group={"wrapper": {"src": child_b}})
+
+    assert child_a == child_b
+    assert hash(child_a) == hash(child_b)
+    assert len({child_a, child_b}) == 1
+
+
+def test_feature_eq_options_nested_feature_cycle_terminates() -> None:
+    """A Feature hidden inside a nested Options in child_options must not cause RecursionError (GAP A)."""
+    child_a = Feature("child")
+    nested_a = Feature("child")
+    child_a.child_options = Options(
+        group={"nested": Options(group={DefaultOptionKeys.in_features: frozenset({nested_a})})}
+    )
+    nested_a.child_options = Options(
+        group={"nested": Options(group={DefaultOptionKeys.in_features: frozenset({child_a})})}
+    )
+
+    child_b = Feature("child")
+    nested_b = Feature("child")
+    child_b.child_options = Options(
+        group={"nested": Options(group={DefaultOptionKeys.in_features: frozenset({nested_b})})}
+    )
+    nested_b.child_options = Options(
+        group={"nested": Options(group={DefaultOptionKeys.in_features: frozenset({child_b})})}
+    )
+
+    assert child_a == child_b
+    assert hash(child_a) == hash(child_b)
+    assert len({child_a, child_b}) == 1
+
+
+def test_feature_eq_nested_in_features_options_distinguished() -> None:
+    """Same-named in_features children with different options must not collapse (GAP B)."""
+    child_a = Feature("src", options={"variant": "A"})
+    child_b = Feature("src", options={"variant": "B"})
+
+    parent_a = Feature("consumer")
+    parent_b = Feature("consumer")
+    parent_a.child_options = Options(group={DefaultOptionKeys.in_features: frozenset({child_a})})
+    parent_b.child_options = Options(group={DefaultOptionKeys.in_features: frozenset({child_b})})
+
+    assert child_a != child_b
+    assert parent_a != parent_b, "same-named in_features children with different options must not collapse"
+    assert len({parent_a, parent_b}) == 2


### PR DESCRIPTION
## Summary

Fixes #608. `Feature.__eq__` compared `self.child_options == other.child_options` directly. `child_options` is engine-stamped consumer metadata whose `group[in_features]` frozenset can hold a `Feature` value-equal to the feature carrying it (the cycle is closed when `Features.build_feature_collection` stamps `feature.child_options`). Comparing those features re-entered `Feature.__eq__` on the cycle, so equality never terminated and raised a nondeterministic `RecursionError` (only tripped on hash-bucket collisions, hence the intermittent, ordering-dependent failures).

## Fix

Introduce `Feature._child_options_key()`, a cycle-safe identity view of `child_options` used by both `__eq__` and `__hash__`:

- Walks `child_options.group` through dicts, nested `Options`, and every container so no `Feature` object survives unreduced (previously a naive comparison recursed forever, and an intermediate name-only reducer still crashed on dict-nested and Options-nested shapes).
- Reduces each nested `Feature` to its full `__eq__`-relevant identity (name, options group, options context, domain, compute frameworks, data type, and recursively its own `child_options`), so it preserves the original deep equality classes rather than coarsening them to names (which would have collapsed same-named `in_features` children that differ only in their options).
- An `id()`-based visited guard collapses any already-seen feature to its name, guaranteeing termination for self- and mutual cycles.

Both `__eq__` and `__hash__` route through the same key, so the equal-objects-equal-hashes contract holds. This replaces the previous fragile `__hash__` flattening workaround and restores `origin/main`'s equivalence classes minus the infinite recursion.

## Tests

New regression file `test_feature_eq_child_options_cycle.py` covers:
- Two value-equal features whose `in_features` frozenset closes a cycle (the reported case): equality, inequality detection, hash consistency, and set/dict membership all terminate.
- A `Feature` hidden in a nested dict forming a mutual cycle.
- A `Feature` hidden in a nested `Options` forming a mutual cycle.
- Same-named `in_features` children with different options must not collapse.

## Validation

Full `tox` is green: 4498 passed, 171 skipped; `ruff format`/`ruff check`/`mypy --strict`/`bandit` all pass.

Reviewed independently by a fresh Claude Opus agent and codex; both findings (incomplete cycle traversal for dict/Options shapes, and over-coarse name-only equality) were accepted and are addressed here.

## Definition of done

- [x] Equality between features with cyclic `child_options` references terminates
- [x] Regression test with two value-equal `in_features` children across two consumers
- [x] tox passes