### PR TITLE
fix: return forwarded key set from inherit_from, drop self-merge clobber (#624)

### DIFF
--- a/attribution/ATTRIBUTION.md
+++ b/attribution/ATTRIBUTION.md
@@ -4,7 +4,7 @@
 | PyYAML                                 | 6.0.3           | MIT License                                        |
 | Pygments                               | 2.20.0          | BSD-2-Clause                                       |
 | annotated-types                        | 0.7.0           | MIT License                                        |
-| ast_serialize                          | 0.5.0           | MIT                                                |
+| ast_serialize                          | 0.6.0           | MIT                                                |
 | asttokens                              | 3.0.1           | Apache 2.0                                         |
 | bandit                                 | 1.9.4           | Apache-2.0                                         |
 | cachetools                             | 6.2.6           | MIT                                                |
@@ -30,18 +30,17 @@
 | joblib                                 | 1.5.3           | BSD-3-Clause                                       |
 | jupyter_client                         | 8.9.1           | BSD License                                        |
 | jupyter_core                           | 5.9.1           | BSD-3-Clause                                       |
-| librt                                  | 0.11.0          | MIT                                                |
+| librt                                  | 0.12.0          | MIT                                                |
 | markdown-it-py                         | 4.2.0           | MIT License                                        |
 | matplotlib-inline                      | 0.2.2           | BSD-3-Clause                                       |
 | mdurl                                  | 0.1.2           | MIT License                                        |
 | mktestdocs                             | 0.2.5           | MIT                                                |
-| mloda                                  | 0.8.0           | Apache-2.0                                         |
+| mloda                                  | 0.9.0           | Apache-2.0                                         |
 | mmh3                                   | 5.2.1           | MIT License                                        |
 | msgpack                                | 1.2.1           | Apache-2.0                                         |
 | mypy                                   | 2.1.0           | MIT                                                |
 | mypy_extensions                        | 1.1.0           | MIT                                                |
 | narwhals                               | 2.22.1          | MIT                                                |
-| nest-asyncio                           | 1.6.0           | BSD License                                        |
 | nest-asyncio2                          | 1.7.2           | BSD License                                        |
 | nltk                                   | 3.9.4           | Apache Software License                            |
 | numpy                                  | 2.5.0           | BSD-3-Clause AND 0BSD AND MIT AND Zlib AND CC0-1.0 |
@@ -55,7 +54,7 @@
 | packageurl-python                      | 0.17.6          | MIT License                                        |
 | packaging                              | 26.2            | Apache-2.0 OR BSD-2-Clause                         |
 | pandas                                 | 3.0.3           | BSD License                                        |
-| pandera                                | 0.32.0          | MIT License                                        |
+| pandera                                | 0.32.1          | MIT License                                        |
 | parso                                  | 0.8.7           | MIT License                                        |
 | pathspec                               | 1.1.1           | Mozilla Public License 2.0 (MPL 2.0)               |
 | pexpect                                | 4.9.0           | ISC License (ISCL)                                 |
@@ -64,8 +63,8 @@
 | pip_audit                              | 2.10.1          | Apache Software License                            |
 | platformdirs                           | 4.10.0          | MIT License                                        |
 | pluggy                                 | 1.6.0           | MIT License                                        |
-| polars                                 | 1.42.0          | MIT License                                        |
-| polars-runtime-32                      | 1.42.0          | MIT License                                        |
+| polars                                 | 1.42.1          | MIT License                                        |
+| polars-runtime-32                      | 1.42.1          | MIT License                                        |
 | prompt_toolkit                         | 3.0.52          | BSD License                                        |
 | psutil                                 | 7.2.2           | BSD-3-Clause                                       |
 | ptyprocess                             | 0.7.0           | ISC License (ISCL)                                 |

--- a/mloda/core/abstract_plugins/components/feature.py
+++ b/mloda/core/abstract_plugins/components/feature.py
@@ -123,6 +123,10 @@ class Feature:
         # feature as an input feature; excluded from equality and hash like link/index.
         self.consumer_attributions: list[tuple[str, frozenset[str]]] = []
 
+        # Resolution-only metadata set by Features.merge_options from the inherit_from return: the
+        # group keys forwarded onto this input feature; excluded from equality and hash like link/index.
+        self.forwarded_group_keys: frozenset[str] = frozenset()
+
         # forward_group, forward_group_exclude and inherit_context_keys are merge directives
         # for input features with forward-by-default semantics (None/True inherit all consumer
         # group options, False isolates, an allowlist restricts, exclude subtracts),

--- a/mloda/core/abstract_plugins/components/feature.py
+++ b/mloda/core/abstract_plugins/components/feature.py
@@ -123,8 +123,8 @@ class Feature:
         # feature as an input feature; excluded from equality and hash like link/index.
         self.consumer_attributions: list[tuple[str, frozenset[str]]] = []
 
-        # Resolution-only metadata set by Features.merge_options from the inherit_from return: the
-        # group keys forwarded onto this input feature; excluded from equality and hash like link/index.
+        # Group keys forwarded onto this input feature, set by Features.merge_options; excluded
+        # from equality and hash like link/index.
         self.forwarded_group_keys: frozenset[str] = frozenset()
 
         # forward_group, forward_group_exclude and inherit_context_keys are merge directives

--- a/mloda/core/abstract_plugins/components/feature_collection.py
+++ b/mloda/core/abstract_plugins/components/feature_collection.py
@@ -59,7 +59,8 @@ class Features:
 
     def merge_options(self, feature: Feature, child_options: Options) -> None:
         """
-        Apply forward-by-default inheritance of the consumer's options onto the input feature.
+        Apply forward-by-default inheritance of the consumer's options onto the input feature and
+        record the forwarded group-key set on the feature.
 
         Delegates to Options.inherit_from: the input feature inherits ALL consumer group
         keys by default; feature.forward_group=False isolates it, an allowlist restricts
@@ -74,7 +75,7 @@ class Features:
         Raises:
             ValueError: If an inherited key conflicts with an existing value
         """
-        feature.options.inherit_from(
+        feature.forwarded_group_keys = feature.options.inherit_from(
             child_options,
             forward_group=feature.forward_group,
             forward_group_exclude=feature.forward_group_exclude,

--- a/mloda/core/abstract_plugins/components/feature_collection.py
+++ b/mloda/core/abstract_plugins/components/feature_collection.py
@@ -59,8 +59,8 @@ class Features:
 
     def merge_options(self, feature: Feature, child_options: Options) -> None:
         """
-        Apply forward-by-default inheritance of the consumer's options onto the input feature and
-        record the forwarded group-key set on the feature.
+        Apply forward-by-default inheritance onto the input feature and record the forwarded
+        group-key set on it.
 
         Delegates to Options.inherit_from: the input feature inherits ALL consumer group
         keys by default; feature.forward_group=False isolates it, an allowlist restricts

--- a/mloda/core/abstract_plugins/components/options.py
+++ b/mloda/core/abstract_plugins/components/options.py
@@ -296,7 +296,7 @@ class Options:
         forward_group_exclude: frozenset[str] = frozenset(),
         inherit_context_keys: frozenset[str] = frozenset(),
         owner: str | None = None,
-    ) -> None:
+    ) -> frozenset[str]:
         """
         Inherit options from the consumer feature that declared this input feature.
 
@@ -332,6 +332,9 @@ class Options:
         The optional ``owner`` (the input feature's name) only enriches the forwarding-conflict
         error message; it changes no behavior otherwise.
 
+        Returns the frozenset of group keys actually forwarded this call. The self-merge no-op
+        returns frozenset() and no longer resets last_forwarded_group_keys.
+
         Raises:
             ValueError: If a forwarded group key already exists on self with a different value
                         (rich message naming the key, both values, and the opt-out remedies,
@@ -344,9 +347,9 @@ class Options:
             # A child that shares the consumer's own Options instance has nothing to forward; treat it
             # as a no-op so a user/plugin passing the consumer's own Options does not self-copy values or
             # stamp self-referential provenance. Bundled code never hits this (string children get a fresh
-            # Options); it is purely defensive.
-            self.last_forwarded_group_keys = frozenset()
-            return
+            # Options); it is purely defensive. Preserves last_forwarded_group_keys (no clobber on a
+            # possibly-shared instance) and returns the empty forwarded set.
+            return frozenset()
 
         memo: dict[int, Any] = {}
 
@@ -409,3 +412,4 @@ class Options:
             inherited_context.update(propagating.keys())
 
         self.inherited_context_keys = self.inherited_context_keys | frozenset(inherited_context)
+        return frozenset(inherited)

--- a/mloda/core/abstract_plugins/components/options.py
+++ b/mloda/core/abstract_plugins/components/options.py
@@ -332,8 +332,7 @@ class Options:
         The optional ``owner`` (the input feature's name) only enriches the forwarding-conflict
         error message; it changes no behavior otherwise.
 
-        Returns the frozenset of group keys actually forwarded this call. The self-merge no-op
-        returns frozenset() and no longer resets last_forwarded_group_keys.
+        Returns the group keys forwarded this call; the self-merge no-op returns frozenset().
 
         Raises:
             ValueError: If a forwarded group key already exists on self with a different value
@@ -344,11 +343,9 @@ class Options:
                         or forward_group=False is combined with a non-empty forward_group_exclude.
         """
         if consumer is self:
-            # A child that shares the consumer's own Options instance has nothing to forward; treat it
-            # as a no-op so a user/plugin passing the consumer's own Options does not self-copy values or
-            # stamp self-referential provenance. Bundled code never hits this (string children get a fresh
-            # Options); it is purely defensive. Preserves last_forwarded_group_keys (no clobber on a
-            # possibly-shared instance) and returns the empty forwarded set.
+            # A child sharing the consumer's own Options has nothing to forward: no-op. Return
+            # frozenset() without touching last_forwarded_group_keys, so a shared instance is never
+            # clobbered. Bundled code never hits this (string children get a fresh Options).
             return frozenset()
 
         memo: dict[int, Any] = {}

--- a/mloda/core/core/engine.py
+++ b/mloda/core/core/engine.py
@@ -393,7 +393,7 @@ class Engine:
             consumer_name = feature_group_class.get_class_name()
             consumer_property_keys = self._property_mapping_keys(feature_group_class)
             for input_feature in features.collection:
-                forwarded_declared_keys = input_feature.options.last_forwarded_group_keys & consumer_property_keys
+                forwarded_declared_keys = input_feature.forwarded_group_keys & consumer_property_keys
                 input_feature.add_consumer_attribution(consumer_name, forwarded_declared_keys)
             if features.child_uuid is None:
                 raise ValueError(f"Features {features} has no parent uuid although it should have one.")

--- a/tests/test_core/test_abstract_plugins/test_components/test_options_inherit_from.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_options_inherit_from.py
@@ -700,7 +700,7 @@ class TestLastForwardedGroupKeys:
     inherit_from call actually forwarded. Each real merge REPLACES it with that
     call's forwarded set (same membership rule as inherited: keys copied AND
     equal-value forwards count; in_features, allowlist carve-outs, and excludes
-    never count). A self-merge RESETS it to frozenset() (whereas inherited is
+    never count). A self-merge PRESERVES it (whereas inherited is also
     preserved). __deepcopy__ preserves it. Default frozenset() at construction.
 
     The engine reads this per-consumer set (intersected with the consumer's
@@ -820,27 +820,215 @@ class TestInheritFromSelfMergeGuard:
 
     ``opts.inherit_from(opts)`` (the consumer IS self) must be a no-op: it must
     NOT deep-copy self's own values into itself, must NOT stamp self-referential
-    provenance, and must RESET last_forwarded_group_keys to frozenset() while
-    PRESERVING the accumulated inherited_group_keys.
+    provenance, and must PRESERVE last_forwarded_group_keys (the aliasing hazard:
+    a shared Options reused as an input feature keeps its recorded forwarded set)
+    while PRESERVING the accumulated inherited_group_keys. It returns frozenset().
     """
 
-    def test_self_merge_is_noop_preserving_provenance_and_resetting_last_forwarded(self) -> None:
+    def test_self_merge_is_noop_preserving_provenance_and_last_forwarded(self) -> None:
         """A self-merge preserves inherited_group_keys, leaves values untouched, adds no
-        new keys, and resets last_forwarded_group_keys to an empty frozenset."""
+        new keys, PRESERVES last_forwarded_group_keys, and returns an empty frozenset."""
         opts = Options(group={"a": 1})
         consumer = Options(group={"a": 1})
-        opts.inherit_from(consumer)
+        real_forwarded = opts.inherit_from(consumer)
 
         assert opts.inherited_group_keys == frozenset({"a"})
+        assert real_forwarded == frozenset({"a"})
+        assert opts.last_forwarded_group_keys == frozenset({"a"})
 
-        opts.inherit_from(opts)
+        self_forwarded = opts.inherit_from(opts)
 
         # Provenance preserved, no self-referential churn.
         assert opts.inherited_group_keys == frozenset({"a"})
         # Values untouched, no new keys introduced.
         assert opts.group == {"a": 1}
-        # A self-merge forwards nothing this call.
-        assert opts.last_forwarded_group_keys == frozenset()
+        # A self-merge forwards nothing this call, so it RETURNS an empty frozenset ...
+        assert self_forwarded == frozenset()
+        # ... but PRESERVES the previously recorded forwarded set (aliasing regression).
+        assert opts.last_forwarded_group_keys == frozenset({"a"})
+
+
+class TestInheritFromReturnValue:
+    """
+    Test suite for the frozenset[str] RETURN VALUE of Options.inherit_from (NEW SPEC).
+
+    inherit_from now returns the set of consumer group keys it forwarded in THIS call,
+    with the same membership rule as last_forwarded_group_keys: keys copied AND keys the
+    child already held with an equal value both count; in_features, allowlist carve-outs,
+    and excluded keys never count. A self-merge (consumer IS self) returns frozenset()
+    without touching the recorded set. The engine consumes this return value (stored on
+    Feature.forwarded_group_keys) for dual-consumption attribution instead of reading the
+    possibly-clobbered last_forwarded_group_keys off the shared Options instance.
+    """
+
+    def test_normal_merge_returns_forwarded_frozenset(self) -> None:
+        """A default merge returns exactly the keys forwarded in that call."""
+        consumer = Options(group={"kg_backend": "neo4j", "top_k": 5})
+        child = Options(group={"own_key": "own_value"})
+
+        returned = child.inherit_from(consumer)
+
+        assert returned == frozenset({"kg_backend", "top_k"})
+
+    def test_return_matches_last_forwarded_membership(self) -> None:
+        """The return value has the same membership as last_forwarded_group_keys."""
+        consumer = Options(group={"kg_backend": "neo4j", "top_k": 5})
+        child = Options(group={"own_key": "own_value"})
+
+        returned = child.inherit_from(consumer)
+
+        assert returned == child.last_forwarded_group_keys
+
+    def test_equal_value_forward_is_in_return(self) -> None:
+        """A forwarded key the child already held with an EQUAL value counts in the return."""
+        consumer = Options(group={"kg_backend": "neo4j", "top_k": 5})
+        child = Options(group={"kg_backend": "neo4j"})
+
+        returned = child.inherit_from(consumer)
+
+        assert returned == frozenset({"kg_backend", "top_k"})
+
+    def test_forward_group_false_returns_empty(self) -> None:
+        """forward_group=False forwards nothing, so the return is empty."""
+        consumer = Options(group={"kg_backend": "neo4j"})
+        child = Options()
+
+        returned = child.inherit_from(consumer, forward_group=False)
+
+        assert returned == frozenset()
+
+    def test_empty_group_consumer_returns_empty(self) -> None:
+        """A consumer with an empty group forwards nothing, so the return is empty."""
+        consumer = Options(group={})
+        child = Options(group={"own_key": "own_value"})
+
+        returned = child.inherit_from(consumer)
+
+        assert returned == frozenset()
+
+    def test_allowlist_carve_out_honored_in_return(self) -> None:
+        """With an allowlist, only the keys actually forwarded appear in the return."""
+        consumer = Options(group={"kg_backend": "neo4j", "top_k": 5})
+        child = Options()
+
+        returned = child.inherit_from(consumer, forward_group=frozenset({"kg_backend", "missing_key"}))
+
+        assert returned == frozenset({"kg_backend"})
+        assert returned == child.last_forwarded_group_keys
+
+    def test_exclude_carve_out_honored_in_return(self) -> None:
+        """An excluded key never appears in the return."""
+        consumer = Options(group={"kg_backend": "neo4j", "top_k": 5})
+        child = Options()
+
+        returned = child.inherit_from(consumer, forward_group_exclude=frozenset({"top_k"}))
+
+        assert returned == frozenset({"kg_backend"})
+        assert returned == child.last_forwarded_group_keys
+
+    def test_in_features_carve_out_honored_in_return(self) -> None:
+        """in_features is never forwarded, so it never appears in the return."""
+        consumer = Options(group={DefaultOptionKeys.in_features: "consumer_source", "kg_backend": "neo4j"})
+        child = Options()
+
+        returned = child.inherit_from(consumer)
+
+        assert returned == frozenset({"kg_backend"})
+
+    def test_self_merge_returns_empty_and_preserves_last_forwarded(self) -> None:
+        """A self-merge on an Options that already recorded a forwarded set (the aliasing
+        hazard: the same instance reused as an input feature) returns frozenset() while
+        the recorded last_forwarded_group_keys survives intact."""
+        consumer = Options(group={"kg_backend": "neo4j"})
+        shared = Options()
+        shared.inherit_from(consumer)
+        assert shared.last_forwarded_group_keys == frozenset({"kg_backend"})
+
+        returned = shared.inherit_from(shared)
+
+        # The self-merge forwards nothing this call ...
+        assert returned == frozenset()
+        # ... and PRESERVES the true forwarded set the engine later attributes provenance from.
+        assert shared.last_forwarded_group_keys == frozenset({"kg_backend"})
+
+    def test_second_merge_return_replaces_not_unions(self) -> None:
+        """Each call's return reflects ONLY that call's forwarded set, not the accumulated union."""
+        consumer_a = Options(group={"kg_backend": "neo4j"})
+        consumer_b = Options(group={"top_k": 5})
+        child = Options()
+
+        first = child.inherit_from(consumer_a)
+        second = child.inherit_from(consumer_b)
+
+        assert first == frozenset({"kg_backend"})
+        assert second == frozenset({"top_k"})
+
+
+class TestFeatureForwardedGroupKeys:
+    """
+    Test suite for Feature.forwarded_group_keys (NEW SPEC).
+
+    Features.merge_options stores the frozenset returned by Options.inherit_from onto
+    feature.forwarded_group_keys, so the engine attributes the dual-consumption warning
+    from this per-feature value instead of reading the (possibly clobbered) shared
+    Options.last_forwarded_group_keys. Default frozenset() on a fresh Feature.
+    """
+
+    def test_fresh_feature_has_empty_forwarded_group_keys(self) -> None:
+        """A freshly constructed Feature carries an empty forwarded_group_keys frozenset."""
+        feature = Feature(name="child")
+
+        assert isinstance(feature.forwarded_group_keys, frozenset)
+        assert feature.forwarded_group_keys == frozenset()
+
+    def test_merge_options_stores_inherit_from_return(self) -> None:
+        """Features.merge_options stores the inherit_from return value onto the feature."""
+        consumer_opts = Options(group={"kg_backend": "neo4j", "top_k": 5})
+        features = Features(
+            [Feature(name="child")],
+            child_options=consumer_opts,
+            child_uuid=uuid4(),
+        )
+
+        (child,) = features.collection
+        assert child.forwarded_group_keys == frozenset({"kg_backend", "top_k"})
+        assert child.forwarded_group_keys == child.options.last_forwarded_group_keys
+
+    def test_merge_options_stored_value_honors_exclude(self) -> None:
+        """The stored forwarded set reflects a feature-level forward_group_exclude carve-out."""
+        consumer_opts = Options(group={"kg_backend": "neo4j", "top_k": 5})
+        features = Features(
+            [Feature(name="child", forward_group_exclude=frozenset({"top_k"}))],
+            child_options=consumer_opts,
+            child_uuid=uuid4(),
+        )
+
+        (child,) = features.collection
+        assert child.forwarded_group_keys == frozenset({"kg_backend"})
+
+    def test_merge_options_stored_value_empty_on_forward_group_false(self) -> None:
+        """An isolated feature (forward_group=False) stores an empty forwarded set."""
+        consumer_opts = Options(group={"kg_backend": "neo4j"})
+        features = Features(
+            [Feature(name="child", forward_group=False)],
+            child_options=consumer_opts,
+            child_uuid=uuid4(),
+        )
+
+        (child,) = features.collection
+        assert child.forwarded_group_keys == frozenset()
+
+    def test_string_child_forwarded_group_keys_recorded(self) -> None:
+        """A bare-string input feature also gets its forwarded set stored."""
+        consumer_opts = Options(group={"kg_backend": "neo4j"})
+        features = Features(
+            ["child"],
+            child_options=consumer_opts,
+            child_uuid=uuid4(),
+        )
+
+        (child,) = features.collection
+        assert child.forwarded_group_keys == frozenset({"kg_backend"})
 
 
 class TestInheritContextKeys:


### PR DESCRIPTION
## Summary

Closes #624. `Options.inherit_from`'s self-merge branch (`consumer is self`) wrote `last_forwarded_group_keys = frozenset()` onto the consumer's own (possibly shared) `Options` instance, a latent aliasing hazard: reusing that `Options` as an input feature would destroy its recorded forwarding provenance. The engine read that field to attribute dual-consumption warnings.

## Change

- `Options.inherit_from` now returns `frozenset[str]`, the group keys it forwarded this call (normal branch returns the forwarded set, self-merge returns `frozenset()`).
- The self-merge branch no longer writes `last_forwarded_group_keys`, so it never clobbers a possibly-shared instance. It preserves the field and returns the empty set.
- `Features.merge_options` stores the return value on the new resolution-only `Feature.forwarded_group_keys` attribute (excluded from eq/hash like `link`/`index`/`consumer_attributions`).
- The engine's `_handle_input_features_recursion` attributes dual-consumption warnings from `input_feature.forwarded_group_keys` (the return value) instead of the mutable `Options.last_forwarded_group_keys`.

In the non-aliasing case the engine read is value-identical to before (both derive from the same `frozenset(inherited)`); under aliasing it is now correct where the shared field could be clobbered.

## Tests

- New `TestInheritFromReturnValue` and `TestFeatureForwardedGroupKeys` suites covering the return value across all forwarding paths (False/None/True/allowlist/exclude/in_features carve-out, equal-value forwards, self-merge) and the `merge_options` storage.
- Updated the self-merge tests: a self-merge now PRESERVES `last_forwarded_group_keys` (aliasing regression) instead of resetting it, and returns `frozenset()`.
- Existing dual-consumption attribution integration tests pass unchanged as regression guards.
- Full `tox` green (pytest, ruff format/check, mypy --strict, bandit, license allowlist).

## Definition of done

- [x] `inherit_from` returns the forwarded key set; the engine uses the return value for attribution.
- [x] Test: a consumer whose `last_forwarded_group_keys` is read after a self-merge still resolves its true forwarded set.
- [x] `tox` passes.