### PR TITLE
test+docs: pin and document forwarded-context FeatureSet split (#625)

### DIFF
--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -235,6 +235,17 @@ counterpart is the child-side **pull** `inherit_context_keys`. For both author-s
 flows see
 [Forwarding Options to Input Features](feature-chain-parser.md#forwarding-options-to-input-features).
 
+A forwarded key also splits FeatureSets by value. A context key delivered via the
+push (`propagate_context_keys`) or the pull (`inherit_context_keys`) enters the
+child's `inherited_context_keys`, and features whose value for that key differs (e.g.
+`env=prod` vs `env=staging`) then compute in separate FeatureSets, one per value;
+equal values still share one computation. The split is per-FeatureGroup and by value,
+not by provenance: once any feature in that scope forwards the key, every feature in
+scope splits on it, including a sibling that set the same key directly in plain
+context. A key that no feature in scope ever forwards stays metadata and does not
+split. This isolates per-value results that previously collapsed into one computation
+where a single value silently won.
+
 ### `group` and `context` are independent namespaces
 
 `group` (which drives resolution and splitting) and `context` (metadata) are

--- a/tests/test_core/test_prepare/test_execution_plan_context_grouping.py
+++ b/tests/test_core/test_prepare/test_execution_plan_context_grouping.py
@@ -30,6 +30,15 @@ def _options_with_inherited_tenant(tenant: str) -> Options:
     return child
 
 
+def _options_with_propagated_env(env: str) -> Options:
+    """Child Options whose "env" context entry was DELIVERED via the caller-side PUSH
+    (consumer.propagate_context_keys), so options.inherited_context_keys provenance is real."""
+    consumer = Options(context={"env": env}, propagate_context_keys=frozenset({"env"}))
+    child = Options(group={"data_source": "prod"})
+    child.inherit_from(consumer)
+    return child
+
+
 def test_features_differing_in_inherited_context_land_in_different_groups() -> None:
     """Same name, group options, compute framework, and data_type but different
     INHERITED context must produce two separate groups."""
@@ -252,6 +261,52 @@ def test_split_context_hashable_empty_cases_return_empty_tuple() -> None:
     )
     assert feature._split_context_hashable(frozenset({"region"})) == (), (
         "A feature carrying none of the split keys in its context must canonicalize to ()."
+    )
+
+
+def test_features_differing_in_propagated_context_land_in_different_groups() -> None:
+    """Same name, group options, compute framework, and data_type but different PROPAGATED
+    (pushed via consumer.propagate_context_keys) context must produce two separate groups."""
+    feature_prod = Feature(
+        "env_scoped_source",
+        options=_options_with_propagated_env("prod"),
+        data_type=DataType.INT32,
+    )
+    feature_staging = Feature(
+        "env_scoped_source",
+        options=_options_with_propagated_env("staging"),
+        data_type=DataType.INT32,
+    )
+
+    groups = _group({feature_prod, feature_staging})
+
+    assert len(groups) == 2, (
+        "Features differing in PROPAGATED (pushed) context must not share a FeatureSet. "
+        f"Expected 2 groups, got {len(groups)}: {groups}"
+    )
+    for group in groups.values():
+        assert len(group) == 1
+
+
+def test_features_with_identical_propagated_context_share_one_group() -> None:
+    """Regression pin: identical group options and identical PROPAGATED context still group
+    together (equal propagated values share one computation)."""
+    feature_a = Feature(
+        "env_scoped_source",
+        options=_options_with_propagated_env("prod"),
+        data_type=DataType.INT32,
+    )
+    feature_b = Feature(
+        "env_scoped_other",
+        options=_options_with_propagated_env("prod"),
+        data_type=DataType.INT32,
+    )
+
+    groups = _group({feature_a, feature_b})
+
+    assert len(groups) == 1, (
+        "Features with identical group options and identical propagated context must share one "
+        f"FeatureSet. Got {len(groups)} groups: {groups}"
     )
 
 


### PR DESCRIPTION
Closes #625.

## Analysis: confirmed a fix, not a regression

PR #597 folds inherited-context values into FeatureSet grouping. A context key delivered to a child via `Options.inherit_from` (the caller-side **push** `propagate_context_keys` or the child-side **pull** `inherit_context_keys`) lands in `options.inherited_context_keys`, and `ExecutionPlan.group_features_by_compute_framework_and_options` unions those keys into `split_keys` and splits features by value.

- **Old behavior (main before #597):** `similarity_hash` excluded all context, so two same-named features that received different forwarded values (e.g. per-tenant `tenant=acme` vs `tenant=beta`) collapsed into one FeatureSet. `calculate_feature` ran once and one value silently won: a latent correctness bug.
- **New behavior:** differing forwarded values compute in separate FeatureSets (one per value); equal values still share one computation. This is a correctness fix.

## Blast radius

- **Unchanged:** plain-context users (context set directly, never forwarded), index-feature users, and any resolution where no feature forwards a key keep `split_keys` empty, so grouping is identical to before.
- **Changed (more computations, correct per-value isolation):** `propagate_context_keys` / `inherit_context_keys` users. The split is per-FeatureGroup scope and by value, not by provenance: once any feature in scope forwards a key, every feature in that scope splits on it, including a sibling that set the same key directly in plain context (already pinned by `test_plain_value_splits_from_inherited_value_when_key_is_a_split_key`).
- No whole-graph cross-contamination: grouping runs on one FeatureGroup's feature set.

## Changes

- **Test pin (push path):** `tests/test_core/test_prepare/test_execution_plan_context_grouping.py` adds `_options_with_propagated_env` plus two tests pinning that differing propagated values split into separate FeatureSets and equal propagated values share one. The pull path was already pinned by the existing `inherit_context_keys` tests (unit + `test_context_isolated_feature_sets_e2e.py`).
- **Migration note:** `docs/docs/in_depth/property-mapping.md` documents the split, its per-scope by-value semantics, and that non-forwarded context stays metadata. (No `CHANGELOG` file exists; semantic-release derives the changelog from commits, so the docs note is the migration note.)

## Review

Two independent deep reviews (Claude Opus + codex). Opus: no blockers, confirmed the push-path test is not a false pass (the split depends specifically on the propagated key). Codex flagged that the first docs draft wrongly implied plain context never splits; corrected to the by-value, per-scope wording above. An unrelated `attribution/ATTRIBUTION.md` regeneration (a `uv sync`/tox side effect) was reverted to keep the PR focused.

`tox` passes (pytest, ruff format/check, license allowlist, mypy --strict, bandit).