### PR TITLE
minor: reader refactor epic: structural classification, template seams, FileSource CSV, transformer graph (#615)

### DIFF
--- a/docs/docs/examples/mloda_basics/4_ml_data_providers_user_steward.py
+++ b/docs/docs/examples/mloda_basics/4_ml_data_providers_user_steward.py
@@ -157,7 +157,7 @@ def _(mo):
     ```python
     class CsvReader(ReadFile):
         @classmethod
-        def suffix(cls) -> Tuple[str, ...]:
+        def suffix(cls) -> tuple[str, ...]:
             return (
                 ".csv",
                 ".CSV",
@@ -165,15 +165,15 @@ def _(mo):
 
         @classmethod
         def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
-            result = pyarrow_csv.read_csv(data_access)
-            return result.select(list(features.get_all_names()))
+            return FileSource(path=data_access, format="csv", columns=tuple(sorted(features.get_all_names())))
 
         @classmethod
         def get_column_names(cls, file_name: str) -> Any:
-            read_options = pyarrow_csv.ReadOptions(skip_rows_after_names=1)
-            table = pyarrow_csv.read_csv(file_name, read_options=read_options)
-            return table.schema.names
+            with open(file_name, newline="", encoding="utf-8-sig") as f:
+                return next(csv.reader(f), [])
     ```
+
+    `load_data` returns a lightweight `FileSource` descriptor; the target compute framework materializes it into its native table type. Overriding `load_data` to return a concrete table directly is equally supported.
 
     As you can see, the implementation is flexible in the sense that if you need something, you can adjust it quite easily. The other files like .json, .parquet and the sqlite access are implemented in a similar fashion.
     """)
@@ -183,6 +183,7 @@ def _(mo):
 @app.cell
 def _():
     # In the following, we will just adjust a bit the CsvReader to handle a different delimiter.
+    # CsvReader2 overrides load_data wholesale, returning a concrete table instead of a FileSource.
 
     from typing import Any, Optional
 

--- a/docs/docs/in_depth/data-access-patterns.md
+++ b/docs/docs/in_depth/data-access-patterns.md
@@ -50,7 +50,35 @@ class ReadFileFeature(FeatureGroup):
 - **ReadDocument**: For unstructured document loading (Markdown, YAML, text). Skips file types owned by ReadFile by default.
 - **DataCreator**: For generating synthetic data (see [access-feature-data](access-feature-data.md#data-creator))
 - **ApiInputData**: For runtime data injection (see [access-feature-data](access-feature-data.md#apidata))
-- **DatabaseConnector**: For database connections
+- **ReadDB**: For database-backed loading
+
+### Writing an input-data reader
+
+Each reader family exposes a recommended hook seam. Overriding `load_data` wholesale remains supported in every family.
+
+- **ReadDB**: implement `produce_rows`, `connect`, and `is_valid_credentials`; optionally `prepare_credentials` and `build_query`.
+- **ReadDocument**: implement `produce_document` and `suffix`; optionally `document_file_type`.
+- **ReadFile**: override `load_data` wholesale to return the table. `CsvReader` resolves to a `FileSource` descriptor that the target compute framework materializes into its native type.
+
+CSV materialization semantics can differ per compute framework: the PythonDict transformer keeps integers beyond int64 exact (pyarrow yields float64) and leaves `NA`/`NaN`/`null` tokens as strings in otherwise-numeric columns (pyarrow parses them as nulls). Parity is tracked in [#662](https://github.com/mloda-ai/mloda/issues/662).
+
+Readers are classified structurally; no reader code is executed for classification. `is_final_reader()` is True when a class overrides `load_data` wholesale, or when it overrides all hooks named by its family's `_final_reader_requires()` (for example `("produce_rows", "connect")` for ReadDB). Family bases (ReadDB, ReadDocument, ReadFile) are never discovered as final readers themselves.
+
+**Warning**: classification is structural (declared is overridden), so an intermediate base that re-declares a hook or `load_data` with a bare `raise NotImplementedError` body is classified as a final reader and enters discovery. Intermediate bases must not re-declare bare hooks; re-anchor the family by declaring `_final_reader_requires` instead.
+
+`_final_reader_requires` is underscore-named but is a stable, documented extension point for third-party reader families.
+
+### Selecting among sibling readers
+
+A feature selects a specific reader with an Option whose key equals the reader's class name (`BaseInputData.data_access_name()`, i.e. `cls.__name__`, unique per class, so sibling readers cannot collide):
+
+``` python
+Feature("value", options={UbaAirReader.__name__: url})
+```
+
+The matched `(ReaderClass, data_access)` pair is stored under the reserved `"BaseInputData"` options key and consumed by `init_reader` at load time.
+
+For non-file sources such as HTTP endpoints, subclassing `ReadFile` and overriding `match_subclass_data_access` plus `load_data` is a supported pattern; on that path `suffix()` is never consulted (it is inert). `ApiInputData` injects in-memory data passed through the API request and is not an HTTP client.
 
 ## MatchData Pattern
 

--- a/mloda/core/abstract_plugins/components/framework_transformer/cfw_transformer.py
+++ b/mloda/core/abstract_plugins/components/framework_transformer/cfw_transformer.py
@@ -1,12 +1,12 @@
-from typing import Any, Optional
+import logging
+import weakref
+from collections import deque
+from typing import Any, ClassVar, Optional
 
 from mloda.core.abstract_plugins.components.framework_transformer.base_transformer import BaseTransformer
 from mloda.core.abstract_plugins.components.utils import get_all_subclasses
 
-try:
-    import pyarrow as pa
-except ImportError:
-    pa = None  # type: ignore[assignment]
+logger = logging.getLogger(__name__)
 
 
 class ComputeFrameworkTransformer:
@@ -14,8 +14,8 @@ class ComputeFrameworkTransformer:
     Manages transformations between different compute frameworks.
 
     This class maintains a registry of available transformers and provides
-    methods to add new transformers. It auto-loads transformer files on first
-    use if no BaseTransformer subclasses are registered yet.
+    methods to add new transformers. It auto-loads transformer files once per
+    process, gated on ``_auto_load_done`` and the disabled-groups set.
 
     To suppress auto-loading of transformer files:
         PluginLoader.disable_auto_load("compute_framework")
@@ -25,8 +25,13 @@ class ComputeFrameworkTransformer:
 
     The transformer registry is a mapping from framework pairs to transformer
     classes, allowing the system to find the appropriate transformer for
-    converting data between any two supported frameworks.
+    converting data between two supported frameworks. Two-way transformers
+    register both directions; one-way transformers register only their
+    forward edge.
     """
+
+    _auto_load_done: ClassVar[bool] = False
+    _warned_zero_edge: ClassVar["weakref.WeakSet[type[BaseTransformer]]"] = weakref.WeakSet()
 
     def __init__(self) -> None:
         """
@@ -61,34 +66,64 @@ class ComputeFrameworkTransformer:
         left = transformer.framework()
         right = transformer.other_framework()
 
-        # Check already added cases
-        if (left, right) in self.transformer_map:
-            if transformer == self.transformer_map[(left, right)]:
-                return True
-            raise ValueError(
-                f"Transformer {transformer} is already registered for the pair ({left}, {right}), but with a different implementation."
-            )
+        # Each edge is registered only when its transform direction is actually overridden,
+        # so BFS never routes through an unimplemented direction.
+        forward_overridden = self._underlying(transformer.transform_fw_to_other_fw) is not self._underlying(
+            BaseTransformer.transform_fw_to_other_fw
+        )
+        reverse_overridden = self._underlying(transformer.transform_other_fw_to_fw) is not self._underlying(
+            BaseTransformer.transform_other_fw_to_fw
+        )
 
-        self.transformer_map[(left, right)] = transformer
-        self.transformer_map[(right, left)] = transformer
-        return True
+        registered = False
+        if forward_overridden:
+            self._register_edge(left, right, transformer)
+            registered = True
+        if reverse_overridden:
+            self._register_edge(right, left, transformer)
+            registered = True
+        if not registered and transformer not in ComputeFrameworkTransformer._warned_zero_edge:
+            ComputeFrameworkTransformer._warned_zero_edge.add(transformer)
+            logger.warning(
+                f"Transformer {transformer.__name__} overrides neither transform direction; no edges were registered."
+            )
+        return registered
+
+    def _register_edge(self, source: type[Any], target: type[Any], transformer: type[BaseTransformer]) -> None:
+        """Write one directional edge, rejecting a collision with a different incumbent.
+
+        The incumbent is only compared by equality (never introspected), so a non-transformer
+        sentinel occupying the pair is handled without calling methods on it.
+        """
+        incumbent = self.transformer_map.get((source, target))
+        if incumbent is not None and incumbent != transformer:
+            raise ValueError(
+                f"Transformer {transformer} is already registered for the pair ({source}, {target}), but with a different implementation."
+            )
+        self.transformer_map[(source, target)] = transformer
+
+    @staticmethod
+    def _underlying(member: Any) -> Any:
+        """Underlying function of a classmethod/staticmethod/plain override, for identity comparison."""
+        return getattr(member, "__func__", member)
 
     def initilize_transformer(self) -> None:
         """
         Initialize the transformer registry with all available transformers.
 
         This method discovers all BaseTransformer subclasses and adds them
-        to the registry. If none are found, auto-loads only transformer files
-        from the compute_framework group via load_matching.
+        to the registry. The transformer files from the compute_framework group
+        are auto-loaded once per process via load_matching, so a stray
+        module-scope import of a single transformer cannot leave the registry
+        partial. Auto-loading is skipped while the group is disabled.
         """
+        from mloda.core.abstract_plugins.plugin_loader.plugin_loader import PluginLoader
+
+        if not ComputeFrameworkTransformer._auto_load_done and "compute_framework" not in PluginLoader._disabled_groups:
+            PluginLoader().load_matching("compute_framework", "*transformer*")
+            ComputeFrameworkTransformer._auto_load_done = True
+
         transformers = get_all_subclasses(BaseTransformer)
-        if not transformers:
-            from mloda.core.abstract_plugins.plugin_loader.plugin_loader import PluginLoader
-
-            if "compute_framework" not in PluginLoader._disabled_groups:
-                PluginLoader().load_matching("compute_framework", "*transformer*")
-                transformers = get_all_subclasses(BaseTransformer)
-
         for transformer in transformers:
             self.add(transformer)
 
@@ -98,9 +133,13 @@ class ComputeFrameworkTransformer:
         """
         Find a transformation chain between two frameworks.
 
-        If a direct transformer exists, returns a single-element list.
-        If no direct transformer exists, tries to find a path through PyArrow
-        as an intermediate format.
+        If a direct transformer exists, returns a single-element list. Otherwise
+        runs a breadth-first shortest-path search over ALL registered edges in
+        transformer_map, so any registered framework (pa.Table is just a regular
+        node) can serve as an intermediate hop. Equal-length paths tie-break on
+        first-registered edge order (map insertion order), making the result
+        deterministic. The map is finite and each framework is visited at most
+        once, so the search always terminates.
 
         Args:
             from_framework: Source framework type
@@ -109,21 +148,61 @@ class ComputeFrameworkTransformer:
         Returns:
             List of transformers to apply in sequence, or None if no path exists
         """
-        # Try direct transformation first
+        # Direct edge always wins
         if (from_framework, to_framework) in self.transformer_map:
             return [self.transformer_map[(from_framework, to_framework)]]
 
-        # If no direct path and PyArrow is available, try chaining through PyArrow
-        if pa is not None:
-            pa_table_type = pa.Table
-            # Check if we can go: from_framework → PyArrow → to_framework
-            if (from_framework, pa_table_type) in self.transformer_map and (
-                pa_table_type,
-                to_framework,
-            ) in self.transformer_map:
-                return [
-                    self.transformer_map[(from_framework, pa_table_type)],
-                    self.transformer_map[(pa_table_type, to_framework)],
-                ]
+        # BFS over registered edges, expanding neighbors in map insertion order
+        queue: deque[type[Any]] = deque([from_framework])
+        visited: set[type[Any]] = {from_framework}
+        parent: dict[type[Any], tuple[type[Any], type[BaseTransformer]]] = {}
+
+        while queue:
+            current = queue.popleft()
+            for (src, dst), transformer in self.transformer_map.items():
+                if src != current or dst in visited:
+                    continue
+                visited.add(dst)
+                parent[dst] = (current, transformer)
+                if dst == to_framework:
+                    chain: list[type[BaseTransformer]] = []
+                    node: type[Any] = to_framework
+                    while node != from_framework:
+                        node, edge_transformer = parent[node]
+                        chain.append(edge_transformer)
+                    chain.reverse()
+                    return chain
+                queue.append(dst)
 
         return None
+
+    def apply_chain(
+        self,
+        from_framework: type[Any],
+        to_framework: type[Any],
+        chain: list[type[BaseTransformer]],
+        data: Any,
+        connection: Any,
+    ) -> Any:
+        """Walk a transformation chain, resolving each intermediate hop's target framework
+        from the transformer map, and apply each transformer in sequence."""
+        current_fw = from_framework
+        for i, transformer_cls in enumerate(chain):
+            if i == len(chain) - 1:
+                target_fw: type[Any] = to_framework
+            else:
+                target_fw = self._resolve_intermediate_target(transformer_cls, current_fw)
+
+            data = transformer_cls.transform(current_fw, target_fw, data, connection)
+            current_fw = target_fw
+
+        return data
+
+    def _resolve_intermediate_target(self, transformer_cls: type[BaseTransformer], current_fw: type[Any]) -> type[Any]:
+        for (src, dst), trans in self.transformer_map.items():
+            if trans == transformer_cls and src == current_fw:
+                return dst
+        raise KeyError(
+            f"No transformer edge found for {transformer_cls} from {current_fw} in the "
+            "transformer map; the transformation chain is inconsistent with the registry."
+        )

--- a/mloda/core/abstract_plugins/components/input_data/api/api_input_data.py
+++ b/mloda/core/abstract_plugins/components/input_data/api/api_input_data.py
@@ -7,6 +7,9 @@ from mloda.core.abstract_plugins.components.options import Options
 class ApiInputData(BaseInputData):
     """
     This class represents api input data, which was passed through the api.
+
+    It injects in-memory data passed through the API and is NOT an HTTP client;
+    HTTP sources are typically ReadFile subclasses overriding match_subclass_data_access.
     """
 
     def matches(

--- a/mloda/core/abstract_plugins/components/input_data/base_input_data.py
+++ b/mloda/core/abstract_plugins/components/input_data/base_input_data.py
@@ -18,6 +18,16 @@ class BaseInputData(ABC):
         """This function should return the name of the data access."""
         return cls.__name__
 
+    @staticmethod
+    def _underlying(member: Any) -> Any:
+        """Underlying function of a classmethod/staticmethod/plain override, for identity comparison."""
+        return getattr(member, "__func__", member)
+
+    @classmethod
+    def _is_overridden(cls, base: type, method_name: str) -> bool:
+        """Structurally check whether cls overrides method_name relative to base."""
+        return cls._underlying(getattr(cls, method_name)) is not cls._underlying(getattr(base, method_name))
+
     def matches(
         self,
         feature_name: str,
@@ -128,7 +138,32 @@ class BaseInputData(ABC):
         options.add_to_group("BaseInputData", (cls_to_be_added, matched_data_access))
 
     def init_reader(self, options: Optional[Options]) -> tuple["BaseInputData", Any]:
-        raise NotImplementedError
+        if options is None:
+            raise ValueError(
+                f"Options were not set for {self.__class__.__name__}.init_reader().\n"
+                "Provide an Options object with a 'BaseInputData' key mapping to a tuple of "
+                "(ReaderClass, data_access).\n"
+                "Example:\n"
+                "  options = Options(context={\n"
+                "      'BaseInputData': (ReaderClass, data_access)\n"
+                "  })"
+            )
+
+        reader_data_access = options.get("BaseInputData")
+
+        if reader_data_access is None:
+            raise ValueError(
+                f"'BaseInputData' key is missing or None in the provided Options for {self.__class__.__name__}.\n"
+                "The 'BaseInputData' key in Options must map to a tuple of "
+                "(ReaderClass, data_access).\n"
+                "Example:\n"
+                "  options = Options(context={\n"
+                "      'BaseInputData': (ReaderClass, data_access)\n"
+                "  })"
+            )
+
+        reader, data_access = reader_data_access
+        return reader(), data_access
 
     def load(self, features: FeatureSet) -> Any:
         _options = None
@@ -154,19 +189,43 @@ class BaseInputData(ABC):
         raise NotImplementedError
 
     @classmethod
-    def supports_scoped_data_access(cls) -> bool:
+    def _final_reader_requires(cls) -> tuple[str, ...]:
         """
-        As we assume that load_data are only implemented in final child classes of scoped data access,
-        we can use this function to check if the class supports scoped data access and is the final child class.
+        A family base redeclares this to name the hooks a subclass must override (relative to
+        that family base) to classify as a final reader; the load_data wholesale-override
+        branch always wins.
         """
-        try:
-            cls.load_data(None, None)  # type: ignore[arg-type]
-        except NotImplementedError:
-            return False
-        except AttributeError:  # Expected as cls.load_data(None, None) should raise an error
-            return True
+        return ()
 
-        return True
+    @classmethod
+    def final_reader_anchor(cls) -> type["BaseInputData"]:
+        """
+        The most-derived class in cls.__mro__ that declares _final_reader_requires in its own
+        __dict__; BaseInputData declares the default, so an anchor always exists.
+        """
+        return next(klass for klass in cls.__mro__ if "_final_reader_requires" in klass.__dict__)
+
+    @classmethod
+    def is_final_reader(cls) -> bool:
+        """
+        Structurally classify whether cls is a final scoped reader; nothing is executed.
+
+        A wholesale load_data override relative to the anchor is always final; otherwise cls
+        is final iff the anchor's required hooks are non-empty and all overridden relative to
+        the anchor. A class that declares _final_reader_requires is a family base and is
+        therefore never final itself: both branches compare relative to the anchor, and
+        nothing is overridden relative to itself.
+        """
+        anchor = cls.final_reader_anchor()
+        if cls._is_overridden(anchor, "load_data"):
+            return True
+        required = cls._final_reader_requires()
+        for name in required:
+            if not hasattr(anchor, name):
+                raise ValueError(
+                    f"Required final-reader hook '{name}' is not defined on anchor class {anchor.__name__}."
+                )
+        return bool(required) and all(cls._is_overridden(anchor, hook) for hook in required)
 
     @classmethod
     def get_class_name(cls) -> str:
@@ -225,7 +284,7 @@ def _collect_filtered_subclasses(cls: Any, parent_class: Any) -> list[type[BaseI
     for subclass in get_all_subclasses(cls):
         if not issubclass(subclass, parent_class):
             continue
-        if subclass.supports_scoped_data_access():
+        if subclass.is_final_reader():
             result.append(subclass)
     return result
 

--- a/mloda/core/abstract_plugins/components/input_data/file_source.py
+++ b/mloda/core/abstract_plugins/components/input_data/file_source.py
@@ -1,0 +1,25 @@
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from mloda.core.abstract_plugins.components.input_data.input_data_descriptor import InputDataDescriptor
+
+
+@dataclass(frozen=True)
+class FileSource(InputDataDescriptor):
+    """Immutable, hashable descriptor for a file-backed input.
+
+    Decouples file input from any compute framework: ``load_data`` resolves a file into
+    this lightweight value object, and a per-framework transformer materializes it into
+    that framework's native type.
+
+    A caller may pass any ``Sequence[str]`` for ``columns``; it is normalized to an
+    immutable ``tuple`` in ``__post_init__`` so the descriptor stays hashable.
+    """
+
+    path: str
+    format: str
+    columns: Sequence[str]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "path", str(self.path))
+        object.__setattr__(self, "columns", tuple(self.columns))

--- a/mloda/core/abstract_plugins/components/input_data/input_data_descriptor.py
+++ b/mloda/core/abstract_plugins/components/input_data/input_data_descriptor.py
@@ -1,0 +1,3 @@
+class InputDataDescriptor:
+    """Marker for a lightweight input descriptor (e.g. FileSource) that has no native
+    framework form and must be materialized into a framework's type via a transformer chain."""

--- a/mloda/core/abstract_plugins/compute_framework.py
+++ b/mloda/core/abstract_plugins/compute_framework.py
@@ -14,6 +14,7 @@ from mloda.core.abstract_plugins.function_extender import (
     _invoke_extender,
 )
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.input_data.input_data_descriptor import InputDataDescriptor
 from mloda.core.abstract_plugins.components.parallelization_modes import ParallelizationMode
 from mloda.core.filter.filter_engine import BaseFilterEngine
 from mloda.core.abstract_plugins.components.mask.base_mask_engine import BaseMaskEngine
@@ -145,11 +146,36 @@ class ComputeFramework(ABC):
         """
         _from_fw = type(data)
         _to_fw = self.expected_data_framework()
-        transformer_cls = self.transformer.transformer_map.get((_from_fw, _to_fw), None)
-        if transformer_cls is not None:
-            return transformer_cls.transform(_from_fw, _to_fw, data, self.framework_connection_object)
+
+        # Same native type: nothing to transform. Guard here so the chain search does not
+        # discover a spurious self-loop (e.g. dict -> pa.Table -> dict) through PyArrow.
+        if _from_fw == _to_fw:
+            return None
+
+        # A direct transformer always applies (e.g. FileSource -> pa.Table, FileSource -> dict).
+        direct = self.transformer.transformer_map.get((_from_fw, _to_fw))
+        if direct is not None:
+            return direct.transform(_from_fw, _to_fw, data, self.framework_connection_object)
+
+        # A multi-hop chain (through pa.Table) is only valid for a descriptor input that has no
+        # native framework form. A plain dict is not a descriptor, so it returns None and the
+        # framework's native transform() branch handles it.
+        if isinstance(data, InputDataDescriptor):
+            return self._materialize_descriptor(data, _from_fw, _to_fw)
 
         return None
+
+    def _materialize_descriptor(self, data: Any, _from_fw: type[Any], _to_fw: Any) -> Any:
+        chain = self.transformer.get_transformation_chain(_from_fw, _to_fw)
+        if chain is None:
+            # _to_fw may be a non-class (expected_data_framework defaults to None); render it safely.
+            target_name = getattr(_to_fw, "__name__", None) or str(_to_fw)
+            raise ValueError(
+                f"Cannot materialize {_from_fw.__name__} into {type(self).__name__}: no transformer is "
+                f"registered from {_from_fw.__name__} to {target_name}. Register a compute-framework "
+                f"transformer for this pair to enable it."
+            )
+        return self.transformer.apply_chain(_from_fw, _to_fw, chain, data, self.framework_connection_object)
 
     def select_data_by_column_names(
         self, data: Any, selected_feature_names: Sequence[FeatureName], column_ordering: Optional[str] = None

--- a/mloda/core/core/step/transform_frame_work_step.py
+++ b/mloda/core/core/step/transform_frame_work_step.py
@@ -132,25 +132,9 @@ class TransformFrameworkStep(Step):
                 f"Available transformers: {list(self.transformer.transformer_map.keys())}"
             )
 
-        # Apply transformations in sequence
-        current_fw = _from_fw
-        for i, transformer_cls in enumerate(transformation_chain):
-            # Determine target framework for this transformation step
-            if i == len(transformation_chain) - 1:
-                # Last step: transform to final target
-                target_fw = _to_fw
-            else:
-                # Intermediate step: find what this transformer outputs
-                # Look for the transformer in the map to determine its output type
-                for (src, dst), trans in self.transformer.transformer_map.items():
-                    if trans == transformer_cls and src == current_fw:
-                        target_fw = dst
-                        break
-
-            data = transformer_cls.transform(current_fw, target_fw, data, cfw.framework_connection_object)
-            current_fw = target_fw  # Update current framework for next iteration
-
-        return data
+        return self.transformer.apply_chain(
+            _from_fw, _to_fw, transformation_chain, data, cfw.framework_connection_object
+        )
 
     def equal_frameworks(self) -> bool:
         if self.from_framework.expected_data_framework() == self.to_framework.expected_data_framework():

--- a/mloda/provider/__init__.py
+++ b/mloda/provider/__init__.py
@@ -33,6 +33,8 @@ from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 
 # Input data classes
 from mloda.core.abstract_plugins.components.input_data.base_input_data import BaseInputData
+from mloda.core.abstract_plugins.components.input_data.file_source import FileSource
+from mloda.core.abstract_plugins.components.input_data.input_data_descriptor import InputDataDescriptor
 from mloda.core.abstract_plugins.components.input_data.api.api_input_data import ApiInputData
 from mloda_plugins.feature_group.input_data.api_data.api_data import ApiInputDataFeature
 from mloda.core.abstract_plugins.components.input_data.api.base_api_data import BaseApiData
@@ -98,6 +100,8 @@ __all__ = [
     "FeatureSet",
     # Input data
     "BaseInputData",
+    "FileSource",
+    "InputDataDescriptor",
     "ApiInputData",
     "ApiInputDataFeature",
     "BaseApiData",

--- a/mloda_plugins/compute_framework/base_implementations/pyarrow/pyarrow_file_source_transformer.py
+++ b/mloda_plugins/compute_framework/base_implementations/pyarrow/pyarrow_file_source_transformer.py
@@ -1,0 +1,38 @@
+from typing import Any
+
+import pyarrow as pa
+
+from mloda.provider import BaseTransformer
+
+
+class FileSourcePyArrowTransformer(BaseTransformer):
+    """Materialize a ``FileSource`` descriptor into a ``pa.Table`` using PyArrow's CSV reader."""
+
+    @classmethod
+    def framework(cls) -> Any:
+        from mloda.core.abstract_plugins.components.input_data.file_source import FileSource
+
+        return FileSource
+
+    @classmethod
+    def other_framework(cls) -> Any:
+        return pa.Table
+
+    @classmethod
+    def import_fw(cls) -> None:
+        import mloda.core.abstract_plugins.components.input_data.file_source  # noqa: F401
+
+    @classmethod
+    def import_other_fw(cls) -> None:
+        import pyarrow as pa  # noqa: F401
+
+    @classmethod
+    def transform_fw_to_other_fw(cls, data: Any) -> Any:
+        if data.format != "csv":
+            raise ValueError(f"FileSourcePyArrowTransformer only supports the 'csv' format, got {data.format!r}.")
+        from pyarrow import csv as pyarrow_csv
+
+        return pyarrow_csv.read_csv(
+            data.path,
+            convert_options=pyarrow_csv.ConvertOptions(include_columns=list(data.columns)),
+        )

--- a/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_file_source_transformer.py
+++ b/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_file_source_transformer.py
@@ -1,0 +1,110 @@
+import csv
+import re
+from typing import Any
+
+from mloda.provider import BaseTransformer
+
+_INT_RE = re.compile(r"^[+-]?[0-9]+$")
+_FLOAT_RE = re.compile(r"^[+-]?(?:[0-9]+\.[0-9]*|\.[0-9]+|[0-9]+)(?:[eE][+-]?[0-9]+)?$")
+_BOOL_MAP: dict[str, bool] = {
+    "true": True,
+    "false": False,
+    "True": True,
+    "False": False,
+    "TRUE": True,
+    "FALSE": False,
+}
+
+
+def _infer_column(cells: list[str | None]) -> list[Any]:
+    """Infer a single column's type once (column-wise) and cast its cells.
+
+    Empty-cell semantics match pyarrow's default CSV reader
+    (``strings_can_be_null=False``): a missing cell in a numeric/bool column
+    becomes ``None``, while a missing cell in a string column becomes ``""``
+    (empty string). An all-empty column (no present cells) stays all ``None``.
+
+    Null tokens (``NA``, ``NaN``, ``null``) inside an otherwise numeric column
+    are not recognized: such a column stays string, whereas pyarrow parses
+    those tokens as nulls.
+
+    Integers beyond int64 range stay exact arbitrary-precision Python ints here,
+    whereas pyarrow's CSV reader yields a lossy ``float64``.
+
+    Both are deliberate divergences from pyarrow, tracked as a follow-up in
+    issue #662.
+    """
+    present = [c for c in cells if c is not None]
+
+    if not present:
+        return list(cells)
+
+    if all(_INT_RE.match(c) for c in present):
+        return [None if c is None else int(c) for c in cells]
+
+    if all(_FLOAT_RE.match(c) for c in present):
+        return [None if c is None else float(c) for c in cells]
+
+    if all(c in _BOOL_MAP for c in present):
+        return [None if c is None else _BOOL_MAP[c] for c in cells]
+
+    return ["" if c is None else c for c in cells]
+
+
+class FileSourceDictTransformer(BaseTransformer):
+    """Materialize a ``FileSource`` descriptor into a columnar ``dict[str, list[Any]]``.
+
+    Uses only the stdlib ``csv`` module, so a CSV can be read into PythonDict without pyarrow.
+    """
+
+    @classmethod
+    def framework(cls) -> Any:
+        from mloda.core.abstract_plugins.components.input_data.file_source import FileSource
+
+        return FileSource
+
+    @classmethod
+    def other_framework(cls) -> Any:
+        return dict
+
+    @classmethod
+    def import_fw(cls) -> None:
+        import mloda.core.abstract_plugins.components.input_data.file_source  # noqa: F401
+
+    @classmethod
+    def import_other_fw(cls) -> None:
+        pass
+
+    @classmethod
+    def transform_fw_to_other_fw(cls, data: Any) -> Any:
+        if data.format != "csv":
+            raise ValueError(f"FileSourceDictTransformer only supports the 'csv' format, got {data.format!r}.")
+
+        with open(data.path, newline="", encoding="utf-8-sig") as f:
+            reader = csv.reader(f)
+            header = next(reader, [])
+
+            index: dict[str, int] = {}
+            for name in data.columns:
+                occurrences = header.count(name)
+                if occurrences > 1:
+                    raise ValueError(
+                        f"Duplicate column {name!r} in CSV header of {data.path}; cannot resolve which one to read."
+                    )
+                if occurrences == 0:
+                    raise ValueError(f"Column {name!r} not found in CSV header of {data.path}")
+                index[name] = header.index(name)
+
+            raw: dict[str, list[str | None]] = {name: [] for name in data.columns}
+            for row_number, row in enumerate(reader, start=1):
+                if not row:
+                    continue
+                if len(row) != len(header):
+                    raise ValueError(
+                        f"Ragged row {row_number} in {data.path}: expected {len(header)} columns, got {len(row)}."
+                    )
+                for name in data.columns:
+                    cell = row[index[name]]
+                    raw[name].append(None if cell == "" else cell)
+
+        return {name: _infer_column(cells) for name, cells in raw.items()}

--- a/mloda_plugins/feature_group/input_data/read_db.py
+++ b/mloda_plugins/feature_group/input_data/read_db.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 from mloda.user import DataAccessCollection
 from mloda.provider import FeatureSet, BaseInputData
 from mloda.user import Options
@@ -14,20 +14,49 @@ class ReadDB(BaseInputData):
     To suppress auto-loading:
         PluginLoader.disable_auto_load("feature_group/input_data/read_dbs")
 
-    The following methods should be implemented in the child classes:
-    - load_data
-    - connect
-    - build_query
-    - is_valid_credentials
-    - check_feature_in_data_access
+    load_data is a template method exposing an opt-in lifecycle seam: a new
+    backend implements ``produce_rows``, ``connect``, and ``is_valid_credentials``
+    (optionally ``prepare_credentials``/``build_query``/``check_feature_in_data_access``)
+    instead of overriding ``load_data`` wholesale. Overriding ``load_data`` directly
+    is still supported.
     """
 
     _auto_load_group: str = "feature_group/input_data/read_dbs"
 
     @classmethod
-    def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
-        """This function should be implemented by child classes."""
+    def prepare_credentials(cls, data_access: Any, features: FeatureSet) -> Any:
+        """Overridable hook to normalize/validate credentials before connecting; default is pass-through."""
+        return data_access
+
+    @classmethod
+    def produce_rows(cls, connection: Any, features: FeatureSet) -> Any:
+        """The per-backend row hook; implement THIS (plus connect and is_valid_credentials) instead of load_data.
+        Return fully materialized rows: close_connection runs in the template's finally block, so a lazy
+        cursor or generator dies after close. The template does not call build_query; call it here if needed."""
         raise NotImplementedError
+
+    @classmethod
+    def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
+        """Template method: probe final-reader classification against the dynamic anchor,
+        prepare credentials, connect, produce rows, then close."""
+        if not cls.is_final_reader():
+            raise NotImplementedError
+
+        credentials = cls.prepare_credentials(data_access, features)
+        connection = cls.get_connection(credentials)
+        try:
+            return cls.produce_rows(connection, features)
+        finally:
+            cls.close_connection(connection)
+
+    @classmethod
+    def _final_reader_requires(cls) -> tuple[str, ...]:
+        """Hook-based discovery requires overriding connect itself; a backend that customizes
+        get_connection but leaves connect abstract must override load_data wholesale or also
+        override connect."""
+        # Requiring connect alongside produce_rows screens out intermediate bases that
+        # supply a shared produce_rows but leave connect abstract.
+        return ("produce_rows", "connect")
 
     @classmethod
     def connect(cls, credentials: Any) -> Any:
@@ -40,32 +69,22 @@ class ReadDB(BaseInputData):
 
     @classmethod
     def is_valid_credentials(cls, credentials: dict[str, Any]) -> bool:
-        """Checks if the given dictionary is a valid credentials object."""
+        """Checks if the given dictionary is a valid credentials object.
+
+        Matcher exception contract: match_read_db_data_access treats only NotImplementedError
+        as a soft no-match; any other exception propagates and aborts matching for every
+        reader sharing the DataAccessCollection.
+        """
         raise NotImplementedError
 
     @classmethod
     def check_feature_in_data_access(cls, feature_name: str, data_access: Any) -> bool:
-        """Obligatory function to check if the feature is in the data access."""
+        """Obligatory function to check if the feature is in the data access.
+
+        Same matcher exception contract as is_valid_credentials: only NotImplementedError
+        is a soft no-match, any other exception propagates.
+        """
         raise NotImplementedError
-
-    def init_reader(self, options: Optional[Options]) -> tuple["ReadDB", Any]:
-        if options is None:
-            raise ValueError(
-                f"Options were not set for {self.__class__.__name__}. "
-                f"Provide an Options object containing a 'BaseInputData' key "
-                f"with a (reader_class, data_access) tuple."
-            )
-
-        reader_data_access = options["BaseInputData"]
-
-        if reader_data_access is None:
-            raise ValueError(
-                f"'BaseInputData' key is missing or None in the provided Options for {self.__class__.__name__}. "
-                f"Set options with Options(group={{'BaseInputData': (ReaderClass, {{...}})}})."
-            )
-
-        reader, data_access = reader_data_access
-        return reader(), data_access
 
     @classmethod
     def match_subclass_data_access(cls, data_access: Any, feature_names: list[str], options: Options) -> Any:

--- a/mloda_plugins/feature_group/input_data/read_document.py
+++ b/mloda_plugins/feature_group/input_data/read_document.py
@@ -25,29 +25,62 @@ class ReadDocument(BaseInputData):
 
     This tells ReadDocument to include .json files and ReadFile to
     auto-exclude them for that feature.
+
+    load_data is a template method exposing an opt-in lifecycle seam: a new
+    reader implements ``produce_document`` (optionally ``document_file_type``)
+    plus ``suffix`` instead of overriding ``load_data`` wholesale; both are
+    required for the class to be discovered as a final reader. Overriding
+    ``load_data`` directly is still supported.
     """
 
     _auto_load_group: str = "feature_group/input_data/read_files"
 
     @classmethod
-    def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
+    def produce_document(cls, file_path: str) -> Any:
+        """The per-format parse hook; a new reader implements THIS instead of overriding load_data wholesale."""
         raise NotImplementedError
+
+    @classmethod
+    def document_file_type(cls, file_path: str) -> str:
+        """Overridable hook for the envelope's file_type; default is the first declared suffix without the dot."""
+        return cls.suffix()[0].lstrip(".")
+
+    @classmethod
+    def _read_text(cls, file_path: str) -> str:
+        """Shared helper for text-based readers: read the whole file as UTF-8 text."""
+        with open(file_path, encoding="utf-8") as file:
+            return file.read()
+
+    @classmethod
+    def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
+        """Template method: probe final-reader classification against the dynamic anchor,
+        resolve the path (a resolved str/Path data access wins; the reader-named options
+        key is the fallback), parse, then wrap the one-row envelope."""
+        if not cls.is_final_reader():
+            raise NotImplementedError
+
+        if isinstance(data_access, (str, Path)):
+            file_path = str(data_access)
+        else:
+            file_path = features.get_options_key(cls.__name__)
+        if file_path is None:
+            raise ValueError(
+                f"No file path for {cls.__name__}: data_access is not a path and the '{cls.__name__}' options key "
+                f"is not set. Select the reader via Feature(name, options={{'{cls.__name__}': '/path/to/file'}}) "
+                "or provide a matching DataAccessCollection."
+            )
+        content = cls.produce_document(file_path)
+        return [{cls.get_class_name(): content, "source": file_path, "file_type": cls.document_file_type(file_path)}]
+
+    @classmethod
+    def _final_reader_requires(cls) -> tuple[str, ...]:
+        # Requiring suffix alongside produce_document screens out intermediate bases that
+        # share produce_document but leave suffix abstract, mirroring ReadDB's connect requirement.
+        return ("produce_document", "suffix")
 
     @classmethod
     def suffix(cls) -> tuple[str, ...]:
         raise NotImplementedError
-
-    def init_reader(self, options: Optional[Options]) -> tuple["ReadDocument", Any]:
-        if options is None:
-            raise ValueError("Options were not set.")
-
-        reader_data_access = options.get("BaseInputData")
-
-        if reader_data_access is None:
-            raise ValueError("Reader data access was not set.")
-
-        reader, data_access = reader_data_access
-        return reader(), data_access
 
     @classmethod
     def match_subclass_data_access(cls, data_access: Any, feature_names: list[str], options: Options) -> Any:
@@ -113,7 +146,7 @@ class ReadDocument(BaseInputData):
             return False
         if not path.endswith(cls.suffix()):
             return False
-        if document_suffixes is not None and cls._is_structured_suffix(path, document_suffixes):
+        if cls._is_structured_suffix(path, document_suffixes):
             return False
         return True
 

--- a/mloda_plugins/feature_group/input_data/read_file.py
+++ b/mloda_plugins/feature_group/input_data/read_file.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 from mloda.user import DataAccessCollection
 from mloda.provider import FeatureSet
 from mloda.provider import BaseInputData
@@ -29,6 +29,10 @@ class ReadFile(BaseInputData):
     - load_data
     - suffix
     - get_column_names
+
+    A ReadFile subclass classifies as a final reader by overriding ``load_data``
+    wholesale. It may return its table directly, or a descriptor materialized by
+    the target compute framework (CsvReader returns a ``FileSource``).
 
     If get_column_names is not implemented, the class will assume the columns are there.
     """
@@ -59,41 +63,18 @@ class ReadFile(BaseInputData):
         raise NotImplementedError
 
     @classmethod
+    def _final_reader_requires(cls) -> tuple[str, ...]:
+        # ReadFile anchors its own subtree so a subclass classifies as a final reader only
+        # by overriding load_data wholesale; there is no hook-based classification here.
+        return ()
+
+    @classmethod
     def suffix(cls) -> tuple[str, ...]:
         raise NotImplementedError
 
     @classmethod
     def get_column_names(cls, file_name: str) -> list[str]:
         raise NotImplementedError
-
-    def init_reader(self, options: Optional[Options]) -> tuple["ReadFile", Any]:
-        if options is None:
-            raise ValueError(
-                f"Options were not set for {self.__class__.__name__}.init_reader().\n"
-                "When using ReadFile-based features, you must provide Options "
-                "with a 'BaseInputData' key.\n"
-                "Example:\n"
-                "  from mloda.user import Feature, Options\n"
-                "  feature = Feature('my_column', options=Options(context={\n"
-                "      'BaseInputData': (CsvReader, '/path/to/file.csv')\n"
-                "  }))"
-            )
-
-        reader_data_access = options.get("BaseInputData")
-
-        if reader_data_access is None:
-            raise ValueError(
-                f"'BaseInputData' key is missing or None in the provided Options for {self.__class__.__name__}.\n"
-                "The 'BaseInputData' key in Options must map to a tuple of "
-                "(ReaderClass, data_access).\n"
-                "Example:\n"
-                "  options = Options(context={\n"
-                "      'BaseInputData': (CsvReader, '/path/to/file.csv')\n"
-                "  })"
-            )
-
-        reader, data_access = reader_data_access
-        return reader(), data_access
 
     @classmethod
     def match_subclass_data_access(cls, data_access: Any, feature_names: list[str], options: Options) -> Any:

--- a/mloda_plugins/feature_group/input_data/read_files/csv.py
+++ b/mloda_plugins/feature_group/input_data/read_files/csv.py
@@ -1,10 +1,7 @@
+import csv
 from typing import Any
 
-try:
-    from pyarrow import csv as pyarrow_csv
-except ImportError:
-    pyarrow_csv = None
-
+from mloda.core.abstract_plugins.components.input_data.file_source import FileSource
 from mloda.provider import FeatureSet
 from mloda_plugins.feature_group.input_data.read_file import ReadFile
 
@@ -13,9 +10,10 @@ class CsvReader(ReadFile):
     """
     Base class for CSV file reading feature groups.
 
-    This feature group enables reading data from CSV (Comma-Separated Values) files,
-    providing efficient data loading using PyArrow for optimal performance. It
-    automatically detects column names and supports various CSV formats.
+    This feature group enables reading data from CSV (Comma-Separated Values) files.
+    ``load_data`` resolves a CSV into a lightweight ``FileSource`` descriptor, so the
+    actual materialization is deferred to the target compute framework's transformer.
+    It automatically detects column names and supports various CSV formats.
 
     ## Supported Operations
 
@@ -138,15 +136,12 @@ class CsvReader(ReadFile):
     - File must be readable and properly formatted
     - Feature names must match column names in the CSV header
     - All features must use the same CSV file
-    - PyArrow library must be installed
 
     ## Additional Notes
 
-    - Uses PyArrow's CSV reader for efficient parsing and memory usage
-    - Automatically detects column types and schema
+    - Header discovery uses the stdlib ``csv`` module (no third-party dependency)
     - Supports both .csv and .CSV file extensions
-    - Only requested columns are loaded into memory for efficiency
-    - The reader automatically skips the header row after reading column names
+    - The materializing transformer selects only the requested columns
     """
 
     @classmethod
@@ -158,13 +153,9 @@ class CsvReader(ReadFile):
 
     @classmethod
     def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
-        if pyarrow_csv is None:
-            raise ImportError("pyarrow is required to read CSV files. Install it with: pip install 'mloda[pyarrow]'")
-        result = pyarrow_csv.read_csv(data_access)
-        return result.select(list(features.get_all_names()))
+        return FileSource(path=data_access, format="csv", columns=tuple(sorted(features.get_all_names())))
 
     @classmethod
     def get_column_names(cls, file_name: str) -> Any:
-        read_options = pyarrow_csv.ReadOptions(skip_rows_after_names=1)
-        table = pyarrow_csv.read_csv(file_name, read_options=read_options)
-        return table.schema.names
+        with open(file_name, newline="", encoding="utf-8-sig") as f:
+            return next(csv.reader(f), [])

--- a/mloda_plugins/feature_group/input_data/read_files/json_document_reader.py
+++ b/mloda_plugins/feature_group/input_data/read_files/json_document_reader.py
@@ -3,8 +3,6 @@ from typing import Any
 
 from mloda_plugins.feature_group.input_data.read_document import ReadDocument
 
-from mloda.provider import FeatureSet
-
 
 class JsonDocumentReader(ReadDocument):
     """Load entire JSON file as a single document value for RAG pipelines."""
@@ -14,13 +12,7 @@ class JsonDocumentReader(ReadDocument):
         return (".json", ".JSON")
 
     @classmethod
-    def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
-        file_path = features.get_options_key(cls.__name__)
-
+    def produce_document(cls, file_path: str) -> Any:
         with open(file_path, "r", encoding="utf-8") as f:
             content = json.load(f)
-
-        json_string = json.dumps(content)
-        file_type = cls.suffix()[0].lstrip(".")
-
-        return [{cls.get_class_name(): json_string, "source": file_path, "file_type": file_type}]
+        return json.dumps(content)

--- a/mloda_plugins/feature_group/input_data/read_files/markdown_document_reader.py
+++ b/mloda_plugins/feature_group/input_data/read_files/markdown_document_reader.py
@@ -2,8 +2,6 @@ from typing import Any
 
 from mloda_plugins.feature_group.input_data.read_document import ReadDocument
 
-from mloda.provider import FeatureSet
-
 
 class MarkdownDocumentReader(ReadDocument):
     @classmethod
@@ -11,12 +9,5 @@ class MarkdownDocumentReader(ReadDocument):
         return (".md",)
 
     @classmethod
-    def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
-        file_path = features.get_options_key(cls.__name__)
-
-        with open(file_path, encoding="utf-8") as file:
-            content = file.read()
-
-        file_type = cls.suffix()[0].lstrip(".")
-
-        return [{cls.get_class_name(): content, "source": file_path, "file_type": file_type}]
+    def produce_document(cls, file_path: str) -> Any:
+        return cls._read_text(file_path)

--- a/mloda_plugins/feature_group/input_data/read_files/text_file_reader.py
+++ b/mloda_plugins/feature_group/input_data/read_files/text_file_reader.py
@@ -2,8 +2,6 @@ from typing import Any
 
 from mloda_plugins.feature_group.input_data.read_document import ReadDocument
 
-from mloda.provider import FeatureSet
-
 
 class TextFileReader(ReadDocument):
     @classmethod
@@ -11,15 +9,8 @@ class TextFileReader(ReadDocument):
         return (".text",)
 
     @classmethod
-    def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
-        file_path = features.get_options_key(cls.__name__)
-
-        with open(file_path, encoding="utf-8") as file:
-            content = file.read()
-
-        file_type = cls.suffix()[0].lstrip(".")
-
-        return [{cls.get_class_name(): content, "source": file_path, "file_type": file_type}]
+    def produce_document(cls, file_path: str) -> Any:
+        return cls._read_text(file_path)
 
 
 class PyFileReader(TextFileReader):

--- a/mloda_plugins/feature_group/input_data/read_files/yaml_document_reader.py
+++ b/mloda_plugins/feature_group/input_data/read_files/yaml_document_reader.py
@@ -4,8 +4,6 @@ from typing import Any
 
 from mloda_plugins.feature_group.input_data.read_document import ReadDocument
 
-from mloda.provider import FeatureSet
-
 
 class YamlDocumentReader(ReadDocument):
     """Load entire YAML file as a single document value for RAG pipelines."""
@@ -15,18 +13,12 @@ class YamlDocumentReader(ReadDocument):
         return (".yaml", ".yml")
 
     @classmethod
-    def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
-        file_path = features.get_options_key(cls.__name__)
-
+    def produce_document(cls, file_path: str) -> Any:
         with open(file_path, "r", encoding="utf-8") as f:
             documents = list(yaml.safe_load_all(f))
+        content = documents[0] if len(documents) == 1 else documents
+        return yaml.dump(content)
 
-        if len(documents) == 1:
-            content = documents[0]
-        else:
-            content = documents
-
-        yaml_string = yaml.dump(content)
-        file_type = Path(file_path).suffix.lstrip(".")
-
-        return [{cls.get_class_name(): yaml_string, "source": file_path, "file_type": file_type}]
+    @classmethod
+    def document_file_type(cls, file_path: str) -> str:
+        return Path(file_path).suffix.lstrip(".")

--- a/tests/test_core/test_abstract_plugins/test_components/test_apply_chain.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_apply_chain.py
@@ -1,0 +1,208 @@
+"""ONE shared chain-application helper on ComputeFrameworkTransformer.
+
+Contract:
+
+  * ``ComputeFrameworkTransformer.apply_chain(from_framework, to_framework, chain, data,
+    connection)`` walks a transformation chain: every intermediate hop resolves its target
+    framework from the transformer map, the LAST hop targets ``to_framework`` directly, and
+    each transformer is applied in sequence.
+  * A chain that names a transformer with NO matching edge from the current framework in
+    the transformer map raises a CLEAR ``KeyError``/``ValueError`` naming the transformer
+    and the framework, never an ``UnboundLocalError``.
+  * ``TransformFrameworkStep.transform`` DELEGATES chain application to ``apply_chain``
+    instead of re-implementing the walk inline.
+
+All frameworks and transformers here are synthetic and defined inside a factory function,
+so nothing leaks into the global BaseTransformer subclass discovery or the compute
+framework enumeration of other tests. No FileSource / file IO involved.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from mloda.core.abstract_plugins.components.framework_transformer.base_transformer import BaseTransformer
+from mloda.core.abstract_plugins.components.framework_transformer.cfw_transformer import (
+    ComputeFrameworkTransformer,
+)
+from mloda.core.core.step.transform_frame_work_step import TransformFrameworkStep
+from mloda.provider import ComputeFramework
+from mloda.provider import FeatureGroup
+from mloda.user import ParallelizationMode
+
+_ChainEnv = tuple[
+    type[Any],  # _FwA
+    type[Any],  # _FwB
+    type[Any],  # _FwC
+    type[BaseTransformer],  # A <-> B
+    type[BaseTransformer],  # B <-> C
+    ComputeFrameworkTransformer,
+]
+
+
+def _chain_env() -> _ChainEnv:
+    """Build a synthetic 2-hop environment A -> B -> C with recording transformers.
+
+    Each transformer appends a tag to the (list) payload, so application ORDER is
+    observable in the final result. The transformer map contains only the synthetic
+    edges, mirroring how ``add`` registers both directions of a pair.
+    """
+
+    class _FwA:
+        pass
+
+    class _FwB:
+        pass
+
+    class _FwC:
+        pass
+
+    class _TransAToB(BaseTransformer):
+        @classmethod
+        def framework(cls) -> Any:
+            return _FwA
+
+        @classmethod
+        def other_framework(cls) -> Any:
+            return _FwB
+
+        @classmethod
+        def import_fw(cls) -> None:
+            raise ImportError("synthetic transformer, never auto-registered")
+
+        @classmethod
+        def import_other_fw(cls) -> None:
+            raise ImportError("synthetic transformer, never auto-registered")
+
+        @classmethod
+        def transform_fw_to_other_fw(cls, data: Any) -> Any:
+            return [*data, "A->B"]
+
+        @classmethod
+        def transform_other_fw_to_fw(cls, data: Any, framework_connection_object: Any | None = None) -> Any:
+            return [*data, "B->A"]
+
+    class _TransBToC(BaseTransformer):
+        @classmethod
+        def framework(cls) -> Any:
+            return _FwB
+
+        @classmethod
+        def other_framework(cls) -> Any:
+            return _FwC
+
+        @classmethod
+        def import_fw(cls) -> None:
+            raise ImportError("synthetic transformer, never auto-registered")
+
+        @classmethod
+        def import_other_fw(cls) -> None:
+            raise ImportError("synthetic transformer, never auto-registered")
+
+        @classmethod
+        def transform_fw_to_other_fw(cls, data: Any) -> Any:
+            return [*data, "B->C"]
+
+        @classmethod
+        def transform_other_fw_to_fw(cls, data: Any, framework_connection_object: Any | None = None) -> Any:
+            return [*data, "C->B"]
+
+    transformer = ComputeFrameworkTransformer()
+    transformer.transformer_map = {
+        (_FwA, _FwB): _TransAToB,
+        (_FwB, _FwA): _TransAToB,
+        (_FwB, _FwC): _TransBToC,
+        (_FwC, _FwB): _TransBToC,
+    }
+    return _FwA, _FwB, _FwC, _TransAToB, _TransBToC, transformer
+
+
+class TestApplyChain:
+    def test_multi_hop_chain_applies_transformers_in_order(self) -> None:
+        """A 2-hop chain A -> B -> C resolves the intermediate target (B) from the map and
+        applies both transformers in sequence.
+        """
+        fw_a, _fw_b, fw_c, trans_ab, trans_bc, transformer = _chain_env()
+
+        result = transformer.apply_chain(fw_a, fw_c, [trans_ab, trans_bc], ["start"], None)
+
+        assert result == ["start", "A->B", "B->C"]
+
+    def test_single_hop_chain_targets_to_framework_directly(self) -> None:
+        """A single-element chain transforms straight to ``to_framework`` (no intermediate
+        resolution involved).
+        """
+        fw_a, fw_b, _fw_c, trans_ab, _trans_bc, transformer = _chain_env()
+
+        result = transformer.apply_chain(fw_a, fw_b, [trans_ab], ["start"], None)
+
+        assert result == ["start", "A->B"]
+
+    def test_inconsistent_chain_raises_clear_error_naming_transformer_and_framework(self) -> None:
+        """A chain whose first transformer has NO edge from the current framework must raise
+        a clear KeyError/ValueError naming the transformer and the framework, and must never
+        surface an ``UnboundLocalError`` from an unbound intermediate target.
+
+        The chain starts at ``_FwA`` but names the B <-> C transformer, which has no edge
+        from ``_FwA`` in the map: the registry and the chain are inconsistent.
+        """
+        fw_a, _fw_b, fw_c, _trans_ab, trans_bc, transformer = _chain_env()
+
+        with pytest.raises((KeyError, ValueError)) as excinfo:
+            transformer.apply_chain(fw_a, fw_c, [trans_bc, trans_bc], ["start"], None)
+
+        message = str(excinfo.value)
+        assert "_TransBToC" in message, message
+        assert "_FwA" in message, message
+
+
+class TestTransformFrameworkStepDelegatesToApplyChain:
+    def test_transform_delegates_chain_application_to_apply_chain(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``TransformFrameworkStep.transform`` hands the resolved chain to
+        ``ComputeFrameworkTransformer.apply_chain`` instead of walking it inline.
+        """
+        fw_a, fw_b, _fw_c, trans_ab, _trans_bc, _transformer = _chain_env()
+
+        # Local ComputeFramework subclasses so nothing is discovered by other tests'
+        # framework enumeration.
+        class _CfwFrom(ComputeFramework):
+            @classmethod
+            def expected_data_framework(cls) -> Any:
+                return fw_a
+
+        class _CfwTo(ComputeFramework):
+            @classmethod
+            def expected_data_framework(cls) -> Any:
+                return fw_b
+
+        step = TransformFrameworkStep(
+            from_framework=_CfwFrom,
+            to_framework=_CfwTo,
+            required_uuids=set(),
+            from_feature_group=FeatureGroup,
+            to_feature_group=FeatureGroup,
+        )
+        step.transformer.transformer_map = {(fw_a, fw_b): trans_ab, (fw_b, fw_a): trans_ab}
+
+        recorded: dict[str, Any] = {}
+
+        def _spy(
+            self: ComputeFrameworkTransformer,
+            from_framework: type[Any],
+            to_framework: type[Any],
+            chain: list[type[BaseTransformer]],
+            data: Any,
+            connection: Any,
+        ) -> Any:
+            recorded["args"] = (from_framework, to_framework, list(chain), data, connection)
+            return "CHAIN_APPLIED"
+
+        monkeypatch.setattr(ComputeFrameworkTransformer, "apply_chain", _spy)
+
+        cfw = _CfwTo(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
+        result = step.transform(cfw, ["payload"], set())
+
+        assert result == "CHAIN_APPLIED"
+        assert recorded["args"] == (fw_a, fw_b, [trans_ab], ["payload"], cfw.framework_connection_object)

--- a/tests/test_core/test_abstract_plugins/test_components/test_is_final_reader.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_is_final_reader.py
@@ -1,0 +1,369 @@
+"""Structural is_final_reader contract on BaseInputData.
+
+- BaseInputData._final_reader_requires() -> tuple[str, ...], default ().
+- BaseInputData.final_reader_anchor() -> type; public anchor resolution.
+- BaseInputData.is_final_reader() -> bool. Replaces the removed execution-probe
+  supports_scoped_data_access.
+- Anchor = most-derived class in cls.__mro__ that declares _final_reader_requires
+  in its own __dict__ (BaseInputData declares the default, so an anchor always exists).
+- If load_data is overridden relative to the anchor: True. Otherwise True iff the
+  required tuple is non-empty and every named hook is overridden relative to the anchor.
+- A required name missing on the anchor raises ValueError naming the hook and the anchor.
+- Classification is purely structural: it never executes load_data or any hook.
+
+ReadDB requires ("produce_rows", "connect") and ReadDocument requires
+("produce_document", "suffix"); both declare a template load_data that probes
+this classification before any lifecycle work. ReadFile stays a pure anchor with
+an empty requires tuple, so its concrete readers classify via the wholesale
+load_data branch.
+
+The synthetic families below are built directly on BaseInputData and expose no
+matching surface (match_subclass_data_access returns None, and their
+data_access_name is just the class name, which no sibling test uses as an
+options key), so they cannot pollute discovery in other tests.
+"""
+
+import gc
+from typing import Any
+
+import pytest
+
+from mloda.core.abstract_plugins.components.input_data.base_input_data import BaseInputData
+from mloda.provider import FeatureSet
+from mloda_plugins.feature_group.input_data.read_db import ReadDB
+from mloda_plugins.feature_group.input_data.read_dbs.sqlite import SQLITEReader
+from mloda_plugins.feature_group.input_data.read_document import ReadDocument
+from mloda_plugins.feature_group.input_data.read_file import ReadFile
+from mloda_plugins.feature_group.input_data.read_files.csv import CsvReader
+from mloda_plugins.feature_group.input_data.read_files.text_file_reader import PyFileReader, TextFileReader
+
+
+def _invoke(cls: type[BaseInputData], method_name: str) -> Any:
+    """Invoke a classmethod on cls by name."""
+    return getattr(cls, method_name)()
+
+
+def _is_final_reader(cls: type[BaseInputData]) -> bool:
+    result = _invoke(cls, "is_final_reader")
+    assert isinstance(result, bool)
+    return result
+
+
+def _final_reader_requires(cls: type[BaseInputData]) -> tuple[str, ...]:
+    result = _invoke(cls, "_final_reader_requires")
+    assert isinstance(result, tuple)
+    return result
+
+
+def _final_reader_anchor(cls: type[BaseInputData]) -> type:
+    result = _invoke(cls, "final_reader_anchor")
+    assert isinstance(result, type)
+    return result
+
+
+class _DefaultPlain(BaseInputData):
+    """Default family (no _final_reader_requires declaration), no load_data override."""
+
+    @classmethod
+    def match_subclass_data_access(cls, data_access: Any, feature_names: list[str], options: Any = None) -> Any:
+        return None
+
+
+class _DefaultWholesale(BaseInputData):
+    """Default family, wholesale load_data override."""
+
+    @classmethod
+    def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
+        return {"unused_synthetic_column": [1]}
+
+    @classmethod
+    def match_subclass_data_access(cls, data_access: Any, feature_names: list[str], options: Any = None) -> Any:
+        return None
+
+
+class _DefaultBareRedeclaration(BaseInputData):
+    """Default family, load_data re-declared with a bare NotImplementedError body.
+
+    Structural classification means declared-is-overridden: this pins the documented
+    convention that intermediate bases must not re-declare bare hooks.
+    """
+
+    @classmethod
+    def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
+        raise NotImplementedError
+
+    @classmethod
+    def match_subclass_data_access(cls, data_access: Any, feature_names: list[str], options: Any = None) -> Any:
+        return None
+
+
+class _FamilyBase(BaseInputData):
+    """Synthetic seam family requiring hook_a and hook_b."""
+
+    @classmethod
+    def _final_reader_requires(cls) -> tuple[str, ...]:
+        return ("hook_a", "hook_b")
+
+    @classmethod
+    def hook_a(cls) -> Any:
+        raise NotImplementedError
+
+    @classmethod
+    def hook_b(cls) -> Any:
+        raise NotImplementedError
+
+    @classmethod
+    def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
+        cls.hook_a()
+        return cls.hook_b()
+
+    @classmethod
+    def match_subclass_data_access(cls, data_access: Any, feature_names: list[str], options: Any = None) -> Any:
+        return None
+
+
+class _OnlyHookA(_FamilyBase):
+    @classmethod
+    def hook_a(cls) -> Any:
+        return "a"
+
+
+class _BothHooks(_FamilyBase):
+    @classmethod
+    def hook_a(cls) -> Any:
+        return "a"
+
+    @classmethod
+    def hook_b(cls) -> Any:
+        return "b"
+
+
+class _WholesaleInFamily(_FamilyBase):
+    @classmethod
+    def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
+        return {"unused_synthetic_column": [2]}
+
+
+_RECORDED_CALLS: list[str] = []
+
+
+class _RecordingHooksOnly(_FamilyBase):
+    """Final via hooks; records every execution so structural classification is provable."""
+
+    @classmethod
+    def hook_a(cls) -> Any:
+        _RECORDED_CALLS.append("hook_a")
+        return None
+
+    @classmethod
+    def hook_b(cls) -> Any:
+        _RECORDED_CALLS.append("hook_b")
+        return None
+
+
+class _RecordingWholesale(_FamilyBase):
+    """Final via wholesale load_data; records every execution."""
+
+    @classmethod
+    def hook_a(cls) -> Any:
+        _RECORDED_CALLS.append("hook_a_wholesale")
+        return None
+
+    @classmethod
+    def hook_b(cls) -> Any:
+        _RECORDED_CALLS.append("hook_b_wholesale")
+        return None
+
+    @classmethod
+    def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
+        _RECORDED_CALLS.append("load_data_wholesale")
+        return None
+
+
+class _SubFamilyBase(_FamilyBase):
+    """Sub-family redeclaring the anchor: requires hook_c instead of hook_a/hook_b."""
+
+    @classmethod
+    def _final_reader_requires(cls) -> tuple[str, ...]:
+        return ("hook_c",)
+
+    @classmethod
+    def hook_c(cls) -> Any:
+        raise NotImplementedError
+
+
+class _SubFamilyChild(_SubFamilyBase):
+    @classmethod
+    def hook_c(cls) -> Any:
+        return "c"
+
+
+class _SubFamilyWholesale(_SubFamilyBase):
+    @classmethod
+    def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
+        return {"unused_synthetic_column": [3]}
+
+
+class _AnchorWithOwnLoadData(_FamilyBase):
+    """Redeclares the anchor and defines its own load_data body in the same class."""
+
+    @classmethod
+    def _final_reader_requires(cls) -> tuple[str, ...]:
+        return ("hook_c",)
+
+    @classmethod
+    def hook_c(cls) -> Any:
+        raise NotImplementedError
+
+    @classmethod
+    def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
+        cls.hook_a()
+        return cls.hook_c()
+
+
+class TestOldNameRemoved:
+    def test_supports_scoped_data_access_is_gone_from_base(self) -> None:
+        assert not hasattr(BaseInputData, "supports_scoped_data_access")
+
+    def test_supports_scoped_data_access_is_gone_from_read_db(self) -> None:
+        assert not hasattr(ReadDB, "supports_scoped_data_access")
+
+
+class TestDefaultFamilyClassification:
+    def test_base_default_requires_is_empty(self) -> None:
+        assert _final_reader_requires(BaseInputData) == ()
+
+    def test_plain_subclass_is_not_final(self) -> None:
+        assert _is_final_reader(_DefaultPlain) is False
+
+    def test_wholesale_load_data_is_final(self) -> None:
+        assert _is_final_reader(_DefaultWholesale) is True
+
+    def test_bare_redeclaration_counts_as_overridden(self) -> None:
+        assert _is_final_reader(_DefaultBareRedeclaration) is True
+
+
+class TestSyntheticSeamFamily:
+    def test_family_base_is_not_final(self) -> None:
+        assert _is_final_reader(_FamilyBase) is False
+
+    def test_partial_hooks_are_not_final(self) -> None:
+        assert _is_final_reader(_OnlyHookA) is False
+
+    def test_all_hooks_are_final(self) -> None:
+        assert _is_final_reader(_BothHooks) is True
+
+    def test_wholesale_load_data_in_family_is_final(self) -> None:
+        assert _is_final_reader(_WholesaleInFamily) is True
+
+    def test_classification_never_executes_hooks_or_load_data(self) -> None:
+        _RECORDED_CALLS.clear()
+        assert _is_final_reader(_RecordingHooksOnly) is True
+        assert _is_final_reader(_RecordingWholesale) is True
+        assert _RECORDED_CALLS == []
+
+
+class TestAnchorRedeclaration:
+    def test_sub_family_base_is_not_final(self) -> None:
+        assert _is_final_reader(_SubFamilyBase) is False
+
+    def test_child_overriding_new_hook_is_final(self) -> None:
+        assert _is_final_reader(_SubFamilyChild) is True
+
+    def test_child_overriding_load_data_relative_to_new_anchor_is_final(self) -> None:
+        assert _is_final_reader(_SubFamilyWholesale) is True
+
+    def test_anchor_redeclaring_requires_with_own_load_data_is_not_final(self) -> None:
+        """Pins the semantics: declaring a requires tuple makes a class a family base,
+        and a family base is never final even with its own load_data; a concrete
+        reader must not redeclare the tuple."""
+        assert _is_final_reader(_AnchorWithOwnLoadData) is False
+
+
+class TestAnchorResolution:
+    """final_reader_anchor() is the public seam ReadDB and ReadDocument build their hook seams on."""
+
+    def test_base_is_its_own_anchor(self) -> None:
+        assert _final_reader_anchor(BaseInputData) is BaseInputData
+
+    def test_default_family_anchors_to_base(self) -> None:
+        assert _final_reader_anchor(_DefaultPlain) is BaseInputData
+        assert _final_reader_anchor(_DefaultWholesale) is BaseInputData
+
+    def test_family_base_is_its_own_anchor(self) -> None:
+        assert _final_reader_anchor(_FamilyBase) is _FamilyBase
+
+    def test_family_members_anchor_to_family_base(self) -> None:
+        assert _final_reader_anchor(_OnlyHookA) is _FamilyBase
+        assert _final_reader_anchor(_BothHooks) is _FamilyBase
+        assert _final_reader_anchor(_WholesaleInFamily) is _FamilyBase
+
+    def test_sub_family_redeclaration_moves_the_anchor(self) -> None:
+        assert _final_reader_anchor(_SubFamilyBase) is _SubFamilyBase
+        assert _final_reader_anchor(_SubFamilyChild) is _SubFamilyBase
+        assert _final_reader_anchor(_SubFamilyWholesale) is _SubFamilyBase
+
+    def test_real_readers_anchor_to_their_family(self) -> None:
+        assert _final_reader_anchor(CsvReader) is ReadFile
+        assert _final_reader_anchor(SQLITEReader) is ReadDB
+        assert _final_reader_anchor(TextFileReader) is ReadDocument
+        assert _final_reader_anchor(PyFileReader) is ReadDocument
+
+
+class TestLoudValidation:
+    def test_missing_required_hook_raises_value_error(self) -> None:
+        class _BadFamily(BaseInputData):
+            @classmethod
+            def _final_reader_requires(cls) -> tuple[str, ...]:
+                return ("nonexistent_hook",)
+
+            @classmethod
+            def match_subclass_data_access(cls, data_access: Any, feature_names: list[str], options: Any = None) -> Any:
+                return None
+
+        with pytest.raises(ValueError) as exc_info:
+            _invoke(_BadFamily, "is_final_reader")
+        assert "nonexistent_hook" in str(exc_info.value)
+        assert "_BadFamily" in str(exc_info.value)
+        # Drop the misconfigured local class from BaseInputData.__subclasses__ so it
+        # cannot raise during discovery in sibling tests running in the same worker.
+        gc.collect()
+
+
+class TestFamilyDeclarations:
+    """ReadDB and ReadDocument declare hook seams; ReadFile stays a pure anchor."""
+
+    def test_family_requires_tuples(self) -> None:
+        assert _final_reader_requires(ReadFile) == ()
+        assert _final_reader_requires(ReadDB) == ("produce_rows", "connect")
+        assert _final_reader_requires(ReadDocument) == ("produce_document", "suffix")
+
+    def test_families_declare_the_anchor_marker_locally(self) -> None:
+        for family in (ReadDB, ReadDocument, ReadFile):
+            assert "_final_reader_requires" in family.__dict__
+
+    def test_read_db_and_read_document_declare_template_load_data(self) -> None:
+        """The families own a template load_data yet still classify as non-final anchors."""
+        assert "load_data" in ReadDB.__dict__
+        assert "load_data" in ReadDocument.__dict__
+        assert _is_final_reader(ReadDB) is False
+        assert _is_final_reader(ReadDocument) is False
+
+    def test_families_do_not_define_classification_locally(self) -> None:
+        for family in (ReadDB, ReadDocument, ReadFile):
+            assert "supports_scoped_data_access" not in family.__dict__
+            assert "is_final_reader" not in family.__dict__
+            assert "final_reader_anchor" not in family.__dict__
+
+
+class TestRealFamilyClassification:
+    def test_concrete_readers_are_final(self) -> None:
+        assert _is_final_reader(SQLITEReader) is True
+        assert _is_final_reader(CsvReader) is True
+        assert _is_final_reader(TextFileReader) is True
+        assert _is_final_reader(PyFileReader) is True
+
+    def test_family_bases_are_not_final(self) -> None:
+        assert _is_final_reader(ReadDB) is False
+        assert _is_final_reader(ReadFile) is False
+        assert _is_final_reader(ReadDocument) is False

--- a/tests/test_core/test_abstract_plugins/test_components/test_transformation_chain_composition.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_transformation_chain_composition.py
@@ -1,0 +1,293 @@
+"""``get_transformation_chain`` composes arbitrary registered edges.
+
+Contract:
+
+  * ``ComputeFrameworkTransformer.get_transformation_chain`` resolves a chain by
+    breadth-first shortest path over ``transformer_map``, composing ANY registered
+    edges, not only the hardcoded ``from -> pa.Table -> to`` two-hop.
+  * A direct edge always wins over any multi-hop path (single-element chain).
+  * Among multi-hop paths the SHORTEST wins; among equally short paths the tie-break
+    is first-registered edge order (insertion order of ``transformer_map``), so the
+    result is deterministic across calls in one process.
+  * ``None`` is returned when no path exists.
+  * The real pa.Table hub (pandas <-> polars) resolves as before.
+
+All synthetic frameworks and transformers are built inside factory helpers, and the
+synthetic transformers raise ``ImportError`` from their import hooks so ``add()`` skips
+them if global subclass discovery ever sees them. The transformer maps are set
+explicitly with BOTH directions per pair, mirroring how ``add()`` registers edges.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from mloda.core.abstract_plugins.components.framework_transformer.base_transformer import BaseTransformer
+from mloda.core.abstract_plugins.components.framework_transformer.cfw_transformer import (
+    ComputeFrameworkTransformer,
+)
+
+_TransformerMap = dict[tuple[type[Any], type[Any]], type[BaseTransformer]]
+
+
+def _new_framework(name: str) -> type[Any]:
+    """Create a fresh synthetic framework type (a plain class, NOT pa.Table)."""
+    return type(name, (), {})
+
+
+def _make_transformer(
+    name: str, fw: type[Any], other_fw: type[Any], forward_tag: str, backward_tag: str
+) -> type[BaseTransformer]:
+    """Build a synthetic recording transformer for the pair (fw, other_fw).
+
+    The import hooks raise ImportError so ``check_imports`` is False: even if global
+    ``BaseTransformer`` subclass discovery sees this class, ``add()`` skips it and the
+    class never leaks into another test's registry.
+    """
+
+    class _Synthetic(BaseTransformer):
+        @classmethod
+        def framework(cls) -> Any:
+            return fw
+
+        @classmethod
+        def other_framework(cls) -> Any:
+            return other_fw
+
+        @classmethod
+        def import_fw(cls) -> None:
+            raise ImportError("synthetic transformer, never auto-registered")
+
+        @classmethod
+        def import_other_fw(cls) -> None:
+            raise ImportError("synthetic transformer, never auto-registered")
+
+        @classmethod
+        def transform_fw_to_other_fw(cls, data: Any) -> Any:
+            return [*data, forward_tag]
+
+        @classmethod
+        def transform_other_fw_to_fw(cls, data: Any, framework_connection_object: Any | None = None) -> Any:
+            return [*data, backward_tag]
+
+    _Synthetic.__name__ = name
+    _Synthetic.__qualname__ = name
+    return _Synthetic
+
+
+def _map_of(*transformers: type[BaseTransformer]) -> _TransformerMap:
+    """Build a transformer map with BOTH directions per pair, in registration order.
+
+    This mirrors ``ComputeFrameworkTransformer.add``: for each transformer the
+    (framework, other_framework) edge is inserted first, then the reverse edge.
+    Insertion order therefore IS first-registered edge order, which the tie-break
+    tests pin.
+    """
+    transformer_map: _TransformerMap = {}
+    for transformer in transformers:
+        left = transformer.framework()
+        right = transformer.other_framework()
+        transformer_map[(left, right)] = transformer
+        transformer_map[(right, left)] = transformer
+    return transformer_map
+
+
+def _registry_with(*transformers: type[BaseTransformer]) -> ComputeFrameworkTransformer:
+    registry = ComputeFrameworkTransformer()
+    registry.transformer_map = _map_of(*transformers)
+    return registry
+
+
+class TestChainCompositionOverRegisteredEdges:
+    """BFS composition over arbitrary registered edges."""
+
+    def test_two_hop_composition_over_non_pyarrow_hub(self) -> None:
+        """A <-> B and B <-> C registered, B is NOT pa.Table: (A, C) resolves to the
+        2-hop chain [T(A,B), T(B,C)].
+        """
+        fw_a = _new_framework("_FwA")
+        fw_b = _new_framework("_FwB")
+        fw_c = _new_framework("_FwC")
+        trans_ab = _make_transformer("_TransAB", fw_a, fw_b, "A->B", "B->A")
+        trans_bc = _make_transformer("_TransBC", fw_b, fw_c, "B->C", "C->B")
+        registry = _registry_with(trans_ab, trans_bc)
+
+        chain = registry.get_transformation_chain(fw_a, fw_c)
+
+        assert chain is not None, (
+            "get_transformation_chain returned None: it must compose registered edges "
+            "(A -> B -> C) instead of only chaining through pa.Table"
+        )
+        assert chain == [trans_ab, trans_bc]
+
+    def test_three_hop_composition_resolves(self) -> None:
+        """Only A <-> B, B <-> C, C <-> D exist: (A, D) resolves to the 3-hop chain
+        [T(A,B), T(B,C), T(C,D)].
+        """
+        fw_a = _new_framework("_FwA")
+        fw_b = _new_framework("_FwB")
+        fw_c = _new_framework("_FwC")
+        fw_d = _new_framework("_FwD")
+        trans_ab = _make_transformer("_TransAB", fw_a, fw_b, "A->B", "B->A")
+        trans_bc = _make_transformer("_TransBC", fw_b, fw_c, "B->C", "C->B")
+        trans_cd = _make_transformer("_TransCD", fw_c, fw_d, "C->D", "D->C")
+        registry = _registry_with(trans_ab, trans_bc, trans_cd)
+
+        chain = registry.get_transformation_chain(fw_a, fw_d)
+
+        assert chain is not None, (
+            "get_transformation_chain returned None: it must compose the registered 3-hop path A -> B -> C -> D"
+        )
+        assert chain == [trans_ab, trans_bc, trans_cd]
+
+    def test_composed_chain_is_executable_by_apply_chain(self) -> None:
+        """The composed 2-hop chain runs end to end via ``apply_chain``."""
+        fw_a = _new_framework("_FwA")
+        fw_b = _new_framework("_FwB")
+        fw_c = _new_framework("_FwC")
+        trans_ab = _make_transformer("_TransAB", fw_a, fw_b, "A->B", "B->A")
+        trans_bc = _make_transformer("_TransBC", fw_b, fw_c, "B->C", "C->B")
+        registry = _registry_with(trans_ab, trans_bc)
+
+        chain = registry.get_transformation_chain(fw_a, fw_c)
+
+        assert chain is not None, (
+            "get_transformation_chain returned None: composed chains must exist so apply_chain can execute them"
+        )
+        result = registry.apply_chain(fw_a, fw_c, chain, ["start"], None)
+        assert result == ["start", "A->B", "B->C"]
+
+
+class TestPathSelection:
+    """Direct edge beats multi-hop; shortest path beats longer paths."""
+
+    def test_direct_edge_wins_over_two_hop_path(self) -> None:
+        """With a direct A <-> C transformer AND a 2-hop A -> B -> C path registered,
+        the direct single-element chain is returned (direct lookup happens first).
+        """
+        fw_a = _new_framework("_FwA")
+        fw_b = _new_framework("_FwB")
+        fw_c = _new_framework("_FwC")
+        trans_ab = _make_transformer("_TransAB", fw_a, fw_b, "A->B", "B->A")
+        trans_bc = _make_transformer("_TransBC", fw_b, fw_c, "B->C", "C->B")
+        trans_ac = _make_transformer("_TransAC", fw_a, fw_c, "A->C", "C->A")
+        registry = _registry_with(trans_ab, trans_bc, trans_ac)
+
+        chain = registry.get_transformation_chain(fw_a, fw_c)
+
+        assert chain == [trans_ac]
+
+    def test_shortest_path_wins_over_longer_path(self) -> None:
+        """With a 3-hop path A -> B1 -> B2 -> C registered FIRST and a 2-hop path
+        A -> X -> C registered second, the 2-hop chain is returned.
+
+        Registering the longer path first makes this discriminating: a naive
+        depth-first walk in insertion order would find the 3-hop path, breadth-first
+        shortest path finds the 2-hop one.
+        """
+        fw_a = _new_framework("_FwA")
+        fw_b1 = _new_framework("_FwB1")
+        fw_b2 = _new_framework("_FwB2")
+        fw_x = _new_framework("_FwX")
+        fw_c = _new_framework("_FwC")
+        trans_ab1 = _make_transformer("_TransAB1", fw_a, fw_b1, "A->B1", "B1->A")
+        trans_b1b2 = _make_transformer("_TransB1B2", fw_b1, fw_b2, "B1->B2", "B2->B1")
+        trans_b2c = _make_transformer("_TransB2C", fw_b2, fw_c, "B2->C", "C->B2")
+        trans_ax = _make_transformer("_TransAX", fw_a, fw_x, "A->X", "X->A")
+        trans_xc = _make_transformer("_TransXC", fw_x, fw_c, "X->C", "C->X")
+        registry = _registry_with(trans_ab1, trans_b1b2, trans_b2c, trans_ax, trans_xc)
+
+        chain = registry.get_transformation_chain(fw_a, fw_c)
+
+        assert chain is not None, (
+            "get_transformation_chain returned None: it must compose registered edges "
+            "and pick the shortest path A -> X -> C"
+        )
+        assert chain == [trans_ax, trans_xc], (
+            f"Expected the SHORTEST path [_TransAX, _TransXC], got {[t.__name__ for t in chain]}"
+        )
+
+
+class TestDeterministicTieBreak:
+    """Equal-length paths: first-registered edge order (map insertion order) wins."""
+
+    def test_tie_break_is_first_registered_edge_order(self) -> None:
+        """Two distinct 2-hop paths A -> B1 -> C and A -> B2 -> C exist, with the B1
+        edges registered first: the chain through B1 is returned.
+        """
+        fw_a = _new_framework("_FwA")
+        fw_b1 = _new_framework("_FwB1")
+        fw_b2 = _new_framework("_FwB2")
+        fw_c = _new_framework("_FwC")
+        trans_ab1 = _make_transformer("_TransAB1", fw_a, fw_b1, "A->B1", "B1->A")
+        trans_b1c = _make_transformer("_TransB1C", fw_b1, fw_c, "B1->C", "C->B1")
+        trans_ab2 = _make_transformer("_TransAB2", fw_a, fw_b2, "A->B2", "B2->A")
+        trans_b2c = _make_transformer("_TransB2C", fw_b2, fw_c, "B2->C", "C->B2")
+        registry = _registry_with(trans_ab1, trans_b1c, trans_ab2, trans_b2c)
+
+        chain = registry.get_transformation_chain(fw_a, fw_c)
+
+        assert chain is not None, (
+            "get_transformation_chain returned None: it must compose one of the two registered 2-hop paths"
+        )
+        assert chain == [trans_ab1, trans_b1c], (
+            "Tie-break must be first-registered edge order (insertion order of "
+            f"transformer_map), i.e. the B1 path; got {[t.__name__ for t in chain]}"
+        )
+
+    def test_repeated_calls_return_the_same_chain(self) -> None:
+        """With two equally short paths registered, repeated calls in one process
+        return the SAME chain object list.
+        """
+        fw_a = _new_framework("_FwA")
+        fw_b1 = _new_framework("_FwB1")
+        fw_b2 = _new_framework("_FwB2")
+        fw_c = _new_framework("_FwC")
+        trans_ab1 = _make_transformer("_TransAB1", fw_a, fw_b1, "A->B1", "B1->A")
+        trans_b1c = _make_transformer("_TransB1C", fw_b1, fw_c, "B1->C", "C->B1")
+        trans_ab2 = _make_transformer("_TransAB2", fw_a, fw_b2, "A->B2", "B2->A")
+        trans_b2c = _make_transformer("_TransB2C", fw_b2, fw_c, "B2->C", "C->B2")
+        registry = _registry_with(trans_ab1, trans_b1c, trans_ab2, trans_b2c)
+
+        first = registry.get_transformation_chain(fw_a, fw_c)
+        second = registry.get_transformation_chain(fw_a, fw_c)
+        third = registry.get_transformation_chain(fw_a, fw_c)
+
+        assert first is not None, "get_transformation_chain returned None: composition is not implemented"
+        assert first == second == third, (
+            f"Chain resolution must be deterministic across calls; got {first}, {second}, {third}"
+        )
+
+
+class TestExistingBehaviorGuards:
+    """Pins that already pass today and must survive the BFS rewrite."""
+
+    def test_no_path_returns_none_for_disconnected_framework(self) -> None:
+        """Only A <-> B is registered; C is disconnected: (A, C) resolves to None."""
+        fw_a = _new_framework("_FwA")
+        fw_b = _new_framework("_FwB")
+        fw_c = _new_framework("_FwC")
+        trans_ab = _make_transformer("_TransAB", fw_a, fw_b, "A->B", "B->A")
+        registry = _registry_with(trans_ab)
+
+        assert registry.get_transformation_chain(fw_a, fw_c) is None
+
+    def test_real_registry_resolves_pandas_polars_via_pyarrow_hub(self) -> None:
+        """The default registry still resolves pandas <-> polars as the exact 2-hop
+        pa.Table chain [T(pandas, pa.Table), T(pa.Table, polars)]."""
+        pd = pytest.importorskip("pandas")
+        pl = pytest.importorskip("polars")
+        pa = pytest.importorskip("pyarrow")
+
+        registry = ComputeFrameworkTransformer()
+
+        chain = registry.get_transformation_chain(pd.DataFrame, pl.DataFrame)
+
+        assert chain is not None
+        assert len(chain) == 2
+        assert chain == [
+            registry.transformer_map[(pd.DataFrame, pa.Table)],
+            registry.transformer_map[(pa.Table, pl.DataFrame)],
+        ]

--- a/tests/test_core/test_optional_pyarrow/test_chain_composition_without_pyarrow.py
+++ b/tests/test_core/test_optional_pyarrow/test_chain_composition_without_pyarrow.py
@@ -1,0 +1,139 @@
+"""Chain COMPOSITION does not require pyarrow.
+
+``get_transformation_chain`` composes registered edges via breadth-first shortest path
+over ``transformer_map``, so with pyarrow completely absent a 2-hop chain over synthetic
+non-pyarrow edges (A -> B -> C) still resolves, and ``apply_chain`` executes it end to
+end: a cross-framework move avoiding pyarrow entirely.
+
+The body runs in a subprocess with pyarrow blocked via ``sys.meta_path`` (see
+``_pyarrow_blocker.run_blocked``), so the test is meaningful both in the dev venv
+(pyarrow installed but blocked) and in the nopyarrow tox env (pyarrow truly absent).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.test_core.test_optional_pyarrow._pyarrow_blocker import run_blocked
+
+_BODY_COMPOSE_AND_APPLY: str = """
+import sys
+
+from mloda.core.abstract_plugins.components.framework_transformer.base_transformer import BaseTransformer
+from mloda.core.abstract_plugins.components.framework_transformer.cfw_transformer import (
+    ComputeFrameworkTransformer,
+)
+
+
+class _FwA:
+    pass
+
+
+class _FwB:
+    pass
+
+
+class _FwC:
+    pass
+
+
+class _TransAB(BaseTransformer):
+    @classmethod
+    def framework(cls):
+        return _FwA
+
+    @classmethod
+    def other_framework(cls):
+        return _FwB
+
+    @classmethod
+    def import_fw(cls):
+        raise ImportError("synthetic transformer, never auto-registered")
+
+    @classmethod
+    def import_other_fw(cls):
+        raise ImportError("synthetic transformer, never auto-registered")
+
+    @classmethod
+    def transform_fw_to_other_fw(cls, data):
+        return [*data, "A->B"]
+
+    @classmethod
+    def transform_other_fw_to_fw(cls, data, framework_connection_object=None):
+        return [*data, "B->A"]
+
+
+class _TransBC(BaseTransformer):
+    @classmethod
+    def framework(cls):
+        return _FwB
+
+    @classmethod
+    def other_framework(cls):
+        return _FwC
+
+    @classmethod
+    def import_fw(cls):
+        raise ImportError("synthetic transformer, never auto-registered")
+
+    @classmethod
+    def import_other_fw(cls):
+        raise ImportError("synthetic transformer, never auto-registered")
+
+    @classmethod
+    def transform_fw_to_other_fw(cls, data):
+        return [*data, "B->C"]
+
+    @classmethod
+    def transform_other_fw_to_fw(cls, data, framework_connection_object=None):
+        return [*data, "C->B"]
+
+
+registry = ComputeFrameworkTransformer()
+# Only the synthetic non-pyarrow edges, both directions per pair, like add() registers.
+registry.transformer_map = {
+    (_FwA, _FwB): _TransAB,
+    (_FwB, _FwA): _TransAB,
+    (_FwB, _FwC): _TransBC,
+    (_FwC, _FwB): _TransBC,
+}
+
+chain = registry.get_transformation_chain(_FwA, _FwC)
+if chain is None:
+    print("CHAIN_IS_NONE")
+    sys.exit(1)
+if chain != [_TransAB, _TransBC]:
+    print("WRONG_CHAIN:" + repr([t.__name__ for t in chain]))
+    sys.exit(1)
+
+result = registry.apply_chain(_FwA, _FwC, chain, ["start"], None)
+if result != ["start", "A->B", "B->C"]:
+    print("WRONG_RESULT:" + repr(result))
+    sys.exit(1)
+
+print("OK:COMPOSED")
+sys.exit(0)
+"""
+
+
+@pytest.mark.timeout(30)
+def test_chain_composition_and_apply_work_without_pyarrow() -> None:
+    """With pyarrow blocked, (A, C) composes to [_TransAB, _TransBC] over synthetic
+    edges and ``apply_chain`` executes the move end to end.
+    """
+    result = run_blocked(_BODY_COMPOSE_AND_APPLY)
+
+    assert "CHAIN_IS_NONE" not in result.stdout, (
+        "get_transformation_chain returned None with pyarrow blocked: composition over "
+        "registered non-pyarrow edges is not implemented.\n"
+        f"--- stdout ---\n{result.stdout}\n"
+        f"--- stderr ---\n{result.stderr}"
+    )
+    assert result.returncode == 0, (
+        "Chain composition/application crashed under blocked pyarrow.\n"
+        f"--- stdout ---\n{result.stdout}\n"
+        f"--- stderr ---\n{result.stderr}"
+    )
+    assert "OK:COMPOSED" in result.stdout, (
+        f"Expected OK:COMPOSED sentinel. Got stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )

--- a/tests/test_core/test_optional_pyarrow/test_csv_backend_neutral_without_pyarrow.py
+++ b/tests/test_core/test_optional_pyarrow/test_csv_backend_neutral_without_pyarrow.py
@@ -1,0 +1,149 @@
+"""Reading a CSV does not require pyarrow.
+
+``CsvReader`` resolves a CSV into a lightweight ``FileSource`` descriptor, and a
+per-compute-framework transformer materializes it into that framework's native type.
+``PythonDictFramework`` therefore reads a CSV using only the stdlib, so
+``mloda.run_all([...], compute_frameworks={PythonDictFramework}, ...)`` succeeds even
+when pyarrow is unavailable. ``CsvReader.get_column_names`` discovers the header with
+the stdlib ``csv`` module, so it works with pyarrow absent too.
+
+Both bodies run in a subprocess with pyarrow blocked via ``sys.meta_path`` (see
+``_pyarrow_blocker.run_blocked``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.test_core.test_optional_pyarrow._pyarrow_blocker import run_blocked
+
+# ---------------------------------------------------------------------------
+# End-to-end: run_all on a CSV with the dict-backed PythonDict framework, no pyarrow.
+# ---------------------------------------------------------------------------
+_BODY_RUN_ALL: str = """
+import csv
+import os
+import sys
+import tempfile
+
+fd, path = tempfile.mkstemp(suffix=".csv")
+os.close(fd)
+# A: integer column, B: non-numeric (stays str), C: float column.
+with open(path, "w", newline="") as f:
+    writer = csv.writer(f)
+    writer.writerow(["A", "B", "C"])
+    writer.writerow(["1", "x", "1.5"])
+    writer.writerow(["2", "y", "2.5"])
+
+try:
+    from mloda.user import DataAccessCollection
+    from mloda.user import PluginLoader
+    from mloda.user import mloda
+    from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
+        PythonDictFramework,
+    )
+
+    PluginLoader.all()
+
+    result = mloda.run_all(
+        ["A", "B", "C"],
+        compute_frameworks={PythonDictFramework},
+        data_access_collection=DataAccessCollection(files={path}),
+    )
+
+    payload = result[0]
+    if not isinstance(payload, dict):
+        print("WRONG_TYPE:" + type(payload).__name__)
+        sys.exit(1)
+
+    a = payload["A"]
+    b = payload["B"]
+    c = payload["C"]
+    # Typed values: without pyarrow, the stdlib transformer must still yield int/float.
+    if a != [1, 2] or not all(isinstance(v, int) and not isinstance(v, bool) for v in a):
+        print("BAD_A:" + repr(a))
+        sys.exit(1)
+    if c != [1.5, 2.5] or not all(isinstance(v, float) for v in c):
+        print("BAD_C:" + repr(c))
+        sys.exit(1)
+    if b != ["x", "y"] or not all(isinstance(v, str) for v in b):
+        print("BAD_B:" + repr(b))
+        sys.exit(1)
+    print("OK:TYPED")
+    sys.exit(0)
+except Exception as e:
+    import traceback
+
+    print("RUN_FAILED:" + type(e).__name__ + ":" + str(e))
+    traceback.print_exc()
+    sys.exit(1)
+finally:
+    os.remove(path)
+"""
+
+
+# ---------------------------------------------------------------------------
+# Stdlib header discovery: CsvReader.get_column_names must work without pyarrow.
+# ---------------------------------------------------------------------------
+_BODY_GET_COLUMN_NAMES: str = """
+import csv
+import os
+import sys
+import tempfile
+
+fd, path = tempfile.mkstemp(suffix=".csv")
+os.close(fd)
+with open(path, "w", newline="") as f:
+    writer = csv.writer(f)
+    writer.writerow(["A", "B"])
+    writer.writerow(["1", "3"])
+    writer.writerow(["2", "4"])
+
+try:
+    from mloda_plugins.feature_group.input_data.read_files.csv import CsvReader
+
+    cols = list(CsvReader.get_column_names(path))
+    print("COLS:" + ",".join(cols))
+    if cols == ["A", "B"]:
+        print("OK")
+    sys.exit(0)
+except Exception as e:
+    print("FAILED:" + type(e).__name__ + ":" + str(e))
+    sys.exit(1)
+finally:
+    os.remove(path)
+"""
+
+
+@pytest.mark.timeout(30)
+def test_csv_reads_into_python_dict_without_pyarrow() -> None:
+    """run_all on a CSV into PythonDict succeeds with pyarrow blocked."""
+    result = run_blocked(_BODY_RUN_ALL)
+
+    assert result.returncode == 0, (
+        "Reading a CSV into PythonDict crashed under blocked pyarrow (or values were not typed).\n"
+        f"--- stdout ---\n{result.stdout}\n"
+        f"--- stderr ---\n{result.stderr}"
+    )
+    assert "OK:TYPED" in result.stdout, (
+        "Expected OK:TYPED sentinel (dict-backed, typed A=int/B=str/C=float values). "
+        f"Got stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+
+@pytest.mark.timeout(30)
+def test_get_column_names_uses_stdlib_without_pyarrow() -> None:
+    """CsvReader.get_column_names returns ["A", "B"] via stdlib with pyarrow blocked."""
+    result = run_blocked(_BODY_GET_COLUMN_NAMES)
+
+    assert result.returncode == 0, (
+        "get_column_names crashed under blocked pyarrow.\n"
+        f"--- stdout ---\n{result.stdout}\n"
+        f"--- stderr ---\n{result.stderr}"
+    )
+    assert "COLS:A,B" in result.stdout, (
+        f"Expected COLS:A,B header sentinel. Got stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert "OK" in result.stdout.splitlines(), (
+        f"Expected standalone OK sentinel. Got stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )

--- a/tests/test_core/test_optional_pyarrow/test_file_readers_without_pyarrow.py
+++ b/tests/test_core/test_optional_pyarrow/test_file_readers_without_pyarrow.py
@@ -1,5 +1,5 @@
-"""Tests that file-reader modules import cleanly under blocked pyarrow and that their
-load_data methods raise ImportError mentioning pyarrow (not a top-level crash).
+"""Tests that file-reader modules import cleanly under blocked pyarrow and that
+CsvReader.load_data resolves a backend-neutral FileSource descriptor without pyarrow.
 """
 
 from __future__ import annotations
@@ -27,21 +27,22 @@ _BODY_CSV_LOAD: str = """
 import sys
 
 try:
+    from mloda.core.abstract_plugins.components.input_data.file_source import FileSource
+    from mloda.provider import FeatureSet
+    from mloda.user import Feature
     from mloda_plugins.feature_group.input_data.read_files.csv import CsvReader
 except Exception as e:
     print("IMPORT_FAILED:" + type(e).__name__)
     sys.exit(0)
 
-try:
-    CsvReader.load_data("/nonexistent/path.csv", None)
-    print("NO_RAISE")
-except ImportError as e:
-    if "pyarrow" in str(e).lower():
-        print("IMPORTERROR")
-    else:
-        print("WRONGMSG:" + str(e))
-except Exception as e:
-    print("WRONG:" + type(e).__name__)
+features = FeatureSet()
+features.add(Feature("A"))
+
+result = CsvReader.load_data("/nonexistent/path.csv", features)
+if isinstance(result, FileSource) and result.format == "csv" and result.columns == ("A",):
+    print("FILESOURCE")
+else:
+    print("WRONG:" + type(result).__name__)
 """
 
 # ---------------------------------------------------------------------------
@@ -116,12 +117,14 @@ def test_csv_reader_imports_without_pyarrow() -> None:
 
 
 @pytest.mark.timeout(30)
-def test_csv_reader_load_data_raises_import_error_without_pyarrow() -> None:
-    """CsvReader.load_data must raise ImportError mentioning pyarrow when pyarrow absent."""
+def test_csv_reader_load_data_returns_file_source_without_pyarrow() -> None:
+    """CsvReader.load_data returns a lightweight FileSource descriptor even when pyarrow
+    is absent; a per-framework transformer materializes it later.
+    """
     result = run_blocked(_BODY_CSV_LOAD)
     assert result.returncode == 0, f"Body crashed.\nstderr:\n{result.stderr}"
-    assert "IMPORTERROR" in result.stdout, (
-        f"Expected IMPORTERROR sentinel. Got stdout: {result.stdout!r}\nstderr: {result.stderr}"
+    assert "FILESOURCE" in result.stdout, (
+        f"Expected FILESOURCE sentinel. Got stdout: {result.stdout!r}\nstderr: {result.stderr}"
     )
 
 

--- a/tests/test_core/test_optional_pyarrow/test_file_source_no_chain_raises.py
+++ b/tests/test_core/test_optional_pyarrow/test_file_source_no_chain_raises.py
@@ -1,0 +1,132 @@
+"""When ``ComputeFramework._materialize_descriptor`` finds no transformation chain, the
+ValueError message is FULLY BACKEND-NEUTRAL.
+
+mloda core has no required backend: pyarrow is an optional extra. So the "no transformer
+chain" error never blames pyarrow. It simply states the missing transformer pair and the
+generic remedy (register a transformer for that pair), identically whether or not pyarrow
+happens to be installed.
+
+The target framework here is a dummy type with no registered transformer, so a
+``FileSource`` cannot be materialized into it via any chain and the "no chain" branch fires
+regardless of whether pyarrow is installed. The pyarrow-availability seam is the module-
+level ``pa`` symbol in ``mloda.core.abstract_plugins.compute_framework``; the tests toggle
+it with monkeypatch instead of depending on the tox env, so they are portable across the
+pyarrow and no-pyarrow envs and can pin the message under both states.
+
+Contract:
+
+  * The message never mentions pyarrow (neither ``pyarrow`` nor ``mloda[pyarrow]``), in
+    either pyarrow state.
+  * It names the source framework (``FileSource``) and carries the generic remedy
+    (``Register`` a ``transformer`` for the pair).
+  * The target is rendered by class name (``_to_fw.__name__`` when ``_to_fw`` is a class),
+    not a raw ``<class '...'>`` repr, and a non-class target (``None``, the documented
+    ``expected_data_framework`` default) still yields a ValueError, not an AttributeError.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import mloda.core.abstract_plugins.compute_framework as compute_framework
+from mloda.core.abstract_plugins.components.input_data.file_source import FileSource
+from mloda.provider import ComputeFramework
+from mloda.user import ParallelizationMode
+
+
+class _Unmaterializable:
+    """A target type with no registered transformer: no FileSource chain can reach it."""
+
+
+def _no_chain_framework() -> ComputeFramework:
+    # Defined locally so the throwaway ComputeFramework subclass is not picked up by other
+    # tests' framework enumeration.
+    class _NoChainFramework(ComputeFramework):
+        @classmethod
+        def expected_data_framework(cls) -> type:
+            return _Unmaterializable
+
+    return _NoChainFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
+
+
+def test_no_chain_message_is_backend_neutral_without_pyarrow(monkeypatch: pytest.MonkeyPatch) -> None:
+    """pyarrow absent: the message does NOT blame pyarrow; it states the missing pair and
+    the generic remedy.
+    """
+    monkeypatch.setattr(compute_framework, "pa", None)
+
+    fw = _no_chain_framework()
+    source = FileSource(path="/nonexistent.csv", format="csv", columns=("A", "B"))
+
+    with pytest.raises(ValueError) as excinfo:
+        fw.transform(source, ["A", "B"])
+
+    message = str(excinfo.value)
+    assert "pyarrow" not in message.lower(), message
+    assert "mloda[pyarrow]" not in message, message
+    assert "FileSource" in message, message
+    assert "Register" in message, message
+    assert "transformer" in message, message
+
+
+def test_no_chain_message_is_backend_neutral_with_pyarrow(monkeypatch: pytest.MonkeyPatch) -> None:
+    """pyarrow present: the message is identical in spirit, still backend-neutral, naming
+    the source framework and the generic remedy."""
+    monkeypatch.setattr(compute_framework, "pa", object())
+
+    fw = _no_chain_framework()
+    source = FileSource(path="/nonexistent.csv", format="csv", columns=("A", "B"))
+
+    with pytest.raises(ValueError) as excinfo:
+        fw.transform(source, ["A", "B"])
+
+    message = str(excinfo.value)
+    assert "pyarrow" not in message.lower(), message
+    assert "mloda[pyarrow]" not in message, message
+    assert "FileSource" in message, message
+    assert "Register" in message, message
+    assert "transformer" in message, message
+    assert _Unmaterializable.__name__ in message, message
+
+
+def test_no_chain_renders_target_by_class_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The target framework is rendered by ``__name__``, not a raw class repr."""
+    monkeypatch.setattr(compute_framework, "pa", object())
+
+    fw = _no_chain_framework()
+    source = FileSource(path="/nonexistent.csv", format="csv", columns=("A", "B"))
+
+    with pytest.raises(ValueError) as excinfo:
+        fw.transform(source, ["A", "B"])
+
+    message = str(excinfo.value)
+    assert _Unmaterializable.__name__ in message, message
+    assert "<class" not in message, message
+
+
+def _none_target_framework() -> ComputeFramework:
+    # A framework that leaves expected_data_framework() at its documented default (None).
+    # Defined locally, distinct from _NoChainFramework, so it is not picked up by other
+    # tests' framework enumeration.
+    class _NoneTargetFramework(ComputeFramework):
+        pass
+
+    return _NoneTargetFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
+
+
+def test_none_target_framework_raises_value_error_not_attribute_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A framework whose expected_data_framework() returns a non-type value (None, the
+    documented default) still raises ValueError, not AttributeError, and still names the
+    source framework.
+    """
+    monkeypatch.setattr(compute_framework, "pa", object())
+
+    fw = _none_target_framework()
+    source = FileSource(path="/nonexistent.csv", format="csv", columns=("A", "B"))
+
+    with pytest.raises(ValueError) as excinfo:
+        fw.transform(source, ["A", "B"])
+
+    assert "FileSource" in str(excinfo.value), str(excinfo.value)

--- a/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_file_source_transformer.py
+++ b/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_file_source_transformer.py
@@ -1,0 +1,260 @@
+"""The stdlib ``FileSource -> dict`` transformer infers types COLUMN-WISE.
+
+Contract for ``FileSourceDictTransformer.transform_fw_to_other_fw`` (matching the
+column semantics pyarrow's CSV reader gives, without pyarrow):
+
+  (a) Empty-cell handling matches pyarrow's default CSV reader (``strings_can_be_null=False``):
+      a NUMERIC column with a missing cell is ``[None, 3]`` (typed where present, ``None`` for the
+      gap); a STRING column's missing interior cell stays ``""`` (empty string, NOT ``None``);
+      an ALL-EMPTY column (every cell empty) is inferred as all-``None``.
+  (b) A column whose non-empty cells are all integers -> ``int``; all decimals -> ``float``;
+      a column mixing numeric and text cells stays ``str``.
+  (c) Numeric-LOOKING text stays ``str``: ``"1_000"`` must NOT parse to ``1000``; leading /
+      trailing whitespace must NOT be stripped-and-parsed; the words ``"NaN"`` / ``"Inf"``
+      alongside non-numeric text stay ``str`` (no ``float('nan')`` / ``float('inf')``).
+  (d) A column whose cells are all in ``{true,false,True,False}`` -> Python ``bool``.
+  (e) Blank interior / trailing lines are skipped (no ``IndexError``).
+  (f) A ragged, non-empty short row raises a clear ``ValueError`` (naming the file path
+      and/or a row number), not a bare ``IndexError``.
+  (g) Duplicate header names raise a clear ``ValueError`` (naming the duplicated column)
+      when a duplicated column is requested, matching pyarrow's refusal.
+  (h) A requested column missing from the header raises a clear ``ValueError`` naming it.
+  (i) A UTF-8 BOM at the start of the file is tolerated (``utf-8-sig``).
+  (j) A non-csv ``FileSource.format`` raises ``ValueError``; the reverse direction
+      (dict -> FileSource) raises ``NotImplementedError``.
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from mloda.core.abstract_plugins.components.input_data.file_source import FileSource
+from mloda.user import DataAccessCollection
+from mloda.user import mloda
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_file_source_transformer import (
+    FileSourceDictTransformer,
+)
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (  # noqa: F401
+    PythonDictFramework,
+)
+from mloda_plugins.feature_group.input_data.read_file_feature import ReadFileFeature  # noqa: F401
+from mloda_plugins.feature_group.input_data.read_files.csv import CsvReader  # noqa: F401
+
+
+def _materialize(tmp_path: Path, content: str, columns: tuple[str, ...]) -> Any:
+    path = tmp_path / "data.csv"
+    path.write_text(content, encoding="utf-8")
+    return FileSourceDictTransformer.transform_fw_to_other_fw(FileSource(path=str(path), format="csv", columns=columns))
+
+
+class TestColumnWiseTypeInference:
+    def test_empty_cell_is_none_and_numeric_column_keeps_ints(self, tmp_path: Path) -> None:
+        """(a) Empty cell -> None; a numeric column with a gap is ``[None, 3]``, not ``["", 3]``."""
+        result = _materialize(tmp_path, "a,b,c\n1,,x\n2,3,y\n", ("a", "b", "c"))
+
+        assert result["a"] == [1, 2]
+        assert result["b"] == [None, 3]
+        assert result["c"] == ["x", "y"]
+
+    def test_string_column_missing_interior_cell_is_empty_string(self, tmp_path: Path) -> None:
+        """(a) A STRING column's missing interior cell stays ``""`` (matches pyarrow), not ``None``."""
+        result = _materialize(tmp_path, "a,b\nx,1\n,2\ny,3\n", ("a", "b"))
+
+        assert result["a"] == ["x", "", "y"]
+        assert result["b"] == [1, 2, 3]
+
+    def test_all_empty_column_is_all_none(self, tmp_path: Path) -> None:
+        """(a) A column whose every cell is empty is inferred as all-``None`` (matches pyarrow)."""
+        result = _materialize(tmp_path, "a,b\n1,\n2,\n", ("a", "b"))
+
+        assert result["a"] == [1, 2]
+        assert result["b"] == [None, None]
+
+    def test_integer_float_and_mixed_columns(self, tmp_path: Path) -> None:
+        """(b) all-int -> int; all-decimal -> float; numeric+text -> str."""
+        result = _materialize(
+            tmp_path,
+            "ints,floats,mixed\n1,1.5,1\n2,2.5,x\n",
+            ("ints", "floats", "mixed"),
+        )
+
+        assert result["ints"] == [1, 2]
+        assert all(isinstance(v, int) and not isinstance(v, bool) for v in result["ints"])
+
+        assert result["floats"] == [1.5, 2.5]
+        assert all(isinstance(v, float) for v in result["floats"])
+
+        # A column mixing a number and text stays entirely string.
+        assert result["mixed"] == ["1", "x"]
+        assert all(isinstance(v, str) for v in result["mixed"])
+
+    def test_numeric_looking_text_stays_string(self, tmp_path: Path) -> None:
+        """(c) ``"1_000"`` and whitespace-padded numbers must NOT be parsed as numbers."""
+        result = _materialize(tmp_path, "a\n1_000\n2\n", ("a",))
+        assert result["a"] == ["1_000", "2"]
+        assert all(isinstance(v, str) for v in result["a"])
+
+    def test_whitespace_padded_number_is_not_parsed(self, tmp_path: Path) -> None:
+        """(c) Leading/trailing whitespace must not be stripped-then-parsed into a number."""
+        result = _materialize(tmp_path, "a\n 1 \n2\n", ("a",))
+        assert result["a"] == [" 1 ", "2"]
+        assert all(isinstance(v, str) for v in result["a"])
+
+    def test_nan_and_inf_words_stay_string(self, tmp_path: Path) -> None:
+        """(c) Text ``NaN`` / ``Inf`` next to non-numeric text stays str (no float coercion)."""
+        result = _materialize(tmp_path, "a,b\nNaN,Inf\nfoo,bar\n", ("a", "b"))
+
+        assert result["a"] == ["NaN", "foo"]
+        assert result["b"] == ["Inf", "bar"]
+        for values in (result["a"], result["b"]):
+            for v in values:
+                assert isinstance(v, str)
+                assert not (isinstance(v, float) and (math.isnan(v) or math.isinf(v)))
+
+    def test_boolean_column(self, tmp_path: Path) -> None:
+        """(d) A column of ``true``/``false`` (any case) -> Python bools."""
+        result = _materialize(tmp_path, "flag\ntrue\nfalse\nTrue\nFalse\n", ("flag",))
+        assert result["flag"] == [True, False, True, False]
+        assert all(isinstance(v, bool) for v in result["flag"])
+
+
+class TestBlankAndRaggedRows:
+    def test_blank_interior_and_trailing_lines_are_skipped(self, tmp_path: Path) -> None:
+        """(e) Fully blank lines are skipped rather than raising IndexError."""
+        result = _materialize(tmp_path, "a,b\n1,2\n\n3,4\n", ("a", "b"))
+        assert result == {"a": [1, 3], "b": [2, 4]}
+
+    def test_ragged_short_row_raises_valueerror_with_context(self, tmp_path: Path) -> None:
+        """(f) A non-empty short row raises a clear ValueError, not a bare IndexError."""
+        path = tmp_path / "data.csv"
+        path.write_text("a,b,c\n1,2,3\n9,8\n", encoding="utf-8")
+
+        with pytest.raises(ValueError) as excinfo:
+            FileSourceDictTransformer.transform_fw_to_other_fw(
+                FileSource(path=str(path), format="csv", columns=("a", "b", "c"))
+            )
+        message = str(excinfo.value)
+        # Must name the file path and/or a row number so the error is actionable.
+        assert str(path) in message or "row" in message.lower(), message
+
+    def test_ragged_long_row_raises_valueerror_with_context(self, tmp_path: Path) -> None:
+        """(f) A row with MORE fields than the header raises a clear ValueError (pyarrow errors too),
+        rather than silently dropping the extra field(s)."""
+        path = tmp_path / "data.csv"
+        path.write_text("a,b\n1,2,3\n", encoding="utf-8")
+
+        with pytest.raises(ValueError) as excinfo:
+            FileSourceDictTransformer.transform_fw_to_other_fw(
+                FileSource(path=str(path), format="csv", columns=("a", "b"))
+            )
+        message = str(excinfo.value)
+        assert str(path) in message or "row" in message.lower(), message
+
+    def test_duplicate_header_raises_valueerror_naming_column(self, tmp_path: Path) -> None:
+        """(g) A duplicated header raises a clear ValueError naming the duplicated column."""
+        path = tmp_path / "data.csv"
+        path.write_text("A,A,B\n1,2,3\n", encoding="utf-8")
+
+        with pytest.raises(ValueError) as excinfo:
+            FileSourceDictTransformer.transform_fw_to_other_fw(
+                FileSource(path=str(path), format="csv", columns=("A", "B"))
+            )
+        message = str(excinfo.value)
+        assert "duplicate" in message.lower()
+        assert "A" in message
+
+    def test_missing_requested_column_raises_valueerror_naming_column(self, tmp_path: Path) -> None:
+        """(h) Requesting a column absent from the header raises a clear ValueError naming it."""
+        path = tmp_path / "data.csv"
+        path.write_text("a,b\n1,2\n", encoding="utf-8")
+
+        with pytest.raises(ValueError) as excinfo:
+            FileSourceDictTransformer.transform_fw_to_other_fw(
+                FileSource(path=str(path), format="csv", columns=("a", "zzz"))
+            )
+        assert "zzz" in str(excinfo.value)
+
+
+class TestEncodingAndFormat:
+    def test_utf8_bom_is_tolerated(self, tmp_path: Path) -> None:
+        """(i) A UTF-8 BOM must not leak into the first header name (utf-8-sig decode)."""
+        path = tmp_path / "data.csv"
+        content = "a,b\n1,x\n2,y\n"
+        path.write_bytes(b"\xef\xbb\xbf" + content.encode("utf-8"))
+
+        result = FileSourceDictTransformer.transform_fw_to_other_fw(
+            FileSource(path=str(path), format="csv", columns=("a", "b"))
+        )
+
+        assert result["a"] == [1, 2]
+        assert result["b"] == ["x", "y"]
+
+    def test_non_csv_format_raises_valueerror(self, tmp_path: Path) -> None:
+        """(j) The stdlib transformer only materializes the 'csv' format."""
+        with pytest.raises(ValueError) as excinfo:
+            FileSourceDictTransformer.transform_fw_to_other_fw(
+                FileSource(path=str(tmp_path / "data.parquet"), format="parquet", columns=("a",))
+            )
+        assert "parquet" in str(excinfo.value)
+
+    def test_reverse_direction_raises_not_implemented(self) -> None:
+        """(j) dict -> FileSource makes no sense; the reverse direction must raise."""
+        with pytest.raises(NotImplementedError):
+            FileSourceDictTransformer.transform_other_fw_to_fw({"a": [1]})
+
+
+class TestDeliberateNullTokenDivergenceFromPyArrow:
+    """PASSING divergence pin: the stdlib materializer does NOT recognize null tokens.
+
+    DELIBERATE divergence, pinned so it cannot drift silently (issue #619 tracks null-token
+    inference as a follow-up): on the SAME CSV file with the column ``1,2,NA``, the stdlib
+    ``FileSourceDictTransformer`` keeps the column entirely string
+    (``["1", "2", "NA"]``, per its documented "such a column currently stays string" rule),
+    while pyarrow's CSV reader treats ``NA`` as a null token and yields ``[1, 2, None]``.
+
+    This test must PASS today. If it ever fails, either the stdlib transformer started
+    inferring null tokens (close #619 and update this pin) or pyarrow changed its default
+    null tokens; both deserve a conscious decision, not a silent drift.
+    """
+
+    def test_na_token_column_diverges_between_dict_and_pyarrow_materializers(self, tmp_path: Path) -> None:
+        path = tmp_path / "data.csv"
+        path.write_text("a\n1\n2\nNA\n", encoding="utf-8")
+        source = FileSource(path=str(path), format="csv", columns=("a",))
+
+        dict_result = FileSourceDictTransformer.transform_fw_to_other_fw(source)
+        assert dict_result["a"] == ["1", "2", "NA"]
+        assert all(isinstance(v, str) for v in dict_result["a"])
+
+        pytest.importorskip("pyarrow")
+        from mloda_plugins.compute_framework.base_implementations.pyarrow.pyarrow_file_source_transformer import (
+            FileSourcePyArrowTransformer,
+        )
+
+        table = FileSourcePyArrowTransformer.transform_fw_to_other_fw(source)
+        assert table.column("a").to_pylist() == [1, 2, None]
+
+
+class TestEndToEndPythonDictCsv:
+    """run_all on a CSV into PythonDict yields None/typed/bool values (mirrors CSV e2e tests)."""
+
+    def test_run_all_reads_typed_none_and_bool(self, tmp_path: Path) -> None:
+        path = tmp_path / "data.csv"
+        # a: int column, b: numeric column with a missing cell, c: boolean column.
+        path.write_text("a,b,c\n1,,true\n2,3,false\n", encoding="utf-8")
+
+        result = mloda.run_all(
+            ["a", "b", "c"],
+            compute_frameworks={PythonDictFramework},
+            data_access_collection=DataAccessCollection(files={str(path)}),
+        )
+
+        payload = result[0]
+        assert isinstance(payload, dict)
+        assert payload["a"] == [1, 2]
+        assert payload["b"] == [None, 3]
+        assert payload["c"] == [True, False]

--- a/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_framework.py
+++ b/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_framework.py
@@ -98,7 +98,13 @@ class TestSqliteFrameworkBasics:
             fw.transform(data=42, feature_names=[])
 
     def test_transform_dict_no_connection_raises(self) -> None:
-        """transform() with dict but no connection set raises ValueError."""
+        """transform() with dict but no connection set raises ValueError.
+
+        A plain dict must use SqliteFramework's native ``from_dict`` ingestion, which
+        raises "connection object is not set" when no connection is configured. It must
+        NOT be rerouted through the pa.Table chain (whose sqlite step raises a different,
+        generic connection message).
+        """
         fw = SqliteFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
         with pytest.raises(ValueError, match="not set"):
             fw.transform(data={"col": [1, 2]}, feature_names=[])

--- a/tests/test_plugins/compute_framework/test_file_source_materialization.py
+++ b/tests/test_plugins/compute_framework/test_file_source_materialization.py
@@ -1,0 +1,94 @@
+"""A ``FileSource`` descriptor materializes via the transformer chain (with pyarrow installed).
+
+* ``PyArrowTable``  -> ``pa.Table`` via the direct ``(FileSource, pa.Table)`` transformer
+  (``FileSourcePyArrowTransformer``), honoring the requested columns via include_columns.
+* ``PandasDataFrame`` -> ``pandas.DataFrame`` via the 2-hop
+  ``FileSource -> pa.Table -> pandas`` chain (FileSource is a descriptor, so multi-hop
+  is allowed for it; a plain dict is NOT rerouted, see test_native_dict_ingestion.py).
+* ``PythonDictFramework`` -> ``dict`` via the direct stdlib ``(FileSource, dict)`` transformer.
+* ``FileSourcePyArrowTransformer`` rejects non-csv formats with ``ValueError`` and the
+  reverse direction (pa.Table -> FileSource) with ``NotImplementedError``.
+"""
+
+from __future__ import annotations
+
+import csv
+import os
+import tempfile
+from collections.abc import Iterator
+
+import pandas as pd
+import pyarrow as pa
+import pytest
+
+from mloda.core.abstract_plugins.components.input_data.file_source import FileSource
+from mloda.user import ParallelizationMode
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.pyarrow.pyarrow_file_source_transformer import (
+    FileSourcePyArrowTransformer,
+)
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
+    PythonDictFramework,
+)
+
+
+@pytest.fixture()
+def csv_path() -> Iterator[str]:
+    fd, path = tempfile.mkstemp(suffix=".csv")
+    os.close(fd)
+    with open(path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["A", "B", "C"])
+        writer.writerow(["1", "3", "x"])
+        writer.writerow(["2", "4", "y"])
+    yield path
+    os.remove(path)
+
+
+def _file_source(csv_path: str) -> FileSource:
+    return FileSource(path=csv_path, format="csv", columns=("A", "B"))
+
+
+class TestFileSourceMaterializesPerFramework:
+    def test_file_source_materializes_to_pyarrow_table(self, csv_path: str) -> None:
+        fw = PyArrowTable(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
+        result = fw.transform(_file_source(csv_path), ["A", "B"])
+        assert isinstance(result, pa.Table)
+        assert set(result.column_names) == {"A", "B"}
+
+    def test_file_source_materializes_to_pandas_dataframe(self, csv_path: str) -> None:
+        """FileSource is a descriptor, so the 2-hop FileSource -> pa.Table -> pandas chain applies."""
+        fw = PandasDataFrame(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
+        result = fw.transform(_file_source(csv_path), ["A", "B"])
+        assert isinstance(result, pd.DataFrame)
+        assert set(result.columns) == {"A", "B"}
+
+    def test_file_source_materializes_to_python_dict(self, csv_path: str) -> None:
+        fw = PythonDictFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
+        result = fw.transform(_file_source(csv_path), ["A", "B"])
+        assert isinstance(result, dict)
+        assert set(result.keys()) == {"A", "B"}
+        assert result["A"] == [1, 2]
+        assert result["B"] == [3, 4]
+
+
+class TestFileSourcePyArrowTransformerContract:
+    def test_only_requested_columns_are_included(self, csv_path: str) -> None:
+        """The pyarrow materialization selects exactly ``FileSource.columns`` (include_columns)."""
+        table = FileSourcePyArrowTransformer.transform_fw_to_other_fw(_file_source(csv_path))
+        assert isinstance(table, pa.Table)
+        assert set(table.column_names) == {"A", "B"}
+        assert table.column("A").to_pylist() == [1, 2]
+
+    def test_non_csv_format_raises_valueerror(self) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            FileSourcePyArrowTransformer.transform_fw_to_other_fw(
+                FileSource(path="/nonexistent.parquet", format="parquet", columns=("A",))
+            )
+        assert "parquet" in str(excinfo.value)
+
+    def test_reverse_direction_raises_not_implemented(self) -> None:
+        """pa.Table -> FileSource makes no sense; the reverse direction must raise."""
+        with pytest.raises(NotImplementedError):
+            FileSourcePyArrowTransformer.transform_other_fw_to_fw(pa.table({"A": [1]}))

--- a/tests/test_plugins/compute_framework/test_native_dict_ingestion.py
+++ b/tests/test_plugins/compute_framework/test_native_dict_ingestion.py
@@ -1,0 +1,97 @@
+"""Regression pins for root ingestion in ``apply_compute_framework_transformer``.
+
+These pass TODAY on this branch (root ingestion only applies a DIRECT transformer) and
+must KEEP passing once descriptor-gated multi-hop materialization lands for FileSource:
+
+  * Same-native-type input returns ``None`` (no spurious self-loop such as
+    dict -> pa.Table -> dict discovered through the chain search).
+  * A direct transformer still applies (pa.Table -> dict for PythonDict).
+  * A plain dict is NEVER multi-hop routed through ``pa.Table``: only an input-data
+    DESCRIPTOR (FileSource) may take the multi-hop chain. The framework's own native
+    ``transform`` branch (e.g. ``pd.DataFrame.from_dict``) handles the dict instead.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+import pyarrow as pa
+
+from mloda.user import ParallelizationMode
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
+    PythonDictFramework,
+)
+
+
+def _pandas_fw() -> PandasDataFrame:
+    return PandasDataFrame(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
+
+
+def _python_dict_fw() -> PythonDictFramework:
+    return PythonDictFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
+
+
+class TestSameNativeTypeReturnsNone:
+    """Input already of the expected native type is not transformed (returns None)."""
+
+    def test_pyarrow_table_input_into_pyarrow_framework_returns_none(self) -> None:
+        fw = PyArrowTable(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
+        assert fw.apply_compute_framework_transformer(pa.table({"a": [1, 2]})) is None
+
+    def test_dict_input_into_python_dict_framework_returns_none(self) -> None:
+        fw = _python_dict_fw()
+        assert fw.apply_compute_framework_transformer({"a": [1, 2]}) is None
+
+
+class TestDirectTransformerStillApplies:
+    def test_pyarrow_table_materializes_into_python_dict_via_direct_transformer(self) -> None:
+        fw = _python_dict_fw()
+        result = fw.apply_compute_framework_transformer(pa.table({"a": [1, 2]}))
+        assert result == {"a": [1, 2]}
+
+
+class TestPandasNativeDictIngestion:
+    """A plain dict handed to PandasDataFrame uses ``pd.DataFrame.from_dict``, not pa.Table."""
+
+    def test_mixed_type_dict_is_not_rerouted_through_pyarrow(self) -> None:
+        """PandasDataFrame.transform must build a DataFrame natively for a mixed-type column.
+
+        If the dict were rerouted through the ``dict -> pa.Table -> pandas`` chain, the
+        first hop would raise ``pyarrow.ArrowInvalid`` ("Could not convert 'x' with type
+        str") before the native ``from_dict`` branch runs.
+        """
+        fw = _pandas_fw()
+
+        result = fw.transform({"a": [1, "x"]}, ["a"])
+
+        assert isinstance(result, pd.DataFrame), f"Expected a pandas DataFrame, got {type(result)!r}"
+        # Mixed int/str column stays object dtype (pandas' native behavior).
+        assert str(result["a"].dtype) == "object"
+        assert list(result["a"]) == [1, "x"]
+
+    def test_apply_transformer_does_not_multihop_a_plain_dict(self) -> None:
+        """The multi-hop (pa.Table) chain must not apply to a plain dict.
+
+        ``apply_compute_framework_transformer`` must return ``None`` for a plain dict whose
+        only registered path to pandas is the 2-hop ``dict -> pa.Table -> pandas`` chain, so
+        the framework falls through to its native dict handling. Only an input-data
+        DESCRIPTOR (FileSource) may be multi-hop materialized.
+        """
+        fw = _pandas_fw()
+
+        assert fw.apply_compute_framework_transformer({"a": [1, "x"]}) is None
+
+
+class TestPythonDictNativePassthrough:
+    """PythonDict passthrough of a native columnar dict is unaffected by the seam (guard)."""
+
+    def test_native_columnar_dict_passes_through_unchanged(self) -> None:
+        fw = _python_dict_fw()
+        data: dict[str, list[Any]] = {"a": [1, 2], "b": ["x", "y"]}
+
+        result = fw.transform(data, ["a", "b"])
+
+        assert result == {"a": [1, 2], "b": ["x", "y"]}

--- a/tests/test_plugins/compute_framework/test_one_way_transformer_edges.py
+++ b/tests/test_plugins/compute_framework/test_one_way_transformer_edges.py
@@ -1,0 +1,191 @@
+"""One-way transformers register ONLY their forward edge.
+
+For a one-way transformer (e.g. the FileSource materializers, whose reverse direction is
+meaningless), a registered reverse edge would be a trap: the BFS in
+``get_transformation_chain`` could route a chain through it, and ``apply_chain`` would then
+crash mid-chain with a bare ``NotImplementedError`` from ``transform_other_fw_to_fw``.
+
+Contract:
+
+  * ``add()`` detects STRUCTURALLY that a transformer does not override
+    ``transform_other_fw_to_fw`` relative to ``BaseTransformer`` (function identity via the
+    ``_underlying`` idiom of ``BaseInputData._is_overridden``) and then registers ONLY the
+    forward edge ``(framework(), other_framework())``, never the reverse pair.
+  * The two FileSource transformers do not override ``transform_other_fw_to_fw``, so the
+    default registry contains ``(FileSource, dict)`` and ``(FileSource, pa.Table)`` but NOT
+    the reverse pairs.
+  * With the reverse edge unregistered, a route that would only exist via a one-way
+    transformer's reverse edge resolves to ``None`` instead of a chain that would crash.
+
+Isolation note: the synthetic frameworks and transformers are built fresh inside factory
+functions per test. Their import hooks succeed (``add()`` must accept them), so a lingering
+function-local class can be picked up by another test's ``ComputeFrameworkTransformer()``
+discovery; that is harmless because each call creates FRESH framework types that are
+unreachable from any real framework and can never collide on a pair.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from mloda.core.abstract_plugins.components.framework_transformer.base_transformer import BaseTransformer
+from mloda.core.abstract_plugins.components.framework_transformer.cfw_transformer import (
+    ComputeFrameworkTransformer,
+)
+
+
+def _empty_registry() -> ComputeFrameworkTransformer:
+    """A registry whose map only reflects the add() calls made by the test itself."""
+    registry = ComputeFrameworkTransformer()
+    registry.transformer_map = {}
+    return registry
+
+
+def _make_one_way_transformer(name: str, fw: type[Any], other_fw: type[Any]) -> type[BaseTransformer]:
+    """A transformer overriding ONLY transform_fw_to_other_fw; the reverse hook stays
+    BaseTransformer's raising default. Import hooks succeed so add() accepts it."""
+
+    class _OneWay(BaseTransformer):
+        @classmethod
+        def framework(cls) -> Any:
+            return fw
+
+        @classmethod
+        def other_framework(cls) -> Any:
+            return other_fw
+
+        @classmethod
+        def import_fw(cls) -> None:
+            pass
+
+        @classmethod
+        def import_other_fw(cls) -> None:
+            pass
+
+        @classmethod
+        def transform_fw_to_other_fw(cls, data: Any) -> Any:
+            return [*data, f"{fw.__name__}->{other_fw.__name__}"]
+
+    _OneWay.__name__ = name
+    _OneWay.__qualname__ = name
+    return _OneWay
+
+
+def _make_two_way_transformer(name: str, fw: type[Any], other_fw: type[Any]) -> type[BaseTransformer]:
+    """A transformer overriding BOTH directions. Import hooks succeed so add() accepts it."""
+
+    class _TwoWay(BaseTransformer):
+        @classmethod
+        def framework(cls) -> Any:
+            return fw
+
+        @classmethod
+        def other_framework(cls) -> Any:
+            return other_fw
+
+        @classmethod
+        def import_fw(cls) -> None:
+            pass
+
+        @classmethod
+        def import_other_fw(cls) -> None:
+            pass
+
+        @classmethod
+        def transform_fw_to_other_fw(cls, data: Any) -> Any:
+            return [*data, f"{fw.__name__}->{other_fw.__name__}"]
+
+        @classmethod
+        def transform_other_fw_to_fw(cls, data: Any, framework_connection_object: Any | None = None) -> Any:
+            return [*data, f"{other_fw.__name__}->{fw.__name__}"]
+
+    _TwoWay.__name__ = name
+    _TwoWay.__qualname__ = name
+    return _TwoWay
+
+
+class TestAddRegistersOneWayTransformersForwardOnly:
+    def test_one_way_transformer_registers_only_the_forward_edge(self) -> None:
+        """(1a) A transformer WITHOUT a transform_other_fw_to_fw override registers only
+        (framework(), other_framework()).
+        """
+        fw_src = type("_FwSrc", (), {})
+        fw_dst = type("_FwDst", (), {})
+        one_way = _make_one_way_transformer("_OneWaySrcDst", fw_src, fw_dst)
+        registry = _empty_registry()
+
+        assert registry.add(one_way) is True
+
+        assert registry.transformer_map.get((fw_src, fw_dst)) is one_way
+        assert (fw_dst, fw_src) not in registry.transformer_map, (
+            "add() must not register the reverse edge of a one-way transformer: its "
+            "transform_other_fw_to_fw is BaseTransformer's raising default, so the edge "
+            "can only crash apply_chain with a bare NotImplementedError"
+        )
+
+    def test_two_way_transformer_registers_both_edges(self) -> None:
+        """(1b) Guard: a transformer overriding BOTH directions still registers both pairs."""
+        fw_src = type("_FwSrc", (), {})
+        fw_dst = type("_FwDst", (), {})
+        two_way = _make_two_way_transformer("_TwoWaySrcDst", fw_src, fw_dst)
+        registry = _empty_registry()
+
+        assert registry.add(two_way) is True
+
+        assert registry.transformer_map.get((fw_src, fw_dst)) is two_way
+        assert registry.transformer_map.get((fw_dst, fw_src)) is two_way
+
+
+class TestRealRegistryFileSourceEdgesAreForwardOnly:
+    def test_file_source_dict_edge_is_forward_only(self) -> None:
+        """(1c) Default registry: (FileSource, dict) is registered, (dict, FileSource) is not."""
+        from mloda.core.abstract_plugins.components.input_data.file_source import FileSource
+
+        registry = ComputeFrameworkTransformer()
+
+        assert (FileSource, dict) in registry.transformer_map
+        assert (dict, FileSource) not in registry.transformer_map, (
+            "dict -> FileSource is meaningless; a registered reverse edge lets the BFS "
+            "route chains through it and crash with NotImplementedError"
+        )
+
+    def test_file_source_pyarrow_edge_is_forward_only(self) -> None:
+        """(1c) Default registry: (FileSource, pa.Table) is registered, (pa.Table, FileSource) is not."""
+        pa = pytest.importorskip("pyarrow")
+        from mloda.core.abstract_plugins.components.input_data.file_source import FileSource
+
+        registry = ComputeFrameworkTransformer()
+
+        assert (FileSource, pa.Table) in registry.transformer_map
+        assert (pa.Table, FileSource) not in registry.transformer_map, (
+            "pa.Table -> FileSource is meaningless; a registered reverse edge lets the BFS "
+            "route chains through it and crash with NotImplementedError"
+        )
+
+
+class TestBfsNeverRoutesThroughOneWayReverseEdges:
+    def test_route_only_reachable_via_one_way_reverse_edge_resolves_to_none(self) -> None:
+        """(1d) The ONLY conceivable route from A to C is A -> B via the REVERSE edge of the
+        one-way transformer T(B, A), then B -> C via a two-way transformer. That route would
+        crash apply_chain (T's transform_other_fw_to_fw is the raising base default), so
+        get_transformation_chain(A, C) must return None.
+        """
+        fw_a = type("_FwA", (), {})
+        fw_b = type("_FwB", (), {})
+        fw_c = type("_FwC", (), {})
+        one_way_b_to_a = _make_one_way_transformer("_OneWayBToA", fw_b, fw_a)
+        two_way_bc = _make_two_way_transformer("_TwoWayBC", fw_b, fw_c)
+
+        registry = _empty_registry()
+        assert registry.add(one_way_b_to_a) is True
+        assert registry.add(two_way_bc) is True
+
+        chain = registry.get_transformation_chain(fw_a, fw_c)
+
+        assert chain is None, (
+            "get_transformation_chain must not build a chain through the reverse edge of a "
+            f"one-way transformer; got {[t.__name__ for t in chain]} which would crash "
+            "apply_chain with a bare NotImplementedError"
+        )

--- a/tests/test_plugins/compute_framework/test_transformer_directional_edges.py
+++ b/tests/test_plugins/compute_framework/test_transformer_directional_edges.py
@@ -1,0 +1,451 @@
+"""``ComputeFrameworkTransformer.add`` registers each edge only when the matching
+transform direction is actually overridden, and rejects a reverse-edge collision the
+same way it rejects a forward-edge collision.
+
+Contract:
+
+  * Requirement A1: the FORWARD edge ``(framework(), other_framework())`` is registered
+    only when ``transform_fw_to_other_fw`` is overridden relative to ``BaseTransformer``
+    (symmetric with the reverse guard). A reverse-only transformer registers ONLY the
+    reverse edge.
+  * Requirement A2: ``get_transformation_chain`` never routes through the absent forward
+    edge of a reverse-only transformer.
+  * Requirement A3: a transformer overriding NEITHER direction registers no edges and
+    ``add()`` returns False.
+  * Requirement A4 (guard): two-way transformers register both edges; forward-only
+    transformers register only the forward edge.
+  * Requirement B1: registering a transformer whose REVERSE edge is already claimed by a
+    DIFFERENT transformer class raises ``ValueError``.
+  * Requirement B2 (guard): re-adding the exact same transformer class is idempotent,
+    returns True and does not raise, for both forward-only and reverse-only transformers.
+
+Isolation note (mirrors ``test_one_way_transformer_edges.py``): every synthetic
+transformer and its framework types are built fresh inside a factory per test, and each
+registry under test has its map reset to ``{}`` so only the test's own ``add()`` calls are
+reflected. Fresh framework types are unreachable from any real framework; the colliding
+pair in B1 lives entirely on function-local types that are dropped once the test returns,
+so it can never poison another test's global transformer discovery.
+"""
+
+from __future__ import annotations
+
+import gc
+import logging
+import weakref
+from typing import Any
+
+import pytest
+
+from mloda.core.abstract_plugins.components.framework_transformer.base_transformer import BaseTransformer
+from mloda.core.abstract_plugins.components.framework_transformer.cfw_transformer import (
+    ComputeFrameworkTransformer,
+)
+
+
+def _empty_registry() -> ComputeFrameworkTransformer:
+    """A registry whose map only reflects the add() calls made by the test itself."""
+    registry = ComputeFrameworkTransformer()
+    registry.transformer_map = {}
+    return registry
+
+
+def _make_forward_only_transformer(name: str, fw: type[Any], other_fw: type[Any]) -> type[BaseTransformer]:
+    """Overrides ONLY ``transform_fw_to_other_fw``; reverse hook stays the raising default."""
+
+    class _ForwardOnly(BaseTransformer):
+        @classmethod
+        def framework(cls) -> Any:
+            return fw
+
+        @classmethod
+        def other_framework(cls) -> Any:
+            return other_fw
+
+        @classmethod
+        def import_fw(cls) -> None:
+            pass
+
+        @classmethod
+        def import_other_fw(cls) -> None:
+            pass
+
+        @classmethod
+        def transform_fw_to_other_fw(cls, data: Any) -> Any:
+            return [*data, f"{fw.__name__}->{other_fw.__name__}"]
+
+    _ForwardOnly.__name__ = name
+    _ForwardOnly.__qualname__ = name
+    return _ForwardOnly
+
+
+def _make_reverse_only_transformer(name: str, fw: type[Any], other_fw: type[Any]) -> type[BaseTransformer]:
+    """Overrides ONLY ``transform_other_fw_to_fw``; forward hook stays the raising default.
+
+    Such a transformer must register ONLY the reverse edge ``(other_framework, framework)``.
+    """
+
+    class _ReverseOnly(BaseTransformer):
+        @classmethod
+        def framework(cls) -> Any:
+            return fw
+
+        @classmethod
+        def other_framework(cls) -> Any:
+            return other_fw
+
+        @classmethod
+        def import_fw(cls) -> None:
+            pass
+
+        @classmethod
+        def import_other_fw(cls) -> None:
+            pass
+
+        @classmethod
+        def transform_other_fw_to_fw(cls, data: Any, framework_connection_object: Any | None = None) -> Any:
+            return [*data, f"{other_fw.__name__}->{fw.__name__}"]
+
+    _ReverseOnly.__name__ = name
+    _ReverseOnly.__qualname__ = name
+    return _ReverseOnly
+
+
+def _make_two_way_transformer(name: str, fw: type[Any], other_fw: type[Any]) -> type[BaseTransformer]:
+    """Overrides BOTH directions; registers both edges."""
+
+    class _TwoWay(BaseTransformer):
+        @classmethod
+        def framework(cls) -> Any:
+            return fw
+
+        @classmethod
+        def other_framework(cls) -> Any:
+            return other_fw
+
+        @classmethod
+        def import_fw(cls) -> None:
+            pass
+
+        @classmethod
+        def import_other_fw(cls) -> None:
+            pass
+
+        @classmethod
+        def transform_fw_to_other_fw(cls, data: Any) -> Any:
+            return [*data, f"{fw.__name__}->{other_fw.__name__}"]
+
+        @classmethod
+        def transform_other_fw_to_fw(cls, data: Any, framework_connection_object: Any | None = None) -> Any:
+            return [*data, f"{other_fw.__name__}->{fw.__name__}"]
+
+    _TwoWay.__name__ = name
+    _TwoWay.__qualname__ = name
+    return _TwoWay
+
+
+class _SeedSentinelTransformer(BaseTransformer):
+    """Module-level occupant used only to pre-seed an already-claimed edge in the B1 test.
+
+    It is a concrete transformer (so it satisfies ``type[BaseTransformer]`` in the map), but
+    its import hooks RAISE, so ``check_imports`` is False and global transformer discovery's
+    ``add()`` returns False without ever registering it. The B1 collision therefore stays
+    confined to the test's local registry (where it is seeded directly, bypassing add()) and
+    can never poison another test's global discovery. Only one genuinely-registering
+    throwaway transformer (``_ReverseOnlyOF``) participates, and alone it collides with
+    nothing globally.
+    """
+
+    @classmethod
+    def framework(cls) -> Any:
+        return type("_SentinelLeft", (), {})
+
+    @classmethod
+    def other_framework(cls) -> Any:
+        return type("_SentinelRight", (), {})
+
+    @classmethod
+    def import_fw(cls) -> None:
+        raise ImportError
+
+    @classmethod
+    def import_other_fw(cls) -> None:
+        raise ImportError
+
+    @classmethod
+    def transform_fw_to_other_fw(cls, data: Any) -> Any:
+        return data
+
+    @classmethod
+    def transform_other_fw_to_fw(cls, data: Any, framework_connection_object: Any | None = None) -> Any:
+        return data
+
+
+def _make_no_direction_transformer(name: str, fw: type[Any], other_fw: type[Any]) -> type[BaseTransformer]:
+    """Overrides NEITHER transform direction; both hooks stay the raising default.
+
+    Import hooks succeed so ``check_imports`` passes and ``add()`` reaches its edge-
+    registration logic; with no direction implemented it must register nothing.
+    """
+
+    class _NoDirection(BaseTransformer):
+        @classmethod
+        def framework(cls) -> Any:
+            return fw
+
+        @classmethod
+        def other_framework(cls) -> Any:
+            return other_fw
+
+        @classmethod
+        def import_fw(cls) -> None:
+            pass
+
+        @classmethod
+        def import_other_fw(cls) -> None:
+            pass
+
+    _NoDirection.__name__ = name
+    _NoDirection.__qualname__ = name
+    return _NoDirection
+
+
+class TestForwardEdgeGuard:
+    def test_reverse_only_transformer_registers_only_the_reverse_edge(self) -> None:
+        """(A1) A reverse-only transformer registers ``(other, framework)`` and NOT
+        ``(framework, other)``.
+        """
+        fw = type("_FwLeft", (), {})
+        other_fw = type("_FwRight", (), {})
+        reverse_only = _make_reverse_only_transformer("_ReverseOnlyLR", fw, other_fw)
+        registry = _empty_registry()
+
+        assert registry.add(reverse_only) is True
+
+        assert registry.transformer_map.get((other_fw, fw)) is reverse_only
+        assert (fw, other_fw) not in registry.transformer_map, (
+            "add() must not register the forward edge of a reverse-only transformer: its "
+            "transform_fw_to_other_fw is BaseTransformer's raising default"
+        )
+
+    def test_chain_never_routes_through_absent_forward_edge(self) -> None:
+        """(A2) The only conceivable route X -> Z goes X -> Y via the ABSENT forward edge of
+        a reverse-only transformer T(framework=X, other=Y), then Y -> Z via a two-way
+        transformer. The forward edge is unregistered, so the chain must be None.
+        """
+        fw_x = type("_FwX", (), {})
+        fw_y = type("_FwY", (), {})
+        fw_z = type("_FwZ", (), {})
+        reverse_only_xy = _make_reverse_only_transformer("_ReverseOnlyXY", fw_x, fw_y)
+        two_way_yz = _make_two_way_transformer("_TwoWayYZ", fw_y, fw_z)
+
+        registry = _empty_registry()
+        assert registry.add(reverse_only_xy) is True
+        assert registry.add(two_way_yz) is True
+
+        chain = registry.get_transformation_chain(fw_x, fw_z)
+
+        assert chain is None, (
+            "get_transformation_chain must not route through the absent forward edge of a "
+            f"reverse-only transformer; got {None if chain is None else [t.__name__ for t in chain]}"
+        )
+
+    def test_no_direction_transformer_registers_nothing_and_returns_false(self) -> None:
+        """(A3) A transformer overriding neither direction registers no edges; add() is False."""
+        fw = type("_FwNoneA", (), {})
+        other_fw = type("_FwNoneB", (), {})
+        no_direction = _make_no_direction_transformer("_NoDirectionAB", fw, other_fw)
+        registry = _empty_registry()
+
+        assert registry.add(no_direction) is False
+        assert (fw, other_fw) not in registry.transformer_map
+        assert (other_fw, fw) not in registry.transformer_map
+
+
+class TestExistingEdgeBehaviorPreserved:
+    def test_two_way_transformer_registers_both_edges(self) -> None:
+        """(A4) A two-way transformer keeps registering both directions."""
+        fw = type("_FwTwoA", (), {})
+        other_fw = type("_FwTwoB", (), {})
+        two_way = _make_two_way_transformer("_TwoWayAB", fw, other_fw)
+        registry = _empty_registry()
+
+        assert registry.add(two_way) is True
+        assert registry.transformer_map.get((fw, other_fw)) is two_way
+        assert registry.transformer_map.get((other_fw, fw)) is two_way
+
+    def test_forward_only_transformer_registers_only_forward_edge(self) -> None:
+        """(A4) A forward-only transformer registers only ``(framework, other)``."""
+        fw = type("_FwFwdA", (), {})
+        other_fw = type("_FwFwdB", (), {})
+        forward_only = _make_forward_only_transformer("_ForwardOnlyAB", fw, other_fw)
+        registry = _empty_registry()
+
+        assert registry.add(forward_only) is True
+        assert registry.transformer_map.get((fw, other_fw)) is forward_only
+        assert (other_fw, fw) not in registry.transformer_map
+
+
+class TestReverseEdgeConflict:
+    def test_reverse_edge_collision_with_different_class_raises(self) -> None:
+        """(B1) The edge (F, O) is already claimed by a DIFFERENT transformer class. A
+        reverse-only transformer T(framework=O, other=F) whose REVERSE edge is exactly (F, O)
+        then tries to claim it; add() must raise ValueError and leave the incumbent in place.
+
+        The incumbent is seeded directly into the local map so the deliberate collision never
+        reaches global transformer discovery (see the module-level isolation note).
+        """
+        fw_f = type("_FwF", (), {})
+        fw_o = type("_FwO", (), {})
+        reverse_only = _make_reverse_only_transformer("_ReverseOnlyOF", fw_o, fw_f)
+
+        registry = _empty_registry()
+        registry.transformer_map[(fw_f, fw_o)] = _SeedSentinelTransformer
+
+        with pytest.raises(ValueError) as excinfo:
+            registry.add(reverse_only)
+
+        assert "already registered" in str(excinfo.value), str(excinfo.value)
+        assert registry.transformer_map.get((fw_f, fw_o)) is _SeedSentinelTransformer, (
+            "the conflicting reverse edge must not overwrite the incumbent transformer"
+        )
+
+    def test_forward_only_reregistration_is_idempotent(self) -> None:
+        """(B2) Re-adding the same forward-only transformer returns True and does not raise."""
+        fw = type("_FwIdemFwdA", (), {})
+        other_fw = type("_FwIdemFwdB", (), {})
+        forward_only = _make_forward_only_transformer("_ForwardOnlyIdem", fw, other_fw)
+        registry = _empty_registry()
+
+        assert registry.add(forward_only) is True
+        assert registry.add(forward_only) is True
+        assert registry.transformer_map.get((fw, other_fw)) is forward_only
+
+    def test_reverse_only_reregistration_is_idempotent(self) -> None:
+        """(B2) Re-adding the same reverse-only transformer returns True and does not raise."""
+        fw = type("_FwIdemRevA", (), {})
+        other_fw = type("_FwIdemRevB", (), {})
+        reverse_only = _make_reverse_only_transformer("_ReverseOnlyIdem", fw, other_fw)
+        registry = _empty_registry()
+
+        assert registry.add(reverse_only) is True
+        assert registry.add(reverse_only) is True
+        assert registry.transformer_map.get((other_fw, fw)) is reverse_only
+
+
+_CFW_TRANSFORMER_LOGGER = "mloda.core.abstract_plugins.components.framework_transformer.cfw_transformer"
+
+
+def _cfw_warnings(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    """WARNING records emitted by the cfw_transformer module logger."""
+    return [
+        record
+        for record in caplog.records
+        if record.name == _CFW_TRANSFORMER_LOGGER and record.levelno == logging.WARNING
+    ]
+
+
+class TestZeroEdgeWarning:
+    """``add()`` WARNS when imports pass but neither transform direction is overridden
+    (zero edges registered), because that silence hides an authoring bug such as a
+    typo'd override. Failed imports and edge-registering transformers stay silent.
+    """
+
+    def test_no_direction_transformer_warns_naming_the_class(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Passing imports plus zero overridden directions: add() is False, no edges, and
+        exactly one WARNING from the cfw_transformer module logger names the class.
+
+        The registry is built BEFORE the transformer class exists, so the registry
+        constructor's discovery pass cannot have already add()-ed (and warned about) the
+        class; the explicit ``registry.add(...)`` below is the sole possible warning source.
+        """
+        registry = _empty_registry()
+        fw = type("_FwWarnA", (), {})
+        other_fw = type("_FwWarnB", (), {})
+        no_direction = _make_no_direction_transformer("_NoDirectionWarnAB", fw, other_fw)
+
+        with caplog.at_level(logging.WARNING, logger=_CFW_TRANSFORMER_LOGGER):
+            assert registry.add(no_direction) is False
+
+        assert (fw, other_fw) not in registry.transformer_map
+        assert (other_fw, fw) not in registry.transformer_map
+
+        warnings = _cfw_warnings(caplog)
+        assert len(warnings) == 1, (
+            "add() must emit exactly one WARNING via the cfw_transformer module logger when a "
+            f"transformer with passing imports registers zero edges; got {len(warnings)} records"
+        )
+        assert "_NoDirectionWarnAB" in warnings[0].getMessage(), (
+            "the warning message must name the transformer class so the author can find the "
+            f"typo'd override; got: {warnings[0].getMessage()!r}"
+        )
+
+    def test_failed_imports_do_not_warn(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A transformer whose import hooks raise is a normal absent-dependency case:
+        add() is False and NO warning is emitted."""
+
+        class _ImportlessLocal(BaseTransformer):
+            @classmethod
+            def framework(cls) -> Any:
+                return type("_FwImportlessA", (), {})
+
+            @classmethod
+            def other_framework(cls) -> Any:
+                return type("_FwImportlessB", (), {})
+
+            @classmethod
+            def import_fw(cls) -> None:
+                raise ImportError
+
+            @classmethod
+            def import_other_fw(cls) -> None:
+                raise ImportError
+
+            @classmethod
+            def transform_fw_to_other_fw(cls, data: Any) -> Any:
+                return data
+
+            @classmethod
+            def transform_other_fw_to_fw(cls, data: Any, framework_connection_object: Any | None = None) -> Any:
+                return data
+
+        registry = _empty_registry()
+
+        with caplog.at_level(logging.WARNING, logger=_CFW_TRANSFORMER_LOGGER):
+            assert registry.add(_ImportlessLocal) is False
+
+        assert _cfw_warnings(caplog) == [], "failed check_imports() must stay silent: it is not an authoring bug"
+
+    def test_edge_registering_transformer_does_not_warn(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A transformer registering at least one edge succeeds silently."""
+        fw = type("_FwQuietA", (), {})
+        other_fw = type("_FwQuietB", (), {})
+        two_way = _make_two_way_transformer("_TwoWayQuietAB", fw, other_fw)
+        registry = _empty_registry()
+
+        with caplog.at_level(logging.WARNING, logger=_CFW_TRANSFORMER_LOGGER):
+            assert registry.add(two_way) is True
+
+        assert _cfw_warnings(caplog) == [], "a transformer that registers edges must not warn"
+
+    def test_zero_edge_dedupe_does_not_retain_transformer_class(self) -> None:
+        """The zero-edge warning dedupe does not keep the transformer class alive.
+
+        After the only strong reference to a warned-about class is dropped, the class must
+        be collectable. ``BaseTransformer.__subclasses__`` holds only weak references, so
+        nothing else pins it; only a strong dedupe container (e.g. a plain set) would.
+        """
+        registry = _empty_registry()
+        fw = type("_FwWeakRefA", (), {})
+        other_fw = type("_FwWeakRefB", (), {})
+        transformer_cls = _make_no_direction_transformer("_NoDirectionWeakRef", fw, other_fw)
+
+        assert registry.add(transformer_cls) is False
+
+        ref = weakref.ref(transformer_cls)
+        del transformer_cls
+        gc.collect()
+
+        assert ref() is None, (
+            "the zero-edge warning dedupe must not retain transformer classes for the process "
+            "lifetime; BaseTransformer.__subclasses__ is weak, so nothing else pins the class"
+        )

--- a/tests/test_plugins/compute_framework/test_transformer_registry_completeness.py
+++ b/tests/test_plugins/compute_framework/test_transformer_registry_completeness.py
@@ -1,0 +1,45 @@
+"""The transformer registry is complete regardless of import order.
+
+The transformer files auto-load ONCE per process, unconditionally on first registry
+construction (unless the group is disabled), so a stray module-scope import of a single
+``BaseTransformer`` subclass before the first ``ComputeFrameworkTransformer()`` construction
+cannot leave the registry partial (e.g. the ``(FileSource, pa.Table)`` edge missing, because
+no production module imports ``FileSourcePyArrowTransformer``).
+
+This module deliberately imports one transformer subclass at MODULE scope to "poison" the
+registry, then asserts the registry is still complete.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pyarrow as pa
+
+from mloda.core.abstract_plugins.components.framework_transformer.cfw_transformer import (
+    ComputeFrameworkTransformer,
+)
+from mloda.core.abstract_plugins.components.input_data.file_source import FileSource
+
+# Module-scope import of a BaseTransformer subclass: this is what poisons the registry.
+# After this import, ``get_all_subclasses(BaseTransformer)`` is non-empty, so a load-only-
+# when-empty glob in ``initilize_transformer`` never runs and other transformers are lost.
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_file_source_transformer import (  # noqa: F401,E501
+    FileSourceDictTransformer,
+)
+
+
+def test_registry_is_complete_despite_module_scope_transformer_import() -> None:
+    """Core transformer pairs must always be present with pyarrow installed."""
+    transformer_map = ComputeFrameworkTransformer().transformer_map
+
+    expected_pairs = {
+        (FileSource, dict): "FileSource -> PythonDict (stdlib csv)",
+        (FileSource, pa.Table): "FileSource -> pa.Table (pyarrow csv)",
+        (dict, pa.Table): "PythonDict -> pa.Table",
+        (pa.Table, dict): "pa.Table -> PythonDict",
+        (pd.DataFrame, pa.Table): "pandas -> pa.Table",
+        (pa.Table, pd.DataFrame): "pa.Table -> pandas",
+    }
+
+    missing = {pair for pair in expected_pairs if pair not in transformer_map}
+    assert not missing, f"Registry incomplete after a module-scope transformer import; missing: {missing}"

--- a/tests/test_plugins/feature_group/input_data/test_init_reader_hoist.py
+++ b/tests/test_plugins/feature_group/input_data/test_init_reader_hoist.py
@@ -1,0 +1,125 @@
+"""Pins init_reader as the single concrete implementation on BaseInputData.
+
+Contract:
+
+    BaseInputData.init_reader(self, options: Optional[Options]) -> tuple[BaseInputData, Any]
+    is concrete; ReadDB, ReadFile, and ReadDocument have no overrides.
+
+    Semantics of the hoisted implementation:
+      - options is None: ValueError whose message starts
+        "Options were not set for {self.__class__.__name__}" and contains "BaseInputData",
+        "Options(context=", and an example line containing "ReaderClass" and "data_access".
+      - options.get("BaseInputData") is None (key missing or None): ValueError containing
+        "'BaseInputData' key is missing or None", the class name, and the same example hints.
+      - happy path: options carrying {"BaseInputData": (SomeReaderClass, data_access)}
+        returns (instance of SomeReaderClass, data_access).
+
+Test isolation note:
+All BaseInputData subclasses used here are defined at MODULE scope, never inside test
+methods, so they are picklable and stable in the global subclass registry. They leave
+every matching-related classmethod (suffix, is_valid_credentials, load_data hooks, ...)
+unimplemented, so they never classify as final readers and plugin discovery in sibling
+tests can never select them.
+"""
+
+from typing import Any
+
+import pytest
+
+from mloda.core.abstract_plugins.components.input_data.base_input_data import BaseInputData
+from mloda.core.abstract_plugins.components.options import Options
+from mloda_plugins.feature_group.input_data.read_db import ReadDB
+from mloda_plugins.feature_group.input_data.read_document import ReadDocument
+from mloda_plugins.feature_group.input_data.read_file import ReadFile
+
+
+class HoistBareInputData(BaseInputData):
+    """Minimal BaseInputData subclass implementing nothing; drives the base init_reader directly."""
+
+
+class HoistSentinelReader(BaseInputData):
+    """Reader class carried inside the 'BaseInputData' options tuple for the happy-path pin."""
+
+
+class HoistDocumentReader(ReadDocument):
+    """ReadDocument family member; pins the message upgrade over the current terse wording."""
+
+
+class TestInitReaderIsHoistedToBase:
+    """After the hoist, the three reader families no longer override init_reader."""
+
+    @pytest.mark.parametrize("family", [ReadDB, ReadFile, ReadDocument])
+    def test_family_does_not_override_init_reader(self, family: type[BaseInputData]) -> None:
+        # init_reader is a plain instance method; accessing it on the class object yields
+        # the plain function, so identity comparison works without __func__ unwrapping.
+        assert family.init_reader is BaseInputData.init_reader
+
+    @pytest.mark.parametrize("family", [ReadDB, ReadFile, ReadDocument])
+    def test_family_dict_has_no_init_reader(self, family: type[BaseInputData]) -> None:
+        assert "init_reader" not in family.__dict__
+
+
+class TestBaseInitReaderIsConcrete:
+    """BaseInputData.init_reader becomes the single concrete implementation."""
+
+    def test_options_none_raises_value_error_not_not_implemented(self) -> None:
+        reader = HoistBareInputData()
+        with pytest.raises(ValueError) as excinfo:
+            reader.init_reader(None)
+        message = str(excinfo.value)
+        assert "HoistBareInputData" in message
+        assert "BaseInputData" in message
+
+    def test_options_none_message_contract(self) -> None:
+        reader = HoistBareInputData()
+        with pytest.raises(ValueError) as excinfo:
+            reader.init_reader(None)
+        message = str(excinfo.value)
+        assert message.startswith("Options were not set for HoistBareInputData")
+        assert "Options(context=" in message
+        assert "ReaderClass" in message
+        assert "data_access" in message
+
+    def test_missing_key_message_contract(self) -> None:
+        reader = HoistBareInputData()
+        options = Options(context={"other_key": "value"})
+        with pytest.raises(ValueError) as excinfo:
+            reader.init_reader(options)
+        message = str(excinfo.value)
+        assert "'BaseInputData' key is missing or None" in message
+        assert "HoistBareInputData" in message
+        assert "ReaderClass" in message
+        assert "data_access" in message
+
+    def test_happy_path_returns_reader_instance_and_data_access(self) -> None:
+        data_access: dict[str, Any] = {"dsn": "x"}
+        options = Options(group={"BaseInputData": (HoistSentinelReader, data_access)})
+        reader, returned_data_access = HoistBareInputData().init_reader(options)
+        assert isinstance(reader, HoistSentinelReader)
+        assert returned_data_access is data_access
+
+
+class TestFamilyBehaviorAfterHoist:
+    """The families keep (or gain) the parameterized error messages through the shared base."""
+
+    @pytest.mark.parametrize(
+        "family, expected_name",
+        [
+            (ReadDB, "ReadDB"),
+            (ReadFile, "ReadFile"),
+            (HoistDocumentReader, "HoistDocumentReader"),
+        ],
+    )
+    def test_options_none_mentions_class_name(self, family: type[BaseInputData], expected_name: str) -> None:
+        reader = family()
+        with pytest.raises(ValueError, match="Options were not set") as excinfo:
+            reader.init_reader(None)
+        assert expected_name in str(excinfo.value)
+
+    def test_read_db_missing_key_matches_base_contract(self) -> None:
+        # Options bracket access returns None for a missing key, so even ReadDB's current
+        # bracket-access implementation must funnel a keyless Options into the same
+        # ValueError as the base (never KeyError or a None-unpack TypeError).
+        options = Options(context={"other_key": "value"})
+        with pytest.raises(ValueError, match="'BaseInputData' key is missing or None"):
+            ReadDB().init_reader(options)

--- a/tests/test_plugins/feature_group/input_data/test_read_dbs/test_read_db_load_data_seam.py
+++ b/tests/test_plugins/feature_group/input_data/test_read_dbs/test_read_db_load_data_seam.py
@@ -1,0 +1,492 @@
+"""Tests for the ReadDB.load_data template-method lifecycle seam.
+
+Contract pinned here:
+
+    ReadDB gains
+      - classmethod prepare_credentials(data_access, features): overridable, default pass-through.
+      - classmethod produce_rows(connection, features): the per-backend row hook; the base
+        default raises NotImplementedError.
+
+    load_data becomes a template method that
+      1. probes the DYNAMIC anchor first: it resolves cls.final_reader_anchor() and checks the
+         anchor's _final_reader_requires() hooks via _is_overridden against THAT anchor (never
+         hardcoded against ReadDB); when the hook set is incomplete it raises NotImplementedError
+         BEFORE any credential or connection work,
+      2. credentials = prepare_credentials(data_access, features)  (default: pass-through),
+      3. connection = get_connection(credentials)  (-> connect()),
+      4. try: return produce_rows(connection, features)
+         finally: close_connection(connection)  (close even when produce_rows raises).
+
+    ReadDB._final_reader_requires() returns ("produce_rows", "connect"): a backend is final iff
+    it overrides BOTH hooks relative to its anchor, or overrides load_data wholesale.
+
+    Consistency contract: for any class, is_final_reader() False implies the template raises
+    NotImplementedError before connection work.
+
+    The matcher exception contract is documented: the docstrings of is_valid_credentials and
+    check_feature_in_data_access mention that only NotImplementedError is treated as a soft
+    no-match by the matcher and any other exception propagates.
+
+Test isolation note:
+All ReadDB subclasses used by these tests are defined at MODULE scope, never inside test
+methods. Function-local subclasses linger in ``ReadDB.__subclasses__()`` (the global plugin
+registry) until GC runs, leaking into sibling tests' plugin discovery, and they are
+unpicklable, which breaks multiprocessing runners. Module-scope classes are picklable and
+stable. Additionally, every seam reader's ``is_valid_credentials`` returns ``False`` so that,
+even if discovered, they can never match a real ``DataAccessCollection`` in a sibling test.
+"""
+
+from typing import Any, ClassVar
+
+import pytest
+
+from mloda_plugins.feature_group.input_data.read_db import ReadDB
+from mloda_plugins.feature_group.input_data.read_dbs.sqlite import SQLITEReader
+
+
+class FakeConnection:
+    """In-test stand-in for a DB connection; records ``close()`` calls."""
+
+    def __init__(self) -> None:
+        self.close_count = 0
+
+    def close(self) -> None:
+        self.close_count += 1
+
+
+# --------------------------------------------------------------------------------------
+# Module-scope readers for the load_data lifecycle seam tests.
+#
+# Defined at MODULE scope (never inside a test) so they are picklable and stable in the
+# plugin registry. ``is_valid_credentials`` returns False on every reader so a leaked
+# class can never match a real DataAccessCollection in a sibling test file. The tests
+# below drive these readers directly and record interactions via ClassVar lists.
+# --------------------------------------------------------------------------------------
+
+
+class _SeamIntermediateDB(ReadDB):
+    """Implements connect but NOT produce_rows; connect must run only after the probe."""
+
+    connect_calls: ClassVar[list[Any]] = []
+
+    @classmethod
+    def connect(cls, credentials: Any) -> Any:
+        cls.connect_calls.append(credentials)
+        return FakeConnection()
+
+    @classmethod
+    def is_valid_credentials(cls, credentials: dict[str, Any]) -> bool:
+        return False
+
+
+class _SeamRowHookNoConnectDB(ReadDB):
+    """Overrides produce_rows but NOT connect: cannot actually connect, so it is not final.
+
+    prepare_credentials records calls: if the probe wrongly passes (e.g. a hardcoded
+    produce_rows-only check), the template would run prepare_credentials before failing on
+    the abstract connect, and the recorder would expose it.
+    """
+
+    prepare_calls: ClassVar[list[Any]] = []
+
+    @classmethod
+    def prepare_credentials(cls, data_access: Any, features: Any) -> Any:
+        cls.prepare_calls.append(data_access)
+        return data_access
+
+    @classmethod
+    def produce_rows(cls, connection: Any, features: Any) -> Any:
+        return {"rows": True}
+
+    @classmethod
+    def is_valid_credentials(cls, credentials: dict[str, Any]) -> bool:
+        return False
+
+
+class _SeamHappyPathDB(ReadDB):
+    """Final reader whose produce_rows returns the supplied connection/features sentinel."""
+
+    @classmethod
+    def connect(cls, credentials: Any) -> Any:
+        return FakeConnection()
+
+    @classmethod
+    def produce_rows(cls, connection: Any, features: Any) -> Any:
+        return {"connection": connection, "features": features}
+
+    @classmethod
+    def is_valid_credentials(cls, credentials: dict[str, Any]) -> bool:
+        return False
+
+
+class _SeamBoomDB(ReadDB):
+    """Final reader whose produce_rows raises; close_connection must still run."""
+
+    created: ClassVar[list[FakeConnection]] = []
+
+    @classmethod
+    def connect(cls, credentials: Any) -> Any:
+        connection = FakeConnection()
+        cls.created.append(connection)
+        return connection
+
+    @classmethod
+    def produce_rows(cls, connection: Any, features: Any) -> Any:
+        raise RuntimeError("boom")
+
+    @classmethod
+    def is_valid_credentials(cls, credentials: dict[str, Any]) -> bool:
+        return False
+
+
+class _SeamConnectRaisesDB(ReadDB):
+    """connect() raises before any connection exists: close_connection must never run."""
+
+    closes: ClassVar[list[Any]] = []
+
+    @classmethod
+    def connect(cls, credentials: Any) -> Any:
+        raise RuntimeError("no connect")
+
+    @classmethod
+    def close_connection(cls, connection: Any) -> None:
+        cls.closes.append(connection)
+
+    @classmethod
+    def produce_rows(cls, connection: Any, features: Any) -> Any:
+        raise AssertionError("produce_rows must not run when connect() raises")
+
+    @classmethod
+    def is_valid_credentials(cls, credentials: dict[str, Any]) -> bool:
+        return False
+
+
+class _SeamTransformDB(ReadDB):
+    """Overrides prepare_credentials; the transformed credentials must reach connect()."""
+
+    received: ClassVar[list[Any]] = []
+
+    @classmethod
+    def prepare_credentials(cls, data_access: Any, features: Any) -> Any:
+        return {"wrapped": data_access}
+
+    @classmethod
+    def connect(cls, credentials: Any) -> Any:
+        cls.received.append(credentials)
+        return FakeConnection()
+
+    @classmethod
+    def produce_rows(cls, connection: Any, features: Any) -> Any:
+        return "rows"
+
+    @classmethod
+    def is_valid_credentials(cls, credentials: dict[str, Any]) -> bool:
+        return False
+
+
+class _SeamPassthroughDB(ReadDB):
+    """Uses the default prepare_credentials; data_access must pass through unchanged."""
+
+    received: ClassVar[list[Any]] = []
+
+    @classmethod
+    def connect(cls, credentials: Any) -> Any:
+        cls.received.append(credentials)
+        return FakeConnection()
+
+    @classmethod
+    def produce_rows(cls, connection: Any, features: Any) -> Any:
+        return "rows"
+
+    @classmethod
+    def is_valid_credentials(cls, credentials: dict[str, Any]) -> bool:
+        return False
+
+
+class _SeamStaticRowHookDB(ReadDB):
+    """produce_rows is a @staticmethod: the probe must unwrap __func__ uniformly."""
+
+    sentinel: ClassVar[dict[str, bool]] = {"static_rows": True}
+    created: ClassVar[list[FakeConnection]] = []
+
+    @classmethod
+    def connect(cls, credentials: Any) -> Any:
+        connection = FakeConnection()
+        cls.created.append(connection)
+        return connection
+
+    @staticmethod
+    def produce_rows(connection: Any, features: Any) -> Any:
+        return _SeamStaticRowHookDB.sentinel
+
+    @classmethod
+    def is_valid_credentials(cls, credentials: dict[str, Any]) -> bool:
+        return False
+
+
+class _SeamWholesaleDB(ReadDB):
+    """Legacy-style backend: overrides load_data wholesale; the template must stay out of the way."""
+
+    connect_calls: ClassVar[list[Any]] = []
+
+    @classmethod
+    def connect(cls, credentials: Any) -> Any:
+        cls.connect_calls.append(credentials)
+        return FakeConnection()
+
+    @classmethod
+    def load_data(cls, data_access: Any, features: Any) -> Any:
+        return {"wholesale": True}
+
+    @classmethod
+    def is_valid_credentials(cls, credentials: dict[str, Any]) -> bool:
+        return False
+
+
+# --------------------------------------------------------------------------------------
+# Third-party sub-family re-anchoring _final_reader_requires below ReadDB.
+#
+# _SubFamilyDB shares produce_rows for the whole sub-family and redeclares the requires
+# tuple, becoming the anchor for its children. Relative to ReadDB its produce_rows IS
+# overridden, so a probe hardcoded against ReadDB would wrongly let _SubFamilyDB.load_data
+# proceed into credential/connection work. The dynamic probe resolves the anchor
+# (_SubFamilyDB itself) and must raise NotImplementedError first.
+# --------------------------------------------------------------------------------------
+
+
+class _SubFamilyDB(ReadDB):
+    """Sub-family base: redeclares the requires tuple and provides a shared produce_rows."""
+
+    connect_calls: ClassVar[list[Any]] = []
+    prepare_calls: ClassVar[list[Any]] = []
+
+    @classmethod
+    def _final_reader_requires(cls) -> tuple[str, ...]:
+        return ("produce_rows", "connect")
+
+    @classmethod
+    def prepare_credentials(cls, data_access: Any, features: Any) -> Any:
+        cls.prepare_calls.append(data_access)
+        return data_access
+
+    @classmethod
+    def produce_rows(cls, connection: Any, features: Any) -> Any:
+        return {"family": "shared", "connection": connection}
+
+    @classmethod
+    def connect(cls, credentials: Any) -> Any:
+        cls.connect_calls.append(credentials)
+        return FakeConnection()
+
+    @classmethod
+    def is_valid_credentials(cls, credentials: dict[str, Any]) -> bool:
+        return False
+
+
+class _SubFamilyChildDB(_SubFamilyDB):
+    """Concrete child overriding both hooks relative to _SubFamilyDB: final, runs the template."""
+
+    created: ClassVar[list[FakeConnection]] = []
+
+    @classmethod
+    def produce_rows(cls, connection: Any, features: Any) -> Any:
+        return {"child": True, "connection": connection, "features": features}
+
+    @classmethod
+    def connect(cls, credentials: Any) -> Any:
+        connection = FakeConnection()
+        cls.created.append(connection)
+        return connection
+
+
+class TestReadDBSeamHooks:
+    def test_produce_rows_base_default_raises_not_implemented(self) -> None:
+        """The base row hook exists on ReadDB and raises NotImplementedError."""
+        with pytest.raises(NotImplementedError):
+            ReadDB.produce_rows(None, None)  # type: ignore[arg-type]
+
+    def test_prepare_credentials_default_is_pass_through(self) -> None:
+        """The default prepare_credentials returns data_access unchanged (identity)."""
+        sentinel = {"host": "db"}
+        assert ReadDB.prepare_credentials(sentinel, None) is sentinel  # type: ignore[arg-type]
+
+    def test_read_db_requires_produce_rows_and_connect(self) -> None:
+        """ReadDB._final_reader_requires() names the phase-2 hook set."""
+        assert ReadDB._final_reader_requires() == ("produce_rows", "connect")
+
+
+class TestReadDBTemplate:
+    def test_seam_happy_path_closes_exactly_once(self) -> None:
+        """A hook-complete backend loads via the inherited template and closes once."""
+        sentinel_features = ["a", "b"]
+        result = _SeamHappyPathDB.load_data({"k": "v"}, sentinel_features)  # type: ignore[arg-type]
+
+        assert result["features"] is sentinel_features
+        connection = result["connection"]
+        assert isinstance(connection, FakeConnection)
+        assert connection.close_count == 1, "close_connection must run exactly once on success"
+
+    def test_close_connection_runs_when_produce_rows_raises(self) -> None:
+        """If produce_rows raises, the exception propagates AND the connection is closed."""
+        _SeamBoomDB.created.clear()
+
+        with pytest.raises(RuntimeError, match="boom"):
+            _SeamBoomDB.load_data({"k": "v"}, None)  # type: ignore[arg-type]
+
+        assert _SeamBoomDB.created, "connect() should have been invoked"
+        assert _SeamBoomDB.created[-1].close_count == 1, "close_connection must run even when produce_rows raises"
+
+    def test_connect_raising_skips_close_connection(self) -> None:
+        """If connect() raises before producing a connection, close_connection must not run."""
+        _SeamConnectRaisesDB.closes.clear()
+
+        with pytest.raises(RuntimeError, match="no connect"):
+            _SeamConnectRaisesDB.load_data({"k": "v"}, None)  # type: ignore[arg-type]
+
+        assert _SeamConnectRaisesDB.closes == [], "close_connection must not run when connect() fails"
+
+    def test_prepare_credentials_override_is_honored(self) -> None:
+        """An overridden prepare_credentials transforms data_access before connect()."""
+        _SeamTransformDB.received.clear()
+
+        raw = {"host": "db"}
+        result = _SeamTransformDB.load_data(raw, None)  # type: ignore[arg-type]
+
+        assert result == "rows"
+        assert _SeamTransformDB.received[-1] == {"wrapped": raw}, "transformed credentials must reach connect()"
+
+    def test_default_prepare_credentials_passes_through_unchanged(self) -> None:
+        """Without an override, prepare_credentials forwards data_access to connect() unchanged."""
+        _SeamPassthroughDB.received.clear()
+
+        raw = {"host": "db2"}
+        _SeamPassthroughDB.load_data(raw, None)  # type: ignore[arg-type]
+
+        assert _SeamPassthroughDB.received[-1] is raw, "default prepare_credentials must pass data_access through"
+
+    def test_staticmethod_produce_rows_runs_seam_end_to_end(self) -> None:
+        """A @staticmethod row hook is probed via __func__ unwrapping and runs the template."""
+        _SeamStaticRowHookDB.created.clear()
+
+        result = _SeamStaticRowHookDB.load_data({"k": "v"}, None)  # type: ignore[arg-type]
+
+        assert result is _SeamStaticRowHookDB.sentinel
+        assert _SeamStaticRowHookDB.created, "connect() should have been invoked"
+        assert _SeamStaticRowHookDB.created[-1].close_count == 1, "close_connection must run exactly once"
+
+
+class TestReadDBProbeIsDynamic:
+    """The template probe resolves the anchor dynamically; it is never hardcoded against ReadDB."""
+
+    def test_sub_family_re_anchors_classification(self) -> None:
+        """Redeclaring _final_reader_requires moves the anchor to the sub-family base."""
+        assert _SubFamilyDB.final_reader_anchor() is _SubFamilyDB
+        assert _SubFamilyChildDB.final_reader_anchor() is _SubFamilyDB
+
+    def test_sub_family_base_is_not_final_and_raises_before_connecting(self) -> None:
+        """The sub-family base shares produce_rows but is not final; load_data must probe
+        against the re-anchored hook set and raise BEFORE prepare/connect run.
+
+        A probe hardcoded against ReadDB would see produce_rows overridden and connect.
+        """
+        _SubFamilyDB.connect_calls.clear()
+        _SubFamilyDB.prepare_calls.clear()
+
+        assert _SubFamilyDB.is_final_reader() is False
+
+        with pytest.raises(NotImplementedError):
+            _SubFamilyDB.load_data({"k": "v"}, None)  # type: ignore[arg-type]
+
+        assert _SubFamilyDB.prepare_calls == [], "prepare_credentials must not run before the dynamic probe"
+        assert _SubFamilyDB.connect_calls == [], "connect() must not run before the dynamic probe"
+
+    def test_sub_family_child_is_final_and_runs_the_template(self) -> None:
+        """A child overriding both hooks relative to the sub-family anchor loads via the template."""
+        _SubFamilyChildDB.created.clear()
+        _SubFamilyDB.prepare_calls.clear()
+
+        assert _SubFamilyChildDB.is_final_reader() is True
+
+        sentinel_features = ["x"]
+        raw = {"k": "v"}
+        result = _SubFamilyChildDB.load_data(raw, sentinel_features)  # type: ignore[arg-type]
+
+        assert result["child"] is True
+        assert result["features"] is sentinel_features
+        assert _SubFamilyDB.prepare_calls == [raw], "the template must run the inherited prepare_credentials"
+        assert _SubFamilyChildDB.created, "connect() should have been invoked"
+        assert _SubFamilyChildDB.created[-1].close_count == 1, "close_connection must run exactly once"
+
+    @pytest.mark.parametrize(
+        "non_final",
+        [ReadDB, _SeamIntermediateDB, _SeamRowHookNoConnectDB, _SubFamilyDB],
+    )
+    def test_non_final_implies_template_raises_not_implemented(self, non_final: type[ReadDB]) -> None:
+        """Consistency contract: is_final_reader() False implies load_data raises NotImplementedError."""
+        assert non_final.is_final_reader() is False
+
+        with pytest.raises(NotImplementedError):
+            non_final.load_data(None, None)  # type: ignore[arg-type]
+
+    def test_intermediate_base_probe_raises_without_connecting(self) -> None:
+        """A base implementing connect but NOT produce_rows must fail the probe before connecting."""
+        _SeamIntermediateDB.connect_calls.clear()
+
+        with pytest.raises(NotImplementedError):
+            _SeamIntermediateDB.load_data({"k": "v"}, None)  # type: ignore[arg-type]
+
+        assert _SeamIntermediateDB.connect_calls == [], "connect() must not run when the probe fails"
+
+    def test_row_hook_without_connect_probe_raises_before_credential_work(self) -> None:
+        """A produce_rows-only class fails the probe before prepare_credentials runs."""
+        _SeamRowHookNoConnectDB.prepare_calls.clear()
+
+        with pytest.raises(NotImplementedError):
+            _SeamRowHookNoConnectDB.load_data({"k": "v"}, None)  # type: ignore[arg-type]
+
+        assert _SeamRowHookNoConnectDB.prepare_calls == [], "prepare_credentials must not run when the probe fails"
+
+
+class TestReadDBClassification:
+    def test_read_db_itself_is_not_final(self) -> None:
+        assert ReadDB.is_final_reader() is False
+
+    def test_hook_complete_backend_is_final_without_load_data_override(self) -> None:
+        """Overriding produce_rows + connect is enough; no wholesale load_data needed."""
+        assert "load_data" not in _SeamHappyPathDB.__dict__
+        assert _SeamHappyPathDB.is_final_reader() is True
+
+    def test_staticmethod_row_hook_backend_is_final(self) -> None:
+        assert _SeamStaticRowHookDB.is_final_reader() is True
+
+    def test_intermediate_base_with_connect_only_is_not_final(self) -> None:
+        assert _SeamIntermediateDB.is_final_reader() is False
+
+    def test_row_hook_without_connect_is_not_final(self) -> None:
+        """connect is in the requires tuple precisely to screen out this shape."""
+        assert _SeamRowHookNoConnectDB.is_final_reader() is False
+
+    def test_wholesale_load_data_override_is_final_and_untouched(self) -> None:
+        """A wholesale override stays final and runs without the template lifecycle."""
+        _SeamWholesaleDB.connect_calls.clear()
+
+        assert _SeamWholesaleDB.is_final_reader() is True
+        assert _SeamWholesaleDB.load_data({"k": "v"}, None) == {"wholesale": True}
+        assert _SeamWholesaleDB.connect_calls == [], "a wholesale load_data must not enter the template"
+
+    def test_sqlite_reader_stays_final_via_wholesale_override(self) -> None:
+        assert "load_data" in SQLITEReader.__dict__
+        assert SQLITEReader.is_final_reader() is True
+
+
+class TestMatcherExceptionContractIsDocumented:
+    """Only NotImplementedError is a soft no-match in the matcher; other exceptions propagate.
+
+    The contract must be stated in the docstrings of the two matcher-facing hooks.
+    """
+
+    def test_is_valid_credentials_docstring_mentions_not_implemented_error(self) -> None:
+        assert "NotImplementedError" in (ReadDB.is_valid_credentials.__doc__ or "")
+
+    def test_check_feature_in_data_access_docstring_mentions_not_implemented_error(self) -> None:
+        assert "NotImplementedError" in (ReadDB.check_feature_in_data_access.__doc__ or "")

--- a/tests/test_plugins/feature_group/input_data/test_read_files/test_csv_backend_neutral_regression.py
+++ b/tests/test_plugins/feature_group/input_data/test_read_files/test_csv_backend_neutral_regression.py
@@ -1,0 +1,81 @@
+"""Regression guards for the compute-framework-neutral CSV seam.
+
+These pass TODAY (they exercise the current pyarrow path) and must KEEP passing after
+CsvReader is reframed around ``FileSource``:
+
+  * PyArrowTable exercises the ``FileSource -> pa.Table`` direct materialization.
+  * PandasDataFrame exercises the ``FileSource -> pa.Table -> pandas`` chained path.
+  * PolarsDataFrame exercises the ``FileSource -> pa.Table -> polars`` chained path.
+
+They only assert that reading a CSV via ``run_all`` yields the requested columns, so they
+stay valid across the refactor. No custom reader/feature-group subclasses are defined, so
+nothing leaks into the global plugin registry.
+"""
+
+from __future__ import annotations
+
+import csv
+import os
+import tempfile
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from mloda.user import DataAccessCollection
+from mloda.user import mloda
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame  # noqa: F401
+from mloda_plugins.compute_framework.base_implementations.polars.dataframe import PolarsDataFrame  # noqa: F401
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable  # noqa: F401
+from mloda_plugins.feature_group.input_data.read_file_feature import ReadFileFeature  # noqa: F401
+from mloda_plugins.feature_group.input_data.read_files.csv import CsvReader  # noqa: F401
+
+
+@pytest.fixture()
+def csv_path() -> Iterator[str]:
+    fd, path = tempfile.mkstemp(suffix=".csv")
+    os.close(fd)
+    with open(path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["A", "B"])
+        writer.writerow(["1", "3"])
+        writer.writerow(["2", "4"])
+    yield path
+    os.remove(path)
+
+
+def test_csv_reads_into_pyarrow_table(csv_path: str) -> None:
+    """FileSource -> pa.Table direct path: PyArrowTable still returns A and B."""
+    result = mloda.run_all(
+        ["A", "B"],
+        compute_frameworks=["PyArrowTable"],
+        data_access_collection=DataAccessCollection(files={csv_path}),
+    )
+    columns = result[0].to_pydict()
+    assert "A" in columns
+    assert "B" in columns
+
+
+def test_csv_reads_into_pandas_dataframe(csv_path: str) -> None:
+    """FileSource -> pa.Table -> pandas chained path: PandasDataFrame still returns A and B."""
+    result = mloda.run_all(
+        ["A", "B"],
+        compute_frameworks=["PandasDataFrame"],
+        data_access_collection=DataAccessCollection(files={csv_path}),
+    )
+    columns: Any = list(result[0].columns)
+    assert "A" in columns
+    assert "B" in columns
+
+
+def test_csv_reads_into_polars_dataframe(csv_path: str) -> None:
+    """FileSource -> pa.Table -> polars chained path: PolarsDataFrame still returns A and B."""
+    pytest.importorskip("polars")
+    result = mloda.run_all(
+        ["A", "B"],
+        compute_frameworks=["PolarsDataFrame"],
+        data_access_collection=DataAccessCollection(files={csv_path}),
+    )
+    columns: Any = list(result[0].columns)
+    assert "A" in columns
+    assert "B" in columns

--- a/tests/test_plugins/feature_group/input_data/test_read_files/test_csv_empty_file.py
+++ b/tests/test_plugins/feature_group/input_data/test_read_files/test_csv_empty_file.py
@@ -1,0 +1,57 @@
+"""An empty CSV does not crash header discovery or poison folder matching.
+
+Contract:
+
+  * ``CsvReader.get_column_names(<zero-byte file>)`` returns ``[]`` instead of raising
+    (there is simply no header to read).
+  * A whitespace/newline-only file returns without raising.
+  * File matching over several candidates skips an empty CSV (its ``validate_columns``
+    returns ``False``) and resolves to the valid CSV, instead of the empty file poisoning
+    discovery with an exception.
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+from mloda_plugins.feature_group.input_data.read_files.csv import CsvReader
+
+
+class TestGetColumnNamesEmptyFile:
+    def test_zero_byte_file_returns_empty_list(self, tmp_path: Path) -> None:
+        """A zero-byte CSV has no header: return ``[]``."""
+        empty = tmp_path / "empty.csv"
+        empty.write_bytes(b"")
+
+        assert list(CsvReader.get_column_names(str(empty))) == []
+
+    def test_whitespace_only_file_does_not_raise(self, tmp_path: Path) -> None:
+        """A newline-only file must be handled without raising."""
+        blank = tmp_path / "blank.csv"
+        blank.write_text("\n", encoding="utf-8")
+
+        # Must not raise; the exact value is unimportant, only that discovery survives.
+        CsvReader.get_column_names(str(blank))
+
+
+class TestEmptyFileDoesNotPoisonMatching:
+    def test_matching_skips_empty_csv_and_resolves_valid_file(self, tmp_path: Path) -> None:
+        """An empty CSV visited before the valid CSV does not abort matching.
+
+        The empty file is listed FIRST so it is definitely inspected first. ``validate_columns``
+        on the empty file returns ``False`` (its columns are ``[]``) and matching continues to
+        the valid CSV.
+        """
+        empty = tmp_path / "empty.csv"
+        empty.write_bytes(b"")
+
+        valid = tmp_path / "data.csv"
+        with open(valid, "w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(["a", "b"])
+            writer.writerow(["1", "2"])
+
+        matched = CsvReader.match_read_file_data_access([str(empty), str(valid)], ["a", "b"])
+
+        assert matched == str(valid)

--- a/tests/test_plugins/feature_group/input_data/test_read_files/test_csv_file_source.py
+++ b/tests/test_plugins/feature_group/input_data/test_read_files/test_csv_file_source.py
@@ -1,0 +1,176 @@
+"""Pins the compute-framework-neutral CSV seam.
+
+Contract:
+
+  1. ``CsvReader.load_data`` RESOLVES a CSV into a lightweight, immutable ``FileSource``
+     descriptor (``.path``, ``.format``, ``.columns``) instead of eagerly materializing a
+     ``pyarrow.Table``. This decouples CSV input from pyarrow: any compute framework can
+     later materialize the descriptor into its own native type.
+
+  2. ``FileSource`` is a frozen dataclass subclassing the ``InputDataDescriptor`` marker;
+     ``columns`` is normalized to a tuple in ``__post_init__`` so the descriptor stays
+     hashable even when built from a list.
+
+  3. A ``(FileSource, dict)`` transformer is registered with
+     ``ComputeFrameworkTransformer`` and materializes a ``FileSource`` into a columnar
+     ``dict[str, list[Any]]`` using only the stdlib.
+
+  4. ``CsvReader.get_column_names`` discovers the header with the stdlib ``csv`` module,
+     decoding UTF-8 explicitly and stripping a leading BOM.
+"""
+
+from __future__ import annotations
+
+import csv
+import os
+import tempfile
+from collections.abc import Iterator
+
+import pytest
+
+from mloda.core.abstract_plugins.components.framework_transformer.cfw_transformer import (
+    ComputeFrameworkTransformer,
+)
+from mloda.core.abstract_plugins.components.input_data.file_source import FileSource
+from mloda.core.abstract_plugins.components.input_data.input_data_descriptor import InputDataDescriptor
+from mloda.provider import FeatureSet
+from mloda.user import Feature
+from mloda_plugins.feature_group.input_data.read_files.csv import CsvReader
+
+
+@pytest.fixture()
+def csv_path() -> Iterator[str]:
+    fd, path = tempfile.mkstemp(suffix=".csv")
+    os.close(fd)
+    # A: integer column, B: non-numeric (stays str), C: float column.
+    with open(path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["A", "B", "C"])
+        writer.writerow(["1", "x", "1.5"])
+        writer.writerow(["2", "y", "2.5"])
+    yield path
+    os.remove(path)
+
+
+def _feature_set(names: list[str]) -> FeatureSet:
+    features = FeatureSet()
+    for name in names:
+        features.add(Feature(name))
+    return features
+
+
+class TestCsvLoadDataResolvesFileSource:
+    """CsvReader.load_data returns a FileSource descriptor, not a materialized table."""
+
+    def test_load_data_returns_file_source(self, csv_path: str) -> None:
+        """load_data resolves to a FileSource descriptor, not a materialized pyarrow.Table."""
+        features = _feature_set(["A", "B"])
+        result = CsvReader.load_data(csv_path, features)
+
+        assert isinstance(result, FileSource), f"Expected a FileSource descriptor, got {type(result)!r}"
+
+    def test_file_source_carries_path_format_and_columns(self, csv_path: str) -> None:
+        """FileSource pins ``.path`` / ``.format`` / ``.columns`` as an immutable, sorted tuple."""
+        features = _feature_set(["A", "B"])
+        result = CsvReader.load_data(csv_path, features)
+
+        assert result.path == csv_path
+        assert result.format == "csv"
+
+        # Deterministic, stable column order: sorted, as an immutable tuple.
+        assert isinstance(result.columns, tuple)
+        assert result.columns == tuple(sorted(features.get_all_names()))
+        assert set(result.columns) == {"A", "B"}
+
+
+class TestFileSourceIsImmutableDescriptor:
+    """FileSource is a small immutable value object marked as an input-data descriptor."""
+
+    def test_file_source_is_an_input_data_descriptor(self) -> None:
+        """The descriptor marker gates multi-hop materialization in root ingestion."""
+        source = FileSource(path="data/x.csv", format="csv", columns=("A", "B"))
+        assert isinstance(source, InputDataDescriptor)
+
+    def test_file_source_columns_is_a_tuple(self) -> None:
+        """``columns`` is normalized to an immutable ``tuple`` in ``__post_init__``."""
+        source = FileSource(path="data/x.csv", format="csv", columns=["A", "B"])
+        assert source.path == "data/x.csv"
+        assert source.format == "csv"
+        assert isinstance(source.columns, tuple)
+        assert source.columns == ("A", "B")
+
+    def test_file_source_is_frozen(self) -> None:
+        """A FileSource must not allow attribute reassignment (immutable descriptor)."""
+        source = FileSource(path="data/x.csv", format="csv", columns=["A", "B"])
+        with pytest.raises(Exception):
+            source.path = "data/y.csv"  # type: ignore[misc]
+
+    def test_file_source_is_hashable(self) -> None:
+        """A genuinely immutable descriptor must be hashable, even when built from a list."""
+        source = FileSource(path="data/x.csv", format="csv", columns=["A", "B"])
+        hash(source)  # must NOT raise
+
+
+class TestFileSourceToDictTransformer:
+    """A (FileSource, dict) transformer materializes the descriptor via the stdlib."""
+
+    def test_transformer_map_has_file_source_dict_pair(self) -> None:
+        """The registry exposes a ``(FileSource, dict)`` transformer."""
+        transformer_map = ComputeFrameworkTransformer().transformer_map
+        assert (FileSource, dict) in transformer_map, (
+            f"Expected a (FileSource, dict) transformer. Registered pairs: {list(transformer_map)!r}"
+        )
+
+    def test_transformer_materializes_columnar_dict_with_typed_values(self, csv_path: str) -> None:
+        """FileSource -> columnar ``dict[str, list]`` with typed (not stringified) values.
+
+        Before the FileSource seam, PythonDict+CSV received typed values via the
+        ``pa.Table -> dict`` path. The stdlib ``(FileSource -> dict)`` transformer must
+        preserve that: an integer column stays ``int``, a float column stays ``float``,
+        and a non-numeric column stays ``str``.
+        """
+        transformer_map = ComputeFrameworkTransformer().transformer_map
+        transformer = transformer_map[(FileSource, dict)]
+
+        source = FileSource(path=csv_path, format="csv", columns=["A", "B", "C"])
+        materialized = transformer.transform(FileSource, dict, source, None)
+
+        assert isinstance(materialized, dict)
+        assert set(materialized.keys()) == {"A", "B", "C"}
+
+        # Integer column: real ints, not strings.
+        assert materialized["A"] == [1, 2]
+        assert all(isinstance(v, int) and not isinstance(v, bool) for v in materialized["A"])
+
+        # Float column: real floats, not strings.
+        assert materialized["C"] == [1.5, 2.5]
+        assert all(isinstance(v, float) for v in materialized["C"])
+
+        # Non-numeric column: stays str.
+        assert materialized["B"] == ["x", "y"]
+        assert all(isinstance(v, str) for v in materialized["B"])
+
+
+class TestCsvHeaderIsUtf8Decoded:
+    """Header discovery must decode UTF-8 explicitly and strip a leading BOM."""
+
+    def test_get_column_names_decodes_utf8_and_strips_bom(self) -> None:
+        """A UTF-8 header (with a non-ASCII name and a BOM) is decoded correctly.
+
+        The file is written as explicit UTF-8 bytes prefixed with a UTF-8 BOM
+        (``\\xef\\xbb\\xbf``). This makes the assertion deterministic regardless of the
+        CI locale: it can only pass with an explicit ``utf-8-sig`` decode.
+        """
+        fd, path = tempfile.mkstemp(suffix=".csv")
+        os.close(fd)
+        content = "café,B\n1,3\n2,4\n"
+        with open(path, "wb") as f:
+            f.write(b"\xef\xbb\xbf" + content.encode("utf-8"))
+        try:
+            names = list(CsvReader.get_column_names(path))
+
+            assert names[0] == "café", f"expected 'café' as the first header, got {names[0]!r}"
+            assert not names[0].startswith("\ufeff"), f"BOM leaked into the first header: {names[0]!r}"
+            assert names == ["café", "B"]
+        finally:
+            os.remove(path)

--- a/tests/test_plugins/feature_group/input_data/test_read_files/test_deterministic_column_order.py
+++ b/tests/test_plugins/feature_group/input_data/test_read_files/test_deterministic_column_order.py
@@ -8,11 +8,20 @@ import pyarrow.feather as pyarrow_feather
 import pyarrow.orc as pyarrow_orc
 import pyarrow.parquet as pyarrow_parquet
 
+from mloda.core.abstract_plugins.components.input_data.file_source import FileSource
 from mloda_plugins.feature_group.input_data.read_files.csv import CsvReader
 from mloda_plugins.feature_group.input_data.read_files.feather import FeatherReader
 from mloda_plugins.feature_group.input_data.read_files.json import JsonReader
 from mloda_plugins.feature_group.input_data.read_files.orc import OrcReader
 from mloda_plugins.feature_group.input_data.read_files.parquet import ParquetReader
+
+
+def _loaded_column_names(result: Any) -> list[str]:
+    """CsvReader resolves a FileSource descriptor whose ``columns`` pins the order;
+    the other readers still return a materialized table with ``column_names``."""
+    if isinstance(result, FileSource):
+        return list(result.columns)
+    return list(result.column_names)
 
 
 class FeatureSetStub:
@@ -86,9 +95,9 @@ class TestDeterministicColumnOrder:
         features = FeatureSetStub(self.physical_columns)
 
         for cls, path in test_cases:
-            result = cls.load_data(path, features)
-            assert result.column_names == self.sorted_columns, (
-                f"{cls.__name__} returned columns {result.column_names}, expected {self.sorted_columns}"
+            columns = _loaded_column_names(cls.load_data(path, features))
+            assert columns == self.sorted_columns, (
+                f"{cls.__name__} returned columns {columns}, expected {self.sorted_columns}"
             )
 
     def _all_readers(self) -> list[tuple[Any, Any]]:
@@ -106,10 +115,8 @@ class TestDeterministicColumnOrder:
         features = FeatureSetStub([])
 
         for cls, path in self._all_readers():
-            result = cls.load_data(path, features)
-            assert result.column_names == [], (
-                f"{cls.__name__} returned columns {result.column_names}, expected [] for empty feature set"
-            )
+            columns = _loaded_column_names(cls.load_data(path, features))
+            assert columns == [], f"{cls.__name__} returned columns {columns}, expected [] for empty feature set"
 
     def test_single_column_feature_set_returns_that_column(self) -> None:
         """A single-column feature set must return exactly that one column.
@@ -117,7 +124,5 @@ class TestDeterministicColumnOrder:
         features = FeatureSetStub(["a1"])
 
         for cls, path in self._all_readers():
-            result = cls.load_data(path, features)
-            assert result.column_names == ["a1"], (
-                f"{cls.__name__} returned columns {result.column_names}, expected ['a1']"
-            )
+            columns = _loaded_column_names(cls.load_data(path, features))
+            assert columns == ["a1"], f"{cls.__name__} returned columns {columns}, expected ['a1']"

--- a/tests/test_plugins/feature_group/input_data/test_read_files/test_file_source_path_and_provider_exports.py
+++ b/tests/test_plugins/feature_group/input_data/test_read_files/test_file_source_path_and_provider_exports.py
@@ -1,0 +1,57 @@
+"""Public provider exports for ``FileSource`` / ``InputDataDescriptor`` and ``FileSource``
+path normalization.
+
+Contract:
+
+  * Requirement F1: ``from mloda.provider import FileSource`` works.
+  * Requirement F2: ``from mloda.provider import InputDataDescriptor`` works.
+  * Requirement F3: both names appear in ``mloda.provider.__all__``.
+  * Requirement G1: ``FileSource.__post_init__`` coerces ``path`` to ``str``, honoring its
+    ``path: str`` annotation (it already coerces ``columns`` to a tuple).
+  * Requirement G2 (guard): the descriptor stays frozen and hashable after coercion.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+import mloda.provider as provider
+from mloda.core.abstract_plugins.components.input_data.file_source import FileSource
+from mloda.core.abstract_plugins.components.input_data.input_data_descriptor import InputDataDescriptor
+
+
+class TestProviderExports:
+    def test_file_source_is_importable_from_provider(self) -> None:
+        """(F1) ``from mloda.provider import FileSource`` resolves to the real class."""
+        exported = importlib.import_module("mloda.provider").FileSource
+        assert exported is FileSource
+
+    def test_input_data_descriptor_is_importable_from_provider(self) -> None:
+        """(F2) ``from mloda.provider import InputDataDescriptor`` resolves to the real class."""
+        exported = importlib.import_module("mloda.provider").InputDataDescriptor
+        assert exported is InputDataDescriptor
+
+    def test_both_names_in_provider_all(self) -> None:
+        """(F3) Both names are advertised in ``mloda.provider.__all__``."""
+        assert "FileSource" in provider.__all__
+        assert "InputDataDescriptor" in provider.__all__
+
+
+class TestFileSourcePathCoercion:
+    def test_path_is_coerced_to_str(self, tmp_path: Path) -> None:
+        """(G1) A ``Path`` passed for ``path`` is normalized to ``str`` in ``__post_init__``."""
+        p = tmp_path / "x.csv"
+        source = FileSource(path=p, format="csv", columns=["a"])  # type: ignore[arg-type]
+        assert isinstance(source.path, str)
+        assert source.path == str(p)
+
+    def test_descriptor_stays_frozen_and_hashable_after_coercion(self, tmp_path: Path) -> None:
+        """(G2) The coerced descriptor remains frozen and hashable."""
+        source = FileSource(path=tmp_path / "x.csv", format="csv", columns=["a"])  # type: ignore[arg-type]
+
+        hash(source)  # must not raise
+        with pytest.raises(Exception):
+            source.path = str(tmp_path / "y.csv")  # type: ignore[misc]

--- a/tests/test_plugins/feature_group/input_data/test_read_files/test_implementations.py
+++ b/tests/test_plugins/feature_group/input_data/test_read_files/test_implementations.py
@@ -12,6 +12,9 @@ import pyarrow.orc as pyarrow_orc
 import pyarrow.parquet as pyarrow_parquet
 import pytest
 
+from mloda_plugins.compute_framework.base_implementations.pyarrow.pyarrow_file_source_transformer import (
+    FileSourcePyArrowTransformer,
+)
 from mloda_plugins.feature_group.input_data.read_files.csv import CsvReader
 from mloda_plugins.feature_group.input_data.read_files.feather import FeatherReader
 from mloda_plugins.feature_group.input_data.read_files.json import JsonReader
@@ -72,6 +75,10 @@ class TestReadFilesImplementations:
 
     def assert_read_file(self, cls: Any, path: Any, reader: Any, features: FeatureSet) -> None:
         result = cls.load_data(path, features)
+
+        # CsvReader resolves a FileSource descriptor; materialize it into a pa.Table.
+        if cls is CsvReader:
+            result = FileSourcePyArrowTransformer.transform_fw_to_other_fw(result)
 
         if cls in (CsvReader, JsonReader):
             expected = reader(path).select(self.columns)

--- a/tests/test_plugins/feature_group/input_data/test_read_files/test_read_document_load_data_seam.py
+++ b/tests/test_plugins/feature_group/input_data/test_read_files/test_read_document_load_data_seam.py
@@ -1,0 +1,570 @@
+"""Tests for the ReadDocument.load_data template-method lifecycle seam.
+
+Contract pinned here (mirrors the ReadDB seam):
+
+    ReadDocument gains
+      - classmethod produce_document(file_path): the per-format parse hook; the base default
+        raises NotImplementedError.
+      - classmethod document_file_type(file_path): overridable; default is
+        cls.suffix()[0].lstrip(".").
+      - classmethod _read_text(file_path): shared helper reading the whole file as UTF-8 text.
+
+    load_data becomes a template method that
+      1. probes the DYNAMIC anchor first: it resolves cls.final_reader_anchor() and checks the
+         anchor's _final_reader_requires() hooks via _is_overridden against THAT anchor (never
+         hardcoded against ReadDocument); when the hook set is incomplete it raises
+         NotImplementedError BEFORE any file read,
+      2. file_path = features.get_options_key(cls.__name__),
+      3. content = cls.produce_document(file_path),
+      4. returns [{cls.get_class_name(): content, "source": file_path,
+                   "file_type": cls.document_file_type(file_path)}].
+
+    ReadDocument._final_reader_requires() returns ("produce_document", "suffix"): a reader is
+    final iff it overrides BOTH hooks relative to its anchor, or overrides load_data wholesale.
+
+    The four in-repo readers (TextFileReader, MarkdownDocumentReader, JsonDocumentReader,
+    YamlDocumentReader) migrate onto the seam: they implement only produce_document (+ suffix;
+    Yaml also overrides document_file_type to report the actual file suffix) and their
+    end-to-end envelopes stay exactly as today.
+
+Test isolation note:
+All ReadDocument subclasses used by these tests are defined at MODULE scope, never inside
+test methods. Function-local subclasses linger in ``ReadDocument.__subclasses__()`` (the
+global plugin registry) until GC runs, leaking into sibling tests' plugin discovery, and
+they are unpicklable, which breaks multiprocessing runners. Module-scope classes are
+picklable and stable. Additionally, every seam reader uses a sentinel suffix in the
+``.zzzdoc2seam*`` family that no real file in this repo or in any sibling test has, so a
+leaked registry entry can never match a file in sibling discovery.
+"""
+
+import json
+from pathlib import Path
+from typing import Any, ClassVar
+
+import pytest
+import yaml
+
+from mloda.provider import FeatureSet
+from mloda.user import Feature
+from mloda_plugins.feature_group.input_data.read_document import ReadDocument
+from mloda_plugins.feature_group.input_data.read_files.json_document_reader import JsonDocumentReader
+from mloda_plugins.feature_group.input_data.read_files.markdown_document_reader import MarkdownDocumentReader
+from mloda_plugins.feature_group.input_data.read_files.text_file_reader import PyFileReader, TextFileReader
+from mloda_plugins.feature_group.input_data.read_files.yaml_document_reader import YamlDocumentReader
+
+
+def _underlying(member: Any) -> Any:
+    """Underlying function of a classmethod/staticmethod/plain override, for identity comparison."""
+    return getattr(member, "__func__", member)
+
+
+class MockFeatureSet:
+    """Mock FeatureSet for driving document readers, mirroring test_markdown_document_reader.py."""
+
+    def __init__(self, options: dict[str, Any]) -> None:
+        self._options = options
+
+    def get_options_key(self, key: str) -> Any:
+        return self._options.get(key)
+
+
+# --------------------------------------------------------------------------------------
+# Module-scope readers for the load_data lifecycle seam tests.
+#
+# Defined at MODULE scope (never inside a test) so they are picklable and stable in the
+# plugin registry. Every suffix is a unique ``.zzzdoc2seam*`` sentinel that matches no
+# real file anywhere, so a leaked class can never be selected by sibling tests' plugin
+# discovery. The tests below drive these readers directly and record interactions via
+# ClassVar lists.
+# --------------------------------------------------------------------------------------
+
+
+class _SeamIntermediateDoc(ReadDocument):
+    """Intermediate base: overrides suffix() but NOT produce_document; not a final reader."""
+
+    @classmethod
+    def suffix(cls) -> tuple[str, ...]:
+        return (".zzzdoc2seamint",)
+
+
+class _SeamHappyPathDoc(ReadDocument):
+    """Final seam reader: overrides suffix + produce_document, records received file paths."""
+
+    received_paths: ClassVar[list[str]] = []
+
+    @classmethod
+    def suffix(cls) -> tuple[str, ...]:
+        return (".zzzdoc2seam",)
+
+    @classmethod
+    def produce_document(cls, file_path: str) -> Any:
+        cls.received_paths.append(file_path)
+        return "produced::" + cls._read_text(file_path)
+
+
+class _CustomFileTypeDoc(ReadDocument):
+    """Final seam reader overriding document_file_type to use the ACTUAL path suffix."""
+
+    @classmethod
+    def suffix(cls) -> tuple[str, ...]:
+        return (".zzzdoc2seamcfta", ".zzzdoc2seamcftb")
+
+    @classmethod
+    def produce_document(cls, file_path: str) -> Any:
+        return cls._read_text(file_path)
+
+    @classmethod
+    def document_file_type(cls, file_path: str) -> str:
+        return Path(file_path).suffix.lstrip(".")
+
+
+class _WholesaleDoc(ReadDocument):
+    """Legacy-style reader: overrides load_data wholesale, no produce_document; still final."""
+
+    @classmethod
+    def suffix(cls) -> tuple[str, ...]:
+        return (".zzzdoc2seamwhole",)
+
+    @classmethod
+    def load_data(cls, data_access: Any, features: Any) -> Any:
+        return [{"_WholesaleDoc": "wholesale", "source": "n/a", "file_type": "zzzdoc2seamwhole"}]
+
+
+class _DocHookNoSuffixDoc(ReadDocument):
+    """Overrides produce_document but NOT suffix: cannot match or label files, so not final.
+
+    The default document_file_type calls cls.suffix(), so the classification screen must
+    reject this shape up front (mirroring ReadDB's connect requirement).
+    """
+
+    produce_calls: ClassVar[list[str]] = []
+
+    @classmethod
+    def produce_document(cls, file_path: str) -> Any:
+        cls.produce_calls.append(file_path)
+        return cls._read_text(file_path)
+
+
+class _DocParseBaseDoc(ReadDocument):
+    """Intermediate base: overrides produce_document, leaves suffix abstract; not final."""
+
+    @classmethod
+    def produce_document(cls, file_path: str) -> Any:
+        return "base"
+
+
+class _SuffixOnlyChildDoc(_DocParseBaseDoc):
+    """Concrete child completing the base with only a sentinel suffix: full hook set, final."""
+
+    @classmethod
+    def suffix(cls) -> tuple[str, ...]:
+        return (".zzzdoc2seamsfxchild",)
+
+
+# --------------------------------------------------------------------------------------
+# Third-party sub-family re-anchoring _final_reader_requires below ReadDocument.
+#
+# _SubFamilyDoc shares produce_document for the whole sub-family and redeclares the
+# requires tuple, becoming the anchor for its children. Relative to ReadDocument its
+# produce_document IS overridden, so a probe hardcoded against ReadDocument would wrongly
+# let _SubFamilyDoc.load_data proceed into the file read. The dynamic probe resolves the
+# anchor (_SubFamilyDoc itself) and must raise NotImplementedError first.
+# --------------------------------------------------------------------------------------
+
+
+class _SubFamilyDoc(ReadDocument):
+    """Sub-family base: redeclares the requires tuple and provides a shared produce_document."""
+
+    produce_calls: ClassVar[list[str]] = []
+
+    @classmethod
+    def _final_reader_requires(cls) -> tuple[str, ...]:
+        return ("produce_document", "suffix")
+
+    @classmethod
+    def suffix(cls) -> tuple[str, ...]:
+        return (".zzzdoc2seamsubfam",)
+
+    @classmethod
+    def produce_document(cls, file_path: str) -> Any:
+        cls.produce_calls.append(file_path)
+        return cls._read_text(file_path)
+
+
+class _SubFamilyChildDoc(_SubFamilyDoc):
+    """Concrete child overriding both hooks relative to _SubFamilyDoc: final, runs the template."""
+
+    @classmethod
+    def suffix(cls) -> tuple[str, ...]:
+        return (".zzzdoc2seamsubchild",)
+
+    @classmethod
+    def produce_document(cls, file_path: str) -> Any:
+        return "child::" + cls._read_text(file_path)
+
+
+class TestReadDocumentSeamHooks:
+    def test_produce_document_base_default_raises_not_implemented(self) -> None:
+        """The base parse hook exists on ReadDocument and raises NotImplementedError."""
+        with pytest.raises(NotImplementedError):
+            ReadDocument.produce_document("/some/where/doc.txt")
+
+    def test_document_file_type_default_is_first_suffix_without_dot(self) -> None:
+        """The default document_file_type is suffix()[0].lstrip(".")."""
+        assert _SeamHappyPathDoc.document_file_type("anything.zzzdoc2seam") == "zzzdoc2seam"
+
+    def test_read_text_reads_utf8(self, tmp_path: Path) -> None:
+        """_read_text is a shared UTF-8 text-reading helper on ReadDocument."""
+        file_path = tmp_path / "doc.txt"
+        file_path.write_text("héllo séam\n", encoding="utf-8")
+
+        assert ReadDocument._read_text(str(file_path)) == "héllo séam\n"
+
+    def test_read_document_requires_produce_document_and_suffix(self) -> None:
+        """ReadDocument._final_reader_requires() names the phase-2 hook set."""
+        assert ReadDocument._final_reader_requires() == ("produce_document", "suffix")
+
+
+class TestReadDocumentTemplate:
+    def test_seam_happy_path_load_data_envelope(self, tmp_path: Path) -> None:
+        """load_data resolves the path from options, parses via the hook, and wraps the envelope."""
+        _SeamHappyPathDoc.received_paths.clear()
+
+        file_path = tmp_path / "doc.zzzdoc2seam"
+        file_path.write_text("hello seam", encoding="utf-8")
+
+        features = MockFeatureSet({"_SeamHappyPathDoc": str(file_path)})
+        result = _SeamHappyPathDoc.load_data(None, features)  # type: ignore[arg-type]
+
+        assert result == [
+            {
+                "_SeamHappyPathDoc": "produced::hello seam",
+                "source": str(file_path),
+                "file_type": "zzzdoc2seam",
+            }
+        ]
+        assert _SeamHappyPathDoc.received_paths == [str(file_path)]
+
+    def test_document_file_type_override_is_honored_in_envelope(self, tmp_path: Path) -> None:
+        """An override using the actual path suffix (like YamlDocumentReader) reaches the envelope."""
+        file_path = tmp_path / "doc.zzzdoc2seamcftb"
+        file_path.write_text("second suffix", encoding="utf-8")
+
+        features = MockFeatureSet({"_CustomFileTypeDoc": str(file_path)})
+        result = _CustomFileTypeDoc.load_data(None, features)  # type: ignore[arg-type]
+
+        assert result == [
+            {
+                "_CustomFileTypeDoc": "second suffix",
+                "source": str(file_path),
+                "file_type": "zzzdoc2seamcftb",
+            }
+        ]
+
+
+class TestReadDocumentProbeIsDynamic:
+    """The template probe resolves the anchor dynamically; it is never hardcoded against ReadDocument."""
+
+    def test_sub_family_re_anchors_classification(self) -> None:
+        """Redeclaring _final_reader_requires moves the anchor to the sub-family base."""
+        assert _SubFamilyDoc.final_reader_anchor() is _SubFamilyDoc
+        assert _SubFamilyChildDoc.final_reader_anchor() is _SubFamilyDoc
+
+    def test_sub_family_base_is_not_final_and_raises_before_reading(self, tmp_path: Path) -> None:
+        """The sub-family base shares produce_document but is not final; load_data must probe
+        against the re-anchored hook set and raise BEFORE any file read.
+
+        The pointed-to path does not exist: a file read would raise FileNotFoundError, so
+        NotImplementedError proves the probe fired first. A probe hardcoded against
+        ReadDocument would see produce_document overridden and read the file.
+        """
+        _SubFamilyDoc.produce_calls.clear()
+
+        assert _SubFamilyDoc.is_final_reader() is False
+
+        missing = tmp_path / "missing.zzzdoc2seamsubfam"
+        features = MockFeatureSet({"_SubFamilyDoc": str(missing)})
+        with pytest.raises(NotImplementedError):
+            _SubFamilyDoc.load_data(None, features)  # type: ignore[arg-type]
+
+        assert _SubFamilyDoc.produce_calls == [], "produce_document must not run before the dynamic probe"
+
+    def test_sub_family_child_is_final_and_runs_the_template(self, tmp_path: Path) -> None:
+        """A child overriding both hooks relative to the sub-family anchor loads via the template."""
+        assert _SubFamilyChildDoc.is_final_reader() is True
+
+        file_path = tmp_path / "doc.zzzdoc2seamsubchild"
+        file_path.write_text("family body", encoding="utf-8")
+
+        features = MockFeatureSet({"_SubFamilyChildDoc": str(file_path)})
+        result = _SubFamilyChildDoc.load_data(None, features)  # type: ignore[arg-type]
+
+        assert result == [
+            {
+                "_SubFamilyChildDoc": "child::family body",
+                "source": str(file_path),
+                "file_type": "zzzdoc2seamsubchild",
+            }
+        ]
+
+    @pytest.mark.parametrize(
+        "non_final",
+        [ReadDocument, _SeamIntermediateDoc, _DocHookNoSuffixDoc, _DocParseBaseDoc, _SubFamilyDoc],
+    )
+    def test_non_final_implies_template_raises_before_any_file_read(
+        self, non_final: type[ReadDocument], tmp_path: Path
+    ) -> None:
+        """Consistency contract: is_final_reader() False implies load_data raises NotImplementedError.
+
+        Every path points at a nonexistent file, so a premature file read would surface as
+        FileNotFoundError instead of NotImplementedError.
+        """
+        assert non_final.is_final_reader() is False
+
+        missing = tmp_path / f"missing_{non_final.__name__}.zzzdoc2seamnone"
+        features = MockFeatureSet({non_final.__name__: str(missing)})
+        with pytest.raises(NotImplementedError):
+            non_final.load_data(None, features)  # type: ignore[arg-type]
+
+    def test_hook_without_suffix_probe_raises_before_reading(self, tmp_path: Path) -> None:
+        """A produce_document-only class fails the probe before its parse hook runs."""
+        _DocHookNoSuffixDoc.produce_calls.clear()
+
+        missing = tmp_path / "missing.zzzdoc2seamnosfx"
+        features = MockFeatureSet({"_DocHookNoSuffixDoc": str(missing)})
+        with pytest.raises(NotImplementedError):
+            _DocHookNoSuffixDoc.load_data(None, features)  # type: ignore[arg-type]
+
+        assert _DocHookNoSuffixDoc.produce_calls == [], "produce_document must not run when the probe fails"
+
+
+class TestReadDocumentClassification:
+    def test_read_document_itself_is_not_final(self) -> None:
+        assert ReadDocument.is_final_reader() is False
+
+    def test_hook_complete_reader_is_final_without_load_data_override(self) -> None:
+        """Overriding produce_document + suffix is enough; no wholesale load_data needed."""
+        assert "load_data" not in _SeamHappyPathDoc.__dict__
+        assert _SeamHappyPathDoc.is_final_reader() is True
+
+    def test_suffix_only_intermediate_base_is_not_final(self) -> None:
+        assert _SeamIntermediateDoc.is_final_reader() is False
+
+    def test_parse_hook_without_suffix_is_not_final(self) -> None:
+        """suffix is in the requires tuple precisely to screen out this shape."""
+        assert _DocHookNoSuffixDoc.is_final_reader() is False
+
+    def test_intermediate_parse_base_without_suffix_is_not_final(self) -> None:
+        assert _DocParseBaseDoc.is_final_reader() is False
+
+    def test_concrete_child_completing_the_hook_set_is_final(self) -> None:
+        """A child adding only suffix on top of a shared parse base is final."""
+        assert _SuffixOnlyChildDoc.is_final_reader() is True
+
+    def test_wholesale_load_data_override_is_final(self) -> None:
+        assert _WholesaleDoc.is_final_reader() is True
+        assert _WholesaleDoc.load_data(None, None) == [
+            {"_WholesaleDoc": "wholesale", "source": "n/a", "file_type": "zzzdoc2seamwhole"}
+        ]
+
+
+class TestInRepoReadersMigrateToTheSeam:
+    """The four concrete readers adopt the seam instead of rewriting load_data,
+    and their end-to-end envelopes stay exactly as today.
+    """
+
+    @pytest.mark.parametrize(
+        "reader",
+        [TextFileReader, MarkdownDocumentReader, JsonDocumentReader, YamlDocumentReader],
+    )
+    def test_readers_use_inherited_load_data_template(self, reader: type[ReadDocument]) -> None:
+        """Each in-repo reader inherits the template and overrides produce_document."""
+        assert "load_data" not in reader.__dict__, f"{reader.__name__} must not override load_data wholesale anymore"
+        assert _underlying(reader.produce_document) is not _underlying(ReadDocument.produce_document), (
+            f"{reader.__name__} must override the produce_document parse hook"
+        )
+
+    def test_text_reader_envelope_stays_exact(self, tmp_path: Path) -> None:
+        file_path = tmp_path / "doc.text"
+        file_path.write_text("plain text body\n", encoding="utf-8")
+
+        features = MockFeatureSet({"TextFileReader": str(file_path)})
+        result = TextFileReader.load_data(None, features)  # type: ignore[arg-type]
+
+        assert result == [{"TextFileReader": "plain text body\n", "source": str(file_path), "file_type": "text"}]
+
+    def test_markdown_reader_envelope_stays_exact(self, tmp_path: Path) -> None:
+        file_path = tmp_path / "doc.md"
+        file_path.write_text("# Title\n\nbody\n", encoding="utf-8")
+
+        features = MockFeatureSet({"MarkdownDocumentReader": str(file_path)})
+        result = MarkdownDocumentReader.load_data(None, features)  # type: ignore[arg-type]
+
+        assert result == [{"MarkdownDocumentReader": "# Title\n\nbody\n", "source": str(file_path), "file_type": "md"}]
+
+    def test_json_reader_envelope_stays_exact(self, tmp_path: Path) -> None:
+        """JSON content is json.dumps of the parsed file."""
+        raw = '{"a": 1, "b": [true, null]}'
+        file_path = tmp_path / "doc.json"
+        file_path.write_text(raw, encoding="utf-8")
+
+        features = MockFeatureSet({"JsonDocumentReader": str(file_path)})
+        result = JsonDocumentReader.load_data(None, features)  # type: ignore[arg-type]
+
+        assert result == [
+            {"JsonDocumentReader": json.dumps(json.loads(raw)), "source": str(file_path), "file_type": "json"}
+        ]
+
+    def test_yaml_reader_envelope_single_document_stays_exact(self, tmp_path: Path) -> None:
+        """YAML content is yaml.dump of the single parsed document."""
+        file_path = tmp_path / "doc.yaml"
+        file_path.write_text("a: 1\nb: two\n", encoding="utf-8")
+
+        features = MockFeatureSet({"YamlDocumentReader": str(file_path)})
+        result = YamlDocumentReader.load_data(None, features)  # type: ignore[arg-type]
+
+        assert result == [
+            {"YamlDocumentReader": yaml.dump({"a": 1, "b": "two"}), "source": str(file_path), "file_type": "yaml"}
+        ]
+
+    def test_yaml_reader_envelope_multi_document_stays_a_list(self, tmp_path: Path) -> None:
+        """Multi-document YAML streams yield yaml.dump of the document list."""
+        file_path = tmp_path / "doc.yaml"
+        file_path.write_text("a: 1\n---\nb: 2\n", encoding="utf-8")
+
+        features = MockFeatureSet({"YamlDocumentReader": str(file_path)})
+        result = YamlDocumentReader.load_data(None, features)  # type: ignore[arg-type]
+
+        assert result == [
+            {"YamlDocumentReader": yaml.dump([{"a": 1}, {"b": 2}]), "source": str(file_path), "file_type": "yaml"}
+        ]
+
+    def test_yml_file_reports_yml_file_type(self, tmp_path: Path) -> None:
+        """Yaml overrides document_file_type so .yml files report 'yml', not suffix()[0]."""
+        file_path = tmp_path / "doc.yml"
+        file_path.write_text("key: value\n", encoding="utf-8")
+
+        features = MockFeatureSet({"YamlDocumentReader": str(file_path)})
+        result = YamlDocumentReader.load_data(None, features)  # type: ignore[arg-type]
+
+        assert result == [
+            {"YamlDocumentReader": yaml.dump({"key": "value"}), "source": str(file_path), "file_type": "yml"}
+        ]
+
+    def test_yaml_document_file_type_uses_actual_path_suffix(self) -> None:
+        """YamlDocumentReader.document_file_type reports the real suffix without touching the file."""
+        assert YamlDocumentReader.document_file_type("/some/where/config.yml") == "yml"
+        assert YamlDocumentReader.document_file_type("/some/where/config.yaml") == "yaml"
+
+
+class TestPyFileReaderStaysOnTheSeam:
+    def test_py_file_reader_inherits_text_reader_and_is_final(self) -> None:
+        """PyFileReader keeps inheriting from TextFileReader and still classifies as final."""
+        assert issubclass(PyFileReader, TextFileReader)
+        assert PyFileReader.is_final_reader() is True
+
+    def test_py_file_reader_uses_inherited_produce_document(self) -> None:
+        """PyFileReader adds only suffix; the parse hook comes from TextFileReader."""
+        assert "load_data" not in PyFileReader.__dict__
+        assert "produce_document" not in PyFileReader.__dict__
+        assert _underlying(PyFileReader.produce_document) is _underlying(TextFileReader.produce_document)
+
+    def test_py_file_reader_envelope_for_py_documents(self, tmp_path: Path) -> None:
+        file_path = tmp_path / "module.py"
+        file_path.write_text("print('hi')\n", encoding="utf-8")
+
+        features = MockFeatureSet({"PyFileReader": str(file_path)})
+        result = PyFileReader.load_data(None, features)  # type: ignore[arg-type]
+
+        assert result == [{"PyFileReader": "print('hi')\n", "source": str(file_path), "file_type": "py"}]
+
+
+class TestReadDocumentUsesResolvedDataAccessPath:
+    """The template uses the RESOLVED data_access path.
+
+    When ``data_access`` is a ``str`` or ``Path`` it IS the file path. Otherwise the template
+    falls back to ``features.get_options_key(cls.__name__)``. On the GLOBAL
+    DataAccessCollection matching path the matched file is stored solely under the reserved
+    ``"BaseInputData"`` options key, so ``get_options_key`` would return ``None``; using the
+    resolved ``data_access`` path instead is what lets ``BaseInputData.load`` hand the matched
+    path through correctly.
+    """
+
+    def test_direct_load_data_uses_data_access_string_path(self, tmp_path: Path) -> None:
+        """(2a) A str data_access is the file path; no reader-named options key needed."""
+        file_path = tmp_path / "doc.text"
+        file_path.write_text("body via data_access\n", encoding="utf-8")
+
+        features = MockFeatureSet({})
+        result = TextFileReader.load_data(str(file_path), features)  # type: ignore[arg-type]
+
+        assert result == [{"TextFileReader": "body via data_access\n", "source": str(file_path), "file_type": "text"}]
+
+    def test_direct_load_data_uses_data_access_path_object(self, tmp_path: Path) -> None:
+        """(2a) A pathlib.Path data_access is the file path as well.
+
+        The source assertion is stringified on purpose: whether the envelope carries the
+        Path or its str form is an implementation detail; the CONTENT and the pointed-to
+        file are the contract.
+        """
+        file_path = tmp_path / "doc.text"
+        file_path.write_text("path object body\n", encoding="utf-8")
+
+        result = TextFileReader.load_data(Path(file_path), MockFeatureSet({}))  # type: ignore[arg-type]
+
+        assert len(result) == 1
+        envelope = result[0]
+        assert envelope["TextFileReader"] == "path object body\n"
+        assert str(envelope["source"]) == str(file_path)
+        assert envelope["file_type"] == "text"
+
+    def test_global_scope_matched_path_reaches_the_template_end_to_end(self, tmp_path: Path) -> None:
+        """(2b) End-to-end global scope: options carry ONLY the reserved BaseInputData tuple
+        (as global DataAccessCollection matching stores it), and instance.load(features)
+        returns the correct envelope.
+        """
+        file_path = tmp_path / "doc.text"
+        file_path.write_text("global scope body\n", encoding="utf-8")
+
+        feature = Feature(name="doc_feature", options={"BaseInputData": (TextFileReader, str(file_path))})
+        feature_set = FeatureSet()
+        feature_set.add(feature)
+
+        instance = TextFileReader()
+        result = instance.load(feature_set)
+
+        assert result == [{"TextFileReader": "global scope body\n", "source": str(file_path), "file_type": "text"}]
+
+    def test_feature_scoped_options_key_still_wins_when_data_access_is_none(self, tmp_path: Path) -> None:
+        """(2c) Guard, passes today and must keep passing: with data_access None the path
+        still resolves from the reader-named options key (feature-scoped access)."""
+        file_path = tmp_path / "doc.text"
+        file_path.write_text("feature scoped body\n", encoding="utf-8")
+
+        features = MockFeatureSet({"TextFileReader": str(file_path)})
+        result = TextFileReader.load_data(None, features)  # type: ignore[arg-type]
+
+        assert result == [{"TextFileReader": "feature scoped body\n", "source": str(file_path), "file_type": "text"}]
+
+
+class TestMissingOptionsKeyGuard:
+    """An absent reader-named options key raises an actionable ValueError.
+
+    On the fallback path (data_access is not a str/Path) the template resolves the file path
+    via ``features.get_options_key(cls.__name__)``. When the options are initialized but do
+    NOT carry the reader-name key, the template raises ValueError naming the reader class and
+    the expected options key (the reader class name) before any parse attempt, instead of a
+    bare TypeError from ``open(None)``.
+    """
+
+    @pytest.mark.parametrize("reader", [TextFileReader, MarkdownDocumentReader])
+    def test_missing_reader_named_key_raises_actionable_value_error(self, reader: type[ReadDocument]) -> None:
+        """Initialized options without the reader-name key: ValueError naming the reader,
+        not a bare TypeError from open(None).
+        """
+        feature = Feature(name="doc_feature", options={"unrelated_key": "unrelated_value"})
+        feature_set = FeatureSet()
+        feature_set.add(feature)
+
+        with pytest.raises(ValueError, match=reader.__name__):
+            reader.load_data(None, feature_set)

--- a/tests/test_plugins/feature_group/input_data/test_read_files/test_read_file.py
+++ b/tests/test_plugins/feature_group/input_data/test_read_files/test_read_file.py
@@ -12,6 +12,9 @@ import pyarrow as pa
 import pyarrow.compute as pc
 
 from mloda.provider import FeatureGroup
+from mloda_plugins.compute_framework.base_implementations.pyarrow.pyarrow_file_source_transformer import (
+    FileSourcePyArrowTransformer,
+)
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable  # noqa: F401
 from mloda.user import DataAccessCollection
 from mloda.user import Feature
@@ -52,7 +55,9 @@ class OverwrittenReadCsvInputDataTestFeatureGroup(ReadFileFeature):
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
         reader = cls.input_data()
         if reader is not None:
-            result = reader.load(features)
+            source = reader.load(features)
+            # ``load`` now yields a FileSource descriptor; materialize it into a pa.Table.
+            result = FileSourcePyArrowTransformer.transform_fw_to_other_fw(source)
 
             new_columns = {
                 col_name: pa.array([value * 2 for value in result[col_name].to_pylist()])


### PR DESCRIPTION
Implements the Reader refactor epic #615 in one PR, in the epic's order. #616 is included as the first step because #535/#618 are structurally blocked by it. Implementation and tests were mined from the preserved `feat/readdb-load-data-seam` branch (PR #559, closed unmerged) where applicable, with the #559 review findings fixed rather than replayed.

Closes #616, closes #617, closes #535, closes #618, closes #610, closes #619, closes #611. Refs #601, #565 (in-repo parts done here; the mloda-registry guide updates remain in that repo).

## Changes by issue

- **#616**: `supports_scoped_data_access` (which classified readers by executing `cls.load_data(None, None)`) is removed. Classification is purely structural: `is_final_reader()` uses `_final_reader_requires()` family anchors and a public `final_reader_anchor()` resolver. Family bases are never discovered as final readers; third-party sub-families can re-anchor. **Breaking**: `supports_scoped_data_access` was a public classmethod; downstream callers must switch to `is_final_reader()`.
- **#617**: the duplicated `init_reader` prologue is hoisted into one concrete `BaseInputData.init_reader` with errors naming the concrete reader class; the three per-family copies are removed.
- **#535**: `ReadDB.load_data` is a documented template method (`prepare_credentials` -> `get_connection` -> `produce_rows` -> `close_connection` in try/finally). The hook probe resolves the dynamic family anchor (fixing the #559 review finding), raising `NotImplementedError` before any connection work. Wholesale `load_data` overrides keep working (the SQLite reader is untouched). The matcher exception contract (only `NotImplementedError` is a soft no-match) is documented on `is_valid_credentials` and `check_feature_in_data_access`.
- **#618**: `ReadDocument.load_data` is the sibling template (`produce_document`, `document_file_type`, one-row envelope), with the same dynamic-anchor probe. The four in-repo document readers implement only `produce_document` (+ `suffix`).
- **#610**: one shared `ComputeFrameworkTransformer.apply_chain` walks transformation chains for both `TransformFrameworkStep` and root ingestion, raising a clear `KeyError` instead of an `UnboundLocalError` on registry inconsistency. Transformer files auto-load once per process so a stray module-scope import cannot leave the registry partial.
- **#619**: `CsvReader.load_data` returns an immutable `FileSource` descriptor; per-framework transformers materialize it (stdlib csv for PythonDict with column-wise inference matching pyarrow semantics; pyarrow for `pa.Table`; pandas/polars chain through `pa.Table`). Multi-hop chains apply only to descriptor inputs, so native dict ingestion is never rerouted, and a descriptor without a registered transformer raises an actionable, backend-neutral error naming the missing framework pair (core has no required deps, so it does not assume pyarrow). CSV into PythonDict works with pyarrow absent (`nopyarrow` env).
- **#611**: `get_transformation_chain` resolves a direct edge first and otherwise runs a BFS shortest-path over all registered transformer edges (first-registered tie-break). `pa.Table` is a regular graph node, the module no longer imports pyarrow, and non-pyarrow chains compose with pyarrow absent.
- **#601/#565 (in-repo)**: the ml_basics example shows the FileSource-based CsvReader; data-access-patterns gains "Writing an input-data reader" and "Selecting among sibling readers" sections (class-name option-key contract, HTTP-source recipe, `suffix()` inert on that path); `ApiInputData` states it injects in-memory data and is not an HTTP client.

## Review

Two independent deep reviews (Claude Opus subagent and codex) ran on the full diff. Accepted and fixed: one-way transformers no longer register reverse edges, so the BFS can never route through an unimplemented direction; the `ReadDocument` template prefers the resolved data-access path (global `DataAccessCollection` matching) over the reader-name options key; the deliberate stdlib-vs-pyarrow null-token inference divergence is pinned by a regression test (implementation stays a #619 follow-up); the `connect` requirement for hook-based `ReadDB` discovery is documented. Rejected: locking around the idempotent transformer auto-load flag.

## Validation

`tox` green (4704 passed, 171 skipped matching `EXPECTED_SKIP_COUNT`, ruff, license allowlist, `mypy --strict` over 773 files, bandit) and `tox -e nopyarrow` green (24 passed, pyarrow confirmed absent).

