### PR TITLE
feat: add ContextRootFeatureGroup base for in-place root feature groups

### DIFF
--- a/mloda/core/abstract_plugins/context_root_feature_group.py
+++ b/mloda/core/abstract_plugins/context_root_feature_group.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
-from typing import ClassVar, Optional
+from abc import abstractmethod
+from typing import Any, ClassVar
 
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.input_data.base_input_data import BaseInputData
 from mloda.core.abstract_plugins.components.input_data.creator.data_creator import DataCreator
 from mloda.core.abstract_plugins.components.options import Options
@@ -13,20 +15,28 @@ from mloda.core.abstract_plugins.feature_group import FeatureGroup
 
 
 class ContextRootFeatureGroup(FeatureGroup):
-    """Root feature group that generates its declared FEATURES in place via DataCreator.
+    """Abstract root feature group that generates its declared FEATURES in place via DataCreator.
 
-    All four overridden methods stay overridable by subclasses.
+    Overrides five members (feature_names_supported, input_data, match_feature_group_criteria,
+    compute_framework_rule, input_features) and requires subclasses to implement calculate_feature.
+    FEATURES is required: a subclass with empty FEATURES matches nothing.
+    Option- or data-access-sensitive matching must override match_feature_group_criteria;
+    overriding input_data() alone does not change matching, which is a pure membership test.
     """
 
     FEATURES: ClassVar[set[str]] = set()
-    COMPUTE_FRAMEWORKS: ClassVar[Optional[set[type[ComputeFramework]]]] = None
+    COMPUTE_FRAMEWORKS: ClassVar[set[type[ComputeFramework]] | None] = None
+
+    @classmethod
+    @abstractmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any: ...
 
     @classmethod
     def feature_names_supported(cls) -> set[str]:
         return set(cls.FEATURES)
 
     @classmethod
-    def input_data(cls) -> Optional[BaseInputData]:
+    def input_data(cls) -> BaseInputData | None:
         return DataCreator(cls.feature_names_supported())
 
     @classmethod
@@ -34,13 +44,13 @@ class ContextRootFeatureGroup(FeatureGroup):
         cls,
         feature_name: FeatureName | str,
         options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
+        data_access_collection: DataAccessCollection | None = None,
     ) -> bool:
         return cls.get_column_base_feature(str(feature_name)) in cls.feature_names_supported()
 
     @classmethod
     def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
-        return cls.COMPUTE_FRAMEWORKS
+        return set(cls.COMPUTE_FRAMEWORKS) if cls.COMPUTE_FRAMEWORKS is not None else None
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
         return None

--- a/mloda/core/abstract_plugins/context_root_feature_group.py
+++ b/mloda/core/abstract_plugins/context_root_feature_group.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import ClassVar, Optional
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.input_data.base_input_data import BaseInputData
+from mloda.core.abstract_plugins.components.input_data.creator.data_creator import DataCreator
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+
+
+class ContextRootFeatureGroup(FeatureGroup):
+    """Root feature group that generates its declared FEATURES in place via DataCreator.
+
+    All four overridden methods stay overridable by subclasses.
+    """
+
+    FEATURES: ClassVar[set[str]] = set()
+    COMPUTE_FRAMEWORKS: ClassVar[Optional[set[type[ComputeFramework]]]] = None
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return set(cls.FEATURES)
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(cls.feature_names_supported())
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return cls.get_column_base_feature(str(feature_name)) in cls.feature_names_supported()
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return cls.COMPUTE_FRAMEWORKS
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None

--- a/mloda/core/abstract_plugins/context_root_feature_group.py
+++ b/mloda/core/abstract_plugins/context_root_feature_group.py
@@ -17,11 +17,21 @@ from mloda.core.abstract_plugins.feature_group import FeatureGroup
 class ContextRootFeatureGroup(FeatureGroup):
     """Abstract root feature group that generates its declared FEATURES in place via DataCreator.
 
-    Overrides five members (feature_names_supported, input_data, match_feature_group_criteria,
-    compute_framework_rule, input_features) and requires subclasses to implement calculate_feature.
-    FEATURES is required: a subclass with empty FEATURES matches nothing.
-    Option- or data-access-sensitive matching must override match_feature_group_criteria;
-    overriding input_data() alone does not change matching, which is a pure membership test.
+    Instead of hand-writing feature_names_supported(), input_data(), match_feature_group_criteria(),
+    and compute_framework_rule(), a subclass declares FEATURES (and optionally COMPUTE_FRAMEWORKS)
+    and implements only calculate_feature::
+
+        class RetrievalFG(ContextRootFeatureGroup):
+            FEATURES = {RETRIEVAL_FEATURE, RETRIEVAL_DOC_FEATURE, RETRIEVAL_DISTANCE_FEATURE}
+            COMPUTE_FRAMEWORKS = {PythonDictFramework}
+
+            @classmethod
+            def calculate_feature(cls, data, features):
+                ...
+
+    FEATURES is required: a subclass with empty FEATURES matches nothing. Matching is a pure
+    membership test, so option- or data-access-sensitive roots must override
+    match_feature_group_criteria (overriding input_data() alone does not change matching).
     """
 
     FEATURES: ClassVar[set[str]] = set()

--- a/mloda/provider/__init__.py
+++ b/mloda/provider/__init__.py
@@ -18,6 +18,7 @@
 # directly and implement input_features and match_feature_group_criteria.
 #
 from mloda.core.abstract_plugins.feature_group import FeatureGroup as FeatureGroup
+from mloda.core.abstract_plugins.context_root_feature_group import ContextRootFeatureGroup as ContextRootFeatureGroup
 
 # Versioning
 from mloda.core.abstract_plugins.components.base_feature_group_version import BaseFeatureGroupVersion
@@ -87,6 +88,7 @@ from mloda.core.abstract_plugins.components.merge.base_merge_engine import BaseM
 __all__ = [
     # Base classes
     "FeatureGroup",
+    "ContextRootFeatureGroup",
     # Versioning
     "BaseFeatureGroupVersion",
     "ComputeFramework",

--- a/tests/test_core/test_abstract_plugins/test_context_root_feature_group.py
+++ b/tests/test_core/test_abstract_plugins/test_context_root_feature_group.py
@@ -1,0 +1,103 @@
+"""Red-phase tests for ContextRootFeatureGroup convenience base class.
+
+These pin the contract of the not-yet-existing ``ContextRootFeatureGroup`` (a
+``FeatureGroup`` subclass for root feature groups that generate data in place via
+``DataCreator``). They MUST fail until the class exists and is exported from
+``mloda.provider``. Test FeatureGroup subclasses use the ``crfg_`` prefix so the
+globally-discovered feature names stay unique and parallel-safe under xdist.
+"""
+
+from typing import Any, ClassVar, Optional
+
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.provider import ContextRootFeatureGroup
+from mloda.provider import DataCreator
+from mloda.provider import FeatureSet
+from mloda.user import mloda
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
+
+
+def test_import_from_provider() -> None:
+    # The class must be importable from the public provider namespace.
+    assert ContextRootFeatureGroup is not None
+
+
+def test_feature_names_supported_returns_copy() -> None:
+    class _CrfgNames(ContextRootFeatureGroup):
+        FEATURES: ClassVar[set[str]] = {"crfg_a", "crfg_b"}
+
+    assert _CrfgNames.feature_names_supported() == {"crfg_a", "crfg_b"}
+
+    # Mutating the returned set must not affect the class attribute.
+    returned = _CrfgNames.feature_names_supported()
+    returned.add("crfg_mutated")
+    assert _CrfgNames.FEATURES == {"crfg_a", "crfg_b"}
+
+
+def test_input_data_is_data_creator_with_features() -> None:
+    class _CrfgInput(ContextRootFeatureGroup):
+        FEATURES: ClassVar[set[str]] = {"crfg_a", "crfg_b"}
+
+    input_data = _CrfgInput.input_data()
+    assert isinstance(input_data, DataCreator)
+    assert input_data.feature_names == {"crfg_a", "crfg_b"}
+
+
+def test_match_feature_group_criteria_base_and_sub_column() -> None:
+    class _CrfgMatch(ContextRootFeatureGroup):
+        FEATURES: ClassVar[set[str]] = {"crfg_a", "crfg_b"}
+
+    options = Options()
+    assert _CrfgMatch.match_feature_group_criteria("crfg_a", options) is True
+    # Sub-column request (~N suffix) resolves to the base feature name.
+    assert _CrfgMatch.match_feature_group_criteria("crfg_a~0", options) is True
+    assert _CrfgMatch.match_feature_group_criteria("not_declared", options) is False
+
+
+def test_compute_framework_rule_default_none() -> None:
+    class _CrfgDefaultCf(ContextRootFeatureGroup):
+        FEATURES: ClassVar[set[str]] = {"crfg_default_cf"}
+
+    assert _CrfgDefaultCf.compute_framework_rule() is None
+
+
+def test_compute_framework_rule_declared() -> None:
+    class _CrfgDeclaredCf(ContextRootFeatureGroup):
+        FEATURES: ClassVar[set[str]] = {"crfg_declared_cf"}
+        COMPUTE_FRAMEWORKS: ClassVar[Optional[set[type]]] = {PythonDictFramework}
+
+    assert _CrfgDeclaredCf.compute_framework_rule() == {PythonDictFramework}
+
+
+class _CrfgRoot(ContextRootFeatureGroup):
+    FEATURES: ClassVar[set[str]] = {"crfg_x", "crfg_y"}
+    COMPUTE_FRAMEWORKS: ClassVar[Optional[set[type]]] = {PythonDictFramework}
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {"crfg_x": [1, 2, 3], "crfg_y": [4, 5, 6]}
+
+
+def test_end_to_end_run_all() -> None:
+    result = mloda.run_all(["crfg_x", "crfg_y"], compute_frameworks=["PythonDictFramework"])
+    assert len(result) == 1
+    assert result[0] == {"crfg_x": [1, 2, 3], "crfg_y": [4, 5, 6]}
+
+
+def test_match_feature_group_criteria_override() -> None:
+    class _CrfgOverride(ContextRootFeatureGroup):
+        FEATURES: ClassVar[set[str]] = {"crfg_declared_only"}
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: Any,
+            options: Options,
+            data_access_collection: Any = None,
+        ) -> bool:
+            return str(feature_name).startswith("custom_")
+
+    options = Options()
+    # Override takes effect: prefix match, not FEATURES membership.
+    assert _CrfgOverride.match_feature_group_criteria("custom_thing", options) is True
+    assert _CrfgOverride.match_feature_group_criteria("crfg_declared_only", options) is False

--- a/tests/test_core/test_abstract_plugins/test_context_root_feature_group.py
+++ b/tests/test_core/test_abstract_plugins/test_context_root_feature_group.py
@@ -7,7 +7,10 @@ These pin the contract of the not-yet-existing ``ContextRootFeatureGroup`` (a
 globally-discovered feature names stay unique and parallel-safe under xdist.
 """
 
+import inspect
 from typing import Any, ClassVar, Optional
+
+import pytest
 
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import ContextRootFeatureGroup
@@ -101,3 +104,46 @@ def test_match_feature_group_criteria_override() -> None:
     # Override takes effect: prefix match, not FEATURES membership.
     assert _CrfgOverride.match_feature_group_criteria("custom_thing", options) is True
     assert _CrfgOverride.match_feature_group_criteria("crfg_declared_only", options) is False
+
+
+def test_base_class_is_abstract() -> None:
+    # The base must be abstract so it is not treated as a concrete shippable plugin.
+    assert inspect.isabstract(ContextRootFeatureGroup) is True
+
+
+def test_subclass_without_calculate_feature_is_abstract() -> None:
+    class _CrfgNoCalc(ContextRootFeatureGroup):
+        FEATURES: ClassVar[set[str]] = {"crfg_nocalc"}
+
+    # Declaring only FEATURES leaves calculate_feature abstract: not instantiable.
+    assert inspect.isabstract(_CrfgNoCalc) is True
+    with pytest.raises(TypeError):
+        _CrfgNoCalc()  # type: ignore[abstract]
+
+    class _CrfgWithCalc(ContextRootFeatureGroup):
+        FEATURES: ClassVar[set[str]] = {"crfg_withcalc"}
+
+        @classmethod
+        def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+            return {"crfg_withcalc": [1]}
+
+    # Defining calculate_feature makes the subclass concrete and instantiable.
+    assert inspect.isabstract(_CrfgWithCalc) is False
+    assert _CrfgWithCalc() is not None
+
+
+def test_compute_framework_rule_returns_copy() -> None:
+    class _CrfgCfCopy(ContextRootFeatureGroup):
+        FEATURES: ClassVar[set[str]] = {"crfg_cf_copy"}
+        COMPUTE_FRAMEWORKS: ClassVar[Optional[set[type]]] = {PythonDictFramework}
+
+        @classmethod
+        def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+            return {"crfg_cf_copy": [1]}
+
+    rule = _CrfgCfCopy.compute_framework_rule()
+    assert rule == {PythonDictFramework}
+
+    # Mutating the returned rule must not affect the class attribute (defensive copy).
+    rule.clear()
+    assert _CrfgCfCopy.COMPUTE_FRAMEWORKS == {PythonDictFramework}


### PR DESCRIPTION
## Summary

Closes #626. Root FeatureGroups that generate their columns in place via `DataCreator`, parameterized by context options, repeated four identical class methods verbatim (`feature_names_supported`, `input_data`, `match_feature_group_criteria`, `compute_framework_rule`). `ContextRootFeatureGroup` supplies all four from two class attributes so a subclass declares only what varies:

```python
class RetrievalFG(ContextRootFeatureGroup):
    FEATURES = {RETRIEVAL_FEATURE, RETRIEVAL_DOC_FEATURE, RETRIEVAL_DISTANCE_FEATURE}
    COMPUTE_FRAMEWORKS = {PythonDictFramework}

    @classmethod
    def calculate_feature(cls, data, features):
        ...
```

Exported from `mloda.provider`. Every method stays overridable for prefix/regex matching or dynamic feature names.

## Design notes

- `feature_names_supported()` is the single source of truth; `input_data()` builds a `DataCreator` over it, and `match_feature_group_criteria()` is a `~N`-safe membership test on it.
- The class is **abstract** (`calculate_feature` is an abstract classmethod). This forces subclasses to implement the one truly-required method and keeps the base out of concrete plugin resolution / strict mode, consistent with the existing base FeatureGroups (`AggregatedFeatureGroup`, `ScalingFeatureGroup`, etc.).
- `compute_framework_rule()` returns a defensive copy (symmetric with `feature_names_supported`).
- Matching is a pure membership test by design (per the issue). Option or data-access-sensitive roots override `match_feature_group_criteria` directly; overriding `input_data()` alone does not change matching.

## Tests

`tests/test_core/test_abstract_plugins/test_context_root_feature_group.py` (11 tests): the four defaults, `~N` sub-column matching, an end-to-end `run_all`, a `match_feature_group_criteria` override, abstractness (base and a subclass missing `calculate_feature`), and defensive-copy semantics.

`tox` is green (pytest, ruff format/check, licenses, mypy --strict, bandit).

## Follow-up (separate repo, out of scope here)

The issue's DoD also asks `mloda-registry/docs/guides/feature-group-patterns/01-root-features.md` to show the shorter form. That guide lives in the `mloda-registry` repo and needs its own PR once this base ships.