### PR TITLE
fix: make Options.inherit_from atomic on multi-key forward conflicts (#623)

### DIFF
--- a/mloda/core/abstract_plugins/components/options.py
+++ b/mloda/core/abstract_plugins/components/options.py
@@ -362,36 +362,43 @@ class Options:
 
         group_keys = group_keys - forward_group_exclude
 
+        # Stage all mutations into locals and run every conflict check first; self is left
+        # untouched until the commit block, so any raise leaves self completely unchanged.
+        new_group = dict(self.group)
+        new_context = dict(self.context)
+
         inherited: set[str] = set()
         for key in sorted(group_keys):
             if key in excluded or key not in consumer.group:
                 continue
-            if key in self.context and self.context[key] != consumer.group[key]:
+            if key in new_context and new_context[key] != consumer.group[key]:
                 owner_clause = f" on input feature '{owner}'" if owner is not None else " on the input feature"
                 raise ValueError(
                     f"Option key '{key}' forwarded from the consumer as a group option conflicts with the "
                     f"same key held in the child's context{owner_clause}: consumer='{consumer.group[key]}', "
-                    f"child context='{self.context[key]}'. Keep the key off the child with "
+                    f"child context='{new_context[key]}'. Keep the key off the child with "
                     f"forward_group_exclude={{'{key}'}}, an allowlist, or forward_group=False."
                 )
-            if key in self.group and self.group[key] != consumer.group[key]:
+            if key in new_group and new_group[key] != consumer.group[key]:
                 owner_clause = f" on input feature '{owner}'" if owner is not None else " on the input feature"
                 raise ValueError(
                     f"Option key '{key}' forwarded from the consumer conflicts with the value already set"
-                    f"{owner_clause}: consumer='{consumer.group[key]}', child='{self.group[key]}'. "
+                    f"{owner_clause}: consumer='{consumer.group[key]}', child='{new_group[key]}'. "
                     f"Keep the key off the child with forward_group_exclude={{'{key}'}}, an allowlist, "
                     "or forward_group=False."
                 )
-            self.add_to_group(key, _isolate_forwarded_value(consumer.group[key], memo))
+            value = _isolate_forwarded_value(consumer.group[key], memo)
+            OptionsValidator.validate_can_add_to_group(key, value, new_group, new_context)
+            new_group[key] = value
             inherited.add(key)
-        self.inherited_group_keys = self.inherited_group_keys | frozenset(inherited)
-        self.last_forwarded_group_keys = frozenset(inherited)
 
         inherited_context: set[str] = set()
         for key in inherit_context_keys:
             if key in excluded or key not in consumer.context:
                 continue
-            self.add_to_context(key, _isolate_forwarded_value(consumer.context[key], memo))
+            value = _isolate_forwarded_value(consumer.context[key], memo)
+            OptionsValidator.validate_can_add_to_context(key, value, new_group, new_context)
+            new_context[key] = value
             inherited_context.add(key)
 
         if consumer.propagate_context_keys and forward_group is not False:
@@ -399,14 +406,18 @@ class Options:
                 k: v for k, v in consumer.context.items() if k in consumer.propagate_context_keys and k not in excluded
             }
 
-            OptionsValidator.validate_no_context_group_conflicts(set(propagating.keys()), set(self.group.keys()))
+            OptionsValidator.validate_no_context_group_conflicts(set(propagating.keys()), set(new_group.keys()))
 
             for key, value in propagating.items():
-                if key in self.context and self.context[key] != value:
-                    raise ValueError(f"Context key '{key}' conflict: consumer='{value}', child='{self.context[key]}'")
+                if key in new_context and new_context[key] != value:
+                    raise ValueError(f"Context key '{key}' conflict: consumer='{value}', child='{new_context[key]}'")
 
-            self.context.update({key: _isolate_forwarded_value(value, memo) for key, value in propagating.items()})
+            new_context.update({key: _isolate_forwarded_value(value, memo) for key, value in propagating.items()})
             inherited_context.update(propagating.keys())
 
+        self.group = new_group
+        self.context = new_context
+        self.inherited_group_keys = self.inherited_group_keys | frozenset(inherited)
+        self.last_forwarded_group_keys = frozenset(inherited)
         self.inherited_context_keys = self.inherited_context_keys | frozenset(inherited_context)
         return frozenset(inherited)

--- a/mloda/core/abstract_plugins/components/options.py
+++ b/mloda/core/abstract_plugins/components/options.py
@@ -415,8 +415,10 @@ class Options:
             new_context.update({key: _isolate_forwarded_value(value, memo) for key, value in propagating.items()})
             inherited_context.update(propagating.keys())
 
-        self.group = new_group
-        self.context = new_context
+        self.group.clear()
+        self.group.update(new_group)
+        self.context.clear()
+        self.context.update(new_context)
         self.inherited_group_keys = self.inherited_group_keys | frozenset(inherited)
         self.last_forwarded_group_keys = frozenset(inherited)
         self.inherited_context_keys = self.inherited_context_keys | frozenset(inherited_context)

--- a/tests/test_core/test_abstract_plugins/test_components/test_options_inherit_from.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_options_inherit_from.py
@@ -1755,3 +1755,73 @@ class TestInheritFromCrossNamespaceIndependence:
         child.inherit_from(consumer)
 
         assert child.group["algo"] == "mean"
+
+
+class TestInheritFromAtomicOnConflict:
+    """
+    Regression pins for issue #623: inherit_from must be ATOMIC on conflict.
+
+    WHY THIS EXISTS:
+    The group forward iterates sorted(group_keys) and calls add_to_group per key,
+    mutating self.group immediately, while the provenance fields
+    (inherited_group_keys, last_forwarded_group_keys) are assigned only AFTER the
+    loop. So a mid-loop conflict on a LATER sorted key raises ValueError after an
+    EARLIER sorted key was already committed to self.group, leaving self partially
+    mutated (polluted group) with stale provenance. The contract SHOULD be atomic:
+    a raise leaves self completely unchanged. These pins arrange a multi-key forward
+    where an earlier sorted key forwards cleanly and a later key conflicts, then
+    assert self is untouched after the raise.
+    """
+
+    def test_group_conflict_is_atomic_no_partial_commit(self) -> None:
+        """The canonical reproduction: consumer group {'aaa': 1, 'zzz': 9} forwarded onto a
+        child holding group {'zzz': 8}. 'aaa' sorts first and forwards cleanly, then 'zzz'
+        conflicts and raises. After the raise the earlier 'aaa' must NOT be committed and
+        provenance must be untouched (empty, as this is the child's first merge)."""
+        consumer = Options(group={"aaa": 1, "zzz": 9})
+        child = Options(group={"zzz": 8})
+
+        with pytest.raises(ValueError):
+            child.inherit_from(consumer)
+
+        assert child.group == {"zzz": 8}
+        assert child.inherited_group_keys == frozenset()
+        assert child.last_forwarded_group_keys == frozenset()
+
+    def test_group_conflict_preserves_pre_existing_provenance(self) -> None:
+        """A child that already inherited a key from a benign consumer must keep its group
+        AND its recorded provenance exactly when a SECOND, conflicting multi-key forward
+        raises. The failed call must not touch self at all."""
+        benign = Options(group={"benign": 7})
+        child = Options(group={"zzz": 8})
+        child.inherit_from(benign)
+
+        group_before = deepcopy(child.group)
+        inherited_before = child.inherited_group_keys
+        last_forwarded_before = child.last_forwarded_group_keys
+        assert inherited_before == frozenset({"benign"})
+        assert last_forwarded_before == frozenset({"benign"})
+
+        conflicting = Options(group={"aaa": 1, "zzz": 9})
+        with pytest.raises(ValueError):
+            child.inherit_from(conflicting)
+
+        assert child.group == group_before
+        assert child.inherited_group_keys == inherited_before
+        assert child.last_forwarded_group_keys == last_forwarded_before
+
+    def test_context_cross_conflict_is_atomic_no_partial_commit(self) -> None:
+        """A forwarded group key that collides with an existing child CONTEXT key raises the
+        cross-conflict branch. Arrange 'aaa' (sorts first) to forward cleanly into group and
+        'zzz' (sorts later) to hit the context cross-conflict. After the raise the earlier
+        'aaa' must NOT be committed to group and provenance must be untouched."""
+        consumer = Options(group={"aaa": 1, "zzz": 9})
+        child = Options(context={"zzz": 8})
+
+        with pytest.raises(ValueError):
+            child.inherit_from(consumer)
+
+        assert "aaa" not in child.group
+        assert child.group == {}
+        assert child.inherited_group_keys == frozenset()
+        assert child.last_forwarded_group_keys == frozenset()


### PR DESCRIPTION
## Summary

`Options.inherit_from` mutated `self.group`/`self.context` key-by-key and assigned provenance (`inherited_group_keys`, `last_forwarded_group_keys`, `inherited_context_keys`) only after the loops. A mid-loop forwarded-key conflict raised `ValueError` leaving the child partially merged with stale provenance. `inherit_from` / `merge_options` are public, so the atomicity contract matters even though mloda's own flow discards the transient child on the raise.

Fixes #623.

## Change

Stage all group/context mutations and provenance into locals, validate every forwarded/inherited key first, then commit to `self` only after all checks pass. On the commit the staged dicts are written back in place (`clear` + `update`) so the public `group`/`context` attributes keep their original dict identity. Any raise now leaves `self` completely unchanged; the success path (values, isolation, error messages, provenance, return value) is unchanged.

## Tests

New class `TestInheritFromAtomicOnConflict` pins the three raise paths:
- multi-key group value-conflict (canonical `{'aaa':1,'zzz':9}` onto `{'zzz':8}`) leaves `child.group` and provenance untouched,
- the same with pre-existing provenance preserved across a failed second merge,
- group/context cross-conflict leaves the earlier forwarded key uncommitted.

`tox` passes (pytest, ruff format/check, pip-licenses, mypy --strict, bandit).