### PR TITLE
feat: add FeatureGroup.declared_option_keys() typed accessor

### DIFF
--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -81,6 +81,13 @@ class FeatureGroup(ABC):
         super().__init_subclass__(**kwargs)
         FeatureChainParser.validate_property_mapping_defaults(cls.__name__, cls.PROPERTY_MAPPING)
 
+    @classmethod
+    def declared_option_keys(cls) -> frozenset[str]:
+        """Return the top-level parameter names declared in ``PROPERTY_MAPPING``."""
+        if cls.PROPERTY_MAPPING is None:
+            return frozenset()
+        return frozenset(str(key) for key in cls.PROPERTY_MAPPING)
+
     def __init__(self) -> None:
         pass
 

--- a/mloda/core/core/engine.py
+++ b/mloda/core/core/engine.py
@@ -178,11 +178,7 @@ class Engine:
         cached = self._property_mapping_keys_cache.get(feature_group_class)
         if cached is not None:
             return cached
-        property_mapping = getattr(feature_group_class, "PROPERTY_MAPPING", None)
-        if isinstance(property_mapping, dict):
-            keys = frozenset(str(key) for key in property_mapping)
-        else:
-            keys = frozenset()
+        keys = feature_group_class.declared_option_keys()
         self._property_mapping_keys_cache[feature_group_class] = keys
         return keys
 

--- a/tests/test_core/test_abstract_plugins/test_feature_group/test_declared_option_keys.py
+++ b/tests/test_core/test_abstract_plugins/test_feature_group/test_declared_option_keys.py
@@ -1,0 +1,143 @@
+"""Tests for FeatureGroup.declared_option_keys() (issue #603).
+
+``declared_option_keys()`` is a classmethod that returns the top-level parameter
+names declared in ``PROPERTY_MAPPING`` -- regardless of whether the mapping was
+authored as a legacy flattened dict or via the ``property_spec`` builder. It
+never returns the inner allowed-value keys (e.g. "add"/"sub").
+"""
+
+from mloda.provider import DefaultOptionKeys, FeatureGroup, property_spec
+
+
+class DefaultMappingFeatureGroup(FeatureGroup):
+    """No PROPERTY_MAPPING override -- exercises the None default."""
+
+
+class LegacyMappingFeatureGroup(FeatureGroup):
+    """Legacy flattened PROPERTY_MAPPING form with a single declared parameter."""
+
+    PROPERTY_MAPPING = {
+        "operation_type": {
+            "add": "Addition",
+            "sub": "Subtraction",
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: True,
+        },
+    }
+
+
+class BuilderMappingFeatureGroup(FeatureGroup):
+    """PROPERTY_MAPPING authored via the property_spec builder."""
+
+    PROPERTY_MAPPING = {
+        "operation_type": property_spec(
+            "the operation to apply",
+            strict=True,
+            allowed_values={"add": "Addition", "sub": "Subtraction"},
+        ),
+    }
+
+
+class MultiKeyMappingFeatureGroup(FeatureGroup):
+    """Multiple declared parameters, mixing legacy and builder-form specs."""
+
+    PROPERTY_MAPPING = {
+        "operation_type": {
+            "add": "Addition",
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: True,
+        },
+        "aggregation_type": property_spec(
+            "the aggregation to apply",
+            strict=True,
+            allowed_values={"sum": "Sum", "mean": "Mean"},
+        ),
+        "window_size": {
+            "3": "three",
+            DefaultOptionKeys.context: False,
+            DefaultOptionKeys.strict_validation: False,
+        },
+    }
+
+
+def test_declared_option_keys_returns_empty_frozenset_when_property_mapping_none() -> None:
+    """PROPERTY_MAPPING unset (None, the default) yields an empty frozenset."""
+    result = DefaultMappingFeatureGroup.declared_option_keys()
+
+    assert result == frozenset()
+
+
+def test_declared_option_keys_returns_top_level_keys_for_legacy_flattened_mapping() -> None:
+    """Legacy flattened form: only the top-level parameter name is returned.
+
+    Inner allowed-value keys ("add"/"sub") and metadata flags must not appear.
+    """
+    result = LegacyMappingFeatureGroup.declared_option_keys()
+
+    assert result == frozenset({"operation_type"})
+    assert "add" not in result
+    assert "sub" not in result
+
+
+def test_declared_option_keys_returns_top_level_keys_for_property_spec_builder_form() -> None:
+    """property_spec builder form: only the top-level parameter name is returned.
+
+    The allowed_values contents ("add"/"sub") must not leak into the result.
+    """
+    result = BuilderMappingFeatureGroup.declared_option_keys()
+
+    assert result == frozenset({"operation_type"})
+    assert "add" not in result
+    assert "sub" not in result
+
+
+def test_declared_option_keys_returns_all_declared_parameter_names() -> None:
+    """Multiple declared parameters all come back, cast to str."""
+    result = MultiKeyMappingFeatureGroup.declared_option_keys()
+
+    assert result == frozenset({"operation_type", "aggregation_type", "window_size"})
+    assert all(isinstance(key, str) for key in result)
+
+
+def test_declared_option_keys_is_callable_without_instantiation() -> None:
+    """The method is a classmethod: callable directly on the class."""
+    result = LegacyMappingFeatureGroup.declared_option_keys()
+
+    assert isinstance(result, frozenset)
+
+
+def test_declared_option_keys_returns_frozenset_type() -> None:
+    """Return type is frozenset, not list/set/dict_keys."""
+    result = MultiKeyMappingFeatureGroup.declared_option_keys()
+
+    assert isinstance(result, frozenset)
+    assert not isinstance(result, (list, set))
+
+
+def test_declared_option_keys_is_immutable() -> None:
+    """The returned frozenset has no mutating methods."""
+    result = LegacyMappingFeatureGroup.declared_option_keys()
+
+    assert not hasattr(result, "add")
+    assert not hasattr(result, "update")
+
+
+def test_declared_option_keys_snapshot_not_tied_to_underlying_dict() -> None:
+    """Mutating the original PROPERTY_MAPPING dict after the call does not
+    retroactively change an already-returned frozenset (unlike a dict_keys view)."""
+    mapping = {
+        "operation_type": {
+            "add": "Addition",
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: True,
+        },
+    }
+
+    class MutableMappingFeatureGroup(FeatureGroup):
+        PROPERTY_MAPPING = mapping
+
+    result = MutableMappingFeatureGroup.declared_option_keys()
+    mapping["new_param"] = {"x": "X"}
+
+    assert result == frozenset({"operation_type"})
+    assert "new_param" not in result

--- a/tests/test_core/test_abstract_plugins/test_feature_group/test_declared_option_keys.py
+++ b/tests/test_core/test_abstract_plugins/test_feature_group/test_declared_option_keys.py
@@ -13,6 +13,12 @@ class DefaultMappingFeatureGroup(FeatureGroup):
     """No PROPERTY_MAPPING override -- exercises the None default."""
 
 
+class EmptyMappingFeatureGroup(FeatureGroup):
+    """PROPERTY_MAPPING explicitly set to an empty dict -- distinct from the None default."""
+
+    PROPERTY_MAPPING = {}
+
+
 class LegacyMappingFeatureGroup(FeatureGroup):
     """Legacy flattened PROPERTY_MAPPING form with a single declared parameter."""
 
@@ -63,6 +69,13 @@ class MultiKeyMappingFeatureGroup(FeatureGroup):
 def test_declared_option_keys_returns_empty_frozenset_when_property_mapping_none() -> None:
     """PROPERTY_MAPPING unset (None, the default) yields an empty frozenset."""
     result = DefaultMappingFeatureGroup.declared_option_keys()
+
+    assert result == frozenset()
+
+
+def test_declared_option_keys_returns_empty_frozenset_when_property_mapping_empty_dict() -> None:
+    """PROPERTY_MAPPING explicitly set to {} also yields an empty frozenset."""
+    result = EmptyMappingFeatureGroup.declared_option_keys()
 
     assert result == frozenset()
 


### PR DESCRIPTION
## Summary

Closes #603.

`PROPERTY_MAPPING` is a feature group's option contract, but engine code had to read it via raw `getattr`/`isinstance` convention. This adds one typed accessor and consolidates the one real duplicate.

- `FeatureGroup.declared_option_keys() -> frozenset[str]`: returns the top-level parameter names declared in `PROPERTY_MAPPING` (empty when unset), form-agnostic across the legacy flattened dict and the `property_spec`/`allowed_values` builder form, since both store the parameter name as the top-level key.
- `Engine._property_mapping_keys` (the dual-consumption warning) now delegates to it instead of hand-rolling `getattr(cls, "PROPERTY_MAPPING", None)` + `isinstance` + key-stringification. The existing per-engine cache is unchanged.
- Unit tests cover: missing mapping, empty dict, legacy flattened form, `property_spec` builder form, multiple mixed-form keys, return type/immutability, and non-tied-to-underlying-dict snapshotting.

## Scope decision

`identify_feature_group.py`'s `_input_feature_forwarding_hint` was deliberately left untouched. It does not do a raw `PROPERTY_MAPPING` getattr today; it detects offending options via a bare-vs-actual `match_feature_group_criteria` probe, specifically so it can catch feature groups that read options ad hoc with no declared `PROPERTY_MAPPING` at all (pinned by `test_hint_names_offending_keys_and_helper` against a feature group with no `PROPERTY_MAPPING`). Routing that hint through `declared_option_keys()` would silently lose that ad-hoc coverage and break the pinned test, so it stays as-is.

## Test plan

- [x] New unit tests: `tests/test_core/test_abstract_plugins/test_feature_group/test_declared_option_keys.py` (9 tests)
- [x] Existing dual-consumption-warning integration test passes unchanged
- [x] Existing forwarding-hint tests pass unchanged
- [x] Full `tox` green (pytest, ruff format/check, mypy --strict, bandit, license allowlist)