### PR TITLE
feat: surface strict-validation rejections to the end user instead of a generic no-match

### DIFF
--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -180,6 +180,30 @@ Options(context={"operation_type": "custom"})  # strict: raises ValueError
 Options(context={"in_features": "any_name"})   # flexible: any value allowed
 ```
 
+### What the end user sees on a strict-validation rejection
+
+The direct call above raises `ValueError` immediately. Going through
+`FeatureChainParserMixin.match_feature_group_criteria` (the default for most
+feature groups) is different: it catches that `ValueError` and returns `False`
+instead, because during resolution one candidate's "no match" must not abort
+the search for another candidate that might still accept the feature.
+
+If every candidate ends up rejecting the feature, the final "No feature groups
+found" error collects the discarded rejection reasons from every mixin-based
+candidate that had one and appends them, naming the feature group, the option
+key, the rejected value, and why it failed:
+
+```
+Feature group(s) rejected an option value while matching 'window_size_windowed':
+  - WindowedFeatureGroup: Property value '14' failed validation for 'window_size'
+```
+
+This is diagnostic only: it does not change `match_feature_group_criteria`'s
+`True`/`False` contract, so a value rejected by one feature group can still
+match a different one, and multi-group fallback resolution keeps working.
+Feature group authors do not need to override `match_feature_group_criteria`
+to get this message.
+
 ## Conditional requirements with `required_when`
 
 Attach a predicate callable to declare an option required only under certain

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -251,18 +251,28 @@ class FeatureChainParserMixin:
     def _strict_validation_rejection_reason(cls, feature_name: str | FeatureName, options: Options) -> str | None:
         """Return the ValueError message that match_feature_group_criteria discards, if any.
 
-        Re-runs the same basic-match call as match_feature_group_criteria, but surfaces
-        the ValueError message instead of swallowing it into a plain False. Returns None
-        when the call succeeds or fails without raising (i.e. an unrelated candidate).
-        Diagnostic-only: does not affect match_feature_group_criteria's behavior.
+        Only surfaces ValueErrors raised by property-mapping validation (genuine
+        strict_validation rejections). A ValueError raised while parsing a
+        PREFIX_PATTERN match (malformed feature name, no chain separator) is a
+        parse error, not an option-value rejection, and is treated as nothing to
+        report. Returns None when nothing was rejected (match succeeded, or the
+        candidate is unrelated). Diagnostic-only: does not affect
+        match_feature_group_criteria's behavior.
         """
+        prefix_patterns = cls._get_prefix_patterns()
+        if prefix_patterns:
+            try:
+                if FeatureChainParser._match_pattern_based_feature(feature_name, prefix_patterns, CHAIN_SEPARATOR):
+                    return None
+            except ValueError:
+                return None
+
+        property_mapping = cls._get_property_mapping()
+        if property_mapping is None:
+            return None
+
         try:
-            FeatureChainParser.match_configuration_feature_chain_parser(
-                feature_name,
-                options,
-                property_mapping=cls._get_property_mapping(),
-                prefix_patterns=cls._get_prefix_patterns(),
-            )
+            FeatureChainParser._validate_options_against_property_mapping(options, property_mapping)
         except ValueError as exc:
             return str(exc)
         return None

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -248,6 +248,26 @@ class FeatureChainParserMixin:
         return result
 
     @classmethod
+    def _strict_validation_rejection_reason(cls, feature_name: str | FeatureName, options: Options) -> str | None:
+        """Return the ValueError message that match_feature_group_criteria discards, if any.
+
+        Re-runs the same basic-match call as match_feature_group_criteria, but surfaces
+        the ValueError message instead of swallowing it into a plain False. Returns None
+        when the call succeeds or fails without raising (i.e. an unrelated candidate).
+        Diagnostic-only: does not affect match_feature_group_criteria's behavior.
+        """
+        try:
+            FeatureChainParser.match_configuration_feature_chain_parser(
+                feature_name,
+                options,
+                property_mapping=cls._get_property_mapping(),
+                prefix_patterns=cls._get_prefix_patterns(),
+            )
+        except ValueError as exc:
+            return str(exc)
+        return None
+
+    @classmethod
     def _validate_forwarded_name_mismatch(
         cls,
         feature_name: str | FeatureName,

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -238,6 +238,30 @@ class IdentifyFeatureGroupClass:
             f"or forward_group=False on the child in the consumer's input_features."
         )
 
+    def _strict_validation_rejection_hint(
+        self, feature: Feature, accessible_plugins: FeatureGroupEnvironmentMapping
+    ) -> Optional[str]:
+        reasons: list[tuple[str, str]] = []
+        for feature_group in accessible_plugins:
+            if not self._filter_feature_group_by_domain(feature_group, feature):
+                continue
+            if not self._filter_feature_group_by_scope(feature_group, feature):
+                continue
+
+            rejection_check = getattr(feature_group, "_strict_validation_rejection_reason", None)
+            if rejection_check is None:
+                continue
+
+            reason = rejection_check(feature.name, feature.options)
+            if reason is not None:
+                reasons.append((feature_group.get_class_name(), reason))
+
+        if not reasons:
+            return None
+
+        lines = "\n".join(f"  - {class_name}: {reason}" for class_name, reason in sorted(reasons))
+        return f"Feature group(s) rejected an option value while matching '{str(feature.name)}':\n{lines}"
+
     def _build_no_feature_group_error(
         self, feature: Feature, accessible_plugins: FeatureGroupEnvironmentMapping
     ) -> str:
@@ -262,6 +286,10 @@ class IdentifyFeatureGroupClass:
         forwarding_hint = self._input_feature_forwarding_hint(feature, accessible_plugins)
         if forwarding_hint is not None:
             msg += f"\n{forwarding_hint}"
+
+        strict_validation_hint = self._strict_validation_rejection_hint(feature, accessible_plugins)
+        if strict_validation_hint is not None:
+            msg += f"\n{strict_validation_hint}"
 
         known_names: list[str] = []
         for fg_class in accessible_plugins:

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_strict_validation_returns_false.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_strict_validation_returns_false.py
@@ -52,6 +52,12 @@ class SubGroupWithValidationFunction(BaseMode):
     }
 
 
+class MalformedPrefixFeatureGroup(FeatureChainParserMixin):
+    """PREFIX_PATTERN matches names with no chain separator, triggering a parse ValueError unrelated to option validation."""
+
+    PREFIX_PATTERN = r"^malformed_prefix_(\w+)$"
+
+
 class TestStrictValidationReturnsFalse:
     """Tests that strict_validation failures return False instead of raising ValueError."""
 
@@ -127,3 +133,11 @@ class TestStrictValidationRejectionReason:
         reason = SubGroupA._strict_validation_rejection_reason(feature_name, options)
 
         assert reason is None
+
+    def test_malformed_prefix_match_returns_none(self) -> None:
+        """PREFIX_PATTERN matches but the name has no chain separator: this is a
+        malformed-name parse ValueError, not an option-value rejection, so it must
+        return None rather than the parser's "has no source feature" message."""
+        result = MalformedPrefixFeatureGroup._strict_validation_rejection_reason("malformed_prefix_test", Options())
+
+        assert result is None

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_strict_validation_returns_false.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_strict_validation_returns_false.py
@@ -81,3 +81,49 @@ class TestStrictValidationReturnsFalse:
         result = SubGroupWithValidationFunction.match_feature_group_criteria(feature_name, options)
 
         assert result is False
+
+
+class TestStrictValidationRejectionReason:
+    """Tests that _strict_validation_rejection_reason surfaces the discarded ValueError message."""
+
+    def test_membership_check_rejection_returns_message(self) -> None:
+        """SubGroupA with mode=mode_b should return the membership-check message, not None."""
+        feature_name = FeatureName("any_feature")
+        options = Options(group={"mode": "mode_b"})
+
+        assert SubGroupA.match_feature_group_criteria(feature_name, options) is False
+
+        reason = SubGroupA._strict_validation_rejection_reason(feature_name, options)
+
+        assert reason is not None
+        assert "mode_b" in reason
+        assert "mode" in reason
+
+    def test_matching_value_returns_none(self) -> None:
+        """SubGroupA with mode=mode_a matches, so there is no rejection reason."""
+        feature_name = FeatureName("any_feature")
+        options = Options(group={"mode": "mode_a"})
+
+        reason = SubGroupA._strict_validation_rejection_reason(feature_name, options)
+
+        assert reason is None
+
+    def test_validation_function_rejection_returns_message(self) -> None:
+        """SubGroupWithValidationFunction with an invalid mode returns the validation_function message."""
+        feature_name = FeatureName("any_feature")
+        options = Options(group={"mode": "invalid_prefix"})
+
+        reason = SubGroupWithValidationFunction._strict_validation_rejection_reason(feature_name, options)
+
+        assert reason is not None
+        assert "invalid_prefix" in reason
+        assert "mode" in reason
+
+    def test_unrelated_candidate_returns_none(self) -> None:
+        """When the relevant property is entirely absent, this is a non-match, not a rejection."""
+        feature_name = FeatureName("any_feature")
+        options = Options(group={})
+
+        reason = SubGroupA._strict_validation_rejection_reason(feature_name, options)
+
+        assert reason is None

--- a/tests/test_core/test_prepare/test_identify_feature_group_error_message.py
+++ b/tests/test_core/test_prepare/test_identify_feature_group_error_message.py
@@ -12,6 +12,9 @@ from mloda.core.abstract_plugins.components.data_access_collection import DataAc
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
 from mloda.core.abstract_plugins.components.domain import Domain
 from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import (
+    FeatureChainParserMixin,
+)
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
@@ -634,4 +637,94 @@ class TestInputFeatureForwardingHint:
         )
         assert "in_features" not in error_message, (
             f"Reserved key 'in_features' must NOT be listed as offending, but got: {error_message}"
+        )
+
+
+class StrictWindowFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+    """Config-based feature group with a strict, validated 'window_size' property.
+
+    Deliberately does NOT override match_feature_group_criteria, so it exercises the
+    mixin's default swallow-to-False path: a validation_function rejection inside
+    FeatureChainParser._validate_property_value raises ValueError, which
+    match_feature_group_criteria catches and turns into a plain False, discarding the
+    actionable message. _strict_validation_rejection_reason recovers that message.
+    """
+
+    PROPERTY_MAPPING = {
+        "window_size": {
+            "explanation": "Size of window",
+            DefaultOptionKeys.strict_validation: True,
+            DefaultOptionKeys.validation_function: lambda v: isinstance(v, int) and 0 < v <= 13,
+        },
+        DefaultOptionKeys.in_features: {"explanation": "source", DefaultOptionKeys.context: True},
+    }
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class TestStrictValidationRejectionHint:
+    """Tests for the (not yet wired) strict-validation rejection hint in the
+    no-feature-group error.
+
+    Once wired, the no-feature-group-found error should consult
+    FeatureChainParserMixin._strict_validation_rejection_reason for each accessible
+    candidate and surface the discarded ValueError (e.g. "Property value '14' failed
+    validation for 'window_size'") together with the culprit class name, instead of
+    only the generic "No feature groups found" message.
+    """
+
+    def test_hint_names_rejected_option_value_and_class(self) -> None:
+        feature = Feature(
+            "strict_window_test_feature",
+            Options(context={DefaultOptionKeys.in_features: "src", "window_size": 14}),
+        )
+
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            StrictWindowFeatureGroup: {MockComputeFramework},
+        }
+
+        with pytest.raises(ValueError) as exc_info:
+            IdentifyFeatureGroupClass(
+                feature=feature,
+                accessible_plugins=accessible_plugins,
+                links=None,
+                data_access_collection=None,
+            )
+
+        error_message = str(exc_info.value)
+
+        assert "window_size" in error_message, (
+            f"Error message should name the rejected option 'window_size', but got: {error_message}"
+        )
+        assert "14" in error_message, f"Error message should include the rejected value '14', but got: {error_message}"
+        assert "StrictWindowFeatureGroup" in error_message, (
+            f"Error message should name the culprit feature group, but got: {error_message}"
+        )
+
+    def test_no_hint_when_feature_is_unrelated(self) -> None:
+        """A feature with none of the mapped keys present is a non-match, not a
+        rejection: match_feature_group_criteria returns False without raising, so
+        _strict_validation_rejection_reason must find nothing to surface."""
+        feature = Feature("totally_unrelated_feature")
+
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            StrictWindowFeatureGroup: {MockComputeFramework},
+        }
+
+        with pytest.raises(ValueError) as exc_info:
+            IdentifyFeatureGroupClass(
+                feature=feature,
+                accessible_plugins=accessible_plugins,
+                links=None,
+                data_access_collection=None,
+            )
+
+        error_message = str(exc_info.value)
+
+        assert "StrictWindowFeatureGroup" not in error_message, (
+            f"Error message should NOT name a feature group for an unrelated feature, but got: {error_message}"
+        )
+        assert "window_size" not in error_message, (
+            f"Error message should NOT mention 'window_size' for an unrelated feature, but got: {error_message}"
         )

--- a/tests/test_core/test_prepare/test_identify_feature_group_error_message.py
+++ b/tests/test_core/test_prepare/test_identify_feature_group_error_message.py
@@ -663,15 +663,32 @@ class StrictWindowFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         return None
 
 
-class TestStrictValidationRejectionHint:
-    """Tests for the (not yet wired) strict-validation rejection hint in the
-    no-feature-group error.
+class StrictMaxWindowFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+    """Second strict-rejecting config-based feature group, mapping a different key
+    ('max_window') than StrictWindowFeatureGroup, used to verify the hint names
+    every rejecting candidate rather than only the first.
+    """
 
-    Once wired, the no-feature-group-found error should consult
+    PROPERTY_MAPPING = {
+        "max_window": {
+            "explanation": "Maximum window size",
+            DefaultOptionKeys.strict_validation: True,
+            DefaultOptionKeys.validation_function: lambda v: isinstance(v, int) and 0 < v <= 13,
+        },
+        DefaultOptionKeys.in_features: {"explanation": "source", DefaultOptionKeys.context: True},
+    }
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class TestStrictValidationRejectionHint:
+    """Tests for the strict-validation rejection hint in the no-feature-group error.
+
+    The no-feature-group-found error consults
     FeatureChainParserMixin._strict_validation_rejection_reason for each accessible
-    candidate and surface the discarded ValueError (e.g. "Property value '14' failed
-    validation for 'window_size'") together with the culprit class name, instead of
-    only the generic "No feature groups found" message.
+    candidate and surfaces the discarded ValueError (e.g. "Property value '14' failed
+    validation for 'window_size'") together with the culprit class name(s).
     """
 
     def test_hint_names_rejected_option_value_and_class(self) -> None:
@@ -727,4 +744,40 @@ class TestStrictValidationRejectionHint:
         )
         assert "window_size" not in error_message, (
             f"Error message should NOT mention 'window_size' for an unrelated feature, but got: {error_message}"
+        )
+
+    def test_hint_names_all_rejecting_classes(self) -> None:
+        """When multiple accessible candidates each reject the same feature via strict
+        validation, the hint must name every one of them, not just the first."""
+        feature = Feature(
+            "strict_multi_test_feature",
+            Options(
+                context={
+                    DefaultOptionKeys.in_features: "src",
+                    "window_size": 14,
+                    "max_window": 20,
+                }
+            ),
+        )
+
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            StrictWindowFeatureGroup: {MockComputeFramework},
+            StrictMaxWindowFeatureGroup: {MockComputeFramework},
+        }
+
+        with pytest.raises(ValueError) as exc_info:
+            IdentifyFeatureGroupClass(
+                feature=feature,
+                accessible_plugins=accessible_plugins,
+                links=None,
+                data_access_collection=None,
+            )
+
+        error_message = str(exc_info.value)
+
+        assert "StrictWindowFeatureGroup" in error_message, (
+            f"Error message should name StrictWindowFeatureGroup, but got: {error_message}"
+        )
+        assert "StrictMaxWindowFeatureGroup" in error_message, (
+            f"Error message should name StrictMaxWindowFeatureGroup, but got: {error_message}"
         )

--- a/tests/test_plugins/integration_plugins/chainer/test_property_spec_validation_e2e.py
+++ b/tests/test_plugins/integration_plugins/chainer/test_property_spec_validation_e2e.py
@@ -135,12 +135,19 @@ class TestPropertySpecValidationFunctionE2E:
             ),
         )
 
-        with pytest.raises(ValueError, match="window_size"):
+        with pytest.raises(ValueError) as exc_info:
             mloda.run_all(
                 [feature],
                 compute_frameworks={PandasDataFrame},
                 plugin_collector=self.plugin_collector,
             )
+
+        error_message = str(exc_info.value)
+        assert "window_size" in error_message
+        assert "14" in error_message
+        # Pins that the message comes from the strict-validation rejection hint (naming
+        # the culprit class), not just that "window_size" appears somewhere by coincidence.
+        assert PropertySpecE2EWindowedFeatureGroup.__name__ in error_message
 
         assert len(CALCULATE_INVOCATIONS) == invocations_before, "rejection must happen before any computation"
 

--- a/tests/test_plugins/integration_plugins/chainer/test_property_spec_validation_e2e.py
+++ b/tests/test_plugins/integration_plugins/chainer/test_property_spec_validation_e2e.py
@@ -9,15 +9,6 @@ validation moments for free:
    window_size raises ValueError before any computation runs.
 2. Authoring time: ``property_spec`` itself rejects a declared default that fails
    the validation_function, at the call site (class-definition time).
-
-The derived feature group uses FeatureChainParserMixin for input_features but
-overrides ``match_feature_group_criteria`` to call
-``FeatureChainParser.match_configuration_feature_chain_parser`` directly, following
-``test_list_valued_options_e2e.py``. The mixin's default match catches the
-validation ValueError and returns False (see
-``test_strict_validation_returns_false.py``), which would surface only as a generic
-"No feature groups found" error; the direct call preserves the actionable message
-naming the rejected option.
 """
 
 from typing import Any, Optional
@@ -30,13 +21,12 @@ from mloda.provider import (
     ComputeFramework,
     DataCreator,
     DefaultOptionKeys,
-    FeatureChainParser,
     FeatureChainParserMixin,
     FeatureGroup,
     FeatureSet,
     property_spec,
 )
-from mloda.user import Feature, FeatureName, Options, PluginCollector, mloda
+from mloda.user import Feature, Options, PluginCollector, mloda
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 
 # Records calculate_feature invocations so tests can assert that planning-time
@@ -81,20 +71,6 @@ class PropertySpecE2EWindowedFeatureGroup(FeatureChainParserMixin, FeatureGroup)
         ),
         DefaultOptionKeys.in_features: property_spec("Source feature to window over"),
     }
-
-    @classmethod
-    def match_feature_group_criteria(
-        cls,
-        feature_name: FeatureName | str,
-        options: Options,
-        data_access_collection: Optional[Any] = None,
-    ) -> bool:
-        _name = str(feature_name) if isinstance(feature_name, FeatureName) else feature_name
-        return FeatureChainParser.match_configuration_feature_chain_parser(
-            _name,
-            options,
-            property_mapping=cls.PROPERTY_MAPPING,
-        )
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:


### PR DESCRIPTION
## Summary

Closes #599. `FeatureChainParserMixin.match_feature_group_criteria` swallowed the `ValueError` raised by strict-validated `PROPERTY_MAPPING` entries into a plain `False`, so an end user only saw a generic "No feature groups found" error, with no mention of the rejected option, value, or reason.

## Design decision

Chose direction 1 from the issue (non-breaking near-miss diagnostics), over the breaking alternatives (2/3), to preserve multi-group fallback matching: a value rejected by one feature group can still match a different one, which the issue itself flags as a hard constraint. `match_feature_group_criteria`'s `True`/`False` contract is untouched.

- Added `FeatureChainParserMixin._strict_validation_rejection_reason`, a diagnostic-only classmethod that re-derives the discarded `ValueError` message without changing matching behavior. It's scoped to genuine strict-validation rejections only, not parser/shape errors from malformed chained names (caught in review, see below).
- `IdentifyFeatureGroupClass` now collects these near-miss reasons from every candidate and appends them to the final "No feature groups found" error, mirroring the existing compute-framework and forwarding-hint diagnostics in the same file.
- Removed the `match_feature_group_criteria` override workaround in `test_property_spec_validation_e2e.py`, which existed only to bypass this gap; the mixin's default path now surfaces the actionable message unaided.
- Documented the new behavior in `docs/docs/in_depth/property-mapping.md`.

## Review

Ran two independent deep reviews (a fresh Opus agent and codex) against the diff:

- codex found a real correctness issue: the first cut of `_strict_validation_rejection_reason` caught every `ValueError` from the matching call, including a parser error for malformed chained names (`PREFIX_PATTERN` matches but no chain separator present), mislabeling it as "rejected an option value." Fixed by splitting the prefix-pattern and property-mapping branches so only genuine strict-validation failures are surfaced.
- Opus confirmed the design is sound (name-agnostic config matching means the hint never points at a truly unrelated feature group) and flagged three minor test-quality items, all addressed: a stale "not yet wired" docstring, a weak e2e assertion that didn't pin the culprit class name, and missing coverage for multiple simultaneously-rejecting candidates.

## Test plan

- [x] `tox` passes (pytest, ruff format/check, mypy --strict, bandit, license allowlist)
- [x] New unit tests for `_strict_validation_rejection_reason` (membership-check rejection, validation_function rejection, absent-key non-match, malformed-prefix parse error)
- [x] New unit tests for the wired hint in `IdentifyFeatureGroupClass` (single rejection, multi-candidate rejection, no spurious hint for unrelated candidates)
- [x] `test_property_spec_validation_e2e.py`'s planning-time rejection test now exercises the mixin's default path (no override) and pins the culprit class name in the message