### PR TITLE
feat: public strict columnar_to_rows, is_columnar, homogenize_rows via mloda.user

### DIFF
--- a/docs/docs/chapter1/compute-frameworks.md
+++ b/docs/docs/chapter1/compute-frameworks.md
@@ -171,6 +171,21 @@ result[0]  # Returns dict[str, list[Any]] (columnar)
 
 A feature group running on PythonDictFramework may also return row-wise data as a list of dicts; it is normalized to the columnar form, and all rows must have identical keys.
 
+#### Columnar helpers
+
+`columnar_to_rows`, `homogenize_rows`, `is_columnar`, and `rows_to_columnar` are importable from `mloda.user`. `columnar_to_rows` is strict: it raises `ValueError` on anything that is not a valid columnar dict. Use `is_columnar` to branch first:
+
+``` python
+from mloda.user import columnar_to_rows, is_columnar
+
+def to_rows_lenient(data):
+    if isinstance(data, list):
+        return data
+    return columnar_to_rows(data) if is_columnar(data) else []
+```
+
+Strictness stays in the library; forgiveness is application policy.
+
 Example using Polars frameworks:
 ``` python
 from mloda.user import mloda

--- a/docs/docs/chapter1/compute-frameworks.md
+++ b/docs/docs/chapter1/compute-frameworks.md
@@ -12,7 +12,7 @@ The compute framework concept provides significant flexibility and enables a var
 -   Testing: Easily compare different compute technologies or frameworks.
 -   Migrations: Move from one environment to another (e.g., local to cloud or db to other db) without changing the underlying feature definitions.
 
-This flexibility is one of mloda’s key advantages, allowing users to decouple feature definitions from specific computation technologies—something that traditional feature stores don’t easily offer.
+This flexibility is one of mloda’s key advantages, allowing users to decouple feature definitions from specific computation technologies, something that traditional feature stores don’t easily offer.
 
 #### 2. Balancing Flexibility and Complexity
 

--- a/mloda/user/__init__.py
+++ b/mloda/user/__init__.py
@@ -68,6 +68,14 @@ _LAZY_COMPUTE_FRAMEWORKS: dict[str, str] = {
     "IcebergFramework": "mloda_plugins.compute_framework.base_implementations.iceberg.iceberg_framework",
 }
 
+# Lazy python_dict helper exports (same PEP 562 contract as the framework classes).
+_LAZY_PYTHON_DICT_UTILS: dict[str, str] = {
+    "columnar_to_rows": "mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils",
+    "homogenize_rows": "mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils",
+    "is_columnar": "mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils",
+    "rows_to_columnar": "mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils",
+}
+
 if TYPE_CHECKING:
     # Static re-exports for mypy/tooling; not imported at runtime.
     from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framework import (
@@ -85,6 +93,12 @@ if TYPE_CHECKING:
     from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
         PythonDictFramework as PythonDictFramework,
     )
+    from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils import (
+        columnar_to_rows as columnar_to_rows,
+        homogenize_rows as homogenize_rows,
+        is_columnar as is_columnar,
+        rows_to_columnar as rows_to_columnar,
+    )
     from mloda_plugins.compute_framework.base_implementations.spark.spark_framework import (
         SparkFramework as SparkFramework,
     )
@@ -94,8 +108,8 @@ if TYPE_CHECKING:
 
 
 def __getattr__(name: str) -> Any:
-    # PEP 562 lazy resolution of optional compute-framework classes.
-    module_path = _LAZY_COMPUTE_FRAMEWORKS.get(name)
+    # PEP 562 lazy resolution of optional compute-framework classes and python_dict helpers.
+    module_path = _LAZY_COMPUTE_FRAMEWORKS.get(name) or _LAZY_PYTHON_DICT_UTILS.get(name)
     if module_path is not None:
         module = importlib.import_module(module_path)
         return getattr(module, name)
@@ -103,8 +117,8 @@ def __getattr__(name: str) -> Any:
 
 
 def __dir__() -> list[str]:
-    # Surface the lazy framework names for REPL/IDE completion.
-    return sorted(set(globals()) | _LAZY_COMPUTE_FRAMEWORKS.keys())
+    # Surface the lazy names for REPL/IDE completion.
+    return sorted(set(globals()) | _LAZY_COMPUTE_FRAMEWORKS.keys() | _LAZY_PYTHON_DICT_UTILS.keys())
 
 
 __all__ = [

--- a/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_framework.py
@@ -16,7 +16,10 @@ from mloda_plugins.compute_framework.base_implementations.python_dict.python_dic
 from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_mask_engine import (
     PythonDictMaskEngine,
 )
-from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils import rows_to_columnar
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils import (
+    rows_to_columnar,
+    validate_columnar_dict,
+)
 
 
 class PythonDictFramework(ComputeFramework):
@@ -118,21 +121,8 @@ class PythonDictFramework(ComputeFramework):
 
     @staticmethod
     def _validate_columnar_dict(data: dict[str, Any]) -> None:
-        """Enforce the columnar contract on a dict: every value is a list and all value-lists
-        share one length. ``{}`` is schema-less and always valid. Shared by ``transform`` and
-        ``validate_native_data`` so both agree on what a valid columnar frame is.
-        """
-        if not data:
-            return
-
-        if not all(isinstance(v, list) for v in data.values()):
-            raise ValueError(
-                f"Columnar dict values must all be lists (rows must arrive as a list of dicts). Got: {data}"
-            )
-
-        lengths = {len(v) for v in data.values()}
-        if len(lengths) > 1:
-            raise ValueError(f"All columns must have the same length. Got column lengths {lengths}.")
+        """Delegate to the shared ``validate_columnar_dict``, the single source of the columnar contract."""
+        validate_columnar_dict(data)
 
     def validate_native_data(self, data: Any) -> None:
         """Enforce the columnar contract when a dict result bypasses ``transform``.

--- a/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_merge_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_merge_engine.py
@@ -6,7 +6,7 @@ from mloda.core.abstract_plugins.components.link import AsOfJoinConfig
 from mloda.provider import BaseMergeEngine
 from mloda.user import Index
 from mloda.user import JoinType
-from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils import row_count
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils import columnar_to_rows
 from mloda_plugins.compute_framework.base_implementations.python_dict import python_dict_type_semantics
 
 
@@ -30,8 +30,7 @@ class PythonDictMergeEngine(BaseMergeEngine):
 
     @classmethod
     def _to_rows(cls, data: dict[str, list[Any]]) -> list[dict[str, Any]]:
-        n = row_count(data)
-        return [{col: data[col][i] for col in data} for i in range(n)]
+        return columnar_to_rows(data)
 
     @staticmethod
     def _to_columnar(rows: list[dict[str, Any]], columns: list[str]) -> dict[str, list[Any]]:

--- a/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_utils.py
+++ b/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_utils.py
@@ -29,7 +29,10 @@ def rows_to_columnar(rows: list[dict[str, Any]]) -> dict[str, list[Any]]:
 
 
 def columnar_to_rows(data: dict[str, Any] | list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Pivot a columnar dict to row-wise ``list[dict]``. Row-wise list input is returned unchanged."""
+    """Pivot a columnar dict to row-wise ``list[dict]``. Row-wise list input is returned unchanged.
+
+    List input is returned by identity, not copied. It is trusted: its elements are not validated.
+    """
     if isinstance(data, list):
         return data
     if not isinstance(data, dict):

--- a/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_utils.py
+++ b/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_utils.py
@@ -28,16 +28,17 @@ def rows_to_columnar(rows: list[dict[str, Any]]) -> dict[str, list[Any]]:
     return {key: [row[key] for row in rows] for key in first_keys}
 
 
-def columnar_to_rows(data: dict[str, Any] | list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Pivot a columnar dict to row-wise ``list[dict]``. Row-wise list input is returned unchanged.
-
-    List input is returned by identity, not copied. It is trusted: its elements are not validated.
-    """
-    if isinstance(data, list):
-        return data
+def is_columnar(data: Any) -> bool:
+    """True iff data is a dict whose values are all lists of one shared length."""
     if not isinstance(data, dict):
-        raise ValueError(f"Expected columnar dict or list of dictionaries, got {type(data)}")
+        return False
+    if not all(isinstance(column, list) for column in data.values()):
+        return False
+    return len({len(column) for column in data.values()}) <= 1
 
+
+def validate_columnar_dict(data: dict[str, Any]) -> None:
+    """Raise ValueError unless every value is a list and all value-lists share one length."""
     lengths = set()
     for key, column in data.items():
         if not isinstance(column, list):
@@ -45,6 +46,14 @@ def columnar_to_rows(data: dict[str, Any] | list[dict[str, Any]]) -> list[dict[s
         lengths.add(len(column))
     if len(lengths) > 1:
         raise ValueError(f"Inconsistent column lengths: {sorted(lengths)}.")
+
+
+def columnar_to_rows(data: dict[str, Any]) -> list[dict[str, Any]]:
+    """Pivot a columnar dict to row-wise ``list[dict]``. Anything else raises ValueError."""
+    if not isinstance(data, dict):
+        raise ValueError(f"Expected columnar dict (row-wise lists are no longer accepted), got {type(data)}")
+
+    validate_columnar_dict(data)
 
     return [{key: data[key][i] for key in data} for i in range(row_count(data))]
 

--- a/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_utils.py
+++ b/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_utils.py
@@ -26,3 +26,34 @@ def rows_to_columnar(rows: list[dict[str, Any]]) -> dict[str, list[Any]]:
             raise ValueError(f"Inconsistent row keys at index {i}: expected {first_keys_set}, got {set(item.keys())}.")
 
     return {key: [row[key] for row in rows] for key in first_keys}
+
+
+def columnar_to_rows(data: dict[str, Any] | list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Pivot a columnar dict to row-wise ``list[dict]``. Row-wise list input is returned unchanged."""
+    if isinstance(data, list):
+        return data
+    if not isinstance(data, dict):
+        raise ValueError(f"Expected columnar dict or list of dictionaries, got {type(data)}")
+
+    lengths = set()
+    for key, column in data.items():
+        if not isinstance(column, list):
+            raise ValueError(f"Expected list column values, but column {key!r} is {type(column)}")
+        lengths.add(len(column))
+    if len(lengths) > 1:
+        raise ValueError(f"Inconsistent column lengths: {sorted(lengths)}.")
+
+    return [{key: data[key][i] for key in data} for i in range(row_count(data))]
+
+
+def homogenize_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return new row dicts carrying the union of keys in first-occurrence order, missing keys as ``None``."""
+    keys: list[str] = []
+    for i, item in enumerate(rows):
+        if not isinstance(item, dict):
+            raise ValueError(f"Expected list of dictionaries, but item at index {i} is {type(item)}")
+        for key in item:
+            if key not in keys:
+                keys.append(key)
+
+    return [{key: row.get(key) for key in keys} for row in rows]

--- a/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_utils.py
+++ b/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_utils.py
@@ -39,11 +39,10 @@ def is_columnar(data: Any) -> bool:
 
 def validate_columnar_dict(data: dict[str, Any]) -> None:
     """Raise ValueError unless every value is a list and all value-lists share one length."""
-    lengths = set()
     for key, column in data.items():
         if not isinstance(column, list):
             raise ValueError(f"Expected list column values, but column {key!r} is {type(column)}")
-        lengths.add(len(column))
+    lengths = {len(column) for column in data.values()}
     if len(lengths) > 1:
         raise ValueError(f"Inconsistent column lengths: {sorted(lengths)}.")
 

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_compute_framework_exports.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_compute_framework_exports.py
@@ -71,3 +71,35 @@ class TestUnknownAttributeStillRaises:
     def test_unknown_attribute_raises_attribute_error(self) -> None:
         with pytest.raises(AttributeError):
             mloda.user.DefinitelyNotAnExportedSymbol
+
+
+# python_dict helper functions follow the same lazy-export contract as the framework
+# classes: importable from mloda.user, identical to the canonical source object,
+# out of __all__, surfaced by __dir__.
+_PYTHON_DICT_UTILS_MODULE = "mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils"
+
+HELPER_EXPORT_MATRIX: list[tuple[str, str]] = [
+    ("columnar_to_rows", _PYTHON_DICT_UTILS_MODULE),
+    ("homogenize_rows", _PYTHON_DICT_UTILS_MODULE),
+    ("is_columnar", _PYTHON_DICT_UTILS_MODULE),
+]
+
+_HELPER_MATRIX_IDS = [symbol for symbol, _source in HELPER_EXPORT_MATRIX]
+
+
+class TestPythonDictHelperExportMatrix:
+    @pytest.mark.parametrize(("symbol", "source_module"), HELPER_EXPORT_MATRIX, ids=_HELPER_MATRIX_IDS)
+    def test_helper_excluded_from_all_but_discoverable_via_dir(self, symbol: str, source_module: str) -> None:
+        assert symbol not in mloda.user.__all__, (
+            f"mloda.user.__all__ must NOT list '{symbol}' (keeps wildcard import dependency-free)"
+        )
+        assert symbol in dir(mloda.user), f"mloda.user.__dir__ must surface '{symbol}' for discoverability"
+
+    @pytest.mark.parametrize(("symbol", "source_module"), HELPER_EXPORT_MATRIX, ids=_HELPER_MATRIX_IDS)
+    def test_helper_is_identical_to_source_object(self, symbol: str, source_module: str) -> None:
+        source = _source_module(source_module)
+        assert hasattr(source, symbol), f"{source.__name__} must define '{symbol}'"
+        assert hasattr(mloda.user, symbol), f"mloda.user must expose '{symbol}'"
+        assert getattr(mloda.user, symbol) is getattr(source, symbol), (
+            f"mloda.user.{symbol} must be the identical object from {source.__name__}"
+        )

--- a/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_framework.py
+++ b/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_framework.py
@@ -159,6 +159,22 @@ class TestPythonDictFramework:
         assert framework.filter_engine() == PythonDictFilterEngine
 
 
+class TestFrameworkColumnarValidationAgreesWithHelper:
+    def test_validate_native_data_and_validate_columnar_dict_agree_on_ragged_dict(self) -> None:
+        """The framework's columnar validation and the utils validator reject the same ragged dict."""
+        from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils import (
+            validate_columnar_dict,
+        )
+
+        ragged: dict[str, Any] = {"a": [1, 2], "b": [1]}
+        framework = PythonDictFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
+
+        with pytest.raises(ValueError):
+            framework.validate_native_data(ragged)
+        with pytest.raises(ValueError):
+            validate_columnar_dict(ragged)
+
+
 class TestPythonDictDtypeExtraction(DtypeExtractionTestMixin):
     """Test PythonDictFramework._extract_column_dtype using shared mixin."""
 

--- a/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_utils.py
+++ b/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_utils.py
@@ -7,16 +7,17 @@ import pytest
 from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils import (
     columnar_to_rows,
     homogenize_rows,
+    is_columnar,
     rows_to_columnar,
+    validate_columnar_dict,
 )
 
 
 class TestColumnarToRows:
-    def test_list_input_passes_through_by_identity(self) -> None:
-        """A row-wise list input is returned unchanged, as the same object."""
-        rows: list[dict[str, Any]] = [{"a": 1}, {"a": 2}]
-        result = columnar_to_rows(rows)
-        assert result is rows
+    def test_list_input_raises(self) -> None:
+        """Strict dict-only: a row-wise list is no longer passed through."""
+        with pytest.raises(ValueError):
+            columnar_to_rows([{"a": 1}])  # type: ignore[arg-type]
 
     def test_columnar_dict_pivots_to_rows(self) -> None:
         """A columnar dict pivots into a list of row dicts."""
@@ -114,3 +115,45 @@ class TestHomogenizeRows:
         """Homogenized mixed-key rows compose with ``rows_to_columnar`` into a columnar dict."""
         rows: list[dict[str, Any]] = [{"a": 1}, {"b": 2}]
         assert rows_to_columnar(homogenize_rows(rows)) == {"a": [1, None], "b": [None, 2]}
+
+
+class TestIsColumnar:
+    def test_equal_length_list_columns_is_true(self) -> None:
+        assert is_columnar({"a": [1, 2], "b": [3, 4]}) is True
+
+    def test_empty_dict_is_true(self) -> None:
+        """The schema-less ``{}`` counts as columnar."""
+        assert is_columnar({}) is True
+
+    def test_zero_row_dict_is_true(self) -> None:
+        assert is_columnar({"a": []}) is True
+
+    def test_ragged_column_lengths_is_false(self) -> None:
+        assert is_columnar({"a": [1, 2], "b": [1]}) is False
+
+    def test_non_list_value_is_false(self) -> None:
+        assert is_columnar({"a": 5}) is False
+
+    def test_tuple_value_is_false(self) -> None:
+        """A tuple column is not a list and is not columnar."""
+        assert is_columnar({"a": (1, 2)}) is False
+
+    @pytest.mark.parametrize("data", [None, "text", 5, [{"a": 1}]])
+    def test_non_dict_input_is_false(self, data: Any) -> None:
+        assert is_columnar(data) is False
+
+
+class TestValidateColumnarDict:
+    def test_valid_dict_does_not_raise(self) -> None:
+        validate_columnar_dict({"a": [1], "b": [2]})
+
+    def test_empty_dict_does_not_raise(self) -> None:
+        validate_columnar_dict({})
+
+    def test_ragged_column_lengths_raise(self) -> None:
+        with pytest.raises(ValueError):
+            validate_columnar_dict({"a": [1, 2], "b": [1]})
+
+    def test_non_list_value_raises(self) -> None:
+        with pytest.raises(ValueError):
+            validate_columnar_dict({"a": 5})

--- a/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_utils.py
+++ b/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_utils.py
@@ -1,0 +1,109 @@
+"""Red-phase tests for the ``columnar_to_rows`` and ``homogenize_rows`` python_dict_utils helpers (issue 648)."""
+
+from typing import Any
+
+import pytest
+
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils import (
+    columnar_to_rows,
+    homogenize_rows,
+    rows_to_columnar,
+)
+
+
+class TestColumnarToRows:
+    def test_list_input_passes_through_by_identity(self) -> None:
+        """A row-wise list input is returned unchanged, as the same object."""
+        rows: list[dict[str, Any]] = [{"a": 1}, {"a": 2}]
+        result = columnar_to_rows(rows)
+        assert result is rows
+
+    def test_columnar_dict_pivots_to_rows(self) -> None:
+        """A columnar dict pivots into a list of row dicts."""
+        data: dict[str, list[Any]] = {"a": [1, 2], "b": ["x", "y"]}
+        assert columnar_to_rows(data) == [{"a": 1, "b": "x"}, {"a": 2, "b": "y"}]
+
+    def test_pivot_preserves_key_insertion_order(self) -> None:
+        """Each row dict keeps the columnar dict's key insertion order."""
+        data: dict[str, list[Any]] = {"b": [1], "a": [2], "c": [3]}
+        result = columnar_to_rows(data)
+        assert [list(row.keys()) for row in result] == [["b", "a", "c"]]
+
+    def test_schemaless_empty_dict_returns_empty_list(self) -> None:
+        """The schema-less ``{}`` yields no rows."""
+        assert columnar_to_rows({}) == []
+
+    def test_schema_bearing_zero_row_dict_returns_empty_list(self) -> None:
+        """A schema-bearing zero-row dict yields no rows."""
+        assert columnar_to_rows({"doc_id": []}) == []
+
+    def test_none_cell_values_survive_pivot(self) -> None:
+        """``None`` cells are carried through to the row dicts."""
+        data: dict[str, list[Any]] = {"a": [1, None], "b": [None, 2]}
+        assert columnar_to_rows(data) == [{"a": 1, "b": None}, {"a": None, "b": 2}]
+
+    def test_ragged_column_lengths_raise(self) -> None:
+        """Columns of differing length are invalid columnar input."""
+        with pytest.raises(ValueError):
+            columnar_to_rows({"a": [1, 2], "b": [1]})
+
+    def test_non_list_column_value_raises(self) -> None:
+        """A dict whose value is not a list is not columnar and is rejected."""
+        with pytest.raises(ValueError):
+            columnar_to_rows({"a": 5})
+
+    def test_none_input_raises(self) -> None:
+        with pytest.raises(ValueError):
+            columnar_to_rows(None)  # type: ignore[arg-type]
+
+    def test_string_input_raises(self) -> None:
+        with pytest.raises(ValueError):
+            columnar_to_rows("text")  # type: ignore[arg-type]
+
+    def test_int_input_raises(self) -> None:
+        with pytest.raises(ValueError):
+            columnar_to_rows(5)  # type: ignore[arg-type]
+
+    def test_round_trip_with_rows_to_columnar(self) -> None:
+        """``columnar_to_rows(rows_to_columnar(rows))`` is the identity for homogeneous rows."""
+        rows: list[dict[str, Any]] = [{"a": 1, "b": "x"}, {"a": 2, "b": "y"}, {"a": None, "b": "z"}]
+        assert columnar_to_rows(rows_to_columnar(rows)) == rows
+
+
+class TestHomogenizeRows:
+    def test_missing_keys_backfilled_with_none(self) -> None:
+        """Missing keys are filled with ``None``, never with ``[]`` or another placeholder."""
+        rows: list[dict[str, Any]] = [{"a": 1}, {"a": 2, "b": 3}]
+        result = homogenize_rows(rows)
+        assert result == [{"a": 1, "b": None}, {"a": 2, "b": 3}]
+        assert result[0]["b"] is None
+
+    def test_key_order_is_first_occurrence_union(self) -> None:
+        """Every output row carries the union of keys in first-occurrence order."""
+        rows: list[dict[str, Any]] = [{"b": 1}, {"a": 2}, {"c": 3}]
+        result = homogenize_rows(rows)
+        assert [list(row.keys()) for row in result] == [["b", "a", "c"]] * 3
+
+    def test_uniform_rows_returned_equal_but_as_new_objects(self) -> None:
+        """Already-uniform rows come back equal, yet as fresh dict objects."""
+        rows: list[dict[str, Any]] = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
+        result = homogenize_rows(rows)
+        assert result == rows
+        assert result[0] is not rows[0]
+
+    def test_empty_list_returns_empty_list(self) -> None:
+        assert homogenize_rows([]) == []
+
+    def test_explicit_none_values_are_kept(self) -> None:
+        """Values that are explicitly ``None`` are preserved, not treated as missing."""
+        rows: list[dict[str, Any]] = [{"a": None, "b": 1}, {"a": 2, "b": None}]
+        assert homogenize_rows(rows) == [{"a": None, "b": 1}, {"a": 2, "b": None}]
+
+    def test_non_dict_item_raises(self) -> None:
+        with pytest.raises(ValueError):
+            homogenize_rows([{"a": 1}, "not a dict"])  # type: ignore[list-item]
+
+    def test_output_is_accepted_by_rows_to_columnar(self) -> None:
+        """Homogenized mixed-key rows compose with ``rows_to_columnar`` into a columnar dict."""
+        rows: list[dict[str, Any]] = [{"a": 1}, {"b": 2}]
+        assert rows_to_columnar(homogenize_rows(rows)) == {"a": [1, None], "b": [None, 2]}

--- a/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_utils.py
+++ b/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_utils.py
@@ -84,6 +84,13 @@ class TestHomogenizeRows:
         result = homogenize_rows(rows)
         assert [list(row.keys()) for row in result] == [["b", "a", "c"]] * 3
 
+    def test_union_key_order_with_interleaved_multi_key_rows(self) -> None:
+        """Multi-key rows interleave into a first-occurrence union order shared by every row."""
+        rows: list[dict[str, Any]] = [{"a": 1, "c": 2}, {"b": 3}]
+        result = homogenize_rows(rows)
+        assert [list(row.keys()) for row in result] == [["a", "c", "b"]] * 2
+        assert result == [{"a": 1, "c": 2, "b": None}, {"a": None, "c": None, "b": 3}]
+
     def test_uniform_rows_returned_equal_but_as_new_objects(self) -> None:
         """Already-uniform rows come back equal, yet as fresh dict objects."""
         rows: list[dict[str, Any]] = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]


### PR DESCRIPTION
## Summary

Closes #648. Ships the public inverse of `rows_to_columnar` plus the helpers downstream repos need to build their own edge policies, all importable from `mloda.user`.

- `columnar_to_rows(data)`: strict pivot of a columnar `dict[str, list]` to row dicts, preserving key insertion order. `{}` and schema-bearing zero-row dicts return `[]`. Everything else raises `ValueError`: ragged column lengths, non-list column values, and non-dict input including row-wise lists.
- `is_columnar(data) -> bool`: non-raising precondition test (dict, all values lists, one shared length). This is the predicate both downstream consumers had to hand-roll.
- `validate_columnar_dict(data)`: the single raising validator for the columnar contract. `PythonDictFramework._validate_columnar_dict` now delegates to it, so the contract lives in one place (framework error wording switched to the per-column style).
- `homogenize_rows(rows)`: new row dicts carrying the union of keys in first-occurrence order, missing keys backfilled with `None`. Output satisfies `rows_to_columnar`.
- All four helpers (plus `rows_to_columnar`) are lazily exported from `mloda.user` via the #649/#653 mechanism: out of `__all__`, surfaced by `__dir__`, identical to the canonical `python_dict_utils` objects.
- `PythonDictMergeEngine._to_rows` delegates to `columnar_to_rows`; its call sites are untouched.

## Deliberate deviation from #648

The issue asked for list input to pass through unchanged. That passthrough is removed: list input raises `ValueError`. Nothing is released yet, so this costs no users, and it closes the one unvalidated hole in an otherwise strict function (identity return, no element validation, aliasing). Callers with maybe-list boundaries branch with `is_columnar` or `isinstance`; the docs show the three-line lenient wrapper.

## Ecosystem context (verified against the downstream repos)

- rag_integration (mloda-ai/rag_integration#81, merged) keeps a local copy in `feature_groups/columnar.py`. `homogenize_rows` is a drop-in for its 4 source call sites. `columnar_to_rows` is deliberately NOT a drop-in: their copy returns `[]` on junk input where this one raises. Their recent fix `8e58b82` (lenient pivot silently corrupting row-wise input in `flatten_result`) is exactly the failure mode this strictness catches at the origin; `is_columnar` replaces the predicate that fix hand-rolled.
- open-kgo: the empty-dict-to-`[]` ask is honored. Its ragged ask is honored as an explicit policy, but the opposite one it currently implements: its GrandCypher reader truncates ragged engine output to the shortest column as a backend-quirk workaround. That stays local to open-kgo; silent truncation does not belong in the shared layer.
- stefan_x_mloda, aic/credit-risk-monorepo, and mvp/prototypes are on row-wise mloda (0.5.3 to 0.6.1) and get a strict, loud pivot for their 0.9.x migrations.

Principle: the library exports the invariant (strict pivot plus the precondition test); applications own their forgiveness.

## Docs

Short "Columnar helpers" subsection in `docs/docs/chapter1/compute-frameworks.md` with the public import path and the downstream lenient-wrapper recipe.

## Testing

- `tests/.../python_dict/test_python_dict_utils.py`: 34 tests pinning the strict pivot, `is_columnar` truth table, validator, empty semantics, `None` survival, ordering, and round trips with `rows_to_columnar`.
- Export matrix extended in `test_compute_framework_exports.py` for the lazy `mloda.user` helpers.
- Framework/helper agreement test on ragged input.
- Full `tox` gate green (4643 passed; ruff, mypy --strict, pip-licenses, bandit).
- Reviewed independently by a fresh Claude Opus deep review and codex; accepted findings applied.
