### PR TITLE
feat: public import path for concrete compute frameworks (mloda.user)

### DIFF
--- a/docs/docs/chapter1/compute-frameworks.md
+++ b/docs/docs/chapter1/compute-frameworks.md
@@ -86,8 +86,7 @@ In this example, we define a compute framework rule inside the feature group. Th
 import pyarrow.compute as pc
 import pyarrow as pa
 
-from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
-from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda.user import PyArrowTable, PandasDataFrame
 from mloda.provider import FeatureGroup
 
 
@@ -133,6 +132,17 @@ In this case, the feature group ExampleB will only run on the PyArrowTable frame
 | **IcebergFramework** | Apache Iceberg Tables | Schema evolution, time travel, data lake management | Data lake scenarios, versioned datasets, large-scale analytics | pyiceberg, pyarrow |
 | **SparkFramework** | Apache Spark DataFrames | Distributed processing, scalability, fault tolerance | Big data, distributed computing, production clusters | pyspark, Java 8+ |
 | **PythonDictFramework** | dict[str, list[Any]] (columnar) | Zero dependencies, simple, lightweight | Minimal environments, education, prototyping | None (Python stdlib only) |
+
+##### Importing a Compute Framework
+
+Every stock compute framework is importable directly from `mloda.user`, so you do not need the deep `mloda_plugins.compute_framework.base_implementations...` path:
+
+```python
+from mloda.user import PythonDictFramework, PandasDataFrame, PolarsDataFrame, PolarsLazyDataFrame
+from mloda.user import PyArrowTable, SqliteFramework, DuckDBFramework, IcebergFramework, SparkFramework
+```
+
+These are resolved lazily, so `import mloda.user` stays dependency-free: a framework whose backend (e.g. `pyarrow`) is not installed only raises `ModuleNotFoundError` when you actually import that class. The deep import paths keep working unchanged.
 
 ##### Automatic Dependency Detection
 

--- a/mloda/user/__init__.py
+++ b/mloda/user/__init__.py
@@ -1,3 +1,6 @@
+import importlib
+from typing import TYPE_CHECKING, Any
+
 # API
 from mloda.core.api.request import mlodaAPI
 
@@ -50,6 +53,54 @@ from mloda.core.api.plugin_docs import (
 mloda = mlodaAPI
 stream_all = mlodaAPI.stream_all
 
+# Lazy compute-framework exports (issue #649): resolved on demand so that
+# ``import mloda.user`` stays dependency-free and optional backends propagate
+# ModuleNotFoundError only at access time.
+_LAZY_COMPUTE_FRAMEWORKS: dict[str, str] = {
+    "PythonDictFramework": "mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework",
+    "PandasDataFrame": "mloda_plugins.compute_framework.base_implementations.pandas.dataframe",
+    "PolarsDataFrame": "mloda_plugins.compute_framework.base_implementations.polars.dataframe",
+    "PolarsLazyDataFrame": "mloda_plugins.compute_framework.base_implementations.polars.lazy_dataframe",
+    "PyArrowTable": "mloda_plugins.compute_framework.base_implementations.pyarrow.table",
+    "SqliteFramework": "mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_framework",
+    "DuckDBFramework": "mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framework",
+    "SparkFramework": "mloda_plugins.compute_framework.base_implementations.spark.spark_framework",
+    "IcebergFramework": "mloda_plugins.compute_framework.base_implementations.iceberg.iceberg_framework",
+}
+
+if TYPE_CHECKING:
+    # Static re-exports for mypy/tooling; not imported at runtime.
+    from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framework import (
+        DuckDBFramework as DuckDBFramework,
+    )
+    from mloda_plugins.compute_framework.base_implementations.iceberg.iceberg_framework import (
+        IcebergFramework as IcebergFramework,
+    )
+    from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame as PandasDataFrame
+    from mloda_plugins.compute_framework.base_implementations.polars.dataframe import PolarsDataFrame as PolarsDataFrame
+    from mloda_plugins.compute_framework.base_implementations.polars.lazy_dataframe import (
+        PolarsLazyDataFrame as PolarsLazyDataFrame,
+    )
+    from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable as PyArrowTable
+    from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
+        PythonDictFramework as PythonDictFramework,
+    )
+    from mloda_plugins.compute_framework.base_implementations.spark.spark_framework import (
+        SparkFramework as SparkFramework,
+    )
+    from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_framework import (
+        SqliteFramework as SqliteFramework,
+    )
+
+
+def __getattr__(name: str) -> Any:
+    # PEP 562 lazy resolution of optional compute-framework classes.
+    module_path = _LAZY_COMPUTE_FRAMEWORKS.get(name)
+    if module_path is not None:
+        module = importlib.import_module(module_path)
+        return getattr(module, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 __all__ = [
     # API
     "mlodaAPI",
@@ -91,4 +142,14 @@ __all__ = [
     "get_extender_docs",
     "list_registered",
     "resolve_feature",
+    # Compute frameworks (lazy, issue #649)
+    "PythonDictFramework",
+    "PandasDataFrame",
+    "PolarsDataFrame",
+    "PolarsLazyDataFrame",
+    "PyArrowTable",
+    "SqliteFramework",
+    "DuckDBFramework",
+    "SparkFramework",
+    "IcebergFramework",
 ]

--- a/mloda/user/__init__.py
+++ b/mloda/user/__init__.py
@@ -101,6 +101,12 @@ def __getattr__(name: str) -> Any:
         return getattr(module, name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
+
+def __dir__() -> list[str]:
+    # Surface the lazy framework names for REPL/IDE completion.
+    return sorted(set(globals()) | _LAZY_COMPUTE_FRAMEWORKS.keys())
+
+
 __all__ = [
     # API
     "mlodaAPI",
@@ -142,14 +148,4 @@ __all__ = [
     "get_extender_docs",
     "list_registered",
     "resolve_feature",
-    # Compute frameworks (lazy, issue #649)
-    "PythonDictFramework",
-    "PandasDataFrame",
-    "PolarsDataFrame",
-    "PolarsLazyDataFrame",
-    "PyArrowTable",
-    "SqliteFramework",
-    "DuckDBFramework",
-    "SparkFramework",
-    "IcebergFramework",
 ]

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_compute_framework_exports.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_compute_framework_exports.py
@@ -1,11 +1,13 @@
 """Compute-framework export matrix for mloda.user (issue #649).
 
-Contract: the 9 concrete ComputeFramework classes must be importable directly
-from mloda.user (e.g. ``from mloda.user import PythonDictFramework``) while
-``import mloda.user`` stays dependency-free. Each symbol is listed in
-mloda.user.__all__ and is the identical object defined in its canonical
-mloda_plugins source module; the old deep-path imports keep working; and an
-unknown attribute on mloda.user still raises AttributeError.
+Contract: the 9 concrete ComputeFramework classes are importable directly from
+mloda.user (e.g. ``from mloda.user import PythonDictFramework``) via PEP 562
+lazy ``__getattr__``, while ``import mloda.user`` stays dependency-free. They are
+deliberately kept OUT of mloda.user.__all__ so ``from mloda.user import *`` stays
+dependency-free in minimal installs, but they ARE surfaced by ``__dir__`` for
+discoverability. Each resolves to the identical object defined in its canonical
+mloda_plugins source module; the deep-path imports keep working; and an unknown
+attribute on mloda.user still raises AttributeError.
 """
 
 import importlib
@@ -38,8 +40,12 @@ def _source_module(source_module: str) -> ModuleType:
 
 class TestComputeFrameworkExportMatrix:
     @pytest.mark.parametrize(("symbol", "source_module"), EXPORT_MATRIX, ids=_MATRIX_IDS)
-    def test_symbol_listed_in_user_all(self, symbol: str, source_module: str) -> None:
-        assert symbol in mloda.user.__all__, f"mloda.user must list '{symbol}' in __all__"
+    def test_symbol_excluded_from_all_but_discoverable_via_dir(self, symbol: str, source_module: str) -> None:
+        # Kept out of __all__ so wildcard import stays dependency-free, but surfaced by __dir__.
+        assert symbol not in mloda.user.__all__, (
+            f"mloda.user.__all__ must NOT list '{symbol}' (keeps wildcard import dependency-free)"
+        )
+        assert symbol in dir(mloda.user), f"mloda.user.__dir__ must surface '{symbol}' for discoverability"
 
     @pytest.mark.parametrize(("symbol", "source_module"), EXPORT_MATRIX, ids=_MATRIX_IDS)
     def test_symbol_is_identical_to_source_object(self, symbol: str, source_module: str) -> None:
@@ -51,14 +57,17 @@ class TestComputeFrameworkExportMatrix:
         )
 
     @pytest.mark.parametrize(("symbol", "source_module"), EXPORT_MATRIX, ids=_MATRIX_IDS)
-    def test_deep_path_import_still_works(self, symbol: str, source_module: str) -> None:
-        source = _source_module(source_module)
-        assert getattr(source, symbol) is getattr(mloda.user, symbol), (
-            f"deep-path {source.__name__}.{symbol} must stay the identical object as mloda.user.{symbol}"
+    def test_deep_path_import_yields_same_object(self, symbol: str, source_module: str) -> None:
+        # Independently import via the real deep path (mloda_plugins...<module>) and
+        # assert identity with the lazily-resolved mloda.user attribute (no breaking change).
+        deep_path_module = importlib.import_module(source_module)
+        deep_path_object = getattr(deep_path_module, symbol)
+        assert deep_path_object is getattr(mloda.user, symbol), (
+            f"deep-path {source_module}.{symbol} must be the identical object as mloda.user.{symbol}"
         )
 
 
 class TestUnknownAttributeStillRaises:
     def test_unknown_attribute_raises_attribute_error(self) -> None:
         with pytest.raises(AttributeError):
-            mloda.user.DefinitelyNotAnExportedSymbol  # type: ignore[attr-defined]
+            mloda.user.DefinitelyNotAnExportedSymbol

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_compute_framework_exports.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_compute_framework_exports.py
@@ -1,0 +1,64 @@
+"""Compute-framework export matrix for mloda.user (issue #649).
+
+Contract: the 9 concrete ComputeFramework classes must be importable directly
+from mloda.user (e.g. ``from mloda.user import PythonDictFramework``) while
+``import mloda.user`` stays dependency-free. Each symbol is listed in
+mloda.user.__all__ and is the identical object defined in its canonical
+mloda_plugins source module; the old deep-path imports keep working; and an
+unknown attribute on mloda.user still raises AttributeError.
+"""
+
+import importlib
+from types import ModuleType
+
+import pytest
+
+import mloda.user
+
+# Source modules are resolved lazily so a missing optional backend fails only its own matrix row.
+# (symbol exported by mloda.user, canonical source module holding the class)
+EXPORT_MATRIX: list[tuple[str, str]] = [
+    ("PythonDictFramework", "mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework"),
+    ("PandasDataFrame", "mloda_plugins.compute_framework.base_implementations.pandas.dataframe"),
+    ("PolarsDataFrame", "mloda_plugins.compute_framework.base_implementations.polars.dataframe"),
+    ("PolarsLazyDataFrame", "mloda_plugins.compute_framework.base_implementations.polars.lazy_dataframe"),
+    ("PyArrowTable", "mloda_plugins.compute_framework.base_implementations.pyarrow.table"),
+    ("SqliteFramework", "mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_framework"),
+    ("DuckDBFramework", "mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framework"),
+    ("SparkFramework", "mloda_plugins.compute_framework.base_implementations.spark.spark_framework"),
+    ("IcebergFramework", "mloda_plugins.compute_framework.base_implementations.iceberg.iceberg_framework"),
+]
+
+_MATRIX_IDS = [symbol for symbol, _source in EXPORT_MATRIX]
+
+
+def _source_module(source_module: str) -> ModuleType:
+    return importlib.import_module(source_module)
+
+
+class TestComputeFrameworkExportMatrix:
+    @pytest.mark.parametrize(("symbol", "source_module"), EXPORT_MATRIX, ids=_MATRIX_IDS)
+    def test_symbol_listed_in_user_all(self, symbol: str, source_module: str) -> None:
+        assert symbol in mloda.user.__all__, f"mloda.user must list '{symbol}' in __all__"
+
+    @pytest.mark.parametrize(("symbol", "source_module"), EXPORT_MATRIX, ids=_MATRIX_IDS)
+    def test_symbol_is_identical_to_source_object(self, symbol: str, source_module: str) -> None:
+        source = _source_module(source_module)
+        assert hasattr(source, symbol), f"{source.__name__} must define '{symbol}'"
+        assert hasattr(mloda.user, symbol), f"mloda.user must expose '{symbol}'"
+        assert getattr(mloda.user, symbol) is getattr(source, symbol), (
+            f"mloda.user.{symbol} must be the identical object from {source.__name__}"
+        )
+
+    @pytest.mark.parametrize(("symbol", "source_module"), EXPORT_MATRIX, ids=_MATRIX_IDS)
+    def test_deep_path_import_still_works(self, symbol: str, source_module: str) -> None:
+        source = _source_module(source_module)
+        assert getattr(source, symbol) is getattr(mloda.user, symbol), (
+            f"deep-path {source.__name__}.{symbol} must stay the identical object as mloda.user.{symbol}"
+        )
+
+
+class TestUnknownAttributeStillRaises:
+    def test_unknown_attribute_raises_attribute_error(self) -> None:
+        with pytest.raises(AttributeError):
+            mloda.user.DefinitelyNotAnExportedSymbol  # type: ignore[attr-defined]

--- a/tests/test_core/test_optional_pyarrow/test_import_without_pyarrow.py
+++ b/tests/test_core/test_optional_pyarrow/test_import_without_pyarrow.py
@@ -43,12 +43,28 @@ if os.environ.get("MLODA_TEST_BLOCK_PYARROW", "1") == "1":
     assert _pyarrow_blocked, "pyarrow should be blocked but was importable"
 
 # The eager import path of mloda.user must not require pyarrow.
+import importlib
+
 import mloda.user
 from mloda.user import mloda, Feature, PluginCollector
+
+# Dependency-free lazy access: PythonDictFramework must resolve from mloda.user
+# even with pyarrow blocked, because PythonDict needs no optional backend.
+from mloda.user import PythonDictFramework
+
+# Accessing a pyarrow-backed framework via mloda.user must fail cleanly and only
+# at access time, raising ModuleNotFoundError (pyarrow blocked), not eagerly on
+# ``import mloda.user`` above. Resolve the package via importlib under a distinct
+# name: the local ``mloda`` above is the mlodaAPI alias, not the package module.
+_user_mod = importlib.import_module("mloda.user")
+_pyarrow_access_blocked = False
+try:
+    _user_mod.PyArrowTable
+except ModuleNotFoundError:
+    _pyarrow_access_blocked = True
+assert _pyarrow_access_blocked, "mloda.user.PyArrowTable must raise ModuleNotFoundError while pyarrow is blocked"
+
 from mloda.provider import FeatureGroup, FeatureSet, DataCreator, BaseInputData
-from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
-    PythonDictFramework,
-)
 
 from typing import Any, Optional
 

--- a/tests/test_core/test_optional_pyarrow/test_import_without_pyarrow.py
+++ b/tests/test_core/test_optional_pyarrow/test_import_without_pyarrow.py
@@ -46,6 +46,10 @@ if os.environ.get("MLODA_TEST_BLOCK_PYARROW", "1") == "1":
 import importlib
 
 import mloda.user
+
+# Importing mloda.user must not eagerly import optional backend libraries.
+assert "pyarrow" not in sys.modules, "import mloda.user must not eagerly import pyarrow"
+
 from mloda.user import mloda, Feature, PluginCollector
 
 # Dependency-free lazy access: PythonDictFramework must resolve from mloda.user


### PR DESCRIPTION
## Summary

Closes #649. The stock concrete `ComputeFramework` implementations had no public import path: only the abstract `ComputeFramework` base was public, so callers had to reach into `mloda_plugins.compute_framework.base_implementations...` (open-kgo built its own re-export facade just to avoid this).

The nine stock frameworks are now importable directly from `mloda.user`:

```python
from mloda.user import PythonDictFramework, PandasDataFrame, PolarsDataFrame, PolarsLazyDataFrame
from mloda.user import PyArrowTable, SqliteFramework, DuckDBFramework, SparkFramework, IcebergFramework
```

The issue listed six frameworks; this also covers `DuckDBFramework`, `SparkFramework`, and `IcebergFramework` (the "check also other plugins" ask), so every concrete compute framework has a public path.

## Design

mloda core declares `dependencies = []`: every backend is optional, and `import mloda.user` must not pull one in. So exports are resolved lazily via a PEP 562 module-level `__getattr__`:

- `import mloda.user` stays dependency-free (no backend imported at import time; a `sys.modules` assertion in the no-pyarrow test locks this in).
- A missing backend (e.g. `pyarrow`) raises `ModuleNotFoundError` only when that specific class is accessed.
- The framework names are intentionally kept out of `__all__` so `from mloda.user import *` remains dependency-free in minimal installs (an early review caught that listing them there made wildcard import eagerly resolve and fail). A `__dir__` keeps them discoverable in the REPL/IDE.
- Existing deep-path imports still resolve to the identical object: no breaking change.

## Tests

- `tests/test_core/test_abstract_plugins/test_plugin_registry/test_compute_framework_exports.py`: matrix over the nine frameworks asserting lazy identity with the canonical source object, the independent deep-path import still works, the not-in-`__all__` / discoverable-via-`__dir__` contract, and that unknown attributes still raise `AttributeError`.
- `tests/test_core/test_optional_pyarrow/test_import_without_pyarrow.py`: extended so the pyarrow-blocked subprocess asserts `import mloda.user` imports no backend, `PythonDictFramework` resolves dependency-free, and `PyArrowTable` raises `ModuleNotFoundError` only at access time.

## Docs

`docs/docs/chapter1/compute-frameworks.md`: the ExampleB snippet now uses the short `from mloda.user import ...` path, plus a note on the short import path and its lazy, dependency-free behavior.

`tox` is green (pytest, ruff format, ruff check, pip-licenses, mypy --strict, bandit). Two independent reviews (a fresh Opus agent and codex) gated the change; the `import *` regression they surfaced is fixed here.
