### PR TITLE
ci: keep committed ATTRIBUTION.md at release, document regeneration flow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,10 +32,12 @@ jobs:
 
       - name: Generate License Files
         env:
-          NO_WRITE_ATTRIBUTION_MD: " "
           TOX_WRITE_THIRD_PARTY_LICENSES: true
         run: |
             tox -e python310
+            # Ship the committed ATTRIBUTION.md, not a copy regenerated from this
+            # runner's environment; tox also rewrites it, so restore the tracked one.
+            git checkout -- attribution/ATTRIBUTION.md
             if [ ! -f "attribution/ATTRIBUTION.md" ]; then
               echo "Error: Expected file attribution/ATTRIBUTION.md does not exist"
               exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,7 @@ source .venv/bin/activate
 - **Tests**: every new feature or bug fix must come with tests; follow the patterns in the existing `tests/` tree. Tests must be parallel-safe (pytest-xdist) and finish under the 10-second timeout. The default tox env asserts `EXPECTED_SKIP_COUNT=147`; if a test you add is skipped, update the count or unskip it.
 - **Supply chain**: `[tool.uv] exclude-newer = "7 days"` in `pyproject.toml` defers new dependency releases by 7 days. Do not edit this without a reason.
 - **Licenses**: dependencies must satisfy the allowlist in `tox.ini` (Apache-2.0, BSD, MIT, MPL-2.0, PSF, ISC, LGPLv2+). Adding a dependency with a non-listed license fails tox.
+- **`attribution/ATTRIBUTION.md`**: `tox` regenerates this file from the installed dependency versions on every run, so a dependency change shows up as a diff here. This is intended: commit the update as part of the same change so the tracked file stays current. The release workflow does not regenerate it; it ships the committed copy, so keeping it up to date in PRs is what keeps releases accurate.
 - **Commits**: use [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, `docs:`, `test:`, `refactor:`, `minor:`). semantic-release computes the next version. This project deviates from the standard: the minor version (middle number) bumps only on `minor:` commits; `feat:` is treated as a patch bump.
 
 ## Issue Creation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,7 @@ source .venv/bin/activate
 - **Tests**: every new feature or bug fix must come with tests; follow the patterns in the existing `tests/` tree. Tests must be parallel-safe (pytest-xdist) and finish under the 10-second timeout. The default tox env asserts `EXPECTED_SKIP_COUNT=147`; if a test you add is skipped, update the count or unskip it.
 - **Supply chain**: `[tool.uv] exclude-newer = "7 days"` in `pyproject.toml` defers new dependency releases by 7 days. Do not edit this without a reason.
 - **Licenses**: dependencies must satisfy the allowlist in `tox.ini` (Apache-2.0, BSD, MIT, MPL-2.0, PSF, ISC, LGPLv2+). Adding a dependency with a non-listed license fails tox.
+- **`attribution/ATTRIBUTION.md`**: `tox` regenerates this file from the installed dependency versions on every run, so a dependency change shows up as a diff here. This is intended: commit the update as part of the same change so the tracked file stays current. The release workflow does not regenerate it; it ships the committed copy, so keeping it up to date in PRs is what keeps releases accurate.
 - **Commits**: use [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, `docs:`, `test:`, `refactor:`, `minor:`). semantic-release computes the next version. This project deviates from the standard: the minor version (middle number) bumps only on `minor:` commits; `feat:` is treated as a patch bump.
 
 ### mypy iteration notes


### PR DESCRIPTION
Closes #612.

## Behavior

`tox` regenerates `attribution/ATTRIBUTION.md` from the installed dependency versions on every run. That is intentional: the file should be kept current and committed as dependencies change. This PR makes that the documented, supported flow and keeps releases accurate.

| Context | ATTRIBUTION.md |
|---|---|
| Local `tox` / PR CI | regenerated (commit the diff if deps changed) |
| Release job | ships the committed copy (restored after tox), never a runner-built one |

## Changes

- `.github/workflows/release.yaml`: restore the tracked `ATTRIBUTION.md` after the license `tox` run so the release asset is the committed/reviewed file, and drop the dead `NO_WRITE_ATTRIBUTION_MD` env (tox strips it without a `passenv`, so it never did anything). `THIRD_PARTY_LICENSES.md` is still regenerated.
- `CLAUDE.md` / `AGENTS.md`: document the regenerate-and-commit flow and that release does not regenerate.

`tox.ini` is intentionally left unchanged.
