### PR TITLE
docs: fix join_data.md PyArrow as-of matrix and lock it with a test

### DIFF
--- a/docs/docs/in_depth/join_data.md
+++ b/docs/docs/in_depth/join_data.md
@@ -81,16 +81,21 @@ engine and does not support joins.
 
 Cross-backend caveats to be aware of:
 
--   **`direction='nearest'`** is supported on `pandas`, `polars`, `pyarrow`, and `python_dict`. The
-    SQL/Spark backends (`duckdb`, `sqlite`, `spark`) raise `ValueError` for `nearest`, as there is
-    no clean SQL form.
+-   **`direction='nearest'`** is supported on `pandas`, `polars`, and `python_dict`. `pyarrow` and the
+    SQL/Spark backends (`duckdb`, `sqlite`, `spark`) raise `ValueError` for `nearest`: Acero's
+    `join_asof` and the SQL forms express only a directional (forward/backward) match.
 -   **`tolerance`** accepts `float | int | timedelta`. A `timedelta` tolerance is forwarded natively
-    by `pandas`/`polars`/`pyarrow`, but the SQL/Spark backends (`duckdb`, `sqlite`, `spark`) cannot
-    derive a numeric tolerance from a `timedelta` without knowing the time column's storage and will
-    raise `ValueError`; provide a numeric tolerance (e.g. epoch seconds matching the time column).
-    This is enforced inside the merge engine at run time, not at `Link.asof(...)` construction.
+    only by `pandas`/`polars`/`python_dict`. `pyarrow` and the SQL/Spark backends (`duckdb`, `sqlite`,
+    `spark`) cannot derive a numeric tolerance from a `timedelta` and raise `ValueError`; provide a
+    numeric tolerance (e.g. epoch seconds matching the time column). This is enforced inside the merge
+    engine at run time, not at `Link.asof(...)` construction.
+-   **`pyarrow` is the most restrictive as-of backend.** Backed by Acero's `Table.join_asof`, it
+    rejects `direction='nearest'`, requires an *integer* `tolerance` (an integer-valued float such as
+    `5.0` is accepted, `5.5` is not; `timedelta` is rejected), and rejects `allow_exact_matches=False`
+    (Acero's match range always includes the exact-time row). Treat it like the SQL backends
+    (directional match, numeric tolerance), not like `pandas`/`polars`.
 -   **Overlapping non-key columns.** If the left and right frames share a column name other than the
-    by-keys/time columns, `pandas`/`pyarrow` keep both with `_x`/`_y` suffixes, whereas the
+    by-keys/time columns, `pandas` keeps both with `_x`/`_y` suffixes, whereas `pyarrow` and the
     SQL/`polars`/`python_dict` backends keep the left column and drop the right one. Rename
     conflicting columns upstream if you need both.
 -   **Time-column dtype.** As-of time columns must be ordered (datetime, numeric, or timedelta). A
@@ -109,8 +114,8 @@ Cross-backend caveats to be aware of:
     [comparison contract](comparison-contract.md)).
 -   **Ties.** When two right rows share the identical boundary timestamp within a by-key, the chosen
     row is backend-defined (each engine applies its own internal tie rule). `python_dict`,
-    `sqlite`, and `spark` resolve ties deterministically (smallest surviving right column values
-    win); the other backends follow their native `merge_asof`/`ASOF JOIN` behavior. Do not rely on
+    `duckdb`, `sqlite`, and `spark` resolve ties deterministically (smallest surviving right column
+    values win); the other backends follow their native `merge_asof` behavior. Do not rely on
     a specific tied row being selected across backends.
 
 #### Link

--- a/tests/test_plugins/compute_framework/base_implementations/test_asof_capability_matrix.py
+++ b/tests/test_plugins/compute_framework/base_implementations/test_asof_capability_matrix.py
@@ -1,0 +1,211 @@
+"""Regression-lock for the per-backend as-of (point-in-time join) capability matrix.
+
+Pins each real merge engine's ``nearest`` / ``timedelta`` / ``exclude_exact`` behavior.
+Keep ``ASOF_CAPABILITY_MATRIX`` in sync with docs/docs/in_depth/join_data.md.
+"""
+
+import sqlite3
+from datetime import datetime, timedelta
+from typing import Any, Callable, Optional
+
+import pytest
+
+from mloda.core.abstract_plugins.components.link import AsOfJoinConfig
+from mloda.provider import BaseMergeEngine
+from mloda.user import Index
+from tests.test_plugins.compute_framework.test_tooling.multi_index.test_data_converter import DataConverter
+
+try:
+    import pandas as pd
+except ImportError:
+    pd = None
+
+try:
+    import polars as pl
+except ImportError:
+    pl = None  # type: ignore
+
+try:
+    import pyarrow as pa
+except ImportError:
+    pa = None  # type: ignore[assignment]
+
+try:
+    import duckdb
+except ImportError:
+    duckdb = None  # type: ignore[assignment]
+
+from mloda_plugins.compute_framework.base_implementations.pandas.pandas_merge_engine import PandasMergeEngine
+from mloda_plugins.compute_framework.base_implementations.polars.polars_merge_engine import PolarsMergeEngine
+from mloda_plugins.compute_framework.base_implementations.pyarrow.pyarrow_merge_engine import PyArrowMergeEngine
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_merge_engine import (
+    PythonDictMergeEngine,
+)
+from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_merge_engine import DuckDBMergeEngine
+from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_relation import DuckdbRelation
+from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_framework import _regexp
+from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_merge_engine import SqliteMergeEngine
+from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_relation import SqliteRelation
+
+
+# Mirrors docs/docs/in_depth/join_data.md; update both together.
+# True = the capability succeeds, False = merge_asof raises ValueError.
+# spark is intentionally excluded (not exercised in CI); it mirrors duckdb/sqlite:
+# nearest=False, timedelta=False, exclude_exact=True.
+ASOF_CAPABILITY_MATRIX: dict[str, dict[str, bool]] = {
+    "pandas": {"nearest": True, "timedelta": True, "exclude_exact": True},
+    "polars": {"nearest": True, "timedelta": True, "exclude_exact": True},
+    "python_dict": {"nearest": True, "timedelta": True, "exclude_exact": True},
+    "pyarrow": {"nearest": False, "timedelta": False, "exclude_exact": False},
+    "duckdb": {"nearest": False, "timedelta": False, "exclude_exact": True},
+    "sqlite": {"nearest": False, "timedelta": False, "exclude_exact": True},
+}
+
+CAPABILITIES = ("nearest", "timedelta", "exclude_exact")
+
+# Substring each rejecting backend's ValueError message must contain, so an unrelated
+# ValueError (e.g. from validate_asof_time_columns) cannot silently satisfy the test.
+_RAISE_MATCH = {"nearest": "nearest", "timedelta": "timedelta", "exclude_exact": "allow_exact_matches"}
+
+
+def _sqlite_connection() -> Any:
+    conn = sqlite3.connect(":memory:")
+    conn.create_function("REGEXP", 2, _regexp)
+    return conn
+
+
+class BackendSpec:
+    """Bundles the engine class, framework type, and connection factory for a backend."""
+
+    def __init__(
+        self,
+        name: str,
+        engine_class: type[BaseMergeEngine] | None,
+        framework_type: type[Any] | None,
+        connection_factory: Callable[[], Optional[Any]],
+        missing: bool,
+    ) -> None:
+        self.name = name
+        self.engine_class = engine_class
+        self.framework_type = framework_type
+        self.connection_factory = connection_factory
+        self.missing = missing
+
+
+# PyArrow is the DataConverter interchange format, so every backend needs it.
+BACKEND_SPECS: dict[str, BackendSpec] = {
+    "pandas": BackendSpec(
+        "pandas",
+        PandasMergeEngine,
+        pd.DataFrame if pd is not None else None,
+        lambda: None,
+        missing=pd is None or pa is None,
+    ),
+    "polars": BackendSpec(
+        "polars",
+        PolarsMergeEngine,
+        pl.DataFrame if pl is not None else None,
+        lambda: None,
+        missing=pl is None or pa is None,
+    ),
+    "python_dict": BackendSpec(
+        "python_dict",
+        PythonDictMergeEngine,
+        dict,
+        lambda: None,
+        missing=pa is None,
+    ),
+    "pyarrow": BackendSpec(
+        "pyarrow",
+        PyArrowMergeEngine,
+        pa.Table if pa is not None else None,
+        lambda: None,
+        missing=pa is None,
+    ),
+    "duckdb": BackendSpec(
+        "duckdb",
+        DuckDBMergeEngine,
+        DuckdbRelation,
+        lambda: duckdb.connect() if duckdb is not None else None,
+        missing=duckdb is None or pa is None,
+    ),
+    "sqlite": BackendSpec(
+        "sqlite",
+        SqliteMergeEngine,
+        SqliteRelation,
+        _sqlite_connection,
+        missing=pa is None,
+    ),
+}
+
+
+def _config_for(capability: str) -> AsOfJoinConfig:
+    if capability == "nearest":
+        return AsOfJoinConfig(left_time_column="t", right_time_column="t", direction="nearest")
+    if capability == "exclude_exact":
+        return AsOfJoinConfig(
+            left_time_column="t", right_time_column="t", direction="backward", allow_exact_matches=False
+        )
+    # timedelta
+    return AsOfJoinConfig(
+        left_time_column="t", right_time_column="t", direction="backward", tolerance=timedelta(seconds=5)
+    )
+
+
+def _rows_for(capability: str) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    if capability == "timedelta":
+        # Datetime time column makes the timedelta tolerance meaningful for succeeding backends.
+        left = [{"k": 1, "t": datetime(2021, 1, 1, 0, 0, 10), "lv": 100}]
+        right = [{"k": 1, "t": datetime(2021, 1, 1, 0, 0, 8), "rv": 1.0}]
+        return left, right
+    # Numeric time column for nearest and exclude_exact.
+    left = [{"k": 1, "t": 10, "lv": 100}]
+    right = [{"k": 1, "t": 10, "rv": 1.0}, {"k": 1, "t": 8, "rv": 2.0}]
+    return left, right
+
+
+def _params() -> list[Any]:
+    params: list[Any] = []
+    for backend, capabilities in ASOF_CAPABILITY_MATRIX.items():
+        spec = BACKEND_SPECS[backend]
+        for capability in CAPABILITIES:
+            _ = capabilities[capability]
+            params.append(
+                pytest.param(
+                    backend,
+                    capability,
+                    id=f"{backend}-{capability}",
+                    marks=pytest.mark.skipif(
+                        spec.missing, reason=f"Optional dependency for {backend} is not installed."
+                    ),
+                )
+            )
+    return params
+
+
+@pytest.mark.parametrize("backend, capability", _params())
+def test_asof_capability_matrix(backend: str, capability: str) -> None:
+    """Each (backend, capability) must match the documented matrix against the real engine."""
+    spec = BACKEND_SPECS[backend]
+    expected = ASOF_CAPABILITY_MATRIX[backend][capability]
+
+    conv = DataConverter()
+    connection = spec.connection_factory()
+    assert spec.engine_class is not None
+    assert spec.framework_type is not None
+    framework_type = spec.framework_type
+    engine = spec.engine_class(connection) if connection is not None else spec.engine_class()
+
+    left_rows, right_rows = _rows_for(capability)
+    left = conv.to_framework(left_rows, framework_type, connection)
+    right = conv.to_framework(right_rows, framework_type, connection)
+    index = Index(("k",))
+    config = _config_for(capability)
+
+    if expected:
+        result = engine.merge_asof(left, right, index, index, config)
+        # Materialize lazy backends (duckdb / lazy relations); the call must not raise.
+        conv.from_framework(result, framework_type)
+    else:
+        with pytest.raises(ValueError, match=_RAISE_MATCH[capability]):
+            engine.merge_asof(left, right, index, index, config)


### PR DESCRIPTION
## Summary

`docs/docs/in_depth/join_data.md` claimed the PyArrow as-of backend supports `direction="nearest"` and forwards a `timedelta` tolerance natively, but `PyArrowMergeEngine.merge_asof` rejects both (plus `allow_exact_matches=False`) and requires an integer tolerance. Acero's `Table.join_asof` only expresses a directional (forward/backward) match with an integer tolerance, so PyArrow belongs with the SQL backends, not with pandas/polars. Fixes #635.

## Doc corrections (`join_data.md`)

- `direction='nearest'`: removed `pyarrow` from the supported list; it now sits with the SQL/Spark backends that raise `ValueError`.
- `timedelta` tolerance: forwarded natively only by `pandas`/`polars`/`python_dict`; `pyarrow` and the SQL/Spark backends require a numeric tolerance. `python_dict` was also missing from this list and is now included.
- Added a dedicated PyArrow caveat: it is the most restrictive as-of backend (rejects `nearest`, requires an integer tolerance, rejects `allow_exact_matches=False`).
- Overlapping non-key columns: `pyarrow` drops the colliding right column (verified by the engine and its tests), so it was moved out of the "keep both with `_x`/`_y`" group (now `pandas` only).
- Ties: added `duckdb` to the deterministic tie-break list (it ranks with `ROW_NUMBER`, not a native `ASOF JOIN`).

## Regression lock (new test)

`tests/test_plugins/compute_framework/base_implementations/test_asof_capability_matrix.py` asserts the documented per-backend `nearest` / `timedelta` / `exclude_exact` matrix against the real merge engines (pandas, polars, python_dict, pyarrow, duckdb, sqlite; spark excluded as it is not in CI), building inputs through the shared `DataConverter`. The `ValueError` cases are pinned by message so an unrelated validation error cannot silently pass. `ASOF_CAPABILITY_MATRIX` mirrors the doc and is kept in sync by convention.

## Validation

`tox` green (4661 passed, 171 skipped, `mypy --strict` clean, ruff/bandit clean); the new file adds 0 skips. Reviewed independently by a fresh Claude Opus agent and codex; accepted findings folded in.