### PR TITLE
feat: honor user request sequence for column_ordering="request_order"

### DIFF
--- a/mloda/core/abstract_plugins/compute_framework.py
+++ b/mloda/core/abstract_plugins/compute_framework.py
@@ -152,13 +152,19 @@ class ComputeFramework(ABC):
         return None
 
     def select_data_by_column_names(
-        self, data: Any, selected_feature_names: Sequence[FeatureName], column_ordering: Optional[str] = None
+        self,
+        data: Any,
+        selected_feature_names: Sequence[FeatureName],
+        column_ordering: Optional[str] = None,
+        request_feature_order: Optional[list[str]] = None,
     ) -> Any:
         """
         If you only want to store the requested features, implement this functionality depending on your framework.
 
         e.g. if you are using pyarrow, you can use the following code:
         return data.select([f.name for f in selected_feature_names])
+
+        request_feature_order: Optional ordered feature names driving 'request_order' output sequence
         """
         return data
 
@@ -775,6 +781,7 @@ Available join types:
         selected_feature_names: Sequence[FeatureName],
         column_names: set[str],
         ordering: Optional[str] = None,
+        request_feature_order: Optional[list[str]] = None,
     ) -> set[str] | list[str]:
         """
         Identifies columns that match feature names or follow the naming convention pattern.
@@ -786,6 +793,7 @@ Available join types:
             selected_feature_names: A sequence of FeatureName objects representing the requested features
             column_names: A set of strings representing the available column names in the data
             ordering: Optional ordering mode - None for Set, "alphabetical" or "request_order" for List
+            request_feature_order: Optional ordered feature names driving 'request_order' output sequence
 
         Returns:
             A set of column names (default) or list if ordering is specified
@@ -825,13 +833,19 @@ Available join types:
             return sorted(_selected_feature_names)
 
         # ordering == "request_order"
+        order_source = request_feature_order if request_feature_order else [str(f) for f in selected_feature_names]
         result: list[str] = []
-        for feature in dict.fromkeys(selected_feature_names):
-            feature_name_str = str(feature)
+        appended: set[str] = set()
+        for name in dict.fromkeys(order_source):
             matching_cols = []
             for col in _selected_feature_names:
-                if col == feature_name_str or col.startswith(f"{feature_name_str}~"):
+                if col in appended:
+                    continue
+                if col == name or col.startswith(f"{name}~"):
                     matching_cols.append(col)
             matching_cols.sort()
             result.extend(matching_cols)
+            appended.update(matching_cols)
+        # Fallback: never drop a matched column not covered by order_source.
+        result.extend(sorted(_selected_feature_names - appended))
         return result

--- a/mloda/core/core/engine.py
+++ b/mloda/core/core/engine.py
@@ -70,6 +70,7 @@ class Engine:
 
         self.data_access_collection = data_access_collection
         self.column_ordering = column_ordering
+        self.request_feature_order: list[str] = [str(f.name) for f in features]
         self._dual_consumption_warned: set[tuple[str, str, frozenset[str]]] = set()
         self._property_mapping_keys_cache: dict[type[FeatureGroup], frozenset[str]] = {}
         self.execution_planner = self.create_setup_execution_plan(features)
@@ -100,6 +101,7 @@ class Engine:
             execution_plan_copy,
             flight_server,
             column_ordering=self.column_ordering,
+            request_feature_order=self.request_feature_order,
             tfs_connection_map=self.tfs_connection_map,
         )
         if isinstance(orchestrator, ExecutionOrchestrator):

--- a/mloda/core/runtime/data_lifecycle_manager.py
+++ b/mloda/core/runtime/data_lifecycle_manager.py
@@ -18,7 +18,10 @@ class DataLifecycleManager:
     """
 
     def __init__(
-        self, transformer: Optional[ComputeFrameworkTransformer] = None, column_ordering: Optional[str] = None
+        self,
+        transformer: Optional[ComputeFrameworkTransformer] = None,
+        column_ordering: Optional[str] = None,
+        request_feature_order: Optional[list[str]] = None,
     ) -> None:
         """
         Initializes DataLifecycleManager with empty state and transformer.
@@ -33,6 +36,7 @@ class DataLifecycleManager:
         self.artifacts: dict[str, Any] = {}
         self.transformer = transformer if transformer is not None else ComputeFrameworkTransformer()
         self.column_ordering = column_ordering
+        self.request_feature_order = request_feature_order
 
     def drop_data_for_finished_cfws(
         self, finished_ids: set[UUID], cfw_collection: dict[UUID, ComputeFramework], location: Optional[str] = None
@@ -133,7 +137,12 @@ class DataLifecycleManager:
         if not cfw._extract_column_names(data):
             return data
 
-        return cfw.select_data_by_column_names(data, selected_feature_names, column_ordering=self.column_ordering)
+        return cfw.select_data_by_column_names(
+            data,
+            selected_feature_names,
+            column_ordering=self.column_ordering,
+            request_feature_order=self.request_feature_order,
+        )
 
     def get_results(self) -> list[Any]:
         """

--- a/mloda/core/runtime/run.py
+++ b/mloda/core/runtime/run.py
@@ -43,6 +43,7 @@ class ExecutionOrchestrator:
         execution_planner: ExecutionPlan,
         flight_server: Optional[ParallelRunnerFlightServer] = None,
         column_ordering: Optional[str] = None,
+        request_feature_order: Optional[list[str]] = None,
         tfs_connection_map: Optional[dict[type[ComputeFramework], Any]] = None,
     ) -> None:
         """
@@ -62,7 +63,9 @@ class ExecutionOrchestrator:
         self.worker_manager = WorkerManager()
 
         # Data lifecycle - delegate to DataLifecycleManager
-        self.data_lifecycle_manager = DataLifecycleManager(column_ordering=column_ordering)
+        self.data_lifecycle_manager = DataLifecycleManager(
+            column_ordering=column_ordering, request_feature_order=request_feature_order
+        )
 
         self._step_lock = threading.Lock()
 

--- a/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/duckdb/duckdb_framework.py
@@ -100,7 +100,11 @@ class DuckDBFramework(ComputeFramework):
         return DuckDBMergeEngine
 
     def select_data_by_column_names(
-        self, data: Any, selected_feature_names: Sequence[FeatureName], column_ordering: Optional[str] = None
+        self,
+        data: Any,
+        selected_feature_names: Sequence[FeatureName],
+        column_ordering: Optional[str] = None,
+        request_feature_order: Optional[list[str]] = None,
     ) -> Any:
         """Materialize the final result as a PyArrow Table.
 
@@ -109,7 +113,7 @@ class DuckDBFramework(ComputeFramework):
         """
         column_names = set(data.columns)
         _selected_feature_names = self.identify_naming_convention(
-            selected_feature_names, column_names, ordering=column_ordering
+            selected_feature_names, column_names, ordering=column_ordering, request_feature_order=request_feature_order
         )
 
         selected_columns = list(_selected_feature_names)

--- a/mloda_plugins/compute_framework/base_implementations/iceberg/iceberg_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/iceberg/iceberg_framework.py
@@ -109,7 +109,11 @@ class IcebergFramework(ComputeFramework):
         )
 
     def select_data_by_column_names(
-        self, data: Any, selected_feature_names: Sequence[FeatureName], column_ordering: Optional[str] = None
+        self,
+        data: Any,
+        selected_feature_names: Sequence[FeatureName],
+        column_ordering: Optional[str] = None,
+        request_feature_order: Optional[list[str]] = None,
     ) -> Any:
         """
         Select specific columns from Iceberg table.
@@ -127,7 +131,7 @@ class IcebergFramework(ComputeFramework):
 
         column_names = set(data.schema().column_names)
         _selected_feature_names = self.identify_naming_convention(
-            selected_feature_names, column_names, ordering=column_ordering
+            selected_feature_names, column_names, ordering=column_ordering, request_feature_order=request_feature_order
         )
 
         # Use Iceberg's scan with column selection

--- a/mloda_plugins/compute_framework/base_implementations/pandas/dataframe.py
+++ b/mloda_plugins/compute_framework/base_implementations/pandas/dataframe.py
@@ -35,11 +35,15 @@ class PandasDataFrame(ComputeFramework):
         return PandasMergeEngine
 
     def select_data_by_column_names(
-        self, data: Any, selected_feature_names: Sequence[FeatureName], column_ordering: Optional[str] = None
+        self,
+        data: Any,
+        selected_feature_names: Sequence[FeatureName],
+        column_ordering: Optional[str] = None,
+        request_feature_order: Optional[list[str]] = None,
     ) -> Any:
         column_names = set(data.columns)
         _selected_feature_names = self.identify_naming_convention(
-            selected_feature_names, column_names, ordering=column_ordering
+            selected_feature_names, column_names, ordering=column_ordering, request_feature_order=request_feature_order
         )
         return data[[f for f in _selected_feature_names]]
 

--- a/mloda_plugins/compute_framework/base_implementations/polars/dataframe.py
+++ b/mloda_plugins/compute_framework/base_implementations/polars/dataframe.py
@@ -35,11 +35,15 @@ class PolarsDataFrame(ComputeFramework):
         return PolarsMergeEngine
 
     def select_data_by_column_names(
-        self, data: Any, selected_feature_names: Sequence[FeatureName], column_ordering: Optional[str] = None
+        self,
+        data: Any,
+        selected_feature_names: Sequence[FeatureName],
+        column_ordering: Optional[str] = None,
+        request_feature_order: Optional[list[str]] = None,
     ) -> Any:
         column_names = set(data.columns)
         _selected_feature_names = self.identify_naming_convention(
-            selected_feature_names, column_names, ordering=column_ordering
+            selected_feature_names, column_names, ordering=column_ordering, request_feature_order=request_feature_order
         )
         return data.select(list(_selected_feature_names))
 

--- a/mloda_plugins/compute_framework/base_implementations/polars/lazy_dataframe.py
+++ b/mloda_plugins/compute_framework/base_implementations/polars/lazy_dataframe.py
@@ -36,11 +36,15 @@ class PolarsLazyDataFrame(PolarsDataFrame):
         return PolarsExprMaskEngine
 
     def select_data_by_column_names(
-        self, data: Any, selected_feature_names: Sequence[FeatureName], column_ordering: Optional[str] = None
+        self,
+        data: Any,
+        selected_feature_names: Sequence[FeatureName],
+        column_ordering: Optional[str] = None,
+        request_feature_order: Optional[list[str]] = None,
     ) -> Any:
         column_names = set(data.collect_schema().names())
         _selected_feature_names = self.identify_naming_convention(
-            selected_feature_names, column_names, ordering=column_ordering
+            selected_feature_names, column_names, ordering=column_ordering, request_feature_order=request_feature_order
         )
         # Select the columns and collect the lazy evaluation since this is the final result step
         lazy_result = data.select(list(_selected_feature_names))

--- a/mloda_plugins/compute_framework/base_implementations/pyarrow/table.py
+++ b/mloda_plugins/compute_framework/base_implementations/pyarrow/table.py
@@ -48,11 +48,15 @@ class PyArrowTable(ComputeFramework):
         return PyArrowMaskEngine
 
     def select_data_by_column_names(
-        self, data: Any, selected_feature_names: Sequence[FeatureName], column_ordering: Optional[str] = None
+        self,
+        data: Any,
+        selected_feature_names: Sequence[FeatureName],
+        column_ordering: Optional[str] = None,
+        request_feature_order: Optional[list[str]] = None,
     ) -> Any:
         column_names = set(data.schema.names)
         _selected_feature_names = self.identify_naming_convention(
-            selected_feature_names, column_names, ordering=column_ordering
+            selected_feature_names, column_names, ordering=column_ordering, request_feature_order=request_feature_order
         )
         return data.select([f for f in _selected_feature_names])
 

--- a/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_framework.py
@@ -58,12 +58,16 @@ class PythonDictFramework(ComputeFramework):
         data: dict[str, list[Any]],
         selected_feature_names: Sequence[FeatureName],
         column_ordering: Optional[str] = None,
+        request_feature_order: Optional[list[str]] = None,
     ) -> dict[str, list[Any]]:
         if not data:
             return {}
 
         _selected_feature_names = self.identify_naming_convention(
-            selected_feature_names, set(data.keys()), ordering=column_ordering
+            selected_feature_names,
+            set(data.keys()),
+            ordering=column_ordering,
+            request_feature_order=request_feature_order,
         )
 
         # Copy the column lists so mutating the selection cannot mutate framework internals.

--- a/mloda_plugins/compute_framework/base_implementations/spark/spark_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/spark/spark_framework.py
@@ -79,11 +79,15 @@ class SparkFramework(ComputeFramework):
         return SparkMergeEngine
 
     def select_data_by_column_names(
-        self, data: Any, selected_feature_names: Sequence[FeatureName], column_ordering: Optional[str] = None
+        self,
+        data: Any,
+        selected_feature_names: Sequence[FeatureName],
+        column_ordering: Optional[str] = None,
+        request_feature_order: Optional[list[str]] = None,
     ) -> Any:
         column_names = set(data.columns)
         _selected_feature_names = self.identify_naming_convention(
-            selected_feature_names, column_names, ordering=column_ordering
+            selected_feature_names, column_names, ordering=column_ordering, request_feature_order=request_feature_order
         )
         return data.select(*list(_selected_feature_names))
 

--- a/mloda_plugins/compute_framework/base_implementations/sqlite/sqlite_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/sqlite/sqlite_framework.py
@@ -55,11 +55,15 @@ class SqliteFramework(ComputeFramework):
         return SqliteMergeEngine
 
     def select_data_by_column_names(
-        self, data: Any, selected_feature_names: Sequence[FeatureName], column_ordering: Optional[str] = None
+        self,
+        data: Any,
+        selected_feature_names: Sequence[FeatureName],
+        column_ordering: Optional[str] = None,
+        request_feature_order: Optional[list[str]] = None,
     ) -> Any:
         column_names = set(data.columns)
         _selected_feature_names = self.identify_naming_convention(
-            selected_feature_names, column_names, ordering=column_ordering
+            selected_feature_names, column_names, ordering=column_ordering, request_feature_order=request_feature_order
         )
 
         selected_columns = list(_selected_feature_names)

--- a/tests/test_core/test_abstract_plugins/test_column_ordering.py
+++ b/tests/test_core/test_abstract_plugins/test_column_ordering.py
@@ -136,6 +136,26 @@ class TestIdentifyNamingConvention:
         with pytest.raises(ValueError):
             cfw.identify_naming_convention([FeatureName("A")], {"A"}, ordering="invalid")
 
+    def test_request_order_honors_request_feature_order(self) -> None:
+        cfw = create_compute_framework()
+        result = cfw.identify_naming_convention(
+            [FeatureName("A"), FeatureName("B"), FeatureName("C")],
+            {"A", "B", "C"},
+            ordering="request_order",
+            request_feature_order=["C", "A", "B"],
+        )
+        assert result == ["C", "A", "B"]
+
+    def test_request_feature_order_with_grouped_sub_columns(self) -> None:
+        cfw = create_compute_framework()
+        result = cfw.identify_naming_convention(
+            [FeatureName("Temp"), FeatureName("Hum")],
+            {"Temp~mean", "Temp~max", "Hum~mean", "Hum~max"},
+            ordering="request_order",
+            request_feature_order=["Hum", "Temp"],
+        )
+        assert result == ["Hum~max", "Hum~mean", "Temp~max", "Temp~mean"]
+
 
 # --- API Parameter Tests ---
 
@@ -206,7 +226,7 @@ class TestColumnOrderingThreading:
 
         dlm.get_result_data(mock_cfw, [FeatureName("col")])
         mock_cfw.select_data_by_column_names.assert_called_once_with(
-            mock_cfw.data, [FeatureName("col")], column_ordering="alphabetical"
+            mock_cfw.data, [FeatureName("col")], column_ordering="alphabetical", request_feature_order=None
         )
 
     def test_compute_framework_select_accepts_column_ordering(self) -> None:
@@ -375,3 +395,25 @@ class TestEndToEndColumnOrdering:
 
         # Columns should be in alphabetical order regardless of request order
         assert list(df.columns) == ["FeatureA", "FeatureB", "FeatureC", "FeatureD", "FeatureE"]
+
+    def test_request_order_returns_columns_in_request_sequence(self) -> None:
+        """Request features E, C, A, D, B, verify result preserves that exact request order."""
+        plugin_collector = PluginCollector.enabled_feature_groups({MultiFeatureGroup})
+
+        result = mloda.run_all(
+            [
+                Feature(name="FeatureE"),
+                Feature(name="FeatureC"),
+                Feature(name="FeatureA"),
+                Feature(name="FeatureD"),
+                Feature(name="FeatureB"),
+            ],
+            compute_frameworks={PandasDataFrame},
+            plugin_collector=plugin_collector,
+            column_ordering="request_order",
+        )
+
+        assert len(result) == 1
+        df = result[0]
+
+        assert list(df.columns) == ["FeatureE", "FeatureC", "FeatureA", "FeatureD", "FeatureB"]

--- a/tests/test_core/test_runtime/test_data_lifecycle_manager.py
+++ b/tests/test_core/test_runtime/test_data_lifecycle_manager.py
@@ -298,7 +298,7 @@ class TestDataLifecycleManagerGetResultData:
 
         assert result == selected_data
         mock_cfw.select_data_by_column_names.assert_called_once_with(
-            mock_cfw.data, selected_feature_names, column_ordering=None
+            mock_cfw.data, selected_feature_names, column_ordering=None, request_feature_order=None
         )
 
     def test_get_result_data_downloads_from_flight_server_when_location_provided(self) -> None:
@@ -328,7 +328,7 @@ class TestDataLifecycleManagerGetResultData:
             mock_flight_server.download_table.assert_called_once_with(location, str(mock_cfw.uuid))
             mock_cfw.convert_flight_server_data_back.assert_called_once_with(downloaded_data, manager.transformer)
             mock_cfw.select_data_by_column_names.assert_called_once_with(
-                converted_data, selected_feature_names, column_ordering=None
+                converted_data, selected_feature_names, column_ordering=None, request_feature_order=None
             )
             assert result == selected_data
 


### PR DESCRIPTION
Closes #637.

## Problem

`column_ordering="request_order"` never ordered result columns by the user request sequence. `identify_naming_convention` iterated `selected_feature_names`, but that arrived as an unordered set sourced from a per-step `FeatureSet` accessor that carried no request order, so `request_order` effectively behaved like `alphabetical`.

## Fix

Thread an ordered `request_feature_order: list[str]` from the API request down to the column-selection step, mirroring the existing `column_ordering` path:

- `Engine` captures the ordered request names from the `Features` collection and forwards them to `ExecutionOrchestrator`, then `DataLifecycleManager`.
- `DataLifecycleManager.get_result_data` passes `request_feature_order` into `select_data_by_column_names`.
- `identify_naming_convention` request_order branch orders columns by that global list, grouping `~`-suffixed sub-columns per feature (sorted within each), with a fallback that appends any matched column whose feature name is not in the list so nothing is dropped.
- All in-repo `select_data_by_column_names` overrides accept and forward the new keyword.

## Result

Requesting features E, C, A, D, B with `column_ordering="request_order"` now yields columns in exactly that order.

## Tests

End-to-end test asserting the real multi-feature request order, plus unit tests for `identify_naming_convention` with `request_feature_order` (including grouped sub-columns). Full `tox` passes (pytest, ruff, mypy --strict, licenses, bandit).

## Review

Two independent deep reviews (Claude Opus and codex) found no blockers. Accepted fixes: collapsed a redundant None-branch in `get_result_data` to a single unconditional call and documented the new parameter.