### PR TITLE
docs: sweep open issues for stale symbol names after public-API renames (#592)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,4 +26,5 @@ Closes #
 - [ ] `tox` passes locally (tests, `ruff format --check`, `ruff check`, `mypy --strict`, `bandit`, license check)
 - [ ] Tests added or updated for the change (and the skip count adjusted if needed)
 - [ ] Documentation updated where relevant
+- [ ] If this renames or removes a public symbol: open issues swept for the old name ([CONTRIBUTING](../CONTRIBUTING.md#renaming-or-removing-public-api))
 - [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,5 +26,5 @@ Closes #
 - [ ] `tox` passes locally (tests, `ruff format --check`, `ruff check`, `mypy --strict`, `bandit`, license check)
 - [ ] Tests added or updated for the change (and the skip count adjusted if needed)
 - [ ] Documentation updated where relevant
-- [ ] If this renames or removes a public symbol: open issues swept for the old name ([CONTRIBUTING](../CONTRIBUTING.md#renaming-or-removing-public-api))
+- [ ] If this renames or removes a public symbol: open issues swept for the old name ([CONTRIBUTING](https://github.com/mloda-ai/mloda/blob/main/CONTRIBUTING.md#renaming-or-removing-public-api))
 - [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,6 +118,22 @@ git checkout -b fix/short-description
 5. Push your branch to your fork and open a pull request targeting `main`.
 6. CI runs the full tox suite on Python 3.10, 3.11, 3.12, 3.13, and 3.14. All checks must pass before merge.
 
+### Renaming or Removing Public API
+
+Open issues cite public symbols as code pointers. When a PR renames or removes one (a `FeatureGroup` hook, a `ComputeFramework` method, an extender type, a `DefaultOptionKeys` member), sweep the backlog for the old name in the same PR:
+
+```bash
+gh issue list --repo mloda-ai/mloda --state open --search "<old name> in:body"
+```
+
+Update each hit to the new name, or close the issue if the change made it moot. A stale pointer costs the next contributor discovery time before any real work starts.
+
+Confirm the symbol is really gone by grepping the public surface, not the whole tree. A retired symbol usually lives on in tests that assert its removal, so a repo-wide grep still reports hits and hides the rename:
+
+```bash
+git grep -w "<old name>" -- mloda/ mloda_plugins/   # no output: gone from the public surface
+```
+
 ## License
 
 By contributing, you agree that your contributions will be licensed under the [Apache License, Version 2.0](https://github.com/mloda-ai/mloda/blob/main/LICENSE).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,16 +123,18 @@ git checkout -b fix/short-description
 Open issues cite public symbols as code pointers. When a PR renames or removes one (a `FeatureGroup` hook, a `ComputeFramework` method, an extender type, a `DefaultOptionKeys` member), sweep the backlog for the old name in the same PR:
 
 ```bash
-gh issue list --repo mloda-ai/mloda --state open --search "<old name> in:body"
+gh issue list --repo mloda-ai/mloda --state open --search "<old name>"
 ```
 
-Update each hit to the new name, or close the issue if the change made it moot. A stale pointer costs the next contributor discovery time before any real work starts.
+Search the bare symbol name with no `in:` qualifier: the default covers title, body, and comments, and a stale name in a title is just as costly as one in a code pointer. Update each hit to the new name, or close the issue if the change made it moot.
 
-Confirm the symbol is really gone by grepping the public surface, not the whole tree. A retired symbol usually lives on in tests that assert its removal, so a repo-wide grep still reports hits and hides the rename:
+Confirm the symbol is really gone by grepping the shipped code rather than the whole tree. A retired symbol usually lives on in tests that assert its removal, so a repo-wide grep still reports hits and hides the rename:
 
 ```bash
-git grep -w "<old name>" -- mloda/ mloda_plugins/   # no output: gone from the public surface
+git grep -wF "<old name>" -- mloda/ mloda_plugins/   # no output: gone from the shipped code
 ```
+
+Grep the bare leaf name (`feature_chainer_parser_key`), not the dotted path (`DefaultOptionKeys.feature_chainer_parser_key`), so the definition site is covered and not just the call sites.
 
 ## License
 


### PR DESCRIPTION
## Summary

Closes #592.

Renaming or removing a public symbol silently invalidates the code pointers in the open-issue backlog, so whoever picks the issue up burns discovery time working out that the name is stale before any real work starts. This adds the missing process step and reports the one-off sweep.

## Process (DoD item 1)

- `CONTRIBUTING.md`: a "Renaming or Removing Public API" section under the PR workflow. Sweep the backlog for the old name in the same PR that renames it, and update or close each hit.
- `.github/PULL_REQUEST_TEMPLATE.md`: one conditional checklist item pointing at that section.

Two non-obvious points are documented because both bit during the sweep:

- **Search the bare name, no `in:` qualifier.** GitHub's default already covers title, body and comments; `in:body` *narrows* it. Issue #591 carries the retired `feature_chainer_parser_key` in its **title**, and `in:body` returned nothing for it.
- **Grep `mloda/ mloda_plugins/`, not the whole tree.** A retired symbol usually survives in a test asserting its removal, so a repo-wide grep reports hits and hides the rename. `feature_chainer_parser_key` still matches one test file for exactly this reason.

## Backlog sweep (DoD item 2)

Swept all 22 open issues: extracted every backticked symbol, discarded the ones that were never in `mloda/`/`mloda_plugins/` on `main` (forward-looking proposal names, e.g. the reader-refactor epic's `FileSource` / `is_final_reader`, which live on unmerged #642), and checked the rest against merged history.

Exactly two symbols were ever public and are now gone:

| Symbol | Retired by | Open issues |
|---|---|---|
| `WrapperFunctionExtender` (now `Extender`) | `cfed507` | #592 only, as its own example |
| `feature_chainer_parser_key`, `Options.update_with_protected_keys`, `Options.forward_for_input_feature` | `82ed355` (`feat!:`) | #591 |

**The backlog is clean apart from #591**, which is stale end to end: it asks whether `DefaultOptionKeys.feature_chainer_parser_key` should be renamed, but `82ed355` deleted the key outright and replaced the merge-protection mechanism with `Options.inherit_from` plus typed opt-outs (`forward_group`, `forward_group_exclude`). Every code pointer in it is dead, and the "blocked until after the next release" condition has passed (0.9.0 shipped). Handled separately so this PR stays reviewable.

## Validation

`tox` green (4647 passed, 171 skipped, ruff, license allowlist, `mypy --strict`, bandit). Docs-only, no runtime surface.

## Review

Two independent deep reviews (Claude Opus and codex). Both caught that the PR-template link was relative, which 404s in a rendered PR body (a template is issue text, not a repo file), so the checklist pointed nowhere in the one place it is read. Opus additionally caught the `in:body` recall bug above. Both fixed in the second commit; the minor findings (bare leaf name, `-wF`, wording) were folded in too.