### PR TITLE
feat: resolve_feature accepts an optional Options (#640)

### DIFF
--- a/docs/docs/in_depth/compute-framework-integration.md
+++ b/docs/docs/in_depth/compute-framework-integration.md
@@ -52,10 +52,10 @@ is built for you.
 
 The debug inspector `resolve_feature(name)` reflects the hook too: its
 `ResolvedFeature` result carries `supported_compute_frameworks` and
-`unsupported_compute_frameworks` (evaluated under default options, since the
-inspector does not know the caller's `Options`), and a feature that matches a
-group but is unsupported on every installed framework resolves to
-`feature_group=None` with a capability error rather than appearing runnable.
+`unsupported_compute_frameworks` (evaluated under default options unless you
+pass `options=`, see [Discover Plugins](discover-plugins.md)), and a feature
+that matches a group but is unsupported on every installed framework resolves
+to `feature_group=None` with a capability error rather than appearing runnable.
 
 ### Empty Results
 

--- a/docs/docs/in_depth/discover-plugins.md
+++ b/docs/docs/in_depth/discover-plugins.md
@@ -24,18 +24,24 @@ This is useful for:
 
 ### Option-Gated Feature Groups
 
-Some FeatureGroups only match when an option is present, and
-`supports_compute_framework` may also depend on the options. Matching and the
-compute framework split default to empty `Options`, so pass the options the
-feature would really run with:
+Matching and the compute framework split both run under the options you pass.
+A FeatureGroup whose `match_feature_group_criteria` or
+`supports_compute_framework` reads an option therefore only resolves when you
+supply it. Without `options` the evaluation uses empty `Options`, and such a
+group reports no candidates:
 
 ``` python
-from mloda.user import Options
 from mloda.steward import resolve_feature
+from mloda.user import Options, PluginLoader
 
-result = resolve_feature("value__median_agg", options=Options(group={"partition_by": ["customer_id"]}))
-print(result.supported_compute_frameworks)
+PluginLoader.all()
+
+# The group-by aggregation FeatureGroups in mloda-registry match only when partition_by is set.
+result = resolve_feature("sales__sum_aggr", options=Options(group={"partition_by": ["customer_id"]}))
+print(result.feature_group, result.supported_compute_frameworks)
 ```
+
+`options` and `plugin_collector` are keyword-only, so pass them by name.
 
 ### Inspecting Candidates
 

--- a/docs/docs/in_depth/discover-plugins.md
+++ b/docs/docs/in_depth/discover-plugins.md
@@ -22,6 +22,21 @@ This is useful for:
 - Understanding which plugin handles a feature
 - Identifying conflicts when multiple FeatureGroups match
 
+### Option-Gated Feature Groups
+
+Some FeatureGroups only match when an option is present, and
+`supports_compute_framework` may also depend on the options. Matching and the
+compute framework split default to empty `Options`, so pass the options the
+feature would really run with:
+
+``` python
+from mloda.user import Options
+from mloda.steward import resolve_feature
+
+result = resolve_feature("value__median_agg", options=Options(group={"partition_by": ["customer_id"]}))
+print(result.supported_compute_frameworks)
+```
+
 ### Inspecting Candidates
 
 When resolution fails due to conflicts, check the candidates:

--- a/docs/docs/in_depth/mloda-api.md
+++ b/docs/docs/in_depth/mloda-api.md
@@ -116,6 +116,8 @@ print(f"Candidates: {[fg.__name__ for fg in result.candidates]}")
 **Parameters:**
 
 - **feature_name** (`str`): The name of the feature to resolve.
+- **options** (`Options | None`, keyword-only): Options used for matching and for the compute framework capability split. Defaults to empty `Options`. Required to resolve FeatureGroups that gate matching on an option.
+- **plugin_collector** (`PluginCollector | None`, keyword-only): Restricts the FeatureGroups considered, and threads its `allow_redefinition` flag into deduplication.
 
 **Returns:** `ResolvedFeature` dataclass with fields:
 

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -55,6 +55,27 @@ def _dedup_degrading_on_conflict(
         return dedup_feature_group_subclasses(feature_groups, allow_redefinition=True)
 
 
+def _match_recording_validation_errors(
+    fg_class: type[FeatureGroup],
+    feature_name: FeatureName,
+    options: Options,
+    validation_errors: list[str],
+) -> bool:
+    """Match a feature group, degrading a validation ValueError into "not a match" and recording its message.
+
+    resolve_feature is a non-throwing debug API, but matching can raise ValueError once caller
+    options reach the feature chain parser (e.g. a forwarded option contradicting the feature name).
+    Such a candidate is not a match, and the reason is recorded so it can be surfaced in the error.
+    """
+    try:
+        return fg_class.match_feature_group_criteria(feature_name, options, None)
+    except ValueError as exc:
+        message = str(exc)
+        if message not in validation_errors:
+            validation_errors.append(message)
+        return False
+
+
 def get_feature_group_docs(
     name: Optional[str] = None,
     search: Optional[str] = None,
@@ -266,6 +287,7 @@ def get_extender_docs(
 
 def resolve_feature(
     feature_name: str,
+    *,
     options: Optional[Options] = None,
     plugin_collector: Optional[PluginCollector] = None,
 ) -> ResolvedFeature:
@@ -276,18 +298,23 @@ def resolve_feature(
     the given feature name. It applies subclass filtering to prefer more
     specific (child) classes over parent classes.
 
+    Never raises: matching errors are reported in the returned ResolvedFeature.error.
+
     Args:
         feature_name: The name of the feature to resolve.
-        options: Options used for matching and capability checks. Defaults to empty Options.
-        plugin_collector: Optional PluginCollector; its ``allow_redefinition`` flag is threaded into deduplication.
+        options: Keyword-only. Options used for matching and capability checks. An empty or omitted Options is
+            the documented default.
+        plugin_collector: Keyword-only. Its ``allow_redefinition`` flag is threaded into deduplication.
 
     Returns:
         ResolvedFeature containing the resolved FeatureGroup (if found),
         all matching candidates, and any error message.
     """
     resolved_options = options if options is not None else Options()
-    options_caveat = "default options" if options is None else "the provided options"
+    is_default_options = not resolved_options.group and not resolved_options.context
+    options_caveat = "default options" if is_default_options else "the provided options"
     allow_redefinition = plugin_collector.allow_redefinition if plugin_collector is not None else False
+    validation_errors: list[str] = []
     fg_classes: set[type[FeatureGroup]] = get_all_subclasses(FeatureGroup)
     if plugin_collector is not None:
         fg_classes = {fg for fg in fg_classes if plugin_collector.applicable_feature_group_class(fg)}
@@ -297,7 +324,9 @@ def resolve_feature(
         raw_conflicts = list(getattr(exc, "conflicts", []))
         feature_name_obj = FeatureName(feature_name)
         matching_conflicts = [
-            fg for fg in raw_conflicts if fg.match_feature_group_criteria(feature_name_obj, resolved_options, None)
+            fg
+            for fg in raw_conflicts
+            if _match_recording_validation_errors(fg, feature_name_obj, resolved_options, validation_errors)
         ]
         return ResolvedFeature(
             feature_name=feature_name,
@@ -309,15 +338,18 @@ def resolve_feature(
     feature_name_obj = FeatureName(feature_name)
 
     for fg in all_fgs:
-        if fg.match_feature_group_criteria(feature_name_obj, resolved_options, None):
+        if _match_recording_validation_errors(fg, feature_name_obj, resolved_options, validation_errors):
             candidates.append(fg)
 
     if not candidates:
+        error = f"No FeatureGroup found for feature name: {feature_name}"
+        if validation_errors:
+            error = f"{error} Rejected during matching: {' | '.join(validation_errors)}"
         return ResolvedFeature(
             feature_name=feature_name,
             feature_group=None,
             candidates=[],
-            error=f"No FeatureGroup found for feature name: {feature_name}",
+            error=error,
         )
 
     supported, rejected = split_frameworks_by_capability(candidates, feature_name_obj, resolved_options)

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -264,7 +264,11 @@ def get_extender_docs(
     return sorted(results, key=lambda x: x.name)
 
 
-def resolve_feature(feature_name: str, plugin_collector: Optional[PluginCollector] = None) -> ResolvedFeature:
+def resolve_feature(
+    feature_name: str,
+    options: Optional[Options] = None,
+    plugin_collector: Optional[PluginCollector] = None,
+) -> ResolvedFeature:
     """
     Resolve a feature name to its matching FeatureGroup class.
 
@@ -274,14 +278,15 @@ def resolve_feature(feature_name: str, plugin_collector: Optional[PluginCollecto
 
     Args:
         feature_name: The name of the feature to resolve.
-        plugin_collector: Optional PluginCollector. When provided, its
-            ``allow_redefinition`` flag is threaded into deduplication so that
-            redefined FeatureGroup classes (e.g. via reload) do not raise.
+        options: Options used for matching and capability checks. Defaults to empty Options.
+        plugin_collector: Optional PluginCollector; its ``allow_redefinition`` flag is threaded into deduplication.
 
     Returns:
         ResolvedFeature containing the resolved FeatureGroup (if found),
         all matching candidates, and any error message.
     """
+    resolved_options = options if options is not None else Options()
+    options_caveat = "default options" if options is None else "the provided options"
     allow_redefinition = plugin_collector.allow_redefinition if plugin_collector is not None else False
     fg_classes: set[type[FeatureGroup]] = get_all_subclasses(FeatureGroup)
     if plugin_collector is not None:
@@ -292,7 +297,7 @@ def resolve_feature(feature_name: str, plugin_collector: Optional[PluginCollecto
         raw_conflicts = list(getattr(exc, "conflicts", []))
         feature_name_obj = FeatureName(feature_name)
         matching_conflicts = [
-            fg for fg in raw_conflicts if fg.match_feature_group_criteria(feature_name_obj, Options(), None)
+            fg for fg in raw_conflicts if fg.match_feature_group_criteria(feature_name_obj, resolved_options, None)
         ]
         return ResolvedFeature(
             feature_name=feature_name,
@@ -304,7 +309,7 @@ def resolve_feature(feature_name: str, plugin_collector: Optional[PluginCollecto
     feature_name_obj = FeatureName(feature_name)
 
     for fg in all_fgs:
-        if fg.match_feature_group_criteria(feature_name_obj, Options(), None):
+        if fg.match_feature_group_criteria(feature_name_obj, resolved_options, None):
             candidates.append(fg)
 
     if not candidates:
@@ -315,7 +320,7 @@ def resolve_feature(feature_name: str, plugin_collector: Optional[PluginCollecto
             error=f"No FeatureGroup found for feature name: {feature_name}",
         )
 
-    supported, rejected = split_frameworks_by_capability(candidates, feature_name_obj, Options())
+    supported, rejected = split_frameworks_by_capability(candidates, feature_name_obj, resolved_options)
     supported_names = sorted(c.get_class_name() for c in supported)
     rejected_names = sorted(c.get_class_name() for c in rejected)
 
@@ -327,7 +332,7 @@ def resolve_feature(feature_name: str, plugin_collector: Optional[PluginCollecto
             error=(
                 f"Feature '{feature_name}' matches {[c.get_class_name() for c in candidates]} "
                 f"but is unsupported on all installed compute frameworks "
-                f"(evaluated under default options): {rejected_names}."
+                f"(evaluated under {options_caveat}): {rejected_names}."
             ),
             supported_compute_frameworks=[],
             unsupported_compute_frameworks=rejected_names,

--- a/mloda/core/api/plugin_info.py
+++ b/mloda/core/api/plugin_info.py
@@ -41,7 +41,7 @@ class ResolvedFeature:
     feature_group: Optional[type["FeatureGroup"]]
     candidates: list[type["FeatureGroup"]]
     error: Optional[str]
-    # Frameworks supporting the feature, evaluated under default options.
+    # Frameworks supporting the feature, evaluated under the options passed to resolve_feature (empty by default).
     supported_compute_frameworks: list[str] = field(default_factory=list)
-    # Frameworks rejecting the feature, evaluated under default options.
+    # Frameworks rejecting the feature, evaluated under the options passed to resolve_feature (empty by default).
     unsupported_compute_frameworks: list[str] = field(default_factory=list)

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -352,7 +352,7 @@ class IdentifyFeatureGroupClass:
             msg += f"\nDid you mean one of: {similar}?"
 
         msg += (
-            "\nUse resolve_feature(name) to debug feature resolution."
+            "\nUse resolve_feature(name, options=...) to debug feature resolution."
             "\nFor troubleshooting guide, see: "
             "https://mloda-ai.github.io/mloda/in_depth/troubleshooting/feature-group-resolution-errors/"
         )

--- a/tests/test_core/test_api/test_resolve_feature.py
+++ b/tests/test_core/test_api/test_resolve_feature.py
@@ -15,6 +15,7 @@ from mloda.core.abstract_plugins.components.data_access_collection import DataAc
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
 from mloda.core.api.plugin_info import ResolvedFeature
 from mloda.core.api.plugin_docs import resolve_feature
 from mloda.user import PluginLoader
@@ -26,6 +27,10 @@ from mloda_plugins.compute_framework.base_implementations.python_dict.python_dic
 
 SPLIT_CAP_FEATURE = "SplitCapResolveFeature"
 ALL_REJECTED_CAP_FEATURE = "AllRejectedCapResolveFeature"
+OPTION_GATED_FEATURE = "OptionGatedResolveFeature"
+OPTION_CAP_FEATURE = "OptionCapResolveFeature"
+PARTITION_BY_KEY = "partition_by"
+ALLOW_PYTHON_DICT_KEY = "allow_python_dict"
 
 
 class SplitCapResolveFeatureGroup(FeatureGroup):
@@ -89,6 +94,63 @@ class AllRejectedCapResolveFeatureGroup(FeatureGroup):
         compute_framework: type[ComputeFramework],
     ) -> bool:
         return False
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class OptionGatedResolveFeatureGroup(FeatureGroup):
+    """Matches its feature name only when the caller supplies a truthy 'partition_by' option."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame, PythonDictFramework}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        if isinstance(feature_name, FeatureName):
+            feature_name = str(feature_name)
+        if feature_name != OPTION_GATED_FEATURE:
+            return False
+        return bool(options.get(PARTITION_BY_KEY))
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class OptionCapResolveFeatureGroup(FeatureGroup):
+    """Matches its feature name always, but only supports PythonDictFramework when an option opts in."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame, PythonDictFramework}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        if isinstance(feature_name, FeatureName):
+            feature_name = str(feature_name)
+        return feature_name == OPTION_CAP_FEATURE
+
+    @classmethod
+    def supports_compute_framework(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        compute_framework: type[ComputeFramework],
+    ) -> bool:
+        if compute_framework is PythonDictFramework:
+            return bool(options.get(ALLOW_PYTHON_DICT_KEY))
+        return True
 
     def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
         return None
@@ -397,3 +459,94 @@ class TestResolveFeatureCapabilityAware:
         assert "PandasDataFrame" in result.unsupported_compute_frameworks
         assert "PandasDataFrame" not in result.supported_compute_frameworks
         assert "PythonDictFramework" not in result.supported_compute_frameworks
+
+
+class TestResolveFeatureWithOptions:
+    """resolve_feature accepts caller-supplied Options and threads them through matching (issue #640)."""
+
+    def test_option_gated_feature_does_not_resolve_without_options(self) -> None:
+        """Without options, an option-gated FeatureGroup never matches, so resolution fails."""
+        result = resolve_feature(OPTION_GATED_FEATURE)
+
+        assert result.feature_group is None
+        assert result.candidates == []
+        assert result.error is not None
+
+    def test_option_gated_feature_resolves_with_options(self) -> None:
+        """With the gating option supplied, the option-gated FeatureGroup resolves."""
+        result = resolve_feature(OPTION_GATED_FEATURE, options=Options(group={PARTITION_BY_KEY: ["id"]}))
+
+        assert result.feature_group is OptionGatedResolveFeatureGroup
+        assert result.error is None
+        assert OptionGatedResolveFeatureGroup in result.candidates
+        assert result.supported_compute_frameworks
+        assert "PandasDataFrame" in result.supported_compute_frameworks
+
+    def test_options_default_is_equivalent_to_explicit_empty_options(self) -> None:
+        """options=None must behave exactly like a fresh, empty Options."""
+        implicit = resolve_feature(OPTION_GATED_FEATURE)
+        explicit = resolve_feature(OPTION_GATED_FEATURE, options=Options())
+
+        assert explicit.feature_group is implicit.feature_group
+        assert explicit.candidates == implicit.candidates
+        assert explicit.error == implicit.error
+
+    def test_supports_compute_framework_sees_default_options(self) -> None:
+        """Without options, the capability hook rejects PythonDictFramework."""
+        result = resolve_feature(OPTION_CAP_FEATURE)
+
+        assert result.feature_group is OptionCapResolveFeatureGroup
+        assert "PandasDataFrame" in result.supported_compute_frameworks
+        assert "PythonDictFramework" in result.unsupported_compute_frameworks
+
+    def test_supports_compute_framework_sees_caller_options(self) -> None:
+        """With the opt-in option, the capability hook accepts PythonDictFramework too."""
+        result = resolve_feature(OPTION_CAP_FEATURE, options=Options(group={ALLOW_PYTHON_DICT_KEY: True}))
+
+        assert result.feature_group is OptionCapResolveFeatureGroup
+        assert "PandasDataFrame" in result.supported_compute_frameworks
+        assert "PythonDictFramework" in result.supported_compute_frameworks
+        assert "PythonDictFramework" not in result.unsupported_compute_frameworks
+
+    def test_plugin_collector_keyword_still_works_without_options(self) -> None:
+        """plugin_collector remains usable as a keyword argument on its own."""
+        collector = PluginCollector.enabled_feature_groups({OptionCapResolveFeatureGroup})
+
+        result = resolve_feature(OPTION_CAP_FEATURE, plugin_collector=collector)
+
+        assert result.feature_group is OptionCapResolveFeatureGroup
+        assert result.error is None
+
+    def test_plugin_collector_keyword_works_alongside_options(self) -> None:
+        """plugin_collector and options can be combined as keyword arguments."""
+        collector = PluginCollector.enabled_feature_groups({OptionGatedResolveFeatureGroup})
+
+        result = resolve_feature(
+            OPTION_GATED_FEATURE,
+            options=Options(group={PARTITION_BY_KEY: ["id"]}),
+            plugin_collector=collector,
+        )
+
+        assert result.feature_group is OptionGatedResolveFeatureGroup
+        assert result.candidates == [OptionGatedResolveFeatureGroup]
+        assert result.error is None
+
+    def test_all_rejected_error_keeps_default_options_caveat_without_options(self) -> None:
+        """Without caller options, the all-rejected error still names the default-options caveat."""
+        result = resolve_feature(ALL_REJECTED_CAP_FEATURE)
+
+        assert result.feature_group is None
+        assert result.error is not None
+        assert "default options" in result.error
+
+    def test_all_rejected_error_drops_default_options_caveat_with_options(self) -> None:
+        """With caller options, the all-rejected error must not claim it evaluated default options."""
+        result = resolve_feature(ALL_REJECTED_CAP_FEATURE, options=Options(group={PARTITION_BY_KEY: ["id"]}))
+
+        assert result.feature_group is None
+        assert result.error is not None
+        assert "default options" not in result.error, (
+            f"Error must not claim default options when the caller supplied options, got: {result.error}"
+        )
+        assert "PandasDataFrame" in result.error
+        assert "PythonDictFramework" in result.error

--- a/tests/test_core/test_api/test_resolve_feature.py
+++ b/tests/test_core/test_api/test_resolve_feature.py
@@ -7,11 +7,13 @@ and candidate tracking.
 """
 
 import pytest
-from typing import Optional
+from typing import Any, Optional
 
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
@@ -31,6 +33,9 @@ OPTION_GATED_FEATURE = "OptionGatedResolveFeature"
 OPTION_CAP_FEATURE = "OptionCapResolveFeature"
 PARTITION_BY_KEY = "partition_by"
 ALLOW_PYTHON_DICT_KEY = "allow_python_dict"
+
+PROBE_TYPE_KEY = "resolve_probe_type"
+PROBE_FEATURE = "value__median_resolveprobe"
 
 
 class SplitCapResolveFeatureGroup(FeatureGroup):
@@ -156,10 +161,36 @@ class OptionCapResolveFeatureGroup(FeatureGroup):
         return None
 
 
+class ForwardMismatchResolveFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+    """Chain-parsed group whose match raises ValueError on a forwarded/name option mismatch."""
+
+    PREFIX_PATTERN = r".*__([\w]+)_resolveprobe$"
+
+    PROPERTY_MAPPING = {
+        PROBE_TYPE_KEY: {
+            "median": "Median value",
+            "sum": "Sum of values",
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: True,
+        },
+    }
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame, PythonDictFramework}
+
+
 @pytest.fixture(scope="module", autouse=True)
 def load_plugins() -> None:
     """Load all plugins before running tests in this module."""
     PluginLoader.all()
+
+
+def _forwarded_mismatch_options() -> Options:
+    """Options whose forwarded probe type ('sum') contradicts the name-parsed one ('median')."""
+    options = Options(group={PROBE_TYPE_KEY: "sum"})
+    options.inherited_group_keys = frozenset({PROBE_TYPE_KEY})
+    return options
 
 
 class TestResolvedFeatureDataclass:
@@ -483,13 +514,20 @@ class TestResolveFeatureWithOptions:
         assert "PandasDataFrame" in result.supported_compute_frameworks
 
     def test_options_default_is_equivalent_to_explicit_empty_options(self) -> None:
-        """options=None must behave exactly like a fresh, empty Options."""
-        implicit = resolve_feature(OPTION_GATED_FEATURE)
-        explicit = resolve_feature(OPTION_GATED_FEATURE, options=Options())
+        """options=None must behave exactly like a fresh, empty Options, on every resolution outcome."""
+        for feature_name in (OPTION_GATED_FEATURE, OPTION_CAP_FEATURE, ALL_REJECTED_CAP_FEATURE, SPLIT_CAP_FEATURE):
+            implicit = resolve_feature(feature_name)
+            explicit = resolve_feature(feature_name, options=Options())
 
-        assert explicit.feature_group is implicit.feature_group
-        assert explicit.candidates == implicit.candidates
-        assert explicit.error == implicit.error
+            assert explicit.feature_group is implicit.feature_group, feature_name
+            assert explicit.candidates == implicit.candidates, feature_name
+            assert explicit.error == implicit.error, feature_name
+            assert explicit.supported_compute_frameworks == implicit.supported_compute_frameworks, feature_name
+            assert explicit.unsupported_compute_frameworks == implicit.unsupported_compute_frameworks, feature_name
+
+        # Guard against a trivially-passing comparison: options must actually be threaded through.
+        gated = resolve_feature(OPTION_GATED_FEATURE, options=Options(group={PARTITION_BY_KEY: ["id"]}))
+        assert gated.feature_group is OptionGatedResolveFeatureGroup
 
     def test_supports_compute_framework_sees_default_options(self) -> None:
         """Without options, the capability hook rejects PythonDictFramework."""
@@ -550,3 +588,118 @@ class TestResolveFeatureWithOptions:
         )
         assert "PandasDataFrame" in result.error
         assert "PythonDictFramework" in result.error
+
+
+class TestResolveFeatureIsNonThrowing:
+    """resolve_feature is a debug API: matching errors surface as ResolvedFeature.error, never as exceptions."""
+
+    def test_forwarded_name_mismatch_does_not_propagate_value_error(self) -> None:
+        """A ValueError raised by match_feature_group_criteria must not escape resolve_feature."""
+        result = resolve_feature(PROBE_FEATURE, options=_forwarded_mismatch_options())
+
+        assert isinstance(result, ResolvedFeature)
+        assert result.feature_name == PROBE_FEATURE
+
+    def test_forwarded_name_mismatch_reports_no_feature_group(self) -> None:
+        """A candidate that raises during matching must not be resolved as the winner."""
+        result = resolve_feature(PROBE_FEATURE, options=_forwarded_mismatch_options())
+
+        assert result.feature_group is None
+
+    def test_forwarded_name_mismatch_surfaces_validation_reason_in_error(self) -> None:
+        """The error must carry the underlying validation reason so the user sees why nothing matched."""
+        result = resolve_feature(PROBE_FEATURE, options=_forwarded_mismatch_options())
+
+        assert result.error is not None
+        assert PROBE_TYPE_KEY in result.error, f"Error must name the rejected option key, got: {result.error}"
+        assert "forwarded" in result.error.lower(), (
+            f"Error must surface the forwarded-name-mismatch reason, got: {result.error}"
+        )
+
+    def test_probe_group_resolves_normally_without_conflicting_forwarded_options(self) -> None:
+        """The probe group is a normal, resolvable group: only the mismatch case is an error."""
+        result = resolve_feature(PROBE_FEATURE)
+
+        assert result.feature_group is ForwardMismatchResolveFeatureGroup
+        assert result.error is None
+
+
+class TestResolveFeatureOptionsNoneEqualsEmpty:
+    """options=None and options=Options() are indistinguishable, including in error wording."""
+
+    def test_all_rejected_error_identical_for_none_and_explicit_empty_options(self) -> None:
+        """The all-rejected error string must not depend on how the empty options were supplied."""
+        implicit = resolve_feature(ALL_REJECTED_CAP_FEATURE)
+        explicit = resolve_feature(ALL_REJECTED_CAP_FEATURE, options=Options())
+
+        assert implicit.error is not None
+        assert explicit.error == implicit.error, (
+            f"options=Options() must produce the same error as options=None, got: {explicit.error!r} "
+            f"vs {implicit.error!r}"
+        )
+
+    def test_explicit_empty_options_keeps_default_options_caveat(self) -> None:
+        """An explicitly-passed empty Options is the documented default, so it keeps the default-options caveat."""
+        result = resolve_feature(ALL_REJECTED_CAP_FEATURE, options=Options())
+
+        assert result.error is not None
+        assert "default options" in result.error, (
+            f"An empty Options is the default, so the caveat must stay, got: {result.error}"
+        )
+
+    def test_non_empty_options_still_drops_default_options_caveat(self) -> None:
+        """Only a non-empty Options drops the default-options wording."""
+        result = resolve_feature(ALL_REJECTED_CAP_FEATURE, options=Options(group={PARTITION_BY_KEY: ["id"]}))
+
+        assert result.error is not None
+        assert "default options" not in result.error, (
+            f"Non-empty caller options must drop the default-options caveat, got: {result.error}"
+        )
+
+
+class TestResolveFeatureKeywordOnlyArguments:
+    """options and plugin_collector are keyword-only, so legacy positional calls fail loudly."""
+
+    def test_positional_options_raises_type_error(self) -> None:
+        """resolve_feature(name, Options()) must raise TypeError instead of silently binding."""
+        resolve_feature_untyped: Any = resolve_feature
+
+        with pytest.raises(TypeError):
+            resolve_feature_untyped(OPTION_CAP_FEATURE, Options())
+
+    def test_positional_plugin_collector_raises_type_error(self) -> None:
+        """A legacy resolve_feature(name, collector) call must raise TypeError, not bind a collector into options."""
+        resolve_feature_untyped: Any = resolve_feature
+        collector = PluginCollector.enabled_feature_groups({OptionCapResolveFeatureGroup})
+
+        with pytest.raises(TypeError):
+            resolve_feature_untyped(OPTION_CAP_FEATURE, collector)
+
+    def test_options_keyword_still_works(self) -> None:
+        """The options keyword form remains supported."""
+        result = resolve_feature(OPTION_GATED_FEATURE, options=Options(group={PARTITION_BY_KEY: ["id"]}))
+
+        assert result.feature_group is OptionGatedResolveFeatureGroup
+        assert result.error is None
+
+    def test_plugin_collector_keyword_still_works(self) -> None:
+        """The plugin_collector keyword form remains supported."""
+        collector = PluginCollector.enabled_feature_groups({OptionCapResolveFeatureGroup})
+
+        result = resolve_feature(OPTION_CAP_FEATURE, plugin_collector=collector)
+
+        assert result.feature_group is OptionCapResolveFeatureGroup
+        assert result.error is None
+
+    def test_both_keywords_together_still_work(self) -> None:
+        """Both keyword arguments can be combined."""
+        collector = PluginCollector.enabled_feature_groups({OptionGatedResolveFeatureGroup})
+
+        result = resolve_feature(
+            OPTION_GATED_FEATURE,
+            options=Options(group={PARTITION_BY_KEY: ["id"]}),
+            plugin_collector=collector,
+        )
+
+        assert result.feature_group is OptionGatedResolveFeatureGroup
+        assert result.error is None


### PR DESCRIPTION
Closes #640.

## Problem

`resolve_feature` evaluated matching and the compute framework capability split under a fresh default `Options()`. FeatureGroups that gate `match_feature_group_criteria` on an option (the group-by `AggregationFeatureGroup` in mloda-registry needs `partition_by`) therefore returned zero candidates and could not be resolved at all, so callers could not ask "which frameworks support this feature?" for those families.

## Change

`resolve_feature(feature_name, *, options=None, plugin_collector=None)`. The options are threaded to the dedup-conflict filter, the candidate match loop, and `split_frameworks_by_capability`. The default stays empty `Options()`, so existing behavior is unchanged.

Three follow-ups from review, all in the second commit:

- **Keyword-only.** `options` sits ahead of `plugin_collector`, so a positional `resolve_feature(name, collector)` would have silently bound a `PluginCollector` into `options` and misresolved. Both optional arguments are keyword-only, so such a call now raises `TypeError`. Every call site in the repo already used keywords.
- **Still non-throwing.** Once caller options reach the feature chain parser, `_validate_forwarded_name_mismatch` can raise `ValueError` (a forwarded option contradicting the feature name). `resolve_feature` is a documented non-throwing debug API, so matching degrades that into "not a match" and surfaces the reason in `ResolvedFeature.error`.
- **`options=None` == `Options()`.** The "evaluated under default options" caveat is now derived from the options being empty, not from `options is None`, so both forms report identically.

Docs: the new argument is documented, the claim that the inspector cannot know the caller's `Options` is gone, and the resolution error hint now points at `resolve_feature(name, options=...)`.

## Tests

New coverage in `tests/test_core/test_api/test_resolve_feature.py`: an option-gated FeatureGroup resolves only with options and then reports a non-empty `supported_compute_frameworks`; options reach `supports_compute_framework` and change the supported/unsupported split; the forwarded-mismatch case returns an error instead of raising; positional arguments raise `TypeError`; and `options=None` matches an explicit empty `Options()` everywhere.

`tox` green: 4689 passed, 171 skipped, ruff/mypy --strict/bandit clean. Doc tests pass in the docs env.