### PR TITLE
fix: guard remaining get_feature_group_docs reads with safe_field (#609)

### DIFF
--- a/docs/docs/in_depth/discover-plugins.md
+++ b/docs/docs/in_depth/discover-plugins.md
@@ -84,8 +84,7 @@ The discovery functions above walk every live plugin subclass and introspect it.
 Plugins can be broken, exotic, or built at runtime (via `type()`, notebook
 re-execution, or `importlib.reload`), so introspecting one class can fail. The
 guarded catalog reads follow one shared contract so that a broken plugin
-degrades a field instead of sinking the catalog call; not every read is guarded
-yet (see below).
+degrades a field instead of sinking the catalog call.
 
 Every failure a plugin can cause falls into one of three tiers:
 
@@ -125,15 +124,18 @@ and resolution paths intentionally differ:
 ### Shared helper
 
 The annotate tier is a single shared helper,
-`safe_field(read, fallback, catching=(Exception,))` in
+`safe_field(read, fallback, catching=(Exception,), field="")` in
 `mloda.core.abstract_plugins.components.utils`: it calls the `read` thunk and
-returns `fallback` if the read raises one of `catching`. The guarded annotate
-sites route through it (the feature-group version, the four compute-framework
-fields, and extender wraps), so the next catalog function or info field reaches
-for one helper instead of re-deriving a `try/except`. The remaining overridable
-reads in `get_feature_group_docs` (class name, description, compute framework
-definition, supported feature names, prefix) are not yet guarded, so a plugin
-raising there still propagates (a known follow-up gap).
+returns `fallback` if the read raises one of `catching`. Every overridable read
+in a catalog walk is annotate tier and routes through it, so the next catalog
+function or info field reaches for one helper instead of re-deriving a
+`try/except`. Identity fields fall back to the base-class implementation rather
+than a sentinel: a feature group whose `get_class_name()` raises is listed under
+its `__name__`, and one whose `prefix()` raises gets `"<__name__>_"`. A swallowed
+read is always logged as a WARNING naming the `field` label and the exception, so
+degrading is never silent. A feature group whose `compute_framework_definition()`
+degrades to `[]` is excluded by a `compute_framework=` filter, mirroring how a
+framework degraded to `is_available=False` is excluded by `available_only=True`.
 `get_compute_framework_docs` uses the default broad `catching` (any failure
 degrades the field), while the narrower named guards `_safe_version` (in
 `plugin_docs.py`) and `_safe_class_source_hash` (one layer down in

--- a/docs/docs/in_depth/discover-plugins.md
+++ b/docs/docs/in_depth/discover-plugins.md
@@ -129,24 +129,18 @@ The annotate tier is a single shared helper,
 returns `fallback` if the read raises one of `catching`, so a catalog function or
 info field reaches for one helper instead of re-deriving a `try/except`.
 
-Logging is opt-in via the `field` label. The five labelled reads in
-`get_feature_group_docs` warn on swallow, naming the class, the field and the
-exception, because a raise there means a broken plugin. The unlabelled guards
-degrade silently, because degrading there is expected by design: source
-introspection fails for `type()`-built classes, a framework availability probe
-raises when an optional backend is not installed, and Iceberg's `merge_engine()`
-deliberately raises `NotImplementedError`. Warning on those would be log spam.
+Fallbacks are base-class-derived rather than sentinels, so a degraded entry stays
+usable: a broken `description()` falls back to the class docstring (or `__name__`),
+which keeps it findable via `search=`, and a broken `prefix()` to `"<__name__>_"`.
+The reads that feed a filter (`get_class_name()`, `description()`, `version()`)
+also reject a non-str return, so a wrong type degrades too instead of sinking the
+call at the filter.
 
-The guarded reads that feed a filter (`get_class_name()` for `name=` and the
-final sort, `description()` for `search=`, `version()` for `version_contains=`)
-also validate that the plugin returned a `str`, so a plugin that returns the
-wrong type degrades through the same path instead of sinking the whole call.
-Fallbacks are base-class-derived rather than sentinels: a feature group whose
-`description()` degrades is documented with its docstring (or, lacking one, its
-`__name__`), which keeps it findable via `search=`; one whose `prefix()` raises
-gets `"<__name__>_"`. A feature group whose `compute_framework_definition()`
-degrades to `[]` is excluded by a `compute_framework=` filter, mirroring how a
-framework degraded to `is_available=False` is excluded by `available_only=True`.
+Logging is opt-in via `field`: the labelled `get_feature_group_docs` reads warn on
+swallow, where a raise does mean a broken plugin. The unlabelled guards stay silent
+because degrading there is by design (source introspection of `type()`-built
+classes, an availability probe without its optional backend, Iceberg's deliberate
+`NotImplementedError` from `merge_engine()`).
 
 `get_compute_framework_docs` uses the default broad `catching` (any failure
 degrades the field), while the narrower named guards `_safe_version` (in

--- a/docs/docs/in_depth/discover-plugins.md
+++ b/docs/docs/in_depth/discover-plugins.md
@@ -126,16 +126,28 @@ and resolution paths intentionally differ:
 The annotate tier is a single shared helper,
 `safe_field(read, fallback, catching=(Exception,), field="")` in
 `mloda.core.abstract_plugins.components.utils`: it calls the `read` thunk and
-returns `fallback` if the read raises one of `catching`. Every overridable read
-in a catalog walk is annotate tier and routes through it, so the next catalog
-function or info field reaches for one helper instead of re-deriving a
-`try/except`. Identity fields fall back to the base-class implementation rather
-than a sentinel: a feature group whose `get_class_name()` raises is listed under
-its `__name__`, and one whose `prefix()` raises gets `"<__name__>_"`. A swallowed
-read is always logged as a WARNING naming the `field` label and the exception, so
-degrading is never silent. A feature group whose `compute_framework_definition()`
+returns `fallback` if the read raises one of `catching`, so a catalog function or
+info field reaches for one helper instead of re-deriving a `try/except`.
+
+Logging is opt-in via the `field` label. The five labelled reads in
+`get_feature_group_docs` warn on swallow, naming the class, the field and the
+exception, because a raise there means a broken plugin. The unlabelled guards
+degrade silently, because degrading there is expected by design: source
+introspection fails for `type()`-built classes, a framework availability probe
+raises when an optional backend is not installed, and Iceberg's `merge_engine()`
+deliberately raises `NotImplementedError`. Warning on those would be log spam.
+
+The guarded reads that feed a filter (`get_class_name()` for `name=` and the
+final sort, `description()` for `search=`, `version()` for `version_contains=`)
+also validate that the plugin returned a `str`, so a plugin that returns the
+wrong type degrades through the same path instead of sinking the whole call.
+Fallbacks are base-class-derived rather than sentinels: a feature group whose
+`description()` degrades is documented with its docstring (or, lacking one, its
+`__name__`), which keeps it findable via `search=`; one whose `prefix()` raises
+gets `"<__name__>_"`. A feature group whose `compute_framework_definition()`
 degrades to `[]` is excluded by a `compute_framework=` filter, mirroring how a
 framework degraded to `is_available=False` is excluded by `available_only=True`.
+
 `get_compute_framework_docs` uses the default broad `catching` (any failure
 degrades the field), while the narrower named guards `_safe_version` (in
 `plugin_docs.py`) and `_safe_class_source_hash` (one layer down in

--- a/mloda/core/abstract_plugins/components/utils.py
+++ b/mloda/core/abstract_plugins/components/utils.py
@@ -9,11 +9,20 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 
 
-def safe_field(read: Callable[[], T], fallback: T, catching: tuple[type[Exception], ...] = (Exception,)) -> T:
-    """Annotate tier: degrade a single unreadable field to a fallback instead of failing the whole discovery call."""
+def safe_field(
+    read: Callable[[], T],
+    fallback: T,
+    catching: tuple[type[Exception], ...] = (Exception,),
+    field: str = "",
+) -> T:
+    """Annotate tier: degrade a single unreadable field to a fallback instead of failing the whole discovery call.
+
+    A swallowed read is logged as a WARNING naming `field` and the exception, so the broken plugin stays diagnosable.
+    """
     try:
         return read()
-    except catching:
+    except catching as exc:
+        logger.warning("Degraded field '%s': %s: %s", field, type(exc).__name__, exc)
         return fallback
 
 

--- a/mloda/core/abstract_plugins/components/utils.py
+++ b/mloda/core/abstract_plugins/components/utils.py
@@ -17,12 +17,15 @@ def safe_field(
 ) -> T:
     """Annotate tier: degrade a single unreadable field to a fallback instead of failing the whole discovery call.
 
-    A swallowed read is logged as a WARNING naming `field` and the exception, so the broken plugin stays diagnosable.
+    A labelled read (non-empty `field`) warns on swallow; an unlabelled read degrades silently, because degrading
+    there is expected.
     """
     try:
         return read()
     except catching as exc:
-        logger.warning("Degraded field '%s': %s: %s", field, type(exc).__name__, exc)
+        if field:
+            # str(exc), not exc: a retained log record must not pin the traceback, its frames and the plugin class.
+            logger.warning("Degraded field '%s': %s: %s", field, type(exc).__name__, str(exc))
         return fallback
 
 

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -77,14 +77,11 @@ def get_feature_group_docs(
     before calling this function (e.g., via PluginLoader.all()).
 
     Returns gracefully on redefinition conflicts: instead of raising, each
-    conflicting class is documented as its most recently defined (live)
-    version. Reports "unavailable" as version for classes whose source
-    cannot be introspected.
+    conflicting class is documented as its most recently defined (live) version.
 
-    Degrades per field rather than failing the call: a name, description,
-    compute framework list, supported feature name set or prefix that raises
-    (or, where it feeds a filter, returns a non-str) falls back to a
-    base-class-derived value and logs a WARNING naming the class and field.
+    Degrades per field instead of failing the call: a read that raises, or that
+    returns a non-str where the field feeds a filter, falls back to a
+    base-class-derived value ("unavailable" for version).
 
     Args:
         name: Filter by feature group name (case-insensitive partial match).

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -99,13 +99,20 @@ def get_feature_group_docs(
         if fg_class.__module__ == "__main__":
             continue
 
-        fg_name = fg_class.get_class_name()
-        description = fg_class.description()
+        cls_name = fg_class.__name__
+        fg_name = safe_field(lambda: fg_class.get_class_name(), cls_name, field=f"{cls_name}.get_class_name")
+        description = safe_field(lambda: fg_class.description(), "", field=f"{cls_name}.description")
         version = _safe_version(fg_class)
         module = fg_class.__module__
-        compute_frameworks = [cfw.__name__ for cfw in fg_class.compute_framework_definition()]
-        supported_feature_names = fg_class.feature_names_supported()
-        prefix = fg_class.prefix()
+        compute_frameworks: list[str] = safe_field(
+            lambda: [cfw.__name__ for cfw in fg_class.compute_framework_definition()],
+            [],
+            field=f"{cls_name}.compute_framework_definition",
+        )
+        supported_feature_names: set[str] = safe_field(
+            lambda: fg_class.feature_names_supported(), set(), field=f"{cls_name}.feature_names_supported"
+        )
+        prefix = safe_field(lambda: fg_class.prefix(), f"{cls_name}_", field=f"{cls_name}.prefix")
 
         if name is not None and name.lower() not in fg_name.lower():
             continue

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -40,9 +40,16 @@ def list_registered(plugin_type: type[Any]) -> list[type[Any]]:
     return PluginRegistry.default().list_registered(plugin_type)
 
 
+def _as_str(value: Any) -> str:
+    """Return `value` unchanged, raising TypeError if a plugin returned a non-str, so the guarded read degrades."""
+    if not isinstance(value, str):
+        raise TypeError(f"expected str, got {type(value).__name__}")
+    return value
+
+
 def _safe_version(fg_class: type[FeatureGroup]) -> str:
-    """Return the feature group version or "unavailable" if source introspection fails."""
-    return safe_field(lambda: fg_class.version(), "unavailable", catching=SOURCE_INTROSPECTION_ERRORS)
+    """Return the feature group version or "unavailable" if source introspection fails or version() is not a str."""
+    return safe_field(lambda: _as_str(fg_class.version()), "unavailable", catching=SOURCE_INTROSPECTION_ERRORS)
 
 
 def _dedup_degrading_on_conflict(
@@ -74,6 +81,11 @@ def get_feature_group_docs(
     version. Reports "unavailable" as version for classes whose source
     cannot be introspected.
 
+    Degrades per field rather than failing the call: a name, description,
+    compute framework list, supported feature name set or prefix that raises
+    (or, where it feeds a filter, returns a non-str) falls back to a
+    base-class-derived value and logs a WARNING naming the class and field.
+
     Args:
         name: Filter by feature group name (case-insensitive partial match).
         search: Search in feature group description (case-insensitive partial match).
@@ -100,8 +112,9 @@ def get_feature_group_docs(
             continue
 
         cls_name = fg_class.__name__
-        fg_name = safe_field(lambda: fg_class.get_class_name(), cls_name, field=f"{cls_name}.get_class_name")
-        description = safe_field(lambda: fg_class.description(), "", field=f"{cls_name}.description")
+        fg_name = safe_field(lambda: _as_str(fg_class.get_class_name()), cls_name, field=f"{cls_name}.get_class_name")
+        doc_fallback = (fg_class.__doc__ or "").strip() or cls_name
+        description = safe_field(lambda: _as_str(fg_class.description()), doc_fallback, field=f"{cls_name}.description")
         version = _safe_version(fg_class)
         module = fg_class.__module__
         compute_frameworks: list[str] = safe_field(

--- a/tests/test_core/test_abstract_plugins/test_components/test_safe_field.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_safe_field.py
@@ -4,10 +4,13 @@ safe_field is the "annotate" tier: it reads one introspected field and, if the
 read raises an exception in `catching`, returns a caller-supplied fallback
 instead of propagating. Exceptions outside `catching` still propagate.
 
-A swallowed read is not silent: safe_field logs a WARNING naming the field
-label (the optional `field` argument) and the exception it swallowed, so a
-broken plugin is diagnosable from the logs even though the catalog call
-degrades instead of failing.
+Logging is opt-in via the `field` label. A swallowed read with a non-empty
+`field` logs a WARNING naming the label and the exception, so a broken plugin
+stays diagnosable even though the catalog call degrades instead of failing.
+A swallowed read WITHOUT a `field` label is completely silent: those call sites
+are by-design degradations on healthy systems (source introspection of
+type()-built classes, a deliberately unimplemented merge engine, an uninstalled
+optional backend), where a WARNING would be pure log spam.
 """
 
 import logging
@@ -27,6 +30,11 @@ def _warning_messages(caplog: pytest.LogCaptureFixture) -> list[str]:
         for record in caplog.records
         if record.levelno == logging.WARNING and record.name == SAFE_FIELD_LOGGER
     ]
+
+
+def _module_messages(caplog: pytest.LogCaptureFixture) -> list[str]:
+    """Return messages emitted by the safe_field module logger at any level."""
+    return [record.getMessage() for record in caplog.records if record.name == SAFE_FIELD_LOGGER]
 
 
 class TestSafeFieldSuccessPath:
@@ -108,6 +116,48 @@ class TestSafeFieldWarnsOnSwallow:
         assert "missing_key" in messages[0]
 
 
+class TestSafeFieldUnlabelledSwallowIsSilent:
+    """A swallowed read without a field label logs nothing at all.
+
+    The unlabelled call sites degrade by design on a healthy system, so warning
+    on them is log spam. Only a labelled read opts into a WARNING.
+    """
+
+    def test_unlabelled_swallow_logs_nothing(self, caplog: pytest.LogCaptureFixture) -> None:
+        def raises() -> str:
+            raise RuntimeError("boom")
+
+        with caplog.at_level(logging.DEBUG, logger=SAFE_FIELD_LOGGER):
+            result = safe_field(raises, "unavailable")
+
+        assert result == "unavailable"
+        assert _module_messages(caplog) == [], "An unlabelled swallow must not log anything"
+
+    def test_empty_field_label_swallow_logs_nothing(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Passing field="" explicitly is the same as passing no label: silent."""
+
+        def raises() -> str:
+            raise RuntimeError("boom")
+
+        with caplog.at_level(logging.DEBUG, logger=SAFE_FIELD_LOGGER):
+            result = safe_field(raises, "unavailable", field="")
+
+        assert result == "unavailable"
+        assert _module_messages(caplog) == [], "An empty field label must not log anything"
+
+    def test_unlabelled_swallow_of_narrow_catching_logs_nothing(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Source-introspection style call sites (narrow catching, no label) stay silent."""
+
+        def raises() -> str:
+            raise OSError("source not found")
+
+        with caplog.at_level(logging.DEBUG, logger=SAFE_FIELD_LOGGER):
+            result = safe_field(raises, "unavailable", catching=(OSError, TypeError))
+
+        assert result == "unavailable"
+        assert _module_messages(caplog) == []
+
+
 class TestSafeFieldSuccessPathIsSilent:
     """The success path never logs: only a degraded read is worth a warning."""
 
@@ -116,14 +166,14 @@ class TestSafeFieldSuccessPathIsSilent:
             result = safe_field(lambda: 42, -1, field="version")
 
         assert result == 42
-        assert [record.getMessage() for record in caplog.records if record.name == SAFE_FIELD_LOGGER] == []
+        assert _module_messages(caplog) == []
 
     def test_success_path_logs_nothing_without_field_label(self, caplog: pytest.LogCaptureFixture) -> None:
         with caplog.at_level(logging.DEBUG, logger=SAFE_FIELD_LOGGER):
             result = safe_field(lambda: 42, -1)
 
         assert result == 42
-        assert [record.getMessage() for record in caplog.records if record.name == SAFE_FIELD_LOGGER] == []
+        assert _module_messages(caplog) == []
 
 
 class TestSafeFieldFieldLabelKeepsExistingBehavior:

--- a/tests/test_core/test_abstract_plugins/test_components/test_safe_field.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_safe_field.py
@@ -3,13 +3,30 @@
 safe_field is the "annotate" tier: it reads one introspected field and, if the
 read raises an exception in `catching`, returns a caller-supplied fallback
 instead of propagating. Exceptions outside `catching` still propagate.
+
+A swallowed read is not silent: safe_field logs a WARNING naming the field
+label (the optional `field` argument) and the exception it swallowed, so a
+broken plugin is diagnosable from the logs even though the catalog call
+degrades instead of failing.
 """
 
+import logging
 from typing import Any
 
 import pytest
 
 from mloda.core.abstract_plugins.components.utils import safe_field
+
+SAFE_FIELD_LOGGER = "mloda.core.abstract_plugins.components.utils"
+
+
+def _warning_messages(caplog: pytest.LogCaptureFixture) -> list[str]:
+    """Return WARNING messages emitted by the safe_field module logger."""
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno == logging.WARNING and record.name == SAFE_FIELD_LOGGER
+    ]
 
 
 class TestSafeFieldSuccessPath:
@@ -57,3 +74,83 @@ class TestSafeFieldFallbackIdentity:
         result = safe_field(raises, fallback)
 
         assert result is fallback
+
+
+class TestSafeFieldWarnsOnSwallow:
+    """A swallowed read logs a WARNING naming the field label and the exception."""
+
+    def test_swallowed_read_logs_warning_with_field_label_and_exception(self, caplog: pytest.LogCaptureFixture) -> None:
+        def raises() -> str:
+            raise RuntimeError("boom")
+
+        with caplog.at_level(logging.WARNING, logger=SAFE_FIELD_LOGGER):
+            result = safe_field(raises, "unavailable", field="description")
+
+        assert result == "unavailable"
+
+        messages = _warning_messages(caplog)
+        assert len(messages) == 1, f"Expected exactly one WARNING, got {messages}"
+        assert "description" in messages[0], "Warning must name the field that was being read"
+        assert "boom" in messages[0], "Warning must carry the swallowed exception message"
+
+    def test_swallowed_read_warning_names_the_exception_type(self, caplog: pytest.LogCaptureFixture) -> None:
+        def raises() -> str:
+            raise KeyError("missing_key")
+
+        with caplog.at_level(logging.WARNING, logger=SAFE_FIELD_LOGGER):
+            result = safe_field(raises, "unavailable", field="prefix")
+
+        assert result == "unavailable"
+
+        messages = _warning_messages(caplog)
+        assert len(messages) == 1, f"Expected exactly one WARNING, got {messages}"
+        assert "prefix" in messages[0]
+        assert "missing_key" in messages[0]
+
+
+class TestSafeFieldSuccessPathIsSilent:
+    """The success path never logs: only a degraded read is worth a warning."""
+
+    def test_success_path_logs_nothing_with_field_label(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.DEBUG, logger=SAFE_FIELD_LOGGER):
+            result = safe_field(lambda: 42, -1, field="version")
+
+        assert result == 42
+        assert [record.getMessage() for record in caplog.records if record.name == SAFE_FIELD_LOGGER] == []
+
+    def test_success_path_logs_nothing_without_field_label(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.DEBUG, logger=SAFE_FIELD_LOGGER):
+            result = safe_field(lambda: 42, -1)
+
+        assert result == 42
+        assert [record.getMessage() for record in caplog.records if record.name == SAFE_FIELD_LOGGER] == []
+
+
+class TestSafeFieldFieldLabelKeepsExistingBehavior:
+    """The field label is additive: fallback and narrow-catching semantics are unchanged."""
+
+    def test_field_label_is_optional(self) -> None:
+        """Existing call sites that pass no field label keep working."""
+
+        def raises() -> str:
+            raise RuntimeError("boom")
+
+        assert safe_field(raises, "unavailable") == "unavailable"
+
+    def test_fallback_still_returned_with_field_label(self) -> None:
+        def raises() -> str:
+            raise OSError("disk gone")
+
+        assert safe_field(raises, "fallback", catching=(OSError, TypeError), field="version") == "fallback"
+
+    def test_unlisted_exception_still_propagates_with_field_label(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A narrow catching tuple still propagates unlisted types, and nothing is logged."""
+
+        def raises() -> str:
+            raise ValueError("not caught")
+
+        with caplog.at_level(logging.DEBUG, logger=SAFE_FIELD_LOGGER):
+            with pytest.raises(ValueError):
+                safe_field(raises, "fallback", catching=(OSError, TypeError), field="version")
+
+        assert _warning_messages(caplog) == [], "A propagated exception is not a swallowed read, so it must not warn"

--- a/tests/test_core/test_api/test_plugin_docs.py
+++ b/tests/test_core/test_api/test_plugin_docs.py
@@ -1,5 +1,6 @@
 import gc
 import inspect
+import logging
 from typing import Any
 
 import pytest
@@ -17,6 +18,8 @@ from mloda.core.api.plugin_docs import (
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.user import PluginLoader
+
+SAFE_FIELD_LOGGER = "mloda.core.abstract_plugins.components.utils"
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -268,8 +271,13 @@ class TestGetFeatureGroupDocsDegradedFieldReads:
             del _DocsGetClassNameBoomFG
             gc.collect()
 
-    def test_description_raising_degrades_to_empty_string(self) -> None:
-        """A broken description() falls back to the empty string."""
+    def test_description_raising_degrades_to_class_docstring(self) -> None:
+        """A broken description() falls back to the class docstring, as compute frameworks already do.
+
+        The fallback is base-class-derived, not "": an empty description would hide the
+        broken plugin from every ``search=`` query, which is exactly the masking risk the
+        degradation is meant to avoid.
+        """
 
         class _DocsDescriptionBoomFG(FeatureGroup):
             """Test double whose description() raises."""
@@ -281,9 +289,25 @@ class TestGetFeatureGroupDocsDegradedFieldReads:
         try:
             by_name = {fg.name: fg for fg in get_feature_group_docs()}
             assert "_DocsDescriptionBoomFG" in by_name, "Degraded class must still be documented"
-            assert by_name["_DocsDescriptionBoomFG"].description == ""
+            assert by_name["_DocsDescriptionBoomFG"].description == "Test double whose description() raises."
         finally:
             del _DocsDescriptionBoomFG
+            gc.collect()
+
+    def test_description_raising_without_docstring_degrades_to_class_name(self) -> None:
+        """With no docstring to fall back on, a broken description() degrades to the class name."""
+
+        class _DocsDescriptionNoDocstringFG(FeatureGroup):
+            @classmethod
+            def description(cls) -> str:
+                raise RuntimeError("boom")
+
+        try:
+            by_name = {fg.name: fg for fg in get_feature_group_docs()}
+            assert "_DocsDescriptionNoDocstringFG" in by_name, "Degraded class must still be documented"
+            assert by_name["_DocsDescriptionNoDocstringFG"].description == "_DocsDescriptionNoDocstringFG"
+        finally:
+            del _DocsDescriptionNoDocstringFG
             gc.collect()
 
     def test_compute_framework_definition_raising_degrades_to_empty_list(self) -> None:
@@ -302,6 +326,57 @@ class TestGetFeatureGroupDocsDegradedFieldReads:
             assert by_name["_DocsFrameworkBoomFG"].compute_frameworks == []
         finally:
             del _DocsFrameworkBoomFG
+            gc.collect()
+
+    def test_compute_framework_rule_raising_degrades_to_empty_list(self) -> None:
+        """The realistic break: compute_framework_definition() is @final, but the rule hook it calls is not.
+
+        A plugin cannot override the final definition hook, so the way a real plugin breaks
+        framework discovery is by raising from the overridable compute_framework_rule().
+        That exception surfaces through the final method and must degrade the same way.
+        """
+
+        class _DocsFrameworkRuleBoomFG(FeatureGroup):
+            """Test double whose compute_framework_rule() raises."""
+
+            @classmethod
+            def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+                raise RuntimeError("boom")
+
+        try:
+            by_name = {fg.name: fg for fg in get_feature_group_docs()}
+            assert "_DocsFrameworkRuleBoomFG" in by_name, "Degraded class must still be documented"
+            assert by_name["_DocsFrameworkRuleBoomFG"].compute_frameworks == []
+        finally:
+            del _DocsFrameworkRuleBoomFG
+            gc.collect()
+
+    def test_degraded_compute_framework_rule_excluded_by_compute_framework_filter(self) -> None:
+        """A class whose compute_framework_rule() raises is excluded by a compute_framework= filter."""
+        baseline = get_feature_group_docs()
+        canonical_name: str | None = None
+        for fg in baseline:
+            if len(fg.compute_frameworks) > 0:
+                canonical_name = fg.compute_frameworks[0]
+                break
+        assert canonical_name is not None, "Need a feature group with at least one compute framework"
+
+        class _DocsFrameworkRuleFilterBoomFG(FeatureGroup):
+            """Test double whose compute_framework_rule() raises."""
+
+            @classmethod
+            def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+                raise RuntimeError("boom")
+
+        try:
+            unfiltered = {fg.name for fg in get_feature_group_docs()}
+            assert "_DocsFrameworkRuleFilterBoomFG" in unfiltered, "Degraded class must still be documented"
+
+            filtered = get_feature_group_docs(compute_framework=canonical_name)
+            assert len(filtered) > 0, "Healthy feature groups must still match the framework filter"
+            assert "_DocsFrameworkRuleFilterBoomFG" not in {fg.name for fg in filtered}
+        finally:
+            del _DocsFrameworkRuleFilterBoomFG
             gc.collect()
 
     def test_feature_names_supported_raising_degrades_to_empty_set(self) -> None:
@@ -377,25 +452,40 @@ class TestGetFeatureGroupDocsDegradedFieldReads:
             del _DocsNameFilterBoomFG
             gc.collect()
 
-    def test_degraded_description_excluded_by_search_filter(self) -> None:
-        """A class whose description() raises degrades to "" and so matches no search query."""
+    def test_degraded_description_still_findable_by_search_filter(self) -> None:
+        """A class whose description() raises stays findable via search= on its docstring.
+
+        Degrading to the docstring keeps a broken plugin discoverable; degrading to ""
+        would make it invisible to every search query.
+        """
 
         class _DocsSearchBoomFG(FeatureGroup):
-            """Test double whose description() raises with a searchable docstring."""
+            """Test double whose description() raises, keyword lodestarquux."""
 
             @classmethod
             def description(cls) -> str:
-                raise RuntimeError("searchable boom")
+                raise RuntimeError("boom")
 
         try:
-            unfiltered = {fg.name: fg for fg in get_feature_group_docs()}
-            assert "_DocsSearchBoomFG" in unfiltered, "Degraded class must still be documented"
-            assert unfiltered["_DocsSearchBoomFG"].description == ""
-
-            searched = {fg.name for fg in get_feature_group_docs(search="searchable")}
-            assert "_DocsSearchBoomFG" not in searched, "An empty description must not match a search query"
+            searched = {fg.name for fg in get_feature_group_docs(search="lodestarquux")}
+            assert "_DocsSearchBoomFG" in searched, "A degraded description must stay searchable via the docstring"
         finally:
             del _DocsSearchBoomFG
+            gc.collect()
+
+    def test_degraded_description_without_docstring_findable_by_class_name_search(self) -> None:
+        """With no docstring, the degraded description is the class name and search= finds it there."""
+
+        class _DocsSearchNoDocstringBoomFG(FeatureGroup):
+            @classmethod
+            def description(cls) -> str:
+                raise RuntimeError("boom")
+
+        try:
+            searched = {fg.name for fg in get_feature_group_docs(search="_DocsSearchNoDocstringBoomFG")}
+            assert "_DocsSearchNoDocstringBoomFG" in searched
+        finally:
+            del _DocsSearchNoDocstringBoomFG
             gc.collect()
 
     def test_degraded_compute_frameworks_excluded_by_compute_framework_filter(self) -> None:
@@ -428,6 +518,218 @@ class TestGetFeatureGroupDocsDegradedFieldReads:
             assert "_DocsFrameworkFilterBoomFG" not in {fg.name for fg in filtered}
         finally:
             del _DocsFrameworkFilterBoomFG
+            gc.collect()
+
+
+class TestGetFeatureGroupDocsContractViolations:
+    """A plugin that returns the WRONG TYPE degrades through the same path as one that raises.
+
+    Raising is not the only way a plugin breaks its contract. A ``description()`` that
+    returns ``None`` raises nothing, so a guard keyed only on exceptions never fires and
+    the catalog call dies later, in the ``search=`` filter, with an ``AttributeError``.
+    The two reads that feed filters (``get_class_name`` for ``name=`` and the sort,
+    ``description`` for ``search=``) must validate the returned type inside the guard so a
+    contract violation degrades to the same base-class-derived fallback.
+
+    Isolation follows the sibling class: doubles are function-local and reaped in ``finally``.
+    """
+
+    def test_description_returning_none_does_not_sink_the_search_filter(self) -> None:
+        """description() -> None must not blow up search=, it degrades to the docstring."""
+
+        class _DocsDescriptionNoneFG(FeatureGroup):
+            """Test double whose description() returns None, keyword ripcordquux."""
+
+            @classmethod
+            def description(cls) -> Any:
+                return None
+
+        try:
+            searched = {fg.name for fg in get_feature_group_docs(search="ripcordquux")}
+            assert "_DocsDescriptionNoneFG" in searched, "A None description must degrade to the docstring"
+        finally:
+            del _DocsDescriptionNoneFG
+            gc.collect()
+
+    def test_description_returning_none_degrades_to_class_docstring(self) -> None:
+        """The unfiltered catalog reports the base-class-derived fallback, not None."""
+
+        class _DocsDescriptionNoneUnfilteredFG(FeatureGroup):
+            """Test double whose description() returns None."""
+
+            @classmethod
+            def description(cls) -> Any:
+                return None
+
+        try:
+            by_name = {fg.name: fg for fg in get_feature_group_docs()}
+            assert "_DocsDescriptionNoneUnfilteredFG" in by_name, "Contract-violating class must still be documented"
+            assert (
+                by_name["_DocsDescriptionNoneUnfilteredFG"].description
+                == "Test double whose description() returns None."
+            )
+        finally:
+            del _DocsDescriptionNoneUnfilteredFG
+            gc.collect()
+
+    def test_get_class_name_returning_non_str_does_not_sink_the_name_filter(self) -> None:
+        """get_class_name() -> non-str must not blow up name=, it degrades to the class __name__."""
+
+        class _DocsClassNameNonStrFG(FeatureGroup):
+            """Test double whose get_class_name() returns an int."""
+
+            @classmethod  # type: ignore[misc]
+            def get_class_name(cls) -> Any:
+                return 42
+
+        try:
+            filtered = get_feature_group_docs(name="_DocsClassNameNonStrFG")
+            assert [fg.name for fg in filtered] == ["_DocsClassNameNonStrFG"]
+        finally:
+            del _DocsClassNameNonStrFG
+            gc.collect()
+
+    def test_get_class_name_returning_non_str_degrades_in_unfiltered_catalog(self) -> None:
+        """The unfiltered catalog (which sorts by name) also survives a non-str name."""
+
+        class _DocsClassNameNonStrUnfilteredFG(FeatureGroup):
+            """Test double whose get_class_name() returns an int."""
+
+            @classmethod  # type: ignore[misc]
+            def get_class_name(cls) -> Any:
+                return 42
+
+        try:
+            by_name = {fg.name: fg for fg in get_feature_group_docs()}
+            assert "_DocsClassNameNonStrUnfilteredFG" in by_name, "Contract-violating class must still be documented"
+            assert by_name["_DocsClassNameNonStrUnfilteredFG"].name == "_DocsClassNameNonStrUnfilteredFG"
+        finally:
+            del _DocsClassNameNonStrUnfilteredFG
+            gc.collect()
+
+    def test_version_returning_non_str_does_not_sink_the_version_filter(self) -> None:
+        """version() -> non-str must not blow up version_contains=, it degrades to "unavailable".
+
+        The third read that feeds a filter. A non-str version passes the exception-only guard
+        and then dies in ``version_contains not in version``, exactly as the None description
+        dies in the search filter.
+        """
+
+        class _DocsVersionNonStrFG(FeatureGroup):
+            """Test double whose version() returns an int."""
+
+            @classmethod
+            def version(cls) -> Any:
+                return 42
+
+        try:
+            filtered = get_feature_group_docs(version_contains="unavailable")
+            assert "_DocsVersionNonStrFG" in {fg.name for fg in filtered}, (
+                "A non-str version must degrade to the documented sentinel and stay filterable"
+            )
+        finally:
+            del _DocsVersionNonStrFG
+            gc.collect()
+
+    def test_version_returning_non_str_degrades_to_unavailable(self) -> None:
+        """The unfiltered catalog reports the "unavailable" sentinel, not the non-str value."""
+
+        class _DocsVersionNonStrUnfilteredFG(FeatureGroup):
+            """Test double whose version() returns an int."""
+
+            @classmethod
+            def version(cls) -> Any:
+                return 42
+
+        try:
+            by_name = {fg.name: fg for fg in get_feature_group_docs()}
+            assert "_DocsVersionNonStrUnfilteredFG" in by_name, "Contract-violating class must still be documented"
+            assert by_name["_DocsVersionNonStrUnfilteredFG"].version == "unavailable"
+        finally:
+            del _DocsVersionNonStrUnfilteredFG
+            gc.collect()
+
+    def test_version_degradation_stays_silent(self, caplog: pytest.LogCaptureFixture) -> None:
+        """_safe_version is unlabelled by design, so a degraded version read logs nothing."""
+
+        class _DocsVersionSilentFG(FeatureGroup):
+            """Test double whose version() returns an int."""
+
+            @classmethod
+            def version(cls) -> Any:
+                return 42
+
+        try:
+            with caplog.at_level(logging.DEBUG, logger=SAFE_FIELD_LOGGER):
+                by_name = {fg.name: fg for fg in get_feature_group_docs()}
+
+            assert by_name["_DocsVersionSilentFG"].version == "unavailable"
+
+            messages = [record.getMessage() for record in caplog.records if record.name == SAFE_FIELD_LOGGER]
+            assert messages == [], f"An unlabelled version degradation must be silent, got {messages}"
+        finally:
+            del _DocsVersionSilentFG
+            gc.collect()
+
+
+class TestDegradedReadLogging:
+    """Feature-group reads are labelled, so they warn. Compute-framework reads are not, so they stay silent.
+
+    The labels are the only thing that makes a degraded plugin diagnosable, so they are
+    asserted here: dropping ``field=`` from the feature-group call sites must fail a test.
+    The compute-framework call sites are deliberately unlabelled, because they degrade by
+    design on a healthy system (an uninstalled optional backend, a deliberately
+    unimplemented merge engine), and warning on those is log spam.
+    """
+
+    def test_degraded_feature_group_read_logs_warning_naming_class_and_field(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        class _DocsWarnBoomFG(FeatureGroup):
+            """Test double whose description() raises."""
+
+            @classmethod
+            def description(cls) -> str:
+                raise RuntimeError("boom")
+
+        try:
+            with caplog.at_level(logging.WARNING, logger=SAFE_FIELD_LOGGER):
+                get_feature_group_docs()
+
+            messages = [
+                record.getMessage()
+                for record in caplog.records
+                if record.levelno == logging.WARNING and record.name == SAFE_FIELD_LOGGER
+            ]
+            matching = [msg for msg in messages if "_DocsWarnBoomFG.description" in msg]
+            assert len(matching) >= 1, f"Expected a WARNING naming '_DocsWarnBoomFG.description', got {messages}"
+            assert "boom" in matching[0], "Warning must carry the swallowed exception message"
+        finally:
+            del _DocsWarnBoomFG
+            gc.collect()
+
+    def test_degraded_compute_framework_read_logs_nothing(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Compute-framework field reads are unlabelled by design, so a degraded read is silent."""
+
+        class _DocsSilentBoomCFW(ComputeFramework):
+            """Test double whose availability probe raises."""
+
+            @staticmethod
+            def is_available() -> bool:
+                raise RuntimeError("boom")
+
+        try:
+            with caplog.at_level(logging.DEBUG, logger=SAFE_FIELD_LOGGER):
+                results = get_compute_framework_docs()
+
+            by_name = {cfw.name: cfw for cfw in results}
+            assert "_DocsSilentBoomCFW" in by_name, "Degraded framework must still be documented"
+            assert by_name["_DocsSilentBoomCFW"].is_available is False
+
+            messages = [record.getMessage() for record in caplog.records if record.name == SAFE_FIELD_LOGGER]
+            assert messages == [], f"Unlabelled compute-framework reads must degrade silently, got {messages}"
+        finally:
+            del _DocsSilentBoomCFW
             gc.collect()
 
 

--- a/tests/test_core/test_api/test_plugin_docs.py
+++ b/tests/test_core/test_api/test_plugin_docs.py
@@ -15,6 +15,7 @@ from mloda.core.api.plugin_docs import (
     _safe_version,
 )
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.user import PluginLoader
 
 
@@ -232,6 +233,202 @@ class TestGetFeatureGroupDocs:
 
         assert len(lower_filtered) == expected
         assert len(upper_filtered) == expected
+
+
+class TestGetFeatureGroupDocsDegradedFieldReads:
+    """A FeatureGroup with one broken introspection hook degrades that field, it does not sink the catalog.
+
+    ``get_feature_group_docs`` reads five plugin-overridable classmethods per class.
+    Each read routes through ``safe_field`` with a base-class-derived fallback
+    (issue #609), mirroring the ``is_available`` guard already proven for compute
+    frameworks. Degraded entries stay in the catalog and are filtered on their
+    degraded values.
+
+    Isolation: every test double is defined inside its test function and reaped in
+    a ``finally`` block (``del`` plus ``gc.collect()``), because plugin docs walk the
+    live ``__subclasses__()`` registry and a leaked class would corrupt sibling
+    tests' catalog calls. This mirrors ``test_get_compute_framework_docs_degrades_when_is_available_raises``.
+    """
+
+    def test_get_class_name_raising_degrades_to_dunder_name(self) -> None:
+        """A broken get_class_name() falls back to the class __name__."""
+
+        class _DocsGetClassNameBoomFG(FeatureGroup):
+            """Test double whose get_class_name() raises."""
+
+            @classmethod  # type: ignore[misc]
+            def get_class_name(cls) -> str:
+                raise RuntimeError("boom")
+
+        try:
+            by_name = {fg.name: fg for fg in get_feature_group_docs()}
+            assert "_DocsGetClassNameBoomFG" in by_name, "Degraded class must still be documented under its __name__"
+            assert by_name["_DocsGetClassNameBoomFG"].name == "_DocsGetClassNameBoomFG"
+        finally:
+            del _DocsGetClassNameBoomFG
+            gc.collect()
+
+    def test_description_raising_degrades_to_empty_string(self) -> None:
+        """A broken description() falls back to the empty string."""
+
+        class _DocsDescriptionBoomFG(FeatureGroup):
+            """Test double whose description() raises."""
+
+            @classmethod
+            def description(cls) -> str:
+                raise RuntimeError("boom")
+
+        try:
+            by_name = {fg.name: fg for fg in get_feature_group_docs()}
+            assert "_DocsDescriptionBoomFG" in by_name, "Degraded class must still be documented"
+            assert by_name["_DocsDescriptionBoomFG"].description == ""
+        finally:
+            del _DocsDescriptionBoomFG
+            gc.collect()
+
+    def test_compute_framework_definition_raising_degrades_to_empty_list(self) -> None:
+        """A broken compute_framework_definition() falls back to an empty framework list."""
+
+        class _DocsFrameworkBoomFG(FeatureGroup):
+            """Test double whose compute_framework_definition() raises."""
+
+            @classmethod  # type: ignore[misc]
+            def compute_framework_definition(cls) -> set[type[ComputeFramework]]:
+                raise RuntimeError("boom")
+
+        try:
+            by_name = {fg.name: fg for fg in get_feature_group_docs()}
+            assert "_DocsFrameworkBoomFG" in by_name, "Degraded class must still be documented"
+            assert by_name["_DocsFrameworkBoomFG"].compute_frameworks == []
+        finally:
+            del _DocsFrameworkBoomFG
+            gc.collect()
+
+    def test_feature_names_supported_raising_degrades_to_empty_set(self) -> None:
+        """A broken feature_names_supported() falls back to an empty set."""
+
+        class _DocsFeatureNamesBoomFG(FeatureGroup):
+            """Test double whose feature_names_supported() raises."""
+
+            @classmethod
+            def feature_names_supported(cls) -> set[str]:
+                raise RuntimeError("boom")
+
+        try:
+            by_name = {fg.name: fg for fg in get_feature_group_docs()}
+            assert "_DocsFeatureNamesBoomFG" in by_name, "Degraded class must still be documented"
+            assert by_name["_DocsFeatureNamesBoomFG"].supported_feature_names == set()
+        finally:
+            del _DocsFeatureNamesBoomFG
+            gc.collect()
+
+    def test_prefix_raising_degrades_to_class_name_prefix(self) -> None:
+        """A broken prefix() falls back to the base-class convention "<__name__>_"."""
+
+        class _DocsPrefixBoomFG(FeatureGroup):
+            """Test double whose prefix() raises."""
+
+            @classmethod
+            def prefix(cls) -> str:
+                raise RuntimeError("boom")
+
+        try:
+            by_name = {fg.name: fg for fg in get_feature_group_docs()}
+            assert "_DocsPrefixBoomFG" in by_name, "Degraded class must still be documented"
+            assert by_name["_DocsPrefixBoomFG"].prefix == "_DocsPrefixBoomFG_"
+        finally:
+            del _DocsPrefixBoomFG
+            gc.collect()
+
+    def test_broken_feature_group_does_not_sink_the_catalog(self) -> None:
+        """With a raising subclass live, every other feature group is still listed."""
+        baseline = {fg.name for fg in get_feature_group_docs()}
+        assert len(baseline) > 0, "Need a populated baseline catalog"
+
+        class _DocsSinkBoomFG(FeatureGroup):
+            """Test double whose description() raises."""
+
+            @classmethod
+            def description(cls) -> str:
+                raise RuntimeError("boom")
+
+        try:
+            degraded = {fg.name for fg in get_feature_group_docs()}
+            assert baseline.issubset(degraded), "A broken plugin must not drop healthy feature groups"
+            assert "_DocsSinkBoomFG" in degraded
+        finally:
+            del _DocsSinkBoomFG
+            gc.collect()
+
+    def test_degraded_name_still_findable_by_name_filter(self) -> None:
+        """A class whose get_class_name() raises is findable via name=<its real __name__>."""
+
+        class _DocsNameFilterBoomFG(FeatureGroup):
+            """Test double whose get_class_name() raises."""
+
+            @classmethod  # type: ignore[misc]
+            def get_class_name(cls) -> str:
+                raise RuntimeError("boom")
+
+        try:
+            filtered = get_feature_group_docs(name="_DocsNameFilterBoomFG")
+            assert [fg.name for fg in filtered] == ["_DocsNameFilterBoomFG"]
+        finally:
+            del _DocsNameFilterBoomFG
+            gc.collect()
+
+    def test_degraded_description_excluded_by_search_filter(self) -> None:
+        """A class whose description() raises degrades to "" and so matches no search query."""
+
+        class _DocsSearchBoomFG(FeatureGroup):
+            """Test double whose description() raises with a searchable docstring."""
+
+            @classmethod
+            def description(cls) -> str:
+                raise RuntimeError("searchable boom")
+
+        try:
+            unfiltered = {fg.name: fg for fg in get_feature_group_docs()}
+            assert "_DocsSearchBoomFG" in unfiltered, "Degraded class must still be documented"
+            assert unfiltered["_DocsSearchBoomFG"].description == ""
+
+            searched = {fg.name for fg in get_feature_group_docs(search="searchable")}
+            assert "_DocsSearchBoomFG" not in searched, "An empty description must not match a search query"
+        finally:
+            del _DocsSearchBoomFG
+            gc.collect()
+
+    def test_degraded_compute_frameworks_excluded_by_compute_framework_filter(self) -> None:
+        """A class whose compute_framework_definition() raises is excluded by a compute_framework= filter.
+
+        This mirrors how a compute framework degraded to is_available=False is excluded
+        by available_only=True: the degraded value, not the exception, drives the filter.
+        """
+        baseline = get_feature_group_docs()
+        canonical_name: str | None = None
+        for fg in baseline:
+            if len(fg.compute_frameworks) > 0:
+                canonical_name = fg.compute_frameworks[0]
+                break
+        assert canonical_name is not None, "Need a feature group with at least one compute framework"
+
+        class _DocsFrameworkFilterBoomFG(FeatureGroup):
+            """Test double whose compute_framework_definition() raises."""
+
+            @classmethod  # type: ignore[misc]
+            def compute_framework_definition(cls) -> set[type[ComputeFramework]]:
+                raise RuntimeError("boom")
+
+        try:
+            unfiltered = {fg.name for fg in get_feature_group_docs()}
+            assert "_DocsFrameworkFilterBoomFG" in unfiltered, "Degraded class must still be documented"
+
+            filtered = get_feature_group_docs(compute_framework=canonical_name)
+            assert len(filtered) > 0, "Healthy feature groups must still match the framework filter"
+            assert "_DocsFrameworkFilterBoomFG" not in {fg.name for fg in filtered}
+        finally:
+            del _DocsFrameworkFilterBoomFG
+            gc.collect()
 
 
 class TestGetComputeFrameworkDocs:


### PR DESCRIPTION
Closes #609.

## The decision the issue asked for

#609 was blocked on a design call: annotate, skip, or propagate, per field. The answer recorded here is **annotate for all five**, with **base-class-derived fallbacks rather than sentinels**.

| Field | Fallback |
|---|---|
| `get_class_name()` | `cls.__name__` |
| `description()` | class docstring, or `cls.__name__` |
| `compute_framework_definition()` | `[]` |
| `feature_names_supported()` | `set()` |
| `prefix()` | `f"{cls.__name__}_"` |

The issue's third open question (what would a sentinel for `get_class_name()` even mean?) dissolves: every one of these has a real fallback on the class itself, so a degraded entry stays named, sorted and findable rather than showing up as `"unavailable"`.

The second open question (masking risk) is answered by making degradation loud instead of by keeping the blast radius. Detonating the whole catalog is an expensive way to deliver feedback to one plugin author, and it delivers it to the caller, who may not even own the broken plugin. A degraded read now logs a WARNING naming the class and the field.

Skip was rejected: it is reserved for things that are not entries (abstract bases, `__main__`), not for entries that are broken. Doc-only propagation was rejected because the gap is an artifact of what #606 happened to touch, not a considered policy: `discover-plugins.md` claimed the invariant "a broken plugin degrades a field instead of sinking the catalog call" and then admitted it was false for the five most-used reads on the most common plugin type.

## What the reviews changed

Two independent deep reviews ran against the first commit, and both rejected part of it. The second commit is the fix round.

**Logging is opt-in, not unconditional.** The first pass warned on every swallow, which retro-fitted a WARNING onto the pre-existing call sites where swallowing is the *designed* outcome: Iceberg deliberately raises `NotImplementedError` from `merge_engine()`, an availability probe raises `ImportError` when an optional backend is absent, and source introspection fails for `type()`-built and notebook-reloaded classes on the engine run path, where the same condition is already logged at DEBUG two lines away. A healthy `get_compute_framework_docs()` call emitted four warnings, three from unbroken code. Only labelled reads warn now, which also means no call site can emit a log line that cannot say what degraded.

**Wrong-typed returns degrade too, not just raises.** `safe_field` guards reads that raise; it does nothing for a plugin that returns the wrong type. A `description()` returning `None` still killed the entire call at the `search=` filter, a non-str `get_class_name()` killed the `name=` filter and the final `sorted()`, and a non-str `version()` killed `version_contains=`. The three filter-feeding reads now validate their return type inside the thunk, so a contract violation degrades through the same path.

**The `description` fallback is the class docstring, not an empty string.** An empty string made a degraded plugin invisible to `search=`, which is precisely the masking risk the issue raised. The docstring fallback mirrors what `get_compute_framework_docs` already does.

**`safe_field` logs `str(exc)`, not the exception object.** A retained log record (caplog, a buffering handler, an error reporter) would otherwise pin `exc` to its traceback to its frames to the plugin class, keeping broken plugin classes alive after a catalog walk.

## Notes

- `get_class_name` and `compute_framework_definition` are `@final`, so the guard on the former is belt-and-braces (a `type()`-built class can still override it at runtime). `compute_framework_definition` is `@final` but calls the overridable `compute_framework_rule()`, which is the break a real plugin can actually cause, and it is covered.
- Follow-up worth filing: surface degradation in the returned data (a `degraded_fields` list on the Info objects) so tooling and CI can see it without scraping logs. It touches all three Info types, so it is deliberately out of scope here.

## Verification

`tox` green (4700 passed, 171 skipped, no new skips; ruff format, ruff check, licenses, `mypy --strict`, bandit), run twice under different random seeds.