### PR TITLE
feat: declarative subtype universe and per-backend support on FeatureGroup

### DIFF
--- a/docs/docs/in_depth/compute-framework-integration.md
+++ b/docs/docs/in_depth/compute-framework-integration.md
@@ -77,22 +77,40 @@ class StatFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 
     @classmethod
     def supported_subtypes(cls, compute_framework):
-        if compute_framework is SQLiteFramework:
+        if compute_framework is SqliteFramework:
             return frozenset({"sum"})  # median is unsupported on SQLite
         return cls.subtype_universe()
 ```
 
 `subtype_universe()` derives from the key's declared values, and
 `supports_compute_framework` is then derived from both: no override needed. A
-subtype outside the universe (a parametric one such as `ntile_2`) stays allowed,
-so the hook never double-gates what matching already rejects. Families that
-flatten several axes into one subtype override `subtype_universe()` themselves.
+subtype outside the declared universe (unknown, or parametric such as `ntile_2`)
+stays open on every framework, because matching does not reject it either. The
+gate therefore only narrows what the family itself declared.
+
+Exactly two declaration shapes are legal, both enforced at class-definition time:
+
+- **Shape A (single key)**: `SUBTYPE_KEY` names a `PROPERTY_MAPPING` key with an
+  enumerable value space (`allowed_values`). `subtype_universe()` may still be
+  overridden to narrow or compute it; resolution keeps using the key. A key that is
+  not declared, or one validated only by a `validation_function` (no enumerable
+  values), is a `ValueError`.
+- **Shape B (flattened)**: `SUBTYPE_KEY` stays `None` and the class overrides BOTH
+  `subtype_universe()` and `resolve_subtype()`, for families whose subtype combines
+  several keys (e.g. `frame_type` x `frame_unit` into `rows_1`). Overriding only
+  `subtype_universe()` is a `ValueError`: the flattened subtype would be unenforceable.
 
 The declaration is enumerable without probing: `subtype_support_matrix()` returns
 framework class name -> supported subtypes (and raises if a framework claims a
-subtype outside the universe), and `get_feature_group_docs()` exposes the same
-data as `subtype_key`, `subtypes` and `subtype_support`. `resolve_feature(name)`
-reports the concrete feature's `subtype`.
+subtype outside the universe), and `get_feature_group_docs()` exposes the same data
+as `subtype_key`, `subtypes`, `subtype_support` and `subtype_error` (the rejection
+message when a family misdeclares a capability). `resolve_feature(name)` reports the
+concrete feature's `subtype`.
+
+The matrix reports the **declared** frameworks of `compute_framework_definition()`,
+not the installed or importable ones (unlike `ResolvedFeature.supported_compute_frameworks`,
+which is availability-filtered). An abstract base declares the universe and reports an
+empty matrix; its concrete per-framework subclasses carry the support.
 
 ### Empty Results
 

--- a/docs/docs/in_depth/compute-framework-integration.md
+++ b/docs/docs/in_depth/compute-framework-integration.md
@@ -57,6 +57,43 @@ inspector does not know the caller's `Options`), and a feature that matches a
 group but is unsupported on every installed framework resolves to
 `feature_group=None` with a capability error rather than appearing runnable.
 
+### Declaring Capability per Subtype
+
+When a family's operations are enumerated by one `PROPERTY_MAPPING` key (the
+aggregation type, the scaler type, ...), name that key with `SUBTYPE_KEY` and
+declare which subtypes each framework supports:
+
+``` python
+class StatFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+    SUBTYPE_KEY = "stat_type"
+    PREFIX_PATTERN = r".*__([\w]+)_stat$"
+    PROPERTY_MAPPING = {
+        "stat_type": property_spec(
+            "statistic to compute",
+            strict=True,
+            allowed_values={"sum": "Sum of values", "median": "Median value"},
+        ),
+    }
+
+    @classmethod
+    def supported_subtypes(cls, compute_framework):
+        if compute_framework is SQLiteFramework:
+            return frozenset({"sum"})  # median is unsupported on SQLite
+        return cls.subtype_universe()
+```
+
+`subtype_universe()` derives from the key's declared values, and
+`supports_compute_framework` is then derived from both: no override needed. A
+subtype outside the universe (a parametric one such as `ntile_2`) stays allowed,
+so the hook never double-gates what matching already rejects. Families that
+flatten several axes into one subtype override `subtype_universe()` themselves.
+
+The declaration is enumerable without probing: `subtype_support_matrix()` returns
+framework class name -> supported subtypes (and raises if a framework claims a
+subtype outside the universe), and `get_feature_group_docs()` exposes the same
+data as `subtype_key`, `subtypes` and `subtype_support`. `resolve_feature(name)`
+reports the concrete feature's `subtype`.
+
 ### Empty Results
 
 The contract is: a **final** requested feature must return a *schema-bearing*

--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -77,9 +77,39 @@ class FeatureGroup(ABC):
     See ``docs/in_depth/property-mapping.md`` for the full specification.
     """
 
+    SUBTYPE_KEY: ClassVar[Optional[str]] = None
+    """Name of the ``PROPERTY_MAPPING`` key carrying this family's subtype discriminator.
+
+    ``None`` (the default) means the family has no subtype dimension. Setting it to a
+    key that ``PROPERTY_MAPPING`` does not declare is a class-definition error, unless
+    the class overrides ``subtype_universe()`` (families that flatten several axes).
+    """
+
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
         FeatureChainParser.validate_property_mapping_defaults(cls.__name__, cls.PROPERTY_MAPPING)
+        cls._validate_subtype_key()
+
+    @classmethod
+    def _validate_subtype_key(cls) -> None:
+        """Reject a SUBTYPE_KEY that names no PROPERTY_MAPPING key at class-definition time."""
+        key = cls.SUBTYPE_KEY
+        if key is None:
+            return
+
+        declared = getattr(cls.subtype_universe, "__func__", None)
+        base = getattr(FeatureGroup.subtype_universe, "__func__", None)
+        if declared is not base:
+            return
+
+        if key in cls.declared_option_keys():
+            return
+
+        raise ValueError(
+            f"{cls.__name__}.SUBTYPE_KEY = '{key}' is not declared in its PROPERTY_MAPPING. "
+            f"Declare the key in PROPERTY_MAPPING, or override subtype_universe() to define the "
+            f"subtypes explicitly."
+        )
 
     @classmethod
     def declared_option_keys(cls) -> frozenset[str]:
@@ -87,6 +117,84 @@ class FeatureGroup(ABC):
         if cls.PROPERTY_MAPPING is None:
             return frozenset()
         return frozenset(str(key) for key in cls.PROPERTY_MAPPING)
+
+    @classmethod
+    def declared_option_values(cls, key: str) -> frozenset[str]:
+        """Return the declared value space of a ``PROPERTY_MAPPING`` key.
+
+        Handles both the ``DefaultOptionKeys.allowed_values`` form and the legacy
+        flattened form. Empty when the key is absent or declares no value space.
+        """
+        if cls.PROPERTY_MAPPING is None or key not in cls.PROPERTY_MAPPING:
+            return frozenset()
+
+        values = FeatureChainParser._extract_property_values(cls.PROPERTY_MAPPING[key])
+        if not isinstance(values, (dict, list, tuple, set, frozenset)):
+            return frozenset()
+        return frozenset(str(value) for value in values)
+
+    @classmethod
+    def subtype_universe(cls) -> frozenset[str]:
+        """Return every subtype this family defines.
+
+        Defaults to the declared value space of ``SUBTYPE_KEY``. Override for families
+        whose subtype is a flattened combination of several PROPERTY_MAPPING keys.
+        """
+        if cls.SUBTYPE_KEY is None:
+            return frozenset()
+        return cls.declared_option_values(cls.SUBTYPE_KEY)
+
+    @classmethod
+    def supported_subtypes(cls, compute_framework: type[ComputeFramework]) -> frozenset[str]:
+        """Return the subtypes supported on ``compute_framework``. Defaults to the full universe."""
+        return cls.subtype_universe()
+
+    @classmethod
+    def resolve_subtype(cls, feature_name: FeatureName | str, options: Options) -> Optional[str]:
+        """Resolve a concrete feature's subtype from its name, else from ``options[SUBTYPE_KEY]``."""
+        key = cls.SUBTYPE_KEY
+        if key is None:
+            return None
+
+        patterns = [
+            pattern
+            for pattern in (getattr(cls, "PREFIX_PATTERN", None), getattr(cls, "SUFFIX_PATTERN", None))
+            if pattern is not None
+        ]
+        subtype, _ = FeatureChainParser.parse_feature_name(str(feature_name), patterns)
+        if subtype is not None:
+            return subtype
+
+        value = options.get(key)
+        if value is not None:
+            return str(value)
+        return None
+
+    @final
+    @classmethod
+    def subtype_support_matrix(cls) -> dict[str, frozenset[str]]:
+        """Map each declared compute framework class name to the subtypes it supports.
+
+        Empty when the family has no subtype dimension. Raises when a framework declares
+        support for a subtype outside ``subtype_universe()``.
+        """
+        if cls.SUBTYPE_KEY is None:
+            return {}
+
+        universe = cls.subtype_universe()
+        matrix: dict[str, frozenset[str]] = {}
+
+        for compute_framework in cls.compute_framework_definition():
+            supported = cls.supported_subtypes(compute_framework)
+            outside = supported - universe
+            if outside:
+                raise ValueError(
+                    f"{cls.__name__}.supported_subtypes({compute_framework.get_class_name()}) declares "
+                    f"{sorted(outside)}, which is outside its subtype universe {sorted(universe)}."
+                )
+            matrix[compute_framework.get_class_name()] = supported
+
+        return matrix
 
     def __init__(self) -> None:
         pass
@@ -482,16 +590,31 @@ class FeatureGroup(ABC):
     ) -> bool:
         """Per-feature, per-framework capability check evaluated at match time.
 
-        Returns ``True`` (the default) to allow the framework. Override to declare
-        that a specific operation (encoded in ``feature_name``/``options``) is
-        unsupported on ``compute_framework`` -- return ``False`` and the matcher
-        removes that framework from the candidate set for this feature only.
-        Unlike ``compute_framework_rule`` (a static class-level set), this hook sees
-        the concrete feature, so it can reject an op on one backend while allowing
-        others. If every candidate framework is rejected, the matcher surfaces a
-        distinguishable error instead of a generic "no feature group" message.
+        The default is derived from the subtype declaration: a feature whose subtype is
+        in ``subtype_universe()`` but not in ``supported_subtypes(compute_framework)`` is
+        rejected; everything else is allowed. Families without a ``SUBTYPE_KEY``, features
+        whose subtype does not resolve, and parametric subtypes outside the universe (e.g.
+        ``ntile_2``) all stay allowed, so this hook never double-gates what matching and
+        strict validation already reject.
+
+        Override to declare capability directly. Returning ``False`` makes the matcher
+        remove that framework from the candidate set for this feature only. Unlike
+        ``compute_framework_rule`` (a static class-level set), this hook sees the concrete
+        feature, so it can reject an op on one backend while allowing others. If every
+        candidate framework is rejected, the matcher surfaces a distinguishable error
+        instead of a generic "no feature group" message.
         """
-        return True
+        if cls.SUBTYPE_KEY is None:
+            return True
+
+        subtype = cls.resolve_subtype(feature_name, options)
+        if subtype is None:
+            return True
+
+        if subtype not in cls.subtype_universe():
+            return True
+
+        return subtype in cls.supported_subtypes(compute_framework)
 
     @final
     @classmethod

--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import logging
 from typing import Any, ClassVar, Callable, Iterable, Optional, final
 from abc import ABC
@@ -10,7 +11,10 @@ from mloda.core.abstract_plugins.components.data_types import DataType
 
 from mloda.core.abstract_plugins.components.domain import Domain
 from mloda.core.abstract_plugins.components.base_feature_group_version import BaseFeatureGroupVersion
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import (
+    CHAIN_SEPARATOR,
+    FeatureChainParser,
+)
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.input_data.api.api_input_data import ApiInputData
 from mloda.core.abstract_plugins.components.input_data.base_input_data import BaseInputData
@@ -80,36 +84,62 @@ class FeatureGroup(ABC):
     SUBTYPE_KEY: ClassVar[Optional[str]] = None
     """Name of the ``PROPERTY_MAPPING`` key carrying this family's subtype discriminator.
 
-    ``None`` (the default) means the family has no subtype dimension. Setting it to a
-    key that ``PROPERTY_MAPPING`` does not declare is a class-definition error, unless
-    the class overrides ``subtype_universe()`` (families that flatten several axes).
+    Exactly two declaration shapes are legal, both enforced at class-definition time:
+
+    Shape A (single key): ``SUBTYPE_KEY`` names a key that ``PROPERTY_MAPPING`` declares,
+    and that key has an enumerable value space (``allowed_values`` or the legacy flattened
+    form). ``subtype_universe()`` may still be overridden to narrow or compute the
+    universe, but resolution keeps using the key.
+
+    Shape B (flattened): ``SUBTYPE_KEY`` stays ``None`` and the class overrides BOTH
+    ``subtype_universe()`` and ``resolve_subtype()``, for families whose subtype combines
+    several PROPERTY_MAPPING keys.
+
+    ``None`` with no overrides (the default) means the family has no subtype dimension.
     """
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
         FeatureChainParser.validate_property_mapping_defaults(cls.__name__, cls.PROPERTY_MAPPING)
-        cls._validate_subtype_key()
+        cls._validate_subtype_declaration()
 
     @classmethod
-    def _validate_subtype_key(cls) -> None:
-        """Reject a SUBTYPE_KEY that names no PROPERTY_MAPPING key at class-definition time."""
+    def _overrides(cls, method_name: str) -> bool:
+        """Report whether ``cls`` (or an ancestor below FeatureGroup) overrides a subtype hook."""
+        declared = getattr(getattr(cls, method_name), "__func__", None)
+        base = getattr(getattr(FeatureGroup, method_name), "__func__", None)
+        return declared is not base
+
+    @classmethod
+    def _validate_subtype_declaration(cls) -> None:
+        """Enforce the two legal subtype declaration shapes at class-definition time."""
         key = cls.SUBTYPE_KEY
+
         if key is None:
+            if cls._overrides("subtype_universe") and not cls._overrides("resolve_subtype"):
+                raise ValueError(
+                    f"{cls.__name__} overrides subtype_universe() with SUBTYPE_KEY = None, but does not "
+                    f"override resolve_subtype(). A flattened subtype is unenforceable without it: override "
+                    f"resolve_subtype(), or set SUBTYPE_KEY to a declared PROPERTY_MAPPING key."
+                )
             return
 
-        declared = getattr(cls.subtype_universe, "__func__", None)
-        base = getattr(FeatureGroup.subtype_universe, "__func__", None)
-        if declared is not base:
+        if key not in cls.declared_option_keys():
+            raise ValueError(
+                f"{cls.__name__}.SUBTYPE_KEY = '{key}' is not declared in its PROPERTY_MAPPING. "
+                f"Declare the key in PROPERTY_MAPPING, or leave SUBTYPE_KEY as None and override both "
+                f"subtype_universe() and resolve_subtype() to define a flattened subtype."
+            )
+
+        if cls._overrides("subtype_universe"):
             return
 
-        if key in cls.declared_option_keys():
-            return
-
-        raise ValueError(
-            f"{cls.__name__}.SUBTYPE_KEY = '{key}' is not declared in its PROPERTY_MAPPING. "
-            f"Declare the key in PROPERTY_MAPPING, or override subtype_universe() to define the "
-            f"subtypes explicitly."
-        )
+        if not cls.declared_option_values(key):
+            raise ValueError(
+                f"{cls.__name__}.SUBTYPE_KEY = '{key}' names a PROPERTY_MAPPING key with no enumerable "
+                f"value space, so its subtype universe would be empty while strict validation still accepts "
+                f"values. Declare allowed_values for '{key}', or override subtype_universe()."
+            )
 
     @classmethod
     def declared_option_keys(cls) -> frozenset[str]:
@@ -137,8 +167,9 @@ class FeatureGroup(ABC):
     def subtype_universe(cls) -> frozenset[str]:
         """Return every subtype this family defines.
 
-        Defaults to the declared value space of ``SUBTYPE_KEY``. Override for families
-        whose subtype is a flattened combination of several PROPERTY_MAPPING keys.
+        Defaults to the declared value space of ``SUBTYPE_KEY``. Families that flatten
+        several PROPERTY_MAPPING keys into one subtype override this together with
+        ``resolve_subtype()`` (Shape B).
         """
         if cls.SUBTYPE_KEY is None:
             return frozenset()
@@ -151,7 +182,11 @@ class FeatureGroup(ABC):
 
     @classmethod
     def resolve_subtype(cls, feature_name: FeatureName | str, options: Options) -> Optional[str]:
-        """Resolve a concrete feature's subtype from its name, else from ``options[SUBTYPE_KEY]``."""
+        """Resolve a concrete feature's subtype from its name, else from ``options[SUBTYPE_KEY]``.
+
+        Never raises: a name that matches a pattern but carries no source feature simply
+        does not resolve, because this hook runs at match time and must stay a lookup.
+        """
         key = cls.SUBTYPE_KEY
         if key is None:
             return None
@@ -161,9 +196,13 @@ class FeatureGroup(ABC):
             for pattern in (getattr(cls, "PREFIX_PATTERN", None), getattr(cls, "SUFFIX_PATTERN", None))
             if pattern is not None
         ]
-        subtype, _ = FeatureChainParser.parse_feature_name(str(feature_name), patterns)
-        if subtype is not None:
-            return subtype
+
+        name = str(feature_name)
+        source_feature, separator, _ = name.rpartition(CHAIN_SEPARATOR)
+        if separator and source_feature:
+            subtype, _ = FeatureChainParser.parse_feature_name(name, patterns)
+            if subtype is not None:
+                return subtype
 
         value = options.get(key)
         if value is not None:
@@ -175,13 +214,19 @@ class FeatureGroup(ABC):
     def subtype_support_matrix(cls) -> dict[str, frozenset[str]]:
         """Map each declared compute framework class name to the subtypes it supports.
 
-        Empty when the family has no subtype dimension. Raises when a framework declares
-        support for a subtype outside ``subtype_universe()``.
+        Reports the DECLARED frameworks of ``compute_framework_definition()``, not the
+        installed ones. Empty for an abstract class: an abstract base declares the subtype
+        universe, while its concrete per-framework subclasses carry the support. Also empty
+        when the family has no subtype dimension. Raises when a framework declares support
+        for a subtype outside ``subtype_universe()``.
         """
-        if cls.SUBTYPE_KEY is None:
+        if inspect.isabstract(cls):
             return {}
 
         universe = cls.subtype_universe()
+        if not universe:
+            return {}
+
         matrix: dict[str, frozenset[str]] = {}
 
         for compute_framework in cls.compute_framework_definition():
@@ -590,12 +635,12 @@ class FeatureGroup(ABC):
     ) -> bool:
         """Per-feature, per-framework capability check evaluated at match time.
 
-        The default is derived from the subtype declaration: a feature whose subtype is
-        in ``subtype_universe()`` but not in ``supported_subtypes(compute_framework)`` is
-        rejected; everything else is allowed. Families without a ``SUBTYPE_KEY``, features
-        whose subtype does not resolve, and parametric subtypes outside the universe (e.g.
-        ``ntile_2``) all stay allowed, so this hook never double-gates what matching and
-        strict validation already reject.
+        The default is derived from the subtype declaration, for both declaration shapes: a
+        feature whose subtype is in ``subtype_universe()`` but not in
+        ``supported_subtypes(compute_framework)`` is rejected; everything else is allowed.
+        Families without a subtype universe, features whose subtype does not resolve, and
+        subtypes outside the declared universe (unknown or parametric, e.g. ``ntile_2``) all
+        stay allowed, so the gate only narrows what the family itself declared.
 
         Override to declare capability directly. Returning ``False`` makes the matcher
         remove that framework from the candidate set for this feature only. Unlike
@@ -604,14 +649,12 @@ class FeatureGroup(ABC):
         candidate framework is rejected, the matcher surfaces a distinguishable error
         instead of a generic "no feature group" message.
         """
-        if cls.SUBTYPE_KEY is None:
+        universe = cls.subtype_universe()
+        if not universe:
             return True
 
         subtype = cls.resolve_subtype(feature_name, options)
-        if subtype is None:
-            return True
-
-        if subtype not in cls.subtype_universe():
+        if subtype is None or subtype not in universe:
             return True
 
         return subtype in cls.supported_subtypes(compute_framework)

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -106,6 +106,11 @@ def get_feature_group_docs(
         compute_frameworks = [cfw.__name__ for cfw in fg_class.compute_framework_definition()]
         supported_feature_names = fg_class.feature_names_supported()
         prefix = fg_class.prefix()
+        empty_universe: frozenset[str] = frozenset()
+        empty_matrix: dict[str, frozenset[str]] = {}
+        subtypes = sorted(safe_field(lambda: fg_class.subtype_universe(), empty_universe))
+        support_matrix = safe_field(lambda: fg_class.subtype_support_matrix(), empty_matrix)
+        subtype_support = {cfw_name: sorted(supported) for cfw_name, supported in support_matrix.items()}
 
         if name is not None and name.lower() not in fg_name.lower():
             continue
@@ -130,6 +135,9 @@ def get_feature_group_docs(
                 compute_frameworks=compute_frameworks,
                 supported_feature_names=supported_feature_names,
                 prefix=prefix,
+                subtype_key=fg_class.SUBTYPE_KEY,
+                subtypes=subtypes,
+                subtype_support=subtype_support,
             )
         )
 
@@ -336,13 +344,15 @@ def resolve_feature(feature_name: str, plugin_collector: Optional[PluginCollecto
     filtered = _filter_subclasses(candidates)
 
     if len(filtered) == 1:
+        resolved = filtered[0]
         return ResolvedFeature(
             feature_name=feature_name,
-            feature_group=filtered[0],
+            feature_group=resolved,
             candidates=candidates,
             error=None,
             supported_compute_frameworks=supported_names,
             unsupported_compute_frameworks=rejected_names,
+            subtype=safe_field(lambda: resolved.resolve_subtype(feature_name_obj, Options()), None),
         )
 
     conflicting_names = [fg.__name__ for fg in filtered]

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -45,6 +45,19 @@ def _safe_version(fg_class: type[FeatureGroup]) -> str:
     return safe_field(lambda: fg_class.version(), "unavailable", catching=SOURCE_INTROSPECTION_ERRORS)
 
 
+def _subtype_support(fg_class: type[FeatureGroup]) -> tuple[dict[str, list[str]], Optional[str]]:
+    """Read the subtype support matrix, degrading a misdeclared capability to (empty matrix, message).
+
+    ``safe_field`` cannot carry the rejection message, and a misdeclared capability must stay
+    distinguishable from a group that legitimately supports nothing.
+    """
+    try:
+        matrix = fg_class.subtype_support_matrix()
+    except Exception as exc:
+        return {}, str(exc)
+    return {cfw_name: sorted(supported) for cfw_name, supported in matrix.items()}, None
+
+
 def _dedup_degrading_on_conflict(
     feature_groups: set[type[FeatureGroup]], allow_redefinition: bool
 ) -> set[type[FeatureGroup]]:
@@ -107,10 +120,8 @@ def get_feature_group_docs(
         supported_feature_names = fg_class.feature_names_supported()
         prefix = fg_class.prefix()
         empty_universe: frozenset[str] = frozenset()
-        empty_matrix: dict[str, frozenset[str]] = {}
         subtypes = sorted(safe_field(lambda: fg_class.subtype_universe(), empty_universe))
-        support_matrix = safe_field(lambda: fg_class.subtype_support_matrix(), empty_matrix)
-        subtype_support = {cfw_name: sorted(supported) for cfw_name, supported in support_matrix.items()}
+        subtype_support, subtype_error = _subtype_support(fg_class)
 
         if name is not None and name.lower() not in fg_name.lower():
             continue
@@ -138,6 +149,7 @@ def get_feature_group_docs(
                 subtype_key=fg_class.SUBTYPE_KEY,
                 subtypes=subtypes,
                 subtype_support=subtype_support,
+                subtype_error=subtype_error,
             )
         )
 

--- a/mloda/core/api/plugin_info.py
+++ b/mloda/core/api/plugin_info.py
@@ -14,6 +14,12 @@ class FeatureGroupInfo:
     compute_frameworks: list[str]
     supported_feature_names: set[str]
     prefix: str
+    # PROPERTY_MAPPING key carrying the subtype discriminator, None without a subtype dimension.
+    subtype_key: Optional[str] = None
+    # Every subtype the family declares, sorted.
+    subtypes: list[str] = field(default_factory=list)
+    # Compute framework class name -> supported subtypes, sorted.
+    subtype_support: dict[str, list[str]] = field(default_factory=dict)
 
 
 @dataclass
@@ -45,3 +51,5 @@ class ResolvedFeature:
     supported_compute_frameworks: list[str] = field(default_factory=list)
     # Frameworks rejecting the feature, evaluated under default options.
     unsupported_compute_frameworks: list[str] = field(default_factory=list)
+    # Subtype resolved from the feature name/options by the resolved feature group.
+    subtype: Optional[str] = None

--- a/mloda/core/api/plugin_info.py
+++ b/mloda/core/api/plugin_info.py
@@ -18,8 +18,10 @@ class FeatureGroupInfo:
     subtype_key: Optional[str] = None
     # Every subtype the family declares, sorted.
     subtypes: list[str] = field(default_factory=list)
-    # Compute framework class name -> supported subtypes, sorted.
+    # Compute framework class name -> supported subtypes, sorted. Declared frameworks, not installed ones.
     subtype_support: dict[str, list[str]] = field(default_factory=dict)
+    # Why subtype_support is empty: a misdeclared capability, instead of a silently empty matrix.
+    subtype_error: Optional[str] = None
 
 
 @dataclass

--- a/mloda_plugins/feature_group/experimental/aggregated_feature_group/base.py
+++ b/mloda_plugins/feature_group/experimental/aggregated_feature_group/base.py
@@ -85,6 +85,9 @@ class AggregatedFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     # Option key for aggregation type
     AGGREGATION_TYPE = "aggregation_type"
 
+    # The aggregation type is this family's subtype discriminator.
+    SUBTYPE_KEY = AGGREGATION_TYPE
+
     # Define supported aggregation types
     AGGREGATION_TYPES = {
         "sum": "Sum of values",

--- a/tests/test_core/test_api/test_subtype_docs.py
+++ b/tests/test_core/test_api/test_subtype_docs.py
@@ -1,0 +1,158 @@
+"""Tests for the subtype enumeration API (issue #639).
+
+Contract under test (to be implemented by the Green agent):
+
+9.  ``FeatureGroupInfo`` gains ``subtype_key``, ``subtypes`` (sorted) and
+    ``subtype_support`` (framework class name -> sorted subtypes). All are
+    defaulted, so existing construction keeps working, and
+    ``get_feature_group_docs()`` populates them.
+10. ``ResolvedFeature`` gains ``subtype``, populated by ``resolve_feature()``
+    from the resolved feature group's ``resolve_subtype(feature_name, Options())``.
+
+All tests fail until the feature exists.
+"""
+
+from typing import Optional
+
+import pytest
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.api.plugin_docs import get_feature_group_docs, resolve_feature
+from mloda.core.api.plugin_info import FeatureGroupInfo, ResolvedFeature
+from mloda.provider import FeatureChainParserMixin, FeatureGroup, property_spec
+from mloda.user import PluginLoader
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
+    PythonDictFramework,
+)
+
+
+DOCS_SUBTYPE_FEATURE = "revenue__median_docstat"
+
+
+class DocsSubtypeFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+    """Subtype-carrying family with a bounded framework definition for the docs API."""
+
+    SUBTYPE_KEY = "stat_type"
+    PREFIX_PATTERN = r".*__([\w]+)_docstat$"
+
+    PROPERTY_MAPPING = {
+        "stat_type": property_spec(
+            "statistic to compute",
+            strict=True,
+            allowed_values={"sum": "Sum of values", "median": "Median value"},
+        ),
+    }
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame, PythonDictFramework}
+
+    @classmethod
+    def supported_subtypes(cls, compute_framework: type[ComputeFramework]) -> frozenset[str]:
+        if compute_framework is PythonDictFramework:
+            return frozenset({"sum"})
+        return cls.subtype_universe()
+
+
+class DocsNoSubtypeFeatureGroup(FeatureGroup):
+    """Family without a subtype dimension: the new fields stay empty."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == cls.get_class_name()
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+@pytest.fixture(scope="module", autouse=True)
+def load_plugins() -> None:
+    """Load all plugins before running tests in this module."""
+    PluginLoader.all()
+
+
+def _info_for(name: str) -> FeatureGroupInfo:
+    results = [info for info in get_feature_group_docs(name=name) if info.name == name]
+    assert len(results) == 1, f"Expected exactly one FeatureGroupInfo for '{name}', got {[r.name for r in results]}"
+    return results[0]
+
+
+class TestFeatureGroupInfoSubtypeFields:
+    """Contract 9: FeatureGroupInfo carries the subtype universe and support matrix."""
+
+    def test_fields_default_so_existing_construction_keeps_working(self) -> None:
+        info = FeatureGroupInfo(
+            name="test_group",
+            description="A test feature group",
+            version="1.0.0",
+            module="mloda_plugins.test_module",
+            compute_frameworks=["pandas"],
+            supported_feature_names={"feature1"},
+            prefix="test_",
+        )
+
+        assert info.subtype_key is None
+        assert info.subtypes == []
+        assert info.subtype_support == {}
+
+    def test_docs_populate_subtype_key_and_sorted_subtypes(self) -> None:
+        info = _info_for("DocsSubtypeFeatureGroup")
+
+        assert info.subtype_key == "stat_type"
+        assert info.subtypes == ["median", "sum"], "subtypes must be sorted"
+
+    def test_docs_populate_the_subtype_support_matrix(self) -> None:
+        info = _info_for("DocsSubtypeFeatureGroup")
+
+        assert info.subtype_support == {
+            "PandasDataFrame": ["median", "sum"],
+            "PythonDictFramework": ["sum"],
+        }
+
+    def test_fields_stay_empty_without_a_subtype_dimension(self) -> None:
+        info = _info_for("DocsNoSubtypeFeatureGroup")
+
+        assert info.subtype_key is None
+        assert info.subtypes == []
+        assert info.subtype_support == {}
+
+
+class TestResolvedFeatureSubtype:
+    """Contract 10: ResolvedFeature.subtype comes from the resolved feature group."""
+
+    def test_field_defaults_to_none(self) -> None:
+        result = ResolvedFeature("n", None, [], None)
+
+        assert result.subtype is None
+
+    def test_resolve_feature_populates_the_subtype(self) -> None:
+        result = resolve_feature(DOCS_SUBTYPE_FEATURE)
+
+        assert result.feature_group is DocsSubtypeFeatureGroup, f"Unexpected resolution: {result.error}"
+        assert result.subtype == "median"
+
+    def test_subtype_is_none_for_a_feature_group_without_a_subtype_dimension(self) -> None:
+        result = resolve_feature(DocsNoSubtypeFeatureGroup.get_class_name())
+
+        assert result.feature_group is DocsNoSubtypeFeatureGroup, f"Unexpected resolution: {result.error}"
+        assert result.subtype is None
+
+    def test_subtype_is_none_when_nothing_resolves(self) -> None:
+        result = resolve_feature("CompletelyUnknownSubtypeFeature12345XYZ")
+
+        assert result.feature_group is None
+        assert result.subtype is None

--- a/tests/test_core/test_api/test_subtype_docs.py
+++ b/tests/test_core/test_api/test_subtype_docs.py
@@ -1,18 +1,21 @@
 """Tests for the subtype enumeration API (issue #639).
 
-Contract under test (to be implemented by the Green agent):
+Contract under test:
 
-9.  ``FeatureGroupInfo`` gains ``subtype_key``, ``subtypes`` (sorted) and
-    ``subtype_support`` (framework class name -> sorted subtypes). All are
-    defaulted, so existing construction keeps working, and
-    ``get_feature_group_docs()`` populates them.
+9.  ``FeatureGroupInfo`` gains ``subtype_key``, ``subtypes`` (sorted),
+    ``subtype_support`` (framework class name -> sorted subtypes) and
+    ``subtype_error``. All are defaulted, so existing construction keeps working,
+    and ``get_feature_group_docs()`` populates them.
 10. ``ResolvedFeature`` gains ``subtype``, populated by ``resolve_feature()``
     from the resolved feature group's ``resolve_subtype(feature_name, Options())``.
-
-All tests fail until the feature exists.
+11. An ABSTRACT base documents its subtype universe but an EMPTY support matrix.
+12. A misdeclared capability is SURFACED, not swallowed: ``subtype_support`` stays
+    empty and ``subtype_error`` carries the rejection message. Healthy groups in the
+    same call keep ``subtype_error is None``.
 """
 
-from typing import Optional
+from abc import abstractmethod
+from typing import Any, Optional
 
 import pytest
 
@@ -32,6 +35,8 @@ from mloda_plugins.compute_framework.base_implementations.python_dict.python_dic
 
 
 DOCS_SUBTYPE_FEATURE = "revenue__median_docstat"
+
+AGGREGATION_SUBTYPES = ["avg", "count", "max", "mean", "median", "min", "std", "sum", "var"]
 
 
 class DocsSubtypeFeatureGroup(FeatureChainParserMixin, FeatureGroup):
@@ -79,6 +84,26 @@ class DocsNoSubtypeFeatureGroup(FeatureGroup):
         return None
 
 
+class DocsAbstractSubtypeFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+    """Abstract base: documents the universe, but declares no per-framework support."""
+
+    SUBTYPE_KEY = "stat_type"
+    PREFIX_PATTERN = r".*__([\w]+)_docsabstract$"
+
+    PROPERTY_MAPPING = {
+        "stat_type": property_spec(
+            "statistic to compute",
+            strict=True,
+            allowed_values={"sum": "Sum of values", "median": "Median value"},
+        ),
+    }
+
+    @classmethod
+    @abstractmethod
+    def _perform_stat(cls, data: Any, stat_type: str) -> Any:
+        """Framework-specific implementation, supplied by the concrete subclass."""
+
+
 @pytest.fixture(scope="module", autouse=True)
 def load_plugins() -> None:
     """Load all plugins before running tests in this module."""
@@ -108,6 +133,7 @@ class TestFeatureGroupInfoSubtypeFields:
         assert info.subtype_key is None
         assert info.subtypes == []
         assert info.subtype_support == {}
+        assert info.subtype_error is None
 
     def test_docs_populate_subtype_key_and_sorted_subtypes(self) -> None:
         info = _info_for("DocsSubtypeFeatureGroup")
@@ -122,6 +148,7 @@ class TestFeatureGroupInfoSubtypeFields:
             "PandasDataFrame": ["median", "sum"],
             "PythonDictFramework": ["sum"],
         }
+        assert info.subtype_error is None
 
     def test_fields_stay_empty_without_a_subtype_dimension(self) -> None:
         info = _info_for("DocsNoSubtypeFeatureGroup")
@@ -129,6 +156,116 @@ class TestFeatureGroupInfoSubtypeFields:
         assert info.subtype_key is None
         assert info.subtypes == []
         assert info.subtype_support == {}
+        assert info.subtype_error is None
+
+
+class TestAbstractBaseDocs:
+    """Contract 11: an abstract base documents the universe, not a fabricated support matrix."""
+
+    def test_abstract_test_base_reports_subtypes_without_support(self) -> None:
+        info = _info_for("DocsAbstractSubtypeFeatureGroup")
+
+        assert info.subtypes == ["median", "sum"]
+        assert info.subtype_support == {}, "An abstract base must not claim support on every framework"
+        assert info.subtype_error is None
+
+    def test_abstract_aggregated_base_reports_subtypes_without_support(self) -> None:
+        info = _info_for("AggregatedFeatureGroup")
+
+        assert info.subtypes == AGGREGATION_SUBTYPES
+        assert info.subtype_support == {}, (
+            "AggregatedFeatureGroup is abstract: frameworks without an aggregation "
+            "implementation must not be documented as supporting every aggregation type"
+        )
+        assert info.subtype_error is None
+
+    def test_concrete_aggregated_subclass_documents_its_framework(self) -> None:
+        info = _info_for("PandasAggregatedFeatureGroup")
+
+        assert info.subtype_support == {"PandasDataFrame": AGGREGATION_SUBTYPES}
+        assert info.subtype_error is None
+
+
+class TestMisdeclaredCapabilityIsSurfaced:
+    """Contract 12: a misdeclared capability is reported via subtype_error, not swallowed."""
+
+    def test_misdeclared_group_is_documented_with_an_error(self) -> None:
+        class DocsMisdeclaredFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+            """Declares a capability outside its own universe."""
+
+            SUBTYPE_KEY = "stat_type"
+            PREFIX_PATTERN = r".*__([\w]+)_docsbroken$"
+
+            PROPERTY_MAPPING = {
+                "stat_type": property_spec(
+                    "statistic to compute",
+                    strict=True,
+                    allowed_values={"sum": "Sum of values", "median": "Median value"},
+                ),
+            }
+
+            @classmethod
+            def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+                return {PandasDataFrame}
+
+            @classmethod
+            def supported_subtypes(cls, compute_framework: type[ComputeFramework]) -> frozenset[str]:
+                return frozenset({"sum", "bogus_stat"})
+
+            @classmethod
+            def _perform_stat(cls, data: Any, stat_type: str) -> Any:
+                return None
+
+        infos = {info.name: info for info in get_feature_group_docs(name="Docs")}
+
+        broken = infos["DocsMisdeclaredFeatureGroup"]
+        assert broken.subtypes == ["median", "sum"], "The universe is still reported"
+        assert broken.subtype_support == {}, "A misdeclared matrix degrades to empty"
+        assert broken.subtype_error is not None, (
+            "A misdeclared capability must be distinguishable from a legitimately unsupported group"
+        )
+        assert "bogus_stat" in broken.subtype_error, (
+            f"The error must name the offending subtype, but got: {broken.subtype_error}"
+        )
+
+        healthy = infos["DocsSubtypeFeatureGroup"]
+        assert healthy.subtype_error is None, "Other groups in the same call must document cleanly"
+        assert healthy.subtype_support == {
+            "PandasDataFrame": ["median", "sum"],
+            "PythonDictFramework": ["sum"],
+        }
+
+    def test_unrelated_plugins_still_document_cleanly(self) -> None:
+        class DocsOtherMisdeclaredFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+            """Second misdeclared group: it must not poison unrelated documentation."""
+
+            SUBTYPE_KEY = "stat_type"
+            PREFIX_PATTERN = r".*__([\w]+)_docsbroken2$"
+
+            PROPERTY_MAPPING = {
+                "stat_type": property_spec(
+                    "statistic to compute",
+                    strict=True,
+                    allowed_values={"sum": "Sum of values"},
+                ),
+            }
+
+            @classmethod
+            def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+                return {PandasDataFrame}
+
+            @classmethod
+            def supported_subtypes(cls, compute_framework: type[ComputeFramework]) -> frozenset[str]:
+                return frozenset({"also_bogus"})
+
+        infos = get_feature_group_docs(name="Aggregated")
+
+        assert infos, "The aggregated family must still be documented"
+        for info in infos:
+            assert info.subtype_error is None, f"{info.name} must document cleanly: {info.subtype_error}"
+
+        concrete = {info.name: info for info in infos}["PandasAggregatedFeatureGroup"]
+        assert concrete.subtype_support == {"PandasDataFrame": AGGREGATION_SUBTYPES}
 
 
 class TestResolvedFeatureSubtype:

--- a/tests/test_core/test_prepare/test_subtype_universe.py
+++ b/tests/test_core/test_prepare/test_subtype_universe.py
@@ -1,0 +1,532 @@
+"""Tests for the declarative subtype universe on FeatureGroup (issue #639).
+
+Contract under test (to be implemented by the Green agent):
+
+1. ``FeatureGroup.SUBTYPE_KEY: ClassVar[str | None] = None`` names the
+   PROPERTY_MAPPING key carrying the family's subtype discriminator.
+2. ``declared_option_values(key)`` returns a key's declared value space
+   (``allowed_values`` form and legacy flattened form).
+3. ``subtype_universe()`` returns the subtypes the family defines.
+4. ``supported_subtypes(compute_framework)`` returns the subtypes supported on
+   one framework, defaulting to the full universe.
+5. ``resolve_subtype(feature_name, options)`` returns a concrete feature's subtype.
+6. ``supports_compute_framework`` default is DERIVED from 3/4/5.
+7. ``subtype_support_matrix()`` (``@final``) enumerates framework -> subtypes and
+   raises on a capability declared outside the universe.
+8. ``__init_subclass__`` rejects a SUBTYPE_KEY absent from PROPERTY_MAPPING unless
+   the class overrides ``subtype_universe()``.
+
+All tests fail until the feature exists.
+"""
+
+from typing import Optional
+
+import pytest
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+from mloda.provider import DefaultOptionKeys, FeatureChainParserMixin, FeatureGroup, property_spec
+
+
+class SubtypeFwAlpha(ComputeFramework):
+    """First compute framework used in subtype tests."""
+
+
+class SubtypeFwBeta(ComputeFramework):
+    """Second compute framework used in subtype tests."""
+
+
+class NoSubtypeFeatureGroup(FeatureGroup):
+    """Family without a subtype dimension: SUBTYPE_KEY stays None."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class LegacyValuesFeatureGroup(FeatureGroup):
+    """Legacy flattened PROPERTY_MAPPING: value space is the non-metadata keys."""
+
+    PROPERTY_MAPPING = {
+        "stat_type": {
+            "sum": "Sum of values",
+            "median": "Median value",
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: True,
+        },
+        "meta_only": {
+            "explanation": "A key that declares no value space",
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: False,
+        },
+    }
+
+
+class AllowedValuesFeatureGroup(FeatureGroup):
+    """property_spec form: value space comes from ``allowed_values``."""
+
+    PROPERTY_MAPPING = {
+        "stat_type": property_spec(
+            "statistic to compute",
+            strict=True,
+            allowed_values={"sum": "Sum of values", "median": "Median value"},
+        ),
+        "frame_unit": property_spec(
+            "frame unit",
+            strict=True,
+            allowed_values=["rows", "range"],
+        ),
+    }
+
+
+class SplitStatFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+    """Family with a subtype dimension and a per-framework capability subset.
+
+    SubtypeFwBeta supports only "sum"; SubtypeFwAlpha supports the full universe.
+    """
+
+    SUBTYPE_KEY = "stat_type"
+    PREFIX_PATTERN = r".*__([\w]+)_splitstat$"
+
+    PROPERTY_MAPPING = {
+        "stat_type": property_spec(
+            "statistic to compute",
+            strict=True,
+            allowed_values={"sum": "Sum of values", "median": "Median value", "mode": "Most frequent value"},
+        ),
+    }
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {SubtypeFwAlpha, SubtypeFwBeta}
+
+    @classmethod
+    def supported_subtypes(cls, compute_framework: type[ComputeFramework]) -> frozenset[str]:
+        if compute_framework is SubtypeFwBeta:
+            return frozenset({"sum"})
+        return cls.subtype_universe()
+
+
+class FullUniverseStatFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+    """Same shape as SplitStatFeatureGroup but without a supported_subtypes override."""
+
+    SUBTYPE_KEY = "stat_type"
+    PREFIX_PATTERN = r".*__([\w]+)_fullstat$"
+
+    PROPERTY_MAPPING = {
+        "stat_type": property_spec(
+            "statistic to compute",
+            strict=True,
+            allowed_values={"sum": "Sum of values", "median": "Median value", "mode": "Most frequent value"},
+        ),
+    }
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {SubtypeFwAlpha, SubtypeFwBeta}
+
+
+class ExplicitOverrideStatFeatureGroup(SplitStatFeatureGroup):
+    """An explicit supports_compute_framework override beats the derived default."""
+
+    @classmethod
+    def supports_compute_framework(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        compute_framework: type[ComputeFramework],
+    ) -> bool:
+        return True
+
+
+class MisdeclaredCapabilityFeatureGroup(SplitStatFeatureGroup):
+    """Declares a capability outside the universe: the matrix must reject it."""
+
+    @classmethod
+    def supported_subtypes(cls, compute_framework: type[ComputeFramework]) -> frozenset[str]:
+        return frozenset({"sum", "bogus_stat"})
+
+
+class FrameSpecFeatureGroup(FeatureGroup):
+    """Two-axis family: flattens frame_type x frame_unit into compound subtypes.
+
+    SUBTYPE_KEY names no PROPERTY_MAPPING key, which is allowed because
+    subtype_universe() is overridden.
+    """
+
+    SUBTYPE_KEY = "frame_spec"
+
+    PROPERTY_MAPPING = {
+        "frame_type": property_spec("frame type", strict=True, allowed_values=["rows", "range"]),
+        "frame_unit": property_spec("frame unit", strict=True, allowed_values=["1", "7"]),
+    }
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {SubtypeFwAlpha}
+
+    @classmethod
+    def subtype_universe(cls) -> frozenset[str]:
+        return frozenset({"rows_1", "rows_7", "range_1", "range_7"})
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class TestDeclaredOptionValues:
+    """Contract 2: declared_option_values(key) -> frozenset[str]."""
+
+    def test_returns_empty_frozenset_when_property_mapping_is_none(self) -> None:
+        assert NoSubtypeFeatureGroup.declared_option_values("stat_type") == frozenset()
+
+    def test_returns_empty_frozenset_when_key_is_absent(self) -> None:
+        assert AllowedValuesFeatureGroup.declared_option_values("not_declared") == frozenset()
+
+    def test_legacy_flattened_form_subtracts_reserved_metadata_keys(self) -> None:
+        result = LegacyValuesFeatureGroup.declared_option_values("stat_type")
+
+        assert result == frozenset({"sum", "median"})
+        assert str(DefaultOptionKeys.context) not in result
+        assert str(DefaultOptionKeys.strict_validation) not in result
+
+    def test_legacy_spec_without_value_space_returns_empty_frozenset(self) -> None:
+        assert LegacyValuesFeatureGroup.declared_option_values("meta_only") == frozenset()
+
+    def test_allowed_values_mapping_form(self) -> None:
+        assert AllowedValuesFeatureGroup.declared_option_values("stat_type") == frozenset({"sum", "median"})
+
+    def test_allowed_values_iterable_form(self) -> None:
+        assert AllowedValuesFeatureGroup.declared_option_values("frame_unit") == frozenset({"rows", "range"})
+
+    def test_returns_frozenset_of_strings(self) -> None:
+        result = AllowedValuesFeatureGroup.declared_option_values("stat_type")
+
+        assert isinstance(result, frozenset)
+        assert all(isinstance(value, str) for value in result)
+
+
+class TestSubtypeKeyAndUniverse:
+    """Contracts 1 and 3: SUBTYPE_KEY default and subtype_universe()."""
+
+    def test_subtype_key_defaults_to_none(self) -> None:
+        assert FeatureGroup.SUBTYPE_KEY is None
+        assert NoSubtypeFeatureGroup.SUBTYPE_KEY is None
+
+    def test_universe_is_empty_without_subtype_key(self) -> None:
+        assert NoSubtypeFeatureGroup.subtype_universe() == frozenset()
+
+    def test_universe_derives_from_declared_option_values(self) -> None:
+        assert SplitStatFeatureGroup.SUBTYPE_KEY == "stat_type"
+        assert SplitStatFeatureGroup.subtype_universe() == frozenset({"sum", "median", "mode"})
+
+    def test_universe_override_wins_for_multi_axis_family(self) -> None:
+        assert FrameSpecFeatureGroup.subtype_universe() == frozenset({"rows_1", "rows_7", "range_1", "range_7"})
+
+
+class TestSupportedSubtypes:
+    """Contract 4: supported_subtypes(compute_framework)."""
+
+    def test_default_is_the_full_universe(self) -> None:
+        universe = FullUniverseStatFeatureGroup.subtype_universe()
+
+        assert FullUniverseStatFeatureGroup.supported_subtypes(SubtypeFwAlpha) == universe
+        assert FullUniverseStatFeatureGroup.supported_subtypes(SubtypeFwBeta) == universe
+
+    def test_override_returns_a_subset_per_framework(self) -> None:
+        assert SplitStatFeatureGroup.supported_subtypes(SubtypeFwBeta) == frozenset({"sum"})
+        assert SplitStatFeatureGroup.supported_subtypes(SubtypeFwAlpha) == frozenset({"sum", "median", "mode"})
+
+    def test_default_is_empty_without_subtype_dimension(self) -> None:
+        assert NoSubtypeFeatureGroup.supported_subtypes(SubtypeFwAlpha) == frozenset()
+
+
+class TestResolveSubtype:
+    """Contract 5: resolve_subtype(feature_name, options)."""
+
+    def test_resolves_from_the_feature_name_pattern(self) -> None:
+        assert SplitStatFeatureGroup.resolve_subtype("revenue__median_splitstat", Options()) == "median"
+
+    def test_accepts_a_feature_name_object(self) -> None:
+        resolved = SplitStatFeatureGroup.resolve_subtype(FeatureName("revenue__median_splitstat"), Options())
+
+        assert resolved == "median"
+
+    def test_resolves_from_options_when_the_name_does_not_parse(self) -> None:
+        options = Options(context={"stat_type": "mode"})
+
+        assert SplitStatFeatureGroup.resolve_subtype("placeholder", options) == "mode"
+
+    def test_options_value_is_stringified(self) -> None:
+        options = Options(context={"stat_type": 7})
+
+        assert SplitStatFeatureGroup.resolve_subtype("placeholder", options) == "7"
+
+    def test_name_parsing_takes_precedence_over_options(self) -> None:
+        options = Options(context={"stat_type": "sum"})
+
+        assert SplitStatFeatureGroup.resolve_subtype("revenue__median_splitstat", options) == "median"
+
+    def test_returns_none_when_neither_path_resolves(self) -> None:
+        assert SplitStatFeatureGroup.resolve_subtype("plain_feature", Options()) is None
+
+    def test_returns_none_without_subtype_key(self) -> None:
+        options = Options(context={"stat_type": "sum"})
+
+        assert NoSubtypeFeatureGroup.resolve_subtype("plain_feature", options) is None
+
+
+class TestDerivedSupportsComputeFramework:
+    """Contract 6: supports_compute_framework derived from the universe."""
+
+    def test_true_without_subtype_key(self) -> None:
+        options = Options(context={"stat_type": "median"})
+
+        assert NoSubtypeFeatureGroup.supports_compute_framework("anything", options, SubtypeFwBeta) is True
+
+    def test_true_when_the_subtype_does_not_resolve(self) -> None:
+        assert SplitStatFeatureGroup.supports_compute_framework("plain_feature", Options(), SubtypeFwBeta) is True
+
+    def test_true_for_a_parametric_subtype_outside_the_universe(self) -> None:
+        """Parametric subtypes (ntile_2, top_3) must stay open: this hook must not double-gate."""
+        resolved = SplitStatFeatureGroup.resolve_subtype("revenue__ntile_2_splitstat", Options())
+        assert resolved == "ntile_2"
+        assert resolved not in SplitStatFeatureGroup.subtype_universe()
+
+        assert (
+            SplitStatFeatureGroup.supports_compute_framework("revenue__ntile_2_splitstat", Options(), SubtypeFwBeta)
+            is True
+        )
+
+    def test_true_when_the_subtype_is_supported_on_the_framework(self) -> None:
+        assert (
+            SplitStatFeatureGroup.supports_compute_framework("revenue__sum_splitstat", Options(), SubtypeFwBeta) is True
+        )
+        assert (
+            SplitStatFeatureGroup.supports_compute_framework("revenue__median_splitstat", Options(), SubtypeFwAlpha)
+            is True
+        )
+
+    def test_false_when_the_subtype_is_unsupported_on_the_framework(self) -> None:
+        assert (
+            SplitStatFeatureGroup.supports_compute_framework("revenue__median_splitstat", Options(), SubtypeFwBeta)
+            is False
+        )
+
+    def test_false_for_the_config_based_path(self) -> None:
+        options = Options(context={"stat_type": "median"})
+
+        assert SplitStatFeatureGroup.supports_compute_framework("placeholder", options, SubtypeFwBeta) is False
+
+    def test_explicit_override_beats_the_derived_default(self) -> None:
+        assert ExplicitOverrideStatFeatureGroup.supported_subtypes(SubtypeFwBeta) == frozenset({"sum"})
+        assert (
+            ExplicitOverrideStatFeatureGroup.supports_compute_framework(
+                "revenue__median_splitstat", Options(), SubtypeFwBeta
+            )
+            is True
+        )
+
+    def test_base_feature_group_default_stays_true(self) -> None:
+        assert FeatureGroup.supports_compute_framework("anything", Options(), SubtypeFwAlpha) is True
+
+
+class TestSubtypeSupportMatrix:
+    """Contract 7: subtype_support_matrix() enumerates support without probing."""
+
+    def test_maps_framework_class_name_to_supported_subtypes(self) -> None:
+        matrix = SplitStatFeatureGroup.subtype_support_matrix()
+
+        assert matrix == {
+            "SubtypeFwAlpha": frozenset({"sum", "median", "mode"}),
+            "SubtypeFwBeta": frozenset({"sum"}),
+        }
+
+    def test_default_matrix_gives_every_framework_the_full_universe(self) -> None:
+        matrix = FullUniverseStatFeatureGroup.subtype_support_matrix()
+
+        assert matrix == {
+            "SubtypeFwAlpha": frozenset({"sum", "median", "mode"}),
+            "SubtypeFwBeta": frozenset({"sum", "median", "mode"}),
+        }
+
+    def test_empty_dict_without_subtype_dimension(self) -> None:
+        assert NoSubtypeFeatureGroup.subtype_support_matrix() == {}
+
+    def test_raises_when_a_capability_lies_outside_the_universe(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+            MisdeclaredCapabilityFeatureGroup.subtype_support_matrix()
+
+        message = str(exc_info.value)
+        assert "bogus_stat" in message, f"Error must name the offending subtype, but got: {message}"
+
+    def test_multi_axis_family_matrix_uses_the_overridden_universe(self) -> None:
+        matrix = FrameSpecFeatureGroup.subtype_support_matrix()
+
+        assert matrix == {"SubtypeFwAlpha": frozenset({"rows_1", "rows_7", "range_1", "range_7"})}
+
+
+class TestSubtypeKeyClassDefinitionValidation:
+    """Contract 8: a SUBTYPE_KEY absent from PROPERTY_MAPPING is a class-definition error."""
+
+    def test_raises_when_subtype_key_is_not_a_property_mapping_key(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+
+            class BrokenSubtypeFeatureGroup(FeatureGroup):
+                SUBTYPE_KEY = "missing_key"
+
+                PROPERTY_MAPPING = {
+                    "stat_type": property_spec("statistic", strict=True, allowed_values=["sum"]),
+                }
+
+        message = str(exc_info.value)
+        assert "BrokenSubtypeFeatureGroup" in message, f"Error must name the class, but got: {message}"
+        assert "missing_key" in message, f"Error must name the bad key, but got: {message}"
+
+    def test_raises_when_property_mapping_is_none(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+
+            class NoMappingSubtypeFeatureGroup(FeatureGroup):
+                SUBTYPE_KEY = "stat_type"
+
+        message = str(exc_info.value)
+        assert "NoMappingSubtypeFeatureGroup" in message, f"Error must name the class, but got: {message}"
+        assert "stat_type" in message, f"Error must name the bad key, but got: {message}"
+
+    def test_no_raise_when_subtype_universe_is_overridden(self) -> None:
+        class OverriddenUniverseFeatureGroup(FeatureGroup):
+            SUBTYPE_KEY = "compound_key"
+
+            @classmethod
+            def subtype_universe(cls) -> frozenset[str]:
+                return frozenset({"a_1", "b_2"})
+
+        assert OverriddenUniverseFeatureGroup.subtype_universe() == frozenset({"a_1", "b_2"})
+
+    def test_no_raise_for_a_declared_subtype_key(self) -> None:
+        class ValidSubtypeFeatureGroup(FeatureGroup):
+            SUBTYPE_KEY = "stat_type"
+
+            PROPERTY_MAPPING = {
+                "stat_type": property_spec("statistic", strict=True, allowed_values=["sum", "median"]),
+            }
+
+        assert ValidSubtypeFeatureGroup.subtype_universe() == frozenset({"sum", "median"})
+
+
+class TestDerivedCapabilityAtMatchTime:
+    """The derived hook drives resolution: route-around and the dedicated pin error."""
+
+    def test_route_around_the_unsupported_framework(self) -> None:
+        feature = Feature("revenue__median_splitstat")
+
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            SplitStatFeatureGroup: {SubtypeFwAlpha, SubtypeFwBeta},
+        }
+
+        identified = IdentifyFeatureGroupClass(
+            feature=feature,
+            accessible_plugins=accessible_plugins,
+            links=None,
+            data_access_collection=None,
+        )
+
+        feature_group_class, compute_frameworks = identified.get()
+        assert feature_group_class is SplitStatFeatureGroup
+        assert compute_frameworks == {SubtypeFwAlpha}, (
+            f"'median' is unsupported on SubtypeFwBeta and must be narrowed out; got {compute_frameworks}"
+        )
+
+    def test_supported_subtype_keeps_every_framework(self) -> None:
+        feature = Feature("revenue__sum_splitstat")
+
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            SplitStatFeatureGroup: {SubtypeFwAlpha, SubtypeFwBeta},
+        }
+
+        identified = IdentifyFeatureGroupClass(
+            feature=feature,
+            accessible_plugins=accessible_plugins,
+            links=None,
+            data_access_collection=None,
+        )
+
+        _, compute_frameworks = identified.get()
+        assert compute_frameworks == {SubtypeFwAlpha, SubtypeFwBeta}
+
+    def test_pin_to_unsupported_framework_raises_the_capability_error(self) -> None:
+        feature = Feature("revenue__median_splitstat")
+        feature.compute_frameworks = {SubtypeFwBeta}
+
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            SplitStatFeatureGroup: {SubtypeFwAlpha, SubtypeFwBeta},
+        }
+
+        with pytest.raises(ValueError) as exc_info:
+            IdentifyFeatureGroupClass(
+                feature=feature,
+                accessible_plugins=accessible_plugins,
+                links=None,
+                data_access_collection=None,
+            )
+
+        message = str(exc_info.value)
+        lowered = message.lower()
+        assert "unsupported" in lowered or "not supported" in lowered, (
+            f"Capability error must signal an unsupported framework, but got: {message}"
+        )
+        assert SubtypeFwBeta.get_class_name() in message, f"Error must name the rejected framework, but got: {message}"
+        assert SubtypeFwAlpha.get_class_name() in message, (
+            f"Error must name the supported framework, but got: {message}"
+        )
+        assert "Did you mean" not in message, (
+            f"Capability error must skip the fuzzy suggestion path, but got: {message}"
+        )
+
+    def test_parametric_subtype_is_not_gated_at_match_time(self) -> None:
+        """An unknown/parametric subtype stays open on every framework."""
+        feature = Feature("revenue__ntile_2_splitstat")
+
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            SplitStatFeatureGroup: {SubtypeFwAlpha, SubtypeFwBeta},
+        }
+
+        identified = IdentifyFeatureGroupClass(
+            feature=feature,
+            accessible_plugins=accessible_plugins,
+            links=None,
+            data_access_collection=None,
+        )
+
+        _, compute_frameworks = identified.get()
+        assert compute_frameworks == {SubtypeFwAlpha, SubtypeFwBeta}
+
+    def test_feature_group_without_subtype_dimension_is_unaffected(self) -> None:
+        feature = Feature(NoSubtypeFeatureGroup.get_class_name())
+
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            NoSubtypeFeatureGroup: {SubtypeFwAlpha, SubtypeFwBeta},
+        }
+
+        identified = IdentifyFeatureGroupClass(
+            feature=feature,
+            accessible_plugins=accessible_plugins,
+            links=None,
+            data_access_collection=None,
+        )
+
+        feature_group_class, compute_frameworks = identified.get()
+        assert feature_group_class is NoSubtypeFeatureGroup
+        assert compute_frameworks == {SubtypeFwAlpha, SubtypeFwBeta}
+
+
+def test_match_feature_group_criteria_still_accepts_the_unsupported_subtype() -> None:
+    """Capability is orthogonal to matching: the feature group still matches the name."""
+    matched = SplitStatFeatureGroup.match_feature_group_criteria(
+        FeatureName("revenue__median_splitstat"), Options(), DataAccessCollection()
+    )
+
+    assert matched is True

--- a/tests/test_core/test_prepare/test_subtype_universe.py
+++ b/tests/test_core/test_prepare/test_subtype_universe.py
@@ -1,6 +1,6 @@
 """Tests for the declarative subtype universe on FeatureGroup (issue #639).
 
-Contract under test (to be implemented by the Green agent):
+Contract under test:
 
 1. ``FeatureGroup.SUBTYPE_KEY: ClassVar[str | None] = None`` names the
    PROPERTY_MAPPING key carrying the family's subtype discriminator.
@@ -9,17 +9,27 @@ Contract under test (to be implemented by the Green agent):
 3. ``subtype_universe()`` returns the subtypes the family defines.
 4. ``supported_subtypes(compute_framework)`` returns the subtypes supported on
    one framework, defaulting to the full universe.
-5. ``resolve_subtype(feature_name, options)`` returns a concrete feature's subtype.
-6. ``supports_compute_framework`` default is DERIVED from 3/4/5.
-7. ``subtype_support_matrix()`` (``@final``) enumerates framework -> subtypes and
-   raises on a capability declared outside the universe.
-8. ``__init_subclass__`` rejects a SUBTYPE_KEY absent from PROPERTY_MAPPING unless
-   the class overrides ``subtype_universe()``.
+5. ``resolve_subtype(feature_name, options)`` returns a concrete feature's subtype
+   and NEVER raises.
+6. ``supports_compute_framework`` default is DERIVED from 3/4/5, for both
+   declaration shapes.
+7. ``subtype_support_matrix()`` (``@final``) enumerates framework -> subtypes,
+   returns ``{}`` for an ABSTRACT class (an abstract base declares the universe,
+   not the support), and raises on a capability declared outside the universe.
+8. Class-definition validation. Exactly two declaration shapes are legal:
 
-All tests fail until the feature exists.
+   Shape A: ``SUBTYPE_KEY`` names a declared PROPERTY_MAPPING key whose declared
+   value space is non-empty (or the class overrides ``subtype_universe()``).
+
+   Shape B: ``SUBTYPE_KEY`` stays ``None`` and the class overrides BOTH
+   ``subtype_universe()`` and ``resolve_subtype()`` (flattened multi-axis families).
+
+   Anything else is a ValueError at class-definition time.
 """
 
-from typing import Optional
+import inspect
+from abc import abstractmethod
+from typing import Any, Optional
 
 import pytest
 
@@ -27,10 +37,11 @@ from mloda.core.abstract_plugins.components.data_access_collection import DataAc
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.components.utils import get_all_subclasses
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
 from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
-from mloda.provider import DefaultOptionKeys, FeatureChainParserMixin, FeatureGroup, property_spec
+from mloda.provider import DefaultOptionKeys, FeatureChainParser, FeatureChainParserMixin, FeatureGroup, property_spec
 
 
 class SubtypeFwAlpha(ComputeFramework):
@@ -84,7 +95,7 @@ class AllowedValuesFeatureGroup(FeatureGroup):
 
 
 class SplitStatFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-    """Family with a subtype dimension and a per-framework capability subset.
+    """Shape A family with a per-framework capability subset.
 
     SubtypeFwBeta supports only "sum"; SubtypeFwAlpha supports the full universe.
     """
@@ -143,22 +154,53 @@ class ExplicitOverrideStatFeatureGroup(SplitStatFeatureGroup):
         return True
 
 
-class MisdeclaredCapabilityFeatureGroup(SplitStatFeatureGroup):
-    """Declares a capability outside the universe: the matrix must reject it."""
+class AbstractStatFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+    """Abstract base: declares the subtype universe, but no per-framework support.
 
-    @classmethod
-    def supported_subtypes(cls, compute_framework: type[ComputeFramework]) -> frozenset[str]:
-        return frozenset({"sum", "bogus_stat"})
-
-
-class FrameSpecFeatureGroup(FeatureGroup):
-    """Two-axis family: flattens frame_type x frame_unit into compound subtypes.
-
-    SUBTYPE_KEY names no PROPERTY_MAPPING key, which is allowed because
-    subtype_universe() is overridden.
+    ``compute_framework_rule()`` is None (all frameworks), which is exactly the shape
+    that must NOT be turned into a fabricated "every framework supports everything"
+    capability claim.
     """
 
-    SUBTYPE_KEY = "frame_spec"
+    SUBTYPE_KEY = "stat_type"
+    PREFIX_PATTERN = r".*__([\w]+)_abstractstat$"
+
+    PROPERTY_MAPPING = {
+        "stat_type": property_spec(
+            "statistic to compute",
+            strict=True,
+            allowed_values={"sum": "Sum of values", "median": "Median value"},
+        ),
+    }
+
+    @classmethod
+    @abstractmethod
+    def _perform_stat(cls, data: Any, stat_type: str) -> Any:
+        """Framework-specific implementation, supplied by the concrete subclass."""
+
+
+class OpenConcreteStatFeatureGroup(AbstractStatFeatureGroup):
+    """Concrete subclass that keeps ``compute_framework_rule() -> None``.
+
+    Rule None genuinely means "all frameworks", so this class DOES report every
+    declared framework. Abstractness, not the rule, is what suppresses the matrix.
+    """
+
+    @classmethod
+    def _perform_stat(cls, data: Any, stat_type: str) -> Any:
+        return None
+
+
+class FrameSpecFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+    """Shape B family: flattens frame_type x frame_unit into one compound subtype.
+
+    SUBTYPE_KEY stays None; the class overrides BOTH subtype_universe() and
+    resolve_subtype(), so the flattened subtype is enforceable.
+    SubtypeFwBeta has no range frames.
+    """
+
+    SUBTYPE_KEY = None
+    PREFIX_PATTERN = r".*__([\w]+)_framespec$"
 
     PROPERTY_MAPPING = {
         "frame_type": property_spec("frame type", strict=True, allowed_values=["rows", "range"]),
@@ -167,14 +209,29 @@ class FrameSpecFeatureGroup(FeatureGroup):
 
     @classmethod
     def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
-        return {SubtypeFwAlpha}
+        return {SubtypeFwAlpha, SubtypeFwBeta}
 
     @classmethod
     def subtype_universe(cls) -> frozenset[str]:
         return frozenset({"rows_1", "rows_7", "range_1", "range_7"})
 
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
-        return None
+    @classmethod
+    def supported_subtypes(cls, compute_framework: type[ComputeFramework]) -> frozenset[str]:
+        if compute_framework is SubtypeFwBeta:
+            return frozenset({"rows_1", "rows_7"})
+        return cls.subtype_universe()
+
+    @classmethod
+    def resolve_subtype(cls, feature_name: FeatureName | str, options: Options) -> Optional[str]:
+        parsed, _ = FeatureChainParser.parse_feature_name(str(feature_name), [cls.PREFIX_PATTERN])
+        if parsed is not None:
+            return parsed
+
+        frame_type = options.get("frame_type")
+        frame_unit = options.get("frame_unit")
+        if frame_type is None or frame_unit is None:
+            return None
+        return f"{frame_type}_{frame_unit}"
 
 
 class TestDeclaredOptionValues:
@@ -223,7 +280,8 @@ class TestSubtypeKeyAndUniverse:
         assert SplitStatFeatureGroup.SUBTYPE_KEY == "stat_type"
         assert SplitStatFeatureGroup.subtype_universe() == frozenset({"sum", "median", "mode"})
 
-    def test_universe_override_wins_for_multi_axis_family(self) -> None:
+    def test_universe_override_wins_for_the_flattened_family(self) -> None:
+        assert FrameSpecFeatureGroup.SUBTYPE_KEY is None
         assert FrameSpecFeatureGroup.subtype_universe() == frozenset({"rows_1", "rows_7", "range_1", "range_7"})
 
 
@@ -231,10 +289,8 @@ class TestSupportedSubtypes:
     """Contract 4: supported_subtypes(compute_framework)."""
 
     def test_default_is_the_full_universe(self) -> None:
-        universe = FullUniverseStatFeatureGroup.subtype_universe()
-
-        assert FullUniverseStatFeatureGroup.supported_subtypes(SubtypeFwAlpha) == universe
-        assert FullUniverseStatFeatureGroup.supported_subtypes(SubtypeFwBeta) == universe
+        assert FullUniverseStatFeatureGroup.supported_subtypes(SubtypeFwAlpha) == frozenset({"sum", "median", "mode"})
+        assert FullUniverseStatFeatureGroup.supported_subtypes(SubtypeFwBeta) == frozenset({"sum", "median", "mode"})
 
     def test_override_returns_a_subset_per_framework(self) -> None:
         assert SplitStatFeatureGroup.supported_subtypes(SubtypeFwBeta) == frozenset({"sum"})
@@ -245,7 +301,7 @@ class TestSupportedSubtypes:
 
 
 class TestResolveSubtype:
-    """Contract 5: resolve_subtype(feature_name, options)."""
+    """Contract 5: resolve_subtype(feature_name, options) resolves, and never raises."""
 
     def test_resolves_from_the_feature_name_pattern(self) -> None:
         assert SplitStatFeatureGroup.resolve_subtype("revenue__median_splitstat", Options()) == "median"
@@ -277,6 +333,15 @@ class TestResolveSubtype:
         options = Options(context={"stat_type": "sum"})
 
         assert NoSubtypeFeatureGroup.resolve_subtype("plain_feature", options) is None
+
+    def test_never_raises_on_a_pattern_match_without_a_source_feature(self) -> None:
+        """A name matching PREFIX_PATTERN with an empty source segment must not blow up."""
+        assert SplitStatFeatureGroup.resolve_subtype("__median_splitstat", Options()) is None
+
+    def test_capability_hook_stays_a_bool_on_a_source_less_name(self) -> None:
+        assert (
+            SplitStatFeatureGroup.supports_compute_framework("__median_splitstat", Options(), SubtypeFwBeta) is True
+        ), "A match-time capability hook must return a bool, never raise"
 
 
 class TestDerivedSupportsComputeFramework:
@@ -334,6 +399,69 @@ class TestDerivedSupportsComputeFramework:
         assert FeatureGroup.supports_compute_framework("anything", Options(), SubtypeFwAlpha) is True
 
 
+class TestFlattenedSubtypeIsEnforced:
+    """Contract 6, Shape B: the flattened subtype gates capability, it is not decorative."""
+
+    def test_false_for_an_unsupported_flattened_subtype_on_the_name_path(self) -> None:
+        assert (
+            FrameSpecFeatureGroup.supports_compute_framework("revenue__range_7_framespec", Options(), SubtypeFwBeta)
+            is False
+        ), "SubtypeFwBeta declares no range frames, so 'range_7' must be rejected"
+
+    def test_true_for_a_supported_flattened_subtype_on_the_name_path(self) -> None:
+        assert (
+            FrameSpecFeatureGroup.supports_compute_framework("revenue__rows_1_framespec", Options(), SubtypeFwBeta)
+            is True
+        )
+        assert (
+            FrameSpecFeatureGroup.supports_compute_framework("revenue__range_7_framespec", Options(), SubtypeFwAlpha)
+            is True
+        )
+
+    def test_false_for_an_unsupported_flattened_subtype_on_the_config_path(self) -> None:
+        options = Options(context={"frame_type": "range", "frame_unit": "7"})
+
+        assert FrameSpecFeatureGroup.resolve_subtype("placeholder", options) == "range_7"
+        assert FrameSpecFeatureGroup.supports_compute_framework("placeholder", options, SubtypeFwBeta) is False
+
+    def test_identify_routes_around_the_framework_without_the_flattened_subtype(self) -> None:
+        feature = Feature("revenue__range_7_framespec")
+
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            FrameSpecFeatureGroup: {SubtypeFwAlpha, SubtypeFwBeta},
+        }
+
+        identified = IdentifyFeatureGroupClass(
+            feature=feature,
+            accessible_plugins=accessible_plugins,
+            links=None,
+            data_access_collection=None,
+        )
+
+        feature_group_class, compute_frameworks = identified.get()
+        assert feature_group_class is FrameSpecFeatureGroup
+        assert compute_frameworks == {SubtypeFwAlpha}, (
+            f"'range_7' is unsupported on SubtypeFwBeta and must be narrowed out; got {compute_frameworks}"
+        )
+
+    def test_supported_flattened_subtype_keeps_every_framework(self) -> None:
+        feature = Feature("revenue__rows_1_framespec")
+
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            FrameSpecFeatureGroup: {SubtypeFwAlpha, SubtypeFwBeta},
+        }
+
+        identified = IdentifyFeatureGroupClass(
+            feature=feature,
+            accessible_plugins=accessible_plugins,
+            links=None,
+            data_access_collection=None,
+        )
+
+        _, compute_frameworks = identified.get()
+        assert compute_frameworks == {SubtypeFwAlpha, SubtypeFwBeta}
+
+
 class TestSubtypeSupportMatrix:
     """Contract 7: subtype_support_matrix() enumerates support without probing."""
 
@@ -356,21 +484,52 @@ class TestSubtypeSupportMatrix:
     def test_empty_dict_without_subtype_dimension(self) -> None:
         assert NoSubtypeFeatureGroup.subtype_support_matrix() == {}
 
+    def test_abstract_class_reports_no_support_matrix(self) -> None:
+        """An abstract base declares the universe; only concrete classes carry the support."""
+        assert inspect.isabstract(AbstractStatFeatureGroup) is True
+        assert AbstractStatFeatureGroup.subtype_universe() == frozenset({"sum", "median"})
+        assert AbstractStatFeatureGroup.subtype_support_matrix() == {}, (
+            "An abstract base with compute_framework_rule() -> None must not claim that every "
+            "installed framework supports every subtype"
+        )
+
+    def test_concrete_class_with_rule_none_reports_every_framework(self) -> None:
+        """Rule None genuinely means 'all frameworks': abstractness, not the rule, gates the matrix."""
+        assert inspect.isabstract(OpenConcreteStatFeatureGroup) is False
+        assert OpenConcreteStatFeatureGroup.compute_framework_rule() is None
+
+        matrix = OpenConcreteStatFeatureGroup.subtype_support_matrix()
+
+        expected_frameworks = {cfw.get_class_name() for cfw in get_all_subclasses(ComputeFramework)}
+        assert set(matrix) == expected_frameworks
+        assert "SubtypeFwAlpha" in matrix
+        assert all(supported == frozenset({"sum", "median"}) for supported in matrix.values())
+
     def test_raises_when_a_capability_lies_outside_the_universe(self) -> None:
+        class MisdeclaredCapabilityFeatureGroup(SplitStatFeatureGroup):
+            """Declares a capability outside the universe: the matrix must reject it."""
+
+            @classmethod
+            def supported_subtypes(cls, compute_framework: type[ComputeFramework]) -> frozenset[str]:
+                return frozenset({"sum", "bogus_stat"})
+
         with pytest.raises(ValueError) as exc_info:
             MisdeclaredCapabilityFeatureGroup.subtype_support_matrix()
 
         message = str(exc_info.value)
         assert "bogus_stat" in message, f"Error must name the offending subtype, but got: {message}"
 
-    def test_multi_axis_family_matrix_uses_the_overridden_universe(self) -> None:
+    def test_flattened_family_matrix_uses_the_overridden_universe(self) -> None:
         matrix = FrameSpecFeatureGroup.subtype_support_matrix()
 
-        assert matrix == {"SubtypeFwAlpha": frozenset({"rows_1", "rows_7", "range_1", "range_7"})}
+        assert matrix == {
+            "SubtypeFwAlpha": frozenset({"rows_1", "rows_7", "range_1", "range_7"}),
+            "SubtypeFwBeta": frozenset({"rows_1", "rows_7"}),
+        }
 
 
 class TestSubtypeKeyClassDefinitionValidation:
-    """Contract 8: a SUBTYPE_KEY absent from PROPERTY_MAPPING is a class-definition error."""
+    """Contract 8, Shape A: SUBTYPE_KEY must name a declared key with a value space."""
 
     def test_raises_when_subtype_key_is_not_a_property_mapping_key(self) -> None:
         with pytest.raises(ValueError) as exc_info:
@@ -396,15 +555,24 @@ class TestSubtypeKeyClassDefinitionValidation:
         assert "NoMappingSubtypeFeatureGroup" in message, f"Error must name the class, but got: {message}"
         assert "stat_type" in message, f"Error must name the bad key, but got: {message}"
 
-    def test_no_raise_when_subtype_universe_is_overridden(self) -> None:
-        class OverriddenUniverseFeatureGroup(FeatureGroup):
-            SUBTYPE_KEY = "compound_key"
+    def test_raises_for_an_undeclared_subtype_key_even_with_a_universe_override(self) -> None:
+        """A universe override is no longer an escape hatch for a bogus SUBTYPE_KEY: use Shape B."""
+        with pytest.raises(ValueError) as exc_info:
 
-            @classmethod
-            def subtype_universe(cls) -> frozenset[str]:
-                return frozenset({"a_1", "b_2"})
+            class HalfFlattenedFeatureGroup(FeatureGroup):
+                SUBTYPE_KEY = "frame_spec"
 
-        assert OverriddenUniverseFeatureGroup.subtype_universe() == frozenset({"a_1", "b_2"})
+                PROPERTY_MAPPING = {
+                    "frame_type": property_spec("frame type", strict=True, allowed_values=["rows", "range"]),
+                }
+
+                @classmethod
+                def subtype_universe(cls) -> frozenset[str]:
+                    return frozenset({"rows_1", "range_7"})
+
+        message = str(exc_info.value)
+        assert "HalfFlattenedFeatureGroup" in message, f"Error must name the class, but got: {message}"
+        assert "frame_spec" in message, f"Error must name the bad key, but got: {message}"
 
     def test_no_raise_for_a_declared_subtype_key(self) -> None:
         class ValidSubtypeFeatureGroup(FeatureGroup):
@@ -415,6 +583,149 @@ class TestSubtypeKeyClassDefinitionValidation:
             }
 
         assert ValidSubtypeFeatureGroup.subtype_universe() == frozenset({"sum", "median"})
+
+    def test_no_raise_when_a_declared_key_is_paired_with_a_universe_override(self) -> None:
+        class NarrowedUniverseFeatureGroup(FeatureGroup):
+            SUBTYPE_KEY = "stat_type"
+
+            PROPERTY_MAPPING = {
+                "stat_type": property_spec("statistic", strict=True, allowed_values=["sum", "median"]),
+            }
+
+            @classmethod
+            def subtype_universe(cls) -> frozenset[str]:
+                return frozenset({"sum"})
+
+        assert NarrowedUniverseFeatureGroup.subtype_universe() == frozenset({"sum"})
+
+
+class TestSubtypeKeyValueSpaceValidation:
+    """Contract 8: a SUBTYPE_KEY with no enumerable value space is a class-definition error."""
+
+    def test_raises_for_a_predicate_only_subtype_key(self) -> None:
+        """strict_validation by predicate accepts values that the universe cannot enumerate."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class PredicateOnlySubtypeFeatureGroup(FeatureGroup):
+                SUBTYPE_KEY = "stat_type"
+
+                PROPERTY_MAPPING = {
+                    "stat_type": property_spec(
+                        "statistic",
+                        strict=True,
+                        validation_function=lambda value: isinstance(value, str),
+                    ),
+                }
+
+        message = str(exc_info.value)
+        assert "PredicateOnlySubtypeFeatureGroup" in message, f"Error must name the class, but got: {message}"
+        assert "stat_type" in message, f"Error must name the key, but got: {message}"
+        assert "allowed_values" in message or "subtype_universe" in message, (
+            f"Error must point at allowed_values or a subtype_universe() override, but got: {message}"
+        )
+
+    def test_raises_for_a_key_without_any_declared_value_space(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+
+            class EmptySpaceSubtypeFeatureGroup(FeatureGroup):
+                SUBTYPE_KEY = "stat_type"
+
+                PROPERTY_MAPPING = {
+                    "stat_type": {
+                        "explanation": "A key that declares no value space",
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: False,
+                    },
+                }
+
+        message = str(exc_info.value)
+        assert "EmptySpaceSubtypeFeatureGroup" in message, f"Error must name the class, but got: {message}"
+        assert "stat_type" in message, f"Error must name the key, but got: {message}"
+
+    def test_no_raise_when_the_predicate_only_key_pairs_with_a_universe_override(self) -> None:
+        class PredicateWithUniverseFeatureGroup(FeatureGroup):
+            SUBTYPE_KEY = "stat_type"
+
+            PROPERTY_MAPPING = {
+                "stat_type": property_spec(
+                    "statistic",
+                    strict=True,
+                    validation_function=lambda value: isinstance(value, str),
+                ),
+            }
+
+            @classmethod
+            def subtype_universe(cls) -> frozenset[str]:
+                return frozenset({"sum", "median"})
+
+        assert PredicateWithUniverseFeatureGroup.subtype_universe() == frozenset({"sum", "median"})
+
+    def test_no_raise_for_allowed_values(self) -> None:
+        class AllowedValuesSubtypeFeatureGroup(FeatureGroup):
+            SUBTYPE_KEY = "stat_type"
+
+            PROPERTY_MAPPING = {
+                "stat_type": property_spec("statistic", strict=True, allowed_values=["sum", "median"]),
+            }
+
+        assert AllowedValuesSubtypeFeatureGroup.subtype_universe() == frozenset({"sum", "median"})
+
+
+class TestFlattenedShapeClassDefinitionValidation:
+    """Contract 8, Shape B: a universe override without SUBTYPE_KEY must pair with resolve_subtype."""
+
+    def test_raises_when_the_universe_override_is_unpaired(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+
+            class UnpairedFlattenedFeatureGroup(FeatureGroup):
+                SUBTYPE_KEY = None
+
+                PROPERTY_MAPPING = {
+                    "frame_type": property_spec("frame type", strict=True, allowed_values=["rows", "range"]),
+                    "frame_unit": property_spec("frame unit", strict=True, allowed_values=["1", "7"]),
+                }
+
+                @classmethod
+                def subtype_universe(cls) -> frozenset[str]:
+                    return frozenset({"rows_1", "range_7"})
+
+        message = str(exc_info.value)
+        assert "UnpairedFlattenedFeatureGroup" in message, f"Error must name the class, but got: {message}"
+        assert "subtype_universe" in message, f"Error must name subtype_universe(), but got: {message}"
+        assert "resolve_subtype" in message, f"Error must name resolve_subtype(), but got: {message}"
+
+    def test_no_raise_when_both_overrides_are_present(self) -> None:
+        class PairedFlattenedFeatureGroup(FeatureGroup):
+            SUBTYPE_KEY = None
+
+            PROPERTY_MAPPING = {
+                "frame_type": property_spec("frame type", strict=True, allowed_values=["rows", "range"]),
+                "frame_unit": property_spec("frame unit", strict=True, allowed_values=["1", "7"]),
+            }
+
+            @classmethod
+            def subtype_universe(cls) -> frozenset[str]:
+                return frozenset({"rows_1", "range_7"})
+
+            @classmethod
+            def resolve_subtype(cls, feature_name: FeatureName | str, options: Options) -> Optional[str]:
+                frame_type = options.get("frame_type")
+                frame_unit = options.get("frame_unit")
+                if frame_type is None or frame_unit is None:
+                    return None
+                return f"{frame_type}_{frame_unit}"
+
+        options = Options(context={"frame_type": "range", "frame_unit": "7"})
+        assert PairedFlattenedFeatureGroup.subtype_universe() == frozenset({"rows_1", "range_7"})
+        assert PairedFlattenedFeatureGroup.resolve_subtype("placeholder", options) == "range_7"
+
+    def test_no_raise_without_any_subtype_declaration(self) -> None:
+        class PlainFeatureGroup(FeatureGroup):
+            PROPERTY_MAPPING = {
+                "frame_type": property_spec("frame type", strict=True, allowed_values=["rows", "range"]),
+            }
+
+        assert PlainFeatureGroup.subtype_universe() == frozenset()
 
 
 class TestDerivedCapabilityAtMatchTime:

--- a/tests/test_plugins/feature_group/experimental/test_base_aggregated_feature_group/test_aggregated_subtype_universe.py
+++ b/tests/test_plugins/feature_group/experimental/test_base_aggregated_feature_group/test_aggregated_subtype_universe.py
@@ -1,36 +1,52 @@
 """Tests for the subtype universe on AggregatedFeatureGroup (issue #639).
 
-Contract under test (to be implemented by the Green agent):
+Contract under test:
 
-11. ``AggregatedFeatureGroup.SUBTYPE_KEY = AGGREGATION_TYPE``, so the family's
-    subtype universe is ``AGGREGATION_TYPES`` and both the string-based and the
-    config-based path resolve a concrete feature's subtype. The change is
-    behavior-neutral: the default ``supported_subtypes()`` is the full universe,
-    so every framework still supports every aggregation type.
-
-All tests fail until the feature exists.
+- ``AggregatedFeatureGroup.SUBTYPE_KEY = AGGREGATION_TYPE``, so the family's subtype
+  universe is exactly the nine declared aggregation types, pinned literally here: a
+  test that re-derives the expectation from ``AGGREGATION_TYPES`` cannot catch drift.
+- The reported universe equals what strict validation accepts: every subtype matches on
+  the string path and on the config path, and a value outside it is rejected.
+- The abstract base declares the universe but NO support matrix. Only the concrete,
+  per-framework subclasses carry the matrix.
+- ``resolve_subtype`` never raises, not even for a name that matches PREFIX_PATTERN
+  without a source feature.
 """
 
 from mloda.core.abstract_plugins.components.options import Options
+from mloda.provider import DefaultOptionKeys
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.polars.lazy_dataframe import PolarsLazyDataFrame
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
 from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
     PythonDictFramework,
 )
 from mloda_plugins.feature_group.experimental.aggregated_feature_group.base import AggregatedFeatureGroup
 from mloda_plugins.feature_group.experimental.aggregated_feature_group.pandas import PandasAggregatedFeatureGroup
+from mloda_plugins.feature_group.experimental.aggregated_feature_group.polars_lazy import (
+    PolarsLazyAggregatedFeatureGroup,
+)
+from mloda_plugins.feature_group.experimental.aggregated_feature_group.pyarrow import PyArrowAggregatedFeatureGroup
+
+
+# The aggregation universe, pinned literally. Adding or renaming an aggregation type
+# must fail here, which is the point of not reading AGGREGATION_TYPES.
+AGGREGATION_UNIVERSE = frozenset({"sum", "min", "max", "avg", "mean", "count", "std", "var", "median"})
 
 
 def test_subtype_key_is_the_aggregation_type() -> None:
-    assert AggregatedFeatureGroup.SUBTYPE_KEY == AggregatedFeatureGroup.AGGREGATION_TYPE
     assert AggregatedFeatureGroup.SUBTYPE_KEY == "aggregation_type"
+    assert AggregatedFeatureGroup.SUBTYPE_KEY == AggregatedFeatureGroup.AGGREGATION_TYPE
 
 
-def test_universe_is_the_declared_aggregation_types() -> None:
-    assert AggregatedFeatureGroup.subtype_universe() == frozenset(AggregatedFeatureGroup.AGGREGATION_TYPES)
+def test_universe_is_the_nine_declared_aggregation_types() -> None:
+    assert AggregatedFeatureGroup.subtype_universe() == AGGREGATION_UNIVERSE
 
 
-def test_universe_is_inherited_by_the_framework_subclass() -> None:
-    assert PandasAggregatedFeatureGroup.subtype_universe() == frozenset(AggregatedFeatureGroup.AGGREGATION_TYPES)
+def test_universe_is_inherited_by_the_framework_subclasses() -> None:
+    assert PandasAggregatedFeatureGroup.subtype_universe() == AGGREGATION_UNIVERSE
+    assert PyArrowAggregatedFeatureGroup.subtype_universe() == AGGREGATION_UNIVERSE
+    assert PolarsLazyAggregatedFeatureGroup.subtype_universe() == AGGREGATION_UNIVERSE
 
 
 def test_resolve_subtype_from_the_feature_name() -> None:
@@ -47,25 +63,85 @@ def test_resolve_subtype_returns_none_for_an_unrelated_name() -> None:
     assert AggregatedFeatureGroup.resolve_subtype("sales", Options()) is None
 
 
-def test_supported_subtypes_default_to_the_full_universe() -> None:
-    universe = AggregatedFeatureGroup.subtype_universe()
+def test_resolve_subtype_never_raises_for_a_name_without_a_source_feature() -> None:
+    """'__sum_aggr' matches PREFIX_PATTERN but carries no source feature."""
+    assert AggregatedFeatureGroup.resolve_subtype("__sum_aggr", Options()) is None
 
-    assert PandasAggregatedFeatureGroup.supported_subtypes(PandasDataFrame) == universe
-    assert PandasAggregatedFeatureGroup.supported_subtypes(PythonDictFramework) == universe
+
+def test_capability_hook_never_raises_for_a_name_without_a_source_feature() -> None:
+    """A match-time capability hook must return a bool, never raise."""
+    assert AggregatedFeatureGroup.supports_compute_framework("__sum_aggr", Options(), PandasDataFrame) is True
+
+
+def test_supported_subtypes_default_to_the_full_universe() -> None:
+    assert PandasAggregatedFeatureGroup.supported_subtypes(PandasDataFrame) == AGGREGATION_UNIVERSE
+    assert PandasAggregatedFeatureGroup.supported_subtypes(PythonDictFramework) == AGGREGATION_UNIVERSE
 
 
 def test_change_is_behavior_neutral_for_supports_compute_framework() -> None:
     """Every declared aggregation type stays supported on every framework."""
-    for aggregation_type in AggregatedFeatureGroup.AGGREGATION_TYPES:
+    for aggregation_type in sorted(AGGREGATION_UNIVERSE):
         feature_name = f"sales__{aggregation_type}_aggr"
         assert (
             PandasAggregatedFeatureGroup.supports_compute_framework(feature_name, Options(), PandasDataFrame) is True
         ), f"'{aggregation_type}' must stay supported on PandasDataFrame"
 
 
-def test_subtype_support_matrix_gives_every_framework_the_full_universe() -> None:
-    universe = PandasAggregatedFeatureGroup.subtype_universe()
-    matrix = PandasAggregatedFeatureGroup.subtype_support_matrix()
+def test_abstract_base_declares_the_universe_but_no_support_matrix() -> None:
+    """AggregatedFeatureGroup is abstract: it must not claim support on every installed framework."""
+    assert AggregatedFeatureGroup.subtype_universe() == AGGREGATION_UNIVERSE
+    assert AggregatedFeatureGroup.subtype_support_matrix() == {}, (
+        "The abstract base declares the universe, not the support. Frameworks without an "
+        "aggregation implementation (SqliteFramework, SparkFramework, ...) must not appear."
+    )
 
-    assert matrix, "The matrix must enumerate the declared compute framework(s)"
-    assert all(supported == universe for supported in matrix.values())
+
+def test_concrete_framework_subclasses_carry_the_support_matrix() -> None:
+    assert PandasAggregatedFeatureGroup.subtype_support_matrix() == {"PandasDataFrame": AGGREGATION_UNIVERSE}
+    assert PyArrowAggregatedFeatureGroup.subtype_support_matrix() == {"PyArrowTable": AGGREGATION_UNIVERSE}
+    assert PolarsLazyAggregatedFeatureGroup.subtype_support_matrix() == {"PolarsLazyDataFrame": AGGREGATION_UNIVERSE}
+
+
+def test_compute_framework_definitions_back_the_concrete_matrices() -> None:
+    assert PandasAggregatedFeatureGroup.compute_framework_definition() == {PandasDataFrame}
+    assert PyArrowAggregatedFeatureGroup.compute_framework_definition() == {PyArrowTable}
+    assert PolarsLazyAggregatedFeatureGroup.compute_framework_definition() == {PolarsLazyDataFrame}
+
+
+class TestUniverseEqualsWhatStrictValidationAccepts:
+    """The load-bearing invariant of issue #639: no drift between universe and strict validation."""
+
+    def test_every_subtype_matches_on_the_string_path(self) -> None:
+        for aggregation_type in sorted(AGGREGATION_UNIVERSE):
+            feature_name = f"sales__{aggregation_type}_aggr"
+            assert AggregatedFeatureGroup.match_feature_group_criteria(feature_name, Options()) is True, (
+                f"'{aggregation_type}' is in the reported universe, so '{feature_name}' must match"
+            )
+
+    def test_every_subtype_matches_on_the_config_path(self) -> None:
+        for aggregation_type in sorted(AGGREGATION_UNIVERSE):
+            options = Options(
+                context={
+                    AggregatedFeatureGroup.AGGREGATION_TYPE: aggregation_type,
+                    DefaultOptionKeys.in_features: "sales",
+                }
+            )
+            assert AggregatedFeatureGroup.match_feature_group_criteria("placeholder", options) is True, (
+                f"'{aggregation_type}' is in the reported universe, so strict validation must accept it"
+            )
+
+    def test_a_value_outside_the_universe_is_rejected_on_the_config_path(self) -> None:
+        options = Options(
+            context={
+                AggregatedFeatureGroup.AGGREGATION_TYPE: "p95",
+                DefaultOptionKeys.in_features: "sales",
+            }
+        )
+
+        assert "p95" not in AGGREGATION_UNIVERSE
+        assert AggregatedFeatureGroup.match_feature_group_criteria("placeholder", options) is False
+
+    def test_every_subtype_resolves_back_to_itself(self) -> None:
+        for aggregation_type in sorted(AGGREGATION_UNIVERSE):
+            resolved = AggregatedFeatureGroup.resolve_subtype(f"sales__{aggregation_type}_aggr", Options())
+            assert resolved == aggregation_type

--- a/tests/test_plugins/feature_group/experimental/test_base_aggregated_feature_group/test_aggregated_subtype_universe.py
+++ b/tests/test_plugins/feature_group/experimental/test_base_aggregated_feature_group/test_aggregated_subtype_universe.py
@@ -1,0 +1,71 @@
+"""Tests for the subtype universe on AggregatedFeatureGroup (issue #639).
+
+Contract under test (to be implemented by the Green agent):
+
+11. ``AggregatedFeatureGroup.SUBTYPE_KEY = AGGREGATION_TYPE``, so the family's
+    subtype universe is ``AGGREGATION_TYPES`` and both the string-based and the
+    config-based path resolve a concrete feature's subtype. The change is
+    behavior-neutral: the default ``supported_subtypes()`` is the full universe,
+    so every framework still supports every aggregation type.
+
+All tests fail until the feature exists.
+"""
+
+from mloda.core.abstract_plugins.components.options import Options
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
+    PythonDictFramework,
+)
+from mloda_plugins.feature_group.experimental.aggregated_feature_group.base import AggregatedFeatureGroup
+from mloda_plugins.feature_group.experimental.aggregated_feature_group.pandas import PandasAggregatedFeatureGroup
+
+
+def test_subtype_key_is_the_aggregation_type() -> None:
+    assert AggregatedFeatureGroup.SUBTYPE_KEY == AggregatedFeatureGroup.AGGREGATION_TYPE
+    assert AggregatedFeatureGroup.SUBTYPE_KEY == "aggregation_type"
+
+
+def test_universe_is_the_declared_aggregation_types() -> None:
+    assert AggregatedFeatureGroup.subtype_universe() == frozenset(AggregatedFeatureGroup.AGGREGATION_TYPES)
+
+
+def test_universe_is_inherited_by_the_framework_subclass() -> None:
+    assert PandasAggregatedFeatureGroup.subtype_universe() == frozenset(AggregatedFeatureGroup.AGGREGATION_TYPES)
+
+
+def test_resolve_subtype_from_the_feature_name() -> None:
+    assert AggregatedFeatureGroup.resolve_subtype("sales__sum_aggr", Options()) == "sum"
+
+
+def test_resolve_subtype_from_the_config_based_path() -> None:
+    options = Options(context={AggregatedFeatureGroup.AGGREGATION_TYPE: "max"})
+
+    assert AggregatedFeatureGroup.resolve_subtype("placeholder", options) == "max"
+
+
+def test_resolve_subtype_returns_none_for_an_unrelated_name() -> None:
+    assert AggregatedFeatureGroup.resolve_subtype("sales", Options()) is None
+
+
+def test_supported_subtypes_default_to_the_full_universe() -> None:
+    universe = AggregatedFeatureGroup.subtype_universe()
+
+    assert PandasAggregatedFeatureGroup.supported_subtypes(PandasDataFrame) == universe
+    assert PandasAggregatedFeatureGroup.supported_subtypes(PythonDictFramework) == universe
+
+
+def test_change_is_behavior_neutral_for_supports_compute_framework() -> None:
+    """Every declared aggregation type stays supported on every framework."""
+    for aggregation_type in AggregatedFeatureGroup.AGGREGATION_TYPES:
+        feature_name = f"sales__{aggregation_type}_aggr"
+        assert (
+            PandasAggregatedFeatureGroup.supports_compute_framework(feature_name, Options(), PandasDataFrame) is True
+        ), f"'{aggregation_type}' must stay supported on PandasDataFrame"
+
+
+def test_subtype_support_matrix_gives_every_framework_the_full_universe() -> None:
+    universe = PandasAggregatedFeatureGroup.subtype_universe()
+    matrix = PandasAggregatedFeatureGroup.subtype_support_matrix()
+
+    assert matrix, "The matrix must enumerate the declared compute framework(s)"
+    assert all(supported == universe for supported in matrix.values())


### PR DESCRIPTION
Closes #639.

## Problem

A FeatureGroup family's capability truth had no declarative home. `supports_compute_framework` (0.9.0) gives the per-feature, per-framework *decision*, but a caller cannot *enumerate* what a family offers: there is no declared subtype universe. The registry's `DataOperationsCatalog` therefore reconstructs one by building a synthetic feature name plus Options per candidate subtype and probing the hook, alongside hand-rolled `supported_*()` sets and test twins. One fact ("SQLite cannot do median") ends up written in three places, which is how two real capability lies accumulated unnoticed.

## What this adds

The discriminator already exists: `PROPERTY_MAPPING["aggregation_type"]` declares the valid values under `strict_validation`. Core now names it and hangs per-backend support off it.

On `FeatureGroup`:

- `SUBTYPE_KEY` names the PROPERTY_MAPPING key carrying the family's subtype discriminator.
- `subtype_universe()` derives the universe from that key, so the enumerated universe and what strict validation accepts read from the same source.
- `supported_subtypes(compute_framework)` defaults to the full universe; a per-framework subclass narrows it.
- `resolve_subtype(feature_name, options)` resolves a concrete feature's subtype (name pattern first, then options).
- `supports_compute_framework` is now **derived** from the declaration instead of hand-duplicated per family. Subtypes outside the declared universe (unknown, or parametric like `ntile_2`) stay open, so the gate only narrows what the family declared.
- `subtype_support_matrix()` enumerates framework to supported subtypes with no synthetic-feature probing, and raises when a backend declares support outside the universe. That is the machine-checked link that was missing.
- `declared_option_values(key)`, a public companion to `declared_option_keys()`.

Two declaration shapes are checked at class-definition time:

- **Shape A**: `SUBTYPE_KEY` names a real PROPERTY_MAPPING key with an enumerable value space.
- **Shape B**: `SUBTYPE_KEY` is None and the family overrides both `subtype_universe()` and `resolve_subtype()` (families flattening several axes, e.g. frame_type x frame_unit).

Enumeration API: `FeatureGroupInfo` gains `subtype_key`, `subtypes`, `subtype_support` and `subtype_error`; `ResolvedFeature` gains `subtype`. `AggregatedFeatureGroup` declares `SUBTYPE_KEY` as the dogfood case (behavior-neutral).

Backward compatible: a feature group that does not set `SUBTYPE_KEY` behaves exactly as before.

## Review pass

Two independent deep reviews ran against the first commit. The second commit fixes what they found:

- **Abstract bases fabricated a matrix.** `compute_framework_rule() is None` returns *all* frameworks, so `AggregatedFeatureGroup` claimed Sqlite and Spark support `median`. A catalog trusting that would get a worse answer than probing. Abstract classes now declare the universe; concrete per-framework subclasses carry the support matrix.
- **The multi-axis escape hatch was unenforceable.** Overriding `subtype_universe()` while `resolve_subtype()` still keyed off `SUBTYPE_KEY` left the gate dead: the matrix said "unsupported" and the runtime scheduled it anyway. Now checked at class definition and covered by a route-around test through `IdentifyFeatureGroupClass`.
- **A predicate-validated key reported an empty universe** while strict validation accepted values by predicate. Rejected at class definition.
- **The misdeclaration ValueError was swallowed** by `safe_field`, documenting a broken family as "N subtypes, zero frameworks". Now surfaced as `subtype_error`.
- **`resolve_subtype` could raise** out of the capability hook for a name matching the pattern with no source feature (`__sum_aggr`). Guarded.

## Follow-ups (not in scope)

- Parametric/open subtype spaces (`ntile_N`, `top_N`) have no representation: the universe cannot express them, so they stay open rather than enumerable.
- A registry catalog cannot distinguish "explicitly declared no subtypes" from "never opted in", since both are `SUBTYPE_KEY = None`.
- `AGGREGATION_TYPES` and `PROPERTY_MAPPING` are snapshot-coupled at class-body evaluation: a subclass extending `AGGREGATION_TYPES` without redefining `PROPERTY_MAPPING` drifts. Pre-existing and orthogonal.

## Tests

`tox` green: 4759 passed, 171 skipped; ruff format, ruff check, pip-licenses, mypy --strict, bandit all pass.

New tests pin the load-bearing invariant the issue asks for (the reported universe equals what strict validation accepts), the derived route-around and pin-to-unsupported error, the abstract-versus-concrete matrix split, the two declaration shapes, and the enumeration API.