### PR TITLE
feat: expose the resolved execution plan as a public API (#647)

### DIFF
--- a/docs/docs/in_depth/mloda-api.md
+++ b/docs/docs/in_depth/mloda-api.md
@@ -126,23 +126,29 @@ print(f"Candidates: {[fg.__name__ for fg in result.candidates]}")
 
 ##### explain and resolved_plan
 
-The runtime counterpart to `resolve_feature`: `mlodaAPI.explain(...)` builds the execution plan for a request without running it, and `session.resolved_plan()` returns the same records for a prepared session (before or after `run()`). Both return a `list[PlanStep]` in execution-plan order.
+The runtime counterpart to `resolve_feature`: `mlodaAPI.explain(...)` builds the execution plan for a request without running it, and `session.resolved_plan()` returns the same records for a prepared session (before or after `run()`). Both return a `list[PlanStep]` in execution-plan order. Every `explain` parameter after `features` is keyword-only.
+
+`explain` re-resolves the plan from scratch. It answers "what would this request resolve to", it is not a record of a prior `run_all` execution. To match a `run_all` resolution, pass the same `parallelization_modes`: `run_all` defaults to `{ParallelizationMode.SYNC}`, `prepare`/`explain` default to `None`, and compute frameworks are filtered by mode.
 
 ``` python
 from mloda.user import mloda
 
+# "sales" here stands for a root feature one of your own FeatureGroups provides.
 for step in mloda.explain(["sales__mean_aggr"], compute_frameworks=["PandasDataFrame"]):
     print(step.step_kind, step.feature_names, step.feature_group_name, step.compute_framework_name)
 ```
 
 **Returns:** `PlanStep` dataclass (frozen) with fields:
 
-- **step_kind** (`str`): `"compute"`, `"join"` or `"transform"`.
-- **feature_names** (`tuple[str, ...]`): Features computed by a compute step, empty otherwise.
-- **feature_group** (`type[FeatureGroup] | None`): Resolved FeatureGroup, the destination for a transform step, None for a join.
-- **compute_framework** (`type[ComputeFramework] | None`): Selected ComputeFramework, the destination for a transform step, the left side for a join.
-- **source_feature_group** / **source_compute_framework**: Origin of a transform step; the right side framework for a join.
-- **feature_group_name** / **compute_framework_name** (`str | None`): Class names of the above, None when unset.
+- **step_kind** (`Literal["compute", "join", "transform"]`).
+- **feature_names** (`tuple[str, ...]`): Features computed by a compute step, empty otherwise. This includes engine-injected features (link index features, global-filter features), so it is not a clean "requested feature name -> FeatureGroup" map: the same index name can appear under two different FeatureGroups in one plan.
+- **feature_group** (`type[FeatureGroup] | None`): Resolved FeatureGroup; the destination for a transform step; the link's declared left side for a join.
+- **compute_framework** (`type[ComputeFramework] | None`): Selected ComputeFramework; the destination for a transform step; the merge destination for a join.
+- **source_feature_group** / **source_compute_framework**: Origin of a transform step. For a join: the link's declared right side, and the framework merged in.
+- **join_type** (`str | None`): The link's join type (`"inner"`, `"left"`, ...) for a join step, None otherwise.
+- **feature_group_name** / **compute_framework_name** / **source_feature_group_name** / **source_compute_framework_name** (`str | None`): Class names of the above, None when unset.
+
+Join semantics, honestly: for a join step the `*_feature_group` fields are the link's declared left/right sides, while `compute_framework`/`source_compute_framework` are the merge destination and the framework merged in. The planner swaps those two frameworks for `RIGHT` joins, so they are not guaranteed to be the frameworks of the declared left/right sides.
 
 ##### get_feature_group_docs
 

--- a/docs/docs/in_depth/mloda-api.md
+++ b/docs/docs/in_depth/mloda-api.md
@@ -124,6 +124,26 @@ print(f"Candidates: {[fg.__name__ for fg in result.candidates]}")
 - **candidates** (`List[Type[FeatureGroup]]`): All FeatureGroups that matched before subclass filtering.
 - **error** (`str | None`): Error message if resolution failed (no match or multiple conflicts).
 
+##### explain and resolved_plan
+
+The runtime counterpart to `resolve_feature`: `mlodaAPI.explain(...)` builds the execution plan for a request without running it, and `session.resolved_plan()` returns the same records for a prepared session (before or after `run()`). Both return a `list[PlanStep]` in execution-plan order.
+
+``` python
+from mloda.user import mloda
+
+for step in mloda.explain(["sales__mean_aggr"], compute_frameworks=["PandasDataFrame"]):
+    print(step.step_kind, step.feature_names, step.feature_group_name, step.compute_framework_name)
+```
+
+**Returns:** `PlanStep` dataclass (frozen) with fields:
+
+- **step_kind** (`str`): `"compute"`, `"join"` or `"transform"`.
+- **feature_names** (`tuple[str, ...]`): Features computed by a compute step, empty otherwise.
+- **feature_group** (`type[FeatureGroup] | None`): Resolved FeatureGroup, the destination for a transform step, None for a join.
+- **compute_framework** (`type[ComputeFramework] | None`): Selected ComputeFramework, the destination for a transform step, the left side for a join.
+- **source_feature_group** / **source_compute_framework**: Origin of a transform step; the right side framework for a join.
+- **feature_group_name** / **compute_framework_name** (`str | None`): Class names of the above, None when unset.
+
 ##### get_feature_group_docs
 
 Get documentation for feature groups with optional filtering.

--- a/mloda/core/api/plan_info.py
+++ b/mloda/core/api/plan_info.py
@@ -1,5 +1,6 @@
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable, Optional, TYPE_CHECKING
+from typing import Literal, Optional, TYPE_CHECKING
 
 from mloda.core.core.step.feature_group_step import FeatureGroupStep
 from mloda.core.core.step.join_step import JoinStep
@@ -14,16 +15,29 @@ if TYPE_CHECKING:
 class PlanStep:
     """One step of a resolved execution plan.
 
-    ``step_kind`` is "compute", "join" or "transform". For transform steps, ``feature_group`` and
-    ``compute_framework`` are the destination and the ``source_*`` fields are the origin.
+    ``step_kind`` is "compute", "join" or "transform".
+
+    compute: ``feature_names`` are the names computed by ``feature_group`` on ``compute_framework``.
+    The names include engine-injected features (link index features, global-filter features), so they
+    are not only the requested ones. ``source_*`` and ``join_type`` are None.
+
+    transform: ``feature_group``/``compute_framework`` are the destination, ``source_*`` the origin.
+
+    join: ``feature_group``/``source_feature_group`` are the link's declared left/right sides, and
+    ``join_type`` its join type. ``compute_framework`` is the merge destination and
+    ``source_compute_framework`` the framework merged in. Those two are not necessarily the
+    frameworks of the declared left/right sides: ``ExecutionPlan.run_link`` swaps them for RIGHT
+    joins (and when no child needs the declared orientation), so for a RIGHT join the destination
+    framework belongs to the declared right side.
     """
 
-    step_kind: str
+    step_kind: Literal["compute", "join", "transform"]
     feature_names: tuple[str, ...]
     feature_group: Optional[type["FeatureGroup"]]
     compute_framework: Optional[type["ComputeFramework"]]
     source_feature_group: Optional[type["FeatureGroup"]]
     source_compute_framework: Optional[type["ComputeFramework"]]
+    join_type: Optional[str] = None
 
     @property
     def feature_group_name(self) -> Optional[str]:
@@ -33,11 +47,23 @@ class PlanStep:
     def compute_framework_name(self) -> Optional[str]:
         return None if self.compute_framework is None else self.compute_framework.get_class_name()
 
+    @property
+    def source_feature_group_name(self) -> Optional[str]:
+        return None if self.source_feature_group is None else self.source_feature_group.get_class_name()
+
+    @property
+    def source_compute_framework_name(self) -> Optional[str]:
+        return None if self.source_compute_framework is None else self.source_compute_framework.get_class_name()
+
 
 def build_plan_steps(
     execution_plan: Iterable[TransformFrameworkStep | JoinStep | FeatureGroupStep],
 ) -> list[PlanStep]:
-    """Map the steps of an ExecutionPlan onto PlanStep records, in execution-plan order."""
+    """Map the steps of an ExecutionPlan onto PlanStep records, in execution-plan order.
+
+    Raises ValueError on an unknown step, mirroring ``ExecutionPlan.add_tfs``: a plan that silently
+    drops a step it does not understand is a lie.
+    """
     plan: list[PlanStep] = []
 
     for step in execution_plan:
@@ -68,11 +94,14 @@ def build_plan_steps(
                 PlanStep(
                     step_kind="join",
                     feature_names=(),
-                    feature_group=None,
+                    feature_group=step.link.left_feature_group,
                     compute_framework=step.left_framework,
-                    source_feature_group=None,
+                    source_feature_group=step.link.right_feature_group,
                     source_compute_framework=step.right_framework,
+                    join_type=step.link.jointype.value,
                 )
             )
+        else:
+            raise ValueError(f"Element {step} is not a valid element.")
 
     return plan

--- a/mloda/core/api/plan_info.py
+++ b/mloda/core/api/plan_info.py
@@ -1,0 +1,78 @@
+from dataclasses import dataclass
+from typing import Iterable, Optional, TYPE_CHECKING
+
+from mloda.core.core.step.feature_group_step import FeatureGroupStep
+from mloda.core.core.step.join_step import JoinStep
+from mloda.core.core.step.transform_frame_work_step import TransformFrameworkStep
+
+if TYPE_CHECKING:
+    from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+    from mloda.core.abstract_plugins.feature_group import FeatureGroup
+
+
+@dataclass(frozen=True)
+class PlanStep:
+    """One step of a resolved execution plan.
+
+    ``step_kind`` is "compute", "join" or "transform". For transform steps, ``feature_group`` and
+    ``compute_framework`` are the destination and the ``source_*`` fields are the origin.
+    """
+
+    step_kind: str
+    feature_names: tuple[str, ...]
+    feature_group: Optional[type["FeatureGroup"]]
+    compute_framework: Optional[type["ComputeFramework"]]
+    source_feature_group: Optional[type["FeatureGroup"]]
+    source_compute_framework: Optional[type["ComputeFramework"]]
+
+    @property
+    def feature_group_name(self) -> Optional[str]:
+        return None if self.feature_group is None else self.feature_group.get_class_name()
+
+    @property
+    def compute_framework_name(self) -> Optional[str]:
+        return None if self.compute_framework is None else self.compute_framework.get_class_name()
+
+
+def build_plan_steps(
+    execution_plan: Iterable[TransformFrameworkStep | JoinStep | FeatureGroupStep],
+) -> list[PlanStep]:
+    """Map the steps of an ExecutionPlan onto PlanStep records, in execution-plan order."""
+    plan: list[PlanStep] = []
+
+    for step in execution_plan:
+        if isinstance(step, FeatureGroupStep):
+            plan.append(
+                PlanStep(
+                    step_kind="compute",
+                    feature_names=tuple(str(name) for name in step.features.get_all_names()),
+                    feature_group=step.feature_group,
+                    compute_framework=step.compute_framework,
+                    source_feature_group=None,
+                    source_compute_framework=None,
+                )
+            )
+        elif isinstance(step, TransformFrameworkStep):
+            plan.append(
+                PlanStep(
+                    step_kind="transform",
+                    feature_names=(),
+                    feature_group=step.to_feature_group,
+                    compute_framework=step.to_framework,
+                    source_feature_group=step.from_feature_group,
+                    source_compute_framework=step.from_framework,
+                )
+            )
+        elif isinstance(step, JoinStep):
+            plan.append(
+                PlanStep(
+                    step_kind="join",
+                    feature_names=(),
+                    feature_group=None,
+                    compute_framework=step.left_framework,
+                    source_feature_group=None,
+                    source_compute_framework=step.right_framework,
+                )
+            )
+
+    return plan

--- a/mloda/core/api/request.py
+++ b/mloda/core/api/request.py
@@ -6,6 +6,7 @@ from mloda.core.abstract_plugins.components.input_data.api.api_input_data_collec
 )
 from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
 from mloda.core.core.engine import Engine
+from mloda.core.api.plan_info import PlanStep, build_plan_steps
 from mloda.core.api.prepare.setup_compute_framework import SetupComputeFramework
 from mloda.core.prepare.accessible_plugins import filter_extenders_by_strict_mode
 from mloda.core.filter.global_filter import GlobalFilter
@@ -245,6 +246,49 @@ class mlodaAPI:
             column_ordering=column_ordering,
             parallelization_modes=parallelization_modes,
         )
+
+    @classmethod
+    def explain(
+        cls,
+        features: Features | list[Feature | str],
+        compute_frameworks: set[type[ComputeFramework]] | Optional[list[str]] = None,
+        links: Optional[set[Link]] = None,
+        data_access_collection: Optional[DataAccessCollection] = None,
+        global_filter: Optional[GlobalFilter] = None,
+        api_data: Optional[dict[str, dict[str, Any]]] = None,
+        plugin_collector: Optional[PluginCollector] = None,
+        copy_features: bool = True,
+        strict_type_enforcement: bool = False,
+        column_ordering: Optional[str] = None,
+        parallelization_modes: Optional[set[ParallelizationMode]] = None,
+    ) -> list[PlanStep]:
+        """Resolve the execution plan without executing it.
+
+        Same as ``prepare(...).resolved_plan()``: no feature is computed.
+        """
+        session = cls.prepare(
+            features,
+            compute_frameworks,
+            links,
+            data_access_collection,
+            global_filter,
+            api_data=api_data,
+            plugin_collector=plugin_collector,
+            copy_features=copy_features,
+            strict_type_enforcement=strict_type_enforcement,
+            column_ordering=column_ordering,
+            parallelization_modes=parallelization_modes,
+        )
+        return session.resolved_plan()
+
+    def resolved_plan(self) -> list[PlanStep]:
+        """Return the resolved execution plan of this session as ``PlanStep`` records.
+
+        Available after ``prepare()`` and unchanged by ``run()``.
+        """
+        if self.engine is None:
+            raise ValueError("Internal error: engine not initialized. This is likely a bug in mloda.")
+        return build_plan_steps(self.engine.execution_planner)
 
     def run(
         self,

--- a/mloda/core/api/request.py
+++ b/mloda/core/api/request.py
@@ -251,6 +251,7 @@ class mlodaAPI:
     def explain(
         cls,
         features: Features | list[Feature | str],
+        *,
         compute_frameworks: set[type[ComputeFramework]] | Optional[list[str]] = None,
         links: Optional[set[Link]] = None,
         data_access_collection: Optional[DataAccessCollection] = None,
@@ -264,7 +265,14 @@ class mlodaAPI:
     ) -> list[PlanStep]:
         """Resolve the execution plan without executing it.
 
-        Same as ``prepare(...).resolved_plan()``: no feature is computed.
+        Same as ``prepare(...).resolved_plan()``: no feature is computed. The plan is re-resolved
+        from scratch, so this answers "what would this request resolve to", not "what did a previous
+        ``run_all`` execute". To mirror a ``run_all`` resolution, pass the same
+        ``parallelization_modes``: ``run_all`` defaults to ``{ParallelizationMode.SYNC}`` while
+        ``prepare``/``explain`` default to None, and ``SetupComputeFramework`` filters compute
+        frameworks by mode.
+
+        Every parameter after ``features`` is keyword-only.
         """
         session = cls.prepare(
             features,

--- a/mloda/steward/__init__.py
+++ b/mloda/steward/__init__.py
@@ -1,6 +1,9 @@
 # Plugin inspection/metadata
 from mloda.core.api.plugin_info import FeatureGroupInfo, ComputeFrameworkInfo, ExtenderInfo, ResolvedFeature
 
+# Resolved execution plan
+from mloda.core.api.plan_info import PlanStep
+
 # Documentation/discovery
 from mloda.core.api.plugin_docs import (
     get_feature_group_docs,
@@ -32,6 +35,8 @@ __all__ = [
     "ComputeFrameworkInfo",
     "ExtenderInfo",
     "ResolvedFeature",
+    # Resolved execution plan
+    "PlanStep",
     # Documentation
     "get_feature_group_docs",
     "get_compute_framework_docs",

--- a/mloda/user/__init__.py
+++ b/mloda/user/__init__.py
@@ -4,6 +4,9 @@ from typing import TYPE_CHECKING, Any
 # API
 from mloda.core.api.request import mlodaAPI
 
+# Resolved execution plan
+from mloda.core.api.plan_info import PlanStep
+
 # Features
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_collection import Features
@@ -125,6 +128,8 @@ __all__ = [
     # API
     "mlodaAPI",
     "mloda",
+    # Resolved execution plan
+    "PlanStep",
     # Features
     "Feature",
     "Features",

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_persona_exports.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_persona_exports.py
@@ -7,7 +7,8 @@ PluginRegistryCollisionError. mloda.steward exports PluginRegistry,
 list_registered, and the governance objects PluginPolicy, ApprovalStatus, and
 PluginPolicyViolationError. Every export is the identical object from its core
 module and is listed in the namespace's __all__. Governance objects are
-steward-only: mloda.user and mloda.provider gain nothing.
+steward-only: mloda.user and mloda.provider gain nothing. PlanStep, the resolved
+execution-plan record, is shared by mloda.user and mloda.steward.
 """
 
 import importlib
@@ -30,6 +31,7 @@ _SOURCE_MODULES: dict[str, str] = {
     "core_registry": "mloda.core.abstract_plugins.plugin_registry.plugin_registry",
     "plugin_docs": "mloda.core.api.plugin_docs",
     "core_policy": "mloda.core.abstract_plugins.plugin_registry.plugin_policy",
+    "plan_info": "mloda.core.api.plan_info",
 }
 
 
@@ -49,6 +51,9 @@ EXPORT_MATRIX: list[tuple[str, str, str]] = [
     ("steward", "PluginPolicy", "core_policy"),
     ("steward", "ApprovalStatus", "core_policy"),
     ("steward", "PluginPolicyViolationError", "core_policy"),
+    # Resolved execution plan (issue #647): the same PlanStep record for users and stewards.
+    ("user", "PlanStep", "plan_info"),
+    ("steward", "PlanStep", "plan_info"),
 ]
 
 _MATRIX_IDS = [f"{namespace}-{symbol}" for namespace, symbol, _source in EXPORT_MATRIX]

--- a/tests/test_core/test_api/test_plan_info.py
+++ b/tests/test_core/test_api/test_plan_info.py
@@ -3,22 +3,32 @@
 Contract under test:
   * ``mloda.core.api.plan_info.PlanStep`` is a frozen dataclass describing one step of the
     resolved execution plan: ``step_kind``, ``feature_names``, ``feature_group``,
-    ``compute_framework``, ``source_feature_group``, ``source_compute_framework`` plus the
-    convenience properties ``feature_group_name`` and ``compute_framework_name``.
+    ``compute_framework``, ``source_feature_group``, ``source_compute_framework``, ``join_type``
+    plus the convenience properties ``feature_group_name``, ``compute_framework_name``,
+    ``source_feature_group_name`` and ``source_compute_framework_name``.
+  * ``step_kind`` is typed ``Literal["compute", "join", "transform"]``.
+  * Join steps are not blank records: ``feature_group``/``source_feature_group`` are the link's
+    declared left/right feature groups, ``compute_framework`` is the merge destination framework
+    and ``source_compute_framework`` the framework merged in, ``join_type`` the link's join type.
+  * ``build_plan_steps`` raises ``ValueError`` on a step it does not know, instead of dropping it.
   * ``mlodaAPI.resolved_plan()`` returns ``list[PlanStep]`` on a prepared session, both before
-    and after ``run()``, in execution-plan order.
-  * ``mlodaAPI.explain(features, ...)`` mirrors the ``run_all`` parameter shape, prepares without
-    executing and returns the same records as ``prepare(...).resolved_plan()``.
+    and after ``run()``, in execution-plan order, and matches the plan that actually executed.
+  * ``mlodaAPI.explain(features, ...)`` mirrors the ``prepare`` parameter shape with keyword-only
+    parameters after ``features``, prepares without executing and returns the same records as
+    ``prepare(...).resolved_plan()``.
   * ``PlanStep`` is exported from both ``mloda.user`` and ``mloda.steward``.
 
 A caller must reach all of this without importing anything from the internal execution-step
 package; ``TestCallerNeedsNoInternalImport`` locks that in for this module itself.
+
+Root feature names in this module carry a ``plan_info_`` prefix on purpose: a ``DataCreator``
+claim is registry-wide, so generic names like ``sales`` would leak into every other test.
 """
 
 import ast
 import dataclasses
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Literal, Optional, get_args, get_origin
 
 import pandas as pd
 import pyarrow as pa
@@ -28,6 +38,7 @@ import pytest
 # with the ``mloda`` mlodaAPI alias imported below.
 import mloda.steward as mloda_steward
 import mloda.user as mloda_user
+from mloda.core.api.plan_info import build_plan_steps
 from mloda.provider import BaseInputData, ComputeFramework, DataCreator, FeatureGroup, FeatureSet
 from mloda.user import (
     Feature,
@@ -56,11 +67,11 @@ class PlanInfoPandasSource(FeatureGroup):
 
     @classmethod
     def input_data(cls) -> Optional[BaseInputData]:
-        return DataCreator({"sales", "price"})
+        return DataCreator({"plan_info_sales", "plan_info_price"})
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-        return pd.DataFrame({"sales": [100, 200, 300], "price": [1.0, 2.0, 3.0]})
+        return pd.DataFrame({"plan_info_sales": [100, 200, 300], "plan_info_price": [1.0, 2.0, 3.0]})
 
     @classmethod
     def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
@@ -72,11 +83,11 @@ class PlanInfoArrowSource(FeatureGroup):
 
     @classmethod
     def input_data(cls) -> Optional[BaseInputData]:
-        return DataCreator({"arrow_sales"})
+        return DataCreator({"plan_info_arrow_sales"})
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-        return pa.table({"arrow_sales": [100, 200, 300]})
+        return pa.table({"plan_info_arrow_sales": [100, 200, 300]})
 
     @classmethod
     def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
@@ -92,7 +103,7 @@ class PlanInfoNeverExecutes(FeatureGroup):
 
     @classmethod
     def input_data(cls) -> Optional[BaseInputData]:
-        return DataCreator({"never_executed"})
+        return DataCreator({"plan_info_never_executed"})
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
@@ -104,15 +115,15 @@ class PlanInfoNeverExecutes(FeatureGroup):
 
 
 class PlanInfoLeftSource(FeatureGroup):
-    """Left side of the join scenario."""
+    """Left side of the single-framework join scenario."""
 
     @classmethod
     def input_data(cls) -> Optional[BaseInputData]:
-        return DataCreator({"jid", "left_val"})
+        return DataCreator({"plan_info_jid", "plan_info_left_val"})
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-        return pd.DataFrame({"jid": [1, 2, 3], "left_val": [10, 20, 30]})
+        return pd.DataFrame({"plan_info_jid": [1, 2, 3], "plan_info_left_val": [10, 20, 30]})
 
     @classmethod
     def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
@@ -120,19 +131,19 @@ class PlanInfoLeftSource(FeatureGroup):
 
     @classmethod
     def index_columns(cls) -> Optional[list[Index]]:
-        return [Index(("jid",))]
+        return [Index(("plan_info_jid",))]
 
 
 class PlanInfoRightSource(FeatureGroup):
-    """Right side of the join scenario."""
+    """Right side of the single-framework join scenario."""
 
     @classmethod
     def input_data(cls) -> Optional[BaseInputData]:
-        return DataCreator({"jid", "right_val"})
+        return DataCreator({"plan_info_jid", "plan_info_right_val"})
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-        return pd.DataFrame({"jid": [1, 2, 3], "right_val": [1.5, 2.5, 3.5]})
+        return pd.DataFrame({"plan_info_jid": [1, 2, 3], "plan_info_right_val": [1.5, 2.5, 3.5]})
 
     @classmethod
     def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
@@ -140,18 +151,18 @@ class PlanInfoRightSource(FeatureGroup):
 
     @classmethod
     def index_columns(cls) -> Optional[list[Index]]:
-        return [Index(("jid",))]
+        return [Index(("plan_info_jid",))]
 
 
 class PlanInfoJoinConsumer(FeatureGroup):
     """Consumes features from both join sides, which forces a join step into the plan."""
 
     def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
-        return {Feature("left_val"), Feature("right_val")}
+        return {Feature("plan_info_left_val"), Feature("plan_info_right_val")}
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-        data["PlanInfoJoinConsumer"] = data["left_val"] * data["right_val"]
+        data["PlanInfoJoinConsumer"] = data["plan_info_left_val"] * data["plan_info_right_val"]
         return data
 
     @classmethod
@@ -163,13 +174,84 @@ class PlanInfoJoinConsumer(FeatureGroup):
         return {cls.get_class_name()}
 
 
+class PlanInfoCrossLeftPandas(FeatureGroup):
+    """Left side of the cross-framework join scenario: pandas."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({"plan_info_xjid", "plan_info_xleft_val"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return pd.DataFrame({"plan_info_xjid": [1, 2, 3], "plan_info_xleft_val": [10, 20, 30]})
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+    @classmethod
+    def index_columns(cls) -> Optional[list[Index]]:
+        return [Index(("plan_info_xjid",))]
+
+
+class PlanInfoCrossRightArrow(FeatureGroup):
+    """Right side of the cross-framework join scenario: pyarrow.
+
+    Distinct framework from the left side, so a left/right swap in the plan records is
+    detectable instead of being hidden behind two identical frameworks.
+    """
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({"plan_info_xjid", "plan_info_xright_val"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return pa.table({"plan_info_xjid": [1, 2, 3], "plan_info_xright_val": [1.5, 2.5, 3.5]})
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PyArrowTable}
+
+    @classmethod
+    def index_columns(cls) -> Optional[list[Index]]:
+        return [Index(("plan_info_xjid",))]
+
+
+class PlanInfoCrossConsumer(FeatureGroup):
+    """Consumes one feature per side of the cross-framework join."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return {Feature("plan_info_xleft_val"), Feature("plan_info_xright_val")}
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        data["PlanInfoCrossConsumer"] = data["plan_info_xleft_val"] * data["plan_info_xright_val"]
+        return data
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return {cls.get_class_name()}
+
+
+class PlanInfoUnknownStep:
+    """Not a FeatureGroupStep/TransformFrameworkStep/JoinStep: build_plan_steps must reject it."""
+
+
 _AGGREGATION_PLUGINS = PluginCollector.enabled_feature_groups({PlanInfoPandasSource, PandasAggregatedFeatureGroup})
 _TRANSFORM_PLUGINS = PluginCollector.enabled_feature_groups({PlanInfoArrowSource, PandasAggregatedFeatureGroup})
 _NEVER_EXECUTES_PLUGINS = PluginCollector.enabled_feature_groups({PlanInfoNeverExecutes})
 _JOIN_PLUGINS = PluginCollector.enabled_feature_groups({PlanInfoLeftSource, PlanInfoRightSource, PlanInfoJoinConsumer})
+_CROSS_JOIN_PLUGINS = PluginCollector.enabled_feature_groups(
+    {PlanInfoCrossLeftPandas, PlanInfoCrossRightArrow, PlanInfoCrossConsumer}
+)
 
 # The chained request from the issue: an aggregated feature over a source feature.
-_CHAINED_FEATURES: list[Feature | str] = ["sales__mean_aggr"]
+_CHAINED_FEATURES: list[Feature | str] = ["plan_info_sales__mean_aggr"]
 
 
 def _prepare_chained_session() -> mlodaAPI:
@@ -177,6 +259,31 @@ def _prepare_chained_session() -> mlodaAPI:
         _CHAINED_FEATURES,
         compute_frameworks={PandasDataFrame},
         plugin_collector=_AGGREGATION_PLUGINS,
+    )
+
+
+def _prepare_single_framework_join_session() -> mlodaAPI:
+    link = Link.inner(JoinSpec(PlanInfoLeftSource, "plan_info_jid"), JoinSpec(PlanInfoRightSource, "plan_info_jid"))
+
+    return mloda.prepare(
+        ["PlanInfoJoinConsumer"],
+        compute_frameworks={PandasDataFrame},
+        links={link},
+        plugin_collector=_JOIN_PLUGINS,
+    )
+
+
+def _prepare_cross_framework_join_session() -> mlodaAPI:
+    link = Link.inner(
+        JoinSpec(PlanInfoCrossLeftPandas, "plan_info_xjid"),
+        JoinSpec(PlanInfoCrossRightArrow, "plan_info_xjid"),
+    )
+
+    return mloda.prepare(
+        ["PlanInfoCrossConsumer"],
+        compute_frameworks={PandasDataFrame, PyArrowTable},
+        links={link},
+        plugin_collector=_CROSS_JOIN_PLUGINS,
     )
 
 
@@ -196,7 +303,7 @@ class TestPlanStepDataclass:
     def test_plan_step_is_frozen(self) -> None:
         step = PlanStep(
             step_kind="compute",
-            feature_names=("sales__mean_aggr",),
+            feature_names=("plan_info_sales__mean_aggr",),
             feature_group=PandasAggregatedFeatureGroup,
             compute_framework=PandasDataFrame,
             source_feature_group=None,
@@ -216,24 +323,53 @@ class TestPlanStepDataclass:
             "compute_framework",
             "source_feature_group",
             "source_compute_framework",
+            "join_type",
         ]
 
-    def test_name_properties_return_class_names(self) -> None:
+    def test_join_type_defaults_to_none(self) -> None:
+        """Compute and transform steps must not need to pass join_type."""
         step = PlanStep(
             step_kind="compute",
-            feature_names=("sales__mean_aggr",),
-            feature_group=PandasAggregatedFeatureGroup,
+            feature_names=("plan_info_sales",),
+            feature_group=PlanInfoPandasSource,
             compute_framework=PandasDataFrame,
             source_feature_group=None,
             source_compute_framework=None,
         )
 
+        assert step.join_type is None
+
+        join_type_field = {field.name: field for field in dataclasses.fields(PlanStep)}["join_type"]
+        assert join_type_field.default is None
+
+    def test_step_kind_is_a_literal_of_the_three_kinds(self) -> None:
+        """step_kind is typed, so a caller can exhaustively match on it."""
+        annotation = PlanStep.__annotations__["step_kind"]
+
+        # Annotated as Any: typeshed's get_origin overloads cannot express `is Literal`,
+        # so a precisely typed operand would trip mypy's strict_equality check.
+        origin: Any = get_origin(annotation)
+        assert origin is Literal, f"step_kind must be a Literal, got {annotation!r}"
+        assert set(get_args(annotation)) == {"compute", "join", "transform"}
+
+    def test_name_properties_return_class_names(self) -> None:
+        step = PlanStep(
+            step_kind="transform",
+            feature_names=(),
+            feature_group=PandasAggregatedFeatureGroup,
+            compute_framework=PandasDataFrame,
+            source_feature_group=PlanInfoArrowSource,
+            source_compute_framework=PyArrowTable,
+        )
+
         assert step.feature_group_name == "PandasAggregatedFeatureGroup"
         assert step.compute_framework_name == "PandasDataFrame"
+        assert step.source_feature_group_name == "PlanInfoArrowSource"
+        assert step.source_compute_framework_name == "PyArrowTable"
 
     def test_name_properties_are_none_when_class_is_none(self) -> None:
         step = PlanStep(
-            step_kind="join",
+            step_kind="compute",
             feature_names=(),
             feature_group=None,
             compute_framework=None,
@@ -243,12 +379,14 @@ class TestPlanStepDataclass:
 
         assert step.feature_group_name is None
         assert step.compute_framework_name is None
+        assert step.source_feature_group_name is None
+        assert step.source_compute_framework_name is None
 
     def test_plan_steps_compare_by_value(self) -> None:
         """Records must be value-comparable so callers can diff two plans."""
         first = PlanStep(
             step_kind="compute",
-            feature_names=("sales",),
+            feature_names=("plan_info_sales",),
             feature_group=PlanInfoPandasSource,
             compute_framework=PandasDataFrame,
             source_feature_group=None,
@@ -256,7 +394,7 @@ class TestPlanStepDataclass:
         )
         second = PlanStep(
             step_kind="compute",
-            feature_names=("sales",),
+            feature_names=("plan_info_sales",),
             feature_group=PlanInfoPandasSource,
             compute_framework=PandasDataFrame,
             source_feature_group=None,
@@ -264,6 +402,45 @@ class TestPlanStepDataclass:
         )
 
         assert first == second
+
+    def test_join_type_participates_in_equality(self) -> None:
+        """Two otherwise identical join records with different join types must not compare equal."""
+        inner = PlanStep(
+            step_kind="join",
+            feature_names=(),
+            feature_group=PlanInfoLeftSource,
+            compute_framework=PandasDataFrame,
+            source_feature_group=PlanInfoRightSource,
+            source_compute_framework=PandasDataFrame,
+            join_type="inner",
+        )
+        outer = dataclasses.replace(inner, join_type="outer")
+
+        assert inner != outer
+
+
+# ---------------------------------------------------------------------------
+# build_plan_steps rejects unknown steps
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPlanStepsRejectsUnknownSteps:
+    """An unmapped step must be loud, not silently dropped: a plan missing a step is a lie."""
+
+    def test_unknown_step_raises_value_error(self) -> None:
+        unknown_plan: Any = [PlanInfoUnknownStep()]
+
+        with pytest.raises(ValueError, match="PlanInfoUnknownStep"):
+            build_plan_steps(unknown_plan)
+
+    def test_unknown_step_raises_even_when_mixed_with_known_steps(self) -> None:
+        session = _prepare_chained_session()
+        assert session.engine is not None
+
+        mixed_plan: Any = [*session.engine.execution_planner, PlanInfoUnknownStep()]
+
+        with pytest.raises(ValueError):
+            build_plan_steps(mixed_plan)
 
 
 # ---------------------------------------------------------------------------
@@ -289,33 +466,34 @@ class TestResolvedPlanForChainedFeature:
         source_step, aggregation_step = compute_steps
 
         # The root source feature the aggregation chains off.
-        assert source_step.feature_names == ("sales",)
+        assert source_step.feature_names == ("plan_info_sales",)
         assert source_step.feature_group is PlanInfoPandasSource
         assert source_step.compute_framework is PandasDataFrame
 
         # The concrete aggregation implementation on the selected framework.
-        assert aggregation_step.feature_names == ("sales__mean_aggr",)
+        assert aggregation_step.feature_names == ("plan_info_sales__mean_aggr",)
         assert aggregation_step.feature_group is PandasAggregatedFeatureGroup
         assert aggregation_step.compute_framework is PandasDataFrame
 
         assert aggregation_step.feature_group_name == "PandasAggregatedFeatureGroup"
         assert aggregation_step.compute_framework_name == "PandasDataFrame"
 
-    def test_compute_steps_carry_no_source_fields(self) -> None:
-        """source_* fields are transform/join specific and stay None on compute steps."""
+    def test_compute_steps_carry_no_source_or_join_fields(self) -> None:
+        """source_* and join_type are transform/join specific and stay None on compute steps."""
         plan = _prepare_chained_session().resolved_plan()
 
         for step in (step for step in plan if step.step_kind == "compute"):
             assert step.source_feature_group is None
             assert step.source_compute_framework is None
+            assert step.join_type is None
 
     def test_feature_names_are_strings_and_sorted(self) -> None:
         """feature_names mirrors FeatureSet.get_all_names(): a sorted tuple of strings.
 
-        Requested as ["sales", "price"], reported sorted as ("price", "sales").
+        Requested as ["plan_info_sales", "plan_info_price"], reported sorted.
         """
         session = mloda.prepare(
-            ["sales", "price"],
+            ["plan_info_sales", "plan_info_price"],
             compute_frameworks={PandasDataFrame},
             plugin_collector=_AGGREGATION_PLUGINS,
         )
@@ -327,7 +505,7 @@ class TestResolvedPlanForChainedFeature:
         names = source_steps[0].feature_names
         assert isinstance(names, tuple)
         assert all(isinstance(name, str) for name in names)
-        assert names == ("price", "sales")
+        assert names == ("plan_info_price", "plan_info_sales")
         assert list(names) == sorted(names)
 
     def test_plan_is_in_execution_order(self) -> None:
@@ -362,7 +540,34 @@ class TestResolvedPlanBeforeAndAfterRun:
 
         # Sanity check that the session really did execute.
         assert len(results) == 1
-        assert "sales__mean_aggr" in results[0].columns
+        assert "plan_info_sales__mean_aggr" in results[0].columns
+
+    def test_resolved_plan_matches_the_plan_that_actually_executed(self) -> None:
+        """The reported plan must be the plan that ran.
+
+        ``resolved_plan()`` reads the engine's planner, while ``Engine.compute`` deep-copies that
+        planner before executing. Comparing against the runner's copy is what proves the reported
+        records describe the executed steps, not a plan that was silently rewritten on the way in.
+        """
+        session = _prepare_chained_session()
+
+        session.run()
+
+        assert session.runner is not None
+        executed_plan = build_plan_steps(session.runner.execution_planner)
+
+        assert executed_plan == session.resolved_plan()
+
+    def test_join_plan_matches_the_plan_that_actually_executed(self) -> None:
+        """Same claim on a plan that contains a join step."""
+        session = _prepare_single_framework_join_session()
+
+        session.run()
+
+        assert session.runner is not None
+        executed_plan = build_plan_steps(session.runner.execution_planner)
+
+        assert executed_plan == session.resolved_plan()
 
 
 # ---------------------------------------------------------------------------
@@ -395,14 +600,14 @@ class TestExplain:
     def test_explain_does_not_execute_the_plan(self) -> None:
         """PlanInfoNeverExecutes.calculate_feature raises. explain() must still succeed."""
         explained = mlodaAPI.explain(
-            ["never_executed"],
+            ["plan_info_never_executed"],
             compute_frameworks={PandasDataFrame},
             plugin_collector=_NEVER_EXECUTES_PLUGINS,
         )
 
         assert len(explained) == 1
         assert explained[0].feature_group is PlanInfoNeverExecutes
-        assert explained[0].feature_names == ("never_executed",)
+        assert explained[0].feature_names == ("plan_info_never_executed",)
 
     def test_explain_is_reachable_from_the_mloda_alias(self) -> None:
         explained = mloda.explain(
@@ -412,6 +617,29 @@ class TestExplain:
         )
 
         assert all(isinstance(step, PlanStep) for step in explained)
+
+    def test_explain_takes_only_features_positionally(self) -> None:
+        """Everything after ``features`` is keyword-only.
+
+        ``run_all`` and ``explain`` have different parameter orders (``run_all``'s 5th positional
+        is ``parallelization_modes``, ``explain``'s would be ``global_filter``). A caller who
+        reshapes a ``run_all`` call into an ``explain`` call must get a TypeError, not a plan
+        silently built from misassigned arguments.
+        """
+        # Typed as Any on purpose: the point is the runtime signature, not what mypy allows.
+        explain: Any = mlodaAPI.explain
+
+        with pytest.raises(TypeError):
+            explain(_CHAINED_FEATURES, {PandasDataFrame})
+
+    def test_explain_still_accepts_its_parameters_by_keyword(self) -> None:
+        explained = mlodaAPI.explain(
+            _CHAINED_FEATURES,
+            compute_frameworks={PandasDataFrame},
+            plugin_collector=_AGGREGATION_PLUGINS,
+        )
+
+        assert len(explained) == 2
 
 
 # ---------------------------------------------------------------------------
@@ -424,7 +652,7 @@ class TestTransformStepMapping:
 
     def test_transform_step_maps_from_and_to_group_and_framework(self) -> None:
         session = mloda.prepare(
-            ["arrow_sales__mean_aggr"],
+            ["plan_info_arrow_sales__mean_aggr"],
             compute_frameworks={PandasDataFrame, PyArrowTable},
             plugin_collector=_TRANSFORM_PLUGINS,
         )
@@ -442,10 +670,14 @@ class TestTransformStepMapping:
         assert transform.compute_framework is PandasDataFrame
         assert transform.source_feature_group is PlanInfoArrowSource
         assert transform.source_compute_framework is PyArrowTable
+        assert transform.join_type is None
+
+        assert transform.source_feature_group_name == "PlanInfoArrowSource"
+        assert transform.source_compute_framework_name == "PyArrowTable"
 
     def test_transform_step_sits_between_its_compute_steps(self) -> None:
         session = mloda.prepare(
-            ["arrow_sales__mean_aggr"],
+            ["plan_info_arrow_sales__mean_aggr"],
             compute_frameworks={PandasDataFrame, PyArrowTable},
             plugin_collector=_TRANSFORM_PLUGINS,
         )
@@ -458,42 +690,29 @@ class TestTransformStepMapping:
 class TestJoinStepMapping:
     """Two linked pandas sources consumed by one feature group produce a join step."""
 
-    def test_join_step_maps_frameworks_and_has_no_feature_group(self) -> None:
-        link = Link.inner(JoinSpec(PlanInfoLeftSource, "jid"), JoinSpec(PlanInfoRightSource, "jid"))
-
-        session = mloda.prepare(
-            ["PlanInfoJoinConsumer"],
-            compute_frameworks={PandasDataFrame},
-            links={link},
-            plugin_collector=_JOIN_PLUGINS,
-        )
-
-        plan = session.resolved_plan()
+    def test_join_step_reports_the_linked_feature_groups_and_join_type(self) -> None:
+        plan = _prepare_single_framework_join_session().resolved_plan()
 
         join_steps = [step for step in plan if step.step_kind == "join"]
         assert len(join_steps) == 1, f"expected one join step, got {[s.step_kind for s in plan]}"
 
         join = join_steps[0]
 
-        # join: no feature group, no feature names; frameworks are left (compute) and right (source).
+        # A join record is not blank: it names the link's declared sides and its join type.
         assert join.feature_names == ()
-        assert join.feature_group is None
-        assert join.feature_group_name is None
+        assert join.feature_group is PlanInfoLeftSource
+        assert join.source_feature_group is PlanInfoRightSource
+        assert join.join_type == "inner"
+
+        assert join.feature_group_name == "PlanInfoLeftSource"
+        assert join.source_feature_group_name == "PlanInfoRightSource"
+
+        # Both sides live on pandas here; the cross-framework test below is the one with teeth.
         assert join.compute_framework is PandasDataFrame
         assert join.source_compute_framework is PandasDataFrame
-        assert join.source_feature_group is None
 
     def test_join_plan_contains_both_sources_and_the_consumer(self) -> None:
-        link = Link.inner(JoinSpec(PlanInfoLeftSource, "jid"), JoinSpec(PlanInfoRightSource, "jid"))
-
-        session = mloda.prepare(
-            ["PlanInfoJoinConsumer"],
-            compute_frameworks={PandasDataFrame},
-            links={link},
-            plugin_collector=_JOIN_PLUGINS,
-        )
-
-        plan = session.resolved_plan()
+        plan = _prepare_single_framework_join_session().resolved_plan()
 
         compute_groups = {step.feature_group for step in plan if step.step_kind == "compute"}
         assert compute_groups == {PlanInfoLeftSource, PlanInfoRightSource, PlanInfoJoinConsumer}
@@ -502,6 +721,73 @@ class TestJoinStepMapping:
         kinds = [step.step_kind for step in plan]
         last_compute = len(kinds) - 1 - kinds[::-1].index("compute")
         assert kinds.index("join") < last_compute
+
+
+class TestCrossFrameworkJoinStepMapping:
+    """The join sides live on different frameworks, so left/right cannot be confused.
+
+    ``ExecutionPlan.run_link`` may swap ``left_framework``/``right_framework`` relative to the
+    link declaration, so the record's frameworks are the merge destination and the merged-in
+    source, while ``feature_group``/``source_feature_group`` stay the link's declared sides.
+    """
+
+    def test_join_step_frameworks_are_destination_and_source(self) -> None:
+        plan = _prepare_cross_framework_join_session().resolved_plan()
+
+        join_steps = [step for step in plan if step.step_kind == "join"]
+        assert len(join_steps) == 1, f"expected one join step, got {[s.step_kind for s in plan]}"
+
+        join = join_steps[0]
+
+        # Distinct classes: swapping them would flip these assertions.
+        assert join.compute_framework is PandasDataFrame
+        assert join.source_compute_framework is PyArrowTable
+        assert join.compute_framework_name == "PandasDataFrame"
+        assert join.source_compute_framework_name == "PyArrowTable"
+
+        # The link's declared sides, independent of any framework swap.
+        assert join.feature_names == ()
+        assert join.feature_group is PlanInfoCrossLeftPandas
+        assert join.source_feature_group is PlanInfoCrossRightArrow
+        assert join.join_type == "inner"
+
+    def test_cross_framework_join_plan_has_a_transform_into_the_join_destination(self) -> None:
+        plan = _prepare_cross_framework_join_session().resolved_plan()
+
+        transform_steps = [step for step in plan if step.step_kind == "transform"]
+        assert len(transform_steps) == 1, f"expected one transform step, got {[s.step_kind for s in plan]}"
+
+        transform = transform_steps[0]
+
+        assert transform.feature_names == ()
+        assert transform.compute_framework is PandasDataFrame
+        assert transform.source_compute_framework is PyArrowTable
+        assert transform.feature_group is PlanInfoCrossLeftPandas
+        assert transform.source_feature_group is PlanInfoCrossRightArrow
+        assert transform.join_type is None
+
+    def test_cross_framework_join_plan_shape(self) -> None:
+        plan = _prepare_cross_framework_join_session().resolved_plan()
+
+        kinds = [step.step_kind for step in plan]
+        assert kinds.count("join") == 1
+        assert kinds.count("transform") == 1
+        assert kinds.count("compute") == 3
+
+        # The two sources are computed on their own frameworks before the join merges them.
+        left_step = next(step for step in plan if step.feature_group is PlanInfoCrossLeftPandas)
+        assert left_step.step_kind == "compute"
+        assert left_step.compute_framework is PandasDataFrame
+        assert set(left_step.feature_names) == {"plan_info_xjid", "plan_info_xleft_val"}
+
+        right_step = next(step for step in plan if step.feature_group is PlanInfoCrossRightArrow)
+        assert right_step.step_kind == "compute"
+        assert right_step.compute_framework is PyArrowTable
+        assert set(right_step.feature_names) == {"plan_info_xjid", "plan_info_xright_val"}
+
+        assert kinds.index("join") < kinds.index("compute", kinds.index("join"))
+        consumer_index = [step.feature_group for step in plan].index(PlanInfoCrossConsumer)
+        assert kinds.index("join") < consumer_index
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_core/test_api/test_plan_info.py
+++ b/tests/test_core/test_api/test_plan_info.py
@@ -1,0 +1,542 @@
+"""Tests for the public resolved-execution-plan API (issue #647).
+
+Contract under test:
+  * ``mloda.core.api.plan_info.PlanStep`` is a frozen dataclass describing one step of the
+    resolved execution plan: ``step_kind``, ``feature_names``, ``feature_group``,
+    ``compute_framework``, ``source_feature_group``, ``source_compute_framework`` plus the
+    convenience properties ``feature_group_name`` and ``compute_framework_name``.
+  * ``mlodaAPI.resolved_plan()`` returns ``list[PlanStep]`` on a prepared session, both before
+    and after ``run()``, in execution-plan order.
+  * ``mlodaAPI.explain(features, ...)`` mirrors the ``run_all`` parameter shape, prepares without
+    executing and returns the same records as ``prepare(...).resolved_plan()``.
+  * ``PlanStep`` is exported from both ``mloda.user`` and ``mloda.steward``.
+
+A caller must reach all of this without importing anything from the internal execution-step
+package; ``TestCallerNeedsNoInternalImport`` locks that in for this module itself.
+"""
+
+import ast
+import dataclasses
+from pathlib import Path
+from typing import Any, Optional
+
+import pandas as pd
+import pyarrow as pa
+import pytest
+
+# Aliased: a bare ``import mloda.user`` would bind the name ``mloda`` to the package and collide
+# with the ``mloda`` mlodaAPI alias imported below.
+import mloda.steward as mloda_steward
+import mloda.user as mloda_user
+from mloda.provider import BaseInputData, ComputeFramework, DataCreator, FeatureGroup, FeatureSet
+from mloda.user import (
+    Feature,
+    FeatureName,
+    Index,
+    JoinSpec,
+    Link,
+    Options,
+    PlanStep,
+    PluginCollector,
+    mloda,
+    mlodaAPI,
+)
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+from mloda_plugins.feature_group.experimental.aggregated_feature_group.pandas import PandasAggregatedFeatureGroup
+
+
+# ---------------------------------------------------------------------------
+# Test feature groups
+# ---------------------------------------------------------------------------
+
+
+class PlanInfoPandasSource(FeatureGroup):
+    """Pandas root source feeding the chained aggregation request."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({"sales", "price"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return pd.DataFrame({"sales": [100, 200, 300], "price": [1.0, 2.0, 3.0]})
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+
+class PlanInfoArrowSource(FeatureGroup):
+    """PyArrow root source: forces a transform step into the pandas aggregation group."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({"arrow_sales"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return pa.table({"arrow_sales": [100, 200, 300]})
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PyArrowTable}
+
+
+class PlanInfoNeverExecutes(FeatureGroup):
+    """Plans fine, but blows up if anything actually executes it.
+
+    ``explain()`` must never reach ``calculate_feature``, so a successful explain call over this
+    feature group proves that explain does not execute the plan.
+    """
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({"never_executed"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        raise RuntimeError("explain() must not execute the plan: calculate_feature was called")
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+
+class PlanInfoLeftSource(FeatureGroup):
+    """Left side of the join scenario."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({"jid", "left_val"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return pd.DataFrame({"jid": [1, 2, 3], "left_val": [10, 20, 30]})
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+    @classmethod
+    def index_columns(cls) -> Optional[list[Index]]:
+        return [Index(("jid",))]
+
+
+class PlanInfoRightSource(FeatureGroup):
+    """Right side of the join scenario."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({"jid", "right_val"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return pd.DataFrame({"jid": [1, 2, 3], "right_val": [1.5, 2.5, 3.5]})
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+    @classmethod
+    def index_columns(cls) -> Optional[list[Index]]:
+        return [Index(("jid",))]
+
+
+class PlanInfoJoinConsumer(FeatureGroup):
+    """Consumes features from both join sides, which forces a join step into the plan."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return {Feature("left_val"), Feature("right_val")}
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        data["PlanInfoJoinConsumer"] = data["left_val"] * data["right_val"]
+        return data
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return {cls.get_class_name()}
+
+
+_AGGREGATION_PLUGINS = PluginCollector.enabled_feature_groups({PlanInfoPandasSource, PandasAggregatedFeatureGroup})
+_TRANSFORM_PLUGINS = PluginCollector.enabled_feature_groups({PlanInfoArrowSource, PandasAggregatedFeatureGroup})
+_NEVER_EXECUTES_PLUGINS = PluginCollector.enabled_feature_groups({PlanInfoNeverExecutes})
+_JOIN_PLUGINS = PluginCollector.enabled_feature_groups({PlanInfoLeftSource, PlanInfoRightSource, PlanInfoJoinConsumer})
+
+# The chained request from the issue: an aggregated feature over a source feature.
+_CHAINED_FEATURES: list[Feature | str] = ["sales__mean_aggr"]
+
+
+def _prepare_chained_session() -> mlodaAPI:
+    return mloda.prepare(
+        _CHAINED_FEATURES,
+        compute_frameworks={PandasDataFrame},
+        plugin_collector=_AGGREGATION_PLUGINS,
+    )
+
+
+# ---------------------------------------------------------------------------
+# PlanStep dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestPlanStepDataclass:
+    """PlanStep is a frozen dataclass with the documented fields and name properties."""
+
+    def test_plan_step_is_a_dataclass(self) -> None:
+        # Kept apart from the frozen check: is_dataclass() narrows PlanStep for mypy, which
+        # would make every later PlanStep(...) construction in the same function untyped.
+        assert dataclasses.is_dataclass(PlanStep)
+
+    def test_plan_step_is_frozen(self) -> None:
+        step = PlanStep(
+            step_kind="compute",
+            feature_names=("sales__mean_aggr",),
+            feature_group=PandasAggregatedFeatureGroup,
+            compute_framework=PandasDataFrame,
+            source_feature_group=None,
+            source_compute_framework=None,
+        )
+
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            step.step_kind = "join"  # type: ignore[misc]
+
+    def test_plan_step_exposes_documented_fields(self) -> None:
+        field_names = [field.name for field in dataclasses.fields(PlanStep)]
+
+        assert field_names == [
+            "step_kind",
+            "feature_names",
+            "feature_group",
+            "compute_framework",
+            "source_feature_group",
+            "source_compute_framework",
+        ]
+
+    def test_name_properties_return_class_names(self) -> None:
+        step = PlanStep(
+            step_kind="compute",
+            feature_names=("sales__mean_aggr",),
+            feature_group=PandasAggregatedFeatureGroup,
+            compute_framework=PandasDataFrame,
+            source_feature_group=None,
+            source_compute_framework=None,
+        )
+
+        assert step.feature_group_name == "PandasAggregatedFeatureGroup"
+        assert step.compute_framework_name == "PandasDataFrame"
+
+    def test_name_properties_are_none_when_class_is_none(self) -> None:
+        step = PlanStep(
+            step_kind="join",
+            feature_names=(),
+            feature_group=None,
+            compute_framework=None,
+            source_feature_group=None,
+            source_compute_framework=None,
+        )
+
+        assert step.feature_group_name is None
+        assert step.compute_framework_name is None
+
+    def test_plan_steps_compare_by_value(self) -> None:
+        """Records must be value-comparable so callers can diff two plans."""
+        first = PlanStep(
+            step_kind="compute",
+            feature_names=("sales",),
+            feature_group=PlanInfoPandasSource,
+            compute_framework=PandasDataFrame,
+            source_feature_group=None,
+            source_compute_framework=None,
+        )
+        second = PlanStep(
+            step_kind="compute",
+            feature_names=("sales",),
+            feature_group=PlanInfoPandasSource,
+            compute_framework=PandasDataFrame,
+            source_feature_group=None,
+            source_compute_framework=None,
+        )
+
+        assert first == second
+
+
+# ---------------------------------------------------------------------------
+# Definition of done: chained aggregated feature
+# ---------------------------------------------------------------------------
+
+
+class TestResolvedPlanForChainedFeature:
+    """DoD: requesting a chained ``*__mean_aggr`` feature exposes the concrete aggregation
+    FeatureGroup implementation on the selected compute framework."""
+
+    def test_resolved_plan_reports_source_and_aggregation_compute_steps(self) -> None:
+        session = _prepare_chained_session()
+
+        plan = session.resolved_plan()
+
+        assert isinstance(plan, list)
+        assert all(isinstance(step, PlanStep) for step in plan)
+
+        compute_steps = [step for step in plan if step.step_kind == "compute"]
+        assert len(compute_steps) == 2, f"expected two compute steps, got {[s.step_kind for s in plan]}"
+
+        source_step, aggregation_step = compute_steps
+
+        # The root source feature the aggregation chains off.
+        assert source_step.feature_names == ("sales",)
+        assert source_step.feature_group is PlanInfoPandasSource
+        assert source_step.compute_framework is PandasDataFrame
+
+        # The concrete aggregation implementation on the selected framework.
+        assert aggregation_step.feature_names == ("sales__mean_aggr",)
+        assert aggregation_step.feature_group is PandasAggregatedFeatureGroup
+        assert aggregation_step.compute_framework is PandasDataFrame
+
+        assert aggregation_step.feature_group_name == "PandasAggregatedFeatureGroup"
+        assert aggregation_step.compute_framework_name == "PandasDataFrame"
+
+    def test_compute_steps_carry_no_source_fields(self) -> None:
+        """source_* fields are transform/join specific and stay None on compute steps."""
+        plan = _prepare_chained_session().resolved_plan()
+
+        for step in (step for step in plan if step.step_kind == "compute"):
+            assert step.source_feature_group is None
+            assert step.source_compute_framework is None
+
+    def test_feature_names_are_strings_and_sorted(self) -> None:
+        """feature_names mirrors FeatureSet.get_all_names(): a sorted tuple of strings.
+
+        Requested as ["sales", "price"], reported sorted as ("price", "sales").
+        """
+        session = mloda.prepare(
+            ["sales", "price"],
+            compute_frameworks={PandasDataFrame},
+            plugin_collector=_AGGREGATION_PLUGINS,
+        )
+
+        plan = session.resolved_plan()
+        source_steps = [step for step in plan if step.feature_group is PlanInfoPandasSource]
+        assert len(source_steps) == 1
+
+        names = source_steps[0].feature_names
+        assert isinstance(names, tuple)
+        assert all(isinstance(name, str) for name in names)
+        assert names == ("price", "sales")
+        assert list(names) == sorted(names)
+
+    def test_plan_is_in_execution_order(self) -> None:
+        """The source must be planned before the aggregation that consumes it."""
+        plan = _prepare_chained_session().resolved_plan()
+
+        groups = [step.feature_group for step in plan if step.step_kind == "compute"]
+        assert groups.index(PlanInfoPandasSource) < groups.index(PandasAggregatedFeatureGroup)
+
+
+# ---------------------------------------------------------------------------
+# resolved_plan() before and after run()
+# ---------------------------------------------------------------------------
+
+
+class TestResolvedPlanBeforeAndAfterRun:
+    def test_resolved_plan_available_after_prepare_without_running(self) -> None:
+        session = _prepare_chained_session()
+
+        plan = session.resolved_plan()
+
+        assert len(plan) > 0
+
+    def test_resolved_plan_is_unchanged_by_run(self) -> None:
+        session = _prepare_chained_session()
+
+        before_run = session.resolved_plan()
+        results = session.run()
+        after_run = session.resolved_plan()
+
+        assert after_run == before_run
+
+        # Sanity check that the session really did execute.
+        assert len(results) == 1
+        assert "sales__mean_aggr" in results[0].columns
+
+
+# ---------------------------------------------------------------------------
+# explain()
+# ---------------------------------------------------------------------------
+
+
+class TestExplain:
+    def test_explain_matches_prepare_resolved_plan(self) -> None:
+        explained = mlodaAPI.explain(
+            _CHAINED_FEATURES,
+            compute_frameworks={PandasDataFrame},
+            plugin_collector=_AGGREGATION_PLUGINS,
+        )
+        prepared = _prepare_chained_session().resolved_plan()
+
+        assert explained == prepared
+
+    def test_explain_returns_plan_steps(self) -> None:
+        explained = mlodaAPI.explain(
+            _CHAINED_FEATURES,
+            compute_frameworks={PandasDataFrame},
+            plugin_collector=_AGGREGATION_PLUGINS,
+        )
+
+        assert isinstance(explained, list)
+        assert all(isinstance(step, PlanStep) for step in explained)
+        assert [step.feature_group for step in explained] == [PlanInfoPandasSource, PandasAggregatedFeatureGroup]
+
+    def test_explain_does_not_execute_the_plan(self) -> None:
+        """PlanInfoNeverExecutes.calculate_feature raises. explain() must still succeed."""
+        explained = mlodaAPI.explain(
+            ["never_executed"],
+            compute_frameworks={PandasDataFrame},
+            plugin_collector=_NEVER_EXECUTES_PLUGINS,
+        )
+
+        assert len(explained) == 1
+        assert explained[0].feature_group is PlanInfoNeverExecutes
+        assert explained[0].feature_names == ("never_executed",)
+
+    def test_explain_is_reachable_from_the_mloda_alias(self) -> None:
+        explained = mloda.explain(
+            _CHAINED_FEATURES,
+            compute_frameworks={PandasDataFrame},
+            plugin_collector=_AGGREGATION_PLUGINS,
+        )
+
+        assert all(isinstance(step, PlanStep) for step in explained)
+
+
+# ---------------------------------------------------------------------------
+# transform and join step mapping
+# ---------------------------------------------------------------------------
+
+
+class TestTransformStepMapping:
+    """A PyArrow source feeding the pandas aggregation group produces a transform step."""
+
+    def test_transform_step_maps_from_and_to_group_and_framework(self) -> None:
+        session = mloda.prepare(
+            ["arrow_sales__mean_aggr"],
+            compute_frameworks={PandasDataFrame, PyArrowTable},
+            plugin_collector=_TRANSFORM_PLUGINS,
+        )
+
+        plan = session.resolved_plan()
+
+        transform_steps = [step for step in plan if step.step_kind == "transform"]
+        assert len(transform_steps) == 1, f"expected one transform step, got {[s.step_kind for s in plan]}"
+
+        transform = transform_steps[0]
+
+        # transform: feature_group/compute_framework are the destination, source_* the origin.
+        assert transform.feature_names == ()
+        assert transform.feature_group is PandasAggregatedFeatureGroup
+        assert transform.compute_framework is PandasDataFrame
+        assert transform.source_feature_group is PlanInfoArrowSource
+        assert transform.source_compute_framework is PyArrowTable
+
+    def test_transform_step_sits_between_its_compute_steps(self) -> None:
+        session = mloda.prepare(
+            ["arrow_sales__mean_aggr"],
+            compute_frameworks={PandasDataFrame, PyArrowTable},
+            plugin_collector=_TRANSFORM_PLUGINS,
+        )
+
+        kinds = [step.step_kind for step in session.resolved_plan()]
+
+        assert kinds == ["compute", "transform", "compute"]
+
+
+class TestJoinStepMapping:
+    """Two linked pandas sources consumed by one feature group produce a join step."""
+
+    def test_join_step_maps_frameworks_and_has_no_feature_group(self) -> None:
+        link = Link.inner(JoinSpec(PlanInfoLeftSource, "jid"), JoinSpec(PlanInfoRightSource, "jid"))
+
+        session = mloda.prepare(
+            ["PlanInfoJoinConsumer"],
+            compute_frameworks={PandasDataFrame},
+            links={link},
+            plugin_collector=_JOIN_PLUGINS,
+        )
+
+        plan = session.resolved_plan()
+
+        join_steps = [step for step in plan if step.step_kind == "join"]
+        assert len(join_steps) == 1, f"expected one join step, got {[s.step_kind for s in plan]}"
+
+        join = join_steps[0]
+
+        # join: no feature group, no feature names; frameworks are left (compute) and right (source).
+        assert join.feature_names == ()
+        assert join.feature_group is None
+        assert join.feature_group_name is None
+        assert join.compute_framework is PandasDataFrame
+        assert join.source_compute_framework is PandasDataFrame
+        assert join.source_feature_group is None
+
+    def test_join_plan_contains_both_sources_and_the_consumer(self) -> None:
+        link = Link.inner(JoinSpec(PlanInfoLeftSource, "jid"), JoinSpec(PlanInfoRightSource, "jid"))
+
+        session = mloda.prepare(
+            ["PlanInfoJoinConsumer"],
+            compute_frameworks={PandasDataFrame},
+            links={link},
+            plugin_collector=_JOIN_PLUGINS,
+        )
+
+        plan = session.resolved_plan()
+
+        compute_groups = {step.feature_group for step in plan if step.step_kind == "compute"}
+        assert compute_groups == {PlanInfoLeftSource, PlanInfoRightSource, PlanInfoJoinConsumer}
+
+        # The join must be planned before the consumer that depends on it.
+        kinds = [step.step_kind for step in plan]
+        last_compute = len(kinds) - 1 - kinds[::-1].index("compute")
+        assert kinds.index("join") < last_compute
+
+
+# ---------------------------------------------------------------------------
+# Public surface
+# ---------------------------------------------------------------------------
+
+
+class TestPlanStepIsPubliclyExported:
+    def test_plan_step_exported_from_user_and_steward(self) -> None:
+        assert "PlanStep" in mloda_user.__all__
+        assert "PlanStep" in mloda_steward.__all__
+
+    def test_user_and_steward_export_the_same_object(self) -> None:
+        assert mloda_user.PlanStep is mloda_steward.PlanStep
+        assert mloda_user.PlanStep is PlanStep
+
+
+class TestCallerNeedsNoInternalImport:
+    """The whole public plan API must be reachable without touching internal execution steps."""
+
+    def test_this_module_imports_nothing_from_the_internal_core_package(self) -> None:
+        tree = ast.parse(Path(__file__).read_text(encoding="utf-8"))
+
+        imported: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported.update(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module is not None:
+                imported.add(node.module)
+
+        internal = "mloda.core.core"
+        offenders = sorted(name for name in imported if name == internal or name.startswith(f"{internal}."))
+
+        assert not offenders, f"the public plan API must not require {internal} imports, found: {offenders}"
+
+    def test_public_entry_points_exist_on_the_public_api(self) -> None:
+        assert hasattr(mlodaAPI, "resolved_plan")
+        assert hasattr(mlodaAPI, "explain")

--- a/tests/test_mloda_imports.py
+++ b/tests/test_mloda_imports.py
@@ -73,6 +73,8 @@ def test_import_user_full() -> None:
         # Plugin discovery
         PluginLoader,
         PluginCollector,
+        # Resolved execution plan
+        PlanStep,
     )
 
     # mloda
@@ -103,6 +105,10 @@ def test_import_user_full() -> None:
     # Plugin discovery
     assert PluginLoader is not None
     assert PluginCollector is not None
+    # Resolved execution plan
+    assert PlanStep is not None
+    assert callable(mlodaAPI.explain)
+    assert hasattr(mlodaAPI, "resolved_plan")
 
 
 # =============================================================================
@@ -206,12 +212,16 @@ def test_import_steward_governance() -> None:
         # Function extenders (audit, monitoring, observability)
         Extender,
         ExtenderHook,
+        # Resolved execution plan
+        PlanStep,
     )
 
     # Plugin inspection
     assert FeatureGroupInfo is not None
     assert ComputeFrameworkInfo is not None
     assert ExtenderInfo is not None
+    # Resolved execution plan
+    assert PlanStep is not None
     # Documentation
     assert get_feature_group_docs is not None
     assert get_compute_framework_docs is not None


### PR DESCRIPTION
Closes #647.

## Summary

Exposes the resolved execution plan (feature names, concrete FeatureGroup, compute framework, step kind) as a public API. Everything needed already existed inside the engine; it just had no supported way out, so catalogs and governance tools had to reach into `mloda.core.core`.

Nothing new is computed: the records are read from the plan the engine already builds.

## API

- `session.resolved_plan() -> list[PlanStep]` for the `prepare` / `run` path. Available right after `prepare()`, and unchanged by `run()`.
- `mlodaAPI.explain(features, *, ...) -> list[PlanStep]` for the `run_all` path: resolves the plan without executing it. Parameters after `features` are keyword-only.
- `PlanStep` is re-exported from `mloda.user` and `mloda.steward`, where it is the runtime counterpart of the static `resolve_feature` (which returns candidates but no winner, because the winner is decided per request by the engine).

`PlanStep` carries `step_kind` (`Literal["compute", "join", "transform"]`), `feature_names`, `feature_group`, `compute_framework`, `source_feature_group`, `source_compute_framework`, `join_type`, plus `*_name` accessors for callers that only want class names.

## Notes for reviewers

Two honest caveats are documented rather than papered over:

- **Join steps.** `feature_group` / `source_feature_group` are the link's *declared* left and right sides, while `compute_framework` / `source_compute_framework` are the merge *destination* and the framework merged in. These are not always the same orientation: `ExecutionPlan.run_link` swaps left and right for `JoinType.RIGHT`. A cross-framework join test (pandas left, pyarrow right) pins the mapping, since a same-framework test cannot detect a swap.
- **`feature_names` is not a clean requested-name map.** It includes engine-injected features (link index features, global-filter features), so the same index name can appear under two different FeatureGroups in one plan. A catalog building `{name: feature_group}` naively would collide.

`explain()` re-resolves the plan from scratch: it answers "what would this request resolve to", not "what served that earlier `run_all`". To match a `run_all` resolution, pass the same `parallelization_modes` (`run_all` defaults to `{SYNC}`, `prepare` / `explain` to `None`, and framework selection is filtered by mode).

`build_plan_steps` raises `ValueError` on a step type it does not know, mirroring `ExecutionPlan.add_tfs`, rather than silently dropping it from a record that governance tooling is meant to trust.

## Tests

- The definition-of-done case from the issue: a chained `*__mean_aggr` request resolves to the concrete aggregation FeatureGroup on the selected framework.
- The reported plan equals the plan that actually executed (built from the runner's own deep-copied plan after `run()`), which is the claim worth proving.
- Cross-framework join and transform step mappings, unknown-step rejection, keyword-only `explain`, and persona export locks in `test_persona_exports.py` / `test_mloda_imports.py`.

`tox` green: 4708 passed, ruff, `mypy --strict`, bandit.
