### PR TITLE
fix: one identity for reader class-as-key selection, pin the sibling-reader contract (#565)

### DIFF
--- a/docs/docs/in_depth/data-access-patterns.md
+++ b/docs/docs/in_depth/data-access-patterns.md
@@ -76,6 +76,8 @@ A feature selects a specific reader with an Option whose key equals the reader's
 Feature("value", options={UbaAirReader.__name__: url})
 ```
 
+The reader class itself is also accepted as the key, e.g. `Feature("value", options={UbaAirReader: url})`.
+
 The matched `(ReaderClass, data_access)` pair is stored under the reserved `"BaseInputData"` options key and consumed by `init_reader` at load time.
 
 For non-file sources such as HTTP endpoints, subclassing `ReadFile` and overriding `match_subclass_data_access` plus `load_data` is a supported pattern; on that path `suffix()` is never consulted (it is inert). `ApiInputData` injects in-memory data passed through the API request and is not an HTTP client.

--- a/docs/docs/in_depth/data-access-patterns.md
+++ b/docs/docs/in_depth/data-access-patterns.md
@@ -76,7 +76,7 @@ A feature selects a specific reader with an Option whose key equals the reader's
 Feature("value", options={UbaAirReader.__name__: url})
 ```
 
-The reader class itself is also accepted as the key, e.g. `Feature("value", options={UbaAirReader: url})`.
+The reader class itself is also accepted as the key, e.g. `Feature("value", options={UbaAirReader: url})`; it is normalized to the class-name string when the Options object is constructed, so both forms are one identity.
 
 The matched `(ReaderClass, data_access)` pair is stored under the reserved `"BaseInputData"` options key and consumed by `init_reader` at load time.
 

--- a/mloda/core/abstract_plugins/components/hashable_dict.py
+++ b/mloda/core/abstract_plugins/components/hashable_dict.py
@@ -3,7 +3,15 @@ from typing import Any
 
 def _make_hashable(value: Any) -> Any:
     if isinstance(value, dict):
-        return tuple(sorted((k, _make_hashable(v)) for k, v in value.items()))
+        items = [(k, _make_hashable(v)) for k, v in value.items()]
+        # Mixed-type keys (e.g. reader class plus str) are unorderable; fall back to a
+        # type-robust deterministic sort. The common orderable case stays unchanged.
+        try:
+            return tuple(sorted(items))
+        except TypeError:
+            return tuple(
+                sorted(items, key=lambda kv: (kv[0].__class__.__module__, kv[0].__class__.__qualname__, repr(kv[0])))
+            )
     if isinstance(value, (list, tuple)):
         return tuple(_make_hashable(item) for item in value)
     if isinstance(value, set):

--- a/mloda/core/abstract_plugins/components/options.py
+++ b/mloda/core/abstract_plugins/components/options.py
@@ -59,6 +59,16 @@ def _isolate_forwarded_value(value: Any, memo: dict[int, Any]) -> Any:
     return value
 
 
+def _normalize_reader_class_keys(d: dict[str, Any]) -> dict[str, Any]:
+    """Reader class keys normalize to data_access_name() so both documented key forms
+    (class object and class-name string) share one identity."""
+    if not any(isinstance(k, type) for k in d):
+        return d
+    return {
+        (k.data_access_name() if isinstance(k, type) and hasattr(k, "data_access_name") else k): v for k, v in d.items()
+    }
+
+
 def validate_forwarding_directives(
     forward_group: frozenset[str] | bool | None, forward_group_exclude: frozenset[str]
 ) -> None:
@@ -132,8 +142,8 @@ class Options:
         context: Optional[dict[str, Any]] = None,
         propagate_context_keys: frozenset[str] | None = None,
     ) -> None:
-        self.group = group or {}
-        self.context = context or {}
+        self.group = _normalize_reader_class_keys(group) if group else {}
+        self.context = _normalize_reader_class_keys(context) if context else {}
         self.propagate_context_keys: frozenset[str] = propagate_context_keys or frozenset()
         self.inherited_group_keys: frozenset[str] = frozenset()
         self.inherited_context_keys: frozenset[str] = frozenset()

--- a/tests/test_plugins/feature_group/input_data/test_sibling_reader_selection.py
+++ b/tests/test_plugins/feature_group/input_data/test_sibling_reader_selection.py
@@ -1,0 +1,210 @@
+"""
+Pins the input-data reader SELECTION contract (issue #565).
+
+A feature selects a specific reader with an Option whose key equals the reader's
+class name (``BaseInputData.data_access_name()``, i.e. ``cls.__name__``). The key
+may also be the reader class itself. The matched ``(ReaderClass, data_access)``
+pair is stored under the reserved ``"BaseInputData"`` options key and consumed by
+``init_reader`` at load time. For non-file sources (e.g. HTTP), subclassing
+``ReadFile`` and overriding ``match_subclass_data_access`` plus ``load_data`` is
+the sanctioned pattern; ``suffix()`` is inert on that path.
+
+Isolation: test readers defined here are discovered process-wide via
+``get_all_subclasses``. Every reader's ``match_subclass_data_access`` therefore
+requires a unique marker value (or marker options key) and returns None otherwise,
+so it can never hijack matching in other tests running in the same worker process.
+"""
+
+from typing import Any, cast
+
+import pyarrow as pa
+import pytest
+
+from mloda.core.abstract_plugins.components.input_data.base_input_data import BaseInputData
+from mloda.provider import FeatureSet
+from mloda.user import Feature
+from mloda.user import Options
+from mloda.user import PluginCollector
+from mloda.user import mloda
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable  # noqa: F401
+from mloda_plugins.feature_group.input_data.read_file import ReadFile
+from mloda_plugins.feature_group.input_data.read_file_feature import ReadFileFeature
+
+
+_ACCESS_A = "sibling_sel_565_access_a"
+_ACCESS_B = "sibling_sel_565_access_b"
+_URL_MARKER_KEY = "sibling_sel_565_url_marker"
+_URL_ACCESS = "fake-http://example/sibling_sel_565/data"
+_URL_FEATURE_NAME = "sibling_sel_565_url_value"
+_URL_FEATURE_VALUES = [11, 22, 33]
+
+
+class SiblingSel565ReaderA(ReadFile):
+    """Final reader (wholesale load_data override) that only matches its own marker access string."""
+
+    @classmethod
+    def match_subclass_data_access(cls, data_access: Any, feature_names: list[str], options: Options) -> Any:
+        if data_access == _ACCESS_A:
+            return data_access
+        return None
+
+    @classmethod
+    def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
+        return {"sibling_sel_565_a": [1]}
+
+
+class SiblingSel565ReaderB(ReadFile):
+    """Sibling of SiblingSel565ReaderA; only matches its own marker access string."""
+
+    @classmethod
+    def match_subclass_data_access(cls, data_access: Any, feature_names: list[str], options: Options) -> Any:
+        if data_access == _ACCESS_B:
+            return data_access
+        return None
+
+    @classmethod
+    def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
+        return {"sibling_sel_565_b": [2]}
+
+
+class SiblingSel565UrlReader(ReadFile):
+    """URL-style reader recipe: overrides match_subclass_data_access and load_data wholesale.
+
+    Deliberately does NOT override suffix(): the option-key selection path never
+    consults it, which the end-to-end tests pin. Matching requires this test's
+    unique marker option key so the reader never matches in other tests.
+    """
+
+    @classmethod
+    def match_subclass_data_access(cls, data_access: Any, feature_names: list[str], options: Options) -> Any:
+        if options.get(_URL_MARKER_KEY) is None:
+            return None
+        if isinstance(data_access, str) and data_access.startswith("fake-http://"):
+            return data_access
+        return None
+
+    @classmethod
+    def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
+        return pa.table({_URL_FEATURE_NAME: _URL_FEATURE_VALUES})
+
+
+class SiblingSel565NotAReader:
+    """Has get_class_name but is not a BaseInputData subclass."""
+
+    @classmethod
+    def get_class_name(cls) -> str:
+        return cls.__name__
+
+
+class TestSiblingSelectionViaClassNameStringKey:
+    """Group A: sibling selection via class-name string option key (unit level)."""
+
+    def test_string_key_routes_to_reader_a(self) -> None:
+        options = Options({SiblingSel565ReaderA.__name__: _ACCESS_A})
+        assert BaseInputData.feature_scope_data_access(options, "sibling_sel_565_feat") is True
+        assert options.get("BaseInputData") == (SiblingSel565ReaderA, _ACCESS_A)
+
+    def test_string_key_routes_to_reader_b_no_sibling_collision(self) -> None:
+        options = Options({SiblingSel565ReaderB.__name__: _ACCESS_B})
+        assert BaseInputData.feature_scope_data_access(options, "sibling_sel_565_feat") is True
+        assert options.get("BaseInputData") == (SiblingSel565ReaderB, _ACCESS_B)
+
+    def test_unknown_key_matches_no_reader(self) -> None:
+        options = Options({"SiblingSel565NoSuchReader": _ACCESS_A})
+        assert BaseInputData.feature_scope_data_access(options, "sibling_sel_565_feat") is False
+        assert "BaseInputData" not in options
+
+
+class TestSiblingSelectionViaClassKey:
+    """Group B: the option key may be the reader class itself."""
+
+    def test_class_as_key_resolves_like_string_form(self) -> None:
+        options = Options(cast(dict[str, Any], {SiblingSel565ReaderA: _ACCESS_A}))
+        assert BaseInputData.feature_scope_data_access(options, "sibling_sel_565_feat") is True
+        assert options.get("BaseInputData") == (SiblingSel565ReaderA, _ACCESS_A)
+
+    def test_key_normalization_string_and_class(self) -> None:
+        assert BaseInputData.deal_with_base_input_data_name_as_cls_or_str("SiblingSel565ReaderA") == (
+            "SiblingSel565ReaderA"
+        )
+        assert (
+            BaseInputData.deal_with_base_input_data_name_as_cls_or_str(SiblingSel565ReaderA) == "SiblingSel565ReaderA"
+        )
+
+    def test_non_base_input_data_class_key_raises(self) -> None:
+        with pytest.raises(ValueError, match="not a subclass of BaseInputData"):
+            BaseInputData.deal_with_base_input_data_name_as_cls_or_str(SiblingSel565NotAReader)
+
+    def test_non_string_key_raises(self) -> None:
+        with pytest.raises(ValueError, match="is not a string"):
+            BaseInputData.deal_with_base_input_data_name_as_cls_or_str(42)
+
+
+class TestReservedBaseInputDataKey:
+    """Group C: reserved "BaseInputData" options key semantics."""
+
+    def test_add_base_input_data_identical_pair_is_noop_different_pair_raises(self) -> None:
+        options = Options()
+        BaseInputData.add_base_input_data_to_options(SiblingSel565ReaderA, _ACCESS_A, options)
+        BaseInputData.add_base_input_data_to_options(SiblingSel565ReaderA, _ACCESS_A, options)
+        assert options.get("BaseInputData") == (SiblingSel565ReaderA, _ACCESS_A)
+        with pytest.raises(ValueError, match="BaseInputData already set with different values"):
+            BaseInputData.add_base_input_data_to_options(SiblingSel565ReaderB, _ACCESS_B, options)
+
+    def test_init_reader_consumes_stored_tuple(self) -> None:
+        options = Options(group={"BaseInputData": (SiblingSel565ReaderA, _ACCESS_A)})
+        reader, data_access = SiblingSel565ReaderA().init_reader(options)
+        assert isinstance(reader, SiblingSel565ReaderA)
+        assert data_access == _ACCESS_A
+
+    def test_init_reader_none_options_raises(self) -> None:
+        with pytest.raises(ValueError, match="Options were not set"):
+            SiblingSel565ReaderA().init_reader(None)
+
+    def test_init_reader_missing_base_input_data_key_raises(self) -> None:
+        with pytest.raises(ValueError, match="'BaseInputData' key is missing"):
+            SiblingSel565ReaderA().init_reader(Options())
+
+
+class TestUrlReaderRecipeEndToEnd:
+    """Group D: sanctioned non-file (HTTP-style) reader recipe, end to end."""
+
+    def test_url_reader_is_final_and_suffix_inert(self) -> None:
+        assert SiblingSel565UrlReader.is_final_reader() is True
+        with pytest.raises(NotImplementedError):
+            SiblingSel565UrlReader.suffix()
+
+    def test_url_reader_end_to_end_string_key(self) -> None:
+        feature = Feature(
+            name=_URL_FEATURE_NAME,
+            options={
+                SiblingSel565UrlReader.__name__: _URL_ACCESS,
+                _URL_MARKER_KEY: True,
+            },
+        )
+        features: list[Feature | str] = [feature]
+        result = mloda.run_all(
+            features,
+            compute_frameworks=["PyArrowTable"],
+            plugin_collector=PluginCollector.enabled_feature_groups({ReadFileFeature}),
+        )
+        assert result[0].to_pydict()[_URL_FEATURE_NAME] == _URL_FEATURE_VALUES
+
+    def test_url_reader_end_to_end_class_key(self) -> None:
+        feature = Feature(
+            name=_URL_FEATURE_NAME,
+            options=cast(
+                dict[str, Any],
+                {
+                    SiblingSel565UrlReader: _URL_ACCESS,
+                    _URL_MARKER_KEY: True,
+                },
+            ),
+        )
+        features: list[Feature | str] = [feature]
+        result = mloda.run_all(
+            features,
+            compute_frameworks=["PyArrowTable"],
+            plugin_collector=PluginCollector.enabled_feature_groups({ReadFileFeature}),
+        )
+        assert result[0].to_pydict()[_URL_FEATURE_NAME] == _URL_FEATURE_VALUES

--- a/tests/test_plugins/feature_group/input_data/test_sibling_reader_selection.py
+++ b/tests/test_plugins/feature_group/input_data/test_sibling_reader_selection.py
@@ -208,3 +208,42 @@ class TestUrlReaderRecipeEndToEnd:
             plugin_collector=PluginCollector.enabled_feature_groups({ReadFileFeature}),
         )
         assert result[0].to_pydict()[_URL_FEATURE_NAME] == _URL_FEATURE_VALUES
+
+
+class TestClassKeyNormalization565:
+    """Group E: class option keys must be identity-equivalent to their data_access_name() string form.
+
+    Pins the fix for the class-key/string-key identity split: a reader class used as an
+    Options key should be normalized to ``cls.data_access_name()`` when the Options object
+    is constructed, so both spellings hash, compare, and look up identically.
+    """
+
+    def test_options_class_key_equals_string_key(self) -> None:
+        class_keyed = Options(cast(dict[str, Any], {SiblingSel565ReaderA: _ACCESS_A}))
+        string_keyed = Options({SiblingSel565ReaderA.__name__: _ACCESS_A})
+        assert class_keyed == string_keyed
+        assert hash(class_keyed) == hash(string_keyed)
+
+    def test_feature_class_key_equals_string_key(self) -> None:
+        class_keyed = Feature(
+            name="sibling_sel_565_norm_feat",
+            options=cast(dict[str, Any], {SiblingSel565ReaderA: _ACCESS_A}),
+        )
+        string_keyed = Feature(
+            name="sibling_sel_565_norm_feat",
+            options={SiblingSel565ReaderA.__name__: _ACCESS_A},
+        )
+        assert class_keyed == string_keyed
+        assert hash(class_keyed) == hash(string_keyed)
+        assert len({class_keyed, string_keyed}) == 1
+
+    def test_child_options_with_class_key_hashable(self) -> None:
+        feature = Feature(name="sibling_sel_565_child_feat")
+        feature.child_options = Options(
+            cast(dict[str, Any], {SiblingSel565ReaderA: _ACCESS_A, "sibling_sel_565_child_marker": True})
+        )
+        assert isinstance(hash(feature), int)
+
+    def test_options_get_by_string_after_class_key_construction(self) -> None:
+        options = Options(cast(dict[str, Any], {SiblingSel565ReaderA: _ACCESS_A}))
+        assert options.get(SiblingSel565ReaderA.__name__) == _ACCESS_A


### PR DESCRIPTION
Closes the mloda-side test/ergonomics item of #565 (the mloda-registry guide page stays open there, coordinated with #601).

## What

- Pins the sibling-reader selection contract with 18 tests (`test_sibling_reader_selection.py`): class-name string key routing among sibling readers, the typed class-as-key form, the reserved `"BaseInputData"` tuple storage plus `init_reader` consumption and its error paths, and the sanctioned URL-based `ReadFile` recipe end to end with `suffix()` proven inert.
- Fixes two bugs the tests exposed in the class-as-key selection form:
  - `_make_hashable` crashed with `TypeError` when an options dict mixed a reader class key with string keys (mixed-type key sort). The orderable fast path is unchanged; a type-robust deterministic sort kicks in only where hashing previously raised.
  - The class key and its name string were distinct identities (double-executing equal work; crashing `Feature._reduce` via forwarded `child_options`). `Options.__init__` now normalizes reader-class keys to `data_access_name()`, so both documented forms share one identity and `get()` by name works after class-keyed construction.
- Documents the class-as-key form and its construction-time normalization in `data-access-patterns.md`.

## Review

Two independent deep reviews (Claude and codex) ran on the initial commit. Accepted and fixed: forwarded `child_options` crash and the string/class key identity split (both in the second commit). Rejected: repr-address nondeterminism in the sort fallback (unreachable for real key types) and generic robustness of `Feature._reduce` for exotic non-reader keys (pre-existing, out of scope).

`tox` green on both commits (4934 tests, mypy --strict, ruff, bandit, licenses).
