### PR TITLE
feat: persona-framed declarative subtype capability on FeatureGroup

### DIFF
--- a/docs/docs/in_depth/compute-framework-integration.md
+++ b/docs/docs/in_depth/compute-framework-integration.md
@@ -106,11 +106,14 @@ and features without a subtype stay open; the declaration never rejects more
 than it claims to know.
 
 **The data steward** audits capability without probing synthetic features.
-`subtype_support_matrix()` returns the supported subtypes per declared
-compute framework; abstract bases report their universe but no matrix.
-`get_feature_group_docs()` carries the same picture per entry: `subtype_key`,
-`subtypes` (the sorted universe), `parametric_subtypes`, `subtype_support`
-(declared frameworks, not installed ones) and `subtype_error`, which
+`subtype_support_matrix()` returns the supported subtypes per compute
+framework from `compute_framework_definition()`: the declared rule, or every
+loaded framework when the family declares no `compute_framework_rule`.
+Abstract bases report their universe but no matrix. A family that
+hand-overrides `supports_compute_framework` gets no declared matrix; the
+misfit surfaces as `subtype_error`. `get_feature_group_docs()` carries the
+same picture per entry: `subtype_key`, `subtypes` (the sorted universe),
+`parametric_subtypes`, `subtype_support` and `subtype_error`, which
 distinguishes a misdeclared capability (support claimed outside the universe)
 from a legitimately empty matrix.
 

--- a/docs/docs/in_depth/compute-framework-integration.md
+++ b/docs/docs/in_depth/compute-framework-integration.md
@@ -57,6 +57,67 @@ pass `options=`, see [Discover Plugins](discover-plugins.md)), and a feature
 that matches a group but is unsupported on every installed framework resolves
 to `feature_group=None` with a capability error rather than appearing runnable.
 
+### Declaring capability per subtype
+
+Many families are not one operation but a set of subtypes: a window family with
+`median`, `sum` and `lag`, or a rank family with `dense` plus a parametric
+`ntile_<n>`. Hand-writing `supports_compute_framework` for these hides the
+capability picture inside imperative code. The subtype declaration turns it
+into data.
+
+**The data provider** declares the dimension once. In the common shape,
+`SUBTYPE_KEY` names the option key that holds the subtype, with an enumerable
+value space in `PROPERTY_MAPPING`; parametric families such as `ntile` join
+the universe via `PARAMETRIC_SUBTYPE_FAMILIES`. Per-framework capability is
+one `supported_subtypes()` override:
+
+``` python
+class RankFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+    SUBTYPE_KEY = "rank_type"
+    PARAMETRIC_SUBTYPE_FAMILIES = {"ntile": "N-tile bucketing"}
+    PREFIX_PATTERN = r".*__([\w]+)_rank$"
+    PROPERTY_MAPPING = {
+        "rank_type": property_spec(
+            "Rank subtype.",
+            strict=True,
+            allowed_values={"dense": "Dense ranking", "ordinal": "Ordinal ranking"},
+        ),
+    }
+
+    @classmethod
+    def supported_subtypes(cls, compute_framework):
+        if compute_framework is PythonDictFramework:
+            return cls.subtype_universe() - {"ntile"}  # ntile needs vectorized bucketing
+        return cls.subtype_universe()
+```
+
+The second shape covers flattened multi-axis families whose subtype is not a
+single option key: keep `SUBTYPE_KEY = None` and override both
+`subtype_universe()` and `resolve_subtype()`. Both shapes are enforced at
+class definition, so a half declaration (a `SUBTYPE_KEY` absent from
+`PROPERTY_MAPPING`, a universe override without a resolver) fails at import
+instead of silently doing nothing.
+
+The derived `supports_compute_framework` gates match-time routing from this
+declaration: it resolves the feature's subtype, canonicalizes parametric
+instances (`ntile_2` becomes `ntile`) and checks `supported_subtypes()`, so
+`value__ntile_2_rank` routes around an incapable backend. Undeclared subtypes
+and features without a subtype stay open; the declaration never rejects more
+than it claims to know.
+
+**The data steward** audits capability without probing synthetic features.
+`subtype_support_matrix()` returns the supported subtypes per declared
+compute framework; abstract bases report their universe but no matrix.
+`get_feature_group_docs()` carries the same picture per entry: `subtype_key`,
+`subtypes` (the sorted universe), `parametric_subtypes`, `subtype_support`
+(declared frameworks, not installed ones) and `subtype_error`, which
+distinguishes a misdeclared capability (support claimed outside the universe)
+from a legitimately empty matrix.
+
+**The data user** sees the outcome on the debug inspector:
+`resolve_feature(name, options=...)` reports `subtype` (e.g. `ntile_2`) and
+`subtype_family` (`ntile`, set only for parametric instances).
+
 ### Empty Results
 
 The contract is: a **final** requested feature must return a *schema-bearing*

--- a/docs/docs/in_depth/compute-framework-integration.md
+++ b/docs/docs/in_depth/compute-framework-integration.md
@@ -59,17 +59,11 @@ to `feature_group=None` with a capability error rather than appearing runnable.
 
 ### Declaring capability per subtype
 
-Many families are not one operation but a set of subtypes: a window family with
-`median`, `sum` and `lag`, or a rank family with `dense` plus a parametric
-`ntile_<n>`. Hand-writing `supports_compute_framework` for these hides the
-capability picture inside imperative code. The subtype declaration turns it
-into data.
+Families with multiple subtypes declare per-backend capability as data
+instead of a hand-written `supports_compute_framework`.
 
-**The data provider** declares the dimension once. In the common shape,
-`SUBTYPE_KEY` names the option key that holds the subtype, with an enumerable
-value space in `PROPERTY_MAPPING`; parametric families such as `ntile` join
-the universe via `PARAMETRIC_SUBTYPE_FAMILIES`. Per-framework capability is
-one `supported_subtypes()` override:
+**The data provider** declares the dimension once; per-framework capability
+is one `supported_subtypes()` override:
 
 ``` python
 class RankFeatureGroup(FeatureChainParserMixin, FeatureGroup):
@@ -87,39 +81,32 @@ class RankFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     @classmethod
     def supported_subtypes(cls, compute_framework):
         if compute_framework is PythonDictFramework:
-            return cls.subtype_universe() - {"ntile"}  # ntile needs vectorized bucketing
+            return cls.subtype_universe() - {"ntile"}
         return cls.subtype_universe()
 ```
 
-The second shape covers flattened multi-axis families whose subtype is not a
-single option key: keep `SUBTYPE_KEY = None` and override both
-`subtype_universe()` and `resolve_subtype()`. Both shapes are enforced at
-class definition, so a half declaration (a `SUBTYPE_KEY` absent from
-`PROPERTY_MAPPING`, a universe override without a resolver) fails at import
-instead of silently doing nothing.
+Two shapes, enforced at class definition; a half declaration fails at import:
 
-The derived `supports_compute_framework` gates match-time routing from this
-declaration: it resolves the feature's subtype, canonicalizes parametric
-instances (`ntile_2` becomes `ntile`) and checks `supported_subtypes()`, so
-`value__ntile_2_rank` routes around an incapable backend. Undeclared subtypes
-and features without a subtype stay open; the declaration never rejects more
-than it claims to know.
+- Shape A: `SUBTYPE_KEY` names the option key with an enumerable value space
+  in `PROPERTY_MAPPING`; parametric families join via
+  `PARAMETRIC_SUBTYPE_FAMILIES`.
+- Shape B (flattened multi-axis families): keep `SUBTYPE_KEY = None`,
+  override both `subtype_universe()` and `resolve_subtype()`.
 
-**The data steward** audits capability without probing synthetic features.
-`subtype_support_matrix()` returns the supported subtypes per compute
-framework from `compute_framework_definition()`: the declared rule, or every
-loaded framework when the family declares no `compute_framework_rule`.
-Abstract bases report their universe but no matrix. A family that
-hand-overrides `supports_compute_framework` gets no declared matrix; the
-misfit surfaces as `subtype_error`. `get_feature_group_docs()` carries the
-same picture per entry: `subtype_key`, `subtypes` (the sorted universe),
-`parametric_subtypes`, `subtype_support` and `subtype_error`, which
-distinguishes a misdeclared capability (support claimed outside the universe)
-from a legitimately empty matrix.
+The derived `supports_compute_framework` canonicalizes parametric instances
+(`ntile_2` becomes `ntile`) and gates declared subtypes by
+`supported_subtypes()`; undeclared subtypes and features without one stay open.
 
-**The data user** sees the outcome on the debug inspector:
-`resolve_feature(name, options=...)` reports `subtype` (e.g. `ntile_2`) and
-`subtype_family` (`ntile`, set only for parametric instances).
+**The data steward** audits capability via `subtype_support_matrix()`
+(supported subtypes per framework from `compute_framework_definition()`;
+empty for abstract bases) and `get_feature_group_docs()` (`subtype_key`,
+`subtypes`, `parametric_subtypes`, `subtype_support`, `subtype_error`). A
+hand-overridden `supports_compute_framework` yields no declared matrix; the
+misfit surfaces as `subtype_error`.
+
+**The data user** sees the outcome on `resolve_feature(name, options=...)`:
+`subtype` (e.g. `ntile_2`) and `subtype_family` (`ntile`, parametric
+instances only).
 
 ### Empty Results
 

--- a/docs/docs/in_depth/discover-plugins.md
+++ b/docs/docs/in_depth/discover-plugins.md
@@ -81,8 +81,10 @@ fgs = get_feature_group_docs(compute_framework="PandasDataframe")
 Each `FeatureGroupInfo` also documents the family's subtype declaration:
 `subtype_key` (the discriminator option key, `None` without one), `subtypes`
 (the sorted universe), `parametric_subtypes` (family names like `ntile`),
-`subtype_support` (sorted supported subtypes per declared compute framework,
-not per installed one; empty for abstract bases) and `subtype_error` (set when
+`subtype_support` (sorted supported subtypes per framework from
+`compute_framework_definition()`: the declared rule, or every loaded framework
+when the family declares no `compute_framework_rule`; empty for abstract
+bases) and `subtype_error` (set when
 the class declares support outside its universe, so a misdeclared capability
 is distinguishable from a legitimately empty matrix). See
 [Declaring capability per subtype](compute-framework-integration.md#declaring-capability-per-subtype).

--- a/docs/docs/in_depth/discover-plugins.md
+++ b/docs/docs/in_depth/discover-plugins.md
@@ -43,12 +43,10 @@ print(result.feature_group, result.supported_compute_frameworks)
 
 `options` and `plugin_collector` are keyword-only, so pass them by name.
 
-When exactly one FeatureGroup resolves, `ResolvedFeature` also reports the
-feature's subtype: `subtype` is the value resolved from the name or the passed
-options (e.g. `"sum"` for `sales__sum_aggr`), and `subtype_family` is the
-parametric family name when the subtype is a parametric instance (`"ntile"`
-for `ntile_2`), else `None`. Both stay `None` for families without a subtype
-dimension or when nothing resolves.
+When exactly one FeatureGroup resolves, `ResolvedFeature` also reports
+`subtype` (resolved from the name or the passed options, e.g. `"sum"` for
+`sales__sum_aggr`) and `subtype_family` (the parametric family name, `"ntile"`
+for `ntile_2`); both are `None` when nothing resolves.
 
 ### Inspecting Candidates
 
@@ -78,15 +76,10 @@ fgs = get_feature_group_docs(name="timestamp")
 fgs = get_feature_group_docs(compute_framework="PandasDataframe")
 ```
 
-Each `FeatureGroupInfo` also documents the family's subtype declaration:
-`subtype_key` (the discriminator option key, `None` without one), `subtypes`
-(the sorted universe), `parametric_subtypes` (family names like `ntile`),
-`subtype_support` (sorted supported subtypes per framework from
-`compute_framework_definition()`: the declared rule, or every loaded framework
-when the family declares no `compute_framework_rule`; empty for abstract
-bases) and `subtype_error` (set when
-the class declares support outside its universe, so a misdeclared capability
-is distinguishable from a legitimately empty matrix). See
+Each `FeatureGroupInfo` also carries the subtype declaration: `subtype_key`,
+`subtypes` (the sorted universe), `parametric_subtypes`, `subtype_support`
+(supported subtypes per framework; empty for abstract bases) and
+`subtype_error` (set when the declaration is invalid). See
 [Declaring capability per subtype](compute-framework-integration.md#declaring-capability-per-subtype).
 
 ## Inspecting Compute Frameworks

--- a/docs/docs/in_depth/discover-plugins.md
+++ b/docs/docs/in_depth/discover-plugins.md
@@ -43,6 +43,13 @@ print(result.feature_group, result.supported_compute_frameworks)
 
 `options` and `plugin_collector` are keyword-only, so pass them by name.
 
+When exactly one FeatureGroup resolves, `ResolvedFeature` also reports the
+feature's subtype: `subtype` is the value resolved from the name or the passed
+options (e.g. `"sum"` for `sales__sum_aggr`), and `subtype_family` is the
+parametric family name when the subtype is a parametric instance (`"ntile"`
+for `ntile_2`), else `None`. Both stay `None` for families without a subtype
+dimension or when nothing resolves.
+
 ### Inspecting Candidates
 
 When resolution fails due to conflicts, check the candidates:
@@ -70,6 +77,15 @@ fgs = get_feature_group_docs(name="timestamp")
 # Filter by compute framework
 fgs = get_feature_group_docs(compute_framework="PandasDataframe")
 ```
+
+Each `FeatureGroupInfo` also documents the family's subtype declaration:
+`subtype_key` (the discriminator option key, `None` without one), `subtypes`
+(the sorted universe), `parametric_subtypes` (family names like `ntile`),
+`subtype_support` (sorted supported subtypes per declared compute framework,
+not per installed one; empty for abstract bases) and `subtype_error` (set when
+the class declares support outside its universe, so a misdeclared capability
+is distinguishable from a legitimately empty matrix). See
+[Declaring capability per subtype](compute-framework-integration.md#declaring-capability-per-subtype).
 
 ## Inspecting Compute Frameworks
 

--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -103,8 +103,10 @@ class FeatureGroup(ABC):
 
     @classmethod
     def _overrides(cls, method_name: str) -> bool:
-        """True when cls replaces the FeatureGroup base classmethod."""
-        return getattr(cls, method_name).__func__ is not getattr(FeatureGroup, method_name).__func__
+        """True when cls replaces the FeatureGroup base classmethod; a non-classmethod shadow counts as an override."""
+        own = getattr(getattr(cls, method_name), "__func__", None)
+        base = getattr(getattr(FeatureGroup, method_name), "__func__", None)
+        return own is not base
 
     @classmethod
     def _validate_subtype_declaration(cls) -> None:
@@ -116,6 +118,11 @@ class FeatureGroup(ABC):
                 raise ValueError(
                     f"{cls.__name__} overrides subtype_universe() without SUBTYPE_KEY; "
                     f"it must also override resolve_subtype()."
+                )
+            if cls._overrides("resolve_subtype") and not universe_overridden:
+                raise ValueError(
+                    f"{cls.__name__} overrides resolve_subtype() without SUBTYPE_KEY; "
+                    f"it must also override subtype_universe(), otherwise the resolver is inert."
                 )
             if cls.PARAMETRIC_SUBTYPE_FAMILIES and not universe_overridden:
                 raise ValueError(
@@ -202,7 +209,12 @@ class FeatureGroup(ABC):
 
     @classmethod
     def canonical_subtype(cls, subtype: str) -> str:
-        """Collapse a parametric instance ``<family>_<digits>`` to its family name, else identity."""
+        """Collapse a parametric instance ``<family>_<digits>`` to its family name, else identity.
+
+        A declared universe member never collapses, even when it looks parametric.
+        """
+        if subtype in cls.subtype_universe():
+            return subtype
         stem, separator, tail = subtype.rpartition("_")
         if separator and tail.isdigit() and stem in (cls.PARAMETRIC_SUBTYPE_FAMILIES or ()):
             return stem
@@ -214,7 +226,8 @@ class FeatureGroup(ABC):
         """Audit surface: supported subtypes per declared compute framework.
 
         Empty for abstract classes and families without a subtype dimension. Raises
-        ValueError when declared support exceeds the subtype universe.
+        ValueError when declared support exceeds the subtype universe, or when the
+        class hand-overrides supports_compute_framework.
         """
         if inspect.isabstract(cls):
             return {}
@@ -222,6 +235,12 @@ class FeatureGroup(ABC):
         universe = cls.subtype_universe()
         if not universe:
             return {}
+
+        if cls._overrides("supports_compute_framework"):
+            raise ValueError(
+                f"{cls.get_class_name()} overrides supports_compute_framework, so the hand-written hook makes "
+                f"the declared subtype support matrix unverifiable; the declaration is not authoritative."
+            )
 
         matrix: dict[str, frozenset[str]] = {}
         for compute_framework in cls.compute_framework_definition():

--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -82,19 +82,13 @@ class FeatureGroup(ABC):
     """
 
     SUBTYPE_KEY: ClassVar[Optional[str]] = None
-    """Declares the subtype dimension of a feature group family.
-
-    Shape A: name a declared ``PROPERTY_MAPPING`` key with an enumerable value space.
-    Shape B: keep ``None`` and override BOTH ``subtype_universe()`` and ``resolve_subtype()``
-    for flattened multi-axis families.
-    """
+    """Subtype dimension of the family. Shape A: name a ``PROPERTY_MAPPING`` key with an
+    enumerable value space. Shape B: keep ``None`` and override BOTH ``subtype_universe()``
+    and ``resolve_subtype()``."""
 
     PARAMETRIC_SUBTYPE_FAMILIES: ClassVar[Optional[dict[str, str]]] = None
-    """Maps parametric subtype family names (e.g. ``ntile`` for ``ntile_2``) to descriptions.
-
-    Legal only alongside a subtype dimension (Shape A ``SUBTYPE_KEY`` or a Shape B
-    ``subtype_universe()`` override); family names join the subtype universe.
-    """
+    """Parametric subtype family names (e.g. ``ntile`` for ``ntile_2``) mapped to descriptions;
+    they join the subtype universe. Legal only alongside a subtype dimension."""
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
@@ -160,10 +154,8 @@ class FeatureGroup(ABC):
 
     @classmethod
     def declared_option_values(cls, key: str) -> frozenset[str]:
-        """Return the enumerable value space declared for a ``PROPERTY_MAPPING`` key.
-
-        Predicate-only keys and absent keys have an empty value space; values are stringified.
-        """
+        """Return the stringified enumerable value space of a ``PROPERTY_MAPPING`` key;
+        predicate-only and absent keys yield an empty set."""
         if cls.PROPERTY_MAPPING is None or key not in cls.PROPERTY_MAPPING:
             return frozenset()
         extracted = FeatureChainParser._extract_property_values(cls.PROPERTY_MAPPING[key])
@@ -209,10 +201,8 @@ class FeatureGroup(ABC):
 
     @classmethod
     def canonical_subtype(cls, subtype: str) -> str:
-        """Collapse a parametric instance ``<family>_<digits>`` to its family name, else identity.
-
-        A declared universe member never collapses, even when it looks parametric.
-        """
+        """Collapse a parametric instance ``<family>_<digits>`` to its family name, else identity;
+        a declared universe member never collapses."""
         if subtype in cls.subtype_universe():
             return subtype
         stem, separator, tail = subtype.rpartition("_")
@@ -223,12 +213,9 @@ class FeatureGroup(ABC):
     @final
     @classmethod
     def subtype_support_matrix(cls) -> dict[str, frozenset[str]]:
-        """Audit surface: supported subtypes per declared compute framework.
-
-        Empty for abstract classes and families without a subtype dimension. Raises
-        ValueError when declared support exceeds the subtype universe, or when the
-        class hand-overrides supports_compute_framework.
-        """
+        """Supported subtypes per declared compute framework; empty for abstract classes and
+        families without a subtype dimension. Raises ValueError on support outside the
+        universe or a hand-overridden supports_compute_framework."""
         if inspect.isabstract(cls):
             return {}
 
@@ -657,9 +644,8 @@ class FeatureGroup(ABC):
         others. If every candidate framework is rejected, the matcher surfaces a
         distinguishable error instead of a generic "no feature group" message.
 
-        The default derives the verdict from the subtype declaration: features whose
-        canonical subtype is declared are gated by ``supported_subtypes()``; everything
-        else (no subtype dimension, unresolved or undeclared subtype) stays open.
+        The default gates a declared canonical subtype by ``supported_subtypes()``;
+        everything else (no subtype dimension, unresolved or undeclared subtype) stays open.
         """
         universe = cls.subtype_universe()
         if not universe:

--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import logging
 from typing import Any, ClassVar, Callable, Iterable, Optional, final
 from abc import ABC
@@ -10,7 +11,10 @@ from mloda.core.abstract_plugins.components.data_types import DataType
 
 from mloda.core.abstract_plugins.components.domain import Domain
 from mloda.core.abstract_plugins.components.base_feature_group_version import BaseFeatureGroupVersion
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import (
+    CHAIN_SEPARATOR,
+    FeatureChainParser,
+)
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.input_data.api.api_input_data import ApiInputData
 from mloda.core.abstract_plugins.components.input_data.base_input_data import BaseInputData
@@ -77,9 +81,68 @@ class FeatureGroup(ABC):
     See ``docs/in_depth/property-mapping.md`` for the full specification.
     """
 
+    SUBTYPE_KEY: ClassVar[Optional[str]] = None
+    """Declares the subtype dimension of a feature group family.
+
+    Shape A: name a declared ``PROPERTY_MAPPING`` key with an enumerable value space.
+    Shape B: keep ``None`` and override BOTH ``subtype_universe()`` and ``resolve_subtype()``
+    for flattened multi-axis families.
+    """
+
+    PARAMETRIC_SUBTYPE_FAMILIES: ClassVar[Optional[dict[str, str]]] = None
+    """Maps parametric subtype family names (e.g. ``ntile`` for ``ntile_2``) to descriptions.
+
+    Legal only alongside a subtype dimension (Shape A ``SUBTYPE_KEY`` or a Shape B
+    ``subtype_universe()`` override); family names join the subtype universe.
+    """
+
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
         FeatureChainParser.validate_property_mapping_defaults(cls.__name__, cls.PROPERTY_MAPPING)
+        cls._validate_subtype_declaration()
+
+    @classmethod
+    def _overrides(cls, method_name: str) -> bool:
+        """True when cls replaces the FeatureGroup base classmethod."""
+        return getattr(cls, method_name).__func__ is not getattr(FeatureGroup, method_name).__func__
+
+    @classmethod
+    def _validate_subtype_declaration(cls) -> None:
+        """Enforce the two legal subtype declaration shapes at class-definition time."""
+        universe_overridden = cls._overrides("subtype_universe")
+
+        if cls.SUBTYPE_KEY is None:
+            if universe_overridden and not cls._overrides("resolve_subtype"):
+                raise ValueError(
+                    f"{cls.__name__} overrides subtype_universe() without SUBTYPE_KEY; "
+                    f"it must also override resolve_subtype()."
+                )
+            if cls.PARAMETRIC_SUBTYPE_FAMILIES and not universe_overridden:
+                raise ValueError(
+                    f"{cls.__name__} declares PARAMETRIC_SUBTYPE_FAMILIES without a subtype dimension; "
+                    f"set SUBTYPE_KEY or override subtype_universe() and resolve_subtype()."
+                )
+            return
+
+        if cls.SUBTYPE_KEY not in cls.declared_option_keys():
+            raise ValueError(
+                f"{cls.__name__} declares SUBTYPE_KEY '{cls.SUBTYPE_KEY}', "
+                f"which is not a declared PROPERTY_MAPPING key."
+            )
+
+        declared_values = cls.declared_option_values(cls.SUBTYPE_KEY)
+        if not declared_values and not universe_overridden:
+            raise ValueError(
+                f"{cls.__name__} declares SUBTYPE_KEY '{cls.SUBTYPE_KEY}' without an enumerable value space; "
+                f"declare allowed values or override subtype_universe()."
+            )
+
+        colliding = frozenset(cls.PARAMETRIC_SUBTYPE_FAMILIES or ()) & declared_values
+        if colliding:
+            raise ValueError(
+                f"{cls.__name__} declares parametric subtype families {sorted(colliding)} that collide "
+                f"with declared values of SUBTYPE_KEY '{cls.SUBTYPE_KEY}'."
+            )
 
     @classmethod
     def declared_option_keys(cls) -> frozenset[str]:
@@ -87,6 +150,90 @@ class FeatureGroup(ABC):
         if cls.PROPERTY_MAPPING is None:
             return frozenset()
         return frozenset(str(key) for key in cls.PROPERTY_MAPPING)
+
+    @classmethod
+    def declared_option_values(cls, key: str) -> frozenset[str]:
+        """Return the enumerable value space declared for a ``PROPERTY_MAPPING`` key.
+
+        Predicate-only keys and absent keys have an empty value space; values are stringified.
+        """
+        if cls.PROPERTY_MAPPING is None or key not in cls.PROPERTY_MAPPING:
+            return frozenset()
+        extracted = FeatureChainParser._extract_property_values(cls.PROPERTY_MAPPING[key])
+        if not isinstance(extracted, (dict, list, tuple, set, frozenset)):
+            return frozenset()
+        return frozenset(str(value) for value in extracted)
+
+    @classmethod
+    def subtype_universe(cls) -> frozenset[str]:
+        """Return every subtype this family declares: SUBTYPE_KEY values plus parametric family names."""
+        if cls.SUBTYPE_KEY is None:
+            return frozenset()
+        return cls.declared_option_values(cls.SUBTYPE_KEY) | frozenset(cls.PARAMETRIC_SUBTYPE_FAMILIES or ())
+
+    @classmethod
+    def supported_subtypes(cls, compute_framework: type[ComputeFramework]) -> frozenset[str]:
+        """Return the subtypes this class supports on a compute framework; defaults to the full universe."""
+        return cls.subtype_universe()
+
+    @classmethod
+    def resolve_subtype(cls, feature_name: FeatureName | str, options: Options) -> Optional[str]:
+        """Resolve the raw subtype of a concrete feature: name parsing first, then options; never raises."""
+        if cls.SUBTYPE_KEY is None:
+            return None
+
+        name = str(feature_name)
+        source, separator, _ = name.rpartition(CHAIN_SEPARATOR)
+        if separator and source:
+            patterns = [
+                pattern
+                for pattern in (getattr(cls, "PREFIX_PATTERN", None), getattr(cls, "SUFFIX_PATTERN", None))
+                if isinstance(pattern, str)
+            ]
+            if patterns:
+                parsed, _parsed_source = FeatureChainParser.parse_feature_name(name, patterns)
+                if parsed is not None:
+                    return parsed
+
+        value = options.get(cls.SUBTYPE_KEY)
+        if value is None:
+            return None
+        return str(value)
+
+    @classmethod
+    def canonical_subtype(cls, subtype: str) -> str:
+        """Collapse a parametric instance ``<family>_<digits>`` to its family name, else identity."""
+        stem, separator, tail = subtype.rpartition("_")
+        if separator and tail.isdigit() and stem in (cls.PARAMETRIC_SUBTYPE_FAMILIES or ()):
+            return stem
+        return subtype
+
+    @final
+    @classmethod
+    def subtype_support_matrix(cls) -> dict[str, frozenset[str]]:
+        """Audit surface: supported subtypes per declared compute framework.
+
+        Empty for abstract classes and families without a subtype dimension. Raises
+        ValueError when declared support exceeds the subtype universe.
+        """
+        if inspect.isabstract(cls):
+            return {}
+
+        universe = cls.subtype_universe()
+        if not universe:
+            return {}
+
+        matrix: dict[str, frozenset[str]] = {}
+        for compute_framework in cls.compute_framework_definition():
+            supported = cls.supported_subtypes(compute_framework)
+            overreach = supported - universe
+            if overreach:
+                raise ValueError(
+                    f"{cls.get_class_name()} declares supported subtypes {sorted(overreach)} on "
+                    f"{compute_framework.get_class_name()} that are outside its subtype universe."
+                )
+            matrix[compute_framework.get_class_name()] = supported
+        return matrix
 
     def __init__(self) -> None:
         pass
@@ -490,8 +637,24 @@ class FeatureGroup(ABC):
         the concrete feature, so it can reject an op on one backend while allowing
         others. If every candidate framework is rejected, the matcher surfaces a
         distinguishable error instead of a generic "no feature group" message.
+
+        The default derives the verdict from the subtype declaration: features whose
+        canonical subtype is declared are gated by ``supported_subtypes()``; everything
+        else (no subtype dimension, unresolved or undeclared subtype) stays open.
         """
-        return True
+        universe = cls.subtype_universe()
+        if not universe:
+            return True
+
+        subtype = cls.resolve_subtype(feature_name, options)
+        if subtype is None:
+            return True
+
+        canonical = cls.canonical_subtype(subtype)
+        if canonical not in universe:
+            return True
+
+        return canonical in cls.supported_subtypes(compute_framework)
 
     @final
     @classmethod

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -96,6 +96,20 @@ def _match_recording_validation_errors(
         return False
 
 
+def _resolved_subtype_fields(
+    fg_class: type[FeatureGroup], feature_name: FeatureName, options: Options
+) -> tuple[Optional[str], Optional[str]]:
+    """Resolve (subtype, subtype_family) for a candidate, degrading a raising declaration to (None, None)."""
+    subtype: Optional[str] = safe_field(lambda: fg_class.resolve_subtype(feature_name, options), None)
+    if subtype is None:
+        return None, None
+    raw_subtype = subtype
+    canonical = safe_field(lambda: fg_class.canonical_subtype(raw_subtype), raw_subtype)
+    if canonical != raw_subtype:
+        return subtype, canonical
+    return subtype, None
+
+
 def get_feature_group_docs(
     name: Optional[str] = None,
     search: Optional[str] = None,
@@ -157,16 +171,6 @@ def get_feature_group_docs(
             lambda: fg_class.feature_names_supported(), set(), field=f"{cls_name}.feature_names_supported"
         )
         prefix = safe_field(lambda: fg_class.prefix(), f"{cls_name}_", field=f"{cls_name}.prefix")
-        subtype_key: Optional[str] = safe_field(lambda: fg_class.SUBTYPE_KEY, None, field=f"{cls_name}.SUBTYPE_KEY")
-        subtypes: list[str] = safe_field(
-            lambda: sorted(fg_class.subtype_universe()), [], field=f"{cls_name}.subtype_universe"
-        )
-        parametric_subtypes: list[str] = safe_field(
-            lambda: sorted(fg_class.PARAMETRIC_SUBTYPE_FAMILIES or {}),
-            [],
-            field=f"{cls_name}.PARAMETRIC_SUBTYPE_FAMILIES",
-        )
-        subtype_support, subtype_error = _subtype_support_or_error(fg_class)
 
         if name is not None and name.lower() not in fg_name.lower():
             continue
@@ -181,6 +185,17 @@ def get_feature_group_docs(
 
         if version_contains is not None and version_contains not in version:
             continue
+
+        subtype_key: Optional[str] = safe_field(lambda: fg_class.SUBTYPE_KEY, None, field=f"{cls_name}.SUBTYPE_KEY")
+        subtypes: list[str] = safe_field(
+            lambda: sorted(fg_class.subtype_universe()), [], field=f"{cls_name}.subtype_universe"
+        )
+        parametric_subtypes: list[str] = safe_field(
+            lambda: sorted(fg_class.PARAMETRIC_SUBTYPE_FAMILIES or {}),
+            [],
+            field=f"{cls_name}.PARAMETRIC_SUBTYPE_FAMILIES",
+        )
+        subtype_support, subtype_error = _subtype_support_or_error(fg_class)
 
         results.append(
             FeatureGroupInfo(
@@ -397,11 +412,23 @@ def resolve_feature(
             error=error,
         )
 
-    supported, rejected = split_frameworks_by_capability(candidates, feature_name_obj, resolved_options)
+    # A raising plugin declaration must not escape the never-raises contract; degrade to no split.
+    empty_split: tuple[set[type[ComputeFramework]], set[type[ComputeFramework]]] = (set(), set())
+    supported, rejected = safe_field(
+        lambda: split_frameworks_by_capability(candidates, feature_name_obj, resolved_options),
+        empty_split,
+    )
     supported_names = sorted(c.get_class_name() for c in supported)
     rejected_names = sorted(c.get_class_name() for c in rejected)
+    filtered = _filter_subclasses(candidates)
 
     if not supported and rejected:
+        subtype_unsupported: Optional[str] = None
+        subtype_family_unsupported: Optional[str] = None
+        if len(filtered) == 1:
+            subtype_unsupported, subtype_family_unsupported = _resolved_subtype_fields(
+                filtered[0], feature_name_obj, resolved_options
+            )
         return ResolvedFeature(
             feature_name=feature_name,
             feature_group=None,
@@ -413,19 +440,13 @@ def resolve_feature(
             ),
             supported_compute_frameworks=[],
             unsupported_compute_frameworks=rejected_names,
+            subtype=subtype_unsupported,
+            subtype_family=subtype_family_unsupported,
         )
-
-    filtered = _filter_subclasses(candidates)
 
     if len(filtered) == 1:
         resolved = filtered[0]
-        subtype: Optional[str] = safe_field(lambda: resolved.resolve_subtype(feature_name_obj, resolved_options), None)
-        subtype_family: Optional[str] = None
-        if subtype is not None:
-            raw_subtype = subtype
-            canonical = safe_field(lambda: resolved.canonical_subtype(raw_subtype), raw_subtype)
-            if canonical != raw_subtype:
-                subtype_family = canonical
+        subtype, subtype_family = _resolved_subtype_fields(resolved, feature_name_obj, resolved_options)
         return ResolvedFeature(
             feature_name=feature_name,
             feature_group=resolved,

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -52,6 +52,19 @@ def _safe_version(fg_class: type[FeatureGroup]) -> str:
     return safe_field(lambda: _as_str(fg_class.version()), "unavailable", catching=SOURCE_INTROSPECTION_ERRORS)
 
 
+def _subtype_support_or_error(fg_class: type[FeatureGroup]) -> tuple[dict[str, list[str]], Optional[str]]:
+    """Return the sorted subtype support matrix, degrading a raising class to ({}, message).
+
+    safe_field cannot carry the failure message, and a misdeclared capability (ValueError
+    from subtype_support_matrix) must land in subtype_error instead of being swallowed.
+    """
+    try:
+        matrix = fg_class.subtype_support_matrix()
+    except Exception as exc:
+        return {}, str(exc)
+    return {framework: sorted(supported) for framework, supported in matrix.items()}, None
+
+
 def _dedup_degrading_on_conflict(
     feature_groups: set[type[FeatureGroup]], allow_redefinition: bool
 ) -> set[type[FeatureGroup]]:
@@ -144,6 +157,16 @@ def get_feature_group_docs(
             lambda: fg_class.feature_names_supported(), set(), field=f"{cls_name}.feature_names_supported"
         )
         prefix = safe_field(lambda: fg_class.prefix(), f"{cls_name}_", field=f"{cls_name}.prefix")
+        subtype_key: Optional[str] = safe_field(lambda: fg_class.SUBTYPE_KEY, None, field=f"{cls_name}.SUBTYPE_KEY")
+        subtypes: list[str] = safe_field(
+            lambda: sorted(fg_class.subtype_universe()), [], field=f"{cls_name}.subtype_universe"
+        )
+        parametric_subtypes: list[str] = safe_field(
+            lambda: sorted(fg_class.PARAMETRIC_SUBTYPE_FAMILIES or {}),
+            [],
+            field=f"{cls_name}.PARAMETRIC_SUBTYPE_FAMILIES",
+        )
+        subtype_support, subtype_error = _subtype_support_or_error(fg_class)
 
         if name is not None and name.lower() not in fg_name.lower():
             continue
@@ -168,6 +191,11 @@ def get_feature_group_docs(
                 compute_frameworks=compute_frameworks,
                 supported_feature_names=supported_feature_names,
                 prefix=prefix,
+                subtype_key=subtype_key,
+                subtypes=subtypes,
+                parametric_subtypes=parametric_subtypes,
+                subtype_support=subtype_support,
+                subtype_error=subtype_error,
             )
         )
 
@@ -390,13 +418,23 @@ def resolve_feature(
     filtered = _filter_subclasses(candidates)
 
     if len(filtered) == 1:
+        resolved = filtered[0]
+        subtype: Optional[str] = safe_field(lambda: resolved.resolve_subtype(feature_name_obj, resolved_options), None)
+        subtype_family: Optional[str] = None
+        if subtype is not None:
+            raw_subtype = subtype
+            canonical = safe_field(lambda: resolved.canonical_subtype(raw_subtype), raw_subtype)
+            if canonical != raw_subtype:
+                subtype_family = canonical
         return ResolvedFeature(
             feature_name=feature_name,
-            feature_group=filtered[0],
+            feature_group=resolved,
             candidates=candidates,
             error=None,
             supported_compute_frameworks=supported_names,
             unsupported_compute_frameworks=rejected_names,
+            subtype=subtype,
+            subtype_family=subtype_family,
         )
 
     conflicting_names = [fg.__name__ for fg in filtered]

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -53,11 +53,7 @@ def _safe_version(fg_class: type[FeatureGroup]) -> str:
 
 
 def _subtype_support_or_error(fg_class: type[FeatureGroup]) -> tuple[dict[str, list[str]], Optional[str]]:
-    """Return the sorted subtype support matrix, degrading a raising class to ({}, message).
-
-    safe_field cannot carry the failure message, and a misdeclared capability (ValueError
-    from subtype_support_matrix) must land in subtype_error instead of being swallowed.
-    """
+    """Return the sorted subtype support matrix, degrading a raising class to ({}, message)."""
     try:
         matrix = fg_class.subtype_support_matrix()
     except Exception as exc:
@@ -412,7 +408,7 @@ def resolve_feature(
             error=error,
         )
 
-    # A raising plugin declaration must not escape the never-raises contract; degrade to no split.
+    # Degrade a raising plugin declaration to an empty split; resolve_feature never raises.
     empty_split: tuple[set[type[ComputeFramework]], set[type[ComputeFramework]]] = (set(), set())
     supported, rejected = safe_field(
         lambda: split_frameworks_by_capability(candidates, feature_name_obj, resolved_options),

--- a/mloda/core/api/plugin_info.py
+++ b/mloda/core/api/plugin_info.py
@@ -20,10 +20,9 @@ class FeatureGroupInfo:
     subtypes: list[str] = field(default_factory=list)
     # Sorted parametric subtype family names (e.g. "ntile" covering "ntile_2").
     parametric_subtypes: list[str] = field(default_factory=list)
-    # Sorted supported subtypes per framework from compute_framework_definition(): the declared rule, or every
-    # loaded framework when the family declares no compute_framework_rule. Empty for abstract classes.
+    # Sorted supported subtypes per framework from compute_framework_definition(); empty for abstract classes.
     subtype_support: dict[str, list[str]] = field(default_factory=dict)
-    # Message when the capability declaration is invalid (misdeclared support), None for a legitimately empty matrix.
+    # Message when the capability declaration is invalid, None for a legitimately empty matrix.
     subtype_error: Optional[str] = None
 
 

--- a/mloda/core/api/plugin_info.py
+++ b/mloda/core/api/plugin_info.py
@@ -20,7 +20,8 @@ class FeatureGroupInfo:
     subtypes: list[str] = field(default_factory=list)
     # Sorted parametric subtype family names (e.g. "ntile" covering "ntile_2").
     parametric_subtypes: list[str] = field(default_factory=list)
-    # Sorted supported subtypes per DECLARED compute framework (not installed ones); empty for abstract classes.
+    # Sorted supported subtypes per framework from compute_framework_definition(): the declared rule, or every
+    # loaded framework when the family declares no compute_framework_rule. Empty for abstract classes.
     subtype_support: dict[str, list[str]] = field(default_factory=dict)
     # Message when the capability declaration is invalid (misdeclared support), None for a legitimately empty matrix.
     subtype_error: Optional[str] = None

--- a/mloda/core/api/plugin_info.py
+++ b/mloda/core/api/plugin_info.py
@@ -14,6 +14,16 @@ class FeatureGroupInfo:
     compute_frameworks: list[str]
     supported_feature_names: set[str]
     prefix: str
+    # Subtype discriminator option key of the family, None when it has no subtype dimension.
+    subtype_key: Optional[str] = None
+    # Sorted subtype universe: declared subtype values plus parametric family names.
+    subtypes: list[str] = field(default_factory=list)
+    # Sorted parametric subtype family names (e.g. "ntile" covering "ntile_2").
+    parametric_subtypes: list[str] = field(default_factory=list)
+    # Sorted supported subtypes per DECLARED compute framework (not installed ones); empty for abstract classes.
+    subtype_support: dict[str, list[str]] = field(default_factory=dict)
+    # Message when the capability declaration is invalid (misdeclared support), None for a legitimately empty matrix.
+    subtype_error: Optional[str] = None
 
 
 @dataclass
@@ -45,3 +55,7 @@ class ResolvedFeature:
     supported_compute_frameworks: list[str] = field(default_factory=list)
     # Frameworks rejecting the feature, evaluated under the options passed to resolve_feature (empty by default).
     unsupported_compute_frameworks: list[str] = field(default_factory=list)
+    # Resolved subtype of the feature under the passed options, None when none resolves.
+    subtype: Optional[str] = None
+    # Family name only when the subtype is a parametric instance (e.g. "ntile" for "ntile_2"), else None.
+    subtype_family: Optional[str] = None

--- a/mloda_plugins/feature_group/experimental/aggregated_feature_group/base.py
+++ b/mloda_plugins/feature_group/experimental/aggregated_feature_group/base.py
@@ -85,6 +85,9 @@ class AggregatedFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     # Option key for aggregation type
     AGGREGATION_TYPE = "aggregation_type"
 
+    # The aggregation type is this family's subtype discriminator.
+    SUBTYPE_KEY = AGGREGATION_TYPE
+
     # Define supported aggregation types
     AGGREGATION_TYPES = {
         "sum": "Sum of values",

--- a/mloda_plugins/feature_group/experimental/aggregated_feature_group/base.py
+++ b/mloda_plugins/feature_group/experimental/aggregated_feature_group/base.py
@@ -85,7 +85,7 @@ class AggregatedFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     # Option key for aggregation type
     AGGREGATION_TYPE = "aggregation_type"
 
-    # The aggregation type is this family's subtype discriminator.
+    # Subtype discriminator of this family.
     SUBTYPE_KEY = AGGREGATION_TYPE
 
     # Define supported aggregation types

--- a/tests/test_core/test_api/test_subtype_docs.py
+++ b/tests/test_core/test_api/test_subtype_docs.py
@@ -1,0 +1,331 @@
+"""Failing tests pinning the Phase 2 subtype documentation contract (issue #639)."""
+
+from abc import abstractmethod
+from typing import Optional
+
+import pytest
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.provider import FeatureChainParserMixin, FeatureGroup, property_spec
+from mloda.steward import FeatureGroupInfo, ResolvedFeature, get_feature_group_docs, resolve_feature
+from mloda.user import PluginLoader
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
+    PythonDictFramework,
+)
+
+
+WINDOW_KEY = "sudoc_window_function"
+WINDOW_UNIVERSE = frozenset({"median", "sum", "lag"})
+WINDOW_DICT_SUPPORTED = frozenset({"sum", "lag"})
+
+RANK_KEY = "suranked_rank_type"
+RANK_NAMED = frozenset({"dense", "ordinal"})
+RANK_FAMILIES = {"ntile": "N-tile bucketing", "top": "Top-N selection"}
+RANK_UNIVERSE = RANK_NAMED | frozenset(RANK_FAMILIES)
+
+ABSTRACT_KEY = "sudocabs_window_function"
+ABSTRACT_UNIVERSE = frozenset({"median", "sum"})
+
+OVERREACH_KEY = "sudocbad_kind"
+OVERREACH_UNIVERSE = frozenset({"fast", "slow"})
+OVERREACH_BOGUS = "sudocbad_bogus"
+
+OPTION_KEY = "sudoc_op_kind"
+OPTION_FEATURE = "sudoc_option_feature"
+PLAIN_FEATURE = "sudoc_plain_feature"
+
+
+class SuDocWindowFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+    """Shape A family with a per-framework supported_subtypes override."""
+
+    SUBTYPE_KEY = WINDOW_KEY
+    PREFIX_PATTERN = r".*__([\w]+)_sudoc$"
+    PROPERTY_MAPPING = {
+        WINDOW_KEY: property_spec(
+            "Window function subtype.",
+            strict=True,
+            allowed_values={"median": "Median", "sum": "Sum", "lag": "Lag"},
+        ),
+    }
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame, PythonDictFramework}
+
+    @classmethod
+    def supported_subtypes(cls, compute_framework: type[ComputeFramework]) -> frozenset[str]:
+        if compute_framework is PythonDictFramework:
+            return WINDOW_DICT_SUPPORTED
+        return WINDOW_UNIVERSE
+
+
+class SuRankedDocFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+    """Rank-like family: named subtypes plus parametric families, 'ntile' unsupported on one framework."""
+
+    SUBTYPE_KEY = RANK_KEY
+    PARAMETRIC_SUBTYPE_FAMILIES = RANK_FAMILIES
+    PREFIX_PATTERN = r".*__([\w]+)_suranked$"
+    PROPERTY_MAPPING = {
+        RANK_KEY: property_spec(
+            "Rank subtype.",
+            strict=True,
+            allowed_values={"dense": "Dense ranking", "ordinal": "Ordinal ranking"},
+        ),
+    }
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame, PythonDictFramework}
+
+    @classmethod
+    def supported_subtypes(cls, compute_framework: type[ComputeFramework]) -> frozenset[str]:
+        if compute_framework is PythonDictFramework:
+            return RANK_UNIVERSE - {"ntile"}
+        return RANK_UNIVERSE
+
+
+class SuDocAbstractWindowFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+    """Abstract base declaring a subtype universe; support belongs to concrete members."""
+
+    SUBTYPE_KEY = ABSTRACT_KEY
+    PREFIX_PATTERN = r".*__([\w]+)_sudocabs$"
+    PROPERTY_MAPPING = {
+        ABSTRACT_KEY: property_spec(
+            "Abstract window function subtype.",
+            strict=True,
+            allowed_values={"median": "Median", "sum": "Sum"},
+        ),
+    }
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame, PythonDictFramework}
+
+    @abstractmethod
+    def _sudoc_backend_marker(self) -> None: ...
+
+
+class SuDocOverreachFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+    """Misdeclared family: declares support for a subtype outside its universe."""
+
+    SUBTYPE_KEY = OVERREACH_KEY
+    PREFIX_PATTERN = r".*__([\w]+)_sudocbad$"
+    PROPERTY_MAPPING = {
+        OVERREACH_KEY: property_spec(
+            "Misdeclared kind.",
+            strict=True,
+            allowed_values={"fast": "Fast", "slow": "Slow"},
+        ),
+    }
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame, PythonDictFramework}
+
+    @classmethod
+    def supported_subtypes(cls, compute_framework: type[ComputeFramework]) -> frozenset[str]:
+        return OVERREACH_UNIVERSE | {OVERREACH_BOGUS}
+
+
+class SuDocOptionFeatureGroup(FeatureGroup):
+    """Fixed-name family whose subtype resolves from options only."""
+
+    SUBTYPE_KEY = OPTION_KEY
+    PROPERTY_MAPPING = {
+        OPTION_KEY: property_spec(
+            "Operation kind.",
+            strict=True,
+            allowed_values={"sum": "Sum", "median": "Median"},
+        ),
+    }
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame, PythonDictFramework}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == OPTION_FEATURE
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class SuDocPlainFeatureGroup(FeatureGroup):
+    """Family without a subtype dimension."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame, PythonDictFramework}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == PLAIN_FEATURE
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+@pytest.fixture(scope="module", autouse=True)
+def load_plugins() -> None:
+    """Load all plugins before running tests in this module."""
+    PluginLoader.all()
+
+
+def _doc_for(name: str) -> FeatureGroupInfo:
+    """Fetch the single FeatureGroupInfo whose name matches exactly."""
+    exact = [doc for doc in get_feature_group_docs(name=name) if doc.name == name]
+    assert len(exact) == 1, f"expected exactly one doc for {name}, got {[doc.name for doc in exact]}"
+    return exact[0]
+
+
+class TestContractAFeatureGroupInfoFields:
+    """Contract A: FeatureGroupInfo gains defaulted subtype fields."""
+
+    def test_positional_construction_defaults_new_fields(self) -> None:
+        info = FeatureGroupInfo("n", "d", "v", "m", [], set(), "n_")
+        assert info.subtype_key is None
+        assert info.subtypes == []
+        assert info.parametric_subtypes == []
+        assert info.subtype_support == {}
+        assert info.subtype_error is None
+
+    def test_keyword_construction_accepts_new_fields(self) -> None:
+        info = FeatureGroupInfo(
+            "n",
+            "d",
+            "v",
+            "m",
+            [],
+            set(),
+            "n_",
+            subtype_key="k",
+            subtypes=["a", "b"],
+            parametric_subtypes=["b"],
+            subtype_support={"Fw": ["a", "b"]},
+            subtype_error="boom",
+        )
+        assert info.subtype_key == "k"
+        assert info.subtypes == ["a", "b"]
+        assert info.parametric_subtypes == ["b"]
+        assert info.subtype_support == {"Fw": ["a", "b"]}
+        assert info.subtype_error == "boom"
+
+    def test_mutable_defaults_are_not_shared(self) -> None:
+        first = FeatureGroupInfo("n1", "d", "v", "m", [], set(), "n1_")
+        second = FeatureGroupInfo("n2", "d", "v", "m", [], set(), "n2_")
+        first.subtypes.append("x")
+        first.parametric_subtypes.append("x")
+        first.subtype_support["Fw"] = ["x"]
+        assert second.subtypes == []
+        assert second.parametric_subtypes == []
+        assert second.subtype_support == {}
+
+
+class TestContractBFeatureGroupDocs:
+    """Contract B: get_feature_group_docs populates the subtype fields."""
+
+    def test_shape_a_family_reports_key_universe_and_support(self) -> None:
+        doc = _doc_for("SuDocWindowFeatureGroup")
+        assert doc.subtype_key == WINDOW_KEY
+        assert doc.subtypes == sorted(WINDOW_UNIVERSE)
+        assert doc.parametric_subtypes == []
+        assert doc.subtype_support == {
+            "PandasDataFrame": sorted(WINDOW_UNIVERSE),
+            "PythonDictFramework": sorted(WINDOW_DICT_SUPPORTED),
+        }
+        assert doc.subtype_error is None
+
+    def test_parametric_families_are_enumerable_without_probing(self) -> None:
+        doc = _doc_for("SuRankedDocFeatureGroup")
+        assert doc.subtype_key == RANK_KEY
+        assert doc.subtypes == sorted(RANK_UNIVERSE)
+        assert doc.parametric_subtypes == sorted(RANK_FAMILIES)
+        assert doc.subtype_support == {
+            "PandasDataFrame": sorted(RANK_UNIVERSE),
+            "PythonDictFramework": sorted(RANK_UNIVERSE - {"ntile"}),
+        }
+        assert doc.subtype_error is None
+
+    def test_family_without_subtype_dimension_keeps_defaults(self) -> None:
+        doc = _doc_for("SuDocPlainFeatureGroup")
+        assert doc.subtype_key is None
+        assert doc.subtypes == []
+        assert doc.parametric_subtypes == []
+        assert doc.subtype_support == {}
+        assert doc.subtype_error is None
+
+    def test_abstract_base_reports_universe_without_support(self) -> None:
+        doc = _doc_for("SuDocAbstractWindowFeatureGroup")
+        assert doc.subtype_key == ABSTRACT_KEY
+        assert doc.subtypes == sorted(ABSTRACT_UNIVERSE)
+        assert doc.parametric_subtypes == []
+        assert doc.subtype_support == {}
+        assert doc.subtype_error is None
+
+    def test_misdeclared_family_is_surfaced_not_swallowed(self) -> None:
+        docs = get_feature_group_docs()
+        by_name = {doc.name: doc for doc in docs}
+
+        bad = by_name["SuDocOverreachFeatureGroup"]
+        assert bad.subtypes == sorted(OVERREACH_UNIVERSE)
+        assert bad.subtype_support == {}
+        assert bad.subtype_error is not None
+        assert OVERREACH_BOGUS in bad.subtype_error
+
+        healthy = by_name["SuDocWindowFeatureGroup"]
+        assert healthy.subtype_error is None
+
+
+class TestContractCResolvedFeatureSubtype:
+    """Contract C: ResolvedFeature carries the resolved subtype and its parametric family."""
+
+    def test_direct_construction_defaults_to_none(self) -> None:
+        result = ResolvedFeature("n", None, [], None)
+        assert result.subtype is None
+        assert result.subtype_family is None
+
+    def test_string_path_resolves_subtype(self) -> None:
+        result = resolve_feature("value__median_sudoc")
+        assert result.feature_group is SuDocWindowFeatureGroup
+        assert result.subtype == "median"
+        assert result.subtype_family is None
+
+    def test_parametric_path_resolves_subtype_and_family(self) -> None:
+        result = resolve_feature("value__ntile_2_suranked")
+        assert result.feature_group is SuRankedDocFeatureGroup
+        assert result.subtype == "ntile_2"
+        assert result.subtype_family == "ntile"
+
+    def test_options_path_resolves_subtype(self) -> None:
+        result = resolve_feature(OPTION_FEATURE, options=Options(context={OPTION_KEY: "sum"}))
+        assert result.feature_group is SuDocOptionFeatureGroup
+        assert result.subtype == "sum"
+        assert result.subtype_family is None
+
+    def test_family_without_subtype_dimension_gives_none(self) -> None:
+        result = resolve_feature(PLAIN_FEATURE)
+        assert result.feature_group is SuDocPlainFeatureGroup
+        assert result.subtype is None
+        assert result.subtype_family is None
+
+    def test_nothing_resolves_gives_none(self) -> None:
+        result = resolve_feature(OPTION_FEATURE)
+        assert result.feature_group is SuDocOptionFeatureGroup
+        assert result.subtype is None
+        assert result.subtype_family is None

--- a/tests/test_core/test_api/test_subtype_docs.py
+++ b/tests/test_core/test_api/test_subtype_docs.py
@@ -329,3 +329,138 @@ class TestContractCResolvedFeatureSubtype:
         assert result.feature_group is SuDocOptionFeatureGroup
         assert result.subtype is None
         assert result.subtype_family is None
+
+
+R4_KEY = "sudocr4_kind"
+R4_UNIVERSE = frozenset({"median", "sum", "ntile"})
+
+R5_KEY = "sudocr5_kind"
+
+R6_KEY = "sudocr6_kind"
+R6_UNIVERSE = frozenset({"median", "sum"})
+
+
+class SuDocR4RejectingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+    """Family whose single declared framework rejects everything except 'sum'."""
+
+    SUBTYPE_KEY = R4_KEY
+    PARAMETRIC_SUBTYPE_FAMILIES = {"ntile": "N-tile bucketing"}
+    PREFIX_PATTERN = r".*__([\w]+)_sudocr4$"
+    PROPERTY_MAPPING = {
+        R4_KEY: property_spec(
+            "Operation kind rejected almost everywhere.",
+            strict=True,
+            allowed_values={"median": "Median", "sum": "Sum"},
+        ),
+    }
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PythonDictFramework}
+
+    @classmethod
+    def supported_subtypes(cls, compute_framework: type[ComputeFramework]) -> frozenset[str]:
+        return frozenset({"sum"})
+
+
+class SuDocR5RaisingSupportFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+    """Family whose subtype declaration raises when queried; resolution must degrade, not raise."""
+
+    SUBTYPE_KEY = R5_KEY
+    PREFIX_PATTERN = r".*__([\w]+)_sudocr5$"
+    PROPERTY_MAPPING = {
+        R5_KEY: property_spec(
+            "Operation kind with an exploding declaration.",
+            strict=True,
+            allowed_values={"median": "Median", "sum": "Sum"},
+        ),
+    }
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PythonDictFramework}
+
+    @classmethod
+    def supported_subtypes(cls, compute_framework: type[ComputeFramework]) -> frozenset[str]:
+        raise RuntimeError("sudocr5 declaration exploded")
+
+
+class SuDocR6HookOverrideFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+    """Family with a subtype universe AND a hand-written supports_compute_framework hook."""
+
+    SUBTYPE_KEY = R6_KEY
+    PREFIX_PATTERN = r".*__([\w]+)_sudocr6$"
+    PROPERTY_MAPPING = {
+        R6_KEY: property_spec(
+            "Operation kind gated by a hand-written hook.",
+            strict=True,
+            allowed_values={"median": "Median", "sum": "Sum"},
+        ),
+    }
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame, PythonDictFramework}
+
+    @classmethod
+    def supports_compute_framework(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        compute_framework: type[ComputeFramework],
+    ) -> bool:
+        return True
+
+
+class TestContractDUnsupportedEverywhereReportsSubtype:
+    """R4: the unsupported-everywhere branch still reports the resolved subtype."""
+
+    def test_unsupported_everywhere_still_reports_subtype(self) -> None:
+        result = resolve_feature("value__median_sudocr4")
+        assert result.feature_group is None
+        assert result.candidates == [SuDocR4RejectingFeatureGroup]
+        assert result.error is not None
+        assert "unsupported" in result.error
+        assert result.supported_compute_frameworks == []
+        assert result.unsupported_compute_frameworks == ["PythonDictFramework"]
+        assert result.subtype == "median"
+        assert result.subtype_family is None
+
+    def test_unsupported_everywhere_parametric_instance_reports_family(self) -> None:
+        result = resolve_feature("value__ntile_3_sudocr4")
+        assert result.feature_group is None
+        assert result.error is not None
+        assert "unsupported" in result.error
+        assert result.subtype == "ntile_3"
+        assert result.subtype_family == "ntile"
+
+
+class TestContractERaisingDeclarationDegrades:
+    """R5: a raising supported_subtypes never propagates out of resolve_feature."""
+
+    def test_raising_declaration_degrades_capability_split(self) -> None:
+        result = resolve_feature("value__median_sudocr5")
+        assert result.feature_group is SuDocR5RaisingSupportFeatureGroup
+        assert result.error is None
+        assert result.supported_compute_frameworks == []
+        assert result.unsupported_compute_frameworks == []
+        assert result.subtype == "median"
+        assert result.subtype_family is None
+
+
+class TestContractFHookOverrideSurfacedInDocs:
+    """R6: docs surface a hook-overriding family as subtype_error instead of a fabricated matrix."""
+
+    def test_hook_override_reported_as_subtype_error(self) -> None:
+        docs = get_feature_group_docs()
+        by_name = {doc.name: doc for doc in docs}
+
+        hooked = by_name["SuDocR6HookOverrideFeatureGroup"]
+        assert hooked.subtype_key == R6_KEY
+        assert hooked.subtypes == sorted(R6_UNIVERSE)
+        assert hooked.subtype_support == {}
+        assert hooked.subtype_error is not None
+        assert "supports_compute_framework" in hooked.subtype_error
+
+        healthy = by_name["SuDocWindowFeatureGroup"]
+        assert healthy.subtype_error is None

--- a/tests/test_core/test_prepare/test_subtype_universe.py
+++ b/tests/test_core/test_prepare/test_subtype_universe.py
@@ -1,0 +1,619 @@
+"""Failing tests pinning the Phase 1 declarative subtype universe contract (issue #639)."""
+
+from abc import abstractmethod
+from typing import Optional
+
+import pytest
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+from mloda.provider import DefaultOptionKeys, FeatureChainParserMixin, FeatureGroup, property_spec
+
+
+SUBTYPE_KEY_NAME = "sustatu_window_function"
+WINDOW_UNIVERSE = frozenset({"median", "sum", "lag", "ntile"})
+BETA_SUPPORTED = frozenset({"sum", "lag"})
+FLATTENED_UNIVERSE = frozenset({"rows_7", "range_7", "rows_all"})
+PLAIN_FEATURE = "sustatu_plain_feature"
+FLATTENED_FEATURE = "sustatu_flattened_feature"
+
+
+def _sustatu_is_positive_int(value: object) -> bool:
+    return isinstance(value, int) and value > 0
+
+
+class SubtypeUFwAlpha(ComputeFramework):
+    """First dummy compute framework for subtype-universe tests."""
+
+
+class SubtypeUFwBeta(ComputeFramework):
+    """Second dummy compute framework for subtype-universe tests."""
+
+
+class SubtypeUWindowBaseFG(FeatureChainParserMixin, FeatureGroup):
+    """Shape A declaration: SUBTYPE_KEY with allowed values plus a parametric family."""
+
+    SUBTYPE_KEY = SUBTYPE_KEY_NAME
+    PARAMETRIC_SUBTYPE_FAMILIES = {"ntile": "N-tile bucketing"}
+    PREFIX_PATTERN = r".*__([\w]+)_sustatw$"
+    PROPERTY_MAPPING = {
+        SUBTYPE_KEY_NAME: property_spec(
+            "Window function subtype.",
+            strict=True,
+            allowed_values={"median": "Median", "sum": "Sum", "lag": "Lag"},
+        ),
+    }
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {SubtypeUFwAlpha, SubtypeUFwBeta}
+
+
+class SubtypeUWindowFG(SubtypeUWindowBaseFG):
+    """Concrete window family member narrowing subtype support on SubtypeUFwBeta."""
+
+    @classmethod
+    def supported_subtypes(cls, compute_framework: type[ComputeFramework]) -> frozenset[str]:
+        if compute_framework is SubtypeUFwBeta:
+            return BETA_SUPPORTED
+        return WINDOW_UNIVERSE
+
+
+class SubtypeUAbstractWindowFG(SubtypeUWindowBaseFG):
+    """Abstract member of the window family; declares the universe, not support."""
+
+    @abstractmethod
+    def _sustatu_backend_marker(self) -> None: ...
+
+
+class SubtypeUOverreachFG(SubtypeUWindowBaseFG):
+    """Declares support for a subtype outside its universe; the audit must flag it."""
+
+    @classmethod
+    def supported_subtypes(cls, compute_framework: type[ComputeFramework]) -> frozenset[str]:
+        return WINDOW_UNIVERSE | {"sustatu_bogus"}
+
+
+class SubtypeUExplicitOverrideFG(SubtypeUWindowFG):
+    """Explicit supports_compute_framework override; must win over the derived gate."""
+
+    @classmethod
+    def supports_compute_framework(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        compute_framework: type[ComputeFramework],
+    ) -> bool:
+        return True
+
+
+class SubtypeUPlainFG(FeatureGroup):
+    """Family without any subtype dimension."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {SubtypeUFwAlpha, SubtypeUFwBeta}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == PLAIN_FEATURE
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class SubtypeUFlattenedFG(FeatureGroup):
+    """Shape B declaration: flattened frame_type x frame_unit subtype, SUBTYPE_KEY stays None."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {SubtypeUFwAlpha, SubtypeUFwBeta}
+
+    @classmethod
+    def subtype_universe(cls) -> frozenset[str]:
+        return FLATTENED_UNIVERSE
+
+    @classmethod
+    def resolve_subtype(cls, feature_name: FeatureName | str, options: Options) -> Optional[str]:
+        frame_type = options.get("sustatu_frame_type")
+        frame_unit = options.get("sustatu_frame_unit")
+        if frame_type is None or frame_unit is None:
+            return None
+        return f"{frame_type}_{frame_unit}"
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == FLATTENED_FEATURE
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class SubtypeUPredicateUniverseFG(FeatureChainParserMixin, FeatureGroup):
+    """Shape A with a predicate-only key made legal by an explicit subtype_universe override."""
+
+    SUBTYPE_KEY = "sustatu_pred_key"
+    PREFIX_PATTERN = r".*__([\w]+)_sustatp$"
+    PROPERTY_MAPPING = {
+        "sustatu_pred_key": property_spec(
+            "Predicate-validated subtype.",
+            strict=True,
+            validation_function=_sustatu_is_positive_int,
+        ),
+    }
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {SubtypeUFwAlpha, SubtypeUFwBeta}
+
+    @classmethod
+    def subtype_universe(cls) -> frozenset[str]:
+        return frozenset({"p1", "p2"})
+
+
+class SubtypeUValueSpaceFG(FeatureGroup):
+    """PROPERTY_MAPPING with spec-form, list-form, legacy flattened and predicate-only keys."""
+
+    PROPERTY_MAPPING = {
+        "sustatu_algo": property_spec("Algorithm.", strict=True, allowed_values={"a1": "A one", "a2": "A two"}),
+        "sustatu_kind": property_spec("Kind.", strict=True, allowed_values=["x1", "x2"]),
+        "sustatu_bucket": property_spec("Bucket count.", strict=True, allowed_values={2: "two", 7: "seven"}),
+        "sustatu_mode": {
+            "fast": "Fast mode",
+            "slow": "Slow mode",
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: True,
+        },
+        "sustatu_n": property_spec("Predicate-only key.", strict=True, validation_function=_sustatu_is_positive_int),
+    }
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class TestContract01SubtypeKeyDefault:
+    """Contract 1: SUBTYPE_KEY class attribute with default None."""
+
+    def test_base_default_is_none(self) -> None:
+        assert FeatureGroup.SUBTYPE_KEY is None
+
+    def test_untouched_subclass_default_is_none(self) -> None:
+        assert SubtypeUPlainFG.SUBTYPE_KEY is None
+
+    def test_declaring_subclass_carries_key(self) -> None:
+        assert FeatureGroup.SUBTYPE_KEY is None
+        assert SubtypeUWindowBaseFG.SUBTYPE_KEY == SUBTYPE_KEY_NAME
+
+
+class TestContract02ParametricSubtypeFamiliesDefault:
+    """Contract 2: PARAMETRIC_SUBTYPE_FAMILIES class attribute with default None."""
+
+    def test_base_default_is_none(self) -> None:
+        assert FeatureGroup.PARAMETRIC_SUBTYPE_FAMILIES is None
+
+    def test_untouched_subclass_default_is_none(self) -> None:
+        assert SubtypeUPlainFG.PARAMETRIC_SUBTYPE_FAMILIES is None
+
+    def test_declaring_subclass_carries_families(self) -> None:
+        assert FeatureGroup.PARAMETRIC_SUBTYPE_FAMILIES is None
+        assert SubtypeUWindowBaseFG.PARAMETRIC_SUBTYPE_FAMILIES == {"ntile": "N-tile bucketing"}
+
+
+class TestContract03DeclaredOptionValues:
+    """Contract 3: declared_option_values(key) returns the declared value space of a key."""
+
+    def test_property_spec_dict_allowed_values(self) -> None:
+        assert SubtypeUValueSpaceFG.declared_option_values("sustatu_algo") == frozenset({"a1", "a2"})
+
+    def test_property_spec_list_allowed_values(self) -> None:
+        assert SubtypeUValueSpaceFG.declared_option_values("sustatu_kind") == frozenset({"x1", "x2"})
+
+    def test_non_string_values_are_stringified(self) -> None:
+        values = SubtypeUValueSpaceFG.declared_option_values("sustatu_bucket")
+        assert values == frozenset({"2", "7"})
+        assert all(isinstance(value, str) for value in values)
+
+    def test_legacy_flattened_form_excludes_reserved_keys(self) -> None:
+        assert SubtypeUValueSpaceFG.declared_option_values("sustatu_mode") == frozenset({"fast", "slow"})
+
+    def test_predicate_only_key_has_empty_value_space(self) -> None:
+        assert SubtypeUValueSpaceFG.declared_option_values("sustatu_n") == frozenset()
+
+    def test_absent_key_returns_empty(self) -> None:
+        assert SubtypeUValueSpaceFG.declared_option_values("sustatu_absent") == frozenset()
+
+    def test_property_mapping_none_returns_empty(self) -> None:
+        assert SubtypeUPlainFG.declared_option_values("anything") == frozenset()
+
+    def test_result_is_frozenset(self) -> None:
+        assert isinstance(SubtypeUValueSpaceFG.declared_option_values("sustatu_algo"), frozenset)
+        assert isinstance(SubtypeUPlainFG.declared_option_values("anything"), frozenset)
+
+
+class TestContract04SubtypeUniverse:
+    """Contract 4: subtype_universe() = declared values of SUBTYPE_KEY plus parametric family names."""
+
+    def test_universe_unions_declared_values_and_families(self) -> None:
+        assert SubtypeUWindowBaseFG.subtype_universe() == WINDOW_UNIVERSE
+
+    def test_universe_empty_without_subtype_key(self) -> None:
+        assert SubtypeUPlainFG.subtype_universe() == frozenset()
+        assert FeatureGroup.subtype_universe() == frozenset()
+
+    def test_universe_is_frozenset(self) -> None:
+        assert isinstance(SubtypeUWindowBaseFG.subtype_universe(), frozenset)
+
+    def test_universe_override_is_honored(self) -> None:
+        # supported_subtypes is the base-provided default; red today via AttributeError.
+        assert SubtypeUFlattenedFG.supported_subtypes(SubtypeUFwAlpha) == FLATTENED_UNIVERSE
+        assert SubtypeUFlattenedFG.subtype_universe() == FLATTENED_UNIVERSE
+
+
+class TestContract05SupportedSubtypes:
+    """Contract 5: supported_subtypes(cfw) defaults to the full universe; subclasses narrow."""
+
+    def test_default_is_full_universe(self) -> None:
+        assert SubtypeUWindowBaseFG.supported_subtypes(SubtypeUFwAlpha) == WINDOW_UNIVERSE
+        assert SubtypeUWindowBaseFG.supported_subtypes(SubtypeUFwBeta) == WINDOW_UNIVERSE
+
+    def test_subclass_narrows_per_framework(self) -> None:
+        assert SubtypeUWindowFG.supported_subtypes(SubtypeUFwBeta) < SubtypeUWindowFG.subtype_universe()
+        assert SubtypeUWindowFG.supported_subtypes(SubtypeUFwBeta) == BETA_SUPPORTED
+        assert SubtypeUWindowFG.supported_subtypes(SubtypeUFwAlpha) == WINDOW_UNIVERSE
+
+    def test_default_follows_universe_override(self) -> None:
+        assert SubtypeUFlattenedFG.supported_subtypes(SubtypeUFwBeta) == FLATTENED_UNIVERSE
+
+    def test_predicate_only_key_with_universe_override(self) -> None:
+        assert SubtypeUPredicateUniverseFG.supported_subtypes(SubtypeUFwAlpha) == frozenset({"p1", "p2"})
+
+
+class TestContract06ResolveSubtype:
+    """Contract 6: resolve_subtype resolves the raw subtype from the name, then options; never raises."""
+
+    def test_resolves_from_feature_name(self) -> None:
+        assert SubtypeUWindowBaseFG.resolve_subtype("value__median_sustatw", Options()) == "median"
+
+    def test_accepts_feature_name_object(self) -> None:
+        assert SubtypeUWindowBaseFG.resolve_subtype(FeatureName("value__lag_sustatw"), Options()) == "lag"
+
+    def test_parametric_instance_resolves_raw(self) -> None:
+        assert SubtypeUWindowBaseFG.resolve_subtype("value__ntile_2_sustatw", Options()) == "ntile_2"
+
+    def test_bare_chained_name_does_not_resolve_from_name_and_never_raises(self) -> None:
+        assert SubtypeUWindowBaseFG.resolve_subtype("__sum_sustatw", Options()) is None
+
+    def test_bare_chained_name_falls_back_to_options(self) -> None:
+        options = Options(group={SUBTYPE_KEY_NAME: "median"})
+        assert SubtypeUWindowBaseFG.resolve_subtype("__sum_sustatw", options) == "median"
+
+    def test_resolves_from_options_when_name_does_not_parse(self) -> None:
+        options = Options(group={SUBTYPE_KEY_NAME: "median"})
+        assert SubtypeUWindowBaseFG.resolve_subtype("sustatu_unchained", options) == "median"
+
+    def test_options_value_is_stringified(self) -> None:
+        options = Options(group={SUBTYPE_KEY_NAME: 7})
+        assert SubtypeUWindowBaseFG.resolve_subtype("sustatu_unchained", options) == "7"
+
+    def test_name_parsing_takes_precedence_over_options(self) -> None:
+        options = Options(group={SUBTYPE_KEY_NAME: "median"})
+        assert SubtypeUWindowBaseFG.resolve_subtype("value__sum_sustatw", options) == "sum"
+
+    def test_none_when_neither_resolves(self) -> None:
+        assert SubtypeUWindowBaseFG.resolve_subtype("sustatu_unchained", Options()) is None
+
+    def test_none_when_subtype_key_is_none(self) -> None:
+        options = Options(group={SUBTYPE_KEY_NAME: "median"})
+        assert SubtypeUPlainFG.resolve_subtype("value__sum_sustatw", options) is None
+
+    def test_shape_b_override_resolves_flattened_subtype(self) -> None:
+        # Base default must exist and stay None-returning; red today via AttributeError.
+        assert FeatureGroup.resolve_subtype("anything", Options()) is None
+        options = Options(group={"sustatu_frame_type": "rows", "sustatu_frame_unit": "7"})
+        assert SubtypeUFlattenedFG.resolve_subtype(FLATTENED_FEATURE, options) == "rows_7"
+
+
+class TestContract07CanonicalSubtype:
+    """Contract 7: canonical_subtype collapses <family>_<digits> to the family, else identity."""
+
+    def test_parametric_instance_collapses_to_family(self) -> None:
+        assert SubtypeUWindowBaseFG.canonical_subtype("ntile_2") == "ntile"
+
+    def test_stem_that_is_not_a_family_stays_identity(self) -> None:
+        assert SubtypeUWindowBaseFG.canonical_subtype("ntile_2_3") == "ntile_2_3"
+
+    def test_plain_subtype_stays_identity(self) -> None:
+        assert SubtypeUWindowBaseFG.canonical_subtype("median") == "median"
+
+    def test_declared_value_is_not_a_family(self) -> None:
+        assert SubtypeUWindowBaseFG.canonical_subtype("sum_2") == "sum_2"
+
+    def test_non_digit_suffix_stays_identity(self) -> None:
+        assert SubtypeUWindowBaseFG.canonical_subtype("ntile_x") == "ntile_x"
+
+    def test_without_families_everything_is_identity(self) -> None:
+        assert SubtypeUPlainFG.canonical_subtype("ntile_2") == "ntile_2"
+        assert FeatureGroup.canonical_subtype("anything_3") == "anything_3"
+
+
+class TestContract08DerivedSupportsComputeFramework:
+    """Contract 8: the default supports_compute_framework is derived from the declaration."""
+
+    def test_base_keeps_returning_true(self) -> None:
+        assert FeatureGroup.subtype_universe() == frozenset()
+        assert FeatureGroup.supports_compute_framework("anything", Options(), SubtypeUFwAlpha) is True
+
+    def test_empty_universe_is_open(self) -> None:
+        assert SubtypeUPlainFG.subtype_universe() == frozenset()
+        assert SubtypeUPlainFG.supports_compute_framework(PLAIN_FEATURE, Options(), SubtypeUFwBeta) is True
+
+    def test_unresolved_subtype_is_open(self) -> None:
+        assert SubtypeUWindowFG.resolve_subtype("sustatu_unchained", Options()) is None
+        assert SubtypeUWindowFG.supports_compute_framework("sustatu_unchained", Options(), SubtypeUFwBeta) is True
+
+    def test_unknown_subtype_is_open(self) -> None:
+        assert SubtypeUWindowFG.canonical_subtype("zzz") == "zzz"
+        assert SubtypeUWindowFG.supports_compute_framework("value__zzz_sustatw", Options(), SubtypeUFwBeta) is True
+
+    def test_declared_subtype_gated_by_supported_subtypes(self) -> None:
+        assert SubtypeUWindowFG.supports_compute_framework("value__median_sustatw", Options(), SubtypeUFwBeta) is False
+        assert SubtypeUWindowFG.supports_compute_framework("value__median_sustatw", Options(), SubtypeUFwAlpha) is True
+        assert SubtypeUWindowFG.supports_compute_framework("value__sum_sustatw", Options(), SubtypeUFwBeta) is True
+
+    def test_parametric_instance_gated_via_canonical_family(self) -> None:
+        assert SubtypeUWindowFG.supports_compute_framework("value__ntile_4_sustatw", Options(), SubtypeUFwBeta) is False
+        assert SubtypeUWindowFG.supports_compute_framework("value__ntile_4_sustatw", Options(), SubtypeUFwAlpha) is True
+
+    def test_options_resolved_subtype_is_gated_too(self) -> None:
+        options = Options(group={SUBTYPE_KEY_NAME: "median"})
+        assert SubtypeUWindowFG.supports_compute_framework("sustatu_unchained", options, SubtypeUFwBeta) is False
+
+    def test_explicit_override_wins(self) -> None:
+        # The derived gate on the parent rejects the subtype, the child's explicit override wins.
+        assert SubtypeUWindowFG.supports_compute_framework("value__median_sustatw", Options(), SubtypeUFwBeta) is False
+        assert SubtypeUExplicitOverrideFG.supported_subtypes(SubtypeUFwBeta) == BETA_SUPPORTED
+        result = SubtypeUExplicitOverrideFG.supports_compute_framework(
+            "value__median_sustatw", Options(), SubtypeUFwBeta
+        )
+        assert result is True
+
+
+class TestContract09SubtypeSupportMatrix:
+    """Contract 9: subtype_support_matrix() audit surface per compute framework."""
+
+    def test_matrix_maps_every_declared_framework(self) -> None:
+        matrix = SubtypeUWindowFG.subtype_support_matrix()
+        assert matrix == {
+            SubtypeUFwAlpha.get_class_name(): WINDOW_UNIVERSE,
+            SubtypeUFwBeta.get_class_name(): BETA_SUPPORTED,
+        }
+
+    def test_matrix_empty_for_abstract_class(self) -> None:
+        assert SubtypeUAbstractWindowFG.subtype_support_matrix() == {}
+
+    def test_matrix_empty_for_empty_universe(self) -> None:
+        assert SubtypeUPlainFG.subtype_support_matrix() == {}
+
+    def test_matrix_rejects_support_outside_universe(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+            SubtypeUOverreachFG.subtype_support_matrix()
+        message = str(exc_info.value)
+        assert "sustatu_bogus" in message
+        assert "SubtypeUOverreachFG" in message
+
+
+class TestContract10DeclarationValidation:
+    """Contract 10: exactly two legal declaration shapes, enforced at class definition time."""
+
+    def test_shape_a_declaration_is_legal(self) -> None:
+        # SubtypeUWindowBaseFG was defined at module scope without error; pin its derived universe.
+        assert SubtypeUWindowBaseFG.subtype_universe() == WINDOW_UNIVERSE
+
+    def test_subtype_key_absent_from_property_mapping_raises(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+
+            class SubtypeUBrokenAbsentKeyFG(FeatureGroup):
+                SUBTYPE_KEY = "sustatu_missing_key"
+                PROPERTY_MAPPING = {
+                    "sustatu_other": property_spec("Other.", strict=True, allowed_values={"v1": "V one"}),
+                }
+
+        message = str(exc_info.value)
+        assert "SubtypeUBrokenAbsentKeyFG" in message
+        assert "sustatu_missing_key" in message
+
+    def test_subtype_key_without_property_mapping_raises(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+
+            class SubtypeUBrokenNoMappingFG(FeatureGroup):
+                SUBTYPE_KEY = "sustatu_missing_key"
+
+        message = str(exc_info.value)
+        assert "SubtypeUBrokenNoMappingFG" in message
+        assert "sustatu_missing_key" in message
+
+    def test_predicate_only_value_space_without_universe_override_raises(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+
+            class SubtypeUBrokenPredicateOnlyFG(FeatureGroup):
+                SUBTYPE_KEY = "sustatu_pred_only_key"
+                PROPERTY_MAPPING = {
+                    "sustatu_pred_only_key": property_spec(
+                        "Predicate-only subtype key.",
+                        strict=True,
+                        validation_function=_sustatu_is_positive_int,
+                    ),
+                }
+
+        message = str(exc_info.value)
+        assert "SubtypeUBrokenPredicateOnlyFG" in message
+        assert "sustatu_pred_only_key" in message
+
+    def test_predicate_only_key_with_universe_override_is_legal(self) -> None:
+        # SubtypeUPredicateUniverseFG was defined at module scope without error. Its key has no
+        # enumerable value space, which is exactly why the explicit universe override is required.
+        assert SubtypeUPredicateUniverseFG.declared_option_values("sustatu_pred_key") == frozenset()
+        assert SubtypeUPredicateUniverseFG.subtype_universe() == frozenset({"p1", "p2"})
+
+    def test_universe_override_alone_without_subtype_key_raises(self) -> None:
+        with pytest.raises(ValueError):
+
+            class SubtypeUBrokenUniverseOnlyFG(FeatureGroup):
+                @classmethod
+                def subtype_universe(cls) -> frozenset[str]:
+                    return frozenset({"rows_7"})
+
+    def test_shape_b_with_both_overrides_is_legal(self) -> None:
+        # SubtypeUFlattenedFG was defined at module scope without error; pin the derived gate.
+        assert SubtypeUFlattenedFG.supported_subtypes(SubtypeUFwAlpha) == FLATTENED_UNIVERSE
+
+    def test_parametric_families_without_subtype_dimension_raises(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+
+            class SubtypeUBrokenFamiliesOnlyFG(FeatureGroup):
+                PARAMETRIC_SUBTYPE_FAMILIES = {"ntile": "N-tile bucketing"}
+
+        assert "SubtypeUBrokenFamiliesOnlyFG" in str(exc_info.value)
+
+    def test_parametric_family_colliding_with_declared_value_raises(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+
+            class SubtypeUBrokenCollidingFamilyFG(FeatureGroup):
+                SUBTYPE_KEY = "sustatu_colliding_key"
+                PARAMETRIC_SUBTYPE_FAMILIES = {"median": "Collides with a declared value"}
+                PROPERTY_MAPPING = {
+                    "sustatu_colliding_key": property_spec(
+                        "Colliding subtype key.",
+                        strict=True,
+                        allowed_values={"median": "Median", "sum": "Sum"},
+                    ),
+                }
+
+        message = str(exc_info.value)
+        assert "SubtypeUBrokenCollidingFamilyFG" in message
+        assert "median" in message
+
+
+class TestContract11MatchTimeIntegration:
+    """Contract 11: the declaration is enforced through IdentifyFeatureGroupClass."""
+
+    def test_unsupported_subtype_is_routed_to_capable_framework(self) -> None:
+        feature = Feature("value__median_sustatw")
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            SubtypeUWindowFG: {SubtypeUFwAlpha, SubtypeUFwBeta},
+        }
+
+        identified = IdentifyFeatureGroupClass(
+            feature=feature,
+            accessible_plugins=accessible_plugins,
+            links=None,
+            data_access_collection=None,
+        )
+
+        feature_group_class, compute_frameworks = identified.get()
+        assert feature_group_class is SubtypeUWindowFG
+        assert compute_frameworks == {SubtypeUFwAlpha}, (
+            f"'median' is unsupported on SubtypeUFwBeta and must be routed around; got {compute_frameworks}"
+        )
+
+    def test_pin_to_incapable_framework_raises_capability_error(self) -> None:
+        feature = Feature("value__median_sustatw")
+        feature.compute_frameworks = {SubtypeUFwBeta}
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            SubtypeUWindowFG: {SubtypeUFwAlpha, SubtypeUFwBeta},
+        }
+
+        with pytest.raises(ValueError) as exc_info:
+            IdentifyFeatureGroupClass(
+                feature=feature,
+                accessible_plugins=accessible_plugins,
+                links=None,
+                data_access_collection=None,
+            )
+
+        message = str(exc_info.value)
+        lowered = message.lower()
+        assert "unsupported" in lowered or "not supported" in lowered, (
+            f"Error must signal an unsupported framework, but got: {message}"
+        )
+        assert SubtypeUFwBeta.get_class_name() in message
+        assert SubtypeUFwAlpha.get_class_name() in message
+        assert "Did you mean" not in message
+
+    def test_parametric_instance_is_routed_around(self) -> None:
+        feature = Feature("value__ntile_2_sustatw")
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            SubtypeUWindowFG: {SubtypeUFwAlpha, SubtypeUFwBeta},
+        }
+
+        identified = IdentifyFeatureGroupClass(
+            feature=feature,
+            accessible_plugins=accessible_plugins,
+            links=None,
+            data_access_collection=None,
+        )
+
+        feature_group_class, compute_frameworks = identified.get()
+        assert feature_group_class is SubtypeUWindowFG
+        assert compute_frameworks == {SubtypeUFwAlpha}, (
+            f"Family 'ntile' is unsupported on SubtypeUFwBeta, so 'ntile_2' must be routed around; "
+            f"got {compute_frameworks}"
+        )
+
+    def test_unknown_subtype_keeps_every_framework(self) -> None:
+        assert SubtypeUWindowFG.canonical_subtype("zzz") == "zzz"
+
+        feature = Feature("value__zzz_sustatw")
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            SubtypeUWindowFG: {SubtypeUFwAlpha, SubtypeUFwBeta},
+        }
+
+        identified = IdentifyFeatureGroupClass(
+            feature=feature,
+            accessible_plugins=accessible_plugins,
+            links=None,
+            data_access_collection=None,
+        )
+
+        _, compute_frameworks = identified.get()
+        assert compute_frameworks == {SubtypeUFwAlpha, SubtypeUFwBeta}, (
+            f"An undeclared subtype must stay open on every framework; got {compute_frameworks}"
+        )
+
+    def test_family_without_subtype_dimension_is_unaffected(self) -> None:
+        assert SubtypeUPlainFG.subtype_universe() == frozenset()
+
+        feature = Feature(PLAIN_FEATURE)
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            SubtypeUPlainFG: {SubtypeUFwAlpha, SubtypeUFwBeta},
+        }
+
+        identified = IdentifyFeatureGroupClass(
+            feature=feature,
+            accessible_plugins=accessible_plugins,
+            links=None,
+            data_access_collection=None,
+        )
+
+        _, compute_frameworks = identified.get()
+        assert compute_frameworks == {SubtypeUFwAlpha, SubtypeUFwBeta}
+
+    def test_matching_stays_orthogonal_to_subtype_support(self) -> None:
+        assert SubtypeUWindowFG.resolve_subtype("value__median_sustatw", Options()) == "median"
+        assert "median" not in SubtypeUWindowFG.supported_subtypes(SubtypeUFwBeta)
+        assert SubtypeUWindowFG.match_feature_group_criteria("value__median_sustatw", Options()) is True

--- a/tests/test_core/test_prepare/test_subtype_universe.py
+++ b/tests/test_core/test_prepare/test_subtype_universe.py
@@ -617,3 +617,106 @@ class TestContract11MatchTimeIntegration:
         assert SubtypeUWindowFG.resolve_subtype("value__median_sustatw", Options()) == "median"
         assert "median" not in SubtypeUWindowFG.supported_subtypes(SubtypeUFwBeta)
         assert SubtypeUWindowFG.match_feature_group_criteria("value__median_sustatw", Options()) is True
+
+
+R2_SUBTYPE_KEY = "sustatr2_op"
+R2_UNIVERSE = frozenset({"lag_1", "sum", "lag"})
+R2_BETA_SUPPORTED = frozenset({"lag_1", "sum"})
+
+
+class SubtypeULagLiteralBaseFG(FeatureChainParserMixin, FeatureGroup):
+    """Universe containing the literal declared value 'lag_1' alongside the parametric family 'lag'."""
+
+    SUBTYPE_KEY = R2_SUBTYPE_KEY
+    PARAMETRIC_SUBTYPE_FAMILIES = {"lag": "Lag by N rows"}
+    PREFIX_PATTERN = r".*__([\w]+)_sustatr2$"
+    PROPERTY_MAPPING = {
+        R2_SUBTYPE_KEY: property_spec(
+            "Operation subtype with a parametric-looking declared member.",
+            strict=True,
+            allowed_values={"lag_1": "Lag by one row", "sum": "Sum"},
+        ),
+    }
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {SubtypeUFwAlpha, SubtypeUFwBeta}
+
+
+class SubtypeULagLiteralNarrowFG(SubtypeULagLiteralBaseFG):
+    """Supports the literal 'lag_1' but not the 'lag' family on SubtypeUFwBeta."""
+
+    @classmethod
+    def supported_subtypes(cls, compute_framework: type[ComputeFramework]) -> frozenset[str]:
+        if compute_framework is SubtypeUFwBeta:
+            return R2_BETA_SUPPORTED
+        return R2_UNIVERSE
+
+
+class SubtypeUHookMatrixAbstractFG(SubtypeUExplicitOverrideFG):
+    """Abstract hook-overriding family member; the matrix audit must stay empty."""
+
+    @abstractmethod
+    def _sustatu_hook_abstract_marker(self) -> None: ...
+
+
+class SubtypeUHookMatrixPlainFG(FeatureGroup):
+    """Hook override without a subtype dimension; the matrix audit must stay empty."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {SubtypeUFwAlpha, SubtypeUFwBeta}
+
+    @classmethod
+    def supports_compute_framework(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        compute_framework: type[ComputeFramework],
+    ) -> bool:
+        return True
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class TestR1ResolverOnlyDeclarationRaises:
+    """R1: overriding only resolve_subtype without a subtype dimension is inert and must raise."""
+
+    def test_resolver_only_override_without_universe_raises_at_definition(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+
+            class SubtypeUBrokenResolverOnlyFG(FeatureGroup):
+                @classmethod
+                def resolve_subtype(cls, feature_name: FeatureName | str, options: Options) -> Optional[str]:
+                    return "rows_7"
+
+        assert "SubtypeUBrokenResolverOnlyFG" in str(exc_info.value)
+
+
+class TestR2DeclaredUniverseMemberNeverCollapses:
+    """R2: canonical_subtype keeps a declared universe member even when it looks parametric."""
+
+    def test_class_shape_is_legal_and_declared_member_stays_identity(self) -> None:
+        assert SubtypeULagLiteralBaseFG.subtype_universe() == R2_UNIVERSE
+        assert SubtypeULagLiteralBaseFG.canonical_subtype("lag_1") == "lag_1"
+        assert SubtypeULagLiteralBaseFG.canonical_subtype("lag_7") == "lag"
+
+    def test_derived_gate_distinguishes_declared_member_from_family_instance(self) -> None:
+        gate = SubtypeULagLiteralNarrowFG.supports_compute_framework
+        assert gate("value__lag_1_sustatr2", Options(), SubtypeUFwBeta) is True
+        assert gate("value__lag_7_sustatr2", Options(), SubtypeUFwBeta) is False
+        assert gate("value__lag_7_sustatr2", Options(), SubtypeUFwAlpha) is True
+
+
+class TestR3HookOverrideMakesMatrixUnverifiable:
+    """R3: a hand-written supports_compute_framework makes the declared matrix non-authoritative."""
+
+    def test_matrix_raises_for_hook_overrider_and_spares_undimensioned_classes(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+            SubtypeUExplicitOverrideFG.subtype_support_matrix()
+        message = str(exc_info.value)
+        assert "supports_compute_framework" in message
+        assert "SubtypeUExplicitOverrideFG" in message
+        assert SubtypeUHookMatrixAbstractFG.subtype_support_matrix() == {}
+        assert SubtypeUHookMatrixPlainFG.subtype_support_matrix() == {}

--- a/tests/test_core/test_prepare/test_subtype_universe.py
+++ b/tests/test_core/test_prepare/test_subtype_universe.py
@@ -465,8 +465,7 @@ class TestContract10DeclarationValidation:
         assert "sustatu_pred_only_key" in message
 
     def test_predicate_only_key_with_universe_override_is_legal(self) -> None:
-        # SubtypeUPredicateUniverseFG was defined at module scope without error. Its key has no
-        # enumerable value space, which is exactly why the explicit universe override is required.
+        # SubtypeUPredicateUniverseFG was defined at module scope without error despite its predicate-only key.
         assert SubtypeUPredicateUniverseFG.declared_option_values("sustatu_pred_key") == frozenset()
         assert SubtypeUPredicateUniverseFG.subtype_universe() == frozenset({"p1", "p2"})
 

--- a/tests/test_plugins/feature_group/experimental/test_base_aggregated_feature_group/test_aggregated_subtype_universe.py
+++ b/tests/test_plugins/feature_group/experimental/test_base_aggregated_feature_group/test_aggregated_subtype_universe.py
@@ -1,0 +1,82 @@
+"""Failing tests pinning the subtype-universe dogfooding of AggregatedFeatureGroup (issue #639, Phase 2)."""
+
+import inspect
+
+from mloda.core.abstract_plugins.components.options import Options
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
+    PythonDictFramework,
+)
+from mloda_plugins.feature_group.experimental.aggregated_feature_group.base import AggregatedFeatureGroup
+from mloda_plugins.feature_group.experimental.aggregated_feature_group.pandas import PandasAggregatedFeatureGroup
+
+
+AGGREGATION_UNIVERSE = frozenset(AggregatedFeatureGroup.AGGREGATION_TYPES)
+
+
+class TestAggregatedSubtypeDeclaration:
+    """AggregatedFeatureGroup declares its aggregation types as its subtype universe."""
+
+    def test_subtype_key_is_aggregation_type(self) -> None:
+        assert AggregatedFeatureGroup.SUBTYPE_KEY == AggregatedFeatureGroup.AGGREGATION_TYPE
+        assert AggregatedFeatureGroup.SUBTYPE_KEY == "aggregation_type"
+
+    def test_universe_matches_declared_aggregation_types(self) -> None:
+        assert AggregatedFeatureGroup.subtype_universe() == AGGREGATION_UNIVERSE
+
+    def test_pandas_subclass_inherits_universe(self) -> None:
+        assert PandasAggregatedFeatureGroup.subtype_universe() == AGGREGATION_UNIVERSE
+
+
+class TestAggregatedResolveSubtype:
+    """resolve_subtype resolves aggregation types from the name and the config path."""
+
+    def test_resolves_from_feature_name(self) -> None:
+        assert AggregatedFeatureGroup.resolve_subtype("sales__sum_aggr", Options()) == "sum"
+
+    def test_resolves_from_config_path(self) -> None:
+        options = Options(context={AggregatedFeatureGroup.AGGREGATION_TYPE: "max"})
+        assert AggregatedFeatureGroup.resolve_subtype("aggr_config_placeholder", options) == "max"
+
+    def test_unrelated_name_resolves_to_none(self) -> None:
+        # Anchor on the declaration so this test is red until SUBTYPE_KEY lands.
+        assert AggregatedFeatureGroup.SUBTYPE_KEY == AggregatedFeatureGroup.AGGREGATION_TYPE
+        assert AggregatedFeatureGroup.resolve_subtype("sales_total", Options()) is None
+
+
+class TestAggregatedSupportedSubtypes:
+    """supported_subtypes defaults to the full universe on the concrete Pandas class."""
+
+    def test_default_is_full_universe_for_any_framework(self) -> None:
+        assert PandasAggregatedFeatureGroup.supported_subtypes(PandasDataFrame) == AGGREGATION_UNIVERSE
+        assert PandasAggregatedFeatureGroup.supported_subtypes(PythonDictFramework) == AGGREGATION_UNIVERSE
+
+
+class TestAggregatedBehaviorNeutral:
+    """The declaration is behavior-neutral: every aggregation type stays supported on PandasDataFrame."""
+
+    def test_every_aggregation_type_stays_supported_on_pandas(self) -> None:
+        # Anchor on the declared universe so this test is red until SUBTYPE_KEY lands.
+        assert PandasAggregatedFeatureGroup.subtype_universe() == AGGREGATION_UNIVERSE
+        for aggregation_type in AggregatedFeatureGroup.AGGREGATION_TYPES:
+            supported = PandasAggregatedFeatureGroup.supports_compute_framework(
+                f"sales__{aggregation_type}_aggr", Options(), PandasDataFrame
+            )
+            assert supported is True, f"'{aggregation_type}' must stay supported on PandasDataFrame"
+
+
+class TestAggregatedSubtypeSupportMatrix:
+    """subtype_support_matrix reflects abstractness and gives every framework the full universe."""
+
+    def test_abstract_base_declares_universe_but_no_matrix(self) -> None:
+        assert inspect.isabstract(AggregatedFeatureGroup)
+        # Anchor on the declared universe so this test is red until SUBTYPE_KEY lands.
+        assert AggregatedFeatureGroup.subtype_universe() == AGGREGATION_UNIVERSE
+        assert AggregatedFeatureGroup.subtype_support_matrix() == {}
+
+    def test_pandas_matrix_gives_every_framework_the_full_universe(self) -> None:
+        matrix = PandasAggregatedFeatureGroup.subtype_support_matrix()
+        assert matrix, "the concrete Pandas class must have a non-empty support matrix"
+        declared = {cfw.get_class_name() for cfw in PandasAggregatedFeatureGroup.compute_framework_definition()}
+        assert set(matrix) == declared
+        assert matrix == {PandasDataFrame.get_class_name(): AGGREGATION_UNIVERSE}


### PR DESCRIPTION
Part of #639. Supersedes #663 (closed: persona-blind, no parametric subtype support).

## Problem

Capability truth for a FeatureGroup family has no declarative home. `supports_compute_framework` answers the per-feature decision, but nothing enumerates what a family offers, so the registry's `DataOperationsCatalog` probes the hook with synthetic feature names and facts get duplicated.

## Solution, by persona

**Data provider (`mloda.provider`)**: declare once. `SUBTYPE_KEY` names the PROPERTY_MAPPING discriminator, `PARAMETRIC_SUBTYPE_FAMILIES` declares open families (`ntile_N`), `supported_subtypes(cfw)` narrows per framework. `supports_compute_framework` is derived from the declaration; undeclared subtypes stay open. Two declaration shapes, enforced at class definition; half declarations, predicate-only keys, and family collisions fail at import.

**Data user (`mloda.user`)**: `resolve_feature(name, options)` reports `subtype` and `subtype_family` (also on the unsupported-everywhere branch) and keeps its never-raises contract. Routing sends a feature, including parametric instances, to the frameworks that support its subtype; pinning to an incapable one fails at planning naming the capable ones.

**Data steward (`mloda.steward`)**: `subtype_support_matrix()` and new `FeatureGroupInfo` fields (`subtype_key`, `subtypes`, `parametric_subtypes`, `subtype_support`, `subtype_error`) enumerate capability without probing. The declaration cannot lie: abstract bases report no fabricated matrix, misdeclarations surface as `subtype_error`, and a hand-overridden hook voids the declared matrix.

`AggregatedFeatureGroup` dogfoods `SUBTYPE_KEY`, behavior-neutral. Families that do not opt in are unchanged.

## Review pass

Two independent deep reviews; all six findings fixed in the fix commit (inert resolver-only declaration, false parametric collapse of a declared value, fabricated matrix for hook-overriders, dropped subtype on the all-rejected branch, never-raises hole in the capability split, doc wording and docs-filter efficiency).

## Follow-ups

Re-express the registry's `DataOperationsCatalog` on this declaration (registry repo; #639 stays open until then). A catalog still cannot distinguish "declared no subtypes" from "never opted in".

## Tests

`tox` green: 5058 passed, 171 skipped; ruff, pip-licenses, mypy --strict, bandit pass. 98 new tests pin the declaration shapes, the derived gate, the enumeration API, and the honesty guarantees.
