### PR TITLE
minor: one coherent model for the PROPERTY_MAPPING validation layer (#600)

### DIFF
--- a/docs/docs/in_depth/feature-chain-parser.md
+++ b/docs/docs/in_depth/feature-chain-parser.md
@@ -230,11 +230,11 @@ class AggregatedFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 
 The three-arg form `cls._resolve_operation(feature_name, options, config_key)` is also supported for contexts where the name and options are already separate (e.g., `match_feature_group_criteria`).
 
-#### 5. Type Validation with `type_validator`
+#### 5. Whole-Value Validation with `match_guard`
 
-Add a `DefaultOptionKeys.type_validator` callable to a PROPERTY_MAPPING entry to validate the shape or composite type of the raw option value. The mixin calls the validator after basic matching succeeds. If it returns a falsy value, `match_feature_group_criteria` returns False.
+Add a `DefaultOptionKeys.match_guard` callable to a PROPERTY_MAPPING entry to validate the shape of the raw option value. The mixin calls it after basic matching succeeds, and a falsy return makes `match_feature_group_criteria` return False (a non-match, not an error).
 
-Use `type_validator` when you need to validate the whole value (e.g., must be a list of strings). Use `validation_function` with `strict_validation=True` when you need to validate individual parsed elements (after list unpacking).
+Reach for `match_guard` when the constraint is about the value as a whole (a list of strings, a dict, an ordering). Reach for `element_validator` with `strict_validation=True` when the constraint is about each element on its own.
 
 ``` python
 def _is_list_of_strings(value):
@@ -245,12 +245,14 @@ class GroupAggregation(FeatureChainParserMixin, FeatureGroup):
         "partition_by": {
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.type_validator: _is_list_of_strings,
+            DefaultOptionKeys.match_guard: _is_list_of_strings,
         },
     }
 ```
 
-The validator is only called when the option is present (not None). Missing options are handled by the base PROPERTY_MAPPING validation. Validators must be pure functions with no side effects, since they may be called multiple times during feature group resolution. Return values use truthy/falsy semantics. If the validator raises a TypeError, ValueError, or AttributeError, the exception is caught and the value is treated as invalid (match returns False).
+The guard is only called when the option is present (not None). Validators must be pure functions, since they may be called several times during resolution. If the guard raises a TypeError, ValueError, or AttributeError, the exception is caught and the value is treated as invalid (match returns False).
+
+The full model, which invariant fires at which moment, the precedence between the two callables, and what a validator receives for each container type, lives in one place: [PROPERTY_MAPPING Configuration](property-mapping.md).
 
 ## Modern Implementation in Feature Groups
 
@@ -351,9 +353,9 @@ def calculate_feature(self, features, options):
 
 ### 5. Advanced PROPERTY_MAPPING Features
 
-#### Validation Functions
+#### Element Validators
 
-For complex validation beyond simple value lists:
+For per-element rules that a fixed value list cannot express:
 
 ``` python
 PROPERTY_MAPPING = {
@@ -361,7 +363,7 @@ PROPERTY_MAPPING = {
         "explanation": "Number of dimensions for reduction",
         DefaultOptionKeys.context: True,
         DefaultOptionKeys.strict_validation: True,
-        DefaultOptionKeys.validation_function: lambda x: isinstance(x, int) and x > 0,
+        DefaultOptionKeys.element_validator: lambda x: isinstance(x, int) and x > 0,
     },
 }
 ```

--- a/docs/docs/in_depth/feature-group-matching.md
+++ b/docs/docs/in_depth/feature-group-matching.md
@@ -80,7 +80,7 @@ PROPERTY_MAPPING = {
         "explanation": "Size of the time window",
         DefaultOptionKeys.context: True,
         DefaultOptionKeys.strict_validation: True,
-        DefaultOptionKeys.validation_function: lambda x: isinstance(x, int) and x > 0,
+        DefaultOptionKeys.element_validator: lambda x: isinstance(x, int) and x > 0,
     },
 }
 ```

--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -1,38 +1,88 @@
 # PROPERTY_MAPPING Configuration
 
-`PROPERTY_MAPPING` defines parameter validation and classification for modern
-feature groups via the unified parser.
+`PROPERTY_MAPPING` declares the options a feature group accepts, and how each one is
+validated. This page is the single source of truth for that model: what a spec may
+contain, which invariant is checked at which moment, what runs against end-user
+values in what order, and what each failure produces.
 
-## Basic structure
+Two rules carry most of the model:
+
+1. **The spec declares the arity, not the caller.** Whether the user writes a list, a
+   tuple, a set, or a frozenset never changes what a validator receives.
+2. **A rejected value is not always an error.** Some failures raise; others just mean
+   "this feature group does not match", which lets a different candidate win.
+
+## The lifecycle: which invariant fires when
+
+| Moment | Mechanism | Checks | Receives | On failure |
+| --- | --- | --- | --- | --- |
+| Import time (`property_spec(...)` call) | Authoring invariants | strict needs `allowed_values` or an `element_validator`; `allowed_values` without strict; empty `allowed_values`; validators are callable | The spec being built | `ValueError` at import |
+| Class definition (`FeatureGroup.__init_subclass__`) | Removed-key guard | No spec uses a removed key (`validation_function`, `type_validator`) | Every spec in the mapping | `ValueError` naming the replacement |
+| Class definition | `check_declared_default` | A strict, non-`None` `default` is accepted by its own key | The declared default | `ValueError` at class definition |
+| Match time (parser) | `allowed_values` membership | Each element is in the accepted set | One element | `ValueError`, surfaced to the end user |
+| Match time (parser) | `element_validator` | Each element satisfies a predicate | One element | `ValueError`, surfaced to the end user |
+| Match time (mixin) | `required_when` | A conditionally required option is present | `Options` | Non-match (`False`) |
+| Match time (mixin) | `match_guard` | The whole value has an acceptable shape | The raw value | Non-match (`False`) |
+| Match time (mixin) | `MIN/MAX_IN_FEATURES` | In-feature count is within bounds | The in-features | Non-match (`False`) |
+
+Match-time mechanisms run in that order. `element_validator` **replaces** membership
+rather than adding to it: when a key declares one, `allowed_values` is not consulted.
+Because the parser runs before the mixin, an element rejected by membership or by
+`element_validator` short-circuits, and `match_guard` is never reached.
+
+## Choosing a mechanism
+
+| You want to say | Use |
+| --- | --- |
+| "This option accepts exactly these values" | `allowed_values` + `strict_validation: True` |
+| "Each value must satisfy a rule I cannot enumerate" (positive int, float in range) | `element_validator` (requires strict) |
+| "The value as a whole must have this shape" (a dict, a list of exactly 3, an ordering) | `match_guard` |
+| "This option is required only when another option says so" | `required_when` |
+
+The two callables differ on both axes, which is what their names now say:
+
+- **`element_validator`** sees **one element**, only under `strict_validation`, and a
+  falsy return **raises** `ValueError`. The user gave a value the group claims to own
+  but cannot accept, so they are told.
+- **`match_guard`** sees the **raw whole value**, with or without strict, and a falsy
+  return is a plain **non-match**. The group is saying "not mine", so resolution moves
+  on and another feature group may still take the feature.
+
+Both must be pure functions. They may be called several times during resolution (once
+per candidate feature group).
+
+## What a validator receives
+
+Container syntax is not part of the contract. For membership and `element_validator`,
+every sequence unpacks element-wise and identically:
 
 ``` python
-from mloda.provider import DefaultOptionKeys
-
-PROPERTY_MAPPING = {
-    "parameter_name": {
-        "value1": "Description of value1",
-        "value2": "Description of value2",
-        DefaultOptionKeys.context: True,           # classification (see below)
-        DefaultOptionKeys.strict_validation: True,  # validation mode
-    },
-    DefaultOptionKeys.in_features: {
-        "explanation": "Source feature description",
-        DefaultOptionKeys.context: True,
-        DefaultOptionKeys.strict_validation: False,
-    },
-}
+# All four hand the element_validator exactly "a" and then "b".
+Options(context={"ops": ["a", "b"]})
+Options(context={"ops": ("a", "b")})
+Options(context={"ops": {"a", "b"}})
+Options(context={"ops": frozenset({"a", "b"})})
 ```
 
-In this flattened form the allowed values share one dict with the metadata flags.
-The parser recovers the value space by subtracting the reserved metadata keys
-(`RESERVED_PROPERTY_KEYS`: `explanation`, `allowed_values`, `default`, `context`,
-`group`, `strict_validation`, `validation_function`, `required_when`,
-`type_validator`). It stays fully supported.
+- A `str` is a **scalar**, not a sequence of characters: `"abc"` is the single element
+  `"abc"`.
+- A `dict` is **one composite value**, not a sequence of its keys. Validating its shape
+  is `match_guard`'s job.
+- Elements keep their real type: an `int` element arrives as `1`, never `"1"`.
+- An **empty** container is *present* and vacuously valid: it has no elements, so no
+  validator runs, and it still satisfies the required-presence check. This is distinct
+  from the option being absent.
 
-## Recommended: explicit `allowed_values`
+`match_guard` is unaffected by any of this: it always receives the raw value with its
+original container type.
 
-Declaring the value space under `DefaultOptionKeys.allowed_values` keeps it
-separate from the flags, so a doc-only key can never widen an allowed set:
+## Authoring a spec
+
+Three forms build the same plain dict. The contract is the dict, so all three are
+equivalent to the parser.
+
+**Recommended, explicit `allowed_values`:** keeps the value space separate from the
+flags, so a doc-only key can never widen an accepted set.
 
 ``` python
 "operation_type": {
@@ -42,18 +92,11 @@ separate from the flags, so a doc-only key can never widen an allowed set:
 }
 ```
 
-When present, the parser uses `allowed_values` directly and ignores other non-flag
-keys. It may be a value-to-docstring mapping or a re-iterable collection (list,
-tuple, set), but not a one-shot iterator (a generator would exhaust, behaving like
-an empty set; `property_spec` materializes iterables for you). `allowed_values` and
-`explanation` are reserved names and cannot be literal accepted values.
+`allowed_values` may be a value-to-docstring mapping or a re-iterable collection, but
+not a one-shot iterator (a generator would exhaust and behave like an empty set).
 
-### Builder: `property_spec`
-
-`property_spec` builds the same dict and validates its invariants at construction
-(strict needs a non-empty `allowed_values` or a `validation_function`;
-`allowed_values` without strict is a no-op; a strict `default` must be accepted).
-The contract stays a plain dict, so this is optional sugar:
+**Builder, `property_spec`:** the same dict, with the authoring invariants checked at
+construction instead of at class definition.
 
 ``` python
 from mloda.provider import property_spec
@@ -68,14 +111,24 @@ PROPERTY_MAPPING = {
 }
 ```
 
-Three optional callable passthroughs are emitted only when provided:
+It also takes `element_validator`, `match_guard`, and `required_when`, emitted only
+when provided. Its declared-default check is not a separate implementation: it calls
+the same `FeatureChainParser.check_declared_default` the class-definition hook uses,
+so the two cannot drift.
 
-- `validation_function`: requires `strict=True`; then strict no longer needs
-  `allowed_values`, and a declared `default` is checked through the function. If it
-  raises on the default, the builder wraps it as a `ValueError` (original chained as
-  `__cause__`), mirroring core's class-definition check.
-- `required_when`: conditional-requirement predicate; no strict requirement.
-- `type_validator`: raw-value shape check; no strict requirement.
+**Legacy flattened form:** allowed values share one dict with the metadata flags, and
+the parser recovers the value space by subtracting `RESERVED_PROPERTY_KEYS`. Still
+supported, but the explicit form is preferred precisely because subtraction is easy to
+get wrong.
+
+``` python
+"parameter_name": {
+    "value1": "Description of value1",
+    "value2": "Description of value2",
+    DefaultOptionKeys.context: True,
+    DefaultOptionKeys.strict_validation: True,
+}
+```
 
 ## Parameter classification
 
@@ -87,53 +140,11 @@ Three optional callable passthroughs are emitted only when provided:
 "data_source": {"production": "Production data", DefaultOptionKeys.group: True}
 ```
 
-## Validation modes
+## Declared defaults must be honored
 
-`strict_validation` defaults to `False` (listed values are illustrative). Set it to
-`True` to accept only listed values.
-
-**`validation_function`** (requires `strict_validation=True`) validates individual
-parsed elements; the parser unpacks lists and calls it per element:
-
-``` python
-"window_size": {
-    "explanation": "Size of time window",
-    DefaultOptionKeys.validation_function: lambda x: isinstance(x, int) and x > 0,
-    DefaultOptionKeys.strict_validation: True,
-}
-```
-
-**`type_validator`** checks the shape of the raw value before any list unpacking. It
-does not require `strict_validation` and must return truthy for the match to
-succeed:
-
-``` python
-def _is_list_of_strings(value):
-    return isinstance(value, list) and all(isinstance(item, str) for item in value)
-
-"partition_by": {
-    "explanation": "List of columns to partition by",
-    DefaultOptionKeys.context: True,
-    DefaultOptionKeys.type_validator: _is_list_of_strings,
-}
-```
-
-When both are present, `validation_function` runs first (per parsed element), then
-`type_validator` on the raw value. Both must be pure functions.
-
-## Default values
-
-``` python
-"method": {"linear": "Linear", "cubic": "Cubic", DefaultOptionKeys.default: "linear"}
-```
-
-### Declared defaults must be honored
-
-Under `strict_validation: True`, a declared `default` must be a value the key
-accepts. mloda enforces this at class-definition time: a `PROPERTY_MAPPING` whose
-strict `default` is outside the accepted set (or fails its `validation_function`)
-raises `ValueError` immediately, naming the class, key, default, and accepted
-values. This closes a gap where omitting the key would apply an unrevalidated
+Under `strict_validation: True`, a declared `default` must be a value the key accepts.
+This is enforced at class-definition time, naming the class, key, default, and accepted
+values, which closes the gap where omitting the key would apply an unrevalidated
 default.
 
 ``` python
@@ -146,71 +157,42 @@ default.
 }
 ```
 
-Resolve it by adding the default to the accepted values, or removing it (a key with
-no default and no `required_when` is unconditionally required). `required_when` does
-NOT exempt a key: when its predicate returns `False` and the key is omitted, the
-default still applies, so an unaccepted default would still slip through. A `default`
-of `None` is always legal (the "unset" sentinel), and the check is a no-op when
-`strict_validation` is `False`.
+Fix it by adding the default to the accepted values, or by removing it (a key with no
+default and no `required_when` is unconditionally required). `required_when` does NOT
+exempt a key: when its predicate returns `False` and the key is omitted, the default
+still applies, so an unaccepted default would still slip through. A `default` of `None`
+is always legal (the "unset" sentinel), and the check is a no-op when strict is off.
 
-## Usage in feature groups
+A validator that *raises* when called with the declared default is reported distinctly
+from one that merely *rejects* it, with the original exception chained as `__cause__`.
 
-``` python
-class MyFeatureGroup(FeatureGroup):
-    PROPERTY_MAPPING = {
-        "operation_type": {
-            "sum": "Sum operation",
-            "avg": "Average operation",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-        },
-        DefaultOptionKeys.in_features: {"explanation": "Source feature", DefaultOptionKeys.context: True},
-    }
+## What the end user sees on a rejection
 
-    @classmethod
-    def match_feature_group_criteria(cls, feature_name, options, data_access_collection=None):
-        return FeatureChainParser.match_configuration_feature_chain_parser(
-            feature_name, options, property_mapping=cls.PROPERTY_MAPPING
-        )
-```
+A direct `FeatureChainParser` call raises `ValueError` immediately. Going through
+`FeatureChainParserMixin.match_feature_group_criteria` (the default for most feature
+groups) is different: it catches that `ValueError` and returns `False`, because during
+resolution one candidate's "no match" must not abort the search for another candidate
+that might still accept the feature.
 
-``` python
-Options(context={"operation_type": "sum"})     # valid: "sum" is in mapping
-Options(context={"operation_type": "custom"})  # strict: raises ValueError
-Options(context={"in_features": "any_name"})   # flexible: any value allowed
-```
-
-### What the end user sees on a strict-validation rejection
-
-The direct call above raises `ValueError` immediately. Going through
-`FeatureChainParserMixin.match_feature_group_criteria` (the default for most
-feature groups) is different: it catches that `ValueError` and returns `False`
-instead, because during resolution one candidate's "no match" must not abort
-the search for another candidate that might still accept the feature.
-
-If every candidate ends up rejecting the feature, the final "No feature groups
-found" error collects the discarded rejection reasons from every mixin-based
-candidate that had one and appends them, naming the feature group, the option
-key, the rejected value, and why it failed:
+If every candidate rejects the feature, the final "No feature groups found" error
+collects the discarded reasons and appends them:
 
 ```
 Feature group(s) rejected an option value while matching 'window_size_windowed':
   - WindowedFeatureGroup: Property value '14' failed validation for 'window_size'
 ```
 
-This is diagnostic only: it does not change `match_feature_group_criteria`'s
-`True`/`False` contract, so a value rejected by one feature group can still
-match a different one, and multi-group fallback resolution keeps working.
-Feature group authors do not need to override `match_feature_group_criteria`
-to get this message.
+This is diagnostic only. It does not change the `True`/`False` contract, so a value
+rejected by one feature group can still match another, and multi-group fallback
+resolution keeps working. Authors get this for free.
 
 ## Conditional requirements with `required_when`
 
-Attach a predicate callable to declare an option required only under certain
-conditions. It receives an effective `Options` and returns `True` when the option is
-required. This works for both config-based and string-based features (for the
-latter, the operation parsed from the feature name is merged in first, so predicates
-see values from both sources).
+Attach a predicate to declare an option required only under certain conditions. It
+receives an effective `Options` and returns `True` when the option is required. This
+works for config-based and string-based features alike (for the latter, the operation
+parsed from the feature name is merged in first, so predicates see values from both
+sources).
 
 ``` python
 _ORDER_DEPENDENT = {"first", "last"}
@@ -232,11 +214,42 @@ PROPERTY_MAPPING = {
 }
 ```
 
-When the predicate returns `True` and the option is absent,
-`match_feature_group_criteria` returns `False`; entries with `required_when` are
-otherwise treated as optional. The predicate must be a pure, callable
+When the predicate returns `True` and the option is absent, the match fails; entries
+with `required_when` are otherwise optional. The predicate must be a pure, callable
 `(Options) -> bool` that does not raise. Non-callable values are skipped with a
 warning; non-bool truthy returns count as `True`.
+
+## Migrating from the removed key names
+
+`validation_function` and `type_validator` are **removed**, with no aliases. They did
+not communicate their difference, and `type_validator` additionally collided by
+substring with the unrelated `DataTypeValidator`.
+
+| Removed | Use |
+| --- | --- |
+| `validation_function` | `element_validator` |
+| `type_validator` | `match_guard` |
+
+Both routes fail loudly, so no spec silently changes meaning: the old enum members are
+gone (`AttributeError` at import), and a spec still carrying the old string key raises
+at class definition, naming the replacement.
+
+One semantic change comes with the rename. `element_validator` now genuinely receives
+one element per call for every container type; previously a sequence was stringified
+and arrived as, for example, `"('a', 'b')"`. A validator written to inspect a whole
+container (`isinstance(x, list) and all(...)`) must therefore either become a
+per-element rule, or move to `match_guard` if it really is a whole-value check.
+
+## Where each invariant is pinned
+
+| Invariant | Test |
+| --- | --- |
+| Renamed keys, removed-key guard, shared default seam, precedence | `tests/.../feature_chainer/test_property_mapping_unified_model.py` |
+| Container invariance, no stringification, str-as-scalar, dict-as-composite, empty containers | `tests/.../feature_chainer/test_property_mapping_sequence_unpacking.py` |
+| Plugin specs behave identically across containers | `tests/test_plugins/feature_group/experimental/test_property_mapping_container_invariance.py` |
+| Declared-default invariant at class definition | `tests/test_core/test_abstract_plugins/test_property_mapping_default_invariant.py` |
+| Rejection reasons surfaced to the end user | `tests/test_core/test_prepare/test_identify_feature_group_error_message.py` |
+| `property_spec` authoring invariants | `tests/.../feature_chainer/test_property_spec_builder.py` |
 
 ## Context propagation
 

--- a/mloda/core/abstract_plugins/components/default_options_key.py
+++ b/mloda/core/abstract_plugins/components/default_options_key.py
@@ -30,10 +30,10 @@ class DefaultOptionKeys(str, Enum):
     group = "group"
     order_by = "order_by"
     strict_validation = "strict_validation"
-    validation_function = "validation_function"
+    element_validator = "element_validator"
     strict_type_enforcement = "strict_type_enforcement"
     required_when = "required_when"
-    type_validator = "type_validator"
+    match_guard = "match_guard"
 
     def __str__(self) -> str:
         return self.value
@@ -53,8 +53,17 @@ RESERVED_PROPERTY_KEYS: frozenset[Any] = frozenset(
         DefaultOptionKeys.context,
         DefaultOptionKeys.group,
         DefaultOptionKeys.strict_validation,
-        DefaultOptionKeys.validation_function,
+        DefaultOptionKeys.element_validator,
         DefaultOptionKeys.required_when,
-        DefaultOptionKeys.type_validator,
+        DefaultOptionKeys.match_guard,
     }
 )
+
+# Removed PROPERTY_MAPPING keys mapped to their replacement (issue #600). These names are no
+# longer reserved metadata, so a leftover stale key would be absorbed into a legacy flattened
+# spec's accepted VALUE set. ``FeatureChainParser.validate_property_mapping_defaults`` rejects
+# them at class-definition time instead.
+REMOVED_PROPERTY_KEYS: dict[str, DefaultOptionKeys] = {
+    "validation_function": DefaultOptionKeys.element_validator,
+    "type_validator": DefaultOptionKeys.match_guard,
+}

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -10,7 +10,11 @@ from typing import Any, Optional
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
-from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys, RESERVED_PROPERTY_KEYS
+from mloda.core.abstract_plugins.components.default_options_key import (
+    REMOVED_PROPERTY_KEYS,
+    RESERVED_PROPERTY_KEYS,
+    DefaultOptionKeys,
+)
 
 # Separator constants for feature name parsing
 CHAIN_SEPARATOR = "__"  # Separates chained transformations (source→suffix)
@@ -122,10 +126,10 @@ class FeatureChainParser:
         return isinstance(property_value, dict) and property_value.get(DefaultOptionKeys.strict_validation, False)
 
     @classmethod
-    def _get_validation_function(cls, property_value: Any) -> Any:
-        """Get validation function from property mapping if present."""
+    def _get_element_validator(cls, property_value: Any) -> Any:
+        """Get the per-element validator from a property mapping spec if present."""
         if isinstance(property_value, dict):
-            return property_value.get(DefaultOptionKeys.validation_function, None)
+            return property_value.get(DefaultOptionKeys.element_validator, None)
         return None
 
     @classmethod
@@ -133,22 +137,27 @@ class FeatureChainParser:
         cls, found_property_val: Any, property_value: Any, property_name: str, original_property_config: Any
     ) -> None:
         """
-        Unified validation function: if strict validation -> apply validation function OR check membership.
+        Unified validation: if strict validation -> apply the element_validator OR check membership.
 
         Raises ValueError if validation fails, otherwise returns None.
         """
         if not cls._is_strict_validation(original_property_config):
             return  # No validation needed
 
-        validation_function = cls._get_validation_function(original_property_config)
+        element_validator = cls._get_element_validator(original_property_config)
 
-        if validation_function is not None:
-            # Use validation function if available
-            if not validation_function(found_property_val):
+        if element_validator is not None:
+            # Use the element validator if available
+            if not element_validator(found_property_val):
                 raise ValueError(f"Property value '{found_property_val}' failed validation for '{property_name}'")
         else:
-            # Fallback to membership check
-            if found_property_val not in property_value:
+            # Fallback to membership check. An unhashable element (e.g. a dict) can never be
+            # a member of the accepted set, so it is a clean rejection, not a TypeError.
+            try:
+                is_member = found_property_val in property_value
+            except TypeError:
+                is_member = False
+            if not is_member:
                 raise ValueError(f"Property value '{found_property_val}' not found in mapping for '{property_name}'")
 
     @classmethod
@@ -203,101 +212,139 @@ class FeatureChainParser:
         return property_value
 
     @classmethod
-    def validate_property_mapping_defaults(cls, owner_name: str, property_mapping: dict[str, Any] | None) -> None:
-        """Validate declared PROPERTY_MAPPING defaults at class-definition time.
+    def check_declared_default(cls, owner: str, key: str, spec: dict[str, Any]) -> None:
+        """Check one spec's declared default against its own strict-validation rules.
 
-        For every key whose spec is a dict and declares a non-``None``
-        ``DefaultOptionKeys.default`` under strict validation, the declared default
-        must be in the accepted set or pass the key's ``validation_function``.
-        A ``validation_function`` that itself errors when called with the default is
+        This is the single implementation of the default-check semantics, shared by
+        ``validate_property_mapping_defaults`` (class-definition time) and by the
+        ``property_spec`` authoring helper, so the two can never drift apart.
+
+        Under strict validation, a non-``None`` declared default must pass the key's
+        ``element_validator`` if it has one, otherwise be a member of the accepted set.
+        An ``element_validator`` that itself errors when called with the default is
         reported as having raised (with the original exception chained as the cause),
-        which is distinct from the function running and rejecting the default.
+        which is distinct from the validator running and rejecting the default.
         ``DefaultOptionKeys.required_when`` does NOT exempt this check: it is a
         conditional requirement, so the default still applies on the predicate-false
         branch. The remedies are to add the default to the accepted values or to
         remove the default (a key with no default is required).
+
+        Raises ValueError on violation, otherwise returns None.
         """
-        if property_mapping is None:
+        if DefaultOptionKeys.default not in spec:
             return
 
-        def _message(key: str, default: Any, detail: str) -> str:
+        default = spec[DefaultOptionKeys.default]
+        if default is None:
+            return
+
+        if not cls._is_strict_validation(spec):
+            return
+
+        def _message(detail: str) -> str:
             return (
-                f"{owner_name}.PROPERTY_MAPPING['{key}'] declares default {default!r}, "
+                f"{owner} declares default {default!r} for '{key}', "
                 f"but {detail} under strict_validation. "
                 f"Add the default to the accepted values, or remove the default "
                 f"(a key with no default is required)."
             )
 
+        element_validator = cls._get_element_validator(spec)
+        if element_validator is not None:
+            try:
+                verdict = element_validator(default)
+            except Exception as exc:
+                raise ValueError(
+                    _message("the key's element_validator raised an error when called with that default")
+                ) from exc
+            if not verdict:
+                raise ValueError(_message("that default is rejected by the key's element_validator"))
+            return
+
+        extracted = cls._extract_property_values(spec)
+        try:
+            cls._validate_property_value(default, extracted, key, spec)
+        except (ValueError, TypeError) as exc:
+            detail = f"that default is not one of the accepted values {sorted(extracted, key=repr)}"
+            raise ValueError(_message(detail)) from exc
+
+    @classmethod
+    def validate_property_mapping_defaults(cls, owner_name: str, property_mapping: dict[str, Any] | None) -> None:
+        """Validate a PROPERTY_MAPPING at class-definition time.
+
+        Rejects specs that still carry a removed key (see ``REMOVED_PROPERTY_KEYS``) and
+        delegates every declared default to ``check_declared_default``.
+        """
+        if property_mapping is None:
+            return
+
         for key, spec in property_mapping.items():
             if not isinstance(spec, dict):
                 continue
-            if DefaultOptionKeys.default not in spec:
-                continue
+            cls._reject_removed_property_keys(owner_name, key, spec)
+            cls.check_declared_default(f"{owner_name}.PROPERTY_MAPPING", key, spec)
 
-            default = spec[DefaultOptionKeys.default]
-            if default is None:
-                continue
+    @classmethod
+    def _reject_removed_property_keys(cls, owner_name: str, key: str, spec: dict[str, Any]) -> None:
+        """Fail loudly on a spec that still uses a removed PROPERTY_MAPPING key.
 
-            validation_function = cls._get_validation_function(spec)
-            if validation_function is not None:
-                if not cls._is_strict_validation(spec):
-                    continue
-                try:
-                    verdict = validation_function(default)
-                except Exception as exc:
-                    raise ValueError(
-                        _message(
-                            key, default, "the key's validation_function raised an error when called with that default"
-                        )
-                    ) from exc
-                if not verdict:
-                    raise ValueError(
-                        _message(key, default, "that default is rejected by the key's validation_function")
-                    )
-                continue
+        The removed keys are no longer reserved metadata, so ``_extract_property_values``
+        would absorb a leftover one into a legacy flattened spec's accepted value space,
+        silently widening what the feature group matches. Rejecting the spec turns that
+        silent corruption into an actionable migration error.
+        """
+        for stale, replacement in REMOVED_PROPERTY_KEYS.items():
+            if stale in spec:
+                raise ValueError(
+                    f"{owner_name}.PROPERTY_MAPPING['{key}'] uses the removed key '{stale}'. "
+                    f"Rename it to '{replacement.value}' (DefaultOptionKeys.{replacement.value})."
+                )
 
-            extracted = cls._extract_property_values(spec)
-            try:
-                cls._validate_property_value(default, extracted, key, spec)
-            except (ValueError, TypeError) as exc:
-                detail = f"that default is not one of the accepted values {sorted(extracted, key=repr)}"
-                raise ValueError(_message(key, default, detail)) from exc
+    @classmethod
+    def _unpack_property_value(cls, found_property_value: Any) -> list[Any]:
+        """Unpack an option value into the elements the spec validates.
+
+        The spec declares the arity, not the caller's Python syntax: every sequence
+        container (list, tuple, set, frozenset) unpacks element-wise and identically.
+        A ``str`` is a scalar, not a sequence of characters, and a ``dict`` is one
+        composite value, not a sequence of its keys. Elements keep their real type;
+        the only normalization is a ``Feature`` reduced to its name.
+        """
+        if isinstance(found_property_value, (list, tuple, set, frozenset)):
+            elements = list(found_property_value)
+        else:
+            elements = [found_property_value]
+
+        return [element.name if isinstance(element, Feature) else element for element in elements]
 
     @classmethod
     def _process_found_property_value(
         cls, found_property_value: Any, property_value: Any, property_name: str, original_property_config: Any
-    ) -> set[str]:
-        if isinstance(found_property_value, list):
-            found_property_value = tuple(found_property_value)
-        if not isinstance(found_property_value, frozenset):
-            found_property_value = frozenset([found_property_value])
-
-        collected_property_value = set()
-        for found_property_val in found_property_value:
-            if isinstance(found_property_val, Feature):
-                found_property_val = found_property_val.name
-
-            if isinstance(found_property_val, tuple):
-                # Convert tuple to string representation for hashability
-                found_property_val = str(found_property_val)
-
+    ) -> list[Any]:
+        collected_property_value: list[Any] = []
+        for found_property_val in cls._unpack_property_value(found_property_value):
             # Use unified validation function
             cls._validate_property_value(found_property_val, property_value, property_name, original_property_config)
 
-            collected_property_value.add(found_property_val)
+            collected_property_value.append(found_property_val)
 
         return collected_property_value
 
     @classmethod
     def _validate_final_properties(
-        cls, property_tracker: dict[str, None | set[str]], property_mapping: dict[str, Any]
+        cls, property_tracker: dict[str, list[Any] | None], property_mapping: dict[str, Any]
     ) -> bool:
-        """Validate that all required properties have values."""
+        """Validate that all required properties are present.
+
+        Presence is tracked explicitly: ``None`` means the option was absent, while an
+        empty list means it was present with zero elements (an empty container), which
+        is vacuously valid and still satisfies the required-presence check.
+        """
         for key, value in property_tracker.items():
             property_config = property_mapping[key]
             can_skip = cls._can_skip_required_check(property_config)
 
-            if not value and not can_skip:
+            if value is None and not can_skip:
                 return False
         return True
 
@@ -313,25 +360,20 @@ class FeatureChainParser:
         Returns:
             True if validation passes, False otherwise
         """
-        property_tracker: dict[str, None | set[str]] = {}
+        # None marks an absent option; a list (possibly empty) marks a present one.
+        property_tracker: dict[str, list[Any] | None] = {}
         for key in property_mapping:
             property_tracker[key] = None
 
         # Process each property in the mapping
         for property_name, property_value in property_mapping.items():
             found_property_value = options.get(property_name)
-            can_skip = cls._can_skip_required_check(property_value)
             property_value = cls._extract_property_values(property_value)
 
-            # Handle missing properties
+            # Handle missing properties: leave the tracker at None, so the final check
+            # decides whether the option was required.
             if found_property_value is None:
-                if can_skip:
-                    # Property with default or conditional requirement - mark as processed but empty
-                    property_tracker[property_name] = set()
-                    continue
-                else:
-                    # Required property not present - skip (will fail validation later)
-                    continue
+                continue
 
             collected_property_value = cls._process_found_property_value(
                 found_property_value, property_value, property_name, property_mapping[property_name]

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -1,13 +1,13 @@
 """
 Mixin class providing default implementations for feature chain parsing.
 
-Validation Design: ``type_validator`` vs ``validation_function``
-================================================================
+Validation Design: ``element_validator`` vs ``match_guard``
+==========================================================
 
 PROPERTY_MAPPING supports two callable-valued keys that validate option values.
 They serve different purposes and run at different points in the pipeline.
 
-``validation_function`` (``DefaultOptionKeys.validation_function``)
+``element_validator`` (``DefaultOptionKeys.element_validator``)
   - Requires ``strict_validation: True`` on the same mapping entry.
   - Runs inside ``FeatureChainParser._validate_property_value`` during
     ``_validate_options_against_property_mapping``.
@@ -19,22 +19,22 @@ They serve different purposes and run at different points in the pipeline.
   - Use case: validating that each individual element satisfies a constraint
     (e.g., ``lambda x: isinstance(x, int) and x > 0``).
 
-``type_validator`` (``DefaultOptionKeys.type_validator``)
+``match_guard`` (``DefaultOptionKeys.match_guard``)
   - Does **not** require ``strict_validation``.
   - Runs inside ``FeatureChainParserMixin.match_feature_group_criteria``
     **after** basic matching succeeds (pattern + property mapping validation).
   - Receives the **raw option value** exactly as stored in Options, before any
     list unpacking or element iteration.
   - On failure: logs a debug message and returns ``False`` (non-match). If the
-    validator raises an exception, the exception is caught, logged, and the
-    value is treated as invalid.
+    guard raises an exception, the exception is caught, logged, and the value is
+    treated as invalid.
   - Use case: validating the shape or composite type of the whole value
     (e.g., ``lambda v: isinstance(v, list) and all(isinstance(i, str) for i in v)``).
 
-When both are present on the same mapping entry, ``validation_function`` runs
+When both are present on the same mapping entry, ``element_validator`` runs
 first (during property mapping validation) on each parsed element, then
-``type_validator`` runs on the raw value. If ``validation_function`` rejects an
-element, the match fails with a ``ValueError`` before ``type_validator`` is
+``match_guard`` runs on the raw value. If ``element_validator`` rejects an
+element, the match fails with a ``ValueError`` before ``match_guard`` is
 reached.
 
 Validators must be pure functions with no side effects. They may be called
@@ -186,12 +186,12 @@ class FeatureChainParserMixin:
         Delegates to FeatureChainParser.match_configuration_feature_chain_parser() and
         optionally calls _validate_string_match() hook for custom validation.
 
-        After basic matching succeeds, enforces ``type_validator`` constraints from
+        After basic matching succeeds, enforces ``match_guard`` constraints from
         PROPERTY_MAPPING entries. For each entry that defines a
-        ``DefaultOptionKeys.type_validator`` callable, the validator is called with
-        the raw option value. Returning a falsy value causes this method to return
-        False. If the validator raises an exception, it is caught and the value is
-        treated as invalid. See the module docstring for the full validation design.
+        ``DefaultOptionKeys.match_guard`` callable, the guard is called with the raw
+        option value. Returning a falsy value causes this method to return False. If
+        the guard raises an exception, it is caught and the value is treated as
+        invalid. See the module docstring for the full validation design.
 
         Also enforces MIN_IN_FEATURES / MAX_IN_FEATURES constraints when
         in_features is present in options.
@@ -239,7 +239,7 @@ class FeatureChainParserMixin:
         if not cls._validate_required_when(result, feature_name, prefix_patterns, property_mapping, options):
             return False
 
-        if not cls._validate_type_validators(result, options, property_mapping):
+        if not cls._validate_match_guards(result, options, property_mapping):
             return False
 
         if not cls._validate_in_features(result, options):
@@ -361,24 +361,24 @@ class FeatureChainParserMixin:
         return True
 
     @classmethod
-    def _validate_type_validators(cls, result: bool, options: Options, property_mapping: dict[str, Any] | None) -> bool:
-        # Enforce type_validator constraints from PROPERTY_MAPPING
+    def _validate_match_guards(cls, result: bool, options: Options, property_mapping: dict[str, Any] | None) -> bool:
+        # Enforce match_guard constraints from PROPERTY_MAPPING
         if result and property_mapping is not None:
             for key, mapping_entry in property_mapping.items():
                 if not isinstance(mapping_entry, dict):
                     continue
-                validator = mapping_entry.get(DefaultOptionKeys.type_validator)
-                if validator is None:
+                guard = mapping_entry.get(DefaultOptionKeys.match_guard)
+                if guard is None:
                     continue
                 value = options.get(key)
                 if value is None:
                     continue
                 try:
-                    if not validator(value):
-                        logger.debug("type_validator for '%s' rejected value %r", key, value)
+                    if not guard(value):
+                        logger.debug("match_guard for '%s' rejected value %r", key, value)
                         return False
                 except (TypeError, ValueError, AttributeError) as exc:
-                    logger.debug("type_validator for '%s' raised %s for value %r", key, exc, value)
+                    logger.debug("match_guard for '%s' raised %s for value %r", key, exc, value)
                     return False
         return True
 
@@ -388,8 +388,11 @@ class FeatureChainParserMixin:
         if result and hasattr(cls, "MIN_IN_FEATURES") and hasattr(cls, "MAX_IN_FEATURES"):
             in_features_raw = options.get(DefaultOptionKeys.in_features)
             if in_features_raw is not None:
-                in_features = options.get_in_features()
-                count = len(in_features)
+                if isinstance(in_features_raw, (list, tuple, set, frozenset)) and not in_features_raw:
+                    # Present but empty: zero in_features, a non-match rather than an error.
+                    count = 0
+                else:
+                    count = len(options.get_in_features())
                 if count < cls.MIN_IN_FEATURES:
                     return False
                 if cls.MAX_IN_FEATURES is not None and count > cls.MAX_IN_FEATURES:

--- a/mloda/core/abstract_plugins/components/feature_chainer/property_spec.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/property_spec.py
@@ -10,6 +10,7 @@ from collections.abc import Callable, Iterable, Mapping
 from typing import Any
 
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 
 
 def property_spec(
@@ -19,66 +20,52 @@ def property_spec(
     allowed_values: Mapping[Any, str] | Iterable[Any] | None = None,
     default: Any = None,
     context: bool = True,
-    validation_function: Callable[..., Any] | None = None,
+    element_validator: Callable[..., Any] | None = None,
     required_when: Callable[..., Any] | None = None,
-    type_validator: Callable[..., Any] | None = None,
+    match_guard: Callable[..., Any] | None = None,
 ) -> dict[str, Any]:
     if allowed_values is not None and not isinstance(allowed_values, Mapping):
         allowed_values = tuple(allowed_values)
 
-    if validation_function is not None and not callable(validation_function):
-        raise ValueError(f"property_spec({explanation!r}): validation_function must be callable.")
+    if element_validator is not None and not callable(element_validator):
+        raise ValueError(f"property_spec({explanation!r}): element_validator must be callable.")
 
     if required_when is not None and not callable(required_when):
         raise ValueError(f"property_spec({explanation!r}): required_when must be callable.")
 
-    if type_validator is not None and not callable(type_validator):
-        raise ValueError(f"property_spec({explanation!r}): type_validator must be callable.")
+    if match_guard is not None and not callable(match_guard):
+        raise ValueError(f"property_spec({explanation!r}): match_guard must be callable.")
 
-    if validation_function is not None and not strict:
-        raise ValueError(f"property_spec({explanation!r}): validation_function is never enforced without strict=True.")
+    if element_validator is not None and not strict:
+        raise ValueError(f"property_spec({explanation!r}): element_validator is never enforced without strict=True.")
 
     if strict and allowed_values is not None and not allowed_values:
         raise ValueError(f"property_spec({explanation!r}): an empty allowed_values would reject every value.")
 
-    if strict and allowed_values is None and validation_function is None:
+    if strict and allowed_values is None and element_validator is None:
         raise ValueError(
-            f"property_spec({explanation!r}): strict=True needs a non-empty allowed_values or a validation_function."
+            f"property_spec({explanation!r}): strict=True needs a non-empty allowed_values or an element_validator."
         )
 
     if not strict and allowed_values is not None:
         raise ValueError(f"property_spec({explanation!r}): allowed_values is never enforced without strict=True.")
 
-    if strict and default is not None:
-        if validation_function is not None:
-            try:
-                verdict = validation_function(default)
-            except Exception as exc:
-                raise ValueError(
-                    f"property_spec({explanation!r}): validation_function raised an error when called with default {default!r}."
-                ) from exc
-            if not verdict:
-                raise ValueError(
-                    f"property_spec({explanation!r}): default {default!r} is rejected by the validation_function."
-                )
-        elif allowed_values is not None:
-            accepted = set(allowed_values.keys()) if isinstance(allowed_values, Mapping) else set(allowed_values)
-            if default not in accepted:
-                raise ValueError(
-                    f"property_spec({explanation!r}): default {default!r} is not in the accepted set {accepted}."
-                )
-
     spec: dict[str, Any] = {"explanation": explanation}
     if allowed_values is not None:
         spec[DefaultOptionKeys.allowed_values] = allowed_values
-    if validation_function is not None:
-        spec[DefaultOptionKeys.validation_function] = validation_function
+    if element_validator is not None:
+        spec[DefaultOptionKeys.element_validator] = element_validator
     if required_when is not None:
         spec[DefaultOptionKeys.required_when] = required_when
-    if type_validator is not None:
-        spec[DefaultOptionKeys.type_validator] = type_validator
+    if match_guard is not None:
+        spec[DefaultOptionKeys.match_guard] = match_guard
     spec[DefaultOptionKeys.context] = context
     spec[DefaultOptionKeys.strict_validation] = strict
     if default is not None:
         spec[DefaultOptionKeys.default] = default
+
+    # The declared-default semantics live in core, so the builder and the
+    # class-definition check cannot drift apart.
+    FeatureChainParser.check_declared_default(f"property_spec({explanation!r})", explanation, spec)
+
     return spec

--- a/mloda/core/abstract_plugins/components/options.py
+++ b/mloda/core/abstract_plugins/components/options.py
@@ -253,7 +253,7 @@ class Options:
             else:
                 raise TypeError(f"Cannot convert {type(item)} to Feature. Expected Feature object or str.")
 
-        if isinstance(val, (list, set, frozenset)):
+        if isinstance(val, (list, tuple, set, frozenset)):
             return frozenset(_convert_to_feature(item) for item in val)
         elif isinstance(val, str):
             # Handle comma-separated strings
@@ -266,7 +266,8 @@ class Options:
             return frozenset([_convert_to_feature(val)])
         else:
             raise TypeError(
-                f"Unsupported type for source feature: {type(val)}. Expected frozenset, str, list, set, or Feature object."
+                f"Unsupported type for source feature: {type(val)}. "
+                "Expected list, tuple, set, frozenset, str, or Feature object."
             )
 
     def __deepcopy__(self, memo: dict[int, Any]) -> "Options":

--- a/mloda_plugins/feature_group/experimental/clustering/base.py
+++ b/mloda_plugins/feature_group/experimental/clustering/base.py
@@ -121,7 +121,7 @@ class ClusteringFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             "explanation": "Number of clusters or 'auto' for automatic determination",
             DefaultOptionKeys.context: True,  # Mark as context parameter
             DefaultOptionKeys.strict_validation: True,  # Enable strict validation
-            DefaultOptionKeys.validation_function: lambda value: (
+            DefaultOptionKeys.element_validator: lambda value: (
                 value == "auto" or (isinstance(value, (int, str)) and str(value).isdigit() and int(value) > 0)
             ),
         },
@@ -135,7 +135,7 @@ class ClusteringFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             DefaultOptionKeys.context: True,  # Mark as context parameter
             DefaultOptionKeys.strict_validation: False,  # Flexible validation
             DefaultOptionKeys.default: False,  # Default is False (don't output probabilities)
-            DefaultOptionKeys.validation_function: lambda value: isinstance(value, bool),
+            DefaultOptionKeys.element_validator: lambda value: isinstance(value, bool),
         },
     }
 

--- a/mloda_plugins/feature_group/experimental/dimensionality_reduction/base.py
+++ b/mloda_plugins/feature_group/experimental/dimensionality_reduction/base.py
@@ -130,7 +130,7 @@ class DimensionalityReductionFeatureGroup(FeatureChainParserMixin, FeatureGroup)
             "explanation": "Target dimension for the reduction (positive integer)",
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.validation_function: lambda value: (
+            DefaultOptionKeys.element_validator: lambda value: (
                 isinstance(value, (int, str)) and str(value).isdigit() and int(value) > 0
             ),
         },
@@ -145,7 +145,7 @@ class DimensionalityReductionFeatureGroup(FeatureChainParserMixin, FeatureGroup)
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: False,
             DefaultOptionKeys.default: 250,
-            DefaultOptionKeys.validation_function: lambda value: (
+            DefaultOptionKeys.element_validator: lambda value: (
                 isinstance(value, (int, str)) and str(value).isdigit() and int(value) > 0
             ),
         },
@@ -154,7 +154,7 @@ class DimensionalityReductionFeatureGroup(FeatureChainParserMixin, FeatureGroup)
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: False,
             DefaultOptionKeys.default: 50,
-            DefaultOptionKeys.validation_function: lambda value: (
+            DefaultOptionKeys.element_validator: lambda value: (
                 isinstance(value, (int, str)) and str(value).isdigit() and int(value) > 0
             ),
         },
@@ -183,7 +183,7 @@ class DimensionalityReductionFeatureGroup(FeatureChainParserMixin, FeatureGroup)
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: False,
             DefaultOptionKeys.default: 200,
-            DefaultOptionKeys.validation_function: lambda value: (
+            DefaultOptionKeys.element_validator: lambda value: (
                 isinstance(value, (int, str)) and str(value).isdigit() and int(value) > 0
             ),
         },
@@ -193,7 +193,7 @@ class DimensionalityReductionFeatureGroup(FeatureChainParserMixin, FeatureGroup)
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: False,
             DefaultOptionKeys.default: 5,
-            DefaultOptionKeys.validation_function: lambda value: (
+            DefaultOptionKeys.element_validator: lambda value: (
                 isinstance(value, (int, str)) and str(value).isdigit() and int(value) > 0
             ),
         },

--- a/mloda_plugins/feature_group/experimental/forecasting/base.py
+++ b/mloda_plugins/feature_group/experimental/forecasting/base.py
@@ -134,7 +134,7 @@ class ForecastingFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featu
             "explanation": "Forecast horizon (number of time units to predict)",
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.validation_function: lambda x: (
+            DefaultOptionKeys.element_validator: lambda x: (
                 (isinstance(x, int) or (isinstance(x, str) and x.isdigit())) and int(x) > 0
             ),
         },
@@ -153,7 +153,7 @@ class ForecastingFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featu
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: False,
             DefaultOptionKeys.default: False,  # Default is False (don't output confidence intervals)
-            DefaultOptionKeys.validation_function: lambda value: isinstance(value, bool),
+            DefaultOptionKeys.element_validator: lambda value: isinstance(value, bool),
         },
     }
 

--- a/mloda_plugins/feature_group/experimental/geo_distance/base.py
+++ b/mloda_plugins/feature_group/experimental/geo_distance/base.py
@@ -112,13 +112,9 @@ class GeoDistanceFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             "explanation": "Source features (exactly 2 point features required)",
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.validation_function: lambda x: (
-                # Accept individual strings (when parser iterates over list elements)
-                isinstance(x, str)
-                or
-                # Accept collections with exactly 2 elements (when validating the whole list)
-                (isinstance(x, (list, tuple, frozenset, set)) and len(x) == 2)
-            ),
+            # Core unpacks the sequence, so this judges ONE point feature name.
+            # The arity (exactly 2) is enforced by MIN_IN_FEATURES / MAX_IN_FEATURES.
+            DefaultOptionKeys.element_validator: lambda point: isinstance(point, str),
         },
     }
 

--- a/mloda_plugins/feature_group/experimental/text_cleaning/base.py
+++ b/mloda_plugins/feature_group/experimental/text_cleaning/base.py
@@ -96,23 +96,8 @@ class TextCleaningFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             **SUPPORTED_OPERATIONS,  # All supported operations as valid options
             DefaultOptionKeys.context: True,  # Mark as context parameter
             DefaultOptionKeys.strict_validation: True,  # Enable strict validation
-            DefaultOptionKeys.validation_function: lambda operations: (
-                # Handle both actual tuples/lists and string representations
-                (
-                    isinstance(operations, (tuple, list))
-                    and all(op in TextCleaningFeatureGroup.SUPPORTED_OPERATIONS for op in operations)
-                )
-                or (
-                    isinstance(operations, str)
-                    and operations.startswith("(")
-                    and operations.endswith(")")
-                    and all(
-                        op.strip("'\" ,") in TextCleaningFeatureGroup.SUPPORTED_OPERATIONS
-                        for op in operations.strip("()").split(",")
-                        if op.strip("'\" ,")
-                    )
-                )
-            ),
+            # The option is a sequence of operations; core unpacks it, so this judges ONE operation.
+            DefaultOptionKeys.element_validator: lambda op: op in TextCleaningFeatureGroup.SUPPORTED_OPERATIONS,
         },
         DefaultOptionKeys.in_features: {
             "explanation": "Source feature to apply text cleaning operations to",

--- a/mloda_plugins/feature_group/experimental/time_window/base.py
+++ b/mloda_plugins/feature_group/experimental/time_window/base.py
@@ -104,7 +104,7 @@ class TimeWindowFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featur
             "explanation": "Size of the time window (must be positive integer)",
             DefaultOptionKeys.context: True,  # Mark as context parameter
             DefaultOptionKeys.strict_validation: True,  # Enable strict validation
-            DefaultOptionKeys.validation_function: lambda x: (
+            DefaultOptionKeys.element_validator: lambda x: (
                 (isinstance(x, int) and x > 0) or (isinstance(x, str) and x.isdigit() and int(x) > 0)
             ),
         },

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_allowed_values.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_allowed_values.py
@@ -69,9 +69,9 @@ class TestReservedPropertyKeys:
             DefaultOptionKeys.context,
             DefaultOptionKeys.group,
             DefaultOptionKeys.strict_validation,
-            DefaultOptionKeys.validation_function,
+            DefaultOptionKeys.element_validator,
             DefaultOptionKeys.required_when,
-            DefaultOptionKeys.type_validator,
+            DefaultOptionKeys.match_guard,
             DefaultOptionKeys.allowed_values,
         ):
             assert member in RESERVED_PROPERTY_KEYS

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_sequence_unpacking.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_sequence_unpacking.py
@@ -1,0 +1,288 @@
+"""Uniform sequence unpacking for PROPERTY_MAPPING validation (issue #600).
+
+The SPEC declares the arity, not the caller's Python syntax. What a validator receives
+must not depend on whether the user typed a list, a tuple, a set or a frozenset.
+
+* ``element_validator`` and the membership check see ELEMENTS. Every sequence container
+  (list, tuple, set, frozenset) unpacks element-wise and identically.
+* Elements arrive as their real values with their real types. The old
+  ``str(tuple)`` hop (a hashability workaround, for values that were already hashable)
+  is gone: an int element arrives as ``1``, never as ``"1"`` or ``"(1, 2)"``.
+* A scalar is exactly one element. A ``str`` is a SCALAR, not a sequence of characters.
+* A ``dict`` is a COMPOSITE value, not a sequence to iterate over its keys.
+* ``match_guard`` is unaffected: it still receives the raw, whole, un-unpacked value with
+  its original container type. It is the escape hatch for genuinely composite values
+  (shape, length, ordering, cross-element constraints).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.provider import DefaultOptionKeys
+
+
+class _Recorder:
+    """Callable that records every value it was handed and always accepts."""
+
+    def __init__(self, verdict: bool = True) -> None:
+        self.calls: list[Any] = []
+        self._verdict = verdict
+
+    def __call__(self, value: Any) -> bool:
+        self.calls.append(value)
+        return self._verdict
+
+
+def _strict_element_validator_group(validator: Any) -> type[FeatureChainParserMixin]:
+    """A feature group whose single key is strictly validated element-wise."""
+
+    class ElementFeatureGroup(FeatureChainParserMixin):
+        PROPERTY_MAPPING = {
+            "ops": {
+                "explanation": "Operations to apply",
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: True,
+                DefaultOptionKeys.element_validator: validator,
+            }
+        }
+
+    return ElementFeatureGroup
+
+
+def _strict_membership_group() -> type[FeatureChainParserMixin]:
+    """A feature group whose single key is strictly validated against an accepted set."""
+
+    class MembershipFeatureGroup(FeatureChainParserMixin):
+        PROPERTY_MAPPING = {
+            "ops": {
+                "explanation": "Operations to apply",
+                DefaultOptionKeys.allowed_values: {"a": "A", "b": "B"},
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: True,
+            }
+        }
+
+    return MembershipFeatureGroup
+
+
+def _match_guard_group(guard: Any) -> type[FeatureChainParserMixin]:
+    """A feature group whose single key is guarded on its raw, whole value."""
+
+    class GuardedFeatureGroup(FeatureChainParserMixin):
+        PROPERTY_MAPPING = {
+            "ops": {
+                "explanation": "Operations to apply",
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: False,
+                DefaultOptionKeys.match_guard: guard,
+            }
+        }
+
+    return GuardedFeatureGroup
+
+
+CONTAINERS: list[tuple[str, Any]] = [
+    ("list", ["a", "b"]),
+    ("tuple", ("a", "b")),
+    ("set", {"a", "b"}),
+    ("frozenset", frozenset({"a", "b"})),
+]
+
+INT_CONTAINERS: list[tuple[str, Any]] = [
+    ("list", [1, 2]),
+    ("tuple", (1, 2)),
+    ("set", {1, 2}),
+    ("frozenset", frozenset({1, 2})),
+]
+
+EMPTY_CONTAINERS: list[tuple[str, Any]] = [
+    ("list", []),
+    ("tuple", ()),
+    ("set", set()),
+    ("frozenset", frozenset()),
+]
+
+
+class TestUniformSequenceUnpacking:
+    """Every sequence container unpacks element-wise and identically."""
+
+    @pytest.mark.parametrize(("label", "value"), CONTAINERS, ids=[label for label, _ in CONTAINERS])
+    def test_element_validator_sees_the_same_elements_for_every_container(self, label: str, value: Any) -> None:
+        """list, tuple, set and frozenset all yield exactly the elements "a" and "b"."""
+        validator = _Recorder()
+        group = _strict_element_validator_group(validator)
+
+        assert group.match_feature_group_criteria("any_feature", Options(context={"ops": value})) is True
+        assert set(validator.calls) == {"a", "b"}, f"{label} must unpack into its elements"
+        assert len(validator.calls) == 2
+
+    @pytest.mark.parametrize(("label", "value"), CONTAINERS, ids=[label for label, _ in CONTAINERS])
+    def test_membership_check_unpacks_every_container(self, label: str, value: Any) -> None:
+        """The membership check also runs per element, for every container type."""
+        group = _strict_membership_group()
+
+        assert group.match_feature_group_criteria("any_feature", Options(context={"ops": value})) is True
+
+    @pytest.mark.parametrize(
+        ("label", "value"),
+        [
+            ("list", ["a", "nope"]),
+            ("tuple", ("a", "nope")),
+            ("set", {"a", "nope"}),
+            ("frozenset", frozenset({"a", "nope"})),
+        ],
+        ids=["list", "tuple", "set", "frozenset"],
+    )
+    def test_membership_rejects_a_bad_element_in_every_container(self, label: str, value: Any) -> None:
+        """One element outside the accepted set rejects the whole option, whatever the container."""
+        group = _strict_membership_group()
+
+        assert group.match_feature_group_criteria("any_feature", Options(context={"ops": value})) is False
+
+    @pytest.mark.parametrize(("label", "value"), INT_CONTAINERS, ids=[label for label, _ in INT_CONTAINERS])
+    def test_elements_keep_their_real_type_no_stringification(self, label: str, value: Any) -> None:
+        """The ``str(tuple)`` workaround is gone: an int element arrives as ``1``, not ``"1"``.
+
+        This is the regression that would silently come back: a tuple used to reach the
+        validator as the single string ``"(1, 2)"``.
+        """
+        validator = _Recorder()
+        group = _strict_element_validator_group(validator)
+
+        assert group.match_feature_group_criteria("any_feature", Options(context={"ops": value})) is True
+        assert set(validator.calls) == {1, 2}
+        assert all(isinstance(call, int) for call in validator.calls), f"{label} elements must stay ints"
+        assert all(not isinstance(call, str) for call in validator.calls), "no stringification, ever"
+
+    def test_single_element_tuple_is_not_stringified(self) -> None:
+        """A one-element tuple yields that element, not ``"('a',)"``."""
+        validator = _Recorder()
+        group = _strict_element_validator_group(validator)
+
+        assert group.match_feature_group_criteria("any_feature", Options(context={"ops": ("a",)})) is True
+        assert validator.calls == ["a"]
+
+
+class TestScalarsAreSingleElements:
+    """A scalar value is exactly one element, and a string is a scalar."""
+
+    def test_string_does_not_unpack_into_characters(self) -> None:
+        """``"abc"`` validates as the single element ``"abc"``, never as 'a', 'b', 'c'."""
+        validator = _Recorder()
+        group = _strict_element_validator_group(validator)
+
+        assert group.match_feature_group_criteria("any_feature", Options(context={"ops": "abc"})) is True
+        assert validator.calls == ["abc"]
+
+    def test_scalar_int_is_one_element(self) -> None:
+        """A bare int is one element and keeps its type."""
+        validator = _Recorder()
+        group = _strict_element_validator_group(validator)
+
+        assert group.match_feature_group_criteria("any_feature", Options(context={"ops": 7})) is True
+        assert validator.calls == [7]
+
+    def test_string_membership_matches_the_whole_string(self) -> None:
+        """A scalar string is checked against the accepted set as a whole."""
+        group = _strict_membership_group()
+
+        assert group.match_feature_group_criteria("any_feature", Options(context={"ops": "a"})) is True
+        assert group.match_feature_group_criteria("any_feature", Options(context={"ops": "ab"})) is False
+
+
+class TestEmptySequences:
+    """A present-but-empty sequence still satisfies the required-presence check."""
+
+    @pytest.mark.parametrize(("label", "value"), EMPTY_CONTAINERS, ids=[label for label, _ in EMPTY_CONTAINERS])
+    def test_empty_container_is_present_and_vacuously_valid(self, label: str, value: Any) -> None:
+        """An empty container has no elements: the validator never runs, and the key counts as present."""
+        validator = _Recorder(verdict=False)
+        group = _strict_element_validator_group(validator)
+
+        assert group.match_feature_group_criteria("any_feature", Options(context={"ops": value})) is True
+        assert validator.calls == [], f"an empty {label} has no elements to validate"
+
+    @pytest.mark.parametrize(("label", "value"), EMPTY_CONTAINERS, ids=[label for label, _ in EMPTY_CONTAINERS])
+    def test_empty_container_passes_membership_vacuously(self, label: str, value: Any) -> None:
+        """No element means nothing to reject, so a strict membership key still matches."""
+        group = _strict_membership_group()
+
+        assert group.match_feature_group_criteria("any_feature", Options(context={"ops": value})) is True
+
+
+class TestDictIsACompositeValue:
+    """A dict option is ONE composite value, not a sequence unpacked over its keys.
+
+    Unpacking a dict over its keys would silently drop the values, and a dict has no
+    element-wise meaning: shape checks on a mapping are exactly what ``match_guard``
+    exists for. So the element_validator sees the dict itself, and nothing raises.
+    """
+
+    def test_element_validator_receives_the_whole_dict(self) -> None:
+        """The dict arrives as one element, with its keys and values intact."""
+        validator = _Recorder()
+        group = _strict_element_validator_group(validator)
+        value = {"a": 1, "b": 2}
+
+        assert group.match_feature_group_criteria("any_feature", Options(context={"ops": value})) is True
+        assert validator.calls == [value]
+        assert validator.calls[0] is value, "the dict must not be copied, unpacked or stringified"
+
+    def test_dict_is_a_non_match_under_a_membership_key_without_raising(self) -> None:
+        """A dict cannot be a member of an accepted set, so it is a clean non-match, not a crash."""
+        group = _strict_membership_group()
+
+        assert group.match_feature_group_criteria("any_feature", Options(context={"ops": {"a": 1}})) is False
+
+
+class TestMatchGuardSeesTheRawValue:
+    """``match_guard`` is unaffected by unpacking: raw, whole value, original container type."""
+
+    @pytest.mark.parametrize(
+        ("label", "value"),
+        [
+            ("list", ["a", "b"]),
+            ("tuple", ("a", "b")),
+            ("set", {"a", "b"}),
+            ("frozenset", frozenset({"a", "b"})),
+            ("dict", {"a": 1}),
+            ("str", "abc"),
+        ],
+        ids=["list", "tuple", "set", "frozenset", "dict", "str"],
+    )
+    def test_guard_receives_the_original_container(self, label: str, value: Any) -> None:
+        """The guard sees the very object the user passed, with its type preserved."""
+        guard = _Recorder()
+        group = _match_guard_group(guard)
+
+        assert group.match_feature_group_criteria("any_feature", Options(context={"ops": value})) is True
+        assert guard.calls == [value]
+        assert type(guard.calls[0]) is type(value), f"{label} must reach the match_guard un-unpacked"
+
+    def test_guard_can_still_reject_on_shape_while_elements_pass(self) -> None:
+        """The two live side by side: the validator judges elements, the guard judges the whole."""
+        validator = _Recorder()
+        guard = _Recorder(verdict=False)
+
+        class BothFeatureGroup(FeatureChainParserMixin):
+            PROPERTY_MAPPING = {
+                "ops": {
+                    "explanation": "Operations to apply",
+                    DefaultOptionKeys.context: True,
+                    DefaultOptionKeys.strict_validation: True,
+                    DefaultOptionKeys.element_validator: validator,
+                    DefaultOptionKeys.match_guard: guard,
+                }
+            }
+
+        value = ("a", "b")
+
+        assert BothFeatureGroup.match_feature_group_criteria("any_feature", Options(context={"ops": value})) is False
+        assert set(validator.calls) == {"a", "b"}, "the element_validator sees elements"
+        assert guard.calls == [value], "the match_guard sees the raw tuple"
+        assert type(guard.calls[0]) is tuple

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_type_constraints.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_type_constraints.py
@@ -56,13 +56,13 @@ class MockWithTypeConstraint(FeatureChainParserMixin):
             "explanation": "List of columns to partition by",
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.type_validator: _is_list_of_strings,
+            DefaultOptionKeys.match_guard: _is_list_of_strings,
         },
     }
 
 
-class MockStrictWithTypeValidator(FeatureChainParserMixin):
-    """Feature group combining strict_validation=True with type_validator on the same entry."""
+class MockStrictWithMatchGuard(FeatureChainParserMixin):
+    """Feature group combining strict_validation=True with match_guard on the same entry."""
 
     PREFIX_PATTERN = r".*__([\w]+)_strict$"
 
@@ -72,17 +72,17 @@ class MockStrictWithTypeValidator(FeatureChainParserMixin):
             "slow": "Slow mode",
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.type_validator: lambda v: isinstance(v, str),
+            DefaultOptionKeys.match_guard: lambda v: isinstance(v, str),
         },
     }
 
 
-class MockStrictWithOrthogonalTypeValidator(FeatureChainParserMixin):
-    """Feature group where type_validator rejects values that pass strict membership.
+class MockStrictWithOrthogonalMatchGuard(FeatureChainParserMixin):
+    """Feature group where match_guard rejects values that pass strict membership.
 
-    The mapping allows "fast" and "slow", but the type_validator requires
+    The mapping allows "fast" and "slow", but the match_guard requires
     strings of at most 3 characters. "fast" (4 chars) and "slow" (4 chars) both
-    pass strict membership but fail the type_validator length check.
+    pass strict membership but fail the match_guard length check.
     """
 
     PREFIX_PATTERN = r".*__([\w]+)_ortho$"
@@ -94,13 +94,13 @@ class MockStrictWithOrthogonalTypeValidator(FeatureChainParserMixin):
             "ok": "OK mode",
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.type_validator: _max_length_3,
+            DefaultOptionKeys.match_guard: _max_length_3,
         },
     }
 
 
 class MockWithRaisingValidator(FeatureChainParserMixin):
-    """Feature group whose type_validator raises on invalid input."""
+    """Feature group whose match_guard raises on invalid input."""
 
     PREFIX_PATTERN = r".*__([\w]+)_raise$"
 
@@ -109,7 +109,7 @@ class MockWithRaisingValidator(FeatureChainParserMixin):
             "explanation": "A list of items",
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.type_validator: _raising_validator,
+            DefaultOptionKeys.match_guard: _raising_validator,
         },
     }
 
@@ -128,17 +128,17 @@ class MockWithoutTypeConstraint(FeatureChainParserMixin):
     }
 
 
-class TestTypeConstraintValidation:
-    """Tests for type_validator in PROPERTY_MAPPING."""
+class TestMatchGuardValidation:
+    """Tests for match_guard in PROPERTY_MAPPING."""
 
     def test_rejects_invalid_type(self) -> None:
-        """match_feature_group_criteria returns False when type_validator fails."""
+        """match_feature_group_criteria returns False when match_guard fails."""
         options = Options(context={"operation": "sum", "partition_by": "not_a_list"})
         result = MockWithTypeConstraint.match_feature_group_criteria("my_feature", options)
         assert result is False
 
     def test_accepts_valid_type(self) -> None:
-        """match_feature_group_criteria returns True when type_validator passes."""
+        """match_feature_group_criteria returns True when match_guard passes."""
         options = Options(context={"operation": "sum", "partition_by": ["region", "category"]})
         result = MockWithTypeConstraint.match_feature_group_criteria("my_feature", options)
         assert result is True
@@ -156,7 +156,7 @@ class TestTypeConstraintValidation:
         assert result is True
 
     def test_no_type_constraint_unaffected(self) -> None:
-        """Entries without type_validator are unaffected."""
+        """Entries without match_guard are unaffected."""
         options = Options(context={"operation": "sum"})
         result = MockWithoutTypeConstraint.match_feature_group_criteria("my_feature", options)
         assert result is True
@@ -174,47 +174,47 @@ class TestTypeConstraintValidation:
         assert result is True
 
     def test_string_match_rejects_invalid_type(self) -> None:
-        """String-based match also rejects when type_validator fails."""
+        """String-based match also rejects when match_guard fails."""
         options = Options(context={"operation": "sum", "partition_by": "not_a_list"})
         result = MockWithTypeConstraint.match_feature_group_criteria("source__sum_typed", options)
         assert result is False
 
-    def test_strict_validation_with_type_validator_accepts_valid(self) -> None:
-        """Both strict membership and type_validator pass for a valid mapping value."""
+    def test_strict_validation_with_match_guard_accepts_valid(self) -> None:
+        """Both strict membership and match_guard pass for a valid mapping value."""
         options = Options(context={"mode": "fast"})
-        result = MockStrictWithTypeValidator.match_feature_group_criteria("my_feature", options)
+        result = MockStrictWithMatchGuard.match_feature_group_criteria("my_feature", options)
         assert result is True
 
-    def test_strict_validation_with_type_validator_rejects_non_string(self) -> None:
-        """strict_validation rejects a non-string before type_validator runs."""
+    def test_strict_validation_with_match_guard_rejects_non_string(self) -> None:
+        """strict_validation rejects a non-string before match_guard runs."""
         options = Options(context={"mode": 123})
-        result = MockStrictWithTypeValidator.match_feature_group_criteria("my_feature", options)
+        result = MockStrictWithMatchGuard.match_feature_group_criteria("my_feature", options)
         assert result is False
 
-    def test_strict_validation_with_type_validator_rejects_unknown_value(self) -> None:
-        """strict_validation rejects a value not in the mapping, even if type_validator passes."""
+    def test_strict_validation_with_match_guard_rejects_unknown_value(self) -> None:
+        """strict_validation rejects a value not in the mapping, even if match_guard passes."""
         options = Options(context={"mode": "turbo"})
-        result = MockStrictWithTypeValidator.match_feature_group_criteria("my_feature", options)
+        result = MockStrictWithMatchGuard.match_feature_group_criteria("my_feature", options)
         assert result is False
 
-    def test_type_validator_rejects_value_that_passes_strict_membership(self) -> None:
-        """type_validator can reject a value that passes strict membership.
+    def test_match_guard_rejects_value_that_passes_strict_membership(self) -> None:
+        """match_guard can reject a value that passes strict membership.
 
         "fast" is in the mapping (passes membership) but has 4 characters
-        (fails the max-length-3 type_validator). This proves type_validator
+        (fails the max-length-3 match_guard). This proves match_guard
         runs independently of strict validation.
         """
         options = Options(context={"mode": "fast"})
-        result = MockStrictWithOrthogonalTypeValidator.match_feature_group_criteria("my_feature", options)
+        result = MockStrictWithOrthogonalMatchGuard.match_feature_group_criteria("my_feature", options)
         assert result is False
 
-    def test_type_validator_accepts_value_that_passes_both(self) -> None:
-        """A value that passes both strict membership and type_validator is accepted.
+    def test_match_guard_accepts_value_that_passes_both(self) -> None:
+        """A value that passes both strict membership and match_guard is accepted.
 
         "ok" is in the mapping (2 chars <= 3), so both checks pass.
         """
         options = Options(context={"mode": "ok"})
-        result = MockStrictWithOrthogonalTypeValidator.match_feature_group_criteria("my_feature", options)
+        result = MockStrictWithOrthogonalMatchGuard.match_feature_group_criteria("my_feature", options)
         assert result is True
 
     def test_raising_validator_treated_as_non_match(self) -> None:
@@ -230,7 +230,7 @@ class TestTypeConstraintValidation:
         assert result is True
 
 
-class TypeValidatorTestDataCreator(ATestDataCreator):
+class MatchGuardTestDataCreator(ATestDataCreator):
     compute_framework = PandasDataFrame
 
     @classmethod
@@ -241,8 +241,8 @@ class TypeValidatorTestDataCreator(ATestDataCreator):
         }
 
 
-class TypeValidatedAggregation(FeatureChainParserMixin, FeatureGroup):
-    """Feature group that uses type_validator to enforce partition_by is list[str]."""
+class MatchGuardedAggregation(FeatureChainParserMixin, FeatureGroup):
+    """Feature group that uses match_guard to enforce partition_by is list[str]."""
 
     PREFIX_PATTERN = r".*__([\w]+)_tvaggr$"
     AGGREGATION_TYPE = "aggregation_type"
@@ -260,7 +260,7 @@ class TypeValidatedAggregation(FeatureChainParserMixin, FeatureGroup):
             "explanation": "List of columns to partition by",
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.type_validator: _is_list_of_strings,
+            DefaultOptionKeys.match_guard: _is_list_of_strings,
         },
     }
 
@@ -284,13 +284,11 @@ class TypeValidatedAggregation(FeatureChainParserMixin, FeatureGroup):
 
 
 class TestTypeConstraintIntegrationRunAll:
-    """End-to-end test: type_validator works through mloda.run_all()."""
+    """End-to-end test: match_guard works through mloda.run_all()."""
 
     def test_valid_type_runs_successfully(self) -> None:
         """Feature with valid partition_by type runs through the full pipeline."""
-        plugin_collector = PluginCollector.enabled_feature_groups(
-            {TypeValidatorTestDataCreator, TypeValidatedAggregation}
-        )
+        plugin_collector = PluginCollector.enabled_feature_groups({MatchGuardTestDataCreator, MatchGuardedAggregation})
 
         feature = Feature(
             "sales_sum",
@@ -314,9 +312,7 @@ class TestTypeConstraintIntegrationRunAll:
 
     def test_invalid_type_raises_value_error(self) -> None:
         """Feature with invalid partition_by type is rejected and raises ValueError."""
-        plugin_collector = PluginCollector.enabled_feature_groups(
-            {TypeValidatorTestDataCreator, TypeValidatedAggregation}
-        )
+        plugin_collector = PluginCollector.enabled_feature_groups({MatchGuardTestDataCreator, MatchGuardedAggregation})
 
         feature = Feature(
             "sales_sum",

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_unified_model.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_unified_model.py
@@ -1,0 +1,723 @@
+"""One coherent mental model for the PROPERTY_MAPPING validation layer (issue #600).
+
+Two decisions are pinned here.
+
+1. Hard rename, no back-compat. The two callable-valued PROPERTY_MAPPING keys get
+   names that state what they do:
+
+   * ``element_validator`` (was ``validation_function``): runs on EACH parsed element
+     after list unpacking, requires ``strict_validation=True``, and on a falsy return
+     RAISES ``ValueError`` (recovered by the mixin as a non-match, surfaced to the user
+     via ``_strict_validation_rejection_reason``).
+   * ``match_guard`` (was ``type_validator``): runs on the RAW option value with no list
+     unpacking, does NOT require ``strict_validation``, and on a falsy return simply
+     means "this feature group does not match" (debug log, ``False``, no error).
+
+   The old names are GONE: no enum members, no aliases. A spec dict still carrying the
+   stale string key must FAIL LOUDLY at class-definition time rather than be silently
+   ignored: once the stale keys leave ``RESERVED_PROPERTY_KEYS``, a legacy flattened
+   spec would otherwise absorb the stale CALLABLE into its accepted VALUE set, silently
+   widening what the feature group matches.
+
+2. Shared default-check semantics. ``property_spec`` and
+   ``FeatureChainParser.validate_property_mapping_defaults`` encoded the same rules for a
+   declared default twice. There is now ONE implementation,
+   ``FeatureChainParser.check_declared_default(owner, key, spec)``, that both entry points
+   route through, so the "validator RAISED" vs "validator REJECTED" distinction cannot
+   drift between them.
+"""
+
+from __future__ import annotations
+
+import gc
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from mloda.core.abstract_plugins.components.default_options_key import (
+    RESERVED_PROPERTY_KEYS,
+    DefaultOptionKeys,
+)
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
+from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.components.utils import get_all_subclasses
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.provider import property_spec
+
+STALE_ELEMENT_VALIDATOR_KEY = "validation_function"
+STALE_MATCH_GUARD_KEY = "type_validator"
+
+
+@pytest.fixture(autouse=True)
+def _no_feature_group_registry_pollution() -> Any:
+    """Guarantee this module never leaks throwaway FeatureGroup subclasses.
+
+    Mirrors ``test_property_mapping_default_invariant.py``: the class-definition tests
+    below define FeatureGroup subclasses, which linger in ``FeatureGroup.__subclasses__()``
+    until a GC cycle runs and would otherwise be seen by tests that enumerate feature groups.
+    """
+    yield
+    gc.collect()
+    gc.collect()
+    leaked = [c for c in get_all_subclasses(FeatureGroup) if c.__module__ == __name__]
+    assert not leaked, f"Leaked FeatureGroup subclasses from {__name__}: {[c.__name__ for c in leaked]}"
+
+
+class _Recorder:
+    """Callable validator/guard that records exactly what it was called with."""
+
+    def __init__(self, verdict: bool = True) -> None:
+        self.calls: list[Any] = []
+        self._verdict = verdict
+
+    def __call__(self, value: Any) -> bool:
+        self.calls.append(value)
+        return self._verdict
+
+
+class _PositiveIntRecorder:
+    """Element validator: accepts positive ints, records every element it saw."""
+
+    def __init__(self) -> None:
+        self.calls: list[Any] = []
+
+    def __call__(self, value: Any) -> bool:
+        self.calls.append(value)
+        return isinstance(value, int) and value > 0
+
+
+class _ListOfStringsRecorder:
+    """Match guard: accepts a list of strings, records every raw value it saw."""
+
+    def __init__(self) -> None:
+        self.calls: list[Any] = []
+
+    def __call__(self, value: Any) -> bool:
+        self.calls.append(value)
+        return isinstance(value, list) and all(isinstance(item, str) for item in value)
+
+
+class _RaisingRecorder:
+    """Validator/guard that raises instead of returning a verdict."""
+
+    def __init__(self) -> None:
+        self.calls: list[Any] = []
+
+    def __call__(self, value: Any) -> bool:
+        self.calls.append(value)
+        raise TypeError(f"boom for {value!r}")
+
+
+def _positive_int(value: Any) -> bool:
+    return isinstance(value, int) and value > 0
+
+
+def _boom(value: Any) -> bool:
+    raise RuntimeError("boom")
+
+
+class TestRenamedKeys:
+    """The two keys carry their new names, and the old names are gone (no aliases)."""
+
+    def test_element_validator_member_exists(self) -> None:
+        """``DefaultOptionKeys.element_validator`` exists with value ``"element_validator"``."""
+        assert DefaultOptionKeys.element_validator.value == "element_validator"
+        assert DefaultOptionKeys("element_validator") is DefaultOptionKeys.element_validator
+
+    def test_match_guard_member_exists(self) -> None:
+        """``DefaultOptionKeys.match_guard`` exists with value ``"match_guard"``."""
+        assert DefaultOptionKeys.match_guard.value == "match_guard"
+        assert DefaultOptionKeys("match_guard") is DefaultOptionKeys.match_guard
+
+    def test_old_members_are_gone(self) -> None:
+        """The old enum members no longer exist: attribute access raises ``AttributeError``."""
+        with pytest.raises(AttributeError):
+            getattr(DefaultOptionKeys, STALE_ELEMENT_VALIDATOR_KEY)
+        with pytest.raises(AttributeError):
+            getattr(DefaultOptionKeys, STALE_MATCH_GUARD_KEY)
+
+    def test_old_values_are_not_members(self) -> None:
+        """The old string values do not resolve to any member (no value alias)."""
+        with pytest.raises(ValueError):
+            DefaultOptionKeys(STALE_ELEMENT_VALIDATOR_KEY)
+        with pytest.raises(ValueError):
+            DefaultOptionKeys(STALE_MATCH_GUARD_KEY)
+
+    def test_reserved_property_keys_carry_the_new_members(self) -> None:
+        """``RESERVED_PROPERTY_KEYS`` reserves the new keys, so they never leak into a value space."""
+        assert DefaultOptionKeys.element_validator in RESERVED_PROPERTY_KEYS
+        assert DefaultOptionKeys.match_guard in RESERVED_PROPERTY_KEYS
+
+    def test_reserved_property_keys_drop_the_old_strings(self) -> None:
+        """The stale string keys are no longer reserved metadata."""
+        assert STALE_ELEMENT_VALIDATOR_KEY not in RESERVED_PROPERTY_KEYS
+        assert STALE_MATCH_GUARD_KEY not in RESERVED_PROPERTY_KEYS
+
+
+class TestRenamedInternalHelpers:
+    """The internal helpers follow the rename, so the vocabulary is consistent end to end."""
+
+    def test_parser_exposes_get_element_validator(self) -> None:
+        """``FeatureChainParser._get_element_validator`` replaces ``_get_validation_function``."""
+        assert not hasattr(FeatureChainParser, "_get_validation_function")
+
+        validator = _positive_int
+        spec = {DefaultOptionKeys.element_validator: validator}
+        assert FeatureChainParser._get_element_validator(spec) is validator
+        assert FeatureChainParser._get_element_validator({}) is None
+
+    def test_mixin_exposes_validate_match_guards(self) -> None:
+        """``FeatureChainParserMixin._validate_match_guards`` replaces ``_validate_type_validators``."""
+        assert not hasattr(FeatureChainParserMixin, "_validate_type_validators")
+        assert hasattr(FeatureChainParserMixin, "_validate_match_guards")
+
+
+class TestStaleKeysFailLoudly:
+    """A spec dict still carrying a stale key is rejected at class definition, never honored.
+
+    This is NOT backwards compatibility. Silently ignoring the stale key would be worse
+    than the old behavior: with the key no longer reserved, ``_extract_property_values``
+    would absorb the stale CALLABLE into the accepted VALUE set of a legacy flattened
+    spec, silently widening what the feature group matches. The guard converts that
+    silent corruption into an actionable migration error.
+    """
+
+    def test_stale_validation_function_key_rejected_at_class_definition(self) -> None:
+        """A PROPERTY_MAPPING carrying ``"validation_function"`` raises, naming ``element_validator``."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class StaleValidationFunctionFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {
+                    "operation_type": {
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: True,
+                        STALE_ELEMENT_VALIDATOR_KEY: _positive_int,
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "StaleValidationFunctionFeatureGroup" in message
+        assert "operation_type" in message
+        assert STALE_ELEMENT_VALIDATOR_KEY in message
+        assert "element_validator" in message
+
+    def test_stale_type_validator_key_rejected_at_class_definition(self) -> None:
+        """A PROPERTY_MAPPING carrying ``"type_validator"`` raises, naming ``match_guard``."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class StaleTypeValidatorFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {
+                    "partition_by": {
+                        "explanation": "List of columns to partition by",
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: False,
+                        STALE_MATCH_GUARD_KEY: _positive_int,
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "StaleTypeValidatorFeatureGroup" in message
+        assert "partition_by" in message
+        assert STALE_MATCH_GUARD_KEY in message
+        assert "match_guard" in message
+
+    def test_legacy_flattened_stale_spec_rejected_at_class_definition(self) -> None:
+        """The legacy flattened form (values inline, no ``allowed_values``) is guarded too."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class LegacyFlattenedStaleFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {
+                    "operation_type": {
+                        "add": "Addition",
+                        "sub": "Subtraction",
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: True,
+                        STALE_ELEMENT_VALIDATOR_KEY: _positive_int,
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "element_validator" in message
+
+    def test_parser_entry_point_rejects_stale_spec(self) -> None:
+        """The guard lives in core, so validating a stale mapping directly also raises."""
+        mapping: dict[str, Any] = {
+            "operation_type": {
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: True,
+                STALE_ELEMENT_VALIDATOR_KEY: _positive_int,
+            }
+        }
+
+        with pytest.raises(ValueError, match="element_validator"):
+            FeatureChainParser.validate_property_mapping_defaults("SomeOwner", mapping)
+
+    def test_stale_callable_is_never_absorbed_into_the_accepted_value_set(self) -> None:
+        """The regression this guard exists to prevent: the stale callable as an allowed VALUE.
+
+        With ``"validation_function"`` no longer reserved, a legacy flattened spec would
+        expose the callable itself as a member of the accepted set, so an option whose
+        value IS that callable would match. Matching such a spec must never succeed.
+        """
+        validator = _positive_int
+        mapping: dict[str, Any] = {
+            "operation_type": {
+                "add": "Addition",
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: True,
+                STALE_ELEMENT_VALIDATOR_KEY: validator,
+            }
+        }
+
+        try:
+            matched = FeatureChainParser.match_configuration_feature_chain_parser(
+                "any_feature", Options(context={"operation_type": validator}), mapping
+            )
+        except ValueError:
+            matched = False
+
+        assert matched is False
+
+
+class TestElementValidatorSemantics:
+    """``element_validator``: per element, strict-only, falsy -> ``ValueError``."""
+
+    def test_runs_on_each_element_after_list_unpacking(self) -> None:
+        """A list option is unpacked: the validator sees each element, never the list."""
+        validator = _PositiveIntRecorder()
+
+        class ElementFeatureGroup(FeatureChainParserMixin):
+            PROPERTY_MAPPING = {
+                "window_size": {
+                    "explanation": "Sizes of time windows",
+                    DefaultOptionKeys.context: True,
+                    DefaultOptionKeys.strict_validation: True,
+                    DefaultOptionKeys.element_validator: validator,
+                }
+            }
+
+        options = Options(context={"window_size": [1, 2, 3]})
+
+        assert ElementFeatureGroup.match_feature_group_criteria("any_feature", options) is True
+        assert set(validator.calls) == {1, 2, 3}
+
+    def test_rejected_element_is_a_non_match(self) -> None:
+        """A falsy verdict on any element makes the whole feature group not match."""
+        validator = _PositiveIntRecorder()
+
+        class RejectingElementFeatureGroup(FeatureChainParserMixin):
+            PROPERTY_MAPPING = {
+                "window_size": {
+                    "explanation": "Sizes of time windows",
+                    DefaultOptionKeys.context: True,
+                    DefaultOptionKeys.strict_validation: True,
+                    DefaultOptionKeys.element_validator: validator,
+                }
+            }
+
+        options = Options(context={"window_size": [1, -3]})
+
+        assert RejectingElementFeatureGroup.match_feature_group_criteria("any_feature", options) is False
+        assert validator.calls, "the element_validator must have been called"
+        assert all(not isinstance(call, list) for call in validator.calls), "elements, not the raw list"
+
+    def test_rejection_raises_value_error_in_the_parser(self) -> None:
+        """The rejection is a ``ValueError`` at the parser seam (the mixin recovers it)."""
+        mapping: dict[str, Any] = {
+            "window_size": {
+                "explanation": "Size of time window",
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: True,
+                DefaultOptionKeys.element_validator: _positive_int,
+            }
+        }
+
+        with pytest.raises(ValueError, match="window_size"):
+            FeatureChainParser.match_configuration_feature_chain_parser(
+                "any_feature", Options(context={"window_size": -3}), mapping
+            )
+
+    def test_rejection_is_surfaced_via_strict_validation_rejection_reason(self) -> None:
+        """The discarded ``ValueError`` message reaches the user diagnostic hook."""
+
+        class SurfacedElementFeatureGroup(FeatureChainParserMixin):
+            PROPERTY_MAPPING = {
+                "window_size": {
+                    "explanation": "Size of time window",
+                    DefaultOptionKeys.context: True,
+                    DefaultOptionKeys.strict_validation: True,
+                    DefaultOptionKeys.element_validator: _positive_int,
+                }
+            }
+
+        options = Options(context={"window_size": -3})
+
+        assert SurfacedElementFeatureGroup.match_feature_group_criteria("any_feature", options) is False
+
+        reason = SurfacedElementFeatureGroup._strict_validation_rejection_reason("any_feature", options)
+
+        assert reason is not None
+        assert "window_size" in reason
+        assert "-3" in reason
+
+    def test_not_enforced_without_strict_validation(self) -> None:
+        """``element_validator`` is strict-only: without ``strict_validation`` it never runs."""
+        validator = _PositiveIntRecorder()
+
+        class NonStrictElementFeatureGroup(FeatureChainParserMixin):
+            PROPERTY_MAPPING = {
+                "window_size": {
+                    "explanation": "Size of time window",
+                    DefaultOptionKeys.context: True,
+                    DefaultOptionKeys.strict_validation: False,
+                    DefaultOptionKeys.element_validator: validator,
+                }
+            }
+
+        options = Options(context={"window_size": -3})
+
+        assert NonStrictElementFeatureGroup.match_feature_group_criteria("any_feature", options) is True
+        assert validator.calls == []
+
+
+class TestMatchGuardSemantics:
+    """``match_guard``: raw whole value, no strict requirement, falsy -> non-match, no error."""
+
+    def test_runs_on_the_raw_value_without_strict_validation(self) -> None:
+        """The guard sees the raw list, un-unpacked, with ``strict_validation`` off."""
+        guard = _ListOfStringsRecorder()
+
+        class GuardedFeatureGroup(FeatureChainParserMixin):
+            PROPERTY_MAPPING = {
+                "partition_by": {
+                    "explanation": "List of columns to partition by",
+                    DefaultOptionKeys.context: True,
+                    DefaultOptionKeys.strict_validation: False,
+                    DefaultOptionKeys.match_guard: guard,
+                }
+            }
+
+        options = Options(context={"partition_by": ["region", "category"]})
+
+        assert GuardedFeatureGroup.match_feature_group_criteria("any_feature", options) is True
+        assert guard.calls == [["region", "category"]]
+
+    def test_falsy_guard_is_a_silent_non_match(self) -> None:
+        """A falsy verdict returns ``False`` from ``match_feature_group_criteria``, it does not raise."""
+        guard = _ListOfStringsRecorder()
+
+        class RejectingGuardFeatureGroup(FeatureChainParserMixin):
+            PROPERTY_MAPPING = {
+                "partition_by": {
+                    "explanation": "List of columns to partition by",
+                    DefaultOptionKeys.context: True,
+                    DefaultOptionKeys.strict_validation: False,
+                    DefaultOptionKeys.match_guard: guard,
+                }
+            }
+
+        options = Options(context={"partition_by": "region"})
+
+        assert RejectingGuardFeatureGroup.match_feature_group_criteria("any_feature", options) is False
+        assert guard.calls == ["region"]
+
+    def test_falsy_guard_is_not_a_strict_validation_rejection(self) -> None:
+        """A guard non-match is not an option-value rejection, so it has no rejection reason."""
+
+        class QuietGuardFeatureGroup(FeatureChainParserMixin):
+            PROPERTY_MAPPING = {
+                "partition_by": {
+                    "explanation": "List of columns to partition by",
+                    DefaultOptionKeys.context: True,
+                    DefaultOptionKeys.strict_validation: False,
+                    DefaultOptionKeys.match_guard: _ListOfStringsRecorder(),
+                }
+            }
+
+        options = Options(context={"partition_by": "region"})
+
+        assert QuietGuardFeatureGroup._strict_validation_rejection_reason("any_feature", options) is None
+
+    def test_raising_guard_is_caught_and_treated_as_non_match(self) -> None:
+        """A guard that raises is caught: non-match, no exception escapes."""
+        guard = _RaisingRecorder()
+
+        class RaisingGuardFeatureGroup(FeatureChainParserMixin):
+            PROPERTY_MAPPING = {
+                "items": {
+                    "explanation": "A list of items",
+                    DefaultOptionKeys.context: True,
+                    DefaultOptionKeys.strict_validation: False,
+                    DefaultOptionKeys.match_guard: guard,
+                }
+            }
+
+        options = Options(context={"items": "not_a_list"})
+
+        assert RaisingGuardFeatureGroup.match_feature_group_criteria("any_feature", options) is False
+        assert guard.calls == ["not_a_list"]
+
+
+class TestElementValidatorAndMatchGuardPrecedence:
+    """With both on one entry, the element_validator runs first and its rejection wins."""
+
+    def test_element_validator_rejection_short_circuits_the_match_guard(self) -> None:
+        """A rejected element fails the match before the guard is ever consulted."""
+        validator = _PositiveIntRecorder()
+        guard = _Recorder(verdict=True)
+
+        class BothFeatureGroup(FeatureChainParserMixin):
+            PROPERTY_MAPPING = {
+                "window_size": {
+                    "explanation": "Size of time window",
+                    DefaultOptionKeys.context: True,
+                    DefaultOptionKeys.strict_validation: True,
+                    DefaultOptionKeys.element_validator: validator,
+                    DefaultOptionKeys.match_guard: guard,
+                }
+            }
+
+        options = Options(context={"window_size": -3})
+
+        assert BothFeatureGroup.match_feature_group_criteria("any_feature", options) is False
+        assert validator.calls == [-3]
+        assert guard.calls == [], "the match_guard must not be reached once an element was rejected"
+
+    def test_match_guard_runs_when_every_element_passes(self) -> None:
+        """When the element_validator accepts, the guard still gets the raw value."""
+        validator = _PositiveIntRecorder()
+        guard = _Recorder(verdict=False)
+
+        class BothPassFeatureGroup(FeatureChainParserMixin):
+            PROPERTY_MAPPING = {
+                "window_size": {
+                    "explanation": "Size of time window",
+                    DefaultOptionKeys.context: True,
+                    DefaultOptionKeys.strict_validation: True,
+                    DefaultOptionKeys.element_validator: validator,
+                    DefaultOptionKeys.match_guard: guard,
+                }
+            }
+
+        options = Options(context={"window_size": [1, 2]})
+
+        assert BothPassFeatureGroup.match_feature_group_criteria("any_feature", options) is False
+        assert set(validator.calls) == {1, 2}
+        assert guard.calls == [[1, 2]], "the match_guard sees the raw, un-unpacked value"
+
+
+class TestCheckDeclaredDefaultSeam:
+    """``FeatureChainParser.check_declared_default`` is the ONE default-check implementation."""
+
+    def test_is_a_no_op_for_a_valid_declared_default(self) -> None:
+        """A default the spec honors passes silently."""
+        spec: dict[str, Any] = {
+            DefaultOptionKeys.allowed_values: {"add": "Addition"},
+            DefaultOptionKeys.strict_validation: True,
+            DefaultOptionKeys.default: "add",
+        }
+
+        assert FeatureChainParser.check_declared_default("Owner", "operation_type", spec) is None
+
+    def test_raises_for_a_default_outside_the_accepted_set(self) -> None:
+        """A default outside the accepted set raises, naming the owner and the key."""
+        spec: dict[str, Any] = {
+            DefaultOptionKeys.allowed_values: {"add": "Addition"},
+            DefaultOptionKeys.strict_validation: True,
+            DefaultOptionKeys.default: "mul",
+        }
+
+        with pytest.raises(ValueError) as exc_info:
+            FeatureChainParser.check_declared_default("Owner", "operation_type", spec)
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "Owner" in message
+        assert "operation_type" in message
+        assert "mul" in message
+
+    def test_feature_group_definition_routes_through_the_seam(self) -> None:
+        """``FeatureGroup.__init_subclass__`` delegates its default check to the shared seam."""
+        spec = {
+            DefaultOptionKeys.allowed_values: {"add": "Addition"},
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: True,
+            DefaultOptionKeys.default: "add",
+        }
+
+        with patch.object(FeatureChainParser, "check_declared_default") as spy:
+
+            class RoutedFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {"operation_type": spec}
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        assert spy.call_count == 1
+        passed = list(spy.call_args.args) + list(spy.call_args.kwargs.values())
+        assert "operation_type" in passed
+        assert spec in passed
+
+    def test_property_spec_routes_through_the_seam(self) -> None:
+        """``property_spec`` delegates its default check to the same shared seam."""
+        with patch.object(FeatureChainParser, "check_declared_default") as spy:
+            property_spec("op", strict=True, allowed_values={"add": "Addition"}, default="add")
+
+        assert spy.call_count == 1
+        passed = list(spy.call_args.args) + list(spy.call_args.kwargs.values())
+        assert any(isinstance(arg, str) and "property_spec" in arg for arg in passed), (
+            "property_spec must pass an owner label identifying itself"
+        )
+
+    def test_property_spec_owner_label_carries_the_explanation(self) -> None:
+        """The shared error message identifies the offending ``property_spec`` call."""
+        with pytest.raises(ValueError) as exc_info:
+            property_spec("op", strict=True, allowed_values={"add": "Addition"}, default="mul")
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "property_spec" in message
+        assert "op" in message
+        assert "mul" in message
+
+
+class TestRaisedVersusRejectedThroughBothEntryPoints:
+    """The raised/rejected distinction is identical through both entry points, by construction."""
+
+    def test_class_definition_reports_a_raising_element_validator_as_raised(self) -> None:
+        """A validator that errors on the default reports "raised", chaining the original."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class RaisingFnFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {
+                    "operation_type": {
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: True,
+                        DefaultOptionKeys.element_validator: _boom,
+                        DefaultOptionKeys.default: "x",
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        cause_is_runtime_error = isinstance(exc_info.value.__cause__, RuntimeError)
+        del exc_info
+        assert "RaisingFnFeatureGroup" in message
+        assert "raised" in message
+        assert "rejected by" not in message
+        assert cause_is_runtime_error, "expected the original RuntimeError chained as __cause__"
+
+    def test_class_definition_reports_a_rejecting_element_validator_as_rejected(self) -> None:
+        """A validator that runs and returns falsy reports "rejected by"."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class RejectingFnFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {
+                    "operation_type": {
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: True,
+                        DefaultOptionKeys.element_validator: _positive_int,
+                        DefaultOptionKeys.default: -1,
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "RejectingFnFeatureGroup" in message
+        assert "rejected by" in message
+        assert "raised" not in message
+
+    def test_property_spec_reports_a_raising_element_validator_as_raised(self) -> None:
+        """The same wording and the same chaining, through the ``property_spec`` entry point."""
+        with pytest.raises(ValueError) as exc_info:
+            property_spec("op", strict=True, element_validator=_boom, default=5)
+
+        message = str(exc_info.value)
+        cause_is_runtime_error = isinstance(exc_info.value.__cause__, RuntimeError)
+        del exc_info
+        assert "raised" in message
+        assert "rejected by" not in message
+        assert cause_is_runtime_error, "expected the original RuntimeError chained as __cause__"
+
+    def test_property_spec_reports_a_rejecting_element_validator_as_rejected(self) -> None:
+        """The same wording for a genuine rejection, through the ``property_spec`` entry point."""
+        with pytest.raises(ValueError) as exc_info:
+            property_spec("op", strict=True, element_validator=_positive_int, default=-1)
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "rejected by" in message
+        assert "raised" not in message
+
+
+class TestPropertySpecEmitsTheNewKeys:
+    """``property_spec`` speaks the new vocabulary: new kwargs in, new keys out."""
+
+    def test_emits_element_validator_key(self) -> None:
+        """``element_validator=`` lands under ``DefaultOptionKeys.element_validator``."""
+        spec = property_spec("op", strict=True, element_validator=_positive_int)
+
+        assert spec[DefaultOptionKeys.element_validator] is _positive_int
+        assert spec[DefaultOptionKeys.strict_validation] is True
+
+    def test_emits_match_guard_key(self) -> None:
+        """``match_guard=`` lands under ``DefaultOptionKeys.match_guard``, no strict needed."""
+        guard = _ListOfStringsRecorder()
+        spec = property_spec("cols", match_guard=guard)
+
+        assert spec[DefaultOptionKeys.match_guard] is guard
+        assert spec[DefaultOptionKeys.strict_validation] is False
+
+    def test_omitted_new_keys_are_absent(self) -> None:
+        """An omitted validator/guard is absent, never present-and-``None``."""
+        spec = property_spec("op")
+
+        assert DefaultOptionKeys.element_validator not in spec
+        assert DefaultOptionKeys.match_guard not in spec
+
+    def test_stale_kwargs_are_gone(self) -> None:
+        """The old keyword arguments no longer exist: passing them fails loudly."""
+        with pytest.raises((TypeError, ValueError)):
+            property_spec("op", strict=True, validation_function=_positive_int)  # type: ignore[call-arg]
+        with pytest.raises((TypeError, ValueError)):
+            property_spec("op", type_validator=_positive_int)  # type: ignore[call-arg]
+
+    def test_authoring_invariants_still_live_in_property_spec(self) -> None:
+        """The authoring-time-only invariants stay put; only the default check moved to core."""
+        with pytest.raises(ValueError):
+            property_spec("op", strict=True)
+        with pytest.raises(ValueError):
+            property_spec("op", allowed_values={"add": "Addition"})
+        with pytest.raises(ValueError):
+            property_spec("op", strict=True, element_validator=_positive_int, allowed_values=[])
+        not_callable: Any = "not callable"
+        with pytest.raises(ValueError):
+            property_spec("op", strict=True, element_validator=not_callable)
+        with pytest.raises(ValueError):
+            property_spec("op", match_guard=not_callable)

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_spec_builder.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_spec_builder.py
@@ -212,7 +212,7 @@ class TestPropertySpecDefaultOmission:
 
 
 def _positive_int(value: Any) -> bool:
-    """Shared validator for the ``validation_function`` passthrough tests (issue #536)."""
+    """Shared validator for the ``element_validator`` passthrough tests (issue #536)."""
     return isinstance(value, int) and value > 0
 
 
@@ -227,7 +227,7 @@ def _always_required(options: Any) -> bool:
 
 
 def _is_list_of_strings(value: Any) -> bool:
-    """``type_validator`` accepting only a list of strings (issue #536)."""
+    """``match_guard`` accepting only a list of strings (issue #536)."""
     return isinstance(value, list) and all(isinstance(item, str) for item in value)
 
 
@@ -236,65 +236,65 @@ def _boom(value: Any) -> bool:
     raise RuntimeError("boom")
 
 
-class TestPropertySpecValidationFunction:
-    """``validation_function`` passthrough (issue #536).
+class TestPropertySpecElementValidator:
+    """``element_validator`` passthrough (issue #536).
 
-    Core's ``_validate_property_value`` applies a spec's ``validation_function``
+    Core's ``_validate_property_value`` applies a spec's ``element_validator``
     INSTEAD of the membership check under strict validation, so a strict spec with
-    a ``validation_function`` and no ``allowed_values`` is valid and meaningful
+    an ``element_validator`` and no ``allowed_values`` is valid and meaningful
     (see the ``window_size`` example in ``docs/docs/in_depth/property-mapping.md``).
-    Like ``allowed_values``, a ``validation_function`` is only enforced under
+    Like ``allowed_values``, an ``element_validator`` is only enforced under
     strict validation, so passing it without ``strict=True`` is a silent no-op
     and is rejected.
     """
 
-    def test_strict_with_validation_function_needs_no_allowed_values(self) -> None:
-        """``strict=True`` plus a ``validation_function`` needs no ``allowed_values``."""
-        spec = property_spec("d", strict=True, validation_function=_positive_int)
+    def test_strict_with_element_validator_needs_no_allowed_values(self) -> None:
+        """``strict=True`` plus an ``element_validator`` needs no ``allowed_values``."""
+        spec = property_spec("d", strict=True, element_validator=_positive_int)
 
         assert spec["explanation"] == "d"
-        assert spec[DefaultOptionKeys.validation_function] is _positive_int
+        assert spec[DefaultOptionKeys.element_validator] is _positive_int
         assert spec[DefaultOptionKeys.strict_validation] is True
         assert spec[DefaultOptionKeys.context] is True
 
-    def test_validation_function_without_strict_raises(self) -> None:
-        """A ``validation_function`` is never enforced without ``strict`` (silent no-op)."""
+    def test_element_validator_without_strict_raises(self) -> None:
+        """A ``element_validator`` is never enforced without ``strict`` (silent no-op)."""
         with pytest.raises(ValueError):
-            property_spec("d", validation_function=_positive_int)
+            property_spec("d", element_validator=_positive_int)
 
-    def test_non_callable_validation_function_raises(self) -> None:
-        """A non-callable ``validation_function`` is rejected up front."""
+    def test_non_callable_element_validator_raises(self) -> None:
+        """A non-callable ``element_validator`` is rejected up front."""
         not_callable: Any = "not callable"
         with pytest.raises(ValueError):
-            property_spec("d", strict=True, validation_function=not_callable)
+            property_spec("d", strict=True, element_validator=not_callable)
 
 
-class TestPropertySpecValidationFunctionDefault:
-    """Strict defaults are checked via the ``validation_function`` when present (issue #536).
+class TestPropertySpecElementValidatorDefault:
+    """Strict defaults are checked via the ``element_validator`` when present (issue #536).
 
     Mirrors ``FeatureChainParser.validate_property_mapping_defaults``: when a spec
-    carries a ``validation_function``, the strict default check uses it, taking
+    carries an ``element_validator``, the strict default check uses it, taking
     precedence over membership in ``allowed_values``.
     """
 
-    def test_strict_default_accepted_by_validation_function(self) -> None:
-        """A default the ``validation_function`` accepts is legal without ``allowed_values``."""
-        spec = property_spec("d", strict=True, validation_function=_positive_int, default=5)
+    def test_strict_default_accepted_by_element_validator(self) -> None:
+        """A default the ``element_validator`` accepts is legal without ``allowed_values``."""
+        spec = property_spec("d", strict=True, element_validator=_positive_int, default=5)
 
         assert spec[DefaultOptionKeys.default] == 5
 
-    def test_strict_default_rejected_by_validation_function_raises(self) -> None:
-        """A default the ``validation_function`` rejects is illegal."""
+    def test_strict_default_rejected_by_element_validator_raises(self) -> None:
+        """A default the ``element_validator`` rejects is illegal."""
         with pytest.raises(ValueError):
-            property_spec("d", strict=True, validation_function=_positive_int, default=-1)
+            property_spec("d", strict=True, element_validator=_positive_int, default=-1)
 
-    def test_validation_function_takes_precedence_over_allowed_values(self) -> None:
-        """With both present, the default is checked via the ``validation_function``, not membership."""
-        spec = property_spec("d", strict=True, allowed_values={"add": "A"}, validation_function=_is_mul, default="mul")
+    def test_element_validator_takes_precedence_over_allowed_values(self) -> None:
+        """With both present, the default is checked via the ``element_validator``, not membership."""
+        spec = property_spec("d", strict=True, allowed_values={"add": "A"}, element_validator=_is_mul, default="mul")
 
         assert spec[DefaultOptionKeys.default] == "mul"
         assert spec[DefaultOptionKeys.allowed_values] == {"add": "A"}
-        assert spec[DefaultOptionKeys.validation_function] is _is_mul
+        assert spec[DefaultOptionKeys.element_validator] is _is_mul
 
 
 class TestPropertySpecRequiredWhen:
@@ -318,26 +318,26 @@ class TestPropertySpecRequiredWhen:
             property_spec("d", required_when=not_callable)
 
 
-class TestPropertySpecTypeValidator:
-    """``type_validator`` passthrough (issue #536).
+class TestPropertySpecMatchGuard:
+    """``match_guard`` passthrough (issue #536).
 
-    ``type_validator`` checks the raw option value's shape before any list
-    unpacking and, unlike ``validation_function``, does not require strict
+    ``match_guard`` checks the raw option value's shape before any list
+    unpacking and, unlike ``element_validator``, does not require strict
     validation.
     """
 
-    def test_type_validator_emitted_without_strict(self) -> None:
-        """The validator is emitted under ``DefaultOptionKeys.type_validator`` without ``strict``."""
-        spec = property_spec("d", type_validator=_is_list_of_strings)
+    def test_match_guard_emitted_without_strict(self) -> None:
+        """The validator is emitted under ``DefaultOptionKeys.match_guard`` without ``strict``."""
+        spec = property_spec("d", match_guard=_is_list_of_strings)
 
-        assert spec[DefaultOptionKeys.type_validator] is _is_list_of_strings
+        assert spec[DefaultOptionKeys.match_guard] is _is_list_of_strings
         assert spec[DefaultOptionKeys.strict_validation] is False
 
-    def test_non_callable_type_validator_raises(self) -> None:
-        """A non-callable ``type_validator`` is rejected up front."""
+    def test_non_callable_match_guard_raises(self) -> None:
+        """A non-callable ``match_guard`` is rejected up front."""
         not_callable: Any = "not callable"
         with pytest.raises(ValueError):
-            property_spec("d", type_validator=not_callable)
+            property_spec("d", match_guard=not_callable)
 
 
 class TestPropertySpecPassthroughOmission:
@@ -351,27 +351,27 @@ class TestPropertySpecPassthroughOmission:
     def test_omitted_passthroughs_are_absent(self) -> None:
         """Only explicitly passed passthrough keys are emitted; the rest are absent."""
         plain = property_spec("d")
-        assert DefaultOptionKeys.validation_function not in plain
+        assert DefaultOptionKeys.element_validator not in plain
         assert DefaultOptionKeys.required_when not in plain
-        assert DefaultOptionKeys.type_validator not in plain
+        assert DefaultOptionKeys.match_guard not in plain
 
         with_required_when = property_spec("d", required_when=_always_required)
-        assert DefaultOptionKeys.validation_function not in with_required_when
-        assert DefaultOptionKeys.type_validator not in with_required_when
+        assert DefaultOptionKeys.element_validator not in with_required_when
+        assert DefaultOptionKeys.match_guard not in with_required_when
 
-        with_type_validator = property_spec("d", type_validator=_is_list_of_strings)
-        assert DefaultOptionKeys.validation_function not in with_type_validator
-        assert DefaultOptionKeys.required_when not in with_type_validator
+        with_match_guard = property_spec("d", match_guard=_is_list_of_strings)
+        assert DefaultOptionKeys.element_validator not in with_match_guard
+        assert DefaultOptionKeys.required_when not in with_match_guard
 
 
-class TestPropertySpecValidationFunctionRoundTrip:
-    """A strict ``validation_function`` spec matches core semantics end to end (issue #536)."""
+class TestPropertySpecElementValidatorRoundTrip:
+    """A strict ``element_validator`` spec matches core semantics end to end (issue #536)."""
 
-    def test_class_definition_accepts_validation_function_default(self) -> None:
+    def test_class_definition_accepts_element_validator_default(self) -> None:
         """The built entry defines without error and equals the hand-written dict.
 
         Core's class-definition check (``validate_property_mapping_defaults``)
-        accepts a strict default via the ``validation_function``; the helper must
+        accepts a strict default via the ``element_validator``; the helper must
         emit exactly the dict an author would hand-write for that spec.
         """
 
@@ -381,7 +381,7 @@ class TestPropertySpecValidationFunctionRoundTrip:
                 "window_size": property_spec(
                     "Size of time window",
                     strict=True,
-                    validation_function=_positive_int,
+                    element_validator=_positive_int,
                     default=5,
                 )
             }
@@ -394,7 +394,7 @@ class TestPropertySpecValidationFunctionRoundTrip:
 
         hand_written: dict[str, Any] = {
             "explanation": "Size of time window",
-            DefaultOptionKeys.validation_function: _positive_int,
+            DefaultOptionKeys.element_validator: _positive_int,
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
             DefaultOptionKeys.default: 5,
@@ -405,21 +405,21 @@ class TestPropertySpecValidationFunctionRoundTrip:
         FeatureChainParser.validate_property_mapping_defaults("HandWritten", {"window_size": hand_written})
 
 
-class TestPropertySpecRaisingValidationFunction:
-    """A ``validation_function`` that raises on the default is wrapped (issue #536).
+class TestPropertySpecRaisingElementValidator:
+    """A ``element_validator`` that raises on the default is wrapped (issue #536).
 
     Mirrors core's ``FeatureChainParser.validate_property_mapping_defaults``, which
-    distinguishes "the validation_function raised when called with the default"
-    from "the validation_function ran and rejected the default": both surface as
+    distinguishes "the element_validator raised when called with the default"
+    from "the element_validator ran and rejected the default": both surface as
     ``ValueError``, with the original exception chained as ``__cause__`` in the
     raising case. The builder's strict-default check must behave the same way
     instead of letting the author's exception propagate raw.
     """
 
-    def test_raising_validation_function_wraps_as_value_error_with_cause(self) -> None:
+    def test_raising_element_validator_wraps_as_value_error_with_cause(self) -> None:
         """``_boom`` raising ``RuntimeError`` surfaces as ``ValueError`` with the original chained."""
         with pytest.raises(ValueError) as exc_info:
-            property_spec("d", strict=True, validation_function=_boom, default=5)
+            property_spec("d", strict=True, element_validator=_boom, default=5)
 
         assert isinstance(exc_info.value.__cause__, RuntimeError)
 
@@ -427,17 +427,17 @@ class TestPropertySpecRaisingValidationFunction:
 class TestPropertySpecEmptyAllowedValues:
     """An explicitly empty ``allowed_values`` is always an authoring mistake (issue #536).
 
-    Even when a ``validation_function`` is present (so the spec would still be
+    Even when an ``element_validator`` is present (so the spec would still be
     enforceable), an explicitly empty allowed set is dead configuration: core's
     ``_extract_property_values`` would surface it as an empty accepted set. The
     builder must reject it up front instead of silently emitting a dead, empty
     ``allowed_values`` key.
     """
 
-    def test_empty_allowed_values_with_validation_function_raises(self) -> None:
+    def test_empty_allowed_values_with_element_validator_raises(self) -> None:
         """``strict=True`` with ``allowed_values=[]`` raises even though a validator is present."""
         with pytest.raises(ValueError):
-            property_spec("d", strict=True, validation_function=_positive_int, allowed_values=[])
+            property_spec("d", strict=True, element_validator=_positive_int, allowed_values=[])
 
 
 class TestPropertySpecPassthroughRegressionGuards:
@@ -446,16 +446,16 @@ class TestPropertySpecPassthroughRegressionGuards:
     def test_falsy_non_none_default_is_still_validated(self) -> None:
         """``default=0`` is falsy but not ``None``, so it must still be checked (and rejected)."""
         with pytest.raises(ValueError):
-            property_spec("d", strict=True, validation_function=_positive_int, default=0)
+            property_spec("d", strict=True, element_validator=_positive_int, default=0)
 
-    def test_validation_function_precedence_also_rejects_allowed_member(self) -> None:
+    def test_element_validator_precedence_also_rejects_allowed_member(self) -> None:
         """With both present, a default IN ``allowed_values`` is still rejected by the validator."""
         with pytest.raises(ValueError):
             property_spec(
                 "d",
                 strict=True,
                 allowed_values={"add": "A"},
-                validation_function=_positive_int,
+                element_validator=_positive_int,
                 default="add",
             )
 
@@ -471,14 +471,14 @@ class TestPropertySpecPassthroughRegressionGuards:
         }
         assert built == hand_written
 
-    def test_type_validator_spec_equals_hand_written_dict(self) -> None:
-        """A ``type_validator`` spec is exactly the dict an author would hand-write."""
-        built = property_spec("d", type_validator=_is_list_of_strings)
+    def test_match_guard_spec_equals_hand_written_dict(self) -> None:
+        """A ``match_guard`` spec is exactly the dict an author would hand-write."""
+        built = property_spec("d", match_guard=_is_list_of_strings)
 
         hand_written: dict[str, Any] = {
             "explanation": "d",
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.type_validator: _is_list_of_strings,
+            DefaultOptionKeys.match_guard: _is_list_of_strings,
         }
         assert built == hand_written

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_strict_validation_returns_false.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_strict_validation_returns_false.py
@@ -41,13 +41,13 @@ class SubGroupB(BaseMode):
     }
 
 
-class SubGroupWithValidationFunction(BaseMode):
-    """Subclass with a custom validation function."""
+class SubGroupWithElementValidator(BaseMode):
+    """Subclass with a custom element validator."""
 
     PROPERTY_MAPPING = {
         "mode": {
             DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.validation_function: lambda v: v.startswith("valid_"),
+            DefaultOptionKeys.element_validator: lambda v: v.startswith("valid_"),
         }
     }
 
@@ -79,12 +79,12 @@ class TestStrictValidationReturnsFalse:
 
         assert result is True
 
-    def test_validation_function_failure_returns_false(self) -> None:
-        """Custom validation_function rejection should return False, not raise ValueError."""
+    def test_element_validator_failure_returns_false(self) -> None:
+        """Custom element_validator rejection should return False, not raise ValueError."""
         feature_name = FeatureName("any_feature")
         options = Options(group={"mode": "invalid_prefix"})
 
-        result = SubGroupWithValidationFunction.match_feature_group_criteria(feature_name, options)
+        result = SubGroupWithElementValidator.match_feature_group_criteria(feature_name, options)
 
         assert result is False
 
@@ -114,12 +114,12 @@ class TestStrictValidationRejectionReason:
 
         assert reason is None
 
-    def test_validation_function_rejection_returns_message(self) -> None:
-        """SubGroupWithValidationFunction with an invalid mode returns the validation_function message."""
+    def test_element_validator_rejection_returns_message(self) -> None:
+        """SubGroupWithElementValidator with an invalid mode returns the element_validator message."""
         feature_name = FeatureName("any_feature")
         options = Options(group={"mode": "invalid_prefix"})
 
-        reason = SubGroupWithValidationFunction._strict_validation_rejection_reason(feature_name, options)
+        reason = SubGroupWithElementValidator._strict_validation_rejection_reason(feature_name, options)
 
         assert reason is not None
         assert "invalid_prefix" in reason

--- a/tests/test_core/test_abstract_plugins/test_property_mapping_default_invariant.py
+++ b/tests/test_core/test_abstract_plugins/test_property_mapping_default_invariant.py
@@ -3,7 +3,7 @@
 At class definition time, for every PROPERTY_MAPPING key whose spec is a dict and
 declares a non-``None`` ``DefaultOptionKeys.default``, the declared default must be
 honored by the key's own strict-validation rules (be in the accepted set or pass the
-``validation_function``). Otherwise defining the FeatureGroup subclass must raise
+``element_validator``). Otherwise defining the FeatureGroup subclass must raise
 ``ValueError`` immediately.
 
 ``DefaultOptionKeys.required_when`` is NOT an escape hatch: it expresses a conditional
@@ -190,9 +190,9 @@ class TestStrictEnumeratedDefaultInvariant:
         assert NonStrictFeatureGroup.PROPERTY_MAPPING["operation_type"][DefaultOptionKeys.default] == "mul"
 
     def test_rejects_empty_accepted_set_under_strict_validation(self) -> None:
-        """A strict key with no enumerated values and no validation_function rejects a default.
+        """A strict key with no enumerated values and no element_validator rejects a default.
 
-        Without any accepted values and without a ``validation_function``, the
+        Without any accepted values and without a ``element_validator``, the
         declared default can never be honored, so defining the FeatureGroup subclass
         must raise ``ValueError``.
         """
@@ -247,11 +247,11 @@ class TestStrictEnumeratedDefaultInvariant:
         assert "operation_type" in message
 
 
-class TestStrictValidationFunctionDefaultInvariant:
-    """Strict validation driven by a validation_function callable."""
+class TestStrictElementValidatorDefaultInvariant:
+    """Strict validation driven by an element_validator callable."""
 
-    def test_rejects_default_failing_validation_function(self) -> None:
-        """A strict key whose default fails its validation_function must reject at class definition."""
+    def test_rejects_default_failing_element_validator(self) -> None:
+        """A strict key whose default fails its element_validator must reject at class definition."""
         with pytest.raises(ValueError) as exc_info:
 
             class BadFnDefaultFeatureGroup(FeatureChainParserMixin, FeatureGroup):
@@ -260,7 +260,7 @@ class TestStrictValidationFunctionDefaultInvariant:
                     "operation_type": {
                         DefaultOptionKeys.context: True,
                         DefaultOptionKeys.strict_validation: True,
-                        DefaultOptionKeys.validation_function: lambda v: v in {"x", "y"},
+                        DefaultOptionKeys.element_validator: lambda v: v in {"x", "y"},
                         DefaultOptionKeys.default: "z",
                     }
                 }
@@ -274,8 +274,8 @@ class TestStrictValidationFunctionDefaultInvariant:
         assert "operation_type" in message
         assert "z" in message
 
-    def test_accepts_default_passing_validation_function(self) -> None:
-        """A strict key whose default passes its validation_function defines without error."""
+    def test_accepts_default_passing_element_validator(self) -> None:
+        """A strict key whose default passes its element_validator defines without error."""
 
         class GoodFnDefaultFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             PREFIX_PATTERN = r".*__([\w]+)_op$"
@@ -283,7 +283,7 @@ class TestStrictValidationFunctionDefaultInvariant:
                 "operation_type": {
                     DefaultOptionKeys.context: True,
                     DefaultOptionKeys.strict_validation: True,
-                    DefaultOptionKeys.validation_function: lambda v: v in {"x", "y"},
+                    DefaultOptionKeys.element_validator: lambda v: v in {"x", "y"},
                     DefaultOptionKeys.default: "x",
                 }
             }
@@ -326,7 +326,7 @@ class TestDefaultInvariantErrorMessaging:
     default to the accepted values, or remove the default. ``required_when`` is NOT a
     remedy (its predicate being False still lets the bad default apply silently), so
     the message must never advise it. The message must also distinguish a default that
-    was genuinely rejected by a working validation_function from a validation_function
+    was genuinely rejected by a working element_validator from an element_validator
     that itself errored when called.
     """
 
@@ -395,13 +395,13 @@ class TestDefaultInvariantErrorMessaging:
         del exc_info
         assert "['add', 'sub']" in message
 
-    def test_buggy_validation_function_reported_as_raised_not_rejected(self) -> None:
-        """A validation_function that errors when called is reported as having raised.
+    def test_buggy_element_validator_reported_as_raised_not_rejected(self) -> None:
+        """A element_validator that errors when called is reported as having raised.
 
         ``lambda: True`` takes no arguments, so calling it with the default raises
-        ``TypeError``. That is a bug in the plugin's validation_function, not a
+        ``TypeError``. That is a bug in the plugin's element_validator, not a
         verdict on the default, so the invariant must still surface a ``ValueError``
-        at class definition, must say the validation_function raised (not that the
+        at class definition, must say the element_validator raised (not that the
         default was "rejected by" it), and must chain the original ``TypeError`` as
         the cause.
         """
@@ -413,7 +413,7 @@ class TestDefaultInvariantErrorMessaging:
                     "operation_type": {
                         DefaultOptionKeys.context: True,
                         DefaultOptionKeys.strict_validation: True,
-                        DefaultOptionKeys.validation_function: lambda: True,
+                        DefaultOptionKeys.element_validator: lambda: True,
                         DefaultOptionKeys.default: "x",
                     }
                 }
@@ -433,9 +433,9 @@ class TestDefaultInvariantErrorMessaging:
         assert cause_is_type_error, "expected the original TypeError chained as __cause__"
 
     def test_genuine_rejection_still_labeled_as_rejection(self) -> None:
-        """A working validation_function that returns False is still reported as a rejection.
+        """A working element_validator that returns False is still reported as a rejection.
 
-        Distinguishing a buggy validation_function (it raised) must not erase the
+        Distinguishing a buggy element_validator (it raised) must not erase the
         rejection wording for the genuine case: a callable that runs and returns
         False has rejected the default, and the message must say so.
         """
@@ -447,7 +447,7 @@ class TestDefaultInvariantErrorMessaging:
                     "operation_type": {
                         DefaultOptionKeys.context: True,
                         DefaultOptionKeys.strict_validation: True,
-                        DefaultOptionKeys.validation_function: lambda v: False,
+                        DefaultOptionKeys.element_validator: lambda v: False,
                         DefaultOptionKeys.default: "x",
                     }
                 }
@@ -461,16 +461,16 @@ class TestDefaultInvariantErrorMessaging:
         del exc_info
         assert "RejectingFnFeatureGroup" in message
         assert "operation_type" in message
-        assert "rejected by the key's validation_function" in message
+        assert "rejected by the key's element_validator" in message
 
-    def test_validation_function_raising_attribute_error_reports_raised(self) -> None:
-        """A validation_function raising ``AttributeError`` surfaces as the curated ``ValueError``.
+    def test_element_validator_raising_attribute_error_reports_raised(self) -> None:
+        """A element_validator raising ``AttributeError`` surfaces as the curated ``ValueError``.
 
         ``lambda v: v.startswith("a")`` crashes with ``AttributeError`` for the
-        non-string default ``5``. That is a bug in the plugin's validation_function,
+        non-string default ``5``. That is a bug in the plugin's element_validator,
         not a verdict on the default, so the invariant must still surface a
         ``ValueError`` at class definition naming the class and key, must say the
-        validation_function raised (not that the default was "rejected by" it), and
+        element_validator raised (not that the default was "rejected by" it), and
         must chain the original ``AttributeError`` as the cause. The raw
         ``AttributeError`` must never escape class definition.
         """
@@ -482,7 +482,7 @@ class TestDefaultInvariantErrorMessaging:
                     "operation_type": {
                         DefaultOptionKeys.context: True,
                         DefaultOptionKeys.strict_validation: True,
-                        DefaultOptionKeys.validation_function: lambda v: v.startswith("a"),
+                        DefaultOptionKeys.element_validator: lambda v: v.startswith("a"),
                         DefaultOptionKeys.default: 5,
                     }
                 }
@@ -501,13 +501,13 @@ class TestDefaultInvariantErrorMessaging:
         assert "rejected by" not in message
         assert cause_is_attribute_error, "expected the original AttributeError chained as __cause__"
 
-    def test_validation_function_raising_value_error_reports_raised(self) -> None:
-        """A validation_function raising ``ValueError`` internally is reported as having raised.
+    def test_element_validator_raising_value_error_reports_raised(self) -> None:
+        """A element_validator raising ``ValueError`` internally is reported as having raised.
 
         ``lambda v: int(v) > 0`` crashes with ``ValueError`` for the default
         ``"abc"``: the function never returned a verdict, it errored. The invariant
         must not misreport this as the default being "rejected by" the
-        validation_function; it must say the validation_function raised and chain
+        element_validator; it must say the element_validator raised and chain
         the original ``ValueError`` as the cause.
         """
         with pytest.raises(ValueError) as exc_info:
@@ -518,7 +518,7 @@ class TestDefaultInvariantErrorMessaging:
                     "operation_type": {
                         DefaultOptionKeys.context: True,
                         DefaultOptionKeys.strict_validation: True,
-                        DefaultOptionKeys.validation_function: lambda v: int(v) > 0,
+                        DefaultOptionKeys.element_validator: lambda v: int(v) > 0,
                         DefaultOptionKeys.default: "abc",
                     }
                 }

--- a/tests/test_core/test_prepare/test_identify_feature_group_error_message.py
+++ b/tests/test_core/test_prepare/test_identify_feature_group_error_message.py
@@ -644,7 +644,7 @@ class StrictWindowFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     """Config-based feature group with a strict, validated 'window_size' property.
 
     Deliberately does NOT override match_feature_group_criteria, so it exercises the
-    mixin's default swallow-to-False path: a validation_function rejection inside
+    mixin's default swallow-to-False path: an element_validator rejection inside
     FeatureChainParser._validate_property_value raises ValueError, which
     match_feature_group_criteria catches and turns into a plain False, discarding the
     actionable message. _strict_validation_rejection_reason recovers that message.
@@ -654,7 +654,7 @@ class StrictWindowFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         "window_size": {
             "explanation": "Size of window",
             DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.validation_function: lambda v: isinstance(v, int) and 0 < v <= 13,
+            DefaultOptionKeys.element_validator: lambda v: isinstance(v, int) and 0 < v <= 13,
         },
         DefaultOptionKeys.in_features: {"explanation": "source", DefaultOptionKeys.context: True},
     }
@@ -673,7 +673,7 @@ class StrictMaxWindowFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         "max_window": {
             "explanation": "Maximum window size",
             DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.validation_function: lambda v: isinstance(v, int) and 0 < v <= 13,
+            DefaultOptionKeys.element_validator: lambda v: isinstance(v, int) and 0 < v <= 13,
         },
         DefaultOptionKeys.in_features: {"explanation": "source", DefaultOptionKeys.context: True},
     }

--- a/tests/test_plugins/feature_group/experimental/test_property_mapping_consistency.py
+++ b/tests/test_plugins/feature_group/experimental/test_property_mapping_consistency.py
@@ -75,7 +75,7 @@ class TestPropertyMappingConsistency:
         for prop_key, entry in mapping.items():
             if not isinstance(entry, dict):
                 continue
-            if DefaultOptionKeys.validation_function in entry:
+            if DefaultOptionKeys.element_validator in entry:
                 continue
             non_metadata_keys = [
                 k

--- a/tests/test_plugins/feature_group/experimental/test_property_mapping_container_invariance.py
+++ b/tests/test_plugins/feature_group/experimental/test_property_mapping_container_invariance.py
@@ -1,0 +1,116 @@
+"""Plugin-level fallout of uniform sequence unpacking (issue #600).
+
+Core used to hand a tuple option to the ``element_validator`` as the STRING
+``"('a', 'b')"`` while handing a list option its real elements. Plugins that accept a
+sequence option had to defend against both shapes, so the container the user typed
+leaked into what the feature group matched.
+
+Once elements arrive properly, an ``element_validator`` is a per-ELEMENT predicate and
+nothing else. These tests pin that contract at the plugin surface: the same operations
+match whether the caller writes a list, a tuple or a frozenset.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from mloda.provider import DefaultOptionKeys
+from mloda.user import Options
+from mloda_plugins.feature_group.experimental.geo_distance.base import GeoDistanceFeatureGroup
+from mloda_plugins.feature_group.experimental.text_cleaning.base import TextCleaningFeatureGroup
+
+VALID_OPERATIONS: list[tuple[str, Any]] = [
+    ("list", ["normalize", "remove_stopwords"]),
+    ("tuple", ("normalize", "remove_stopwords")),
+    ("frozenset", frozenset({"normalize", "remove_stopwords"})),
+]
+
+INVALID_OPERATIONS: list[tuple[str, Any]] = [
+    ("list", ["normalize", "bogus_operation"]),
+    ("tuple", ("normalize", "bogus_operation")),
+    ("frozenset", frozenset({"normalize", "bogus_operation"})),
+]
+
+
+def _text_cleaning_options(operations: Any) -> Options:
+    return Options(
+        context={
+            TextCleaningFeatureGroup.CLEANING_OPERATIONS: operations,
+            DefaultOptionKeys.in_features: "review",
+        }
+    )
+
+
+class TestTextCleaningOperationsAreValidatedPerElement:
+    """Each cleaning operation is validated individually against ``SUPPORTED_OPERATIONS``.
+
+    The plugin's ``element_validator`` currently string-parses a stringified tuple back
+    apart (``op.strip("'\\" ,")``) because core used to stringify tuples. That workaround
+    only ever worked for tuples: a list of the very same operations does not match today.
+    """
+
+    @pytest.mark.parametrize(("label", "operations"), VALID_OPERATIONS, ids=[label for label, _ in VALID_OPERATIONS])
+    def test_supported_operations_match_in_any_container(self, label: str, operations: Any) -> None:
+        """The same supported operations match whether written as a list, tuple or frozenset."""
+        assert TextCleaningFeatureGroup.match_feature_group_criteria("placeholder", _text_cleaning_options(operations))
+
+    @pytest.mark.parametrize(
+        ("label", "operations"), INVALID_OPERATIONS, ids=[label for label, _ in INVALID_OPERATIONS]
+    )
+    def test_unsupported_operation_rejects_in_any_container(self, label: str, operations: Any) -> None:
+        """One unsupported operation rejects the feature group, whatever the container."""
+        assert not TextCleaningFeatureGroup.match_feature_group_criteria(
+            "placeholder", _text_cleaning_options(operations)
+        )
+
+    def test_every_supported_operation_is_accepted_on_its_own(self) -> None:
+        """Each declared operation passes the per-element check in a single-element sequence."""
+        for operation in TextCleaningFeatureGroup.SUPPORTED_OPERATIONS:
+            assert TextCleaningFeatureGroup.match_feature_group_criteria(
+                "placeholder", _text_cleaning_options([operation])
+            ), f"{operation} must be accepted"
+
+    def test_operations_validator_is_a_plain_per_element_membership_check(self) -> None:
+        """The declared ``element_validator`` judges ONE operation, not a container of them.
+
+        Calling it with a whole container must not be how it works: it receives an
+        element. This is what lets the plugin's lambda collapse to a membership check.
+        """
+        spec = TextCleaningFeatureGroup.PROPERTY_MAPPING[TextCleaningFeatureGroup.CLEANING_OPERATIONS]
+        validator = spec[DefaultOptionKeys.element_validator]
+
+        assert validator("normalize") is True
+        assert validator("bogus_operation") is False
+
+
+class TestGeoDistanceInFeaturesContainerInvariance:
+    """``in_features`` matches identically whichever sequence container carries the points.
+
+    The plugin's ``element_validator`` carries a dead branch that accepts "collections
+    with exactly 2 elements (when validating the whole list)", a leftover from the days
+    when a container could reach it whole. With uniform unpacking it only ever sees
+    individual point names, and a tuple must behave exactly like a list.
+    """
+
+    @pytest.mark.parametrize(
+        ("label", "in_features"),
+        [
+            ("list", ["point1", "point2"]),
+            ("tuple", ("point1", "point2")),
+            ("frozenset", frozenset({"point1", "point2"})),
+            ("set", {"point1", "point2"}),
+        ],
+        ids=["list", "tuple", "frozenset", "set"],
+    )
+    def test_two_points_match_in_any_container(self, label: str, in_features: Any) -> None:
+        """Two point features match whether written as a list, tuple, set or frozenset."""
+        options = Options(
+            context={
+                GeoDistanceFeatureGroup.DISTANCE_TYPE: "haversine",
+                DefaultOptionKeys.in_features: in_features,
+            }
+        )
+
+        assert GeoDistanceFeatureGroup.match_feature_group_criteria("placeholder", options) is True

--- a/tests/test_plugins/feature_group/test_default_options_key_graduation.py
+++ b/tests/test_plugins/feature_group/test_default_options_key_graduation.py
@@ -26,7 +26,7 @@ class TestDefaultOptionKeysCoreLocation:
             "group",
             "order_by",
             "strict_validation",
-            "validation_function",
+            "element_validator",
             "strict_type_enforcement",
         ]
         for key in expected_keys:

--- a/tests/test_plugins/integration_plugins/chainer/context/test_parameter_resolution_unit.py
+++ b/tests/test_plugins/integration_plugins/chainer/context/test_parameter_resolution_unit.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 
 from mloda.user import Feature
@@ -243,11 +245,13 @@ class TestParameterResolutionUnit:
             context={DefaultOptionKeys.in_features: frozenset(), "ident": "identifier1"},
         )
 
-        # This should fail because empty frozenset means no source features
+        # A present-but-empty container has zero elements, so there is nothing to reject:
+        # the property mapping passes vacuously. Arity ("at least one source feature") is
+        # enforced by MIN_IN_FEATURES in FeatureChainParserMixin, not by the value check.
         result = FeatureChainParser.match_configuration_feature_chain_parser(
             "test_feature", options_empty_frozenset, property_mapping
         )
-        assert result is False, "Should fail validation with empty frozenset for source features"
+        assert result is True, "An empty frozenset is present with zero elements, hence vacuously valid"
 
         # Test: Special test value for property2
         options_special_value = Options(
@@ -289,33 +293,34 @@ class TestParameterResolutionUnit:
         """Test the _validate_final_properties logic."""
         property_mapping = ChainedContextFeatureGroupTest.PROPERTY_MAPPING
 
-        # Test: All required properties present
-        property_tracker_valid = {
-            "ident": {"identifier1"},
-            "property2": {"value1"},
-            DefaultOptionKeys.in_features: {"Sales"},
-            "property3": set(),  # Optional, can be empty
+        # Test: All required properties present. The tracker holds the collected elements;
+        # None means the option was absent, an empty list means present with zero elements.
+        property_tracker_valid: dict[str, list[Any] | None] = {
+            "ident": ["identifier1"],
+            "property2": ["value1"],
+            DefaultOptionKeys.in_features: ["Sales"],
+            "property3": [],  # Optional, can be empty
         }
 
-        result = FeatureChainParser._validate_final_properties(property_tracker_valid, property_mapping)  # type: ignore
+        result = FeatureChainParser._validate_final_properties(property_tracker_valid, property_mapping)
         assert result is True, "Should pass validation when all required properties are present"
 
         # Test: Required property missing
-        property_tracker_missing_required = {
+        property_tracker_missing_required: dict[str, list[Any] | None] = {
             "ident": None,  # Required property missing
-            "property2": {"value1"},
-            DefaultOptionKeys.in_features: {"Sales"},
-            "property3": set(),
+            "property2": ["value1"],
+            DefaultOptionKeys.in_features: ["Sales"],
+            "property3": [],
         }
 
         result = FeatureChainParser._validate_final_properties(property_tracker_missing_required, property_mapping)
         assert result is False, "Should fail validation when required property is missing"
 
         # Test: Optional property missing (should still pass)
-        property_tracker_missing_optional = {
-            "ident": {"identifier1"},
-            "property2": {"value1"},
-            DefaultOptionKeys.in_features: {"Sales"},
+        property_tracker_missing_optional: dict[str, list[Any] | None] = {
+            "ident": ["identifier1"],
+            "property2": ["value1"],
+            DefaultOptionKeys.in_features: ["Sales"],
             "property3": None,  # Optional property missing
         }
 

--- a/tests/test_plugins/integration_plugins/chainer/test_property_spec_validation_e2e.py
+++ b/tests/test_plugins/integration_plugins/chainer/test_property_spec_validation_e2e.py
@@ -1,14 +1,14 @@
-"""End-to-end tests for the property_spec validation_function passthrough (issue #536).
+"""End-to-end tests for the property_spec element_validator passthrough (issue #536).
 
 Demonstrates the user-facing story of PR feat/property-spec-passthroughs: a feature
 group author declares a "window_size" option via
-``property_spec(..., strict=True, validation_function=...)`` and gets two distinct
+``property_spec(..., strict=True, element_validator=...)`` and gets two distinct
 validation moments for free:
 
 1. Planning time: an end-user request through the public mloda API with an invalid
    window_size raises ValueError before any computation runs.
 2. Authoring time: ``property_spec`` itself rejects a declared default that fails
-   the validation_function, at the call site (class-definition time).
+   the element_validator, at the call site (class-definition time).
 """
 
 from typing import Any, Optional
@@ -60,14 +60,14 @@ class PropertySpecE2EWindowedFeatureGroup(FeatureChainParserMixin, FeatureGroup)
     """Derived feature group whose "window_size" option is guarded by property_spec.
 
     The computation (base column + window_size) is intentionally trivial; the point
-    is the validation_function passthrough, not rolling-window logic.
+    is the element_validator passthrough, not rolling-window logic.
     """
 
     PROPERTY_MAPPING = {
         "window_size": property_spec(
             "Size of the time window, at most 13",
             strict=True,
-            validation_function=is_valid_window_size,
+            element_validator=is_valid_window_size,
         ),
         DefaultOptionKeys.in_features: property_spec("Source feature to window over"),
     }
@@ -152,11 +152,11 @@ class TestPropertySpecValidationFunctionE2E:
         assert len(CALCULATE_INVOCATIONS) == invocations_before, "rejection must happen before any computation"
 
     def test_author_side_default_rejected_at_call_site(self) -> None:
-        """A default rejected by the validation_function fails at the property_spec call."""
-        with pytest.raises(ValueError, match="default 14 is rejected by the validation_function"):
+        """A default rejected by the element_validator fails at the property_spec call."""
+        with pytest.raises(ValueError, match=r"default 14 .*rejected by the key's element_validator"):
             property_spec(
                 "Size of the time window, at most 13",
                 strict=True,
-                validation_function=is_valid_window_size,
+                element_validator=is_valid_window_size,
                 default=14,
             )


### PR DESCRIPTION
Closes #600.

Answering "what validates my option value, and when?" required reading four source files and two docs pages. Worse, the answer the docs gave was wrong, and plugins had grown workarounds around the gap.

## The rename (breaking, no aliases)

Each name now encodes the two axes that actually distinguish the two callables: what it receives, and what a falsy return *does*.

| removed | use | receives | on falsy |
| --- | --- | --- | --- |
| `validation_function` | `element_validator` | one element, strict only | raises `ValueError`, surfaced to the user |
| `type_validator` | `match_guard` | the raw value, any mode | the feature group does not match |

`match_guard` is the substantive correction. `type_validator` read like a type check that would raise, when in fact a falsy return silently means "not my feature group" and lets another candidate win. It also collided by substring with the unrelated `DataTypeValidator`.

**Nothing breaks silently.** The old enum members are gone (`AttributeError` at import), and a spec still carrying an old string key raises at class definition naming its replacement:

```
LegacyPlugin.PROPERTY_MAPPING['ops'] uses the removed key 'validation_function'.
Rename it to 'element_validator' (DefaultOptionKeys.element_validator).
```

That guard is load-bearing, not courteous. The parser recovers a legacy flattened spec's value space by *subtracting* the reserved keys, so merely un-reserving the old names would let a leftover `"validation_function": <lambda>` be absorbed as an allowed **value** and quietly widen the accepted set.

## The docs were describing a model that did not exist

`validation_function` was documented as receiving "individual parsed elements after list unpacking." It never did. Sequences were converted to a tuple, wrapped as a single value, and **stringified**, so a validator received `"('a', 'b')"`. The proof is `text_cleaning`, whose validator defensively handled *"both actual tuples/lists and string representations"* and parsed the stringified tuple back apart with `op.strip("'\" ,")`. It matched only when its operations arrived as a tuple; the same operations as a list silently failed to match.

Fixed, so that **the spec declares the arity, not the caller's Python syntax**:

- `list`, `tuple`, `set`, `frozenset` unpack element-wise and identically.
- Elements keep their real type. The `str()` hop is deleted: it was a hashability workaround (tuples are already hashable) that had leaked into the public validation contract.
- A `str` stays a scalar, not a sequence of characters. A `dict` is one composite value.
- An empty container is *present* and vacuously valid, which required presence tracking that distinguishes "absent" from "present with zero elements" instead of inferring it from truthiness.

### Two latent crashes fall out of that

- A `set`- or `dict`-valued option raised an uncaught `TypeError` straight through `match_feature_group_criteria` (the mixin only catches `ValueError`), taking down resolution. Now an ordinary verdict.
- `Options.get_in_features` rejected `tuple`, despite its own error message claiming to accept it. Now accepted.

### The workarounds die with the bug

`text_cleaning`'s 12-line defensive validator collapses to `lambda op: op in SUPPORTED_OPERATIONS`, and `geo_distance` sheds a dead whole-container branch (arity is already `MIN/MAX_IN_FEATURES`).

## The duplication is gone

`property_spec` and `validate_property_mapping_defaults` no longer keep two copies of the declared-default semantics (validator-before-membership, and the raised-vs-rejected distinction). Both call `FeatureChainParser.check_declared_default`. The tests **patch the seam** rather than merely asserting equivalent behavior, since equivalent behavior is exactly what let the two copies drift in the first place.

## One page

`docs/in_depth/property-mapping.md` is now the single source of truth: a lifecycle table (moment x mechanism x input x error), a decision guide for picking between the four mechanisms, precedence stated once, and a map from each invariant to the test pinning it. The other pages cross-reference it instead of restating it.

## Migration

Downstream: mloda-registry has one call site and three guides (issue filed).

An `element_validator` that inspected a whole container must become a per-element rule, or move to `match_guard` if it genuinely is a whole-value check. This cannot bite silently: the rename must be done consciously first, because the old key raises.

## Tests

`tox` green: 5047 passed, 171 skipped, `ruff` clean, `mypy --strict` clean (786 files), bandit clean. 87 new tests across three files, including regression guards pinning that a stringified element can never come back (`int` elements must arrive as `1`, not `"1"`) and that a `str` is never shredded into characters.
