### PR TITLE
docs: state the one-way transformer contract on BaseTransformer (#645)

### DIFF
--- a/docs/docs/in_depth/framework-transformers.md
+++ b/docs/docs/in_depth/framework-transformers.md
@@ -107,7 +107,7 @@ Key features:
 1. During initialization, `ComputeFrameworkTransformer` checks for existing `BaseTransformer` subclasses
 2. If none are found, it auto-loads only `*transformer*` files from the `compute_framework` group
 3. Each transformer is registered in a mapping from framework pairs to transformer classes
-4. The mapping is bidirectional, allowing transformations in both directions
+4. Each direction is registered only if the transformer implements that direction's hook: two-way transformers register both edges, one-way transformers only their forward edge
 
 ### Transformation Process
 
@@ -156,15 +156,20 @@ PyArrow Table → SparkPyarrowTransformer → Spark DataFrame (optional SparkSes
 To create a custom transformer for a new pair of frameworks:
 
 1. Subclass `BaseTransformer`
-2. Implement the required methods:
+2. Implement the four required methods:
    - `framework()` - Return the primary framework type
    - `other_framework()` - Return the secondary framework type
    - `import_fw()` - Import the primary framework module
    - `import_other_fw()` - Import the secondary framework module
-   - `transform_fw_to_other_fw()` - Transform from primary to secondary
-   - `transform_other_fw_to_fw()` - Transform from secondary to primary
+3. Implement the direction hooks the transformer supports:
+   - `transform_fw_to_other_fw()` - Transform from primary to secondary; registers the forward edge
+   - `transform_other_fw_to_fw()` - Transform from secondary to primary; registers the reverse edge
 
-Example:
+Each direction hook you implement registers that direction's edge, so implementing both yields a two-way transformer usable in chains in either direction.
+
+**One-way transformers**: to declare a direction unsupported, leave its hook unimplemented. Do not override it with `raise NotImplementedError`: registration keys off the override itself, not its body, so a raising override registers a dead edge that the chain search will route through and then crash on, instead of reporting "no chain exists". `FileSourcePyArrowTransformer` and `FileSourceDictTransformer` are the reference one-way implementations; both simply omit `transform_other_fw_to_fw()`.
+
+Example of a two-way transformer:
 
 ```python
 from typing import Any, Optional

--- a/docs/docs/in_depth/framework-transformers.md
+++ b/docs/docs/in_depth/framework-transformers.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Framework transformers are a key component of mloda's compute framework system, enabling seamless conversion between different data representations. They allow feature groups to work with multiple compute frameworks by providing bidirectional transformation capabilities.
+Framework transformers are a key component of mloda's compute framework system, enabling seamless conversion between different data representations. They allow feature groups to work with multiple compute frameworks by providing transformations between framework representations, one-way or two-way.
 
 ## Core Components
 
@@ -45,12 +45,12 @@ from mloda.core.abstract_plugins.plugin_loader.plugin_loader import PluginLoader
 PluginLoader.disable_auto_load("compute_framework")
 ```
 
-### PandasPyarrowTransformer
+### PandasPyArrowTransformer
 
-The `PandasPyarrowTransformer` is a concrete implementation of `BaseTransformer` that handles conversions between Pandas DataFrames and PyArrow Tables.
+The `PandasPyArrowTransformer` is a concrete implementation of `BaseTransformer` that handles conversions between Pandas DataFrames and PyArrow Tables.
 
 ``` python
-class PandasPyarrowTransformer(BaseTransformer):
+class PandasPyArrowTransformer(BaseTransformer):
     """
     Transformer for converting between Pandas DataFrame and PyArrow Table.
     """
@@ -61,12 +61,12 @@ Key features:
 - Handles metadata properly during transformations
 - Ensures clean conversion by removing framework-specific metadata
 
-### DuckDBPyarrowTransformer
+### DuckDBPyArrowTransformer
 
-The `DuckDBPyarrowTransformer` is a concrete implementation of `BaseTransformer` that handles conversions between DuckDB Relations and PyArrow Tables.
+The `DuckDBPyArrowTransformer` is a concrete implementation of `BaseTransformer`, via `SqlBasePyArrowTransformer`, that handles conversions between DuckDB Relations and PyArrow Tables.
 
 ``` python
-class DuckDBPyarrowTransformer(BaseTransformer):
+class DuckDBPyArrowTransformer(SqlBasePyArrowTransformer):
     """
     Transformer for converting between DuckDB relations and PyArrow Table.
     """
@@ -80,12 +80,12 @@ Key features:
 
 **Important**: The DuckDB transformer requires a connection object when transforming from PyArrow to DuckDB. This is because DuckDB relations must be associated with a specific database connection.
 
-### SparkPyarrowTransformer
+### SparkPyArrowTransformer
 
-The `SparkPyarrowTransformer` is a concrete implementation of `BaseTransformer` that handles conversions between Spark DataFrames and PyArrow Tables.
+The `SparkPyArrowTransformer` is a concrete implementation of `BaseTransformer` that handles conversions between Spark DataFrames and PyArrow Tables.
 
 ``` python
-class SparkPyarrowTransformer(BaseTransformer):
+class SparkPyArrowTransformer(BaseTransformer):
     """
     Transformer for converting between Spark DataFrame and PyArrow Table.
     """
@@ -107,7 +107,7 @@ Key features:
 1. During initialization, `ComputeFrameworkTransformer` checks for existing `BaseTransformer` subclasses
 2. If none are found, it auto-loads only `*transformer*` files from the `compute_framework` group
 3. Each transformer is registered in a mapping from framework pairs to transformer classes
-4. Each direction is registered only if the transformer implements that direction's hook: two-way transformers register both edges, one-way transformers only their forward edge
+4. Each direction is registered only if the transformer implements that direction's hook: two-way transformers register both edges, one-way transformers register only the edge whose hook they implement
 
 ### Transformation Process
 
@@ -122,33 +122,33 @@ When data needs to be transformed from one framework to another:
 ### Example Flow
 
 ```
-Pandas DataFrame → PandasPyarrowTransformer → PyArrow Table
+Pandas DataFrame → PandasPyArrowTransformer → PyArrow Table
 ```
 
 Or in the reverse direction:
 
 ```
-PyArrow Table → PandasPyarrowTransformer → Pandas DataFrame
+PyArrow Table → PandasPyArrowTransformer → Pandas DataFrame
 ```
 
 For DuckDB transformations:
 
 ```
-DuckDB Relation → DuckDBPyarrowTransformer → PyArrow Table
+DuckDB Relation → DuckDBPyArrowTransformer → PyArrow Table
 ```
 
 ```
-PyArrow Table → DuckDBPyarrowTransformer → DuckDB Relation (requires connection)
+PyArrow Table → DuckDBPyArrowTransformer → DuckDB Relation (requires connection)
 ```
 
 For Spark transformations:
 
 ```
-Spark DataFrame → SparkPyarrowTransformer → PyArrow Table
+Spark DataFrame → SparkPyArrowTransformer → PyArrow Table
 ```
 
 ```
-PyArrow Table → SparkPyarrowTransformer → Spark DataFrame (optional SparkSession)
+PyArrow Table → SparkPyArrowTransformer → Spark DataFrame (optional SparkSession)
 ```
 
 ## Creating Custom Transformers
@@ -167,7 +167,7 @@ To create a custom transformer for a new pair of frameworks:
 
 Each direction hook you implement registers that direction's edge, so implementing both yields a two-way transformer usable in chains in either direction.
 
-**One-way transformers**: to declare a direction unsupported, leave its hook unimplemented. Do not override it with `raise NotImplementedError`: registration keys off the override itself, not its body, so a raising override registers a dead edge that the chain search will route through and then crash on, instead of reporting "no chain exists". `FileSourcePyArrowTransformer` and `FileSourceDictTransformer` are the reference one-way implementations; both simply omit `transform_other_fw_to_fw()`.
+**One-way transformers**: to declare a direction unsupported, leave its hook unimplemented. Either hook may be omitted, and only the edge of the implemented hook is registered. Do not override the omitted one with `raise NotImplementedError`: registration keys off the override itself, not its body, so a raising override registers a dead edge that the chain search can route through and then crash on, instead of reporting "no chain exists". Omitting both hooks registers no edge at all: the transformer is inert and only a warning is logged. Override detection resolves through the MRO, so a subclass of a two-way transformer (for example `DuckDBPyArrowTransformer`, which extends `SqlBasePyArrowTransformer`) inherits both overrides and cannot drop a direction by omission. `FileSourcePyArrowTransformer` and `FileSourceDictTransformer` are the reference one-way implementations; both simply omit `transform_other_fw_to_fw()`.
 
 Example of a two-way transformer:
 

--- a/docs/docs/in_depth/framework-transformers.md
+++ b/docs/docs/in_depth/framework-transformers.md
@@ -165,9 +165,11 @@ To create a custom transformer for a new pair of frameworks:
    - `transform_fw_to_other_fw()` - Transform from primary to secondary; registers the forward edge
    - `transform_other_fw_to_fw()` - Transform from secondary to primary; registers the reverse edge
 
-Each direction hook you implement registers that direction's edge, so implementing both yields a two-way transformer usable in chains in either direction.
+**One-way transformers**: implement only the direction you support. Either hook may be omitted, and only an implemented hook's edge is registered (omit both and nothing is registered, with a warning).
 
-**One-way transformers**: to declare a direction unsupported, leave its hook unimplemented. Either hook may be omitted, and only the edge of the implemented hook is registered. Do not override the omitted one with `raise NotImplementedError`: registration keys off the override itself, not its body, so a raising override registers a dead edge that the chain search can route through and then crash on, instead of reporting "no chain exists". Omitting both hooks registers no edge at all: the transformer is inert and only a warning is logged. Override detection resolves through the MRO, so a subclass of a two-way transformer (for example `DuckDBPyArrowTransformer`, which extends `SqlBasePyArrowTransformer`) inherits both overrides and cannot drop a direction by omission. `FileSourcePyArrowTransformer` and `FileSourceDictTransformer` are the reference one-way implementations; both simply omit `transform_other_fw_to_fw()`.
+- Never override an unsupported hook with `raise NotImplementedError`: registration keys off the override itself, not its body, so the dead edge is registered, and a chain routes through it and crashes instead of reporting "no chain exists".
+- Override detection resolves through the MRO, so a subclass of a two-way transformer (for example `DuckDBPyArrowTransformer`) inherits both overrides and cannot drop a direction by omission.
+- `FileSourcePyArrowTransformer` and `FileSourceDictTransformer` are the reference one-way implementations; both omit `transform_other_fw_to_fw()`.
 
 Example of a two-way transformer:
 

--- a/mloda/core/abstract_plugins/components/framework_transformer/base_transformer.py
+++ b/mloda/core/abstract_plugins/components/framework_transformer/base_transformer.py
@@ -15,12 +15,8 @@ class BaseTransformer:
     1. Subclass BaseTransformer
     2. Implement all abstract methods
     3. Define the source and target frameworks
-    4. Implement each transform direction the transformer supports: transform_fw_to_other_fw registers
-       the forward edge, transform_other_fw_to_fw the reverse edge, implementing both makes the
-       transformer two-way. To declare a direction unsupported, leave its hook unimplemented; do not
-       override it with a raising body, because any override registers the edge and the chain search
-       can then route through it. Omitting both hooks registers no edge at all: the transformer stays
-       out of the registry and only a warning is logged.
+    4. Implement each direction you support. An edge is registered only for an overridden hook, so omit
+       a hook (never override it with a raise) to declare that direction unsupported.
 
     The transformer will be automatically discovered and registered with the
     ComputeFrameworkTransformer.
@@ -153,20 +149,15 @@ class BaseTransformer:
         """
         raise NotImplementedError
 
-    # The two transform hooks below are deliberately NOT @abstractmethod: the decorator is inert here
-    # (BaseTransformer has no ABC metaclass) and signals "you must implement this", contradicting the
-    # one-way contract. They must still exist, because add() detects an override by comparing function
-    # identity against them. Their raising bodies are a fail-loud default for a hook called without
-    # consulting transformer_map; chain walks never reach them, as an edge exists only for an override.
+    # The two transform hooks below are deliberately NOT @abstractmethod, which would contradict the
+    # one-way contract. They must still exist: add() detects an override by function identity against them.
 
     @classmethod
     def transform_fw_to_other_fw(cls, data: Any) -> Any:
         """
         Transform data from the primary framework to the secondary framework.
 
-        Implementing this hook registers the forward edge (framework(), other_framework()); leaving it
-        unimplemented declares that direction unsupported. Do not override it with a raising body: the
-        edge keys off the override, not its body, so chains would route through it and crash mid-flight.
+        Implementing this registers the forward edge; omit it to declare the direction unsupported.
 
         Args:
             data: Data in the primary framework format
@@ -181,9 +172,7 @@ class BaseTransformer:
         """
         Transform data from the secondary framework to the primary framework.
 
-        Implementing this hook registers the reverse edge (other_framework(), framework()); leaving it
-        unimplemented declares that direction unsupported. Do not override it with a raising body: the
-        edge keys off the override, not its body, so chains would route through it and crash mid-flight.
+        Implementing this registers the reverse edge; omit it to declare the direction unsupported.
 
         Args:
             data: Data in the secondary framework format

--- a/mloda/core/abstract_plugins/components/framework_transformer/base_transformer.py
+++ b/mloda/core/abstract_plugins/components/framework_transformer/base_transformer.py
@@ -15,7 +15,11 @@ class BaseTransformer:
     1. Subclass BaseTransformer
     2. Implement all abstract methods
     3. Define the source and target frameworks
-    4. Implement the transformation logic in both directions
+    4. Implement each transform direction the transformer supports. Implementing
+       transform_fw_to_other_fw registers the forward edge, transform_other_fw_to_fw registers the
+       reverse edge, and implementing both makes the transformer two-way. To declare a direction
+       unsupported, leave its hook unimplemented; do not override it with a raising body, because
+       any override registers the edge and the chain search will then route through it.
 
     The transformer will be automatically discovered and registered with the
     ComputeFrameworkTransformer.
@@ -148,11 +152,18 @@ class BaseTransformer:
         """
         raise NotImplementedError
 
+    # The two transform hooks below are deliberately NOT @abstractmethod: the decorator is inert here
+    # (BaseTransformer has no ABC metaclass) and it signals "you must implement this", which
+    # contradicts the one-way contract. Their raising bodies are load-bearing: apply_chain relies on them.
+
     @classmethod
-    @abstractmethod
     def transform_fw_to_other_fw(cls, data: Any) -> Any:
         """
         Transform data from the primary framework to the secondary framework.
+
+        Implementing this hook registers the forward edge (framework(), other_framework()) for chain
+        composition; leaving it unimplemented declares that direction unsupported. Do not override it
+        with a raising body: the edge would still be registered and chains would crash mid-flight.
 
         Args:
             data: Data in the primary framework format
@@ -163,10 +174,13 @@ class BaseTransformer:
         raise NotImplementedError
 
     @classmethod
-    @abstractmethod
     def transform_other_fw_to_fw(cls, data: Any, framework_connection_object: Optional[Any] = None) -> Any:
         """
         Transform data from the secondary framework to the primary framework.
+
+        Implementing this hook registers the reverse edge (other_framework(), framework()) for chain
+        composition; leaving it unimplemented declares that direction unsupported. Do not override it
+        with a raising body: the edge would still be registered and chains would crash mid-flight.
 
         Args:
             data: Data in the secondary framework format

--- a/mloda/core/abstract_plugins/components/framework_transformer/base_transformer.py
+++ b/mloda/core/abstract_plugins/components/framework_transformer/base_transformer.py
@@ -15,11 +15,12 @@ class BaseTransformer:
     1. Subclass BaseTransformer
     2. Implement all abstract methods
     3. Define the source and target frameworks
-    4. Implement each transform direction the transformer supports. Implementing
-       transform_fw_to_other_fw registers the forward edge, transform_other_fw_to_fw registers the
-       reverse edge, and implementing both makes the transformer two-way. To declare a direction
-       unsupported, leave its hook unimplemented; do not override it with a raising body, because
-       any override registers the edge and the chain search will then route through it.
+    4. Implement each transform direction the transformer supports: transform_fw_to_other_fw registers
+       the forward edge, transform_other_fw_to_fw the reverse edge, implementing both makes the
+       transformer two-way. To declare a direction unsupported, leave its hook unimplemented; do not
+       override it with a raising body, because any override registers the edge and the chain search
+       can then route through it. Omitting both hooks registers no edge at all: the transformer stays
+       out of the registry and only a warning is logged.
 
     The transformer will be automatically discovered and registered with the
     ComputeFrameworkTransformer.
@@ -153,17 +154,19 @@ class BaseTransformer:
         raise NotImplementedError
 
     # The two transform hooks below are deliberately NOT @abstractmethod: the decorator is inert here
-    # (BaseTransformer has no ABC metaclass) and it signals "you must implement this", which
-    # contradicts the one-way contract. Their raising bodies are load-bearing: apply_chain relies on them.
+    # (BaseTransformer has no ABC metaclass) and signals "you must implement this", contradicting the
+    # one-way contract. They must still exist, because add() detects an override by comparing function
+    # identity against them. Their raising bodies are a fail-loud default for a hook called without
+    # consulting transformer_map; chain walks never reach them, as an edge exists only for an override.
 
     @classmethod
     def transform_fw_to_other_fw(cls, data: Any) -> Any:
         """
         Transform data from the primary framework to the secondary framework.
 
-        Implementing this hook registers the forward edge (framework(), other_framework()) for chain
-        composition; leaving it unimplemented declares that direction unsupported. Do not override it
-        with a raising body: the edge would still be registered and chains would crash mid-flight.
+        Implementing this hook registers the forward edge (framework(), other_framework()); leaving it
+        unimplemented declares that direction unsupported. Do not override it with a raising body: the
+        edge keys off the override, not its body, so chains would route through it and crash mid-flight.
 
         Args:
             data: Data in the primary framework format
@@ -178,9 +181,9 @@ class BaseTransformer:
         """
         Transform data from the secondary framework to the primary framework.
 
-        Implementing this hook registers the reverse edge (other_framework(), framework()) for chain
-        composition; leaving it unimplemented declares that direction unsupported. Do not override it
-        with a raising body: the edge would still be registered and chains would crash mid-flight.
+        Implementing this hook registers the reverse edge (other_framework(), framework()); leaving it
+        unimplemented declares that direction unsupported. Do not override it with a raising body: the
+        edge keys off the override, not its body, so chains would route through it and crash mid-flight.
 
         Args:
             data: Data in the secondary framework format

--- a/mloda/core/abstract_plugins/components/framework_transformer/cfw_transformer.py
+++ b/mloda/core/abstract_plugins/components/framework_transformer/cfw_transformer.py
@@ -25,10 +25,8 @@ class ComputeFrameworkTransformer:
 
     The transformer registry is a mapping from framework pairs to transformer
     classes, allowing the system to find the appropriate transformer for
-    converting data between two supported frameworks. Each direction is
-    registered only if its transform hook is overridden: two-way transformers
-    register both edges, one-way transformers only the edge whose hook they
-    implement.
+    converting data between two supported frameworks. A direction's edge is
+    registered only if its transform hook is overridden.
     """
 
     _auto_load_done: ClassVar[bool] = False

--- a/mloda/core/abstract_plugins/components/framework_transformer/cfw_transformer.py
+++ b/mloda/core/abstract_plugins/components/framework_transformer/cfw_transformer.py
@@ -25,9 +25,10 @@ class ComputeFrameworkTransformer:
 
     The transformer registry is a mapping from framework pairs to transformer
     classes, allowing the system to find the appropriate transformer for
-    converting data between two supported frameworks. Two-way transformers
-    register both directions; one-way transformers register only their
-    forward edge.
+    converting data between two supported frameworks. Each direction is
+    registered only if its transform hook is overridden: two-way transformers
+    register both edges, one-way transformers only the edge whose hook they
+    implement.
     """
 
     _auto_load_done: ClassVar[bool] = False

--- a/tests/test_plugins/compute_framework/test_one_way_transformer_edges.py
+++ b/tests/test_plugins/compute_framework/test_one_way_transformer_edges.py
@@ -17,6 +17,16 @@ Contract:
   * With the reverse edge unregistered, a route that would only exist via a one-way
     transformer's reverse edge resolves to ``None`` instead of a chain that would crash.
 
+ANTI-PATTERN (pinned by ``TestRaisingOverrideAntiPatternRegistersTheEdge`` below): expressing
+"this direction is not supported" by OVERRIDING the unused hook with a bare
+``raise NotImplementedError``. Since ``add()`` decides structurally, on function identity, an
+override, ANY override, including a purely raising one, is the "register this edge" signal.
+The dead edge therefore lands in the map, the BFS in ``get_transformation_chain`` cheerfully
+routes a chain through it, and ``apply_chain`` blows up mid-chain with a bare
+``NotImplementedError`` instead of the caller getting a clean "no chain exists" ``None``.
+The only correct way to declare a direction unsupported is to LEAVE IT UNIMPLEMENTED and
+inherit ``BaseTransformer``'s default.
+
 Isolation note: the synthetic frameworks and transformers are built fresh inside factory
 functions per test. Their import hooks succeed (``add()`` must accept them), so a lingering
 function-local class can be picked up by another test's ``ComputeFrameworkTransformer()``
@@ -106,6 +116,46 @@ def _make_two_way_transformer(name: str, fw: type[Any], other_fw: type[Any]) -> 
     return _TwoWay
 
 
+def _make_raising_override_transformer(name: str, fw: type[Any], other_fw: type[Any]) -> type[BaseTransformer]:
+    """ANTI-PATTERN factory: a one-way transformer that spells its unused direction out as a
+    bare ``raise NotImplementedError`` override instead of omitting it.
+
+    The body is semantically identical to the inherited default, but the override gives
+    ``transform_other_fw_to_fw`` a NEW function identity, and function identity is precisely
+    the signal ``add()`` reads. So the reverse edge gets registered and becomes a live route
+    that can only ever crash. Contrast ``_make_one_way_transformer``, which omits the hook.
+    """
+
+    class _RaisingOverride(BaseTransformer):
+        @classmethod
+        def framework(cls) -> Any:
+            return fw
+
+        @classmethod
+        def other_framework(cls) -> Any:
+            return other_fw
+
+        @classmethod
+        def import_fw(cls) -> None:
+            pass
+
+        @classmethod
+        def import_other_fw(cls) -> None:
+            pass
+
+        @classmethod
+        def transform_fw_to_other_fw(cls, data: Any) -> Any:
+            return [*data, f"{fw.__name__}->{other_fw.__name__}"]
+
+        @classmethod
+        def transform_other_fw_to_fw(cls, data: Any, framework_connection_object: Any | None = None) -> Any:
+            raise NotImplementedError
+
+    _RaisingOverride.__name__ = name
+    _RaisingOverride.__qualname__ = name
+    return _RaisingOverride
+
+
 class TestAddRegistersOneWayTransformersForwardOnly:
     def test_one_way_transformer_registers_only_the_forward_edge(self) -> None:
         """(1a) A transformer WITHOUT a transform_other_fw_to_fw override registers only
@@ -189,3 +239,78 @@ class TestBfsNeverRoutesThroughOneWayReverseEdges:
             f"one-way transformer; got {[t.__name__ for t in chain]} which would crash "
             "apply_chain with a bare NotImplementedError"
         )
+
+
+class TestRaisingOverrideAntiPatternRegistersTheEdge:
+    """Pins WHY ``raise NotImplementedError`` is the WRONG way to express one-way.
+
+    ``add()`` classifies a direction as implemented by comparing function identity against
+    ``BaseTransformer``. A raising override is still an override, so it reads as "implemented"
+    and its edge is registered. These tests document the resulting trap so nobody re-derives
+    the anti-pattern from the old two-way convention. The fix is never a smarter exception;
+    it is to OMIT the unused hook entirely.
+    """
+
+    def test_raising_override_registers_the_reverse_edge_but_omission_does_not(self) -> None:
+        """(2a) Same intent, "this direction is unsupported", two spellings, opposite outcomes.
+
+        Overriding ``transform_other_fw_to_fw`` with a bare raise REGISTERS the reverse edge;
+        omitting the override does not. The two transformers get their OWN fresh framework
+        pairs, never a shared one: two distinct classes claiming the same pair would collide in
+        the next registry's discovery pass and poison unrelated tests (see the isolation note).
+        """
+        anti_src = type("_FwAntiSrc", (), {})
+        anti_dst = type("_FwAntiDst", (), {})
+        ok_src = type("_FwOmittedSrc", (), {})
+        ok_dst = type("_FwOmittedDst", (), {})
+        anti_pattern = _make_raising_override_transformer("_RaisingOverrideSrcDst", anti_src, anti_dst)
+        correct = _make_one_way_transformer("_OmittedSrcDst", ok_src, ok_dst)
+
+        registry = _empty_registry()
+        assert registry.add(anti_pattern) is True
+        assert registry.add(correct) is True
+
+        assert registry.transformer_map.get((anti_dst, anti_src)) is anti_pattern, (
+            "a bare `raise NotImplementedError` override changes the function identity of "
+            "transform_other_fw_to_fw, which IS add()'s 'register this edge' signal; the dead "
+            "reverse edge is therefore registered. This is the anti-pattern being pinned"
+        )
+        assert (ok_dst, ok_src) not in registry.transformer_map, (
+            "the correct one-way spelling omits transform_other_fw_to_fw entirely, leaving "
+            "BaseTransformer's default in place, so no reverse edge is registered"
+        )
+
+        assert registry.transformer_map.get((anti_src, anti_dst)) is anti_pattern
+        assert registry.transformer_map.get((ok_src, ok_dst)) is correct
+
+    def test_chain_routes_through_the_raising_edge_and_apply_chain_raises(self) -> None:
+        """(2b) The concrete failure mode: a SELECTED chain that detonates mid-flight.
+
+        Topology mirrors the one-way (1d) test, with the anti-pattern transformer in place of
+        the correct one-way: the only route A -> C is A -> B via the raising REVERSE edge of
+        T(framework=B, other=A), then B -> C via a two-way transformer.
+
+        Because that reverse edge is registered, get_transformation_chain does NOT return the
+        honest None the caller could handle. It hands back a chain that looks valid, and
+        apply_chain then dies inside the raising hook with a bare NotImplementedError, far from
+        the plugin author who wrote it.
+        """
+        fw_a = type("_FwAntiA", (), {})
+        fw_b = type("_FwAntiB", (), {})
+        fw_c = type("_FwAntiC", (), {})
+        anti_pattern_b_to_a = _make_raising_override_transformer("_RaisingOverrideBToA", fw_b, fw_a)
+        two_way_bc = _make_two_way_transformer("_TwoWayAntiBC", fw_b, fw_c)
+
+        registry = _empty_registry()
+        assert registry.add(anti_pattern_b_to_a) is True
+        assert registry.add(two_way_bc) is True
+
+        chain = registry.get_transformation_chain(fw_a, fw_c)
+
+        assert chain == [anti_pattern_b_to_a, two_way_bc], (
+            "the registered raising edge makes A -> B -> C look routable, so the BFS selects a "
+            f"chain instead of returning None; got {None if chain is None else [t.__name__ for t in chain]}"
+        )
+
+        with pytest.raises(NotImplementedError):
+            registry.apply_chain(fw_a, fw_c, chain, ["seed"], None)

--- a/tests/test_plugins/compute_framework/test_one_way_transformer_edges.py
+++ b/tests/test_plugins/compute_framework/test_one_way_transformer_edges.py
@@ -17,13 +17,9 @@ Contract:
   * With the reverse edge unregistered, a route that would only exist via a one-way
     transformer's reverse edge resolves to ``None`` instead of a chain that would crash.
 
-ANTI-PATTERN (pinned by ``TestRaisingOverrideAntiPatternRegistersTheEdge`` below): declaring
-"this direction is not supported" by OVERRIDING the unused hook with a bare
-``raise NotImplementedError``. Since ``add()`` decides on function identity, ANY override, even
-a purely raising one, is the "register this edge" signal: the dead edge lands in the map, the
-BFS routes a chain through it, and ``apply_chain`` crashes mid-chain with a bare
-``NotImplementedError`` instead of the caller getting a clean "no chain exists" ``None``.
-Declare a direction unsupported by leaving its hook unimplemented, never by raising.
+ANTI-PATTERN (pinned by ``TestRaisingOverrideAntiPatternRegistersTheEdge``): ANY override of the
+unused hook, even a bare ``raise NotImplementedError``, registers the edge, so the BFS can route
+through it and ``apply_chain`` crashes mid-chain instead of returning ``None``. Omit the hook.
 
 Isolation note: the synthetic frameworks and transformers are built fresh inside factory
 functions per test. Their import hooks succeed (``add()`` must accept them), so a lingering
@@ -115,8 +111,7 @@ def _make_two_way_transformer(name: str, fw: type[Any], other_fw: type[Any]) -> 
 
 
 def _make_raising_override_transformer(name: str, fw: type[Any], other_fw: type[Any]) -> type[BaseTransformer]:
-    """ANTI-PATTERN factory: spells the unused direction as a bare raising override instead of
-    omitting it. Contrast ``_make_one_way_transformer``, which omits the hook."""
+    """ANTI-PATTERN factory: spells the unused direction as a bare raising override instead of omitting it."""
 
     class _RaisingOverride(BaseTransformer):
         @classmethod
@@ -234,16 +229,11 @@ class TestBfsNeverRoutesThroughOneWayReverseEdges:
 
 
 class TestRaisingOverrideAntiPatternRegistersTheEdge:
-    """Pins the ANTI-PATTERN described in the module docstring."""
+    """Pins the ANTI-PATTERN from the module docstring."""
 
     def test_raising_override_registers_the_reverse_edge_but_omission_does_not(self) -> None:
-        """(2a) Same intent, two spellings: a raising override registers the reverse edge,
-        omitting the hook does not.
-
-        Each transformer gets its OWN fresh framework pair, never a shared one: two classes
-        claiming the same pair collide in the next registry's discovery pass and poison
-        unrelated tests.
-        """
+        """(2a) Same intent, two spellings: the raising override registers the reverse edge, omission does not."""
+        # Disjoint framework pairs: two transformers on one pair collide in the next registry's discovery pass.
         anti_src = type("_FwAntiSrc", (), {})
         anti_dst = type("_FwAntiDst", (), {})
         ok_src = type("_FwOmittedSrc", (), {})
@@ -256,23 +246,15 @@ class TestRaisingOverrideAntiPatternRegistersTheEdge:
         assert registry.add(correct) is True
 
         assert registry.transformer_map.get((anti_dst, anti_src)) is anti_pattern, (
-            "a raising override still gives transform_other_fw_to_fw a new function identity, "
-            "which IS add()'s 'register this edge' signal, so the dead reverse edge is registered"
+            "a raising override must still register the dead reverse edge"
         )
-        assert (ok_dst, ok_src) not in registry.transformer_map, (
-            "omitting transform_other_fw_to_fw leaves BaseTransformer's default in place, so no "
-            "reverse edge is registered"
-        )
+        assert (ok_dst, ok_src) not in registry.transformer_map, "omitting the hook must register no reverse edge"
 
         assert registry.transformer_map.get((anti_src, anti_dst)) is anti_pattern
         assert registry.transformer_map.get((ok_src, ok_dst)) is correct
 
     def test_chain_routes_through_the_raising_edge_and_apply_chain_raises(self) -> None:
-        """(2b) The failure mode. Topology mirrors (1d) with the anti-pattern transformer in
-        place of the correct one-way: the only route A -> C runs through the raising REVERSE
-        edge of T(framework=B, other=A). Instead of an honest None, the BFS hands back a chain
-        that looks valid and apply_chain dies inside the raising hook.
-        """
+        """(2b) Failure mode: (1d)'s topology, but the only route A -> C runs through the raising reverse edge."""
         fw_a = type("_FwAntiA", (), {})
         fw_b = type("_FwAntiB", (), {})
         fw_c = type("_FwAntiC", (), {})
@@ -286,8 +268,7 @@ class TestRaisingOverrideAntiPatternRegistersTheEdge:
         chain = registry.get_transformation_chain(fw_a, fw_c)
 
         assert chain == [anti_pattern_b_to_a, two_way_bc], (
-            "the registered raising edge makes A -> B -> C look routable, so the BFS selects a "
-            f"chain instead of returning None; got {None if chain is None else [t.__name__ for t in chain]}"
+            f"the raising edge makes A -> B -> C routable; got {None if chain is None else [t.__name__ for t in chain]}"
         )
 
         with pytest.raises(NotImplementedError):

--- a/tests/test_plugins/compute_framework/test_one_way_transformer_edges.py
+++ b/tests/test_plugins/compute_framework/test_one_way_transformer_edges.py
@@ -17,15 +17,13 @@ Contract:
   * With the reverse edge unregistered, a route that would only exist via a one-way
     transformer's reverse edge resolves to ``None`` instead of a chain that would crash.
 
-ANTI-PATTERN (pinned by ``TestRaisingOverrideAntiPatternRegistersTheEdge`` below): expressing
+ANTI-PATTERN (pinned by ``TestRaisingOverrideAntiPatternRegistersTheEdge`` below): declaring
 "this direction is not supported" by OVERRIDING the unused hook with a bare
-``raise NotImplementedError``. Since ``add()`` decides structurally, on function identity, an
-override, ANY override, including a purely raising one, is the "register this edge" signal.
-The dead edge therefore lands in the map, the BFS in ``get_transformation_chain`` cheerfully
-routes a chain through it, and ``apply_chain`` blows up mid-chain with a bare
+``raise NotImplementedError``. Since ``add()`` decides on function identity, ANY override, even
+a purely raising one, is the "register this edge" signal: the dead edge lands in the map, the
+BFS routes a chain through it, and ``apply_chain`` crashes mid-chain with a bare
 ``NotImplementedError`` instead of the caller getting a clean "no chain exists" ``None``.
-The only correct way to declare a direction unsupported is to LEAVE IT UNIMPLEMENTED and
-inherit ``BaseTransformer``'s default.
+Declare a direction unsupported by leaving its hook unimplemented, never by raising.
 
 Isolation note: the synthetic frameworks and transformers are built fresh inside factory
 functions per test. Their import hooks succeed (``add()`` must accept them), so a lingering
@@ -117,14 +115,8 @@ def _make_two_way_transformer(name: str, fw: type[Any], other_fw: type[Any]) -> 
 
 
 def _make_raising_override_transformer(name: str, fw: type[Any], other_fw: type[Any]) -> type[BaseTransformer]:
-    """ANTI-PATTERN factory: a one-way transformer that spells its unused direction out as a
-    bare ``raise NotImplementedError`` override instead of omitting it.
-
-    The body is semantically identical to the inherited default, but the override gives
-    ``transform_other_fw_to_fw`` a NEW function identity, and function identity is precisely
-    the signal ``add()`` reads. So the reverse edge gets registered and becomes a live route
-    that can only ever crash. Contrast ``_make_one_way_transformer``, which omits the hook.
-    """
+    """ANTI-PATTERN factory: spells the unused direction as a bare raising override instead of
+    omitting it. Contrast ``_make_one_way_transformer``, which omits the hook."""
 
     class _RaisingOverride(BaseTransformer):
         @classmethod
@@ -242,22 +234,15 @@ class TestBfsNeverRoutesThroughOneWayReverseEdges:
 
 
 class TestRaisingOverrideAntiPatternRegistersTheEdge:
-    """Pins WHY ``raise NotImplementedError`` is the WRONG way to express one-way.
-
-    ``add()`` classifies a direction as implemented by comparing function identity against
-    ``BaseTransformer``. A raising override is still an override, so it reads as "implemented"
-    and its edge is registered. These tests document the resulting trap so nobody re-derives
-    the anti-pattern from the old two-way convention. The fix is never a smarter exception;
-    it is to OMIT the unused hook entirely.
-    """
+    """Pins the ANTI-PATTERN described in the module docstring."""
 
     def test_raising_override_registers_the_reverse_edge_but_omission_does_not(self) -> None:
-        """(2a) Same intent, "this direction is unsupported", two spellings, opposite outcomes.
+        """(2a) Same intent, two spellings: a raising override registers the reverse edge,
+        omitting the hook does not.
 
-        Overriding ``transform_other_fw_to_fw`` with a bare raise REGISTERS the reverse edge;
-        omitting the override does not. The two transformers get their OWN fresh framework
-        pairs, never a shared one: two distinct classes claiming the same pair would collide in
-        the next registry's discovery pass and poison unrelated tests (see the isolation note).
+        Each transformer gets its OWN fresh framework pair, never a shared one: two classes
+        claiming the same pair collide in the next registry's discovery pass and poison
+        unrelated tests.
         """
         anti_src = type("_FwAntiSrc", (), {})
         anti_dst = type("_FwAntiDst", (), {})
@@ -271,29 +256,22 @@ class TestRaisingOverrideAntiPatternRegistersTheEdge:
         assert registry.add(correct) is True
 
         assert registry.transformer_map.get((anti_dst, anti_src)) is anti_pattern, (
-            "a bare `raise NotImplementedError` override changes the function identity of "
-            "transform_other_fw_to_fw, which IS add()'s 'register this edge' signal; the dead "
-            "reverse edge is therefore registered. This is the anti-pattern being pinned"
+            "a raising override still gives transform_other_fw_to_fw a new function identity, "
+            "which IS add()'s 'register this edge' signal, so the dead reverse edge is registered"
         )
         assert (ok_dst, ok_src) not in registry.transformer_map, (
-            "the correct one-way spelling omits transform_other_fw_to_fw entirely, leaving "
-            "BaseTransformer's default in place, so no reverse edge is registered"
+            "omitting transform_other_fw_to_fw leaves BaseTransformer's default in place, so no "
+            "reverse edge is registered"
         )
 
         assert registry.transformer_map.get((anti_src, anti_dst)) is anti_pattern
         assert registry.transformer_map.get((ok_src, ok_dst)) is correct
 
     def test_chain_routes_through_the_raising_edge_and_apply_chain_raises(self) -> None:
-        """(2b) The concrete failure mode: a SELECTED chain that detonates mid-flight.
-
-        Topology mirrors the one-way (1d) test, with the anti-pattern transformer in place of
-        the correct one-way: the only route A -> C is A -> B via the raising REVERSE edge of
-        T(framework=B, other=A), then B -> C via a two-way transformer.
-
-        Because that reverse edge is registered, get_transformation_chain does NOT return the
-        honest None the caller could handle. It hands back a chain that looks valid, and
-        apply_chain then dies inside the raising hook with a bare NotImplementedError, far from
-        the plugin author who wrote it.
+        """(2b) The failure mode. Topology mirrors (1d) with the anti-pattern transformer in
+        place of the correct one-way: the only route A -> C runs through the raising REVERSE
+        edge of T(framework=B, other=A). Instead of an honest None, the BFS hands back a chain
+        that looks valid and apply_chain dies inside the raising hook.
         """
         fw_a = type("_FwAntiA", (), {})
         fw_b = type("_FwAntiB", (), {})


### PR DESCRIPTION
Closes #645.

## Problem

Since the reader refactor, `ComputeFrameworkTransformer.add()` registers a directional edge **if and only if** that direction's transform hook is overridden, compared by function identity. That contract lived only in `cfw_transformer` internals. `BaseTransformer`, the class authors actually subclass, still told them to "implement the transformation logic in both directions".

So an author writing a one-way transformer (a descriptor materializer, a sink, a lossy export) would naturally reach for the old anti-pattern and override the unused direction with `raise NotImplementedError`. That override *is* the register-this-edge signal, so the dead edge lands in the map, the BFS chain search can select it, and `apply_chain` then crashes mid-chain with a bare `NotImplementedError` instead of the caller getting a clean "no chain exists".

## Change

State the contract where authors read it, and stop teaching the anti-pattern.

- `BaseTransformer`: the class docstring and both transform hook docstrings now say that implementing a hook registers that direction's edge, and that a direction is declared unsupported by *leaving the hook unimplemented*, not by raising.
- Drop `@abstractmethod` from the two transform hooks. It was inert (no ABC metaclass, so it was never enforced) and it signalled "you must implement this", contradicting the contract. The four genuinely required hooks keep it. Both hooks keep their raising bodies and still exist on `BaseTransformer`: `add()` uses them as the identity anchor for override detection.
- `framework-transformers.md`: separate the four required methods from the two direction hooks, document the one-way case against the `FileSource` reference implementations, and fix the registration section, which still claimed the mapping is bidirectional.
- Pin the anti-pattern in tests: a raising override registers the edge, the chain search selects it, and `apply_chain` raises. This is a characterization test of the existing trap, so it passes on arrival by design.

The contract is documented **symmetrically**: `add()` is direction-blind, so a transformer overriding only the reverse hook registers only the reverse edge. Also documented: omitting both hooks registers nothing and only warns, and override detection resolves through the MRO, so a subclass of a two-way transformer cannot drop a direction by omission.

No runtime behavior changes.

## Review

Two independent deep reviews (Claude Opus and codex). codex found no regression and confirmed empirically that the `@abstractmethod` removal is inert even for a subclass mixing in `ABC`.

The Opus review caught a genuine bug in the first commit: the new anchor comment claimed the raising bodies were load-bearing "because `apply_chain` relies on them", which is **false**. `apply_chain` only walks registered edges, so it can never reach `BaseTransformer`'s defaults. Fixed in the second commit, along with the forward-biased contract wording, the miscased `PyArrow` class names on the docs page, and the missing MRO caveat.

## Notes

- `tox` green: 4996 passed, 171 skipped, ruff, `mypy --strict`, bandit all clean.
- `attribution/ATTRIBUTION.md` is deliberately **not** touched. tox regenerates it and it showed unrelated local venv drift (a stray `nest-asyncio` and a numpy point bump); this change adds no dependency.
- Out of scope, needs its own follow-up in another repo: the mloda-registry guide `docs/guides/compute-framework-patterns/08-framework-transformer.md` still says "implement bidirectional conversion" and lists both transform hooks as required methods.
- Unrelated latent bug found while testing: `test_is_final_reader.py` leaks a locally defined `_BadFamily` subclass that can break `test_sibling_reader_selection.py` when both land in the same xdist worker. Reproducible at pristine `main`, independent of this PR.