### PR TITLE
feat: config loader can express the per-feature FeatureGroup resolution scope (#582)

### DIFF
--- a/docs/docs/in_depth/feature-config.md
+++ b/docs/docs/in_depth/feature-config.md
@@ -74,6 +74,7 @@ Combine strings and objects:
 | `context_options` | object | No | Context parameters (metadata, doesn't affect resolution) |
 | `propagate_context_keys` | array | No | Context keys that propagate to dependent features |
 | `column_index` | integer | No | Index for multi-output features (adds `~N` suffix) |
+| `feature_group` | string | No | Resolution-only scope naming the feature group class that should serve this feature |
 
 ## Configuration Approaches
 
@@ -112,6 +113,18 @@ For explicit separation of group and context parameters:
 ```
 
 Note: `options` and `group_options`/`context_options` are mutually exclusive.
+
+### Feature Group Scope
+
+When two enabled sources declare the same column, a bare name is ambiguous. Use `feature_group` to scope the request to one feature group class. The scope is resolution-only: it does not affect feature identity and is not added to the options.
+
+```json
+[
+    {"name": "subject_token", "feature_group": "ClaimsReader"}
+]
+```
+
+The config form takes the class name as a string and matches that exact class name only. The class-object form (`Feature("subject_token", feature_group=ClaimsReader)`), which also matches registered subclasses, stays Python-only because JSON cannot carry a class object. See [Feature Group resolution errors](troubleshooting/feature-group-resolution-errors.md).
 
 ## Worked Example: Window, Rank, and Percentile Features
 

--- a/docs/docs/in_depth/feature-config.md
+++ b/docs/docs/in_depth/feature-config.md
@@ -126,6 +126,12 @@ When two enabled sources declare the same column, a bare name is ambiguous. Use 
 
 The config form takes the class name as a string and matches that exact class name only. The class-object form (`Feature("subject_token", feature_group=ClaimsReader)`), which also matches registered subclasses, stays Python-only because JSON cannot carry a class object. See [Feature Group resolution errors](troubleshooting/feature-group-resolution-errors.md).
 
+Name the concrete feature group class that will execute, not an abstract family base. Because the string matches the exact class name only, `{"feature_group": "AggregatedFeatureGroup"}` (an abstract base) fails with "No feature groups found", while `{"feature_group": "PandasAggregatedFeatureGroup"}` works. 12 of the 38 shipped feature groups are abstract bases with per-framework concrete subclasses, so this is the common case.
+
+`feature_group` is a top-level field, next to `name`. Putting it inside `options`, `group_options`, or `context_options` is rejected with a validation error.
+
+The scope is excluded from feature identity, so listing the same feature name twice in one config array with two different scopes raises `Duplicate feature setup: <name>`. To read the same column from two sources, give them distinct derived feature names.
+
 ## Worked Example: Window, Rank, and Percentile Features
 
 Row-preserving operations (window aggregation, rank, percentile) cannot be requested by a bare name: the Feature Group only matches when the request also carries the partition/order options its matcher needs. The feature name encodes the operation (`{source}__{operation}`); the matcher then requires those options to be present. It reads them via `options.get` (group first, then context), so they resolve from either side, but `context_options` is the right home.

--- a/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
+++ b/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
@@ -59,6 +59,14 @@ Feature("subject_token", feature_group=ClaimsReader)
 Feature("subject_token", feature_group="ClaimsReader")
 ```
 
+From a JSON config, the string form is available as the `feature_group` field:
+
+``` json
+[
+    {"name": "subject_token", "feature_group": "ClaimsReader"}
+]
+```
+
 Caveats:
 
 - The string form matches the exact class name only: it does not match subclasses, and two classes with the same name in different modules stay ambiguous. The class-object form matches the class and its registered subclasses, preferring the most specific subclass, so prefer the class object.

--- a/mloda/core/api/feature_config/loader.py
+++ b/mloda/core/api/feature_config/loader.py
@@ -13,7 +13,7 @@ from typing import Any
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.api.feature_config.parser import parse_json
-from mloda.core.api.feature_config.models import FeatureConfig
+from mloda.core.api.feature_config.models import FeatureConfig, validate_feature_group_scope
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
 
 
@@ -51,11 +51,14 @@ def process_nested_features(options: dict[str, Any]) -> dict[str, Any]:
                 else:
                     processed_nested_options["in_features"] = in_features
 
-            # Create the Feature object; the nested dict carries its own resolution scope.
+            # Create the Feature object; the nested dict carries its own resolution scope,
+            # validated in the config layer so it fails config-style, not Python-surface.
+            nested_feature_group = value.get("feature_group")
+            validate_feature_group_scope(nested_feature_group)
             processed[key] = Feature(
                 name=feature_name,
                 options=processed_nested_options,
-                feature_group=value.get("feature_group"),
+                feature_group=nested_feature_group,
             )
         elif isinstance(value, dict):
             # Recursively process nested dicts

--- a/mloda/core/api/feature_config/loader.py
+++ b/mloda/core/api/feature_config/loader.py
@@ -51,8 +51,12 @@ def process_nested_features(options: dict[str, Any]) -> dict[str, Any]:
                 else:
                     processed_nested_options["in_features"] = in_features
 
-            # Create the Feature object
-            processed[key] = Feature(name=feature_name, options=processed_nested_options)
+            # Create the Feature object; the nested dict carries its own resolution scope.
+            processed[key] = Feature(
+                name=feature_name,
+                options=processed_nested_options,
+                feature_group=value.get("feature_group"),
+            )
         elif isinstance(value, dict):
             # Recursively process nested dicts
             processed[key] = process_nested_features(value)
@@ -103,7 +107,7 @@ def load_features_from_config(config_str: str, format: str = "json") -> list[Fea
                     if item.propagate_context_keys
                     else None,
                 )
-                feature = Feature(name=feature_name, options=options)
+                feature = Feature(name=feature_name, options=options, feature_group=item.feature_group)
                 features.append(feature)
             # Check if in_features exists and create Options accordingly
             elif item.in_features:
@@ -112,12 +116,12 @@ def load_features_from_config(config_str: str, format: str = "json") -> list[Fea
                 # Always convert to frozenset for consistency (even single items)
                 source_value = frozenset(item.in_features)
                 options = Options(group=processed_options, context={DefaultOptionKeys.in_features: source_value})
-                feature = Feature(name=feature_name, options=options)
+                feature = Feature(name=feature_name, options=options, feature_group=item.feature_group)
                 features.append(feature)
             else:
                 # Process nested features in options before creating Feature
                 processed_options = process_nested_features(item.options)
-                feature = Feature(name=feature_name, options=processed_options)
+                feature = Feature(name=feature_name, options=processed_options, feature_group=item.feature_group)
                 features.append(feature)
         else:
             raise ValueError(f"Unexpected config item type: {type(item)}")

--- a/mloda/core/api/feature_config/models.py
+++ b/mloda/core/api/feature_config/models.py
@@ -20,6 +20,7 @@ class FeatureConfig:
     context_options: Optional[dict[str, Any]] = None
     propagate_context_keys: Optional[list[str]] = None
     column_index: Optional[int] = None
+    feature_group: Optional[str] = None
 
     def __post_init__(self) -> None:
         """Validate that options and group_options/context_options are mutually exclusive."""
@@ -29,6 +30,11 @@ class FeatureConfig:
             raise ValueError(
                 "'propagate_context_keys' requires 'context_options'; "
                 "it is meaningless without context options and would otherwise be silently dropped"
+            )
+        # Config is string-only: JSON cannot carry a class object, so the class-object scope stays Python-only.
+        if self.feature_group is not None and not isinstance(self.feature_group, str):
+            raise ValueError(
+                f"'feature_group' must be a class-name string or None, got {type(self.feature_group).__name__}"
             )
 
 
@@ -48,6 +54,7 @@ def feature_config_schema() -> dict[str, Any]:
             "context_options": {"type": "object"},
             "propagate_context_keys": {"type": "array", "items": {"type": "string"}},
             "column_index": {"type": "integer"},
+            "feature_group": {"type": "string"},
         },
         "required": ["name"],
         "additionalProperties": False,

--- a/mloda/core/api/feature_config/models.py
+++ b/mloda/core/api/feature_config/models.py
@@ -8,6 +8,32 @@ feature configuration files.
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
+FEATURE_GROUP_SCOPE_KEY = "feature_group"
+
+
+def validate_feature_group_scope(feature_group: Any) -> None:
+    """Config is string-only: JSON cannot carry a class object, so the class-object scope stays Python-only.
+
+    Shared by FeatureConfig and the nested in_features path so both raise the same config-style ValueError.
+    """
+    if feature_group is not None and not isinstance(feature_group, str):
+        raise ValueError(
+            f"'{FEATURE_GROUP_SCOPE_KEY}' must be a class-name string or None, got {type(feature_group).__name__}"
+        )
+
+
+def reject_misplaced_feature_group_scope(container: Optional[dict[str, Any]], container_name: str) -> None:
+    """Reject the scope written as a top-level key of an option container instead of the top-level field.
+
+    Only top-level keys are checked: a nested scope legitimately lives inside an
+    ``in_features`` dict value, which is not a key of the container.
+    """
+    if container and FEATURE_GROUP_SCOPE_KEY in container:
+        raise ValueError(
+            f"'{FEATURE_GROUP_SCOPE_KEY}' must be a top-level field of the feature config, "
+            f"not a key of '{container_name}'. Move it next to 'name'."
+        )
+
 
 @dataclass
 class FeatureConfig:
@@ -23,7 +49,7 @@ class FeatureConfig:
     feature_group: Optional[str] = None
 
     def __post_init__(self) -> None:
-        """Validate that options and group_options/context_options are mutually exclusive."""
+        """Validate option container exclusivity, propagate_context_keys, and the feature_group scope."""
         if self.options and (self.group_options or self.context_options):
             raise ValueError("Cannot use both 'options' and 'group_options'/'context_options'")
         if self.propagate_context_keys and not self.context_options:
@@ -31,11 +57,10 @@ class FeatureConfig:
                 "'propagate_context_keys' requires 'context_options'; "
                 "it is meaningless without context options and would otherwise be silently dropped"
             )
-        # Config is string-only: JSON cannot carry a class object, so the class-object scope stays Python-only.
-        if self.feature_group is not None and not isinstance(self.feature_group, str):
-            raise ValueError(
-                f"'feature_group' must be a class-name string or None, got {type(self.feature_group).__name__}"
-            )
+        validate_feature_group_scope(self.feature_group)
+        reject_misplaced_feature_group_scope(self.options, "options")
+        reject_misplaced_feature_group_scope(self.group_options, "group_options")
+        reject_misplaced_feature_group_scope(self.context_options, "context_options")
 
 
 def feature_config_schema() -> dict[str, Any]:

--- a/tests/test_core/test_api/feature_config/test_feature_config_feature_group_scope.py
+++ b/tests/test_core/test_api/feature_config/test_feature_config_feature_group_scope.py
@@ -11,7 +11,7 @@ only, because JSON cannot carry a class object) that
 ``load_features_from_config`` forwards to ``Feature(feature_group=...)`` on every
 branch, so ``feature.feature_group_scope`` carries the scope.
 
-Normalisation stays owned by ``Feature._set_feature_group_scope``: an empty or
+Normalization stays owned by ``Feature._set_feature_group_scope``: an empty or
 whitespace-only string becomes None, a padded name is stripped.
 """
 
@@ -278,7 +278,7 @@ def test_loader_without_feature_group_keeps_scope_none() -> None:
 
 
 def test_loader_empty_feature_group_string_normalizes_to_none() -> None:
-    """An empty or whitespace-only scope normalises to None, exactly as Feature does."""
+    """An empty or whitespace-only scope normalizes to None, exactly as Feature does."""
     config_str = """[
         {"name": "empty_scope", "feature_group": ""},
         {"name": "blank_scope", "feature_group": "   "}
@@ -341,3 +341,128 @@ def test_config_with_feature_group_resolves_to_scoped_source() -> None:
             values = list(result["subject_token"])
 
     assert values == ["s1", "s2", "s3", "s4"]
+
+
+# ---------------------------------------------------------------------------
+# Misplaced scope: "feature_group" inside an option container is a hard error
+#
+# The scope is a TOP-LEVEL field. Writing it inside "options" (or the
+# group/context variants) instead silently turns it into an ordinary option:
+# the scope stays None, the key poisons the option hash, and resolution still
+# fails with "Multiple feature groups found" without ever mentioning the key
+# that was ignored. JSON is the documented surface for AI agents, so this
+# misplacement is likely and must fail loudly at config-validation time.
+# ---------------------------------------------------------------------------
+
+
+def test_feature_config_rejects_feature_group_key_inside_options() -> None:
+    """A "feature_group" key inside 'options' is a misplaced scope and raises ValueError."""
+    with pytest.raises(ValueError) as exc_info:
+        FeatureConfig(name="subject_token", options={"feature_group": "Source582A"})
+
+    message = str(exc_info.value)
+    assert "feature_group" in message
+    assert "top-level" in message
+
+
+def test_feature_config_rejects_feature_group_key_inside_group_options() -> None:
+    """A "feature_group" key inside 'group_options' is a misplaced scope and raises ValueError."""
+    with pytest.raises(ValueError) as exc_info:
+        FeatureConfig(name="subject_token", group_options={"feature_group": "Source582A"})
+
+    message = str(exc_info.value)
+    assert "feature_group" in message
+    assert "top-level" in message
+
+
+def test_feature_config_rejects_feature_group_key_inside_context_options() -> None:
+    """A "feature_group" key inside 'context_options' is a misplaced scope and raises ValueError."""
+    with pytest.raises(ValueError) as exc_info:
+        FeatureConfig(name="subject_token", context_options={"feature_group": "Source582A"})
+
+    message = str(exc_info.value)
+    assert "feature_group" in message
+    assert "top-level" in message
+
+
+def test_loader_rejects_misplaced_feature_group_key_in_options() -> None:
+    """Through the JSON surface, a scope written inside 'options' fails loudly instead of becoming an option."""
+    config_str = json.dumps([{"name": "subject_token", "options": {"feature_group": "Source582A"}}])
+
+    with pytest.raises(ValueError) as exc_info:
+        load_features_from_config(config_str, format="json")
+
+    message = str(exc_info.value)
+    assert "feature_group" in message
+    assert "top-level" in message
+
+
+# ---------------------------------------------------------------------------
+# Nested in_features: validation errors follow the CONFIG style
+#
+# The top-level field raises a config-style ValueError for a non-string scope.
+# A nested in_features dict must not fall through to the Python-surface
+# TypeError raised by Feature; the config surface is one surface.
+# ---------------------------------------------------------------------------
+
+
+def test_process_nested_features_rejects_non_string_scope() -> None:
+    """A non-string "feature_group" in a nested in_features dict raises config-style ValueError."""
+    options: dict[str, Any] = {
+        "in_features": {"name": "subject_token", "feature_group": 123},
+    }
+
+    with pytest.raises(ValueError) as exc_info:
+        process_nested_features(options)
+
+    assert "feature_group" in str(exc_info.value)
+
+
+def test_loader_rejects_non_string_scope_in_nested_in_features() -> None:
+    """Through the loader, a non-string nested scope raises ValueError, not the Python-surface TypeError."""
+    config_str = json.dumps(
+        [
+            {
+                "name": "outer_feature",
+                "options": {"in_features": {"name": "subject_token", "feature_group": 123}},
+            }
+        ]
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        load_features_from_config(config_str, format="json")
+
+    assert "feature_group" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Characterization: one config array cannot request the same name twice with
+# two different scopes. The scope is excluded from Feature identity, so the two
+# entries collide in the request-level Features validation.
+# ---------------------------------------------------------------------------
+
+
+def test_config_same_name_two_scopes_raises_duplicate_feature_setup() -> None:
+    """Characterization: the same name under two scopes in one config array is a duplicate.
+
+    Mirrors the Python-side pin in
+    tests/test_plugins/compute_framework/test_per_feature_fg_scope_integration.py.
+    Scope is not part of Feature identity, so the two features compare equal and
+    Features raises "Duplicate feature setup". Reading one column from two
+    sources needs two separate requests, not two array entries.
+    """
+    config_str = json.dumps(
+        [
+            {"name": "subject_token", "feature_group": Source582A.get_class_name()},
+            {"name": "subject_token", "feature_group": Source582B.get_class_name()},
+        ]
+    )
+
+    features = load_features_from_config(config_str, format="json")
+
+    with pytest.raises(ValueError, match="Duplicate feature setup"):
+        mloda.run_all(
+            features,
+            compute_frameworks={PandasDataFrame},
+            plugin_collector=PluginCollector.enabled_feature_groups({Source582A, Source582B}),
+        )

--- a/tests/test_core/test_api/feature_config/test_feature_config_feature_group_scope.py
+++ b/tests/test_core/test_api/feature_config/test_feature_config_feature_group_scope.py
@@ -1,0 +1,343 @@
+"""Config-loader support for the per-feature FeatureGroup resolution scope (issue #582).
+
+PR #575 (issue #508) added a resolution-only scope on ``Feature``:
+
+    Feature("subject_token", feature_group=SomeSource)
+    Feature("subject_token", feature_group="SomeSource")
+
+It is reachable only through the Python constructor. These tests pin the JSON
+config equivalent: a ``feature_group`` field on ``FeatureConfig`` (STRING form
+only, because JSON cannot carry a class object) that
+``load_features_from_config`` forwards to ``Feature(feature_group=...)`` on every
+branch, so ``feature.feature_group_scope`` carries the scope.
+
+Normalisation stays owned by ``Feature._set_feature_group_scope``: an empty or
+whitespace-only string becomes None, a padded name is stripped.
+"""
+
+import json
+from typing import Any, Optional
+
+import pytest
+
+from mloda.core.api.feature_config.loader import load_features_from_config, process_nested_features
+from mloda.core.api.feature_config.models import FeatureConfig
+from mloda.core.api.feature_config.parser import parse_json
+from mloda.provider import BaseInputData
+from mloda.provider import DataCreator
+from mloda.provider import DefaultOptionKeys
+from mloda.provider import FeatureGroup
+from mloda.provider import FeatureSet
+from mloda.user import Feature
+from mloda.user import PluginCollector
+from mloda.user import mloda
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+
+
+class Source582A(FeatureGroup):
+    """Source A: provides the shared "subject_token" plus "scoped_value_a"."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={"subject_token", "scoped_value_a"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {
+            "subject_token": ["s1", "s2", "s3", "s4"],
+            "scoped_value_a": [10, 20, 30, 40],
+        }
+
+
+class Source582B(FeatureGroup):
+    """Source B: also provides the shared "subject_token" plus "scoped_value_b"."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={"subject_token", "scoped_value_b"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {
+            "subject_token": ["b1", "b2"],
+            "scoped_value_b": [1, 2],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Model contract: FeatureConfig carries an optional string feature_group
+# ---------------------------------------------------------------------------
+
+
+def test_feature_config_feature_group_defaults_to_none() -> None:
+    """Without the field, FeatureConfig.feature_group is None."""
+    config = FeatureConfig(name="subject_token")
+
+    assert config.feature_group is None
+
+
+def test_feature_config_accepts_feature_group_string() -> None:
+    """A class-name string is accepted and stored on FeatureConfig.feature_group."""
+    config = FeatureConfig(name="subject_token", feature_group="Source582A")
+
+    assert config.feature_group == "Source582A"
+
+
+def test_feature_config_rejects_non_string_feature_group() -> None:
+    """A non-string, non-None feature_group raises ValueError (config validation style)."""
+    with pytest.raises(ValueError) as exc_info:
+        FeatureConfig(name="subject_token", feature_group=123)  # type: ignore[arg-type]
+
+    message = str(exc_info.value)
+    assert "feature_group" in message
+    # Guard against a false pass while the field does not yet exist: the current
+    # "unexpected keyword argument 'feature_group'" TypeError must NOT satisfy this.
+    assert "unexpected keyword" not in message
+
+
+def test_feature_config_rejects_feature_group_class_object() -> None:
+    """The class-object form stays Python-only: a class in config raises ValueError.
+
+    JSON cannot carry a class, so the config field is string-only. Passing a
+    FeatureGroup class through the dataclass must be rejected loudly rather than
+    creating a config that no config file could ever express.
+    """
+    with pytest.raises(ValueError) as exc_info:
+        FeatureConfig(name="subject_token", feature_group=Source582A)  # type: ignore[arg-type]
+
+    message = str(exc_info.value)
+    assert "feature_group" in message
+    assert "unexpected keyword" not in message
+
+
+# ---------------------------------------------------------------------------
+# Parser contract: the JSON "feature_group" key survives parse_json
+# ---------------------------------------------------------------------------
+
+
+def test_parse_json_accepts_feature_group_field() -> None:
+    """parse_json maps the JSON "feature_group" key onto FeatureConfig.feature_group."""
+    config_str = """[
+        {"name": "subject_token", "feature_group": "Source582A"}
+    ]"""
+
+    result = parse_json(config_str)
+
+    assert len(result) == 1
+    assert isinstance(result[0], FeatureConfig)
+    assert result[0].feature_group == "Source582A"
+
+
+def test_parse_json_without_feature_group_keeps_none() -> None:
+    """A config item without the field parses to feature_group None (no regression)."""
+    config_str = """[
+        {"name": "subject_token", "options": {"param": "value"}}
+    ]"""
+
+    result = parse_json(config_str)
+
+    assert len(result) == 1
+    assert isinstance(result[0], FeatureConfig)
+    assert result[0].feature_group is None
+
+
+# ---------------------------------------------------------------------------
+# Loader contract: the scope is forwarded on EVERY branch of the loader
+# ---------------------------------------------------------------------------
+
+
+def test_loader_forwards_scope_on_plain_options_branch() -> None:
+    """The plain 'options' branch forwards feature_group to Feature.feature_group_scope."""
+    config_str = """[
+        {"name": "subject_token", "options": {"param": "value"}, "feature_group": "Source582A"}
+    ]"""
+
+    result = load_features_from_config(config_str)
+
+    assert len(result) == 1
+    assert isinstance(result[0], Feature)
+    assert result[0].feature_group_scope == "Source582A"
+    assert result[0].options.group.get("param") == "value"
+
+
+def test_loader_forwards_scope_on_in_features_branch() -> None:
+    """The 'in_features' branch forwards feature_group to Feature.feature_group_scope."""
+    config_str = """[
+        {
+            "name": "scale__subject_token",
+            "in_features": ["subject_token"],
+            "options": {"method": "standard"},
+            "feature_group": "Source582A"
+        }
+    ]"""
+
+    result = load_features_from_config(config_str)
+
+    assert len(result) == 1
+    assert isinstance(result[0], Feature)
+    assert result[0].feature_group_scope == "Source582A"
+    assert result[0].options.context.get(DefaultOptionKeys.in_features) == frozenset({"subject_token"})
+
+
+def test_loader_forwards_scope_on_group_context_options_branch() -> None:
+    """The 'group_options'/'context_options' branch forwards feature_group too."""
+    config_str = """[
+        {
+            "name": "subject_token",
+            "group_options": {"threshold": 0.5},
+            "context_options": {"metadata": "test"},
+            "feature_group": "Source582A"
+        }
+    ]"""
+
+    result = load_features_from_config(config_str)
+
+    assert len(result) == 1
+    assert isinstance(result[0], Feature)
+    assert result[0].feature_group_scope == "Source582A"
+    assert result[0].options.group.get("threshold") == 0.5
+    assert result[0].options.context.get("metadata") == "test"
+
+
+def test_loader_forwards_scope_with_column_index() -> None:
+    """The scope survives the column_index tilde-suffix path."""
+    config_str = """[
+        {"name": "subject_token", "column_index": 1, "feature_group": "Source582A"}
+    ]"""
+
+    result = load_features_from_config(config_str)
+
+    assert len(result) == 1
+    assert isinstance(result[0], Feature)
+    assert result[0].name == "subject_token~1"
+    assert result[0].feature_group_scope == "Source582A"
+
+
+def test_process_nested_features_forwards_scope_to_nested_feature() -> None:
+    """A nested in_features dict scopes its OWN Feature via its own "feature_group" key."""
+    options: dict[str, Any] = {
+        "in_features": {"name": "subject_token", "feature_group": "Source582A"},
+    }
+
+    processed = process_nested_features(options)
+
+    nested = processed["in_features"]
+    assert isinstance(nested, Feature)
+    assert nested.name == "subject_token"
+    assert nested.feature_group_scope == "Source582A"
+
+
+def test_loader_forwards_scope_to_nested_in_features_feature() -> None:
+    """Through the loader, a nested in_features Feature carries the nested dict's scope."""
+    config_str = """[
+        {
+            "name": "outer_feature",
+            "options": {
+                "in_features": {"name": "subject_token", "feature_group": "Source582A"}
+            }
+        }
+    ]"""
+
+    result = load_features_from_config(config_str)
+
+    assert len(result) == 1
+    assert isinstance(result[0], Feature)
+    nested = result[0].options.group.get("in_features")
+    assert isinstance(nested, Feature)
+    assert nested.feature_group_scope == "Source582A"
+
+
+def test_loader_scope_does_not_pollute_options() -> None:
+    """The scope is resolution-only: it must not leak into options.group or options.context."""
+    config_str = """[
+        {"name": "subject_token", "options": {"param": "value"}, "feature_group": "Source582A"}
+    ]"""
+
+    result = load_features_from_config(config_str)
+
+    assert isinstance(result[0], Feature)
+    assert "feature_group" not in result[0].options.group
+    assert "feature_group" not in result[0].options.context
+
+
+def test_loader_without_feature_group_keeps_scope_none() -> None:
+    """No regression: configs without the field produce features with scope None on all branches."""
+    config_str = """[
+        "plain_string",
+        {"name": "plain_options", "options": {"param": "value"}},
+        {"name": "with_in_features", "in_features": ["subject_token"]},
+        {"name": "with_group_context", "group_options": {"a": 1}, "context_options": {"b": 2}}
+    ]"""
+
+    result = load_features_from_config(config_str)
+
+    assert len(result) == 4
+    for item in result[1:]:
+        assert isinstance(item, Feature)
+        assert item.feature_group_scope is None
+
+
+def test_loader_empty_feature_group_string_normalizes_to_none() -> None:
+    """An empty or whitespace-only scope normalises to None, exactly as Feature does."""
+    config_str = """[
+        {"name": "empty_scope", "feature_group": ""},
+        {"name": "blank_scope", "feature_group": "   "}
+    ]"""
+
+    result = load_features_from_config(config_str)
+
+    assert len(result) == 2
+    for item in result:
+        assert isinstance(item, Feature)
+        assert item.feature_group_scope is None
+
+
+def test_loader_padded_feature_group_string_is_stripped() -> None:
+    """A padded class-name scope is stored stripped, exactly as Feature does."""
+    config_str = """[
+        {"name": "subject_token", "feature_group": " Source582A "}
+    ]"""
+
+    result = load_features_from_config(config_str)
+
+    assert isinstance(result[0], Feature)
+    assert result[0].feature_group_scope == "Source582A"
+
+
+# ---------------------------------------------------------------------------
+# End to end through mloda.run_all: the config field disambiguates a shared key
+# ---------------------------------------------------------------------------
+
+
+def test_config_without_feature_group_is_ambiguous() -> None:
+    """Characterization: a config request for the shared key is ambiguous without a scope."""
+    config_str = json.dumps([{"name": "subject_token"}])
+
+    features = load_features_from_config(config_str, format="json")
+
+    with pytest.raises(ValueError, match="Multiple feature groups found"):
+        mloda.run_all(
+            features,
+            compute_frameworks={PandasDataFrame},
+            plugin_collector=PluginCollector.enabled_feature_groups({Source582A, Source582B}),
+        )
+
+
+def test_config_with_feature_group_resolves_to_scoped_source() -> None:
+    """The config scope resolves the shared key to exactly one source, and run_all returns its data."""
+    config_str = json.dumps([{"name": "subject_token", "feature_group": Source582A.get_class_name()}])
+
+    features = load_features_from_config(config_str, format="json")
+
+    results = mloda.run_all(
+        features,
+        compute_frameworks={PandasDataFrame},
+        plugin_collector=PluginCollector.enabled_feature_groups({Source582A, Source582B}),
+    )
+
+    values: list[str] = []
+    for result in results:
+        if "subject_token" in result.columns:
+            values = list(result["subject_token"])
+
+    assert values == ["s1", "s2", "s3", "s4"]

--- a/tests/test_core/test_api/feature_config/test_feature_config_schema.py
+++ b/tests/test_core/test_api/feature_config/test_feature_config_schema.py
@@ -35,3 +35,15 @@ def test_feature_config_schema_includes_propagate_context_keys() -> None:
     prop = schema["properties"]["propagate_context_keys"]
     assert prop["type"] == "array", "'propagate_context_keys' should be an array"
     assert prop["items"] == {"type": "string"}, "'propagate_context_keys' items should be strings"
+
+
+def test_feature_config_schema_includes_feature_group() -> None:
+    """Test that the schema advertises the feature_group resolution scope field (issue #582).
+
+    The config scope is the string form only (JSON cannot carry a class object),
+    so the schema exposes it as a plain string property.
+    """
+    schema = feature_config_schema()
+
+    assert "feature_group" in schema["properties"], "'feature_group' should be in schema properties"
+    assert schema["properties"]["feature_group"] == {"type": "string"}, "'feature_group' should be a string"


### PR DESCRIPTION
Closes #582.

## Problem

PR #575 (issue #508) added a resolution-only scope on `Feature`:

```python
Feature("subject_token", feature_group=ClaimsReader)   # class object
Feature("subject_token", feature_group="ClaimsReader") # class-name string
```

It was reachable only through the Python constructor. `FeatureConfig` rejects unknown fields and the loader never populated a scope, so a config-driven request for a column that two enabled sources both declare still failed with "Multiple feature groups found", with no way to opt into the scope.

## Change

- `FeatureConfig` accepts an optional `feature_group` field. String form only: JSON cannot carry a class object, so the class-object form stays Python-only. A non-string value raises `ValueError` in the existing config validation style, and `feature_config_schema()` exposes the field.
- `load_features_from_config` forwards the scope to `Feature(feature_group=...)` at every construction site: the plain `options` branch, the `in_features` branch, the `group_options`/`context_options` branch, and the nested `in_features` Feature built in `process_nested_features` (which takes the scope from the nested dict's own key).
- A `feature_group` key written *inside* `options`, `group_options` or `context_options` is now rejected. Previously it was silently swallowed as an ordinary option: the scope stayed unset, the key poisoned the option hash, and resolution failed without ever naming the ignored key. This surface is documented as the primary interface for AI agents and LLMs, so the misplacement is likely and now fails loudly. Only top-level keys are checked, so a legitimate nested `in_features` scope still works.
- Validation is shared by the top-level field and the nested path, so both raise the same config-style `ValueError` rather than the nested one leaking a Python-surface `TypeError`.

## Tests

23 tests in `test_feature_config_feature_group_scope.py` plus a schema test. They pin the model contract, the parser, forwarding on all four loader branches (including `column_index` and the nested path), that the scope does not leak into `options`, and normalization consistency with `Feature` (empty string to None, padded name stripped).

End to end: two enabled sources both declare `subject_token`. Requesting it from JSON without a scope raises "Multiple feature groups found" (characterization); with `{"name": "subject_token", "feature_group": "Source582A"}` it resolves to exactly that source and `run_all` returns its data. The two sources return different row counts, so resolving to the wrong one fails the assertion rather than passing.

A characterization test also pins that the same name listed twice with two different scopes raises `Duplicate feature setup`, since the scope is excluded from feature identity.

## Docs

`feature-config.md` gains the field and a "Feature Group Scope" section: the string must name the concrete class that will execute, not an abstract family base (12 of the 38 shipped feature groups are abstract bases with per-framework subclasses, so `AggregatedFeatureGroup` fails where `PandasAggregatedFeatureGroup` works). The troubleshooting guide's "scope a feature to one source" section gains the JSON form.

## Known limitation (follow-up)

The string form matches the exact class name, so a config user cannot name an abstract family base and rely on the subclass-preferring semantics the class-object form gives Python users. Making the string resolve against registered subclasses would close that gap; it changes core resolution semantics, so it is left to a follow-up issue.

`tox` passes.