### PR TITLE
feat: express the per-feature FeatureGroup resolution scope in the config loader (#582)

### DIFF
--- a/docs/docs/in_depth/feature-config.md
+++ b/docs/docs/in_depth/feature-config.md
@@ -74,6 +74,7 @@ Combine strings and objects:
 | `context_options` | object | No | Context parameters (metadata, doesn't affect resolution) |
 | `propagate_context_keys` | array | No | Context keys that propagate to dependent features |
 | `column_index` | integer | No | Index for multi-output features (adds `~N` suffix) |
+| `feature_group` | string | No | Feature Group class name the feature resolves to (resolution-only scope) |
 
 ## Configuration Approaches
 
@@ -112,6 +113,20 @@ For explicit separation of group and context parameters:
 ```
 
 Note: `options` and `group_options`/`context_options` are mutually exclusive.
+
+### Feature Group Scope
+
+When two enabled sources declare the same column (for example a shared join key), the bare name is ambiguous and resolution fails with "Multiple feature groups found". Use `feature_group` to scope the request to one source:
+
+```json
+[
+    {"name": "subject_token", "feature_group": "ClaimsReader"},
+    {"name": "claims_amount"},
+    {"name": "labs_result"}
+]
+```
+
+The config form takes the class-name string only, since JSON cannot express a class object. The string matches the exact class name: it does not match subclasses, and two classes with the same name in different modules stay ambiguous. In Python, `Feature("subject_token", feature_group=ClaimsReader)` also accepts the class object. The scope is resolution-only and excluded from feature identity, so the same name scoped to two different sources cannot be requested twice in one list; see [Feature Group resolution errors](troubleshooting/feature-group-resolution-errors.md).
 
 ## Worked Example: Window, Rank, and Percentile Features
 

--- a/docs/docs/in_depth/feature-config.md
+++ b/docs/docs/in_depth/feature-config.md
@@ -126,7 +126,7 @@ When two enabled sources declare the same column (for example a shared join key)
 ]
 ```
 
-The config form takes the class-name string only, since JSON cannot express a class object. The string matches the exact class name: it does not match subclasses, and two classes with the same name in different modules stay ambiguous. In Python, `Feature("subject_token", feature_group=ClaimsReader)` also accepts the class object. The scope is resolution-only and excluded from feature identity, so the same name scoped to two different sources cannot be requested twice in one list; see [Feature Group resolution errors](troubleshooting/feature-group-resolution-errors.md).
+The config form takes a non-empty class-name string only, since JSON cannot express a class object. The string matches the exact class name: it does not match subclasses, and two classes with the same name in different modules stay ambiguous. In Python, `Feature("subject_token", feature_group=ClaimsReader)` also accepts the class object. The scope is resolution-only and excluded from feature identity, so requesting the same name scoped to two different sources in one list raises `ValueError: Duplicate feature setup: <name>` rather than silently dropping one; see [Feature Group resolution errors](troubleshooting/feature-group-resolution-errors.md).
 
 ## Worked Example: Window, Rank, and Percentile Features
 

--- a/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
+++ b/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
@@ -59,6 +59,16 @@ Feature("subject_token", feature_group=ClaimsReader)
 Feature("subject_token", feature_group="ClaimsReader")
 ```
 
+The same scope in a JSON config ([feature config](../feature-config.md)):
+
+``` json
+[
+    {"name": "subject_token", "feature_group": "ClaimsReader"}
+]
+```
+
+The config form takes the class-name string only, because JSON cannot express a class object; the class-object form is Python-only.
+
 Caveats:
 
 - The string form matches the exact class name only: it does not match subclasses, and two classes with the same name in different modules stay ambiguous. The class-object form matches the class and its registered subclasses, preferring the most specific subclass, so prefer the class object.

--- a/mloda/core/api/feature_config/loader.py
+++ b/mloda/core/api/feature_config/loader.py
@@ -13,7 +13,7 @@ from typing import Any
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.api.feature_config.parser import parse_json
-from mloda.core.api.feature_config.models import FeatureConfig
+from mloda.core.api.feature_config.models import FeatureConfig, validate_feature_group_scope
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
 
 
@@ -51,11 +51,14 @@ def process_nested_features(options: dict[str, Any]) -> dict[str, Any]:
                 else:
                     processed_nested_options["in_features"] = in_features
 
+            # The nested dict skips FeatureConfig, so validate its scope with the same rules
+            nested_feature_group = validate_feature_group_scope(value.get("feature_group"))
+
             # Create the Feature object, keeping any nested resolution scope
             processed[key] = Feature(
                 name=feature_name,
                 options=processed_nested_options,
-                feature_group=value.get("feature_group"),
+                feature_group=nested_feature_group,
             )
         elif isinstance(value, dict):
             # Recursively process nested dicts

--- a/mloda/core/api/feature_config/loader.py
+++ b/mloda/core/api/feature_config/loader.py
@@ -51,8 +51,12 @@ def process_nested_features(options: dict[str, Any]) -> dict[str, Any]:
                 else:
                     processed_nested_options["in_features"] = in_features
 
-            # Create the Feature object
-            processed[key] = Feature(name=feature_name, options=processed_nested_options)
+            # Create the Feature object, keeping any nested resolution scope
+            processed[key] = Feature(
+                name=feature_name,
+                options=processed_nested_options,
+                feature_group=value.get("feature_group"),
+            )
         elif isinstance(value, dict):
             # Recursively process nested dicts
             processed[key] = process_nested_features(value)
@@ -103,7 +107,7 @@ def load_features_from_config(config_str: str, format: str = "json") -> list[Fea
                     if item.propagate_context_keys
                     else None,
                 )
-                feature = Feature(name=feature_name, options=options)
+                feature = Feature(name=feature_name, options=options, feature_group=item.feature_group)
                 features.append(feature)
             # Check if in_features exists and create Options accordingly
             elif item.in_features:
@@ -112,12 +116,12 @@ def load_features_from_config(config_str: str, format: str = "json") -> list[Fea
                 # Always convert to frozenset for consistency (even single items)
                 source_value = frozenset(item.in_features)
                 options = Options(group=processed_options, context={DefaultOptionKeys.in_features: source_value})
-                feature = Feature(name=feature_name, options=options)
+                feature = Feature(name=feature_name, options=options, feature_group=item.feature_group)
                 features.append(feature)
             else:
                 # Process nested features in options before creating Feature
                 processed_options = process_nested_features(item.options)
-                feature = Feature(name=feature_name, options=processed_options)
+                feature = Feature(name=feature_name, options=processed_options, feature_group=item.feature_group)
                 features.append(feature)
         else:
             raise ValueError(f"Unexpected config item type: {type(item)}")

--- a/mloda/core/api/feature_config/models.py
+++ b/mloda/core/api/feature_config/models.py
@@ -9,6 +9,20 @@ from dataclasses import dataclass, field
 from typing import Any, Optional
 
 
+def validate_feature_group_scope(value: Any) -> Optional[str]:
+    """Config scope is a non-empty class-name string; the class-object form is Python-only."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError(
+            "'feature_group' must be a feature group class-name string; "
+            "the class-object form is only available in Python, not in a config"
+        )
+    if not value.strip():
+        raise ValueError("'feature_group' must be a non-empty feature group class-name string")
+    return value
+
+
 @dataclass
 class FeatureConfig:
     """Model for a feature configuration with name and options."""
@@ -31,11 +45,7 @@ class FeatureConfig:
                 "'propagate_context_keys' requires 'context_options'; "
                 "it is meaningless without context options and would otherwise be silently dropped"
             )
-        if self.feature_group is not None and not isinstance(self.feature_group, str):
-            raise ValueError(
-                "'feature_group' must be a feature group class-name string; "
-                "the class-object form is only available in Python, not in a config"
-            )
+        validate_feature_group_scope(self.feature_group)
 
 
 def feature_config_schema() -> dict[str, Any]:
@@ -54,7 +64,7 @@ def feature_config_schema() -> dict[str, Any]:
             "context_options": {"type": "object"},
             "propagate_context_keys": {"type": "array", "items": {"type": "string"}},
             "column_index": {"type": "integer"},
-            "feature_group": {"type": "string"},
+            "feature_group": {"type": "string", "minLength": 1},
         },
         "required": ["name"],
         "additionalProperties": False,

--- a/mloda/core/api/feature_config/models.py
+++ b/mloda/core/api/feature_config/models.py
@@ -20,6 +20,7 @@ class FeatureConfig:
     context_options: Optional[dict[str, Any]] = None
     propagate_context_keys: Optional[list[str]] = None
     column_index: Optional[int] = None
+    feature_group: Optional[str] = None
 
     def __post_init__(self) -> None:
         """Validate that options and group_options/context_options are mutually exclusive."""
@@ -29,6 +30,11 @@ class FeatureConfig:
             raise ValueError(
                 "'propagate_context_keys' requires 'context_options'; "
                 "it is meaningless without context options and would otherwise be silently dropped"
+            )
+        if self.feature_group is not None and not isinstance(self.feature_group, str):
+            raise ValueError(
+                "'feature_group' must be a feature group class-name string; "
+                "the class-object form is only available in Python, not in a config"
             )
 
 
@@ -48,6 +54,7 @@ def feature_config_schema() -> dict[str, Any]:
             "context_options": {"type": "object"},
             "propagate_context_keys": {"type": "array", "items": {"type": "string"}},
             "column_index": {"type": "integer"},
+            "feature_group": {"type": "string"},
         },
         "required": ["name"],
         "additionalProperties": False,

--- a/tests/test_core/test_api/feature_config/test_feature_config_feature_group_scope.py
+++ b/tests/test_core/test_api/feature_config/test_feature_config_feature_group_scope.py
@@ -5,9 +5,10 @@ enabled feature groups both declare. The JSON config schema has no equivalent
 field, so config-file users hit "Multiple feature groups found".
 
 These tests pin the config-side field: FeatureConfig.feature_group holds a
-class-name STRING (the class-object form stays Python-only), the loader forwards
-it to Feature at every construction site, non-string values are rejected with
-ValueError, and the schema advertises it.
+non-empty class-name STRING (the class-object form stays Python-only), the loader
+forwards it to Feature at every construction site (including the nested
+in_features path, which bypasses FeatureConfig validation), invalid values are
+rejected with ValueError, and the schema advertises it.
 """
 
 from typing import Any, Optional
@@ -64,6 +65,34 @@ def test_feature_config_rejects_class_object_feature_group() -> None:
 
     with pytest.raises(ValueError):
         FeatureConfig(name="shared_token", feature_group=bad_value)
+
+
+def test_feature_config_rejects_empty_feature_group() -> None:
+    """An empty feature_group is a config mistake, not a silent "no scope"."""
+    with pytest.raises(ValueError, match="feature_group"):
+        FeatureConfig(name="shared_token", feature_group="")
+
+
+def test_feature_config_rejects_whitespace_only_feature_group() -> None:
+    """A whitespace-only feature_group strips to nothing and must be rejected too."""
+    with pytest.raises(ValueError, match="feature_group"):
+        FeatureConfig(name="shared_token", feature_group="   ")
+
+
+def test_loader_rejects_empty_feature_group() -> None:
+    """The loader rejects an empty feature_group instead of dropping the scope."""
+    config_str = '[{"name": "shared_token", "feature_group": ""}]'
+
+    with pytest.raises(ValueError, match="feature_group"):
+        load_features_from_config(config_str)
+
+
+def test_loader_rejects_whitespace_only_feature_group() -> None:
+    """The loader rejects a whitespace-only feature_group instead of dropping the scope."""
+    config_str = '[{"name": "shared_token", "feature_group": "   "}]'
+
+    with pytest.raises(ValueError, match="feature_group"):
+        load_features_from_config(config_str)
 
 
 # ---------------------------------------------------------------------------
@@ -202,6 +231,101 @@ def test_loader_nested_in_features_feature_carries_feature_group() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Loader: the nested in_features dict is validated like a FeatureConfig
+#
+# The nested dict never passes through FeatureConfig.__post_init__, so its
+# feature_group must be validated on the nested path too. Otherwise Feature()
+# raises a raw TypeError ("feature_group must be a FeatureGroup subclass, ...")
+# and a config-file user gets a Python-API error out of a config error.
+# ---------------------------------------------------------------------------
+
+CONFIG_STYLE_MESSAGE = "must be a feature group class-name string"
+
+
+def test_nested_in_features_rejects_non_string_feature_group() -> None:
+    """A non-string nested feature_group raises the config-style ValueError, not a TypeError."""
+    options: dict[str, Any] = {
+        "scaler_type": "minmax",
+        "in_features": {
+            "name": "shared_token",
+            "feature_group": 123,
+            "options": {"in_features": "age"},
+        },
+    }
+
+    with pytest.raises(ValueError, match=CONFIG_STYLE_MESSAGE):
+        process_nested_features(options)
+
+
+def test_nested_in_features_rejects_class_object_feature_group() -> None:
+    """The class-object scope form stays Python-only on the nested config path as well."""
+
+    class NotJsonExpressibleNested(FeatureGroup):
+        """Placeholder feature group used as an invalid nested config value."""
+
+    options: dict[str, Any] = {
+        "in_features": {
+            "name": "shared_token",
+            "feature_group": NotJsonExpressibleNested,
+        },
+    }
+
+    with pytest.raises(ValueError, match=CONFIG_STYLE_MESSAGE):
+        process_nested_features(options)
+
+
+def test_loader_nested_in_features_rejects_non_string_feature_group() -> None:
+    """The same nested rejection surfaces through load_features_from_config on a JSON string."""
+    config_str = """[
+        {
+            "name": "outer_feature",
+            "options": {
+                "scaler_type": "minmax",
+                "in_features": {
+                    "name": "shared_token",
+                    "feature_group": 123,
+                    "options": {"in_features": "age"}
+                }
+            }
+        }
+    ]"""
+
+    with pytest.raises(ValueError, match=CONFIG_STYLE_MESSAGE):
+        load_features_from_config(config_str)
+
+
+def test_nested_in_features_rejects_empty_feature_group() -> None:
+    """An empty nested feature_group is rejected instead of silently stripped to None."""
+    options: dict[str, Any] = {
+        "in_features": {
+            "name": "shared_token",
+            "feature_group": "",
+        },
+    }
+
+    with pytest.raises(ValueError, match="feature_group"):
+        process_nested_features(options)
+
+
+def test_loader_nested_in_features_rejects_whitespace_only_feature_group() -> None:
+    """A whitespace-only nested feature_group is rejected through the loader too."""
+    config_str = """[
+        {
+            "name": "outer_feature",
+            "options": {
+                "in_features": {
+                    "name": "shared_token",
+                    "feature_group": "   "
+                }
+            }
+        }
+    ]"""
+
+    with pytest.raises(ValueError, match="feature_group"):
+        load_features_from_config(config_str)
+
+
+# ---------------------------------------------------------------------------
 # Regression: configs without the field are unchanged
 # ---------------------------------------------------------------------------
 
@@ -237,6 +361,13 @@ def test_feature_config_schema_includes_feature_group() -> None:
 
     assert "feature_group" in schema["properties"], "'feature_group' should be in schema properties"
     assert schema["properties"]["feature_group"]["type"] == "string"
+
+
+def test_feature_config_schema_feature_group_is_non_empty() -> None:
+    """The schema states the non-empty constraint the validation enforces."""
+    schema = feature_config_schema()
+
+    assert schema["properties"]["feature_group"]["minLength"] == 1
 
 
 # ---------------------------------------------------------------------------
@@ -299,12 +430,10 @@ def test_end2end_scoped_config_feature_resolves_to_source_a() -> None:
 
     results = _run(config_str)
 
-    values: list[str] = []
-    for df in results:
-        if "config_shared_token" in df.columns:
-            values = list(df["config_shared_token"].values)
-
-    assert values == ["a1", "a2"]
+    assert len(results) == 1
+    df = results[0]
+    assert "config_shared_token" in df.columns
+    assert list(df["config_shared_token"].values) == ["a1", "a2"]
 
 
 def test_end2end_scoped_config_feature_resolves_to_source_b() -> None:
@@ -313,9 +442,7 @@ def test_end2end_scoped_config_feature_resolves_to_source_b() -> None:
 
     results = _run(config_str)
 
-    values: list[str] = []
-    for df in results:
-        if "config_shared_token" in df.columns:
-            values = list(df["config_shared_token"].values)
-
-    assert values == ["b1", "b2"]
+    assert len(results) == 1
+    df = results[0]
+    assert "config_shared_token" in df.columns
+    assert list(df["config_shared_token"].values) == ["b1", "b2"]

--- a/tests/test_core/test_api/feature_config/test_feature_config_feature_group_scope.py
+++ b/tests/test_core/test_api/feature_config/test_feature_config_feature_group_scope.py
@@ -1,0 +1,321 @@
+"""Per-feature FeatureGroup scope in the JSON config loader (issue #582).
+
+Feature(name, feature_group=...) can disambiguate a shared column name that two
+enabled feature groups both declare. The JSON config schema has no equivalent
+field, so config-file users hit "Multiple feature groups found".
+
+These tests pin the config-side field: FeatureConfig.feature_group holds a
+class-name STRING (the class-object form stays Python-only), the loader forwards
+it to Feature at every construction site, non-string values are rejected with
+ValueError, and the schema advertises it.
+"""
+
+from typing import Any, Optional
+
+import pytest
+
+from mloda.core.api.feature_config.loader import load_features_from_config, process_nested_features
+from mloda.core.api.feature_config.models import FeatureConfig, feature_config_schema
+from mloda.core.api.feature_config.parser import parse_json
+from mloda.provider import BaseInputData
+from mloda.provider import DataCreator
+from mloda.provider import FeatureGroup
+from mloda.provider import FeatureSet
+from mloda.user import Feature
+from mloda.user import PluginCollector
+from mloda.user import mloda
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+
+
+# ---------------------------------------------------------------------------
+# Model: FeatureConfig.feature_group
+# ---------------------------------------------------------------------------
+
+
+def test_feature_config_accepts_feature_group_string() -> None:
+    """FeatureConfig carries an optional feature_group class-name string."""
+    config = FeatureConfig(name="shared_token", feature_group="ConfigScopeSourceA")
+
+    assert config.feature_group == "ConfigScopeSourceA"
+
+
+def test_feature_config_feature_group_defaults_to_none() -> None:
+    """Configs that omit feature_group keep it as None."""
+    config = FeatureConfig(name="shared_token")
+
+    assert config.feature_group is None
+
+
+def test_feature_config_rejects_non_string_feature_group() -> None:
+    """A non-string feature_group raises ValueError in the config validation style."""
+    bad_value: Any = 123
+
+    with pytest.raises(ValueError):
+        FeatureConfig(name="shared_token", feature_group=bad_value)
+
+
+def test_feature_config_rejects_class_object_feature_group() -> None:
+    """The class-object scope form is Python-only and not expressible in a config."""
+
+    class NotJsonExpressible(FeatureGroup):
+        """Placeholder feature group used as an invalid config value."""
+
+    bad_value: Any = NotJsonExpressible
+
+    with pytest.raises(ValueError):
+        FeatureConfig(name="shared_token", feature_group=bad_value)
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+
+def test_parse_json_populates_feature_group() -> None:
+    """parse_json maps the JSON feature_group key onto FeatureConfig."""
+    config_str = '[{"name": "shared_token", "feature_group": "ConfigScopeSourceA"}]'
+
+    items = parse_json(config_str)
+
+    assert len(items) == 1
+    item = items[0]
+    assert isinstance(item, FeatureConfig)
+    assert item.feature_group == "ConfigScopeSourceA"
+
+
+# ---------------------------------------------------------------------------
+# Loader: every Feature construction site forwards the scope
+# ---------------------------------------------------------------------------
+
+
+def test_loader_forwards_feature_group_plain_options_branch() -> None:
+    """The plain-options branch forwards feature_group to Feature."""
+    config_str = """[
+        {
+            "name": "shared_token",
+            "feature_group": "ConfigScopeSourceA",
+            "options": {"param": "value"}
+        }
+    ]"""
+
+    result = load_features_from_config(config_str)
+
+    assert isinstance(result[0], Feature)
+    assert result[0].feature_group_scope == "ConfigScopeSourceA"
+    assert result[0].options.group.get("param") == "value"
+
+
+def test_loader_forwards_feature_group_in_features_branch() -> None:
+    """The in_features branch forwards feature_group to Feature."""
+    config_str = """[
+        {
+            "name": "derived_token",
+            "feature_group": "ConfigScopeSourceA",
+            "in_features": ["age"],
+            "options": {"method": "standard"}
+        }
+    ]"""
+
+    result = load_features_from_config(config_str)
+
+    assert isinstance(result[0], Feature)
+    assert result[0].feature_group_scope == "ConfigScopeSourceA"
+
+
+def test_loader_forwards_feature_group_group_context_options_branch() -> None:
+    """The group_options/context_options branch forwards feature_group to Feature."""
+    config_str = """[
+        {
+            "name": "modern_token",
+            "feature_group": "ConfigScopeSourceA",
+            "group_options": {"threshold": 0.5},
+            "context_options": {"metadata": "test"}
+        }
+    ]"""
+
+    result = load_features_from_config(config_str)
+
+    assert isinstance(result[0], Feature)
+    assert result[0].feature_group_scope == "ConfigScopeSourceA"
+    assert result[0].options.group.get("threshold") == 0.5
+    assert result[0].options.context.get("metadata") == "test"
+
+
+def test_loader_forwards_feature_group_with_column_index() -> None:
+    """A scoped feature keeps the tilde column-index name and the scope."""
+    config_str = """[
+        {
+            "name": "shared_token",
+            "feature_group": "ConfigScopeSourceA",
+            "column_index": 1
+        }
+    ]"""
+
+    result = load_features_from_config(config_str)
+
+    assert isinstance(result[0], Feature)
+    assert result[0].name == "shared_token~1"
+    assert result[0].feature_group_scope == "ConfigScopeSourceA"
+
+
+def test_nested_in_features_feature_carries_feature_group() -> None:
+    """The nested in_features Feature built by process_nested_features carries the scope."""
+    options: dict[str, Any] = {
+        "scaler_type": "minmax",
+        "in_features": {
+            "name": "shared_token",
+            "feature_group": "ConfigScopeSourceA",
+            "options": {"in_features": "age"},
+        },
+    }
+
+    processed = process_nested_features(options)
+
+    nested = processed["in_features"]
+    assert isinstance(nested, Feature)
+    assert nested.name == "shared_token"
+    assert nested.feature_group_scope == "ConfigScopeSourceA"
+
+
+def test_loader_nested_in_features_feature_carries_feature_group() -> None:
+    """End of the nested path: the loader keeps the scope on the nested Feature."""
+    config_str = """[
+        {
+            "name": "outer_feature",
+            "options": {
+                "scaler_type": "minmax",
+                "in_features": {
+                    "name": "shared_token",
+                    "feature_group": "ConfigScopeSourceA",
+                    "options": {"in_features": "age"}
+                }
+            }
+        }
+    ]"""
+
+    result = load_features_from_config(config_str)
+
+    assert isinstance(result[0], Feature)
+    nested = result[0].options.group.get("in_features")
+    assert isinstance(nested, Feature)
+    assert nested.feature_group_scope == "ConfigScopeSourceA"
+
+
+# ---------------------------------------------------------------------------
+# Regression: configs without the field are unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_configs_without_feature_group_have_no_scope() -> None:
+    """Configs that omit feature_group produce features with no scope in every branch."""
+    config_str = """[
+        {"name": "plain", "options": {"param": "value"}},
+        {"name": "with_in_features", "in_features": ["age"]},
+        {
+            "name": "with_group_context",
+            "group_options": {"threshold": 0.5},
+            "context_options": {"metadata": "test"}
+        }
+    ]"""
+
+    result = load_features_from_config(config_str)
+
+    assert len(result) == 3
+    for item in result:
+        assert isinstance(item, Feature)
+        assert item.feature_group_scope is None
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+
+def test_feature_config_schema_includes_feature_group() -> None:
+    """The schema advertises feature_group as a string property."""
+    schema = feature_config_schema()
+
+    assert "feature_group" in schema["properties"], "'feature_group' should be in schema properties"
+    assert schema["properties"]["feature_group"]["type"] == "string"
+
+
+# ---------------------------------------------------------------------------
+# End to end: two enabled sources declaring the same shared column name
+# ---------------------------------------------------------------------------
+
+
+class ConfigScopeSourceA(FeatureGroup):
+    """Source A: provides the shared "config_shared_token" plus "config_value_a"."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={"config_shared_token", "config_value_a"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {
+            "config_shared_token": ["a1", "a2"],
+            "config_value_a": [1, 2],
+        }
+
+
+class ConfigScopeSourceB(FeatureGroup):
+    """Source B: also provides the shared "config_shared_token" plus "config_value_b"."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={"config_shared_token", "config_value_b"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {
+            "config_shared_token": ["b1", "b2"],
+            "config_value_b": [3, 4],
+        }
+
+
+def _run(config_str: str) -> list[Any]:
+    features = load_features_from_config(config_str, format="json")
+    return list(
+        mloda.run_all(
+            features,
+            compute_frameworks={PandasDataFrame},
+            plugin_collector=PluginCollector.enabled_feature_groups({ConfigScopeSourceA, ConfigScopeSourceB}),
+        )
+    )
+
+
+def test_end2end_unscoped_config_feature_is_ambiguous() -> None:
+    """Characterization: the bare shared name without feature_group stays ambiguous."""
+    config_str = '[{"name": "config_shared_token"}]'
+
+    with pytest.raises(ValueError, match="Multiple feature groups found"):
+        _run(config_str)
+
+
+def test_end2end_scoped_config_feature_resolves_to_source_a() -> None:
+    """The same config with feature_group resolves uniquely and returns Source A's data."""
+    config_str = '[{"name": "config_shared_token", "feature_group": "ConfigScopeSourceA"}]'
+
+    results = _run(config_str)
+
+    values: list[str] = []
+    for df in results:
+        if "config_shared_token" in df.columns:
+            values = list(df["config_shared_token"].values)
+
+    assert values == ["a1", "a2"]
+
+
+def test_end2end_scoped_config_feature_resolves_to_source_b() -> None:
+    """Scoping the same config name to Source B returns Source B's data instead."""
+    config_str = '[{"name": "config_shared_token", "feature_group": "ConfigScopeSourceB"}]'
+
+    results = _run(config_str)
+
+    values: list[str] = []
+    for df in results:
+        if "config_shared_token" in df.columns:
+            values = list(df["config_shared_token"].values)
+
+    assert values == ["b1", "b2"]


### PR DESCRIPTION
Closes #582.

## Problem

`Feature("subject_token", feature_group=ClaimsReader)` (added in #575) scopes a request to one source so a column that two enabled sources both declare resolves uniquely. The scope was reachable only through the Python constructor: `FeatureConfig` rejects unknown fields and the loader never populated `feature_group_scope`, so a config-driven request for a shared key still failed with "Multiple feature groups found" and had no way to opt in.

## Change

- `FeatureConfig` accepts an optional `feature_group` field holding a class-name string. JSON cannot express a class object, so that form stays Python-only and is rejected here.
- `load_features_from_config` forwards the scope to `Feature(feature_group=...)` at every construction site, including the nested `in_features` Feature built by `process_nested_features`, which dropped the key silently before.
- Both paths share `validate_feature_group_scope`, so a nested dict (which never passes through `FeatureConfig`) raises the same config-style `ValueError` instead of leaking a `TypeError` from `Feature`.
- An empty or whitespace-only scope is rejected rather than stripped to `None`: in a static config it is always a mistake, and silently dropping it hands the author back the exact ambiguity error the field exists to prevent. The Python API keeps its strip-to-None behavior.
- `feature_config_schema()` advertises `feature_group` as a non-empty string.

## Docs

`feature-config.md` gains the field row and a Feature Group Scope section; the troubleshooting guide shows the JSON form next to the existing Python snippets.

## Tests

26 tests in `test_feature_config_feature_group_scope.py`. End to end, two enabled sources declare the same column: the bare name still raises "Multiple feature groups found", and the same config with `feature_group` resolves uniquely to source A or B and returns that source's data. Configs omitting the field are unchanged.

`tox` green: 5020 passed, ruff clean, mypy --strict clean, bandit clean.

## Known gaps (pre-existing, not addressed here)

- Unknown keys in a nested `in_features` dict are ignored silently (only the top level enforces `additionalProperties`), so a nested `feature_grp` typo degrades to no scope.
- The `group_options`/`context_options` branch never calls `process_nested_features`, so nested feature dicts there are left as raw dicts.

Both are independent of this field and worth a separate issue.