### PR TITLE
feat: run_all and stream_all results expose the resolved plan (#647)

### DIFF
--- a/attribution/ATTRIBUTION.md
+++ b/attribution/ATTRIBUTION.md
@@ -41,9 +41,10 @@
 | mypy                                   | 2.1.0           | MIT                                                |
 | mypy_extensions                        | 1.1.0           | MIT                                                |
 | narwhals                               | 2.23.0          | MIT                                                |
+| nest-asyncio                           | 1.6.0           | BSD License                                        |
 | nest-asyncio2                          | 1.7.2           | BSD License                                        |
 | nltk                                   | 3.9.4           | Apache Software License                            |
-| numpy                                  | 2.5.0           | BSD-3-Clause AND 0BSD AND MIT AND Zlib AND CC0-1.0 |
+| numpy                                  | 2.5.1           | BSD-3-Clause AND 0BSD AND MIT AND Zlib AND CC0-1.0 |
 | opentelemetry-api                      | 1.43.0          | Apache-2.0                                         |
 | opentelemetry-instrumentation          | 0.64b0          | Apache Software License                            |
 | opentelemetry-instrumentation-logging  | 0.64b0          | Apache Software License                            |

--- a/docs/docs/in_depth/mloda-api.md
+++ b/docs/docs/in_depth/mloda-api.md
@@ -153,7 +153,9 @@ for step in mloda.explain(["sales__mean_aggr"], compute_frameworks=["PandasDataF
 **Returns:** `PlanStep` dataclass (frozen) with fields:
 
 - **step_kind** (`Literal["compute", "join", "transform"]`).
-- **feature_names** (`tuple[str, ...]`): Features computed by a compute step, empty otherwise. This includes engine-injected features (link index features, global-filter features), so it is not a clean "requested feature name -> FeatureGroup" map: the same index name can appear under two different FeatureGroups in one plan.
+- **feature_names** (`tuple[str, ...]`): Features computed by a compute step, empty otherwise. This includes engine-injected features (link index features, global-filter features); use the requested/injected split below to tell them apart.
+- **requested_feature_names** (`tuple[str, ...]`): The user-requested subset of `feature_names` on a compute step, empty for join and transform steps.
+- **injected_feature_names** (`tuple[str, ...]`): The engine-injected/dependency remainder of `feature_names` on a compute step, empty for join and transform steps.
 - **feature_group** (`type[FeatureGroup] | None`): Resolved FeatureGroup; the destination for a transform step; the link's declared left side for a join.
 - **compute_framework** (`type[ComputeFramework] | None`): Selected ComputeFramework; the destination for a transform step; the merge destination for a join.
 - **source_feature_group** / **source_compute_framework**: Origin of a transform step. For a join: the link's declared right side, and the framework merged in.

--- a/docs/docs/in_depth/mloda-api.md
+++ b/docs/docs/in_depth/mloda-api.md
@@ -138,7 +138,9 @@ from mloda.user import mloda
 results = mloda.run_all(["sales__mean_aggr"], compute_frameworks=["PandasDataFrame"])
 for step in results.plan:
     print(step.step_kind, step.feature_names)
-``` To match a `run_all` resolution, pass the same `parallelization_modes`: `run_all` defaults to `{ParallelizationMode.SYNC}`, `prepare`/`explain` default to `None`, and compute frameworks are filtered by mode.
+```
+
+To match a `run_all` resolution, pass the same `parallelization_modes`: `run_all` defaults to `{ParallelizationMode.SYNC}`, `prepare`/`explain` default to `None`, and compute frameworks are filtered by mode.
 
 ``` python
 from mloda.user import mloda

--- a/docs/docs/in_depth/mloda-api.md
+++ b/docs/docs/in_depth/mloda-api.md
@@ -130,7 +130,15 @@ print(f"Candidates: {[fg.__name__ for fg in result.candidates]}")
 
 The runtime counterpart to `resolve_feature`: `mlodaAPI.explain(...)` builds the execution plan for a request without running it, and `session.resolved_plan()` returns the same records for a prepared session (before or after `run()`). Both return a `list[PlanStep]` in execution-plan order. Every `explain` parameter after `features` is keyword-only.
 
-`explain` re-resolves the plan from scratch. It answers "what would this request resolve to", it is not a record of a prior `run_all` execution. To match a `run_all` resolution, pass the same `parallelization_modes`: `run_all` defaults to `{ParallelizationMode.SYNC}`, `prepare`/`explain` default to `None`, and compute frameworks are filtered by mode.
+`explain` re-resolves the plan from scratch. It answers "what would this request resolve to", it is not a record of a prior `run_all` execution. For the plan of a run that actually happened, use the return value directly: `run_all` returns a `RunResult` (a `list` with a read-only `plan` property) and `stream_all` returns a `ResultStream` (generator-compatible, `plan` available before consuming). One planning pass serves both the results and the plan, unlike `explain`, which re-resolves.
+
+``` python
+from mloda.user import mloda
+
+results = mloda.run_all(["sales__mean_aggr"], compute_frameworks=["PandasDataFrame"])
+for step in results.plan:
+    print(step.step_kind, step.feature_names)
+``` To match a `run_all` resolution, pass the same `parallelization_modes`: `run_all` defaults to `{ParallelizationMode.SYNC}`, `prepare`/`explain` default to `None`, and compute frameworks are filtered by mode.
 
 ``` python
 from mloda.user import mloda

--- a/docs/docs/in_depth/streaming.md
+++ b/docs/docs/in_depth/streaming.md
@@ -9,6 +9,8 @@ for result in mloda.stream_all(["FeatureA", "FeatureB", "FeatureC"]):
     print(result)
 ```
 
+`stream_all` returns a `ResultStream`: it iterates exactly like the old generator and additionally exposes a `.plan` property with the resolved execution plan. Planning happens eagerly, so an unresolvable request raises at the `stream_all` call, not at first iteration.
+
 ## Comparison with `run_all`
 
 `run_all` returns all results at once after every feature group has finished:

--- a/mloda/core/api/plan_info.py
+++ b/mloda/core/api/plan_info.py
@@ -21,6 +21,8 @@ class PlanStep:
     The names include engine-injected features (link index features, global-filter features):
     ``requested_feature_names`` holds the user-requested names, ``injected_feature_names`` the
     engine-injected/dependency remainder; both are empty for join and transform steps.
+    The split is name-based, so a name that is both user-requested and engine-injected within
+    one step counts as requested only.
     ``source_*`` and ``join_type`` are None.
 
     transform: ``feature_group``/``compute_framework`` are the destination, ``source_*`` the origin.

--- a/mloda/core/api/plan_info.py
+++ b/mloda/core/api/plan_info.py
@@ -18,8 +18,10 @@ class PlanStep:
     ``step_kind`` is "compute", "join" or "transform".
 
     compute: ``feature_names`` are the names computed by ``feature_group`` on ``compute_framework``.
-    The names include engine-injected features (link index features, global-filter features), so they
-    are not only the requested ones. ``source_*`` and ``join_type`` are None.
+    The names include engine-injected features (link index features, global-filter features):
+    ``requested_feature_names`` holds the user-requested names, ``injected_feature_names`` the
+    engine-injected/dependency remainder; both are empty for join and transform steps.
+    ``source_*`` and ``join_type`` are None.
 
     transform: ``feature_group``/``compute_framework`` are the destination, ``source_*`` the origin.
 
@@ -38,6 +40,8 @@ class PlanStep:
     source_feature_group: Optional[type["FeatureGroup"]]
     source_compute_framework: Optional[type["ComputeFramework"]]
     join_type: Optional[str] = None
+    requested_feature_names: tuple[str, ...] = ()
+    injected_feature_names: tuple[str, ...] = ()
 
     @property
     def feature_group_name(self) -> Optional[str]:
@@ -68,14 +72,19 @@ def build_plan_steps(
 
     for step in execution_plan:
         if isinstance(step, FeatureGroupStep):
+            feature_names = tuple(str(name) for name in step.features.get_all_names())
+            requested = tuple(sorted(str(name) for name in step.features.get_initial_requested_features()))
+            injected = tuple(sorted(set(feature_names) - set(requested)))
             plan.append(
                 PlanStep(
                     step_kind="compute",
-                    feature_names=tuple(str(name) for name in step.features.get_all_names()),
+                    feature_names=feature_names,
                     feature_group=step.feature_group,
                     compute_framework=step.compute_framework,
                     source_feature_group=None,
                     source_compute_framework=None,
+                    requested_feature_names=requested,
+                    injected_feature_names=injected,
                 )
             )
         elif isinstance(step, TransformFrameworkStep):

--- a/mloda/core/api/request.py
+++ b/mloda/core/api/request.py
@@ -5,8 +5,9 @@ from mloda.core.abstract_plugins.components.input_data.api.api_input_data_collec
     ApiInputDataCollection,
 )
 from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
-from mloda.core.core.engine import Engine
+from mloda.core.core.engine import Engine as Engine
 from mloda.core.api.plan_info import PlanStep, build_plan_steps
+from mloda.core.api.run_result import ResultStream, RunResult
 from mloda.core.api.prepare.setup_compute_framework import SetupComputeFramework
 from mloda.core.prepare.accessible_plugins import filter_extenders_by_strict_mode
 from mloda.core.filter.global_filter import GlobalFilter
@@ -112,7 +113,7 @@ class mlodaAPI:
         copy_features: bool = True,
         strict_type_enforcement: bool = False,
         column_ordering: Optional[str] = None,
-    ) -> list[Any]:
+    ) -> RunResult:
         """
         Run feature computation in one step.
 
@@ -136,11 +137,12 @@ class mlodaAPI:
             strict_type_enforcement: If True, enforce strict type matching for typed features.
 
         Returns:
-            List of computed results, one per feature group in execution plan
-            order. Each element is a compute-framework object (e.g.
-            ``pd.DataFrame``, ``pa.Table``) containing only the columns for
-            the requested features resolved by that group. When all requested
-            features resolve to a single group, the list has one element.
+            ``RunResult``, a list of computed results, one per feature group in
+            execution plan order. Each element is a compute-framework object
+            (e.g. ``pd.DataFrame``, ``pa.Table``) containing only the columns
+            for the requested features resolved by that group. When all
+            requested features resolve to a single group, the list has one
+            element. ``result.plan`` exposes the resolved plan of this run.
 
         Example:
             result = mloda.run_all(
@@ -161,12 +163,13 @@ class mlodaAPI:
             column_ordering=column_ordering,
             parallelization_modes=parallelization_modes,
         )
-        return session.run(
+        results = session.run(
             api_data=api_data,
             parallelization_modes=parallelization_modes,
             flight_server=flight_server,
             function_extender=function_extender,
         )
+        return RunResult(results, session)
 
     @classmethod
     def stream_all(
@@ -184,14 +187,15 @@ class mlodaAPI:
         copy_features: bool = True,
         strict_type_enforcement: bool = False,
         column_ordering: Optional[str] = None,
-    ) -> Generator[Any, None, None]:
+    ) -> ResultStream:
         """Stream results at feature-group granularity.
 
         Like ``run_all`` but yields each feature group's result as it completes.
-        ``list(stream_all(...))`` equals ``run_all(...)``.
+        ``list(stream_all(...))`` equals ``run_all(...)``. Planning happens eagerly
+        at the call; the returned ``ResultStream`` exposes ``plan`` before iteration.
 
-        Yields:
-            One complete result per feature group.
+        Returns:
+            ``ResultStream`` yielding one complete result per feature group.
         """
         session = cls.prepare(
             features,
@@ -206,11 +210,14 @@ class mlodaAPI:
             column_ordering=column_ordering,
             parallelization_modes=parallelization_modes,
         )
-        yield from session.stream_run(
-            api_data=api_data,
-            parallelization_modes=parallelization_modes,
-            flight_server=flight_server,
-            function_extender=function_extender,
+        return ResultStream(
+            session.stream_run(
+                api_data=api_data,
+                parallelization_modes=parallelization_modes,
+                flight_server=flight_server,
+                function_extender=function_extender,
+            ),
+            session,
         )
 
     @classmethod

--- a/mloda/core/api/request.py
+++ b/mloda/core/api/request.py
@@ -5,6 +5,8 @@ from mloda.core.abstract_plugins.components.input_data.api.api_input_data_collec
     ApiInputDataCollection,
 )
 from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
+
+# Explicit alias re-exports Engine under no_implicit_reexport so tests can patch mloda.core.api.request.Engine.
 from mloda.core.core.engine import Engine as Engine
 from mloda.core.api.plan_info import PlanStep, build_plan_steps
 from mloda.core.api.run_result import ResultStream, RunResult
@@ -169,7 +171,7 @@ class mlodaAPI:
             flight_server=flight_server,
             function_extender=function_extender,
         )
-        return RunResult(results, session)
+        return RunResult(results, session.resolved_plan())
 
     @classmethod
     def stream_all(
@@ -210,6 +212,7 @@ class mlodaAPI:
             column_ordering=column_ordering,
             parallelization_modes=parallelization_modes,
         )
+        # Planning is eager in prepare, so the plan snapshot is available before iteration.
         return ResultStream(
             session.stream_run(
                 api_data=api_data,
@@ -217,7 +220,7 @@ class mlodaAPI:
                 flight_server=flight_server,
                 function_extender=function_extender,
             ),
-            session,
+            session.resolved_plan(),
         )
 
     @classmethod

--- a/mloda/core/api/run_result.py
+++ b/mloda/core/api/run_result.py
@@ -1,4 +1,4 @@
-"""Run results that carry the resolved plan of the run that produced them (issue #647 follow-up)."""
+"""Run results that carry the resolved plan of the run that produced them."""
 
 from collections.abc import Generator
 from types import TracebackType

--- a/mloda/core/api/run_result.py
+++ b/mloda/core/api/run_result.py
@@ -1,39 +1,39 @@
-"""Run results that know the session that produced them (issue #647 follow-up)."""
+"""Run results that carry the resolved plan of the run that produced them (issue #647 follow-up)."""
 
 from collections.abc import Generator
 from types import TracebackType
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from mloda.core.api.plan_info import PlanStep
 
-if TYPE_CHECKING:
-    from mloda.core.api.request import mlodaAPI
-
 
 class RunResult(list[Any]):
-    """The results list of a ``run_all`` call, plus the resolved plan of the run that produced it."""
+    """The results list of a ``run_all`` call, plus the resolved plan of the run that produced it.
 
-    def __init__(self, results: list[Any], session: "mlodaAPI") -> None:
+    Slicing and concatenation return a plain ``list`` without ``plan`` (standard list-subclass behavior).
+    """
+
+    def __init__(self, results: list[Any], plan: list[PlanStep]) -> None:
         super().__init__(results)
-        self._session = session
+        self._plan = plan
 
     @property
     def plan(self) -> list[PlanStep]:
         """Resolved execution plan of the run that produced these results."""
-        return self._session.resolved_plan()
+        return self._plan
 
 
 class ResultStream(Generator[Any, None, None]):
     """A ``stream_all`` result stream: iterates like a generator and exposes the resolved plan."""
 
-    def __init__(self, stream: Generator[Any, None, None], session: "mlodaAPI") -> None:
+    def __init__(self, stream: Generator[Any, None, None], plan: list[PlanStep]) -> None:
         self._stream = stream
-        self._session = session
+        self._plan = plan
 
     @property
     def plan(self) -> list[PlanStep]:
         """Resolved execution plan, available before any element is consumed."""
-        return self._session.resolved_plan()
+        return self._plan
 
     def send(self, value: None, /) -> Any:
         return self._stream.send(value)

--- a/mloda/core/api/run_result.py
+++ b/mloda/core/api/run_result.py
@@ -1,0 +1,52 @@
+"""Run results that know the session that produced them (issue #647 follow-up)."""
+
+from collections.abc import Generator
+from types import TracebackType
+from typing import TYPE_CHECKING, Any
+
+from mloda.core.api.plan_info import PlanStep
+
+if TYPE_CHECKING:
+    from mloda.core.api.request import mlodaAPI
+
+
+class RunResult(list[Any]):
+    """The results list of a ``run_all`` call, plus the resolved plan of the run that produced it."""
+
+    def __init__(self, results: list[Any], session: "mlodaAPI") -> None:
+        super().__init__(results)
+        self._session = session
+
+    @property
+    def plan(self) -> list[PlanStep]:
+        """Resolved execution plan of the run that produced these results."""
+        return self._session.resolved_plan()
+
+
+class ResultStream(Generator[Any, None, None]):
+    """A ``stream_all`` result stream: iterates like a generator and exposes the resolved plan."""
+
+    def __init__(self, stream: Generator[Any, None, None], session: "mlodaAPI") -> None:
+        self._stream = stream
+        self._session = session
+
+    @property
+    def plan(self) -> list[PlanStep]:
+        """Resolved execution plan, available before any element is consumed."""
+        return self._session.resolved_plan()
+
+    def send(self, value: None, /) -> Any:
+        return self._stream.send(value)
+
+    def throw(
+        self,
+        typ: type[BaseException] | BaseException,
+        val: BaseException | object = None,
+        tb: TracebackType | None = None,
+        /,
+    ) -> Any:
+        if isinstance(typ, BaseException):
+            return self._stream.throw(typ)
+        if val is None and tb is None:
+            return self._stream.throw(typ)
+        return self._stream.throw(typ, val, tb)

--- a/mloda/user/__init__.py
+++ b/mloda/user/__init__.py
@@ -6,6 +6,7 @@ from mloda.core.api.request import mlodaAPI
 
 # Resolved execution plan
 from mloda.core.api.plan_info import PlanStep
+from mloda.core.api.run_result import ResultStream, RunResult
 
 # Features
 from mloda.core.abstract_plugins.components.feature import Feature
@@ -130,6 +131,8 @@ __all__ = [
     "mloda",
     # Resolved execution plan
     "PlanStep",
+    "RunResult",
+    "ResultStream",
     # Features
     "Feature",
     "Features",

--- a/tests/test_core/test_abstract_plugins/test_components/test_is_final_reader.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_is_final_reader.py
@@ -24,6 +24,7 @@ options key), so they cannot pollute discovery in other tests.
 """
 
 import gc
+import weakref
 from typing import Any
 
 import pytest
@@ -321,13 +322,21 @@ class TestLoudValidation:
             def match_subclass_data_access(cls, data_access: Any, feature_names: list[str], options: Any = None) -> Any:
                 return None
 
+        bad_family = weakref.ref(_BadFamily)
+
         with pytest.raises(ValueError) as exc_info:
             _invoke(_BadFamily, "is_final_reader")
         assert "nonexistent_hook" in str(exc_info.value)
         assert "_BadFamily" in str(exc_info.value)
         # Drop the misconfigured local class from BaseInputData.__subclasses__ so it
         # cannot raise during discovery in sibling tests running in the same worker.
+        # The collect must happen after dropping exc_info because its captured
+        # traceback frames pin the class; the weakref assert fails loudly if the
+        # class ever becomes uncollectable again.
+        del exc_info
+        del _BadFamily
         gc.collect()
+        assert bad_family() is None
 
 
 class TestFamilyDeclarations:

--- a/tests/test_core/test_api/test_classmethod_consistency.py
+++ b/tests/test_core/test_api/test_classmethod_consistency.py
@@ -1,7 +1,7 @@
 """Tests that all mlodaAPI entry points use @classmethod so subclasses dispatch correctly."""
 
+import collections.abc
 import inspect
-import types
 from typing import Any, Optional
 from unittest.mock import patch
 
@@ -124,13 +124,17 @@ class TestBaseClassBehaviorUnchanged:
         assert len(result) == 1
 
     def test_stream_all_still_returns_generator(self) -> None:
+        from mloda.user import ResultStream
+
         result = mlodaAPI.stream_all(
             _features,
             compute_frameworks={PandasDataFrame},
             api_data=_api_data,
             plugin_collector=_enabled,
         )
-        assert isinstance(result, types.GeneratorType)
+        assert isinstance(result, collections.abc.Generator)
+        assert isinstance(result, ResultStream)
+        assert not isinstance(result, list)
 
     def test_mloda_alias_run_all_works(self) -> None:
         result = mloda.run_all(
@@ -143,7 +147,7 @@ class TestBaseClassBehaviorUnchanged:
         assert len(result) == 1
 
     def test_stream_all_importable_from_user_still_works(self) -> None:
-        from mloda.user import stream_all
+        from mloda.user import ResultStream, stream_all
 
         result = stream_all(
             _features,
@@ -151,6 +155,8 @@ class TestBaseClassBehaviorUnchanged:
             api_data=_api_data,
             plugin_collector=_enabled,
         )
-        assert isinstance(result, types.GeneratorType)
+        assert isinstance(result, collections.abc.Generator)
+        assert isinstance(result, ResultStream)
+        assert not isinstance(result, list)
         results = list(result)
         assert len(results) == 1

--- a/tests/test_core/test_api/test_plan_info.py
+++ b/tests/test_core/test_api/test_plan_info.py
@@ -10,6 +10,10 @@ Contract under test:
   * Join steps are not blank records: ``feature_group``/``source_feature_group`` are the link's
     declared left/right feature groups, ``compute_framework`` is the merge destination framework
     and ``source_compute_framework`` the framework merged in, ``join_type`` the link's join type.
+  * ``PlanStep`` also carries ``requested_feature_names`` and ``injected_feature_names``, both
+    defaulting to ``()``. On compute steps they partition ``feature_names`` into the names the user
+    asked for (``initial_requested_data`` is True) and the names the engine injected (chained
+    sources, link index features). Join and transform steps keep both empty.
   * ``build_plan_steps`` raises ``ValueError`` on a step it does not know, instead of dropping it.
   * ``mlodaAPI.resolved_plan()`` returns ``list[PlanStep]`` on a prepared session, both before
     and after ``run()``, in execution-plan order, and matches the plan that actually executed.
@@ -324,6 +328,8 @@ class TestPlanStepDataclass:
             "source_feature_group",
             "source_compute_framework",
             "join_type",
+            "requested_feature_names",
+            "injected_feature_names",
         ]
 
     def test_join_type_defaults_to_none(self) -> None:
@@ -417,6 +423,42 @@ class TestPlanStepDataclass:
         outer = dataclasses.replace(inner, join_type="outer")
 
         assert inner != outer
+
+
+class TestPlanStepRequestedAndInjectedFields:
+    """PlanStep splits feature_names into user-requested and engine-injected names."""
+
+    @staticmethod
+    def _compute_step() -> PlanStep:
+        return PlanStep(
+            step_kind="compute",
+            feature_names=("plan_info_sales",),
+            feature_group=PlanInfoPandasSource,
+            compute_framework=PandasDataFrame,
+            source_feature_group=None,
+            source_compute_framework=None,
+        )
+
+    def test_requested_and_injected_default_to_empty_tuples(self) -> None:
+        """A caller constructing a PlanStep by hand must not need to pass either field."""
+        step = self._compute_step()
+
+        assert step.requested_feature_names == ()
+        assert step.injected_feature_names == ()
+
+        fields_by_name = {field.name: field for field in dataclasses.fields(PlanStep)}
+        assert fields_by_name["requested_feature_names"].default == ()
+        assert fields_by_name["injected_feature_names"].default == ()
+
+    def test_requested_and_injected_participate_in_equality(self) -> None:
+        """Two records that only differ in the requested/injected split must not compare equal."""
+        base = self._compute_step()
+        with_requested = dataclasses.replace(base, requested_feature_names=("plan_info_sales",))
+        with_injected = dataclasses.replace(base, injected_feature_names=("plan_info_sales",))
+
+        assert base != with_requested
+        assert base != with_injected
+        assert with_requested != with_injected
 
 
 # ---------------------------------------------------------------------------
@@ -788,6 +830,79 @@ class TestCrossFrameworkJoinStepMapping:
         assert kinds.index("join") < kinds.index("compute", kinds.index("join"))
         consumer_index = [step.feature_group for step in plan].index(PlanInfoCrossConsumer)
         assert kinds.index("join") < consumer_index
+
+
+# ---------------------------------------------------------------------------
+# requested vs engine-injected feature names
+# ---------------------------------------------------------------------------
+
+
+class TestRequestedAndInjectedForChainedFeature:
+    """Only the chained ``*__mean_aggr`` name was requested: the source it chains off is injected."""
+
+    def test_source_step_features_are_all_injected(self) -> None:
+        plan = _prepare_chained_session().resolved_plan()
+
+        source_step = next(step for step in plan if step.feature_group is PlanInfoPandasSource)
+
+        assert source_step.requested_feature_names == ()
+        assert source_step.injected_feature_names == source_step.feature_names
+        assert source_step.injected_feature_names == ("plan_info_sales",)
+
+    def test_aggregation_step_features_are_all_requested(self) -> None:
+        plan = _prepare_chained_session().resolved_plan()
+
+        aggregation_step = next(step for step in plan if step.feature_group is PandasAggregatedFeatureGroup)
+
+        assert aggregation_step.requested_feature_names == aggregation_step.feature_names
+        assert aggregation_step.requested_feature_names == ("plan_info_sales__mean_aggr",)
+        assert aggregation_step.injected_feature_names == ()
+
+
+class TestRequestedAndInjectedForJoinPlans:
+    """Join and transform steps carry no names; compute steps partition feature_names exactly."""
+
+    def test_join_and_transform_steps_keep_both_fields_empty(self) -> None:
+        plan = _prepare_cross_framework_join_session().resolved_plan()
+
+        non_compute_steps = [step for step in plan if step.step_kind != "compute"]
+        assert {step.step_kind for step in non_compute_steps} == {"join", "transform"}
+
+        for step in non_compute_steps:
+            assert step.requested_feature_names == ()
+            assert step.injected_feature_names == ()
+
+    def test_compute_steps_partition_feature_names_disjointly(self) -> None:
+        """requested and injected are disjoint, sorted, and their union is feature_names exactly."""
+        plans = [
+            _prepare_single_framework_join_session().resolved_plan(),
+            _prepare_cross_framework_join_session().resolved_plan(),
+        ]
+
+        for plan in plans:
+            for step in (step for step in plan if step.step_kind == "compute"):
+                requested = set(step.requested_feature_names)
+                injected = set(step.injected_feature_names)
+
+                assert requested.isdisjoint(injected)
+                assert tuple(sorted(requested | injected)) == step.feature_names
+                assert list(step.requested_feature_names) == sorted(requested)
+                assert list(step.injected_feature_names) == sorted(injected)
+
+    def test_link_index_feature_is_injected_not_requested(self) -> None:
+        """Only ``PlanInfoCrossConsumer`` was requested: the link's index feature on the source
+        compute step is engine-injected, and the consumer's own name is the requested one."""
+        plan = _prepare_cross_framework_join_session().resolved_plan()
+
+        left_step = next(step for step in plan if step.feature_group is PlanInfoCrossLeftPandas)
+        assert left_step.requested_feature_names == ()
+        assert "plan_info_xjid" in left_step.injected_feature_names
+        assert "plan_info_xjid" not in left_step.requested_feature_names
+        assert left_step.injected_feature_names == left_step.feature_names
+
+        consumer_step = next(step for step in plan if step.feature_group is PlanInfoCrossConsumer)
+        assert consumer_step.requested_feature_names == ("PlanInfoCrossConsumer",)
+        assert consumer_step.injected_feature_names == ()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_core/test_api/test_run_result.py
+++ b/tests/test_core/test_api/test_run_result.py
@@ -1,4 +1,4 @@
-"""Tests for run results that know their run (issue #647 follow-up).
+"""Tests for run results that know their run.
 
 Contract under test:
   * ``mloda.core.api.run_result.RunResult`` is the return type of ``mlodaAPI.run_all``. It IS the
@@ -35,7 +35,7 @@ from tests.test_core.test_api.test_plan_info import PlanInfoPandasSource
 
 _PLUGINS = PluginCollector.enabled_feature_groups({PlanInfoPandasSource, PandasAggregatedFeatureGroup})
 
-# The chained request from issue #647: an aggregated feature over a source feature.
+# A chained request: an aggregated feature over a source feature.
 _CHAINED_FEATURES: list[Feature | str] = ["plan_info_sales__mean_aggr"]
 
 # Two feature groups resolve here, so the stream yields two elements and can be closed early.
@@ -109,7 +109,7 @@ class TestRunResultPlan:
             setattr(results, "plan", [])
 
     def test_chained_request_plan_contains_the_aggregation_compute_step(self) -> None:
-        """Issue #647 DoD: the plan names the concrete aggregation group and framework."""
+        """The plan names the concrete aggregation group and framework."""
         results = _run_all()
 
         compute_steps = [step for step in results.plan if step.step_kind == "compute"]

--- a/tests/test_core/test_api/test_run_result.py
+++ b/tests/test_core/test_api/test_run_result.py
@@ -1,0 +1,253 @@
+"""Tests for run results that know their run (issue #647 follow-up).
+
+Contract under test:
+  * ``mloda.core.api.run_result.RunResult`` is the return type of ``mlodaAPI.run_all``. It IS the
+    results list (drop-in for every existing list use) and additionally exposes a read-only
+    ``plan`` property returning ``list[PlanStep]``, the resolved plan of the run that produced it.
+  * ``mloda.core.api.run_result.ResultStream`` is the return type of ``mlodaAPI.stream_all``. It
+    iterates exactly like the old generator, satisfies ``collections.abc.Generator``, is not a
+    list, and exposes the same ``plan`` property, available before any element is consumed.
+  * ``stream_all`` plans eagerly: an unresolvable request raises at the call, not at iteration.
+  * One planning pass per one-shot call: ``run_all`` constructs exactly one Engine and accessing
+    ``plan`` afterwards constructs no further Engine.
+  * Both classes are exported from ``mloda.user``.
+
+The chained ``plan_info_sales__mean_aggr`` request reuses the feature groups registered by
+``tests/test_core/test_api/test_plan_info.py`` so no new registry-wide DataCreator claim is made.
+"""
+
+import collections.abc
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+# Aliased: a bare ``import mloda.user`` would bind the name ``mloda`` to the package and collide
+# with the ``mloda`` mlodaAPI alias imported below.
+import mloda.user as mloda_user
+from mloda.core.api.request import Engine
+from mloda.user import Feature, ParallelizationMode, PlanStep, PluginCollector, mloda, mlodaAPI
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.feature_group.experimental.aggregated_feature_group.pandas import PandasAggregatedFeatureGroup
+from tests.test_core.test_api.test_plan_info import PlanInfoPandasSource
+
+_PLUGINS = PluginCollector.enabled_feature_groups({PlanInfoPandasSource, PandasAggregatedFeatureGroup})
+
+# The chained request from issue #647: an aggregated feature over a source feature.
+_CHAINED_FEATURES: list[Feature | str] = ["plan_info_sales__mean_aggr"]
+
+# Two feature groups resolve here, so the stream yields two elements and can be closed early.
+_TWO_GROUP_FEATURES: list[Feature | str] = ["plan_info_sales", "plan_info_sales__mean_aggr"]
+
+
+# Helpers return Any on purpose: the concrete return types (RunResult/ResultStream) are exactly
+# what these tests assert at runtime.
+def _run_all(features: list[Feature | str] | None = None) -> Any:
+    return mlodaAPI.run_all(
+        features if features is not None else _CHAINED_FEATURES,
+        compute_frameworks={PandasDataFrame},
+        parallelization_modes={ParallelizationMode.SYNC},
+        plugin_collector=_PLUGINS,
+    )
+
+
+def _stream_all(features: list[Feature | str] | None = None) -> Any:
+    return mlodaAPI.stream_all(
+        features if features is not None else _CHAINED_FEATURES,
+        compute_frameworks={PandasDataFrame},
+        parallelization_modes={ParallelizationMode.SYNC},
+        plugin_collector=_PLUGINS,
+    )
+
+
+class TestRunAllReturnsRunResult:
+    """run_all returns a RunResult that is a list in every observable way."""
+
+    def test_run_all_returns_a_run_result(self) -> None:
+        from mloda.user import RunResult
+
+        results = _run_all()
+
+        assert type(results) is RunResult
+        assert isinstance(results, list)
+
+    def test_run_result_behaves_like_a_plain_list(self) -> None:
+        """Backward-compat pin: len, indexing, iteration and equality with a plain list."""
+        results = _run_all()
+
+        as_list = list(results)
+        assert results == as_list
+        assert len(results) == len(as_list) == 1
+        assert results[0] is as_list[0]
+        assert [item for item in results] == as_list
+        assert "plan_info_sales__mean_aggr" in results[0].columns
+
+
+class TestRunResultPlan:
+    """results.plan is the resolved plan of the run that produced the results."""
+
+    def test_plan_is_a_list_of_plan_steps(self) -> None:
+        results = _run_all()
+
+        plan = results.plan
+
+        assert isinstance(plan, list)
+        assert len(plan) > 0
+        assert all(isinstance(step, PlanStep) for step in plan)
+
+    def test_repeated_plan_access_returns_equal_plans(self) -> None:
+        results = _run_all()
+
+        assert results.plan == results.plan
+
+    def test_plan_is_read_only(self) -> None:
+        results = _run_all()
+
+        with pytest.raises(AttributeError):
+            setattr(results, "plan", [])
+
+    def test_chained_request_plan_contains_the_aggregation_compute_step(self) -> None:
+        """Issue #647 DoD: the plan names the concrete aggregation group and framework."""
+        results = _run_all()
+
+        compute_steps = [step for step in results.plan if step.step_kind == "compute"]
+        aggregation_steps = [step for step in compute_steps if "plan_info_sales__mean_aggr" in step.feature_names]
+        assert len(aggregation_steps) == 1, f"expected one aggregation step, got {compute_steps}"
+
+        aggregation = aggregation_steps[0]
+        assert aggregation.feature_group is PandasAggregatedFeatureGroup
+        assert aggregation.compute_framework is PandasDataFrame
+
+    def test_plan_equals_resolved_plan_of_an_equivalent_prepared_session(self) -> None:
+        results = _run_all()
+
+        session = mloda.prepare(
+            _CHAINED_FEATURES,
+            compute_frameworks={PandasDataFrame},
+            plugin_collector=_PLUGINS,
+            parallelization_modes={ParallelizationMode.SYNC},
+        )
+
+        assert results.plan == session.resolved_plan()
+
+
+class TestSinglePlanningPass:
+    """run_all plans exactly once; reading the plan afterwards must not re-plan."""
+
+    def test_run_all_constructs_one_engine_and_plan_access_adds_none(self) -> None:
+        constructions: list[object] = []
+
+        class CountingEngine(Engine):
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                constructions.append(object())
+                super().__init__(*args, **kwargs)
+
+        with patch("mloda.core.api.request.Engine", CountingEngine):
+            results = _run_all()
+            assert len(constructions) == 1
+
+            _ = results.plan
+            assert len(constructions) == 1
+
+
+class TestStreamAllReturnsResultStream:
+    """stream_all returns a ResultStream: a Generator with a plan, not a list."""
+
+    def test_stream_all_returns_a_result_stream(self) -> None:
+        from mloda.user import ResultStream
+
+        stream = _stream_all()
+
+        assert isinstance(stream, ResultStream)
+        assert isinstance(stream, collections.abc.Generator)
+        assert not isinstance(stream, list)
+
+    def test_plan_available_before_consumption_and_unchanged_after(self) -> None:
+        stream = _stream_all()
+
+        plan_before = stream.plan
+        assert isinstance(plan_before, list)
+        assert all(isinstance(step, PlanStep) for step in plan_before)
+        assert any(step.step_kind == "compute" for step in plan_before)
+
+        results = list(stream)
+        assert len(results) == 1
+
+        assert stream.plan == plan_before
+
+    def test_stream_content_still_matches_run_all(self) -> None:
+        """Backward-compat pin: list(stream_all(...)) equals run_all(...) content-wise."""
+        streamed = list(_stream_all())
+        ran = _run_all()
+
+        assert len(streamed) == len(ran) == 1
+        assert streamed[0]["plan_info_sales__mean_aggr"].tolist() == ran[0]["plan_info_sales__mean_aggr"].tolist()
+
+
+class TestStreamAllPlansEagerly:
+    """An unresolvable request must raise at the stream_all call, not at first iteration."""
+
+    def test_unresolvable_feature_raises_at_the_call(self) -> None:
+        # Deliberately no iteration: the bare call itself must raise.
+        with pytest.raises(ValueError, match="No feature groups found"):
+            mlodaAPI.stream_all(
+                ["run_result_unresolvable_647"],
+                compute_frameworks={PandasDataFrame},
+                parallelization_modes={ParallelizationMode.SYNC},
+                plugin_collector=_PLUGINS,
+            )
+
+
+class TestStreamEarlyClose:
+    """A partially consumed stream can be closed without error."""
+
+    def test_close_after_first_element(self) -> None:
+        from mloda.user import ResultStream
+
+        stream = _stream_all(_TWO_GROUP_FEATURES)
+        assert isinstance(stream, ResultStream)
+
+        first = next(stream)
+        assert first is not None
+
+        stream.close()
+
+
+class TestPublicExports:
+    """RunResult and ResultStream are exported from mloda.user and back the entry points."""
+
+    def test_exported_from_user_and_defined_in_run_result_module(self) -> None:
+        from mloda.core.api.run_result import ResultStream as ModuleResultStream
+        from mloda.core.api.run_result import RunResult as ModuleRunResult
+        from mloda.user import ResultStream, RunResult
+
+        assert RunResult is ModuleRunResult
+        assert ResultStream is ModuleResultStream
+        assert "RunResult" in mloda_user.__all__
+        assert "ResultStream" in mloda_user.__all__
+
+    def test_entry_points_return_the_exported_classes(self) -> None:
+        from mloda.user import ResultStream, RunResult
+
+        assert type(_run_all()) is RunResult
+        assert isinstance(_stream_all(), ResultStream)
+
+
+class TestSubclassDispatch:
+    """Subclassed entry points keep dispatching and keep the new return type."""
+
+    def test_subclass_run_all_returns_a_run_result(self) -> None:
+        from mloda.user import RunResult
+
+        class CustomAPI(mlodaAPI):
+            pass
+
+        results = CustomAPI.run_all(
+            _CHAINED_FEATURES,
+            compute_frameworks={PandasDataFrame},
+            parallelization_modes={ParallelizationMode.SYNC},
+            plugin_collector=_PLUGINS,
+        )
+
+        assert isinstance(results, RunResult)
+        assert len(results) == 1

--- a/tests/test_core/test_api/test_run_result.py
+++ b/tests/test_core/test_api/test_run_result.py
@@ -17,6 +17,8 @@ The chained ``plan_info_sales__mean_aggr`` request reuses the feature groups reg
 """
 
 import collections.abc
+import copy
+import pickle  # nosec B403
 from typing import Any
 from unittest.mock import patch
 
@@ -231,6 +233,48 @@ class TestPublicExports:
 
         assert type(_run_all()) is RunResult
         assert isinstance(_stream_all(), ResultStream)
+
+
+class TestRunResultIsPlainData:
+    """RunResult is plain data: picklable, deep-copyable, and free of the producing session."""
+
+    def test_pickle_round_trip_preserves_content(self) -> None:
+        results = _run_all()
+
+        loaded = pickle.loads(pickle.dumps(results))  # nosec B301
+
+        assert len(loaded) == len(results) == 1
+        assert loaded[0]["plan_info_sales__mean_aggr"].tolist() == results[0]["plan_info_sales__mean_aggr"].tolist()
+
+    def test_pickle_round_trip_preserves_type_and_plan(self) -> None:
+        from mloda.user import RunResult
+
+        results = _run_all()
+
+        loaded = pickle.loads(pickle.dumps(results))  # nosec B301
+
+        assert type(loaded) is RunResult
+        assert loaded.plan == results.plan
+
+    def test_deepcopy_preserves_content(self) -> None:
+        results = _run_all()
+
+        copied = copy.deepcopy(results)
+
+        assert len(copied) == len(results) == 1
+        assert copied[0]["plan_info_sales__mean_aggr"].tolist() == results[0]["plan_info_sales__mean_aggr"].tolist()
+
+    def test_run_result_does_not_retain_the_session(self) -> None:
+        """Memory pin: the plan is snapshotted eagerly, the session reference is dropped."""
+        results = _run_all()
+
+        assert not hasattr(results, "_session")
+
+    def test_result_stream_does_not_retain_the_session(self) -> None:
+        """Memory pin: same session-free contract for stream_all."""
+        stream = _stream_all()
+
+        assert not hasattr(stream, "_session")
 
 
 class TestSubclassDispatch:

--- a/tests/test_core/test_runtime/conftest.py
+++ b/tests/test_core/test_runtime/conftest.py
@@ -1,0 +1,7 @@
+"""Registers the EngineRunnerTest feature groups so test_stream_all.py resolves them standalone.
+
+stream_all now plans eagerly, so ``EngineRunnerTest1`` must be a loaded FeatureGroup subclass at
+call time, not only when the full suite's collection has imported its defining module.
+"""
+
+import tests.test_core.test_integration.test_core.test_runner_one_compute_framework  # noqa: F401

--- a/tests/test_core/test_runtime/test_stream_all.py
+++ b/tests/test_core/test_runtime/test_stream_all.py
@@ -1,7 +1,7 @@
 """Unit tests for mlodaAPI.stream_all classmethod."""
 
+import collections.abc
 import inspect
-import types
 
 
 class TestStreamAllClassMethod:
@@ -14,7 +14,7 @@ class TestStreamAllClassMethod:
 
     def test_stream_all_returns_generator(self) -> None:
         from mloda.core.api.request import mlodaAPI
-        from mloda.user import Feature, Features, ParallelizationMode
+        from mloda.user import Feature, Features, ParallelizationMode, ResultStream
         from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
 
         features = Features([Feature(name="EngineRunnerTest1", initial_requested_data=True)])
@@ -24,7 +24,9 @@ class TestStreamAllClassMethod:
             parallelization_modes={ParallelizationMode.SYNC},
         )
 
-        assert isinstance(result, types.GeneratorType)
+        assert isinstance(result, collections.abc.Generator)
+        assert isinstance(result, ResultStream)
+        assert not isinstance(result, list)
 
     def test_stream_all_accessible_via_mloda_alias(self) -> None:
         from mloda.user import mloda
@@ -41,7 +43,7 @@ class TestStreamAllImportFromUser:
         assert callable(stream_all)
 
     def test_stream_all_returns_generator_via_user_import(self) -> None:
-        from mloda.user import Feature, Features, ParallelizationMode, stream_all
+        from mloda.user import Feature, Features, ParallelizationMode, ResultStream, stream_all
         from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
 
         features = Features([Feature(name="EngineRunnerTest1", initial_requested_data=True)])
@@ -51,5 +53,6 @@ class TestStreamAllImportFromUser:
             parallelization_modes={ParallelizationMode.SYNC},
         )
 
-        assert isinstance(result, types.GeneratorType)
+        assert isinstance(result, collections.abc.Generator)
+        assert isinstance(result, ResultStream)
         assert not isinstance(result, list)


### PR DESCRIPTION
Replaces #669 (follow-up to #666 / issue #647). #669 exposed the plan of an actual run by adding `run_all_with_plan`, a tuple-returning twin that copied all 13 `run_all` parameters, and it explicitly could not cover `stream_all` because a generator cannot return a tuple. This PR takes the higher-level route: the session already knows everything about a run, so the results it hands out carry that knowledge instead of each artifact growing its own entry point.

## What

Results now know their run. No new entry points, no duplicated signatures, streaming included:

- `run_all` returns `RunResult`, a `list` subclass. It is the same results list as before, plus a read-only `plan` property with the `list[PlanStep]` of the run that produced it, snapshotted from the single planning pass of that call (no re-resolution, unlike `explain`).
- `stream_all` returns `ResultStream`, a `collections.abc.Generator` subclass wrapping the previous generator. Iteration, `next()`, `send`, `throw`, `close`, and `list(...)` behave as before, and the same `plan` property is available before, during, and after consumption.
- Both are exported from `mloda.user`.

## Behavior changes

- `stream_all` plans eagerly at the call, so an unresolvable request raises `ValueError` at `stream_all(...)` instead of at first iteration. The runner context still opens only on first iteration.
- The `stream_all` return value is no longer a CPython `types.GeneratorType` instance. The pinned contract moves to the `collections.abc.Generator` ABC; typed code annotated with `Generator[Any, None, None]` keeps checking.
- `RunResult` neither retains the session nor the engine: the plan is a snapshot, so `pickle` and `deepcopy` of results keep working exactly as for a plain list (covered by tests). Slicing and concatenation return a plain `list`, as with any list subclass.

## Review pass

Two independent deep reviews (a fresh Opus agent and codex) ran against the diff. Both flagged the same real bug in the first version: holding the producing session inside `RunResult` broke `pickle`/`deepcopy` (the runner owns a thread lock) and pinned engine memory for the results' lifetime. Fixed by snapshotting the plan; regression-tested. The Opus review also caught a malformed closing code fence in the docs that swallowed two paragraphs on the rendered page (fixed), and confirmed the plan cannot diverge from the executed one (`Engine.compute` runs on a deepcopy of the planner). Rejected: keeping `types.GeneratorType` compatibility (deliberate contract change, noted above) and restructuring the three-arg `throw` delegation (required for protocol fidelity, unreachable in normal use).

## Unrelated fix included

`test: make the _BadFamily loud-validation cleanup deterministic`: a pre-existing isolation leak from #671, exposed here by the shifted xdist distribution. The loud-validation test's `gc.collect()` ran while `exc_info` still pinned `_BadFamily` through captured traceback frames, so the class leaked into `BaseInputData.__subclasses__` and crashed sibling-reader discovery tests sharing the worker. The cleanup now drops the references first and asserts collection via weakref.

## Tests

`tests/test_core/test_api/test_run_result.py` (21 tests): list behavior of `RunResult`, plan of a chained `*__mean_aggr` request carrying the concrete FeatureGroup and framework (issue #647 DoD), plan equality with an equivalent `prepare` session, exactly one Engine construction per call, `ResultStream` protocol and plan before/during/after consumption, eager-planning error timing, early `close()`, pickle/deepcopy round-trips, no session retention, exports, subclass dispatch. Four existing `types.GeneratorType` pins were flipped to the ABC on purpose.

Full `tox` gate green: 4999 passed, 171 skipped, ruff, `mypy --strict`, bandit.
