### PR TITLE
fix: reject a feature_group scope key written inside an option container (#582)

### DIFF
--- a/docs/docs/in_depth/feature-config.md
+++ b/docs/docs/in_depth/feature-config.md
@@ -128,6 +128,8 @@ When two enabled sources declare the same column (for example a shared join key)
 
 The config form takes a non-empty class-name string only, since JSON cannot express a class object. The string matches the exact class name: it does not match subclasses, and two classes with the same name in different modules stay ambiguous. In Python, `Feature("subject_token", feature_group=ClaimsReader)` also accepts the class object. The scope is resolution-only and excluded from feature identity, so requesting the same name scoped to two different sources in one list raises `ValueError: Duplicate feature setup: <name>` rather than silently dropping one; see [Feature Group resolution errors](troubleshooting/feature-group-resolution-errors.md).
 
+`feature_group` is a top-level field next to `name`: writing it inside `options`, `group_options`, or `context_options` is rejected with a validation error.
+
 ## Worked Example: Window, Rank, and Percentile Features
 
 Row-preserving operations (window aggregation, rank, percentile) cannot be requested by a bare name: the Feature Group only matches when the request also carries the partition/order options its matcher needs. The feature name encodes the operation (`{source}__{operation}`); the matcher then requires those options to be present. It reads them via `options.get` (group first, then context), so they resolve from either side, but `context_options` is the right home.

--- a/mloda/core/api/feature_config/models.py
+++ b/mloda/core/api/feature_config/models.py
@@ -23,6 +23,15 @@ def validate_feature_group_scope(value: Any) -> Optional[str]:
     return value
 
 
+def validate_feature_group_not_in_options(options: Optional[dict[str, Any]], container_name: str) -> None:
+    """Scope is a config field, not an option: a top-level 'feature_group' key in a container is a misplacement."""
+    if options and "feature_group" in options:
+        raise ValueError(
+            f"'feature_group' must not be a top-level key of '{container_name}'; "
+            "move it next to 'name' as a feature config field"
+        )
+
+
 @dataclass
 class FeatureConfig:
     """Model for a feature configuration with name and options."""
@@ -46,6 +55,9 @@ class FeatureConfig:
                 "it is meaningless without context options and would otherwise be silently dropped"
             )
         validate_feature_group_scope(self.feature_group)
+        validate_feature_group_not_in_options(self.options, "options")
+        validate_feature_group_not_in_options(self.group_options, "group_options")
+        validate_feature_group_not_in_options(self.context_options, "context_options")
 
 
 def feature_config_schema() -> dict[str, Any]:

--- a/tests/test_core/test_api/feature_config/test_feature_config_feature_group_scope.py
+++ b/tests/test_core/test_api/feature_config/test_feature_config_feature_group_scope.py
@@ -326,6 +326,65 @@ def test_loader_nested_in_features_rejects_whitespace_only_feature_group() -> No
 
 
 # ---------------------------------------------------------------------------
+# Misplaced scope: "feature_group" inside an option container is a hard error
+#
+# The scope is a TOP-LEVEL field. Written inside "options" (or the group/context
+# variants) it is silently swallowed as an ordinary option: feature_group_scope
+# stays None, the key poisons the option hash and the matcher inputs, and
+# resolution still fails with "Multiple feature groups found" without ever
+# naming the key that was ignored. JSON is the documented surface for AI agents,
+# so this misplacement is likely and must fail loudly at validation time.
+#
+# Only TOP-LEVEL keys of each container are checked: a nested scope legitimately
+# lives at options["in_features"]["feature_group"], which is a dict VALUE.
+# ---------------------------------------------------------------------------
+
+MISPLACED_KEY_TERMS = ("feature_group", "top-level")
+
+
+def test_feature_config_rejects_feature_group_key_inside_options() -> None:
+    """A feature_group key inside 'options' is a misplaced scope and raises ValueError."""
+    with pytest.raises(ValueError) as exc_info:
+        FeatureConfig(name="shared_token", options={"feature_group": "ConfigScopeSourceA"})
+
+    message = str(exc_info.value)
+    for term in MISPLACED_KEY_TERMS:
+        assert term in message
+
+
+def test_feature_config_rejects_feature_group_key_inside_group_options() -> None:
+    """A feature_group key inside 'group_options' is a misplaced scope and raises ValueError."""
+    with pytest.raises(ValueError) as exc_info:
+        FeatureConfig(name="shared_token", group_options={"feature_group": "ConfigScopeSourceA"})
+
+    message = str(exc_info.value)
+    for term in MISPLACED_KEY_TERMS:
+        assert term in message
+
+
+def test_feature_config_rejects_feature_group_key_inside_context_options() -> None:
+    """A feature_group key inside 'context_options' is a misplaced scope and raises ValueError."""
+    with pytest.raises(ValueError) as exc_info:
+        FeatureConfig(name="shared_token", context_options={"feature_group": "ConfigScopeSourceA"})
+
+    message = str(exc_info.value)
+    for term in MISPLACED_KEY_TERMS:
+        assert term in message
+
+
+def test_loader_rejects_misplaced_feature_group_key_in_options() -> None:
+    """Through the JSON surface, a scope written inside 'options' fails loudly instead of becoming an option."""
+    config_str = '[{"name": "shared_token", "options": {"feature_group": "ConfigScopeSourceA"}}]'
+
+    with pytest.raises(ValueError) as exc_info:
+        load_features_from_config(config_str, format="json")
+
+    message = str(exc_info.value)
+    for term in MISPLACED_KEY_TERMS:
+        assert term in message
+
+
+# ---------------------------------------------------------------------------
 # Regression: configs without the field are unchanged
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Follow-up to #678 (issue #582), which shipped the `feature_group` resolution scope on the config loader. This closes one gap that landed with it.

## Problem

A `feature_group` key written *inside* an option container is silently swallowed as an ordinary option:

```json
{"name": "subject_token", "options": {"feature_group": "ClaimsReader"}}
```

The scope stays unset, the key becomes a group option (so it also poisons the option hash and the matcher inputs), and resolution still fails with the very error the author was trying to fix:

```
ValueError: Multiple feature groups found for feature 'subject_token': ...
```

Nothing in that message mentions the ignored `feature_group` key. The author did write a scope; it just went one level too deep.

This is the one place the config surface adds a footgun the Python surface does not. A Python author reads a signature. A JSON author has no such guard, and `additionalProperties: False` in `feature_config_schema()` does not apply *inside* `options`. `feature-config.md` frames this surface as the primary interface for AI agents and LLMs, which makes the misplacement more likely, not less.

## Change

`FeatureConfig` rejects a top-level `feature_group` key in `options`, `group_options`, or `context_options`, and points the author at the top-level field:

```
ValueError: 'feature_group' must not be a top-level key of 'options'; move it next to 'name' as a feature config field
```

Only the top-level keys of each container are checked. A nested `in_features` scope lives at `options["in_features"]["feature_group"]`, which is a dict *value* rather than a key of `options`, so it is untouched: the nested-scope tests shipped in #678 still pass and pin that seam.

## Tests

Four tests: the key rejected in each of the three containers, plus the same misplacement through the JSON surface end to end (`parse_json` builds `FeatureConfig`, so the model check covers the loader for free). They fail on current `main` with `DID NOT RAISE`.

`tox` passes.

## Credit

Found by an independent review of a parallel implementation of #582. The other findings from that review are filed as #680, #681, #682, and #683.