### PR TITLE
minor: reject unknown and malformed PROPERTY_MAPPING specs, retire the flattened form

### DIFF
--- a/docs/docs/in_depth/feature-chain-parser.md
+++ b/docs/docs/in_depth/feature-chain-parser.md
@@ -124,13 +124,13 @@ class MyFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 
     PROPERTY_MAPPING = {
         "operation_type": {
-            "sum": "Sum operation",
-            "avg": "Average operation",
-            DefaultOptionKeys.mloda_context: True,
+            DefaultOptionKeys.allowed_values: {"sum": "Sum operation", "avg": "Average operation"},
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: True,
         },
         DefaultOptionKeys.in_features: {
             "explanation": "Source feature",
-            DefaultOptionKeys.mloda_context: True,
+            DefaultOptionKeys.context: True,
         },
     }
 
@@ -271,9 +271,11 @@ class MyFeatureGroup(FeatureGroup):
     PROPERTY_MAPPING = {
         # Feature-specific parameter
         "operation_type": {
-            "sum": "Sum aggregation",
-            "avg": "Average aggregation", 
-            "max": "Maximum aggregation",
+            DefaultOptionKeys.allowed_values: {
+                "sum": "Sum aggregation",
+                "avg": "Average aggregation",
+                "max": "Maximum aggregation",
+            },
             DefaultOptionKeys.context: True,  # Context parameter
             DefaultOptionKeys.strict_validation: True,  # Strict validation
         },
@@ -375,13 +377,16 @@ Specify default values for optional parameters:
 ``` python
 PROPERTY_MAPPING = {
     "window_size": {
-        "7": "7-day window",
-        "30": "30-day window",
+        DefaultOptionKeys.allowed_values: {"7": "7-day window", "30": "30-day window"},
         DefaultOptionKeys.default: "7",  # Default value
         DefaultOptionKeys.context: True,
+        DefaultOptionKeys.strict_validation: True,
     },
 }
 ```
+
+Under strict validation a declared default must itself be an accepted value; that is
+checked at class definition.
 
 #### Group vs Context Classification
 
@@ -389,15 +394,13 @@ PROPERTY_MAPPING = {
 PROPERTY_MAPPING = {
     # Group parameter - affects Feature Group resolution
     "data_source": {
-        "production": "Production data",
-        "staging": "Staging data", 
+        DefaultOptionKeys.allowed_values: {"production": "Production data", "staging": "Staging data"},
         DefaultOptionKeys.group: True,  # Explicit group parameter
         DefaultOptionKeys.strict_validation: True,
     },
     # Context parameter - doesn't affect resolution
     "algorithm_type": {
-        "kmeans": "K-means clustering",
-        "dbscan": "DBSCAN clustering",
+        "explanation": "Clustering algorithm",
         DefaultOptionKeys.context: True,  # Context parameter
         DefaultOptionKeys.strict_validation: False,  # Flexible validation
     },

--- a/docs/docs/in_depth/feature-group-matching.md
+++ b/docs/docs/in_depth/feature-group-matching.md
@@ -35,9 +35,11 @@ The `PROPERTY_MAPPING` defines how configuration-based features are validated:
 ```python
 PROPERTY_MAPPING = {
     "aggregation_type": {
-        "sum": "Sum aggregation",
-        "avg": "Average aggregation",
-        "max": "Maximum aggregation",
+        DefaultOptionKeys.allowed_values: {
+            "sum": "Sum aggregation",
+            "avg": "Average aggregation",
+            "max": "Maximum aggregation",
+        },
         DefaultOptionKeys.context: True,
         DefaultOptionKeys.strict_validation: True,
     },
@@ -48,6 +50,9 @@ PROPERTY_MAPPING = {
     },
 }
 ```
+
+Accepted values are declared under `allowed_values`. Any other key in a spec is an
+unknown key and raises at class definition.
 
 ### 3. Validation Modes
 

--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -16,8 +16,10 @@ Two rules carry most of the model:
 
 | Moment | Mechanism | Checks | Receives | On failure |
 | --- | --- | --- | --- | --- |
-| Import time (`property_spec(...)` call) | Authoring invariants | strict needs `allowed_values` or an `element_validator`; `allowed_values` without strict; empty `allowed_values`; validators are callable | The spec being built | `ValueError` at import |
-| Class definition (`FeatureGroup.__init_subclass__`) | Spec schema (`PROPERTY_SPEC_KEYS`) | Every key of a spec is a known spec key | Every spec in the mapping | `ValueError` naming the class, key, and offender |
+| Import time (`property_spec(...)` call) | Authoring invariants | strict needs `allowed_values` or an `element_validator`; empty `allowed_values`; `element_validator` without strict; validators are callable; `allowed_values` is not a str/bytes | The spec being built | `ValueError` at import |
+| Class definition (`FeatureGroup.__init_subclass__`) | Spec is a dict | A spec is a spec dict, not a bare container | Every spec in the mapping | `ValueError` naming the class and key |
+| Class definition | Spec schema (`PROPERTY_SPEC_KEYS`) | Every KEY of a spec is a known spec key | Every spec in the mapping | `ValueError` listing every offender |
+| Class definition | Spec shape | Every VALUE has the right shape: `allowed_values` is a Collection and not a str/bytes; validators are callable; `strict_validation` is a bool | Every spec in the mapping | `ValueError` naming the key and the real fault |
 | Class definition | Strict needs a value space | `strict_validation: True` has a non-empty `allowed_values` or an `element_validator` | Every spec in the mapping | `ValueError` at class definition |
 | Class definition | `check_declared_default` | A strict, non-`None` `default` is accepted by its own key | The declared default | `ValueError` at class definition |
 | Match time (parser) | `allowed_values` membership | Each element is in the accepted set | One element | `ValueError`, surfaced to the end user |
@@ -31,8 +33,12 @@ rather than adding to it: when a key declares one, `allowed_values` is not consu
 Because the parser runs before the mixin, an element rejected by membership or by
 `element_validator` short-circuits, and `match_guard` is never reached.
 
-The class-definition rules run in table order: the schema first, because a spec with an
-unknown key is malformed and its remaining keys cannot be trusted to mean what they say.
+The class-definition rules run in table order, and the order is load-bearing. The schema
+runs before the shape rules, because a spec with an unknown key is malformed and its
+remaining keys cannot be trusted to mean what they say (a *removed* key in particular must
+be reported as a rename, not as some downstream shape error). The shape rules run before
+the last two, which read those values: a non-callable `element_validator` reaching
+`check_declared_default` would be blamed on the default instead.
 
 ## Choosing a mechanism
 
@@ -98,10 +104,8 @@ raises at class definition. There is one authoring form, plus a builder for it.
 }
 ```
 
-`allowed_values` may be a value-to-docstring mapping or a re-iterable collection, but
-not a one-shot iterator (a generator would exhaust and behave like an empty set). A spec
-that declares no `allowed_values` declares an **empty** value space; the space is never
-inferred from the spec's other keys.
+A spec that declares no `allowed_values` declares an **empty** value space; the space is
+never inferred from the spec's other keys.
 
 That is what makes the unknown-key rule possible, and it is the point of it. A typo'd
 flag has exactly one reading now:
@@ -112,6 +116,30 @@ flag has exactly one reading now:
     "strict_validaton": True,  # ValueError: unknown spec key. Did you mean 'strict_validation'?
 }
 ```
+
+## A spec has a shape, not just a key set
+
+Locking down the key names is only half the contract; the value under each key is checked
+too, all at class definition.
+
+`allowed_values` must be a **Collection**: a value-to-docstring mapping, or a tuple, list,
+set or frozenset. Three shapes raise:
+
+- a **`str` or `bytes`**, which a forgotten comma produces (`("add")` is the str `"add"`,
+  not a one-tuple). Membership would silently degrade into a substring test, accepting
+  `"a"`, `"ad"` and `""`.
+- a **generator**, which is truthy whether or not it yields anything, and is consumed by
+  the first read. It makes matching stateful, and a declared `default` burns it at class
+  definition so every later value is rejected.
+- a **scalar**, for which `value in 5` raises a `TypeError` that the match path swallows
+  into a silent reject-everything.
+
+`element_validator`, `required_when` and `match_guard` must be **callable**, and
+`strict_validation` must be a real **bool** (truthiness would make `"false"` mean strict).
+
+`allowed_values` is checked for shape whether or not the spec is strict, because a
+non-strict value space is still *consumed*: it maps a value parsed out of a feature name
+back onto its `PROPERTY_MAPPING` key. It is a mapping aid there, never an enforcement.
 
 **Builder, `property_spec`:** the same dict, with the authoring invariants checked at
 construction instead of at class definition.
@@ -296,6 +324,7 @@ per-element rule, or move to `match_guard` if it really is a whole-value check.
 | Invariant | Test |
 | --- | --- |
 | Spec schema, unknown-key rule, strict needs a value space | `tests/.../feature_chainer/test_property_mapping_spec_schema.py` |
+| Spec shape: Collection value space, callable validators, bool flag | `tests/.../feature_chainer/test_property_mapping_spec_shape.py` |
 | Renamed keys, removed-key guard, shared default seam, precedence | `tests/.../feature_chainer/test_property_mapping_unified_model.py` |
 | Container invariance, no stringification, str-as-scalar, dict-as-composite, empty containers | `tests/.../feature_chainer/test_property_mapping_sequence_unpacking.py` |
 | Plugin specs behave identically across containers | `tests/test_plugins/feature_group/experimental/test_property_mapping_container_invariance.py` |

--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -17,7 +17,8 @@ Two rules carry most of the model:
 | Moment | Mechanism | Checks | Receives | On failure |
 | --- | --- | --- | --- | --- |
 | Import time (`property_spec(...)` call) | Authoring invariants | strict needs `allowed_values` or an `element_validator`; `allowed_values` without strict; empty `allowed_values`; validators are callable | The spec being built | `ValueError` at import |
-| Class definition (`FeatureGroup.__init_subclass__`) | Removed-key guard | No spec uses a removed key (`validation_function`, `type_validator`) | Every spec in the mapping | `ValueError` naming the replacement |
+| Class definition (`FeatureGroup.__init_subclass__`) | Spec schema (`PROPERTY_SPEC_KEYS`) | Every key of a spec is a known spec key | Every spec in the mapping | `ValueError` naming the class, key, and offender |
+| Class definition | Strict needs a value space | `strict_validation: True` has a non-empty `allowed_values` or an `element_validator` | Every spec in the mapping | `ValueError` at class definition |
 | Class definition | `check_declared_default` | A strict, non-`None` `default` is accepted by its own key | The declared default | `ValueError` at class definition |
 | Match time (parser) | `allowed_values` membership | Each element is in the accepted set | One element | `ValueError`, surfaced to the end user |
 | Match time (parser) | `element_validator` | Each element satisfies a predicate | One element | `ValueError`, surfaced to the end user |
@@ -29,6 +30,9 @@ Match-time mechanisms run in that order. `element_validator` **replaces** member
 rather than adding to it: when a key declares one, `allowed_values` is not consulted.
 Because the parser runs before the mixin, an element rejected by membership or by
 `element_validator` short-circuits, and `match_guard` is never reached.
+
+The class-definition rules run in table order: the schema first, because a spec with an
+unknown key is malformed and its remaining keys cannot be trusted to mean what they say.
 
 ## Choosing a mechanism
 
@@ -78,14 +82,16 @@ original container type.
 
 ## Authoring a spec
 
-Three forms build the same plain dict. The contract is the dict, so all three are
-equivalent to the parser.
+A spec is a plain dict whose keys all come from the schema, `PROPERTY_SPEC_KEYS`:
+`explanation`, `allowed_values`, `default`, `context`, `group`, `strict_validation`,
+`element_validator`, `required_when`, `match_guard`. Anything else is an unknown key and
+raises at class definition. There is one authoring form, plus a builder for it.
 
-**Recommended, explicit `allowed_values`:** keeps the value space separate from the
-flags, so a doc-only key can never widen an accepted set.
+**The form: accepted values go under `allowed_values`.**
 
 ``` python
 "operation_type": {
+    "explanation": "Arithmetic operation",
     DefaultOptionKeys.allowed_values: {"add": "Addition", "sub": "Subtraction"},
     DefaultOptionKeys.context: True,
     DefaultOptionKeys.strict_validation: True,
@@ -93,7 +99,19 @@ flags, so a doc-only key can never widen an accepted set.
 ```
 
 `allowed_values` may be a value-to-docstring mapping or a re-iterable collection, but
-not a one-shot iterator (a generator would exhaust and behave like an empty set).
+not a one-shot iterator (a generator would exhaust and behave like an empty set). A spec
+that declares no `allowed_values` declares an **empty** value space; the space is never
+inferred from the spec's other keys.
+
+That is what makes the unknown-key rule possible, and it is the point of it. A typo'd
+flag has exactly one reading now:
+
+``` python
+"operation_type": {
+    DefaultOptionKeys.allowed_values: {"add": "Addition"},
+    "strict_validaton": True,  # ValueError: unknown spec key. Did you mean 'strict_validation'?
+}
+```
 
 **Builder, `property_spec`:** the same dict, with the authoring invariants checked at
 construction instead of at class definition.
@@ -116,28 +134,29 @@ when provided. Its declared-default check is not a separate implementation: it c
 the same `FeatureChainParser.check_declared_default` the class-definition hook uses,
 so the two cannot drift.
 
-**Legacy flattened form:** allowed values share one dict with the metadata flags, and
-the parser recovers the value space by subtracting `RESERVED_PROPERTY_KEYS`. Still
-supported, but the explicit form is preferred precisely because subtraction is easy to
-get wrong.
+## Strict validation needs a value space
 
-``` python
-"parameter_name": {
-    "value1": "Description of value1",
-    "value2": "Description of value2",
-    DefaultOptionKeys.context: True,
-    DefaultOptionKeys.strict_validation: True,
-}
-```
+`strict_validation: True` needs something to validate against: a non-empty
+`allowed_values`, or an `element_validator`. With neither, the accepted set is empty and
+the key rejects every value, so the spec can never match. That is rejected at class
+definition, and `property_spec` refuses to build it.
 
 ## Parameter classification
 
 ``` python
 # Context parameter: does not affect Feature Group splitting
-"aggregation_type": {"sum": "Sum aggregation", DefaultOptionKeys.context: True}
+"aggregation_type": {
+    DefaultOptionKeys.allowed_values: {"sum": "Sum aggregation"},
+    DefaultOptionKeys.context: True,
+    DefaultOptionKeys.strict_validation: True,
+}
 
 # Group parameter: affects Feature Group splitting
-"data_source": {"production": "Production data", DefaultOptionKeys.group: True}
+"data_source": {
+    DefaultOptionKeys.allowed_values: {"production": "Production data"},
+    DefaultOptionKeys.group: True,
+    DefaultOptionKeys.strict_validation: True,
+}
 ```
 
 ## Declared defaults must be honored
@@ -150,8 +169,7 @@ default.
 ``` python
 # Rejected at class definition: "mul" is not accepted.
 "operation_type": {
-    "add": "Addition",
-    "sub": "Subtraction",
+    DefaultOptionKeys.allowed_values: {"add": "Addition", "sub": "Subtraction"},
     DefaultOptionKeys.strict_validation: True,
     DefaultOptionKeys.default: "mul",
 }
@@ -202,7 +220,9 @@ def _needs_order_by(options: Options) -> bool:
 
 PROPERTY_MAPPING = {
     "aggregation_type": {
-        "sum": "Sum", "avg": "Average", "first": "First", "last": "Last",
+        DefaultOptionKeys.allowed_values: {
+            "sum": "Sum", "avg": "Average", "first": "First", "last": "Last",
+        },
         DefaultOptionKeys.context: True,
         DefaultOptionKeys.strict_validation: True,
     },
@@ -219,6 +239,36 @@ with `required_when` are otherwise optional. The predicate must be a pure, calla
 `(Options) -> bool` that does not raise. Non-callable values are skipped with a
 warning; non-bool truthy returns count as `True`.
 
+## Migrating from the flattened form
+
+The **flattened form**, where accepted values shared one dict with the metadata flags, is
+**retired**. The parser used to recover the value space by subtracting the known keys,
+which meant any key it did not recognize was silently absorbed as an accepted *value*. A
+typo'd `strict_validaton: True` therefore turned strict validation off *and* became an
+accepted value, with nothing raised anywhere. It is unfixable while the form exists,
+because a typo'd flag and a legitimate value are written identically.
+
+To convert, move the bare value entries under `allowed_values` and leave the flags where
+they are:
+
+``` python
+# Before                              # After
+"operation_type": {                   "operation_type": {
+    "add": "Addition",                    DefaultOptionKeys.allowed_values: {
+    "sub": "Subtraction",                     "add": "Addition",
+    DefaultOptionKeys.context: True,          "sub": "Subtraction",
+    DefaultOptionKeys.strict_validation: True,  },
+}                                         DefaultOptionKeys.context: True,
+                                          DefaultOptionKeys.strict_validation: True,
+                                      }
+```
+
+A spec that splats a shared constant (`**AGGREGATION_TYPES`) assigns it instead:
+`DefaultOptionKeys.allowed_values: AGGREGATION_TYPES`.
+
+Nothing changes silently: an unmigrated spec raises at class definition, because its
+value entries are now unknown keys.
+
 ## Migrating from the removed key names
 
 `validation_function` and `type_validator` are **removed**, with no aliases. They did
@@ -231,8 +281,9 @@ substring with the unrelated `DataTypeValidator`.
 | `type_validator` | `match_guard` |
 
 Both routes fail loudly, so no spec silently changes meaning: the old enum members are
-gone (`AttributeError` at import), and a spec still carrying the old string key raises
-at class definition, naming the replacement.
+gone (`AttributeError` at import), and a spec still carrying the old string key is an
+unknown key, so it raises at class definition. Being a *removed* key rather than an
+arbitrary one, the error names the replacement instead of guessing at it.
 
 One semantic change comes with the rename. `element_validator` now genuinely receives
 one element per call for every container type; previously a sequence was stringified
@@ -244,6 +295,7 @@ per-element rule, or move to `match_guard` if it really is a whole-value check.
 
 | Invariant | Test |
 | --- | --- |
+| Spec schema, unknown-key rule, strict needs a value space | `tests/.../feature_chainer/test_property_mapping_spec_schema.py` |
 | Renamed keys, removed-key guard, shared default seam, precedence | `tests/.../feature_chainer/test_property_mapping_unified_model.py` |
 | Container invariance, no stringification, str-as-scalar, dict-as-composite, empty containers | `tests/.../feature_chainer/test_property_mapping_sequence_unpacking.py` |
 | Plugin specs behave identically across containers | `tests/test_plugins/feature_group/experimental/test_property_mapping_container_invariance.py` |

--- a/mloda/core/abstract_plugins/components/default_options_key.py
+++ b/mloda/core/abstract_plugins/components/default_options_key.py
@@ -42,10 +42,8 @@ class DefaultOptionKeys(str, Enum):
         return self.value.__format__(format_spec)
 
 
-# The SCHEMA of a PROPERTY_MAPPING spec dict: the complete set of permitted keys. A spec's
-# value space is declared under ``allowed_values``, never inferred, so every other key must be
-# one of these. ``FeatureChainParser.validate_property_mapping_defaults`` rejects any unknown
-# key at class-definition time, which is what stops a typo'd flag from being read as a value.
+# The SCHEMA of a PROPERTY_MAPPING spec dict: the complete set of permitted keys. Rejecting any
+# other key at class definition is what stops a typo'd flag from being read as an allowed value.
 PROPERTY_SPEC_KEYS: frozenset[Any] = frozenset(
     {
         "explanation",
@@ -60,8 +58,8 @@ PROPERTY_SPEC_KEYS: frozenset[Any] = frozenset(
     }
 )
 
-# Removed PROPERTY_MAPPING keys mapped to their replacement (issue #600). They are unknown keys
-# like any other; this map only gives the unknown-key error a precise remedy to name.
+# Removed keys mapped to their replacement (issue #600). They are unknown keys like any other;
+# this map only gives the unknown-key error an exact remedy to name.
 REMOVED_PROPERTY_KEYS: dict[str, DefaultOptionKeys] = {
     "validation_function": DefaultOptionKeys.element_validator,
     "type_validator": DefaultOptionKeys.match_guard,

--- a/mloda/core/abstract_plugins/components/default_options_key.py
+++ b/mloda/core/abstract_plugins/components/default_options_key.py
@@ -42,10 +42,11 @@ class DefaultOptionKeys(str, Enum):
         return self.value.__format__(format_spec)
 
 
-# Single source of truth for spec-internal metadata keys in a PROPERTY_MAPPING entry.
-# ``FeatureChainParser._extract_property_values`` subtracts this set to recover a spec's
-# legacy flattened value space, so a new doc-only key cannot silently widen an allowed set.
-RESERVED_PROPERTY_KEYS: frozenset[Any] = frozenset(
+# The SCHEMA of a PROPERTY_MAPPING spec dict: the complete set of permitted keys. A spec's
+# value space is declared under ``allowed_values``, never inferred, so every other key must be
+# one of these. ``FeatureChainParser.validate_property_mapping_defaults`` rejects any unknown
+# key at class-definition time, which is what stops a typo'd flag from being read as a value.
+PROPERTY_SPEC_KEYS: frozenset[Any] = frozenset(
     {
         "explanation",
         DefaultOptionKeys.allowed_values,
@@ -59,10 +60,8 @@ RESERVED_PROPERTY_KEYS: frozenset[Any] = frozenset(
     }
 )
 
-# Removed PROPERTY_MAPPING keys mapped to their replacement (issue #600). These names are no
-# longer reserved metadata, so a leftover stale key would be absorbed into a legacy flattened
-# spec's accepted VALUE set. ``FeatureChainParser.validate_property_mapping_defaults`` rejects
-# them at class-definition time instead.
+# Removed PROPERTY_MAPPING keys mapped to their replacement (issue #600). They are unknown keys
+# like any other; this map only gives the unknown-key error a precise remedy to name.
 REMOVED_PROPERTY_KEYS: dict[str, DefaultOptionKeys] = {
     "validation_function": DefaultOptionKeys.element_validator,
     "type_validator": DefaultOptionKeys.match_guard,

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -4,6 +4,7 @@ Feature chain parser for handling feature name chaining across feature groups.
 
 from __future__ import annotations
 
+import difflib
 import re
 from typing import Any, Optional
 
@@ -11,8 +12,8 @@ from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.components.default_options_key import (
+    PROPERTY_SPEC_KEYS,
     REMOVED_PROPERTY_KEYS,
-    RESERVED_PROPERTY_KEYS,
     DefaultOptionKeys,
 )
 
@@ -201,14 +202,14 @@ class FeatureChainParser:
     def _extract_property_values(cls, property_value: Any) -> Any:
         """Extract a spec's declared value space.
 
-        Prefers an explicit ``DefaultOptionKeys.allowed_values`` field; otherwise
-        falls back to the legacy flattened form (all entries minus the reserved
-        metadata keys).
+        The value space is DECLARED under ``DefaultOptionKeys.allowed_values``, never inferred.
+        A spec without it declares an EMPTY value space. Recovering the space by subtracting the
+        known keys (the retired flattened form) silently absorbed every unrecognized key as an
+        accepted value, which made a typo'd flag indistinguishable from a legitimate value.
+        A non-dict spec value is its own value space and is handed back verbatim.
         """
         if isinstance(property_value, dict):
-            if DefaultOptionKeys.allowed_values in property_value:
-                return property_value[DefaultOptionKeys.allowed_values]
-            return {k: v for k, v in property_value.items() if k not in RESERVED_PROPERTY_KEYS}
+            return property_value.get(DefaultOptionKeys.allowed_values, {})
         return property_value
 
     @classmethod
@@ -272,8 +273,17 @@ class FeatureChainParser:
     def validate_property_mapping_defaults(cls, owner_name: str, property_mapping: dict[str, Any] | None) -> None:
         """Validate a PROPERTY_MAPPING at class-definition time.
 
-        Rejects specs that still carry a removed key (see ``REMOVED_PROPERTY_KEYS``) and
-        delegates every declared default to ``check_declared_default``.
+        Three rules, in this order:
+
+        1. Every key of a spec must be in ``PROPERTY_SPEC_KEYS`` (the spec schema).
+        2. ``strict_validation: True`` needs a non-empty ``allowed_values`` or an
+           ``element_validator`` to validate against.
+        3. A declared default must satisfy the spec's own rules (``check_declared_default``).
+
+        The schema rule runs first on purpose: a spec that trips it is malformed, and its
+        remaining keys cannot be trusted to mean what they appear to mean.
+
+        A non-dict spec value is not a spec dict, so it carries no keys to check and is skipped.
         """
         if property_mapping is None:
             return
@@ -281,24 +291,68 @@ class FeatureChainParser:
         for key, spec in property_mapping.items():
             if not isinstance(spec, dict):
                 continue
-            cls._reject_removed_property_keys(owner_name, key, spec)
+            cls._reject_unknown_spec_keys(owner_name, key, spec)
+            cls._reject_strict_without_value_space(owner_name, key, spec)
             cls.check_declared_default(f"{owner_name}.PROPERTY_MAPPING", key, spec)
 
     @classmethod
-    def _reject_removed_property_keys(cls, owner_name: str, key: str, spec: dict[str, Any]) -> None:
-        """Fail loudly on a spec that still uses a removed PROPERTY_MAPPING key.
+    def _reject_unknown_spec_keys(cls, owner_name: str, key: str, spec: dict[str, Any]) -> None:
+        """Fail loudly on any key that is not part of the spec schema.
 
-        The removed keys are no longer reserved metadata, so ``_extract_property_values``
-        would absorb a leftover one into a legacy flattened spec's accepted value space,
-        silently widening what the feature group matches. Rejecting the spec turns that
-        silent corruption into an actionable migration error.
+        The value space is declared under ``allowed_values``, so an unrecognized key is never a
+        value: it is an authoring mistake. This is the one rule that covers all of them, with two
+        message variants. A key that was REMOVED names its replacement; any other unknown key gets
+        the nearest known key suggested, so ``strict_validaton`` reads as a typo instead of
+        silently turning strict validation off while joining the accepted values.
+
+        A removed key is reported ahead of any other unknown key, because it is the one offender
+        with an exact remedy.
         """
-        for stale, replacement in REMOVED_PROPERTY_KEYS.items():
-            if stale in spec:
-                raise ValueError(
-                    f"{owner_name}.PROPERTY_MAPPING['{key}'] uses the removed key '{stale}'. "
-                    f"Rename it to '{replacement.value}' (DefaultOptionKeys.{replacement.value})."
-                )
+        known = sorted(str(k) for k in PROPERTY_SPEC_KEYS)
+        unknown = [spec_key for spec_key in spec if spec_key not in PROPERTY_SPEC_KEYS]
+        if not unknown:
+            return
+
+        offender = next((k for k in unknown if str(k) in REMOVED_PROPERTY_KEYS), unknown[0])
+        prefix = f"{owner_name}.PROPERTY_MAPPING['{key}'] has unknown spec key '{offender}'."
+
+        replacement = REMOVED_PROPERTY_KEYS.get(str(offender))
+        if replacement is not None:
+            raise ValueError(
+                f"{prefix} It was removed: rename it to '{replacement.value}' (DefaultOptionKeys.{replacement.value})."
+            )
+
+        suggestion = difflib.get_close_matches(str(offender), known, n=1)
+        hint = f" Did you mean '{suggestion[0]}'?" if suggestion else ""
+        raise ValueError(
+            f"{prefix}{hint} A spec may only carry the keys {known}. Accepted VALUES belong "
+            f"under '{DefaultOptionKeys.allowed_values.value}'."
+        )
+
+    @classmethod
+    def _reject_strict_without_value_space(cls, owner_name: str, key: str, spec: dict[str, Any]) -> None:
+        """Fail loudly on strict validation that has nothing to validate against.
+
+        Strict with neither a non-empty ``allowed_values`` nor an ``element_validator`` accepts
+        nothing, so it rejects every value: a spec that can never match. ``property_spec``
+        already refuses to build one, so core enforces the same invariant to stay in step.
+        """
+        if not cls._is_strict_validation(spec):
+            return
+
+        if cls._get_element_validator(spec) is not None:
+            return
+
+        if spec.get(DefaultOptionKeys.allowed_values):
+            return
+
+        raise ValueError(
+            f"{owner_name}.PROPERTY_MAPPING['{key}'] sets "
+            f"{DefaultOptionKeys.strict_validation.value}=True but declares no value space, "
+            f"so it would reject every value. Declare a non-empty "
+            f"'{DefaultOptionKeys.allowed_values.value}' or an "
+            f"'{DefaultOptionKeys.element_validator.value}'."
+        )
 
     @classmethod
     def _unpack_property_value(cls, found_property_value: Any) -> list[Any]:

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -201,13 +201,10 @@ class FeatureChainParser:
 
     @classmethod
     def _extract_property_values(cls, property_value: Any) -> Any:
-        """Extract a spec's declared value space.
+        """Return a spec's declared value space (``allowed_values``), or {} if it declares none.
 
-        The value space is DECLARED under ``DefaultOptionKeys.allowed_values``, never inferred.
-        A spec without it declares an EMPTY value space. Recovering the space by subtracting the
-        known keys (the retired flattened form) silently absorbed every unrecognized key as an
-        accepted value, which made a typo'd flag indistinguishable from a legitimate value.
-        A non-dict spec value is its own value space and is handed back verbatim.
+        Never inferred by subtracting the known keys: the retired flattened form did that, and it
+        absorbed every unrecognized key as an accepted value.
         """
         if isinstance(property_value, dict):
             return property_value.get(DefaultOptionKeys.allowed_values, {})
@@ -215,23 +212,11 @@ class FeatureChainParser:
 
     @classmethod
     def check_declared_default(cls, owner: str, key: str, spec: dict[str, Any]) -> None:
-        """Check one spec's declared default against its own strict-validation rules.
+        """Check a spec's declared default against its own strict-validation rules.
 
-        This is the single implementation of the default-check semantics, shared by
-        ``validate_property_mapping_defaults`` (class-definition time) and by the
-        ``property_spec`` authoring helper, so the two can never drift apart.
-
-        Under strict validation, a non-``None`` declared default must pass the key's
-        ``element_validator`` if it has one, otherwise be a member of the accepted set.
-        An ``element_validator`` that itself errors when called with the default is
-        reported as having raised (with the original exception chained as the cause),
-        which is distinct from the validator running and rejecting the default.
-        ``DefaultOptionKeys.required_when`` does NOT exempt this check: it is a
-        conditional requirement, so the default still applies on the predicate-false
-        branch. The remedies are to add the default to the accepted values or to
-        remove the default (a key with no default is required).
-
-        Raises ValueError on violation, otherwise returns None.
+        Shared by ``validate_property_mapping_defaults`` and ``property_spec`` so the two cannot
+        drift. ``required_when`` does NOT exempt the check: the default still applies on the
+        predicate-false branch.
         """
         if DefaultOptionKeys.default not in spec:
             return
@@ -274,27 +259,11 @@ class FeatureChainParser:
     def validate_property_mapping_defaults(cls, owner_name: str, property_mapping: dict[str, Any] | None) -> None:
         """Validate a PROPERTY_MAPPING at class-definition time.
 
-        Five rules, in this order:
-
-        1. A spec must BE a spec dict (``_reject_non_dict_spec``). A bare container has nowhere
-           to put a flag, so it would bypass every rule below it.
-        2. Every KEY of a spec must be in ``PROPERTY_SPEC_KEYS``, the spec schema
-           (``_reject_unknown_spec_keys``).
-        3. Every VALUE of a spec must have the right SHAPE (``_reject_malformed_spec_values``):
-           ``allowed_values`` is a Collection and never a str/bytes, the validator keys are
-           callable, and ``strict_validation`` is a real bool.
-        4. ``strict_validation: True`` needs a non-empty ``allowed_values`` or an
-           ``element_validator`` to validate against (``_reject_strict_without_value_space``).
-        5. A declared default must satisfy the spec's own rules (``check_declared_default``).
-
-        The order is load-bearing. The schema rule runs before the shape rules because a spec
-        with an unknown key is malformed, and its remaining keys cannot be trusted to mean what
-        they appear to mean; a REMOVED key in particular is the one offender with an exact
-        remedy, so it must be reported as a rename rather than as a downstream shape error. The
-        shape rules in turn run before rules 4 and 5, which read those values and would otherwise
-        mis-diagnose a malformed one: a non-callable ``element_validator`` reaching
-        ``check_declared_default`` gets blamed on the default, and a non-Collection
-        ``allowed_values`` passes rule 4's non-empty test purely on truthiness.
+        The rule ORDER below is load-bearing. Schema before shape: an unknown key means the
+        remaining keys cannot be trusted, and a removed key must be reported as a rename rather
+        than as some downstream shape error. Shape before the strict and default rules: those
+        read the values the shape rule validates, so a malformed one would be mis-diagnosed (a
+        non-callable ``element_validator`` gets blamed on the default).
         """
         if property_mapping is None:
             return
@@ -308,12 +277,7 @@ class FeatureChainParser:
 
     @classmethod
     def _reject_non_dict_spec(cls, owner_name: str, key: str, spec: Any) -> None:
-        """Fail loudly on a spec that is not a spec dict.
-
-        A bare container (``{"op": ["add", "sub"]}``) carries no keys, so every rule below it has
-        nothing to inspect and it slips through all of them. There is one authoring form, and it
-        is a dict.
-        """
+        """Reject a bare container: it carries no keys, so every rule below would skip it."""
         if isinstance(spec, dict):
             return
 
@@ -324,16 +288,10 @@ class FeatureChainParser:
 
     @classmethod
     def _reject_unknown_spec_keys(cls, owner_name: str, key: str, spec: dict[str, Any]) -> None:
-        """Fail loudly on any key that is not part of the spec schema.
+        """Reject every key outside the spec schema, reporting them all in one message.
 
-        The value space is declared under ``allowed_values``, so an unrecognized key is never a
-        value: it is an authoring mistake. This is the one rule that covers all of them, with two
-        message variants. A key that was REMOVED names its replacement; any other unknown key gets
-        the nearest known key suggested, so ``strict_validaton`` reads as a typo instead of
-        silently turning strict validation off while joining the accepted values.
-
-        EVERY unknown key is reported, so fixing one does not just reveal the next. Removed keys
-        lead, because they are the offenders with an exact remedy, but they never hide the rest.
+        Removed keys lead, because they are the offenders with an exact remedy, but they never
+        hide the rest.
         """
         unknown = [spec_key for spec_key in spec if spec_key not in PROPERTY_SPEC_KEYS]
         if not unknown:
@@ -360,20 +318,12 @@ class FeatureChainParser:
 
     @classmethod
     def _reject_malformed_spec_values(cls, owner_name: str, key: str, spec: dict[str, Any]) -> None:
-        """Fail loudly on a spec key whose VALUE has the wrong shape.
+        """Reject a spec key whose VALUE has the wrong shape.
 
-        Locking down the key names alone left the values unchecked, which reopens the same silent
-        widening one layer down. Three shapes are pinned here:
-
-        * ``allowed_values`` must be a ``Collection``, and never a ``str``/``bytes``. A forgotten
-          comma turns ``("add")`` into the str ``"add"``, and membership then silently degrades
-          into a SUBSTRING test that accepts ``"a"``, ``"ad"`` and ``""``. A generator is truthy
-          whether or not it is empty, and is consumed by the first thing that reads it, which
-          makes matching stateful; a scalar makes ``value in 5`` raise a ``TypeError`` that the
-          match path swallows into a silent reject-everything.
-        * the callable-valued keys must actually be callable, or a ``TypeError`` escapes out of
-          matching (and, with a declared default, gets mis-reported as a default problem).
-        * ``strict_validation`` must be a real ``bool``: truthiness makes ``"false"`` mean strict.
+        ``allowed_values`` must never be a ``str``/``bytes``: ``in`` would silently become a
+        SUBSTRING test. It must be a ``Collection`` at all: a generator is truthy even when empty
+        and is consumed by the first read, and a scalar makes ``value in 5`` raise a ``TypeError``
+        that the match path swallows into a silent reject-everything.
         """
         prefix = f"{owner_name}.PROPERTY_MAPPING['{key}']"
 
@@ -417,15 +367,11 @@ class FeatureChainParser:
 
     @classmethod
     def _reject_strict_without_value_space(cls, owner_name: str, key: str, spec: dict[str, Any]) -> None:
-        """Fail loudly on strict validation that has nothing to validate against.
+        """Reject strict validation with nothing to validate against: it would reject every value.
 
-        Strict with neither a non-empty ``allowed_values`` nor an ``element_validator`` accepts
-        nothing, so it rejects every value: a spec that can never match. ``property_spec``
-        already refuses to build one, so core enforces the same invariant to stay in step.
-
-        "Non-empty" is a ``len`` test, not a truthiness test. ``_reject_malformed_spec_values``
-        has already established that the value space is a ``Collection``, which is what makes it
-        checkable: a generator object is truthy even when it yields nothing.
+        "Non-empty" is a ``len`` test rather than truthiness ON PURPOSE: the shape rule has
+        already established the value space is a ``Collection``, and a generator is truthy even
+        when it yields nothing.
         """
         if not cls._is_strict_validation(spec):
             return

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import difflib
 import re
+from collections.abc import Collection
 from typing import Any, Optional
 
 from mloda.core.abstract_plugins.components.feature import Feature
@@ -273,27 +274,53 @@ class FeatureChainParser:
     def validate_property_mapping_defaults(cls, owner_name: str, property_mapping: dict[str, Any] | None) -> None:
         """Validate a PROPERTY_MAPPING at class-definition time.
 
-        Three rules, in this order:
+        Five rules, in this order:
 
-        1. Every key of a spec must be in ``PROPERTY_SPEC_KEYS`` (the spec schema).
-        2. ``strict_validation: True`` needs a non-empty ``allowed_values`` or an
-           ``element_validator`` to validate against.
-        3. A declared default must satisfy the spec's own rules (``check_declared_default``).
+        1. A spec must BE a spec dict (``_reject_non_dict_spec``). A bare container has nowhere
+           to put a flag, so it would bypass every rule below it.
+        2. Every KEY of a spec must be in ``PROPERTY_SPEC_KEYS``, the spec schema
+           (``_reject_unknown_spec_keys``).
+        3. Every VALUE of a spec must have the right SHAPE (``_reject_malformed_spec_values``):
+           ``allowed_values`` is a Collection and never a str/bytes, the validator keys are
+           callable, and ``strict_validation`` is a real bool.
+        4. ``strict_validation: True`` needs a non-empty ``allowed_values`` or an
+           ``element_validator`` to validate against (``_reject_strict_without_value_space``).
+        5. A declared default must satisfy the spec's own rules (``check_declared_default``).
 
-        The schema rule runs first on purpose: a spec that trips it is malformed, and its
-        remaining keys cannot be trusted to mean what they appear to mean.
-
-        A non-dict spec value is not a spec dict, so it carries no keys to check and is skipped.
+        The order is load-bearing. The schema rule runs before the shape rules because a spec
+        with an unknown key is malformed, and its remaining keys cannot be trusted to mean what
+        they appear to mean; a REMOVED key in particular is the one offender with an exact
+        remedy, so it must be reported as a rename rather than as a downstream shape error. The
+        shape rules in turn run before rules 4 and 5, which read those values and would otherwise
+        mis-diagnose a malformed one: a non-callable ``element_validator`` reaching
+        ``check_declared_default`` gets blamed on the default, and a non-Collection
+        ``allowed_values`` passes rule 4's non-empty test purely on truthiness.
         """
         if property_mapping is None:
             return
 
         for key, spec in property_mapping.items():
-            if not isinstance(spec, dict):
-                continue
+            cls._reject_non_dict_spec(owner_name, key, spec)
             cls._reject_unknown_spec_keys(owner_name, key, spec)
+            cls._reject_malformed_spec_values(owner_name, key, spec)
             cls._reject_strict_without_value_space(owner_name, key, spec)
             cls.check_declared_default(f"{owner_name}.PROPERTY_MAPPING", key, spec)
+
+    @classmethod
+    def _reject_non_dict_spec(cls, owner_name: str, key: str, spec: Any) -> None:
+        """Fail loudly on a spec that is not a spec dict.
+
+        A bare container (``{"op": ["add", "sub"]}``) carries no keys, so every rule below it has
+        nothing to inspect and it slips through all of them. There is one authoring form, and it
+        is a dict.
+        """
+        if isinstance(spec, dict):
+            return
+
+        raise ValueError(
+            f"{owner_name}.PROPERTY_MAPPING['{key}'] is a {type(spec).__name__}, not a spec dict. "
+            f"Declare the accepted values under '{DefaultOptionKeys.allowed_values.value}' inside a spec dict."
+        )
 
     @classmethod
     def _reject_unknown_spec_keys(cls, owner_name: str, key: str, spec: dict[str, Any]) -> None:
@@ -305,29 +332,88 @@ class FeatureChainParser:
         the nearest known key suggested, so ``strict_validaton`` reads as a typo instead of
         silently turning strict validation off while joining the accepted values.
 
-        A removed key is reported ahead of any other unknown key, because it is the one offender
-        with an exact remedy.
+        EVERY unknown key is reported, so fixing one does not just reveal the next. Removed keys
+        lead, because they are the offenders with an exact remedy, but they never hide the rest.
         """
-        known = sorted(str(k) for k in PROPERTY_SPEC_KEYS)
         unknown = [spec_key for spec_key in spec if spec_key not in PROPERTY_SPEC_KEYS]
         if not unknown:
             return
 
-        offender = next((k for k in unknown if str(k) in REMOVED_PROPERTY_KEYS), unknown[0])
-        prefix = f"{owner_name}.PROPERTY_MAPPING['{key}'] has unknown spec key '{offender}'."
+        known = sorted(str(k) for k in PROPERTY_SPEC_KEYS)
+        removed = [k for k in unknown if str(k) in REMOVED_PROPERTY_KEYS]
+        others = [k for k in unknown if str(k) not in REMOVED_PROPERTY_KEYS]
 
-        replacement = REMOVED_PROPERTY_KEYS.get(str(offender))
-        if replacement is not None:
-            raise ValueError(
-                f"{prefix} It was removed: rename it to '{replacement.value}' (DefaultOptionKeys.{replacement.value})."
-            )
+        faults: list[str] = []
+        for spec_key in removed:
+            replacement = REMOVED_PROPERTY_KEYS[str(spec_key)].value
+            faults.append(f"'{spec_key}' was removed, rename it to '{replacement}' (DefaultOptionKeys.{replacement})")
+        for spec_key in others:
+            suggestion = difflib.get_close_matches(str(spec_key), known, n=1)
+            hint = f", did you mean '{suggestion[0]}'?" if suggestion else ""
+            faults.append(f"'{spec_key}' is unknown{hint}")
 
-        suggestion = difflib.get_close_matches(str(offender), known, n=1)
-        hint = f" Did you mean '{suggestion[0]}'?" if suggestion else ""
         raise ValueError(
-            f"{prefix}{hint} A spec may only carry the keys {known}. Accepted VALUES belong "
+            f"{owner_name}.PROPERTY_MAPPING['{key}'] has unknown spec key(s): {'; '.join(faults)}. "
+            f"A spec may only carry the keys {known}. Accepted VALUES belong "
             f"under '{DefaultOptionKeys.allowed_values.value}'."
         )
+
+    @classmethod
+    def _reject_malformed_spec_values(cls, owner_name: str, key: str, spec: dict[str, Any]) -> None:
+        """Fail loudly on a spec key whose VALUE has the wrong shape.
+
+        Locking down the key names alone left the values unchecked, which reopens the same silent
+        widening one layer down. Three shapes are pinned here:
+
+        * ``allowed_values`` must be a ``Collection``, and never a ``str``/``bytes``. A forgotten
+          comma turns ``("add")`` into the str ``"add"``, and membership then silently degrades
+          into a SUBSTRING test that accepts ``"a"``, ``"ad"`` and ``""``. A generator is truthy
+          whether or not it is empty, and is consumed by the first thing that reads it, which
+          makes matching stateful; a scalar makes ``value in 5`` raise a ``TypeError`` that the
+          match path swallows into a silent reject-everything.
+        * the callable-valued keys must actually be callable, or a ``TypeError`` escapes out of
+          matching (and, with a declared default, gets mis-reported as a default problem).
+        * ``strict_validation`` must be a real ``bool``: truthiness makes ``"false"`` mean strict.
+        """
+        prefix = f"{owner_name}.PROPERTY_MAPPING['{key}']"
+
+        flag_key = DefaultOptionKeys.strict_validation
+        if flag_key in spec and not isinstance(spec[flag_key], bool):
+            flag = spec[flag_key]
+            raise ValueError(
+                f"{prefix} sets '{flag_key.value}' to {flag!r} ({type(flag).__name__}), "
+                f"which must be a real bool. A truthy non-bool silently enables strict validation."
+            )
+
+        if DefaultOptionKeys.allowed_values in spec:
+            allowed_values = spec[DefaultOptionKeys.allowed_values]
+            if isinstance(allowed_values, (str, bytes)):
+                raise ValueError(
+                    f"{prefix} declares '{DefaultOptionKeys.allowed_values.value}' as a "
+                    f"{type(allowed_values).__name__} ({allowed_values!r}), which would make membership a "
+                    f"SUBSTRING test. Wrap it in a container, for example a one-element tuple: "
+                    f"({allowed_values!r},)."
+                )
+            if not isinstance(allowed_values, Collection):
+                raise ValueError(
+                    f"{prefix} declares '{DefaultOptionKeys.allowed_values.value}' as a "
+                    f"{type(allowed_values).__name__}, which is not a Collection. A value space must be "
+                    f"sized and re-iterable (a dict, tuple, list, set or frozenset); a generator is "
+                    f"consumed by the first read and a scalar has no members."
+                )
+
+        for validator_key in (
+            DefaultOptionKeys.element_validator,
+            DefaultOptionKeys.required_when,
+            DefaultOptionKeys.match_guard,
+        ):
+            if validator_key in spec and not callable(spec[validator_key]):
+                value = spec[validator_key]
+                raise ValueError(
+                    f"{prefix} declares '{validator_key.value}' as a {type(value).__name__} "
+                    f"({value!r}), which is not callable. It must be a callable taking the value "
+                    f"and returning a bool."
+                )
 
     @classmethod
     def _reject_strict_without_value_space(cls, owner_name: str, key: str, spec: dict[str, Any]) -> None:
@@ -336,6 +422,10 @@ class FeatureChainParser:
         Strict with neither a non-empty ``allowed_values`` nor an ``element_validator`` accepts
         nothing, so it rejects every value: a spec that can never match. ``property_spec``
         already refuses to build one, so core enforces the same invariant to stay in step.
+
+        "Non-empty" is a ``len`` test, not a truthiness test. ``_reject_malformed_spec_values``
+        has already established that the value space is a ``Collection``, which is what makes it
+        checkable: a generator object is truthy even when it yields nothing.
         """
         if not cls._is_strict_validation(spec):
             return
@@ -343,7 +433,8 @@ class FeatureChainParser:
         if cls._get_element_validator(spec) is not None:
             return
 
-        if spec.get(DefaultOptionKeys.allowed_values):
+        allowed_values = spec.get(DefaultOptionKeys.allowed_values)
+        if allowed_values is not None and len(allowed_values) > 0:
             return
 
         raise ValueError(

--- a/mloda/core/abstract_plugins/components/feature_chainer/property_spec.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/property_spec.py
@@ -24,9 +24,8 @@ def property_spec(
     required_when: Callable[..., Any] | None = None,
     match_guard: Callable[..., Any] | None = None,
 ) -> dict[str, Any]:
-    # A str/bytes is iterable, so tuple("add") would silently build ('a', 'd', 'd'). Reject the
-    # shape before materializing it. This is about the value space itself, so it holds whether or
-    # not the spec is strict.
+    # A str/bytes is iterable, so tuple("add") would silently build ('a', 'd', 'd'): reject the
+    # shape before materializing it. Holds whether or not the spec is strict.
     if isinstance(allowed_values, (str, bytes)):
         raise ValueError(
             f"property_spec({explanation!r}): allowed_values is a {type(allowed_values).__name__} "
@@ -46,9 +45,9 @@ def property_spec(
     if match_guard is not None and not callable(match_guard):
         raise ValueError(f"property_spec({explanation!r}): match_guard must be callable.")
 
-    # element_validator really is dead without strict: _validate_property_value returns early on a
-    # non-strict spec. allowed_values is NOT: a non-strict value space is still consumed, to map a
-    # name-parsed operation_config back onto its PROPERTY_MAPPING key.
+    # Dead without strict: _validate_property_value returns early on a non-strict spec. allowed_values
+    # is NOT dead there, so it has no such rule: a non-strict value space still maps a name-parsed
+    # value back onto its PROPERTY_MAPPING key.
     if element_validator is not None and not strict:
         raise ValueError(f"property_spec({explanation!r}): element_validator is never enforced without strict=True.")
 

--- a/mloda/core/abstract_plugins/components/feature_chainer/property_spec.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/property_spec.py
@@ -24,6 +24,16 @@ def property_spec(
     required_when: Callable[..., Any] | None = None,
     match_guard: Callable[..., Any] | None = None,
 ) -> dict[str, Any]:
+    # A str/bytes is iterable, so tuple("add") would silently build ('a', 'd', 'd'). Reject the
+    # shape before materializing it. This is about the value space itself, so it holds whether or
+    # not the spec is strict.
+    if isinstance(allowed_values, (str, bytes)):
+        raise ValueError(
+            f"property_spec({explanation!r}): allowed_values is a {type(allowed_values).__name__} "
+            f"({allowed_values!r}), which would make membership a substring test. Wrap it in a "
+            f"container, for example a one-element tuple: ({allowed_values!r},)."
+        )
+
     if allowed_values is not None and not isinstance(allowed_values, Mapping):
         allowed_values = tuple(allowed_values)
 
@@ -36,6 +46,9 @@ def property_spec(
     if match_guard is not None and not callable(match_guard):
         raise ValueError(f"property_spec({explanation!r}): match_guard must be callable.")
 
+    # element_validator really is dead without strict: _validate_property_value returns early on a
+    # non-strict spec. allowed_values is NOT: a non-strict value space is still consumed, to map a
+    # name-parsed operation_config back onto its PROPERTY_MAPPING key.
     if element_validator is not None and not strict:
         raise ValueError(f"property_spec({explanation!r}): element_validator is never enforced without strict=True.")
 
@@ -46,9 +59,6 @@ def property_spec(
         raise ValueError(
             f"property_spec({explanation!r}): strict=True needs a non-empty allowed_values or an element_validator."
         )
-
-    if not strict and allowed_values is not None:
-        raise ValueError(f"property_spec({explanation!r}): allowed_values is never enforced without strict=True.")
 
     spec: dict[str, Any] = {"explanation": explanation}
     if allowed_values is not None:

--- a/mloda_plugins/feature_group/experimental/aggregated_feature_group/base.py
+++ b/mloda_plugins/feature_group/experimental/aggregated_feature_group/base.py
@@ -107,9 +107,9 @@ class AggregatedFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     # Property mapping for configuration-based feature creation
     PROPERTY_MAPPING = {
         AGGREGATION_TYPE: {
-            **AGGREGATION_TYPES,  # All supported aggregation types as valid values
-            DefaultOptionKeys.context: True,  # Mark as context parameter
-            DefaultOptionKeys.strict_validation: True,  # Enable strict validation
+            DefaultOptionKeys.allowed_values: AGGREGATION_TYPES,
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: True,
         },
         DefaultOptionKeys.in_features: {
             "explanation": "Source feature to aggregate",

--- a/mloda_plugins/feature_group/experimental/clustering/base.py
+++ b/mloda_plugins/feature_group/experimental/clustering/base.py
@@ -113,9 +113,9 @@ class ClusteringFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     # Property mapping for configuration-based feature creation
     PROPERTY_MAPPING = {
         ALGORITHM: {
-            **CLUSTERING_ALGORITHMS,  # All supported algorithms as valid values
-            DefaultOptionKeys.context: True,  # Mark as context parameter
-            DefaultOptionKeys.strict_validation: True,  # Enable strict validation
+            DefaultOptionKeys.allowed_values: CLUSTERING_ALGORITHMS,
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: True,
         },
         K_VALUE: {
             "explanation": "Number of clusters or 'auto' for automatic determination",

--- a/mloda_plugins/feature_group/experimental/data_quality/missing_value/base.py
+++ b/mloda_plugins/feature_group/experimental/data_quality/missing_value/base.py
@@ -166,7 +166,7 @@ class MissingValueFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 
     PROPERTY_MAPPING = {
         IMPUTATION_METHOD: {
-            **IMPUTATION_METHODS,
+            DefaultOptionKeys.allowed_values: IMPUTATION_METHODS,
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
         },

--- a/mloda_plugins/feature_group/experimental/dimensionality_reduction/base.py
+++ b/mloda_plugins/feature_group/experimental/dimensionality_reduction/base.py
@@ -122,7 +122,7 @@ class DimensionalityReductionFeatureGroup(FeatureChainParserMixin, FeatureGroup)
 
     PROPERTY_MAPPING = {
         ALGORITHM: {
-            **REDUCTION_ALGORITHMS,
+            DefaultOptionKeys.allowed_values: REDUCTION_ALGORITHMS,
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
         },
@@ -159,20 +159,24 @@ class DimensionalityReductionFeatureGroup(FeatureChainParserMixin, FeatureGroup)
             ),
         },
         TSNE_METHOD: {
-            "barnes_hut": "Barnes-Hut approximation (faster, O(n log n))",
-            "exact": "Exact method (slower, O(n^2))",
             "explanation": "t-SNE computation method",
+            DefaultOptionKeys.allowed_values: {
+                "barnes_hut": "Barnes-Hut approximation (faster, O(n log n))",
+                "exact": "Exact method (slower, O(n^2))",
+            },
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
             DefaultOptionKeys.default: "barnes_hut",
         },
         # PCA specific parameters
         PCA_SVD_SOLVER: {
-            "auto": "Automatically choose solver based on data shape",
-            "full": "Full SVD using LAPACK",
-            "arpack": "Truncated SVD using ARPACK",
-            "randomized": "Randomized SVD",
             "explanation": "SVD solver algorithm for PCA",
+            DefaultOptionKeys.allowed_values: {
+                "auto": "Automatically choose solver based on data shape",
+                "full": "Full SVD using LAPACK",
+                "arpack": "Truncated SVD using ARPACK",
+                "randomized": "Randomized SVD",
+            },
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
             DefaultOptionKeys.default: "auto",

--- a/mloda_plugins/feature_group/experimental/forecasting/base.py
+++ b/mloda_plugins/feature_group/experimental/forecasting/base.py
@@ -126,7 +126,7 @@ class ForecastingFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featu
     # Property mapping for configuration-based features with group/context separation
     PROPERTY_MAPPING = {
         ALGORITHM: {
-            **FORECASTING_ALGORITHMS,
+            DefaultOptionKeys.allowed_values: FORECASTING_ALGORITHMS,
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
         },
@@ -139,7 +139,7 @@ class ForecastingFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featu
             ),
         },
         TIME_UNIT: {
-            **TimeReferenceMixin.TIME_UNITS,
+            DefaultOptionKeys.allowed_values: TimeReferenceMixin.TIME_UNITS,
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
         },

--- a/mloda_plugins/feature_group/experimental/geo_distance/base.py
+++ b/mloda_plugins/feature_group/experimental/geo_distance/base.py
@@ -104,7 +104,7 @@ class GeoDistanceFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     # Property mapping for configuration-based features with group/context separation
     PROPERTY_MAPPING = {
         DISTANCE_TYPE: {
-            **DISTANCE_TYPES,
+            DefaultOptionKeys.allowed_values: DISTANCE_TYPES,
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
         },

--- a/mloda_plugins/feature_group/experimental/node_centrality/base.py
+++ b/mloda_plugins/feature_group/experimental/node_centrality/base.py
@@ -141,12 +141,12 @@ class NodeCentralityFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     PROPERTY_MAPPING = {
         # Context parameters (don't affect Feature Group resolution)
         CENTRALITY_TYPE: {
-            **CENTRALITY_TYPES,  # All supported centrality types as valid options
+            DefaultOptionKeys.allowed_values: CENTRALITY_TYPES,
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
         },
         GRAPH_TYPE: {
-            **GRAPH_TYPES,  # All supported graph types as valid options
+            DefaultOptionKeys.allowed_values: GRAPH_TYPES,
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
             DefaultOptionKeys.default: "undirected",

--- a/mloda_plugins/feature_group/experimental/sklearn/encoding/base.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/encoding/base.py
@@ -179,9 +179,9 @@ class EncodingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     # Property mapping for new configuration-based approach
     PROPERTY_MAPPING = {
         ENCODER_TYPE: {
-            **SUPPORTED_ENCODERS,  # All supported encoder types as valid options
-            DefaultOptionKeys.context: True,  # Context parameter
-            DefaultOptionKeys.strict_validation: True,  # Enable strict validation
+            DefaultOptionKeys.allowed_values: SUPPORTED_ENCODERS,
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: True,
         },
         DefaultOptionKeys.in_features: {
             "explanation": "Source feature to encode",

--- a/mloda_plugins/feature_group/experimental/sklearn/pipeline/base.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/pipeline/base.py
@@ -91,10 +91,10 @@ class SklearnPipelineFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     # Property mapping for new configuration-based approach
     PROPERTY_MAPPING = {
         PIPELINE_NAME: {
-            **PIPELINE_TYPES,  # All supported pipeline types as valid options
+            DefaultOptionKeys.allowed_values: PIPELINE_TYPES,
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.default: None,  # Default is None as steps + params also work
+            DefaultOptionKeys.default: None,
         },
         PIPELINE_STEPS: {
             "explanation": "List of pipeline steps as (name, transformer) tuples",

--- a/mloda_plugins/feature_group/experimental/sklearn/scaling/base.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/scaling/base.py
@@ -89,9 +89,9 @@ class ScalingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     # Property mapping for new configuration-based approach
     PROPERTY_MAPPING = {
         SCALER_TYPE: {
-            **SUPPORTED_SCALERS,  # All supported scaler types as valid options
-            DefaultOptionKeys.context: True,  # Context parameter
-            DefaultOptionKeys.strict_validation: True,  # Enable strict validation
+            DefaultOptionKeys.allowed_values: SUPPORTED_SCALERS,
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: True,
         },
         DefaultOptionKeys.in_features: {
             "explanation": "Source feature to scale",

--- a/mloda_plugins/feature_group/experimental/text_cleaning/base.py
+++ b/mloda_plugins/feature_group/experimental/text_cleaning/base.py
@@ -93,9 +93,9 @@ class TextCleaningFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     # Property mapping for configuration-based features
     PROPERTY_MAPPING = {
         CLEANING_OPERATIONS: {
-            **SUPPORTED_OPERATIONS,  # All supported operations as valid options
-            DefaultOptionKeys.context: True,  # Mark as context parameter
-            DefaultOptionKeys.strict_validation: True,  # Enable strict validation
+            DefaultOptionKeys.allowed_values: SUPPORTED_OPERATIONS,
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: True,
             # The option is a sequence of operations; core unpacks it, so this judges ONE operation.
             DefaultOptionKeys.element_validator: lambda op: op in TextCleaningFeatureGroup.SUPPORTED_OPERATIONS,
         },

--- a/mloda_plugins/feature_group/experimental/time_window/base.py
+++ b/mloda_plugins/feature_group/experimental/time_window/base.py
@@ -95,9 +95,9 @@ class TimeWindowFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featur
     PROPERTY_MAPPING = {
         # Window function parameter (context parameter)
         WINDOW_FUNCTION: {
-            **WINDOW_FUNCTIONS,  # Reference existing WINDOW_FUNCTIONS dict
-            DefaultOptionKeys.context: True,  # Mark as context parameter
-            DefaultOptionKeys.strict_validation: True,  # Enable strict validation
+            DefaultOptionKeys.allowed_values: WINDOW_FUNCTIONS,
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: True,
         },
         # Window size parameter (context parameter)
         WINDOW_SIZE: {
@@ -110,9 +110,9 @@ class TimeWindowFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featur
         },
         # Time unit parameter (context parameter)
         TIME_UNIT: {
-            **TimeReferenceMixin.TIME_UNITS,  # Reference shared TIME_UNITS dict
-            DefaultOptionKeys.context: True,  # Mark as context parameter
-            DefaultOptionKeys.strict_validation: True,  # Enable strict validation
+            DefaultOptionKeys.allowed_values: TimeReferenceMixin.TIME_UNITS,
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: True,
         },
         # Source feature parameter (context parameter)
         DefaultOptionKeys.in_features: {

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_feature_chain_parser_mixin.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_feature_chain_parser_mixin.py
@@ -19,8 +19,7 @@ class MockFeatureGroup(FeatureChainParserMixin):
     PREFIX_PATTERN = r".*__([\w]+)_test$"
     PROPERTY_MAPPING = {
         "operation": {
-            "op1": "Operation 1",
-            "op2": "Operation 2",
+            DefaultOptionKeys.allowed_values: {"op1": "Operation 1", "op2": "Operation 2"},
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
         }
@@ -34,8 +33,7 @@ class MockFeatureGroupCustomSeparator(FeatureChainParserMixin):
     IN_FEATURE_SEPARATOR = ","
     PROPERTY_MAPPING = {
         "operation": {
-            "op1": "Operation 1",
-            "op2": "Operation 2",
+            DefaultOptionKeys.allowed_values: {"op1": "Operation 1", "op2": "Operation 2"},
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
         }
@@ -50,7 +48,7 @@ class MockFeatureGroupWithMinMax(FeatureChainParserMixin):
     MAX_IN_FEATURES = 3
     PROPERTY_MAPPING = {
         "operation": {
-            "op1": "Operation 1",
+            DefaultOptionKeys.allowed_values: {"op1": "Operation 1"},
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
         }
@@ -75,7 +73,7 @@ class MockFeatureGroupWithoutMinMax(FeatureChainParserMixin):
     MAX_IN_FEATURES = _HiddenAttribute()
     PROPERTY_MAPPING = {
         "operation": {
-            "op1": "Operation 1",
+            DefaultOptionKeys.allowed_values: {"op1": "Operation 1"},
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
         }
@@ -88,7 +86,7 @@ class MockFeatureGroupWithValidationHook(FeatureChainParserMixin):
     PREFIX_PATTERN = r".*__([\w]+)_test$"
     PROPERTY_MAPPING = {
         "operation": {
-            "op1": "Operation 1",
+            DefaultOptionKeys.allowed_values: {"op1": "Operation 1"},
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
         }

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_allowed_values.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_allowed_values.py
@@ -4,15 +4,15 @@ PROPERTY_MAPPING specs historically conflated allowed-value->docstring entries,
 ``DefaultOptionKeys`` flag keys, and a magic plain-string ``"explanation"`` doc key
 in one namespace. ``FeatureChainParser._extract_property_values`` recovered the
 allowed-value set by subtracting a hardcoded blocklist. This module pins the
-additive, backward-compatible improvement:
+``DefaultOptionKeys.allowed_values`` field that replaced that:
 
-* a single ``RESERVED_PROPERTY_KEYS`` frozenset is the one source of truth for
-  spec-internal metadata keys,
-* a new ``DefaultOptionKeys.allowed_values`` member lets authors declare the
-  allowed-value mapping explicitly,
-* ``_extract_property_values`` honors ``allowed_values`` when present and falls
-  back to the legacy flattened form otherwise, so both membership validation and
-  the class-definition default invariant follow automatically.
+* authors DECLARE the accepted values under ``allowed_values``,
+* ``_extract_property_values`` returns exactly that mapping, so both membership
+  validation and the class-definition default invariant follow automatically,
+* nothing else in the spec can widen the value space.
+
+The subtraction fallback (and with it the flattened authoring form) is gone; the
+spec SCHEMA that replaces it is pinned in ``test_property_mapping_spec_schema.py``.
 
 Reject semantics: ``match_configuration_feature_chain_parser`` raises ``ValueError``
 for a strict value outside the accepted set (verified against the existing parser),
@@ -28,7 +28,6 @@ import pytest
 
 from mloda.core.abstract_plugins.components.default_options_key import (
     DefaultOptionKeys,
-    RESERVED_PROPERTY_KEYS,
 )
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import (
     FeatureChainParser,
@@ -58,24 +57,12 @@ def _no_feature_group_registry_pollution() -> Any:
     assert not leaked, f"Leaked FeatureGroup subclasses from {__name__}: {[c.__name__ for c in leaked]}"
 
 
-class TestReservedPropertyKeys:
-    """``RESERVED_PROPERTY_KEYS`` is the single source of truth for metadata keys."""
+class TestAllowedValuesKey:
+    """``allowed_values`` is the field a spec declares its value space under.
 
-    def test_reserved_property_keys_importable_and_complete(self) -> None:
-        """The frozenset is importable and contains every spec-internal metadata key."""
-        assert isinstance(RESERVED_PROPERTY_KEYS, frozenset)
-        for member in (
-            DefaultOptionKeys.default,
-            DefaultOptionKeys.context,
-            DefaultOptionKeys.group,
-            DefaultOptionKeys.strict_validation,
-            DefaultOptionKeys.element_validator,
-            DefaultOptionKeys.required_when,
-            DefaultOptionKeys.match_guard,
-            DefaultOptionKeys.allowed_values,
-        ):
-            assert member in RESERVED_PROPERTY_KEYS
-        assert "explanation" in RESERVED_PROPERTY_KEYS
+    The completeness of the surrounding key set is the spec SCHEMA now, pinned as
+    ``PROPERTY_SPEC_KEYS`` in ``test_property_mapping_spec_schema.py``.
+    """
 
     def test_allowed_values_enum_member_exists(self) -> None:
         """``DefaultOptionKeys.allowed_values`` exists and stringifies to ``allowed_values``."""
@@ -84,7 +71,12 @@ class TestReservedPropertyKeys:
 
 
 class TestStrictMembershipViaAllowedValues:
-    """Strict membership flows through the explicit ``allowed_values`` field."""
+    """Strict membership flows through the explicit ``allowed_values`` field.
+
+    This is the ONLY way to declare a value space. The flattened form that once carried the
+    same values inline is retired, and is now rejected at class definition (see
+    ``test_property_mapping_spec_schema.py::TestUnknownSpecKeyFailsAtClassDefinition``).
+    """
 
     def test_allowed_values_field_accepts_and_rejects(self) -> None:
         """A spec using ``allowed_values`` accepts members and rejects non-members."""
@@ -104,37 +96,6 @@ class TestStrictMembershipViaAllowedValues:
                 return data
 
         property_mapping = AllowedValuesFeatureGroup.PROPERTY_MAPPING
-
-        assert (
-            FeatureChainParser.match_configuration_feature_chain_parser(
-                "any_feature", Options(context={"operation_type": "add"}), property_mapping
-            )
-            is True
-        )
-        with pytest.raises(ValueError, match="mul"):
-            FeatureChainParser.match_configuration_feature_chain_parser(
-                "any_feature", Options(context={"operation_type": "mul"}), property_mapping
-            )
-
-    def test_legacy_flattened_form_still_validates(self) -> None:
-        """An equivalent legacy spec (top-level entries) gives the same accept/reject results."""
-
-        class LegacyFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-            PREFIX_PATTERN = r".*__([\w]+)_op$"
-            PROPERTY_MAPPING = {
-                "operation_type": {
-                    "add": "Addition",
-                    "sub": "Subtraction",
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: True,
-                }
-            }
-
-            @classmethod
-            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                return data
-
-        property_mapping = LegacyFeatureGroup.PROPERTY_MAPPING
 
         assert (
             FeatureChainParser.match_configuration_feature_chain_parser(

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_required_when.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_required_when.py
@@ -40,10 +40,12 @@ class MockWithConditionalRequired(FeatureChainParserMixin):
 
     PROPERTY_MAPPING = {
         "aggregation_type": {
-            "sum": "Sum of values",
-            "avg": "Average of values",
-            "first": "First value (requires order_by)",
-            "last": "Last value (requires order_by)",
+            DefaultOptionKeys.allowed_values: {
+                "sum": "Sum of values",
+                "avg": "Average of values",
+                "first": "First value (requires order_by)",
+                "last": "Last value (requires order_by)",
+            },
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
         },
@@ -136,7 +138,7 @@ class TestRequiredWhenUnit:
             PREFIX_PATTERN = r".*__([\w]+)_windowed$"
             PROPERTY_MAPPING = {
                 "aggregation_type": {
-                    "sum": "Sum",
+                    DefaultOptionKeys.allowed_values: {"sum": "Sum"},
                     DefaultOptionKeys.context: True,
                     DefaultOptionKeys.strict_validation: True,
                 },
@@ -166,8 +168,7 @@ class TestRequiredWhenUnit:
             PREFIX_PATTERN = r".*__([\w]+)_windowed$"
             PROPERTY_MAPPING = {
                 "aggregation_type": {
-                    "sum": "Sum",
-                    "first": "First",
+                    DefaultOptionKeys.allowed_values: {"sum": "Sum", "first": "First"},
                     DefaultOptionKeys.context: True,
                     DefaultOptionKeys.strict_validation: True,
                 },
@@ -255,8 +256,7 @@ class ConditionalRequiredFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 
     PROPERTY_MAPPING = {
         "aggregation_type": {
-            "sum": "Sum of values",
-            "first": "First value (requires order_by)",
+            DefaultOptionKeys.allowed_values: {"sum": "Sum of values", "first": "First value (requires order_by)"},
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
         },

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_spec_schema.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_spec_schema.py
@@ -1,0 +1,537 @@
+"""A PROPERTY_MAPPING spec has a SCHEMA: unknown keys are errors, never allowed values (issue #600).
+
+The legacy flattened authoring form is retired here. It recovered a spec's allowed-value
+space by SUBTRACTING the reserved metadata keys, which means every key the parser did not
+recognize was silently absorbed as an accepted VALUE. One typo, two silent failures::
+
+    {"add": "Addition", "sub": "Subtraction", "strict_validaton": True}   # missing an 'i'
+
+    _extract_property_values(...) -> {"add": ..., "sub": ..., "strict_validaton": True}
+                                     the typo'd FLAG is now an accepted VALUE
+    _is_strict_validation(...)    -> False
+                                     strict validation is silently OFF
+
+Nothing raised, at any lifecycle moment. This module pins the hard break that makes that
+impossible to express:
+
+1. A spec's value space is DECLARED under ``DefaultOptionKeys.allowed_values``. It is never
+   inferred by subtraction, so a spec without ``allowed_values`` declares an EMPTY value
+   space (and, being non-strict, accepts anything).
+2. Because the value space is explicit, every remaining key in a spec must be a known spec
+   key. ONE general rule at class-definition time rejects any unknown key, naming the owning
+   class, the property key and the offender. For a REMOVED key the message names its
+   replacement; otherwise it suggests the nearest known key.
+3. The known-key set is the spec SCHEMA now, not a subtraction set: ``PROPERTY_SPEC_KEYS``
+   replaces ``RESERVED_PROPERTY_KEYS`` (hard rename, no alias).
+4. Now checkable: ``strict_validation: True`` requires a non-empty ``allowed_values`` OR an
+   ``element_validator``. Strict with neither accepts nothing and rejects every value. This
+   mirrors the invariant ``property_spec`` already enforces, so core and the builder agree.
+"""
+
+from __future__ import annotations
+
+import gc
+from typing import Any
+
+import pytest
+
+from mloda.core.abstract_plugins.components import default_options_key as default_options_key_module
+from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
+from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.components.utils import get_all_subclasses
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+
+TYPO_STRICT_KEY = "strict_validaton"  # the headline typo: 'strict_validation' minus one 'i'
+STALE_ELEMENT_VALIDATOR_KEY = "validation_function"
+STALE_MATCH_GUARD_KEY = "type_validator"
+
+
+@pytest.fixture(autouse=True)
+def _no_feature_group_registry_pollution() -> Any:
+    """Guarantee this module never leaks throwaway FeatureGroup subclasses.
+
+    Mirrors ``test_property_mapping_unified_model.py``: the class-definition tests below
+    define FeatureGroup subclasses, which linger in ``FeatureGroup.__subclasses__()`` until
+    a GC cycle runs and would otherwise be seen by tests that enumerate feature groups.
+    """
+    yield
+    gc.collect()
+    gc.collect()
+    leaked = [c for c in get_all_subclasses(FeatureGroup) if c.__module__ == __name__]
+    assert not leaked, f"Leaked FeatureGroup subclasses from {__name__}: {[c.__name__ for c in leaked]}"
+
+
+def _positive_int(value: Any) -> bool:
+    return isinstance(value, int) and value > 0
+
+
+class TestSpecSchemaKeySet:
+    """The known-key set is the spec SCHEMA: ``PROPERTY_SPEC_KEYS``, and only that name."""
+
+    def test_property_spec_keys_exists_and_is_complete(self) -> None:
+        """``PROPERTY_SPEC_KEYS`` is an importable frozenset holding every known spec key."""
+        spec_keys = getattr(default_options_key_module, "PROPERTY_SPEC_KEYS", None)
+
+        assert spec_keys is not None, "PROPERTY_SPEC_KEYS must exist in default_options_key"
+        assert isinstance(spec_keys, frozenset)
+        for member in (
+            DefaultOptionKeys.allowed_values,
+            DefaultOptionKeys.default,
+            DefaultOptionKeys.context,
+            DefaultOptionKeys.group,
+            DefaultOptionKeys.strict_validation,
+            DefaultOptionKeys.element_validator,
+            DefaultOptionKeys.required_when,
+            DefaultOptionKeys.match_guard,
+        ):
+            assert member in spec_keys
+        assert "explanation" in spec_keys
+
+    def test_reserved_property_keys_is_gone(self) -> None:
+        """The subtraction-set name is retired: no alias, no re-export."""
+        assert not hasattr(default_options_key_module, "RESERVED_PROPERTY_KEYS"), (
+            "RESERVED_PROPERTY_KEYS is renamed to PROPERTY_SPEC_KEYS, with no alias"
+        )
+
+
+class TestUnknownSpecKeyFailsAtClassDefinition:
+    """The headline: a typo'd flag can no longer be expressed silently.
+
+    Any key that is not a known spec key raises at class definition, naming the owning
+    class, the property key and the offending key.
+    """
+
+    def test_typo_flag_key_rejected_at_class_definition(self) -> None:
+        """``strict_validaton`` (one character off) raises, and the message suggests the real key."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class TypoFlagFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {
+                    "operation_type": {
+                        "explanation": "The arithmetic operation to apply",
+                        DefaultOptionKeys.allowed_values: {"add": "Addition", "sub": "Subtraction"},
+                        DefaultOptionKeys.context: True,
+                        TYPO_STRICT_KEY: True,
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "TypoFlagFeatureGroup" in message
+        assert "operation_type" in message
+        assert TYPO_STRICT_KEY in message
+        assert DefaultOptionKeys.strict_validation.value in message, (
+            "the message must name the key the author meant (nearest-known-key suggestion)"
+        )
+
+    def test_arbitrary_unknown_key_rejected_at_class_definition(self) -> None:
+        """An unknown key with no near miss still raises, naming class, property and offender."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class UnknownKeyFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {
+                    "window_size": {
+                        "explanation": "Size of the time window",
+                        DefaultOptionKeys.context: True,
+                        "documentation_url": "https://example.invalid/window_size",
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "UnknownKeyFeatureGroup" in message
+        assert "window_size" in message
+        assert "documentation_url" in message
+
+    def test_legacy_flattened_value_entries_are_unknown_keys(self) -> None:
+        """The legacy flattened form is retired: inline value entries are now unknown keys."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class LegacyFlattenedFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {
+                    "operation_type": {
+                        "add": "Addition",
+                        "sub": "Subtraction",
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: True,
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "LegacyFlattenedFeatureGroup" in message
+        assert "operation_type" in message
+        assert "add" in message
+        assert DefaultOptionKeys.allowed_values.value in message, (
+            "the remedy is to declare the value space under allowed_values"
+        )
+
+    def test_parser_entry_point_rejects_unknown_key(self) -> None:
+        """The rule lives in core, so validating a mapping directly raises the same way."""
+        mapping: dict[str, Any] = {
+            "operation_type": {
+                DefaultOptionKeys.allowed_values: {"add": "Addition"},
+                DefaultOptionKeys.context: True,
+                TYPO_STRICT_KEY: True,
+            }
+        }
+
+        with pytest.raises(ValueError) as exc_info:
+            FeatureChainParser.validate_property_mapping_defaults("SomeOwner", mapping)
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "SomeOwner" in message
+        assert TYPO_STRICT_KEY in message
+
+    def test_typo_flag_is_never_absorbed_into_the_accepted_value_set(self) -> None:
+        """The regression this whole change exists to prevent, checked through MATCHING.
+
+        Under the old subtraction rule the typo'd flag became a member of the accepted set,
+        so a feature whose option value is literally ``"strict_validaton"`` matched, while
+        strict validation was silently off. No feature group may ever accept that.
+        """
+        matched: bool
+
+        try:
+
+            class AbsorbedTypoFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {
+                    "operation_type": {
+                        "add": "Addition",
+                        "sub": "Subtraction",
+                        TYPO_STRICT_KEY: True,
+                        DefaultOptionKeys.context: True,
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+            matched = AbsorbedTypoFeatureGroup.match_feature_group_criteria(
+                "any_feature", Options(context={"operation_type": TYPO_STRICT_KEY})
+            )
+        except ValueError:
+            matched = False
+
+        assert matched is False, "an unknown spec key must never become an accepted option value"
+
+
+class TestExtractPropertyValuesReadsAllowedValuesOnly:
+    """``_extract_property_values`` returns exactly what ``allowed_values`` declares."""
+
+    def test_flattened_spec_no_longer_widens_the_value_space(self) -> None:
+        """No ``allowed_values`` means an EMPTY value space, never the leftover entries.
+
+        Unreachable through class definition now, so the parser seam is tested directly.
+        """
+        spec: dict[Any, Any] = {
+            "add": "Addition",
+            "sub": "Subtraction",
+            DefaultOptionKeys.context: True,
+        }
+
+        extracted = FeatureChainParser._extract_property_values(spec)
+
+        assert not extracted, "a spec with no allowed_values declares no value space"
+        assert "add" not in extracted
+        assert "sub" not in extracted
+
+    def test_stray_unknown_key_does_not_widen_a_declared_value_space(self) -> None:
+        """With ``allowed_values`` declared, a stray key is never appended to the value space."""
+        spec: dict[Any, Any] = {
+            "explanation": "The arithmetic operation to apply",
+            DefaultOptionKeys.allowed_values: {"add": "Addition"},
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: True,
+            TYPO_STRICT_KEY: True,
+        }
+
+        extracted = FeatureChainParser._extract_property_values(spec)
+
+        assert extracted == {"add": "Addition"}
+        assert TYPO_STRICT_KEY not in extracted
+
+    def test_empty_value_space_is_returned_for_a_spec_without_allowed_values(self) -> None:
+        """A metadata-only spec (the ``in_features`` shape) declares no value space."""
+        spec: dict[Any, Any] = {
+            "explanation": "The input features",
+            DefaultOptionKeys.context: True,
+        }
+
+        assert not FeatureChainParser._extract_property_values(spec)
+
+
+class TestKnownKeySpecsAreAccepted:
+    """The valid authoring forms keep working: this rule rejects only UNKNOWN keys."""
+
+    def test_allowed_values_plus_known_flags_defines_and_matches(self) -> None:
+        """``allowed_values`` plus known flags is the canonical strict spec."""
+
+        class ExplicitFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+            PROPERTY_MAPPING = {
+                "operation_type": {
+                    "explanation": "The arithmetic operation to apply",
+                    DefaultOptionKeys.allowed_values: {"add": "Addition", "sub": "Subtraction"},
+                    DefaultOptionKeys.context: True,
+                    DefaultOptionKeys.strict_validation: True,
+                    DefaultOptionKeys.default: "add",
+                }
+            }
+
+            @classmethod
+            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                return data
+
+        assert (
+            ExplicitFeatureGroup.match_feature_group_criteria("any_feature", Options(context={"operation_type": "sub"}))
+            is True
+        )
+        assert (
+            ExplicitFeatureGroup.match_feature_group_criteria("any_feature", Options(context={"operation_type": "mul"}))
+            is False
+        )
+
+    def test_metadata_only_spec_declares_no_value_space_and_accepts_anything(self) -> None:
+        """No ``allowed_values`` and no strict (the ``in_features`` shape) stays valid."""
+
+        class MetadataOnlyFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+            PROPERTY_MAPPING = {
+                DefaultOptionKeys.in_features: {
+                    "explanation": "The input features",
+                    DefaultOptionKeys.context: True,
+                }
+            }
+
+            @classmethod
+            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                return data
+
+        assert (
+            MetadataOnlyFeatureGroup.match_feature_group_criteria(
+                "any_feature", Options(context={DefaultOptionKeys.in_features.value: "anything_at_all"})
+            )
+            is True
+        )
+
+    def test_match_guard_only_spec_defines(self) -> None:
+        """A non-strict guarded spec carries only known keys and defines cleanly."""
+
+        class GuardedFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+            PROPERTY_MAPPING = {
+                "partition_by": {
+                    "explanation": "List of columns to partition by",
+                    DefaultOptionKeys.context: True,
+                    DefaultOptionKeys.strict_validation: False,
+                    DefaultOptionKeys.match_guard: _positive_int,
+                }
+            }
+
+            @classmethod
+            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                return data
+
+        assert DefaultOptionKeys.match_guard in GuardedFeatureGroup.PROPERTY_MAPPING["partition_by"]
+
+
+class TestRemovedKeysFoldIntoTheGeneralRule:
+    """The removed-key guard becomes a MESSAGE VARIANT of the unknown-key rule, not a second check."""
+
+    def test_removed_element_validator_key_names_its_replacement(self) -> None:
+        """``validation_function`` is an unknown key whose message names ``element_validator``."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class StaleElementValidatorFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {
+                    "operation_type": {
+                        "explanation": "The arithmetic operation to apply",
+                        DefaultOptionKeys.allowed_values: {"add": "Addition"},
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: True,
+                        STALE_ELEMENT_VALIDATOR_KEY: _positive_int,
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "StaleElementValidatorFeatureGroup" in message
+        assert "operation_type" in message
+        assert STALE_ELEMENT_VALIDATOR_KEY in message
+        assert DefaultOptionKeys.element_validator.value in message
+
+    def test_removed_match_guard_key_names_its_replacement(self) -> None:
+        """``type_validator`` is an unknown key whose message names ``match_guard``."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class StaleMatchGuardFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {
+                    "partition_by": {
+                        "explanation": "List of columns to partition by",
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: False,
+                        STALE_MATCH_GUARD_KEY: _positive_int,
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "StaleMatchGuardFeatureGroup" in message
+        assert "partition_by" in message
+        assert STALE_MATCH_GUARD_KEY in message
+        assert DefaultOptionKeys.match_guard.value in message
+
+
+class TestStrictValidationNeedsAValueSpace:
+    """``strict_validation: True`` needs something to validate AGAINST.
+
+    Strict with neither a non-empty ``allowed_values`` nor an ``element_validator`` accepts
+    nothing and rejects every value: a spec that can never match. ``property_spec`` already
+    rejects this at import time; core now agrees, so the two entry points cannot drift.
+    """
+
+    def test_strict_without_allowed_values_or_element_validator_raises(self) -> None:
+        """Strict, but nothing to validate against: raises at class definition."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class EmptyStrictFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {
+                    "operation_type": {
+                        "explanation": "The arithmetic operation to apply",
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: True,
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "EmptyStrictFeatureGroup" in message
+        assert "operation_type" in message
+        assert DefaultOptionKeys.allowed_values.value in message
+        assert DefaultOptionKeys.element_validator.value in message
+
+    def test_strict_with_empty_allowed_values_raises(self) -> None:
+        """An empty declared value space would reject every value: raises at class definition."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class EmptyAllowedValuesFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {
+                    "operation_type": {
+                        "explanation": "The arithmetic operation to apply",
+                        DefaultOptionKeys.allowed_values: {},
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: True,
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "EmptyAllowedValuesFeatureGroup" in message
+        assert "operation_type" in message
+
+    def test_parser_entry_point_rejects_strict_without_a_value_space(self) -> None:
+        """The invariant lives in core, so validating a mapping directly raises too."""
+        mapping: dict[str, Any] = {
+            "operation_type": {
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: True,
+            }
+        }
+
+        with pytest.raises(ValueError, match="operation_type"):
+            FeatureChainParser.validate_property_mapping_defaults("SomeOwner", mapping)
+
+    def test_strict_with_element_validator_only_is_fine(self) -> None:
+        """An ``element_validator`` IS a value space: no ``allowed_values`` needed."""
+
+        class StrictValidatorFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+            PROPERTY_MAPPING = {
+                "window_size": {
+                    "explanation": "Size of the time window",
+                    DefaultOptionKeys.context: True,
+                    DefaultOptionKeys.strict_validation: True,
+                    DefaultOptionKeys.element_validator: _positive_int,
+                }
+            }
+
+            @classmethod
+            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                return data
+
+        assert (
+            StrictValidatorFeatureGroup.match_feature_group_criteria("any_feature", Options(context={"window_size": 7}))
+            is True
+        )
+
+    def test_strict_with_non_empty_allowed_values_is_fine(self) -> None:
+        """A non-empty declared value space is the other way to satisfy the invariant."""
+
+        class StrictAllowedValuesFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+            PROPERTY_MAPPING = {
+                "operation_type": {
+                    "explanation": "The arithmetic operation to apply",
+                    DefaultOptionKeys.allowed_values: {"add": "Addition"},
+                    DefaultOptionKeys.context: True,
+                    DefaultOptionKeys.strict_validation: True,
+                }
+            }
+
+            @classmethod
+            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                return data
+
+        assert (
+            StrictAllowedValuesFeatureGroup.match_feature_group_criteria(
+                "any_feature", Options(context={"operation_type": "add"})
+            )
+            is True
+        )
+
+
+class TestNonDictSpecValuesKeepTodaysBehavior:
+    """A non-dict spec value is not a spec dict, so the schema rule has nothing to check.
+
+    Characterization, deliberately unchanged: ``validate_property_mapping_defaults`` skips
+    non-dict entries and ``_extract_property_values`` hands them back verbatim.
+    """
+
+    def test_non_dict_spec_value_is_accepted_at_class_definition(self) -> None:
+        """A non-dict spec value neither raises nor is treated as a key-bearing spec."""
+        mapping: dict[str, Any] = {"operation_type": ["add", "sub"]}
+
+        assert FeatureChainParser.validate_property_mapping_defaults("SomeOwner", mapping) is None
+
+    def test_non_dict_spec_value_is_its_own_value_space(self) -> None:
+        """``_extract_property_values`` returns a non-dict spec value unchanged."""
+        assert FeatureChainParser._extract_property_values(["add", "sub"]) == ["add", "sub"]

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_spec_schema.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_spec_schema.py
@@ -519,19 +519,57 @@ class TestStrictValidationNeedsAValueSpace:
         )
 
 
-class TestNonDictSpecValuesKeepTodaysBehavior:
-    """A non-dict spec value is not a spec dict, so the schema rule has nothing to check.
+class TestNonDictSpecValuesAreRejected:
+    """A spec must BE a spec dict: a bare container bypasses every class-definition rule.
 
-    Characterization, deliberately unchanged: ``validate_property_mapping_defaults`` skips
-    non-dict entries and ``_extract_property_values`` hands them back verbatim.
+    ``PROPERTY_MAPPING = {"op": ["add", "sub", "strict_validaton"]}`` defines cleanly today and
+    the list is handed back verbatim as the value space, because all three rules skip non-dicts.
+    It is not a widening hole in the strict sense (a bare container has nowhere to put
+    ``strict_validation``, so it can never be strict), but it contradicts the one-authoring-form
+    contract the schema rule establishes, and it is the one shape the repo-wide guard cannot see.
+    No in-repo spec is a non-dict, so this is a clean hard break, consistent with the rest.
     """
 
-    def test_non_dict_spec_value_is_accepted_at_class_definition(self) -> None:
-        """A non-dict spec value neither raises nor is treated as a key-bearing spec."""
+    def test_non_dict_spec_value_rejected_at_class_definition(self) -> None:
+        """A bare list where a spec dict belongs raises, naming the class and the property key."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class BareContainerFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {"operation_type": ["add", "sub"]}
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "BareContainerFeatureGroup" in message
+        assert "operation_type" in message
+
+    def test_parser_entry_point_rejects_a_non_dict_spec_value(self) -> None:
+        """The rule lives in core, so validating a mapping directly raises the same way."""
         mapping: dict[str, Any] = {"operation_type": ["add", "sub"]}
 
-        assert FeatureChainParser.validate_property_mapping_defaults("SomeOwner", mapping) is None
+        with pytest.raises(ValueError, match="operation_type"):
+            FeatureChainParser.validate_property_mapping_defaults("SomeOwner", mapping)
 
-    def test_non_dict_spec_value_is_its_own_value_space(self) -> None:
-        """``_extract_property_values`` returns a non-dict spec value unchanged."""
-        assert FeatureChainParser._extract_property_values(["add", "sub"]) == ["add", "sub"]
+    def test_non_dict_spec_value_cannot_smuggle_a_typo_flag_as_an_accepted_value(self) -> None:
+        """The schema rule's whole point, checked on the shape that used to skip it."""
+        matched: bool
+
+        try:
+
+            class SmuggledTypoFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {"operation_type": ["add", "sub", TYPO_STRICT_KEY]}
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+            matched = SmuggledTypoFeatureGroup.match_feature_group_criteria(
+                "any_feature", Options(context={"operation_type": TYPO_STRICT_KEY})
+            )
+        except ValueError:
+            matched = False
+
+        assert matched is False, "a spec must be a spec dict, so a bare container can carry no flags at all"

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_spec_shape.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_spec_shape.py
@@ -1,0 +1,934 @@
+"""A PROPERTY_MAPPING spec has a SHAPE, not just a key set (issue #600 follow-up).
+
+``test_property_mapping_spec_schema.py`` closed the unknown-KEY hole: every key of a spec must
+be a known spec key. That rule is airtight, but it says nothing about the SHAPE OF THE VALUE
+under each key, which reopens the same class of silent widening from the other side:
+
+    {DefaultOptionKeys.allowed_values: ("add"), DefaultOptionKeys.strict_validation: True}
+
+A forgotten comma makes that a ``str``, not a one-tuple. It defines cleanly, and at match time
+``found_val in "add"`` is a SUBSTRING test: ``"add"``, ``"a"``, ``"ad"``, ``"dd"`` and ``""``
+are all accepted. The retired flattened form could never express this (its value space was
+always a dict), so this is net-new surface opened by making ``allowed_values`` the one channel.
+
+The same truthiness-shaped hole runs through the rest of the layer:
+
+* ``strict_validation`` needing a "non-empty" value space is a TRUTHINESS test, so an EMPTY
+  generator passes (a generator object is always truthy), a NON-EMPTY one passes and is then
+  CONSUMED (matching becomes stateful and order-dependent), and a scalar passes and then makes
+  ``value in 5`` raise a ``TypeError`` that is swallowed into a silent reject-everything.
+* the callable-valued keys are checked for PRESENCE, not CALLABILITY, so a list under
+  ``element_validator`` escapes as ``TypeError: 'list' object is not callable`` out of matching,
+  and with a declared default the broad ``except Exception`` in ``check_declared_default``
+  rewrites it into a confidently WRONG message about the default.
+* ``_is_strict_validation`` is truthiness-based, so ``strict_validation: "false"`` is strict and
+  the error message asserts ``strict_validation=True`` about a spec that never said so.
+* ``property_spec`` refuses to build a NON-STRICT spec with ``allowed_values``, on the premise
+  that "allowed_values is never enforced without strict=True". That premise is false: the value
+  space of a non-strict spec is consumed by ``_find_property_key_for_value`` and
+  ``_build_effective_options`` to map a name-parsed value back to its PROPERTY_MAPPING key.
+
+This module pins the shape rules that close all of it. The ordering constraint from the schema
+module is preserved: the unknown-key rule still runs FIRST, so a spec carrying a removed key is
+still reported as a rename, not as a shape error.
+"""
+
+from __future__ import annotations
+
+import gc
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
+from mloda.core.abstract_plugins.components.feature_chainer.property_spec import property_spec
+from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.components.utils import get_all_subclasses
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+
+TYPO_STRICT_KEY = "strict_validaton"  # 'strict_validation' minus one 'i'
+TYPO_CONTEXT_KEY = "contxt"  # 'context' minus one 'e'
+STALE_ELEMENT_VALIDATOR_KEY = "validation_function"
+
+
+@pytest.fixture(autouse=True)
+def _no_feature_group_registry_pollution() -> Any:
+    """Guarantee this module never leaks throwaway FeatureGroup subclasses.
+
+    Mirrors ``test_property_mapping_spec_schema.py``: the class-definition tests below define
+    FeatureGroup subclasses, which linger in ``FeatureGroup.__subclasses__()`` until a GC cycle
+    runs and would otherwise be seen by tests that enumerate feature groups.
+    """
+    yield
+    gc.collect()
+    gc.collect()
+    leaked = [c for c in get_all_subclasses(FeatureGroup) if c.__module__ == __name__]
+    assert not leaked, f"Leaked FeatureGroup subclasses from {__name__}: {[c.__name__ for c in leaked]}"
+
+
+def _positive_int(value: Any) -> bool:
+    return isinstance(value, int) and value > 0
+
+
+def _one_shot_values() -> Iterator[str]:
+    """A NON-EMPTY generator: truthy, but a one-shot value space that empties itself."""
+    yield "add"
+    yield "sub"
+
+
+def _no_values() -> Iterator[str]:
+    """An EMPTY generator: still truthy, so it passes a truthiness-based non-empty test."""
+    yield from ()
+
+
+class TestAllowedValuesMustBeACollection:
+    """``allowed_values`` declares a VALUE SPACE, so it must be a Collection, never a str.
+
+    A ``str`` is the dangerous case: it is a perfectly good Collection of characters, so
+    membership silently degrades into a substring test. ``bytes`` behaves the same way. Both
+    are rejected outright, because no author ever means "any substring of this word".
+    """
+
+    def test_str_allowed_values_rejected_at_class_definition(self) -> None:
+        """A ``str`` value space (the forgotten-comma bug) raises, naming the real fault."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class StrAllowedValuesFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {
+                    "operation_type": {
+                        # A forgotten comma: ("add") is the str "add", not the tuple ("add",).
+                        DefaultOptionKeys.allowed_values: "add",
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: True,
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "StrAllowedValuesFeatureGroup" in message
+        assert "operation_type" in message
+        assert DefaultOptionKeys.allowed_values.value in message
+        assert "str" in message, "the message must name the offending shape, not just say 'invalid'"
+
+    def test_bytes_allowed_values_rejected_at_class_definition(self) -> None:
+        """``bytes`` substring-matches exactly like ``str``, so it is rejected the same way."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class BytesAllowedValuesFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {
+                    "operation_type": {
+                        DefaultOptionKeys.allowed_values: b"add",
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: True,
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "BytesAllowedValuesFeatureGroup" in message
+        assert DefaultOptionKeys.allowed_values.value in message
+
+    @pytest.mark.parametrize("candidate", ["add", "a", "ad", "dd", ""])
+    def test_str_allowed_values_never_substring_matches(self, candidate: str) -> None:
+        """The regression itself, checked through MATCHING.
+
+        Every one of these is accepted today: the full word, each of its substrings, and the
+        empty string. A spec that cannot be defined can never accept any of them.
+        """
+        matched: bool
+
+        try:
+
+            class SubstringMatchFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {
+                    "operation_type": {
+                        DefaultOptionKeys.allowed_values: "add",
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: True,
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+            matched = SubstringMatchFeatureGroup.match_feature_group_criteria(
+                "any_feature", Options(context={"operation_type": candidate})
+            )
+        except ValueError:
+            matched = False
+
+        assert matched is False, "a str allowed_values must never turn membership into a substring test"
+
+    def test_parser_entry_point_rejects_str_allowed_values(self) -> None:
+        """The rule lives in core, so validating a mapping directly raises the same way."""
+        mapping: dict[str, Any] = {
+            "operation_type": {
+                DefaultOptionKeys.allowed_values: "add",
+                DefaultOptionKeys.strict_validation: True,
+            }
+        }
+
+        with pytest.raises(ValueError, match="operation_type"):
+            FeatureChainParser.validate_property_mapping_defaults("SomeOwner", mapping)
+
+    def test_str_allowed_values_rejected_without_strict_validation(self) -> None:
+        """The shape rule is about the value space itself, so it does not depend on strict.
+
+        A non-strict value space is still consumed (name-parsed value -> property key), so a
+        str there would substring-map arbitrary operation configs onto the wrong key.
+        """
+        mapping: dict[str, Any] = {
+            "operation_type": {
+                DefaultOptionKeys.allowed_values: "add",
+                DefaultOptionKeys.strict_validation: False,
+            }
+        }
+
+        with pytest.raises(ValueError, match="operation_type"):
+            FeatureChainParser.validate_property_mapping_defaults("SomeOwner", mapping)
+
+    @pytest.mark.parametrize(
+        "value_space",
+        [
+            {"add": "Addition", "sub": "Subtraction"},
+            ("add", "sub"),
+            ["add", "sub"],
+            {"add", "sub"},
+            frozenset({"add", "sub"}),
+        ],
+        ids=["dict", "tuple", "list", "set", "frozenset"],
+    )
+    def test_every_real_collection_form_still_defines_and_matches(self, value_space: Any) -> None:
+        """The guard rejects only non-Collections: every legitimate container keeps working."""
+
+        class CollectionValueSpaceFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+            PROPERTY_MAPPING = {
+                "operation_type": {
+                    DefaultOptionKeys.allowed_values: value_space,
+                    DefaultOptionKeys.context: True,
+                    DefaultOptionKeys.strict_validation: True,
+                }
+            }
+
+            @classmethod
+            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                return data
+
+        assert (
+            CollectionValueSpaceFeatureGroup.match_feature_group_criteria(
+                "any_feature", Options(context={"operation_type": "add"})
+            )
+            is True
+        )
+        assert (
+            CollectionValueSpaceFeatureGroup.match_feature_group_criteria(
+                "any_feature", Options(context={"operation_type": "mul"})
+            )
+            is False
+        )
+
+
+class TestNonEmptyIsNotATruthinessTest:
+    """ "Strict needs a non-empty value space" must mean non-empty, not merely truthy.
+
+    A generator object and a scalar are both truthy and both pass the rule today, each in a
+    different, worse-than-empty way. The Collection guard is what makes "non-empty" checkable.
+    """
+
+    def test_empty_generator_allowed_values_rejected(self) -> None:
+        """An EMPTY generator is truthy, so it slips past the strict-needs-a-value-space rule."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class EmptyGeneratorFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {
+                    "operation_type": {
+                        DefaultOptionKeys.allowed_values: _no_values(),
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: True,
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "EmptyGeneratorFeatureGroup" in message
+        assert DefaultOptionKeys.allowed_values.value in message
+
+    def test_non_empty_generator_allowed_values_rejected(self) -> None:
+        """A NON-EMPTY generator is a one-shot value space, so it is not a value space at all."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class GeneratorFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {
+                    "operation_type": {
+                        DefaultOptionKeys.allowed_values: _one_shot_values(),
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: True,
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "GeneratorFeatureGroup" in message
+        assert DefaultOptionKeys.allowed_values.value in message
+
+    def test_generator_allowed_values_never_makes_matching_stateful(self) -> None:
+        """Matching the SAME value twice must give the SAME answer.
+
+        Today a generator value space is consumed by matching: the first match succeeds, the
+        second raises "not found in mapping". That makes matching order-dependent, and so
+        nondeterministic under pytest-xdist. A spec that cannot be defined cannot be stateful.
+        """
+        matches: list[bool]
+
+        try:
+
+            class StatefulGeneratorFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {
+                    "operation_type": {
+                        DefaultOptionKeys.allowed_values: _one_shot_values(),
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: True,
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+            options = Options(context={"operation_type": "add"})
+            matches = [StatefulGeneratorFeatureGroup.match_feature_group_criteria("any_feature", options)] * 1
+            matches.append(StatefulGeneratorFeatureGroup.match_feature_group_criteria("any_feature", options))
+        except ValueError:
+            matches = [False, False]
+
+        assert matches[0] == matches[1], "matching must not depend on how often the value space was consulted"
+        assert matches == [False, False], "a generator is not a value space, so the spec must not be definable"
+
+    def test_generator_allowed_values_with_a_default_is_rejected_not_burnt(self) -> None:
+        """With a declared default, ``check_declared_default`` burns the generator at definition.
+
+        Today this class defines cleanly and then rejects EVERY runtime value, including the
+        very values it declares, because the default check consumed the value space.
+        """
+        with pytest.raises(ValueError):
+
+            class BurntGeneratorFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {
+                    "operation_type": {
+                        DefaultOptionKeys.allowed_values: _one_shot_values(),
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: True,
+                        DefaultOptionKeys.default: "add",
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+    def test_scalar_allowed_values_rejected(self) -> None:
+        """A scalar is truthy, then ``value in 5`` raises a TypeError that is swallowed.
+
+        The spec silently rejects every value, including the scalar itself.
+        """
+        with pytest.raises(ValueError) as exc_info:
+
+            class ScalarAllowedValuesFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {
+                    "window_size": {
+                        DefaultOptionKeys.allowed_values: 5,
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: True,
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "ScalarAllowedValuesFeatureGroup" in message
+        assert "window_size" in message
+        assert DefaultOptionKeys.allowed_values.value in message
+
+    def test_strict_with_empty_collection_allowed_values_still_raises(self) -> None:
+        """The existing empty-value-space rule survives the shape guard, for every container."""
+        mapping: dict[str, Any] = {
+            "operation_type": {
+                DefaultOptionKeys.allowed_values: (),
+                DefaultOptionKeys.strict_validation: True,
+            }
+        }
+
+        with pytest.raises(ValueError, match="operation_type"):
+            FeatureChainParser.validate_property_mapping_defaults("SomeOwner", mapping)
+
+
+class TestValidatorKeysMustBeCallable:
+    """``element_validator``, ``required_when`` and ``match_guard`` are checked for CALLABILITY.
+
+    Today they are checked only for PRESENCE. ``property_spec`` DOES check callability, so core
+    and the builder disagree: a hand-written spec can carry a list where a callable belongs.
+    """
+
+    def test_non_callable_element_validator_rejected_at_class_definition(self) -> None:
+        """A list under ``element_validator`` raises at definition, naming the real fault."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class NonCallableElementValidatorFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {
+                    "operation_type": {
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: True,
+                        DefaultOptionKeys.element_validator: ["add", "sub"],
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "NonCallableElementValidatorFeatureGroup" in message
+        assert "operation_type" in message
+        assert DefaultOptionKeys.element_validator.value in message
+        assert "callable" in message
+
+    def test_non_callable_element_validator_message_does_not_blame_the_default(self) -> None:
+        """The headline mis-diagnosis: with a default, the broad ``except Exception`` lies.
+
+        ``check_declared_default`` catches the ``TypeError: 'list' object is not callable`` and
+        reports "the key's element_validator raised an error when called with that default. Add
+        the default to the accepted values, or remove the default", none of which is the fault.
+        """
+        with pytest.raises(ValueError) as exc_info:
+
+            class BlamedDefaultFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {
+                    "operation_type": {
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: True,
+                        DefaultOptionKeys.element_validator: ["add", "sub"],
+                        DefaultOptionKeys.default: "add",
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        del exc_info
+        assert DefaultOptionKeys.element_validator.value in message
+        assert "callable" in message
+        assert "Add the default to the accepted values" not in message, (
+            "a non-callable validator is not a default problem, and must not be reported as one"
+        )
+
+    def test_non_callable_element_validator_never_reaches_match_time(self) -> None:
+        """Today matching a spec with a list validator escapes ``'list' object is not callable``.
+
+        The class definition must reject it, so no ``TypeError`` can ever leave matching. An
+        escaping ``TypeError`` fails this test rather than being caught.
+        """
+        matched: bool
+
+        try:
+
+            class EscapingTypeErrorFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {
+                    "operation_type": {
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: True,
+                        DefaultOptionKeys.element_validator: ["add", "sub"],
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+            matched = EscapingTypeErrorFeatureGroup.match_feature_group_criteria(
+                "any_feature", Options(context={"operation_type": "add"})
+            )
+        except ValueError:
+            matched = False
+
+        assert matched is False
+
+    def test_non_callable_required_when_rejected_at_class_definition(self) -> None:
+        """A non-callable ``required_when`` is silently skipped with a warning today."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class NonCallableRequiredWhenFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {
+                    "region": {
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.required_when: ["prod"],
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "NonCallableRequiredWhenFeatureGroup" in message
+        assert "region" in message
+        assert DefaultOptionKeys.required_when.value in message
+        assert "callable" in message
+
+    def test_non_callable_match_guard_rejected_at_class_definition(self) -> None:
+        """A non-callable ``match_guard`` silently turns into a reject-everything guard today."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class NonCallableMatchGuardFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {
+                    "partition_by": {
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.match_guard: "not_a_callable",
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "NonCallableMatchGuardFeatureGroup" in message
+        assert "partition_by" in message
+        assert DefaultOptionKeys.match_guard.value in message
+        assert "callable" in message
+
+    def test_parser_entry_point_rejects_non_callable_validator(self) -> None:
+        """The rule lives in core, so validating a mapping directly raises the same way."""
+        mapping: dict[str, Any] = {
+            "operation_type": {
+                DefaultOptionKeys.strict_validation: True,
+                DefaultOptionKeys.element_validator: ["add", "sub"],
+            }
+        }
+
+        with pytest.raises(ValueError, match="callable"):
+            FeatureChainParser.validate_property_mapping_defaults("SomeOwner", mapping)
+
+    def test_callable_validators_still_define(self) -> None:
+        """The guard rejects only non-callables: real callables keep working, unchanged."""
+
+        class CallableValidatorsFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+            PROPERTY_MAPPING = {
+                "window_size": {
+                    DefaultOptionKeys.context: True,
+                    DefaultOptionKeys.strict_validation: True,
+                    DefaultOptionKeys.element_validator: _positive_int,
+                    DefaultOptionKeys.match_guard: _positive_int,
+                }
+            }
+
+            @classmethod
+            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                return data
+
+        assert (
+            CallableValidatorsFeatureGroup.match_feature_group_criteria(
+                "any_feature", Options(context={"window_size": 7})
+            )
+            is True
+        )
+
+
+class TestSchemaRuleStillRunsFirst:
+    """The unknown-key rule keeps precedence over the new shape rules.
+
+    A malformed spec's remaining keys cannot be trusted, and a REMOVED key is the one offender
+    with an exact remedy. The shape rules must slot in BEHIND the schema rule, so a stale spec
+    is still reported as a rename.
+    """
+
+    def test_removed_key_is_reported_even_when_a_shape_rule_also_fires(self) -> None:
+        """A stale key plus a bad ``allowed_values`` shape: the rename still leads."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class StaleAndMisshapenFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {
+                    "operation_type": {
+                        DefaultOptionKeys.allowed_values: "add",
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: True,
+                        STALE_ELEMENT_VALIDATOR_KEY: _positive_int,
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        del exc_info
+        assert STALE_ELEMENT_VALIDATOR_KEY in message
+        assert DefaultOptionKeys.element_validator.value in message
+
+    def test_unknown_key_is_reported_even_when_a_validator_is_not_callable(self) -> None:
+        """An unknown key plus a non-callable validator: the unknown key still leads."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class UnknownAndNonCallableFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {
+                    "operation_type": {
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: True,
+                        DefaultOptionKeys.element_validator: ["add"],
+                        "documentation_url": "https://example.invalid/op",
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "documentation_url" in message
+
+
+class TestEveryUnknownKeyIsReported:
+    """The unknown-key message lists EVERY offender, not just the first one.
+
+    Fixing one typo and re-running to discover the next is a needless round trip, and with a
+    removed key present the typo is never mentioned at all.
+    """
+
+    def test_all_unknown_keys_are_listed(self) -> None:
+        """Two typo'd keys, one message: both are named."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class TwoTyposFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {
+                    "operation_type": {
+                        DefaultOptionKeys.allowed_values: {"add": "Addition"},
+                        TYPO_STRICT_KEY: True,
+                        TYPO_CONTEXT_KEY: True,
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        del exc_info
+        assert TYPO_STRICT_KEY in message
+        assert TYPO_CONTEXT_KEY in message, "every unknown key must be reported, not just the first"
+
+    def test_removed_key_leads_but_other_unknown_keys_are_still_listed(self) -> None:
+        """A removed key still leads with its exact remedy, and the typo is named too."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class StalePlusTypoFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {
+                    "operation_type": {
+                        DefaultOptionKeys.allowed_values: {"add": "Addition"},
+                        DefaultOptionKeys.strict_validation: True,
+                        STALE_ELEMENT_VALIDATOR_KEY: _positive_int,
+                        TYPO_CONTEXT_KEY: True,
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        del exc_info
+        assert STALE_ELEMENT_VALIDATOR_KEY in message
+        assert DefaultOptionKeys.element_validator.value in message, "the removed key keeps its exact remedy"
+        assert TYPO_CONTEXT_KEY in message, "a removed key must not hide the other unknown keys"
+
+
+class TestStrictValidationFlagMustBeBool:
+    """``strict_validation`` must be a real ``bool``, not merely truthy.
+
+    ``_is_strict_validation`` is truthiness-based, so ``strict_validation: "false"`` reads as
+    strict. The error message then asserts ``strict_validation=True`` about a spec that literally
+    says ``"false"``. Requiring a real bool is the fix rather than softening the message: a truthy
+    non-bool flag is itself a latent bug of exactly the kind this layer exists to eliminate, and
+    no spec in the repository passes a non-bool today.
+    """
+
+    @pytest.mark.parametrize("flag", ["false", "true", 1, 0, "", None], ids=repr)
+    def test_non_bool_strict_validation_flag_rejected(self, flag: Any) -> None:
+        """Any non-bool flag raises at class definition, truthy or falsy."""
+        mapping: dict[str, Any] = {
+            "operation_type": {
+                DefaultOptionKeys.allowed_values: {"add": "Addition"},
+                DefaultOptionKeys.strict_validation: flag,
+            }
+        }
+
+        with pytest.raises(ValueError, match="strict_validation"):
+            FeatureChainParser.validate_property_mapping_defaults("SomeOwner", mapping)
+
+    def test_non_bool_flag_message_does_not_assert_strict_validation_is_true(self) -> None:
+        """The message must not claim ``strict_validation=True`` about a spec saying ``"false"``."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class TruthyStringStrictFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {
+                    "operation_type": {
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: "false",
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "TruthyStringStrictFeatureGroup" in message
+        assert DefaultOptionKeys.strict_validation.value in message
+        assert "bool" in message
+        assert "strict_validation=True" not in message, (
+            "the spec says 'false': the message must not assert a value the author never wrote"
+        )
+
+    def test_truthy_non_bool_flag_never_silently_enables_strict_matching(self) -> None:
+        """A ``"false"`` flag reads as strict today, so the spec does the OPPOSITE of what it says.
+
+        The observable tell is the ValueError the strict path raises and
+        ``match_feature_group_criteria`` swallows: ``_strict_validation_rejection_reason``
+        surfaces it. A flag saying ``"false"`` must never produce a strict rejection, and after
+        the guard it cannot: the spec does not define at all.
+        """
+        reason: str | None
+
+        try:
+
+            class SilentlyStrictFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {
+                    "operation_type": {
+                        DefaultOptionKeys.allowed_values: {"add": "Addition"},
+                        DefaultOptionKeys.context: True,
+                        DefaultOptionKeys.strict_validation: "false",
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+            reason = SilentlyStrictFeatureGroup._strict_validation_rejection_reason(
+                "any_feature", Options(context={"operation_type": "mul"})
+            )
+        except ValueError:
+            reason = None
+
+        assert reason is None, "a spec whose flag literally says 'false' must never enforce strict validation"
+
+    @pytest.mark.parametrize("flag", [True, False], ids=["True", "False"])
+    def test_real_bool_flags_still_define(self, flag: bool) -> None:
+        """Both real bools keep working: the guard rejects only non-bools."""
+
+        class RealBoolStrictFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+            PROPERTY_MAPPING = {
+                "operation_type": {
+                    DefaultOptionKeys.allowed_values: {"add": "Addition"},
+                    DefaultOptionKeys.context: True,
+                    DefaultOptionKeys.strict_validation: flag,
+                }
+            }
+
+            @classmethod
+            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                return data
+
+        assert (
+            RealBoolStrictFeatureGroup.match_feature_group_criteria(
+                "any_feature", Options(context={"operation_type": "add"})
+            )
+            is True
+        )
+
+
+def _region_required_in_prod(options: Options) -> bool:
+    """``region`` is only required when deploying to prod."""
+    return bool(options.get("env") == "prod")
+
+
+class TestPropertySpecBuildsNonStrictValueSpace:
+    """``property_spec`` must be able to build a NON-STRICT spec WITH ``allowed_values``.
+
+    It refuses today, on the premise "allowed_values is never enforced without strict=True".
+    That premise is false. A non-strict value space IS consumed, by two seams that call
+    ``_extract_property_values`` unconditionally:
+
+    * ``FeatureChainParserMixin._find_property_key_for_value`` (the forwarded-name-mismatch guard)
+    * ``FeatureChainParserMixin._build_effective_options`` (required_when)
+
+    Both use it to map a name-parsed ``operation_config`` back to its PROPERTY_MAPPING key.
+    Before the flattened form was retired, such a spec carried its values flattened; now
+    ``allowed_values`` is the ONLY channel, and the builder refuses the shape the repository's
+    own fixtures need (``propagate_context_feature.py`` 'env', ``chainer_context_feature.py``
+    'property3'), which is why those fixtures are hand-written dicts.
+    """
+
+    def test_property_spec_builds_a_non_strict_spec_with_allowed_values(self) -> None:
+        """The shape the fixtures need: a declared value space, no strict enforcement."""
+        spec = property_spec(
+            "Deployment environment",
+            strict=False,
+            allowed_values={"prod": "Production", "staging": "Staging"},
+        )
+
+        assert spec[DefaultOptionKeys.allowed_values] == {"prod": "Production", "staging": "Staging"}
+        assert spec[DefaultOptionKeys.strict_validation] is False
+
+    def test_built_non_strict_value_space_maps_a_name_parsed_value_to_its_property_key(self) -> None:
+        """``_find_property_key_for_value`` recovers the key from a NON-STRICT value space."""
+        mapping: dict[str, Any] = {
+            "env": property_spec(
+                "Deployment environment",
+                strict=False,
+                allowed_values={"prod": "Production", "staging": "Staging"},
+            )
+        }
+
+        assert FeatureChainParserMixin._find_property_key_for_value(mapping, "prod") == "env"
+        assert FeatureChainParserMixin._find_property_key_for_value(mapping, "nonsense") is None
+
+    def test_built_non_strict_value_space_merges_the_name_parsed_value_into_effective_options(self) -> None:
+        """``_build_effective_options`` maps the name-parsed value onto the key via that space."""
+        mapping: dict[str, Any] = {
+            "env": property_spec(
+                "Deployment environment",
+                strict=False,
+                allowed_values={"prod": "Production", "staging": "Staging"},
+            )
+        }
+
+        effective = FeatureChainParserMixin._build_effective_options(
+            "service__prod", [r".*__([\w]+)$"], mapping, Options()
+        )
+
+        assert effective.get("env") == "prod"
+
+    def test_non_strict_value_space_drives_required_when_end_to_end(self) -> None:
+        """The whole point: without the value space, ``required_when`` never sees the env.
+
+        ``region`` is required only for prod. The env arrives from the feature NAME, so it can
+        only reach the predicate if the non-strict value space maps 'prod' back onto 'env'.
+        """
+
+        class DeploymentFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+            PREFIX_PATTERN = r".*__([\w]+)_deploy$"
+            PROPERTY_MAPPING = {
+                "env": property_spec(
+                    "Deployment environment",
+                    strict=False,
+                    allowed_values={"prod": "Production", "staging": "Staging"},
+                ),
+                "region": property_spec("Target region", required_when=_region_required_in_prod),
+            }
+
+            @classmethod
+            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                return data
+
+        assert DeploymentFeatureGroup.match_feature_group_criteria("service__prod_deploy", Options()) is False, (
+            "prod deployments require a region, which required_when can only know via the value space"
+        )
+        assert (
+            DeploymentFeatureGroup.match_feature_group_criteria(
+                "service__prod_deploy", Options(context={"region": "eu"})
+            )
+            is True
+        )
+        assert DeploymentFeatureGroup.match_feature_group_criteria("service__staging_deploy", Options()) is True, (
+            "staging needs no region"
+        )
+
+    def test_non_strict_spec_still_accepts_values_outside_its_value_space(self) -> None:
+        """A non-strict value space is a mapping aid, not an enforcement: it never rejects."""
+
+        class UnenforcedValueSpaceFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+            PROPERTY_MAPPING = {
+                "env": property_spec(
+                    "Deployment environment",
+                    strict=False,
+                    allowed_values={"prod": "Production", "staging": "Staging"},
+                )
+            }
+
+            @classmethod
+            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                return data
+
+        assert (
+            UnenforcedValueSpaceFeatureGroup.match_feature_group_criteria(
+                "any_feature", Options(context={"env": "dev"})
+            )
+            is True
+        )
+
+    def test_property_spec_still_rejects_element_validator_without_strict(self) -> None:
+        """The OTHER never-enforced-without-strict rule is true, and stays.
+
+        ``element_validator`` really is dead without strict: ``_validate_property_value`` returns
+        early when the spec is not strict. Only the ``allowed_values`` premise was false.
+        """
+        with pytest.raises(ValueError, match="element_validator"):
+            property_spec("Window size", strict=False, element_validator=_positive_int)
+
+    def test_property_spec_rejects_a_str_allowed_values(self) -> None:
+        """``tuple("add")`` is ``('a', 'd', 'd')``: the builder must not silently do that."""
+        with pytest.raises(ValueError, match="allowed_values"):
+            property_spec("Operation", strict=True, allowed_values="add")
+
+    def test_property_spec_rejects_a_str_allowed_values_without_strict(self) -> None:
+        """Now that a non-strict value space is legal, it must be shape-checked for its own sake.
+
+        This must be rejected for its SHAPE. It is rejected today, but on the false premise that
+        a non-strict ``allowed_values`` is never enforced, so the message is asserted to have
+        dropped that premise.
+        """
+        with pytest.raises(ValueError) as exc_info:
+            property_spec("Operation", strict=False, allowed_values="add")
+
+        message = str(exc_info.value)
+        del exc_info
+        assert DefaultOptionKeys.allowed_values.value in message
+        assert "never enforced without strict" not in message, (
+            "a non-strict value space IS consumed (name-parsed value -> property key), "
+            "so the only fault here is the str shape"
+        )
+
+    def test_property_spec_rejects_bytes_allowed_values(self) -> None:
+        """``bytes`` substring-matches like ``str`` and is rejected the same way."""
+        with pytest.raises(ValueError, match="allowed_values"):
+            property_spec("Operation", strict=True, allowed_values=b"add")

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_type_constraints.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_type_constraints.py
@@ -47,8 +47,7 @@ class MockWithTypeConstraint(FeatureChainParserMixin):
 
     PROPERTY_MAPPING = {
         "operation": {
-            "sum": "Sum of values",
-            "avg": "Average of values",
+            DefaultOptionKeys.allowed_values: {"sum": "Sum of values", "avg": "Average of values"},
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
         },
@@ -68,8 +67,7 @@ class MockStrictWithMatchGuard(FeatureChainParserMixin):
 
     PROPERTY_MAPPING = {
         "mode": {
-            "fast": "Fast mode",
-            "slow": "Slow mode",
+            DefaultOptionKeys.allowed_values: {"fast": "Fast mode", "slow": "Slow mode"},
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
             DefaultOptionKeys.match_guard: lambda v: isinstance(v, str),
@@ -89,9 +87,7 @@ class MockStrictWithOrthogonalMatchGuard(FeatureChainParserMixin):
 
     PROPERTY_MAPPING = {
         "mode": {
-            "fast": "Fast mode",
-            "slow": "Slow mode",
-            "ok": "OK mode",
+            DefaultOptionKeys.allowed_values: {"fast": "Fast mode", "slow": "Slow mode", "ok": "OK mode"},
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
             DefaultOptionKeys.match_guard: _max_length_3,
@@ -121,7 +117,7 @@ class MockWithoutTypeConstraint(FeatureChainParserMixin):
 
     PROPERTY_MAPPING = {
         "operation": {
-            "sum": "Sum of values",
+            DefaultOptionKeys.allowed_values: {"sum": "Sum of values"},
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
         },
@@ -252,7 +248,7 @@ class MatchGuardedAggregation(FeatureChainParserMixin, FeatureGroup):
 
     PROPERTY_MAPPING = {
         "aggregation_type": {
-            "sum": "Sum of values",
+            DefaultOptionKeys.allowed_values: {"sum": "Sum of values"},
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
         },

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_unified_model.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_unified_model.py
@@ -15,9 +15,9 @@ Two decisions are pinned here.
 
    The old names are GONE: no enum members, no aliases. A spec dict still carrying the
    stale string key must FAIL LOUDLY at class-definition time rather than be silently
-   ignored: once the stale keys leave ``RESERVED_PROPERTY_KEYS``, a legacy flattened
-   spec would otherwise absorb the stale CALLABLE into its accepted VALUE set, silently
-   widening what the feature group matches.
+   ignored. The stale keys are not part of the spec schema (``PROPERTY_SPEC_KEYS``), so
+   the general unknown-key rule catches them; being REMOVED keys, they get the message
+   variant that names their replacement.
 
 2. Shared default-check semantics. ``property_spec`` and
    ``FeatureChainParser.validate_property_mapping_defaults`` encoded the same rules for a
@@ -36,7 +36,7 @@ from unittest.mock import patch
 import pytest
 
 from mloda.core.abstract_plugins.components.default_options_key import (
-    RESERVED_PROPERTY_KEYS,
+    PROPERTY_SPEC_KEYS,
     DefaultOptionKeys,
 )
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
@@ -146,15 +146,15 @@ class TestRenamedKeys:
         with pytest.raises(ValueError):
             DefaultOptionKeys(STALE_MATCH_GUARD_KEY)
 
-    def test_reserved_property_keys_carry_the_new_members(self) -> None:
-        """``RESERVED_PROPERTY_KEYS`` reserves the new keys, so they never leak into a value space."""
-        assert DefaultOptionKeys.element_validator in RESERVED_PROPERTY_KEYS
-        assert DefaultOptionKeys.match_guard in RESERVED_PROPERTY_KEYS
+    def test_spec_schema_carries_the_new_members(self) -> None:
+        """``PROPERTY_SPEC_KEYS`` admits the new keys, so a spec may carry them."""
+        assert DefaultOptionKeys.element_validator in PROPERTY_SPEC_KEYS
+        assert DefaultOptionKeys.match_guard in PROPERTY_SPEC_KEYS
 
-    def test_reserved_property_keys_drop_the_old_strings(self) -> None:
-        """The stale string keys are no longer reserved metadata."""
-        assert STALE_ELEMENT_VALIDATOR_KEY not in RESERVED_PROPERTY_KEYS
-        assert STALE_MATCH_GUARD_KEY not in RESERVED_PROPERTY_KEYS
+    def test_spec_schema_drops_the_old_strings(self) -> None:
+        """The stale string keys are not part of the spec schema, so they are unknown keys."""
+        assert STALE_ELEMENT_VALIDATOR_KEY not in PROPERTY_SPEC_KEYS
+        assert STALE_MATCH_GUARD_KEY not in PROPERTY_SPEC_KEYS
 
 
 class TestRenamedInternalHelpers:
@@ -178,11 +178,10 @@ class TestRenamedInternalHelpers:
 class TestStaleKeysFailLoudly:
     """A spec dict still carrying a stale key is rejected at class definition, never honored.
 
-    This is NOT backwards compatibility. Silently ignoring the stale key would be worse
-    than the old behavior: with the key no longer reserved, ``_extract_property_values``
-    would absorb the stale CALLABLE into the accepted VALUE set of a legacy flattened
-    spec, silently widening what the feature group matches. The guard converts that
-    silent corruption into an actionable migration error.
+    This is NOT backwards compatibility. A stale key is simply not in the spec schema, so the
+    general unknown-key rule rejects it; because it is a REMOVED key, the error names the
+    replacement instead of guessing at one. Silently ignoring it would leave the spec claiming a
+    validation it does not perform, so the rule converts that into an actionable migration error.
     """
 
     def test_stale_validation_function_key_rejected_at_class_definition(self) -> None:
@@ -234,11 +233,11 @@ class TestStaleKeysFailLoudly:
         assert STALE_MATCH_GUARD_KEY in message
         assert "match_guard" in message
 
-    def test_legacy_flattened_stale_spec_rejected_at_class_definition(self) -> None:
-        """The legacy flattened form (values inline, no ``allowed_values``) is guarded too."""
+    def test_stale_key_is_reported_ahead_of_other_unknown_keys(self) -> None:
+        """A spec with several unknown keys still names the stale one: it has the exact remedy."""
         with pytest.raises(ValueError) as exc_info:
 
-            class LegacyFlattenedStaleFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+            class MultiOffenderStaleFeatureGroup(FeatureChainParserMixin, FeatureGroup):
                 PROPERTY_MAPPING = {
                     "operation_type": {
                         "add": "Addition",
@@ -255,6 +254,7 @@ class TestStaleKeysFailLoudly:
 
         message = str(exc_info.value)
         del exc_info
+        assert STALE_ELEMENT_VALIDATOR_KEY in message
         assert "element_validator" in message
 
     def test_parser_entry_point_rejects_stale_spec(self) -> None:
@@ -273,9 +273,9 @@ class TestStaleKeysFailLoudly:
     def test_stale_callable_is_never_absorbed_into_the_accepted_value_set(self) -> None:
         """The regression this guard exists to prevent: the stale callable as an allowed VALUE.
 
-        With ``"validation_function"`` no longer reserved, a legacy flattened spec would
-        expose the callable itself as a member of the accepted set, so an option whose
-        value IS that callable would match. Matching such a spec must never succeed.
+        A spec is not always reached through class definition, so matching is checked too. The
+        stale callable must never end up a member of the accepted set, which is what recovering
+        the value space by subtraction used to do. Matching such a spec must never succeed.
         """
         validator = _positive_int
         mapping: dict[str, Any] = {

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_unified_model.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_unified_model.py
@@ -709,11 +709,16 @@ class TestPropertySpecEmitsTheNewKeys:
             property_spec("op", type_validator=_positive_int)  # type: ignore[call-arg]
 
     def test_authoring_invariants_still_live_in_property_spec(self) -> None:
-        """The authoring-time-only invariants stay put; only the default check moved to core."""
+        """The authoring-time-only invariants stay put; only the default check moved to core.
+
+        ``allowed_values`` without strict is NOT among them: a non-strict value space is still
+        consumed (name-parsed value -> property key). ``element_validator`` without strict is,
+        because it really is never enforced. See ``test_property_mapping_spec_shape.py``.
+        """
         with pytest.raises(ValueError):
             property_spec("op", strict=True)
         with pytest.raises(ValueError):
-            property_spec("op", allowed_values={"add": "Addition"})
+            property_spec("op", element_validator=_positive_int)
         with pytest.raises(ValueError):
             property_spec("op", strict=True, element_validator=_positive_int, allowed_values=[])
         not_callable: Any = "not callable"

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_spec_builder.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_spec_builder.py
@@ -5,9 +5,12 @@ arguments, validating the invariants that previously had to be enforced by hand:
 
 * ``strict=True`` requires a non-empty ``allowed_values`` (a strict enum with no
   value space rejects everything),
-* ``allowed_values`` without ``strict`` is a silent no-op and is rejected,
 * a strict, non-``None`` ``default`` must be within the allowed set,
 * a one-shot iterable for ``allowed_values`` is materialized so it survives reuse.
+
+``allowed_values`` WITHOUT ``strict`` is legal: a non-strict value space is not
+enforced, but it is consumed, to map a name-parsed value back onto its
+PROPERTY_MAPPING key. See ``test_property_mapping_spec_shape.py``.
 """
 
 from __future__ import annotations
@@ -77,11 +80,6 @@ class TestPropertySpecInvariants:
         """``strict=True`` with no value space rejects everything, so it is illegal."""
         with pytest.raises(ValueError):
             property_spec("d", strict=True)
-
-    def test_allowed_values_without_strict_raises(self) -> None:
-        """``allowed_values`` is never enforced without ``strict`` (silent no-op), so it is rejected."""
-        with pytest.raises(ValueError):
-            property_spec("d", allowed_values={"a": "A"})
 
     def test_strict_default_outside_allowed_set_raises(self) -> None:
         """A strict, non-``None`` default must be within the allowed set."""

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_resolve_operation.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_resolve_operation.py
@@ -28,8 +28,7 @@ class MockResolverFG(FeatureChainParserMixin):
 
     PROPERTY_MAPPING = {
         "aggregation_type": {
-            "sum": "Sum",
-            "avg": "Average",
+            DefaultOptionKeys.allowed_values: {"sum": "Sum", "avg": "Average"},
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
         },

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_strict_validation_returns_false.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_strict_validation_returns_false.py
@@ -12,8 +12,7 @@ class BaseMode(FeatureChainParserMixin):
 
     PROPERTY_MAPPING = {
         "mode": {
-            "mode_a": "Mode A",
-            "mode_b": "Mode B",
+            DefaultOptionKeys.allowed_values: {"mode_a": "Mode A", "mode_b": "Mode B"},
             DefaultOptionKeys.strict_validation: True,
         }
     }
@@ -23,10 +22,7 @@ class SubGroupA(BaseMode):
     """Subclass that only accepts mode_a."""
 
     PROPERTY_MAPPING = {
-        "mode": {
-            "mode_a": "Mode A",
-            DefaultOptionKeys.strict_validation: True,
-        }
+        "mode": {DefaultOptionKeys.allowed_values: {"mode_a": "Mode A"}, DefaultOptionKeys.strict_validation: True}
     }
 
 
@@ -34,10 +30,7 @@ class SubGroupB(BaseMode):
     """Subclass that only accepts mode_b."""
 
     PROPERTY_MAPPING = {
-        "mode": {
-            "mode_b": "Mode B",
-            DefaultOptionKeys.strict_validation: True,
-        }
+        "mode": {DefaultOptionKeys.allowed_values: {"mode_b": "Mode B"}, DefaultOptionKeys.strict_validation: True}
     }
 
 

--- a/tests/test_core/test_abstract_plugins/test_components/test_feature_collection_forwarding.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_feature_collection_forwarding.py
@@ -217,7 +217,7 @@ class _ForwardingChainedGroup(FeatureChainParserMixin):
     PREFIX_PATTERN = r".*__([\w]+)_fwdchain$"
     PROPERTY_MAPPING = {
         "operation": {
-            "op1": "Operation 1",
+            DefaultOptionKeys.allowed_values: {"op1": "Operation 1"},
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
         }

--- a/tests/test_core/test_abstract_plugins/test_components/test_forwarded_name_mismatch.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_forwarded_name_mismatch.py
@@ -47,8 +47,10 @@ class _NameMismatchChainedGroup(FeatureChainParserMixin):
     PREFIX_PATTERN = r".*__(sum|max)_namemis579$"
     PROPERTY_MAPPING = {
         OPERATION_KEY: {
-            "sum": "Sum of the in feature (namemis579 fixture)",
-            "max": "Maximum of the in feature (namemis579 fixture)",
+            DefaultOptionKeys.allowed_values: {
+                "sum": "Sum of the in feature (namemis579 fixture)",
+                "max": "Maximum of the in feature (namemis579 fixture)",
+            },
             DefaultOptionKeys.strict_validation: True,
         }
     }

--- a/tests/test_core/test_abstract_plugins/test_feature_group/test_declared_option_keys.py
+++ b/tests/test_core/test_abstract_plugins/test_feature_group/test_declared_option_keys.py
@@ -2,9 +2,11 @@
 
 ``declared_option_keys()`` is a classmethod that returns the top-level parameter
 names declared in ``PROPERTY_MAPPING`` -- regardless of whether the mapping was
-authored as a legacy flattened dict or via the ``property_spec`` builder. It
+authored as a hand-written spec dict or via the ``property_spec`` builder. It
 never returns the inner allowed-value keys (e.g. "add"/"sub").
 """
+
+from typing import Any
 
 from mloda.provider import DefaultOptionKeys, FeatureGroup, property_spec
 
@@ -19,13 +21,12 @@ class EmptyMappingFeatureGroup(FeatureGroup):
     PROPERTY_MAPPING = {}
 
 
-class LegacyMappingFeatureGroup(FeatureGroup):
-    """Legacy flattened PROPERTY_MAPPING form with a single declared parameter."""
+class HandWrittenMappingFeatureGroup(FeatureGroup):
+    """Hand-written PROPERTY_MAPPING spec dict with a single declared parameter."""
 
     PROPERTY_MAPPING = {
         "operation_type": {
-            "add": "Addition",
-            "sub": "Subtraction",
+            DefaultOptionKeys.allowed_values: {"add": "Addition", "sub": "Subtraction"},
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
         },
@@ -45,11 +46,11 @@ class BuilderMappingFeatureGroup(FeatureGroup):
 
 
 class MultiKeyMappingFeatureGroup(FeatureGroup):
-    """Multiple declared parameters, mixing legacy and builder-form specs."""
+    """Multiple declared parameters, mixing hand-written and builder-form specs."""
 
     PROPERTY_MAPPING = {
         "operation_type": {
-            "add": "Addition",
+            DefaultOptionKeys.allowed_values: {"add": "Addition"},
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
         },
@@ -59,7 +60,7 @@ class MultiKeyMappingFeatureGroup(FeatureGroup):
             allowed_values={"sum": "Sum", "mean": "Mean"},
         ),
         "window_size": {
-            "3": "three",
+            DefaultOptionKeys.allowed_values: {"3": "three"},
             DefaultOptionKeys.context: False,
             DefaultOptionKeys.strict_validation: False,
         },
@@ -80,12 +81,12 @@ def test_declared_option_keys_returns_empty_frozenset_when_property_mapping_empt
     assert result == frozenset()
 
 
-def test_declared_option_keys_returns_top_level_keys_for_legacy_flattened_mapping() -> None:
-    """Legacy flattened form: only the top-level parameter name is returned.
+def test_declared_option_keys_returns_top_level_keys_for_hand_written_mapping() -> None:
+    """Hand-written spec dict: only the top-level parameter name is returned.
 
     Inner allowed-value keys ("add"/"sub") and metadata flags must not appear.
     """
-    result = LegacyMappingFeatureGroup.declared_option_keys()
+    result = HandWrittenMappingFeatureGroup.declared_option_keys()
 
     assert result == frozenset({"operation_type"})
     assert "add" not in result
@@ -114,7 +115,7 @@ def test_declared_option_keys_returns_all_declared_parameter_names() -> None:
 
 def test_declared_option_keys_is_callable_without_instantiation() -> None:
     """The method is a classmethod: callable directly on the class."""
-    result = LegacyMappingFeatureGroup.declared_option_keys()
+    result = HandWrittenMappingFeatureGroup.declared_option_keys()
 
     assert isinstance(result, frozenset)
 
@@ -129,7 +130,7 @@ def test_declared_option_keys_returns_frozenset_type() -> None:
 
 def test_declared_option_keys_is_immutable() -> None:
     """The returned frozenset has no mutating methods."""
-    result = LegacyMappingFeatureGroup.declared_option_keys()
+    result = HandWrittenMappingFeatureGroup.declared_option_keys()
 
     assert not hasattr(result, "add")
     assert not hasattr(result, "update")
@@ -138,9 +139,9 @@ def test_declared_option_keys_is_immutable() -> None:
 def test_declared_option_keys_snapshot_not_tied_to_underlying_dict() -> None:
     """Mutating the original PROPERTY_MAPPING dict after the call does not
     retroactively change an already-returned frozenset (unlike a dict_keys view)."""
-    mapping = {
+    mapping: dict[str, Any] = {
         "operation_type": {
-            "add": "Addition",
+            DefaultOptionKeys.allowed_values: {"add": "Addition"},
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
         },
@@ -150,7 +151,7 @@ def test_declared_option_keys_snapshot_not_tied_to_underlying_dict() -> None:
         PROPERTY_MAPPING = mapping
 
     result = MutableMappingFeatureGroup.declared_option_keys()
-    mapping["new_param"] = {"x": "X"}
+    mapping["new_param"] = {"explanation": "added after the snapshot"}
 
     assert result == frozenset({"operation_type"})
     assert "new_param" not in result

--- a/tests/test_core/test_abstract_plugins/test_property_mapping_default_invariant.py
+++ b/tests/test_core/test_abstract_plugins/test_property_mapping_default_invariant.py
@@ -69,8 +69,7 @@ class TestStrictEnumeratedDefaultInvariant:
                 PREFIX_PATTERN = r".*__([\w]+)_op$"
                 PROPERTY_MAPPING = {
                     "operation_type": {
-                        "add": "Addition",
-                        "sub": "Subtraction",
+                        DefaultOptionKeys.allowed_values: {"add": "Addition", "sub": "Subtraction"},
                         DefaultOptionKeys.context: True,
                         DefaultOptionKeys.strict_validation: True,
                         DefaultOptionKeys.default: "mul",
@@ -95,8 +94,7 @@ class TestStrictEnumeratedDefaultInvariant:
             PREFIX_PATTERN = r".*__([\w]+)_op$"
             PROPERTY_MAPPING = {
                 "operation_type": {
-                    "add": "Addition",
-                    "sub": "Subtraction",
+                    DefaultOptionKeys.allowed_values: {"add": "Addition", "sub": "Subtraction"},
                     DefaultOptionKeys.context: True,
                     DefaultOptionKeys.strict_validation: True,
                     DefaultOptionKeys.default: "add",
@@ -123,8 +121,7 @@ class TestStrictEnumeratedDefaultInvariant:
                 PREFIX_PATTERN = r".*__([\w]+)_op$"
                 PROPERTY_MAPPING = {
                     "operation_type": {
-                        "add": "Addition",
-                        "sub": "Subtraction",
+                        DefaultOptionKeys.allowed_values: {"add": "Addition", "sub": "Subtraction"},
                         DefaultOptionKeys.context: True,
                         DefaultOptionKeys.strict_validation: True,
                         DefaultOptionKeys.default: "mul",
@@ -154,8 +151,10 @@ class TestStrictEnumeratedDefaultInvariant:
             PREFIX_PATTERN = r".*__([\w]+)_op$"
             PROPERTY_MAPPING = {
                 "operation_type": {
-                    "feature_engineering": "Feature engineering step",
-                    "scaling": "Scaling step",
+                    DefaultOptionKeys.allowed_values: {
+                        "feature_engineering": "Feature engineering step",
+                        "scaling": "Scaling step",
+                    },
                     DefaultOptionKeys.context: True,
                     DefaultOptionKeys.strict_validation: True,
                     DefaultOptionKeys.default: None,
@@ -175,8 +174,7 @@ class TestStrictEnumeratedDefaultInvariant:
             PREFIX_PATTERN = r".*__([\w]+)_op$"
             PROPERTY_MAPPING = {
                 "operation_type": {
-                    "add": "Addition",
-                    "sub": "Subtraction",
+                    DefaultOptionKeys.allowed_values: {"add": "Addition", "sub": "Subtraction"},
                     DefaultOptionKeys.context: True,
                     DefaultOptionKeys.strict_validation: False,
                     DefaultOptionKeys.default: "mul",
@@ -230,8 +228,7 @@ class TestStrictEnumeratedDefaultInvariant:
                 PREFIX_PATTERN = r".*__([\w]+)_op$"
                 PROPERTY_MAPPING = {
                     "operation_type": {
-                        "add": "Addition",
-                        "sub": "Subtraction",
+                        DefaultOptionKeys.allowed_values: {"add": "Addition", "sub": "Subtraction"},
                         DefaultOptionKeys.context: True,
                         DefaultOptionKeys.strict_validation: True,
                         DefaultOptionKeys.default: ["mul"],
@@ -305,8 +302,7 @@ class TestNoDefaultDeclared:
             PREFIX_PATTERN = r".*__([\w]+)_op$"
             PROPERTY_MAPPING = {
                 "operation_type": {
-                    "add": "Addition",
-                    "sub": "Subtraction",
+                    DefaultOptionKeys.allowed_values: {"add": "Addition", "sub": "Subtraction"},
                     DefaultOptionKeys.context: True,
                     DefaultOptionKeys.strict_validation: True,
                 }
@@ -344,8 +340,7 @@ class TestDefaultInvariantErrorMessaging:
                 PREFIX_PATTERN = r".*__([\w]+)_op$"
                 PROPERTY_MAPPING = {
                     "operation_type": {
-                        "add": "Addition",
-                        "sub": "Subtraction",
+                        DefaultOptionKeys.allowed_values: {"add": "Addition", "sub": "Subtraction"},
                         DefaultOptionKeys.context: True,
                         DefaultOptionKeys.strict_validation: True,
                         DefaultOptionKeys.default: "mul",
@@ -378,8 +373,7 @@ class TestDefaultInvariantErrorMessaging:
                 PREFIX_PATTERN = r".*__([\w]+)_op$"
                 PROPERTY_MAPPING = {
                     "operation_type": {
-                        "add": "Addition",
-                        "sub": "Subtraction",
+                        DefaultOptionKeys.allowed_values: {"add": "Addition", "sub": "Subtraction"},
                         DefaultOptionKeys.context: True,
                         DefaultOptionKeys.strict_validation: True,
                         DefaultOptionKeys.default: "mul",

--- a/tests/test_core/test_api/test_resolve_feature.py
+++ b/tests/test_core/test_api/test_resolve_feature.py
@@ -168,8 +168,7 @@ class ForwardMismatchResolveFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 
     PROPERTY_MAPPING = {
         PROBE_TYPE_KEY: {
-            "median": "Median value",
-            "sum": "Sum of values",
+            DefaultOptionKeys.allowed_values: {"median": "Median value", "sum": "Sum of values"},
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
         },

--- a/tests/test_plugins/feature_group/experimental/test_property_mapping_consistency.py
+++ b/tests/test_plugins/feature_group/experimental/test_property_mapping_consistency.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import pytest
 
-from mloda.core.abstract_plugins.components.default_options_key import RESERVED_PROPERTY_KEYS
+from mloda.core.abstract_plugins.components.default_options_key import PROPERTY_SPEC_KEYS
 from mloda.provider import DefaultOptionKeys
 from mloda_plugins.feature_group.experimental.aggregated_feature_group.base import AggregatedFeatureGroup
 from mloda_plugins.feature_group.experimental.clustering.base import ClusteringFeatureGroup
@@ -31,12 +31,6 @@ ALL_PLUGINS: list[type[Any]] = [
     TextCleaningFeatureGroup,
     TimeWindowFeatureGroup,
 ]
-
-# Derive from the single source of truth so this set can never drift again.
-# ``in_features`` is intentionally NOT in RESERVED_PROPERTY_KEYS (it is a property
-# NAME, not a spec-internal metadata flag), but the consistency tests still treat
-# it as metadata, so add it here.
-METADATA_KEYS: frozenset[Any] = RESERVED_PROPERTY_KEYS | {DefaultOptionKeys.in_features}
 
 DOK_VALUES: list[str] = [dok.value for dok in DefaultOptionKeys]
 
@@ -69,6 +63,25 @@ class TestPropertyMappingConsistency:
             f"DefaultOptionKeys enum members should be used: {violations}"
         )
 
+    def test_only_known_spec_keys(self, plugin_cls: type[Any]) -> None:
+        """Every key of every spec is part of the spec schema.
+
+        Derived from the single source of truth, so a plugin cannot reintroduce a bare value
+        entry (the retired flattened form) or a typo'd flag without this failing.
+        """
+        mapping: dict[str, Any] = plugin_cls.PROPERTY_MAPPING
+        violations: list[tuple[str, str]] = []
+        for prop_key, entry in mapping.items():
+            if not isinstance(entry, dict):
+                continue
+            for key in entry:
+                if key not in PROPERTY_SPEC_KEYS:
+                    violations.append((str(prop_key), str(key)))
+        assert violations == [], (
+            f"{plugin_cls.__name__} PROPERTY_MAPPING carries keys outside the spec schema "
+            f"(accepted values belong under allowed_values): {violations}"
+        )
+
     def test_enum_entries_have_strict_validation_true(self, plugin_cls: type[Any]) -> None:
         mapping: dict[str, Any] = plugin_cls.PROPERTY_MAPPING
         violations: list[str] = []
@@ -77,12 +90,8 @@ class TestPropertyMappingConsistency:
                 continue
             if DefaultOptionKeys.element_validator in entry:
                 continue
-            non_metadata_keys = [
-                k
-                for k in entry
-                if k not in METADATA_KEYS and not (k in DOK_VALUES and not isinstance(k, DefaultOptionKeys))
-            ]
-            if len(non_metadata_keys) < 2:
+            allowed_values = entry.get(DefaultOptionKeys.allowed_values) or {}
+            if len(allowed_values) < 2:
                 continue
             sv_value = entry.get(DefaultOptionKeys.strict_validation)
             if sv_value is not True:

--- a/tests/test_plugins/integration_plugins/chainer/chainer_context_feature.py
+++ b/tests/test_plugins/integration_plugins/chainer/chainer_context_feature.py
@@ -22,25 +22,24 @@ class ChainedContextFeatureGroupTest(FeatureGroup):
 
     PROPERTY_MAPPING = {
         "ident": {
-            "identifier1": "explanation",
-            "identifier2": "explanation",
-            DefaultOptionKeys.context: True,  # Mark as context parameter
-            DefaultOptionKeys.strict_validation: True,  # Enable strict validation for ident
+            DefaultOptionKeys.allowed_values: {"identifier1": "explanation", "identifier2": "explanation"},
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: True,
         },
         "property2": {
-            "value1": "explanation",
-            "value2": "explanation",
-            "specific_val_3_test": "explanation",  # Special case for testing
-            DefaultOptionKeys.strict_validation: True,  # Enable strict validation for property2
-            DefaultOptionKeys.default: "value1",  # Default value
-            # Not marked as context -> defaults to group parameter
+            DefaultOptionKeys.allowed_values: {
+                "value1": "explanation",
+                "value2": "explanation",
+                "specific_val_3_test": "explanation",
+            },
+            DefaultOptionKeys.strict_validation: True,
+            DefaultOptionKeys.default: "value1",
         },
         "property3": {
-            "opt_val1": "explanation",
-            "opt_val2": "explanation",
-            DefaultOptionKeys.default: "opt_val1",  # Default value
-            DefaultOptionKeys.context: True,  # Mark as context parameter
-            DefaultOptionKeys.strict_validation: False,  # Disable strict validation for property3
+            DefaultOptionKeys.allowed_values: {"opt_val1": "explanation", "opt_val2": "explanation"},
+            DefaultOptionKeys.default: "opt_val1",
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: False,
         },
         DefaultOptionKeys.in_features: {
             "explanation": "explanation",

--- a/tests/test_plugins/integration_plugins/chainer/context/test_parameter_resolution_unit.py
+++ b/tests/test_plugins/integration_plugins/chainer/context/test_parameter_resolution_unit.py
@@ -26,21 +26,20 @@ class TestParameterResolutionUnit:
 
         property_mapping = {
             "ident": {
-                "identifier1": "explanation",
-                "identifier2": "explanation",
-                DefaultOptionKeys.context: True,  # Mark as context parameter
+                DefaultOptionKeys.allowed_values: {"identifier1": "explanation", "identifier2": "explanation"},
+                DefaultOptionKeys.context: True,
             },
             "property2": {
-                "value1": "explanation",
-                "value2": "explanation",
-                "specific_val_3_test": "explanation",  # Special case for testing
-                # Not marked as context -> defaults to group parameter
+                DefaultOptionKeys.allowed_values: {
+                    "value1": "explanation",
+                    "value2": "explanation",
+                    "specific_val_3_test": "explanation",
+                }
             },
             "property3": {
-                "opt_val1": "explanation",
-                "opt_val2": "explanation",
-                DefaultOptionKeys.default: "opt_val1",  # Default value
-                DefaultOptionKeys.context: True,  # Mark as context parameter
+                DefaultOptionKeys.allowed_values: {"opt_val1": "explanation", "opt_val2": "explanation"},
+                DefaultOptionKeys.default: "opt_val1",
+                DefaultOptionKeys.context: True,
             },
             DefaultOptionKeys.in_features: {
                 "explanation": "explanation",
@@ -266,23 +265,24 @@ class TestParameterResolutionUnit:
 
     def test_parameter_extraction_logic(self) -> None:
         """Test the _extract_property_values logic."""
-        # Test: Extract values from dict with default key
+        # Test: the declared value space is returned, the metadata keys around it are not
         property_value_with_default = {
-            "opt_val1": "explanation",
-            "opt_val2": "explanation",
+            DefaultOptionKeys.allowed_values: {"opt_val1": "explanation", "opt_val2": "explanation"},
             DefaultOptionKeys.default: "opt_val1",
             DefaultOptionKeys.context: True,
         }
 
         extracted = FeatureChainParser._extract_property_values(property_value_with_default)
         expected = {"opt_val1": "explanation", "opt_val2": "explanation"}
-        assert extracted == expected, "Should extract values and remove metadata keys"
+        assert extracted == expected, "Should return exactly the declared allowed_values"
 
-        # Test: Extract values from dict without optional key
-        property_value_without_optional = {"value1": "explanation", "value2": "explanation"}
+        # Test: a spec that declares no allowed_values declares an EMPTY value space. It is
+        # never recovered by subtracting the known keys, which is what used to absorb an
+        # unrecognized key as an accepted value.
+        property_value_without_allowed_values = {"value1": "explanation", "value2": "explanation"}
 
-        extracted = FeatureChainParser._extract_property_values(property_value_without_optional)
-        assert extracted == property_value_without_optional, "Should return unchanged when no optional key"
+        extracted = FeatureChainParser._extract_property_values(property_value_without_allowed_values)
+        assert extracted == {}, "Should declare an empty value space when allowed_values is absent"
 
         # Test: Extract values from non-dict
         property_value_non_dict = "simple_value"
@@ -333,9 +333,8 @@ class TestParameterResolutionUnit:
         # Test property mapping with mixed strict/flexible validation
         property_mapping_mixed = {
             "strict_param": {
-                "allowed_value1": "explanation",
-                "allowed_value2": "explanation",
-                DefaultOptionKeys.strict_validation: True,  # Explicit strict validation
+                DefaultOptionKeys.allowed_values: {"allowed_value1": "explanation", "allowed_value2": "explanation"},
+                DefaultOptionKeys.strict_validation: True,
                 DefaultOptionKeys.context: True,
             },
             "flexible_param": {
@@ -472,21 +471,17 @@ class TestParameterResolutionUnit:
 
         property_mapping_complex = {
             "algorithm_type": {
-                "sum": "explanation",
-                "avg": "explanation",
-                # No strict_validation flag -> defaults to False (flexible)
+                DefaultOptionKeys.allowed_values: {"sum": "explanation", "avg": "explanation"},
                 DefaultOptionKeys.context: True,
             },
             "data_source": {
-                "production": "explanation",
-                "staging": "explanation",
-                DefaultOptionKeys.strict_validation: True,  # Restrict data sources
-                DefaultOptionKeys.group: True,  # This affects grouping
+                DefaultOptionKeys.allowed_values: {"production": "explanation", "staging": "explanation"},
+                DefaultOptionKeys.strict_validation: True,
+                DefaultOptionKeys.group: True,
             },
             "debug_mode": {
-                "true": "explanation",
-                "false": "explanation",
-                DefaultOptionKeys.strict_validation: False,  # Explicit flexible validation
+                DefaultOptionKeys.allowed_values: {"true": "explanation", "false": "explanation"},
+                DefaultOptionKeys.strict_validation: False,
                 DefaultOptionKeys.context: True,
             },
             DefaultOptionKeys.in_features: {

--- a/tests/test_plugins/integration_plugins/chainer/propagate_context_feature.py
+++ b/tests/test_plugins/integration_plugins/chainer/propagate_context_feature.py
@@ -20,14 +20,12 @@ class PropagateContextFeatureGroupTest(FeatureGroup):
 
     PROPERTY_MAPPING = {
         "ident": {
-            "identifier1": "multiplier 2",
-            "identifier2": "multiplier 3",
+            DefaultOptionKeys.allowed_values: {"identifier1": "multiplier 2", "identifier2": "multiplier 3"},
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
         },
         "env": {
-            "prod": "production offset 1000",
-            "staging": "staging offset 500",
+            DefaultOptionKeys.allowed_values: {"prod": "production offset 1000", "staging": "staging offset 500"},
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: False,
             DefaultOptionKeys.default: None,

--- a/tests/test_plugins/integration_plugins/test_forwarded_name_mismatch_e2e.py
+++ b/tests/test_plugins/integration_plugins/test_forwarded_name_mismatch_e2e.py
@@ -65,8 +65,10 @@ class NameMis579ChainedGroup(FeatureChainParserMixin, FeatureGroup):
     PREFIX_PATTERN = r".*__(sum|max)_namemis579$"
     PROPERTY_MAPPING = {
         OPERATION_KEY: {
-            "sum": "Sum of the in feature (namemis579 fixture)",
-            "max": "Maximum of the in feature (namemis579 fixture)",
+            DefaultOptionKeys.allowed_values: {
+                "sum": "Sum of the in feature (namemis579 fixture)",
+                "max": "Maximum of the in feature (namemis579 fixture)",
+            },
             DefaultOptionKeys.strict_validation: True,
         }
     }

--- a/tests/test_plugins/integration_plugins/test_input_feature_option_forwarding_e2e.py
+++ b/tests/test_plugins/integration_plugins/test_input_feature_option_forwarding_e2e.py
@@ -179,7 +179,7 @@ class ForwardingE2EChainedGroup(FeatureChainParserMixin, FeatureGroup):
     PREFIX_PATTERN = r".*__([\w]+)_e2echain579fwd$"
     PROPERTY_MAPPING = {
         "operation": {
-            "double": "Doubles the source values",
+            DefaultOptionKeys.allowed_values: {"double": "Doubles the source values"},
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
         },


### PR DESCRIPTION
Stacked on #673. Review that one first; this PR's base is its branch.

## The bug

A one-character typo silently disabled validation **and** widened the accepted value set:

```python
{"add": "Addition", "sub": "Subtraction", "strict_validaton": True}   # missing the 'i'
```

`strict_validation` is off (the real flag is absent), and the string `"strict_validaton"` is now an **accepted value**. No error at import, at class definition, or at match. A feature group whose option value was literally `"strict_validaton"` would match.

The cause is the legacy flattened form: the parser recovered a spec's value space by **subtracting** the known metadata keys, so any key it did not recognize became a value.

## Why the form had to go

The bug is unfixable while the flattened form exists. In it, a typo'd flag and a legitimate allowed value are *syntactically identical*, so no rule can tell them apart. Every fix that preserves the form is a heuristic (guess by edit distance, or sniff whether the value looks like a docstring), which is the accidental complexity #600 exists to remove.

So a spec declares its value space explicitly under `allowed_values`, `_extract_property_values` never falls back to subtraction, and an unknown key becomes an error:

```
TypoPlugin.PROPERTY_MAPPING['op'] has unknown spec key 'strict_validaton'.
Did you mean 'strict_validation'? A spec may only carry the keys [...].
Accepted VALUES belong under 'allowed_values'.
```

`RESERVED_PROPERTY_KEYS` becomes `PROPERTY_SPEC_KEYS`: it is no longer a set to subtract, it is the schema of permitted keys. The removed-key guard from #673 folds in as a **message variant** rather than surviving as a parallel check, since "you used `validation_function`" was only ever the special case of "you used a key not in the schema" whose remedy we happened to know.

## The second commit: a review caught the same bug one layer down

Making `allowed_values` mandatory closed the key hole but opened a **value-shape** hole. A forgotten comma:

```python
{allowed_values: ("add"), strict_validation: True}   # a str, not a tuple
```

makes membership a **substring test**. Verified: `"add"`, `"a"`, `"ad"`, `"dd"` and `""` were all accepted. The flattened form could never express this, because its value space was always a dict, so this was net-new surface.

The same truthiness assumption let three more shapes through:

- an **empty generator** is truthy, so a strict spec passed with no value space;
- a **non-empty generator** passed and was then *consumed*: first match succeeded, second raised. Matching became stateful and order-dependent, which under `pytest-xdist` is nondeterministic. With a declared default it was burnt at class-definition time instead, after which *every* value was rejected, including a declared-legal one;
- a **scalar** passed, and the resulting `TypeError` was already caught and rewritten, so `allowed_values: 5` produced the plausible-but-false `Property value '5' not found in mapping`, rejecting the value it declared.

So specs are now validated for **shape**, not only key names: `allowed_values` must be a `Collection` and never `str`/`bytes`; validators must be callable; `strict_validation` must be a real `bool` (`"false"` previously *enabled* strict validation, doing the opposite of what it says); and a spec must be a dict, which a bare container bypassed entirely.

## Rule order is the design

`validate_property_mapping_defaults` is five ordered rules:

1. spec must be a dict (a bare container has no keys, so it slips past every other rule)
2. **key names** (schema)
3. **value shapes**
4. strict needs a value space
5. declared default is honored

The schema rule stays ahead of the shape rule, so a removed key is reported as a *rename* rather than as a downstream shape error. The shape rule runs before rules 4 and 5 because those **read** the values it validates: a non-callable `element_validator` no longer reaches `check_declared_default`, whose broad except-clause used to rewrite `'list' object is not callable` into *"Add the default to the accepted values"*, a remedy with no relation to the fault. And because shape is established first, rule 4's non-empty test is an honest `len()` instead of truthiness.

## Also from the review

- Unknown keys are all reported at once, led by a removed key and its exact remedy, so fixing one typo no longer just reveals the next.
- `property_spec` no longer refuses a non-strict spec with `allowed_values`. That premise was false: the mixin consults a non-strict value space to map a name-parsed operation back onto its property key, and four in-repo fixtures need exactly that shape. Retiring the flattened form is what made the builder's refusal load-bearing, since `allowed_values` became the only channel.

## Migration

78 specs across 30 files moved to explicit `allowed_values`. All 208 in-repo `FeatureGroup` subclasses were scanned: none was relying on absorption for its value space, and none declares a non-Collection `allowed_values`, a non-callable validator, a non-bool `strict_validation`, or a non-dict spec. So the hardening breaks no existing spec.

## Tests

`tox` green: 5129 passed, 171 skipped, ruff clean, `mypy --strict` clean (788 files), bandit clean.

BREAKING CHANGE: the legacy flattened form is removed. Accepted values must be declared under `DefaultOptionKeys.allowed_values`; a bare value entry is now an unknown spec key and raises. `RESERVED_PROPERTY_KEYS` is renamed to `PROPERTY_SPEC_KEYS` with no alias.
