### PR TITLE
feat: composed declarative subtype capability on FeatureGroup (SubtypeDeclaration) (#639)

### DIFF
--- a/attribution/ATTRIBUTION.md
+++ b/attribution/ATTRIBUTION.md
@@ -41,7 +41,6 @@
 | mypy                                   | 2.1.0           | MIT                                                |
 | mypy_extensions                        | 1.1.0           | MIT                                                |
 | narwhals                               | 2.23.0          | MIT                                                |
-| nest-asyncio                           | 1.6.0           | BSD License                                        |
 | nest-asyncio2                          | 1.7.2           | BSD License                                        |
 | nltk                                   | 3.9.4           | Apache Software License                            |
 | numpy                                  | 2.5.1           | BSD-3-Clause AND 0BSD AND MIT AND Zlib AND CC0-1.0 |

--- a/docs/docs/in_depth/compute-framework-integration.md
+++ b/docs/docs/in_depth/compute-framework-integration.md
@@ -85,8 +85,8 @@ Two shapes, enforced at class definition; a half declaration fails at import:
 
 - Shape A: `key` names a `PROPERTY_MAPPING` key with an enumerable value
   space; `parametric_families` join the universe by family name.
-- Shape B (flattened multi-axis families): declare the universe explicitly
-  with a resolver:
+- Shape B (multi-axis families collapsed into one subtype id): declare the
+  universe explicitly with a resolver:
 
 ``` python
 def resolve_window(feature_name: str, options: Options) -> str | None:
@@ -96,7 +96,9 @@ SUBTYPES = SubtypeDeclaration(universe={"median", "sum"}, resolver=resolve_windo
 ```
 
 `supported` is a sparse per-framework override: frameworks absent from it
-keep the full universe. The derived
+keep the full universe. A key naming no declared framework is a silent no-op
+for matching but raises from `subtype_support_matrix()`, so a typo surfaces
+as `subtype_error` in the audit. The derived
 `supports_compute_framework` canonicalizes parametric instances (`ntile_2`
 becomes `ntile`) and gates declared subtypes by the declaration; undeclared
 subtypes and features without one stay open.

--- a/docs/docs/in_depth/compute-framework-integration.md
+++ b/docs/docs/in_depth/compute-framework-integration.md
@@ -86,9 +86,17 @@ Two shapes, enforced at class definition; a half declaration fails at import:
 - Shape A: `key` names a `PROPERTY_MAPPING` key with an enumerable value
   space; `parametric_families` join the universe by family name.
 - Shape B (flattened multi-axis families): declare the universe explicitly
-  with a resolver, `SubtypeDeclaration(universe={"median", "sum"}, resolver=my_resolver)`.
+  with a resolver:
 
-Frameworks absent from `supported` keep the full universe. The derived
+``` python
+def resolve_window(feature_name: str, options: Options) -> str | None:
+    return options.get("window_function")
+
+SUBTYPES = SubtypeDeclaration(universe={"median", "sum"}, resolver=resolve_window)
+```
+
+`supported` is a sparse per-framework override: frameworks absent from it
+keep the full universe. The derived
 `supports_compute_framework` canonicalizes parametric instances (`ntile_2`
 becomes `ntile`) and gates declared subtypes by the declaration; undeclared
 subtypes and features without one stay open.

--- a/docs/docs/in_depth/compute-framework-integration.md
+++ b/docs/docs/in_depth/compute-framework-integration.md
@@ -57,6 +57,53 @@ pass `options=`, see [Discover Plugins](discover-plugins.md)), and a feature
 that matches a group but is unsupported on every installed framework resolves
 to `feature_group=None` with a capability error rather than appearing runnable.
 
+### Declaring capability per subtype
+
+Families with multiple subtypes declare per-backend capability as data
+instead of a hand-written `supports_compute_framework`.
+
+**The data provider** declares the dimension once with `SUBTYPES`:
+
+``` python
+class RankFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+    SUBTYPES = SubtypeDeclaration(
+        key="rank_type",
+        parametric_families={"ntile": "N-tile bucketing"},
+        supported={"PythonDictFramework": {"dense", "ordinal"}},
+    )
+    PREFIX_PATTERN = r".*__([\w]+)_rank$"
+    PROPERTY_MAPPING = {
+        "rank_type": property_spec(
+            "Rank subtype.",
+            strict=True,
+            allowed_values={"dense": "Dense ranking", "ordinal": "Ordinal ranking"},
+        ),
+    }
+```
+
+Two shapes, enforced at class definition; a half declaration fails at import:
+
+- Shape A: `key` names a `PROPERTY_MAPPING` key with an enumerable value
+  space; `parametric_families` join the universe by family name.
+- Shape B (flattened multi-axis families): declare the universe explicitly
+  with a resolver, `SubtypeDeclaration(universe={"median", "sum"}, resolver=my_resolver)`.
+
+Frameworks absent from `supported` keep the full universe. The derived
+`supports_compute_framework` canonicalizes parametric instances (`ntile_2`
+becomes `ntile`) and gates declared subtypes by the declaration; undeclared
+subtypes and features without one stay open.
+
+**The data steward** audits capability via `subtype_support_matrix()`
+(supported subtypes per framework from `compute_framework_definition()`;
+empty for abstract bases) and `get_feature_group_docs()` (`subtype_key`,
+`subtypes`, `parametric_subtypes`, `subtype_support`, `subtype_error`). A
+hand-overridden `supports_compute_framework` yields no declared matrix; the
+misfit surfaces as `subtype_error`.
+
+**The data user** sees the outcome on `resolve_feature(name, options=...)`:
+`subtype` (e.g. `ntile_2`) and `subtype_family` (`ntile`, parametric
+instances only).
+
 ### Empty Results
 
 The contract is: a **final** requested feature must return a *schema-bearing*

--- a/docs/docs/in_depth/discover-plugins.md
+++ b/docs/docs/in_depth/discover-plugins.md
@@ -43,6 +43,11 @@ print(result.feature_group, result.supported_compute_frameworks)
 
 `options` and `plugin_collector` are keyword-only, so pass them by name.
 
+When exactly one FeatureGroup resolves, `ResolvedFeature` also reports
+`subtype` (resolved from the name or the passed options, e.g. `"sum"` for
+`sales__sum_aggr`) and `subtype_family` (the parametric family name, `"ntile"`
+for `ntile_2`); both are `None` when nothing resolves.
+
 ### Inspecting Candidates
 
 When resolution fails due to conflicts, check the candidates:
@@ -70,6 +75,13 @@ fgs = get_feature_group_docs(name="timestamp")
 # Filter by compute framework
 fgs = get_feature_group_docs(compute_framework="PandasDataframe")
 ```
+
+Each `FeatureGroupInfo` also carries the subtype declaration: `subtype_key`
+(the `SUBTYPES.key`, `None` for flattened and undeclared families), `subtypes`
+(the sorted universe), `parametric_subtypes`, `subtype_support` (supported
+subtypes per framework; empty for abstract bases) and `subtype_error` (set
+when the declaration is invalid). See
+[Declaring capability per subtype](compute-framework-integration.md#declaring-capability-per-subtype).
 
 ## Inspecting Compute Frameworks
 

--- a/docs/docs/in_depth/discover-plugins.md
+++ b/docs/docs/in_depth/discover-plugins.md
@@ -44,9 +44,10 @@ print(result.feature_group, result.supported_compute_frameworks)
 `options` and `plugin_collector` are keyword-only, so pass them by name.
 
 When exactly one FeatureGroup resolves, `ResolvedFeature` also reports
-`subtype` (resolved from the name or the passed options, e.g. `"sum"` for
-`sales__sum_aggr`) and `subtype_family` (the parametric family name, `"ntile"`
-for `ntile_2`); both are `None` when nothing resolves.
+`subtype` (resolved from the name, the passed options, or the key's declared
+default, e.g. `"sum"` for `sales__sum_aggr`) and `subtype_family` (the
+parametric family name, `"ntile"` for `ntile_2`); both are `None` when
+nothing resolves.
 
 ### Inspecting Candidates
 
@@ -77,7 +78,7 @@ fgs = get_feature_group_docs(compute_framework="PandasDataframe")
 ```
 
 Each `FeatureGroupInfo` also carries the subtype declaration: `subtype_key`
-(the `SUBTYPES.key`, `None` for flattened and undeclared families), `subtypes`
+(the `SUBTYPES.key`, `None` for shape-B and undeclared families), `subtypes`
 (the sorted universe), `parametric_subtypes`, `subtype_support` (supported
 subtypes per framework; empty for abstract bases) and `subtype_error` (set
 when the declaration is invalid). See

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -200,7 +200,7 @@ class FeatureChainParser:
             return DefaultOptionKeys.group
 
     @classmethod
-    def _extract_property_values(cls, property_value: Any) -> Any:
+    def extract_property_values(cls, property_value: Any) -> Any:
         """Return a spec's declared value space (``allowed_values``), or {} if it declares none.
 
         Never inferred by subtracting the known keys: the retired flattened form did that, and it
@@ -209,6 +209,11 @@ class FeatureChainParser:
         if isinstance(property_value, dict):
             return property_value.get(DefaultOptionKeys.allowed_values, {})
         return property_value
+
+    @classmethod
+    def _extract_property_values(cls, property_value: Any) -> Any:
+        """Alias kept for existing callers."""
+        return cls.extract_property_values(property_value)
 
     @classmethod
     def check_declared_default(cls, owner: str, key: str, spec: dict[str, Any]) -> None:

--- a/mloda/core/abstract_plugins/components/subtype_declaration.py
+++ b/mloda/core/abstract_plugins/components/subtype_declaration.py
@@ -15,7 +15,10 @@ class SubtypeDeclaration:
     enumerable value space (``key``); shape B declares an explicit ``universe``
     together with a ``resolver``. ``parametric_families`` and ``supported`` are
     legal in both shapes. ``supported`` is a sparse per-framework override:
-    frameworks absent from it keep the full universe. Shape-A checks that
+    frameworks absent from it keep the full universe. A ``supported`` key naming
+    no declared framework is a silent no-op for the planning gate;
+    ``subtype_support_matrix()`` raises on it (the audit is the loud surface).
+    Shape-A checks that
     depend on ``PROPERTY_MAPPING`` run in ``FeatureGroup.__init_subclass__``.
     """
 

--- a/mloda/core/abstract_plugins/components/subtype_declaration.py
+++ b/mloda/core/abstract_plugins/components/subtype_declaration.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass
+
+from mloda.core.abstract_plugins.components.options import Options
+
+
+@dataclass(frozen=True, kw_only=True)
+class SubtypeDeclaration:
+    """Declarative subtype dimension of a FeatureGroup family.
+
+    Exactly two legal shapes: shape A names a ``PROPERTY_MAPPING`` key with an
+    enumerable value space (``key``); shape B declares an explicit ``universe``
+    together with a ``resolver``. ``parametric_families`` and ``supported`` are
+    legal in both shapes. Shape-A checks that depend on ``PROPERTY_MAPPING``
+    run in ``FeatureGroup.__init_subclass__``.
+    """
+
+    key: str | None = None
+    universe: Iterable[str] | None = None
+    resolver: Callable[[str, Options], str | None] | None = None
+    parametric_families: Mapping[str, str] | None = None
+    supported: Mapping[str, Iterable[str]] | None = None
+
+    def __post_init__(self) -> None:
+        if self.universe is not None:
+            object.__setattr__(self, "universe", frozenset(self.universe))
+        if self.parametric_families is not None:
+            object.__setattr__(self, "parametric_families", dict(self.parametric_families))
+        if self.supported is not None:
+            object.__setattr__(self, "supported", {name: frozenset(values) for name, values in self.supported.items()})
+
+        if self.key is not None and (self.universe is not None or self.resolver is not None):
+            raise ValueError("SubtypeDeclaration: 'key' cannot be combined with 'universe' or 'resolver'.")
+        if self.universe is not None and self.resolver is None:
+            raise ValueError("SubtypeDeclaration: 'universe' requires a 'resolver'.")
+        if self.resolver is not None and self.universe is None:
+            raise ValueError("SubtypeDeclaration: 'resolver' requires a 'universe'.")
+        if self.key is None and self.universe is None:
+            raise ValueError(
+                "SubtypeDeclaration: declare either 'key' (shape A) or 'universe' with 'resolver' (shape B)."
+            )
+
+        if self.universe is None:
+            return
+
+        literals = frozenset(self.universe)
+        families = self.family_names()
+        colliding = families & literals
+        if colliding:
+            raise ValueError(
+                f"SubtypeDeclaration: parametric families {sorted(colliding)} collide with declared universe members."
+            )
+
+        if self.supported is not None:
+            full_universe = literals | families
+            for framework_name, values in self.supported.items():
+                overreach = frozenset(values) - full_universe
+                if overreach:
+                    raise ValueError(
+                        f"SubtypeDeclaration: supported subtypes {sorted(overreach)} on "
+                        f"{framework_name} are outside the declared universe."
+                    )
+
+    def family_names(self) -> frozenset[str]:
+        return frozenset(self.parametric_families or ())

--- a/mloda/core/abstract_plugins/components/subtype_declaration.py
+++ b/mloda/core/abstract_plugins/components/subtype_declaration.py
@@ -41,7 +41,7 @@ class SubtypeDeclaration:
                 self,
                 "supported",
                 MappingProxyType(
-                    {name: frozenset(str(value) for value in values) for name, values in self.supported.items()}
+                    {str(name): frozenset(str(value) for value in values) for name, values in self.supported.items()}
                 ),
             )
 
@@ -78,6 +78,12 @@ class SubtypeDeclaration:
                         f"SubtypeDeclaration: supported subtypes {sorted(overreach)} on "
                         f"{framework_name} are outside the declared universe."
                     )
+
+    def __hash__(self) -> int:
+        # MappingProxyType is unhashable; hash the mappings as frozensets of items.
+        families = frozenset((self.parametric_families or {}).items())
+        supported = frozenset((name, frozenset(values)) for name, values in (self.supported or {}).items())
+        return hash((self.key, self.universe, self.resolver, families, supported))
 
     def family_names(self) -> frozenset[str]:
         return frozenset(self.parametric_families or ())

--- a/mloda/core/abstract_plugins/components/subtype_declaration.py
+++ b/mloda/core/abstract_plugins/components/subtype_declaration.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
+from types import MappingProxyType
 
 from mloda.core.abstract_plugins.components.options import Options
 
@@ -13,8 +14,9 @@ class SubtypeDeclaration:
     Exactly two legal shapes: shape A names a ``PROPERTY_MAPPING`` key with an
     enumerable value space (``key``); shape B declares an explicit ``universe``
     together with a ``resolver``. ``parametric_families`` and ``supported`` are
-    legal in both shapes. Shape-A checks that depend on ``PROPERTY_MAPPING``
-    run in ``FeatureGroup.__init_subclass__``.
+    legal in both shapes. ``supported`` is a sparse per-framework override:
+    frameworks absent from it keep the full universe. Shape-A checks that
+    depend on ``PROPERTY_MAPPING`` run in ``FeatureGroup.__init_subclass__``.
     """
 
     key: str | None = None
@@ -25,11 +27,23 @@ class SubtypeDeclaration:
 
     def __post_init__(self) -> None:
         if self.universe is not None:
-            object.__setattr__(self, "universe", frozenset(self.universe))
+            object.__setattr__(self, "universe", frozenset(str(value) for value in self.universe))
         if self.parametric_families is not None:
-            object.__setattr__(self, "parametric_families", dict(self.parametric_families))
+            object.__setattr__(
+                self,
+                "parametric_families",
+                MappingProxyType(
+                    {str(family): description for family, description in self.parametric_families.items()}
+                ),
+            )
         if self.supported is not None:
-            object.__setattr__(self, "supported", {name: frozenset(values) for name, values in self.supported.items()})
+            object.__setattr__(
+                self,
+                "supported",
+                MappingProxyType(
+                    {name: frozenset(str(value) for value in values) for name, values in self.supported.items()}
+                ),
+            )
 
         if self.key is not None and (self.universe is not None or self.resolver is not None):
             raise ValueError("SubtypeDeclaration: 'key' cannot be combined with 'universe' or 'resolver'.")
@@ -46,6 +60,8 @@ class SubtypeDeclaration:
             return
 
         literals = frozenset(self.universe)
+        if not literals:
+            raise ValueError("SubtypeDeclaration: 'universe' must not be empty; that is half a declaration.")
         families = self.family_names()
         colliding = families & literals
         if colliding:

--- a/mloda/core/abstract_plugins/components/utils.py
+++ b/mloda/core/abstract_plugins/components/utils.py
@@ -29,6 +29,18 @@ def safe_field(
         return fallback
 
 
+def safe_field_with_error(
+    read: Callable[[], T],
+    fallback: T,
+    catching: tuple[type[Exception], ...] = (Exception,),
+) -> tuple[T, str | None]:
+    """Like safe_field, but returns (value, None) on success and (fallback, str(exc)) on a raise."""
+    try:
+        return read(), None
+    except catching as exc:
+        return fallback, str(exc)
+
+
 def get_all_subclasses(cls: Any, log_n_subclasses: int = 0) -> set[type[Any]]:
     all_subclasses = set()
 

--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -26,7 +26,7 @@ from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.components.index.index import Index
-from mloda.core.abstract_plugins.components.utils import get_all_subclasses
+from mloda.core.abstract_plugins.components.utils import get_all_subclasses, safe_field
 
 logger = logging.getLogger(__name__)
 
@@ -91,6 +91,8 @@ class FeatureGroup(ABC):
         "supported_subtypes",
         "resolve_subtype",
         "canonical_subtype",
+        "subtype_support_matrix",
+        "declared_option_values",
     )
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
@@ -185,8 +187,8 @@ class FeatureGroup(ABC):
     @final
     @classmethod
     def supported_subtypes(cls, compute_framework: type[ComputeFramework]) -> frozenset[str]:
-        """Subtypes supported on a compute framework; frameworks absent from the declaration
-        support the full universe."""
+        """Subtypes supported on a compute framework; ``supported`` is a sparse override, so
+        frameworks absent from it keep the full universe."""
         declaration = cls.SUBTYPES
         if declaration is None:
             return frozenset()
@@ -205,8 +207,12 @@ class FeatureGroup(ABC):
             return None
 
         name = str(feature_name)
-        if declaration.resolver is not None:
-            return declaration.resolver(name, options)
+        resolver = declaration.resolver
+        if resolver is not None:
+            resolved = safe_field(lambda: resolver(name, options), None)
+            if resolved is None:
+                return None
+            return str(resolved)
         if declaration.key is None:
             return None
 

--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -84,7 +84,8 @@ class FeatureGroup(ABC):
 
     SUBTYPES: ClassVar[Optional[SubtypeDeclaration]] = None
     """Declarative subtype dimension of the family; ``None`` means no subtype dimension.
-    The derived accessors below are the only surface and must not be overridden."""
+    The derived accessors below are the only surface and must not be overridden.
+    Enforced at class definition time; runtime attribute assignment is not guarded."""
 
     _DERIVED_SUBTYPE_ACCESSORS: ClassVar[tuple[str, ...]] = (
         "subtype_universe",
@@ -168,7 +169,7 @@ class FeatureGroup(ABC):
         predicate-only and absent keys yield an empty set."""
         if cls.PROPERTY_MAPPING is None or key not in cls.PROPERTY_MAPPING:
             return frozenset()
-        extracted = FeatureChainParser._extract_property_values(cls.PROPERTY_MAPPING[key])
+        extracted = FeatureChainParser.extract_property_values(cls.PROPERTY_MAPPING[key])
         if not isinstance(extracted, (dict, list, tuple, set, frozenset)):
             return frozenset()
         return frozenset(str(value) for value in extracted)
@@ -266,6 +267,16 @@ class FeatureGroup(ABC):
                 f"{cls.get_class_name()} overrides supports_compute_framework, so the hand-written hook makes "
                 f"the declared subtype support matrix unverifiable; the declaration is not authoritative."
             )
+
+        declaration = cls.SUBTYPES
+        if declaration is not None and declaration.supported is not None:
+            declared_frameworks = {cfw.get_class_name() for cfw in cls.compute_framework_definition()}
+            unmatched = sorted(set(declaration.supported) - declared_frameworks)
+            if unmatched:
+                raise ValueError(
+                    f"{cls.get_class_name()} declares supported subtypes for {unmatched}, "
+                    f"which name no declared compute framework of the class."
+                )
 
         return {
             compute_framework.get_class_name(): cls.supported_subtypes(compute_framework)

--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -8,6 +8,7 @@ from abc import ABC
 from mloda.core.abstract_plugins.components.base_artifact import BaseArtifact
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.data_types import DataType
+from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
 
 from mloda.core.abstract_plugins.components.domain import Domain
 from mloda.core.abstract_plugins.components.base_feature_group_version import BaseFeatureGroupVersion
@@ -178,12 +179,18 @@ class FeatureGroup(ABC):
     @classmethod
     def subtype_universe(cls) -> frozenset[str]:
         """Every subtype this family declares: declared values or literals plus family names."""
+        cached: frozenset[str] | None = cls.__dict__.get("_subtype_universe_cache")
+        if cached is not None:
+            return cached
         declaration = cls.SUBTYPES
         if declaration is None:
-            return frozenset()
-        if declaration.key is not None:
-            return cls.declared_option_values(declaration.key) | declaration.family_names()
-        return frozenset(declaration.universe or ()) | declaration.family_names()
+            universe: frozenset[str] = frozenset()
+        elif declaration.key is not None:
+            universe = cls.declared_option_values(declaration.key) | declaration.family_names()
+        else:
+            universe = frozenset(declaration.universe or ()) | declaration.family_names()
+        setattr(cls, "_subtype_universe_cache", universe)
+        return universe
 
     @final
     @classmethod
@@ -225,13 +232,26 @@ class FeatureGroup(ABC):
                 if isinstance(pattern, str)
             ]
             if patterns:
-                parsed, _parsed_source = FeatureChainParser.parse_feature_name(name, patterns)
+                # Malformed patterns degrade to the options fallback instead of raising.
+                parsed = safe_field(lambda: FeatureChainParser.parse_feature_name(name, patterns)[0], None)
                 if parsed is not None:
                     return parsed
 
-        value = options.get(declaration.key)
+        key = declaration.key
+        spec = (cls.PROPERTY_MAPPING or {}).get(key)
+        value = options.get(key)
+        if value is None and isinstance(spec, dict):
+            value = spec.get(DefaultOptionKeys.default)
         if value is None:
             return None
+        if spec is not None:
+            # Mirror matcher normalization: unwrap singleton containers and validate.
+            extracted = FeatureChainParser.extract_property_values(spec)
+            normalized = safe_field(
+                lambda: FeatureChainParser._process_found_property_value(value, extracted, key, spec), None
+            )
+            if normalized is not None and len(normalized) == 1:
+                return str(next(iter(normalized)))
         return str(value)
 
     @final

--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import inspect
 import logging
+from collections.abc import Collection, Mapping
 from typing import Any, ClassVar, Callable, Iterable, Optional, final
 from abc import ABC
 
@@ -151,7 +152,7 @@ class FeatureGroup(ABC):
         if cls.PROPERTY_MAPPING is None or key not in cls.PROPERTY_MAPPING:
             return frozenset()
         extracted = FeatureChainParser.extract_property_values(cls.PROPERTY_MAPPING[key])
-        if not isinstance(extracted, (dict, list, tuple, set, frozenset)):
+        if not isinstance(extracted, (Mapping, Collection)) or isinstance(extracted, (str, bytes)):
             return frozenset()
         return frozenset(str(value) for value in extracted)
 

--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -136,7 +136,7 @@ class FeatureGroup(ABC):
         if not declared_values:
             raise ValueError(
                 f"{cls.__name__} declares subtype key '{declaration.key}' without an enumerable value space; "
-                f"predicate-validated keys must declare a flattened universe with a resolver instead."
+                f"predicate-validated keys must declare an explicit universe with a resolver instead."
             )
 
         colliding = declaration.family_names() & declared_values

--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import logging
 from typing import Any, ClassVar, Callable, Iterable, Optional, final
 from abc import ABC
@@ -10,7 +11,11 @@ from mloda.core.abstract_plugins.components.data_types import DataType
 
 from mloda.core.abstract_plugins.components.domain import Domain
 from mloda.core.abstract_plugins.components.base_feature_group_version import BaseFeatureGroupVersion
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import (
+    CHAIN_SEPARATOR,
+    FeatureChainParser,
+)
+from mloda.core.abstract_plugins.components.subtype_declaration import SubtypeDeclaration
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.input_data.api.api_input_data import ApiInputData
 from mloda.core.abstract_plugins.components.input_data.base_input_data import BaseInputData
@@ -77,9 +82,75 @@ class FeatureGroup(ABC):
     See ``docs/in_depth/property-mapping.md`` for the full specification.
     """
 
+    SUBTYPES: ClassVar[Optional[SubtypeDeclaration]] = None
+    """Declarative subtype dimension of the family; ``None`` means no subtype dimension.
+    The derived accessors below are the only surface and must not be overridden."""
+
+    _DERIVED_SUBTYPE_ACCESSORS: ClassVar[tuple[str, ...]] = (
+        "subtype_universe",
+        "supported_subtypes",
+        "resolve_subtype",
+        "canonical_subtype",
+    )
+
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
         FeatureChainParser.validate_property_mapping_defaults(cls.__name__, cls.PROPERTY_MAPPING)
+        cls._reject_derived_accessor_overrides()
+        cls._validate_subtype_declaration()
+
+    @classmethod
+    def _overrides(cls, method_name: str) -> bool:
+        """True when cls replaces the FeatureGroup base classmethod."""
+        own = getattr(getattr(cls, method_name), "__func__", None)
+        base = getattr(getattr(FeatureGroup, method_name), "__func__", None)
+        return own is not base
+
+    @classmethod
+    def _reject_derived_accessor_overrides(cls) -> None:
+        for method_name in cls._DERIVED_SUBTYPE_ACCESSORS:
+            if cls._overrides(method_name):
+                raise ValueError(
+                    f"{cls.__name__} overrides {method_name}(); the subtype accessors are derived from "
+                    f"SUBTYPES and must not be overridden."
+                )
+
+    @classmethod
+    def _validate_subtype_declaration(cls) -> None:
+        """Enforce the shape-A class-dependent checks of SUBTYPES at class-definition time."""
+        declaration = cls.SUBTYPES
+        if declaration is None or declaration.key is None:
+            return
+
+        if declaration.key not in cls.declared_option_keys():
+            raise ValueError(
+                f"{cls.__name__} declares subtype key '{declaration.key}', "
+                f"which is not a declared PROPERTY_MAPPING key."
+            )
+
+        declared_values = cls.declared_option_values(declaration.key)
+        if not declared_values:
+            raise ValueError(
+                f"{cls.__name__} declares subtype key '{declaration.key}' without an enumerable value space; "
+                f"predicate-validated keys must declare a flattened universe with a resolver instead."
+            )
+
+        colliding = declaration.family_names() & declared_values
+        if colliding:
+            raise ValueError(
+                f"{cls.__name__} declares parametric families {sorted(colliding)} that collide "
+                f"with declared values of subtype key '{declaration.key}'."
+            )
+
+        if declaration.supported is not None:
+            universe = declared_values | declaration.family_names()
+            for framework_name, values in declaration.supported.items():
+                overreach = frozenset(values) - universe
+                if overreach:
+                    raise ValueError(
+                        f"{cls.__name__} declares supported subtypes {sorted(overreach)} on "
+                        f"{framework_name} that are outside its subtype universe."
+                    )
 
     @classmethod
     def declared_option_keys(cls) -> frozenset[str]:
@@ -87,6 +158,113 @@ class FeatureGroup(ABC):
         if cls.PROPERTY_MAPPING is None:
             return frozenset()
         return frozenset(str(key) for key in cls.PROPERTY_MAPPING)
+
+    @final
+    @classmethod
+    def declared_option_values(cls, key: str) -> frozenset[str]:
+        """Return the stringified enumerable value space of a ``PROPERTY_MAPPING`` key;
+        predicate-only and absent keys yield an empty set."""
+        if cls.PROPERTY_MAPPING is None or key not in cls.PROPERTY_MAPPING:
+            return frozenset()
+        extracted = FeatureChainParser._extract_property_values(cls.PROPERTY_MAPPING[key])
+        if not isinstance(extracted, (dict, list, tuple, set, frozenset)):
+            return frozenset()
+        return frozenset(str(value) for value in extracted)
+
+    @final
+    @classmethod
+    def subtype_universe(cls) -> frozenset[str]:
+        """Every subtype this family declares: declared values or literals plus family names."""
+        declaration = cls.SUBTYPES
+        if declaration is None:
+            return frozenset()
+        if declaration.key is not None:
+            return cls.declared_option_values(declaration.key) | declaration.family_names()
+        return frozenset(declaration.universe or ()) | declaration.family_names()
+
+    @final
+    @classmethod
+    def supported_subtypes(cls, compute_framework: type[ComputeFramework]) -> frozenset[str]:
+        """Subtypes supported on a compute framework; frameworks absent from the declaration
+        support the full universe."""
+        declaration = cls.SUBTYPES
+        if declaration is None:
+            return frozenset()
+        if declaration.supported is not None:
+            framework_name = compute_framework.get_class_name()
+            if framework_name in declaration.supported:
+                return frozenset(declaration.supported[framework_name])
+        return cls.subtype_universe()
+
+    @final
+    @classmethod
+    def resolve_subtype(cls, feature_name: FeatureName | str, options: Options) -> Optional[str]:
+        """Resolve the raw subtype of a concrete feature: name parsing first, then options; never raises."""
+        declaration = cls.SUBTYPES
+        if declaration is None:
+            return None
+
+        name = str(feature_name)
+        if declaration.resolver is not None:
+            return declaration.resolver(name, options)
+        if declaration.key is None:
+            return None
+
+        source, separator, _ = name.rpartition(CHAIN_SEPARATOR)
+        if separator and source:
+            patterns = [
+                pattern
+                for pattern in (getattr(cls, "PREFIX_PATTERN", None), getattr(cls, "SUFFIX_PATTERN", None))
+                if isinstance(pattern, str)
+            ]
+            if patterns:
+                parsed, _parsed_source = FeatureChainParser.parse_feature_name(name, patterns)
+                if parsed is not None:
+                    return parsed
+
+        value = options.get(declaration.key)
+        if value is None:
+            return None
+        return str(value)
+
+    @final
+    @classmethod
+    def canonical_subtype(cls, subtype: str) -> str:
+        """Collapse a parametric instance ``<family>_<digits>`` to its family name, else identity;
+        a declared universe member never collapses."""
+        declaration = cls.SUBTYPES
+        if declaration is None:
+            return subtype
+        if subtype in cls.subtype_universe():
+            return subtype
+        stem, separator, tail = subtype.rpartition("_")
+        if separator and tail.isdigit() and stem in declaration.family_names():
+            return stem
+        return subtype
+
+    @final
+    @classmethod
+    def subtype_support_matrix(cls) -> dict[str, frozenset[str]]:
+        """Supported subtypes per declared compute framework; empty for abstract classes and
+        families without a subtype dimension. Raises ValueError when the class hand-overrides
+        ``supports_compute_framework``, which makes the declared matrix unverifiable."""
+        if inspect.isabstract(cls):
+            return {}
+
+        universe = cls.subtype_universe()
+        if not universe:
+            return {}
+
+        if cls._overrides("supports_compute_framework"):
+            raise ValueError(
+                f"{cls.get_class_name()} overrides supports_compute_framework, so the hand-written hook makes "
+                f"the declared subtype support matrix unverifiable; the declaration is not authoritative."
+            )
+
+        return {
+            compute_framework.get_class_name(): cls.supported_subtypes(compute_framework)
+            for compute_framework in cls.compute_framework_definition()
+        }
 
     def __init__(self) -> None:
         pass
@@ -490,8 +668,23 @@ class FeatureGroup(ABC):
         the concrete feature, so it can reject an op on one backend while allowing
         others. If every candidate framework is rejected, the matcher surfaces a
         distinguishable error instead of a generic "no feature group" message.
+
+        The default gates a declared canonical subtype by ``supported_subtypes()``;
+        everything else (no subtype dimension, unresolved or undeclared subtype) stays open.
         """
-        return True
+        universe = cls.subtype_universe()
+        if not universe:
+            return True
+
+        subtype = cls.resolve_subtype(feature_name, options)
+        if subtype is None:
+            return True
+
+        canonical = cls.canonical_subtype(subtype)
+        if canonical not in universe:
+            return True
+
+        return canonical in cls.supported_subtypes(compute_framework)
 
     @final
     @classmethod

--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -85,22 +85,11 @@ class FeatureGroup(ABC):
 
     SUBTYPES: ClassVar[Optional[SubtypeDeclaration]] = None
     """Declarative subtype dimension of the family; ``None`` means no subtype dimension.
-    The derived accessors below are the only surface and must not be overridden.
-    Enforced at class definition time; runtime attribute assignment is not guarded."""
-
-    _DERIVED_SUBTYPE_ACCESSORS: ClassVar[tuple[str, ...]] = (
-        "subtype_universe",
-        "supported_subtypes",
-        "resolve_subtype",
-        "canonical_subtype",
-        "subtype_support_matrix",
-        "declared_option_values",
-    )
+    The derived accessors below are ``@final`` (type-checker enforced) and derived from SUBTYPES."""
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
         FeatureChainParser.validate_property_mapping_defaults(cls.__name__, cls.PROPERTY_MAPPING)
-        cls._reject_derived_accessor_overrides()
         cls._validate_subtype_declaration()
 
     @classmethod
@@ -109,15 +98,6 @@ class FeatureGroup(ABC):
         own = getattr(getattr(cls, method_name), "__func__", None)
         base = getattr(getattr(FeatureGroup, method_name), "__func__", None)
         return own is not base
-
-    @classmethod
-    def _reject_derived_accessor_overrides(cls) -> None:
-        for method_name in cls._DERIVED_SUBTYPE_ACCESSORS:
-            if cls._overrides(method_name):
-                raise ValueError(
-                    f"{cls.__name__} overrides {method_name}(); the subtype accessors are derived from "
-                    f"SUBTYPES and must not be overridden."
-                )
 
     @classmethod
     def _validate_subtype_declaration(cls) -> None:

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -21,7 +21,7 @@ from mloda.core.abstract_plugins.components.base_feature_group_version import SO
 from mloda.core.abstract_plugins.components.subtype_declaration import SubtypeDeclaration
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
-from mloda.core.abstract_plugins.components.utils import get_all_subclasses, safe_field
+from mloda.core.abstract_plugins.components.utils import get_all_subclasses, safe_field, safe_field_with_error
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.function_extender import Extender
 from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistry
@@ -55,10 +55,10 @@ def _safe_version(fg_class: type[FeatureGroup]) -> str:
 
 def _subtype_support_or_error(fg_class: type[FeatureGroup]) -> tuple[dict[str, list[str]], Optional[str]]:
     """Return the sorted subtype support matrix, degrading a raising class to ({}, message)."""
-    try:
-        matrix = fg_class.subtype_support_matrix()
-    except Exception as exc:
-        return {}, str(exc)
+    empty: dict[str, frozenset[str]] = {}
+    matrix, error = safe_field_with_error(lambda: fg_class.subtype_support_matrix(), empty)
+    if error is not None:
+        return {}, error
     return {framework: sorted(supported) for framework, supported in matrix.items()}, None
 
 
@@ -408,12 +408,18 @@ def resolve_feature(
             error=error,
         )
 
-    # Degrade a raising plugin declaration to an empty split; resolve_feature never raises.
-    empty_split: tuple[set[type[ComputeFramework]], set[type[ComputeFramework]]] = (set(), set())
-    supported, rejected = safe_field(
+    # Degrade a raising plugin declaration OPEN (all available declared frameworks); resolve_feature never raises.
+    split_result: Optional[tuple[set[type[ComputeFramework]], set[type[ComputeFramework]]]] = safe_field(
         lambda: split_frameworks_by_capability(candidates, feature_name_obj, resolved_options),
-        empty_split,
+        None,
+        field=f"capability split for '{feature_name}'",
     )
+    if split_result is None:
+        open_supported = {
+            cfw for candidate in candidates for cfw in candidate.compute_framework_definition() if cfw.is_available()
+        }
+        split_result = (open_supported, set())
+    supported, rejected = split_result
     supported_names = sorted(c.get_class_name() for c in supported)
     rejected_names = sorted(c.get_class_name() for c in rejected)
     filtered = _filter_subclasses(candidates)

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -409,6 +409,7 @@ def resolve_feature(
         )
 
     # Degrade a raising plugin declaration OPEN (all available declared frameworks); resolve_feature never raises.
+    # The broad catch intentionally drops any partially computed rejection info; degrading open is the contract.
     split_result: Optional[tuple[set[type[ComputeFramework]], set[type[ComputeFramework]]]] = safe_field(
         lambda: split_frameworks_by_capability(candidates, feature_name_obj, resolved_options),
         None,

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -18,6 +18,7 @@ Example:
 from typing import Any, Optional
 
 from mloda.core.abstract_plugins.components.base_feature_group_version import SOURCE_INTROSPECTION_ERRORS
+from mloda.core.abstract_plugins.components.subtype_declaration import SubtypeDeclaration
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
 from mloda.core.abstract_plugins.components.utils import get_all_subclasses, safe_field
@@ -50,6 +51,29 @@ def _as_str(value: Any) -> str:
 def _safe_version(fg_class: type[FeatureGroup]) -> str:
     """Return the feature group version or "unavailable" if source introspection fails or version() is not a str."""
     return safe_field(lambda: _as_str(fg_class.version()), "unavailable", catching=SOURCE_INTROSPECTION_ERRORS)
+
+
+def _subtype_support_or_error(fg_class: type[FeatureGroup]) -> tuple[dict[str, list[str]], Optional[str]]:
+    """Return the sorted subtype support matrix, degrading a raising class to ({}, message)."""
+    try:
+        matrix = fg_class.subtype_support_matrix()
+    except Exception as exc:
+        return {}, str(exc)
+    return {framework: sorted(supported) for framework, supported in matrix.items()}, None
+
+
+def _resolved_subtype_fields(
+    fg_class: type[FeatureGroup], feature_name: FeatureName, options: Options
+) -> tuple[Optional[str], Optional[str]]:
+    """Resolve (subtype, subtype_family) for a candidate, degrading a raising declaration to (None, None)."""
+    subtype: Optional[str] = safe_field(lambda: fg_class.resolve_subtype(feature_name, options), None)
+    if subtype is None:
+        return None, None
+    raw_subtype = subtype
+    canonical = safe_field(lambda: fg_class.canonical_subtype(raw_subtype), raw_subtype)
+    if canonical != raw_subtype:
+        return subtype, canonical
+    return subtype, None
 
 
 def _dedup_degrading_on_conflict(
@@ -159,6 +183,16 @@ def get_feature_group_docs(
         if version_contains is not None and version_contains not in version:
             continue
 
+        declaration: Optional[SubtypeDeclaration] = safe_field(
+            lambda: fg_class.SUBTYPES, None, field=f"{cls_name}.SUBTYPES"
+        )
+        subtype_key = declaration.key if declaration is not None else None
+        subtypes: list[str] = safe_field(
+            lambda: sorted(fg_class.subtype_universe()), [], field=f"{cls_name}.subtype_universe"
+        )
+        parametric_subtypes = sorted(declaration.family_names()) if declaration is not None else []
+        subtype_support, subtype_error = _subtype_support_or_error(fg_class)
+
         results.append(
             FeatureGroupInfo(
                 name=fg_name,
@@ -168,6 +202,11 @@ def get_feature_group_docs(
                 compute_frameworks=compute_frameworks,
                 supported_feature_names=supported_feature_names,
                 prefix=prefix,
+                subtype_key=subtype_key,
+                subtypes=subtypes,
+                parametric_subtypes=parametric_subtypes,
+                subtype_support=subtype_support,
+                subtype_error=subtype_error,
             )
         )
 
@@ -369,11 +408,23 @@ def resolve_feature(
             error=error,
         )
 
-    supported, rejected = split_frameworks_by_capability(candidates, feature_name_obj, resolved_options)
+    # Degrade a raising plugin declaration to an empty split; resolve_feature never raises.
+    empty_split: tuple[set[type[ComputeFramework]], set[type[ComputeFramework]]] = (set(), set())
+    supported, rejected = safe_field(
+        lambda: split_frameworks_by_capability(candidates, feature_name_obj, resolved_options),
+        empty_split,
+    )
     supported_names = sorted(c.get_class_name() for c in supported)
     rejected_names = sorted(c.get_class_name() for c in rejected)
+    filtered = _filter_subclasses(candidates)
 
     if not supported and rejected:
+        subtype_unsupported: Optional[str] = None
+        subtype_family_unsupported: Optional[str] = None
+        if len(filtered) == 1:
+            subtype_unsupported, subtype_family_unsupported = _resolved_subtype_fields(
+                filtered[0], feature_name_obj, resolved_options
+            )
         return ResolvedFeature(
             feature_name=feature_name,
             feature_group=None,
@@ -385,18 +436,22 @@ def resolve_feature(
             ),
             supported_compute_frameworks=[],
             unsupported_compute_frameworks=rejected_names,
+            subtype=subtype_unsupported,
+            subtype_family=subtype_family_unsupported,
         )
 
-    filtered = _filter_subclasses(candidates)
-
     if len(filtered) == 1:
+        resolved = filtered[0]
+        subtype, subtype_family = _resolved_subtype_fields(resolved, feature_name_obj, resolved_options)
         return ResolvedFeature(
             feature_name=feature_name,
-            feature_group=filtered[0],
+            feature_group=resolved,
             candidates=candidates,
             error=None,
             supported_compute_frameworks=supported_names,
             unsupported_compute_frameworks=rejected_names,
+            subtype=subtype,
+            subtype_family=subtype_family,
         )
 
     conflicting_names = [fg.__name__ for fg in filtered]

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -416,9 +416,14 @@ def resolve_feature(
         field=f"capability split for '{feature_name}'",
     )
     if split_result is None:
-        open_supported = {
-            cfw for candidate in candidates for cfw in candidate.compute_framework_definition() if cfw.is_available()
-        }
+        open_supported: set[type[ComputeFramework]] = set()
+        for candidate in candidates:
+            defined: set[type[ComputeFramework]] = safe_field(
+                lambda candidate=candidate: set(candidate.compute_framework_definition()),  # type: ignore[misc]
+                set(),
+                field=f"open-degrade frameworks for '{feature_name}'",
+            )
+            open_supported.update(cfw for cfw in defined if cfw.is_available())
         split_result = (open_supported, set())
     supported, rejected = split_result
     supported_names = sorted(c.get_class_name() for c in supported)

--- a/mloda/core/api/plugin_info.py
+++ b/mloda/core/api/plugin_info.py
@@ -14,6 +14,16 @@ class FeatureGroupInfo:
     compute_frameworks: list[str]
     supported_feature_names: set[str]
     prefix: str
+    # Subtype discriminator option key of the family (SUBTYPES.key), None for shape B and undeclared families.
+    subtype_key: Optional[str] = None
+    # Sorted subtype universe: declared subtype values plus parametric family names.
+    subtypes: list[str] = field(default_factory=list)
+    # Sorted parametric subtype family names (e.g. "ntile" covering "ntile_2").
+    parametric_subtypes: list[str] = field(default_factory=list)
+    # Sorted supported subtypes per framework from compute_framework_definition(); empty for abstract classes.
+    subtype_support: dict[str, list[str]] = field(default_factory=dict)
+    # Message when the capability declaration is invalid, None for a legitimately empty matrix.
+    subtype_error: Optional[str] = None
 
 
 @dataclass
@@ -45,3 +55,7 @@ class ResolvedFeature:
     supported_compute_frameworks: list[str] = field(default_factory=list)
     # Frameworks rejecting the feature, evaluated under the options passed to resolve_feature (empty by default).
     unsupported_compute_frameworks: list[str] = field(default_factory=list)
+    # Resolved subtype of the feature under the passed options, None when none resolves.
+    subtype: Optional[str] = None
+    # Family name only when the subtype is a parametric instance (e.g. "ntile" for "ntile_2"), else None.
+    subtype_family: Optional[str] = None

--- a/mloda/provider/__init__.py
+++ b/mloda/provider/__init__.py
@@ -71,6 +71,9 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
 from mloda.core.abstract_plugins.components.feature_chainer.property_spec import property_spec
 
+# Subtype declaration
+from mloda.core.abstract_plugins.components.subtype_declaration import SubtypeDeclaration
+
 # Transformers
 from mloda.core.abstract_plugins.components.framework_transformer.base_transformer import BaseTransformer
 from mloda.core.abstract_plugins.components.framework_transformer.cfw_transformer import ComputeFrameworkTransformer
@@ -128,6 +131,8 @@ __all__ = [
     "INPUT_SEPARATOR",
     "FeatureChainParserMixin",
     "property_spec",
+    # Subtype declaration
+    "SubtypeDeclaration",
     # Transformers
     "BaseTransformer",
     "ComputeFrameworkTransformer",

--- a/mloda_plugins/feature_group/experimental/aggregated_feature_group/base.py
+++ b/mloda_plugins/feature_group/experimental/aggregated_feature_group/base.py
@@ -15,6 +15,7 @@ from mloda.provider import (
     FeatureChainParserMixin,
 )
 from mloda.provider import DefaultOptionKeys
+from mloda.provider import SubtypeDeclaration
 
 
 class AggregatedFeatureGroup(FeatureChainParserMixin, FeatureGroup):
@@ -84,6 +85,9 @@ class AggregatedFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 
     # Option key for aggregation type
     AGGREGATION_TYPE = "aggregation_type"
+
+    # Declarative subtype dimension of this family.
+    SUBTYPES = SubtypeDeclaration(key=AGGREGATION_TYPE)
 
     # Define supported aggregation types
     AGGREGATION_TYPES = {

--- a/tests/test_core/test_abstract_plugins/test_components/test_safe_field_with_error.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_safe_field_with_error.py
@@ -1,0 +1,23 @@
+"""Failing tests pinning the safe_field_with_error helper (issue #639 follow-up).
+
+The helper does not exist yet; the import failure is the intended red failure.
+"""
+
+from mloda.core.abstract_plugins.components.utils import safe_field_with_error
+
+
+def _sbfix_boom() -> int:
+    raise ValueError("sbfix boom")
+
+
+class TestSbfixSafeFieldWithError:
+    """safe_field_with_error(read, fallback) returns (value, None) or (fallback, str(exc))."""
+
+    def test_success_returns_value_and_none(self) -> None:
+        assert safe_field_with_error(lambda: 5, 0) == (5, None)
+
+    def test_failure_returns_fallback_and_message(self) -> None:
+        value, error = safe_field_with_error(_sbfix_boom, 0)
+        assert value == 0
+        assert error is not None
+        assert "sbfix boom" in error

--- a/tests/test_core/test_api/test_sbdg_resolve_feature_broken_rule.py
+++ b/tests/test_core/test_api/test_sbdg_resolve_feature_broken_rule.py
@@ -1,0 +1,82 @@
+"""Failing test pinning resolve_feature's never-raises contract against a broken
+compute_framework_definition (sbdg defect 1).
+
+The capability split in mloda/core/api/plugin_docs.py (around lines 411-425) is
+safe_field-guarded, but the open-degrade fallback then calls
+candidate.compute_framework_definition() UNGUARDED. A FeatureGroup whose
+compute_framework_rule() raises therefore fails the split (degrading it to None),
+and the fallback re-raises the very exception the guard just swallowed.
+
+Expected failure today: resolve_feature propagates RuntimeError("sbdg rule exploded")
+instead of returning a ResolvedFeature.
+
+The broken class is scoped per test (del + gc.collect(), same pattern as
+test_plugin_docs.py) so it does not leak into the session-wide subclass registry.
+"""
+
+import gc
+from typing import Optional
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.provider import FeatureGroup
+from mloda.steward import ResolvedFeature, resolve_feature
+
+
+SBDG_BROKEN_RULE_FEATURE = "sbdg_broken_rule_feature"
+
+
+def _make_broken_rule_fg() -> type[FeatureGroup]:
+    # Class objects are cyclic; collect leftovers from earlier tests before defining a twin.
+    gc.collect()
+
+    class SbdgBrokenRuleFG(FeatureGroup):
+        """Matches a unique name but its compute_framework_rule raises when consulted."""
+
+        @classmethod
+        def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+            raise RuntimeError("sbdg rule exploded")
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: Optional[DataAccessCollection] = None,
+        ) -> bool:
+            return str(feature_name) == SBDG_BROKEN_RULE_FEATURE
+
+        def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+            return None
+
+    return SbdgBrokenRuleFG
+
+
+class TestSbdgResolveFeatureBrokenRule:
+    """resolve_feature never raises, even when the open-degrade fallback path is hit."""
+
+    def test_resolve_feature_does_not_propagate_the_rule_exception(self) -> None:
+        broken_fg = _make_broken_rule_fg()
+        try:
+            result = resolve_feature(SBDG_BROKEN_RULE_FEATURE)
+            assert isinstance(result, ResolvedFeature)
+            del result
+        finally:
+            del broken_fg
+            gc.collect()
+
+    def test_degenerate_resolution_still_names_the_matching_group(self) -> None:
+        broken_fg = _make_broken_rule_fg()
+        try:
+            result = resolve_feature(SBDG_BROKEN_RULE_FEATURE)
+            assert result.feature_name == SBDG_BROKEN_RULE_FEATURE
+            assert broken_fg in result.candidates
+            # Degenerate path: capability info may be empty, but the resolution itself survives.
+            assert result.feature_group is broken_fg
+            del result
+        finally:
+            del broken_fg
+            gc.collect()

--- a/tests/test_core/test_api/test_subtype_docs.py
+++ b/tests/test_core/test_api/test_subtype_docs.py
@@ -412,10 +412,10 @@ class TestSubDeclDocContractERaisingResolverDegrades:
         assert result.subtype is None
         assert result.subtype_family is None
 
-    def test_raising_resolver_degrades_capability_split(self) -> None:
+    def test_raising_resolver_degrades_capability_split_open(self) -> None:
         result = resolve_feature(R5_FEATURE)
         assert result.feature_group is SubDeclDocRaisingResolverFG
-        assert result.supported_compute_frameworks == []
+        assert result.supported_compute_frameworks == ["PythonDictFramework"]
         assert result.unsupported_compute_frameworks == []
 
 

--- a/tests/test_core/test_api/test_subtype_docs.py
+++ b/tests/test_core/test_api/test_subtype_docs.py
@@ -1,4 +1,4 @@
-"""Failing tests pinning the cycle-2 subtype persona surfaces of issue #639 (docs and resolve_feature)."""
+"""Pinning tests for the cycle-2 subtype persona surfaces of issue #639 (docs and resolve_feature)."""
 
 from abc import abstractmethod
 from typing import Optional

--- a/tests/test_core/test_api/test_subtype_docs.py
+++ b/tests/test_core/test_api/test_subtype_docs.py
@@ -1,0 +1,432 @@
+"""Failing tests pinning the cycle-2 subtype persona surfaces of issue #639 (docs and resolve_feature)."""
+
+from abc import abstractmethod
+from typing import Optional
+
+import pytest
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.provider import FeatureChainParserMixin, FeatureGroup, SubtypeDeclaration, property_spec
+from mloda.steward import FeatureGroupInfo, ResolvedFeature, get_feature_group_docs, resolve_feature
+from mloda.user import PluginLoader
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
+    PythonDictFramework,
+)
+
+
+WINDOW_KEY = "sbdd_window_function"
+WINDOW_UNIVERSE = frozenset({"median", "sum", "lag"})
+WINDOW_DICT_SUPPORTED = frozenset({"sum", "lag"})
+
+RANK_KEY = "sbdd_rank_type"
+RANK_NAMED = frozenset({"dense", "ordinal"})
+RANK_FAMILIES = {"ntile": "N-tile bucketing", "top": "Top-N selection"}
+RANK_UNIVERSE = RANK_NAMED | frozenset(RANK_FAMILIES)
+
+ABSTRACT_KEY = "sbddabs_window_function"
+ABSTRACT_UNIVERSE = frozenset({"median", "sum"})
+
+HOOKED_KEY = "sbddhook_kind"
+HOOKED_UNIVERSE = frozenset({"median", "sum"})
+
+OPTION_KEY = "sbdd_op_kind"
+OPTION_FEATURE = "sbdd_option_feature"
+PLAIN_FEATURE = "sbdd_plain_feature"
+
+R4_KEY = "sbddr4_kind"
+
+R5_FEATURE = "sbdd_resolver_feature"
+
+
+def _sbdd_raising_resolver(feature_name: str, options: Options) -> Optional[str]:
+    raise RuntimeError("sbdd resolver exploded")
+
+
+class SubDeclDocWindowFG(FeatureChainParserMixin, FeatureGroup):
+    """Shape A family with a per-framework supported narrowing in the declaration."""
+
+    SUBTYPES = SubtypeDeclaration(
+        key=WINDOW_KEY,
+        supported={PythonDictFramework.get_class_name(): WINDOW_DICT_SUPPORTED},
+    )
+    PREFIX_PATTERN = r".*__([\w]+)_sbddwin$"
+    PROPERTY_MAPPING = {
+        WINDOW_KEY: property_spec(
+            "Window function subtype.",
+            strict=True,
+            allowed_values={"median": "Median", "sum": "Sum", "lag": "Lag"},
+        ),
+    }
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame, PythonDictFramework}
+
+
+class SubDeclDocRankFG(FeatureChainParserMixin, FeatureGroup):
+    """Rank-like family: named subtypes plus parametric families, 'ntile' unsupported on one framework."""
+
+    SUBTYPES = SubtypeDeclaration(
+        key=RANK_KEY,
+        parametric_families=RANK_FAMILIES,
+        supported={PythonDictFramework.get_class_name(): RANK_UNIVERSE - {"ntile"}},
+    )
+    PREFIX_PATTERN = r".*__([\w]+)_sbddrank$"
+    PROPERTY_MAPPING = {
+        RANK_KEY: property_spec(
+            "Rank subtype.",
+            strict=True,
+            allowed_values={"dense": "Dense ranking", "ordinal": "Ordinal ranking"},
+        ),
+    }
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame, PythonDictFramework}
+
+
+class SubDeclDocAbstractWindowFG(FeatureChainParserMixin, FeatureGroup):
+    """Abstract base declaring a subtype universe; support belongs to concrete members."""
+
+    SUBTYPES = SubtypeDeclaration(key=ABSTRACT_KEY)
+    PREFIX_PATTERN = r".*__([\w]+)_sbddabs$"
+    PROPERTY_MAPPING = {
+        ABSTRACT_KEY: property_spec(
+            "Abstract window function subtype.",
+            strict=True,
+            allowed_values={"median": "Median", "sum": "Sum"},
+        ),
+    }
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame, PythonDictFramework}
+
+    @abstractmethod
+    def _sbdd_backend_marker(self) -> None: ...
+
+
+class SubDeclDocHookOverrideFG(FeatureChainParserMixin, FeatureGroup):
+    """Family with a subtype universe AND a hand-written supports_compute_framework hook."""
+
+    SUBTYPES = SubtypeDeclaration(key=HOOKED_KEY)
+    PREFIX_PATTERN = r".*__([\w]+)_sbddhook$"
+    PROPERTY_MAPPING = {
+        HOOKED_KEY: property_spec(
+            "Operation kind gated by a hand-written hook.",
+            strict=True,
+            allowed_values={"median": "Median", "sum": "Sum"},
+        ),
+    }
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame, PythonDictFramework}
+
+    @classmethod
+    def supports_compute_framework(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        compute_framework: type[ComputeFramework],
+    ) -> bool:
+        return True
+
+
+class SubDeclDocOptionFG(FeatureGroup):
+    """Fixed-name family whose subtype resolves from options only."""
+
+    SUBTYPES = SubtypeDeclaration(key=OPTION_KEY)
+    PROPERTY_MAPPING = {
+        OPTION_KEY: property_spec(
+            "Operation kind.",
+            strict=True,
+            allowed_values={"sum": "Sum", "median": "Median"},
+        ),
+    }
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame, PythonDictFramework}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == OPTION_FEATURE
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class SubDeclDocPlainFG(FeatureGroup):
+    """Family without a subtype dimension."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame, PythonDictFramework}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == PLAIN_FEATURE
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class SubDeclDocR4RejectingFG(FeatureChainParserMixin, FeatureGroup):
+    """Family whose single declared framework rejects everything except 'sum' via the declaration."""
+
+    SUBTYPES = SubtypeDeclaration(
+        key=R4_KEY,
+        parametric_families={"ntile": "N-tile bucketing"},
+        supported={PythonDictFramework.get_class_name(): frozenset({"sum"})},
+    )
+    PREFIX_PATTERN = r".*__([\w]+)_sbddr4$"
+    PROPERTY_MAPPING = {
+        R4_KEY: property_spec(
+            "Operation kind rejected almost everywhere.",
+            strict=True,
+            allowed_values={"median": "Median", "sum": "Sum"},
+        ),
+    }
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PythonDictFramework}
+
+
+class SubDeclDocRaisingResolverFG(FeatureGroup):
+    """Shape B family whose resolver raises when called; resolution must degrade, not raise."""
+
+    SUBTYPES = SubtypeDeclaration(universe={"median", "sum"}, resolver=_sbdd_raising_resolver)
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PythonDictFramework}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == R5_FEATURE
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+@pytest.fixture(scope="module", autouse=True)
+def load_plugins() -> None:
+    """Load all plugins before running tests in this module."""
+    PluginLoader.all()
+
+
+def _doc_for(name: str) -> FeatureGroupInfo:
+    """Fetch the single FeatureGroupInfo whose name matches exactly."""
+    exact = [doc for doc in get_feature_group_docs(name=name) if doc.name == name]
+    assert len(exact) == 1, f"expected exactly one doc for {name}, got {[doc.name for doc in exact]}"
+    return exact[0]
+
+
+class TestSubDeclDocContractAFeatureGroupInfoFields:
+    """Contract A: FeatureGroupInfo gains defaulted subtype fields."""
+
+    def test_positional_construction_defaults_new_fields(self) -> None:
+        info = FeatureGroupInfo("n", "d", "v", "m", [], set(), "n_")
+        assert info.subtype_key is None
+        assert info.subtypes == []
+        assert info.parametric_subtypes == []
+        assert info.subtype_support == {}
+        assert info.subtype_error is None
+
+    def test_keyword_construction_accepts_new_fields(self) -> None:
+        info = FeatureGroupInfo(
+            "n",
+            "d",
+            "v",
+            "m",
+            [],
+            set(),
+            "n_",
+            subtype_key="k",
+            subtypes=["a", "b"],
+            parametric_subtypes=["b"],
+            subtype_support={"Fw": ["a", "b"]},
+            subtype_error="boom",
+        )
+        assert info.subtype_key == "k"
+        assert info.subtypes == ["a", "b"]
+        assert info.parametric_subtypes == ["b"]
+        assert info.subtype_support == {"Fw": ["a", "b"]}
+        assert info.subtype_error == "boom"
+
+    def test_mutable_defaults_are_not_shared(self) -> None:
+        first = FeatureGroupInfo("n1", "d", "v", "m", [], set(), "n1_")
+        second = FeatureGroupInfo("n2", "d", "v", "m", [], set(), "n2_")
+        first.subtypes.append("x")
+        first.parametric_subtypes.append("x")
+        first.subtype_support["Fw"] = ["x"]
+        assert second.subtypes == []
+        assert second.parametric_subtypes == []
+        assert second.subtype_support == {}
+
+
+class TestSubDeclDocContractBFeatureGroupDocs:
+    """Contract B: get_feature_group_docs populates the subtype fields from SUBTYPES."""
+
+    def test_keyed_family_reports_key_universe_and_support(self) -> None:
+        doc = _doc_for("SubDeclDocWindowFG")
+        assert doc.subtype_key == WINDOW_KEY
+        assert doc.subtypes == sorted(WINDOW_UNIVERSE)
+        assert doc.parametric_subtypes == []
+        assert doc.subtype_support == {
+            "PandasDataFrame": sorted(WINDOW_UNIVERSE),
+            "PythonDictFramework": sorted(WINDOW_DICT_SUPPORTED),
+        }
+        assert doc.subtype_error is None
+
+    def test_parametric_families_are_enumerable_without_probing(self) -> None:
+        doc = _doc_for("SubDeclDocRankFG")
+        assert doc.subtype_key == RANK_KEY
+        assert doc.subtypes == sorted(RANK_UNIVERSE)
+        assert doc.parametric_subtypes == sorted(RANK_FAMILIES)
+        assert doc.subtype_support == {
+            "PandasDataFrame": sorted(RANK_UNIVERSE),
+            "PythonDictFramework": sorted(RANK_UNIVERSE - {"ntile"}),
+        }
+        assert doc.subtype_error is None
+
+    def test_family_without_subtype_dimension_keeps_defaults(self) -> None:
+        doc = _doc_for("SubDeclDocPlainFG")
+        assert doc.subtype_key is None
+        assert doc.subtypes == []
+        assert doc.parametric_subtypes == []
+        assert doc.subtype_support == {}
+        assert doc.subtype_error is None
+
+    def test_abstract_base_reports_universe_without_support(self) -> None:
+        doc = _doc_for("SubDeclDocAbstractWindowFG")
+        assert doc.subtype_key == ABSTRACT_KEY
+        assert doc.subtypes == sorted(ABSTRACT_UNIVERSE)
+        assert doc.parametric_subtypes == []
+        assert doc.subtype_support == {}
+        assert doc.subtype_error is None
+
+    def test_raising_matrix_is_surfaced_not_swallowed(self) -> None:
+        bad = _doc_for("SubDeclDocHookOverrideFG")
+        assert bad.subtypes == sorted(HOOKED_UNIVERSE)
+        assert bad.subtype_support == {}
+        assert bad.subtype_error is not None
+        assert "supports_compute_framework" in bad.subtype_error
+
+        healthy = _doc_for("SubDeclDocWindowFG")
+        assert healthy.subtype_error is None
+
+
+class TestSubDeclDocContractCResolvedFeatureSubtype:
+    """Contract C: ResolvedFeature carries the resolved subtype and its parametric family."""
+
+    def test_direct_construction_defaults_to_none(self) -> None:
+        result = ResolvedFeature("n", None, [], None)
+        assert result.subtype is None
+        assert result.subtype_family is None
+
+    def test_string_path_resolves_subtype(self) -> None:
+        result = resolve_feature("value__median_sbddwin")
+        assert result.feature_group is SubDeclDocWindowFG
+        assert result.subtype == "median"
+        assert result.subtype_family is None
+
+    def test_parametric_path_resolves_subtype_and_family(self) -> None:
+        result = resolve_feature("value__ntile_2_sbddrank")
+        assert result.feature_group is SubDeclDocRankFG
+        assert result.subtype == "ntile_2"
+        assert result.subtype_family == "ntile"
+
+    def test_options_path_resolves_subtype(self) -> None:
+        result = resolve_feature(OPTION_FEATURE, options=Options(context={OPTION_KEY: "sum"}))
+        assert result.feature_group is SubDeclDocOptionFG
+        assert result.subtype == "sum"
+        assert result.subtype_family is None
+
+    def test_family_without_subtype_dimension_gives_none(self) -> None:
+        result = resolve_feature(PLAIN_FEATURE)
+        assert result.feature_group is SubDeclDocPlainFG
+        assert result.subtype is None
+        assert result.subtype_family is None
+
+    def test_nothing_resolves_gives_none(self) -> None:
+        result = resolve_feature(OPTION_FEATURE)
+        assert result.feature_group is SubDeclDocOptionFG
+        assert result.subtype is None
+        assert result.subtype_family is None
+
+
+class TestSubDeclDocContractDUnsupportedEverywhere:
+    """Contract D: the unsupported-everywhere branch still reports the resolved subtype."""
+
+    def test_unsupported_everywhere_still_reports_subtype(self) -> None:
+        result = resolve_feature("value__median_sbddr4")
+        assert result.feature_group is None
+        assert result.candidates == [SubDeclDocR4RejectingFG]
+        assert result.error is not None
+        assert "unsupported" in result.error
+        assert result.supported_compute_frameworks == []
+        assert result.unsupported_compute_frameworks == ["PythonDictFramework"]
+        assert result.subtype == "median"
+        assert result.subtype_family is None
+
+    def test_unsupported_everywhere_parametric_instance_reports_family(self) -> None:
+        result = resolve_feature("value__ntile_3_sbddr4")
+        assert result.feature_group is None
+        assert result.error is not None
+        assert "unsupported" in result.error
+        assert result.subtype == "ntile_3"
+        assert result.subtype_family == "ntile"
+
+
+class TestSubDeclDocContractERaisingResolverDegrades:
+    """Contract E: a raising shape-B resolver never propagates out of resolve_feature."""
+
+    def test_raising_resolver_degrades_to_none_subtype(self) -> None:
+        result = resolve_feature(R5_FEATURE)
+        assert isinstance(result, ResolvedFeature)
+        assert result.feature_group is SubDeclDocRaisingResolverFG
+        assert result.error is None
+        assert result.subtype is None
+        assert result.subtype_family is None
+
+    def test_raising_resolver_degrades_capability_split(self) -> None:
+        result = resolve_feature(R5_FEATURE)
+        assert result.feature_group is SubDeclDocRaisingResolverFG
+        assert result.supported_compute_frameworks == []
+        assert result.unsupported_compute_frameworks == []
+
+
+class TestSubDeclDocContractFHookOverrideSurfacedInDocs:
+    """Contract F: docs surface a hook-overriding family as subtype_error instead of a fabricated matrix."""
+
+    def test_hook_override_reported_as_subtype_error(self) -> None:
+        hooked = _doc_for("SubDeclDocHookOverrideFG")
+        assert hooked.subtype_key == HOOKED_KEY
+        assert hooked.subtypes == sorted(HOOKED_UNIVERSE)
+        assert hooked.parametric_subtypes == []
+        assert hooked.subtype_support == {}
+        assert hooked.subtype_error is not None
+        assert "supports_compute_framework" in hooked.subtype_error

--- a/tests/test_core/test_api/test_subtype_docs_degradation.py
+++ b/tests/test_core/test_api/test_subtype_docs_degradation.py
@@ -1,0 +1,115 @@
+"""Failing tests pinning louder degradation of the subtype surfaces (issue #639 follow-up).
+
+Pins: a raising supports_compute_framework override degrades the resolve_feature
+capability split OPEN (all declared frameworks supported) with a warning, and a
+bogus 'supported' framework name surfaces as subtype_error in the docs.
+"""
+
+import logging
+from typing import Optional
+
+import pytest
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.provider import FeatureGroup, SubtypeDeclaration, property_spec
+from mloda.steward import FeatureGroupInfo, get_feature_group_docs, resolve_feature
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
+    PythonDictFramework,
+)
+
+
+SBFIX_HOOK_FEATURE = "sbfix_raising_hook_feature"
+SBFIX_DOC_KEY = "sbfixdoc_kind"
+SBFIX_BOGUS_FRAMEWORK = "SbfixNoSuchDocFramework"
+
+
+class SbfixRaisingHookFG(FeatureGroup):
+    """Hand-written supports_compute_framework hook that raises when consulted."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PythonDictFramework}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == SBFIX_HOOK_FEATURE
+
+    @classmethod
+    def supports_compute_framework(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        compute_framework: type[ComputeFramework],
+    ) -> bool:
+        raise RuntimeError("sbfix hook exploded")
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class SbfixDocBogusSupportedFG(FeatureGroup):
+    """Declaration whose 'supported' names a framework outside compute_framework_rule()."""
+
+    SUBTYPES = SubtypeDeclaration(
+        key=SBFIX_DOC_KEY,
+        supported={SBFIX_BOGUS_FRAMEWORK: {"sum"}},
+    )
+    PROPERTY_MAPPING = {
+        SBFIX_DOC_KEY: property_spec(
+            "Operation kind with a bogus supported framework.",
+            strict=True,
+            allowed_values={"sum": "Sum", "median": "Median"},
+        ),
+    }
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PythonDictFramework}
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+def _sbfix_doc_for(name: str) -> FeatureGroupInfo:
+    exact = [doc for doc in get_feature_group_docs(name=name) if doc.name == name]
+    assert len(exact) == 1, f"expected exactly one doc for {name}, got {[doc.name for doc in exact]}"
+    return exact[0]
+
+
+class TestSbfixRaisingHookDegradesOpen:
+    """A raising capability hook degrades the split OPEN, not empty, and warns."""
+
+    def test_resolves_with_all_declared_frameworks_supported(self) -> None:
+        result = resolve_feature(SBFIX_HOOK_FEATURE)
+        assert result.feature_group is SbfixRaisingHookFG
+        assert result.error is None
+        assert result.supported_compute_frameworks == ["PythonDictFramework"]
+        assert result.unsupported_compute_frameworks == []
+
+    def test_degradation_is_logged_as_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING):
+            result = resolve_feature(SBFIX_HOOK_FEATURE)
+        assert result.feature_group is SbfixRaisingHookFG
+        assert "degraded" in caplog.text.lower()
+        assert "sbfix hook exploded" in caplog.text
+
+
+class TestSbfixBogusSupportedSurfacedInDocs:
+    """Docs surface the undeclared 'supported' framework as subtype_error."""
+
+    def test_docs_report_subtype_error_with_empty_support(self) -> None:
+        doc = _sbfix_doc_for("SbfixDocBogusSupportedFG")
+        assert doc.subtype_key == SBFIX_DOC_KEY
+        assert doc.subtype_support == {}
+        assert doc.subtype_error is not None
+        assert SBFIX_BOGUS_FRAMEWORK in doc.subtype_error
+        assert "SbfixDocBogusSupportedFG" in doc.subtype_error

--- a/tests/test_core/test_prepare/test_sbdg_collection_value_spaces.py
+++ b/tests/test_core/test_prepare/test_sbdg_collection_value_spaces.py
@@ -1,0 +1,73 @@
+"""Failing tests pinning declared_option_values against non-dict Mapping value spaces
+(sbdg defect 2).
+
+property_spec accepts any Mapping | Iterable for allowed_values. Non-Mapping iterables
+(e.g. range) are normalized to a tuple, so they already work. A Mapping that is not a
+plain dict (e.g. types.MappingProxyType) is kept as-is, but
+FeatureGroup.declared_option_values only recognizes
+isinstance(extracted, (dict, list, tuple, set, frozenset)) and silently returns an
+empty value space for it. Consequences pinned here:
+
+- SUBTYPES = SubtypeDeclaration(key=<that key>) fails class creation with
+  "without an enumerable value space" although the spec is legal and enumerable.
+- declared_option_values on a plain (non-SUBTYPES) class returns frozenset() instead
+  of the stringified keys.
+
+A bare str allowed_values is rejected at property_spec construction time (substring
+membership trap), so no legal spec can carry a str value space; no string pin needed.
+"""
+
+from types import MappingProxyType
+
+from mloda.provider import FeatureGroup, SubtypeDeclaration, property_spec
+
+
+SBDG_SIZE_KEY = "sbdg_size"
+SBDG_PROXY_VALUES = MappingProxyType({2: "two", 3: "three", 4: "four"})
+
+
+class SbdgProxyValuesFG(FeatureGroup):
+    """Legal spec whose allowed_values is an immutable Mapping (no SUBTYPES declared)."""
+
+    PROPERTY_MAPPING = {
+        SBDG_SIZE_KEY: property_spec(
+            "Size with an immutable mapping value space.",
+            strict=True,
+            allowed_values=SBDG_PROXY_VALUES,
+        ),
+    }
+
+
+class TestSbdgDeclaredOptionValuesAcceptsMappingProxy:
+    def test_declared_option_values_enumerates_mapping_proxy_keys(self) -> None:
+        assert SbdgProxyValuesFG.declared_option_values(SBDG_SIZE_KEY) == frozenset({"2", "3", "4"})
+
+    def test_range_value_space_is_normalized_and_enumerable(self) -> None:
+        # Regression guard: property_spec materializes non-Mapping iterables to a tuple,
+        # so a range-backed spec is already enumerable.
+        class SbdgRangeValuesFG(FeatureGroup):
+            PROPERTY_MAPPING = {
+                "sbdg_range_size": property_spec(
+                    "Size from a range.",
+                    strict=True,
+                    allowed_values=range(2, 5),
+                ),
+            }
+
+        assert SbdgRangeValuesFG.declared_option_values("sbdg_range_size") == frozenset({"2", "3", "4"})
+
+
+class TestSbdgSubtypeDeclarationOnMappingProxyKey:
+    def test_class_defines_and_universe_enumerates(self) -> None:
+        # Today this raises ValueError "... without an enumerable value space" at class creation.
+        class SbdgProxySubtypesFG(FeatureGroup):
+            PROPERTY_MAPPING = {
+                SBDG_SIZE_KEY: property_spec(
+                    "Size with an immutable mapping value space and SUBTYPES.",
+                    strict=True,
+                    allowed_values=MappingProxyType({2: "two", 3: "three", 4: "four"}),
+                ),
+            }
+            SUBTYPES = SubtypeDeclaration(key=SBDG_SIZE_KEY)
+
+        assert SbdgProxySubtypesFG.subtype_universe() == frozenset({"2", "3", "4"})

--- a/tests/test_core/test_prepare/test_subtype_accessor_override_allowed.py
+++ b/tests/test_core/test_prepare/test_subtype_accessor_override_allowed.py
@@ -1,0 +1,93 @@
+"""Red-phase tests: derived subtype accessor overrides must be allowed at runtime (issue #639 cleanup).
+
+Enforcement of the derived-accessor contract moves to @final + mypy --strict only.
+The runtime guard _reject_derived_accessor_overrides in FeatureGroup.__init_subclass__
+is removed; defining an overriding subclass must succeed and the override takes effect.
+The matrix-voiding check (subtype_support_matrix raising for a hand-written
+supports_compute_framework override) stays.
+"""
+
+from typing import Any, Optional
+
+import pytest
+
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.provider import FeatureGroup, SubtypeDeclaration, property_spec
+
+
+SBRM_KEY = "sbrm_window_function"
+
+
+class SbrmFwAlpha(ComputeFramework):
+    """Dummy compute framework for the override-allowed tests."""
+
+
+class SbrmDeclaredBaseFG(FeatureGroup):
+    """Declared family used as a base for override subclasses."""
+
+    SUBTYPES = SubtypeDeclaration(key=SBRM_KEY)
+    PROPERTY_MAPPING = {
+        SBRM_KEY: property_spec(
+            "Window function subtype.",
+            strict=True,
+            allowed_values={"median": "Median", "sum": "Sum"},
+        ),
+    }
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {SbrmFwAlpha}
+
+
+class TestSbrmDerivedAccessorOverrideAllowed:
+    """Overriding a derived subtype accessor is a mypy-only concern; runtime must not raise."""
+
+    def test_sbrm_canonical_subtype_override_defines_and_takes_effect(self) -> None:
+        def sbrm_canonical(cls: type[FeatureGroup], subtype: str) -> str:
+            return f"sbrm_canon_{subtype}"
+
+        overriding = type(
+            "SbrmCanonicalOverrideFG",
+            (FeatureGroup,),
+            {"canonical_subtype": classmethod(sbrm_canonical)},
+        )
+        assert issubclass(overriding, FeatureGroup)
+        assert overriding.canonical_subtype("median") == "sbrm_canon_median"
+
+    def test_sbrm_resolve_subtype_override_on_declared_family_takes_effect(self) -> None:
+        def sbrm_resolve(cls: type[FeatureGroup], feature_name: FeatureName | str, options: Options) -> Optional[str]:
+            return "sbrm_resolved"
+
+        overriding = type(
+            "SbrmResolveOverrideFG",
+            (SbrmDeclaredBaseFG,),
+            {"resolve_subtype": classmethod(sbrm_resolve)},
+        )
+        assert issubclass(overriding, SbrmDeclaredBaseFG)
+        assert overriding.resolve_subtype("sbrm_any_feature", Options()) == "sbrm_resolved"
+
+
+class TestSbrmMatrixVoidingCheckSurvives:
+    """Contrast pin: hand-written supports_compute_framework still voids the matrix."""
+
+    def test_sbrm_supports_hook_override_still_raises_from_matrix(self) -> None:
+        def sbrm_supports(
+            cls: type[FeatureGroup],
+            feature_name: FeatureName | str,
+            options: Options,
+            compute_framework: type[ComputeFramework],
+        ) -> bool:
+            return True
+
+        overriding: Any = type(
+            "SbrmSupportsOverrideFG",
+            (SbrmDeclaredBaseFG,),
+            {"supports_compute_framework": classmethod(sbrm_supports)},
+        )
+        with pytest.raises(ValueError) as exc_info:
+            overriding.subtype_support_matrix()
+        message = str(exc_info.value)
+        assert "supports_compute_framework" in message
+        assert "SbrmSupportsOverrideFG" in message

--- a/tests/test_core/test_prepare/test_subtype_declaration.py
+++ b/tests/test_core/test_prepare/test_subtype_declaration.py
@@ -735,3 +735,183 @@ class TestDerivedAccessorOverrideRejection:
                 (SubDeclWindowBaseFG,),
                 {"supported_subtypes": classmethod(_subdecl_supported_override)},
             )
+
+
+def _subdecl_setitem(mapping: Any, key: str, value: Any) -> None:
+    mapping[key] = value
+
+
+def _subdecl_raising_resolver(feature_name: str, options: Options) -> Optional[str]:
+    raise RuntimeError("subdecl resolver boom")
+
+
+def _subdecl_int_resolver(feature_name: str, options: Options) -> Any:
+    return 7
+
+
+def _subdecl_matrix_override(cls: type[FeatureGroup]) -> dict[str, frozenset[str]]:
+    return {}
+
+
+def _subdecl_option_values_override(cls: type[FeatureGroup], key: str) -> frozenset[str]:
+    return frozenset()
+
+
+class SubDeclRaisingResolverFG(FeatureGroup):
+    """Shape B whose resolver raises; resolution must degrade instead of propagating."""
+
+    SUBTYPES = SubtypeDeclaration(
+        universe={"boom"},
+        resolver=_subdecl_raising_resolver,
+        supported={SubDeclFwBeta.get_class_name(): frozenset()},
+    )
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class SubDeclIntResolverFG(FeatureGroup):
+    """Shape B whose resolver returns a raw int; the result must be stringified."""
+
+    SUBTYPES = SubtypeDeclaration(
+        universe={"7"},
+        resolver=_subdecl_int_resolver,
+        supported={SubDeclFwBeta.get_class_name(): frozenset()},
+    )
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class TestSubDeclDeepImmutability:
+    """supported and parametric_families are read-only mappings; universe stays a frozenset."""
+
+    def test_shape_a_mappings_reject_item_assignment(self) -> None:
+        decl = SubtypeDeclaration(
+            key="subdecl_immut_key",
+            parametric_families={"fam": "A family"},
+            supported={"SubDeclFwBeta": {"fam"}},
+        )
+        with pytest.raises(TypeError):
+            _subdecl_setitem(decl.supported, "SubDeclFwAlpha", frozenset({"fam"}))
+        with pytest.raises(TypeError):
+            _subdecl_setitem(decl.parametric_families, "fam2", "Another family")
+
+    def test_shape_b_mappings_reject_item_assignment_and_universe_is_frozenset(self) -> None:
+        decl = SubtypeDeclaration(
+            universe={"lit"},
+            resolver=_subdecl_noop_resolver,
+            parametric_families={"fam": "A family"},
+            supported={"SubDeclFwBeta": {"lit", "fam"}},
+        )
+        with pytest.raises(TypeError):
+            _subdecl_setitem(decl.supported, "SubDeclFwAlpha", frozenset({"lit"}))
+        with pytest.raises(TypeError):
+            _subdecl_setitem(decl.parametric_families, "fam2", "Another family")
+        assert isinstance(decl.universe, frozenset)
+
+
+class TestSubDeclStringNormalizationOnIngest:
+    """Every declared value is stringified when the declaration is constructed."""
+
+    def test_numeric_universe_members_are_stringified(self) -> None:
+        raw_universe: set[Any] = {2, 7}
+        decl = SubtypeDeclaration(universe=raw_universe, resolver=_subdecl_noop_resolver)
+        assert decl.universe == frozenset({"2", "7"})
+
+    def test_numeric_supported_values_are_stringified(self) -> None:
+        raw_universe: set[Any] = {2, 7}
+        raw_supported: dict[str, set[Any]] = {"SubDeclSomeFw": {2}}
+        decl = SubtypeDeclaration(universe=raw_universe, resolver=_subdecl_noop_resolver, supported=raw_supported)
+        assert decl.supported == {"SubDeclSomeFw": frozenset({"2"})}
+
+    def test_numeric_parametric_family_keys_are_stringified(self) -> None:
+        raw_families: dict[Any, str] = {5: "Lag by N rows"}
+        decl = SubtypeDeclaration(universe={"lit"}, resolver=_subdecl_noop_resolver, parametric_families=raw_families)
+        assert decl.family_names() == frozenset({"5"})
+
+
+class TestSubDeclKeyedNumericValueSpace:
+    """A keyed declaration over a numeric allowed_values space is definable and gates."""
+
+    def test_numeric_value_space_family_is_definable_and_gates(self) -> None:
+        numeric_supported: dict[str, set[Any]] = {
+            SubDeclFwAlpha.get_class_name(): {2},
+            SubDeclFwBeta.get_class_name(): {7},
+        }
+
+        class SubDeclNumericBucketFG(FeatureGroup):
+            SUBTYPES = SubtypeDeclaration(key="subdecl_num_bucket", supported=numeric_supported)
+            PROPERTY_MAPPING = {
+                "subdecl_num_bucket": property_spec(
+                    "Bucket count.",
+                    strict=True,
+                    allowed_values={2: "two", 7: "seven"},
+                ),
+            }
+
+            @classmethod
+            def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+                return {SubDeclFwAlpha, SubDeclFwBeta}
+
+            def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+                return None
+
+        options = Options(group={"subdecl_num_bucket": 2})
+        gate = SubDeclNumericBucketFG.supports_compute_framework
+        assert gate("subdecl_num_feature", options, SubDeclFwAlpha) is True
+        assert gate("subdecl_num_feature", options, SubDeclFwBeta) is False
+
+
+class TestSubDeclEmptyUniverseRejection:
+    """Shape B must declare a non-empty universe."""
+
+    def test_empty_universe_raises(self) -> None:
+        empty_universe: set[str] = set()
+        with pytest.raises(ValueError):
+            SubtypeDeclaration(universe=empty_universe, resolver=_subdecl_noop_resolver)
+
+
+class TestSubDeclRaisingResolverDegrades:
+    """A raising resolver degrades to unresolved instead of propagating."""
+
+    def test_resolve_subtype_returns_none(self) -> None:
+        assert SubDeclRaisingResolverFG.resolve_subtype("subdecl_raising_feature", Options()) is None
+
+    def test_supports_compute_framework_stays_open(self) -> None:
+        gate = SubDeclRaisingResolverFG.supports_compute_framework
+        assert gate("subdecl_raising_feature", Options(), SubDeclFwBeta) is True
+
+
+class TestSubDeclResolverResultStringified:
+    """A non-string resolver result is stringified before gating."""
+
+    def test_resolve_subtype_stringifies_int_result(self) -> None:
+        assert SubDeclIntResolverFG.resolve_subtype("subdecl_int_feature", Options()) == "7"
+
+    def test_stringified_result_gates_by_supported_subtypes(self) -> None:
+        gate = SubDeclIntResolverFG.supports_compute_framework
+        assert gate("subdecl_int_feature", Options(), SubDeclFwBeta) is False
+        assert gate("subdecl_int_feature", Options(), SubDeclFwAlpha) is True
+
+
+class TestSubDeclExtendedOverrideRejection:
+    """subtype_support_matrix and declared_option_values are also rejected at class definition."""
+
+    def test_subtype_support_matrix_override_rejected(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+            type(
+                "SubDeclOverridesMatrixFG",
+                (FeatureGroup,),
+                {"subtype_support_matrix": classmethod(_subdecl_matrix_override)},
+            )
+        assert "SubDeclOverridesMatrixFG" in str(exc_info.value)
+
+    def test_declared_option_values_override_rejected(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+            type(
+                "SubDeclOverridesOptionValuesFG",
+                (FeatureGroup,),
+                {"declared_option_values": classmethod(_subdecl_option_values_override)},
+            )
+        assert "SubDeclOverridesOptionValuesFG" in str(exc_info.value)

--- a/tests/test_core/test_prepare/test_subtype_declaration.py
+++ b/tests/test_core/test_prepare/test_subtype_declaration.py
@@ -1,4 +1,4 @@
-"""Failing tests pinning the composed SubtypeDeclaration value-object contract (issue #639)."""
+"""Pinning tests for the composed SubtypeDeclaration value-object contract (issue #639)."""
 
 import dataclasses
 from abc import abstractmethod

--- a/tests/test_core/test_prepare/test_subtype_declaration.py
+++ b/tests/test_core/test_prepare/test_subtype_declaration.py
@@ -242,24 +242,6 @@ class SubDeclHookMatrixPlainFG(FeatureGroup):
         return None
 
 
-def _subdecl_universe_override(cls: type[FeatureGroup]) -> frozenset[str]:
-    return frozenset({"rows_7"})
-
-
-def _subdecl_supported_override(cls: type[FeatureGroup], compute_framework: type[ComputeFramework]) -> frozenset[str]:
-    return frozenset()
-
-
-def _subdecl_resolve_override(
-    cls: type[FeatureGroup], feature_name: FeatureName | str, options: Options
-) -> Optional[str]:
-    return "rows_7"
-
-
-def _subdecl_canonical_override(cls: type[FeatureGroup], subtype: str) -> str:
-    return subtype
-
-
 class TestSubtypeDeclarationValueObject:
     """SubtypeDeclaration is a keyword-only frozen dataclass with normalized fields."""
 
@@ -692,54 +674,6 @@ class TestClassDefinitionValidation:
         assert "subdecl_bogus" in message
 
 
-class TestDerivedAccessorOverrideRejection:
-    """The declaration is the only surface: overriding a derived accessor raises at class definition."""
-
-    def test_subtype_universe_override_rejected(self) -> None:
-        with pytest.raises(ValueError) as exc_info:
-            type(
-                "SubDeclOverridesUniverseFG",
-                (FeatureGroup,),
-                {"subtype_universe": classmethod(_subdecl_universe_override)},
-            )
-        assert "SubDeclOverridesUniverseFG" in str(exc_info.value)
-
-    def test_supported_subtypes_override_rejected(self) -> None:
-        with pytest.raises(ValueError) as exc_info:
-            type(
-                "SubDeclOverridesSupportedFG",
-                (FeatureGroup,),
-                {"supported_subtypes": classmethod(_subdecl_supported_override)},
-            )
-        assert "SubDeclOverridesSupportedFG" in str(exc_info.value)
-
-    def test_resolve_subtype_override_rejected(self) -> None:
-        with pytest.raises(ValueError) as exc_info:
-            type(
-                "SubDeclOverridesResolveFG",
-                (FeatureGroup,),
-                {"resolve_subtype": classmethod(_subdecl_resolve_override)},
-            )
-        assert "SubDeclOverridesResolveFG" in str(exc_info.value)
-
-    def test_canonical_subtype_override_rejected(self) -> None:
-        with pytest.raises(ValueError) as exc_info:
-            type(
-                "SubDeclOverridesCanonicalFG",
-                (FeatureGroup,),
-                {"canonical_subtype": classmethod(_subdecl_canonical_override)},
-            )
-        assert "SubDeclOverridesCanonicalFG" in str(exc_info.value)
-
-    def test_override_rejected_even_on_declared_base(self) -> None:
-        with pytest.raises(ValueError):
-            type(
-                "SubDeclOverridesOnDeclaredFG",
-                (SubDeclWindowBaseFG,),
-                {"supported_subtypes": classmethod(_subdecl_supported_override)},
-            )
-
-
 def _subdecl_setitem(mapping: Any, key: str, value: Any) -> None:
     mapping[key] = value
 
@@ -750,14 +684,6 @@ def _subdecl_raising_resolver(feature_name: str, options: Options) -> Optional[s
 
 def _subdecl_int_resolver(feature_name: str, options: Options) -> Any:
     return 7
-
-
-def _subdecl_matrix_override(cls: type[FeatureGroup]) -> dict[str, frozenset[str]]:
-    return {}
-
-
-def _subdecl_option_values_override(cls: type[FeatureGroup], key: str) -> frozenset[str]:
-    return frozenset()
 
 
 class SubDeclRaisingResolverFG(FeatureGroup):
@@ -896,25 +822,3 @@ class TestSubDeclResolverResultStringified:
         gate = SubDeclIntResolverFG.supports_compute_framework
         assert gate("subdecl_int_feature", Options(), SubDeclFwBeta) is False
         assert gate("subdecl_int_feature", Options(), SubDeclFwAlpha) is True
-
-
-class TestSubDeclExtendedOverrideRejection:
-    """subtype_support_matrix and declared_option_values are also rejected at class definition."""
-
-    def test_subtype_support_matrix_override_rejected(self) -> None:
-        with pytest.raises(ValueError) as exc_info:
-            type(
-                "SubDeclOverridesMatrixFG",
-                (FeatureGroup,),
-                {"subtype_support_matrix": classmethod(_subdecl_matrix_override)},
-            )
-        assert "SubDeclOverridesMatrixFG" in str(exc_info.value)
-
-    def test_declared_option_values_override_rejected(self) -> None:
-        with pytest.raises(ValueError) as exc_info:
-            type(
-                "SubDeclOverridesOptionValuesFG",
-                (FeatureGroup,),
-                {"declared_option_values": classmethod(_subdecl_option_values_override)},
-            )
-        assert "SubDeclOverridesOptionValuesFG" in str(exc_info.value)

--- a/tests/test_core/test_prepare/test_subtype_declaration.py
+++ b/tests/test_core/test_prepare/test_subtype_declaration.py
@@ -1,0 +1,737 @@
+"""Failing tests pinning the composed SubtypeDeclaration value-object contract (issue #639)."""
+
+import dataclasses
+from abc import abstractmethod
+from typing import Any, Optional
+
+import pytest
+
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.provider import DefaultOptionKeys, FeatureChainParserMixin, FeatureGroup, SubtypeDeclaration, property_spec
+
+
+SUBDECL_KEY = "subdecl_window_function"
+WINDOW_UNIVERSE = frozenset({"median", "sum", "lag", "ntile"})
+BETA_SUPPORTED = frozenset({"sum", "lag"})
+FLATTENED_LITERALS = frozenset({"rows_7", "range_7", "rows_all"})
+FLATTENED_UNIVERSE = FLATTENED_LITERALS | {"roll"}
+R2_KEY = "subdecl_op"
+R2_UNIVERSE = frozenset({"lag_1", "sum", "lag"})
+R2_BETA_SUPPORTED = frozenset({"lag_1", "sum"})
+PLAIN_FEATURE = "subdecl_plain_feature"
+
+
+def _subdecl_is_positive_int(value: object) -> bool:
+    return isinstance(value, int) and value > 0
+
+
+def _subdecl_noop_resolver(feature_name: str, options: Options) -> Optional[str]:
+    return None
+
+
+def _subdecl_frame_resolver(feature_name: str, options: Options) -> Optional[str]:
+    frame_type = options.get("subdecl_frame_type")
+    frame_unit = options.get("subdecl_frame_unit")
+    if frame_type is None or frame_unit is None:
+        return None
+    return f"{frame_type}_{frame_unit}"
+
+
+def _subdecl_echo_resolver(feature_name: str, options: Options) -> Optional[str]:
+    return feature_name
+
+
+def _subdecl_pred_resolver(feature_name: str, options: Options) -> Optional[str]:
+    value = options.get("subdecl_pred_key")
+    if value is None:
+        return None
+    return f"p{value}"
+
+
+class SubDeclFwAlpha(ComputeFramework):
+    """First dummy compute framework for subtype-declaration tests."""
+
+
+class SubDeclFwBeta(ComputeFramework):
+    """Second dummy compute framework for subtype-declaration tests."""
+
+
+class SubDeclWindowBaseFG(FeatureChainParserMixin, FeatureGroup):
+    """Shape A: keyed declaration with a parametric family."""
+
+    SUBTYPES = SubtypeDeclaration(
+        key=SUBDECL_KEY,
+        parametric_families={"ntile": "N-tile bucketing"},
+    )
+    PREFIX_PATTERN = r".*__([\w]+)_subdeclw$"
+    PROPERTY_MAPPING = {
+        SUBDECL_KEY: property_spec(
+            "Window function subtype.",
+            strict=True,
+            allowed_values={"median": "Median", "sum": "Sum", "lag": "Lag"},
+        ),
+    }
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {SubDeclFwAlpha, SubDeclFwBeta}
+
+
+class SubDeclWindowFG(SubDeclWindowBaseFG):
+    """Narrows subtype support on SubDeclFwBeta through the declaration."""
+
+    SUBTYPES = SubtypeDeclaration(
+        key=SUBDECL_KEY,
+        parametric_families={"ntile": "N-tile bucketing"},
+        supported={SubDeclFwBeta.get_class_name(): BETA_SUPPORTED},
+    )
+
+
+class SubDeclAbstractWindowFG(SubDeclWindowBaseFG):
+    """Abstract member of the window family; the matrix must stay empty."""
+
+    @abstractmethod
+    def _subdecl_backend_marker(self) -> None: ...
+
+
+class SubDeclExplicitOverrideFG(SubDeclWindowFG):
+    """Hand-written supports_compute_framework; wins for matching, voids the matrix."""
+
+    @classmethod
+    def supports_compute_framework(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        compute_framework: type[ComputeFramework],
+    ) -> bool:
+        return True
+
+
+class SubDeclPlainFG(FeatureGroup):
+    """Family without any subtype dimension."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {SubDeclFwAlpha, SubDeclFwBeta}
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class SubDeclFlattenedFG(FeatureGroup):
+    """Shape B: flattened universe with a resolver and a parametric family."""
+
+    SUBTYPES = SubtypeDeclaration(
+        universe=FLATTENED_LITERALS,
+        resolver=_subdecl_frame_resolver,
+        parametric_families={"roll": "Rolling window"},
+    )
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {SubDeclFwAlpha, SubDeclFwBeta}
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class SubDeclEchoFG(FeatureGroup):
+    """Shape B whose resolver echoes the received name; pins stringification and pass-through."""
+
+    SUBTYPES = SubtypeDeclaration(universe={"echo"}, resolver=_subdecl_echo_resolver)
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class SubDeclPredicateUniverseFG(FeatureGroup):
+    """Predicate-only PROPERTY_MAPPING key made legal via a shape B declaration."""
+
+    PROPERTY_MAPPING = {
+        "subdecl_pred_key": property_spec(
+            "Predicate-validated subtype.",
+            strict=True,
+            validation_function=_subdecl_is_positive_int,
+        ),
+    }
+    SUBTYPES = SubtypeDeclaration(universe={"p1", "p2"}, resolver=_subdecl_pred_resolver)
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {SubDeclFwAlpha, SubDeclFwBeta}
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class SubDeclValueSpaceFG(FeatureGroup):
+    """PROPERTY_MAPPING with spec-form, list-form, legacy flattened and predicate-only keys."""
+
+    PROPERTY_MAPPING = {
+        "subdecl_algo": property_spec("Algorithm.", strict=True, allowed_values={"a1": "A one", "a2": "A two"}),
+        "subdecl_kind": property_spec("Kind.", strict=True, allowed_values=["x1", "x2"]),
+        "subdecl_bucket": property_spec("Bucket count.", strict=True, allowed_values={2: "two", 7: "seven"}),
+        "subdecl_mode": {
+            "fast": "Fast mode",
+            "slow": "Slow mode",
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: True,
+        },
+        "subdecl_n": property_spec("Predicate-only key.", strict=True, validation_function=_subdecl_is_positive_int),
+    }
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class SubDeclLagLiteralBaseFG(FeatureChainParserMixin, FeatureGroup):
+    """Keyed universe containing the literal 'lag_1' alongside the parametric family 'lag'."""
+
+    SUBTYPES = SubtypeDeclaration(key=R2_KEY, parametric_families={"lag": "Lag by N rows"})
+    PREFIX_PATTERN = r".*__([\w]+)_subdeclr2$"
+    PROPERTY_MAPPING = {
+        R2_KEY: property_spec(
+            "Operation subtype with a parametric-looking declared member.",
+            strict=True,
+            allowed_values={"lag_1": "Lag by one row", "sum": "Sum"},
+        ),
+    }
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {SubDeclFwAlpha, SubDeclFwBeta}
+
+
+class SubDeclLagLiteralNarrowFG(SubDeclLagLiteralBaseFG):
+    """Supports the literal 'lag_1' but not the 'lag' family on SubDeclFwBeta."""
+
+    SUBTYPES = SubtypeDeclaration(
+        key=R2_KEY,
+        parametric_families={"lag": "Lag by N rows"},
+        supported={SubDeclFwBeta.get_class_name(): R2_BETA_SUPPORTED},
+    )
+
+
+class SubDeclHookMatrixAbstractFG(SubDeclExplicitOverrideFG):
+    """Abstract hook-overriding family member; the matrix audit must stay empty."""
+
+    @abstractmethod
+    def _subdecl_hook_abstract_marker(self) -> None: ...
+
+
+class SubDeclHookMatrixPlainFG(FeatureGroup):
+    """Hook override without a subtype dimension; the matrix audit must stay empty."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {SubDeclFwAlpha, SubDeclFwBeta}
+
+    @classmethod
+    def supports_compute_framework(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        compute_framework: type[ComputeFramework],
+    ) -> bool:
+        return True
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+def _subdecl_universe_override(cls: type[FeatureGroup]) -> frozenset[str]:
+    return frozenset({"rows_7"})
+
+
+def _subdecl_supported_override(cls: type[FeatureGroup], compute_framework: type[ComputeFramework]) -> frozenset[str]:
+    return frozenset()
+
+
+def _subdecl_resolve_override(
+    cls: type[FeatureGroup], feature_name: FeatureName | str, options: Options
+) -> Optional[str]:
+    return "rows_7"
+
+
+def _subdecl_canonical_override(cls: type[FeatureGroup], subtype: str) -> str:
+    return subtype
+
+
+class TestSubtypeDeclarationValueObject:
+    """SubtypeDeclaration is a keyword-only frozen dataclass with normalized fields."""
+
+    def test_public_export_matches_module_path(self) -> None:
+        from mloda.core.abstract_plugins.components.subtype_declaration import SubtypeDeclaration as ModuleDecl
+
+        assert ModuleDecl is SubtypeDeclaration
+
+    def test_fields_are_keyword_only(self) -> None:
+        ctor: Any = SubtypeDeclaration
+        with pytest.raises(TypeError):
+            ctor("subdecl_positional_key")
+
+    def test_universe_iterable_is_normalized_to_frozenset(self) -> None:
+        decl = SubtypeDeclaration(universe=["rows_7", "rows_all", "rows_7"], resolver=_subdecl_noop_resolver)
+        assert decl.universe == frozenset({"rows_7", "rows_all"})
+        assert isinstance(decl.universe, frozenset)
+
+    def test_supported_is_normalized_to_frozensets(self) -> None:
+        decl = SubtypeDeclaration(key="subdecl_any_key", supported={"SubDeclFwBeta": ["sum", "lag", "sum"]})
+        assert decl.supported == {"SubDeclFwBeta": frozenset({"sum", "lag"})}
+        assert decl.supported is not None
+        assert all(isinstance(values, frozenset) for values in decl.supported.values())
+
+    def test_declaration_is_frozen(self) -> None:
+        decl = SubtypeDeclaration(key="subdecl_any_key")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            setattr(decl, "key", "subdecl_other_key")
+
+
+class TestSubtypeDeclarationShapeValidation:
+    """__post_init__ enforces exactly two legal declaration shapes."""
+
+    def test_key_together_with_universe_raises(self) -> None:
+        with pytest.raises(ValueError):
+            SubtypeDeclaration(key="subdecl_any_key", universe={"a"}, resolver=_subdecl_noop_resolver)
+
+    def test_key_together_with_resolver_raises(self) -> None:
+        with pytest.raises(ValueError):
+            SubtypeDeclaration(key="subdecl_any_key", resolver=_subdecl_noop_resolver)
+
+    def test_universe_without_resolver_raises(self) -> None:
+        with pytest.raises(ValueError):
+            SubtypeDeclaration(universe={"a"})
+
+    def test_resolver_without_universe_raises(self) -> None:
+        with pytest.raises(ValueError):
+            SubtypeDeclaration(resolver=_subdecl_noop_resolver)
+
+    def test_empty_declaration_raises(self) -> None:
+        with pytest.raises(ValueError):
+            SubtypeDeclaration()
+
+    def test_families_only_declaration_raises(self) -> None:
+        with pytest.raises(ValueError):
+            SubtypeDeclaration(parametric_families={"ntile": "N-tile bucketing"})
+
+    def test_supported_only_declaration_raises(self) -> None:
+        with pytest.raises(ValueError):
+            SubtypeDeclaration(supported={"SubDeclFwBeta": {"sum"}})
+
+    def test_shape_b_family_colliding_with_universe_literal_raises(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+            SubtypeDeclaration(
+                universe={"ntile", "plain"},
+                resolver=_subdecl_noop_resolver,
+                parametric_families={"ntile": "Collides with a declared literal"},
+            )
+        assert "ntile" in str(exc_info.value)
+
+    def test_shape_b_supported_outside_universe_raises(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+            SubtypeDeclaration(
+                universe={"a"},
+                resolver=_subdecl_noop_resolver,
+                supported={"SubDeclFwBeta": {"subdecl_bogus"}},
+            )
+        assert "subdecl_bogus" in str(exc_info.value)
+
+    def test_shape_b_supported_family_name_is_inside_universe(self) -> None:
+        decl = SubtypeDeclaration(
+            universe={"a"},
+            resolver=_subdecl_noop_resolver,
+            parametric_families={"fam": "A family"},
+            supported={"SubDeclFwBeta": {"fam"}},
+        )
+        assert decl.supported == {"SubDeclFwBeta": frozenset({"fam"})}
+
+
+class TestSubtypesDefault:
+    """SUBTYPES class attribute with default None; one declaration object per family."""
+
+    def test_base_default_is_none(self) -> None:
+        assert FeatureGroup.SUBTYPES is None
+
+    def test_untouched_subclass_default_is_none(self) -> None:
+        assert SubDeclPlainFG.SUBTYPES is None
+
+    def test_declaring_subclass_carries_declaration(self) -> None:
+        assert FeatureGroup.SUBTYPES is None
+        decl = SubDeclWindowBaseFG.SUBTYPES
+        assert decl is not None
+        assert decl.key == SUBDECL_KEY
+        assert decl.parametric_families == {"ntile": "N-tile bucketing"}
+
+
+class TestDeclaredOptionValues:
+    """declared_option_values(key) returns the declared value space of a key."""
+
+    def test_property_spec_dict_allowed_values(self) -> None:
+        assert SubDeclValueSpaceFG.declared_option_values("subdecl_algo") == frozenset({"a1", "a2"})
+
+    def test_property_spec_list_allowed_values(self) -> None:
+        assert SubDeclValueSpaceFG.declared_option_values("subdecl_kind") == frozenset({"x1", "x2"})
+
+    def test_non_string_values_are_stringified(self) -> None:
+        values = SubDeclValueSpaceFG.declared_option_values("subdecl_bucket")
+        assert values == frozenset({"2", "7"})
+        assert all(isinstance(value, str) for value in values)
+
+    def test_legacy_flattened_form_excludes_reserved_keys(self) -> None:
+        assert SubDeclValueSpaceFG.declared_option_values("subdecl_mode") == frozenset({"fast", "slow"})
+
+    def test_predicate_only_key_has_empty_value_space(self) -> None:
+        assert SubDeclValueSpaceFG.declared_option_values("subdecl_n") == frozenset()
+
+    def test_absent_key_returns_empty(self) -> None:
+        assert SubDeclValueSpaceFG.declared_option_values("subdecl_absent") == frozenset()
+
+    def test_property_mapping_none_returns_empty(self) -> None:
+        assert SubDeclPlainFG.declared_option_values("anything") == frozenset()
+
+    def test_result_is_frozenset(self) -> None:
+        assert isinstance(SubDeclValueSpaceFG.declared_option_values("subdecl_algo"), frozenset)
+        assert isinstance(SubDeclPlainFG.declared_option_values("anything"), frozenset)
+
+
+class TestSubtypeUniverse:
+    """subtype_universe() derives from the declaration; empty without one."""
+
+    def test_keyed_universe_unions_declared_values_and_families(self) -> None:
+        assert SubDeclWindowBaseFG.subtype_universe() == WINDOW_UNIVERSE
+
+    def test_shape_b_universe_unions_literals_and_families(self) -> None:
+        assert SubDeclFlattenedFG.subtype_universe() == FLATTENED_UNIVERSE
+
+    def test_universe_empty_without_declaration(self) -> None:
+        assert SubDeclPlainFG.subtype_universe() == frozenset()
+        assert FeatureGroup.subtype_universe() == frozenset()
+
+    def test_universe_is_frozenset(self) -> None:
+        assert isinstance(SubDeclWindowBaseFG.subtype_universe(), frozenset)
+        assert isinstance(SubDeclFlattenedFG.subtype_universe(), frozenset)
+
+
+class TestSupportedSubtypes:
+    """supported_subtypes(cfw) defaults to the full universe; supported entries narrow per framework."""
+
+    def test_default_is_full_universe(self) -> None:
+        assert SubDeclWindowBaseFG.supported_subtypes(SubDeclFwAlpha) == WINDOW_UNIVERSE
+        assert SubDeclWindowBaseFG.supported_subtypes(SubDeclFwBeta) == WINDOW_UNIVERSE
+
+    def test_supported_entry_narrows_only_the_named_framework(self) -> None:
+        assert SubDeclWindowFG.supported_subtypes(SubDeclFwBeta) < SubDeclWindowFG.subtype_universe()
+        assert SubDeclWindowFG.supported_subtypes(SubDeclFwBeta) == BETA_SUPPORTED
+        assert SubDeclWindowFG.supported_subtypes(SubDeclFwAlpha) == WINDOW_UNIVERSE
+
+    def test_shape_b_default_is_full_universe(self) -> None:
+        assert SubDeclFlattenedFG.supported_subtypes(SubDeclFwBeta) == FLATTENED_UNIVERSE
+
+    def test_shape_b_predicate_escape_default(self) -> None:
+        assert SubDeclPredicateUniverseFG.supported_subtypes(SubDeclFwAlpha) == frozenset({"p1", "p2"})
+
+    def test_empty_without_declaration(self) -> None:
+        assert FeatureGroup.supported_subtypes(SubDeclFwAlpha) == frozenset()
+        assert SubDeclPlainFG.supported_subtypes(SubDeclFwBeta) == frozenset()
+
+
+class TestResolveSubtype:
+    """resolve_subtype resolves the raw subtype from the name, then options; never raises."""
+
+    def test_resolves_from_feature_name(self) -> None:
+        assert SubDeclWindowBaseFG.resolve_subtype("value__median_subdeclw", Options()) == "median"
+
+    def test_accepts_feature_name_object(self) -> None:
+        assert SubDeclWindowBaseFG.resolve_subtype(FeatureName("value__lag_subdeclw"), Options()) == "lag"
+
+    def test_parametric_instance_resolves_raw(self) -> None:
+        assert SubDeclWindowBaseFG.resolve_subtype("value__ntile_2_subdeclw", Options()) == "ntile_2"
+
+    def test_bare_chained_name_does_not_resolve_from_name_and_never_raises(self) -> None:
+        assert SubDeclWindowBaseFG.resolve_subtype("__sum_subdeclw", Options()) is None
+
+    def test_bare_chained_name_falls_back_to_options(self) -> None:
+        options = Options(group={SUBDECL_KEY: "median"})
+        assert SubDeclWindowBaseFG.resolve_subtype("__sum_subdeclw", options) == "median"
+
+    def test_resolves_from_options_when_name_does_not_parse(self) -> None:
+        options = Options(group={SUBDECL_KEY: "median"})
+        assert SubDeclWindowBaseFG.resolve_subtype("subdecl_unchained", options) == "median"
+
+    def test_options_value_is_stringified(self) -> None:
+        options = Options(group={SUBDECL_KEY: 7})
+        assert SubDeclWindowBaseFG.resolve_subtype("subdecl_unchained", options) == "7"
+
+    def test_name_parsing_takes_precedence_over_options(self) -> None:
+        options = Options(group={SUBDECL_KEY: "median"})
+        assert SubDeclWindowBaseFG.resolve_subtype("value__sum_subdeclw", options) == "sum"
+
+    def test_none_when_neither_resolves(self) -> None:
+        assert SubDeclWindowBaseFG.resolve_subtype("subdecl_unchained", Options()) is None
+
+    def test_none_without_declaration(self) -> None:
+        options = Options(group={SUBDECL_KEY: "median"})
+        assert SubDeclPlainFG.resolve_subtype("value__sum_subdeclw", options) is None
+        assert FeatureGroup.resolve_subtype("anything", Options()) is None
+
+    def test_shape_b_resolver_result_is_returned(self) -> None:
+        options = Options(group={"subdecl_frame_type": "rows", "subdecl_frame_unit": "7"})
+        assert SubDeclFlattenedFG.resolve_subtype("subdecl_flattened_feature", options) == "rows_7"
+        assert SubDeclFlattenedFG.resolve_subtype("subdecl_flattened_feature", Options()) is None
+
+    def test_shape_b_resolver_receives_stringified_name(self) -> None:
+        assert SubDeclEchoFG.resolve_subtype(FeatureName("subdecl_echo_name"), Options()) == "subdecl_echo_name"
+
+
+class TestCanonicalSubtype:
+    """canonical_subtype collapses <family>_<digits> to the family, else identity."""
+
+    def test_parametric_instance_collapses_to_family(self) -> None:
+        assert SubDeclWindowBaseFG.canonical_subtype("ntile_2") == "ntile"
+
+    def test_stem_that_is_not_a_family_stays_identity(self) -> None:
+        assert SubDeclWindowBaseFG.canonical_subtype("ntile_2_3") == "ntile_2_3"
+
+    def test_plain_subtype_stays_identity(self) -> None:
+        assert SubDeclWindowBaseFG.canonical_subtype("median") == "median"
+
+    def test_declared_value_is_not_a_family(self) -> None:
+        assert SubDeclWindowBaseFG.canonical_subtype("sum_2") == "sum_2"
+
+    def test_non_digit_suffix_stays_identity(self) -> None:
+        assert SubDeclWindowBaseFG.canonical_subtype("ntile_x") == "ntile_x"
+
+    def test_without_families_everything_is_identity(self) -> None:
+        assert SubDeclPlainFG.canonical_subtype("ntile_2") == "ntile_2"
+        assert FeatureGroup.canonical_subtype("anything_3") == "anything_3"
+
+    def test_declared_literal_never_collapses(self) -> None:
+        assert SubDeclLagLiteralBaseFG.subtype_universe() == R2_UNIVERSE
+        assert SubDeclLagLiteralBaseFG.canonical_subtype("lag_1") == "lag_1"
+        assert SubDeclLagLiteralBaseFG.canonical_subtype("lag_7") == "lag"
+
+    def test_shape_b_family_collapse_and_literal_identity(self) -> None:
+        assert SubDeclFlattenedFG.canonical_subtype("roll_3") == "roll"
+        assert SubDeclFlattenedFG.canonical_subtype("rows_7") == "rows_7"
+
+
+class TestDerivedSupportsComputeFramework:
+    """The default supports_compute_framework is derived from the declaration."""
+
+    def test_base_keeps_returning_true(self) -> None:
+        assert FeatureGroup.SUBTYPES is None
+        assert FeatureGroup.subtype_universe() == frozenset()
+        assert FeatureGroup.supports_compute_framework("anything", Options(), SubDeclFwAlpha) is True
+
+    def test_empty_universe_is_open(self) -> None:
+        assert SubDeclPlainFG.subtype_universe() == frozenset()
+        assert SubDeclPlainFG.supports_compute_framework(PLAIN_FEATURE, Options(), SubDeclFwBeta) is True
+
+    def test_unresolved_subtype_is_open(self) -> None:
+        assert SubDeclWindowFG.resolve_subtype("subdecl_unchained", Options()) is None
+        assert SubDeclWindowFG.supports_compute_framework("subdecl_unchained", Options(), SubDeclFwBeta) is True
+
+    def test_unknown_subtype_is_open(self) -> None:
+        assert SubDeclWindowFG.canonical_subtype("zzz") == "zzz"
+        assert SubDeclWindowFG.supports_compute_framework("value__zzz_subdeclw", Options(), SubDeclFwBeta) is True
+
+    def test_declared_subtype_gated_by_supported_subtypes(self) -> None:
+        assert SubDeclWindowFG.supports_compute_framework("value__median_subdeclw", Options(), SubDeclFwBeta) is False
+        assert SubDeclWindowFG.supports_compute_framework("value__median_subdeclw", Options(), SubDeclFwAlpha) is True
+        assert SubDeclWindowFG.supports_compute_framework("value__sum_subdeclw", Options(), SubDeclFwBeta) is True
+
+    def test_parametric_instance_gated_via_canonical_family(self) -> None:
+        assert SubDeclWindowFG.supports_compute_framework("value__ntile_4_subdeclw", Options(), SubDeclFwBeta) is False
+        assert SubDeclWindowFG.supports_compute_framework("value__ntile_4_subdeclw", Options(), SubDeclFwAlpha) is True
+
+    def test_options_resolved_subtype_is_gated_too(self) -> None:
+        options = Options(group={SUBDECL_KEY: "median"})
+        assert SubDeclWindowFG.supports_compute_framework("subdecl_unchained", options, SubDeclFwBeta) is False
+
+    def test_declared_literal_gates_independently_of_its_family(self) -> None:
+        gate = SubDeclLagLiteralNarrowFG.supports_compute_framework
+        assert gate("value__lag_1_subdeclr2", Options(), SubDeclFwBeta) is True
+        assert gate("value__lag_7_subdeclr2", Options(), SubDeclFwBeta) is False
+        assert gate("value__lag_7_subdeclr2", Options(), SubDeclFwAlpha) is True
+
+    def test_explicit_override_wins(self) -> None:
+        assert SubDeclWindowFG.supports_compute_framework("value__median_subdeclw", Options(), SubDeclFwBeta) is False
+        assert SubDeclExplicitOverrideFG.supported_subtypes(SubDeclFwBeta) == BETA_SUPPORTED
+        result = SubDeclExplicitOverrideFG.supports_compute_framework(
+            "value__median_subdeclw", Options(), SubDeclFwBeta
+        )
+        assert result is True
+
+
+class TestSubtypeSupportMatrix:
+    """subtype_support_matrix() audit surface per compute framework."""
+
+    def test_matrix_maps_every_declared_framework(self) -> None:
+        matrix = SubDeclWindowFG.subtype_support_matrix()
+        assert matrix == {
+            SubDeclFwAlpha.get_class_name(): WINDOW_UNIVERSE,
+            SubDeclFwBeta.get_class_name(): BETA_SUPPORTED,
+        }
+
+    def test_matrix_empty_for_abstract_class(self) -> None:
+        assert SubDeclAbstractWindowFG.subtype_support_matrix() == {}
+
+    def test_matrix_empty_for_empty_universe(self) -> None:
+        assert SubDeclPlainFG.subtype_support_matrix() == {}
+
+    def test_matrix_raises_for_hook_overrider_and_spares_undimensioned_classes(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+            SubDeclExplicitOverrideFG.subtype_support_matrix()
+        message = str(exc_info.value)
+        assert "supports_compute_framework" in message
+        assert "SubDeclExplicitOverrideFG" in message
+        assert SubDeclHookMatrixAbstractFG.subtype_support_matrix() == {}
+        assert SubDeclHookMatrixPlainFG.subtype_support_matrix() == {}
+
+
+class TestClassDefinitionValidation:
+    """Shape A class-dependent checks are enforced at class definition time."""
+
+    def test_legal_keyed_declaration_does_not_raise(self) -> None:
+        # SubDeclWindowBaseFG was defined at module scope without error; pin its derived universe.
+        assert SubDeclWindowBaseFG.subtype_universe() == WINDOW_UNIVERSE
+
+    def test_legal_shape_b_declaration_does_not_raise(self) -> None:
+        # SubDeclFlattenedFG was defined at module scope without error; pin the derived default.
+        assert SubDeclFlattenedFG.supported_subtypes(SubDeclFwAlpha) == FLATTENED_UNIVERSE
+
+    def test_key_absent_from_property_mapping_raises(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+
+            class SubDeclBrokenAbsentKeyFG(FeatureGroup):
+                SUBTYPES = SubtypeDeclaration(key="subdecl_missing_key")
+                PROPERTY_MAPPING = {
+                    "subdecl_other": property_spec("Other.", strict=True, allowed_values={"v1": "V one"}),
+                }
+
+        message = str(exc_info.value)
+        assert "SubDeclBrokenAbsentKeyFG" in message
+        assert "subdecl_missing_key" in message
+
+    def test_key_without_property_mapping_raises(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+
+            class SubDeclBrokenNoMappingFG(FeatureGroup):
+                SUBTYPES = SubtypeDeclaration(key="subdecl_missing_key")
+
+        message = str(exc_info.value)
+        assert "SubDeclBrokenNoMappingFG" in message
+        assert "subdecl_missing_key" in message
+
+    def test_predicate_only_key_raises(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+
+            class SubDeclBrokenPredicateOnlyFG(FeatureGroup):
+                SUBTYPES = SubtypeDeclaration(key="subdecl_pred_only_key")
+                PROPERTY_MAPPING = {
+                    "subdecl_pred_only_key": property_spec(
+                        "Predicate-only subtype key.",
+                        strict=True,
+                        validation_function=_subdecl_is_positive_int,
+                    ),
+                }
+
+        message = str(exc_info.value)
+        assert "SubDeclBrokenPredicateOnlyFG" in message
+        assert "subdecl_pred_only_key" in message
+
+    def test_predicate_only_key_can_declare_shape_b(self) -> None:
+        # SubDeclPredicateUniverseFG was defined at module scope without error; shape B is the escape.
+        assert SubDeclPredicateUniverseFG.declared_option_values("subdecl_pred_key") == frozenset()
+        assert SubDeclPredicateUniverseFG.subtype_universe() == frozenset({"p1", "p2"})
+
+    def test_family_colliding_with_declared_value_raises(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+
+            class SubDeclBrokenCollidingFamilyFG(FeatureGroup):
+                SUBTYPES = SubtypeDeclaration(
+                    key="subdecl_colliding_key",
+                    parametric_families={"median": "Collides with a declared value"},
+                )
+                PROPERTY_MAPPING = {
+                    "subdecl_colliding_key": property_spec(
+                        "Colliding subtype key.",
+                        strict=True,
+                        allowed_values={"median": "Median", "sum": "Sum"},
+                    ),
+                }
+
+        message = str(exc_info.value)
+        assert "SubDeclBrokenCollidingFamilyFG" in message
+        assert "median" in message
+
+    def test_supported_outside_universe_raises_at_class_definition(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+
+            class SubDeclBrokenOverreachFG(FeatureGroup):
+                SUBTYPES = SubtypeDeclaration(
+                    key="subdecl_overreach_key",
+                    supported={"SubDeclFwBeta": {"subdecl_bogus"}},
+                )
+                PROPERTY_MAPPING = {
+                    "subdecl_overreach_key": property_spec(
+                        "Overreaching subtype key.",
+                        strict=True,
+                        allowed_values={"v1": "V one"},
+                    ),
+                }
+
+        message = str(exc_info.value)
+        assert "SubDeclBrokenOverreachFG" in message
+        assert "subdecl_bogus" in message
+
+
+class TestDerivedAccessorOverrideRejection:
+    """The declaration is the only surface: overriding a derived accessor raises at class definition."""
+
+    def test_subtype_universe_override_rejected(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+            type(
+                "SubDeclOverridesUniverseFG",
+                (FeatureGroup,),
+                {"subtype_universe": classmethod(_subdecl_universe_override)},
+            )
+        assert "SubDeclOverridesUniverseFG" in str(exc_info.value)
+
+    def test_supported_subtypes_override_rejected(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+            type(
+                "SubDeclOverridesSupportedFG",
+                (FeatureGroup,),
+                {"supported_subtypes": classmethod(_subdecl_supported_override)},
+            )
+        assert "SubDeclOverridesSupportedFG" in str(exc_info.value)
+
+    def test_resolve_subtype_override_rejected(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+            type(
+                "SubDeclOverridesResolveFG",
+                (FeatureGroup,),
+                {"resolve_subtype": classmethod(_subdecl_resolve_override)},
+            )
+        assert "SubDeclOverridesResolveFG" in str(exc_info.value)
+
+    def test_canonical_subtype_override_rejected(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+            type(
+                "SubDeclOverridesCanonicalFG",
+                (FeatureGroup,),
+                {"canonical_subtype": classmethod(_subdecl_canonical_override)},
+            )
+        assert "SubDeclOverridesCanonicalFG" in str(exc_info.value)
+
+    def test_override_rejected_even_on_declared_base(self) -> None:
+        with pytest.raises(ValueError):
+            type(
+                "SubDeclOverridesOnDeclaredFG",
+                (SubDeclWindowBaseFG,),
+                {"supported_subtypes": classmethod(_subdecl_supported_override)},
+            )

--- a/tests/test_core/test_prepare/test_subtype_declaration.py
+++ b/tests/test_core/test_prepare/test_subtype_declaration.py
@@ -154,7 +154,7 @@ class SubDeclPredicateUniverseFG(FeatureGroup):
         "subdecl_pred_key": property_spec(
             "Predicate-validated subtype.",
             strict=True,
-            validation_function=_subdecl_is_positive_int,
+            element_validator=_subdecl_is_positive_int,
         ),
     }
     SUBTYPES = SubtypeDeclaration(universe={"p1", "p2"}, resolver=_subdecl_pred_resolver)
@@ -168,19 +168,19 @@ class SubDeclPredicateUniverseFG(FeatureGroup):
 
 
 class SubDeclValueSpaceFG(FeatureGroup):
-    """PROPERTY_MAPPING with spec-form, list-form, legacy flattened and predicate-only keys."""
+    """PROPERTY_MAPPING with mapping-form, list-form, numeric and predicate-only keys."""
 
     PROPERTY_MAPPING = {
         "subdecl_algo": property_spec("Algorithm.", strict=True, allowed_values={"a1": "A one", "a2": "A two"}),
         "subdecl_kind": property_spec("Kind.", strict=True, allowed_values=["x1", "x2"]),
         "subdecl_bucket": property_spec("Bucket count.", strict=True, allowed_values={2: "two", 7: "seven"}),
-        "subdecl_mode": {
-            "fast": "Fast mode",
-            "slow": "Slow mode",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-        },
-        "subdecl_n": property_spec("Predicate-only key.", strict=True, validation_function=_subdecl_is_positive_int),
+        "subdecl_mode": property_spec(
+            "Mode.",
+            strict=True,
+            context=True,
+            allowed_values={"fast": "Fast mode", "slow": "Slow mode"},
+        ),
+        "subdecl_n": property_spec("Predicate-only key.", strict=True, element_validator=_subdecl_is_positive_int),
     }
 
     def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
@@ -380,8 +380,11 @@ class TestDeclaredOptionValues:
         assert values == frozenset({"2", "7"})
         assert all(isinstance(value, str) for value in values)
 
-    def test_legacy_flattened_form_excludes_reserved_keys(self) -> None:
-        assert SubDeclValueSpaceFG.declared_option_values("subdecl_mode") == frozenset({"fast", "slow"})
+    def test_spec_flags_are_not_part_of_the_value_space(self) -> None:
+        # subdecl_mode carries context/strict_validation flags; only allowed_values is the value space.
+        values = SubDeclValueSpaceFG.declared_option_values("subdecl_mode")
+        assert values == frozenset({"fast", "slow"})
+        assert not values & {str(DefaultOptionKeys.context), str(DefaultOptionKeys.strict_validation)}
 
     def test_predicate_only_key_has_empty_value_space(self) -> None:
         assert SubDeclValueSpaceFG.declared_option_values("subdecl_n") == frozenset()
@@ -635,7 +638,7 @@ class TestClassDefinitionValidation:
                     "subdecl_pred_only_key": property_spec(
                         "Predicate-only subtype key.",
                         strict=True,
-                        validation_function=_subdecl_is_positive_int,
+                        element_validator=_subdecl_is_positive_int,
                     ),
                 }
 

--- a/tests/test_core/test_prepare/test_subtype_declaration_hardening.py
+++ b/tests/test_core/test_prepare/test_subtype_declaration_hardening.py
@@ -1,0 +1,132 @@
+"""Failing tests hardening the SubtypeDeclaration surface (issue #639 follow-up).
+
+Pins: a 'supported' key naming no declared framework is a loud ValueError from
+subtype_support_matrix(); supported keys are stringified on ingest; and the
+declaration is hashable even with mappings set.
+"""
+
+from typing import Any, Optional
+
+import pytest
+
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.provider import FeatureGroup, SubtypeDeclaration, property_spec
+
+
+SBFIX_KEY = "sbfix_kind"
+SBFIX_UNIVERSE = frozenset({"sum", "median"})
+SBFIX_BOGUS_FRAMEWORK = "SbfixNoSuchFramework"
+
+
+def _sbfix_noop_resolver(feature_name: str, options: Options) -> Optional[str]:
+    return None
+
+
+class SbfixFwAlpha(ComputeFramework):
+    """Dummy compute framework for subtype-declaration hardening tests."""
+
+
+class SbfixBogusSupportedFG(FeatureGroup):
+    """Declaration whose 'supported' names a framework the family never declares."""
+
+    SUBTYPES = SubtypeDeclaration(
+        key=SBFIX_KEY,
+        supported={SBFIX_BOGUS_FRAMEWORK: {"sum"}},
+    )
+    PROPERTY_MAPPING = {
+        SBFIX_KEY: property_spec(
+            "Operation kind with a bogus supported framework.",
+            strict=True,
+            allowed_values={"sum": "Sum", "median": "Median"},
+        ),
+    }
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {SbfixFwAlpha}
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class SbfixHealthySupportedFG(FeatureGroup):
+    """Correct declaration for contrast; its matrix must stay clean."""
+
+    SUBTYPES = SubtypeDeclaration(
+        key=SBFIX_KEY,
+        supported={SbfixFwAlpha.get_class_name(): {"sum"}},
+    )
+    PROPERTY_MAPPING = {
+        SBFIX_KEY: property_spec(
+            "Operation kind with a correct supported framework.",
+            strict=True,
+            allowed_values={"sum": "Sum", "median": "Median"},
+        ),
+    }
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {SbfixFwAlpha}
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class TestSbfixMatrixRejectsUndeclaredSupportedFramework:
+    """subtype_support_matrix() raises on a 'supported' key naming no declared framework."""
+
+    def test_class_definition_succeeds_since_values_are_in_universe(self) -> None:
+        assert SbfixBogusSupportedFG.subtype_universe() == SBFIX_UNIVERSE
+
+    def test_matrix_raises_value_error_naming_framework_and_class(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+            SbfixBogusSupportedFG.subtype_support_matrix()
+        message = str(exc_info.value)
+        assert SBFIX_BOGUS_FRAMEWORK in message
+        assert "SbfixBogusSupportedFG" in message
+
+    def test_correct_declaration_still_produces_clean_matrix(self) -> None:
+        assert SbfixHealthySupportedFG.subtype_support_matrix() == {
+            SbfixFwAlpha.get_class_name(): frozenset({"sum"}),
+        }
+
+
+class TestSbfixSupportedKeysStringifiedOnIngest:
+    """Supported keys are stringified when the declaration is constructed."""
+
+    def test_numeric_supported_key_is_stringified(self) -> None:
+        raw_supported: dict[Any, set[str]] = {123: {"2"}}
+        decl = SubtypeDeclaration(universe={"2"}, resolver=_sbfix_noop_resolver, supported=raw_supported)
+        assert decl.supported is not None
+        assert set(decl.supported) == {"123"}
+        assert decl.supported["123"] == frozenset({"2"})
+
+
+class TestSbfixDeclarationHashable:
+    """hash(SubtypeDeclaration(...)) works with parametric_families and supported set."""
+
+    def _make(self, supported_values: set[str]) -> SubtypeDeclaration:
+        return SubtypeDeclaration(
+            universe={"a", "b"},
+            resolver=_sbfix_noop_resolver,
+            parametric_families={"fam": "A family"},
+            supported={"SbfixFwAlpha": supported_values},
+        )
+
+    def test_hash_succeeds_with_mappings_set(self) -> None:
+        decl = self._make({"a", "fam"})
+        assert isinstance(hash(decl), int)
+
+    def test_equal_inputs_are_equal_with_equal_hashes(self) -> None:
+        first = self._make({"a", "fam"})
+        second = self._make({"a", "fam"})
+        assert first == second
+        assert hash(first) == hash(second)
+
+    def test_differing_declaration_is_not_equal(self) -> None:
+        first = self._make({"a", "fam"})
+        third = self._make({"b"})
+        assert first != third

--- a/tests/test_core/test_prepare/test_subtype_matching.py
+++ b/tests/test_core/test_prepare/test_subtype_matching.py
@@ -11,7 +11,7 @@ from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
-from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass, split_frameworks_by_capability
 from mloda.provider import FeatureChainParserMixin, FeatureGroup, SubtypeDeclaration, property_spec
 
 
@@ -282,3 +282,37 @@ class TestFrameSpecLikeFamily:
 
         _, compute_frameworks = _identify(feature, accessible_plugins).get()
         assert compute_frameworks == {SubDeclMatchFwAlpha, SubDeclMatchFwBeta}
+
+
+def _subdeclm_raising_resolver(feature_name: str, options: Options) -> Optional[str]:
+    raise RuntimeError("subdeclm resolver boom")
+
+
+class SubDeclMatchRaisingResolverFG(FeatureGroup):
+    """Shape B family whose resolver raises; planning must degrade open."""
+
+    SUBTYPES = SubtypeDeclaration(
+        universe={"boom"},
+        resolver=_subdeclm_raising_resolver,
+        supported={SubDeclMatchFwBeta.get_class_name(): frozenset()},
+    )
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {SubDeclMatchFwAlpha, SubDeclMatchFwBeta}
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class TestSubDeclMatchPlanningNeverRaises:
+    """A raising resolver must not crash the planning path; the family degrades open."""
+
+    def test_raising_resolver_degrades_open_in_split(self) -> None:
+        supported, rejected = split_frameworks_by_capability(
+            [SubDeclMatchRaisingResolverFG],
+            FeatureName("subdeclm_raising_feature"),
+            Options(),
+        )
+        assert supported == {SubDeclMatchFwAlpha, SubDeclMatchFwBeta}
+        assert rejected == set()

--- a/tests/test_core/test_prepare/test_subtype_matching.py
+++ b/tests/test_core/test_prepare/test_subtype_matching.py
@@ -1,4 +1,4 @@
-"""Failing tests pinning match-time enforcement of SubtypeDeclaration (issue #639)."""
+"""Pinning tests for match-time enforcement of SubtypeDeclaration (issue #639)."""
 
 import re
 from typing import Optional

--- a/tests/test_core/test_prepare/test_subtype_matching.py
+++ b/tests/test_core/test_prepare/test_subtype_matching.py
@@ -1,0 +1,284 @@
+"""Failing tests pinning match-time enforcement of SubtypeDeclaration (issue #639)."""
+
+import re
+from typing import Optional
+
+import pytest
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+from mloda.provider import FeatureChainParserMixin, FeatureGroup, SubtypeDeclaration, property_spec
+
+
+MATCH_KEY = "subdeclm_window_function"
+MATCH_WINDOW_UNIVERSE = frozenset({"median", "sum", "lag", "ntile"})
+MATCH_BETA_SUPPORTED = frozenset({"sum", "lag"})
+MATCH_PLAIN_FEATURE = "subdeclm_plain_feature"
+RANK_UNIVERSE = frozenset({"dense", "ordinal", "ntile"})
+FRAME_LITERALS = frozenset({"rows_1", "rows_7"})
+FRAME_UNIVERSE = FRAME_LITERALS | {"rows"}
+
+
+class SubDeclMatchFwAlpha(ComputeFramework):
+    """First dummy compute framework for subtype-matching tests."""
+
+
+class SubDeclMatchFwBeta(ComputeFramework):
+    """Second dummy compute framework for subtype-matching tests."""
+
+
+class SubDeclMatchWindowFG(FeatureChainParserMixin, FeatureGroup):
+    """Keyed declaration narrowing subtype support on SubDeclMatchFwBeta."""
+
+    SUBTYPES = SubtypeDeclaration(
+        key=MATCH_KEY,
+        parametric_families={"ntile": "N-tile bucketing"},
+        supported={SubDeclMatchFwBeta.get_class_name(): MATCH_BETA_SUPPORTED},
+    )
+    PREFIX_PATTERN = r".*__([\w]+)_subdeclmw$"
+    PROPERTY_MAPPING = {
+        MATCH_KEY: property_spec(
+            "Window function subtype.",
+            strict=True,
+            allowed_values={"median": "Median", "sum": "Sum", "lag": "Lag"},
+        ),
+    }
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {SubDeclMatchFwAlpha, SubDeclMatchFwBeta}
+
+
+class SubDeclMatchPlainFG(FeatureGroup):
+    """Family without any subtype dimension."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {SubDeclMatchFwAlpha, SubDeclMatchFwBeta}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == MATCH_PLAIN_FEATURE
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class SubDeclMatchRankLikeFG(FeatureChainParserMixin, FeatureGroup):
+    """Registry-like keyed parametric family: rank types plus N-tile bucketing."""
+
+    SUBTYPES = SubtypeDeclaration(
+        key="rank_type",
+        parametric_families={"ntile": "N-tile bucketing"},
+        supported={SubDeclMatchFwBeta.get_class_name(): {"dense"}},
+    )
+    PREFIX_PATTERN = r".*__([\w]+)_subdeclmrank$"
+    PROPERTY_MAPPING = {
+        "rank_type": property_spec(
+            "Ranking method.",
+            strict=True,
+            allowed_values={"dense": "Dense rank", "ordinal": "Ordinal rank"},
+        ),
+    }
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {SubDeclMatchFwAlpha, SubDeclMatchFwBeta}
+
+
+def _subdeclm_frame_resolver(feature_name: str, options: Options) -> Optional[str]:
+    match = re.match(r".*__(rows_\d+)_frame$", feature_name)
+    if match is None:
+        return None
+    return match.group(1)
+
+
+class SubDeclMatchFrameSpecFG(FeatureGroup):
+    """Registry-like shape B family: flattened frame spec with a name resolver."""
+
+    SUBTYPES = SubtypeDeclaration(
+        universe=FRAME_LITERALS,
+        resolver=_subdeclm_frame_resolver,
+        parametric_families={"rows": "Row-count frames"},
+        supported={SubDeclMatchFwBeta.get_class_name(): {"rows_1"}},
+    )
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {SubDeclMatchFwAlpha, SubDeclMatchFwBeta}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name).startswith("subdeclm_") and str(feature_name).endswith("_frame")
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+def _identify(feature: Feature, accessible_plugins: FeatureGroupEnvironmentMapping) -> IdentifyFeatureGroupClass:
+    return IdentifyFeatureGroupClass(
+        feature=feature,
+        accessible_plugins=accessible_plugins,
+        links=None,
+        data_access_collection=None,
+    )
+
+
+class TestMatchTimeIntegration:
+    """The declaration is enforced through IdentifyFeatureGroupClass."""
+
+    def test_unsupported_subtype_is_routed_to_capable_framework(self) -> None:
+        feature = Feature("value__median_subdeclmw")
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            SubDeclMatchWindowFG: {SubDeclMatchFwAlpha, SubDeclMatchFwBeta},
+        }
+
+        feature_group_class, compute_frameworks = _identify(feature, accessible_plugins).get()
+        assert feature_group_class is SubDeclMatchWindowFG
+        assert compute_frameworks == {SubDeclMatchFwAlpha}, (
+            f"'median' is unsupported on SubDeclMatchFwBeta and must be routed around; got {compute_frameworks}"
+        )
+
+    def test_pin_to_incapable_framework_raises_capability_error(self) -> None:
+        feature = Feature("value__median_subdeclmw")
+        feature.compute_frameworks = {SubDeclMatchFwBeta}
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            SubDeclMatchWindowFG: {SubDeclMatchFwAlpha, SubDeclMatchFwBeta},
+        }
+
+        with pytest.raises(ValueError) as exc_info:
+            _identify(feature, accessible_plugins)
+
+        message = str(exc_info.value)
+        lowered = message.lower()
+        assert "unsupported" in lowered or "not supported" in lowered, (
+            f"Error must signal an unsupported framework, but got: {message}"
+        )
+        assert SubDeclMatchFwBeta.get_class_name() in message
+        assert SubDeclMatchFwAlpha.get_class_name() in message
+        assert "Did you mean" not in message
+
+    def test_parametric_instance_is_routed_around(self) -> None:
+        feature = Feature("value__ntile_2_subdeclmw")
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            SubDeclMatchWindowFG: {SubDeclMatchFwAlpha, SubDeclMatchFwBeta},
+        }
+
+        feature_group_class, compute_frameworks = _identify(feature, accessible_plugins).get()
+        assert feature_group_class is SubDeclMatchWindowFG
+        assert compute_frameworks == {SubDeclMatchFwAlpha}, (
+            f"Family 'ntile' is unsupported on SubDeclMatchFwBeta, so 'ntile_2' must be routed around; "
+            f"got {compute_frameworks}"
+        )
+
+    def test_unknown_subtype_keeps_every_framework(self) -> None:
+        assert SubDeclMatchWindowFG.canonical_subtype("zzz") == "zzz"
+
+        feature = Feature("value__zzz_subdeclmw")
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            SubDeclMatchWindowFG: {SubDeclMatchFwAlpha, SubDeclMatchFwBeta},
+        }
+
+        _, compute_frameworks = _identify(feature, accessible_plugins).get()
+        assert compute_frameworks == {SubDeclMatchFwAlpha, SubDeclMatchFwBeta}, (
+            f"An undeclared subtype must stay open on every framework; got {compute_frameworks}"
+        )
+
+    def test_family_without_subtype_dimension_is_unaffected(self) -> None:
+        assert SubDeclMatchPlainFG.SUBTYPES is None
+        assert SubDeclMatchPlainFG.subtype_universe() == frozenset()
+
+        feature = Feature(MATCH_PLAIN_FEATURE)
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            SubDeclMatchPlainFG: {SubDeclMatchFwAlpha, SubDeclMatchFwBeta},
+        }
+
+        _, compute_frameworks = _identify(feature, accessible_plugins).get()
+        assert compute_frameworks == {SubDeclMatchFwAlpha, SubDeclMatchFwBeta}
+
+    def test_matching_stays_orthogonal_to_subtype_support(self) -> None:
+        assert SubDeclMatchWindowFG.resolve_subtype("value__median_subdeclmw", Options()) == "median"
+        assert "median" not in SubDeclMatchWindowFG.supported_subtypes(SubDeclMatchFwBeta)
+        assert SubDeclMatchWindowFG.match_feature_group_criteria("value__median_subdeclmw", Options()) is True
+
+
+class TestRankLikeFamily:
+    """Definition of done: a keyed parametric registry-like family routes by declaration alone."""
+
+    def test_universe_enumerates_family_without_probing(self) -> None:
+        assert SubDeclMatchRankLikeFG.subtype_universe() == RANK_UNIVERSE
+
+    def test_parametric_instance_canonicalizes_to_family(self) -> None:
+        assert SubDeclMatchRankLikeFG.canonical_subtype("ntile_2") == "ntile"
+
+    def test_parametric_instance_routes_only_to_capable_framework(self) -> None:
+        feature = Feature("value__ntile_2_subdeclmrank")
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            SubDeclMatchRankLikeFG: {SubDeclMatchFwAlpha, SubDeclMatchFwBeta},
+        }
+
+        feature_group_class, compute_frameworks = _identify(feature, accessible_plugins).get()
+        assert feature_group_class is SubDeclMatchRankLikeFG
+        assert compute_frameworks == {SubDeclMatchFwAlpha}, (
+            f"'ntile' is only supported on SubDeclMatchFwAlpha; got {compute_frameworks}"
+        )
+
+    def test_supported_subtype_runs_on_both_frameworks(self) -> None:
+        feature = Feature("value__dense_subdeclmrank")
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            SubDeclMatchRankLikeFG: {SubDeclMatchFwAlpha, SubDeclMatchFwBeta},
+        }
+
+        _, compute_frameworks = _identify(feature, accessible_plugins).get()
+        assert compute_frameworks == {SubDeclMatchFwAlpha, SubDeclMatchFwBeta}
+
+
+class TestFrameSpecLikeFamily:
+    """Definition of done: a shape B registry-like family resolves from names and routes by narrowing."""
+
+    def test_universe_unions_literals_and_family(self) -> None:
+        assert SubDeclMatchFrameSpecFG.subtype_universe() == FRAME_UNIVERSE
+
+    def test_resolver_parses_subtype_from_name(self) -> None:
+        assert SubDeclMatchFrameSpecFG.resolve_subtype("subdeclm_price__rows_7_frame", Options()) == "rows_7"
+
+    def test_declared_literal_never_collapses_parametrically(self) -> None:
+        # 'rows_7' is a declared literal; 'rows' looking like a family stem must not swallow it.
+        assert SubDeclMatchFrameSpecFG.canonical_subtype("rows_7") == "rows_7"
+        assert SubDeclMatchFrameSpecFG.canonical_subtype("rows_9") == "rows"
+
+    def test_routing_honors_supported_narrowing(self) -> None:
+        feature = Feature("subdeclm_price__rows_7_frame")
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            SubDeclMatchFrameSpecFG: {SubDeclMatchFwAlpha, SubDeclMatchFwBeta},
+        }
+
+        feature_group_class, compute_frameworks = _identify(feature, accessible_plugins).get()
+        assert feature_group_class is SubDeclMatchFrameSpecFG
+        assert compute_frameworks == {SubDeclMatchFwAlpha}, (
+            f"'rows_7' is unsupported on SubDeclMatchFwBeta; got {compute_frameworks}"
+        )
+
+    def test_supported_literal_runs_on_both_frameworks(self) -> None:
+        feature = Feature("subdeclm_price__rows_1_frame")
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            SubDeclMatchFrameSpecFG: {SubDeclMatchFwAlpha, SubDeclMatchFwBeta},
+        }
+
+        _, compute_frameworks = _identify(feature, accessible_plugins).get()
+        assert compute_frameworks == {SubDeclMatchFwAlpha, SubDeclMatchFwBeta}

--- a/tests/test_core/test_prepare/test_subtype_option_parity.py
+++ b/tests/test_core/test_prepare/test_subtype_option_parity.py
@@ -1,0 +1,170 @@
+"""Failing pinning tests for SubtypeDeclaration matcher parity and hardening (issue #639 follow-up).
+
+Defect 1: resolve_subtype reads options.get(key) raw, while
+match_configuration_feature_chain_parser normalizes singleton containers
+(a frozenset element is unwrapped and validated) and treats a declared
+PROPERTY_MAPPING default as an accepted match. A config-accepted feature must
+therefore resolve to the same normalized subtype the matcher validated, and
+supports_compute_framework must gate on it.
+
+Defect 2: resolve_subtype promises "never raises", but a malformed
+PREFIX_PATTERN regex propagates re.error out of parse_feature_name.
+"""
+
+from typing import Optional
+
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.provider import FeatureGroup, SubtypeDeclaration, property_spec
+
+
+SBPAR_KEY = "sbpar_aggregation"
+SBPAR_DEFAULT_KEY = "sbpar_defaulted_aggregation"
+SBPAR_BETA_SUPPORTED = frozenset({"max"})
+SBPAR_UNCHAINED = "sbpar_unchained_feature"
+
+
+class SbparFwAlpha(ComputeFramework):
+    """First dummy compute framework for option-parity tests."""
+
+
+class SbparFwBeta(ComputeFramework):
+    """Second dummy compute framework for option-parity tests; 'sum' is narrowed off it."""
+
+
+class SbparWindowFG(FeatureGroup):
+    """Shape A keyed family; 'sum' is declared unsupported on SbparFwBeta."""
+
+    SUBTYPES = SubtypeDeclaration(
+        key=SBPAR_KEY,
+        supported={SbparFwBeta.get_class_name(): SBPAR_BETA_SUPPORTED},
+    )
+    PROPERTY_MAPPING = {
+        SBPAR_KEY: property_spec(
+            "Aggregation subtype.",
+            strict=True,
+            allowed_values={"sum": "Sum", "max": "Max"},
+        ),
+    }
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {SbparFwAlpha, SbparFwBeta}
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class SbparDefaultedFG(FeatureGroup):
+    """Shape A keyed family whose key declares default='sum'; 'sum' is narrowed off SbparFwBeta."""
+
+    SUBTYPES = SubtypeDeclaration(
+        key=SBPAR_DEFAULT_KEY,
+        supported={SbparFwBeta.get_class_name(): SBPAR_BETA_SUPPORTED},
+    )
+    PROPERTY_MAPPING = {
+        SBPAR_DEFAULT_KEY: property_spec(
+            "Aggregation subtype with a declared default.",
+            strict=True,
+            allowed_values={"sum": "Sum", "max": "Max"},
+            default="sum",
+        ),
+    }
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {SbparFwAlpha, SbparFwBeta}
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class SbparBadPrefixFG(FeatureGroup):
+    """Keyed family whose PREFIX_PATTERN is a malformed regex; must never leak re.error."""
+
+    SUBTYPES = SubtypeDeclaration(
+        key=SBPAR_KEY,
+        supported={SbparFwBeta.get_class_name(): SBPAR_BETA_SUPPORTED},
+    )
+    PREFIX_PATTERN = r"*__(bad"
+    PROPERTY_MAPPING = {
+        SBPAR_KEY: property_spec(
+            "Aggregation subtype.",
+            strict=True,
+            allowed_values={"sum": "Sum", "max": "Max"},
+        ),
+    }
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {SbparFwAlpha, SbparFwBeta}
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class TestSbparSingletonContainerParity:
+    """A singleton frozenset option value is matcher-accepted as 'sum'; resolution must mirror it."""
+
+    def test_matcher_accepts_singleton_frozenset(self) -> None:
+        # Empirical anchor: the matcher unwraps frozenset elements and validates 'sum'.
+        options = Options(group={SBPAR_KEY: frozenset({"sum"})})
+        accepted = FeatureChainParser.match_configuration_feature_chain_parser(
+            SBPAR_UNCHAINED, options, property_mapping=SbparWindowFG.PROPERTY_MAPPING
+        )
+        assert accepted is True
+
+    def test_resolve_subtype_normalizes_singleton_frozenset(self) -> None:
+        options = Options(group={SBPAR_KEY: frozenset({"sum"})})
+        assert SbparWindowFG.resolve_subtype(SBPAR_UNCHAINED, options) == "sum"
+
+    def test_singleton_frozenset_gates_supports_compute_framework(self) -> None:
+        options = Options(group={SBPAR_KEY: frozenset({"sum"})})
+        gate = SbparWindowFG.supports_compute_framework
+        assert gate(SBPAR_UNCHAINED, options, SbparFwBeta) is False
+        assert gate(SBPAR_UNCHAINED, options, SbparFwAlpha) is True
+
+    def test_plain_string_option_baseline_still_gates(self) -> None:
+        # Baseline sanity: the raw-string path already agrees with the matcher.
+        options = Options(group={SBPAR_KEY: "sum"})
+        assert SbparWindowFG.resolve_subtype(SBPAR_UNCHAINED, options) == "sum"
+        assert SbparWindowFG.supports_compute_framework(SBPAR_UNCHAINED, options, SbparFwBeta) is False
+
+
+class TestSbparPropertyMappingDefaultParity:
+    """An absent option with a declared default is matcher-accepted; the default must resolve."""
+
+    def test_matcher_accepts_absent_option_via_default(self) -> None:
+        # Empirical anchor: a key with default='sum' passes validation with empty options.
+        accepted = FeatureChainParser.match_configuration_feature_chain_parser(
+            SBPAR_UNCHAINED, Options(), property_mapping=SbparDefaultedFG.PROPERTY_MAPPING
+        )
+        assert accepted is True
+
+    def test_resolve_subtype_applies_declared_default(self) -> None:
+        assert SbparDefaultedFG.resolve_subtype(SBPAR_UNCHAINED, Options()) == "sum"
+
+    def test_declared_default_gates_supports_compute_framework(self) -> None:
+        gate = SbparDefaultedFG.supports_compute_framework
+        assert gate(SBPAR_UNCHAINED, Options(), SbparFwBeta) is False
+        assert gate(SBPAR_UNCHAINED, Options(), SbparFwAlpha) is True
+
+    def test_explicit_option_overrides_declared_default(self) -> None:
+        options = Options(group={SBPAR_DEFAULT_KEY: "max"})
+        assert SbparDefaultedFG.resolve_subtype(SBPAR_UNCHAINED, options) == "max"
+        assert SbparDefaultedFG.supports_compute_framework(SBPAR_UNCHAINED, options, SbparFwBeta) is True
+
+
+class TestSbparMalformedPrefixPatternNeverRaises:
+    """resolve_subtype degrades to None on a malformed PREFIX_PATTERN instead of raising re.error."""
+
+    def test_resolve_subtype_returns_none_for_chained_name(self) -> None:
+        assert SbparBadPrefixFG.resolve_subtype("value__sum_x", Options()) is None
+
+    def test_supports_compute_framework_stays_open(self) -> None:
+        gate = SbparBadPrefixFG.supports_compute_framework
+        assert gate("value__sum_x", Options(), SbparFwBeta) is True
+        assert gate("value__sum_x", Options(), SbparFwAlpha) is True

--- a/tests/test_plugins/feature_group/experimental/test_base_aggregated_feature_group/test_aggregated_subtype_declaration.py
+++ b/tests/test_plugins/feature_group/experimental/test_base_aggregated_feature_group/test_aggregated_subtype_declaration.py
@@ -1,0 +1,86 @@
+"""Failing tests pinning the SubtypeDeclaration dogfooding of AggregatedFeatureGroup (issue #639, cycle 2)."""
+
+import inspect
+
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.provider import SubtypeDeclaration
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
+    PythonDictFramework,
+)
+from mloda_plugins.feature_group.experimental.aggregated_feature_group.base import AggregatedFeatureGroup
+from mloda_plugins.feature_group.experimental.aggregated_feature_group.pandas import PandasAggregatedFeatureGroup
+
+
+AGGREGATION_UNIVERSE = frozenset(AggregatedFeatureGroup.AGGREGATION_TYPES)
+
+
+class TestAggregatedSubtypeDeclaration:
+    """AggregatedFeatureGroup declares its aggregation types via SUBTYPES."""
+
+    def test_declaration_key_is_aggregation_type(self) -> None:
+        declaration = AggregatedFeatureGroup.SUBTYPES
+        assert declaration is not None
+        assert isinstance(declaration, SubtypeDeclaration)
+        assert declaration.key == AggregatedFeatureGroup.AGGREGATION_TYPE
+        assert declaration.key == "aggregation_type"
+
+    def test_universe_matches_declared_aggregation_types(self) -> None:
+        assert AggregatedFeatureGroup.subtype_universe() == AGGREGATION_UNIVERSE
+
+    def test_pandas_subclass_inherits_universe(self) -> None:
+        assert PandasAggregatedFeatureGroup.subtype_universe() == AGGREGATION_UNIVERSE
+
+
+class TestAggregatedResolveSubtype:
+    """resolve_subtype resolves aggregation types from the name and the options path."""
+
+    def test_resolves_from_feature_name(self) -> None:
+        assert AggregatedFeatureGroup.resolve_subtype("sales__sum_aggr", Options()) == "sum"
+
+    def test_resolves_from_options_path(self) -> None:
+        options = Options(context={AggregatedFeatureGroup.AGGREGATION_TYPE: "max"})
+        assert AggregatedFeatureGroup.resolve_subtype("aggr_config_placeholder", options) == "max"
+
+    def test_unrelated_name_resolves_to_none(self) -> None:
+        # Anchor on the declaration so this test is red until SUBTYPES lands.
+        assert AggregatedFeatureGroup.SUBTYPES is not None
+        assert AggregatedFeatureGroup.resolve_subtype("sales_total", Options()) is None
+
+
+class TestAggregatedSupportedSubtypes:
+    """supported_subtypes defaults to the full universe on the concrete Pandas class."""
+
+    def test_default_is_full_universe_for_any_framework(self) -> None:
+        assert PandasAggregatedFeatureGroup.supported_subtypes(PandasDataFrame) == AGGREGATION_UNIVERSE
+        assert PandasAggregatedFeatureGroup.supported_subtypes(PythonDictFramework) == AGGREGATION_UNIVERSE
+
+
+class TestAggregatedBehaviorNeutral:
+    """The declaration is behavior-neutral: every aggregation type stays supported on PandasDataFrame."""
+
+    def test_every_aggregation_type_stays_supported_on_pandas(self) -> None:
+        # Anchor on the declared universe so this test is red until SUBTYPES lands.
+        assert PandasAggregatedFeatureGroup.subtype_universe() == AGGREGATION_UNIVERSE
+        for aggregation_type in AggregatedFeatureGroup.AGGREGATION_TYPES:
+            supported = PandasAggregatedFeatureGroup.supports_compute_framework(
+                f"sales__{aggregation_type}_aggr", Options(), PandasDataFrame
+            )
+            assert supported is True, f"'{aggregation_type}' must stay supported on PandasDataFrame"
+
+
+class TestAggregatedSubtypeSupportMatrix:
+    """subtype_support_matrix reflects abstractness and gives every framework the full universe."""
+
+    def test_abstract_base_declares_universe_but_no_matrix(self) -> None:
+        assert inspect.isabstract(AggregatedFeatureGroup)
+        # Anchor on the declared universe so this test is red until SUBTYPES lands.
+        assert AggregatedFeatureGroup.subtype_universe() == AGGREGATION_UNIVERSE
+        assert AggregatedFeatureGroup.subtype_support_matrix() == {}
+
+    def test_pandas_matrix_gives_every_framework_the_full_universe(self) -> None:
+        matrix = PandasAggregatedFeatureGroup.subtype_support_matrix()
+        assert matrix, "the concrete Pandas class must have a non-empty support matrix"
+        declared = {cfw.get_class_name() for cfw in PandasAggregatedFeatureGroup.compute_framework_definition()}
+        assert set(matrix) == declared
+        assert matrix == {PandasDataFrame.get_class_name(): AGGREGATION_UNIVERSE}

--- a/tests/test_plugins/feature_group/experimental/test_base_aggregated_feature_group/test_aggregated_subtype_declaration.py
+++ b/tests/test_plugins/feature_group/experimental/test_base_aggregated_feature_group/test_aggregated_subtype_declaration.py
@@ -1,4 +1,4 @@
-"""Failing tests pinning the SubtypeDeclaration dogfooding of AggregatedFeatureGroup (issue #639, cycle 2)."""
+"""Pinning tests for the SubtypeDeclaration dogfooding of AggregatedFeatureGroup (issue #639, cycle 2)."""
 
 import inspect
 


### PR DESCRIPTION
Part of #639. Supersedes #672 (complete rebuild of the prototype under the composed API; no compatibility shims).

## What

One frozen value object declares the whole subtype capability of a FeatureGroup family:

``` python
class AggregatedFeatureGroup(...):
    SUBTYPES = SubtypeDeclaration(key=AGGREGATION_TYPE)

class RankFeatureGroup(...):
    SUBTYPES = SubtypeDeclaration(
        key="rank_type",
        parametric_families={"ntile": "N-tile bucketing"},
        supported={"SqliteFramework": {"dense"}},
    )

class FrameSpecFeatureGroup(...):
    SUBTYPES = SubtypeDeclaration(universe={"rows_1", "rows_7"}, resolver=my_resolver)
```

Exactly two shapes: a `PROPERTY_MAPPING` key with an enumerable value space, or an explicit universe plus resolver for flattened multi-axis families. `SUBTYPES = None` (the default) leaves a family byte-for-byte unchanged.

## Per persona

- Provider (`mloda.provider`): declare once; `supports_compute_framework` is derived. Parametric instances (`ntile_2`) canonicalize to their family for gating; declared literals never collapse.
- User (`mloda.user`): `resolve_feature` reports `subtype` and `subtype_family`, including on the unsupported-everywhere branch, and never raises even when a plugin resolver raises. Routing sends a feature only to frameworks supporting its subtype; pinning to an incapable framework fails at planning naming the capable ones.
- Steward (`mloda.steward`): `subtype_support_matrix()` and the new `FeatureGroupInfo` fields (`subtype_key`, `subtypes`, `parametric_subtypes`, `subtype_support`, `subtype_error`) enumerate capability without synthetic-feature probing.

## The declaration cannot lie

Misdeclarations fail at class definition: half declarations, keys absent from `PROPERTY_MAPPING` or predicate-only, family names colliding with declared values, support outside the universe. The declaration's mappings are read-only; subtype values are stringified on ingest; derived accessors cannot be overridden. A hand-overridden `supports_compute_framework` stays authoritative for matching but voids the declared matrix, surfaced as `subtype_error`. Abstract bases report their universe but no matrix. Undeclared subtypes stay open. A raising resolver degrades open instead of crashing planning.

## Dogfood and registry-shaped coverage

`AggregatedFeatureGroup` declares the keyed shape behavior-neutrally. Tests model the registry catalog's hardest families: rank with parametric `ntile_N` (routed around per framework) and a flattened frame spec (`rows_7` as a literal that never collapses).

## Validation

Two TDD cycles plus a review-fix round; two independent deep reviews on the diff, all seven accepted findings fixed and test-pinned. tox fully green: 5,133 passed, 171 skipped, ruff, mypy --strict (789 files), licenses, bandit.

Docs: `compute-framework-integration.md` (declaration section) and `discover-plugins.md` (enumeration surfaces).

Follow-up (separate, registry repo): re-express `DataOperationsCatalog` on the declaration.
