### PR TITLE
fix: GlobalFilter.add_filter accepts list parameter values (#664)

### DIFF
--- a/mloda/core/filter/filter_parameter.py
+++ b/mloda/core/filter/filter_parameter.py
@@ -20,17 +20,26 @@ class FilterParameter(Protocol):
     def max_exclusive(self) -> bool: ...
 
 
+def _make_hashable(value: Any) -> Any:
+    """Normalize collection values to tuples so the frozen dataclass stays hashable.
+
+    Sets are ordered deterministically, str/bytes stay scalar and are never exploded.
+    """
+    if isinstance(value, (str, bytes)):
+        return value
+    if isinstance(value, (set, frozenset)):
+        return tuple(sorted(value, key=repr))
+    if isinstance(value, list):
+        return tuple(value)
+    return value
+
+
 @dataclass(frozen=True)
 class FilterParameterImpl:
     _raw: tuple[tuple[str, Any], ...]
 
     @classmethod
     def from_dict(cls, params: dict[str, Any]) -> "FilterParameterImpl":
-        # Convert list values to tuples for hashability (frozen dataclass in a set).
-        def _make_hashable(v: Any) -> Any:
-            if isinstance(v, list):
-                return tuple(v)
-            return v
         return cls(_raw=tuple(sorted((k, _make_hashable(v)) for k, v in params.items())))
 
     @property
@@ -39,7 +48,12 @@ class FilterParameterImpl:
 
     @property
     def values(self) -> Optional[list[Any]]:
-        return cast(Optional[list[Any]], self._get("values"))
+        # Stored as a tuple for hashability; hand out the declared list type. Filter engines rely
+        # on this: PySpark's Column.isin only unwraps list/set, so a tuple would silently break it.
+        stored = self._get("values")
+        if isinstance(stored, tuple):
+            return list(stored)
+        return cast(Optional[list[Any]], stored)
 
     @property
     def min_value(self) -> Optional[Any]:

--- a/mloda/core/filter/filter_parameter.py
+++ b/mloda/core/filter/filter_parameter.py
@@ -26,7 +26,12 @@ class FilterParameterImpl:
 
     @classmethod
     def from_dict(cls, params: dict[str, Any]) -> "FilterParameterImpl":
-        return cls(_raw=tuple(sorted(params.items())))
+        # Convert list values to tuples for hashability (frozen dataclass in a set).
+        def _make_hashable(v: Any) -> Any:
+            if isinstance(v, list):
+                return tuple(v)
+            return v
+        return cls(_raw=tuple(sorted((k, _make_hashable(v)) for k, v in params.items())))
 
     @property
     def value(self) -> Optional[Any]:

--- a/tests/test_core/test_filter/test_filter_parameter.py
+++ b/tests/test_core/test_filter/test_filter_parameter.py
@@ -27,12 +27,15 @@ def test_from_dict_with_range_params() -> None:
 
 
 def test_from_dict_with_categorical_values() -> None:
-    """Test creating FilterParameterImpl with multiple values."""
+    """Test creating FilterParameterImpl with multiple values.
+
+    Internal storage normalizes the list to a tuple so the frozen dataclass stays hashable.
+    """
     params = {"values": ["A", "B", "C"]}
     filter_param = FilterParameterImpl.from_dict(params)
 
     assert isinstance(filter_param, FilterParameterImpl)
-    assert filter_param._raw == (("values", ["A", "B", "C"]),)
+    assert filter_param._raw == (("values", ("A", "B", "C")),)
 
 
 def test_from_dict_with_max_exclusive() -> None:
@@ -78,8 +81,14 @@ def test_value_property_with_string_value() -> None:
 
 
 def test_values_property_returns_list_for_categorical() -> None:
-    """Test values property returns list for categorical_inclusion filter."""
+    """Test values property returns list for categorical_inclusion filter.
+
+    The public accessor must honour its declared `Optional[list[Any]]` type even though the
+    internal storage keeps a tuple. Filter engines rely on this: PySpark's `Column.isin` only
+    unwraps list/set arguments, so leaking a tuple silently breaks the Spark categorical filter.
+    """
     filter_param = FilterParameterImpl.from_dict({"values": ["A", "B", "C"]})
+    assert isinstance(filter_param.values, list)
     assert filter_param.values == ["A", "B", "C"]
 
 
@@ -93,6 +102,7 @@ def test_values_property_with_empty_list() -> None:
     """Test values property handles empty list."""
     params: dict[str, Any] = {"values": []}
     filter_param = FilterParameterImpl.from_dict(params)
+    assert isinstance(filter_param.values, list)
     assert filter_param.values == []
 
 
@@ -240,3 +250,73 @@ def test_parameter_sorting_is_consistent() -> None:
 
     assert filter_param1._raw == filter_param2._raw
     assert filter_param1 == filter_param2
+
+
+# --- Collection value normalization tests (see issue #664) ---
+#
+# Contract: collection values are stored hashable (tuple) in `_raw`, but the public `values`
+# property returns a `list`, matching its declared type. Scalars must never be exploded.
+
+
+def test_from_dict_with_list_values_normalizes_raw_to_tuple() -> None:
+    """Test a list value is stored as a tuple internally so the frozen dataclass stays hashable."""
+    filter_param = FilterParameterImpl.from_dict({"values": ["EU", "NA"]})
+
+    assert filter_param._raw == (("values", ("EU", "NA")),)
+    assert isinstance(hash(filter_param), int)
+
+
+def test_from_dict_with_set_values_is_hashable() -> None:
+    """Test a set value is accepted and does not break hashing."""
+    params: dict[str, Any] = {"values": {"EU", "NA"}}
+    filter_param = FilterParameterImpl.from_dict(params)
+
+    assert isinstance(hash(filter_param), int)
+
+
+def test_values_property_returns_list_for_set_input() -> None:
+    """Test a set value comes back out of the public accessor as a list."""
+    params: dict[str, Any] = {"values": {"EU", "NA"}}
+    filter_param = FilterParameterImpl.from_dict(params)
+
+    assert isinstance(filter_param.values, list)
+    assert sorted(filter_param.values) == ["EU", "NA"]
+
+
+def test_values_property_returns_list_for_tuple_input() -> None:
+    """Test a tuple value comes back out of the public accessor as a list."""
+    filter_param = FilterParameterImpl.from_dict({"values": ("EU", "NA")})
+
+    assert isinstance(filter_param.values, list)
+    assert filter_param.values == ["EU", "NA"]
+
+
+def test_values_property_does_not_explode_string_value() -> None:
+    """Test a plain string value is not treated as a sequence of characters.
+
+    Normalizing collection values must not reach into scalars: a string is iterable, so a naive
+    conversion would turn "EU" into ["E", "U"]. `values` is typed as a list, so the scalar is read
+    back through `Any`.
+    """
+    filter_param = FilterParameterImpl.from_dict({"values": "EU"})
+    values: Any = filter_param.values
+
+    assert values == "EU"
+    assert values != ["E", "U"]
+
+
+def test_value_property_does_not_explode_string_value() -> None:
+    """Test the scalar `value` accessor keeps a string intact."""
+    filter_param = FilterParameterImpl.from_dict({"value": "EU"})
+
+    assert filter_param.value == "EU"
+
+
+def test_list_and_tuple_values_are_equal_and_hash_equal() -> None:
+    """Test list and tuple inputs normalize to the same parameter so they deduplicate."""
+    from_list = FilterParameterImpl.from_dict({"values": ["EU"]})
+    from_tuple = FilterParameterImpl.from_dict({"values": ("EU",)})
+
+    assert from_list == from_tuple
+    assert hash(from_list) == hash(from_tuple)
+    assert len({from_list, from_tuple}) == 1

--- a/tests/test_core/test_filter/test_global_filter.py
+++ b/tests/test_core/test_filter/test_global_filter.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta, timezone
+from typing import Any
 
 import pytest
 
@@ -266,3 +267,66 @@ class TestGlobalFilterTimeTravel:
         filter_features = {f.filter_feature.name for f in self.global_filter.filters}
         assert event_time_column in filter_features
         assert validity_time_column in filter_features
+
+
+class TestGlobalFilterCategoricalInclusion:
+    """Collection filter values must survive `GlobalFilter.add_filter` (issue #664).
+
+    `add_filter` puts the `SingleFilter` into a `set`, which hashes the parameter. Collection
+    values therefore need a hashable internal representation, but the public `values` accessor
+    must still hand back a `list` for the filter engines that consume it.
+    """
+
+    def setup_method(self) -> None:
+        self.global_filter = GlobalFilter()
+
+    def _only_filter(self) -> SingleFilter:
+        assert len(self.global_filter.filters) == 1
+        return next(iter(self.global_filter.filters))
+
+    def test_add_filter_with_list_value(self) -> None:
+        """Test add_filter accepts a list value without raising TypeError: unhashable type."""
+        self.global_filter.add_filter("region", FilterType.CATEGORICAL_INCLUSION, {"values": ["EU", "NA"]})
+
+        added_filter = self._only_filter()
+        assert added_filter.filter_type == "categorical_inclusion"
+        assert isinstance(added_filter.parameter, FilterParameterImpl)
+
+    def test_add_filter_with_list_value_exposes_values_as_list(self) -> None:
+        """Test the value round-trips through add_filter as a list, not a tuple."""
+        self.global_filter.add_filter("region", FilterType.CATEGORICAL_INCLUSION, {"values": ["EU", "NA"]})
+
+        values = self._only_filter().parameter.values
+        assert isinstance(values, list)
+        assert values == ["EU", "NA"]
+
+    def test_add_filter_with_set_value(self) -> None:
+        """Test add_filter accepts a set value and exposes it as a list."""
+        parameter: dict[str, Any] = {"values": {"EU", "NA"}}
+        self.global_filter.add_filter("region", FilterType.CATEGORICAL_INCLUSION, parameter)
+
+        values = self._only_filter().parameter.values
+        assert isinstance(values, list)
+        assert sorted(values) == ["EU", "NA"]
+
+    def test_add_filter_with_string_value_is_not_exploded(self) -> None:
+        """Test a scalar string value is not split into its characters."""
+        self.global_filter.add_filter("region", FilterType.CATEGORICAL_INCLUSION, {"values": "EU"})
+
+        values: Any = self._only_filter().parameter.values
+        assert values == "EU"
+        assert values != ["E", "U"]
+
+    def test_add_filter_deduplicates_list_and_tuple_values(self) -> None:
+        """Test list and tuple values normalize to the same filter and deduplicate in the set."""
+        self.global_filter.add_filter("region", FilterType.CATEGORICAL_INCLUSION, {"values": ["EU"]})
+        self.global_filter.add_filter("region", FilterType.CATEGORICAL_INCLUSION, {"values": ("EU",)})
+
+        assert len(self.global_filter.filters) == 1
+
+    def test_add_filter_keeps_distinct_collection_values_apart(self) -> None:
+        """Test different collection values still produce distinct filters."""
+        self.global_filter.add_filter("region", FilterType.CATEGORICAL_INCLUSION, {"values": ["EU"]})
+        self.global_filter.add_filter("region", FilterType.CATEGORICAL_INCLUSION, {"values": ["NA"]})
+
+        assert len(self.global_filter.filters) == 2

--- a/tests/test_core/test_filter/test_single_filter_parameter_integration.py
+++ b/tests/test_core/test_filter/test_single_filter_parameter_integration.py
@@ -62,12 +62,17 @@ def test_value_property_for_equal_filter() -> None:
 
 
 def test_values_property_for_categorical_inclusion() -> None:
-    """Test accessing parameter.values for categorical_inclusion filter."""
+    """Test accessing parameter.values for categorical_inclusion filter.
+
+    Filter engines consume this accessor directly, so it must stay a list regardless of how the
+    parameter is stored internally.
+    """
     single_filter = SingleFilter(
         filter_feature="category",
         filter_type=FilterType.CATEGORICAL_INCLUSION,
         parameter={"values": ["A", "B", "C"]},
     )
+    assert isinstance(single_filter.parameter.values, list)
     assert single_filter.parameter.values == ["A", "B", "C"]
 
 


### PR DESCRIPTION
Fixes #664. Builds on @muhamedfazalps's work in #667, whose commit is preserved here; this PR adds one commit on top to complete the fix and cover it with tests.

## Problem

`GlobalFilter.add_filter()` raised `TypeError: unhashable type: 'list'` for a list filter parameter value, because `FilterParameterImpl` is a frozen dataclass stored in a `set`. The documented `categorical_inclusion` example was not runnable as written.

## What the first commit does

Normalizes list values to tuples in `FilterParameterImpl.from_dict()`, which makes the dataclass hashable and fixes the crash.

## What the second commit adds

The tuple leaked out through the public `values` property, which is declared `Optional[list[Any]]` and returns via `cast`, so mypy stayed silent while the runtime type changed. Filter engines read that property directly, and PySpark's `Column.isin` only unwraps `list`/`set`, never `tuple` (`pyspark/sql/classic/column.py:484`), so a tuple would silently break Spark's categorical inclusion filter. The Spark tests skip without a JVM, so CI would not have caught it.

- Keep the tuple as internal storage for hashability, and hand out the declared `list` type from the accessor.
- Normalize `set` values as well, ordered deterministically (set iteration order is not stable across processes, so the stored tuple would otherwise vary between runs for the same logical filter).
- Exclude `str`/`bytes` from normalization, so a scalar `{"values": "EU"}` is not exploded into `["E", "U"]`.
- Tests exercise `GlobalFilter.add_filter`, the set-insertion path that actually raised, rather than constructing a bare `SingleFilter`. That gap is why the bug shipped.

## Testing

Full `tox` is green: 5035 passed, ruff, mypy --strict and bandit clean. The example from the issue now runs, and `{"values": ["EU"]}` and `{"values": ("EU",)}` now deduplicate inside the `GlobalFilter` set.