### PR TITLE
feat: a class-name feature_group scope reaches subclasses like the class object (#682)

### DIFF
--- a/docs/docs/in_depth/feature-config.md
+++ b/docs/docs/in_depth/feature-config.md
@@ -126,7 +126,11 @@ When two enabled sources declare the same column (for example a shared join key)
 ]
 ```
 
-The config form takes a non-empty class-name string only, since JSON cannot express a class object. The string matches the exact class name: it does not match subclasses, and two classes with the same name in different modules stay ambiguous. In Python, `Feature("subject_token", feature_group=ClaimsReader)` also accepts the class object. The scope is resolution-only and excluded from feature identity, so requesting the same name scoped to two different sources in one list raises `ValueError: Duplicate feature setup: <name>` rather than silently dropping one; see [Feature Group resolution errors](troubleshooting/feature-group-resolution-errors.md).
+The config form takes a non-empty class-name string only, since JSON cannot express a class object. In Python, `Feature("subject_token", feature_group=ClaimsReader)` also accepts the class object.
+
+The string matches the named class and its subclasses, preferring the most specific one, exactly like the class object. Naming an abstract family base such as `"AggregatedFeatureGroup"` therefore selects the concrete subclass for the compute framework of the run, so the config does not have to name a framework-specific class. Two classes with the same name in different modules both match and stay ambiguous, and the root `FeatureGroup` base is rejected.
+
+The scope is resolution-only and excluded from feature identity, so requesting the same name scoped to two different sources in one list raises `ValueError: Duplicate feature setup: <name>` rather than silently dropping one; see [Feature Group resolution errors](troubleshooting/feature-group-resolution-errors.md).
 
 `feature_group` is a top-level field next to `name`: writing it inside `options`, `group_options`, or `context_options` is rejected with a validation error.
 

--- a/docs/docs/in_depth/feature-config.md
+++ b/docs/docs/in_depth/feature-config.md
@@ -128,7 +128,9 @@ When two enabled sources declare the same column (for example a shared join key)
 
 The config form takes a non-empty class-name string only, since JSON cannot express a class object. In Python, `Feature("subject_token", feature_group=ClaimsReader)` also accepts the class object.
 
-The string matches the named class and its subclasses, preferring the most specific one, exactly like the class object. Naming an abstract family base such as `"AggregatedFeatureGroup"` therefore selects the concrete subclass for the compute framework of the run, so the config does not have to name a framework-specific class. Two classes with the same name in different modules both match and stay ambiguous, and the root `FeatureGroup` base is rejected.
+The string matches the named class and its subclasses, preferring the most specific one, exactly like the class object. Naming an abstract family base such as `"AggregatedFeatureGroup"` therefore selects the concrete subclass, so the config does not have to name a compute-framework-specific class.
+
+The scope narrows candidates but does not break ties between them. If the run enables two compute frameworks whose concrete subclasses both match, the family base stays ambiguous and raises, exactly as the bare name does; enable one framework for the run. Two classes with the same name in different modules likewise both match and stay ambiguous, and the root `FeatureGroup` base is rejected.
 
 The scope is resolution-only and excluded from feature identity, so requesting the same name scoped to two different sources in one list raises `ValueError: Duplicate feature setup: <name>` rather than silently dropping one; see [Feature Group resolution errors](troubleshooting/feature-group-resolution-errors.md).
 

--- a/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
+++ b/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
@@ -52,10 +52,10 @@ def get_domain(cls):
 When two enabled sources declare the same column (for example a shared join key), requesting that column by bare name is ambiguous. Scope the request to one source. The scope is resolution-only and does not affect feature identity.
 
 ``` python
-# RECOMMENDED: class object, collision-proof
+# class object, collision-proof
 Feature("subject_token", feature_group=ClaimsReader)
 
-# class-name string form
+# class-name string form, the only form a JSON config can carry
 Feature("subject_token", feature_group="ClaimsReader")
 ```
 
@@ -69,9 +69,18 @@ The same scope in a JSON config ([feature config](../feature-config.md)):
 
 The config form takes the class-name string only, because JSON cannot express a class object; the class-object form is Python-only.
 
+Both forms match the scoped class and its subclasses, preferring the most specific one. Naming an abstract family base therefore selects the concrete subclass for the compute framework of the run, so a config can scope to the family without knowing which framework will execute it:
+
+``` json
+[
+    {"name": "age__mean_aggr", "feature_group": "AggregatedFeatureGroup"}
+]
+```
+
 Caveats:
 
-- The string form matches the exact class name only: it does not match subclasses, and two classes with the same name in different modules stay ambiguous. The class-object form matches the class and its registered subclasses, preferring the most specific subclass, so prefer the class object.
+- The class object is collision-proof; the string form is not. Two classes with the same name in different modules both match the string, so the request stays ambiguous and raises. A base whose subclasses do not narrow to one candidate also raises.
+- The root `FeatureGroup` base is rejected in either form: it would scope to everything.
 - The scope is resolution-only and excluded from Feature identity, so two requests for the same column name scoped to different sources compare equal. Requesting both in one features list raises `ValueError: Duplicate feature setup: <name>` rather than silently dropping one, so you are told, not surprised. Inside a single `input_features()` returning a set literal, a second same-name feature with a different scope is silently deduplicated by the Python set itself before the engine ever sees it, so never scope the same name twice within one feature group. To read the same column from two sources side by side, give them distinct derived feature names.
 
 ## FeatureGroup Redefinition Errors

--- a/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
+++ b/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
@@ -69,7 +69,7 @@ The same scope in a JSON config ([feature config](../feature-config.md)):
 
 The config form takes the class-name string only, because JSON cannot express a class object; the class-object form is Python-only.
 
-Both forms match the scoped class and its subclasses, preferring the most specific one. Naming an abstract family base therefore selects the concrete subclass for the compute framework of the run, so a config can scope to the family without knowing which framework will execute it:
+Both forms match the scoped class and its subclasses, preferring the most specific one. Naming an abstract family base therefore selects the concrete subclass, so a config can scope to the family without naming a compute-framework-specific class:
 
 ``` json
 [
@@ -79,8 +79,10 @@ Both forms match the scoped class and its subclasses, preferring the most specif
 
 Caveats:
 
-- The class object is collision-proof; the string form is not. Two classes with the same name in different modules both match the string, so the request stays ambiguous and raises. A base whose subclasses do not narrow to one candidate also raises.
-- The root `FeatureGroup` base is rejected in either form: it would scope to everything.
+- The scope narrows candidates; it does not break ties between them. If the run enables two compute frameworks whose concrete subclasses both match, the family base stays ambiguous and raises, exactly as the bare name does. Enable one framework for the run, or pin `compute_frameworks` on the `Feature` (Python only).
+- The class object is collision-proof; the string form is not. Two classes with the same name in different modules both match the string, so the request stays ambiguous and raises.
+- Neither form pins one exact class: a subclass of the named class is preferred over it. To resolve to a specific implementation, name that implementation.
+- The root `FeatureGroup` base is rejected in either form: it names no family.
 - The scope is resolution-only and excluded from Feature identity, so two requests for the same column name scoped to different sources compare equal. Requesting both in one features list raises `ValueError: Duplicate feature setup: <name>` rather than silently dropping one, so you are told, not surprised. Inside a single `input_features()` returning a set literal, a second same-name feature with a different scope is silently deduplicated by the Python set itself before the engine ever sees it, so never scope the same name twice within one feature group. To read the same column from two sources side by side, give them distinct derived feature names.
 
 ## FeatureGroup Redefinition Errors

--- a/mloda/core/abstract_plugins/components/feature.py
+++ b/mloda/core/abstract_plugins/components/feature.py
@@ -179,7 +179,7 @@ class Feature:
         root_rejection = "feature_group cannot be the root FeatureGroup base class; a concrete subclass is required"
         if isinstance(feature_group, str):
             stripped = feature_group.strip()
-            # String scopes match by ancestry, so the root base name would match every candidate.
+            # The root names no feature group family; rejected here as in the class-object form below.
             if stripped == FeatureGroup.get_class_name():
                 raise TypeError(root_rejection)
             return stripped or None

--- a/mloda/core/abstract_plugins/components/feature.py
+++ b/mloda/core/abstract_plugins/components/feature.py
@@ -174,13 +174,17 @@ class Feature:
     ) -> str | type[FeatureGroup] | None:
         if feature_group is None:
             return None
-        if isinstance(feature_group, str):
-            stripped = feature_group.strip()
-            return stripped or None
         from mloda.core.abstract_plugins.feature_group import FeatureGroup
 
+        root_rejection = "feature_group cannot be the root FeatureGroup base class; a concrete subclass is required"
+        if isinstance(feature_group, str):
+            stripped = feature_group.strip()
+            # String scopes match by ancestry, so the root base name would match every candidate.
+            if stripped == FeatureGroup.get_class_name():
+                raise TypeError(root_rejection)
+            return stripped or None
         if feature_group is FeatureGroup:
-            raise TypeError("feature_group cannot be the root FeatureGroup base class; a concrete subclass is required")
+            raise TypeError(root_rejection)
         if isinstance(feature_group, type) and issubclass(feature_group, FeatureGroup):
             return feature_group
         raise TypeError(

--- a/mloda/core/api/feature_config/models.py
+++ b/mloda/core/api/feature_config/models.py
@@ -11,6 +11,9 @@ from typing import Any, Optional
 
 def validate_feature_group_scope(value: Any) -> Optional[str]:
     """Config scope is a non-empty class-name string; the class-object form is Python-only."""
+    # Local import: feature_group pulls in the plugin machinery, which this data-model module stays free of.
+    from mloda.core.abstract_plugins.feature_group import FeatureGroup
+
     if value is None:
         return None
     if not isinstance(value, str):
@@ -18,8 +21,14 @@ def validate_feature_group_scope(value: Any) -> Optional[str]:
             "'feature_group' must be a feature group class-name string; "
             "the class-object form is only available in Python, not in a config"
         )
-    if not value.strip():
+    stripped = value.strip()
+    if not stripped:
         raise ValueError("'feature_group' must be a non-empty feature group class-name string")
+    if stripped == FeatureGroup.get_class_name():
+        raise ValueError(
+            "'feature_group' cannot be the root FeatureGroup base class name; it names no feature group family, "
+            "so a concrete subclass name is required"
+        )
     return value
 
 

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -44,9 +44,10 @@ def split_frameworks_by_capability(
 def matches_feature_group_scope(feature_group: type[FeatureGroup], scope: str | type[FeatureGroup]) -> bool:
     """Is the candidate inside the requested scope, for both the class-object and the string form.
 
-    The string form is issubclass expressed over class names, so a config that can only carry a name
-    keeps the same subclass-preferring semantics. The root FeatureGroup base is excluded from the
-    ancestry walk because every candidate carries it, which would make it a wildcard.
+    The string form matches the named class and its subclasses by walking the candidate's ancestry
+    (MRO), so a config that can only carry a name keeps the same subclass-preferring semantics. The
+    root FeatureGroup base is excluded from that walk because every candidate carries it, which would
+    make it a wildcard.
     """
     if isinstance(scope, type):
         return issubclass(feature_group, scope)

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -41,6 +41,21 @@ def split_frameworks_by_capability(
     return supported, rejected
 
 
+def matches_feature_group_scope(feature_group: type[FeatureGroup], scope: str | type[FeatureGroup]) -> bool:
+    """Is the candidate inside the requested scope, for both the class-object and the string form.
+
+    The string form is issubclass expressed over class names, so a config that can only carry a name
+    keeps the same subclass-preferring semantics. The root FeatureGroup base is excluded from the
+    ancestry walk because every candidate carries it, which would make it a wildcard.
+    """
+    if isinstance(scope, type):
+        return issubclass(feature_group, scope)
+    return any(
+        ancestor is not FeatureGroup and issubclass(ancestor, FeatureGroup) and ancestor.get_class_name() == scope
+        for ancestor in feature_group.__mro__
+    )
+
+
 def _scope_callout(feature: Feature) -> str | None:
     """Render the shared scope callout, or None when the feature is unscoped."""
     scope = feature.feature_group_scope
@@ -143,11 +158,7 @@ class IdentifyFeatureGroupClass:
 
     def _filter_feature_group_by_scope(self, feature_group: type[FeatureGroup], feature: Feature) -> bool:
         scope = feature.feature_group_scope
-        if scope is None:
-            return True
-        if isinstance(scope, type):
-            return issubclass(feature_group, scope)
-        return feature_group.get_class_name() == scope
+        return scope is None or matches_feature_group_scope(feature_group, scope)
 
     def _filter_feature_group_by_framework(
         self,

--- a/tests/test_core/test_abstract_plugins/test_components/test_feature_group_scope.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_feature_group_scope.py
@@ -272,6 +272,20 @@ def test_scope_root_feature_group_class_raises_typeerror() -> None:
     assert "unexpected keyword" not in message
 
 
+def test_scope_root_feature_group_name_string_raises_typeerror() -> None:
+    """The root base NAME as a string scope must be rejected too (issue #682).
+
+    String scopes match by ancestry, and every FeatureGroup has the root base in
+    its MRO, so the string "FeatureGroup" would act as a wildcard matching every
+    candidate. It must raise the same TypeError as the class-object root form.
+    """
+    with pytest.raises(TypeError) as exc_info:
+        Feature("x", feature_group="FeatureGroup")
+    message = str(exc_info.value)
+    assert "feature_group" in message
+    assert "unexpected keyword" not in message
+
+
 # ---------------------------------------------------------------------------
 # String normalization: whitespace-only scopes collapse to None
 # ---------------------------------------------------------------------------

--- a/tests/test_core/test_api/feature_config/test_feature_config_feature_group_scope.py
+++ b/tests/test_core/test_api/feature_config/test_feature_config_feature_group_scope.py
@@ -26,7 +26,9 @@ from mloda.user import Feature
 from mloda.user import PluginCollector
 from mloda.user import mloda
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.feature_group.experimental.aggregated_feature_group.base import AggregatedFeatureGroup
 from mloda_plugins.feature_group.experimental.aggregated_feature_group.pandas import PandasAggregatedFeatureGroup
+from mloda_plugins.feature_group.experimental.aggregated_feature_group.pyarrow import PyArrowAggregatedFeatureGroup
 
 
 # ---------------------------------------------------------------------------
@@ -327,6 +329,63 @@ def test_loader_nested_in_features_rejects_whitespace_only_feature_group() -> No
 
 
 # ---------------------------------------------------------------------------
+# The root FeatureGroup base name is rejected by the config layer (issue #682)
+#
+# A string scope matches by ancestry, so the root base name would scope to every
+# candidate. Feature() rejects it with a TypeError, but a config value must fail
+# as a config error: ValueError from the config validation, like every other
+# invalid scope value, on the top-level path AND the nested in_features path.
+# ---------------------------------------------------------------------------
+
+ROOT_BASE_NAME = FeatureGroup.get_class_name()
+
+
+def test_feature_config_rejects_root_feature_group_base_name() -> None:
+    """The root base name is a wildcard scope and must be rejected by FeatureConfig."""
+    with pytest.raises(ValueError, match="feature_group"):
+        FeatureConfig(name="shared_token", feature_group=ROOT_BASE_NAME)
+
+
+def test_loader_rejects_root_feature_group_base_name() -> None:
+    """The loader rejects the root base name with a config ValueError, not a Python TypeError."""
+    config_str = '[{"name": "shared_token", "feature_group": "FeatureGroup"}]'
+
+    with pytest.raises(ValueError, match="feature_group"):
+        load_features_from_config(config_str)
+
+
+def test_nested_in_features_rejects_root_feature_group_base_name() -> None:
+    """The nested path bypasses FeatureConfig, so it must reject the root base name itself."""
+    options: dict[str, Any] = {
+        "in_features": {
+            "name": "shared_token",
+            "feature_group": ROOT_BASE_NAME,
+        },
+    }
+
+    with pytest.raises(ValueError, match="feature_group"):
+        process_nested_features(options)
+
+
+def test_loader_nested_in_features_rejects_root_feature_group_base_name() -> None:
+    """The same nested rejection surfaces through load_features_from_config on a JSON string."""
+    config_str = """[
+        {
+            "name": "outer_feature",
+            "options": {
+                "in_features": {
+                    "name": "shared_token",
+                    "feature_group": "FeatureGroup"
+                }
+            }
+        }
+    ]"""
+
+    with pytest.raises(ValueError, match="feature_group"):
+        load_features_from_config(config_str)
+
+
+# ---------------------------------------------------------------------------
 # Misplaced scope: "feature_group" inside an option container is a hard error
 #
 # The scope is a TOP-LEVEL field. Written inside "options" (or the group/context
@@ -532,7 +591,13 @@ class ConfigScopeAggregationSource(FeatureGroup):
 
 
 def test_end2end_config_abstract_family_base_scope_resolves_to_pandas_subclass() -> None:
-    """A config scoped to 'AggregatedFeatureGroup' runs on the Pandas subclass."""
+    """A config scoped to 'AggregatedFeatureGroup' runs on the Pandas subclass.
+
+    The allowlist keeps the whole family accessible, which is the situation a real
+    config user is in: the scoped abstract base itself, plus a rival concrete
+    sibling for another framework. The base drops out because it cannot be
+    instantiated, the PyArrow sibling because its framework is not enabled.
+    """
     config_str = '[{"name": "config_scope_sales__mean_aggr", "feature_group": "AggregatedFeatureGroup"}]'
 
     features = load_features_from_config(config_str, format="json")
@@ -541,7 +606,12 @@ def test_end2end_config_abstract_family_base_scope_resolves_to_pandas_subclass()
             features,
             compute_frameworks={PandasDataFrame},
             plugin_collector=PluginCollector.enabled_feature_groups(
-                {ConfigScopeAggregationSource, PandasAggregatedFeatureGroup}
+                {
+                    ConfigScopeAggregationSource,
+                    AggregatedFeatureGroup,
+                    PandasAggregatedFeatureGroup,
+                    PyArrowAggregatedFeatureGroup,
+                }
             ),
         )
     )

--- a/tests/test_core/test_api/feature_config/test_feature_config_feature_group_scope.py
+++ b/tests/test_core/test_api/feature_config/test_feature_config_feature_group_scope.py
@@ -26,6 +26,7 @@ from mloda.user import Feature
 from mloda.user import PluginCollector
 from mloda.user import mloda
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.feature_group.experimental.aggregated_feature_group.pandas import PandasAggregatedFeatureGroup
 
 
 # ---------------------------------------------------------------------------
@@ -505,3 +506,46 @@ def test_end2end_scoped_config_feature_resolves_to_source_b() -> None:
     df = results[0]
     assert "config_shared_token" in df.columns
     assert list(df["config_shared_token"].values) == ["b1", "b2"]
+
+
+# ---------------------------------------------------------------------------
+# End to end: a config names an ABSTRACT family base and reaches the concrete
+# per-framework subclass (issue #682)
+#
+# A config can only carry a class-name STRING. Naming the framework-agnostic
+# family base "AggregatedFeatureGroup" must resolve to the concrete
+# PandasAggregatedFeatureGroup for the active compute framework, so the config
+# stays free of a compute-framework-specific leaf class name.
+# ---------------------------------------------------------------------------
+
+
+class ConfigScopeAggregationSource(FeatureGroup):
+    """Source data for the aggregated-family scope test."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={"config_scope_sales"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {"config_scope_sales": [10, 20, 30, 40]}
+
+
+def test_end2end_config_abstract_family_base_scope_resolves_to_pandas_subclass() -> None:
+    """A config scoped to 'AggregatedFeatureGroup' runs on the Pandas subclass."""
+    config_str = '[{"name": "config_scope_sales__mean_aggr", "feature_group": "AggregatedFeatureGroup"}]'
+
+    features = load_features_from_config(config_str, format="json")
+    results = list(
+        mloda.run_all(
+            features,
+            compute_frameworks={PandasDataFrame},
+            plugin_collector=PluginCollector.enabled_feature_groups(
+                {ConfigScopeAggregationSource, PandasAggregatedFeatureGroup}
+            ),
+        )
+    )
+
+    aggregated = [df for df in results if "config_scope_sales__mean_aggr" in df.columns]
+    assert len(aggregated) == 1
+    assert aggregated[0]["config_scope_sales__mean_aggr"].iloc[0] == 25.0

--- a/tests/test_core/test_prepare/test_feature_group_scope_resolution.py
+++ b/tests/test_core/test_prepare/test_feature_group_scope_resolution.py
@@ -1,13 +1,20 @@
-"""Resolution-scope tests for IdentifyFeatureGroupClass (issue #508).
+"""Resolution-scope tests for IdentifyFeatureGroupClass (issues #508, #682).
 
 Two source feature groups (A and B) both match the shared feature name
 "subject_token". Requesting it unscoped is ambiguous ("Multiple feature groups
-found"). The new per-feature scope disambiguates resolution to a single source,
+found"). The per-feature scope disambiguates resolution to a single source,
 by class identity or by class-name string, without changing feature identity.
+
+Both scope forms match by ancestry (#682): a candidate matches when the scoped
+class is in its MRO, or, for the string form, when any class in its MRO (below
+the root FeatureGroup base) carries the scoped name. filter_subclasses then
+prefers the most specific candidate.
 
 Follows the construction conventions in test_identify_feature_group_error_message.py.
 """
 
+import inspect
+from abc import abstractmethod
 from typing import Optional
 
 import pytest
@@ -379,32 +386,194 @@ def test_scoped_ambiguity_callout_precedes_troubleshooting_url() -> None:
 
 
 # ---------------------------------------------------------------------------
-# String-form scopes match the exact class name only (no subclass matching)
+# String-form scopes match by ancestry, like the class-object form (issue #682)
+#
+# A candidate matches a string scope when any class in its FeatureGroup ancestry
+# (its MRO, excluding the root FeatureGroup base) carries that class name. This
+# lets a JSON config name an abstract family base and still reach the concrete
+# per-framework subclass, instead of hard-coding a compute-framework leaf class.
 # ---------------------------------------------------------------------------
 
 
-def test_base_class_name_string_scope_does_not_match_subclass() -> None:
-    """Pinning test: a STRING scope matches the exact class name only, never subclasses.
+def test_base_class_name_string_scope_resolves_to_accessible_subclass() -> None:
+    """A base-name STRING scope matches subclasses of the named class.
 
-    This pins the INTENDED asymmetry between the two scope forms: a class-object
-    scope uses issubclass matching (see
-    test_base_class_scope_resolves_to_accessible_subclass), while the string form
-    'ScopeSourceA' compares against get_class_name() exactly. With only the
-    subclass ScopeSourceASub accessible, the base-name string scope therefore
-    matches nothing and raises 'No feature groups found', naming the scope.
-
-    This is a characterization test of current behaviour; it may already pass.
+    The string form now carries the same subclass-preferring semantics as the
+    class-object form (see test_base_class_scope_resolves_to_accessible_subclass).
+    With only the subclass ScopeSourceASub accessible, the base-name string scope
+    'ScopeSourceA' resolves to that subclass.
     """
     feature = Feature("subject_token", feature_group=ScopeSourceA.get_class_name())
     accessible_plugins: FeatureGroupEnvironmentMapping = {
         ScopeSourceASub: {MockComputeFramework},
     }
 
-    with pytest.raises(ValueError, match="No feature groups found") as exc_info:
+    identifier = IdentifyFeatureGroupClass(
+        feature=feature,
+        accessible_plugins=accessible_plugins,
+        links=None,
+        data_access_collection=None,
+    )
+    resolved_feature_group, _compute_frameworks = identifier.get()
+    assert resolved_feature_group is ScopeSourceASub
+
+
+def test_base_class_name_string_scope_prefers_subclass_when_both_accessible() -> None:
+    """With base AND subclass accessible, a base-name string scope resolves to the subclass.
+
+    Mirrors test_base_class_scope_prefers_subclass_when_both_accessible for the
+    string form: ancestry matching keeps both candidates, then filter_subclasses
+    (same compute-framework set) drops the base in favour of the subclass.
+    """
+    feature = Feature("subject_token", feature_group=ScopeSourceA.get_class_name())
+    accessible_plugins: FeatureGroupEnvironmentMapping = {
+        ScopeSourceA: {MockComputeFramework},
+        ScopeSourceASub: {MockComputeFramework},
+    }
+
+    identifier = IdentifyFeatureGroupClass(
+        feature=feature,
+        accessible_plugins=accessible_plugins,
+        links=None,
+        data_access_collection=None,
+    )
+    resolved_feature_group, _compute_frameworks = identifier.get()
+    assert resolved_feature_group is ScopeSourceASub
+
+
+def test_string_scope_does_not_widen_to_unrelated_groups() -> None:
+    """Ancestry matching stays narrow: non-descendants are still filtered out.
+
+    ScopeSourceB also matches 'subject_token' but is unrelated to the scoped
+    class, so the base-name string scope 'ScopeSourceA' must exclude it. Widening
+    would turn this into 'Multiple feature groups found'.
+    """
+    feature = Feature("subject_token", feature_group=ScopeSourceA.get_class_name())
+    accessible_plugins: FeatureGroupEnvironmentMapping = {
+        ScopeSourceASub: {MockComputeFramework},
+        ScopeSourceB: {MockComputeFramework},
+    }
+
+    identifier = IdentifyFeatureGroupClass(
+        feature=feature,
+        accessible_plugins=accessible_plugins,
+        links=None,
+        data_access_collection=None,
+    )
+    resolved_feature_group, _compute_frameworks = identifier.get()
+    assert resolved_feature_group is ScopeSourceASub
+
+
+class ScopeAbstractFamilyBase(FeatureGroup):
+    """Abstract family base: matches "subject_token" but cannot be instantiated."""
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return {"subject_token"}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == "subject_token"
+
+    @classmethod
+    @abstractmethod
+    def _family_hook(cls) -> str:
+        """Abstract hook that makes this base abstract."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class ScopeConcreteFamilyMember(ScopeAbstractFamilyBase):
+    """The concrete implementation of the abstract family base."""
+
+    @classmethod
+    def _family_hook(cls) -> str:
+        return "concrete"
+
+
+def test_abstract_base_name_string_scope_resolves_to_concrete_subclass() -> None:
+    """A string scope naming an ABSTRACT family base resolves to the concrete subclass.
+
+    This is the config use case of issue #682: a JSON config can only carry a
+    class-name string, so naming the abstract family base must reach the concrete
+    implementation instead of forcing the config to name a framework-specific leaf.
+    """
+    assert inspect.isabstract(ScopeAbstractFamilyBase), "fixture must be abstract"
+    assert not inspect.isabstract(ScopeConcreteFamilyMember), "fixture must be concrete"
+
+    feature = Feature("subject_token", feature_group=ScopeAbstractFamilyBase.get_class_name())
+    accessible_plugins: FeatureGroupEnvironmentMapping = {
+        ScopeAbstractFamilyBase: {MockComputeFramework},
+        ScopeConcreteFamilyMember: {MockComputeFramework},
+        ScopeSourceB: {MockComputeFramework},
+    }
+
+    identifier = IdentifyFeatureGroupClass(
+        feature=feature,
+        accessible_plugins=accessible_plugins,
+        links=None,
+        data_access_collection=None,
+    )
+    resolved_feature_group, _compute_frameworks = identifier.get()
+    assert resolved_feature_group is ScopeConcreteFamilyMember
+
+
+def test_string_scope_matching_two_same_named_bases_stays_ambiguous() -> None:
+    """Ancestry matching does not disambiguate a class-name collision.
+
+    Two distinct base classes share the name 'DupNameAncestorBase' (different
+    "modules"), each with its own concrete subclass. The string scope matches both
+    subclasses through their ancestry, so resolution stays ambiguous and must name
+    the scope.
+    """
+    dup_base_a = type("DupNameAncestorBase", (_DupNameBase,), {})
+    dup_base_b = type("DupNameAncestorBase", (_DupNameBase,), {})
+    sub_a = type("DupNameAncestorSubA", (dup_base_a,), {})
+    sub_b = type("DupNameAncestorSubB", (dup_base_b,), {})
+    accessible_plugins: FeatureGroupEnvironmentMapping = {
+        sub_a: {MockComputeFramework},
+        sub_b: {MockComputeFramework},
+    }
+
+    feature = Feature("subject_token", feature_group="DupNameAncestorBase")
+
+    with pytest.raises(ValueError, match="Multiple feature groups found") as exc_info:
         IdentifyFeatureGroupClass(
             feature=feature,
             accessible_plugins=accessible_plugins,
             links=None,
             data_access_collection=None,
         )
-    assert ScopeSourceA.get_class_name() in str(exc_info.value)
+    assert "Scoped to feature group: 'DupNameAncestorBase'" in str(exc_info.value)
+
+
+def test_base_name_string_scope_with_two_sibling_subclasses_stays_ambiguous() -> None:
+    """A base-name string scope whose siblings do not narrow to one candidate still raises.
+
+    Both subclasses match through the base's name with the same compute-framework
+    set, and neither is a subclass of the other, so filter_subclasses cannot pick
+    a winner. Resolution stays ambiguous.
+    """
+    sibling_one = type("ScopeSiblingOne", (_DupNameBase,), {})
+    sibling_two = type("ScopeSiblingTwo", (_DupNameBase,), {})
+    accessible_plugins: FeatureGroupEnvironmentMapping = {
+        sibling_one: {MockComputeFramework},
+        sibling_two: {MockComputeFramework},
+    }
+
+    feature = Feature("subject_token", feature_group=_DupNameBase.get_class_name())
+
+    with pytest.raises(ValueError, match="Multiple feature groups found") as exc_info:
+        IdentifyFeatureGroupClass(
+            feature=feature,
+            accessible_plugins=accessible_plugins,
+            links=None,
+            data_access_collection=None,
+        )
+    assert "Scoped to feature group: '_DupNameBase'" in str(exc_info.value)

--- a/tests/test_core/test_prepare/test_feature_group_scope_resolution.py
+++ b/tests/test_core/test_prepare/test_feature_group_scope_resolution.py
@@ -26,11 +26,15 @@ from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
-from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass, matches_feature_group_scope
 
 
 class MockComputeFramework(ComputeFramework):
     """Mock compute framework for testing."""
+
+
+class SecondMockComputeFramework(ComputeFramework):
+    """A second mock compute framework, for rival subclasses of different frameworks."""
 
 
 class ScopeSourceA(FeatureGroup):
@@ -577,3 +581,49 @@ def test_base_name_string_scope_with_two_sibling_subclasses_stays_ambiguous() ->
             data_access_collection=None,
         )
     assert "Scoped to feature group: '_DupNameBase'" in str(exc_info.value)
+
+
+def test_base_name_string_scope_with_differing_framework_siblings_stays_ambiguous() -> None:
+    """Rival subclasses on DIFFERENT compute frameworks stay ambiguous under a base-name scope.
+
+    The realistic multi-framework shape: two concrete per-framework siblings of one
+    family base (as PandasAggregatedFeatureGroup and PyArrowAggregatedFeatureGroup
+    are), both enabled. Their compute-framework sets differ, so filter_subclasses
+    takes its early-continue branch and cannot pick a winner, and neither is a
+    subclass of the other. Resolution must raise instead of silently choosing one.
+    """
+    framework_sibling_one = type("ScopeFrameworkSiblingOne", (_DupNameBase,), {})
+    framework_sibling_two = type("ScopeFrameworkSiblingTwo", (_DupNameBase,), {})
+    accessible_plugins: FeatureGroupEnvironmentMapping = {
+        framework_sibling_one: {MockComputeFramework},
+        framework_sibling_two: {SecondMockComputeFramework},
+    }
+
+    feature = Feature("subject_token", feature_group=_DupNameBase.get_class_name())
+
+    with pytest.raises(ValueError, match="Multiple feature groups found") as exc_info:
+        IdentifyFeatureGroupClass(
+            feature=feature,
+            accessible_plugins=accessible_plugins,
+            links=None,
+            data_access_collection=None,
+        )
+    message = str(exc_info.value)
+    assert "Scoped to feature group: '_DupNameBase'" in message
+    assert "ScopeFrameworkSiblingOne" in message
+    assert "ScopeFrameworkSiblingTwo" in message
+
+
+# ---------------------------------------------------------------------------
+# The ancestry predicate never treats the root FeatureGroup base as a wildcard
+# ---------------------------------------------------------------------------
+
+
+def test_root_feature_group_base_name_is_not_a_wildcard_scope() -> None:
+    """The root base name matches nothing, even though it is in every candidate's MRO.
+
+    Pins the root exclusion in the ancestry walk directly: no public path reaches
+    it, because Feature() rejects the root base name before resolution.
+    """
+    assert matches_feature_group_scope(ScopeSourceA, FeatureGroup.get_class_name()) is False
+    assert matches_feature_group_scope(ScopeConcreteFamilyMember, FeatureGroup.get_class_name()) is False


### PR DESCRIPTION
Closes #682.

## Problem

The per-feature `feature_group` resolution scope accepts a FeatureGroup class object or a class-name string. The class-object form matched the named class and its subclasses, preferring the most specific one; the string form matched the exact class name only. JSON configs can carry only the string, so a config author could not name an abstract family base such as `AggregatedFeatureGroup` and had to name the concrete leaf (`PandasAggregatedFeatureGroup`), coupling the config to a compute framework, which nothing else in a feature config does.

## Change

Both forms now share one predicate, `matches_feature_group_scope`. The string form walks the candidate's FeatureGroup ancestry, so it matches the named class and its subclasses just like the class object. The existing abstract-base skip and subclass preference then select the concrete subclass; no resolution machinery changed.

Ambiguity still raises. Two same-named classes in different modules both match. A base whose subclasses do not narrow to one candidate (for example two enabled compute frameworks) stays ambiguous, exactly as the bare feature name does: the scope narrows candidates, it does not break ties between them. The docs now say so.

The root `FeatureGroup` base name is rejected: it names no family. The Python API raises `TypeError` (as the class-object root already did), the config layer raises `ValueError` from `validate_feature_group_scope` like every other invalid scope value.

Deliberate behavior change: a string scope no longer pins one exact class, since a subclass of the named class is now preferred over it. That is the parity the issue asks for, and it matches the class-object form's long-standing behavior.

## Tests

Abstract base named by string resolves to the concrete subclass, including end to end through a JSON config on pandas with the abstract base and a rival PyArrow sibling both loaded. Same-named classes in different modules, sibling subclasses sharing a framework, and sibling subclasses with differing frameworks all still raise. The root name is rejected at the Python and both config entry points, and is pinned as not a wildcard.

tox passes: 5033 tests, ruff, mypy --strict, licenses, bandit.

## Review

Reviewed independently by a fresh Claude Opus agent and by codex. Both flagged the config layer surfacing the root-name rejection as `TypeError` instead of `ValueError`; fixed. The Opus review's ambiguity concern for multi-framework runs was verified as pre-existing and identical for the unscoped request, so it is documented rather than changed.