### PR TITLE
test: pin three uncovered scope-resolution shapes, gate the MRO walk on the name (#682)

### DIFF
--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -51,8 +51,10 @@ def matches_feature_group_scope(feature_group: type[FeatureGroup], scope: str | 
     """
     if isinstance(scope, type):
         return issubclass(feature_group, scope)
+    # Name first: get_class_name() is @final and just returns __name__, while issubclass() on an ABCMeta
+    # class is the expensive check, so the name gate keeps it off nearly every MRO entry.
     return any(
-        ancestor is not FeatureGroup and issubclass(ancestor, FeatureGroup) and ancestor.get_class_name() == scope
+        ancestor.__name__ == scope and ancestor is not FeatureGroup and issubclass(ancestor, FeatureGroup)
         for ancestor in feature_group.__mro__
     )
 

--- a/tests/test_core/test_prepare/test_feature_group_scope_resolution.py
+++ b/tests/test_core/test_prepare/test_feature_group_scope_resolution.py
@@ -15,7 +15,7 @@ Follows the construction conventions in test_identify_feature_group_error_messag
 
 import inspect
 from abc import abstractmethod
-from typing import Optional
+from typing import Any, Optional
 
 import pytest
 
@@ -27,6 +27,11 @@ from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
 from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass, matches_feature_group_scope
+from mloda.provider import BaseInputData, DataCreator, FeatureSet
+from mloda.user import PluginCollector, mloda
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.feature_group.experimental.aggregated_feature_group.base import AggregatedFeatureGroup
+from mloda_plugins.feature_group.experimental.aggregated_feature_group.pandas import PandasAggregatedFeatureGroup
 
 
 class MockComputeFramework(ComputeFramework):
@@ -627,3 +632,179 @@ def test_root_feature_group_base_name_is_not_a_wildcard_scope() -> None:
     """
     assert matches_feature_group_scope(ScopeSourceA, FeatureGroup.get_class_name()) is False
     assert matches_feature_group_scope(ScopeConcreteFamilyMember, FeatureGroup.get_class_name()) is False
+
+
+# ---------------------------------------------------------------------------
+# The scoped abstract base need not be an accessible plugin at all (#682/#688)
+# ---------------------------------------------------------------------------
+
+
+def test_abstract_base_name_string_scope_resolves_when_base_is_not_accessible() -> None:
+    """Characterization: a string scope naming a base that is NOT a key of accessible_plugins resolves.
+
+    PluginCollector.enabled_feature_groups({ConcreteMember}) leaves the abstract
+    family base out of accessible_plugins entirely. The name is matched against the
+    candidate's MRO, not against the accessible keys, so the concrete member must
+    still resolve. A refactor to a lookup over accessible keys would pass every
+    other scope test and break exactly this contract.
+    """
+    assert inspect.isabstract(ScopeAbstractFamilyBase), "fixture must be abstract"
+
+    feature = Feature("subject_token", feature_group=ScopeAbstractFamilyBase.get_class_name())
+    accessible_plugins: FeatureGroupEnvironmentMapping = {
+        ScopeConcreteFamilyMember: {MockComputeFramework},
+        ScopeSourceB: {MockComputeFramework},
+    }
+    assert ScopeAbstractFamilyBase not in accessible_plugins, "the scoped base must be absent from the mapping"
+
+    identifier = IdentifyFeatureGroupClass(
+        feature=feature,
+        accessible_plugins=accessible_plugins,
+        links=None,
+        data_access_collection=None,
+    )
+    resolved_feature_group, _compute_frameworks = identifier.get()
+    assert resolved_feature_group is ScopeConcreteFamilyMember
+
+
+# ---------------------------------------------------------------------------
+# A compute-framework pin narrows a base-name scope POSITIVELY (#682/#688)
+#
+# The negative is pinned by test_base_name_string_scope_with_differing_framework_
+# siblings_stays_ambiguous. These pin the documented escape hatch from that
+# ambiguity: pin compute_frameworks on the Feature (Python only). See
+# docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md.
+#
+# The framework classes below are new because Feature(compute_framework=...) takes
+# a NAME and resolves it across every ComputeFramework subclass in the process;
+# "MockComputeFramework" is defined in several test modules, so a pin by that name
+# would be resolved non-deterministically under xdist.
+# ---------------------------------------------------------------------------
+
+
+class ScopePinnedPrimaryFramework(ComputeFramework):
+    """Uniquely named framework, pinnable by name from a Feature."""
+
+
+class ScopePinnedSecondaryFramework(ComputeFramework):
+    """A rival uniquely named framework, for the second concrete family member."""
+
+
+class ScopeConcreteFamilyMemberSecondary(ScopeAbstractFamilyBase):
+    """A second concrete member of the same family, enabled on the other framework."""
+
+    @classmethod
+    def _family_hook(cls) -> str:
+        return "concrete-secondary"
+
+
+def _framework_split_family() -> FeatureGroupEnvironmentMapping:
+    """Two concrete siblings of one abstract family base, each on its own framework."""
+    return {
+        ScopeConcreteFamilyMember: {ScopePinnedPrimaryFramework},
+        ScopeConcreteFamilyMemberSecondary: {ScopePinnedSecondaryFramework},
+    }
+
+
+def test_framework_pin_narrows_base_name_scope_to_primary_member() -> None:
+    """Characterization: a framework pin resolves the base-name scope ambiguity to that framework's member.
+
+    Premise guard first: unpinned, the two per-framework siblings of the scoped base
+    stay ambiguous. Pinning the framework must then select the sibling enabled on it.
+    This is the documented escape hatch, and a refactor that stopped applying the
+    scope filter and the framework filter together would break it.
+    """
+    unpinned = Feature("subject_token", feature_group=ScopeAbstractFamilyBase.get_class_name())
+    with pytest.raises(ValueError, match="Multiple feature groups found"):
+        IdentifyFeatureGroupClass(
+            feature=unpinned,
+            accessible_plugins=_framework_split_family(),
+            links=None,
+            data_access_collection=None,
+        )
+
+    feature = Feature(
+        "subject_token",
+        feature_group=ScopeAbstractFamilyBase.get_class_name(),
+        compute_framework=ScopePinnedPrimaryFramework.get_class_name(),
+    )
+
+    identifier = IdentifyFeatureGroupClass(
+        feature=feature,
+        accessible_plugins=_framework_split_family(),
+        links=None,
+        data_access_collection=None,
+    )
+    resolved_feature_group, compute_frameworks = identifier.get()
+    assert resolved_feature_group is ScopeConcreteFamilyMember
+    assert compute_frameworks == {ScopePinnedPrimaryFramework}
+
+
+def test_framework_pin_narrows_base_name_scope_to_secondary_member() -> None:
+    """Characterization: pinning the OTHER framework selects the other member of the same family.
+
+    The mirror of the primary case, so the pin is proven to select by framework
+    rather than to hide a fixed iteration order over accessible_plugins.
+    """
+    feature = Feature(
+        "subject_token",
+        feature_group=ScopeAbstractFamilyBase.get_class_name(),
+        compute_framework=ScopePinnedSecondaryFramework.get_class_name(),
+    )
+
+    identifier = IdentifyFeatureGroupClass(
+        feature=feature,
+        accessible_plugins=_framework_split_family(),
+        links=None,
+        data_access_collection=None,
+    )
+    resolved_feature_group, compute_frameworks = identifier.get()
+    assert resolved_feature_group is ScopeConcreteFamilyMemberSecondary
+    assert compute_frameworks == {ScopePinnedSecondaryFramework}
+
+
+# ---------------------------------------------------------------------------
+# End to end through the PYTHON surface with the real shipped family (#682/#688)
+#
+# The config/JSON equivalent lives in
+# tests/test_core/test_api/feature_config/test_feature_config_feature_group_scope.py.
+# ---------------------------------------------------------------------------
+
+
+class ScopePythonAggregationSource(FeatureGroup):
+    """Source data for the Python-surface aggregated-family scope test."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={"scope_python_sales"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {"scope_python_sales": [10, 20, 30, 40]}
+
+
+def test_end2end_python_feature_abstract_family_base_scope_resolves_to_pandas_subclass() -> None:
+    """Characterization: Feature(feature_group="AggregatedFeatureGroup") runs on the Pandas subclass.
+
+    The allowlist enables only the source and the concrete Pandas member, so the
+    scoped abstract base is genuinely not a key of accessible_plugins. Naming it
+    must still reach the concrete subclass through the MRO walk and compute the
+    aggregation, without the caller hard-coding a framework-specific leaf class.
+    """
+    assert inspect.isabstract(AggregatedFeatureGroup), "the scoped family base must stay abstract"
+
+    feature = Feature("scope_python_sales__sum_aggr", feature_group=AggregatedFeatureGroup.get_class_name())
+
+    results = list(
+        mloda.run_all(
+            [feature],
+            compute_frameworks={PandasDataFrame},
+            plugin_collector=PluginCollector.enabled_feature_groups(
+                {ScopePythonAggregationSource, PandasAggregatedFeatureGroup}
+            ),
+        )
+    )
+
+    aggregated = [df for df in results if "scope_python_sales__sum_aggr" in df.columns]
+    assert len(aggregated) == 1
+    assert aggregated[0]["scope_python_sales__sum_aggr"].iloc[0] == 100


### PR DESCRIPTION
Follow-up to #688, which fixed #682 while this branch was in flight. That implementation is sound: I rebased onto it, dropped my equivalent implementation and docs entirely, and kept only what it does not cover.

## Four characterization tests

All four pass against the merged implementation. They are here to lock contracts a refactor could silently break, not to fix anything.

**The scoped abstract base is not a key of `accessible_plugins`.** Every merged abstract-base test keeps the base in the `accessible_plugins` dict next to the concrete member. A `PluginCollector.enabled_feature_groups({ConcreteMember})` run does not: the base is dropped and only the concrete subclass remains. Naming the base by string still has to resolve, because `matches_feature_group_scope` walks the *candidate's* MRO rather than looking the name up among the accessible keys. This is precisely the contract that distinguishes the two designs, and a refactor to a key lookup would pass every other test in the file while breaking this one.

**A framework pin narrows a base-name scope, both ways.** The merged tests pin only the negative: two sibling concrete members on differing compute frameworks leave a base-name scope ambiguous. The documented escape hatch (pin `compute_frameworks` on the Feature) was never pinned. Two tests now cover it in both directions, so selection is proven to be by framework rather than by iteration order.

**The real `AggregatedFeatureGroup` family end to end through the Python surface.** Main has the JSON-config equivalent; this mirrors it through `Feature(...)` + `mloda.run_all`, with the abstract base deliberately kept out of the accessible keys.

One subtlety worth flagging, since it will bite anyone writing a similar test: the framework-pin tests use **uniquely named** `ComputeFramework` fixtures. `Feature(compute_framework=...)` resolves a *name* over `get_all_subclasses(ComputeFramework)`, and five distinct classes named `MockComputeFramework` already exist across `tests/test_core/test_prepare/`. Pinning by that name would resolve non-deterministically as soon as xdist imports the sibling modules into one process.

## One micro-optimization

`matches_feature_group_scope` ran `issubclass(ancestor, FeatureGroup)`, an ABCMeta `__subclasscheck__`, on every entry of every candidate's MRO before the cheap name comparison. Gating on `__name__` first is the same predicate, since `get_class_name()` is `@final` and returns `__name__`, and it keeps the expensive check off nearly every entry. The root exclusion and the `issubclass` leg both stay, the latter still rejecting a non-FeatureGroup mixin that carries a colliding name.

`tox` is green.

## Related issues filed

While building the original implementation, two latent problems surfaced that are out of scope here. Both are filed and labeled `blocked`:

- #692: the default `match_feature_group_criteria` instantiates `cls()`, so an abstract FeatureGroup base that does not override the matcher raises `TypeError` for every feature name and aborts resolution for the whole run. The 12 shipped abstract bases only escape it by inheriting `FeatureChainParserMixin`.
- #693: `resolve_feature` takes no scope argument and does not go through `IdentifyFeatureGroupClass`, so it cannot reproduce a scoped failure, even though the scoped error message tells the user to debug with it.
