### PR TITLE
chore(deps): raise mistune floor to >=3.3.0 and constrain soupsieve >=2.8.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,11 +176,13 @@ exclude-newer-package = { decorator = "2099-01-01T00:00:00Z" }
 # Constraints applied only to transitive dependencies to remediate Dependabot security alerts.
 # - urllib3 >= 2.7.0: GHSA decompression-bomb bypass + sensitive headers across origins
 # - idna   >= 3.15:   idna.encode() bypass of CVE-2024-3651 fix
-# - mistune >= 3.2.1: Heading ID injection XSS (CVE-2026-33079). Note: figclass/figwidth and Math Plugin XSS (GHSA #26, #27) currently have no upstream patch.
+# - mistune >= 3.3.0: quadratic-time parsing DoS in parse_link_text. Also covers the earlier heading ID injection XSS (CVE-2026-33079).
+# - soupsieve >= 2.8.4: memory exhaustion via large comma-separated selector lists; ReDoS in the selector parser
 # - nbconvert >= 7.17.1: arbitrary file read/write via path traversal; uncontrolled search path on Windows
 constraint-dependencies = [
     "urllib3>=2.7.0",
     "idna>=3.15",
-    "mistune>=3.2.1",
+    "mistune>=3.3.0",
+    "soupsieve>=2.8.4",
     "nbconvert>=7.17.1",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -24,8 +24,9 @@ decorator = "2099-01-01T00:00:00Z"
 [manifest]
 constraints = [
     { name = "idna", specifier = ">=3.15" },
-    { name = "mistune", specifier = ">=3.2.1" },
+    { name = "mistune", specifier = ">=3.3.0" },
     { name = "nbconvert", specifier = ">=7.17.1" },
+    { name = "soupsieve", specifier = ">=2.8.4" },
     { name = "urllib3", specifier = ">=2.7.0" },
 ]
 
@@ -1316,14 +1317,14 @@ wheels = [
 
 [[package]]
 name = "mistune"
-version = "3.2.1"
+version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ca/84/620cc3f7e3adf6f5067e10f4dbae71295d8f9e16d5d3f9ef97c40f2f592c/mistune-3.2.1.tar.gz", hash = "sha256:7c8e5501d38bac1582e067e46c8343f17d57ea1aaa735823f3aba1fd59c88a28", size = 98003, upload-time = "2026-05-03T14:33:22.312Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/5f/007786743f962224423753b78f7d7acb0f2ade46d1604f2e0fa2bedf9020/mistune-3.3.2.tar.gz", hash = "sha256:e12ee4f1e74336e91aa1141e35f913b337c40bdf7c0cc49f21fb853a27e8b62f", size = 111284, upload-time = "2026-06-23T00:29:28.568Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/7f/a946aa4f8752b37102b41e64dca18a1976ac705c3a0d1dfe74d820a02552/mistune-3.2.1-py3-none-any.whl", hash = "sha256:78cdb0ba5e938053ccf63651b352508d2efa9411dc8810bfb05f2dc5140c0048", size = 53749, upload-time = "2026-05-03T14:33:20.551Z" },
+    { url = "https://files.pythonhosted.org/packages/44/43/894c2cbbcbdf53b57d1257a249811abe2ee9ab7ef76af301b40f1c054533/mistune-3.3.2-py3-none-any.whl", hash = "sha256:a678a56387d487db7368ede4647cb2ba1deff22ce61f92343e4ebe0ddfce4f2d", size = 61554, upload-time = "2026-06-23T00:29:27.088Z" },
 ]
 
 [[package]]
@@ -3836,11 +3837,11 @@ wheels = [
 
 [[package]]
 name = "soupsieve"
-version = "2.8.3"
+version = "2.8.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Closes three high-severity Dependabot alerts on transitive dependencies by raising their floors in `[tool.uv] constraint-dependencies` and relocking.

| Package | Was | Now | Advisory |
|---|---|---|---|
| mistune | 3.2.1 | 3.3.2 | quadratic-time parsing DoS in `parse_link_text` (fixed in 3.3.0) |
| soupsieve | 2.8.3 | 2.8.4 | memory exhaustion via large comma-separated selector lists |
| soupsieve | 2.8.3 | 2.8.4 | ReDoS in the selector parser |

## Why this mechanism

Both are transitive, not direct: `nbconvert -> mistune` and `nbconvert -> beautifulsoup4 -> soupsieve`, reachable only through the `docs` extra. There is no direct dependency to edit, and a bare `uv lock --upgrade-package` would bump the lock while leaving nothing to enforce the floor on a future re-resolution. `constraint-dependencies` encodes it durably and follows the existing urllib3 / idna / nbconvert precedent in the same block.

Lock churn is limited to those two package blocks (8 insertions, 7 deletions), no packages added or dropped. mistune resolves to 3.3.2 rather than the newer 3.3.3 because 3.3.3 falls inside the `exclude-newer = "7 days"` window. Both licenses (BSD-3-Clause, MIT) are on the allowlist.

## nltk (not fixed here)

The fourth open alert, nltk URL-encoded path traversal in `nltk.data.load()`, is **patched upstream in 3.10.0** (published 2026-07-08), despite GitHub's advisory recording `first_patched_version: null`. That release is not yet selectable under `exclude-newer = "7 days"`; `uv lock --upgrade-package nltk` currently reports no changes. From around 2026-07-15 it can be picked up by raising the `text_cleaning` extra floor to `nltk>=3.10.0` (it is a direct optional dep, so that is a dependency bump, not a constraint).

## Test

`tox` green: 5067 passed, 171 skipped, plus ruff format/check, pip-licenses allowlist, mypy --strict, bandit.