### PR TITLE
docs: link registry plugin guides from README as coding-agent context

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ Built-in and custom extenders give you full lineage - trace any result back to i
 - **[Getting Started](https://mloda-ai.github.io/mloda/chapter1/installation/)** - Installation and first steps
 - **[Plugin Development](https://mloda-ai.github.io/mloda/chapter1/feature-groups/)** - Build your own plugins
 - **[API Reference](https://mloda-ai.github.io/mloda/in_depth/mloda-api/)** - Complete API docs
+- **[Plugin Development Guides](https://github.com/mloda-ai/mloda-registry/tree/main/docs/guides)** - 40+ pattern guides in mloda-registry, also intended as context for coding agents
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a bullet to the README Documentation section linking the mloda-registry plugin development guides (40+ pages), with a hint that they also serve as context for coding agents.

Part of the registry-to-core findability work (tk-379): readers of the core README now reach the guides in one click from the Documentation section instead of only via the Ecosystem table.

## Validation

- Full tox gate green locally (5253 passed, 171 skipped; ruff, mypy strict, bandit, licenses all pass).
- Docs-only change; no runtime surface.