### PR TITLE
ci: skip the test matrix for root markdown-only changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,10 +1,13 @@
 name: CI
 
+# Root-level markdown only: docs/ markdown is executed by tests/test_documentation and must still trigger CI.
 on:
   push:
     branches: [ "main" ]
+    paths-ignore: [ "*.md" ]
   pull_request:
     branches: [ "main" ]
+    paths-ignore: [ "*.md" ]
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,13 +1,20 @@
 name: CI
 
-# Root-level markdown only: docs/ markdown is executed by tests/test_documentation and must still trigger CI.
+# Explicit, not "*.md": CONTRIBUTING.md and docs/ are asserted/executed by tests (guarded by tests/test_documentation/test_ci_paths_ignore.py).
+# Safe only while CI is not a required status check on main: a skipped required check never reports, blocking docs-only PRs.
 on:
   push:
     branches: [ "main" ]
-    paths-ignore: [ "*.md" ]
+    paths-ignore: &docs_only
+      - AGENTS.md
+      - CLAUDE.md
+      - CODE_OF_CONDUCT.md
+      - NOTICE.md
+      - README.md
+      - SECURITY.md
   pull_request:
     branches: [ "main" ]
-    paths-ignore: [ "*.md" ]
+    paths-ignore: *docs_only
 
 permissions:
   contents: read

--- a/.github/workflows/metadata-guard.yaml
+++ b/.github/workflows/metadata-guard.yaml
@@ -1,0 +1,27 @@
+name: Metadata Guard
+
+# ci.yaml skips the matrix for root markdown, but README.md is packaging metadata (pyproject `readme`).
+# Always-on (no paths filters) so deleting or renaming it cannot merge green and break the sdist build.
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  metadata-files-exist:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Assert packaging metadata files exist
+      run: |
+        test -f README.md || {
+          echo "README.md is missing but pyproject.toml references it as packaging metadata (readme)."
+          echo "Restore it, or update pyproject.toml and this guard together."
+          exit 1
+        }

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ Most plugins currently live in `mloda_plugins/` within this repository. The goal
 
 | Repository | Description |
 |------------|-------------|
-| [mloda-registry](https://github.com/mloda-ai/mloda-registry) | Official plugin packages and 40+ development guides |
+| [mloda-registry](https://github.com/mloda-ai/mloda-registry) | Official plugin packages and plugin development guides |
 | [mloda-plugin-template](https://github.com/mloda-ai/mloda-plugin-template) | Cookiecutter template for creating standalone plugins |
 
 ---
@@ -320,7 +320,7 @@ Most plugins currently live in `mloda_plugins/` within this repository. The goal
 
 We welcome contributions.
 
-**Plugin development:** see the [mloda-registry guides](https://github.com/mloda-ai/mloda-registry/tree/main/docs/guides) (40+ step-by-step), or scaffold a new package with the [mloda-plugin-template](https://github.com/mloda-ai/mloda-plugin-template).
+**Plugin development:** see the [mloda-registry guides](https://github.com/mloda-ai/mloda-registry/tree/main/docs/guides) (step-by-step), or scaffold a new package with the [mloda-plugin-template](https://github.com/mloda-ai/mloda-plugin-template).
 
 **Core framework:** start with [`good first issue`](https://github.com/mloda-ai/mloda/labels/good%20first%20issue) or [`help wanted`](https://github.com/mloda-ai/mloda/labels/help%20wanted), then:
 

--- a/tests/test_ci_paths_ignore.py
+++ b/tests/test_ci_paths_ignore.py
@@ -7,7 +7,7 @@ from typing import Any
 import yaml
 
 
-PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
 CI_YAML = PROJECT_ROOT / ".github" / "workflows" / "ci.yaml"
 TRIGGERS = ("push", "pull_request")
 

--- a/tests/test_documentation/test_ci_paths_ignore.py
+++ b/tests/test_documentation/test_ci_paths_ignore.py
@@ -1,0 +1,79 @@
+"""The CI docs-only fast path must never skip CI for files under docs/."""
+
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+CI_YAML = Path(".github/workflows/ci.yaml")
+
+# docs/ content is executed by tests (mktestdocs) or asserted on, so it must always trigger CI.
+PROTECTED_DOCS_PATHS = [
+    "docs/mkdocs.yml",
+    "docs/docs/in_depth/join_data.md",
+    "docs/docs/index.md",
+    "docs/docs/chapter1/installation.md",
+]
+
+
+def _load_ci_config() -> dict[Any, Any]:
+    config: dict[Any, Any] = yaml.safe_load(CI_YAML.read_text(encoding="utf-8"))
+    return config
+
+
+def _triggers() -> dict[str, Any]:
+    # pyyaml (YAML 1.1) parses the `on:` key as the boolean True.
+    config = _load_ci_config()
+    triggers: dict[str, Any] = config.get("on", config.get(True, {}))
+    return triggers
+
+
+def _pattern_to_regex(pattern: str) -> re.Pattern[str]:
+    """Translate a GitHub Actions path filter glob into a regex."""
+    out = ""
+    i = 0
+    while i < len(pattern):
+        char = pattern[i]
+        if pattern.startswith("**", i):
+            out += ".*"
+            i += 2
+        elif char == "*":
+            out += "[^/]*"
+            i += 1
+        elif char == "?":
+            out += "[^/]"
+            i += 1
+        else:
+            out += re.escape(char)
+            i += 1
+    return re.compile(f"^{out}$")
+
+
+def _matches(pattern: str, path: str) -> bool:
+    return _pattern_to_regex(pattern).search(path) is not None
+
+
+def test_paths_ignore_declared_for_push_and_pull_request() -> None:
+    triggers = _triggers()
+    for event in ("push", "pull_request"):
+        config = triggers.get(event) or {}
+        assert isinstance(config.get("paths-ignore"), list), (
+            f"CI trigger '{event}' must declare a 'paths-ignore' list for the docs-only fast path. Got: {config}"
+        )
+
+
+def test_paths_ignore_never_covers_docs_directory() -> None:
+    docs_paths = sorted(str(p) for p in Path("docs").rglob("*.md"))
+    samples = PROTECTED_DOCS_PATHS + docs_paths
+    assert Path("docs/docs/in_depth/join_data.md").exists(), "sample docs path is stale"
+
+    for event in ("push", "pull_request"):
+        for pattern in (_triggers().get(event) or {}).get("paths-ignore", []):
+            covered = [path for path in samples if _matches(str(pattern), path)]
+            assert not covered, (
+                f"CI trigger '{event}' paths-ignore pattern {pattern!r} would skip CI for {covered[:3]}. "
+                "Files under docs/ are executed by tests/test_documentation and must always trigger CI. "
+                "Keep the filter root-level only, e.g. '*.md'."
+            )

--- a/tests/test_documentation/test_ci_paths_ignore.py
+++ b/tests/test_documentation/test_ci_paths_ignore.py
@@ -1,4 +1,4 @@
-"""The CI docs-only fast path must never skip CI for files under docs/."""
+"""The CI docs-only fast path must never skip CI for markdown that tests depend on."""
 
 import re
 from pathlib import Path
@@ -7,15 +7,12 @@ from typing import Any
 import yaml
 
 
-CI_YAML = Path(".github/workflows/ci.yaml")
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+CI_YAML = PROJECT_ROOT / ".github" / "workflows" / "ci.yaml"
+TRIGGERS = ("push", "pull_request")
 
-# docs/ content is executed by tests (mktestdocs) or asserted on, so it must always trigger CI.
-PROTECTED_DOCS_PATHS = [
-    "docs/mkdocs.yml",
-    "docs/docs/in_depth/join_data.md",
-    "docs/docs/index.md",
-    "docs/docs/chapter1/installation.md",
-]
+# Markdown string literals inside the test suite, e.g. "CONTRIBUTING.md" or "docs/docs/index.md".
+MD_LITERAL = re.compile(r"""["']([^"'\n]*?\.md)["']""")
 
 
 def _load_ci_config() -> dict[Any, Any]:
@@ -28,6 +25,11 @@ def _triggers() -> dict[str, Any]:
     config = _load_ci_config()
     triggers: dict[str, Any] = config.get("on", config.get(True, {}))
     return triggers
+
+
+def _trigger_config(event: str) -> dict[str, Any]:
+    config: dict[str, Any] = _triggers().get(event) or {}
+    return config
 
 
 def _pattern_to_regex(pattern: str) -> re.Pattern[str]:
@@ -48,32 +50,71 @@ def _pattern_to_regex(pattern: str) -> re.Pattern[str]:
         else:
             out += re.escape(char)
             i += 1
-    return re.compile(f"^{out}$")
+    return re.compile(out)
 
 
 def _matches(pattern: str, path: str) -> bool:
-    return _pattern_to_regex(pattern).search(path) is not None
+    return _pattern_to_regex(pattern).fullmatch(path) is not None
+
+
+def _markdown_referenced_by_tests() -> set[str]:
+    """Markdown files that the test suite reads or asserts on, so CI must run when they change."""
+    referenced: set[str] = set()
+    for source in (PROJECT_ROOT / "tests").rglob("*.py"):
+        for line in source.read_text(encoding="utf-8").splitlines():
+            if line.lstrip().startswith("#"):
+                continue
+            for literal in MD_LITERAL.findall(line):
+                for candidate in (literal, f"docs/{literal}"):
+                    # Throwaway tmp_path fixture names (a.md, doc.md, ...) do not exist in the repo.
+                    if (PROJECT_ROOT / candidate).is_file():
+                        referenced.add(candidate)
+    return referenced
+
+
+def _protected_paths() -> list[str]:
+    docs = {str(p.relative_to(PROJECT_ROOT)) for p in (PROJECT_ROOT / "docs").rglob("*.md")}
+    return sorted(docs | _markdown_referenced_by_tests())
+
+
+def test_protected_set_is_not_stale() -> None:
+    protected = _protected_paths()
+    assert "docs/docs/index.md" in protected, "docs/ markdown is executed by tests/test_documentation"
+    assert "CONTRIBUTING.md" in protected, "CONTRIBUTING.md content is asserted by tests/test_project_structure.py"
 
 
 def test_paths_ignore_declared_for_push_and_pull_request() -> None:
-    triggers = _triggers()
-    for event in ("push", "pull_request"):
-        config = triggers.get(event) or {}
+    for event in TRIGGERS:
+        config = _trigger_config(event)
         assert isinstance(config.get("paths-ignore"), list), (
             f"CI trigger '{event}' must declare a 'paths-ignore' list for the docs-only fast path. Got: {config}"
         )
 
 
-def test_paths_ignore_never_covers_docs_directory() -> None:
-    docs_paths = sorted(str(p) for p in Path("docs").rglob("*.md"))
-    samples = PROTECTED_DOCS_PATHS + docs_paths
-    assert Path("docs/docs/in_depth/join_data.md").exists(), "sample docs path is stale"
+def test_paths_allowlist_is_absent() -> None:
+    for event in TRIGGERS:
+        assert "paths" not in _trigger_config(event), (
+            f"CI trigger '{event}' must not use a 'paths' allowlist: it would silently drop coverage "
+            "for any file not listed, which this guard cannot check. Use 'paths-ignore' only."
+        )
 
-    for event in ("push", "pull_request"):
-        for pattern in (_triggers().get(event) or {}).get("paths-ignore", []):
-            covered = [path for path in samples if _matches(str(pattern), path)]
+
+def test_paths_ignore_has_no_negation_patterns() -> None:
+    for event in TRIGGERS:
+        for pattern in _trigger_config(event).get("paths-ignore", []):
+            assert not str(pattern).startswith("!"), (
+                f"CI trigger '{event}' paths-ignore pattern {pattern!r} uses negation, which this guard "
+                "cannot reason about. Keep patterns positive."
+            )
+
+
+def test_paths_ignore_never_covers_test_relevant_markdown() -> None:
+    protected = _protected_paths()
+    for event in TRIGGERS:
+        for pattern in _trigger_config(event).get("paths-ignore", []):
+            covered = [path for path in protected if _matches(str(pattern), path)]
             assert not covered, (
                 f"CI trigger '{event}' paths-ignore pattern {pattern!r} would skip CI for {covered[:3]}. "
-                "Files under docs/ are executed by tests/test_documentation and must always trigger CI. "
-                "Keep the filter root-level only, e.g. '*.md'."
+                "These markdown files are executed or asserted on by the test suite, so a change to them "
+                "must run the gate. Narrow the filter to markdown no test depends on."
             )

--- a/tests/test_packaging_metadata_guard.py
+++ b/tests/test_packaging_metadata_guard.py
@@ -1,0 +1,78 @@
+"""Files that pyproject packaging metadata points at must be guarded by an always-on workflow.
+
+ci.yaml's docs-only fast path skips CI for markdown in paths-ignore. README.md is in that list, but
+pyproject's `readme` entry points at it, so a PR that deletes or renames it skips CI, merges green,
+and breaks the sdist/wheel build for everyone afterwards. An always-on workflow (no paths filters)
+must assert those files still exist.
+"""
+
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from tests.test_ci_paths_ignore import PROJECT_ROOT, TRIGGERS, _matches, _trigger_config
+
+
+WORKFLOWS = PROJECT_ROOT / ".github" / "workflows"
+PYPROJECT = PROJECT_ROOT / "pyproject.toml"
+
+# `readme = { file = "README.md", ... }` / `license = { file = "LICENSE" }` / `readme = "README.md"`.
+METADATA_FILE = re.compile(r"""^\s*(?:readme|license)\s*=\s*(?:\{[^}]*?\bfile\s*=\s*)?["']([^"']+)["']""", re.MULTILINE)
+README_KEY = re.compile(r"^\s*readme\s*=", re.MULTILINE)
+
+
+def _packaging_metadata_files() -> set[str]:
+    return set(METADATA_FILE.findall(PYPROJECT.read_text(encoding="utf-8")))
+
+
+def _workflow_triggers(config: dict[Any, Any]) -> dict[str, Any]:
+    # pyyaml (YAML 1.1) parses the `on:` key as the boolean True.
+    triggers: dict[str, Any] = config.get("on", config.get(True, {})) or {}
+    return triggers
+
+
+def _always_on_workflows() -> list[Path]:
+    """Workflows that run on every push and pull_request, unfiltered by path."""
+    always_on: list[Path] = []
+    for path in sorted(WORKFLOWS.glob("*.y*ml")):
+        config: dict[Any, Any] = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        triggers = _workflow_triggers(config)
+        if not all(event in triggers for event in TRIGGERS):
+            continue
+        if any((triggers.get(event) or {}).get(key) for event in TRIGGERS for key in ("paths", "paths-ignore")):
+            continue
+        always_on.append(path)
+    return always_on
+
+
+# No bare markdown filename literal appears anywhere in this module on purpose. The sibling guard
+# (test_ci_paths_ignore.py) scans tests/ for bare .md string literals and treats each one as markdown
+# whose *content* the suite depends on, forbidding ci.yaml from putting it in paths-ignore. This module
+# only asserts such files *exist*, so hardcoding a name here would wrongly protect it from the fast path.
+def test_pyproject_metadata_files_are_discovered() -> None:
+    metadata_files = _packaging_metadata_files()
+    assert metadata_files, "pyproject packaging metadata parse found no files: this guard has gone stale"
+    for target in sorted(metadata_files):
+        assert (PROJECT_ROOT / target).is_file(), f"pyproject packaging metadata points at missing file {target!r}"
+    assert README_KEY.search(PYPROJECT.read_text(encoding="utf-8")), (
+        "pyproject no longer declares a `readme` key: the parse target of this guard has disappeared"
+    )
+
+
+def test_metadata_files_in_paths_ignore_are_guarded_by_an_always_on_workflow() -> None:
+    metadata_files = _packaging_metadata_files()
+    guards = {path: path.read_text(encoding="utf-8") for path in _always_on_workflows()}
+    for event in TRIGGERS:
+        for pattern in _trigger_config(event).get("paths-ignore", []):
+            for target in sorted(metadata_files):
+                if not _matches(str(pattern), target):
+                    continue
+                assert any(target in body for body in guards.values()), (
+                    f"{target!r} is referenced by pyproject packaging metadata but CI trigger '{event}' "
+                    f"paths-ignore pattern {pattern!r} skips the gate when it changes. Deleting or renaming "
+                    f"it would merge green and break the sdist/wheel build. Add an always-on workflow in "
+                    f".github/workflows/ (push + pull_request, no paths/paths-ignore filters) that asserts "
+                    f"{target!r} exists. Always-on workflows found: {sorted(p.name for p in guards)}"
+                )


### PR DESCRIPTION
## Summary

Markdown-only PRs currently pay the full ~2 minute test matrix. This adds a docs-only fast path plus the guards that make it safe.

- `ci.yaml`: `paths-ignore` on `push` and `pull_request` for the root markdown files nothing depends on (AGENTS, CLAUDE, CODE_OF_CONDUCT, NOTICE, README, SECURITY).
- `metadata-guard.yaml`: a new always-on workflow (no path filters) asserting that files referenced by pyproject packaging metadata exist.
- `tests/test_ci_paths_ignore.py` and `tests/test_packaging_metadata_guard.py`: guards that keep the filter honest.
- README: dropped the hardcoded "40+" guide counts, which had already drifted (the real count is 61).

## Why the filter is an explicit list and not `*.md`

Two holes a naive `*.md` filter opens, both closed here:

1. `CONTRIBUTING.md` is excluded from the filter because `tests/test_project_structure.py` makes 15 content assertions against it. A CONTRIBUTING-only PR would otherwise skip CI, merge green, and break the gate for the next unrelated PR.
2. `README.md` stays in the filter (it is the file the fast path exists for), but it is also pyproject `readme` metadata, so a README-only deletion would break the sdist build. The always-on metadata-guard workflow covers that case.

`docs/**` markdown is never ignored: it is executed by `tests/test_documentation` (mktestdocs runs its code blocks).

The guard test derives its protected set from the markdown the suite actually reads, rather than hardcoding a list, so it stays correct as tests change. It also rejects negation patterns and a switch to the `paths:` allowlist form, both of which would silently drop coverage.

## Note on required status checks

This fast path is safe because `main` has no required status checks (the ruleset requires one review). If required checks are ever enabled, a skipped workflow never reports and docs-only PRs become unmergeable. That constraint is recorded in a comment in `ci.yaml`.

## Validation

Full tox gate green: 5260 passed, 171 skipped. The count rose from 5253, which confirms the new guards actually execute (they were initially placed under `tests/test_documentation`, which the default tox env excludes via `--ignore`, so the gate silently never ran them).