### PR TITLE
fix: reject a feature_group scope key inside a nested in_features options dict (#582)

### DIFF
--- a/attribution/ATTRIBUTION.md
+++ b/attribution/ATTRIBUTION.md
@@ -41,6 +41,7 @@
 | mypy                                   | 2.1.0           | MIT                                                |
 | mypy_extensions                        | 1.1.0           | MIT                                                |
 | narwhals                               | 2.23.0          | MIT                                                |
+| nest-asyncio                           | 1.6.0           | BSD License                                        |
 | nest-asyncio2                          | 1.7.2           | BSD License                                        |
 | nltk                                   | 3.9.4           | Apache Software License                            |
 | numpy                                  | 2.5.1           | BSD-3-Clause AND 0BSD AND MIT AND Zlib AND CC0-1.0 |

--- a/mloda/core/api/feature_config/loader.py
+++ b/mloda/core/api/feature_config/loader.py
@@ -13,7 +13,11 @@ from typing import Any
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.api.feature_config.parser import parse_json
-from mloda.core.api.feature_config.models import FeatureConfig, validate_feature_group_scope
+from mloda.core.api.feature_config.models import (
+    FeatureConfig,
+    validate_feature_group_not_in_options,
+    validate_feature_group_scope,
+)
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
 
 
@@ -36,6 +40,7 @@ def process_nested_features(options: dict[str, Any]) -> dict[str, Any]:
 
             # Recursively process nested options
             nested_options = value.get("options", {})
+            validate_feature_group_not_in_options(nested_options, "options")
             processed_nested_options = process_nested_features(nested_options)
 
             # Handle nested in_features (can also be a dict)

--- a/tests/test_core/test_api/feature_config/test_feature_config_feature_group_scope.py
+++ b/tests/test_core/test_api/feature_config/test_feature_config_feature_group_scope.py
@@ -444,6 +444,45 @@ def test_loader_rejects_misplaced_feature_group_key_in_options() -> None:
         assert term in message
 
 
+def test_nested_in_features_rejects_misplaced_feature_group_key_in_options() -> None:
+    """A feature_group key inside the NESTED dict's 'options' is a misplaced scope and raises ValueError."""
+    options: dict[str, Any] = {
+        "in_features": {
+            "name": "shared_token",
+            "options": {"feature_group": "ConfigScopeSourceA"},
+        },
+    }
+
+    with pytest.raises(ValueError) as exc_info:
+        process_nested_features(options)
+
+    message = str(exc_info.value)
+    for term in MISPLACED_KEY_TERMS:
+        assert term in message
+
+
+def test_loader_nested_in_features_rejects_misplaced_feature_group_key_in_options() -> None:
+    """Through the JSON surface, the nested misplaced scope fails loudly instead of becoming an option."""
+    config_str = """[
+        {
+            "name": "outer",
+            "options": {
+                "in_features": {
+                    "name": "shared_token",
+                    "options": {"feature_group": "SomeSource"}
+                }
+            }
+        }
+    ]"""
+
+    with pytest.raises(ValueError) as exc_info:
+        load_features_from_config(config_str, format="json")
+
+    message = str(exc_info.value)
+    for term in MISPLACED_KEY_TERMS:
+        assert term in message
+
+
 # ---------------------------------------------------------------------------
 # Regression: configs without the field are unchanged
 # ---------------------------------------------------------------------------

--- a/tests/test_core/test_api/feature_config/test_feature_config_feature_group_scope.py
+++ b/tests/test_core/test_api/feature_config/test_feature_config_feature_group_scope.py
@@ -461,6 +461,48 @@ def test_nested_in_features_rejects_misplaced_feature_group_key_in_options() -> 
         assert term in message
 
 
+def test_nested_in_features_rejects_misplaced_feature_group_key_two_levels_deep() -> None:
+    """The recursion catches a misplaced scope in the options of a nested feature's own nested feature."""
+    options: dict[str, Any] = {
+        "in_features": {
+            "name": "outer_token",
+            "options": {
+                "in_features": {
+                    "name": "inner_token",
+                    "options": {"feature_group": "ConfigScopeSourceA"},
+                },
+            },
+        },
+    }
+
+    with pytest.raises(ValueError) as exc_info:
+        process_nested_features(options)
+
+    message = str(exc_info.value)
+    for term in MISPLACED_KEY_TERMS:
+        assert term in message
+
+
+def test_nested_in_features_rejects_misplaced_feature_group_key_in_sibling_in_features_dict() -> None:
+    """The sibling in_features-as-dict path also rejects a misplaced scope in that dict's options."""
+    options: dict[str, Any] = {
+        "in_features": {
+            "name": "outer_token",
+            "in_features": {
+                "name": "inner_token",
+                "options": {"feature_group": "ConfigScopeSourceA"},
+            },
+        },
+    }
+
+    with pytest.raises(ValueError) as exc_info:
+        process_nested_features(options)
+
+    message = str(exc_info.value)
+    for term in MISPLACED_KEY_TERMS:
+        assert term in message
+
+
 def test_loader_nested_in_features_rejects_misplaced_feature_group_key_in_options() -> None:
     """Through the JSON surface, the nested misplaced scope fails loudly instead of becoming an option."""
     config_str = """[


### PR DESCRIPTION
Follow-up to #582 / #678, from a review of the superseded PR #677.

## Problem

The misplaced-scope rejection added in #678 checks only the top-level `options`, `group_options`, and `context_options` of `FeatureConfig`. A `feature_group` key written inside the options dict of a nested `in_features` feature definition was still silently swallowed as an ordinary option: the scope stayed unset, the key poisoned the option hash, and resolution failed without ever naming the ignored key.

```json
[{"name": "outer", "options": {"in_features": {"name": "shared_token", "options": {"feature_group": "SomeSource"}}}}]
```

## Change

`process_nested_features` now calls the shared `validate_feature_group_not_in_options` on the nested feature's options dict before recursing, so the nested surface fails with the same config-style `ValueError` as the top level. The legit placement (a `feature_group` key on the nested dict itself, next to its `name`) is unchanged.

## Tests

Four new tests: direct `process_nested_features` rejection, the same through `load_features_from_config`, a two-level-deep misplacement, and the `in_features`-as-dict sibling path, pinning the recursion behavior. Existing tests cover the legit nested placement.

`attribution/ATTRIBUTION.md` picked up `nest-asyncio` from the regenerated tox environment; no dependency was changed by this PR.

`tox` passes (5426 passed, mypy strict, ruff, bandit).
