### PR TITLE
fix: per-instance ComputeFramework uuid and no-arg constructible base

### DIFF
--- a/attribution/ATTRIBUTION.md
+++ b/attribution/ATTRIBUTION.md
@@ -35,13 +35,12 @@
 | matplotlib-inline                      | 0.2.2           | BSD-3-Clause                                       |
 | mdurl                                  | 0.1.2           | MIT License                                        |
 | mktestdocs                             | 0.2.5           | MIT                                                |
-| mloda                                  | 0.9.0           | Apache-2.0                                         |
+| mloda                                  | 0.10.0          | Apache-2.0                                         |
 | mmh3                                   | 5.2.1           | MIT License                                        |
 | msgpack                                | 1.2.1           | Apache-2.0                                         |
 | mypy                                   | 2.1.0           | MIT                                                |
 | mypy_extensions                        | 1.1.0           | MIT                                                |
 | narwhals                               | 2.23.0          | MIT                                                |
-| nest-asyncio                           | 1.6.0           | BSD License                                        |
 | nest-asyncio2                          | 1.7.2           | BSD License                                        |
 | nltk                                   | 3.9.4           | Apache Software License                            |
 | numpy                                  | 2.5.1           | BSD-3-Clause AND 0BSD AND MIT AND Zlib AND CC0-1.0 |

--- a/mloda/core/abstract_plugins/compute_framework.py
+++ b/mloda/core/abstract_plugins/compute_framework.py
@@ -62,9 +62,9 @@ class ComputeFramework(ABC):
 
     def __init__(
         self,
-        mode: ParallelizationMode,
-        children_if_root: frozenset[UUID],
-        uuid: UUID = uuid4(),
+        mode: ParallelizationMode = ParallelizationMode.SYNC,
+        children_if_root: frozenset[UUID] = frozenset(),
+        uuid: UUID | None = None,
         function_extender: Optional[set[Extender]] = None,
     ) -> None:
         """This class is initialized for step execution."""
@@ -75,7 +75,7 @@ class ComputeFramework(ABC):
         self.column_names: set[str] = set()
         self.function_extender = function_extender if function_extender is not None else set()
 
-        self.uuid = uuid
+        self.uuid = uuid or uuid4()
 
         self.transformer = ComputeFrameworkTransformer()
 

--- a/mloda/core/runtime/compute_framework_executor.py
+++ b/mloda/core/runtime/compute_framework_executor.py
@@ -71,7 +71,7 @@ class ComputeFrameworkExecutor:
         new_cfw = cf_class(
             parallelization_mode,
             frozenset(children_if_root),
-            uuid,
+            uuid or uuid4(),
             function_extender=function_extender,
         )
 

--- a/mloda/core/runtime/compute_framework_executor.py
+++ b/mloda/core/runtime/compute_framework_executor.py
@@ -71,7 +71,7 @@ class ComputeFrameworkExecutor:
         new_cfw = cf_class(
             parallelization_mode,
             frozenset(children_if_root),
-            uuid or uuid4(),
+            uuid,
             function_extender=function_extender,
         )
 

--- a/tests/test_core/test_abstract_plugins/test_compute_framework_init_defaults.py
+++ b/tests/test_core/test_abstract_plugins/test_compute_framework_init_defaults.py
@@ -1,10 +1,9 @@
-"""Red-phase tests for ComputeFramework __init__ defaults.
+"""Tests for ComputeFramework.__init__ defaults.
 
 Requirements under test:
-1. Default-constructed instances must each get a fresh uuid (currently the
-   `uuid4()` default is evaluated once at import time, so all instances share it).
-2. The base class should be no-arg constructible with mode=ParallelizationMode.SYNC
-   and children_if_root=frozenset() (currently raises TypeError).
+1. Default-constructed instances must each get a fresh uuid.
+2. The base class is no-arg constructible with mode=ParallelizationMode.SYNC
+   and children_if_root=frozenset().
 3. An explicitly passed uuid is honored.
 """
 

--- a/tests/test_core/test_abstract_plugins/test_compute_framework_init_defaults.py
+++ b/tests/test_core/test_abstract_plugins/test_compute_framework_init_defaults.py
@@ -1,0 +1,37 @@
+"""Red-phase tests for ComputeFramework __init__ defaults.
+
+Requirements under test:
+1. Default-constructed instances must each get a fresh uuid (currently the
+   `uuid4()` default is evaluated once at import time, so all instances share it).
+2. The base class should be no-arg constructible with mode=ParallelizationMode.SYNC
+   and children_if_root=frozenset() (currently raises TypeError).
+3. An explicitly passed uuid is honored.
+"""
+
+from uuid import UUID, uuid4
+
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.components.parallelization_modes import ParallelizationMode
+
+
+class InitDefaultsFramework(ComputeFramework):
+    pass
+
+
+class TestComputeFrameworkInitDefaults:
+    def test_default_uuid_is_unique_per_instance(self) -> None:
+        fw1 = InitDefaultsFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
+        fw2 = InitDefaultsFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
+        assert isinstance(fw1.uuid, UUID)
+        assert fw1.uuid != fw2.uuid
+
+    def test_no_arg_construction_uses_sensible_defaults(self) -> None:
+        fw = InitDefaultsFramework()
+        assert fw.mode == ParallelizationMode.SYNC
+        assert fw.children_if_root == frozenset()
+        assert isinstance(fw.uuid, UUID)
+
+    def test_explicit_uuid_is_honored(self) -> None:
+        explicit = uuid4()
+        fw = InitDefaultsFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset(), uuid=explicit)
+        assert fw.uuid == explicit


### PR DESCRIPTION
## Summary

`ComputeFramework.__init__` declared `uuid: UUID = uuid4()`. The default was evaluated once at import time, so every instance constructed without an explicit uuid shared the same UUID. Since the framework keys registries and arrow-flight uploads by that UUID, default-constructed instances could collide. The dead `if self.uuid is None` guard in `get_uuid` shows the parameter was meant to be optional.

Changes:

- `uuid` is now `UUID | None = None` with a per-instance `uuid4()` fallback.
- `mode` and `children_if_root` gain defaults (`ParallelizationMode.SYNC`, empty frozenset), making the base no-arg constructible so plugin subclasses no longer need to override `__init__` (the override boilerplate was the original bug vector downstream).
- `ComputeFrameworkExecutor.init_compute_framework` still passes a concrete `uuid or uuid4()` so subclass constructors keep receiving a real UUID (review finding).

## Testing

- New tests in `tests/test_core/test_abstract_plugins/test_compute_framework_init_defaults.py`: distinct default uuids per instance, no-arg construction defaults, explicit uuid honored.
- Full `tox` gate green (pytest, ruff, licenses, mypy strict, bandit). `attribution/ATTRIBUTION.md` refreshed by the tox run.

## Review

Two independent deep reviews were run on the diff; the one substantive finding (executor passing `None` instead of a concrete UUID to subclass constructors) is fixed in the follow-up commit.
