### PR TITLE
refactor: name JoinStep frameworks destination and source (#668)

### DIFF
--- a/attribution/ATTRIBUTION.md
+++ b/attribution/ATTRIBUTION.md
@@ -35,13 +35,12 @@
 | matplotlib-inline                      | 0.2.2           | BSD-3-Clause                                       |
 | mdurl                                  | 0.1.2           | MIT License                                        |
 | mktestdocs                             | 0.2.5           | MIT                                                |
-| mloda                                  | 0.9.0           | Apache-2.0                                         |
+| mloda                                  | 0.10.0          | Apache-2.0                                         |
 | mmh3                                   | 5.2.1           | MIT License                                        |
 | msgpack                                | 1.2.1           | Apache-2.0                                         |
 | mypy                                   | 2.1.0           | MIT                                                |
 | mypy_extensions                        | 1.1.0           | MIT                                                |
 | narwhals                               | 2.23.0          | MIT                                                |
-| nest-asyncio                           | 1.6.0           | BSD License                                        |
 | nest-asyncio2                          | 1.7.2           | BSD License                                        |
 | nltk                                   | 3.9.4           | Apache Software License                            |
 | numpy                                  | 2.5.1           | BSD-3-Clause AND 0BSD AND MIT AND Zlib AND CC0-1.0 |

--- a/docs/docs/in_depth/mloda-api.md
+++ b/docs/docs/in_depth/mloda-api.md
@@ -162,7 +162,7 @@ for step in mloda.explain(["sales__mean_aggr"], compute_frameworks=["PandasDataF
 - **join_type** (`str | None`): The link's join type (`"inner"`, `"left"`, ...) for a join step, None otherwise.
 - **feature_group_name** / **compute_framework_name** / **source_feature_group_name** / **source_compute_framework_name** (`str | None`): Class names of the above, None when unset.
 
-Join semantics, honestly: for a join step the `*_feature_group` fields are the link's declared left/right sides, while `compute_framework`/`source_compute_framework` are the merge destination and the framework merged in. The planner swaps those two frameworks for `RIGHT` joins, so they are not guaranteed to be the frameworks of the declared left/right sides.
+Join semantics: for a join step the `*_feature_group` fields are the link's declared left/right sides, while `compute_framework`/`source_compute_framework` are the merge destination and the framework merged in, which may belong to the declared right side.
 
 ##### How the engine tracks request provenance
 

--- a/mloda/core/api/plan_info.py
+++ b/mloda/core/api/plan_info.py
@@ -29,10 +29,7 @@ class PlanStep:
 
     join: ``feature_group``/``source_feature_group`` are the link's declared left/right sides, and
     ``join_type`` its join type. ``compute_framework`` is the merge destination and
-    ``source_compute_framework`` the framework merged in. Those two are not necessarily the
-    frameworks of the declared left/right sides: ``ExecutionPlan.run_link`` swaps them for RIGHT
-    joins (and when no child needs the declared orientation), so for a RIGHT join the destination
-    framework belongs to the declared right side.
+    ``source_compute_framework`` the framework merged in.
     """
 
     step_kind: Literal["compute", "join", "transform"]
@@ -106,9 +103,9 @@ def build_plan_steps(
                     step_kind="join",
                     feature_names=(),
                     feature_group=step.link.left_feature_group,
-                    compute_framework=step.left_framework,
+                    compute_framework=step.destination_framework,
                     source_feature_group=step.link.right_feature_group,
-                    source_compute_framework=step.right_framework,
+                    source_compute_framework=step.source_framework,
                     join_type=step.link.jointype.value,
                 )
             )

--- a/mloda/core/core/step/join_step.py
+++ b/mloda/core/core/step/join_step.py
@@ -13,18 +13,18 @@ class JoinStep(Step):
     def __init__(
         self,
         link: Link,
-        left_framework: type[ComputeFramework],
-        right_framework: type[ComputeFramework],
+        destination_framework: type[ComputeFramework],
+        source_framework: type[ComputeFramework],
         required_uuids: set[UUID],
-        left_framework_uuids: set[UUID],
-        right_framework_uuids: set[UUID],
+        destination_framework_uuids: set[UUID],
+        source_framework_uuids: set[UUID],
     ) -> None:
         self.link = link
-        self.left_framework = left_framework
-        self.right_framework = right_framework
+        self.destination_framework = destination_framework
+        self.source_framework = source_framework
         self.required_uuids = required_uuids
-        self.left_framework_uuids = left_framework_uuids
-        self.right_framework_uuids = right_framework_uuids
+        self.destination_framework_uuids = destination_framework_uuids
+        self.source_framework_uuids = source_framework_uuids
         self.uuid = uuid4()
         self.step_is_done = False
 
@@ -92,10 +92,10 @@ class JoinStep(Step):
         if uuid not in self.required_uuids:
             return None
 
-        if other_framework == self.left_framework:
+        if other_framework == self.destination_framework:
             return self.uuid
 
-        if other_framework == self.right_framework:
+        if other_framework == self.source_framework:
             return self.uuid
         return None
 

--- a/mloda/core/core/step/transform_frame_work_step.py
+++ b/mloda/core/core/step/transform_frame_work_step.py
@@ -21,10 +21,10 @@ class TransformFrameworkStep(Step):
         from_feature_group: type[FeatureGroup],
         to_feature_group: type[FeatureGroup],
         link_id: Optional[UUID] = None,
-        right_framework_uuids: Optional[set[UUID]] = None,
+        source_framework_uuids: Optional[set[UUID]] = None,
     ) -> None:
-        if right_framework_uuids is None:
-            right_framework_uuids = set()
+        if source_framework_uuids is None:
+            source_framework_uuids = set()
         self.from_framework = from_framework
         self.to_framework = to_framework
         self.required_uuids = required_uuids
@@ -35,9 +35,9 @@ class TransformFrameworkStep(Step):
         self.transformer = ComputeFrameworkTransformer()
 
         # This variable is only set, if the TFS was requested by a joinstep.
-        self.right_framework_uuid: Optional[UUID] = None
-        if len(right_framework_uuids) > 0:
-            self.right_framework_uuid = next(iter(right_framework_uuids))
+        self.source_framework_uuid: Optional[UUID] = None
+        if len(source_framework_uuids) > 0:
+            self.source_framework_uuid = next(iter(source_framework_uuids))
 
         self.step_is_done = False
 

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -115,37 +115,39 @@ class ExecutionPlan:
         -> we add this to the required_uuids of the join step of UUID1
 
         We use two loops to make sure that we have the correct order.
-        1) We map the left framework uuid to the link uuid
+        1) We map the destination framework uuid to the link uuid
         2) We use the mapping to update the required_uuids of the join step
         """
 
-        map_left_framework_uuid_to_link_uuid: dict[UUID, set[UUID]] = defaultdict(set)
+        map_destination_framework_uuid_to_link_uuid: dict[UUID, set[UUID]] = defaultdict(set)
 
-        # Map the left framework uuid to the link uuid
+        # Map the destination framework uuid to the link uuid
         for fw in fw_execution_plan:
             if isinstance(fw, JoinStep) and fw.link.jointype in (JoinType.APPEND, JoinType.UNION):
-                if len(fw.left_framework_uuids) > 1:
+                if len(fw.destination_framework_uuids) > 1:
                     raise ValueError(
                         internal_invariant_error(
-                            "APPEND/UNION JoinStep should have exactly 1 left_framework_uuid.",
-                            f"left_framework_uuids={fw.left_framework_uuids}, link={fw.link}",
+                            "APPEND/UNION JoinStep should have exactly 1 destination_framework_uuid.",
+                            f"destination_framework_uuids={fw.destination_framework_uuids}, link={fw.link}",
                         )
                     )
-                map_left_framework_uuid_to_link_uuid[next(iter(fw.left_framework_uuids))].add(fw.link.uuid)
+                map_destination_framework_uuid_to_link_uuid[next(iter(fw.destination_framework_uuids))].add(
+                    fw.link.uuid
+                )
 
         # Use the mapping to update the required_uuids of the join step
         for fw in fw_execution_plan:
             if isinstance(fw, JoinStep) and fw.link.jointype in (JoinType.APPEND, JoinType.UNION):
-                if len(fw.right_framework_uuids) > 1:
+                if len(fw.source_framework_uuids) > 1:
                     raise ValueError(
                         internal_invariant_error(
-                            "APPEND/UNION JoinStep should have exactly 1 right_framework_uuid.",
-                            f"right_framework_uuids={fw.right_framework_uuids}, link={fw.link}",
+                            "APPEND/UNION JoinStep should have exactly 1 source_framework_uuid.",
+                            f"source_framework_uuids={fw.source_framework_uuids}, link={fw.link}",
                         )
                     )
 
-                right_framework_uuid = next(iter(fw.right_framework_uuids))
-                required = map_left_framework_uuid_to_link_uuid.get(right_framework_uuid)
+                source_framework_uuid = next(iter(fw.source_framework_uuids))
+                required = map_destination_framework_uuid_to_link_uuid.get(source_framework_uuid)
                 if required is not None:
                     fw.required_uuids.update(required)
 
@@ -164,13 +166,13 @@ class ExecutionPlan:
             to_feature_group = ep.link.left_feature_group
 
         return TransformFrameworkStep(
-            from_framework=ep.right_framework,
-            to_framework=ep.left_framework,
+            from_framework=ep.source_framework,
+            to_framework=ep.destination_framework,
             required_uuids=deepcopy(ep.required_uuids),
             from_feature_group=from_feature_group,
             to_feature_group=to_feature_group,
             link_id=ep.link.uuid,
-            right_framework_uuids=ep.right_framework_uuids,
+            right_framework_uuids=ep.source_framework_uuids,
         )
 
     def add_tfs(
@@ -183,7 +185,7 @@ class ExecutionPlan:
 
         for ep in execution_plan:
             if isinstance(ep, JoinStep):
-                if ep.left_framework != ep.right_framework:
+                if ep.destination_framework != ep.source_framework:
                     new_tfs = self.fill_tfs_by_joinstep(ep)
 
                     if new_tfs not in self.tfs_collecion:
@@ -191,7 +193,7 @@ class ExecutionPlan:
                         new_execution_plan.append(new_tfs)
                         ep.required_uuids.add(new_tfs.uuid)
 
-                    need_to_upload_collector.update(ep.right_framework_uuids)
+                    need_to_upload_collector.update(ep.source_framework_uuids)
 
                     # We are updating the required uuids after the tfs is added as this makes sure, that the TFS can run in parallel before the join.
                     ep.required_uuids.update(self.joinstep_collection.get_required_join_uuids(ep))
@@ -205,15 +207,15 @@ class ExecutionPlan:
                         if isinstance(inner_ep, FeatureGroupStep):
                             # 1) We do 1 here:
                             for uuid in inner_ep.get_uuids():
-                                if uuid in ep.right_framework_uuids:
+                                if uuid in ep.source_framework_uuids:
                                     # add the link uuid to the children_if_root of the right feature group
                                     inner_ep.add_value_to_children_if_root(ep.link.uuid)
 
                                     # add to upload as this is the right feature group gets accessed in mp by other process
-                                    need_to_upload_collector.update(ep.right_framework_uuids)
+                                    need_to_upload_collector.update(ep.source_framework_uuids)
                                     break
 
-                                if uuid in ep.left_framework_uuids:
+                                if uuid in ep.destination_framework_uuids:
                                     # add the link uuid to the children_if_root of the left feature group
 
                                     store_val = uuid
@@ -221,10 +223,10 @@ class ExecutionPlan:
                             if store_val is None:
                                 continue
 
-                            # Check if any element of ep.left_framework_uuids is in inner_ep.required_uuids
-                            # same for right framework
-                            if any(elem in inner_ep.required_uuids for elem in ep.left_framework_uuids) and any(
-                                elem in inner_ep.required_uuids for elem in ep.right_framework_uuids
+                            # Check if any element of ep.destination_framework_uuids is in inner_ep.required_uuids
+                            # same for source framework
+                            if any(elem in inner_ep.required_uuids for elem in ep.destination_framework_uuids) and any(
+                                elem in inner_ep.required_uuids for elem in ep.source_framework_uuids
                             ):
                                 if ep.link.jointype in (JoinType.APPEND, JoinType.UNION):
                                     self.set_store_value_to_left_most_index_and_update_feature_group(
@@ -309,9 +311,9 @@ class ExecutionPlan:
         #    elif isinstance(ep, JoinStep):
         #        print("JOIN")
         #        print(ep.link.uuid)
-        #        print(ep.left_framework_uuids)
-        #        print(ep.right_framework_uuids)
-        #       print(ep.right_framework.get_class_name(), " -> ", ep.left_framework.get_class_name())
+        #        print(ep.destination_framework_uuids)
+        #        print(ep.source_framework_uuids)
+        #       print(ep.source_framework.get_class_name(), " -> ", ep.destination_framework.get_class_name())
         #        print(ep.required_uuids)
         # print("###############################")
 
@@ -385,8 +387,8 @@ class ExecutionPlan:
             if not right_memory_index:
                 right_memory_index.add(js.link.right_index)
 
-            # Update the UUIDs only if the conditions are met: it is a left most index and is part of the joinstep left framework uuid
-            if store_val == next(iter(js.left_framework_uuids)) and left_most_index == js.link.left_index:
+            # Update the UUIDs only if the conditions are met: it is a left most index and is part of the joinstep destination framework uuid
+            if store_val == next(iter(js.destination_framework_uuids)) and left_most_index == js.link.left_index:
                 inner_ep.tfs_ids = {store_val}
                 inner_ep.features.any_uuid = store_val
 
@@ -406,13 +408,12 @@ class ExecutionPlan:
         pre_execution_plan: list[LinkFrameworkTrekker | FeatureGroupStep],
     ) -> JoinStep | None:
         link = link_fw[0]
-        left_framework = link_fw[1]
-        right_framework = link_fw[2]
+        destination_framework = link_fw[1]
+        source_framework = link_fw[2]
 
-        # Switch left and right index if join type is right, as the algorithm does not care about right or left.
         if link.jointype == JoinType.RIGHT:
-            left_framework = link_fw[2]
-            right_framework = link_fw[1]
+            destination_framework = link_fw[2]
+            source_framework = link_fw[1]
 
         # This gets the id of the children which needs the link to be calculated.
         children_uuids: set[UUID] = set()
@@ -423,12 +424,12 @@ class ExecutionPlan:
             # this part is not working!
 
         if len(children_uuids) == 0:
-            # This is the case if we invert right/left index.
-            left_framework = link_fw[2]
-            right_framework = link_fw[1]
+            # No child needs the declared orientation, so destination and source are the other way around.
+            destination_framework = link_fw[2]
+            source_framework = link_fw[1]
 
             for stored_links, uuids in link_trekker.data.items():
-                if (link, left_framework, right_framework) == stored_links:
+                if (link, destination_framework, source_framework) == stored_links:
                     children_uuids.update(uuids)
 
             if len(children_uuids) == 0:
@@ -442,15 +443,15 @@ class ExecutionPlan:
             required_uuids.update(graph.parent_to_children_mapping[uuid])
 
         # This filters the required_uuids to only the one with the final compute framework.
-        left_framework_uuids: set[UUID] = set()
-        right_framework_uuids: set[UUID] = set()
+        destination_framework_uuids: set[UUID] = set()
+        source_framework_uuids: set[UUID] = set()
 
         for uuid in required_uuids:
-            if graph.get_nodes()[uuid].feature.get_compute_framework() == left_framework:
-                left_framework_uuids.add(uuid)
+            if graph.get_nodes()[uuid].feature.get_compute_framework() == destination_framework:
+                destination_framework_uuids.add(uuid)
 
-            if graph.get_nodes()[uuid].feature.get_compute_framework() == right_framework:
-                right_framework_uuids.add(uuid)
+            if graph.get_nodes()[uuid].feature.get_compute_framework() == source_framework:
+                source_framework_uuids.add(uuid)
 
         # The order shows which items should be added first.
         # Thus, we need to make sure that higher ordered links are calculated first.
@@ -475,7 +476,7 @@ class ExecutionPlan:
             elif result is True:
                 pass
             else:
-                left_framework_uuids, right_framework_uuids = result
+                destination_framework_uuids, source_framework_uuids = result
 
         if link.jointype in (JoinType.APPEND, JoinType.UNION):
             js = self.create_joinstep_in_case_of_append_or_union(
@@ -483,7 +484,12 @@ class ExecutionPlan:
             )
         else:
             js = JoinStep(
-                link, left_framework, right_framework, required_uuids, left_framework_uuids, right_framework_uuids
+                link,
+                destination_framework,
+                source_framework,
+                required_uuids,
+                destination_framework_uuids,
+                source_framework_uuids,
             )
 
         # This makes sure that we do not write on the same datasets due to overlapping joins at once.
@@ -526,7 +532,7 @@ class ExecutionPlan:
         # Initialize variables for feature UUIDs and frameworks
         left_feature_uuid = None
         right_feature_uuid = None
-        left_framework, right_framework = link_fw[1], link_fw[2]
+        destination_framework, source_framework = link_fw[1], link_fw[2]
 
         # Identify the left and right feature UUIDs
         for uuid in required_uuids:
@@ -545,7 +551,7 @@ class ExecutionPlan:
             if left_index == feature_index and feature_feature_group == left_feature_group:
                 if left_feature_uuid is not None:
                     raise ValueError(f"Are the indexes for append or union set double? {left_index}")
-                left_framework = feature.get_compute_framework()
+                destination_framework = feature.get_compute_framework()
                 left_feature_uuid = uuid
 
             # Match the right index and feature group
@@ -553,7 +559,7 @@ class ExecutionPlan:
                 if right_feature_uuid is not None:
                     raise ValueError(f"Are the indexes for append or union set double? {right_index}")
                 right_feature_uuid = uuid
-                right_framework = feature.get_compute_framework()
+                source_framework = feature.get_compute_framework()
 
         # Validate that both feature UUIDs are identified
         if left_feature_uuid is None or right_feature_uuid is None:
@@ -562,22 +568,22 @@ class ExecutionPlan:
             )
 
         # Sanity check for framework consistency
-        if link_fw[1] != left_framework:
+        if link_fw[1] != destination_framework:
             raise ValueError(
-                f"Left framework is not the same as the left framework of the link. {left_framework}. This is a sanity check!"
+                f"Left framework is not the same as the left framework of the link. {destination_framework}. This is a sanity check!"
             )
-        if link_fw[2] != right_framework:
+        if link_fw[2] != source_framework:
             raise ValueError(
-                f"Right framework is not the same as the right framework of the link. {right_framework}. This is a sanity check!"
+                f"Right framework is not the same as the right framework of the link. {source_framework}. This is a sanity check!"
             )
 
         return JoinStep(
             link=link,
-            left_framework=left_framework,
-            right_framework=right_framework,
+            destination_framework=destination_framework,
+            source_framework=source_framework,
             required_uuids={left_feature_uuid, right_feature_uuid},
-            left_framework_uuids={left_feature_uuid},
-            right_framework_uuids={right_feature_uuid},
+            destination_framework_uuids={left_feature_uuid},
+            source_framework_uuids={right_feature_uuid},
         )
 
     def reduce_children_to_one_level(self, children_uuids: set[UUID], graph: Graph) -> set[UUID]:

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -172,7 +172,7 @@ class ExecutionPlan:
             from_feature_group=from_feature_group,
             to_feature_group=to_feature_group,
             link_id=ep.link.uuid,
-            right_framework_uuids=ep.source_framework_uuids,
+            source_framework_uuids=ep.source_framework_uuids,
         )
 
     def add_tfs(
@@ -199,7 +199,7 @@ class ExecutionPlan:
                     ep.required_uuids.update(self.joinstep_collection.get_required_join_uuids(ep))
                 else:
                     # We need to do two things:
-                    # 1) right feature group of the join step needs to know of the link, so that the cfw can be used by the joinstep
+                    # 1) source feature group of the join step needs to know of the link, so that the cfw can be used by the joinstep
                     # 2) The child feature using this join needs to know which cfw to use. We use the tfs vehicle for this.
                     store_val = None
 
@@ -208,15 +208,15 @@ class ExecutionPlan:
                             # 1) We do 1 here:
                             for uuid in inner_ep.get_uuids():
                                 if uuid in ep.source_framework_uuids:
-                                    # add the link uuid to the children_if_root of the right feature group
+                                    # add the link uuid to the children_if_root of the source feature group
                                     inner_ep.add_value_to_children_if_root(ep.link.uuid)
 
-                                    # add to upload as this is the right feature group gets accessed in mp by other process
+                                    # add to upload as this source feature group gets accessed in mp by other process
                                     need_to_upload_collector.update(ep.source_framework_uuids)
                                     break
 
                                 if uuid in ep.destination_framework_uuids:
-                                    # add the link uuid to the children_if_root of the left feature group
+                                    # add the link uuid to the children_if_root of the destination feature group
 
                                     store_val = uuid
 
@@ -387,7 +387,7 @@ class ExecutionPlan:
             if not right_memory_index:
                 right_memory_index.add(js.link.right_index)
 
-            # Update the UUIDs only if the conditions are met: it is a left most index and is part of the joinstep destination framework uuid
+            # Only update when this is the left-most index and belongs to the join step's destination framework.
             if store_val == next(iter(js.destination_framework_uuids)) and left_most_index == js.link.left_index:
                 inner_ep.tfs_ids = {store_val}
                 inner_ep.features.any_uuid = store_val
@@ -570,11 +570,13 @@ class ExecutionPlan:
         # Sanity check for framework consistency
         if link_fw[1] != destination_framework:
             raise ValueError(
-                f"Left framework is not the same as the left framework of the link. {destination_framework}. This is a sanity check!"
+                f"Destination framework does not match the left framework of the link. "
+                f"{destination_framework}. This is a sanity check!"
             )
         if link_fw[2] != source_framework:
             raise ValueError(
-                f"Right framework is not the same as the right framework of the link. {source_framework}. This is a sanity check!"
+                f"Source framework does not match the right framework of the link. "
+                f"{source_framework}. This is a sanity check!"
             )
 
         return JoinStep(

--- a/mloda/core/prepare/joinstep_collection.py
+++ b/mloda/core/prepare/joinstep_collection.py
@@ -9,7 +9,7 @@ class JoinStepCollection:
         self.collection: dict[JoinStep, set[UUID]] = defaultdict(set)
 
     def similar_dependent_joins_uuids(
-        self, left_framework: type[ComputeFramework], right_framework: type[ComputeFramework]
+        self, destination_framework: type[ComputeFramework], source_framework: type[ComputeFramework]
     ) -> set[UUID]:
         """
         This functionality makes sure that we do not write on the same datasets due to overlapping joins at once.
@@ -18,17 +18,19 @@ class JoinStepCollection:
         required_uuids = set()
         for step in self.collection:
             if (
-                step.left_framework == left_framework
-                or step.right_framework == left_framework
-                or step.left_framework == right_framework
-                or step.right_framework == right_framework
+                step.destination_framework == destination_framework
+                or step.source_framework == destination_framework
+                or step.destination_framework == source_framework
+                or step.source_framework == source_framework
             ):
                 required_uuids.update(step.get_uuids())
 
         return required_uuids
 
     def add(self, join_step: JoinStep) -> None:
-        required_join_uuids = self.similar_dependent_joins_uuids(join_step.left_framework, join_step.right_framework)
+        required_join_uuids = self.similar_dependent_joins_uuids(
+            join_step.destination_framework, join_step.source_framework
+        )
         self.collection[join_step] = required_join_uuids
 
     def get_required_join_uuids(self, join_step: JoinStep) -> set[UUID]:

--- a/mloda/core/runtime/compute_framework_executor.py
+++ b/mloda/core/runtime/compute_framework_executor.py
@@ -179,7 +179,7 @@ class ComputeFrameworkExecutor:
 
         elif isinstance(step, JoinStep):
             cfw_uuid = self.cfw_register.get_cfw_uuid(
-                step.left_framework.get_class_name(), next(iter(step.left_framework_uuids))
+                step.destination_framework.get_class_name(), next(iter(step.destination_framework_uuids))
             )
 
         if cfw_uuid is None:
@@ -218,17 +218,17 @@ class ComputeFrameworkExecutor:
             from_cfw = self.prepare_tfs_right_cfw(step)
             from_cfw = self.cfw_collection[from_cfw]
         elif isinstance(step, JoinStep):
-            # Left framework here, because it is already transformed beforehand
-            from_cfw_uuid = self.cfw_register.get_cfw_uuid(step.left_framework.get_class_name(), step.link.uuid)
+            # Destination framework here, because it is already transformed beforehand
+            from_cfw_uuid = self.cfw_register.get_cfw_uuid(step.destination_framework.get_class_name(), step.link.uuid)
 
             if from_cfw_uuid is None:
                 from_cfw_uuid = self.cfw_register.get_cfw_uuid(
-                    step.left_framework.get_class_name(), next(iter(step.right_framework_uuids))
+                    step.destination_framework.get_class_name(), next(iter(step.source_framework_uuids))
                 )
 
             if from_cfw_uuid is None:
                 raise ValueError(
-                    f"from_cfw_uuid should not be none: {step.left_framework.get_class_name()}, {step.link.uuid}"
+                    f"from_cfw_uuid should not be none: {step.destination_framework.get_class_name()}, {step.link.uuid}"
                 )
 
             from_cfw = self.cfw_collection[from_cfw_uuid]

--- a/mloda/core/runtime/compute_framework_executor.py
+++ b/mloda/core/runtime/compute_framework_executor.py
@@ -198,7 +198,7 @@ class ComputeFrameworkExecutor:
         """
         Prepares the right CFW for a TransformFrameworkStep.
         """
-        uuid = step.right_framework_uuid if step.right_framework_uuid else next(iter(step.required_uuids))
+        uuid = step.source_framework_uuid if step.source_framework_uuid else next(iter(step.required_uuids))
 
         cfw_uuid = self.cfw_register.get_cfw_uuid(step.from_framework.get_class_name(), uuid)
 

--- a/mloda/core/runtime/worker/multiprocessing_worker.py
+++ b/mloda/core/runtime/worker/multiprocessing_worker.py
@@ -69,7 +69,7 @@ def _execute_command(
         if from_cfw is None:
             from_cfw = cfw_register.get_cfw_uuid(
                 command.from_framework.get_class_name(),
-                command.right_framework_uuid,
+                command.source_framework_uuid,
             )
 
     data = command.execute(cfw_register, cfw, data=data, from_cfw=from_cfw)

--- a/mloda/core/runtime/worker/multiprocessing_worker.py
+++ b/mloda/core/runtime/worker/multiprocessing_worker.py
@@ -53,12 +53,12 @@ def _execute_command(
 ) -> Any:
     """Executes a given command based on its type."""
     if isinstance(command, JoinStep):
-        # Left framework here, because it is already transformed beforehand
-        from_cfw = cfw_register.get_cfw_uuid(command.left_framework.get_class_name(), command.link.uuid)  # type: ignore[assignment]
+        # Destination framework here, because it is already transformed beforehand
+        from_cfw = cfw_register.get_cfw_uuid(command.destination_framework.get_class_name(), command.link.uuid)  # type: ignore[assignment]
 
         if from_cfw is None:
             from_cfw = cfw_register.get_cfw_uuid(
-                command.left_framework.get_class_name(), next(iter(command.right_framework_uuids))
+                command.destination_framework.get_class_name(), next(iter(command.source_framework_uuids))
             )
 
         if from_cfw is None:

--- a/tests/test_core/test_api/test_plan_info.py
+++ b/tests/test_core/test_api/test_plan_info.py
@@ -768,9 +768,9 @@ class TestJoinStepMapping:
 class TestCrossFrameworkJoinStepMapping:
     """The join sides live on different frameworks, so left/right cannot be confused.
 
-    ``ExecutionPlan.run_link`` may swap ``destination_framework``/``source_framework`` relative to
-    the link declaration, so the record's frameworks are the merge destination and the merged-in
-    source, while ``feature_group``/``source_feature_group`` stay the link's declared sides.
+    ``ExecutionPlan.run_link`` picks the merge destination, which may be the link's declared right
+    side. The record's frameworks are therefore the destination and the merged-in source, while
+    ``feature_group``/``source_feature_group`` stay the link's declared sides.
     """
 
     def test_join_step_frameworks_are_destination_and_source(self) -> None:

--- a/tests/test_core/test_api/test_plan_info.py
+++ b/tests/test_core/test_api/test_plan_info.py
@@ -768,8 +768,8 @@ class TestJoinStepMapping:
 class TestCrossFrameworkJoinStepMapping:
     """The join sides live on different frameworks, so left/right cannot be confused.
 
-    ``ExecutionPlan.run_link`` may swap ``left_framework``/``right_framework`` relative to the
-    link declaration, so the record's frameworks are the merge destination and the merged-in
+    ``ExecutionPlan.run_link`` may swap ``destination_framework``/``source_framework`` relative to
+    the link declaration, so the record's frameworks are the merge destination and the merged-in
     source, while ``feature_group``/``source_feature_group`` stay the link's declared sides.
     """
 

--- a/tests/test_core/test_runtime/test_compute_framework_executor.py
+++ b/tests/test_core/test_runtime/test_compute_framework_executor.py
@@ -453,16 +453,16 @@ class TestPrepareExecuteStep:
         assert result == new_uuid
 
     def test_handles_join_step(self) -> None:
-        """Should handle JoinStep by retrieving left framework CFW."""
+        """Should handle JoinStep by retrieving destination framework CFW."""
         cfw_register = Mock(spec=CfwManager)
         worker_manager = Mock(spec=WorkerManager)
         executor = ComputeFrameworkExecutor(cfw_register, worker_manager)
 
         step = Mock(spec=JoinStep)
-        left_uuid = uuid4()
-        step.left_framework_uuids = {left_uuid}
-        step.left_framework = Mock()
-        step.left_framework.get_class_name.return_value = "LeftCFW"
+        destination_uuid = uuid4()
+        step.destination_framework_uuids = {destination_uuid}
+        step.destination_framework = Mock()
+        step.destination_framework.get_class_name.return_value = "DestinationCFW"
 
         cfw_uuid = uuid4()
         cfw_register.get_cfw_uuid.return_value = cfw_uuid
@@ -581,9 +581,9 @@ class TestPrepareTfsAndJoinStep:
         link_uuid = uuid4()
         step.link = Mock()
         step.link.uuid = link_uuid
-        step.left_framework = Mock()
-        step.left_framework.get_class_name.return_value = "LeftCFW"
-        step.right_framework_uuids = {uuid4()}
+        step.destination_framework = Mock()
+        step.destination_framework.get_class_name.return_value = "DestinationCFW"
+        step.source_framework_uuids = {uuid4()}
 
         from_cfw_uuid = uuid4()
         cfw_register.get_cfw_uuid.return_value = from_cfw_uuid
@@ -595,22 +595,22 @@ class TestPrepareTfsAndJoinStep:
 
         assert result is from_cfw
         # Should first try link.uuid
-        assert cfw_register.get_cfw_uuid.call_args_list[0] == call("LeftCFW", link_uuid)
+        assert cfw_register.get_cfw_uuid.call_args_list[0] == call("DestinationCFW", link_uuid)
 
-    def test_falls_back_to_right_framework_uuids_for_join_step(self) -> None:
-        """Should fallback to right_framework_uuids if link UUID not found."""
+    def test_falls_back_to_source_framework_uuids_for_join_step(self) -> None:
+        """Should fallback to source_framework_uuids if link UUID not found."""
         cfw_register = Mock(spec=CfwManager)
         worker_manager = Mock(spec=WorkerManager)
         executor = ComputeFrameworkExecutor(cfw_register, worker_manager)
 
         step = Mock(spec=JoinStep)
         link_uuid = uuid4()
-        right_uuid = uuid4()
+        source_uuid = uuid4()
         step.link = Mock()
         step.link.uuid = link_uuid
-        step.left_framework = Mock()
-        step.left_framework.get_class_name.return_value = "LeftCFW"
-        step.right_framework_uuids = {right_uuid}
+        step.destination_framework = Mock()
+        step.destination_framework.get_class_name.return_value = "DestinationCFW"
+        step.source_framework_uuids = {source_uuid}
 
         # First call returns None, second returns valid UUID
         from_cfw_uuid = uuid4()
@@ -633,9 +633,9 @@ class TestPrepareTfsAndJoinStep:
         step = Mock(spec=JoinStep)
         step.link = Mock()
         step.link.uuid = uuid4()
-        step.left_framework = Mock()
-        step.left_framework.get_class_name.return_value = "LeftCFW"
-        step.right_framework_uuids = {uuid4()}
+        step.destination_framework = Mock()
+        step.destination_framework.get_class_name.return_value = "DestinationCFW"
+        step.source_framework_uuids = {uuid4()}
 
         cfw_register.get_cfw_uuid.return_value = None
 

--- a/tests/test_core/test_runtime/test_compute_framework_executor.py
+++ b/tests/test_core/test_runtime/test_compute_framework_executor.py
@@ -488,15 +488,15 @@ class TestPrepareExecuteStep:
 class TestPrepareTfsRightCfw:
     """Tests for prepare_tfs_right_cfw method."""
 
-    def test_uses_right_framework_uuid_when_available(self) -> None:
-        """Should use right_framework_uuid when set."""
+    def test_uses_source_framework_uuid_when_available(self) -> None:
+        """Should use source_framework_uuid when set."""
         cfw_register = Mock(spec=CfwManager)
         worker_manager = Mock(spec=WorkerManager)
         executor = ComputeFrameworkExecutor(cfw_register, worker_manager)
 
         step = Mock(spec=TransformFrameworkStep)
-        right_uuid = uuid4()
-        step.right_framework_uuid = right_uuid
+        source_uuid = uuid4()
+        step.source_framework_uuid = source_uuid
         step.from_framework = Mock()
         step.from_framework.get_class_name.return_value = "FromCFW"
 
@@ -506,16 +506,16 @@ class TestPrepareTfsRightCfw:
         result = executor.prepare_tfs_right_cfw(step)
 
         assert result == cfw_uuid
-        cfw_register.get_cfw_uuid.assert_called_once_with("FromCFW", right_uuid)
+        cfw_register.get_cfw_uuid.assert_called_once_with("FromCFW", source_uuid)
 
-    def test_uses_first_required_uuid_when_right_framework_uuid_is_none(self) -> None:
-        """Should use first required UUID when right_framework_uuid is None."""
+    def test_uses_first_required_uuid_when_source_framework_uuid_is_none(self) -> None:
+        """Should use first required UUID when source_framework_uuid is None."""
         cfw_register = Mock(spec=CfwManager)
         worker_manager = Mock(spec=WorkerManager)
         executor = ComputeFrameworkExecutor(cfw_register, worker_manager)
 
         step = Mock(spec=TransformFrameworkStep)
-        step.right_framework_uuid = None
+        step.source_framework_uuid = None
         required_uuid = uuid4()
         step.required_uuids = [required_uuid, uuid4()]
         step.from_framework = Mock()
@@ -536,7 +536,7 @@ class TestPrepareTfsRightCfw:
         executor = ComputeFrameworkExecutor(cfw_register, worker_manager)
 
         step = Mock(spec=TransformFrameworkStep)
-        step.right_framework_uuid = None
+        step.source_framework_uuid = None
         step.required_uuids = [uuid4()]
         step.from_framework = Mock()
         step.from_framework.get_class_name.return_value = "FromCFW"
@@ -557,7 +557,7 @@ class TestPrepareTfsAndJoinStep:
         executor = ComputeFrameworkExecutor(cfw_register, worker_manager)
 
         step = Mock(spec=TransformFrameworkStep)
-        step.right_framework_uuid = uuid4()
+        step.source_framework_uuid = uuid4()
         step.from_framework = Mock()
         step.from_framework.get_class_name.return_value = "FromCFW"
 
@@ -952,7 +952,7 @@ class TestMultiExecuteStep:
         executor = ComputeFrameworkExecutor(cfw_register, worker_manager)
 
         step = Mock(spec=TransformFrameworkStep)
-        step.right_framework_uuid = uuid4()
+        step.source_framework_uuid = uuid4()
         step.from_framework = Mock()
         step.from_framework.get_class_name.return_value = "FromCFW"
         step.required_uuids = [uuid4()]


### PR DESCRIPTION
Closes #668.

`JoinStep.left_framework` / `right_framework` never meant left and right: `ExecutionPlan.run_link` swaps them for `JoinType.RIGHT` joins and again when no child needs the declared orientation. They mean the merge destination and the merge source.

## Changes

- `JoinStep`: `left_framework` / `right_framework` / `left_framework_uuids` / `right_framework_uuids` renamed to `destination_framework` / `source_framework` / `destination_framework_uuids` / `source_framework_uuids`. All internal consumers updated (execution_plan, joinstep_collection, compute_framework_executor, multiprocessing_worker, plan_info).
- `run_link` no longer needs the comment explaining that left is not left.
- `TransformFrameworkStep.right_framework_uuids` / `right_framework_uuid` renamed to `source_framework_uuids` / `source_framework_uuid`: the value is fed straight from the join's source side, so it carried the same misnomer one hop downstream.
- The `PlanStep` join docstring and the resolved-plan docs lose the swap caveat.

No behavior change and no public-surface change: `JoinStep` and `TransformFrameworkStep` live under `mloda/core/core/step/` and are internal. `PlanStep.compute_framework` / `source_compute_framework` already used destination/source naming and are untouched. The declared sides remain on `step.link` (`left_feature_group` / `right_feature_group`).

## Testing

`tox` green: 5426 passed, 171 skipped, ruff format, ruff check, license allowlist, mypy --strict, bandit. The cross-framework join test from PR #666 passes unchanged.