### PR TITLE
fix: reject mis-wrapped top-level credentials instead of iterating them

### DIFF
--- a/mloda/core/abstract_plugins/components/data_access_collection.py
+++ b/mloda/core/abstract_plugins/components/data_access_collection.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterable
 from typing import Any, Callable
 
 from mloda.core.abstract_plugins.components.credential import Credential
@@ -47,7 +48,8 @@ class DataAccessCollection:
             ``HashableDict`` is no longer accepted on the credentials path; the
             class itself stays for hashability-required internals (e.g. ``Options``
             hashing, ``ApiInputDataCollection``). Credentials have no ``set``
-            form (dicts are unhashable).
+            form (dicts are unhashable). Any other top-level ``credentials``
+            value (``str``, ``bytes``, ``int``, ...) raises ``ValueError``.
 
         ``column_to_file`` maps a column to either a file handle or a file path
         (paths are normalized to their handle).
@@ -80,15 +82,19 @@ class DataAccessCollection:
             return None
         if isinstance(credentials, Credential):
             return [credentials.data]
-        if isinstance(credentials, HashableDict):
-            # Not a dict and not iterable, so it would hit the list fallback below and raise TypeError.
-            return [cls._unwrap_credential(credentials)]
         if isinstance(credentials, dict):
             context_keys = tuple(credentials.keys())
             return {
                 handle: cls._validated_credential_value(handle, value, context_keys)
                 for handle, value in credentials.items()
             }
+        if isinstance(credentials, (str, bytes, bytearray)) or not isinstance(credentials, Iterable):
+            # Single mis-wrapped value, not a sequence of credentials. HashableDict raises the migration error.
+            cls._unwrap_credential(credentials)
+            raise ValueError(
+                f"credentials must be a Credential, a dict of {{handle: credential}}, or a list of credentials; "
+                f"got {type(credentials).__name__}."
+            )
         return [cls._unwrap_credential(entry) for entry in credentials]
 
     @staticmethod

--- a/mloda/core/abstract_plugins/components/data_access_collection.py
+++ b/mloda/core/abstract_plugins/components/data_access_collection.py
@@ -80,6 +80,9 @@ class DataAccessCollection:
             return None
         if isinstance(credentials, Credential):
             return [credentials.data]
+        if isinstance(credentials, HashableDict):
+            # Not a dict and not iterable, so it would hit the list fallback below and raise TypeError.
+            return [cls._unwrap_credential(credentials)]
         if isinstance(credentials, dict):
             context_keys = tuple(credentials.keys())
             return {

--- a/tests/test_core/test_abstract_plugins/test_components/test_credential.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_credential.py
@@ -229,6 +229,12 @@ class TestCredentialsPathRejectsHashableDict:
         assert "dict" in lowered
         assert self.SECRET not in msg
 
+    def test_top_level_form_rejects_hashable_dict(self) -> None:
+        # Issue #675: the pre-0.7 top-level shape must raise the migration ValueError, not TypeError.
+        with pytest.raises(ValueError) as excinfo:
+            DataAccessCollection(credentials=HashableDict({"sqlite": self.SECRET}))  # type: ignore[arg-type]
+        self._assert_migration_error(str(excinfo.value))
+
     def test_named_form_rejects_hashable_dict_value(self) -> None:
         with pytest.raises(ValueError) as excinfo:
             DataAccessCollection(credentials={"db": HashableDict({"sqlite": self.SECRET})})

--- a/tests/test_core/test_abstract_plugins/test_components/test_credential.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_credential.py
@@ -258,6 +258,50 @@ class TestCredentialsPathRejectsHashableDict:
         self._assert_migration_error(str(excinfo.value))
 
 
+class TestTopLevelCredentialsRejectsScalarValues:
+    """Issue #675: a top-level scalar ``credentials`` value must be rejected at construction.
+
+    Before the #675 fix, the ``_normalize_credentials`` fallback treated anything not
+    ``Credential`` / ``dict`` / ``HashableDict`` as a SEQUENCE of credentials: a ``str``
+    was iterated per character into bogus auto-handles, ``bytes`` per int, and an ``int``
+    raised a cryptic ``TypeError``.
+
+    The ValueError must name the offending TYPE and the supported shapes
+    (``Credential``, dict of {handle: credential}, list of credentials), and must never
+    echo the value: it may be a secret.
+    """
+
+    SECRET = "/secret/credential/path.db"  # nosec B105
+
+    def _assert_shape_error(self, msg: str, type_name: str) -> None:
+        lowered = msg.lower()
+        assert type_name in lowered
+        assert "Credential" in msg
+        assert "dict" in lowered
+        assert "list" in lowered
+
+    def test_top_level_str_raises_value_error_naming_str_and_never_echoing_secret(self) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            DataAccessCollection(credentials=self.SECRET)  # type: ignore[arg-type]
+        msg = str(excinfo.value)
+        self._assert_shape_error(msg, "str")
+        assert self.SECRET not in msg
+
+    def test_top_level_int_raises_value_error_naming_int_not_cryptic_type_error(self) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            DataAccessCollection(credentials=42)  # type: ignore[arg-type]
+        msg = str(excinfo.value)
+        self._assert_shape_error(msg, "int")
+        assert "42" not in msg
+
+    def test_top_level_bytes_raises_value_error_naming_bytes_and_never_echoing_secret(self) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            DataAccessCollection(credentials=self.SECRET.encode())  # type: ignore[arg-type]
+        msg = str(excinfo.value)
+        self._assert_shape_error(msg, "bytes")
+        assert self.SECRET not in msg
+
+
 class TestResolveAmbiguityRedactsCredentialValues:
     """Cycle 3, Finding A (security): the all-auto ambiguity error in ``resolve()``
     must not print stored credential values verbatim.


### PR DESCRIPTION
Closes #675.

## Problem

`DataAccessCollection(credentials=HashableDict({...}))`, the pre-0.7 top-level call shape, raised `TypeError: 'HashableDict' object is not iterable` instead of the migration `ValueError` that #524 introduced for every other credential position. `HashableDict` is not a `dict` subclass, so `_normalize_credentials` fell through to the list branch and the comprehension raised before `_unwrap_credential` could produce the helpful message. The users most in need of the migration hint got the least helpful error.

## Root cause, and what else it broke

The reported `TypeError` was one symptom of a wider assumption: the fallback treated *anything* that was not a `Credential` or a `dict` as a sequence of credentials. On main today:

| input | behavior |
|---|---|
| `credentials=HashableDict({"sqlite": "/x"})` | `TypeError: 'HashableDict' object is not iterable` |
| `credentials="/secret/path.db"` | no error, the string is iterated per character and 15 bogus credentials are registered under `_auto_credentials_0..14` |
| `credentials=b"abc"` | no error, three `int` credentials registered |
| `credentials=42` | `TypeError: 'int' object is not iterable` |

The string case is the worst: nothing fails at construction, and the user finds out later via a matcher that silently never matches, or a nonsensical "Ambiguous resolve for kind 'credentials': 15 matches".

## Fix

One guard in `_normalize_credentials`, after the `dict` branch and before the list fallback, rejecting `str` / `bytes` / `bytearray` (iterable, but not sequences *of credentials*) and any non-iterable, with a `ValueError` that names the offending type and the three supported shapes. It never interpolates the value, which may be a secret.

`HashableDict` defines no `__iter__`, so it lands in the same guard and `_unwrap_credential` raises the existing migration `ValueError` first. That function remains the single source of the migration message. Genuine sequences (list, tuple, set) are unaffected.

## Tests

- `test_top_level_form_rejects_hashable_dict`: the #675 regression, in the existing `TestCredentialsPathRejectsHashableDict` class alongside the list, named and `add_credentials` cases.
- `TestTopLevelCredentialsRejectsScalarValues`: `str`, `bytes` and `int` now raise a `ValueError` naming the type, and the assertions pin that the secret value is never echoed.

`tox` green: 5433 passed, ruff, pip-licenses, mypy --strict, bandit all clean.

## Reviewed, not fixed here

List-form entries are the only credential position with no mapping validation: `credentials=["/x.db"]` registers a raw string while the semantically identical `add_credentials("/x.db")` raises the friendly mis-wrap error. Tightening that is a behavior change beyond this issue's scope, so it is left for a follow-up rather than smuggled in here.