### PR TITLE
feat: expose __version__ on the public facade modules (#676)

### DIFF
--- a/docs/docs/in_depth/feature-group-version.md
+++ b/docs/docs/in_depth/feature-group-version.md
@@ -28,6 +28,21 @@ def version(cls) -> str:
     return BaseFeatureGroupVersion.version(cls)
 ```
 
+## Reading the mloda Package Version
+
+Three supported programmatic paths, all backed by `mloda.core.version.get_mloda_version()`:
+
+```python
+from mloda.user import __version__          # also on mloda.provider and mloda.steward
+from mloda.core.version import get_mloda_version
+from mloda.provider import BaseFeatureGroupVersion
+
+get_mloda_version()                          # memoized, "0.0.0" if not installed
+BaseFeatureGroupVersion.mloda_version()      # same value
+```
+
+There is no `mloda.__version__`: `mloda` is a PEP 420 namespace root with no `__init__.py`, so plugin packages can add subpackages under it.
+
 ## Benefits
 
 - **Change Detection**: Easily detect when a feature group implementation has changed

--- a/mloda/core/abstract_plugins/components/base_feature_group_version.py
+++ b/mloda/core/abstract_plugins/components/base_feature_group_version.py
@@ -27,11 +27,7 @@ _class_source_hash_cache: "weakref.WeakKeyDictionary[type[Any], str]" = weakref.
 class BaseFeatureGroupVersion(ABC):
     @classmethod
     def mloda_version(cls) -> str:
-        """
-        Retrieves the version of the 'mloda' package using importlib.metadata.
-        If retrieval fails, it returns "0.0.0" as a fallback.
-        The result (including the fallback) is memoized for the process lifetime.
-        """
+        """Returns the installed mloda version via get_mloda_version() (memoized, "0.0.0" fallback)."""
         return get_mloda_version()
 
     @classmethod

--- a/mloda/core/abstract_plugins/components/base_feature_group_version.py
+++ b/mloda/core/abstract_plugins/components/base_feature_group_version.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import ast
-import importlib.metadata
 import inspect
 import linecache
 import hashlib
 import weakref
 from typing import Any, Final
 from abc import ABC
+
+from mloda.core.version import get_mloda_version
 
 # Exceptions inspect.getsource raises for dynamically built classes (no source backing / built-in).
 SOURCE_INTROSPECTION_ERRORS: Final = (OSError, TypeError)
@@ -22,11 +23,6 @@ SOURCE_INTROSPECTION_ERRORS: Final = (OSError, TypeError)
 # not pinned for the process lifetime and can still be garbage-collected.
 _class_source_hash_cache: "weakref.WeakKeyDictionary[type[Any], str]" = weakref.WeakKeyDictionary()
 
-# Package metadata cannot change within a process; docs enumeration calls
-# mloda_version per FeatureGroup subclass, and repeated importlib.metadata
-# parsing was a measured hot path in large test sessions.
-_mloda_version_cache: str | None = None
-
 
 class BaseFeatureGroupVersion(ABC):
     @classmethod
@@ -36,14 +32,7 @@ class BaseFeatureGroupVersion(ABC):
         If retrieval fails, it returns "0.0.0" as a fallback.
         The result (including the fallback) is memoized for the process lifetime.
         """
-        global _mloda_version_cache
-        if _mloda_version_cache is not None:
-            return _mloda_version_cache
-        try:
-            _mloda_version_cache = importlib.metadata.version("mloda")
-        except Exception:
-            _mloda_version_cache = "0.0.0"
-        return _mloda_version_cache
+        return get_mloda_version()
 
     @classmethod
     def class_source_hash(cls, target_class: type[Any]) -> str:

--- a/mloda/core/version.py
+++ b/mloda/core/version.py
@@ -1,0 +1,24 @@
+"""Single source of truth for the installed mloda package version."""
+
+from __future__ import annotations
+
+# Redundant alias form: makes ``importlib`` an explicit re-export so callers (and tests)
+# may patch ``mloda.core.version.importlib.metadata.version`` under mypy --strict.
+import importlib as importlib
+import importlib.metadata
+
+# Package metadata cannot change within a process, so the lookup is memoized:
+# repeated importlib.metadata parsing was a measured hot path (docs enumeration).
+_mloda_version_cache: str | None = None
+
+
+def get_mloda_version() -> str:
+    """Returns the installed 'mloda' version, or "0.0.0" when the distribution is not installed."""
+    global _mloda_version_cache
+    if _mloda_version_cache is not None:
+        return _mloda_version_cache
+    try:
+        _mloda_version_cache = importlib.metadata.version("mloda")
+    except importlib.metadata.PackageNotFoundError:
+        _mloda_version_cache = "0.0.0"
+    return _mloda_version_cache

--- a/mloda/core/version.py
+++ b/mloda/core/version.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-# Redundant alias form: makes ``importlib`` an explicit re-export so callers (and tests)
-# may patch ``mloda.core.version.importlib.metadata.version`` under mypy --strict.
-import importlib as importlib
 import importlib.metadata
 
 # Package metadata cannot change within a process, so the lookup is memoized:
@@ -19,6 +16,7 @@ def get_mloda_version() -> str:
         return _mloda_version_cache
     try:
         _mloda_version_cache = importlib.metadata.version("mloda")
-    except importlib.metadata.PackageNotFoundError:
+    # Broad: __version__ runs at facade import time, so any metadata error must degrade, not break the import.
+    except Exception:
         _mloda_version_cache = "0.0.0"
     return _mloda_version_cache

--- a/mloda/provider/__init__.py
+++ b/mloda/provider/__init__.py
@@ -21,6 +21,7 @@ from mloda.core.abstract_plugins.feature_group import FeatureGroup as FeatureGro
 
 # Versioning
 from mloda.core.abstract_plugins.components.base_feature_group_version import BaseFeatureGroupVersion
+from mloda.core.version import get_mloda_version
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework as ComputeFramework
 from mloda.core.abstract_plugins.compute_framework import EmptyResultError as EmptyResultError
 
@@ -89,7 +90,11 @@ from mloda.core.filter.filter_engine import BaseFilterEngine
 from mloda.core.abstract_plugins.components.mask.base_mask_engine import BaseMaskEngine
 from mloda.core.abstract_plugins.components.merge.base_merge_engine import BaseMergeEngine
 
+__version__ = get_mloda_version()
+
 __all__ = [
+    # Version
+    "__version__",
     # Base classes
     "FeatureGroup",
     # Versioning

--- a/mloda/steward/__init__.py
+++ b/mloda/steward/__init__.py
@@ -1,3 +1,6 @@
+# Version
+from mloda.core.version import get_mloda_version
+
 # Plugin inspection/metadata
 from mloda.core.api.plugin_info import FeatureGroupInfo, ComputeFrameworkInfo, ExtenderInfo, ResolvedFeature
 
@@ -29,7 +32,11 @@ from mloda.core.abstract_plugins.plugin_registry.plugin_policy import (
     PluginPolicyViolationError,
 )
 
+__version__ = get_mloda_version()
+
 __all__ = [
+    # Version
+    "__version__",
     # Plugin inspection
     "FeatureGroupInfo",
     "ComputeFrameworkInfo",

--- a/mloda/user/__init__.py
+++ b/mloda/user/__init__.py
@@ -1,6 +1,9 @@
 import importlib
 from typing import TYPE_CHECKING, Any
 
+# Version
+from mloda.core.version import get_mloda_version
+
 # API
 from mloda.core.api.request import mlodaAPI
 
@@ -53,6 +56,8 @@ from mloda.core.api.plugin_docs import (
     list_registered,
     resolve_feature,
 )
+
+__version__ = get_mloda_version()
 
 mloda = mlodaAPI
 stream_all = mlodaAPI.stream_all
@@ -126,6 +131,8 @@ def __dir__() -> list[str]:
 
 
 __all__ = [
+    # Version
+    "__version__",
     # API
     "mlodaAPI",
     "mloda",

--- a/tests/test_core/test_abstract_plugins/test_components/test_base_feature_group_version.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_base_feature_group_version.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import pytest
 
-import mloda.core.abstract_plugins.components.base_feature_group_version as base_feature_group_version_module
+import mloda.core.version as version_module
 from mloda.provider import BaseFeatureGroupVersion, FeatureGroup
 from tests.test_core.test_abstract_plugins.test_abstract_feature_group import BaseTestFeatureGroup1
 
@@ -17,7 +17,7 @@ class TestBaseFeatureGroupVersion:
         # monkeypatch teardown restores both the version function and the
         # pre-test cache value, so no "1.2.3" poisoning leaks to other tests.
         monkeypatch.setattr(importlib.metadata, "version", lambda pkg: "1.2.3")
-        monkeypatch.setattr(base_feature_group_version_module, "_mloda_version_cache", None)
+        monkeypatch.setattr(version_module, "_mloda_version_cache", None)
 
         composite = BaseTestFeatureGroup1.version()
         # Expected format: "1.2.3-{module_name}-{hash}"
@@ -153,7 +153,7 @@ class TestMlodaVersionMemoization:
         # Earlier tests in the same process may already have populated the
         # memo; reset the module-level cache so this test observes the first
         # lookup. raising=False creates the attribute if it does not exist yet.
-        monkeypatch.setattr(base_feature_group_version_module, "_mloda_version_cache", None, raising=False)
+        monkeypatch.setattr(version_module, "_mloda_version_cache", None, raising=False)
 
         calls: list[str] = []
         real_metadata_version = importlib.metadata.version

--- a/tests/test_core/test_core/test_version.py
+++ b/tests/test_core/test_core/test_version.py
@@ -3,23 +3,9 @@
 from __future__ import annotations
 
 import importlib.metadata
-from collections.abc import Iterator
 from typing import Any
 
 import pytest
-
-
-@pytest.fixture
-def reset_version_cache() -> Iterator[None]:
-    """Restores the memoization cache of mloda.core.version so tests do not poison the process."""
-    import mloda.core.version as version_module
-
-    previous = version_module._mloda_version_cache
-    version_module._mloda_version_cache = None
-    try:
-        yield
-    finally:
-        version_module._mloda_version_cache = previous
 
 
 def test_get_mloda_version_matches_distribution_metadata() -> None:
@@ -28,8 +14,10 @@ def test_get_mloda_version_matches_distribution_metadata() -> None:
     assert get_mloda_version() == importlib.metadata.version("mloda")
 
 
-def test_get_mloda_version_is_memoized(reset_version_cache: None, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_get_mloda_version_is_memoized(monkeypatch: pytest.MonkeyPatch) -> None:
     import mloda.core.version as version_module
+
+    monkeypatch.setattr(version_module, "_mloda_version_cache", None)
 
     calls: list[str] = []
     real_version = importlib.metadata.version
@@ -38,7 +26,7 @@ def test_get_mloda_version_is_memoized(reset_version_cache: None, monkeypatch: p
         calls.append(name)
         return real_version(name)
 
-    monkeypatch.setattr(version_module.importlib.metadata, "version", counting_version)
+    monkeypatch.setattr(importlib.metadata, "version", counting_version)
 
     first = version_module.get_mloda_version()
     second = version_module.get_mloda_version()
@@ -48,15 +36,15 @@ def test_get_mloda_version_is_memoized(reset_version_cache: None, monkeypatch: p
     assert len(calls) == 1, f"expected metadata lookup to be memoized, got {len(calls)} lookups"
 
 
-def test_get_mloda_version_falls_back_when_distribution_missing(
-    reset_version_cache: None, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_get_mloda_version_falls_back_when_distribution_missing(monkeypatch: pytest.MonkeyPatch) -> None:
     import mloda.core.version as version_module
+
+    monkeypatch.setattr(version_module, "_mloda_version_cache", None)
 
     def raise_not_found(name: str) -> str:
         raise importlib.metadata.PackageNotFoundError(name)
 
-    monkeypatch.setattr(version_module.importlib.metadata, "version", raise_not_found)
+    monkeypatch.setattr(importlib.metadata, "version", raise_not_found)
 
     assert version_module.get_mloda_version() == "0.0.0"
 

--- a/tests/test_core/test_core/test_version.py
+++ b/tests/test_core/test_core/test_version.py
@@ -1,0 +1,88 @@
+"""Tests for the mloda core version helper and the facade-level ``__version__`` attributes."""
+
+from __future__ import annotations
+
+import importlib.metadata
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+
+@pytest.fixture
+def reset_version_cache() -> Iterator[None]:
+    """Restores the memoization cache of mloda.core.version so tests do not poison the process."""
+    import mloda.core.version as version_module
+
+    previous = version_module._mloda_version_cache
+    version_module._mloda_version_cache = None
+    try:
+        yield
+    finally:
+        version_module._mloda_version_cache = previous
+
+
+def test_get_mloda_version_matches_distribution_metadata() -> None:
+    from mloda.core.version import get_mloda_version
+
+    assert get_mloda_version() == importlib.metadata.version("mloda")
+
+
+def test_get_mloda_version_is_memoized(reset_version_cache: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    import mloda.core.version as version_module
+
+    calls: list[str] = []
+    real_version = importlib.metadata.version
+
+    def counting_version(name: str) -> str:
+        calls.append(name)
+        return real_version(name)
+
+    monkeypatch.setattr(version_module.importlib.metadata, "version", counting_version)
+
+    first = version_module.get_mloda_version()
+    second = version_module.get_mloda_version()
+
+    assert first == second
+    assert version_module._mloda_version_cache == first
+    assert len(calls) == 1, f"expected metadata lookup to be memoized, got {len(calls)} lookups"
+
+
+def test_get_mloda_version_falls_back_when_distribution_missing(
+    reset_version_cache: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import mloda.core.version as version_module
+
+    def raise_not_found(name: str) -> str:
+        raise importlib.metadata.PackageNotFoundError(name)
+
+    monkeypatch.setattr(version_module.importlib.metadata, "version", raise_not_found)
+
+    assert version_module.get_mloda_version() == "0.0.0"
+
+
+@pytest.mark.parametrize("module_name", ["mloda.user", "mloda.provider", "mloda.steward"])
+def test_facade_modules_expose_version(module_name: str) -> None:
+    import importlib
+
+    module: Any = importlib.import_module(module_name)
+
+    assert hasattr(module, "__version__"), f"{module_name} must expose a module-level __version__"
+    assert isinstance(module.__version__, str)
+    assert module.__version__ == importlib.metadata.version("mloda")
+
+
+def test_base_feature_group_version_uses_helper() -> None:
+    from mloda.core.abstract_plugins.components.base_feature_group_version import BaseFeatureGroupVersion
+    from mloda.core.version import get_mloda_version
+
+    assert BaseFeatureGroupVersion.mloda_version() == get_mloda_version()
+    assert BaseFeatureGroupVersion.mloda_version() == importlib.metadata.version("mloda")
+
+
+def test_mloda_stays_a_namespace_package() -> None:
+    """Regression guard: adding __version__ to facades must not introduce mloda/__init__.py."""
+    import mloda
+
+    assert mloda.__file__ is None, f"mloda must stay a PEP 420 namespace package, got __file__={mloda.__file__}"
+    assert type(mloda.__path__).__name__ == "_NamespacePath"


### PR DESCRIPTION
Closes #676.

## What

Adds `mloda.core.version.get_mloda_version()` as the single memoized source of the installed distribution version, and exposes `__version__` on the three public facades:

```python
from mloda.user import __version__        # also mloda.provider, mloda.steward
from mloda.core.version import get_mloda_version
```

`BaseFeatureGroupVersion.mloda_version()` now delegates to the same helper, so the memo cache lives in one place instead of two.

## Why not `mloda.__version__`

`mloda` is a PEP 420 namespace package on purpose (no `mloda/__init__.py` anywhere), so the sibling distributions (`mloda.registry`, `mloda.community`, `mloda.enterprise`, `mloda.testing`) can ship into the same namespace. Creating a root `__init__.py` to hold `__version__` would turn it into a regular package and break them. The issue's original 'Code pointers' section was corrected for exactly this reason, and a regression test guards the property (`mloda.__file__ is None`).

## Notes

The lookup keeps a broad `except Exception` fallback to `"0.0.0"`: `__version__` is computed at facade import time, so a corrupt or duplicate `dist-info` must degrade rather than break `import mloda.user`.

## Testing

New `tests/test_core/test_core/test_version.py` covers the helper (value, memoization, missing-distribution fallback), the three facade attributes, the delegation, and the namespace-package guard. Full `tox` is green (5437 passed, 171 skipped; ruff, licenses, mypy --strict, bandit).