### PR TITLE
feat: state the remedy in EmptyResultError and document the columnar result contract

### DIFF
--- a/docs/docs/chapter1/feature-groups.md
+++ b/docs/docs/chapter1/feature-groups.md
@@ -68,7 +68,15 @@ Example_id: [[0,2,4,...]]
 
 In this example, we implemented a custom feature group, Example, that multiplies each feature value by 2. By defining a straightforward input_features method and a calculate_feature method, we were able to extend mloda's feature engineering capabilities with custom transformations. We then executed the request by simply modifying the feature names with a prefix ("Example_"), allowing mloda to handle dependencies and computations automatically.
 
-#### 5. Advanced Feature Group Topics
+#### 5. The result contract
+
+A feature group must return its **columns**, even when it has no rows. Zero rows
+is a valid result; zero columns is not, and raises `EmptyResultError`. On the
+PythonDict framework this means a row-oriented `[]` is *not* a valid empty
+result: return `{"my_feature": []}` instead, keeping the column and dropping the
+rows. See [Empty Result Handling](../in_depth/compute-framework-integration.md#empty-results).
+
+#### 6. Advanced Feature Group Topics
 
 For more in-depth information about feature groups, check out these advanced topics:
 
@@ -83,6 +91,6 @@ For more in-depth information about feature groups, check out these advanced top
 - [Mask Engine](../in_depth/mask_engine.md) - Inline masking with `features.mask_engine`
 - [Empty Result Handling](../in_depth/compute-framework-integration.md#empty-results) - Zero rows is always valid; a zero-column (schema-less) result raises `EmptyResultError`
 
-#### 6. Discovering Feature Groups
+#### 7. Discovering Feature Groups
 
 To list all available feature groups and their documentation, use the `get_feature_group_docs()` function from `mloda.steward`.

--- a/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
+++ b/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
@@ -156,6 +156,9 @@ passes through. Only a result that carries no columns at all is rejected.
 On the PythonDict framework, whose native representation is a columnar
 `dict[str, list]`, the schema is the set of keys: `{"col": []}` carries a
 schema, while `{}` (zero columns) is the only schema-less value and raises.
+Returning a row-oriented `[]` ("nothing to ingest": an empty source directory, a
+query with no hits) also carries no columns and therefore raises. Return
+`{"my_feature": []}` instead.
 
 If the schema-less result is genuine (a bug, missing data, wrong filter), this
 error is correct behavior: it protects callers from silently receiving output

--- a/mloda/core/abstract_plugins/compute_framework.py
+++ b/mloda/core/abstract_plugins/compute_framework.py
@@ -576,10 +576,14 @@ class ComputeFramework(ABC):
         if self.data is None:
             return
 
-        if features.get_initial_requested_features() and not self.column_names:
+        requested = features.get_initial_requested_features()
+        if requested and not self.column_names:
+            example = next(iter(requested))
             raise EmptyResultError(
                 f"Result carries no schema (no columns): {feature_group.get_class_name()}. "
-                "A feature must return a schema; zero rows is a valid result, zero columns is not."
+                "A feature must return a schema; zero rows is a valid result, zero columns is not. "
+                f'Return your feature names with empty lists (e.g. {{"{example}": []}}) '
+                "to express an empty result."
             )
 
         from mloda.core.abstract_plugins.components.validators.datatype_validator import DataTypeValidator

--- a/mloda/core/abstract_plugins/compute_framework.py
+++ b/mloda/core/abstract_plugins/compute_framework.py
@@ -578,11 +578,11 @@ class ComputeFramework(ABC):
 
         requested = features.get_initial_requested_features()
         if requested and not self.column_names:
-            example = next(iter(requested))
+            example = ", ".join(f'"{name}": []' for name in requested)
             raise EmptyResultError(
                 f"Result carries no schema (no columns): {feature_group.get_class_name()}. "
                 "A feature must return a schema; zero rows is a valid result, zero columns is not. "
-                f'Return your feature names with empty lists (e.g. {{"{example}": []}}) '
+                f"Return your feature names with empty lists (e.g. {{{example}}}) "
                 "to express an empty result."
             )
 

--- a/tests/test_plugins/compute_framework/base_implementations/pyarrow/test_pyarrow_table.py
+++ b/tests/test_plugins/compute_framework/base_implementations/pyarrow/test_pyarrow_table.py
@@ -167,6 +167,20 @@ class _FakeGuardFeatures:
         return {"a"}
 
 
+class _FakeGuardMultiFeatures:
+    """FeatureSet stand-in requesting two features.
+
+    Mirrors the real ``FeatureSet.get_initial_requested_features()``, which returns a
+    sorted tuple, so the rendered example dict has a deterministic order.
+    """
+
+    def __init__(self) -> None:
+        self.features: list[Any] = []
+
+    def get_initial_requested_features(self) -> tuple[str, ...]:
+        return ("a", "b")
+
+
 class TestPyArrowEmptyResultGuard:
     """Direct unit tests for the EmptyResultError guard on a schema-bearing framework.
 
@@ -200,6 +214,21 @@ class TestPyArrowEmptyResultGuard:
         message = str(excinfo.value)
         assert "empty list" in message
         assert '{"a": []}' in message
+
+    def test_message_lists_all_requested_feature_names(self) -> None:
+        """With several requested features, the example dict must list all of them.
+
+        Showing only the first name leads users to return a partial dict, which clears
+        this guard and then fails downstream on missing-column validation.
+        """
+        framework = PyArrowTable(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
+        framework.data = pa.table({})
+        framework.set_column_names()
+
+        with pytest.raises(EmptyResultError) as excinfo:
+            framework.run_validate_output_features(_FakeGuardFeatureGroup(), _FakeGuardMultiFeatures())
+
+        assert '{"a": [], "b": []}' in str(excinfo.value)
 
     def test_zero_rows_with_schema_does_not_raise(self) -> None:
         """A zero-row but column-bearing table is a valid result; the guard must not fire.

--- a/tests/test_plugins/compute_framework/base_implementations/pyarrow/test_pyarrow_table.py
+++ b/tests/test_plugins/compute_framework/base_implementations/pyarrow/test_pyarrow_table.py
@@ -184,6 +184,23 @@ class TestPyArrowEmptyResultGuard:
         with pytest.raises(EmptyResultError):
             framework.run_validate_output_features(_FakeGuardFeatureGroup(), _FakeGuardFeatures())
 
+    def test_message_states_the_remedy_with_a_requested_feature_name(self) -> None:
+        """The guard message must name the remedy using an actually requested feature name.
+
+        ``_FakeGuardFeatures.get_initial_requested_features()`` requests ``"a"``, so the
+        example dict in the message has to read ``{"a": []}`` rather than a placeholder.
+        """
+        framework = PyArrowTable(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
+        framework.data = pa.table({})
+        framework.set_column_names()
+
+        with pytest.raises(EmptyResultError) as excinfo:
+            framework.run_validate_output_features(_FakeGuardFeatureGroup(), _FakeGuardFeatures())
+
+        message = str(excinfo.value)
+        assert "empty list" in message
+        assert '{"a": []}' in message
+
     def test_zero_rows_with_schema_does_not_raise(self) -> None:
         """A zero-row but column-bearing table is a valid result; the guard must not fire.
 

--- a/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_columnar_contract.py
+++ b/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_columnar_contract.py
@@ -277,3 +277,43 @@ def test_zero_column_result_raises_without_flag(flight_server: Any) -> None:
             flight_server=flight_server,
         )
     assert isinstance(excinfo.value, EmptyResultError)
+
+
+def test_zero_column_error_message_states_the_remedy(flight_server: Any) -> None:
+    """The EmptyResultError must tell the user HOW to express an empty result.
+
+    Diagnosing the failure is not enough: the message has to name the fix, i.e. return the
+    requested feature names mapped to empty lists.
+    """
+    with pytest.raises(EmptyResultError) as excinfo:
+        mloda.run_all(
+            [Feature(name="columnar_zero_column_col")],
+            compute_frameworks=["PythonDictFramework"],
+            plugin_collector=_ENABLED_ZERO_COLUMN,
+            parallelization_modes={ParallelizationMode.SYNC},
+            flight_server=flight_server,
+        )
+
+    message = str(excinfo.value)
+    assert "empty list" in message
+    assert "to express an empty result" in message
+
+
+def test_zero_column_error_message_example_uses_a_requested_feature_name(flight_server: Any) -> None:
+    """The example dict must use a REAL requested feature name, not a placeholder.
+
+    The remedy is only actionable if it shows the user's own feature name, which the guard
+    can read from ``features.get_initial_requested_features()``.
+    """
+    with pytest.raises(EmptyResultError) as excinfo:
+        mloda.run_all(
+            [Feature(name="columnar_zero_column_col")],
+            compute_frameworks=["PythonDictFramework"],
+            plugin_collector=_ENABLED_ZERO_COLUMN,
+            parallelization_modes={ParallelizationMode.SYNC},
+            flight_server=flight_server,
+        )
+
+    message = str(excinfo.value)
+    assert '{"columnar_zero_column_col": []}' in message
+    assert "my_feature" not in message


### PR DESCRIPTION
Closes #705 (Problem 2 only; the CHANGELOG ask in Problem 1 is deliberately out of scope for this PR).

## Problem

Returning `[]` from `calculate_feature` is the natural way for a root FeatureGroup to say "there was nothing to ingest". Since 0.9.0 that raises:

```
EmptyResultError: Result carries no schema (no columns): MarkdownKbBuilderFG.
A feature must return a schema; zero rows is a valid result, zero columns is not.
```

The message describes what is wrong with the internal representation, not what the author should change. The word "schema" appears nowhere in the plugin's code, and the empty path is the least-covered one, so this tends to surface in production rather than CI.

## Change

The error now states the remedy, rendering the feature names that were actually requested:

```
... zero columns is not. Return your feature names with empty lists
(e.g. {"my_feature": []}) to express an empty result.
```

Every requested name is listed, so a multi-output feature group gets `{"a": [], "b": []}` rather than an example that would clear this guard and then fail the missing-column check.

Docs: the FeatureGroup page now states the result contract (columns are required even at zero rows), and the troubleshooting page calls out that a row-oriented `[]` is schema-less and raises, since that is the value users actually return.

## Tests

Four tests, covering the end-to-end `run_all` path on PythonDict and the guard directly on PyArrow: the message states the remedy, the example uses real requested feature names rather than a placeholder, and every requested name is listed. `tox` is green (5444 passed, ruff, mypy --strict, bandit).