### PR TITLE
fix: validate nested in_features dicts through FeatureConfig (#680)

### DIFF
--- a/docs/docs/in_depth/feature-config.md
+++ b/docs/docs/in_depth/feature-config.md
@@ -69,7 +69,7 @@ Combine strings and objects:
 |-------|------|----------|-------------|
 | `name` | string | Yes | Feature name |
 | `options` | object | No | Simple options dict (cannot be used with group_options/context_options) |
-| `in_features` | array | No | Source feature names for chained features |
+| `in_features` | array | No | Array of source feature names for chained features |
 | `group_options` | object | No | Group parameters (affect Feature Group resolution) |
 | `context_options` | object | No | Context parameters (metadata, doesn't affect resolution) |
 | `propagate_context_keys` | array | No | Context keys that propagate to dependent features |
@@ -197,6 +197,28 @@ Multiple source features:
     }
 ]
 ```
+
+### Nested in_features feature dict
+
+Inside `options`, an `in_features` key can hold a feature dict instead of a name, which defines the source feature inline:
+
+```json
+[
+    {
+        "name": "scaled_sales",
+        "options": {
+            "scaler_type": "minmax",
+            "in_features": {
+                "name": "aggregated_sales",
+                "feature_group": "SalesAggregator",
+                "options": {"in_features": "raw_sales"}
+            }
+        }
+    }
+]
+```
+
+A nested dict supports `name`, `options`, `in_features` and `feature_group` only. In a nested `in_features` dict under `options`, the top-level-only fields (`column_index`, `group_options`, `context_options`, `propagate_context_keys`) are rejected, and so is an unknown key. A feature dict must be the direct value of `in_features`: an `in_features` list holds source feature names, not feature dicts.
 
 ## Multi-Column Features
 

--- a/mloda/core/api/feature_config/loader.py
+++ b/mloda/core/api/feature_config/loader.py
@@ -15,10 +15,38 @@ from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.api.feature_config.parser import parse_json
 from mloda.core.api.feature_config.models import (
     FeatureConfig,
-    validate_feature_group_not_in_options,
-    validate_feature_group_scope,
+    parse_nested_feature_config,
+    validate_nested_in_features,
 )
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+
+
+def build_nested_feature(value: dict[str, Any]) -> Feature:
+    """Build a Feature from a nested in_features dict, validated through FeatureConfig.
+
+    Args:
+        value: Nested feature definition under an "in_features" key
+
+    Returns:
+        Feature object for the nested definition
+    """
+    config = parse_nested_feature_config(value)
+    validate_nested_in_features(config.in_features)
+
+    processed_nested_options = process_nested_features(config.options)
+
+    # Sibling in_features: a list of more than one source name stays a list, a 1-element list collapses to its
+    # element, a dict recurses into another nested Feature, a string is a single source name stored as-is.
+    in_features = config.in_features
+    if in_features:
+        if isinstance(in_features, list):
+            processed_nested_options["in_features"] = in_features if len(in_features) > 1 else in_features[0]
+        elif isinstance(in_features, dict):
+            processed_nested_options["in_features"] = build_nested_feature(in_features)
+        else:
+            processed_nested_options["in_features"] = in_features
+
+    return Feature(name=config.name, options=processed_nested_options, feature_group=config.feature_group)
 
 
 def process_nested_features(options: dict[str, Any]) -> dict[str, Any]:
@@ -33,38 +61,7 @@ def process_nested_features(options: dict[str, Any]) -> dict[str, Any]:
     processed: dict[str, Any] = {}
     for key, value in options.items():
         if key == "in_features" and isinstance(value, dict):
-            # This is a nested feature definition - convert it to a Feature object
-            feature_name = value.get("name")
-            if not feature_name:
-                raise ValueError(f"Nested in_features must have a 'name' field: {value}")
-
-            # Recursively process nested options
-            nested_options = value.get("options", {})
-            validate_feature_group_not_in_options(nested_options, "options")
-            processed_nested_options = process_nested_features(nested_options)
-
-            # Handle nested in_features (can also be a dict)
-            in_features = value.get("in_features")
-            if in_features:
-                if isinstance(in_features, list):
-                    # For list, convert each to string (single sources) or keep as-is
-                    processed_nested_options["in_features"] = in_features if len(in_features) > 1 else in_features[0]
-                elif isinstance(in_features, dict):
-                    # Recursively create Feature for in_features
-                    in_features = process_nested_features({"in_features": in_features})["in_features"]
-                    processed_nested_options["in_features"] = in_features
-                else:
-                    processed_nested_options["in_features"] = in_features
-
-            # The nested dict skips FeatureConfig, so validate its scope with the same rules
-            nested_feature_group = validate_feature_group_scope(value.get("feature_group"))
-
-            # Create the Feature object, keeping any nested resolution scope
-            processed[key] = Feature(
-                name=feature_name,
-                options=processed_nested_options,
-                feature_group=nested_feature_group,
-            )
+            processed[key] = build_nested_feature(value)
         elif isinstance(value, dict):
             # Recursively process nested dicts
             processed[key] = process_nested_features(value)

--- a/mloda/core/api/feature_config/models.py
+++ b/mloda/core/api/feature_config/models.py
@@ -5,7 +5,7 @@ This module defines the data models used to validate and parse
 feature configuration files.
 """
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 from typing import Any, Optional
 
 
@@ -45,17 +45,21 @@ def validate_feature_group_not_in_options(options: Optional[dict[str, Any]], con
 class FeatureConfig:
     """Model for a feature configuration with name and options."""
 
-    name: str
-    options: dict[str, Any] = field(default_factory=dict)
-    in_features: Optional[list[str]] = None
+    # metadata={"nested": True} marks the fields a nested in_features dict supports; the rest are top-level only.
+    name: str = field(metadata={"nested": True})
+    options: dict[str, Any] = field(default_factory=dict, metadata={"nested": True})
+    # A nested in_features dict reuses this field for a single source name or a further nested feature dict.
+    in_features: Optional[list[str] | dict[str, Any] | str] = field(default=None, metadata={"nested": True})
     group_options: Optional[dict[str, Any]] = None
     context_options: Optional[dict[str, Any]] = None
     propagate_context_keys: Optional[list[str]] = None
     column_index: Optional[int] = None
-    feature_group: Optional[str] = None
+    feature_group: Optional[str] = field(default=None, metadata={"nested": True})
 
     def __post_init__(self) -> None:
-        """Validate that options and group_options/context_options are mutually exclusive."""
+        """Validate the invariants shared by the top-level and the nested feature dict."""
+        if not isinstance(self.name, str) or not self.name.strip():
+            raise ValueError(f"'name' must be a non-empty string, got: {self.name!r}")
         if self.options and (self.group_options or self.context_options):
             raise ValueError("Cannot use both 'options' and 'group_options'/'context_options'")
         if self.propagate_context_keys and not self.context_options:
@@ -69,11 +73,84 @@ class FeatureConfig:
         validate_feature_group_not_in_options(self.context_options, "context_options")
 
 
+FEATURE_CONFIG_FIELDS = frozenset(f.name for f in fields(FeatureConfig))
+NESTED_FIELDS = frozenset(f.name for f in fields(FeatureConfig) if f.metadata.get("nested"))
+
+
+def validate_top_level_in_features(value: Any) -> None:
+    """Top-level in_features is an array of source feature names.
+
+    Not a __post_init__ invariant: the nested in_features dict legitimately carries a string or a dict here.
+    """
+    if value is None:
+        return
+    if not isinstance(value, list):
+        raise ValueError(
+            f"'in_features' must be an array of source feature names at the top level of a feature config, got: "
+            f"{value!r}"
+        )
+    for element in value:
+        if not isinstance(element, str) or not element.strip():
+            raise ValueError(
+                f"'in_features' must be an array of non-empty source feature names at the top level of a feature "
+                f"config, got element: {element!r}"
+            )
+
+
+def validate_nested_in_features(value: Any) -> None:
+    """A nested in_features value is a source name, a list of source names, or a further nested feature dict."""
+    if value is None:
+        return
+    if isinstance(value, dict):
+        return
+    if isinstance(value, str):
+        if not value.strip():
+            raise ValueError(f"'in_features' must be a non-empty source feature name, got: {value!r}")
+        return
+    if isinstance(value, list):
+        if not value:
+            raise ValueError("'in_features' must not be an empty list; it declares the source features")
+        for element in value:
+            if isinstance(element, dict):
+                raise ValueError(
+                    "'in_features' as a list holds source feature names only; a nested feature dict is supported "
+                    f"as the direct value of 'in_features', not as a list element, got: {element!r}"
+                )
+            if not isinstance(element, str) or not element.strip():
+                raise ValueError(
+                    f"'in_features' as a list holds non-empty source feature names, got element: {element!r}"
+                )
+        return
+    raise ValueError(
+        f"'in_features' must be a source feature name, a list of source feature names, or a nested feature dict, "
+        f"got: {value!r}"
+    )
+
+
+def parse_nested_feature_config(item: dict[str, Any]) -> FeatureConfig:
+    """Validate a nested in_features dict through FeatureConfig, rejecting unknown and top-level-only keys."""
+    if "name" not in item:
+        raise ValueError(f"Nested in_features must have a 'name' field, keys present: {sorted(item)}")
+
+    # An unknown key is a typo, not a misplacement: let FeatureConfig raise the native TypeError naming it,
+    # before the top-level-only check can misreport it. Both checks precede __post_init__, whose invariants
+    # are top-level semantics and would otherwise give misleading advice for a nested dict.
+    if not FEATURE_CONFIG_FIELDS.issuperset(item):
+        FeatureConfig(**item)
+
+    top_level_only = sorted(key for key in item if key not in NESTED_FIELDS)
+    if top_level_only:
+        raise ValueError(
+            f"{top_level_only} is only valid at the top level of a feature config; "
+            "a nested 'in_features' dict supports 'name', 'options', 'in_features' and 'feature_group' only"
+        )
+    return FeatureConfig(**item)
+
+
 def feature_config_schema() -> dict[str, Any]:
     """Return JSON Schema for FeatureConfig model.
 
-    Note: This provides a basic schema representation. For full JSON Schema
-    support, consider using a dedicated schema generation library.
+    FeatureConfig is the enforcement point at both levels; the schema itself is never run by a validator.
     """
     return {
         "type": "object",

--- a/mloda/core/api/feature_config/parser.py
+++ b/mloda/core/api/feature_config/parser.py
@@ -5,7 +5,7 @@ This module provides parsers for configuration files in JSON format.
 """
 
 import json
-from mloda.core.api.feature_config.models import FeatureConfig, FeatureConfigItem
+from mloda.core.api.feature_config.models import FeatureConfig, FeatureConfigItem, validate_top_level_in_features
 
 
 def parse_json(config_str: str) -> list[FeatureConfigItem]:
@@ -27,7 +27,9 @@ def parse_json(config_str: str) -> list[FeatureConfigItem]:
         if isinstance(item, str):
             result.append(item)
         elif isinstance(item, dict):
-            result.append(FeatureConfig(**item))
+            config = FeatureConfig(**item)
+            validate_top_level_in_features(config.in_features)
+            result.append(config)
         else:
             raise ValueError(f"Invalid configuration item: {item}")
 

--- a/tests/test_core/test_api/feature_config/test_feature_config_loader.py
+++ b/tests/test_core/test_api/feature_config/test_feature_config_loader.py
@@ -4,6 +4,9 @@ Unit tests for feature configuration loader.
 This module tests the load_features_from_config function from mloda.core.api.feature_config.loader.
 """
 
+import json
+from typing import Any
+
 import pytest
 
 from mloda.user import Feature
@@ -399,6 +402,85 @@ def test_load_appends_tilde_syntax_to_name() -> None:
     # Fourth: minimal configuration
     assert isinstance(result[3], Feature)
     assert result[3].name == "embedded__description~3"
+
+
+def test_load_features_rejects_in_features_as_string() -> None:
+    """Test that a top-level in_features string is rejected instead of char-splitting (issue #680).
+
+    frozenset("age") is frozenset({'a', 'g', 'e'}), so a string in_features silently
+    becomes three one-character source features. The loader must reject it: in_features
+    is an array of source feature names.
+    """
+    config_str = '[{"name": "scale__age", "in_features": "age"}]'
+
+    with pytest.raises(ValueError, match="in_features") as exc_info:
+        load_features_from_config(config_str, format="json")
+
+    assert "array" in str(exc_info.value)
+
+
+def test_load_features_rejects_in_features_as_dict() -> None:
+    """Test that a top-level in_features dict is rejected instead of collapsing to its keys."""
+    config_str = '[{"name": "scale__age", "in_features": {"name": "age"}}]'
+
+    with pytest.raises(ValueError, match="in_features") as exc_info:
+        load_features_from_config(config_str, format="json")
+
+    assert "array" in str(exc_info.value)
+
+
+def test_load_features_rejects_empty_name() -> None:
+    """Test that an empty top-level 'name' is rejected, matching the nested in_features rule."""
+    config_str = '[{"name": ""}]'
+
+    with pytest.raises(ValueError, match="name"):
+        load_features_from_config(config_str, format="json")
+
+
+# The elements go straight into frozenset(): an int element becomes a bogus source feature and a
+# dict element dies with an internal "unhashable type: 'dict'" TypeError. Every element must be a
+# non-empty source feature name, rejected with a ValueError that names in_features and the element.
+BAD_TOP_LEVEL_IN_FEATURES: list[Any] = [
+    pytest.param([1, 2], 1, id="ints"),
+    pytest.param(["age", 7], 7, id="mixed_int"),
+    pytest.param([{"name": "age"}], {"name": "age"}, id="feature_dict"),
+    pytest.param(["age", ""], "", id="empty_string"),
+    pytest.param(["age", "   "], "   ", id="whitespace_only_string"),
+    pytest.param(["age", None], None, id="null"),
+]
+
+
+@pytest.mark.parametrize("in_features, offender", BAD_TOP_LEVEL_IN_FEATURES)
+def test_load_features_rejects_in_features_element_that_is_not_a_name(in_features: list[Any], offender: Any) -> None:
+    """Test that a top-level in_features element that is not a non-empty name is rejected (issue #680)."""
+    config_str = json.dumps([{"name": "scale__age", "in_features": in_features}])
+
+    with pytest.raises(ValueError, match="in_features") as exc_info:
+        load_features_from_config(config_str, format="json")
+
+    assert repr(offender) in str(exc_info.value)
+
+
+@pytest.mark.parametrize("in_features, offender", BAD_TOP_LEVEL_IN_FEATURES)
+def test_load_features_rejects_in_features_element_with_group_options(in_features: list[Any], offender: Any) -> None:
+    """Test that the group_options branch of the loader rejects the same bad in_features elements."""
+    config_str = json.dumps([{"name": "scale__age", "in_features": in_features, "group_options": {"threshold": 0.5}}])
+
+    with pytest.raises(ValueError, match="in_features") as exc_info:
+        load_features_from_config(config_str, format="json")
+
+    assert repr(offender) in str(exc_info.value)
+
+
+def test_load_features_accepts_in_features_array_of_names() -> None:
+    """Test that the valid top-level in_features array form keeps loading unchanged."""
+    config_str = '[{"name": "scale__age", "in_features": ["age", "weight"]}]'
+
+    result = load_features_from_config(config_str, format="json")
+
+    assert len(result) == 1
+    assert isinstance(result[0], Feature)
+    assert result[0].options.context.get(DefaultOptionKeys.in_features) == frozenset({"age", "weight"})
 
 
 def test_load_features_with_multiple_in_features() -> None:

--- a/tests/test_core/test_api/feature_config/test_feature_config_model.py
+++ b/tests/test_core/test_api/feature_config/test_feature_config_model.py
@@ -5,6 +5,10 @@ This module tests the validation and behavior of the FeatureConfig model
 defined in mloda.core.api.feature_config.models.
 """
 
+from typing import Any
+
+import pytest
+
 from mloda.core.api.feature_config.models import FeatureConfig
 
 
@@ -31,3 +35,23 @@ def test_feature_config_options_default_empty() -> None:
 
     assert config.options == {}
     assert isinstance(config.options, dict)
+
+
+def test_feature_config_rejects_empty_name() -> None:
+    """Test that an empty name is rejected (shared invariant for the top-level and nested paths)."""
+    with pytest.raises(ValueError, match="name"):
+        FeatureConfig(name="")
+
+
+def test_feature_config_rejects_whitespace_only_name() -> None:
+    """Test that a whitespace-only name strips to nothing and is rejected."""
+    with pytest.raises(ValueError, match="name"):
+        FeatureConfig(name="   ")
+
+
+def test_feature_config_rejects_non_string_name() -> None:
+    """Test that a non-string name is rejected: 'name' is a non-empty string."""
+    bad_value: Any = 123
+
+    with pytest.raises(ValueError, match="name"):
+        FeatureConfig(name=bad_value)

--- a/tests/test_core/test_api/feature_config/test_feature_config_nested_validation.py
+++ b/tests/test_core/test_api/feature_config/test_feature_config_nested_validation.py
@@ -1,0 +1,678 @@
+"""Nested in_features dicts are validated like a FeatureConfig (issue #680).
+
+The nested dict under an "in_features" key is built by hand in the loader: only
+'name', 'options', 'in_features' and 'feature_group' are ever read, every other
+key is silently dropped. A typo therefore degrades to a feature with no scope
+instead of failing, while the very same typo at the TOP level is rejected by
+FeatureConfig with a TypeError naming the key.
+
+These tests pin FeatureConfig as the single validation path for both levels:
+an unknown key is rejected at any nesting depth, a top-level-only field written
+into a nested dict is rejected instead of ignored, 'name' must be a non-empty
+string everywhere, and every nested shape that is valid today keeps producing
+the same Feature objects.
+
+They also pin the edges the first fix left open: a sibling 'in_features' list
+holds source feature names only (a feature dict is supported as the direct value
+of 'in_features', never as a list element, and it must not slip through the list
+branch unvalidated), the top-level-only ValueError wins over the top-level
+invariants of FeatureConfig.__post_init__ while an unknown key stays a TypeError,
+and the missing-'name' error lists the keys present rather than dumping an
+options payload that may carry credentials.
+"""
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from mloda.core.api.feature_config.loader import load_features_from_config, process_nested_features
+from mloda.user import Feature
+
+
+def _feature_named(features: list[Feature | str], name: str) -> Feature:
+    """Return the loaded Feature with the given name, failing the test if it is absent."""
+    for item in features:
+        if isinstance(item, Feature) and item.name == name:
+            return item
+    raise AssertionError(f"Feature '{name}' not found in the loaded config")
+
+
+# ---------------------------------------------------------------------------
+# Unknown keys in a nested in_features dict
+#
+# The top level raises "unexpected keyword argument 'feature_grp'" from
+# FeatureConfig; the nested dict must raise the same way instead of building a
+# scope-less feature out of a typo.
+# ---------------------------------------------------------------------------
+
+
+def test_nested_in_features_rejects_unknown_key() -> None:
+    """An unknown key in a nested in_features dict raises and names the key."""
+    options: dict[str, Any] = {
+        "in_features": {"name": "shared_token", "feature_grp": "ClaimsReader"},
+    }
+
+    with pytest.raises(TypeError, match="feature_grp"):
+        process_nested_features(options)
+
+
+def test_loader_nested_in_features_rejects_unknown_key() -> None:
+    """Issue repro: the typo'd nested key is rejected through the JSON surface."""
+    config_str = """[
+        {
+            "name": "outer",
+            "options": {
+                "in_features": {
+                    "name": "shared_token",
+                    "feature_grp": "ClaimsReader"
+                }
+            }
+        }
+    ]"""
+
+    with pytest.raises(TypeError, match="feature_grp"):
+        load_features_from_config(config_str, format="json")
+
+
+def test_nested_in_features_rejects_unknown_key_two_levels_deep() -> None:
+    """The recursion rejects an unknown key in a nested feature's own nested feature."""
+    options: dict[str, Any] = {
+        "in_features": {
+            "name": "outer_token",
+            "options": {
+                "in_features": {"name": "inner_token", "feature_grp": "ClaimsReader"},
+            },
+        },
+    }
+
+    with pytest.raises(TypeError, match="feature_grp"):
+        process_nested_features(options)
+
+
+def test_nested_in_features_rejects_unknown_key_in_sibling_in_features_dict() -> None:
+    """The sibling in_features-as-dict path rejects an unknown key too."""
+    options: dict[str, Any] = {
+        "in_features": {
+            "name": "outer_token",
+            "in_features": {"name": "inner_token", "feature_grp": "ClaimsReader"},
+        },
+    }
+
+    with pytest.raises(TypeError, match="feature_grp"):
+        process_nested_features(options)
+
+
+def test_loader_nested_in_features_rejects_unknown_key_two_levels_deep() -> None:
+    """The deep rejection surfaces through load_features_from_config as well."""
+    config_str = """[
+        {
+            "name": "outer",
+            "options": {
+                "in_features": {
+                    "name": "middle_token",
+                    "options": {
+                        "in_features": {
+                            "name": "inner_token",
+                            "feature_grp": "ClaimsReader"
+                        }
+                    }
+                }
+            }
+        }
+    ]"""
+
+    with pytest.raises(TypeError, match="feature_grp"):
+        load_features_from_config(config_str, format="json")
+
+
+# ---------------------------------------------------------------------------
+# Top-level-only fields inside a nested in_features dict
+#
+# These are keys FeatureConfig knows, but the nested path cannot honor them:
+# today they are read by nobody and silently dropped. They must be rejected
+# with a ValueError naming the offending key.
+# ---------------------------------------------------------------------------
+
+TOP_LEVEL_ONLY_FIELDS: list[tuple[str, Any]] = [
+    ("column_index", 1),
+    ("group_options", {"threshold": 0.5}),
+    ("context_options", {"metadata": "test"}),
+    ("propagate_context_keys", ["metadata"]),
+]
+
+
+@pytest.mark.parametrize("key, value", TOP_LEVEL_ONLY_FIELDS)
+def test_nested_in_features_rejects_top_level_only_field(key: str, value: Any) -> None:
+    """A top-level-only field in a nested dict raises a ValueError naming that key and the top-level rule.
+
+    The 'top level' phrasing is what makes the error actionable: the fix is to move the key up, not to
+    add the sibling key that a top-level invariant would ask for.
+    """
+    options: dict[str, Any] = {
+        "in_features": {"name": "shared_token", key: value},
+    }
+
+    with pytest.raises(ValueError, match=key) as exc_info:
+        process_nested_features(options)
+
+    assert "top level" in str(exc_info.value)
+
+
+@pytest.mark.parametrize("key, value", TOP_LEVEL_ONLY_FIELDS)
+def test_loader_nested_in_features_rejects_top_level_only_field(key: str, value: Any) -> None:
+    """The same rejection surfaces through the JSON surface for every top-level-only field."""
+    config: dict[str, Any] = {
+        "name": "outer",
+        "options": {"in_features": {"name": "shared_token", key: value}},
+    }
+
+    with pytest.raises(ValueError, match=key) as exc_info:
+        load_features_from_config(json.dumps([config]), format="json")
+
+    assert "top level" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# The top-level-only ValueError wins over the top-level-semantics invariants
+#
+# FeatureConfig.__post_init__ enforces invariants that only make sense at the
+# top level. Firing them for a nested dict gives misleading advice: following it
+# (adding 'context_options', dropping 'options') just produces the next error.
+# The "this key is only valid at the top level" message must win.
+# ---------------------------------------------------------------------------
+
+
+def test_nested_propagate_context_keys_reports_top_level_not_missing_context_options() -> None:
+    """'propagate_context_keys' is top-level-only, so it must not be reported as needing 'context_options'."""
+    options: dict[str, Any] = {
+        "in_features": {"name": "shared_token", "propagate_context_keys": ["metadata"]},
+    }
+
+    with pytest.raises(ValueError, match="propagate_context_keys") as exc_info:
+        process_nested_features(options)
+
+    message = str(exc_info.value)
+    assert "top level" in message
+    assert "requires 'context_options'" not in message
+
+
+def test_nested_group_options_beside_options_reports_top_level_not_options_conflict() -> None:
+    """A nested dict with 'options' and 'group_options' names group_options as top-level-only."""
+    options: dict[str, Any] = {
+        "in_features": {
+            "name": "shared_token",
+            "options": {"aggregation_function": "max"},
+            "group_options": {"threshold": 0.5},
+        },
+    }
+
+    with pytest.raises(ValueError, match="group_options") as exc_info:
+        process_nested_features(options)
+
+    message = str(exc_info.value)
+    assert "top level" in message
+    assert "Cannot use both" not in message
+
+
+MISLEADING_INVARIANT_DICTS: list[Any] = [
+    pytest.param(
+        {"name": "shared_token", "propagate_context_keys": ["metadata"]},
+        "propagate_context_keys",
+        id="propagate_context_keys_without_context_options",
+    ),
+    pytest.param(
+        {"name": "shared_token", "options": {"aggregation_function": "max"}, "group_options": {"threshold": 0.5}},
+        "group_options",
+        id="group_options_beside_options",
+    ),
+    pytest.param(
+        {"name": "shared_token", "options": {"aggregation_function": "max"}, "context_options": {"metadata": "test"}},
+        "context_options",
+        id="context_options_beside_options",
+    ),
+]
+
+
+@pytest.mark.parametrize("nested, key", MISLEADING_INVARIANT_DICTS)
+def test_loader_nested_top_level_only_field_wins_over_invariant(nested: dict[str, Any], key: str) -> None:
+    """Through the JSON surface too, the top-level-only rule wins over the top-level invariants."""
+    config: dict[str, Any] = {"name": "outer", "options": {"in_features": nested}}
+
+    with pytest.raises(ValueError, match=key) as exc_info:
+        load_features_from_config(json.dumps([config]), format="json")
+
+    assert "top level" in str(exc_info.value)
+
+
+@pytest.mark.parametrize("key, value", TOP_LEVEL_ONLY_FIELDS)
+def test_nested_unknown_key_wins_over_top_level_only_field(key: str, value: Any) -> None:
+    """An unknown key stays a TypeError even next to a top-level-only key: a typo is not a misplacement."""
+    options: dict[str, Any] = {
+        "in_features": {"name": "shared_token", "feature_grp": "ClaimsReader", key: value},
+    }
+
+    with pytest.raises(TypeError, match="feature_grp"):
+        process_nested_features(options)
+
+
+def test_loader_nested_unknown_key_wins_over_top_level_only_field() -> None:
+    """The unknown-key TypeError beats the top-level-only ValueError through the JSON surface as well."""
+    config: dict[str, Any] = {
+        "name": "outer",
+        "options": {"in_features": {"name": "shared_token", "feature_grp": "ClaimsReader", "column_index": 1}},
+    }
+
+    with pytest.raises(TypeError, match="feature_grp"):
+        load_features_from_config(json.dumps([config]), format="json")
+
+
+# ---------------------------------------------------------------------------
+# 'name' is a non-empty string at both levels
+# ---------------------------------------------------------------------------
+
+
+def test_nested_in_features_rejects_missing_name() -> None:
+    """A nested dict without 'name' raises a ValueError naming the missing field."""
+    options: dict[str, Any] = {
+        "in_features": {"options": {"scaler_type": "minmax"}},
+    }
+
+    with pytest.raises(ValueError, match="name"):
+        process_nested_features(options)
+
+
+def test_nested_in_features_missing_name_error_lists_keys_not_values() -> None:
+    """The missing-'name' error names the keys present, never their values: options can carry credentials."""
+    sensitive_value = "sk-live-51H8xQzZzZ-abcdef"
+    options: dict[str, Any] = {
+        "in_features": {
+            "options": {"api_key": sensitive_value, "scaler_type": "minmax"},
+            "feature_group": "ConfigScopeSourceA",
+        },
+    }
+
+    with pytest.raises(ValueError, match="name") as exc_info:
+        process_nested_features(options)
+
+    message = str(exc_info.value)
+    assert sensitive_value not in message
+    assert "options" in message
+    assert "feature_group" in message
+
+
+def test_loader_nested_in_features_missing_name_error_lists_keys_not_values() -> None:
+    """The same value-free error surfaces through the JSON surface."""
+    sensitive_value = "sk-live-51H8xQzZzZ-abcdef"
+    config: dict[str, Any] = {
+        "name": "outer",
+        "options": {"in_features": {"options": {"api_key": sensitive_value}}},
+    }
+
+    with pytest.raises(ValueError, match="name") as exc_info:
+        load_features_from_config(json.dumps([config]), format="json")
+
+    message = str(exc_info.value)
+    assert sensitive_value not in message
+    assert "options" in message
+
+
+def test_nested_in_features_rejects_empty_name() -> None:
+    """An empty nested 'name' is a config mistake, not a feature called ''."""
+    options: dict[str, Any] = {
+        "in_features": {"name": ""},
+    }
+
+    with pytest.raises(ValueError, match="name"):
+        process_nested_features(options)
+
+
+def test_nested_in_features_rejects_whitespace_only_name() -> None:
+    """A whitespace-only nested 'name' strips to nothing and must be rejected too."""
+    options: dict[str, Any] = {
+        "in_features": {"name": "   "},
+    }
+
+    with pytest.raises(ValueError, match="name"):
+        process_nested_features(options)
+
+
+def test_loader_nested_in_features_rejects_whitespace_only_name() -> None:
+    """The whitespace-only nested name is rejected through the JSON surface as well."""
+    config_str = """[
+        {
+            "name": "outer",
+            "options": {
+                "in_features": {"name": "   "}
+            }
+        }
+    ]"""
+
+    with pytest.raises(ValueError, match="name"):
+        load_features_from_config(config_str, format="json")
+
+
+# ---------------------------------------------------------------------------
+# Regression: every nested shape that is valid today still loads unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_nested_name_and_options_shape_still_loads() -> None:
+    """Shape {name, options}: the nested Feature lands in the outer group options."""
+    config_str = """[
+        {
+            "name": "outer",
+            "options": {
+                "scaler_type": "minmax",
+                "in_features": {
+                    "name": "shared_token",
+                    "options": {"aggregation_function": "max"}
+                }
+            }
+        }
+    ]"""
+
+    result = load_features_from_config(config_str, format="json")
+
+    outer = _feature_named(result, "outer")
+    assert outer.options.group.get("scaler_type") == "minmax"
+    nested = outer.options.group.get("in_features")
+    assert isinstance(nested, Feature)
+    assert nested.name == "shared_token"
+    assert nested.options.group.get("aggregation_function") == "max"
+    assert nested.feature_group_scope is None
+
+
+def test_nested_json_fixture_two_levels_deep_still_loads() -> None:
+    """The 2-level deep 'min_max_nested' fixture keeps its Feature chain and its raw string leaf."""
+    json_path = Path(__file__).parent / "test_config_features.json"
+    config_str = json_path.read_text()
+
+    result = load_features_from_config(config_str, format="json")
+
+    outer = _feature_named(result, "min_max_nested")
+    assert outer.options.group.get("scaler_type") == "minmax"
+
+    level_one = outer.options.group.get("in_features")
+    assert isinstance(level_one, Feature)
+    assert level_one.name == "max_aggregated"
+    assert level_one.options.group.get("aggregation_function") == "max"
+
+    level_two = level_one.options.group.get("in_features")
+    assert isinstance(level_two, Feature)
+    assert level_two.name == "minmaxscaledweght"
+    assert level_two.options.group.get("scaler_type") == "minmax"
+
+    # The innermost leaf is a plain source name inside 'options', not a nested dict
+    assert level_two.options.group.get("in_features") == "weight"
+
+
+def test_nested_name_feature_group_and_options_shape_still_loads() -> None:
+    """Shape {name, feature_group, options}: the scope survives on the nested Feature."""
+    config_str = """[
+        {
+            "name": "outer",
+            "options": {
+                "in_features": {
+                    "name": "shared_token",
+                    "feature_group": "ConfigScopeSourceA",
+                    "options": {"in_features": "age"}
+                }
+            }
+        }
+    ]"""
+
+    result = load_features_from_config(config_str, format="json")
+
+    nested = _feature_named(result, "outer").options.group.get("in_features")
+    assert isinstance(nested, Feature)
+    assert nested.name == "shared_token"
+    assert nested.feature_group_scope == "ConfigScopeSourceA"
+    assert nested.options.group.get("in_features") == "age"
+
+
+def test_nested_name_and_feature_group_shape_still_loads() -> None:
+    """Shape {name, feature_group}: a scoped nested feature with no options at all."""
+    options: dict[str, Any] = {
+        "in_features": {"name": "shared_token", "feature_group": "ConfigScopeSourceA"},
+    }
+
+    processed = process_nested_features(options)
+
+    nested = processed["in_features"]
+    assert isinstance(nested, Feature)
+    assert nested.name == "shared_token"
+    assert nested.feature_group_scope == "ConfigScopeSourceA"
+    assert len(nested.options.group) == 0
+
+
+def test_nested_sibling_in_features_dict_still_loads() -> None:
+    """Shape {name, in_features}: a dict sibling becomes a Feature under the plain 'in_features' key."""
+    options: dict[str, Any] = {
+        "in_features": {
+            "name": "outer_token",
+            "in_features": {"name": "inner_token", "options": {"scaler_type": "minmax"}},
+        },
+    }
+
+    processed = process_nested_features(options)
+
+    outer = processed["in_features"]
+    assert isinstance(outer, Feature)
+    assert outer.name == "outer_token"
+    inner = outer.options.group.get("in_features")
+    assert isinstance(inner, Feature)
+    assert inner.name == "inner_token"
+    assert inner.options.group.get("scaler_type") == "minmax"
+
+
+def test_nested_sibling_in_features_single_element_list_collapses_to_scalar() -> None:
+    """Shape {name, in_features}: a 1-element list collapses to the bare element."""
+    options: dict[str, Any] = {
+        "in_features": {"name": "outer_token", "in_features": ["age"]},
+    }
+
+    processed = process_nested_features(options)
+
+    outer = processed["in_features"]
+    assert isinstance(outer, Feature)
+    assert outer.options.group.get("in_features") == "age"
+
+
+def test_nested_sibling_in_features_multi_element_list_stays_a_list() -> None:
+    """Shape {name, in_features}: a list with more than one entry is kept as a list."""
+    options: dict[str, Any] = {
+        "in_features": {"name": "outer_token", "in_features": ["age", "weight"]},
+    }
+
+    processed = process_nested_features(options)
+
+    outer = processed["in_features"]
+    assert isinstance(outer, Feature)
+    assert outer.options.group.get("in_features") == ["age", "weight"]
+
+
+def test_nested_sibling_in_features_scalar_string_is_kept() -> None:
+    """Shape {name, in_features}: a scalar source name is stored as-is."""
+    options: dict[str, Any] = {
+        "in_features": {"name": "outer_token", "in_features": "age"},
+    }
+
+    processed = process_nested_features(options)
+
+    outer = processed["in_features"]
+    assert isinstance(outer, Feature)
+    assert outer.options.group.get("in_features") == "age"
+
+
+def test_loader_nested_sibling_in_features_list_still_loads() -> None:
+    """The sibling in_features list survives the full JSON surface too."""
+    config_str = """[
+        {
+            "name": "outer",
+            "options": {
+                "in_features": {
+                    "name": "outer_token",
+                    "in_features": ["age", "weight"]
+                }
+            }
+        }
+    ]"""
+
+    result = load_features_from_config(config_str, format="json")
+
+    nested = _feature_named(result, "outer").options.group.get("in_features")
+    assert isinstance(nested, Feature)
+    assert nested.name == "outer_token"
+    assert nested.options.group.get("in_features") == ["age", "weight"]
+
+
+# ---------------------------------------------------------------------------
+# A sibling in_features LIST carries source feature names only
+#
+# The list branch of build_nested_feature stores its elements without looking at
+# them, so a feature dict inside the list is neither validated nor converted: it
+# stays a raw dict in the options. That is the #680 failure mode via the list
+# path. A nested feature dict is supported as the direct VALUE of in_features
+# only; a list holds non-empty source feature name strings.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "in_features",
+    [
+        pytest.param([{"name": "inner_token", "feature_grp": "ClaimsReader"}], id="single_element_list"),
+        pytest.param(["age", {"name": "inner_token"}], id="multi_element_list"),
+    ],
+)
+def test_nested_sibling_in_features_list_rejects_feature_dict_element(in_features: list[Any]) -> None:
+    """A feature dict inside an in_features list is rejected instead of being stored as a raw dict."""
+    options: dict[str, Any] = {
+        "in_features": {"name": "outer_token", "in_features": in_features},
+    }
+
+    with pytest.raises(ValueError, match="in_features") as exc_info:
+        process_nested_features(options)
+
+    message = str(exc_info.value)
+    assert "dict" in message
+    assert "list" in message
+
+
+@pytest.mark.parametrize(
+    "in_features",
+    [
+        pytest.param([1, 2], id="ints"),
+        pytest.param(["age", 7], id="mixed_int"),
+        pytest.param([None], id="null"),
+        pytest.param([["age"]], id="inner_list"),
+    ],
+)
+def test_nested_sibling_in_features_list_rejects_non_string_element(in_features: list[Any]) -> None:
+    """A list element that is not a string is not a source feature name."""
+    options: dict[str, Any] = {
+        "in_features": {"name": "outer_token", "in_features": in_features},
+    }
+
+    with pytest.raises(ValueError, match="in_features"):
+        process_nested_features(options)
+
+
+@pytest.mark.parametrize(
+    "in_features",
+    [
+        pytest.param([""], id="empty_string"),
+        pytest.param(["age", "   "], id="whitespace_only_string"),
+    ],
+)
+def test_nested_sibling_in_features_list_rejects_empty_string_element(in_features: list[Any]) -> None:
+    """An empty or whitespace-only list element names no feature and must be rejected."""
+    options: dict[str, Any] = {
+        "in_features": {"name": "outer_token", "in_features": in_features},
+    }
+
+    with pytest.raises(ValueError, match="in_features"):
+        process_nested_features(options)
+
+
+@pytest.mark.parametrize(
+    "in_features",
+    [
+        pytest.param(123, id="int"),
+        pytest.param(1.5, id="float"),
+        pytest.param(True, id="bool"),
+    ],
+)
+def test_nested_sibling_in_features_rejects_non_string_scalar(in_features: Any) -> None:
+    """A bare non-string scalar is stored as a 'source feature name' today; it is a config mistake."""
+    options: dict[str, Any] = {
+        "in_features": {"name": "outer_token", "in_features": in_features},
+    }
+
+    with pytest.raises(ValueError, match="in_features"):
+        process_nested_features(options)
+
+
+@pytest.mark.parametrize(
+    "in_features",
+    [
+        pytest.param("", id="empty_string"),
+        pytest.param("   ", id="whitespace_only_string"),
+        pytest.param([], id="empty_list"),
+    ],
+)
+def test_nested_sibling_in_features_rejects_empty_value(in_features: Any) -> None:
+    """An empty in_features is silently dropped today; an empty source declaration is a mistake."""
+    options: dict[str, Any] = {
+        "in_features": {"name": "outer_token", "in_features": in_features},
+    }
+
+    with pytest.raises(ValueError, match="in_features"):
+        process_nested_features(options)
+
+
+def test_loader_nested_sibling_in_features_list_rejects_feature_dict_element() -> None:
+    """Issue repro through the list path: the typo'd feature dict inside the list is rejected."""
+    config_str = """[
+        {
+            "name": "outer",
+            "options": {
+                "in_features": {
+                    "name": "mid",
+                    "in_features": [{"name": "a", "feature_grp": "Typo"}]
+                }
+            }
+        }
+    ]"""
+
+    with pytest.raises(ValueError, match="in_features") as exc_info:
+        load_features_from_config(config_str, format="json")
+
+    message = str(exc_info.value)
+    assert "dict" in message
+    assert "list" in message
+
+
+BAD_NESTED_SIBLING_IN_FEATURES: list[Any] = [
+    pytest.param([{"name": "inner_token"}], id="list_with_feature_dict"),
+    pytest.param(["age", {"name": "inner_token"}], id="multi_element_list_with_feature_dict"),
+    pytest.param([1, 2], id="list_of_ints"),
+    pytest.param([""], id="list_with_empty_string"),
+    pytest.param([None], id="list_with_null"),
+    pytest.param(123, id="bare_int"),
+    pytest.param("", id="empty_string"),
+    pytest.param([], id="empty_list"),
+]
+
+
+@pytest.mark.parametrize("in_features", BAD_NESTED_SIBLING_IN_FEATURES)
+def test_loader_nested_sibling_in_features_rejects_invalid_value(in_features: Any) -> None:
+    """Every invalid sibling in_features shape is rejected through the JSON surface."""
+    config: dict[str, Any] = {
+        "name": "outer",
+        "options": {"in_features": {"name": "outer_token", "in_features": in_features}},
+    }
+
+    with pytest.raises(ValueError, match="in_features"):
+        load_features_from_config(json.dumps([config]), format="json")

--- a/tests/test_core/test_api/feature_config/test_feature_config_parser.py
+++ b/tests/test_core/test_api/feature_config/test_feature_config_parser.py
@@ -4,6 +4,9 @@ Unit tests for feature configuration parser.
 This module tests the parse_json function from mloda.core.api.feature_config.parser.
 """
 
+import json
+from typing import Any
+
 import pytest
 
 from mloda.core.api.feature_config.models import FeatureConfig
@@ -361,6 +364,95 @@ def test_parse_json_with_in_features_array() -> None:
     assert result[2].name == "ref_multi_feature"
     assert result[2].in_features == ["base_feature", "other_col"]
     assert result[2].group_options == {"group_param": "value"}
+
+
+def test_parse_json_rejects_unknown_key() -> None:
+    """Test that an unknown top-level key is rejected and named in the error (issue #680).
+
+    FeatureConfig(**item) rejects any key it does not declare, so a typo like
+    'feature_grp' fails loudly instead of being silently ignored. The nested
+    in_features path must behave the same way.
+    """
+    config_str = '[{"name": "shared_token", "feature_grp": "ClaimsReader"}]'
+
+    with pytest.raises(TypeError, match="feature_grp"):
+        parse_json(config_str)
+
+
+def test_parse_json_rejects_empty_name() -> None:
+    """Test that an empty 'name' is rejected instead of producing a feature called ''."""
+    config_str = '[{"name": ""}]'
+
+    with pytest.raises(ValueError, match="name"):
+        parse_json(config_str)
+
+
+def test_parse_json_rejects_whitespace_only_name() -> None:
+    """Test that a whitespace-only 'name' strips to nothing and is rejected."""
+    config_str = '[{"name": "   "}]'
+
+    with pytest.raises(ValueError, match="name"):
+        parse_json(config_str)
+
+
+def test_parse_json_rejects_in_features_as_string() -> None:
+    """Test that a top-level in_features string is rejected instead of char-splitting.
+
+    The loader converts in_features to a frozenset, so the string "age" silently
+    becomes frozenset({'a', 'g', 'e'}). At the top level in_features must be an
+    array of source feature names.
+    """
+    config_str = '[{"name": "scale__age", "in_features": "age"}]'
+
+    with pytest.raises(ValueError, match="in_features") as exc_info:
+        parse_json(config_str)
+
+    assert "array" in str(exc_info.value)
+
+
+def test_parse_json_rejects_in_features_as_dict() -> None:
+    """Test that a top-level in_features dict is rejected; the nested dict form is options-only."""
+    config_str = '[{"name": "scale__age", "in_features": {"name": "age"}}]'
+
+    with pytest.raises(ValueError, match="in_features") as exc_info:
+        parse_json(config_str)
+
+    assert "array" in str(exc_info.value)
+
+
+# A top-level in_features array holds source feature NAMES: the loader feeds it straight into
+# frozenset(), so an int element becomes a bogus source and a dict element dies with an internal
+# "unhashable type: 'dict'" TypeError. Every element must be a non-empty string.
+BAD_TOP_LEVEL_IN_FEATURES: list[Any] = [
+    pytest.param([1, 2], 1, id="ints"),
+    pytest.param(["age", 7], 7, id="mixed_int"),
+    pytest.param([{"name": "age"}], {"name": "age"}, id="feature_dict"),
+    pytest.param(["age", ""], "", id="empty_string"),
+    pytest.param(["age", "   "], "   ", id="whitespace_only_string"),
+    pytest.param(["age", None], None, id="null"),
+]
+
+
+@pytest.mark.parametrize("in_features, offender", BAD_TOP_LEVEL_IN_FEATURES)
+def test_parse_json_rejects_in_features_element_that_is_not_a_name(in_features: list[Any], offender: Any) -> None:
+    """Test that every top-level in_features element must be a non-empty source feature name."""
+    config_str = json.dumps([{"name": "scale__age", "in_features": in_features}])
+
+    with pytest.raises(ValueError, match="in_features") as exc_info:
+        parse_json(config_str)
+
+    assert repr(offender) in str(exc_info.value)
+
+
+def test_parse_json_accepts_in_features_array_of_names() -> None:
+    """Test that the valid top-level in_features array form keeps parsing unchanged."""
+    config_str = '[{"name": "scale__age", "in_features": ["age", "weight"]}]'
+
+    result = parse_json(config_str)
+
+    assert len(result) == 1
+    assert isinstance(result[0], FeatureConfig)
+    assert result[0].in_features == ["age", "weight"]
 
 
 def test_parse_json_rejects_mloda_source_and_in_features_together() -> None:

--- a/tests/test_core/test_api/feature_config/test_feature_config_schema.py
+++ b/tests/test_core/test_api/feature_config/test_feature_config_schema.py
@@ -22,6 +22,17 @@ def test_feature_config_schema_structure() -> None:
     assert "name" in schema["required"], "'name' should be in required fields"
 
 
+def test_feature_config_schema_forbids_additional_properties() -> None:
+    """Test that the schema forbids unknown keys (issue #680).
+
+    FeatureConfig enforces this at the top level and, once the nested in_features
+    dict is validated through FeatureConfig too, at every nesting level.
+    """
+    schema = feature_config_schema()
+
+    assert schema["additionalProperties"] is False, "Unknown config keys must not be allowed"
+
+
 def test_feature_config_schema_includes_propagate_context_keys() -> None:
     """Test that the schema advertises the propagate_context_keys field.
 


### PR DESCRIPTION
Closes #680.

## Problem

A nested `in_features` dict never reached `FeatureConfig`. `process_nested_features` read the four keys it knew (`name`, `options`, `in_features`, `feature_group`) straight off the raw dict and dropped everything else on the floor, so a typo silently degraded to a feature with no resolution scope:

```json
[{"name": "outer", "options": {"in_features": {"name": "shared_token", "feature_grp": "ClaimsReader"}}}]
```

The top level was strict only as an accident of `FeatureConfig(**item)`, and every config invariant had to be hand-mirrored in the loader (#582 alone needed three separate patches for this one gap).

## Fix

`FeatureConfig` is now the single validation path for both levels.

- `parse_nested_feature_config` routes a nested dict through `FeatureConfig`, so an unknown key raises the same `TypeError` naming the key as at the top level (`got an unexpected keyword argument 'feature_grp'. Did you mean 'feature_group'?`), and every `__post_init__` invariant applies. The duplicated scope and empty-name checks are gone from the loader.
- The nested-supported fields are marked on the dataclass with `metadata={"nested": True}` and derived into `NESTED_FIELDS`, so **a new `FeatureConfig` field is rejected in a nested dict by default** rather than silently dropped, with no extra loader code. The top-level-only fields (`column_index`, `group_options`, `context_options`, `propagate_context_keys`) now raise instead of being ignored.
- A nested `in_features` **list** is validated too: it holds source feature names, and a feature dict must be the direct value of `in_features`, not a list element. A dict inside the list previously slipped through unvalidated, which was the same silent-drop bug reached by another path.
- `additionalProperties: False` is kept in `feature_config_schema()`, and is now a true statement rather than an unenforced claim.

## Behavior changes beyond the reported bug

All three were silent corruption before, but they are worth calling out since `fix:` ships as a patch bump:

- `name` must be a non-empty string, **at the top level as well**.
- Top-level `in_features` must be an array of non-empty source feature names. `"in_features": "age"` used to char-split into `frozenset({'a','g','e'})`, and a list containing a dict died inside `frozenset()` with an unhashable-type error.
- Any option dict keyed `in_features` is validated as a feature config, since the loader has always treated it as one.

No config, fixture, doc example or test in the repo relied on the old behavior.

The missing-name error now lists the keys present instead of the whole dict, which could carry credentials in `options`.

## Out of scope

`group_options` and `context_options` still never reach `process_nested_features` (#681). That gap is unchanged, and the docs no longer claim otherwise.

## Tests

`tests/test_core/test_api/feature_config/test_feature_config_nested_validation.py` is new: unknown keys at every nesting depth and through both entry points, top-level-only fields, the `name` invariant, the nested list and scalar shapes, and a regression test per nested shape that is valid today (including the two-level `min_max_nested` fixture). The previously uncovered list and scalar branches of the sibling `in_features` key are now pinned.

`tox` is green: 5471 passed, ruff format and check, `mypy --strict` on 809 files, bandit, license allowlist.

The change was reviewed by two independent deep reviews before this PR; both found the nested-list hole and the check-ordering bug, which are fixed here.