### PR TITLE
fix: drop undeclarable umap algorithm from DimensionalityReductionFeatureGroup (#696)

### DIFF
--- a/mloda_plugins/feature_group/experimental/dimensionality_reduction/base.py
+++ b/mloda_plugins/feature_group/experimental/dimensionality_reduction/base.py
@@ -23,14 +23,13 @@ class DimensionalityReductionFeatureGroup(FeatureChainParserMixin, FeatureGroup)
     Base class for all dimensionality reduction feature groups.
 
     Dimensionality reduction feature groups reduce the dimensionality of feature spaces
-    using various techniques like PCA, t-SNE, UMAP, etc. They support both string-based
+    using various techniques like PCA, t-SNE, Isomap, etc. They support both string-based
     feature creation and configuration-based creation with proper group/context parameter separation.
 
     ## Supported Dimensionality Reduction Algorithms
 
     - `pca`: Principal Component Analysis
     - `tsne`: t-Distributed Stochastic Neighbor Embedding
-    - `umap`: Uniform Manifold Approximation and Projection
     - `ica`: Independent Component Analysis
     - `lda`: Linear Discriminant Analysis
     - `isomap`: Isometric Mapping
@@ -46,7 +45,7 @@ class DimensionalityReductionFeatureGroup(FeatureChainParserMixin, FeatureGroup)
     features = [
         "customer_metrics__pca_2d",      # PCA reduction to 2 dimensions
         "product_features__tsne_3d",     # t-SNE reduction to 3 dimensions
-        "sensor_readings__umap_10d"      # UMAP reduction to 10 dimensions
+        "sensor_readings__isomap_10d"    # Isomap reduction to 10 dimensions
     ]
     ```
 
@@ -106,7 +105,6 @@ class DimensionalityReductionFeatureGroup(FeatureChainParserMixin, FeatureGroup)
     REDUCTION_ALGORITHMS = {
         "pca": "Principal Component Analysis",
         "tsne": "t-Distributed Stochastic Neighbor Embedding",
-        "umap": "Uniform Manifold Approximation and Projection",
         "ica": "Independent Component Analysis",
         "lda": "Linear Discriminant Analysis",
         "isomap": "Isometric Mapping",

--- a/tests/test_plugins/feature_group/experimental/test_dimensionality_reduction_feature_group/test_base_dimensionality_reduction_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/test_dimensionality_reduction_feature_group/test_base_dimensionality_reduction_feature_group.py
@@ -7,6 +7,7 @@ import pytest
 from mloda.user import Feature
 from mloda.user import FeatureName
 from mloda.user import Options
+from mloda.provider import DefaultOptionKeys
 from mloda_plugins.feature_group.experimental.dimensionality_reduction.base import DimensionalityReductionFeatureGroup
 from mloda_plugins.feature_group.experimental.dimensionality_reduction.pandas import (
     PandasDimensionalityReductionFeatureGroup,
@@ -63,9 +64,21 @@ class TestDimensionalityReductionFeatureGroup:
         """A umap feature must fail at planning time, not at compute time."""
         assert not DimensionalityReductionFeatureGroup.match_feature_group_criteria("customer__umap_2d", Options())
 
+        assert not DimensionalityReductionFeatureGroup.match_feature_group_criteria(
+            "placeholder",
+            Options(
+                context={
+                    DimensionalityReductionFeatureGroup.ALGORITHM: "umap",
+                    DimensionalityReductionFeatureGroup.DIMENSION: 2,
+                    DefaultOptionKeys.in_features: "customer_metrics",
+                }
+            ),
+        )
+
     def test_declared_algorithms_are_dispatched_by_pandas(self) -> None:
         """Every declared algorithm must be computable by the pandas implementation."""
         pd = pytest.importorskip("pandas")
+        pytest.importorskip("sklearn")
 
         data = pd.DataFrame(
             {

--- a/tests/test_plugins/feature_group/experimental/test_dimensionality_reduction_feature_group/test_base_dimensionality_reduction_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/test_dimensionality_reduction_feature_group/test_base_dimensionality_reduction_feature_group.py
@@ -55,6 +55,34 @@ class TestDimensionalityReductionFeatureGroup:
         with pytest.raises(ValueError):
             DimensionalityReductionFeatureGroup.parse_reduction_suffix("customer_metrics_pca_2d")
 
+    def test_umap_is_not_declared(self) -> None:
+        """umap is not implemented by any compute framework, so it must not be declared."""
+        assert "umap" not in DimensionalityReductionFeatureGroup.REDUCTION_ALGORITHMS
+
+    def test_umap_feature_does_not_match(self) -> None:
+        """A umap feature must fail at planning time, not at compute time."""
+        assert not DimensionalityReductionFeatureGroup.match_feature_group_criteria("customer__umap_2d", Options())
+
+    def test_declared_algorithms_are_dispatched_by_pandas(self) -> None:
+        """Every declared algorithm must be computable by the pandas implementation."""
+        pd = pytest.importorskip("pandas")
+
+        data = pd.DataFrame(
+            {
+                "f1": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0],
+                "f2": [2.0, 1.0, 4.0, 3.0, 6.0, 5.0, 8.0, 7.0, 10.0, 9.0, 12.0, 11.0],
+                "f3": [5.0, 3.0, 8.0, 1.0, 9.0, 2.0, 7.0, 4.0, 6.0, 12.0, 10.0, 11.0],
+                "target": ["a", "a", "a", "a", "b", "b", "b", "b", "c", "c", "c", "c"],
+            }
+        )
+        source_features = ["f1", "f2", "f3"]
+
+        for algorithm in DimensionalityReductionFeatureGroup.REDUCTION_ALGORITHMS:
+            result = PandasDimensionalityReductionFeatureGroup._perform_reduction(
+                data, algorithm, 2, source_features, Options()
+            )
+            assert result.shape == (12, 2), f"Unexpected result shape for algorithm {algorithm}"
+
     def test_input_features(self) -> None:
         """Test the input_features method."""
         feature_group = PandasDimensionalityReductionFeatureGroup()


### PR DESCRIPTION
Closes #696.

`DimensionalityReductionFeatureGroup` declared `umap` in `REDUCTION_ALGORITHMS`, which feeds `PROPERTY_MAPPING[ALGORITHM]` allowed_values with strict validation. A request for `customer__umap_2d` (or `algorithm="umap"` via Options) therefore passed matching and validation and only failed at compute time, since pandas (the only backend) dispatches pca, tsne, ica, lda, isomap.

Taking option 1 from the issue: drop the declaration rather than pull in umap-learn as a heavy new dependency. The declared universe now matches what the backend can compute, so a umap request is rejected at planning.

Tests: umap is not declared, a umap request does not match on either the string-name path or the Options path, and a drift guard asserts every declared algorithm is actually dispatchable by the pandas implementation.

tox green: 5448 passed, 171 skipped, ruff, mypy strict, bandit clean.