### PR TITLE
fix(tests): match GitHub's zero-directory globstar in the CI paths-ignore guard

### DIFF
--- a/tests/test_ci_paths_ignore.py
+++ b/tests/test_ci_paths_ignore.py
@@ -4,6 +4,7 @@ import re
 from pathlib import Path
 from typing import Any
 
+import pytest
 import yaml
 
 
@@ -38,7 +39,11 @@ def _pattern_to_regex(pattern: str) -> re.Pattern[str]:
     i = 0
     while i < len(pattern):
         char = pattern[i]
-        if pattern.startswith("**", i):
+        if pattern.startswith("**/", i):
+            # `**/` matches zero directories too, so the slash is optional.
+            out += "(?:.*/)?"
+            i += 3
+        elif pattern.startswith("**", i):
             out += ".*"
             i += 2
         elif char == "*":
@@ -75,6 +80,58 @@ def _markdown_referenced_by_tests() -> set[str]:
 def _protected_paths() -> list[str]:
     docs = {str(p.relative_to(PROJECT_ROOT)) for p in (PROJECT_ROOT / "docs").rglob("*.md")}
     return sorted(docs | _markdown_referenced_by_tests())
+
+
+# Composed, not a bare literal: MD_LITERAL scans tests/ for markdown names and treats every one that
+# exists in the repo as content the suite depends on, which would wrongly mark the root README protected.
+ROOT_README = "README" + ".md"
+
+# Patterns paired with GitHub's own documented example matches (filter pattern cheat sheet).
+GLOBSTAR_MATCHES: list[tuple[str, str]] = [
+    ("**/README.md", ROOT_README),
+    ("**/README.md", "js/README.md"),
+    ("**/*.md", ROOT_README),
+    ("**/*-post.md", "my-post.md"),
+    ("**/*-post.md", "path/their-post.md"),
+    ("**.js", "index.js"),
+    ("**.js", "js/index.js"),
+    ("**.js", "src/js/app.js"),
+    ("*.js", "app.js"),
+    ("docs/**", "docs/README.md"),
+    ("docs/**", "docs/mona/octocat.txt"),
+    ("docs/*", "docs/README.md"),
+    ("docs/**/*.md", "docs/README.md"),
+    ("docs/**/*.md", "docs/a/markdown/file.md"),
+    ("**/docs/**", "docs/hello.md"),
+    ("**/docs/**", "dir/docs/my-file.txt"),
+]
+
+# A single `*` stops at a path separator, so the helper must not over-match either.
+GLOBSTAR_NON_MATCHES: list[tuple[str, str]] = [
+    ("*.js", "js/app.js"),
+    ("docs/*", "docs/mona/octocat.txt"),
+    ("**/README.md", "README.md.bak"),
+]
+
+
+def _case_ids(cases: list[tuple[str, str]]) -> list[str]:
+    return [f"{pattern} ~ {path}" for pattern, path in cases]
+
+
+@pytest.mark.parametrize(("pattern", "path"), GLOBSTAR_MATCHES, ids=_case_ids(GLOBSTAR_MATCHES))
+def test_pattern_matches_github_documented_example(pattern: str, path: str) -> None:
+    assert _matches(pattern, path), (
+        f"GitHub documents {path!r} as a match for {pattern!r}, but the helper produced "
+        f"{_pattern_to_regex(pattern).pattern!r}. Under-matching lets the guards pass while GitHub skips the gate."
+    )
+
+
+@pytest.mark.parametrize(("pattern", "path"), GLOBSTAR_NON_MATCHES, ids=_case_ids(GLOBSTAR_NON_MATCHES))
+def test_pattern_does_not_match_beyond_github_semantics(pattern: str, path: str) -> None:
+    assert not _matches(pattern, path), (
+        f"{pattern!r} must not match {path!r}, but the helper produced {_pattern_to_regex(pattern).pattern!r}. "
+        "Over-matching makes the guards fail on filters that are actually safe."
+    )
 
 
 def test_protected_set_is_not_stale() -> None:


### PR DESCRIPTION
## Summary

The docs-only CI fast path (#698) is guarded by `tests/test_ci_paths_ignore.py`, which checks that `paths-ignore` never covers markdown the test suite depends on. That guard translates GitHub path-filter globs into regexes, and the translation is wrong for `**/`.

`_pattern_to_regex` maps `**` to `.*` unconditionally, so `**/README.md` becomes `.*/README\.md`. That requires a slash, so it never matches a root-level `README.md`.

GitHub's [filter pattern cheat sheet](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#filter-pattern-cheat-sheet) defines `**` as "matches zero or more of any character" and documents:

| Pattern | Description | Example matches |
|---|---|---|
| `'**/README.md'` | A README.md file anywhere in the repository. | `README.md`, `js/README.md` |

So `**/` must be able to match **zero** directories.

## Why it matters

The helper under-matched, which is the failing-open direction. If anyone adds `**/*.md` or `**/README.md` to `paths-ignore` (a natural "skip CI for all markdown" edit), then:

- GitHub **would** skip the test matrix when the root `README.md` changes, and `pyproject.toml` references that file as packaging metadata (`readme`), so deleting or renaming it merges green and breaks the sdist/wheel build.
- `test_paths_ignore_never_covers_test_relevant_markdown` would compute "not covered" and pass.
- `test_packaging_metadata_guard.py` shares the same `_matches` helper, so it would go quiet too.

Both safety nets fail open at the same time, for exactly the regression they exist to catch. The same hole applied to the medial form: `docs/**/*.md` did not match `docs/README.md`.

This is **latent, not live**: no `paths-ignore` entry uses `**` today. It is a trap for the next edit.

## Change

Consume `**/` as a single token and emit `(?:.*/)?`, so the slash is optional and zero directories is a valid match. Because the check is positional rather than anchored to the pattern start, the leading (`**/README.md`) and medial (`docs/**/*.md`) forms are both fixed by the one branch. The `*`, `?`, and literal branches are untouched.

Pinned with GitHub's own documented cheat-sheet examples, as both a match table and a non-match table, so the helper cannot drift into over-matching either (`*.js` still refuses `js/app.js`, `docs/*` still refuses `docs/mona/octocat.txt`).

## Test plan

- `tox` green: 5448 passed, 171 skipped, `ruff format --check`, `ruff check`, pip-licenses, `mypy --strict`, and bandit all pass.
- The 5 new zero-directory cases fail on `main` and pass here.
- Guard tests: 26 passed across `test_ci_paths_ignore.py` and `test_packaging_metadata_guard.py`.
- No new skips.

## Note for reviewers

`ROOT_README = "README" + ".md"` is a deliberate concatenation, not a style slip. `MD_LITERAL` scans `tests/` for quoted markdown filenames and treats each one that exists in the repo as markdown whose *content* the suite depends on. A bare `"README.md"` literal in the test tree would mark the root README as protected and fail the guard below it for a reason unrelated to globbing.