### PR TITLE
feat: export columnar helpers from mloda.provider (#707)

### DIFF
--- a/docs/docs/chapter1/compute-frameworks.md
+++ b/docs/docs/chapter1/compute-frameworks.md
@@ -173,10 +173,10 @@ A feature group running on PythonDictFramework may also return row-wise data as 
 
 #### Columnar helpers
 
-`columnar_to_rows`, `homogenize_rows`, `is_columnar`, and `rows_to_columnar` are importable from `mloda.user`. `columnar_to_rows` is strict: it raises `ValueError` on anything that is not a valid columnar dict. Use `is_columnar` to branch first:
+`columnar_to_rows`, `homogenize_rows`, `is_columnar`, and `rows_to_columnar` are importable from `mloda.provider` (plugin/provider code, where pivoting a columnar frame back to rows belongs) and from `mloda.user` (application code unwrapping a `run_all` result). `columnar_to_rows` is strict: it raises `ValueError` on anything that is not a valid columnar dict. Use `is_columnar` to branch first:
 
 ``` python
-from mloda.user import columnar_to_rows, is_columnar
+from mloda.provider import columnar_to_rows, is_columnar
 
 def to_rows_lenient(data):
     if isinstance(data, list):

--- a/mloda/provider/__init__.py
+++ b/mloda/provider/__init__.py
@@ -85,6 +85,14 @@ from mloda.core.abstract_plugins.plugin_registry.plugin_registry import (
     register_plugin,
 )
 
+# Columnar helpers (python_dict)
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils import (
+    columnar_to_rows,
+    homogenize_rows,
+    is_columnar,
+    rows_to_columnar,
+)
+
 # Engines
 from mloda.core.filter.filter_engine import BaseFilterEngine
 from mloda.core.abstract_plugins.components.mask.base_mask_engine import BaseMaskEngine
@@ -144,6 +152,11 @@ __all__ = [
     # Plugin registry
     "PluginRegistryCollisionError",
     "register_plugin",
+    # Columnar helpers (python_dict)
+    "columnar_to_rows",
+    "homogenize_rows",
+    "is_columnar",
+    "rows_to_columnar",
     # Engines
     "BaseFilterEngine",
     "BaseMaskEngine",

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_compute_framework_exports.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_compute_framework_exports.py
@@ -15,6 +15,7 @@ from types import ModuleType
 
 import pytest
 
+import mloda.provider
 import mloda.user
 
 # Source modules are resolved lazily so a missing optional backend fails only its own matrix row.
@@ -82,6 +83,7 @@ HELPER_EXPORT_MATRIX: list[tuple[str, str]] = [
     ("columnar_to_rows", _PYTHON_DICT_UTILS_MODULE),
     ("homogenize_rows", _PYTHON_DICT_UTILS_MODULE),
     ("is_columnar", _PYTHON_DICT_UTILS_MODULE),
+    ("rows_to_columnar", _PYTHON_DICT_UTILS_MODULE),
 ]
 
 _HELPER_MATRIX_IDS = [symbol for symbol, _source in HELPER_EXPORT_MATRIX]
@@ -102,4 +104,32 @@ class TestPythonDictHelperExportMatrix:
         assert hasattr(mloda.user, symbol), f"mloda.user must expose '{symbol}'"
         assert getattr(mloda.user, symbol) is getattr(source, symbol), (
             f"mloda.user.{symbol} must be the identical object from {source.__name__}"
+        )
+
+
+# Provider side (issue #707): pivoting a columnar frame back to rows is a provider-side
+# concern, so the same four helpers are ALSO exported from mloda.provider. Unlike the
+# lazy mloda.user exports, python_dict_utils is stdlib-only and mloda.provider already
+# imports eagerly from mloda_plugins, so these are eager exports listed in __all__.
+class TestPythonDictHelperProviderExportMatrix:
+    @pytest.mark.parametrize(("symbol", "source_module"), HELPER_EXPORT_MATRIX, ids=_HELPER_MATRIX_IDS)
+    def test_helper_importable_from_provider(self, symbol: str, source_module: str) -> None:
+        assert hasattr(mloda.provider, symbol), f"mloda.provider must expose '{symbol}'"
+
+    @pytest.mark.parametrize(("symbol", "source_module"), HELPER_EXPORT_MATRIX, ids=_HELPER_MATRIX_IDS)
+    def test_helper_listed_in_provider_all(self, symbol: str, source_module: str) -> None:
+        assert symbol in mloda.provider.__all__, f"mloda.provider.__all__ must list '{symbol}' (eager export)"
+
+    @pytest.mark.parametrize(("symbol", "source_module"), HELPER_EXPORT_MATRIX, ids=_HELPER_MATRIX_IDS)
+    def test_provider_helper_is_identical_to_source_object(self, symbol: str, source_module: str) -> None:
+        source = _source_module(source_module)
+        assert hasattr(source, symbol), f"{source.__name__} must define '{symbol}'"
+        assert getattr(mloda.provider, symbol) is getattr(source, symbol), (
+            f"mloda.provider.{symbol} must be the identical object from {source.__name__}"
+        )
+
+    @pytest.mark.parametrize(("symbol", "source_module"), HELPER_EXPORT_MATRIX, ids=_HELPER_MATRIX_IDS)
+    def test_provider_and_user_surfaces_agree(self, symbol: str, source_module: str) -> None:
+        assert getattr(mloda.provider, symbol) is getattr(mloda.user, symbol), (
+            f"mloda.provider.{symbol} and mloda.user.{symbol} must be the identical object"
         )


### PR DESCRIPTION
Closes #707.

## Problem

The four python_dict columnar helpers (`columnar_to_rows`, `homogenize_rows`, `is_columnar`, `rows_to_columnar`) were exported from `mloda.user`, the app-facing surface, but not from `mloda.provider`, the plugin-facing one. Since 0.9.0 PythonDict's native representation is columnar `dict[str, list]`, so a row-wise `FeatureGroup` receives a columnar frame in `calculate_feature`. Pivoting it back to rows happens inside the plugin, which forced plugin code to import from the user surface (or from a long internal `mloda_plugins...` path with no stability promise).

## Change

- `mloda/provider/__init__.py` now exports the four helpers and lists them in `__all__`. The import is eager, not lazy like `mloda.user`'s: `python_dict_utils` is stdlib-only, and `mloda.provider` already imports eagerly from `mloda_plugins` (`ApiInputDataFeature`). The `mloda.user` exports stay, since an application unwrapping a `run_all` result legitimately wants `columnar_to_rows` too. Both surfaces resolve to the identical object.
- The compute-frameworks guide now points provider code at `mloda.provider` and application code at `mloda.user`.
- Export tests cover the provider surface (importable, in `__all__`, identical to the canonical source object, and in agreement with `mloda.user`). This also closes a pre-existing gap: `rows_to_columnar` was missing from the user-side matrix, so its export was untested.

## Verification

`tox` green: 5584 passed, 171 skipped, ruff format/check clean, mypy --strict clean, bandit and license checks pass.

Reviewed independently by a second Claude agent and by codex. Neither found anything above low severity. Both confirmed no import cycle (`python_dict_utils` imports only `typing`) and no import-cost regression on `import mloda.provider`.