### PR TITLE
fix: filter on a root FG's own output column crashes or drops the requested column (#712)

### DIFF
--- a/mloda/core/core/engine.py
+++ b/mloda/core/core/engine.py
@@ -346,12 +346,15 @@ class Engine:
             feature_collection.add(feature)
             return True
 
-        if child_uuid:
-            # Find the wanted_uuid in feature_collection
-            wanted_uuid = next((f.uuid for f in feature_collection if feature == f), None)
+        existing_feature = next((f for f in feature_collection if feature == f), None)
 
-            if wanted_uuid is not None:
-                self._update_feature_link_parents(child_uuid, feature.uuid, wanted_uuid, if_index_feature)
+        if existing_feature is not None:
+            # Propagate the requested flag: filter twins must not displace requested output columns (issue #712).
+            if feature.initial_requested_data and not existing_feature.initial_requested_data:
+                existing_feature.initial_requested_data = True
+
+            if child_uuid:
+                self._update_feature_link_parents(child_uuid, feature.uuid, existing_feature.uuid, if_index_feature)
 
         return False
 

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -101,14 +101,17 @@ class GlobalFilter:
         return matched_filters
 
     def unify_options(self, feat_options: Options, filter_options: Options) -> Options:
-        for key, value in feat_options.items():
+        # Preserve each key's category so context keys do not leak into group (issue #712).
+        for key, value in feat_options.group.items():
             if key not in filter_options:
                 filter_options.add_to_group(key, value)
-            else:
-                if filter_options[key] == value:
-                    continue
-                else:
-                    logger.warning(f"Options are not the same. {key} is different. {filter_options[key]} != {value}")
+            elif filter_options[key] != value:
+                logger.warning(f"Options are not the same. {key} is different. {filter_options[key]} != {value}")
+        for key, value in feat_options.context.items():
+            if key not in filter_options:
+                filter_options.add_to_context(key, value)
+            elif filter_options[key] != value:
+                logger.warning(f"Options are not the same. {key} is different. {filter_options[key]} != {value}")
         return filter_options
 
     def criteria(

--- a/tests/test_core/test_filter/test_filter_on_own_output_column.py
+++ b/tests/test_core/test_filter/test_filter_on_own_output_column.py
@@ -1,0 +1,119 @@
+"""Regression tests for issue #712: a GlobalFilter on a column that a root FeatureGroup itself outputs."""
+
+from typing import Any
+
+from mloda.provider import BaseInputData, ComputeFramework, DataCreator, FeatureGroup, FeatureSet
+from mloda.user import Feature, Features, GlobalFilter, Options, ParallelizationMode, PluginCollector
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
+    PythonDictFramework,
+)
+from tests.test_core.test_tooling import MlodaTestRunner
+
+
+class FilterOwnOutputRetrievalFG(FeatureGroup):
+    """Root FeatureGroup that requires context-only options and outputs the filterable distance column."""
+
+    @classmethod
+    def input_data(cls) -> BaseInputData | None:
+        return DataCreator({"retrieval__text", "retrieval__doc_id", "retrieval__distance"})
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PythonDictFramework}
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        opts = features.options
+        assert opts is not None
+        if opts.context.get("query") is None or opts.context.get("index_dir") is None:
+            raise ValueError("FilterOwnOutputRetrievalFG requires options.context['query'] and ['index_dir']")
+        return {
+            "retrieval__text": ["a", "b", "c"],
+            "retrieval__doc_id": [1, 2, 3],
+            "retrieval__distance": [0.1, 0.4, 0.9],
+        }
+
+
+_ENABLED = PluginCollector.enabled_feature_groups({FilterOwnOutputRetrievalFG})
+
+_EXPECTED_FILTERED_RESULT: dict[str, list[Any]] = {
+    "retrieval__text": ["a", "b"],
+    "retrieval__distance": [0.1, 0.4],
+}
+
+
+def _make_context_options() -> Options:
+    """Fresh Options per feature: Options instances are mutated per feature."""
+    return Options(context={"query": "q", "index_dir": "/idx"})
+
+
+def test_filter_by_name_on_own_output_column_with_context_options(flight_server: Any) -> None:
+    """Failure A: filter declared by name must not strip the consumer context keys into group.
+
+    Currently the filter feature lands in its own FeatureSet whose options hold everything in
+    group and an empty context, so calculate_feature raises ValueError. Expected: no crash,
+    both requested columns present, rows filtered to distance <= 0.5.
+    """
+    features = Features(
+        [
+            Feature("retrieval__text", _make_context_options()),
+            Feature("retrieval__distance", _make_context_options()),
+        ]
+    )
+
+    global_filter = GlobalFilter()
+    global_filter.add_filter("retrieval__distance", "max", {"value": 0.5})
+
+    result = MlodaTestRunner.run_api(
+        features,
+        compute_frameworks={PythonDictFramework},
+        parallelization_modes={ParallelizationMode.SYNC},
+        flight_server=flight_server,
+        global_filter=global_filter,
+        plugin_collector=_ENABLED,
+    )
+
+    assert len(result.results) == 1
+    assert result.results[0] == _EXPECTED_FILTERED_RESULT
+
+
+def test_filter_feature_with_matching_options_keeps_requested_column(flight_server: Any) -> None:
+    """Failure B: the filter twin must not dedupe away the genuinely requested column.
+
+    retrieval__text is requested BEFORE retrieval__distance so the engine creates the filter
+    twin first; the requested retrieval__distance is then deduped against the twin and loses
+    its initial_requested_data flag, dropping the column from the result. Expected: both
+    requested columns present, rows filtered to distance <= 0.5.
+    """
+    features = Features(
+        [
+            Feature("retrieval__text", _make_context_options()),
+            Feature("retrieval__distance", _make_context_options()),
+        ]
+    )
+
+    global_filter = GlobalFilter()
+    global_filter.add_filter(Feature("retrieval__distance", _make_context_options()), "max", {"value": 0.5})
+
+    result = MlodaTestRunner.run_api(
+        features,
+        compute_frameworks={PythonDictFramework},
+        parallelization_modes={ParallelizationMode.SYNC},
+        flight_server=flight_server,
+        global_filter=global_filter,
+        plugin_collector=_ENABLED,
+    )
+
+    assert len(result.results) == 1
+    assert result.results[0] == _EXPECTED_FILTERED_RESULT
+
+
+def test_unify_options_preserves_key_category() -> None:
+    """unify_options must keep consumer group keys in group and consumer context keys in context."""
+    global_filter = GlobalFilter()
+
+    unified = global_filter.unify_options(Options(group={"g": 1}, context={"c": 2}), Options())
+
+    assert "c" not in unified.group, f"context key 'c' must not land in group, got group={unified.group}"
+    assert unified.group == {"g": 1}
+    assert unified.context == {"c": 2}


### PR DESCRIPTION
Fixes #712.

Attaching a GlobalFilter to a column that a root feature group itself outputs failed in two ways, both because the engine schedules the filter feature as a real calculable feature:

- Failure A (filter declared by name, FG uses context-only options): `GlobalFilter.unify_options` copied every consumer option into the filter feature via `add_to_group`, moving context keys into group. The filter feature then split into its own FeatureSet batch whose options held everything in group with an empty context, and feature groups reading `options.context[...]` raised ValueError.
- Failure B (filter declared with matching options): the filter twin (new UUID, same name) entered the engine collection while an earlier requested feature was processed, so the genuinely requested feature was deduped against it and lost its `initial_requested_data` flag. The requested column silently vanished from the result.

## Changes

- `GlobalFilter.unify_options` now preserves each consumer key's category: group keys are added via `add_to_group`, context keys via `add_to_context`. The set of forwarded keys and the mismatch warning are unchanged.
- `Engine.add_feature_to_collection` now propagates `initial_requested_data=True` to the retained equal feature in the dedup path, so a filter twin can no longer displace a requested output column regardless of request order. The `child_uuid` link update is unchanged.

## Tests

New regression tests in `tests/test_core/test_filter/test_filter_on_own_output_column.py` cover both failures end to end (PythonDictFramework, context-only options, filter by name and by Feature with matching options) plus a unit test pinning the category preservation in `unify_options`.

`tox` passes: 5569 passed, 171 skipped; ruff, license check, mypy --strict, and bandit all green. Two independent deep reviews of the diff reported no blocking findings; an isolation check confirmed both halves of the fix are required (failure A needs both, failure B the engine half).
