### PR TITLE
feat: let resolve_feature express a feature_group scope (#693)

### DIFF
--- a/docs/docs/in_depth/discover-plugins.md
+++ b/docs/docs/in_depth/discover-plugins.md
@@ -43,6 +43,22 @@ print(result.feature_group, result.supported_compute_frameworks)
 
 `options` and `plugin_collector` are keyword-only, so pass them by name.
 
+### Scoping to a Feature Group
+
+When several FeatureGroups match the same name, such as the framework-specific
+`AggregatedFeatureGroup` subclasses, narrow the resolution with the keyword-only
+`feature_group` argument. It takes a FeatureGroup subclass or its class-name
+string (the string matches the named class and its subclasses), the same forms
+as `Feature(..., feature_group=...)`:
+
+``` python
+result = resolve_feature("sales__sum_aggr", feature_group="PandasAggregatedFeatureGroup")
+```
+
+Scoped failures append `Scoped to feature group: '<Name>'.` to `result.error`,
+mirroring the scoped engine error, so a scoped run can be debugged with the
+same scope.
+
 When exactly one FeatureGroup resolves, `ResolvedFeature` also reports
 `subtype` (resolved from the name, the passed options, or the key's declared
 default, e.g. `"sum"` for `sales__sum_aggr`) and `subtype_family` (the

--- a/mloda/core/abstract_plugins/components/feature.py
+++ b/mloda/core/abstract_plugins/components/feature.py
@@ -18,6 +18,31 @@ from mloda.core.abstract_plugins.components.utils import get_all_subclasses
 from mloda.core.abstract_plugins.components.validators.feature_validator import FeatureValidator
 
 
+def normalize_feature_group_scope(
+    feature_group: str | type[FeatureGroup] | None,
+) -> str | type[FeatureGroup] | None:
+    """Normalize a feature_group scope value, raising TypeError for invalid forms."""
+    if feature_group is None:
+        return None
+    from mloda.core.abstract_plugins.feature_group import FeatureGroup
+
+    root_rejection = "feature_group cannot be the root FeatureGroup base class; a concrete subclass is required"
+    if isinstance(feature_group, str):
+        stripped = feature_group.strip()
+        # The root names no feature group family; rejected here as in the class-object form below.
+        if stripped == FeatureGroup.get_class_name():
+            raise TypeError(root_rejection)
+        return stripped or None
+    if feature_group is FeatureGroup:
+        raise TypeError(root_rejection)
+    if isinstance(feature_group, type) and issubclass(feature_group, FeatureGroup):
+        return feature_group
+    raise TypeError(
+        f"feature_group must be a FeatureGroup subclass, a class-name string, or None, "
+        f"got {type(feature_group).__name__}"
+    )
+
+
 class Feature:
     """Represents a raw feature.
 
@@ -172,25 +197,7 @@ class Feature:
     def _set_feature_group_scope(
         self, feature_group: str | type[FeatureGroup] | None
     ) -> str | type[FeatureGroup] | None:
-        if feature_group is None:
-            return None
-        from mloda.core.abstract_plugins.feature_group import FeatureGroup
-
-        root_rejection = "feature_group cannot be the root FeatureGroup base class; a concrete subclass is required"
-        if isinstance(feature_group, str):
-            stripped = feature_group.strip()
-            # The root names no feature group family; rejected here as in the class-object form below.
-            if stripped == FeatureGroup.get_class_name():
-                raise TypeError(root_rejection)
-            return stripped or None
-        if feature_group is FeatureGroup:
-            raise TypeError(root_rejection)
-        if isinstance(feature_group, type) and issubclass(feature_group, FeatureGroup):
-            return feature_group
-        raise TypeError(
-            f"feature_group must be a FeatureGroup subclass, a class-name string, or None, "
-            f"got {type(feature_group).__name__}"
-        )
+        return normalize_feature_group_scope(feature_group)
 
     @classmethod
     def not_typed(

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -366,7 +366,10 @@ def resolve_feature(
     never-raising debug API that reports candidates, capability splits, and subtype fields and degrades
     per candidate, while IdentifyFeatureGroupClass needs an accessible-plugins environment mapping and
     raises on failure. The scope predicate (matches_feature_group_scope) and callout renderer are shared
-    so scoped semantics cannot drift between the two paths.
+    so scoped semantics cannot drift between the two paths. Beyond that the paths may still differ:
+    _filter_subclasses collapses parent/child purely by issubclass while the engine only collapses candidates
+    sharing the same supported-framework set, and the engine excludes abstract bases while resolve_feature
+    does not.
 
     Args:
         feature_name: The name of the feature to resolve.

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -25,6 +25,7 @@ from mloda.core.abstract_plugins.components.utils import get_all_subclasses, saf
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.function_extender import Extender
 from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistry
+from mloda.core.abstract_plugins.components.feature import normalize_feature_group_scope
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.api.plugin_info import ComputeFrameworkInfo, ExtenderInfo, FeatureGroupInfo, ResolvedFeature
@@ -33,7 +34,11 @@ from mloda.core.prepare.accessible_plugins import (
     dedup_feature_group_subclasses,
     registry_for,
 )
-from mloda.core.prepare.identify_feature_group import split_frameworks_by_capability
+from mloda.core.prepare.identify_feature_group import (
+    matches_feature_group_scope,
+    scope_callout,
+    split_frameworks_by_capability,
+)
 
 
 def list_registered(plugin_type: type[Any]) -> list[type[Any]]:
@@ -346,6 +351,7 @@ def resolve_feature(
     *,
     options: Optional[Options] = None,
     plugin_collector: Optional[PluginCollector] = None,
+    feature_group: str | type[FeatureGroup] | None = None,
 ) -> ResolvedFeature:
     """
     Resolve a feature name to its matching FeatureGroup class.
@@ -356,16 +362,36 @@ def resolve_feature(
 
     Never raises: matching errors are reported in the returned ResolvedFeature.error.
 
+    Design note: resolve_feature intentionally does NOT delegate to IdentifyFeatureGroupClass. It is a
+    never-raising debug API that reports candidates, capability splits, and subtype fields and degrades
+    per candidate, while IdentifyFeatureGroupClass needs an accessible-plugins environment mapping and
+    raises on failure. The scope predicate (matches_feature_group_scope) and callout renderer are shared
+    so scoped semantics cannot drift between the two paths.
+
     Args:
         feature_name: The name of the feature to resolve.
         options: Keyword-only. Options used for matching and capability checks. An empty or omitted Options is
             the documented default.
         plugin_collector: Keyword-only. Its ``allow_redefinition`` flag is threaded into deduplication.
+        feature_group: Keyword-only. Scope resolution to a FeatureGroup subclass or a class-name string,
+            same forms and semantics as ``Feature(..., feature_group=...)``: the string form matches the
+            named class and its subclasses; None (or a whitespace-only string) means unscoped.
 
     Returns:
         ResolvedFeature containing the resolved FeatureGroup (if found),
         all matching candidates, and any error message.
     """
+    try:
+        scope = normalize_feature_group_scope(feature_group)
+    except TypeError as exc:
+        return ResolvedFeature(
+            feature_name=feature_name,
+            feature_group=None,
+            candidates=[],
+            error=str(exc),
+        )
+    callout = scope_callout(scope)
+    scope_suffix = f" {callout}" if callout else ""
     resolved_options = options if options is not None else Options()
     is_default_options = not resolved_options.group and not resolved_options.context
     options_caveat = "default options" if is_default_options else "the provided options"
@@ -382,23 +408,26 @@ def resolve_feature(
         matching_conflicts = [
             fg
             for fg in raw_conflicts
-            if _match_recording_validation_errors(fg, feature_name_obj, resolved_options, validation_errors)
+            if (scope is None or matches_feature_group_scope(fg, scope))
+            and _match_recording_validation_errors(fg, feature_name_obj, resolved_options, validation_errors)
         ]
         return ResolvedFeature(
             feature_name=feature_name,
             feature_group=None,
             candidates=matching_conflicts,
-            error=str(exc),
+            error=f"{exc}{scope_suffix}",
         )
     candidates: list[type[FeatureGroup]] = []
     feature_name_obj = FeatureName(feature_name)
 
     for fg in all_fgs:
+        if scope is not None and not matches_feature_group_scope(fg, scope):
+            continue
         if _match_recording_validation_errors(fg, feature_name_obj, resolved_options, validation_errors):
             candidates.append(fg)
 
     if not candidates:
-        error = f"No FeatureGroup found for feature name: {feature_name}"
+        error = f"No FeatureGroup found for feature name: {feature_name}{scope_suffix}"
         if validation_errors:
             error = f"{error} Rejected during matching: {' | '.join(validation_errors)}"
         return ResolvedFeature(
@@ -444,7 +473,7 @@ def resolve_feature(
             error=(
                 f"Feature '{feature_name}' matches {[c.get_class_name() for c in candidates]} "
                 f"but is unsupported on all installed compute frameworks "
-                f"(evaluated under {options_caveat}): {rejected_names}."
+                f"(evaluated under {options_caveat}): {rejected_names}.{scope_suffix}"
             ),
             supported_compute_frameworks=[],
             unsupported_compute_frameworks=rejected_names,
@@ -471,7 +500,7 @@ def resolve_feature(
         feature_name=feature_name,
         feature_group=None,
         candidates=candidates,
-        error=f"Multiple FeatureGroups match feature name '{feature_name}': {conflicting_names}",
+        error=f"Multiple FeatureGroups match feature name '{feature_name}': {conflicting_names}{scope_suffix}",
         supported_compute_frameworks=supported_names,
         unsupported_compute_frameworks=rejected_names,
     )

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -59,9 +59,8 @@ def matches_feature_group_scope(feature_group: type[FeatureGroup], scope: str | 
     )
 
 
-def _scope_callout(feature: Feature) -> str | None:
-    """Render the shared scope callout, or None when the feature is unscoped."""
-    scope = feature.feature_group_scope
+def scope_callout(scope: str | type[FeatureGroup] | None) -> str | None:
+    """Render the shared scope callout, or None when the scope is unset."""
     if scope is None:
         return None
     scope_name = scope.get_class_name() if isinstance(scope, type) else scope
@@ -187,8 +186,8 @@ class IdentifyFeatureGroupClass:
         if len(feature_group) > 1:
             from mloda.core.abstract_plugins.feature_group import format_feature_group_classes
 
-            scope_callout = _scope_callout(feature)
-            scope_line = f"{scope_callout}\n" if scope_callout else ""
+            callout = scope_callout(feature.feature_group_scope)
+            scope_line = f"{callout}\n" if callout else ""
 
             raise ValueError(
                 f"Multiple feature groups found for feature '{feature.name}':\n"
@@ -321,26 +320,26 @@ class IdentifyFeatureGroupClass:
     def _build_no_feature_group_error(
         self, feature: Feature, accessible_plugins: FeatureGroupEnvironmentMapping
     ) -> str:
-        scope_callout = _scope_callout(feature)
+        callout = scope_callout(feature.feature_group_scope)
 
         # Capability rejections are concrete and specific; prefer them over the abstract-only fallback.
         capability_message = self._capability_rejection_message(feature)
         if capability_message is not None:
-            if scope_callout:
-                return f"{capability_message} {scope_callout}"
+            if callout:
+                return f"{capability_message} {callout}"
             return capability_message
 
         abstract_only_message = self._abstract_only_message(feature, accessible_plugins)
         if abstract_only_message is not None:
-            if scope_callout:
-                return f"{abstract_only_message} {scope_callout}"
+            if callout:
+                return f"{abstract_only_message} {callout}"
             return abstract_only_message
 
         feature_name = str(feature.name)
         msg = f"No feature groups found for feature name: '{feature_name}'."
 
-        if scope_callout:
-            msg += f" {scope_callout}"
+        if callout:
+            msg += f" {callout}"
 
         if not accessible_plugins:
             msg += "\nNo plugins are loaded. Did you call PluginLoader.all()?"
@@ -365,8 +364,9 @@ class IdentifyFeatureGroupClass:
         if similar:
             msg += f"\nDid you mean one of: {similar}?"
 
+        pointer_args = "name, options=..., feature_group=..." if callout else "name, options=..."
         msg += (
-            "\nUse resolve_feature(name, options=...) to debug feature resolution."
+            f"\nUse resolve_feature({pointer_args}) to debug feature resolution."
             "\nFor troubleshooting guide, see: "
             "https://mloda-ai.github.io/mloda/in_depth/troubleshooting/feature-group-resolution-errors/"
         )

--- a/tests/test_core/test_api/test_resolve_feature.py
+++ b/tests/test_core/test_api/test_resolve_feature.py
@@ -857,6 +857,19 @@ class TestResolveFeatureScopedNoMatch:
         assert "Scoped to feature group: 'UnrelatedScopedResolve693FeatureGroup'." in result.error
 
 
+class TestResolveFeatureScopedCapabilityRejection:
+    """A scoped capability-rejection failure keeps the scope callout in its error (issue #693)."""
+
+    def test_scoped_all_rejected_error_carries_scope_callout(self) -> None:
+        """Scoping the all-rejected feature to its own group still fails and names the scope."""
+        result = resolve_feature(ALL_REJECTED_CAP_FEATURE, feature_group="AllRejectedCapResolveFeatureGroup")
+
+        assert result.feature_group is None
+        assert result.error is not None
+        assert "unsupported on all installed compute frameworks" in result.error
+        assert "Scoped to feature group: 'AllRejectedCapResolveFeatureGroup'." in result.error
+
+
 class TestResolveFeatureScopedAmbiguity:
     """A scope that still leaves multiple sibling matches reports a scoped ambiguity (issue #693)."""
 
@@ -876,6 +889,24 @@ class TestResolveFeatureScopeNeverRaises:
     def test_root_feature_group_scope_degrades_into_error(self) -> None:
         """Scoping to the root FeatureGroup base is rejected with a dedicated error, not an exception."""
         result = resolve_feature(SIBLING_SCOPED_FEATURE, feature_group=FeatureGroup)
+
+        assert isinstance(result, ResolvedFeature)
+        assert result.feature_group is None
+        assert result.error is not None
+        assert "root FeatureGroup base class" in result.error
+
+    def test_root_feature_group_string_scope_degrades_into_error(self) -> None:
+        """The string form 'FeatureGroup' is rejected like the class-object root scope."""
+        result = resolve_feature(SIBLING_SCOPED_FEATURE, feature_group="FeatureGroup")
+
+        assert isinstance(result, ResolvedFeature)
+        assert result.feature_group is None
+        assert result.error is not None
+        assert "root FeatureGroup base class" in result.error
+
+    def test_whitespace_padded_root_string_scope_degrades_into_error(self) -> None:
+        """The strip runs before the root check, so '  FeatureGroup  ' is rejected the same way."""
+        result = resolve_feature(SIBLING_SCOPED_FEATURE, feature_group="  FeatureGroup  ")
 
         assert isinstance(result, ResolvedFeature)
         assert result.feature_group is None

--- a/tests/test_core/test_api/test_resolve_feature.py
+++ b/tests/test_core/test_api/test_resolve_feature.py
@@ -20,6 +20,8 @@ from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
 from mloda.core.api.plugin_info import ResolvedFeature
 from mloda.core.api.plugin_docs import resolve_feature
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
 from mloda.user import PluginLoader
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
@@ -36,6 +38,10 @@ ALLOW_PYTHON_DICT_KEY = "allow_python_dict"
 
 PROBE_TYPE_KEY = "resolve_probe_type"
 PROBE_FEATURE = "value__median_resolveprobe"
+
+SIBLING_SCOPED_FEATURE = "SiblingScopedResolve693"
+LONE_CHILD_SCOPED_FEATURE = "LoneChildScopedResolve693"
+UNRELATED_SCOPED_FEATURE = "UnrelatedScopedResolve693"
 
 
 class SplitCapResolveFeatureGroup(FeatureGroup):
@@ -177,6 +183,93 @@ class ForwardMismatchResolveFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     @classmethod
     def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
         return {PandasDataFrame, PythonDictFramework}
+
+
+class ScopedResolveFamilyBase693(FeatureGroup):
+    """Shared base of the scoped-resolve fixture family; never matches a feature name itself."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame, PythonDictFramework}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return False
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class ScopedResolveSiblingOne693(ScopedResolveFamilyBase693):
+    """First concrete sibling; matches the shared sibling feature name."""
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        if isinstance(feature_name, FeatureName):
+            feature_name = str(feature_name)
+        return feature_name == SIBLING_SCOPED_FEATURE
+
+
+class ScopedResolveSiblingTwo693(ScopedResolveFamilyBase693):
+    """Second concrete sibling; matches the same shared sibling feature name."""
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        if isinstance(feature_name, FeatureName):
+            feature_name = str(feature_name)
+        return feature_name == SIBLING_SCOPED_FEATURE
+
+
+class ScopedResolveLoneChild693(ScopedResolveFamilyBase693):
+    """Third family member; the only class matching its own unique feature name."""
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        if isinstance(feature_name, FeatureName):
+            feature_name = str(feature_name)
+        return feature_name == LONE_CHILD_SCOPED_FEATURE
+
+
+class UnrelatedScopedResolve693FeatureGroup(FeatureGroup):
+    """Unrelated scope target: matches only its own distinct feature name, never the sibling one."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame, PythonDictFramework}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        if isinstance(feature_name, FeatureName):
+            feature_name = str(feature_name)
+        return feature_name == UNRELATED_SCOPED_FEATURE
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -702,3 +795,138 @@ class TestResolveFeatureKeywordOnlyArguments:
 
         assert result.feature_group is OptionGatedResolveFeatureGroup
         assert result.error is None
+
+
+class TestResolveFeatureScopedResolve:
+    """resolve_feature accepts a keyword-only feature_group scope that disambiguates siblings (issue #693)."""
+
+    def test_unscoped_sibling_feature_is_ambiguous(self) -> None:
+        """Premise guard: unscoped, the two sibling matches stay ambiguous."""
+        result = resolve_feature(SIBLING_SCOPED_FEATURE)
+
+        assert result.feature_group is None
+        assert result.error is not None
+        assert "Multiple FeatureGroups match" in result.error
+
+    def test_sibling_class_name_string_scope_resolves_that_sibling(self) -> None:
+        """A class-name string scope narrows the ambiguous siblings to exactly the named one."""
+        result = resolve_feature(SIBLING_SCOPED_FEATURE, feature_group="ScopedResolveSiblingOne693")
+
+        assert result.feature_group is ScopedResolveSiblingOne693
+        assert result.error is None
+        assert ScopedResolveSiblingOne693 in result.candidates
+        assert ScopedResolveSiblingTwo693 not in result.candidates
+
+    def test_sibling_class_object_scope_resolves_that_sibling(self) -> None:
+        """A class-object scope narrows the ambiguous siblings via issubclass."""
+        result = resolve_feature(SIBLING_SCOPED_FEATURE, feature_group=ScopedResolveSiblingTwo693)
+
+        assert result.feature_group is ScopedResolveSiblingTwo693
+        assert result.error is None
+        assert ScopedResolveSiblingOne693 not in result.candidates
+
+    def test_base_name_string_scope_resolves_lone_concrete_subclass(self) -> None:
+        """A base-name string scope reaches the only matching concrete subclass through the MRO walk."""
+        result = resolve_feature(LONE_CHILD_SCOPED_FEATURE, feature_group="ScopedResolveFamilyBase693")
+
+        assert result.feature_group is ScopedResolveLoneChild693
+        assert result.error is None
+
+
+class TestResolveFeatureScopedNoMatch:
+    """A scope that excludes every name match degrades into a scoped no-match error (issue #693)."""
+
+    def test_string_scope_excluding_all_matches_reports_scoped_no_match(self) -> None:
+        """Scoping the sibling name to an unrelated class name yields no match plus the scope callout."""
+        result = resolve_feature(SIBLING_SCOPED_FEATURE, feature_group="UnrelatedScopedResolve693FeatureGroup")
+
+        assert result.feature_group is None
+        assert result.candidates == []
+        assert result.error is not None
+        assert "No FeatureGroup found" in result.error
+        assert "Scoped to feature group: 'UnrelatedScopedResolve693FeatureGroup'." in result.error
+
+    def test_class_object_scope_excluding_all_matches_reports_scoped_no_match(self) -> None:
+        """The class-object scope form produces the same scoped no-match callout."""
+        result = resolve_feature(SIBLING_SCOPED_FEATURE, feature_group=UnrelatedScopedResolve693FeatureGroup)
+
+        assert result.feature_group is None
+        assert result.candidates == []
+        assert result.error is not None
+        assert "No FeatureGroup found" in result.error
+        assert "Scoped to feature group: 'UnrelatedScopedResolve693FeatureGroup'." in result.error
+
+
+class TestResolveFeatureScopedAmbiguity:
+    """A scope that still leaves multiple sibling matches reports a scoped ambiguity (issue #693)."""
+
+    def test_base_name_scope_keeping_both_siblings_reports_scoped_ambiguity(self) -> None:
+        """Scoping to the shared base name keeps both siblings, so the ambiguity error names the scope."""
+        result = resolve_feature(SIBLING_SCOPED_FEATURE, feature_group="ScopedResolveFamilyBase693")
+
+        assert result.feature_group is None
+        assert result.error is not None
+        assert "Multiple FeatureGroups match" in result.error
+        assert "Scoped to feature group: 'ScopedResolveFamilyBase693'." in result.error
+
+
+class TestResolveFeatureScopeNeverRaises:
+    """Invalid scopes degrade into ResolvedFeature.error instead of raising (issue #693)."""
+
+    def test_root_feature_group_scope_degrades_into_error(self) -> None:
+        """Scoping to the root FeatureGroup base is rejected with a dedicated error, not an exception."""
+        result = resolve_feature(SIBLING_SCOPED_FEATURE, feature_group=FeatureGroup)
+
+        assert isinstance(result, ResolvedFeature)
+        assert result.feature_group is None
+        assert result.error is not None
+        assert "root FeatureGroup base class" in result.error
+
+    def test_wrong_type_scope_degrades_into_error(self) -> None:
+        """A non-str, non-class scope is rejected with a type-explaining error, not an exception."""
+        invalid_scope: Any = 42
+
+        result = resolve_feature(SIBLING_SCOPED_FEATURE, feature_group=invalid_scope)
+
+        assert isinstance(result, ResolvedFeature)
+        assert result.feature_group is None
+        assert result.error is not None
+        assert "feature_group must be" in result.error
+
+    def test_whitespace_only_scope_behaves_like_unscoped(self) -> None:
+        """A whitespace-only scope string is treated exactly like feature_group=None."""
+        for feature_name in (SIBLING_SCOPED_FEATURE, LONE_CHILD_SCOPED_FEATURE):
+            unscoped = resolve_feature(feature_name)
+            blank_scoped = resolve_feature(feature_name, feature_group="   ")
+
+            assert blank_scoped.feature_group is unscoped.feature_group, feature_name
+            assert blank_scoped.candidates == unscoped.candidates, feature_name
+            assert blank_scoped.error == unscoped.error, feature_name
+
+
+class TestResolveFeatureScopedEngineParity:
+    """A scoped engine failure reproduces through resolve_feature with the same scope (issue #693)."""
+
+    def test_engine_scoped_no_match_reproduces_through_resolve_feature(self) -> None:
+        """The engine's scoped no-match callout reappears in the scoped resolve_feature error."""
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            ScopedResolveSiblingOne693: {PandasDataFrame},
+            ScopedResolveSiblingTwo693: {PandasDataFrame},
+        }
+        feature = Feature(SIBLING_SCOPED_FEATURE, feature_group="UnrelatedScopedResolve693FeatureGroup")
+
+        with pytest.raises(ValueError) as exc_info:
+            IdentifyFeatureGroupClass(
+                feature=feature,
+                accessible_plugins=accessible_plugins,
+                links=None,
+                data_access_collection=None,
+            )
+        engine_message = str(exc_info.value)
+        assert "Scoped to feature group: 'UnrelatedScopedResolve693FeatureGroup'." in engine_message
+
+        result = resolve_feature(SIBLING_SCOPED_FEATURE, feature_group="UnrelatedScopedResolve693FeatureGroup")
+
+        assert result.feature_group is None
+        assert result.error is not None
+        assert "Scoped to feature group: 'UnrelatedScopedResolve693FeatureGroup'." in result.error

--- a/tests/test_core/test_prepare/test_feature_group_dedup.py
+++ b/tests/test_core/test_prepare/test_feature_group_dedup.py
@@ -1238,3 +1238,65 @@ case25 flush-left line at column zero
     # from FeatureGroup.__subclasses__() and cannot leak into later tests.
     del MyFG_NestedFlushLeft25
     gc.collect()
+
+
+# ---------------------------------------------------------------------------
+# Case 26 (issue 693): scoped resolve_feature during a redefinition conflict.
+# The dedup-conflict branch must filter the returned candidates by the
+# feature_group scope AND append the scope callout to the conflict error.
+# ---------------------------------------------------------------------------
+def test_resolve_feature_excluding_scope_empties_conflict_candidates_and_error_keeps_callout() -> None:
+    """A scope excluding the conflicting classes empties candidates while the error keeps conflict and callout."""
+    qualname = "MyFG_Test26_Scope"
+    feature_name = "case26_feature_unique_xyz"
+    src_v1 = _make_fg_source(qualname, feature_name)
+    src_v2 = _make_fg_source(
+        qualname,
+        feature_name,
+        extra_body="    def extra_method(self):\n        return 26\n",
+    )
+
+    v1 = _exec_fg_in_main(qualname, src_v1, "cell-test26-v1")
+    v2 = _exec_fg_in_main(qualname, src_v2, "cell-test26-v2")
+    _REF_STORE.extend([v1, v2])
+
+    # DocsCatalogAnchorFG is unrelated to the exec'd classes, so the scope excludes them.
+    result = resolve_feature(feature_name, feature_group="DocsCatalogAnchorFG")
+
+    assert result.feature_group is None
+    assert result.candidates == [], (
+        f"conflicting classes outside the scope must be filtered from candidates, got: {result.candidates}"
+    )
+    assert result.error is not None
+    assert any(token in result.error for token in (qualname, "redefined", "set_allow_redefinition")), (
+        f"error must still report the redefinition conflict; got: {result.error!r}"
+    )
+    assert "Scoped to feature group: 'DocsCatalogAnchorFG'." in result.error
+
+
+def test_resolve_feature_matching_scope_keeps_conflict_candidates_and_error_keeps_callout() -> None:
+    """A scope naming the conflicting class keeps both versions in candidates and appends the callout."""
+    qualname = "MyFG_Test26_ScopeKeep"
+    feature_name = "case26_keep_feature_unique_xyz"
+    src_v1 = _make_fg_source(qualname, feature_name)
+    src_v2 = _make_fg_source(
+        qualname,
+        feature_name,
+        extra_body="    def extra_method(self):\n        return 262\n",
+    )
+
+    v1 = _exec_fg_in_main(qualname, src_v1, "cell-test26-keep-v1")
+    v2 = _exec_fg_in_main(qualname, src_v2, "cell-test26-keep-v2")
+    _REF_STORE.extend([v1, v2])
+
+    result = resolve_feature(feature_name, feature_group=qualname)
+
+    assert result.feature_group is None
+    assert v1 in result.candidates, f"v1 matches scope and feature name, so it must stay; got: {result.candidates}"
+    assert v2 in result.candidates, f"v2 matches scope and feature name, so it must stay; got: {result.candidates}"
+    assert all(c.__name__ == qualname for c in result.candidates), (
+        f"only in-scope classes may appear in candidates, got: {result.candidates}"
+    )
+    assert result.error is not None
+    assert "set_allow_redefinition" in result.error, f"error must report the conflict; got: {result.error!r}"
+    assert f"Scoped to feature group: '{qualname}'." in result.error

--- a/tests/test_core/test_prepare/test_identify_feature_group_error_message.py
+++ b/tests/test_core/test_prepare/test_identify_feature_group_error_message.py
@@ -319,6 +319,49 @@ class TestNoFeatureGroupFoundErrorMessage:
         assert "Did you mean" not in error_message
 
 
+class TestScopedResolveFeaturePointerWording:
+    """The no-match debug pointer names feature_group exactly when the feature is scoped (issue #693)."""
+
+    def test_scoped_no_match_pointer_includes_feature_group(self) -> None:
+        """A scoped no-match error points at the scoped resolve_feature form."""
+        feature = Feature("nonexistent_xyz", feature_group="KnownFeatureGroup")
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            KnownFeatureGroup: {MockComputeFramework},
+        }
+
+        with pytest.raises(ValueError) as exc_info:
+            IdentifyFeatureGroupClass(
+                feature=feature,
+                accessible_plugins=accessible_plugins,
+                links=None,
+            )
+
+        error_message = str(exc_info.value)
+        assert "Scoped to feature group: 'KnownFeatureGroup'." in error_message
+        assert "resolve_feature(name, options=..., feature_group=...)" in error_message, (
+            f"Scoped no-match errors must point at resolve_feature(name, options=..., feature_group=...), "
+            f"but got: {error_message}"
+        )
+
+    def test_unscoped_no_match_pointer_stays_unscoped(self) -> None:
+        """An unscoped no-match error keeps the plain resolve_feature pointer without feature_group."""
+        feature = Feature("nonexistent_xyz")
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            KnownFeatureGroup: {MockComputeFramework},
+        }
+
+        with pytest.raises(ValueError) as exc_info:
+            IdentifyFeatureGroupClass(
+                feature=feature,
+                accessible_plugins=accessible_plugins,
+                links=None,
+            )
+
+        error_message = str(exc_info.value)
+        assert "resolve_feature(name, options=...)" in error_message
+        assert "feature_group=..." not in error_message
+
+
 class NoComputeFrameworkFeatureGroup(FeatureGroup):
     """Feature group for testing 'no compute framework' error message."""
 


### PR DESCRIPTION
Closes #693.

## Problem

The scoped no-match error recommends debugging with `resolve_feature(name, options=...)`, but `resolve_feature` had no `feature_group` parameter and re-implements matching outside `IdentifyFeatureGroupClass`, so the recommended tool could not reproduce the scoped failure it was recommended for.

## Change

- `resolve_feature` gains a keyword-only `feature_group` argument accepting the same forms as `Feature(..., feature_group=...)`: a FeatureGroup subclass or a class-name string (the string matches the named class and its subclasses). Normalization is shared with `Feature` via the new module-level `normalize_feature_group_scope`.
- Scope filtering reuses the engine's module-level `matches_feature_group_scope` predicate, in both the main candidate loop and the redefinition-conflict branch, so the scope semantics cannot drift between the debug tool and the engine.
- The engine's `_scope_callout` became the public `scope_callout(scope)`; every `resolve_feature` failure path (no match, all frameworks rejected, ambiguity, redefinition conflict) now appends the same "Scoped to feature group: '<Name>'." callout the engine emits.
- Invalid scopes (root `FeatureGroup` base, wrong types) degrade into `ResolvedFeature.error`; the API still never raises. Whitespace-only strings mean unscoped, as in `Feature`.
- When the failing feature is scoped, the engine's debug pointer now reads `resolve_feature(name, options=..., feature_group=...)`; unscoped errors keep the old wording.
- Design decision (per the issue's definition of done): `resolve_feature` stays separate from `IdentifyFeatureGroupClass` rather than delegating, because it is a never-raising debug API that reports candidates, capability splits, and subtype fields and degrades per candidate, while `IdentifyFeatureGroupClass` needs an accessible-plugins environment mapping and raises. The docstring records this and the remaining known divergences (subclass collapse, abstract-base handling).
- Docs: `discover-plugins.md` gets a short scoped-debugging section.

## Tests

Scoped resolve (string and class-object forms, base-name subclass walk), scoped no-match, scoped ambiguity, scoped all-rejected capability error, invalid-scope degradation (root class, root string, whitespace, wrong type), engine parity (a scoped engine failure reproduces through `resolve_feature` with the same callout), engine pointer wording (scoped and unscoped), and scope filtering plus callout in the redefinition-conflict branch.

## Review

Two independent reviews of the diff were run before raising this PR. Accepted findings (three test-coverage gaps, one docstring completeness note) are included. One suggestion, filtering by scope before deduplication, was rejected: the engine also dedups globally before scope filtering (`PreFilterPlugins`), so an unrelated redefinition conflict fails a scoped engine run identically, and diverging here would recreate the drift this issue exists to remove.

`tox` passes: 5584 tests, ruff, mypy --strict, licenses, bandit.
