### PR TITLE
feat: add result_rows tolerant unwrapper for run_all output (#717)

### DIFF
--- a/attribution/ATTRIBUTION.md
+++ b/attribution/ATTRIBUTION.md
@@ -19,7 +19,7 @@
 | duckdb                                 | 1.5.4           | MIT License                                        |
 | execnet                                | 2.1.2           | MIT License                                        |
 | executing                              | 2.2.1           | MIT License                                        |
-| filelock                               | 3.29.5          | MIT License                                        |
+| filelock                               | 3.29.6          | MIT License                                        |
 | fsspec                                 | 2026.6.0        | BSD-3-Clause                                       |
 | idna                                   | 3.18            | BSD-3-Clause                                       |
 | iniconfig                              | 2.3.0           | MIT                                                |
@@ -41,6 +41,7 @@
 | mypy                                   | 2.1.0           | MIT                                                |
 | mypy_extensions                        | 1.1.0           | MIT                                                |
 | narwhals                               | 2.23.0          | MIT                                                |
+| nest-asyncio                           | 1.6.0           | BSD License                                        |
 | nest-asyncio2                          | 1.7.2           | BSD License                                        |
 | nltk                                   | 3.9.4           | Apache Software License                            |
 | numpy                                  | 2.5.1           | BSD-3-Clause AND 0BSD AND MIT AND Zlib AND CC0-1.0 |

--- a/docs/docs/chapter1/compute-frameworks.md
+++ b/docs/docs/chapter1/compute-frameworks.md
@@ -173,7 +173,7 @@ A feature group running on PythonDictFramework may also return row-wise data as 
 
 #### Columnar helpers
 
-`columnar_to_rows`, `homogenize_rows`, `is_columnar`, `result_rows`, and `rows_to_columnar` are importable from `mloda.provider` (plugin/provider code, where pivoting a columnar frame back to rows belongs) and from `mloda.user` (application code unwrapping a `run_all` result). `columnar_to_rows` is strict: it raises `ValueError` on anything that is not a valid columnar dict. `result_rows` is the blessed tolerant unwrapper for `run_all` output: it flattens the partition list into row dicts, and a dict that satisfies `is_columnar` is always treated as a columnar partition, never as a row.
+`columnar_to_rows`, `homogenize_rows`, `is_columnar`, `result_rows`, and `rows_to_columnar` are importable from `mloda.provider` (plugin/provider code, where pivoting a columnar frame back to rows belongs) and from `mloda.user` (application code unwrapping a `run_all` result). `columnar_to_rows` is strict: it raises `ValueError` on anything that is not a valid columnar dict. `result_rows` is the blessed tolerant unwrapper for PythonDict-framework `run_all` output (columnar dicts and row-dict lists): it flattens the partition list into row dicts, and a dict that satisfies `is_columnar` is always treated as a columnar partition, never as a row. It rejects other frameworks' result objects (convert those to rows first).
 
 ``` python
 from mloda.user import mloda, result_rows

--- a/docs/docs/chapter1/compute-frameworks.md
+++ b/docs/docs/chapter1/compute-frameworks.md
@@ -173,18 +173,15 @@ A feature group running on PythonDictFramework may also return row-wise data as 
 
 #### Columnar helpers
 
-`columnar_to_rows`, `homogenize_rows`, `is_columnar`, and `rows_to_columnar` are importable from `mloda.provider` (plugin/provider code, where pivoting a columnar frame back to rows belongs) and from `mloda.user` (application code unwrapping a `run_all` result). `columnar_to_rows` is strict: it raises `ValueError` on anything that is not a valid columnar dict. Use `is_columnar` to branch first:
+`columnar_to_rows`, `homogenize_rows`, `is_columnar`, `result_rows`, and `rows_to_columnar` are importable from `mloda.provider` (plugin/provider code, where pivoting a columnar frame back to rows belongs) and from `mloda.user` (application code unwrapping a `run_all` result). `columnar_to_rows` is strict: it raises `ValueError` on anything that is not a valid columnar dict. `result_rows` is the blessed tolerant unwrapper for `run_all` output: it flattens the partition list into row dicts, and a dict that satisfies `is_columnar` is always treated as a columnar partition, never as a row.
 
 ``` python
-from mloda.provider import columnar_to_rows, is_columnar
+from mloda.user import mloda, result_rows
 
-def to_rows_lenient(data):
-    if isinstance(data, list):
-        return data
-    return columnar_to_rows(data) if is_columnar(data) else []
+rows = result_rows(mloda.run_all(...))
 ```
 
-Strictness stays in the library; forgiveness is application policy.
+Strictness stays in the library; `result_rows` packages the forgiving application-side policy.
 
 Example using Polars frameworks:
 ``` python

--- a/mloda/provider/__init__.py
+++ b/mloda/provider/__init__.py
@@ -90,6 +90,7 @@ from mloda_plugins.compute_framework.base_implementations.python_dict.python_dic
     columnar_to_rows,
     homogenize_rows,
     is_columnar,
+    result_rows,
     rows_to_columnar,
 )
 
@@ -156,6 +157,7 @@ __all__ = [
     "columnar_to_rows",
     "homogenize_rows",
     "is_columnar",
+    "result_rows",
     "rows_to_columnar",
     # Engines
     "BaseFilterEngine",

--- a/mloda/user/__init__.py
+++ b/mloda/user/__init__.py
@@ -82,6 +82,7 @@ _LAZY_PYTHON_DICT_UTILS: dict[str, str] = {
     "columnar_to_rows": "mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils",
     "homogenize_rows": "mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils",
     "is_columnar": "mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils",
+    "result_rows": "mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils",
     "rows_to_columnar": "mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils",
 }
 
@@ -106,6 +107,7 @@ if TYPE_CHECKING:
         columnar_to_rows as columnar_to_rows,
         homogenize_rows as homogenize_rows,
         is_columnar as is_columnar,
+        result_rows as result_rows,
         rows_to_columnar as rows_to_columnar,
     )
     from mloda_plugins.compute_framework.base_implementations.spark.spark_framework import (

--- a/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_utils.py
+++ b/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_utils.py
@@ -58,7 +58,7 @@ def columnar_to_rows(data: dict[str, Any]) -> list[dict[str, Any]]:
 
 
 def result_rows(result: Any) -> list[dict[str, Any]]:
-    """Tolerantly unwrap ``run_all`` output to rows; an ``is_columnar`` dict is always a partition, never a row."""
+    """Unwrap PythonDict ``run_all`` output to rows; an ``is_columnar`` dict is always a partition, never a row."""
     if result is None:
         return []
 
@@ -68,7 +68,10 @@ def result_rows(result: Any) -> list[dict[str, Any]]:
         raise ValueError(f"Ambiguous top-level dict is not columnar: {result!r}")
 
     if not isinstance(result, list):
-        raise ValueError(f"Expected None, a columnar dict, or a list of partitions, got {type(result)}")
+        raise ValueError(
+            f"result_rows only unwraps PythonDict-framework output (columnar dicts and row dicts), got {type(result)};"
+            " convert other compute frameworks' results (e.g. DataFrame or Table objects) to rows first"
+        )
 
     rows: list[dict[str, Any]] = []
     for i, element in enumerate(result):
@@ -77,14 +80,18 @@ def result_rows(result: Any) -> list[dict[str, Any]]:
         if is_columnar(element):
             rows.extend(columnar_to_rows(element))
         elif isinstance(element, dict):
-            rows.append(element)
+            rows.append(dict(element))
         elif isinstance(element, list):
             for j, item in enumerate(element):
                 if not isinstance(item, dict):
                     raise ValueError(f"Nested row list at index {i} contains non-dict at index {j}: {type(item)}")
-            rows.extend(element)
+            rows.extend(dict(item) for item in element)
         else:
-            raise ValueError(f"Unsupported result element at index {i}: {type(element)}")
+            raise ValueError(
+                f"Unsupported result element at index {i}: {type(element)}; result_rows only unwraps"
+                " PythonDict-framework output (columnar dicts and row dicts), convert other compute frameworks'"
+                " results (e.g. DataFrame or Table objects) to rows first"
+            )
     return rows
 
 

--- a/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_utils.py
+++ b/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_utils.py
@@ -57,6 +57,37 @@ def columnar_to_rows(data: dict[str, Any]) -> list[dict[str, Any]]:
     return [{key: data[key][i] for key in data} for i in range(row_count(data))]
 
 
+def result_rows(result: Any) -> list[dict[str, Any]]:
+    """Tolerantly unwrap ``run_all`` output to rows; an ``is_columnar`` dict is always a partition, never a row."""
+    if result is None:
+        return []
+
+    if isinstance(result, dict):
+        if is_columnar(result):
+            return columnar_to_rows(result)
+        raise ValueError(f"Ambiguous top-level dict is not columnar: {result!r}")
+
+    if not isinstance(result, list):
+        raise ValueError(f"Expected None, a columnar dict, or a list of partitions, got {type(result)}")
+
+    rows: list[dict[str, Any]] = []
+    for i, element in enumerate(result):
+        if element is None:
+            continue
+        if is_columnar(element):
+            rows.extend(columnar_to_rows(element))
+        elif isinstance(element, dict):
+            rows.append(element)
+        elif isinstance(element, list):
+            for j, item in enumerate(element):
+                if not isinstance(item, dict):
+                    raise ValueError(f"Nested row list at index {i} contains non-dict at index {j}: {type(item)}")
+            rows.extend(element)
+        else:
+            raise ValueError(f"Unsupported result element at index {i}: {type(element)}")
+    return rows
+
+
 def homogenize_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Return new row dicts carrying the union of keys in first-occurrence order, missing keys as ``None``."""
     keys: list[str] = []

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_compute_framework_exports.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_compute_framework_exports.py
@@ -83,6 +83,7 @@ HELPER_EXPORT_MATRIX: list[tuple[str, str]] = [
     ("columnar_to_rows", _PYTHON_DICT_UTILS_MODULE),
     ("homogenize_rows", _PYTHON_DICT_UTILS_MODULE),
     ("is_columnar", _PYTHON_DICT_UTILS_MODULE),
+    ("result_rows", _PYTHON_DICT_UTILS_MODULE),
     ("rows_to_columnar", _PYTHON_DICT_UTILS_MODULE),
 ]
 
@@ -108,7 +109,7 @@ class TestPythonDictHelperExportMatrix:
 
 
 # Provider side (issue #707): pivoting a columnar frame back to rows is a provider-side
-# concern, so the same four helpers are ALSO exported from mloda.provider. Unlike the
+# concern, so the same helpers are ALSO exported from mloda.provider. Unlike the
 # lazy mloda.user exports, python_dict_utils is stdlib-only and mloda.provider already
 # imports eagerly from mloda_plugins, so these are eager exports listed in __all__.
 class TestPythonDictHelperProviderExportMatrix:

--- a/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_utils.py
+++ b/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_utils.py
@@ -1,13 +1,16 @@
-"""Red-phase tests for the ``columnar_to_rows`` and ``homogenize_rows`` python_dict_utils helpers (issue 648)."""
+"""Red-phase tests for the ``columnar_to_rows``, ``homogenize_rows`` (issue 648) and ``result_rows``
+(issue 717) python_dict_utils helpers."""
 
 from typing import Any
 
 import pytest
 
+from mloda.user import RunResult
 from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils import (
     columnar_to_rows,
     homogenize_rows,
     is_columnar,
+    result_rows,
     rows_to_columnar,
     validate_columnar_dict,
 )
@@ -157,3 +160,103 @@ class TestValidateColumnarDict:
     def test_non_list_value_raises(self) -> None:
         with pytest.raises(ValueError):
             validate_columnar_dict({"a": 5})
+
+
+class TestResultRows:
+    def test_none_returns_empty_list(self) -> None:
+        """``None`` (no result at all) yields no rows."""
+        assert result_rows(None) == []
+
+    def test_empty_list_returns_empty_list(self) -> None:
+        """An empty partition list yields no rows."""
+        assert result_rows([]) == []
+
+    def test_empty_dict_returns_empty_list(self) -> None:
+        """The schema-less ``{}`` yields no rows."""
+        assert result_rows({}) == []
+
+    def test_bare_columnar_dict_pivots_to_rows(self) -> None:
+        """A bare columnar dict pivots into a list of row dicts."""
+        data: dict[str, list[Any]] = {"a": [1, 2], "b": ["x", "y"]}
+        assert result_rows(data) == [{"a": 1, "b": "x"}, {"a": 2, "b": "y"}]
+
+    def test_schema_bearing_zero_row_dict_returns_empty_list(self) -> None:
+        """A schema-bearing zero-row columnar dict yields no rows."""
+        assert result_rows({"a": []}) == []
+
+    def test_list_of_columnar_partitions_concatenates_in_order(self) -> None:
+        """Columnar partitions are pivoted and concatenated in list order."""
+        assert result_rows([{"a": [1]}, {"a": [2]}]) == [{"a": 1}, {"a": 2}]
+
+    def test_single_wrapped_columnar_partition_pivots(self) -> None:
+        """A dict element satisfying ``is_columnar`` is a partition, never a row; this precedence is intentional."""
+        assert result_rows([{"a": [1, 2]}]) == [{"a": 1}, {"a": 2}]
+
+    def test_row_wise_list_passes_through(self) -> None:
+        """Non-columnar dict elements are rows and pass through unchanged."""
+        rows: list[dict[str, Any]] = [{"a": 1}, {"a": 2}]
+        assert result_rows(rows) == [{"a": 1}, {"a": 2}]
+
+    def test_row_wise_list_returns_a_new_list_object(self) -> None:
+        """The pass-through returns a NEW list object, not the input object."""
+        rows: list[dict[str, Any]] = [{"a": 1}, {"a": 2}]
+        result = result_rows(rows)
+        assert result == rows
+        assert result is not rows
+
+    def test_mixed_partition_list_flattens_in_order(self) -> None:
+        """A list element is a partition of row dicts and is extended in order."""
+        assert result_rows([{"a": [1]}, [{"a": 2}, {"a": 3}]]) == [{"a": 1}, {"a": 2}, {"a": 3}]
+
+    def test_none_elements_inside_a_list_are_skipped(self) -> None:
+        """``None`` elements contribute no rows and do not raise."""
+        assert result_rows([None, {"a": [1]}, None]) == [{"a": 1}]
+
+    def test_empty_dict_elements_contribute_no_rows(self) -> None:
+        """An empty dict element is a schema-less partition with zero rows."""
+        assert result_rows([{}, {"a": [1]}]) == [{"a": 1}]
+
+    def test_nested_row_list_with_non_dict_raises(self) -> None:
+        """A nested row-list element must contain only dicts."""
+        with pytest.raises(ValueError):
+            result_rows([[{"a": 1}, 5]])
+
+    def test_int_input_raises(self) -> None:
+        with pytest.raises(ValueError):
+            result_rows(5)
+
+    def test_string_input_raises(self) -> None:
+        with pytest.raises(ValueError):
+            result_rows("text")
+
+    def test_top_level_non_columnar_dict_raises(self) -> None:
+        """A bare non-columnar dict at TOP LEVEL is ambiguous garbage and raises."""
+        with pytest.raises(ValueError):
+            result_rows({"a": 5})
+
+    def test_non_columnar_dict_element_is_a_row(self) -> None:
+        """INSIDE a list the same non-columnar dict is a row and is appended."""
+        assert result_rows([{"a": 5}]) == [{"a": 5}]
+
+    def test_scalar_list_element_raises(self) -> None:
+        with pytest.raises(ValueError):
+            result_rows([5])
+
+    def test_string_list_element_raises(self) -> None:
+        with pytest.raises(ValueError):
+            result_rows(["text"])
+
+    def test_ragged_columnar_looking_dict_raises(self) -> None:
+        """A ragged columnar-looking dict at top level raises via the strict pivot."""
+        with pytest.raises(ValueError):
+            result_rows({"a": [1, 2], "b": [1]})
+
+    def test_run_result_is_unwrapped_like_a_list(self) -> None:
+        """``RunResult`` subclasses ``list`` and is unwrapped like any partition list."""
+        assert result_rows(RunResult([{"a": [1]}], [])) == [{"a": 1}]
+
+    def test_pivot_preserves_key_insertion_order(self) -> None:
+        """A pivoted partition keeps the columnar dict's key insertion order."""
+        result = result_rows({"b": [1], "a": [2]})
+        assert result == [{"b": 1, "a": 2}]
+        assert [list(row.keys()) for row in result] == [["b", "a"]]

--- a/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_utils.py
+++ b/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_utils.py
@@ -247,7 +247,7 @@ class TestResultRows:
             result_rows(["text"])
 
     def test_ragged_columnar_looking_dict_raises(self) -> None:
-        """A ragged columnar-looking dict at top level raises via the strict pivot."""
+        """A ragged columnar-looking dict fails ``is_columnar`` and raises via the ambiguous-dict branch."""
         with pytest.raises(ValueError):
             result_rows({"a": [1, 2], "b": [1]})
 
@@ -260,3 +260,39 @@ class TestResultRows:
         result = result_rows({"b": [1], "a": [2]})
         assert result == [{"b": 1, "a": 2}]
         assert [list(row.keys()) for row in result] == [["b", "a"]]
+
+    def test_passthrough_rows_are_fresh_dict_objects(self) -> None:
+        """Passed-through row dicts are fresh copies, never aliases of the input dicts."""
+        rows: list[dict[str, Any]] = [{"a": 1}]
+        result = result_rows(rows)
+        assert result == rows
+        assert result[0] is not rows[0]
+
+    def test_nested_row_list_rows_are_fresh_dict_objects(self) -> None:
+        """Row dicts taken from a nested row list are fresh copies, never aliases."""
+        inner: dict[str, Any] = {"a": 2}
+        result = result_rows([[inner]])
+        assert result == [{"a": 2}]
+        assert result[0] is not inner
+
+    def test_unsupported_element_error_names_the_pythondict_scope(self) -> None:
+        """The unsupported-element error names PythonDict so other frameworks' users know to convert first."""
+        with pytest.raises(ValueError, match="PythonDict"):
+            result_rows([object()])
+
+    def test_unsupported_top_level_error_names_the_pythondict_scope(self) -> None:
+        """The unsupported-top-level error names PythonDict so other frameworks' users know to convert first."""
+        with pytest.raises(ValueError, match="PythonDict"):
+            result_rows(("not", "a", "list"))
+
+    def test_mixed_columnar_and_bare_row_dict_elements(self) -> None:
+        """A columnar partition pivots while a non-columnar dict element is a row, in one list."""
+        assert result_rows([{"a": [1]}, {"a": 2}]) == [{"a": 1}, {"a": 2}]
+
+    def test_ragged_dict_element_is_a_row_not_a_partition(self) -> None:
+        """A ragged dict fails ``is_columnar``, so inside a list it is a row; real partitions are never ragged."""
+        assert result_rows([{"a": [1, 2], "b": [1]}]) == [{"a": [1, 2], "b": [1]}]
+
+    def test_columnar_dict_inside_nested_list_is_a_row(self) -> None:
+        """Nested lists are row partitions; their columnar-looking dicts are rows, never pivoted recursively."""
+        assert result_rows([[{"a": [1]}]]) == [{"a": [1]}]

--- a/tests/test_plugins/compute_framework/base_implementations/python_dict/test_result_rows_run_all.py
+++ b/tests/test_plugins/compute_framework/base_implementations/python_dict/test_result_rows_run_all.py
@@ -1,0 +1,47 @@
+"""End-to-end test: ``result_rows`` unwraps a PythonDict ``mloda.run_all`` result (issue 717)."""
+
+from typing import Any, Optional
+
+from mloda.provider import BaseInputData
+from mloda.provider import ComputeFramework
+from mloda.provider import DataCreator
+from mloda.provider import FeatureGroup
+from mloda.provider import FeatureSet
+from mloda.user import Feature
+from mloda.user import ParallelizationMode
+from mloda.user import PluginCollector
+from mloda.user import mloda
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils import result_rows
+
+
+class ResultRowsRootFeatureGroup(FeatureGroup):
+    """Root PythonDict FeatureGroup emitting a two-row columnar dict for ``result_rows``."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({"result_rows_e2e_col"})
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PythonDictFramework}
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {"result_rows_e2e_col": [1, 2]}
+
+
+_ENABLED_RESULT_ROWS = PluginCollector.enabled_feature_groups({ResultRowsRootFeatureGroup})
+
+
+def test_result_rows_unwraps_run_all_result(flight_server: Any) -> None:
+    """``result_rows`` flattens the ``run_all`` partition list into the expected row dicts."""
+    result = mloda.run_all(
+        [Feature(name="result_rows_e2e_col")],
+        compute_frameworks=["PythonDictFramework"],
+        plugin_collector=_ENABLED_RESULT_ROWS,
+        parallelization_modes={ParallelizationMode.SYNC},
+        flight_server=flight_server,
+    )
+
+    assert result_rows(result) == [{"result_rows_e2e_col": 1}, {"result_rows_e2e_col": 2}]

--- a/uv.lock
+++ b/uv.lock
@@ -1424,7 +1424,7 @@ wheels = [
 
 [[package]]
 name = "mloda"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Adds `result_rows(result) -> list[dict]`, the tolerant unwrapper for `mlodaAPI.run_all()` output requested in #717. Every consumer so far hand-rolls the same shape dispatch (rag_integration's `flatten_result`, CLI demos' `columnar_to_rows(result[0]) if result else []`, and the docs' own lenient example); this gives them one blessed helper instead.

Closes #717.

## Design

- `columnar_to_rows` stays strict. Instead of a `strict=False` flag (which would reopen inside feature groups the shape ambiguity #648 closed), the tolerant behavior lives in a separate helper aimed at the run_all boundary.
- Semantics: `None` and empty inputs return `[]`; a columnar dict pivots; a list (including `RunResult`) is unwrapped element-wise, where columnar dict elements pivot, non-columnar dict elements are rows, nested lists are row partitions, and `None` elements are skipped. Genuinely uninterpretable shapes still raise `ValueError`, and the messages name the PythonDict scope so pandas/polars users know to convert their results first.
- Precedence: a dict satisfying `is_columnar` is always a partition, never a row. Returned rows are fresh dicts and never alias the input.
- Exported like the other columnar helpers (#713): lazily from `mloda.user`, eagerly from `mloda.provider`. Docs updated; the hand-rolled lenient example is replaced by `result_rows`.

Follow-up candidate (kept out of scope): a per-feature mapping helper. A robust version should be plan-aware via `RunResult.plan` rather than index-based, so it deserves its own issue.

## Testing

- 30 new unit tests pinning the dispatch semantics, aliasing guarantees, error-message scope, and the lazy/eager export contract, plus an end-to-end `run_all` test on PythonDictFramework.
- Two independent deep reviews; all accepted findings (scoped error messages, docs qualifier, uniform row copies, docstring fix, extra pin tests) are addressed in the second commit.
- Full `tox` gate green twice (5686 passed, ruff, mypy --strict, licenses, bandit).
