### PR TITLE
fix: resolve_feature can express a feature group scope, and its verdict matches the engine (#693)

### DIFF
--- a/docs/docs/in_depth/discover-plugins.md
+++ b/docs/docs/in_depth/discover-plugins.md
@@ -60,12 +60,20 @@ resolve_feature("customer_id", feature_group=PolicyReader)      # class
 resolve_feature("customer_id", feature_group="PolicyReader")    # class name
 ```
 
-This reproduces a scoped engine failure. When `mloda.run_all` reports
+Use this to investigate a scoped engine failure. When `mloda.run_all` reports
 `Scoped to feature group: 'PolicyReader'.` for a feature, pass the same scope
-here and `resolve_feature` returns the same verdict in `result.error`, with the
-same callout, instead of raising. An invalid scope (the root `FeatureGroup`
-base, a non-FeatureGroup type) is reported in `result.error` too, while
-`Feature(...)` raises `TypeError` for it.
+here and `resolve_feature` reports the failure in `result.error`, with the same
+callout, instead of raising. An invalid scope (the root `FeatureGroup` base, a
+non-FeatureGroup type) is reported in `result.error` too, while `Feature(...)`
+raises `TypeError` for it.
+
+The two apply the same matching rules (name and scope matching, capability
+split, abstract bases, subclass preference), but `resolve_feature` has no run
+context, so its verdict can still differ where the run does: it ignores links
+and the data access collection, evaluates every available compute framework
+rather than the run's selection, and applies no plugin-registry filter (under
+`MLODA_PLUGIN_REGISTRY_STRICT=strict` the engine drops unregistered feature
+groups, `resolve_feature` does not).
 
 ### Inspecting Candidates
 

--- a/docs/docs/in_depth/discover-plugins.md
+++ b/docs/docs/in_depth/discover-plugins.md
@@ -41,13 +41,31 @@ result = resolve_feature("sales__sum_aggr", options=Options(group={"partition_by
 print(result.feature_group, result.supported_compute_frameworks)
 ```
 
-`options` and `plugin_collector` are keyword-only, so pass them by name.
+`options`, `feature_group` and `plugin_collector` are keyword-only, so pass them by name.
 
 When exactly one FeatureGroup resolves, `ResolvedFeature` also reports
 `subtype` (resolved from the name, the passed options, or the key's declared
 default, e.g. `"sum"` for `sales__sum_aggr`) and `subtype_family` (the
 parametric family name, `"ntile"` for `ntile_2`); both are `None` when
 nothing resolves.
+
+### Scoping to a Feature Group
+
+`feature_group` restricts resolution to one FeatureGroup, exactly as
+`Feature(..., feature_group=...)` does: a class or a class-name string, the
+string form also matching subclasses of the named class.
+
+``` python
+resolve_feature("customer_id", feature_group=PolicyReader)      # class
+resolve_feature("customer_id", feature_group="PolicyReader")    # class name
+```
+
+This reproduces a scoped engine failure. When `mloda.run_all` reports
+`Scoped to feature group: 'PolicyReader'.` for a feature, pass the same scope
+here and `resolve_feature` returns the same verdict in `result.error`, with the
+same callout, instead of raising. An invalid scope (the root `FeatureGroup`
+base, a non-FeatureGroup type) is reported in `result.error` too, while
+`Feature(...)` raises `TypeError` for it.
 
 ### Inspecting Candidates
 

--- a/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
+++ b/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
@@ -83,6 +83,7 @@ Caveats:
 - The class object is collision-proof; the string form is not. Two classes with the same name in different modules both match the string, so the request stays ambiguous and raises.
 - Neither form pins one exact class: a subclass of the named class is preferred over it. To resolve to a specific implementation, name that implementation.
 - The root `FeatureGroup` base is rejected in either form: it names no family.
+- `resolve_feature(name, options=..., feature_group=...)` takes the same scope, in both forms, and reports the scoped resolution outcome instead of raising. Use it to debug a scoped failure ([discover plugins](../discover-plugins.md#scoping-to-a-feature-group) lists the remaining differences from a run).
 - The scope is resolution-only and excluded from Feature identity, so two requests for the same column name scoped to different sources compare equal. Requesting both in one features list raises `ValueError: Duplicate feature setup: <name>` rather than silently dropping one, so you are told, not surprised. Inside a single `input_features()` returning a set literal, a second same-name feature with a different scope is silently deduplicated by the Python set itself before the engine ever sees it, so never scope the same name twice within one feature group. To read the same column from two sources side by side, give them distinct derived feature names.
 
 ## FeatureGroup Redefinition Errors

--- a/mloda/core/abstract_plugins/components/feature.py
+++ b/mloda/core/abstract_plugins/components/feature.py
@@ -18,6 +18,34 @@ from mloda.core.abstract_plugins.components.utils import get_all_subclasses
 from mloda.core.abstract_plugins.components.validators.feature_validator import FeatureValidator
 
 
+def normalize_feature_group_scope(feature_group: str | type[FeatureGroup] | None) -> str | type[FeatureGroup] | None:
+    """Normalize and validate a feature-group scope value, raising TypeError on an invalid one.
+
+    Shared by Feature(..., feature_group=...) and resolve_feature(..., feature_group=...), so the
+    scope means the same thing in both.
+    """
+    if feature_group is None:
+        return None
+    # Local import: feature_group.py imports this module.
+    from mloda.core.abstract_plugins.feature_group import FeatureGroup
+
+    root_rejection = "feature_group cannot be the root FeatureGroup base class; a concrete subclass is required"
+    if isinstance(feature_group, str):
+        stripped = feature_group.strip()
+        # The root names no feature group family; rejected here as in the class-object form below.
+        if stripped == FeatureGroup.get_class_name():
+            raise TypeError(root_rejection)
+        return stripped or None
+    if feature_group is FeatureGroup:
+        raise TypeError(root_rejection)
+    if isinstance(feature_group, type) and issubclass(feature_group, FeatureGroup):
+        return feature_group
+    raise TypeError(
+        f"feature_group must be a FeatureGroup subclass, a class-name string, or None, "
+        f"got {type(feature_group).__name__}"
+    )
+
+
 class Feature:
     """Represents a raw feature.
 
@@ -172,25 +200,7 @@ class Feature:
     def _set_feature_group_scope(
         self, feature_group: str | type[FeatureGroup] | None
     ) -> str | type[FeatureGroup] | None:
-        if feature_group is None:
-            return None
-        from mloda.core.abstract_plugins.feature_group import FeatureGroup
-
-        root_rejection = "feature_group cannot be the root FeatureGroup base class; a concrete subclass is required"
-        if isinstance(feature_group, str):
-            stripped = feature_group.strip()
-            # The root names no feature group family; rejected here as in the class-object form below.
-            if stripped == FeatureGroup.get_class_name():
-                raise TypeError(root_rejection)
-            return stripped or None
-        if feature_group is FeatureGroup:
-            raise TypeError(root_rejection)
-        if isinstance(feature_group, type) and issubclass(feature_group, FeatureGroup):
-            return feature_group
-        raise TypeError(
-            f"feature_group must be a FeatureGroup subclass, a class-name string, or None, "
-            f"got {type(feature_group).__name__}"
-        )
+        return normalize_feature_group_scope(feature_group)
 
     @classmethod
     def not_typed(

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -33,7 +33,12 @@ from mloda.core.prepare.accessible_plugins import (
     dedup_feature_group_subclasses,
     registry_for,
 )
-from mloda.core.prepare.identify_feature_group import split_frameworks_by_capability
+from mloda.core.abstract_plugins.components.feature import normalize_feature_group_scope
+from mloda.core.prepare.identify_feature_group import (
+    matches_feature_group_scope,
+    scope_callout,
+    split_frameworks_by_capability,
+)
 
 
 def list_registered(plugin_type: type[Any]) -> list[type[Any]]:
@@ -341,10 +346,16 @@ def get_extender_docs(
     return sorted(results, key=lambda x: x.name)
 
 
+def _with_callout(message: str, callout: Optional[str]) -> str:
+    """Append the scope callout to a failure message, so a scoped failure is legible as scoped."""
+    return f"{message} {callout}" if callout else message
+
+
 def resolve_feature(
     feature_name: str,
     *,
     options: Optional[Options] = None,
+    feature_group: str | type[FeatureGroup] | None = None,
     plugin_collector: Optional[PluginCollector] = None,
 ) -> ResolvedFeature:
     """
@@ -354,18 +365,36 @@ def resolve_feature(
     the given feature name. It applies subclass filtering to prefer more
     specific (child) classes over parent classes.
 
-    Never raises: matching errors are reported in the returned ResolvedFeature.error.
+    Never raises: matching errors, including an invalid ``feature_group`` scope, are reported in the
+    returned ResolvedFeature.error. ``Feature(..., feature_group=...)`` raises for such a scope instead;
+    that difference is deliberate, a debug API must not blow up on the input it is asked to explain.
+
+    Does not delegate to IdentifyFeatureGroupClass, and so may differ from the engine: it never raises
+    and degrades a candidate whose matching raises ValueError to "not a match" (the engine propagates it),
+    it has no run context and therefore ignores links, the data access collection and the run's compute
+    framework selection, and it does not exclude abstract bases. It shares the matching predicates
+    (match_feature_group_criteria, matches_feature_group_scope, split_frameworks_by_capability) and the
+    scope-callout renderer, which is what keeps the scope verdict aligned with the engine's.
 
     Args:
         feature_name: The name of the feature to resolve.
         options: Keyword-only. Options used for matching and capability checks. An empty or omitted Options is
             the documented default.
+        feature_group: Keyword-only. Restrict resolution to a FeatureGroup subclass or a class-name string,
+            with the same semantics as ``Feature(..., feature_group=...)``: the string form also matches
+            subclasses of the named class.
         plugin_collector: Keyword-only. Its ``allow_redefinition`` flag is threaded into deduplication.
 
     Returns:
         ResolvedFeature containing the resolved FeatureGroup (if found),
         all matching candidates, and any error message.
     """
+    try:
+        scope = normalize_feature_group_scope(feature_group)
+    except TypeError as exc:
+        return ResolvedFeature(feature_name=feature_name, feature_group=None, candidates=[], error=str(exc))
+    callout = scope_callout(scope)
+
     resolved_options = options if options is not None else Options()
     is_default_options = not resolved_options.group and not resolved_options.context
     options_caveat = "default options" if is_default_options else "the provided options"
@@ -394,6 +423,9 @@ def resolve_feature(
     feature_name_obj = FeatureName(feature_name)
 
     for fg in all_fgs:
+        # Scope first: an out-of-scope group's rejection reason must never pollute a scoped error.
+        if scope is not None and not matches_feature_group_scope(fg, scope):
+            continue
         if _match_recording_validation_errors(fg, feature_name_obj, resolved_options, validation_errors):
             candidates.append(fg)
 
@@ -405,7 +437,7 @@ def resolve_feature(
             feature_name=feature_name,
             feature_group=None,
             candidates=[],
-            error=error,
+            error=_with_callout(error, callout),
         )
 
     # Degrade a raising plugin declaration OPEN (all available declared frameworks); resolve_feature never raises.
@@ -441,10 +473,11 @@ def resolve_feature(
             feature_name=feature_name,
             feature_group=None,
             candidates=candidates,
-            error=(
+            error=_with_callout(
                 f"Feature '{feature_name}' matches {[c.get_class_name() for c in candidates]} "
                 f"but is unsupported on all installed compute frameworks "
-                f"(evaluated under {options_caveat}): {rejected_names}."
+                f"(evaluated under {options_caveat}): {rejected_names}.",
+                callout,
             ),
             supported_compute_frameworks=[],
             unsupported_compute_frameworks=rejected_names,
@@ -471,7 +504,9 @@ def resolve_feature(
         feature_name=feature_name,
         feature_group=None,
         candidates=candidates,
-        error=f"Multiple FeatureGroups match feature name '{feature_name}': {conflicting_names}",
+        error=_with_callout(
+            f"Multiple FeatureGroups match feature name '{feature_name}': {conflicting_names}", callout
+        ),
         supported_compute_frameworks=supported_names,
         unsupported_compute_frameworks=rejected_names,
     )

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -15,11 +15,12 @@ Example:
     docs = get_feature_group_docs()
 """
 
+import inspect
 from typing import Any, Optional
 
 from mloda.core.abstract_plugins.components.base_feature_group_version import SOURCE_INTROSPECTION_ERRORS
 from mloda.core.abstract_plugins.components.subtype_declaration import SubtypeDeclaration
-from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.abstract_plugins.feature_group import FeatureGroup, format_feature_group_class
 from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
 from mloda.core.abstract_plugins.components.utils import get_all_subclasses, safe_field, safe_field_with_error
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
@@ -35,9 +36,9 @@ from mloda.core.prepare.accessible_plugins import (
 )
 from mloda.core.abstract_plugins.components.feature import normalize_feature_group_scope
 from mloda.core.prepare.identify_feature_group import (
+    frameworks_by_capability,
     matches_feature_group_scope,
     scope_callout,
-    split_frameworks_by_capability,
 )
 
 
@@ -351,6 +352,30 @@ def _with_callout(message: str, callout: Optional[str]) -> str:
     return f"{message} {callout}" if callout else message
 
 
+def _candidate_frameworks(
+    candidate: type[FeatureGroup], feature_name: FeatureName, options: Options
+) -> tuple[set[type[ComputeFramework]], set[type[ComputeFramework]]]:
+    """Split ONE candidate's available declared frameworks into (supported, rejected).
+
+    Degrades a raising declaration OPEN (every available declared framework counts as supported):
+    resolve_feature never raises, so a plugin that cannot answer must not fail the whole call.
+    """
+    split: Optional[tuple[set[type[ComputeFramework]], set[type[ComputeFramework]]]] = safe_field(
+        lambda: frameworks_by_capability(candidate, feature_name, options),
+        None,
+        field=f"capability split for '{feature_name}' on {candidate.__name__}",
+    )
+    if split is not None:
+        return split
+
+    open_supported: set[type[ComputeFramework]] = safe_field(
+        lambda: {cfw for cfw in candidate.compute_framework_definition() if cfw.is_available()},
+        set(),
+        field=f"open-degrade frameworks for '{feature_name}' on {candidate.__name__}",
+    )
+    return open_supported, set()
+
+
 def resolve_feature(
     feature_name: str,
     *,
@@ -372,9 +397,11 @@ def resolve_feature(
     Does not delegate to IdentifyFeatureGroupClass, and so may differ from the engine: it never raises
     and degrades a candidate whose matching raises ValueError to "not a match" (the engine propagates it),
     it has no run context and therefore ignores links, the data access collection and the run's compute
-    framework selection, and it does not exclude abstract bases. It shares the matching predicates
-    (match_feature_group_criteria, matches_feature_group_scope, split_frameworks_by_capability) and the
-    scope-callout renderer, which is what keeps the scope verdict aligned with the engine's.
+    framework selection, and it applies no plugin-registry filter (under
+    MLODA_PLUGIN_REGISTRY_STRICT=strict the engine drops unregistered feature groups, this does not).
+    It shares the matching predicates (match_feature_group_criteria, matches_feature_group_scope,
+    frameworks_by_capability), the abstract-base and subclass-filter rules, and the scope-callout
+    renderer, which is what keeps its verdict aligned with the engine's.
 
     Args:
         feature_name: The name of the feature to resolve.
@@ -406,31 +433,46 @@ def resolve_feature(
     try:
         all_fgs = list(dedup_feature_group_subclasses(fg_classes, allow_redefinition=allow_redefinition))
     except ValueError as exc:
+        # The conflict is reported even when every conflicting class is out of scope: the engine dedups the
+        # whole class universe BEFORE scoping (PreFilterPlugins._set_feature_groups), so it raises there too.
         raw_conflicts = list(getattr(exc, "conflicts", []))
         feature_name_obj = FeatureName(feature_name)
         matching_conflicts = [
             fg
             for fg in raw_conflicts
-            if _match_recording_validation_errors(fg, feature_name_obj, resolved_options, validation_errors)
+            if (scope is None or matches_feature_group_scope(fg, scope))
+            and _match_recording_validation_errors(fg, feature_name_obj, resolved_options, validation_errors)
         ]
         return ResolvedFeature(
             feature_name=feature_name,
             feature_group=None,
             candidates=matching_conflicts,
-            error=str(exc),
+            error=_with_callout(str(exc), callout),
         )
     candidates: list[type[FeatureGroup]] = []
+    abstract_matches: list[type[FeatureGroup]] = []
     feature_name_obj = FeatureName(feature_name)
 
     for fg in all_fgs:
         # Scope first: an out-of-scope group's rejection reason must never pollute a scoped error.
         if scope is not None and not matches_feature_group_scope(fg, scope):
             continue
-        if _match_recording_validation_errors(fg, feature_name_obj, resolved_options, validation_errors):
-            candidates.append(fg)
+        if not _match_recording_validation_errors(fg, feature_name_obj, resolved_options, validation_errors):
+            continue
+        # Abstract bases cannot be instantiated, so they are never an answer; the engine skips them too.
+        if inspect.isabstract(fg):
+            abstract_matches.append(fg)
+            continue
+        candidates.append(fg)
 
     if not candidates:
         error = f"No FeatureGroup found for feature name: {feature_name}"
+        if abstract_matches:
+            abstract_names = sorted(format_feature_group_class(fg) for fg in abstract_matches)
+            error = (
+                f"{error}. Only abstract feature group base(s) matched, which cannot be "
+                f"instantiated: {abstract_names}. No concrete implementation matched."
+            )
         if validation_errors:
             error = f"{error} Rejected during matching: {' | '.join(validation_errors)}"
         return ResolvedFeature(
@@ -440,27 +482,17 @@ def resolve_feature(
             error=_with_callout(error, callout),
         )
 
-    # Degrade a raising plugin declaration OPEN (all available declared frameworks); resolve_feature never raises.
-    # The broad catch intentionally drops any partially computed rejection info; degrading open is the contract.
-    split_result: Optional[tuple[set[type[ComputeFramework]], set[type[ComputeFramework]]]] = safe_field(
-        lambda: split_frameworks_by_capability(candidates, feature_name_obj, resolved_options),
-        None,
-        field=f"capability split for '{feature_name}'",
-    )
-    if split_result is None:
-        open_supported: set[type[ComputeFramework]] = set()
-        for candidate in candidates:
-            defined: set[type[ComputeFramework]] = safe_field(
-                lambda candidate=candidate: set(candidate.compute_framework_definition()),  # type: ignore[misc]
-                set(),
-                field=f"open-degrade frameworks for '{feature_name}'",
-            )
-            open_supported.update(cfw for cfw in defined if cfw.is_available())
-        split_result = (open_supported, set())
-    supported, rejected = split_result
+    candidate_frameworks = {
+        candidate: _candidate_frameworks(candidate, feature_name_obj, resolved_options) for candidate in candidates
+    }
+    supported: set[type[ComputeFramework]] = set()
+    rejected: set[type[ComputeFramework]] = set()
+    for candidate_supported, candidate_rejected in candidate_frameworks.values():
+        supported.update(candidate_supported)
+        rejected.update(candidate_rejected)
     supported_names = sorted(c.get_class_name() for c in supported)
     rejected_names = sorted(c.get_class_name() for c in rejected)
-    filtered = _filter_subclasses(candidates)
+    filtered = _filter_subclasses(candidates, {fg: split[0] for fg, split in candidate_frameworks.items()})
 
     if not supported and rejected:
         subtype_unsupported: Optional[str] = None
@@ -499,7 +531,9 @@ def resolve_feature(
             subtype_family=subtype_family,
         )
 
-    conflicting_names = [fg.__name__ for fg in filtered]
+    # Name + module (format_feature_group_class): two same-named classes from different modules are exactly
+    # the case a name scope cannot disambiguate, so bare names would render the error useless.
+    conflicting_names = sorted(format_feature_group_class(fg) for fg in filtered)
     return ResolvedFeature(
         feature_name=feature_name,
         feature_group=None,
@@ -512,12 +546,22 @@ def resolve_feature(
     )
 
 
-def _filter_subclasses(feature_groups: list[type[FeatureGroup]]) -> list[type[FeatureGroup]]:
-    """Prefer more specific (child) classes over parent classes."""
+def _filter_subclasses(
+    feature_groups: list[type[FeatureGroup]],
+    supported_frameworks: dict[type[FeatureGroup], set[type[ComputeFramework]]],
+) -> list[type[FeatureGroup]]:
+    """Prefer more specific (child) classes over parent classes, but only on EQUAL framework support.
+
+    Mirrors IdentifyFeatureGroupClass.filter_subclasses: a parent supporting frameworks its child does not
+    is a distinct answer to the engine and stays in the running, so dropping it here would resolve a feature
+    that the engine reports as ambiguous.
+    """
     fgs_to_pop: set[type[FeatureGroup]] = set()
 
     for i_fg in feature_groups:
         for o_fg in feature_groups:
+            if supported_frameworks[i_fg] != supported_frameworks[o_fg]:
+                continue
             if i_fg == o_fg:
                 continue
             if issubclass(i_fg, o_fg):

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -59,9 +59,12 @@ def matches_feature_group_scope(feature_group: type[FeatureGroup], scope: str | 
     )
 
 
-def _scope_callout(feature: Feature) -> str | None:
-    """Render the shared scope callout, or None when the feature is unscoped."""
-    scope = feature.feature_group_scope
+def scope_callout(scope: str | type[FeatureGroup] | None) -> str | None:
+    """Render the shared scope callout, or None when there is no scope.
+
+    Takes the scope value rather than a Feature, so the engine and resolve_feature render it
+    from one place.
+    """
     if scope is None:
         return None
     scope_name = scope.get_class_name() if isinstance(scope, type) else scope
@@ -187,8 +190,8 @@ class IdentifyFeatureGroupClass:
         if len(feature_group) > 1:
             from mloda.core.abstract_plugins.feature_group import format_feature_group_classes
 
-            scope_callout = _scope_callout(feature)
-            scope_line = f"{scope_callout}\n" if scope_callout else ""
+            callout = scope_callout(feature.feature_group_scope)
+            scope_line = f"{callout}\n" if callout else ""
 
             raise ValueError(
                 f"Multiple feature groups found for feature '{feature.name}':\n"
@@ -321,26 +324,26 @@ class IdentifyFeatureGroupClass:
     def _build_no_feature_group_error(
         self, feature: Feature, accessible_plugins: FeatureGroupEnvironmentMapping
     ) -> str:
-        scope_callout = _scope_callout(feature)
+        callout = scope_callout(feature.feature_group_scope)
 
         # Capability rejections are concrete and specific; prefer them over the abstract-only fallback.
         capability_message = self._capability_rejection_message(feature)
         if capability_message is not None:
-            if scope_callout:
-                return f"{capability_message} {scope_callout}"
+            if callout:
+                return f"{capability_message} {callout}"
             return capability_message
 
         abstract_only_message = self._abstract_only_message(feature, accessible_plugins)
         if abstract_only_message is not None:
-            if scope_callout:
-                return f"{abstract_only_message} {scope_callout}"
+            if callout:
+                return f"{abstract_only_message} {callout}"
             return abstract_only_message
 
         feature_name = str(feature.name)
         msg = f"No feature groups found for feature name: '{feature_name}'."
 
-        if scope_callout:
-            msg += f" {scope_callout}"
+        if callout:
+            msg += f" {callout}"
 
         if not accessible_plugins:
             msg += "\nNo plugins are loaded. Did you call PluginLoader.all()?"
@@ -365,8 +368,12 @@ class IdentifyFeatureGroupClass:
         if similar:
             msg += f"\nDid you mean one of: {similar}?"
 
+        # A scoped failure only reproduces through a scoped resolve_feature call, so the pointer names the scope.
+        debug_call = (
+            "resolve_feature(name, options=..., feature_group=...)" if callout else "resolve_feature(name, options=...)"
+        )
         msg += (
-            "\nUse resolve_feature(name, options=...) to debug feature resolution."
+            f"\nUse {debug_call} to debug feature resolution."
             "\nFor troubleshooting guide, see: "
             "https://mloda-ai.github.io/mloda/in_depth/troubleshooting/feature-group-resolution-errors/"
         )

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -16,28 +16,41 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+def frameworks_by_capability(
+    feature_group: type[FeatureGroup],
+    feature_name: FeatureName | str,
+    options: Options,
+) -> tuple[set[type[ComputeFramework]], set[type[ComputeFramework]]]:
+    """Split ONE feature group's available frameworks into (supported, rejected)
+    by the match-time capability hook.
+
+    Considers the frameworks it declares via compute_framework_definition() that are
+    currently available (ComputeFramework.is_available()), and partitions them by
+    supports_compute_framework(feature_name, options, cfw)."""
+    supported: set[type[ComputeFramework]] = set()
+    rejected: set[type[ComputeFramework]] = set()
+    for cfw in feature_group.compute_framework_definition():
+        if not cfw.is_available():
+            continue
+        if feature_group.supports_compute_framework(feature_name, options, cfw):
+            supported.add(cfw)
+        else:
+            rejected.add(cfw)
+    return supported, rejected
+
+
 def split_frameworks_by_capability(
     feature_groups: Iterable[type[FeatureGroup]],
     feature_name: FeatureName | str,
     options: Options,
 ) -> tuple[set[type[ComputeFramework]], set[type[ComputeFramework]]]:
-    """Split each feature group's available frameworks into (supported, rejected)
-    by the match-time capability hook.
-
-    For each feature group, considers the frameworks it declares via
-    compute_framework_definition() that are currently available
-    (ComputeFramework.is_available()), and partitions them by
-    supports_compute_framework(feature_name, options, cfw)."""
+    """Union of frameworks_by_capability over several feature groups."""
     supported: set[type[ComputeFramework]] = set()
     rejected: set[type[ComputeFramework]] = set()
     for fg in feature_groups:
-        for cfw in fg.compute_framework_definition():
-            if not cfw.is_available():
-                continue
-            if fg.supports_compute_framework(feature_name, options, cfw):
-                supported.add(cfw)
-            else:
-                rejected.add(cfw)
+        fg_supported, fg_rejected = frameworks_by_capability(fg, feature_name, options)
+        supported.update(fg_supported)
+        rejected.update(fg_rejected)
     return supported, rejected
 
 

--- a/tests/test_core/test_api/scoped693b_dup_name_module.py
+++ b/tests/test_core/test_api/scoped693b_dup_name_module.py
@@ -1,0 +1,42 @@
+"""A second module holding a FeatureGroup whose class NAME collides with one in the test module.
+
+Scoping by class-name string is the only way a user can disambiguate two same-named feature groups,
+so the ambiguity error resolve_feature renders for them must itself distinguish them (name + module,
+like the engine's format_feature_group_class). This module supplies the twin that lives elsewhere.
+"""
+
+from typing import Optional
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
+    PythonDictFramework,
+)
+
+
+DUP_NAME_FEATURE = "scoped_probe_693b_dup_name"
+
+
+class Scoped693BDupNameProbe(FeatureGroup):
+    """Same class name as the probe in the test module, different module."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame, PythonDictFramework}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == DUP_NAME_FEATURE
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None

--- a/tests/test_core/test_api/test_resolve_feature_scope.py
+++ b/tests/test_core/test_api/test_resolve_feature_scope.py
@@ -1,0 +1,490 @@
+"""Scope-aware resolution tests for resolve_feature() (issue #693).
+
+The engine's no-match error recommends resolve_feature() as THE debug tool, and that error
+even calls out a feature-group scope ("Scoped to feature group: 'X'."). resolve_feature must
+therefore be able to express that same scope, so the recommended tool can reproduce the failure
+it is recommended for.
+
+The contract pinned here:
+  * feature_group= accepts a FeatureGroup subclass object and a class-name string, with the same
+    semantics as Feature(..., feature_group=...): the string form matches the named class AND its
+    subclasses (MRO walk, matches_feature_group_scope), and the root FeatureGroup base is never a
+    wildcard.
+  * A scoped no-match / scoped ambiguity reports the engine's scope callout in the error.
+  * resolve_feature still NEVER raises, not even for an invalid scope, unlike Feature().
+  * A scoped engine failure reproduces through resolve_feature with the same outcome.
+
+Probe feature groups and feature names are prefixed 'Scoped693' / 'scoped_probe_693_' because every
+FeatureGroup subclass in the process is globally visible to matching under pytest-xdist.
+"""
+
+from typing import Any, Optional
+
+import pytest
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.api.plugin_docs import resolve_feature
+from mloda.core.api.plugin_info import ResolvedFeature
+from mloda.user import PluginLoader, mloda
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
+    PythonDictFramework,
+)
+
+
+SHARED_FEATURE = "scoped_probe_693_shared"
+CLAIMS_ONLY_FEATURE = "scoped_probe_693_claims_only"
+POLICY_ONLY_FEATURE = "scoped_probe_693_policy_only"
+SIBLING_FEATURE = "scoped_probe_693_sibling"
+RAISING_FEATURE = "scoped_probe_693_raising"
+RAISING_REASON = "scoped_probe_693 raising source rejects this feature"
+UNKNOWN_SCOPE = "Scoped693CompletelyUnknownScope"
+
+
+def _callout(scope_name: str) -> str:
+    """The scope callout the engine's _scope_callout renders, verbatim."""
+    return f"Scoped to feature group: '{scope_name}'."
+
+
+class Scoped693ClaimsReaderBase(FeatureGroup):
+    """Claims family base: matches the shared name and the claims-only name.
+
+    Bounded compute_framework_rule so the capability split is deterministic.
+    """
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame, PythonDictFramework}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) in {SHARED_FEATURE, CLAIMS_ONLY_FEATURE}
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class Scoped693ClaimsReaderPandas(Scoped693ClaimsReaderBase):
+    """Concrete member of the claims family; inherits the family's name matching."""
+
+
+class Scoped693PolicyReader(FeatureGroup):
+    """Rival source: matches the shared name and its own policy-only name."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame, PythonDictFramework}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) in {SHARED_FEATURE, POLICY_ONLY_FEATURE}
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class Scoped693SiblingBase(FeatureGroup):
+    """Base of two rival siblings, both of which sit inside a scope on this base."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame, PythonDictFramework}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == SIBLING_FEATURE
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class Scoped693SiblingOne(Scoped693SiblingBase):
+    """First sibling; neither sibling is a subclass of the other, so they cannot be narrowed."""
+
+
+class Scoped693SiblingTwo(Scoped693SiblingBase):
+    """Second sibling; rival of Scoped693SiblingOne inside the same scope."""
+
+
+class Scoped693RaisingSource(FeatureGroup):
+    """Matching this group raises ValueError, which resolve_feature degrades to 'not a match'."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame, PythonDictFramework}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        if str(feature_name) == RAISING_FEATURE:
+            raise ValueError(RAISING_REASON)
+        return False
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class Scoped693SafeSource(FeatureGroup):
+    """A well-behaved group matching the same name as the raising one, so it can still win."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame, PythonDictFramework}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == RAISING_FEATURE
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+@pytest.fixture(scope="module", autouse=True)
+def load_plugins() -> None:
+    """Load all plugins before running tests in this module."""
+    PluginLoader.all()
+
+
+class TestScopedResolutionBothForms:
+    """A shared name that is ambiguous unscoped resolves to exactly one group when scoped."""
+
+    def test_shared_name_is_ambiguous_unscoped(self) -> None:
+        """Premise guard: without a scope, the shared name matches both sources."""
+        result = resolve_feature(SHARED_FEATURE)
+
+        assert result.feature_group is None
+        assert result.error is not None
+        assert "Multiple FeatureGroups match" in result.error
+
+    def test_class_object_scope_resolves_uniquely(self) -> None:
+        """A class-object scope on the rival source resolves the shared name to that source."""
+        result = resolve_feature(SHARED_FEATURE, feature_group=Scoped693PolicyReader)
+
+        assert result.feature_group is Scoped693PolicyReader
+        assert result.error is None
+        assert result.candidates == [Scoped693PolicyReader]
+
+    def test_class_name_string_scope_resolves_uniquely(self) -> None:
+        """The class-name string form has the same semantics as the class-object form."""
+        result = resolve_feature(SHARED_FEATURE, feature_group="Scoped693PolicyReader")
+
+        assert result.feature_group is Scoped693PolicyReader
+        assert result.error is None
+        assert result.candidates == [Scoped693PolicyReader]
+
+    def test_class_object_base_scope_matches_subclasses_and_prefers_the_subclass(self) -> None:
+        """A base-class scope keeps the family (issubclass) and subclass filtering picks the member."""
+        result = resolve_feature(SHARED_FEATURE, feature_group=Scoped693ClaimsReaderBase)
+
+        assert result.feature_group is Scoped693ClaimsReaderPandas
+        assert result.error is None
+        assert Scoped693ClaimsReaderBase in result.candidates
+        assert Scoped693ClaimsReaderPandas in result.candidates
+        assert Scoped693PolicyReader not in result.candidates
+
+    def test_class_name_string_base_scope_walks_the_mro(self) -> None:
+        """The string form matches the named class AND its subclasses, like matches_feature_group_scope."""
+        result = resolve_feature(SHARED_FEATURE, feature_group="Scoped693ClaimsReaderBase")
+
+        assert result.feature_group is Scoped693ClaimsReaderPandas
+        assert result.error is None
+        assert Scoped693PolicyReader not in result.candidates
+
+    def test_scoped_resolution_still_reports_the_capability_split(self) -> None:
+        """A scoped resolve keeps the capability-aware fields populated."""
+        result = resolve_feature(SHARED_FEATURE, feature_group=Scoped693PolicyReader)
+
+        assert "PandasDataFrame" in result.supported_compute_frameworks
+        assert "PandasDataFrame" not in result.unsupported_compute_frameworks
+
+    def test_leaf_class_scope_resolves_to_the_leaf(self) -> None:
+        """Scoping to the concrete member itself resolves to it, in both forms."""
+        by_class = resolve_feature(SHARED_FEATURE, feature_group=Scoped693ClaimsReaderPandas)
+        by_name = resolve_feature(SHARED_FEATURE, feature_group="Scoped693ClaimsReaderPandas")
+
+        assert by_class.feature_group is Scoped693ClaimsReaderPandas
+        assert by_name.feature_group is Scoped693ClaimsReaderPandas
+        assert by_class.error is None
+        assert by_name.error is None
+
+
+class TestScopedNoMatch:
+    """A name that resolves fine unscoped but has no candidate inside the scope."""
+
+    def test_claims_only_name_resolves_unscoped(self) -> None:
+        """Premise guard: the claims-only name resolves to the claims family member."""
+        result = resolve_feature(CLAIMS_ONLY_FEATURE)
+
+        assert result.feature_group is Scoped693ClaimsReaderPandas
+        assert result.error is None
+
+    def test_out_of_scope_class_reports_no_feature_group(self) -> None:
+        """Scoping the claims-only name to the rival source leaves no candidate."""
+        result = resolve_feature(CLAIMS_ONLY_FEATURE, feature_group=Scoped693PolicyReader)
+
+        assert result.feature_group is None
+        assert result.candidates == []
+        assert result.error is not None
+
+    def test_out_of_scope_class_error_carries_the_scope_callout(self) -> None:
+        """The error carries the engine's verbatim scope callout, so the failure is legible."""
+        result = resolve_feature(CLAIMS_ONLY_FEATURE, feature_group=Scoped693PolicyReader)
+
+        assert result.error is not None
+        assert _callout("Scoped693PolicyReader") in result.error, (
+            f"Scoped no-match must carry the scope callout, got: {result.error}"
+        )
+
+    def test_out_of_scope_string_error_carries_the_scope_callout(self) -> None:
+        """The string form produces the same scoped no-match error."""
+        result = resolve_feature(CLAIMS_ONLY_FEATURE, feature_group="Scoped693PolicyReader")
+
+        assert result.feature_group is None
+        assert result.error is not None
+        assert _callout("Scoped693PolicyReader") in result.error
+
+    def test_unknown_scope_name_reports_no_feature_group_with_callout(self) -> None:
+        """A scope naming no loaded feature group at all is a scoped no-match, not a crash."""
+        result = resolve_feature(SHARED_FEATURE, feature_group=UNKNOWN_SCOPE)
+
+        assert isinstance(result, ResolvedFeature)
+        assert result.feature_group is None
+        assert result.candidates == []
+        assert result.error is not None
+        assert _callout(UNKNOWN_SCOPE) in result.error
+
+
+class TestScopedAmbiguity:
+    """Two feature groups inside the scope both match: the multiple-match error names the scope."""
+
+    def test_sibling_scope_is_ambiguous_and_names_both_siblings(self) -> None:
+        """A base scope covering two rival siblings cannot be narrowed, so it stays ambiguous."""
+        result = resolve_feature(SIBLING_FEATURE, feature_group=Scoped693SiblingBase)
+
+        assert result.feature_group is None
+        assert result.error is not None
+        assert "Multiple FeatureGroups match" in result.error
+        assert "Scoped693SiblingOne" in result.error
+        assert "Scoped693SiblingTwo" in result.error
+
+    def test_sibling_scope_ambiguity_carries_the_scope_callout(self) -> None:
+        """The multiple-match error must ALSO carry the scope callout."""
+        result = resolve_feature(SIBLING_FEATURE, feature_group=Scoped693SiblingBase)
+
+        assert result.error is not None
+        assert _callout("Scoped693SiblingBase") in result.error, (
+            f"Scoped ambiguity must carry the scope callout, got: {result.error}"
+        )
+
+    def test_sibling_scope_ambiguity_string_form_carries_the_scope_callout(self) -> None:
+        """The string form reaches both siblings through the MRO and stays ambiguous too."""
+        result = resolve_feature(SIBLING_FEATURE, feature_group="Scoped693SiblingBase")
+
+        assert result.feature_group is None
+        assert result.error is not None
+        assert "Multiple FeatureGroups match" in result.error
+        assert _callout("Scoped693SiblingBase") in result.error
+
+    def test_scoping_to_one_sibling_resolves_the_ambiguity(self) -> None:
+        """Narrowing the scope to a single sibling resolves it, proving the ambiguity is scope-shaped."""
+        result = resolve_feature(SIBLING_FEATURE, feature_group=Scoped693SiblingTwo)
+
+        assert result.feature_group is Scoped693SiblingTwo
+        assert result.error is None
+
+
+class TestInvalidScopeNeverRaises:
+    """resolve_feature is a debug API: an invalid scope is reported, never raised."""
+
+    def test_root_feature_group_class_scope_is_reported_not_raised(self) -> None:
+        """Feature() raises TypeError for the root base; resolve_feature must report it instead."""
+        with pytest.raises(TypeError):
+            Feature(SHARED_FEATURE, feature_group=FeatureGroup)
+
+        result = resolve_feature(SHARED_FEATURE, feature_group=FeatureGroup)
+
+        assert isinstance(result, ResolvedFeature)
+        assert result.feature_group is None
+        assert result.error is not None
+        assert "FeatureGroup" in result.error
+
+    def test_root_feature_group_name_scope_is_not_a_wildcard(self) -> None:
+        """The root base NAME must not silently scope to everything; it is reported as invalid."""
+        result = resolve_feature(SHARED_FEATURE, feature_group=FeatureGroup.get_class_name())
+
+        assert result.feature_group is None, "the root base name must never act as a wildcard scope"
+        assert result.error is not None
+
+    def test_non_feature_group_type_scope_is_reported_not_raised(self) -> None:
+        """A non-FeatureGroup type (int) is an invalid scope, reported in error."""
+        resolve_feature_untyped: Any = resolve_feature
+
+        result = resolve_feature_untyped(SHARED_FEATURE, feature_group=int)
+
+        assert isinstance(result, ResolvedFeature)
+        assert result.feature_group is None
+        assert result.error is not None
+        assert "FeatureGroup" in result.error
+
+    def test_non_type_scope_value_is_reported_not_raised(self) -> None:
+        """A scope value that is neither a class nor a string (123) is reported, not raised."""
+        resolve_feature_untyped: Any = resolve_feature
+
+        result = resolve_feature_untyped(SHARED_FEATURE, feature_group=123)
+
+        assert isinstance(result, ResolvedFeature)
+        assert result.feature_name == SHARED_FEATURE
+        assert result.feature_group is None
+        assert result.error is not None
+        assert "FeatureGroup" in result.error
+
+
+class TestScopedMatchingStaysNonThrowing:
+    """A candidate raising ValueError while matching is degraded to 'not a match', scoped or not."""
+
+    def test_raising_candidate_does_not_block_other_candidates(self) -> None:
+        """Unscoped, the raising group is degraded and the safe group still resolves."""
+        result = resolve_feature(RAISING_FEATURE)
+
+        assert result.feature_group is Scoped693SafeSource
+        assert result.error is None
+
+    def test_raising_candidate_does_not_block_a_scoped_sibling(self) -> None:
+        """Scoping to the safe group resolves, even though the raising group matches the same name."""
+        result = resolve_feature(RAISING_FEATURE, feature_group=Scoped693SafeSource)
+
+        assert result.feature_group is Scoped693SafeSource
+        assert result.error is None
+
+    def test_scoping_to_the_raising_candidate_reports_reason_and_callout(self) -> None:
+        """Scoped to the raising group, resolution fails with the validation reason AND the scope callout."""
+        result = resolve_feature(RAISING_FEATURE, feature_group=Scoped693RaisingSource)
+
+        assert isinstance(result, ResolvedFeature)
+        assert result.feature_group is None
+        assert result.error is not None
+        assert RAISING_REASON in result.error, f"Error must surface the rejection reason, got: {result.error}"
+        assert _callout("Scoped693RaisingSource") in result.error, (
+            f"Error must carry the scope callout, got: {result.error}"
+        )
+
+
+class TestScopedEngineParity:
+    """The failure the engine reports for a scoped Feature reproduces through resolve_feature (#693)."""
+
+    @staticmethod
+    def _collector() -> PluginCollector:
+        return PluginCollector.enabled_feature_groups({Scoped693ClaimsReaderPandas, Scoped693PolicyReader})
+
+    def test_engine_raises_for_the_scoped_feature(self) -> None:
+        """Premise: mloda raises for a feature whose only source sits outside the requested scope."""
+        collector = self._collector()
+
+        with pytest.raises(ValueError) as exc_info:
+            list(
+                mloda.run_all(
+                    [Feature(CLAIMS_ONLY_FEATURE, feature_group=Scoped693PolicyReader)],
+                    compute_frameworks={PandasDataFrame},
+                    plugin_collector=collector,
+                )
+            )
+
+        engine_message = str(exc_info.value)
+        assert _callout("Scoped693PolicyReader") in engine_message
+        assert "No feature groups found" in engine_message
+
+    def test_resolve_feature_reproduces_the_engine_failure(self) -> None:
+        """The engine's recommended debug tool reproduces the scoped failure: no group, scope callout."""
+        collector = self._collector()
+
+        result = resolve_feature(CLAIMS_ONLY_FEATURE, feature_group=Scoped693PolicyReader, plugin_collector=collector)
+
+        assert result.feature_group is None
+        assert result.error is not None
+        assert _callout("Scoped693PolicyReader") in result.error
+
+    def test_the_same_feature_resolves_unscoped_under_the_same_collector(self) -> None:
+        """Guard: the feature itself is fine; only the scope makes it fail, in engine and debug tool alike."""
+        collector = self._collector()
+
+        result = resolve_feature(CLAIMS_ONLY_FEATURE, plugin_collector=collector)
+
+        assert result.feature_group is Scoped693ClaimsReaderPandas
+        assert result.error is None
+
+
+class TestUnscopedBehaviourUnchanged:
+    """Scope defaults to None: omitting it and passing None resolve exactly as before."""
+
+    def test_omitted_scope_equals_explicit_none(self) -> None:
+        """feature_group=None must be indistinguishable from omitting the argument, on every outcome."""
+        for feature_name in (SHARED_FEATURE, CLAIMS_ONLY_FEATURE, SIBLING_FEATURE, RAISING_FEATURE):
+            implicit = resolve_feature(feature_name)
+            explicit = resolve_feature(feature_name, feature_group=None)
+
+            assert explicit.feature_group is implicit.feature_group, feature_name
+            assert explicit.candidates == implicit.candidates, feature_name
+            assert explicit.error == implicit.error, feature_name
+            assert explicit.supported_compute_frameworks == implicit.supported_compute_frameworks, feature_name
+
+    def test_unscoped_options_threading_still_works(self) -> None:
+        """Options keep flowing through matching when no scope is given."""
+        result = resolve_feature(CLAIMS_ONLY_FEATURE, options=Options(group={"scoped_probe_693_key": "v"}))
+
+        assert result.feature_group is Scoped693ClaimsReaderPandas
+        assert result.error is None
+
+
+class TestFeatureGroupIsKeywordOnly:
+    """The new scope argument is keyword-only, like options and plugin_collector."""
+
+    def test_positional_scope_raises_type_error(self) -> None:
+        """resolve_feature(name, Scoped693PolicyReader) must raise TypeError instead of binding."""
+        resolve_feature_untyped: Any = resolve_feature
+
+        with pytest.raises(TypeError):
+            resolve_feature_untyped(SHARED_FEATURE, Scoped693PolicyReader)
+
+    def test_scope_combines_with_options_and_plugin_collector(self) -> None:
+        """All three keyword arguments can be combined."""
+        collector = PluginCollector.enabled_feature_groups({Scoped693ClaimsReaderPandas, Scoped693PolicyReader})
+
+        result = resolve_feature(
+            SHARED_FEATURE,
+            options=Options(group={"scoped_probe_693_key": "v"}),
+            feature_group="Scoped693PolicyReader",
+            plugin_collector=collector,
+        )
+
+        assert result.feature_group is Scoped693PolicyReader
+        assert result.error is None

--- a/tests/test_core/test_api/test_resolve_feature_scope.py
+++ b/tests/test_core/test_api/test_resolve_feature_scope.py
@@ -18,6 +18,7 @@ Probe feature groups and feature names are prefixed 'Scoped693' / 'scoped_probe_
 FeatureGroup subclass in the process is globally visible to matching under pytest-xdist.
 """
 
+import inspect
 from typing import Any, Optional
 
 import pytest
@@ -398,6 +399,20 @@ class TestScopedMatchingStaysNonThrowing:
             f"Error must carry the scope callout, got: {result.error}"
         )
 
+    def test_out_of_scope_rejection_reason_never_pollutes_a_scoped_result(self) -> None:
+        """Scope first: an out-of-scope group is never even asked to match, so it cannot report a reason.
+
+        Scoped to the safe group, the raising group sits outside the scope. Its rejection reason must
+        not surface anywhere in the scoped result, which is the invariant the scope-first ordering in
+        resolve_feature exists for.
+        """
+        result = resolve_feature(RAISING_FEATURE, feature_group=Scoped693SafeSource)
+
+        assert result.feature_group is Scoped693SafeSource
+        assert RAISING_REASON not in (result.error or ""), (
+            f"An out-of-scope group's rejection reason must not appear in a scoped error, got: {result.error}"
+        )
+
 
 class TestScopedEngineParity:
     """The failure the engine reports for a scoped Feature reproduces through resolve_feature (#693)."""
@@ -468,12 +483,18 @@ class TestUnscopedBehaviourUnchanged:
 class TestFeatureGroupIsKeywordOnly:
     """The new scope argument is keyword-only, like options and plugin_collector."""
 
-    def test_positional_scope_raises_type_error(self) -> None:
-        """resolve_feature(name, Scoped693PolicyReader) must raise TypeError instead of binding."""
-        resolve_feature_untyped: Any = resolve_feature
+    def test_feature_group_parameter_is_declared_keyword_only(self) -> None:
+        """feature_group must sit behind the '*' in the signature, so it can never bind positionally.
 
-        with pytest.raises(TypeError):
-            resolve_feature_untyped(SHARED_FEATURE, Scoped693PolicyReader)
+        Asserting on the parameter kind, not on a TypeError from a two-positional call: the second
+        positional slot already raised before feature_group existed (options was keyword-only), so
+        such a call proves nothing about this parameter.
+        """
+        parameter = inspect.signature(resolve_feature).parameters["feature_group"]
+
+        assert parameter.kind is inspect.Parameter.KEYWORD_ONLY, (
+            f"feature_group must be keyword-only, got kind: {parameter.kind}"
+        )
 
     def test_scope_combines_with_options_and_plugin_collector(self) -> None:
         """All three keyword arguments can be combined."""

--- a/tests/test_core/test_api/test_resolve_feature_scope_parity.py
+++ b/tests/test_core/test_api/test_resolve_feature_scope_parity.py
@@ -1,0 +1,526 @@
+"""Engine-parity tests for resolve_feature() (issue #693, round 2).
+
+The engine's no-match error now points scoped failures at
+``resolve_feature(name, options=..., feature_group=...)``. That only holds up if the debug tool
+reports the SAME outcome as the engine (IdentifyFeatureGroupClass). These tests pin the four
+places where it does not:
+
+1. Subclass filtering. The engine only drops a parent when parent and child support the SAME
+   compute frameworks (identify_feature_group.py filter_subclasses). resolve_feature drops the
+   parent unconditionally, so a parent/child pair with UNEQUAL framework sets fails in the engine
+   ("Multiple feature groups found") while resolve_feature happily returns the child.
+2. Abstract bases. The engine skips abstract feature groups (inspect.isabstract) and reports an
+   abstract-only error. resolve_feature has no such filter and returns the abstract class.
+3. The redefinition-conflict early return ignores the scope: out-of-scope classes leak into
+   candidates and the scope callout is missing. The conflict itself must still be reported (the
+   engine dedups the whole class universe before scoping, so it raises on an unrelated conflict too).
+4. The ambiguity error renders bare class names, so two same-named classes from different modules
+   read as ['X', 'X'] exactly when the user scoped BY NAME to disambiguate them.
+
+Probe feature groups and feature names are prefixed 'Scoped693B' / 'scoped_probe_693b_' because every
+FeatureGroup subclass in the process is globally visible to matching under pytest-xdist.
+"""
+
+from abc import abstractmethod
+from collections.abc import Iterator
+import linecache
+import sys
+import textwrap
+from typing import Any, Optional, cast
+
+import pytest
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup, format_feature_group_class
+from mloda.core.api.plugin_docs import resolve_feature
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+from mloda.user import PluginLoader, mloda
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
+    PythonDictFramework,
+)
+from tests.test_core.test_api.scoped693b_dup_name_module import (
+    Scoped693BDupNameProbe as OtherModuleDupNameProbe,
+)
+
+
+UNEQUAL_FRAMEWORKS_FEATURE = "scoped_probe_693b_unequal_frameworks"
+EQUAL_FRAMEWORKS_FEATURE = "scoped_probe_693b_equal_frameworks"
+ABSTRACT_ONLY_FEATURE = "scoped_probe_693b_abstract_only"
+ABSTRACT_WITH_CONCRETE_FEATURE = "scoped_probe_693b_abstract_with_concrete"
+CONFLICT_FEATURE = "scoped_probe_693b_conflict"
+DUP_NAME_FEATURE = "scoped_probe_693b_dup_name"
+
+BOTH_FRAMEWORKS: set[type[ComputeFramework]] = {PandasDataFrame, PythonDictFramework}
+
+
+def _callout(scope_name: str) -> str:
+    """The scope callout the engine's scope_callout renders, verbatim."""
+    return f"Scoped to feature group: '{scope_name}'."
+
+
+# --- 1. Unequal framework sets: the engine keeps the parent, resolve_feature drops it ---------
+
+
+class Scoped693BWideParent(FeatureGroup):
+    """Concrete parent declaring TWO frameworks; matches the unequal-frameworks probe name."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame, PythonDictFramework}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == UNEQUAL_FRAMEWORKS_FEATURE
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class Scoped693BNarrowChild(Scoped693BWideParent):
+    """Child of the wide parent, narrowed to ONE framework, so the two support sets differ."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame}
+
+
+class Scoped693BEqualParent(FeatureGroup):
+    """Concrete parent whose child does not narrow the frameworks: the support sets are EQUAL."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame, PythonDictFramework}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == EQUAL_FRAMEWORKS_FEATURE
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class Scoped693BEqualChild(Scoped693BEqualParent):
+    """Child inheriting the parent's frameworks; the engine drops the parent for this pair."""
+
+
+# --- 2. Abstract bases ------------------------------------------------------------------------
+
+
+class Scoped693BAbstractOnlyBase(FeatureGroup):
+    """Abstract base (unimplemented abstract hook) that is the ONLY match for its probe name."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame, PythonDictFramework}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == ABSTRACT_ONLY_FEATURE
+
+    @classmethod
+    @abstractmethod
+    def _scoped693b_abstract_hook(cls, data: Any) -> Any:
+        """Abstract hook that makes this base uninstantiable."""
+        ...
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class Scoped693BAbstractWithConcreteBase(FeatureGroup):
+    """Abstract base that DOES have a concrete subclass matching the same probe name."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame, PythonDictFramework}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == ABSTRACT_WITH_CONCRETE_FEATURE
+
+    @classmethod
+    @abstractmethod
+    def _scoped693b_concrete_hook(cls, data: Any) -> Any:
+        """Abstract hook that makes this base uninstantiable."""
+        ...
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class Scoped693BConcreteMember(Scoped693BAbstractWithConcreteBase):
+    """Concrete member of the abstract family; implements the hook, inherits the frameworks."""
+
+    @classmethod
+    def _scoped693b_concrete_hook(cls, data: Any) -> Any:
+        return data
+
+
+# --- 3. Redefinition conflict + scope ---------------------------------------------------------
+
+
+class Scoped693BConflictScopeTarget(FeatureGroup):
+    """In-scope feature group for the conflict tests; matches the conflict probe name."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame, PythonDictFramework}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == CONFLICT_FEATURE
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+# --- 4. Two same-named classes in different modules --------------------------------------------
+
+
+class Scoped693BDupNameProbe(FeatureGroup):
+    """Same class name as the probe in scoped693b_dup_name_module, different module."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame, PythonDictFramework}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == DUP_NAME_FEATURE
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+# --- Jupyter-style redefinition helpers (mirroring tests/test_core/test_prepare/test_feature_group_dedup.py) ---
+
+# Strong refs, as IPython's Out[N] history keeps them: the stale class stays in FeatureGroup.__subclasses__().
+_REF_STORE: list[Any] = []
+
+
+def _exec_fg_in_main(class_name: str, body: str, cell_label: str) -> type[FeatureGroup]:
+    """Exec a FeatureGroup subclass into __main__, registering its source in linecache."""
+    main_mod = sys.modules["__main__"]
+    src = textwrap.dedent(body)
+    filename = f"<{cell_label}>"
+    linecache.cache[filename] = (len(src), None, src.splitlines(keepends=True), filename)
+    code_obj = compile(src, filename, "exec")
+    exec(code_obj, main_mod.__dict__)  # nosec B102
+    return cast(type[FeatureGroup], main_mod.__dict__[class_name])
+
+
+def _conflicting_pair(label: str) -> tuple[type[FeatureGroup], type[FeatureGroup]]:
+    """Define the same class twice in __main__ with DIFFERENT source: a redefinition conflict.
+
+    Both versions match CONFLICT_FEATURE (via feature_names_supported) and neither is inside the
+    Scoped693BConflictScopeTarget scope, which is what makes them the out-of-scope leak under test.
+
+    ``label`` keeps the (module, qualname) dedup key unique per test: the exec'd classes stay alive
+    in FeatureGroup.__subclasses__() for the rest of the process, so a shared key would grow the
+    conflict group from test to test.
+    """
+    class_name = f"Scoped693BRedefinedProbe_{label}"
+    body = f"""
+from mloda.core.abstract_plugins.feature_group import FeatureGroup as _FG_BASE_
+
+class {class_name}(_FG_BASE_):
+    @classmethod
+    def feature_names_supported(cls):
+        return {{"{CONFLICT_FEATURE}"}}
+"""
+    body_v2 = body + "    def _scoped693b_extra(self):\n        return 693\n"
+
+    v1 = _exec_fg_in_main(class_name, body, f"scoped693b-conflict-{label}-v1")
+    v2 = _exec_fg_in_main(class_name, body_v2, f"scoped693b-conflict-{label}-v2")
+    _REF_STORE.extend([v1, v2])
+    return v1, v2
+
+
+@pytest.fixture(scope="module", autouse=True)
+def load_plugins() -> None:
+    """Load all plugins before running tests in this module."""
+    PluginLoader.all()
+
+
+@pytest.fixture(autouse=True)
+def cleanup_main_module_attrs() -> Iterator[None]:
+    """Unbind exec'd classes from __main__ after each test, so the conflict does not outlive it."""
+    main_mod = sys.modules["__main__"]
+    snapshot = set(main_mod.__dict__.keys())
+    yield
+    for key in set(main_mod.__dict__.keys()) - snapshot:
+        main_mod.__dict__.pop(key, None)
+
+
+def _run_all_scoped(feature: Feature, enabled: set[type[FeatureGroup]]) -> None:
+    """Run the engine for one feature with only the probe feature groups enabled."""
+    list(
+        mloda.run_all(
+            [feature],
+            compute_frameworks=BOTH_FRAMEWORKS,
+            plugin_collector=PluginCollector.enabled_feature_groups(enabled),
+        )
+    )
+
+
+class TestUnequalFrameworkSubclassFilterParity:
+    """The engine keeps a parent whose framework set differs from its child's; so must the debug tool."""
+
+    def test_engine_reports_multiple_feature_groups_for_the_unequal_pair(self) -> None:
+        """Premise: parent {Pandas, PythonDict} and child {Pandas} both survive engine filtering."""
+        with pytest.raises(ValueError) as exc_info:
+            _run_all_scoped(
+                Feature(UNEQUAL_FRAMEWORKS_FEATURE),
+                {Scoped693BWideParent, Scoped693BNarrowChild},
+            )
+
+        assert "Multiple feature groups found" in str(exc_info.value)
+
+    def test_engine_reports_multiple_feature_groups_when_scoped_to_the_parent(self) -> None:
+        """Premise: scoping to the parent keeps both (the child is inside the parent's scope)."""
+        with pytest.raises(ValueError) as exc_info:
+            _run_all_scoped(
+                Feature(UNEQUAL_FRAMEWORKS_FEATURE, feature_group=Scoped693BWideParent),
+                {Scoped693BWideParent, Scoped693BNarrowChild},
+            )
+
+        engine_message = str(exc_info.value)
+        assert "Multiple feature groups found" in engine_message
+        assert _callout("Scoped693BWideParent") in engine_message
+
+    def test_resolve_feature_unscoped_reports_the_same_ambiguity(self) -> None:
+        """resolve_feature must not silently narrow to the child when the framework sets differ."""
+        result = resolve_feature(UNEQUAL_FRAMEWORKS_FEATURE)
+
+        assert result.feature_group is None, (
+            "resolve_feature must mirror the engine: the parent's framework set differs from the "
+            f"child's, so neither wins; got {result.feature_group}"
+        )
+        assert result.error is not None
+        assert "Multiple FeatureGroups match" in result.error
+
+    def test_resolve_feature_scoped_reports_the_same_ambiguity_with_callout(self) -> None:
+        """Scoped to the parent, resolve_feature must reproduce the engine's ambiguity failure."""
+        result = resolve_feature(UNEQUAL_FRAMEWORKS_FEATURE, feature_group=Scoped693BWideParent)
+
+        assert result.feature_group is None, (
+            f"a scoped request that fails in the engine must fail here too; got {result.feature_group}"
+        )
+        assert result.error is not None
+        assert "Multiple FeatureGroups match" in result.error
+        assert _callout("Scoped693BWideParent") in result.error
+
+    def test_engine_prefers_the_child_when_framework_sets_are_equal(self) -> None:
+        """Premise for the regression guard: equal framework sets, so the engine drops the parent."""
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            Scoped693BEqualParent: set(BOTH_FRAMEWORKS),
+            Scoped693BEqualChild: set(BOTH_FRAMEWORKS),
+        }
+
+        identifier = IdentifyFeatureGroupClass(
+            feature=Feature(EQUAL_FRAMEWORKS_FEATURE),
+            accessible_plugins=accessible_plugins,
+            links=None,
+            data_access_collection=None,
+        )
+        resolved, _frameworks = identifier.get()
+
+        assert resolved is Scoped693BEqualChild
+
+    def test_resolve_feature_still_prefers_the_child_when_framework_sets_are_equal(self) -> None:
+        """Regression guard: equal framework sets keep today's subclass-preferring behavior."""
+        result = resolve_feature(EQUAL_FRAMEWORKS_FEATURE)
+
+        assert result.feature_group is Scoped693BEqualChild
+        assert result.error is None
+
+    def test_scoped_resolve_still_prefers_the_child_when_framework_sets_are_equal(self) -> None:
+        """Regression guard: the same holds when scoped to the parent of an equal-set pair."""
+        result = resolve_feature(EQUAL_FRAMEWORKS_FEATURE, feature_group=Scoped693BEqualParent)
+
+        assert result.feature_group is Scoped693BEqualChild
+        assert result.error is None
+
+
+class TestAbstractBaseScopeParity:
+    """An abstract base cannot be instantiated: the engine never lets it win, nor may resolve_feature."""
+
+    def test_engine_rejects_the_abstract_only_scope(self) -> None:
+        """Premise: scoping to an abstract-only base fails in the engine with an abstract callout."""
+        with pytest.raises(ValueError) as exc_info:
+            _run_all_scoped(
+                Feature(ABSTRACT_ONLY_FEATURE, feature_group=Scoped693BAbstractOnlyBase),
+                {Scoped693BAbstractOnlyBase},
+            )
+
+        engine_message = str(exc_info.value)
+        assert "abstract" in engine_message.lower()
+        assert _callout("Scoped693BAbstractOnlyBase") in engine_message
+
+    def test_resolve_feature_unscoped_does_not_resolve_an_abstract_base(self) -> None:
+        """An abstract base is not a usable answer: report it, do not return it."""
+        result = resolve_feature(ABSTRACT_ONLY_FEATURE)
+
+        assert result.feature_group is None, (
+            f"an abstract base can never be instantiated, so it must not resolve; got {result.feature_group}"
+        )
+        assert result.error is not None
+        assert "abstract" in result.error.lower(), (
+            f"the error must say only abstract base(s) matched, got: {result.error}"
+        )
+
+    def test_resolve_feature_scoped_to_an_abstract_base_reports_it_with_the_callout(self) -> None:
+        """The scoped failure carries both the abstract reason and the scope callout."""
+        result = resolve_feature(ABSTRACT_ONLY_FEATURE, feature_group=Scoped693BAbstractOnlyBase)
+
+        assert result.feature_group is None
+        assert result.error is not None
+        assert "abstract" in result.error.lower(), (
+            f"the error must say only abstract base(s) matched, got: {result.error}"
+        )
+        assert _callout("Scoped693BAbstractOnlyBase") in result.error
+
+    def test_abstract_base_with_a_concrete_subclass_still_resolves_to_the_subclass(self) -> None:
+        """Guard: when a concrete subclass also matches, it wins and there is no error."""
+        result = resolve_feature(ABSTRACT_WITH_CONCRETE_FEATURE)
+
+        assert result.feature_group is Scoped693BConcreteMember
+        assert result.error is None
+
+    def test_scoped_abstract_base_with_a_concrete_subclass_resolves_to_the_subclass(self) -> None:
+        """Guard: scoping to the abstract family resolves to its concrete member, as before."""
+        result = resolve_feature(ABSTRACT_WITH_CONCRETE_FEATURE, feature_group=Scoped693BAbstractWithConcreteBase)
+
+        assert result.feature_group is Scoped693BConcreteMember
+        assert result.error is None
+
+
+class TestRedefinitionConflictRespectsTheScope:
+    """The conflict is still reported when scoped, but candidates and the error become scope-aware."""
+
+    def test_unscoped_conflict_reports_the_conflicting_classes(self) -> None:
+        """Premise: the redefinition conflict surfaces as an error and both versions are candidates."""
+        v1, v2 = _conflicting_pair("unscoped")
+
+        result = resolve_feature(CONFLICT_FEATURE)
+
+        assert result.feature_group is None
+        assert result.error is not None
+        assert "redefined" in result.error
+        assert v1 in result.candidates
+        assert v2 in result.candidates
+
+    def test_scoped_conflict_still_reports_the_redefinition(self) -> None:
+        """The engine dedups the whole class universe before scoping, so the conflict still fires."""
+        _conflicting_pair("still_reported")
+
+        result = resolve_feature(CONFLICT_FEATURE, feature_group=Scoped693BConflictScopeTarget)
+
+        assert result.feature_group is None
+        assert result.error is not None
+        assert "redefined" in result.error, f"an out-of-scope conflict must still be reported, got: {result.error}"
+
+    def test_scoped_conflict_error_carries_the_scope_callout(self) -> None:
+        """The conflict error must be legible as a SCOPED failure, like every other scoped error."""
+        _conflicting_pair("callout")
+
+        result = resolve_feature(CONFLICT_FEATURE, feature_group=Scoped693BConflictScopeTarget)
+
+        assert result.error is not None
+        assert _callout("Scoped693BConflictScopeTarget") in result.error, (
+            f"the scoped conflict error must carry the scope callout, got: {result.error}"
+        )
+
+    def test_scoped_conflict_candidates_exclude_out_of_scope_classes(self) -> None:
+        """candidates is 'matching candidates INSIDE the scope', so the conflicting classes drop out."""
+        v1, v2 = _conflicting_pair("candidates")
+
+        result = resolve_feature(CONFLICT_FEATURE, feature_group=Scoped693BConflictScopeTarget)
+
+        assert v1 not in result.candidates, (
+            f"an out-of-scope conflicting class must not leak into candidates, got: {result.candidates}"
+        )
+        assert v2 not in result.candidates, (
+            f"an out-of-scope conflicting class must not leak into candidates, got: {result.candidates}"
+        )
+
+
+class TestSameNamedClassesAreDisambiguated:
+    """Scoping BY NAME is how a user disambiguates; the resulting error must distinguish the twins."""
+
+    def test_engine_ambiguity_error_distinguishes_the_two_modules(self) -> None:
+        """Premise: the engine renders name + module (format_feature_group_class)."""
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            Scoped693BDupNameProbe: {PandasDataFrame},
+            OtherModuleDupNameProbe: {PandasDataFrame},
+        }
+
+        with pytest.raises(ValueError) as exc_info:
+            IdentifyFeatureGroupClass(
+                feature=Feature(DUP_NAME_FEATURE, feature_group="Scoped693BDupNameProbe"),
+                accessible_plugins=accessible_plugins,
+                links=None,
+                data_access_collection=None,
+            )
+
+        engine_message = str(exc_info.value)
+        assert format_feature_group_class(Scoped693BDupNameProbe) in engine_message
+        assert format_feature_group_class(OtherModuleDupNameProbe) in engine_message
+
+    def test_resolve_feature_ambiguity_error_distinguishes_the_two_modules(self) -> None:
+        """['Scoped693BDupNameProbe', 'Scoped693BDupNameProbe'] is useless: render the modules too."""
+        result = resolve_feature(DUP_NAME_FEATURE, feature_group="Scoped693BDupNameProbe")
+
+        assert result.feature_group is None
+        assert result.error is not None
+        assert "Multiple FeatureGroups match" in result.error
+        assert format_feature_group_class(Scoped693BDupNameProbe) in result.error, (
+            f"the ambiguity error must identify the class by name AND module, got: {result.error}"
+        )
+        assert format_feature_group_class(OtherModuleDupNameProbe) in result.error, (
+            f"the ambiguity error must identify the class by name AND module, got: {result.error}"
+        )
+
+    def test_resolve_feature_ambiguity_keeps_both_twins_as_candidates(self) -> None:
+        """Both same-named classes are genuine candidates inside the name scope."""
+        result = resolve_feature(DUP_NAME_FEATURE, feature_group="Scoped693BDupNameProbe")
+
+        assert Scoped693BDupNameProbe in result.candidates
+        assert OtherModuleDupNameProbe in result.candidates

--- a/tests/test_core/test_prepare/test_identify_feature_group_error_message.py
+++ b/tests/test_core/test_prepare/test_identify_feature_group_error_message.py
@@ -319,6 +319,77 @@ class TestNoFeatureGroupFoundErrorMessage:
         assert "Did you mean" not in error_message
 
 
+class TestResolveFeaturePointerNamesTheScope:
+    """The debug pointer must be reproducible: a scoped failure points at resolve_feature WITH the scope.
+
+    The no-match error recommends resolve_feature as the debug tool. When the failing feature carries
+    a feature-group scope, a pointer that only mentions options=... cannot reproduce the failure it is
+    recommended for (issue #693), so it must name feature_group=... as well.
+    """
+
+    def test_scoped_failure_pointer_names_feature_group(self) -> None:
+        feature = Feature("nonexistent_xyz", feature_group=KnownFeatureGroup)
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            KnownFeatureGroup: {MockComputeFramework},
+        }
+
+        with pytest.raises(ValueError) as exc_info:
+            IdentifyFeatureGroupClass(
+                feature=feature,
+                accessible_plugins=accessible_plugins,
+                links=None,
+            )
+
+        error_message = str(exc_info.value)
+
+        assert "Scoped to feature group: 'KnownFeatureGroup'." in error_message, (
+            f"Scoped failure must call out the scope, but got: {error_message}"
+        )
+        assert "resolve_feature(name, options=..., feature_group=...)" in error_message, (
+            f"A scoped failure must point at a resolve_feature call that carries the scope, but got: {error_message}"
+        )
+
+    def test_scoped_failure_pointer_names_a_string_scope_too(self) -> None:
+        feature = Feature("nonexistent_xyz", feature_group="KnownFeatureGroup")
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            KnownFeatureGroup: {MockComputeFramework},
+        }
+
+        with pytest.raises(ValueError) as exc_info:
+            IdentifyFeatureGroupClass(
+                feature=feature,
+                accessible_plugins=accessible_plugins,
+                links=None,
+            )
+
+        error_message = str(exc_info.value)
+
+        assert "Scoped to feature group: 'KnownFeatureGroup'." in error_message
+        assert "resolve_feature(name, options=..., feature_group=...)" in error_message
+
+    def test_unscoped_failure_pointer_omits_feature_group(self) -> None:
+        feature = Feature("nonexistent_xyz")
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            KnownFeatureGroup: {MockComputeFramework},
+        }
+
+        with pytest.raises(ValueError) as exc_info:
+            IdentifyFeatureGroupClass(
+                feature=feature,
+                accessible_plugins=accessible_plugins,
+                links=None,
+            )
+
+        error_message = str(exc_info.value)
+
+        assert "Use resolve_feature(name, options=...) to debug feature resolution." in error_message, (
+            f"An unscoped failure must keep the plain pointer, but got: {error_message}"
+        )
+        assert "feature_group=" not in error_message, (
+            f"An unscoped failure must not advertise a scope argument, but got: {error_message}"
+        )
+
+
 class NoComputeFrameworkFeatureGroup(FeatureGroup):
     """Feature group for testing 'no compute framework' error message."""
 


### PR DESCRIPTION
Closes #693.

## Problem

The engine's no-match error recommends `resolve_feature(name, options=...)` as the debug tool, and the same message can say `Scoped to feature group: 'X'.`. But `resolve_feature` had no way to express a scope, so the recommended tool could not reproduce the very failure it was recommended for. Following the advice re-ran the feature unscoped, which resolves differently, so the one variable that produced the failure was the one the debug tool could not express.

## Change

`resolve_feature` gains a keyword-only `feature_group` scope in both forms (class object and class-name string), normalized through the same validator `Feature(..., feature_group=...)` uses and filtered through the engine's own `matches_feature_group_scope` predicate, so the scope means the same thing on both paths. Every scoped failure carries the shared scope callout, and the engine's debug pointer now names `feature_group=...` when the failing feature is scoped.

### The delegation question (DoD item 3)

`resolve_feature` deliberately stays separate from `IdentifyFeatureGroupClass` rather than delegating. Delegating would break its non-throwing contract: the engine calls `match_feature_group_criteria` directly, so a single feature group that raises `ValueError` while matching would poison the whole resolution, where `resolve_feature` degrades that one candidate to "not a match" and lets the others resolve. Delegating would also discard `ResolvedFeature`'s structured fields and produce an error telling the user to run `resolve_feature`, from inside `resolve_feature`.

Instead the two paths now share every predicate that decides the verdict (`match_feature_group_criteria`, `matches_feature_group_scope`, `frameworks_by_capability`), the abstract-base and subclass-filter rules, and the scope-callout renderer. The remaining divergences are documented in the docstring.

### Engine-parity bugs found in review and fixed

Two independent reviews found cases where the engine **fails** but `resolve_feature` reported **success**, which is the same class of bug as the issue itself:

- **Subclass filtering.** `resolve_feature` dropped a parent class unconditionally, while the engine drops it only when its supported framework set equals the child's. A concrete parent supporting a framework its child does not is a distinct answer to the engine, so features the engine reports as ambiguous were resolving cleanly here.
- **Abstract bases.** A scope naming an abstract base resolved to it with no error, while the engine reports that only abstract bases matched. The new error message points scoped failures at `resolve_feature`, so this would have had the debug tool confidently contradict the error that sent the user to it.
- **Redefinition conflicts.** The conflict path ignored the scope entirely: out-of-scope classes leaked into `candidates` and the callout was dropped. The conflict itself is still reported for an out-of-scope class, because the engine dedups the whole class universe before scoping and raises there too.
- **Ambiguity error.** Two same-named classes from different modules rendered as `['Dup', 'Dup']`, useless precisely when the user scoped by name to disambiguate. Now name and module, like the engine.

The one remaining documented divergence is the plugin-registry strict mode, which the engine applies and this debug API does not.

## Tests

44 new tests: scoped resolve in both forms, scoped no-match, scoped ambiguity, invalid scope reported rather than raised, unscoped behavior unchanged, and engine-parity tests that assert `mloda.run_all` raises and then assert `resolve_feature` reproduces the same verdict for each of the four cases above.

`tox` passes (5710 passed, ruff, pip-licenses, mypy --strict, bandit).