### PR TITLE
feat: export the PythonDict surface from mloda.provider (#716)

### DIFF
--- a/docs/docs/chapter1/compute-frameworks.md
+++ b/docs/docs/chapter1/compute-frameworks.md
@@ -173,7 +173,7 @@ A feature group running on PythonDictFramework may also return row-wise data as 
 
 #### Columnar helpers
 
-`columnar_to_rows`, `homogenize_rows`, `is_columnar`, `result_rows`, and `rows_to_columnar` are importable from `mloda.provider` (plugin/provider code, where pivoting a columnar frame back to rows belongs) and from `mloda.user` (application code unwrapping a `run_all` result). `columnar_to_rows` is strict: it raises `ValueError` on anything that is not a valid columnar dict. `result_rows` is the blessed tolerant unwrapper for PythonDict-framework `run_all` output (columnar dicts and row-dict lists): it flattens the partition list into row dicts, and a dict that satisfies `is_columnar` is always treated as a columnar partition, never as a row. It rejects other frameworks' result objects (convert those to rows first).
+`columnar_to_rows`, `homogenize_rows`, `is_columnar`, `result_rows`, `row_count`, `rows_to_columnar`, and `validate_columnar_dict` are importable from `mloda.provider` (plugin/provider code, where pivoting a columnar frame back to rows belongs) and from `mloda.user` (application code unwrapping a `run_all` result). `columnar_to_rows` is strict: it raises `ValueError` on anything that is not a valid columnar dict. `result_rows` is the blessed tolerant unwrapper for PythonDict-framework `run_all` output (columnar dicts and row-dict lists): it flattens the partition list into row dicts, and a dict that satisfies `is_columnar` is always treated as a columnar partition, never as a row. It rejects other frameworks' result objects (convert those to rows first).
 
 ``` python
 from mloda.user import mloda, result_rows
@@ -182,6 +182,12 @@ rows = result_rows(mloda.run_all(...))
 ```
 
 Strictness stays in the library; `result_rows` packages the forgiving application-side policy.
+
+Plugin code can also import `PythonDictFramework` itself from `mloda.provider` instead of its deep `mloda_plugins` path:
+
+``` python
+from mloda.provider import PythonDictFramework, is_columnar, row_count
+```
 
 Example using Polars frameworks:
 ``` python

--- a/mloda/provider/__init__.py
+++ b/mloda/provider/__init__.py
@@ -85,13 +85,23 @@ from mloda.core.abstract_plugins.plugin_registry.plugin_registry import (
     register_plugin,
 )
 
-# Columnar helpers (python_dict)
+# Columnar helpers (python_dict): stdlib-only module, so eager import is cycle-free.
 from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils import (
     columnar_to_rows,
     homogenize_rows,
     is_columnar,
     result_rows,
+    row_count,
     rows_to_columnar,
+    validate_columnar_dict,
+)
+
+# Eager on purpose: a module-level __getattr__ would make mypy treat every unknown attribute on
+# mloda.provider as Any, silently killing the typo guard for the whole surface.
+# Only PythonDictFramework is exported here: it is the sole dependency-free framework, the other
+# eight need optional backends and cannot be imported eagerly (they stay lazy on mloda.user).
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
+    PythonDictFramework,
 )
 
 # Engines
@@ -153,12 +163,15 @@ __all__ = [
     # Plugin registry
     "PluginRegistryCollisionError",
     "register_plugin",
-    # Columnar helpers (python_dict)
+    # Columnar helpers and framework (python_dict)
     "columnar_to_rows",
     "homogenize_rows",
     "is_columnar",
     "result_rows",
+    "row_count",
     "rows_to_columnar",
+    "validate_columnar_dict",
+    "PythonDictFramework",
     # Engines
     "BaseFilterEngine",
     "BaseMaskEngine",

--- a/mloda/user/__init__.py
+++ b/mloda/user/__init__.py
@@ -83,7 +83,9 @@ _LAZY_PYTHON_DICT_UTILS: dict[str, str] = {
     "homogenize_rows": "mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils",
     "is_columnar": "mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils",
     "result_rows": "mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils",
+    "row_count": "mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils",
     "rows_to_columnar": "mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils",
+    "validate_columnar_dict": "mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils",
 }
 
 if TYPE_CHECKING:
@@ -108,7 +110,9 @@ if TYPE_CHECKING:
         homogenize_rows as homogenize_rows,
         is_columnar as is_columnar,
         result_rows as result_rows,
+        row_count as row_count,
         rows_to_columnar as rows_to_columnar,
+        validate_columnar_dict as validate_columnar_dict,
     )
     from mloda_plugins.compute_framework.base_implementations.spark.spark_framework import (
         SparkFramework as SparkFramework,

--- a/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_filter_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_filter_engine.py
@@ -1,8 +1,8 @@
 import re
 from typing import Any, Callable, cast
 from mloda.core.abstract_plugins.components.contract.comparison_contract import ColumnSemantics
-from mloda.provider import BaseFilterEngine
-from mloda.user import SingleFilter
+from mloda.core.filter.filter_engine import BaseFilterEngine
+from mloda.core.filter.single_filter import SingleFilter
 from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils import rows_to_columnar
 from mloda_plugins.compute_framework.base_implementations.python_dict import python_dict_type_semantics
 

--- a/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_framework.py
+++ b/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_framework.py
@@ -3,13 +3,14 @@ import decimal
 from collections.abc import Sequence
 from typing import Any, Optional
 from mloda.core.abstract_plugins.components.data_types import DataType
-from mloda.provider import BaseMergeEngine
+from mloda.core.abstract_plugins.components.merge.base_merge_engine import BaseMergeEngine
 from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_merge_engine import (
     PythonDictMergeEngine,
 )
-from mloda.user import FeatureName
-from mloda.provider import ComputeFramework
-from mloda.provider import BaseFilterEngine, BaseMaskEngine
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.filter.filter_engine import BaseFilterEngine
+from mloda.core.abstract_plugins.components.mask.base_mask_engine import BaseMaskEngine
 from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_filter_engine import (
     PythonDictFilterEngine,
 )

--- a/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_merge_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_merge_engine.py
@@ -2,10 +2,9 @@ from dataclasses import replace
 from datetime import date, datetime, timedelta
 from typing import Any
 from mloda.core.abstract_plugins.components.contract.comparison_contract import ColumnSemantics
-from mloda.core.abstract_plugins.components.link import AsOfJoinConfig
-from mloda.provider import BaseMergeEngine
-from mloda.user import Index
-from mloda.user import JoinType
+from mloda.core.abstract_plugins.components.link import AsOfJoinConfig, JoinType
+from mloda.core.abstract_plugins.components.merge.base_merge_engine import BaseMergeEngine
+from mloda.core.abstract_plugins.components.index.index import Index
 from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils import columnar_to_rows
 from mloda_plugins.compute_framework.base_implementations.python_dict import python_dict_type_semantics
 

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_compute_framework_exports.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_compute_framework_exports.py
@@ -1,16 +1,21 @@
-"""Compute-framework export matrix for mloda.user (issue #649).
+"""Export contract for the mloda.user and mloda.provider facades (issues #649, #707, #716).
 
-Contract: the 9 concrete ComputeFramework classes are importable directly from
-mloda.user (e.g. ``from mloda.user import PythonDictFramework``) via PEP 562
-lazy ``__getattr__``, while ``import mloda.user`` stays dependency-free. They are
-deliberately kept OUT of mloda.user.__all__ so ``from mloda.user import *`` stays
-dependency-free in minimal installs, but they ARE surfaced by ``__dir__`` for
-discoverability. Each resolves to the identical object defined in its canonical
-mloda_plugins source module; the deep-path imports keep working; and an unknown
-attribute on mloda.user still raises AttributeError.
+mloda.user resolves the 9 concrete ComputeFramework classes and the python_dict helpers via
+PEP 562 lazy ``__getattr__``: they stay OUT of ``__all__`` so ``from mloda.user import *``
+remains dependency-free in minimal installs, but ``__dir__`` surfaces them.
+
+mloda.provider exports the python_dict symbols (PythonDictFramework plus the columnar
+helpers) EAGERLY and lists them in ``__all__``. The plugin modules import their base classes
+from the defining modules instead of the facades, so there is no import cycle to work around
+and mloda.provider must not define a module-level ``__getattr__``.
+
+Every symbol resolves to the identical object defined in its canonical mloda_plugins source
+module, deep-path imports keep working, and unknown attributes still raise AttributeError.
 """
 
 import importlib
+import subprocess  # nosec B404
+import sys
 from types import ModuleType
 
 import pytest
@@ -85,6 +90,9 @@ HELPER_EXPORT_MATRIX: list[tuple[str, str]] = [
     ("is_columnar", _PYTHON_DICT_UTILS_MODULE),
     ("result_rows", _PYTHON_DICT_UTILS_MODULE),
     ("rows_to_columnar", _PYTHON_DICT_UTILS_MODULE),
+    # Issue #716: the columnar surface is only complete with the shape check and the row count.
+    ("row_count", _PYTHON_DICT_UTILS_MODULE),
+    ("validate_columnar_dict", _PYTHON_DICT_UTILS_MODULE),
 ]
 
 _HELPER_MATRIX_IDS = [symbol for symbol, _source in HELPER_EXPORT_MATRIX]
@@ -109,9 +117,9 @@ class TestPythonDictHelperExportMatrix:
 
 
 # Provider side (issue #707): pivoting a columnar frame back to rows is a provider-side
-# concern, so the same helpers are ALSO exported from mloda.provider. Unlike the
-# lazy mloda.user exports, python_dict_utils is stdlib-only and mloda.provider already
-# imports eagerly from mloda_plugins, so these are eager exports listed in __all__.
+# concern, so the same helpers are ALSO exported from mloda.provider. Unlike the lazy
+# mloda.user exports, python_dict_utils is stdlib-only and mloda.provider already imports
+# eagerly from mloda_plugins, so these are eager exports listed in __all__.
 class TestPythonDictHelperProviderExportMatrix:
     @pytest.mark.parametrize(("symbol", "source_module"), HELPER_EXPORT_MATRIX, ids=_HELPER_MATRIX_IDS)
     def test_helper_importable_from_provider(self, symbol: str, source_module: str) -> None:
@@ -134,3 +142,87 @@ class TestPythonDictHelperProviderExportMatrix:
         assert getattr(mloda.provider, symbol) is getattr(mloda.user, symbol), (
             f"mloda.provider.{symbol} and mloda.user.{symbol} must be the identical object"
         )
+
+
+# PythonDictFramework on the provider surface (issue #716): plugin authors reach the framework
+# class from the short namespace instead of the deep mloda_plugins path. The python_dict plugin
+# modules import their base classes from the DEFINING modules (not from the mloda.provider /
+# mloda.user facades), so there is no cycle and the export is eager, exactly like the helpers.
+_PYTHON_DICT_FRAMEWORK_MODULE = "mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework"
+_UNKNOWN_SYMBOL = "DefinitelyNotAnExportedSymbol"
+
+
+class TestPythonDictFrameworkProviderExport:
+    def test_framework_is_identical_to_source_object(self) -> None:
+        source = _source_module(_PYTHON_DICT_FRAMEWORK_MODULE)
+        assert hasattr(mloda.provider, "PythonDictFramework"), "mloda.provider must expose 'PythonDictFramework'"
+        assert getattr(mloda.provider, "PythonDictFramework") is source.PythonDictFramework, (
+            f"mloda.provider.PythonDictFramework must be the identical object from {_PYTHON_DICT_FRAMEWORK_MODULE}"
+        )
+
+    def test_framework_listed_in_provider_all(self) -> None:
+        assert "PythonDictFramework" in mloda.provider.__all__, (
+            "mloda.provider.__all__ must list 'PythonDictFramework' (eager export, stdlib-only plugin module)"
+        )
+
+    def test_provider_and_user_framework_surfaces_agree(self) -> None:
+        assert getattr(mloda.provider, "PythonDictFramework") is getattr(mloda.user, "PythonDictFramework"), (
+            "mloda.provider.PythonDictFramework and mloda.user.PythonDictFramework must be the identical object"
+        )
+
+    def test_unknown_attribute_raises_attribute_error(self) -> None:
+        with pytest.raises(AttributeError):
+            getattr(mloda.provider, _UNKNOWN_SYMBOL)
+
+
+class TestProviderHasNoModuleLevelGetattr:
+    def test_provider_does_not_define_module_getattr(self) -> None:
+        """A module-level __getattr__ on mloda.provider would type-check every typo as Any."""
+        assert "__getattr__" not in vars(mloda.provider), (
+            "mloda.provider must NOT define a module-level __getattr__: mypy honors it as a catch-all, so "
+            "every unknown attribute on the module type-checks as Any and the typo guard silently disappears "
+            "for the whole provider surface ('from mloda.provider import FeatureGropu' would pass mypy --strict "
+            "and only fail at runtime). Export eagerly instead; the import cycle is fixed at its source, where "
+            "the python_dict plugin modules import their base classes from the defining modules, not the facades."
+        )
+
+
+# (id, statements executed in order in a fresh interpreter)
+_IMPORT_ORDERS: list[tuple[str, str]] = [
+    (
+        "plugin_module_first",
+        f"import {_PYTHON_DICT_FRAMEWORK_MODULE} as deep\nimport mloda.provider\n",
+    ),
+    (
+        "provider_first",
+        f"import mloda.provider\nimport {_PYTHON_DICT_FRAMEWORK_MODULE} as deep\n",
+    ),
+]
+
+_IMPORT_ORDER_IDS = [order_id for order_id, _source in _IMPORT_ORDERS]
+
+
+class TestProviderImportOrderCycleGuard:
+    @pytest.mark.parametrize(("order_id", "imports"), _IMPORT_ORDERS, ids=_IMPORT_ORDER_IDS)
+    def test_both_import_orders_resolve_the_same_class(self, order_id: str, imports: str) -> None:
+        """Neither import order may raise ImportError on a mloda.provider <-> python_dict cycle."""
+        script = (
+            f"{imports}"
+            "assert mloda.provider.PythonDictFramework is deep.PythonDictFramework, 'not the same class object'\n"
+            "print('ok')\n"
+        )
+        # Safe: fixed argv (sys.executable + a script built from module-level constants), no shell, no user input.
+        result = subprocess.run(  # nosec B603
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+
+        assert result.returncode == 0, (
+            f"Import order '{order_id}' failed in a fresh interpreter. mloda.provider imports "
+            f"PythonDictFramework eagerly, so the python_dict plugin modules must import their base classes "
+            f"from the defining modules; a facade import there re-enters a partially initialized "
+            f"mloda.provider and raises ImportError.\nstderr:\n{result.stderr}"
+        )
+        assert result.stdout.strip() == "ok"


### PR DESCRIPTION
Closes #716.

## Problem

Downstream code on the PythonDict framework has to spell out a 111-character deep path to reach the helpers and the framework class:

```python
from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils import columnar_to_rows
```

`base_implementations` is an implementation detail downstream code should not need to name.

## Change

- `mloda.provider` now exports `PythonDictFramework`.
- `row_count` and `validate_columnar_dict` join the four columnar helpers already exported from `mloda.provider` and `mloda.user`, so the whole PythonDict surface listed in the issue is reachable from one short namespace.
- Deep paths keep working and resolve to the identical objects.

## Why the export is eager

The python_dict framework, filter engine and merge engine imported their base classes back from the `mloda.provider` / `mloda.user` facades, so a facade importing the framework re-enters a partially initialized module whenever the plugin module is imported first. They now import from the defining modules, as the sibling mask engine already did, which removes the cycle. Import lines only, no behavior change.

The alternative, a lazy PEP 562 `__getattr__` on `mloda.provider`, would hide the cycle at a real cost: mypy honors a module-level `__getattr__` as a catch-all, so every unknown attribute on `mloda.provider` would type-check as `Any` and an import typo such as `from mloda.provider import FeatureGropu` would pass `mypy --strict` and fail only at runtime. A test now pins that `mloda.provider` defines no module-level `__getattr__`.

`mloda.user` keeps its lazy `__getattr__`: its map holds pandas, polars, duckdb, spark and iceberg, which cannot be imported eagerly without breaking the dependency-free import. For the same reason only `PythonDictFramework`, the one dependency-free framework, is exported from `mloda.provider`.

## Tests

`tests/test_core/test_abstract_plugins/test_plugin_registry/test_compute_framework_exports.py`: the six-helper matrix on both surfaces (present, `__all__` semantics, identical objects), the framework export, the no-`__getattr__` guard, and a subprocess guard that pins both import orders in a fresh interpreter so the cycle cannot come back.

`tox` passes: 5676 passed, 171 skipped, ruff, license allowlist, mypy --strict, bandit.