### PR TITLE
refactor: make PROPERTY_MAPPING a typed spec object, not an untyped dict

### DIFF
--- a/attribution/ATTRIBUTION.md
+++ b/attribution/ATTRIBUTION.md
@@ -41,7 +41,6 @@
 | mypy                                   | 2.1.0           | MIT                                                |
 | mypy_extensions                        | 1.1.0           | MIT                                                |
 | narwhals                               | 2.23.0          | MIT                                                |
-| nest-asyncio                           | 1.6.0           | BSD License                                        |
 | nest-asyncio2                          | 1.7.2           | BSD License                                        |
 | nltk                                   | 3.9.4           | Apache Software License                            |
 | numpy                                  | 2.5.1           | BSD-3-Clause AND 0BSD AND MIT AND Zlib AND CC0-1.0 |
@@ -99,7 +98,7 @@
 | tomli                                  | 2.4.1           | MIT                                                |
 | tomli_w                                | 1.2.0           | MIT License                                        |
 | tornado                                | 6.5.7           | Apache Software License                            |
-| tqdm                                   | 4.68.3          | MPL-2.0 AND MIT                                    |
+| tqdm                                   | 4.68.4          | MPL-2.0 AND MIT                                    |
 | traitlets                              | 5.15.1          | BSD License                                        |
 | typeguard                              | 4.5.2           | MIT                                                |
 | types-PyYAML                           | 6.0.12.20260518 | Apache-2.0                                         |

--- a/docs/docs/in_depth/feature-chain-parser.md
+++ b/docs/docs/in_depth/feature-chain-parser.md
@@ -113,7 +113,7 @@ The `FeatureChainParserMixin` provides default implementations for common featur
 
 ``` python
 from mloda.provider import FeatureGroup, FeatureChainParserMixin
-from mloda.provider import DefaultOptionKeys
+from mloda.provider import DefaultOptionKeys, PropertySpec
 
 class MyFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     PREFIX_PATTERN = r".*__my_operation$"
@@ -123,15 +123,12 @@ class MyFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     MAX_IN_FEATURES = 1  # Or None for unlimited
 
     PROPERTY_MAPPING = {
-        "operation_type": {
-            DefaultOptionKeys.allowed_values: {"sum": "Sum operation", "avg": "Average operation"},
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-        },
-        DefaultOptionKeys.in_features: {
-            "explanation": "Source feature",
-            DefaultOptionKeys.context: True,
-        },
+        "operation_type": PropertySpec(
+            "Operation to apply",
+            allowed_values={"sum": "Sum operation", "avg": "Average operation"},
+            strict_validation=True,
+        ),
+        DefaultOptionKeys.in_features: PropertySpec("Source feature"),
     }
 
     # input_features() inherited from FeatureChainParserMixin
@@ -143,7 +140,7 @@ class MyFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 | Attribute | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `PREFIX_PATTERN` | `str` | Required | Regex pattern for matching feature names |
-| `PROPERTY_MAPPING` | `dict` | Required | Parameter validation configuration |
+| `PROPERTY_MAPPING` | `dict[str, PropertySpec]` | Required | Parameter validation configuration |
 | `MIN_IN_FEATURES` | `int` | `1` | Minimum required in_features |
 | `MAX_IN_FEATURES` | `int \| None` | `None` | Maximum allowed in_features (None = unlimited) |
 | `IN_FEATURE_SEPARATOR` | `str` | `"&"` | Separator for multiple in_features |
@@ -223,7 +220,7 @@ The three-arg form `cls._resolve_operation(feature_name, options, config_key)` i
 
 #### 5. Whole-Value Validation with `match_guard`
 
-Add a `DefaultOptionKeys.match_guard` callable to a PROPERTY_MAPPING entry to validate the shape of the raw option value. The mixin calls it after basic matching succeeds, and a falsy return makes `match_feature_group_criteria` return False (a non-match, not an error).
+Give a spec a `match_guard` callable to validate the shape of the raw option value. The mixin calls it after basic matching succeeds, and a falsy return makes `match_feature_group_criteria` return False (a non-match, not an error).
 
 Reach for `match_guard` when the constraint is about the value as a whole (a list of strings, a dict, an ordering). Reach for `element_validator` with `strict_validation=True` when the constraint is about each element on its own.
 
@@ -233,11 +230,10 @@ def _is_list_of_strings(value):
 
 class GroupAggregation(FeatureChainParserMixin, FeatureGroup):
     PROPERTY_MAPPING = {
-        "partition_by": {
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.match_guard: _is_list_of_strings,
-        },
+        "partition_by": PropertySpec(
+            "Columns to partition by",
+            match_guard=_is_list_of_strings,
+        ),
     }
 ```
 
@@ -254,28 +250,28 @@ The modern approach uses `PROPERTY_MAPPING` to define parameter validation and c
 ``` python
 from mloda.provider import FeatureGroup
 from mloda.user import FeatureName
-from mloda.provider import DefaultOptionKeys
+from mloda.provider import DefaultOptionKeys, PropertySpec
 
 class MyFeatureGroup(FeatureGroup):
     PREFIX_PATTERN = r"__([a-zA-Z_]+)_operation$"
 
     PROPERTY_MAPPING = {
         # Feature-specific parameter
-        "operation_type": {
-            DefaultOptionKeys.allowed_values: {
+        "operation_type": PropertySpec(
+            "Operation to apply",
+            allowed_values={
                 "sum": "Sum aggregation",
                 "avg": "Average aggregation",
                 "max": "Maximum aggregation",
             },
-            DefaultOptionKeys.context: True,  # Context parameter
-            DefaultOptionKeys.strict_validation: True,  # Strict validation
-        },
+            context=True,  # Context parameter (the default)
+            strict_validation=True,  # Strict validation
+        ),
         # Source feature parameter
-        DefaultOptionKeys.in_features: {
-            "explanation": "Source feature for the operation",
-            DefaultOptionKeys.context: True,  # Context parameter
-            DefaultOptionKeys.strict_validation: False,  # Flexible validation
-        },
+        DefaultOptionKeys.in_features: PropertySpec(
+            "Source feature for the operation",
+            strict_validation=False,  # Flexible validation
+        ),
     }
 ```
 
@@ -349,12 +345,11 @@ For per-element rules that a fixed value list cannot express:
 
 ``` python
 PROPERTY_MAPPING = {
-    "dimension": {
-        "explanation": "Number of dimensions for reduction",
-        DefaultOptionKeys.context: True,
-        DefaultOptionKeys.strict_validation: True,
-        DefaultOptionKeys.element_validator: lambda x: isinstance(x, int) and x > 0,
-    },
+    "dimension": PropertySpec(
+        "Number of dimensions for reduction",
+        strict_validation=True,
+        element_validator=lambda x: isinstance(x, int) and x > 0,
+    ),
 }
 ```
 
@@ -364,34 +359,39 @@ Specify default values for optional parameters:
 
 ``` python
 PROPERTY_MAPPING = {
-    "window_size": {
-        DefaultOptionKeys.allowed_values: {"7": "7-day window", "30": "30-day window"},
-        DefaultOptionKeys.default: "7",  # Default value
-        DefaultOptionKeys.context: True,
-        DefaultOptionKeys.strict_validation: True,
-    },
+    "window_size": PropertySpec(
+        "Rolling window length in days",
+        allowed_values={"7": "7-day window", "30": "30-day window"},
+        default="7",  # Default value
+        strict_validation=True,
+    ),
 }
 ```
 
 Under strict validation a declared default must itself be an accepted value; that is
-checked at class definition.
+checked when the `PropertySpec` is constructed. Omitting `default` makes the key required;
+`default=None` makes it optional with no value to apply. See
+[Optional keys](property-mapping.md#optional-keys).
 
 #### Group vs Context Classification
+
+There is no `group` field: a group parameter is `context=False`.
 
 ``` python
 PROPERTY_MAPPING = {
     # Group parameter - affects Feature Group resolution
-    "data_source": {
-        DefaultOptionKeys.allowed_values: {"production": "Production data", "staging": "Staging data"},
-        DefaultOptionKeys.group: True,  # Explicit group parameter
-        DefaultOptionKeys.strict_validation: True,
-    },
+    "data_source": PropertySpec(
+        "Data source to read from",
+        allowed_values={"production": "Production data", "staging": "Staging data"},
+        context=False,  # Group parameter
+        strict_validation=True,
+    ),
     # Context parameter - doesn't affect resolution
-    "algorithm_type": {
-        "explanation": "Clustering algorithm",
-        DefaultOptionKeys.context: True,  # Context parameter
-        DefaultOptionKeys.strict_validation: False,  # Flexible validation
-    },
+    "algorithm_type": PropertySpec(
+        "Clustering algorithm",
+        context=True,  # Context parameter (the default)
+        strict_validation=False,  # Flexible validation
+    ),
 }
 ```
 

--- a/docs/docs/in_depth/feature-group-matching.md
+++ b/docs/docs/in_depth/feature-group-matching.md
@@ -30,31 +30,33 @@ Do not call `FeatureChainParser.match_configuration_feature_chain_parser` direct
 The `PROPERTY_MAPPING` defines how configuration-based features are validated:
 
 ```python
+from mloda.provider import PropertySpec
+
 PROPERTY_MAPPING = {
-    "aggregation_type": {
-        DefaultOptionKeys.allowed_values: {
+    "aggregation_type": PropertySpec(
+        "Aggregation to apply",
+        allowed_values={
             "sum": "Sum aggregation",
             "avg": "Average aggregation",
             "max": "Maximum aggregation",
         },
-        DefaultOptionKeys.context: True,
-        DefaultOptionKeys.strict_validation: True,
-    },
-    DefaultOptionKeys.in_features: {
-        "explanation": "Source feature for aggregation",
-        DefaultOptionKeys.context: True,
-        DefaultOptionKeys.strict_validation: False,
-    },
+        strict_validation=True,
+    ),
+    DefaultOptionKeys.in_features: PropertySpec(
+        "Source feature for aggregation",
+        strict_validation=False,
+    ),
 }
 ```
 
-Accepted values are declared under `allowed_values`. Any other key in a spec is an
-unknown key and raises at class definition.
+Every value in the mapping is a `PropertySpec`; accepted values go under `allowed_values`.
+A raw dict spec raises at class definition, and an unknown field is a constructor
+`TypeError`. See [PROPERTY_MAPPING Configuration](property-mapping.md) for the full model.
 
 ### 3. Validation Modes
 
 #### Strict Validation
-When `mloda_strict_validation: True`, parameter values must be in the mapping:
+With `strict_validation=True`, parameter values must be in the value space:
 
 ```python
 # This will match
@@ -65,7 +67,7 @@ options = Options(context={"aggregation_type": "custom"})  # "custom" not in map
 ```
 
 #### Flexible Validation
-When `mloda_strict_validation: False` (default), any value is accepted:
+With `strict_validation=False` (the default), any value is accepted:
 
 ```python
 # Both will match
@@ -78,12 +80,11 @@ For complex validation beyond simple value lists:
 
 ```python
 PROPERTY_MAPPING = {
-    "window_size": {
-        "explanation": "Size of the time window",
-        DefaultOptionKeys.context: True,
-        DefaultOptionKeys.strict_validation: True,
-        DefaultOptionKeys.element_validator: lambda x: isinstance(x, int) and x > 0,
-    },
+    "window_size": PropertySpec(
+        "Size of the time window",
+        strict_validation=True,
+        element_validator=lambda x: isinstance(x, int) and x > 0,
+    ),
 }
 ```
 

--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -1,9 +1,10 @@
 # PROPERTY_MAPPING Configuration
 
-`PROPERTY_MAPPING` declares the options a feature group accepts, and how each one is
-validated. This page is the single source of truth for that model: what a spec may
-contain, which invariant is checked at which moment, what runs against end-user
-values in what order, and what each failure produces.
+`PROPERTY_MAPPING` maps every option key a feature group accepts to a `PropertySpec`: the
+typed, frozen spec that declares how that option is validated. This page is the single
+source of truth for that model: what a spec may contain, which invariant is checked at
+which moment, what runs against end-user values in what order, and what each failure
+produces.
 
 Two rules carry most of the model:
 
@@ -12,150 +13,35 @@ Two rules carry most of the model:
 2. **A rejected value is not always an error.** Some failures raise; others just mean
    "this feature group does not match", which lets a different candidate win.
 
-## The lifecycle: which invariant fires when
-
-| Moment | Mechanism | Checks | Receives | On failure |
-| --- | --- | --- | --- | --- |
-| Import time (`property_spec(...)` call) | Authoring invariants | strict needs `allowed_values` or an `element_validator`; empty `allowed_values`; `element_validator` without strict; validators are callable; `allowed_values` is not a str/bytes | The spec being built | `ValueError` at import |
-| Class definition (`FeatureGroup.__init_subclass__`) | Spec is a dict | A spec is a spec dict, not a bare container | Every spec in the mapping | `ValueError` naming the class and key |
-| Class definition | Spec schema (`PROPERTY_SPEC_KEYS`) | Every KEY of a spec is a known spec key | Every spec in the mapping | `ValueError` listing every offender |
-| Class definition | Spec shape | Every VALUE has the right shape: `allowed_values` is a Collection and not a str/bytes; validators are callable; `strict_validation` is a bool | Every spec in the mapping | `ValueError` naming the key and the real fault |
-| Class definition | Strict needs a value space | `strict_validation: True` has a non-empty `allowed_values` or an `element_validator` | Every spec in the mapping | `ValueError` at class definition |
-| Class definition | `check_declared_default` | A strict, non-`None` `default` is accepted by its own key | The declared default | `ValueError` at class definition |
-| Match time (parser) | `allowed_values` membership | Each element of a **present** option is in the accepted set | One element | `ValueError`, surfaced to the end user |
-| Match time (parser) | `element_validator` | Each element of a **present** option satisfies a predicate | One element | `ValueError`, surfaced to the end user |
-| Match time (parser) | Required presence | A key with no `default` and no `required_when` was provided | The options | Non-match (`False`), config-based path only |
-| Match time (mixin) | `match_guard` | The whole value has an acceptable shape | The raw value | Non-match (`False`) |
-| Match time (mixin) | `MIN/MAX_IN_FEATURES` | In-feature count is within bounds | The in-features | Non-match (`False`) |
-| Match time (guard) | `required_when` | A conditionally required option is present | `Options` | Non-match (`False`) |
-
-Match-time mechanisms run in that order. `element_validator` **replaces** membership
-rather than adding to it: when a key declares one, `allowed_values` is not consulted.
-Because the parser runs before the mixin, an element rejected by membership or by
-`element_validator` short-circuits, and `match_guard` is never reached.
-
-`required_when` is the one mechanism that does not live inside a matcher. A class that
-declares it gets its resolved `match_feature_group_criteria` wrapped at class definition,
-and the wrapper runs the predicates after that matcher returns `True`. Overriding the
-matcher therefore keeps the contract, whether the override delegates or not.
-
-Value validation does not depend on how the feature was created: membership and
-`element_validator` run on **both** match paths, the configuration-based one and the
-string-named one. Only required **presence** differs, enforced on the configuration-based
-path alone, because a key the feature name encodes is satisfied by the name. So
-`"income__pca_2d"` with no options at all still matches, while the same feature group with
-`pca_svd_solver="bogus"` in its options is rejected either way.
-
-The class-definition rules run in table order, and the order is load-bearing. The schema
-runs before the shape rules, because a spec with an unknown key is malformed and its
-remaining keys cannot be trusted to mean what they say (a *removed* key in particular must
-be reported as a rename, not as some downstream shape error). The shape rules run before
-the last two, which read those values: a non-callable `element_validator` reaching
-`check_declared_default` would be blamed on the default instead.
-
-## Choosing a mechanism
-
-| You want to say | Use |
-| --- | --- |
-| "This option accepts exactly these values" | `allowed_values` + `strict_validation: True` |
-| "Each value must satisfy a rule I cannot enumerate" (positive int, float in range) | `element_validator` (requires strict) |
-| "The value as a whole must have this shape" (a dict, a list of exactly 3, an ordering) | `match_guard` |
-| "This option is required only when another option says so" | `required_when` |
-
-The two callables differ on both axes, which is what their names now say:
-
-- **`element_validator`** sees **one element**, only under `strict_validation`, and a
-  falsy return **raises** `ValueError`. The user gave a value the group claims to own
-  but cannot accept, so they are told.
-- **`match_guard`** sees the **raw whole value**, with or without strict, and a falsy
-  return is a plain **non-match**. The group is saying "not mine", so resolution moves
-  on and another feature group may still take the feature.
-
-Both must be pure functions. They may be called several times during resolution (once
-per candidate feature group).
-
-## What a validator receives
-
-Container syntax is not part of the contract. For membership and `element_validator`,
-every sequence unpacks element-wise and identically:
+## The spec type
 
 ``` python
-# All four hand the element_validator exactly "a" and then "b".
-Options(context={"ops": ["a", "b"]})
-Options(context={"ops": ("a", "b")})
-Options(context={"ops": {"a", "b"}})
-Options(context={"ops": frozenset({"a", "b"})})
-```
+from mloda.provider import PropertySpec
 
-- A `str` is a **scalar**, not a sequence of characters: `"abc"` is the single element
-  `"abc"`.
-- A `dict` is **one composite value**, not a sequence of its keys. Validating its shape
-  is `match_guard`'s job.
-- Elements keep their real type: an `int` element arrives as `1`, never `"1"`.
-- An **empty** container is *present* and vacuously valid: it has no elements, so no
-  validator runs, and it still satisfies the required-presence check. This is distinct
-  from the option being absent.
-
-`match_guard` is unaffected by any of this: it always receives the raw value with its
-original container type.
-
-## Authoring a spec
-
-A spec is a plain dict whose keys all come from the schema, `PROPERTY_SPEC_KEYS`:
-`explanation`, `allowed_values`, `default`, `context`, `group`, `strict_validation`,
-`element_validator`, `required_when`, `match_guard`. Anything else is an unknown key and
-raises at class definition. There is one authoring form, plus a builder for it.
-
-**The form: accepted values go under `allowed_values`.**
-
-``` python
-"operation_type": {
-    "explanation": "Arithmetic operation",
-    DefaultOptionKeys.allowed_values: {"add": "Addition", "sub": "Subtraction"},
-    DefaultOptionKeys.context: True,
-    DefaultOptionKeys.strict_validation: True,
+PROPERTY_MAPPING = {
+    "operation_type": PropertySpec(
+        "Arithmetic operation",
+        allowed_values={"add": "Addition", "sub": "Subtraction"},
+        strict_validation=True,
+        default="add",
+    ),
 }
 ```
 
-A spec that declares no `allowed_values` declares an **empty** value space; the space is
-never inferred from the spec's other keys.
+| Field | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `explanation` | `str` | required, positional | What the option means. Also names the spec in construction errors. |
+| `allowed_values` | `Mapping[Any, str]`, any other iterable, or `None` | `None` | The declared value space. A Mapping is `{value: description}` and is kept as given; any other iterable is materialized to a tuple. |
+| `default` | `Any` | `NO_DEFAULT` | Applied when the key is absent. Leaving it at `NO_DEFAULT` declares *no default*, which makes the key required. See [Optional keys](#optional-keys). |
+| `context` | `bool` | `True` | `True`: context parameter. `False`: group parameter, which splits feature groups. |
+| `strict_validation` | `bool` | `False` | Enforce the value space at match time. |
+| `element_validator` | `Callable \| None` | `None` | Per-element predicate. Requires `strict_validation=True`. |
+| `match_guard` | `Callable \| None` | `None` | Whole-value predicate. A falsy return is a non-match. |
+| `required_when` | `Callable \| None` | `None` | `(Options) -> bool`: the key is required only when it returns truthy. |
 
-That is what makes the unknown-key rule possible, and it is the point of it. A typo'd
-flag has exactly one reading now:
-
-``` python
-"operation_type": {
-    DefaultOptionKeys.allowed_values: {"add": "Addition"},
-    "strict_validaton": True,  # ValueError: unknown spec key. Did you mean 'strict_validation'?
-}
-```
-
-## A spec has a shape, not just a key set
-
-Locking down the key names is only half the contract; the value under each key is checked
-too, all at class definition.
-
-`allowed_values` must be a **Collection**: a value-to-docstring mapping, or a tuple, list,
-set or frozenset. Three shapes raise:
-
-- a **`str` or `bytes`**, which a forgotten comma produces (`("add")` is the str `"add"`,
-  not a one-tuple). Membership would silently degrade into a substring test, accepting
-  `"a"`, `"ad"` and `""`.
-- a **generator**, which is truthy whether or not it yields anything, and is consumed by
-  the first read. It makes matching stateful, and a declared `default` burns it at class
-  definition so every later value is rejected.
-- a **scalar**, for which `value in 5` raises a `TypeError` that the match path swallows
-  into a silent reject-everything.
-
-`element_validator`, `required_when` and `match_guard` must be **callable**, and
-`strict_validation` must be a real **bool** (truthiness would make `"false"` mean strict).
-
-`allowed_values` is checked for shape whether or not the spec is strict, because a
-non-strict value space is still *consumed*: it maps a value parsed out of a feature name
-back onto its `PROPERTY_MAPPING` key. It is a mapping aid there, never an enforcement.
-
-**Builder, `property_spec`:** the same dict, with the authoring invariants checked at
-construction instead of at class definition.
+`property_spec(...)` is a thin builder over the same fields. Its keyword is `strict=`,
+which sets `strict_validation`. Both it and `PropertySpec` are exported from
+`mloda.provider`.
 
 ``` python
 from mloda.provider import property_spec
@@ -170,95 +56,234 @@ PROPERTY_MAPPING = {
 }
 ```
 
-It also takes `element_validator`, `match_guard`, and `required_when`, emitted only
-when provided. Its declared-default check is not a separate implementation: it calls
-the same `FeatureChainParser.check_declared_default` the class-definition hook uses,
-so the two cannot drift.
+The type IS the schema. A raw dict spec is rejected at class definition
+(`... is a dict, not a PropertySpec`), and a field name that does not exist is a plain
+constructor `TypeError` that mypy already flags where the spec is written. Nothing a spec
+does not understand can be absorbed silently.
 
-Omitting `default` emits no `default` key and leaves the option **required**, while an
-explicit `default=None` emits the key and makes the option **optional** with a `None`
-default. The exported `NO_DEFAULT` sentinel spells out that omission for a wrapper that
-forwards an optional default through to `property_spec`: passing `NO_DEFAULT` means "no
-default given".
+## The lifecycle: which invariant fires when
+
+| Moment | Mechanism | Checks | Receives | On failure |
+| --- | --- | --- | --- | --- |
+| Author time | `mypy --strict` | The field exists and its declared type fits: `strict_validaton=True` (typo), `strict_validation=1`, `allowed_values=5` | The constructor call | mypy error at the spec literal. Without mypy: an unknown field is a `TypeError`; a wrong type falls through to the row below |
+| Construction (`PropertySpec(...)`) | `__post_init__` | `allowed_values` is not a str/bytes and is a Mapping or an iterable; `strict_validation` is a real bool; the validators are callable; `element_validator` implies strict; strict has a non-empty value space or an `element_validator`; a strict, non-`None` `default` is accepted by the key's own rules | The spec being built | `ValueError` at import, prefixed `PropertySpec('<explanation>')` |
+| Class definition (`FeatureGroup.__init_subclass__`) | Spec type | Every spec IS a `PropertySpec` | Every value in the mapping | `ValueError` naming the class and the key |
+| Match time (parser) | `allowed_values` membership | Each element of a **present** option is in the accepted set | One element | `ValueError`, surfaced to the end user |
+| Match time (parser) | `element_validator` | Each element of a **present** option satisfies a predicate | One element | `ValueError`, surfaced to the end user |
+| Match time (parser) | Required presence | A key that declares no `default` and no `required_when` was provided | The options | Non-match (`False`), configuration-based path only |
+| Match time (mixin) | `match_guard` | The whole value has an acceptable shape | The raw value | Non-match (`False`) |
+| Match time (mixin) | `MIN/MAX_IN_FEATURES` | In-feature count is within bounds | The in-features | Non-match (`False`) |
+| Match time (guard installed at class definition) | `required_when` | A conditionally required option is present | `Options` | Non-match (`False`) |
+
+A spec is constructed inside the class body, so its own rules fire before the class exists.
+Class definition is left with exactly one rule: the type itself. Within `__post_init__` the
+declared-default check runs last, after the shape rules, because it calls the validators the
+shape rules just certified: a non-callable `element_validator` would otherwise be blamed on
+the default.
+
+Match-time mechanisms run in table order. `element_validator` **replaces** membership rather
+than adding to it: when a key declares one, `allowed_values` is not consulted. Because the
+parser runs before the mixin, an element rejected by membership or by `element_validator`
+short-circuits, and `match_guard` is never reached.
+
+Value validation does not depend on how the feature was created: membership and
+`element_validator` run on **both** match paths, the configuration-based one and the
+string-named one. Only required **presence** differs, enforced on the configuration-based
+path alone, because a key the feature name encodes is satisfied by the name. So
+`"income__pca_2d"` with no options at all still matches, while the same feature group with
+`pca_svd_solver="bogus"` in its options is rejected either way.
+
+`required_when` is the one mechanism that does not live inside a matcher. A class that
+declares it gets its resolved `match_feature_group_criteria` wrapped at class definition,
+and the wrapper runs the predicates after that matcher returns `True`. Overriding the
+matcher therefore keeps the contract, whether the override delegates or not.
+
+## Choosing a mechanism
+
+| You want to say | Use |
+| --- | --- |
+| "This option accepts exactly these values" | `allowed_values` + `strict_validation=True` |
+| "Each value must satisfy a rule I cannot enumerate" (positive int, float in range) | `element_validator` (requires strict) |
+| "The value as a whole must have this shape" (a dict, a list of exactly 3, an ordering) | `match_guard` |
+| "This option is required only when another option says so" | `required_when` |
+
+The two callables differ on both axes, which is what their names say:
+
+- **`element_validator`** sees **one element**, only under `strict_validation`, and a falsy
+  return **raises** `ValueError`. The user gave a value the group claims to own but cannot
+  accept, so they are told.
+- **`match_guard`** sees the **raw whole value**, with or without strict, and a falsy return
+  is a plain **non-match**. The group is saying "not mine", so resolution moves on and
+  another feature group may still take the feature. On a spec that also sets
+  `strict_validation=True` the guard means "this value is wrong", so its rejection is reported to
+  the user instead of failing silently.
+
+Both run on both match paths, so declaring both on one spec is about **what** is judged, not
+about where: `element_validator` judges each element and produces the message, while
+`match_guard` judges the raw container that element-wise unpacking would otherwise hide.
+
+Both must be pure functions. They may be called several times during resolution (once per
+candidate feature group).
+
+## What a validator receives
+
+Container syntax is not part of the contract. For membership and `element_validator`, every
+sequence unpacks element-wise and identically:
+
+``` python
+# All four hand the element_validator exactly "a" and then "b".
+Options(context={"ops": ["a", "b"]})
+Options(context={"ops": ("a", "b")})
+Options(context={"ops": {"a", "b"}})
+Options(context={"ops": frozenset({"a", "b"})})
+```
+
+- A `str` is a **scalar**, not a sequence of characters: `"abc"` is the single element
+  `"abc"`.
+- A `dict` is **one composite value**, not a sequence of its keys. Validating its shape is
+  `match_guard`'s job.
+- Elements keep their real type: an `int` element arrives as `1`, never `"1"`.
+- An **empty** container is *present* and vacuously valid: it has no elements, so no
+  validator runs, and it still satisfies the required-presence check. This is distinct from
+  the option being absent.
+
+`match_guard` is unaffected by any of this: it always receives the raw value with its
+original container type.
+
+## The shape of `allowed_values`
+
+A Mapping is the value-space-with-descriptions form and is kept as given. Any other iterable
+(tuple, list, set, frozenset, generator) is materialized to a **tuple** at construction, so a
+generator is consumed once, up front, and can never make matching stateful. Two shapes raise:
+
+- a **`str` or `bytes`**, which a forgotten comma produces (`("add")` is the str `"add"`, not
+  a one-tuple). Membership would silently degrade into a substring test, accepting `"a"`,
+  `"ad"` and `""`.
+- a **scalar**, for which `value in 5` raises a `TypeError` that the match path swallows into
+  a silent reject-everything.
+
+The shape is checked whether or not the spec is strict, because a non-strict value space is
+still *consumed*: it maps a value parsed out of a feature name back onto its
+`PROPERTY_MAPPING` key. It is a mapping aid there, never an enforcement.
+
+A spec that declares no `allowed_values` declares an **empty** value space; the space is never
+inferred from the spec's other fields.
 
 ## Strict validation needs a value space
 
-`strict_validation: True` needs something to validate against: a non-empty
-`allowed_values`, or an `element_validator`. With neither, the accepted set is empty and
-the key rejects every value, so the spec can never match. That is rejected at class
-definition, and `property_spec` refuses to build it.
+`strict_validation=True` needs something to validate against: a non-empty `allowed_values`, or
+an `element_validator`. With neither, the accepted set is empty and the key rejects every
+value, so the spec could never match. The constructor refuses to build it.
 
-## Parameter classification
-
-``` python
-# Context parameter: does not affect Feature Group splitting
-"aggregation_type": {
-    DefaultOptionKeys.allowed_values: {"sum": "Sum aggregation"},
-    DefaultOptionKeys.context: True,
-    DefaultOptionKeys.strict_validation: True,
-}
-
-# Group parameter: affects Feature Group splitting
-"data_source": {
-    DefaultOptionKeys.allowed_values: {"production": "Production data"},
-    DefaultOptionKeys.group: True,
-    DefaultOptionKeys.strict_validation: True,
-}
-```
+An `element_validator` **replaces** membership, so when a key declares one, `allowed_values` is
+never consulted at match time and this rule does not apply: even an empty `allowed_values` is
+inert there, because the validator, not membership, decides.
 
 ## Declared defaults must be honored
 
-Under `strict_validation: True`, a declared `default` must be a value the key accepts.
-This is enforced at class-definition time, naming the class, key, default, and accepted
-values, which closes the gap where omitting the key would apply an unrevalidated
-default.
+Under `strict_validation=True`, a declared non-`None` `default` must be a value the key
+accepts, either by membership or through the `element_validator`. This closes the gap where
+omitting the key would apply an unrevalidated default.
 
 ``` python
-# Rejected at class definition: "mul" is not accepted.
-"operation_type": {
-    DefaultOptionKeys.allowed_values: {"add": "Addition", "sub": "Subtraction"},
-    DefaultOptionKeys.strict_validation: True,
-    DefaultOptionKeys.default: "mul",
+# ValueError at construction: "mul" is not accepted.
+PropertySpec(
+    "Arithmetic operation",
+    allowed_values={"add": "Addition", "sub": "Subtraction"},
+    strict_validation=True,
+    default="mul",
+)
+```
+
+Fix it by adding the default to the accepted values, or by removing it. `required_when` does
+NOT exempt a key: when its predicate returns `False` and the key is omitted, the default still
+applies, so an unaccepted default would still slip through. A declared `default=None` applies
+no value and is always legal, and the check is a no-op when strict is off.
+
+A validator that *raises* when called with the declared default is reported distinctly from
+one that merely *rejects* it, with the original exception chained as `__cause__`.
+
+## Optional keys
+
+Optionality is the `default` field, and the three states are distinct:
+
+| Written | Meaning |
+| --- | --- |
+| `default` omitted (stays `NO_DEFAULT`) | The key declares no default and is **required**. |
+| `default=None` | The key is **optional**; no value is applied when it is absent. |
+| `default=<value>` | The key is **optional**; the value is applied when it is absent, and is checked under strict. |
+
+``` python
+from mloda.provider import PropertySpec
+
+PROPERTY_MAPPING = {
+    "pipeline_steps": PropertySpec(
+        "List of pipeline steps as (name, transformer) tuples",
+        default=None,  # optional: pipeline_name is the alternative
+    ),
 }
 ```
 
-Fix it by adding the default to the accepted values, or by removing it (a key with no
-default and no `required_when` is unconditionally required). `required_when` does NOT
-exempt a key: when its predicate returns `False` and the key is omitted, the default
-still applies, so an unaccepted default would still slip through. A `default` of `None`
-is always legal (the "unset" sentinel), and the check is a no-op when strict is off.
+`NO_DEFAULT` is a sentinel exported from `mloda.provider`; it exists because on a dataclass
+every field is always present, so a plain `None` cannot say both "no default declared" and
+"optional with no value". The retired dict form drew the same line with a *present*
+`default: None` entry. `SklearnPipelineFeatureGroup` is the in-repo example.
 
-A validator that *raises* when called with the declared default is reported distinctly
-from one that merely *rejects* it, with the original exception chained as `__cause__`.
+`required_when` is for a *conditional* requirement, not for optionality: never write a
+predicate that always returns `False` to make a key optional.
+
+## Parameter classification
+
+There is no `group` field: a group parameter is `context=False`.
+
+``` python
+PROPERTY_MAPPING = {
+    # Context parameter (the default): does not affect feature group splitting
+    "aggregation_type": PropertySpec(
+        "Aggregation to apply",
+        allowed_values={"sum": "Sum aggregation"},
+        strict_validation=True,
+    ),
+    # Group parameter: affects feature group splitting
+    "data_source": PropertySpec(
+        "Data source to read from",
+        allowed_values={"production": "Production data"},
+        context=False,
+        strict_validation=True,
+    ),
+}
+```
+
+A caller who places the key explicitly in `Options(group=...)` or `Options(context=...)`
+overrides the spec's classification.
 
 ## What the end user sees on a rejection
 
 A direct `FeatureChainParser` call raises `ValueError` immediately. Going through
-`FeatureChainParserMixin.match_feature_group_criteria` (the default for most feature
-groups) is different: it catches that `ValueError` and returns `False`, because during
-resolution one candidate's "no match" must not abort the search for another candidate
-that might still accept the feature. This holds on both paths: a bad option value on a
-string-named feature is the same non-match as on a configuration-based one.
+`FeatureChainParserMixin.match_feature_group_criteria` (the default for most feature groups)
+is different: it catches that `ValueError` and returns `False`, because during resolution one
+candidate's "no match" must not abort the search for another candidate that might still accept
+the feature. This holds on both paths: a bad option value on a string-named feature is the same
+non-match as on a configuration-based one.
 
-If every candidate rejects the feature, the final "No feature groups found" error
-collects the discarded reasons and appends them:
+If every candidate rejects the feature, the final "No feature groups found" error collects the
+discarded reasons and appends them:
 
 ```
 Feature group(s) rejected an option value while matching 'window_size_windowed':
   - WindowedFeatureGroup: Property value '14' failed validation for 'window_size'
 ```
 
-This is diagnostic only. It does not change the `True`/`False` contract, so a value
-rejected by one feature group can still match another, and multi-group fallback
-resolution keeps working. Authors get this for free.
+This is diagnostic only. It does not change the `True`/`False` contract, so a value rejected by
+one feature group can still match another, and multi-group fallback resolution keeps working.
+Authors get this for free.
 
 ## Conditional requirements with `required_when`
 
-Attach a predicate to declare an option required only under certain conditions. It
-receives an effective `Options` and returns `True` when the option is required. This
-works for config-based and string-based features alike (for the latter, the operation
-parsed from the feature name is merged in first, so predicates see values from both
-sources).
+Attach a predicate to declare an option required only under certain conditions. It receives an
+effective `Options` and returns `True` when the option is required. This works for
+config-based and string-based features alike (for the latter, the operation parsed from the
+feature name is merged in first, so predicates see values from both sources).
 
 ``` python
 _ORDER_DEPENDENT = {"first", "last"}
@@ -267,100 +292,73 @@ def _needs_order_by(options: Options) -> bool:
     return options.get("aggregation_type") in _ORDER_DEPENDENT
 
 PROPERTY_MAPPING = {
-    "aggregation_type": {
-        DefaultOptionKeys.allowed_values: {
+    "aggregation_type": PropertySpec(
+        "Aggregation to apply",
+        allowed_values={
             "sum": "Sum", "avg": "Average", "first": "First", "last": "Last",
         },
-        DefaultOptionKeys.context: True,
-        DefaultOptionKeys.strict_validation: True,
-    },
-    "order_by": {
-        "explanation": "Column to order by within each partition",
-        DefaultOptionKeys.context: True,
-        DefaultOptionKeys.required_when: _needs_order_by,
-    },
+        strict_validation=True,
+    ),
+    "order_by": PropertySpec(
+        "Column to order by within each partition",
+        required_when=_needs_order_by,
+    ),
 }
 ```
 
-When the predicate returns `True` and the option is absent, the match fails; entries
-with `required_when` are otherwise optional. The predicate must be a pure, callable
-`(Options) -> bool` that does not raise. Non-callable values are skipped with a
-warning; non-bool truthy returns count as `True`.
+When the predicate returns `True` and the option is absent, the match fails; entries with
+`required_when` are otherwise optional. The predicate must be pure and must not raise. It is
+callable by construction, and a non-bool truthy return counts as `True`.
 
 The enforcement is installed on the class, not on one matcher, so overriding
-`match_feature_group_criteria` does not lose it: the predicates still run after the
-override returns `True`. Nested guards (an override that delegates into an already guarded
-parent) do not stack: only the outermost one evaluates, so the predicates run exactly once
-per match call. The matcher must be a `classmethod`; a `staticmethod` matcher on a class
-that declares `required_when` is rejected at class definition.
+`match_feature_group_criteria` does not lose it: the predicates still run after the override
+returns `True`. Nested guards (an override that delegates into an already guarded parent) do
+not stack: only the outermost one evaluates, so the predicates run exactly once per match call.
+The matcher must be a `classmethod`; a `staticmethod` matcher on a class that declares
+`required_when` is rejected at class definition.
 
 The guard is installed at class definition, so mutating `PROPERTY_MAPPING` or replacing
 `match_feature_group_criteria` after the class body escapes it.
 
-## Migrating from the flattened form
+## Migrating from the dict form
 
-The **flattened form**, where accepted values shared one dict with the metadata flags, is
-**retired**. The parser used to recover the value space by subtracting the known keys,
-which meant any key it did not recognize was silently absorbed as an accepted *value*. A
-typo'd `strict_validaton: True` therefore turned strict validation off *and* became an
-accepted value, with nothing raised anywhere. It is unfixable while the form exists,
-because a typo'd flag and a legitimate value are written identically.
+Spec dicts are gone. Every value in a `PROPERTY_MAPPING` must be a `PropertySpec`; an
+unmigrated spec raises at class definition, naming the class, the key, and the remedy.
 
-To convert, move the bare value entries under `allowed_values` and leave the flags where
-they are:
-
-``` python
-# Before                              # After
-"operation_type": {                   "operation_type": {
-    "add": "Addition",                    DefaultOptionKeys.allowed_values: {
-    "sub": "Subtraction",                     "add": "Addition",
-    DefaultOptionKeys.context: True,          "sub": "Subtraction",
-    DefaultOptionKeys.strict_validation: True,  },
-}                                         DefaultOptionKeys.context: True,
-                                          DefaultOptionKeys.strict_validation: True,
-                                      }
-```
-
-A spec that splats a shared constant (`**AGGREGATION_TYPES`) assigns it instead:
-`DefaultOptionKeys.allowed_values: AGGREGATION_TYPES`.
-
-Nothing changes silently: an unmigrated spec raises at class definition, because its
-value entries are now unknown keys.
-
-## Migrating from the removed key names
-
-`validation_function` and `type_validator` are **removed**, with no aliases. They did
-not communicate their difference, and `type_validator` additionally collided by
-substring with the unrelated `DataTypeValidator`.
-
-| Removed | Use |
+| Retired | Now |
 | --- | --- |
+| Any spec dict, including the flattened form (accepted values sharing one dict with the flags) | `PropertySpec(...)`, with accepted values under `allowed_values` |
 | `validation_function` | `element_validator` |
 | `type_validator` | `match_guard` |
+| A present `default: None` entry marking a key optional | the `default=None` field (an omitted `default` means the key is required) |
+| `strict_validation` as a spec-dict key | the `strict_validation` field (`strict=` on `property_spec`) |
 
-Both routes fail loudly, so no spec silently changes meaning: the old enum members are
-gone (`AttributeError` at import), and a spec still carrying the old string key is an
-unknown key, so it raises at class definition. Being a *removed* key rather than an
-arbitrary one, the error names the replacement instead of guessing at it.
+Misspelled and retired field names need no dedicated machinery any more: they are keyword
+arguments that do not exist, so the constructor raises `TypeError` at the line where the spec
+is written, and mypy reports them before the code runs.
 
-One semantic change comes with the rename. `element_validator` now genuinely receives
-one element per call for every container type; previously a sequence was stringified
-and arrived as, for example, `"('a', 'b')"`. A validator written to inspect a whole
-container (`isinstance(x, list) and all(...)`) must therefore either become a
-per-element rule, or move to `match_guard` if it really is a whole-value check.
+One semantic change came with the callable renames. `element_validator` receives one element
+per call for every container type; the old `validation_function` saw a stringified sequence
+(`"('a', 'b')"`). A validator written to inspect a whole container
+(`isinstance(x, list) and all(...)`) must become a per-element rule, or move to `match_guard`
+if it really is a whole-value check.
 
 ## Where each invariant is pinned
 
 | Invariant | Test |
 | --- | --- |
-| Spec schema, unknown-key rule, strict needs a value space | `tests/.../feature_chainer/test_property_mapping_spec_schema.py` |
-| Spec shape: Collection value space, callable validators, bool flag | `tests/.../feature_chainer/test_property_mapping_spec_shape.py` |
-| Renamed keys, removed-key guard, shared default seam, precedence | `tests/.../feature_chainer/test_property_mapping_unified_model.py` |
+| `PropertySpec` construction: defaults, immutability, `allowed_values` normalization, flag and callable rules, strict needs a value space | `tests/.../feature_chainer/test_property_spec_type.py` |
+| Unknown or mistyped field caught by mypy at author time | `tests/.../feature_chainer/test_property_spec_author_time.py` |
+| `PROPERTY_MAPPING` accepts nothing but `PropertySpec`, and the pipeline behaves as before | `tests/.../feature_chainer/test_property_spec_hard_break.py` |
+| The constructor IS the schema (no key set left to curate) | `tests/.../feature_chainer/test_property_mapping_spec_schema.py` |
+| Shape rules, relocated from class definition to construction | `tests/.../feature_chainer/test_property_mapping_spec_shape.py` |
+| Declared-default invariant | `tests/test_core/test_abstract_plugins/test_property_mapping_default_invariant.py` |
 | Container invariance, no stringification, str-as-scalar, dict-as-composite, empty containers | `tests/.../feature_chainer/test_property_mapping_sequence_unpacking.py` |
+| Present option values validated on the string-named path too; required presence stays config-only | `tests/.../feature_chainer/test_name_path_validates_option_values.py` |
+| `required_when` survives an overridden matcher, runs exactly once, and demands a classmethod | `tests/.../feature_chainer/test_required_when_enforced_on_override.py` |
 | Plugin specs behave identically across containers | `tests/test_plugins/feature_group/experimental/test_property_mapping_container_invariance.py` |
-| Declared-default invariant at class definition | `tests/test_core/test_abstract_plugins/test_property_mapping_default_invariant.py` |
+| `property_spec` builder surface | `tests/.../feature_chainer/test_property_spec_builder.py` |
 | Rejection reasons surfaced to the end user | `tests/test_core/test_prepare/test_identify_feature_group_error_message.py` |
-| `property_spec` authoring invariants | `tests/.../feature_chainer/test_property_spec_builder.py` |
 
 ## Context propagation
 

--- a/mloda/core/abstract_plugins/components/default_options_key.py
+++ b/mloda/core/abstract_plugins/components/default_options_key.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from typing import Any
 
 
 class DefaultOptionKeys(str, Enum):
@@ -24,43 +23,13 @@ class DefaultOptionKeys(str, Enum):
     in_features = "in_features"
     reference_time = "reference_time"
     time_travel = "time_travel"
-    allowed_values = "allowed_values"
-    default = "default"
     context = "context"
     group = "group"
     order_by = "order_by"
-    strict_validation = "strict_validation"
-    element_validator = "element_validator"
     strict_type_enforcement = "strict_type_enforcement"
-    required_when = "required_when"
-    match_guard = "match_guard"
 
     def __str__(self) -> str:
         return self.value
 
     def __format__(self, format_spec: str) -> str:
         return self.value.__format__(format_spec)
-
-
-# The SCHEMA of a PROPERTY_MAPPING spec dict: the complete set of permitted keys. Rejecting any
-# other key at class definition is what stops a typo'd flag from being read as an allowed value.
-PROPERTY_SPEC_KEYS: frozenset[Any] = frozenset(
-    {
-        "explanation",
-        DefaultOptionKeys.allowed_values,
-        DefaultOptionKeys.default,
-        DefaultOptionKeys.context,
-        DefaultOptionKeys.group,
-        DefaultOptionKeys.strict_validation,
-        DefaultOptionKeys.element_validator,
-        DefaultOptionKeys.required_when,
-        DefaultOptionKeys.match_guard,
-    }
-)
-
-# Removed keys mapped to their replacement (issue #600). They are unknown keys like any other;
-# this map only gives the unknown-key error an exact remedy to name.
-REMOVED_PROPERTY_KEYS: dict[str, DefaultOptionKeys] = {
-    "validation_function": DefaultOptionKeys.element_validator,
-    "type_validator": DefaultOptionKeys.match_guard,
-}

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -5,21 +5,17 @@ Feature chain parser for handling feature name chaining across feature groups.
 from __future__ import annotations
 
 import contextvars
-import difflib
 import functools
 import logging
 import re
-from collections.abc import Collection
+from collections.abc import Callable
 from typing import Any, Optional
 
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
-from mloda.core.abstract_plugins.components.default_options_key import (
-    PROPERTY_SPEC_KEYS,
-    REMOVED_PROPERTY_KEYS,
-    DefaultOptionKeys,
-)
+from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+from mloda.core.abstract_plugins.components.feature_chainer.property_spec import PropertySpec, is_no_default
 from mloda.core.abstract_plugins.components.utils import safe_field
 
 logger = logging.getLogger(__name__)
@@ -130,39 +126,35 @@ class FeatureChainParser:
         return True
 
     @classmethod
-    def _can_skip_required_check(cls, property_value: Any) -> bool:
+    def _can_skip_required_check(cls, spec: PropertySpec) -> bool:
         """Check if the base parser should treat this property as optional.
 
-        Returns True when the property has a default value or uses conditional
-        requirements (required_when).  In both cases the base validation loop
-        should not reject the match just because the option is absent; either
-        the default will be applied later, or the required_when guard installed
-        at class definition will decide.
+        Returns True when the spec DECLARES a default (``NO_DEFAULT`` means it declares none,
+        while a declared ``default=None`` marks the key optional with no value to apply) or uses
+        conditional requirements (required_when). In both cases the base validation loop should
+        not reject the match just because the option is absent; either the default will be applied
+        later, or the required_when guard installed at class definition will decide.
         """
-        if not isinstance(property_value, dict):
-            return False
-        return DefaultOptionKeys.default in property_value or DefaultOptionKeys.required_when in property_value
+        return not is_no_default(spec.default) or spec.required_when is not None
 
     @classmethod
-    def _is_context_parameter(cls, property_value: Any) -> bool:
-        """Check if property is marked as context parameter in mapping."""
-        return isinstance(property_value, dict) and property_value.get(DefaultOptionKeys.context, False)
+    def _is_context_parameter(cls, spec: PropertySpec) -> bool:
+        """Check if the spec marks the property as a context parameter."""
+        return spec.context
 
     @classmethod
-    def _is_strict_validation(cls, property_value: Any) -> bool:
-        """Check if property requires strict validation (values must be in mapping)."""
-        return isinstance(property_value, dict) and property_value.get(DefaultOptionKeys.strict_validation, False)
+    def _is_strict_validation(cls, spec: PropertySpec) -> bool:
+        """Check if the spec requires strict validation (values must be in the value space)."""
+        return spec.strict_validation
 
     @classmethod
-    def _get_element_validator(cls, property_value: Any) -> Any:
-        """Get the per-element validator from a property mapping spec if present."""
-        if isinstance(property_value, dict):
-            return property_value.get(DefaultOptionKeys.element_validator, None)
-        return None
+    def _get_element_validator(cls, spec: PropertySpec) -> Callable[[Any], Any] | None:
+        """Get the spec's per-element validator if present."""
+        return spec.element_validator
 
     @classmethod
     def _validate_property_value(
-        cls, found_property_val: Any, property_value: Any, property_name: str, original_property_config: Any
+        cls, found_property_val: Any, property_value: Any, property_name: str, original_property_config: PropertySpec
     ) -> None:
         """
         Unified validation: if strict validation -> apply the element_validator OR check membership.
@@ -197,7 +189,7 @@ class FeatureChainParser:
                 )
 
     @classmethod
-    def _determine_parameter_category(cls, property_name: str, property_value: Any, options: Options) -> str:
+    def _determine_parameter_category(cls, property_name: str, property_value: PropertySpec, options: Options) -> str:
         """
         Determine whether a parameter should be in group or context category.
 
@@ -234,201 +226,46 @@ class FeatureChainParser:
             return DefaultOptionKeys.group
 
     @classmethod
-    def extract_property_values(cls, property_value: Any) -> Any:
-        """Return a spec's declared value space (``allowed_values``), or {} if it declares none.
-
-        Never inferred by subtracting the known keys: the retired flattened form did that, and it
-        absorbed every unrecognized key as an accepted value.
-        """
-        if isinstance(property_value, dict):
-            return property_value.get(DefaultOptionKeys.allowed_values, {})
-        return property_value
+    def extract_property_values(cls, spec: PropertySpec) -> Any:
+        """Return a spec's declared value space (``allowed_values``), or {} if it declares none."""
+        if spec.allowed_values is None:
+            return {}
+        return spec.allowed_values
 
     @classmethod
-    def _extract_property_values(cls, property_value: Any) -> Any:
+    def _extract_property_values(cls, spec: PropertySpec) -> Any:
         """Alias kept for existing callers."""
-        return cls.extract_property_values(property_value)
+        return cls.extract_property_values(spec)
 
     @classmethod
-    def check_declared_default(cls, owner: str, key: str, spec: dict[str, Any]) -> None:
-        """Check a spec's declared default against its own strict-validation rules.
+    def _require_spec(cls, owner_name: str, key: str, spec: Any) -> PropertySpec:
+        """Reject anything that is not a ``PropertySpec``.
 
-        Shared by ``validate_property_mapping_defaults`` and ``property_spec`` so the two cannot
-        drift. ``required_when`` does NOT exempt the check: the default still applies on the
-        predicate-false branch.
+        The parser entry point is public and takes a mapping straight from a caller, so the type
+        rule cannot live at class-definition time alone: an unmigrated dict would otherwise die
+        with an AttributeError deep in the match path instead of this ValueError.
         """
-        if DefaultOptionKeys.default not in spec:
-            return
+        if isinstance(spec, PropertySpec):
+            return spec
 
-        default = spec[DefaultOptionKeys.default]
-        if default is None:
-            return
-
-        if not cls._is_strict_validation(spec):
-            return
-
-        def _message(detail: str) -> str:
-            return (
-                f"{owner} declares default {default!r} for '{key}', "
-                f"but {detail} under strict_validation. "
-                f"Add the default to the accepted values, or remove the default "
-                f"(a key with no default is required)."
-            )
-
-        element_validator = cls._get_element_validator(spec)
-        if element_validator is not None:
-            try:
-                verdict = element_validator(default)
-            except Exception as exc:
-                raise ValueError(
-                    _message("the key's element_validator raised an error when called with that default")
-                ) from exc
-            if not verdict:
-                raise ValueError(_message("that default is rejected by the key's element_validator"))
-            return
-
-        extracted = cls._extract_property_values(spec)
-        try:
-            cls._validate_property_value(default, extracted, key, spec)
-        except (ValueError, TypeError) as exc:
-            detail = f"that default is not one of the accepted values {sorted(extracted, key=repr)}"
-            raise ValueError(_message(detail)) from exc
+        raise ValueError(
+            f"{owner_name}.PROPERTY_MAPPING['{key}'] is a {type(spec).__name__}, not a PropertySpec. "
+            f"Raw dict specs are no longer accepted; construct PropertySpec(...) or use the "
+            f"property_spec(...) helper."
+        )
 
     @classmethod
     def validate_property_mapping_defaults(cls, owner_name: str, property_mapping: dict[str, Any] | None) -> None:
         """Validate a PROPERTY_MAPPING at class-definition time.
 
-        The rule ORDER below is load-bearing. Schema before shape: an unknown key means the
-        remaining keys cannot be trusted, and a removed key must be reported as a rename rather
-        than as some downstream shape error. Shape before the strict and default rules: those
-        read the values the shape rule validates, so a malformed one would be mis-diagnosed (a
-        non-callable ``element_validator`` gets blamed on the default).
+        Every spec must BE a ``PropertySpec``; a spec validates itself at construction, so the
+        only rule left here is the type itself.
         """
         if property_mapping is None:
             return
 
         for key, spec in property_mapping.items():
-            cls._reject_non_dict_spec(owner_name, key, spec)
-            cls._reject_unknown_spec_keys(owner_name, key, spec)
-            cls._reject_malformed_spec_values(owner_name, key, spec)
-            cls._reject_strict_without_value_space(owner_name, key, spec)
-            cls.check_declared_default(f"{owner_name}.PROPERTY_MAPPING", key, spec)
-
-    @classmethod
-    def _reject_non_dict_spec(cls, owner_name: str, key: str, spec: Any) -> None:
-        """Reject a bare container: it carries no keys, so every rule below would skip it."""
-        if isinstance(spec, dict):
-            return
-
-        raise ValueError(
-            f"{owner_name}.PROPERTY_MAPPING['{key}'] is a {type(spec).__name__}, not a spec dict. "
-            f"Declare the accepted values under '{DefaultOptionKeys.allowed_values.value}' inside a spec dict."
-        )
-
-    @classmethod
-    def _reject_unknown_spec_keys(cls, owner_name: str, key: str, spec: dict[str, Any]) -> None:
-        """Reject every key outside the spec schema, reporting them all in one message.
-
-        Removed keys lead, because they are the offenders with an exact remedy, but they never
-        hide the rest.
-        """
-        unknown = [spec_key for spec_key in spec if spec_key not in PROPERTY_SPEC_KEYS]
-        if not unknown:
-            return
-
-        known = sorted(str(k) for k in PROPERTY_SPEC_KEYS)
-        removed = [k for k in unknown if str(k) in REMOVED_PROPERTY_KEYS]
-        others = [k for k in unknown if str(k) not in REMOVED_PROPERTY_KEYS]
-
-        faults: list[str] = []
-        for spec_key in removed:
-            replacement = REMOVED_PROPERTY_KEYS[str(spec_key)].value
-            faults.append(f"'{spec_key}' was removed, rename it to '{replacement}' (DefaultOptionKeys.{replacement})")
-        for spec_key in others:
-            suggestion = difflib.get_close_matches(str(spec_key), known, n=1)
-            hint = f", did you mean '{suggestion[0]}'?" if suggestion else ""
-            faults.append(f"'{spec_key}' is unknown{hint}")
-
-        raise ValueError(
-            f"{owner_name}.PROPERTY_MAPPING['{key}'] has unknown spec key(s): {'; '.join(faults)}. "
-            f"A spec may only carry the keys {known}. Accepted VALUES belong "
-            f"under '{DefaultOptionKeys.allowed_values.value}'."
-        )
-
-    @classmethod
-    def _reject_malformed_spec_values(cls, owner_name: str, key: str, spec: dict[str, Any]) -> None:
-        """Reject a spec key whose VALUE has the wrong shape.
-
-        ``allowed_values`` must never be a ``str``/``bytes``: ``in`` would silently become a
-        SUBSTRING test. It must be a ``Collection`` at all: a generator is truthy even when empty
-        and is consumed by the first read, and a scalar makes ``value in 5`` raise a ``TypeError``
-        that the match path swallows into a silent reject-everything.
-        """
-        prefix = f"{owner_name}.PROPERTY_MAPPING['{key}']"
-
-        flag_key = DefaultOptionKeys.strict_validation
-        if flag_key in spec and not isinstance(spec[flag_key], bool):
-            flag = spec[flag_key]
-            raise ValueError(
-                f"{prefix} sets '{flag_key.value}' to {flag!r} ({type(flag).__name__}), "
-                f"which must be a real bool. A truthy non-bool silently enables strict validation."
-            )
-
-        if DefaultOptionKeys.allowed_values in spec:
-            allowed_values = spec[DefaultOptionKeys.allowed_values]
-            if isinstance(allowed_values, (str, bytes)):
-                raise ValueError(
-                    f"{prefix} declares '{DefaultOptionKeys.allowed_values.value}' as a "
-                    f"{type(allowed_values).__name__} ({allowed_values!r}), which would make membership a "
-                    f"SUBSTRING test. Wrap it in a container, for example a one-element tuple: "
-                    f"({allowed_values!r},)."
-                )
-            if not isinstance(allowed_values, Collection):
-                raise ValueError(
-                    f"{prefix} declares '{DefaultOptionKeys.allowed_values.value}' as a "
-                    f"{type(allowed_values).__name__}, which is not a Collection. A value space must be "
-                    f"sized and re-iterable (a dict, tuple, list, set or frozenset); a generator is "
-                    f"consumed by the first read and a scalar has no members."
-                )
-
-        for validator_key in (
-            DefaultOptionKeys.element_validator,
-            DefaultOptionKeys.required_when,
-            DefaultOptionKeys.match_guard,
-        ):
-            if validator_key in spec and not callable(spec[validator_key]):
-                value = spec[validator_key]
-                raise ValueError(
-                    f"{prefix} declares '{validator_key.value}' as a {type(value).__name__} "
-                    f"({value!r}), which is not callable. It must be a callable taking the value "
-                    f"and returning a bool."
-                )
-
-    @classmethod
-    def _reject_strict_without_value_space(cls, owner_name: str, key: str, spec: dict[str, Any]) -> None:
-        """Reject strict validation with nothing to validate against: it would reject every value.
-
-        "Non-empty" is a ``len`` test rather than truthiness ON PURPOSE: the shape rule has
-        already established the value space is a ``Collection``, and a generator is truthy even
-        when it yields nothing.
-        """
-        if not cls._is_strict_validation(spec):
-            return
-
-        if cls._get_element_validator(spec) is not None:
-            return
-
-        allowed_values = spec.get(DefaultOptionKeys.allowed_values)
-        if allowed_values is not None and len(allowed_values) > 0:
-            return
-
-        raise ValueError(
-            f"{owner_name}.PROPERTY_MAPPING['{key}'] sets "
-            f"{DefaultOptionKeys.strict_validation.value}=True but declares no value space, "
-            f"so it would reject every value. Declare a non-empty "
-            f"'{DefaultOptionKeys.allowed_values.value}' or an "
-            f"'{DefaultOptionKeys.element_validator.value}'."
-        )
+            cls._require_spec(owner_name, key, spec)
 
     @classmethod
     def _unpack_property_value(cls, found_property_value: Any) -> list[Any]:
@@ -449,7 +286,7 @@ class FeatureChainParser:
 
     @classmethod
     def _process_found_property_value(
-        cls, found_property_value: Any, property_value: Any, property_name: str, original_property_config: Any
+        cls, found_property_value: Any, property_value: Any, property_name: str, original_property_config: PropertySpec
     ) -> list[Any]:
         collected_property_value: list[Any] = []
         for found_property_val in cls._unpack_property_value(found_property_value):
@@ -462,7 +299,7 @@ class FeatureChainParser:
 
     @classmethod
     def _validate_final_properties(
-        cls, property_tracker: dict[str, list[Any] | None], property_mapping: dict[str, Any]
+        cls, property_tracker: dict[str, list[Any] | None], property_mapping: dict[str, PropertySpec]
     ) -> bool:
         """Validate that all required properties are present.
 
@@ -480,7 +317,7 @@ class FeatureChainParser:
 
     @classmethod
     def _collect_option_value(
-        cls, options: Options, property_name: str, property_mapping: dict[str, Any]
+        cls, options: Options, property_name: str, property_mapping: dict[str, PropertySpec]
     ) -> list[Any] | None:
         """Validate one option value and return its elements, or None when the option is absent."""
         found_property_value = options.get(property_name)
@@ -493,18 +330,30 @@ class FeatureChainParser:
         )
 
     @classmethod
-    def _validate_present_option_values(cls, options: Options, property_mapping: dict[str, Any]) -> None:
+    def _validate_present_option_values(cls, options: Options, property_mapping: dict[str, PropertySpec]) -> None:
         """Validate the values of the present options, without enforcing presence of the absent ones."""
+        for property_name, spec in property_mapping.items():
+            # The entry point is public: a caller may hand over an unmigrated mapping that never
+            # passed the class-definition check.
+            cls._require_spec(cls.__name__, property_name, spec)
+
         for property_name in property_mapping:
             cls._collect_option_value(options, property_name, property_mapping)
 
     @classmethod
-    def _validate_options_against_property_mapping(cls, options: Options, property_mapping: dict[str, Any]) -> bool:
+    def _validate_options_against_property_mapping(
+        cls, options: Options, property_mapping: dict[str, PropertySpec]
+    ) -> bool:
         """Validate present option values and enforce required presence. False when a required option is absent.
 
         Raises:
             PropertyValueRejection: If a present option carries a value the mapping rejects
         """
+        for key, spec in property_mapping.items():
+            # The entry point is public: a caller may hand over an unmigrated mapping that never
+            # passed the class-definition check.
+            cls._require_spec(cls.__name__, key, spec)
+
         # None marks an absent option; a list (possibly empty) marks a present one.
         property_tracker: dict[str, list[Any] | None] = {
             property_name: cls._collect_option_value(options, property_name, property_mapping)
@@ -517,7 +366,7 @@ class FeatureChainParser:
         cls,
         feature_name: str | FeatureName,
         options: Options,
-        property_mapping: Optional[dict[str, Any]] = None,
+        property_mapping: Optional[dict[str, PropertySpec]] = None,
         prefix_patterns: Optional[list[Any]] = None,
         pattern: str = CHAIN_SEPARATOR,
     ) -> bool:
@@ -557,7 +406,7 @@ class FeatureChainParser:
     def has_required_when_predicates(property_mapping: dict[str, Any]) -> bool:
         """Return True if any spec in property_mapping declares required_when."""
         for spec in property_mapping.values():
-            if isinstance(spec, dict) and DefaultOptionKeys.required_when in spec:
+            if isinstance(spec, PropertySpec) and spec.required_when is not None:
                 return True
         return False
 
@@ -606,7 +455,7 @@ class FeatureChainParser:
 
         # Find which property mapping key the operation_config value belongs to
         for prop_key, prop_value in property_mapping.items():
-            if not isinstance(prop_value, dict):
+            if not isinstance(prop_value, PropertySpec):
                 continue
             # Already present in options: no merge needed
             if options.get(prop_key) is not None:
@@ -644,13 +493,11 @@ class FeatureChainParser:
 
         effective_options = cls.build_effective_options(feature_name, prefix_patterns, property_mapping, options)
         for key, spec in property_mapping.items():
-            if not isinstance(spec, dict):
+            if not isinstance(spec, PropertySpec):
                 continue
-            predicate = spec.get(DefaultOptionKeys.required_when)
+            # Callability is enforced at PropertySpec construction, so a present predicate is callable.
+            predicate = spec.required_when
             if predicate is None:
-                continue
-            if not callable(predicate):
-                logger.warning("required_when for '%s' in %s is not callable, skipping.", key, owner_name)
                 continue
             if predicate(effective_options) and effective_options.get(key) is None:
                 logger.debug(

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -4,16 +4,16 @@ Mixin class providing default implementations for feature chain parsing.
 Validation Design: ``element_validator`` vs ``match_guard``
 ==========================================================
 
-PROPERTY_MAPPING supports two callable-valued keys that validate option values.
+``PropertySpec`` carries two callable-valued fields that validate option values.
 They serve different purposes and run at different points in the pipeline.
 
-``element_validator`` (``DefaultOptionKeys.element_validator``)
-  - Requires ``strict_validation: True`` on the same mapping entry.
+``element_validator`` (``PropertySpec.element_validator``)
+  - Requires ``strict_validation=True`` on the same spec.
   - Runs inside ``FeatureChainParser._validate_property_value`` on **both** match paths,
     the configuration-based one and the string-named one. Only required *presence* is
     config-based only, because a key encoded in the feature name is satisfied by the name.
   - Receives **individual parsed elements** after list unpacking
-    (``_process_found_property_value`` converts lists to frozensets and
+    (``_process_found_property_value`` unpacks a sequence value into a list and
     iterates over each element).
   - On failure: raises ``PropertyValueRejection`` (a ``ValueError``) with an actionable
     message identifying the property name and the rejected element value. A validator that
@@ -21,7 +21,7 @@ They serve different purposes and run at different points in the pipeline.
   - Use case: validating that each individual element satisfies a constraint
     (e.g., ``lambda x: isinstance(x, int) and x > 0``).
 
-``match_guard`` (``DefaultOptionKeys.match_guard``)
+``match_guard`` (``PropertySpec.match_guard``)
   - Does **not** require ``strict_validation``.
   - Runs inside ``FeatureChainParserMixin.match_feature_group_criteria``
     **after** basic matching succeeds (pattern + property mapping validation).
@@ -33,11 +33,16 @@ They serve different purposes and run at different points in the pipeline.
   - Use case: validating the shape or composite type of the whole value
     (e.g., ``lambda v: isinstance(v, list) and all(isinstance(i, str) for i in v)``).
 
-When both are present on the same mapping entry, ``element_validator`` runs
+When both are present on the same spec, ``element_validator`` runs
 first (during property mapping validation) on each parsed element, then
 ``match_guard`` runs on the raw value. If ``element_validator`` rejects an
 element, the match fails with a ``ValueError`` before ``match_guard`` is
 reached.
+
+A guard rejection on a spec that also sets ``strict_validation=True`` is
+reportable: ``_strict_validation_rejection_reason`` turns it into a message so
+the feature group does not vanish silently. A guard on a non-strict spec keeps
+its "not mine" meaning and reports nothing.
 
 Validators must be pure functions with no side effects. They may be called
 multiple times during feature group resolution (once per candidate feature
@@ -60,6 +65,7 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
     CHAIN_SEPARATOR,
     INPUT_SEPARATOR,
 )
+from mloda.core.abstract_plugins.components.feature_chainer.property_spec import PropertySpec
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
 from mloda.core.abstract_plugins.components.utils import safe_field
 
@@ -77,8 +83,8 @@ class FeatureChainParserMixin:
     - MIN_IN_FEATURES: Optional minimum in_feature count (default: 1)
     - MAX_IN_FEATURES: Optional maximum in_feature count (default: None)
 
-    PROPERTY_MAPPING supports conditional requirements via ``DefaultOptionKeys.required_when``.
-    Attach a predicate ``(Options) -> bool`` to any mapping entry. When the predicate returns
+    PROPERTY_MAPPING supports conditional requirements via ``PropertySpec.required_when``.
+    Attach a predicate ``(Options) -> bool`` to any spec. When the predicate returns
     True and the option value is absent, ``match_feature_group_criteria`` rejects the match.
     When the predicate returns False, the option is treated as optional. The predicates are
     enforced by a guard installed on the class at definition time (see
@@ -92,7 +98,7 @@ class FeatureChainParserMixin:
 
     Predicate contract:
     - Signature: ``(Options) -> bool``
-    - Must be callable (non-callable values are skipped with a warning)
+    - Must be callable (enforced at ``PropertySpec`` construction)
     - Must not raise exceptions
     - Must be a pure function (no side effects)
     - Non-bool truthy return values are treated as True
@@ -198,8 +204,8 @@ class FeatureChainParserMixin:
         Delegates to match_parser_criteria() and optionally calls _validate_string_match() for custom validation.
 
         After basic matching succeeds, enforces ``match_guard`` constraints from
-        PROPERTY_MAPPING entries. For each entry that defines a
-        ``DefaultOptionKeys.match_guard`` callable, the guard is called with the raw
+        PROPERTY_MAPPING entries. For each spec that defines a
+        ``PropertySpec.match_guard`` callable, the guard is called with the raw
         option value. Returning a falsy value causes this method to return False. If
         the guard raises an exception, it is caught and the value is treated as
         invalid. See the module docstring for the full validation design.
@@ -268,10 +274,22 @@ class FeatureChainParserMixin:
 
     @classmethod
     def _strict_validation_rejection_reason(cls, feature_name: str | FeatureName, options: Options) -> str | None:
-        """Return the option-value rejection message that match_feature_group_criteria discards, if any.
+        """Return the rejection message that match_feature_group_criteria discards, if any.
 
-        None when nothing was rejected, and also for a parse error on a malformed name, which is not an
-        option-value rejection. Diagnostic-only: does not affect match_feature_group_criteria's behavior.
+        Reports two kinds of value rejection, both gated on the feature group OTHERWISE matching
+        the feature:
+
+        1. A ValueError raised by option-value validation (a strict_validation rejection). Present
+           option values are validated on both match paths, the string-named one included.
+        2. A match_guard rejection on a spec that also declares strict_validation, which the match
+           path turns into a silent non-match.
+
+        A guard on a non-strict spec means "this feature group does not match", not "this value is
+        wrong", so it stays unreported. A ValueError raised while parsing a PREFIX_PATTERN match
+        (malformed feature name, no chain separator) is a parse error, not an option-value
+        rejection, and is likewise nothing to report. Returns None when nothing was rejected (the
+        match succeeded, or the candidate is unrelated). Diagnostic-only: does not affect
+        match_feature_group_criteria's behavior.
         """
         property_mapping = cls._get_property_mapping()
         if property_mapping is None:
@@ -289,19 +307,35 @@ class FeatureChainParserMixin:
 
         try:
             if name_matched:
+                # The name relates the feature group to the feature, so only the values of the
+                # present options are judged; required presence is the config path's business.
                 FeatureChainParser._validate_present_option_values(options, property_mapping)
             else:
-                FeatureChainParser._validate_options_against_property_mapping(options, property_mapping)
+                matches_mapping = FeatureChainParser._validate_options_against_property_mapping(
+                    options, property_mapping
+                )
+                # Neither the name nor the option set relates this feature group to the feature: its
+                # guards are none of the feature's business.
+                if not matches_mapping:
+                    return None
         except ValueError as exc:
             return str(exc)
-        return None
+
+        rejection = cls._first_rejecting_guard(options, property_mapping)
+        if rejection is None:
+            return None
+
+        key, value = rejection
+        if not property_mapping[key].strict_validation:
+            return None
+        return f"Property value '{value}' rejected by match_guard for '{key}'"
 
     @classmethod
     def _validate_forwarded_name_mismatch(
         cls,
         feature_name: str | FeatureName,
         operation_config: str,
-        property_mapping: dict[str, Any] | None,
+        property_mapping: dict[str, PropertySpec] | None,
         options: Options,
     ) -> None:
         """Reject consumer-forwarded option values that contradict the name-parsed value.
@@ -332,37 +366,58 @@ class FeatureChainParserMixin:
         raise ValueError(message)
 
     @staticmethod
-    def _find_property_key_for_value(property_mapping: dict[str, Any], operation_config: str) -> str | None:
+    def _find_property_key_for_value(property_mapping: dict[str, PropertySpec], operation_config: str) -> str | None:
         """Return the PROPERTY_MAPPING key whose values contain operation_config, if any."""
         for prop_key, prop_value in property_mapping.items():
-            if not isinstance(prop_value, dict):
-                continue
             extracted = FeatureChainParser._extract_property_values(prop_value)
             if operation_config in extracted:
                 return prop_key
         return None
 
     @classmethod
-    def _validate_match_guards(cls, result: bool, options: Options, property_mapping: dict[str, Any] | None) -> bool:
+    def _first_rejecting_guard(
+        cls, options: Options, property_mapping: dict[str, PropertySpec] | None
+    ) -> tuple[str, Any] | None:
+        """Return the (key, value) of the first match_guard that rejects its option value, or None.
+
+        A guard rejects by returning a falsy value or by raising. Shared by the match decision
+        (_validate_match_guards) and the diagnostic (_strict_validation_rejection_reason), so the
+        two can never disagree on what a guard rejected.
+        """
+        if property_mapping is None:
+            return None
+
+        for key, mapping_entry in property_mapping.items():
+            guard = mapping_entry.match_guard
+            if guard is None:
+                continue
+            value = options.get(key)
+            if value is None:
+                continue
+            try:
+                rejected = not guard(value)
+            except (TypeError, ValueError, AttributeError) as exc:
+                logger.debug("match_guard for '%s' raised %s for value %r", key, exc, value)
+                rejected = True
+            if rejected:
+                return key, value
+        return None
+
+    @classmethod
+    def _validate_match_guards(
+        cls, result: bool, options: Options, property_mapping: dict[str, PropertySpec] | None
+    ) -> bool:
         # Enforce match_guard constraints from PROPERTY_MAPPING
-        if result and property_mapping is not None:
-            for key, mapping_entry in property_mapping.items():
-                if not isinstance(mapping_entry, dict):
-                    continue
-                guard = mapping_entry.get(DefaultOptionKeys.match_guard)
-                if guard is None:
-                    continue
-                value = options.get(key)
-                if value is None:
-                    continue
-                try:
-                    if not guard(value):
-                        logger.debug("match_guard for '%s' rejected value %r", key, value)
-                        return False
-                except (TypeError, ValueError, AttributeError) as exc:
-                    logger.debug("match_guard for '%s' raised %s for value %r", key, exc, value)
-                    return False
-        return True
+        if not result:
+            return True
+
+        rejection = cls._first_rejecting_guard(options, property_mapping)
+        if rejection is None:
+            return True
+
+        key, value = rejection
+        logger.debug("match_guard for '%s' rejected value %r", key, value)
+        return False
 
     @classmethod
     def _validate_in_features(cls, result: bool, options: Options) -> bool:
@@ -399,10 +454,10 @@ class FeatureChainParserMixin:
         return FeatureChainParser.prefix_patterns_of(cls)
 
     @classmethod
-    def _get_property_mapping(cls) -> Optional[dict[str, Any]]:
+    def _get_property_mapping(cls) -> Optional[dict[str, PropertySpec]]:
         """Get property mapping from class attribute."""
         if hasattr(cls, "PROPERTY_MAPPING"):
-            return cast(dict[str, Any], cls.PROPERTY_MAPPING)
+            return cast(Optional[dict[str, PropertySpec]], cls.PROPERTY_MAPPING)
         return None
 
     @classmethod
@@ -410,7 +465,7 @@ class FeatureChainParserMixin:
         cls,
         feature_name: str,
         prefix_patterns: list[Any],
-        property_mapping: dict[str, Any],
+        property_mapping: dict[str, PropertySpec],
         options: Options,
     ) -> Options:
         """Merge the value parsed from the feature name into the options the predicates see."""

--- a/mloda/core/abstract_plugins/components/feature_chainer/property_spec.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/property_spec.py
@@ -1,20 +1,19 @@
-"""Authoring helper that builds a conventional PROPERTY_MAPPING spec dict.
+"""The PROPERTY_MAPPING spec type.
 
-The contract stays a plain dict; this only changes authoring, validating the
-invariants up front instead of relying on hand-written spec dicts.
+``PropertySpec`` is the typed, frozen spec and IS the contract: construction enforces every
+invariant (issue #694). ``property_spec`` is a thin builder kept for its authoring surface;
+its ``strict=`` keyword maps to the ``strict_validation=`` field.
 """
 
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass
 from typing import Any
-
-from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 
 
 class _NoDefault:
-    """Sentinel type: ``None`` is a legitimate default, so an omitted default needs its own object."""
+    """Type of the ``NO_DEFAULT`` sentinel."""
 
     def __repr__(self) -> str:
         return "NO_DEFAULT"
@@ -24,74 +23,155 @@ class _NoDefault:
         return "NO_DEFAULT"
 
 
-NO_DEFAULT = _NoDefault()
+NO_DEFAULT: Any = _NoDefault()
+"""The spec declares NO default, which makes the key required.
+
+``default=None`` is a DECLARED default of ``None``: it makes the key optional and applies no
+value. The retired dict form drew that line with a PRESENT ``default: None`` entry; on a
+dataclass every field is always present, so the sentinel carries the distinction instead.
+"""
+
+
+def is_no_default(value: Any) -> bool:
+    """Is this the "declares no default" sentinel?
+
+    A type test, not an identity test: a second imported copy of this module (editable install
+    plus site-packages, importlib.reload) has its own sentinel object, and an identity test would
+    read that copy's sentinel as a declared default.
+    """
+    return isinstance(value, _NoDefault)
+
+
+# The declared type lists the container shapes so a bare str/bytes (the forgotten-comma bug) is
+# an author-time type error rather than a silent substring value space. The runtime is
+# deliberately more lenient: __post_init__ materializes ANY non-Mapping iterable (a generator,
+# a range) to a tuple, and keeps the str/bytes ValueError as the backstop for unchecked callers.
+# A Mapping is the value-space-with-descriptions form and is kept as given.
+AllowedValues = Mapping[Any, str] | tuple[Any, ...] | list[Any] | set[Any] | frozenset[Any]
+
+
+@dataclass(frozen=True)
+class PropertySpec:
+    """Typed, frozen PROPERTY_MAPPING spec. Construction enforces the spec invariants."""
+
+    explanation: str
+    allowed_values: AllowedValues | None = None
+    default: Any = NO_DEFAULT
+    context: bool = True
+    strict_validation: bool = False
+    element_validator: Callable[[Any], Any] | None = None
+    match_guard: Callable[[Any], Any] | None = None
+    required_when: Callable[[Any], Any] | None = None
+
+    def __post_init__(self) -> None:
+        prefix = f"PropertySpec({self.explanation!r})"
+
+        # A str/bytes is iterable, so tuple("add") would silently build ('a', 'd', 'd'): reject the
+        # shape before materializing it.
+        if isinstance(self.allowed_values, (str, bytes)):
+            raise ValueError(
+                f"{prefix}: allowed_values is a {type(self.allowed_values).__name__} "
+                f"({self.allowed_values!r}), which would make membership a substring test. Wrap it in a "
+                f"container, for example a one-element tuple: ({self.allowed_values!r},)."
+            )
+
+        if self.allowed_values is not None and not isinstance(self.allowed_values, Mapping):
+            if not isinstance(self.allowed_values, Iterable):
+                raise ValueError(
+                    f"{prefix}: allowed_values is a {type(self.allowed_values).__name__} "
+                    f"({self.allowed_values!r}), not a Mapping or an iterable of accepted values."
+                )
+            object.__setattr__(self, "allowed_values", tuple(self.allowed_values))
+
+        if not isinstance(self.strict_validation, bool):
+            raise ValueError(
+                f"{prefix}: strict_validation must be a bool, got {type(self.strict_validation).__name__}."
+            )
+
+        if self.element_validator is not None and not callable(self.element_validator):
+            raise ValueError(f"{prefix}: element_validator must be callable.")
+
+        if self.required_when is not None and not callable(self.required_when):
+            raise ValueError(f"{prefix}: required_when must be callable.")
+
+        if self.match_guard is not None and not callable(self.match_guard):
+            raise ValueError(f"{prefix}: match_guard must be callable.")
+
+        if self.element_validator is not None and not self.strict_validation:
+            raise ValueError(f"{prefix}: element_validator is never enforced without strict_validation=True.")
+
+        self._check_value_space(prefix)
+        self._check_declared_default(prefix)
+
+    def _check_value_space(self, prefix: str) -> None:
+        """A strict spec needs something to validate AGAINST.
+
+        An ``element_validator`` IS that value space: the validator, not membership, decides, so
+        ``allowed_values`` is not consulted at all and its emptiness cannot reject anything.
+        """
+        if not self.strict_validation or self.element_validator is not None:
+            return
+
+        if self.allowed_values is not None and not self.allowed_values:
+            raise ValueError(f"{prefix}: an empty allowed_values would reject every value.")
+
+        if self.allowed_values is None:
+            raise ValueError(
+                f"{prefix}: strict_validation=True needs a non-empty allowed_values or an element_validator."
+            )
+
+    def _check_declared_default(self, prefix: str) -> None:
+        """A strict spec's declared default must be within its own value space (issue #530 semantics).
+
+        ``NO_DEFAULT`` declares no default, and a declared ``None`` applies no value: neither has
+        anything to check.
+        """
+        if is_no_default(self.default) or self.default is None or not self.strict_validation:
+            return
+
+        if self.element_validator is not None:
+            try:
+                verdict = self.element_validator(self.default)
+            except Exception as exc:
+                raise ValueError(
+                    f"{prefix}: the element_validator raised an error when called with default {self.default!r}."
+                ) from exc
+            if not verdict:
+                raise ValueError(f"{prefix}: default {self.default!r} is rejected by the element_validator.")
+            return
+
+        if self.allowed_values is None:
+            return
+
+        # Mirrors the match path: an unhashable default can never be a member of a hash-based value
+        # space, so the TypeError is a clean rejection, not an escaping error.
+        try:
+            is_member = self.default in self.allowed_values
+        except TypeError:
+            is_member = False
+        if not is_member:
+            raise ValueError(f"{prefix}: default {self.default!r} is not within the declared allowed_values.")
 
 
 def property_spec(
     explanation: str,
     *,
     strict: bool = False,
-    allowed_values: Mapping[Any, str] | Iterable[Any] | None = None,
+    allowed_values: AllowedValues | None = None,
     default: Any = NO_DEFAULT,
     context: bool = True,
-    element_validator: Callable[..., Any] | None = None,
-    required_when: Callable[..., Any] | None = None,
-    match_guard: Callable[..., Any] | None = None,
-) -> dict[str, Any]:
-    """Build a spec dict: omitting ``default`` keeps the key required, ``default=None`` makes it optional with ``None``."""
-    # A str/bytes is iterable, so tuple("add") would silently build ('a', 'd', 'd'): reject the
-    # shape before materializing it. Holds whether or not the spec is strict.
-    if isinstance(allowed_values, (str, bytes)):
-        raise ValueError(
-            f"property_spec({explanation!r}): allowed_values is a {type(allowed_values).__name__} "
-            f"({allowed_values!r}), which would make membership a substring test. Wrap it in a "
-            f"container, for example a one-element tuple: ({allowed_values!r},)."
-        )
-
-    if allowed_values is not None and not isinstance(allowed_values, Mapping):
-        allowed_values = tuple(allowed_values)
-
-    if element_validator is not None and not callable(element_validator):
-        raise ValueError(f"property_spec({explanation!r}): element_validator must be callable.")
-
-    if required_when is not None and not callable(required_when):
-        raise ValueError(f"property_spec({explanation!r}): required_when must be callable.")
-
-    if match_guard is not None and not callable(match_guard):
-        raise ValueError(f"property_spec({explanation!r}): match_guard must be callable.")
-
-    # Dead without strict: _validate_property_value returns early on a non-strict spec. allowed_values
-    # is NOT dead there, so it has no such rule: a non-strict value space still maps a name-parsed
-    # value back onto its PROPERTY_MAPPING key.
-    if element_validator is not None and not strict:
-        raise ValueError(f"property_spec({explanation!r}): element_validator is never enforced without strict=True.")
-
-    if strict and allowed_values is not None and not allowed_values:
-        raise ValueError(f"property_spec({explanation!r}): an empty allowed_values would reject every value.")
-
-    if strict and allowed_values is None and element_validator is None:
-        raise ValueError(
-            f"property_spec({explanation!r}): strict=True needs a non-empty allowed_values or an element_validator."
-        )
-
-    spec: dict[str, Any] = {"explanation": explanation}
-    if allowed_values is not None:
-        spec[DefaultOptionKeys.allowed_values] = allowed_values
-    if element_validator is not None:
-        spec[DefaultOptionKeys.element_validator] = element_validator
-    if required_when is not None:
-        spec[DefaultOptionKeys.required_when] = required_when
-    if match_guard is not None:
-        spec[DefaultOptionKeys.match_guard] = match_guard
-    spec[DefaultOptionKeys.context] = context
-    spec[DefaultOptionKeys.strict_validation] = strict
-    # Type test, not identity: a second imported copy of this module (editable install plus
-    # site-packages, importlib.reload) has its own sentinel object.
-    if not isinstance(default, _NoDefault):
-        spec[DefaultOptionKeys.default] = default
-
-    # The declared-default semantics live in core, so the builder and the
-    # class-definition check cannot drift apart.
-    FeatureChainParser.check_declared_default(f"property_spec({explanation!r})", explanation, spec)
-
-    return spec
+    element_validator: Callable[[Any], Any] | None = None,
+    required_when: Callable[[Any], Any] | None = None,
+    match_guard: Callable[[Any], Any] | None = None,
+) -> PropertySpec:
+    """Build a ``PropertySpec``; the ``strict=`` keyword sets the ``strict_validation`` field."""
+    return PropertySpec(
+        explanation,
+        allowed_values=allowed_values,
+        default=default,
+        context=context,
+        strict_validation=strict,
+        element_validator=element_validator,
+        match_guard=match_guard,
+        required_when=required_when,
+    )

--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -9,7 +9,6 @@ from abc import ABC
 from mloda.core.abstract_plugins.components.base_artifact import BaseArtifact
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.data_types import DataType
-from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
 
 from mloda.core.abstract_plugins.components.domain import Domain
 from mloda.core.abstract_plugins.components.base_feature_group_version import BaseFeatureGroupVersion
@@ -17,6 +16,7 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
     CHAIN_SEPARATOR,
     FeatureChainParser,
 )
+from mloda.core.abstract_plugins.components.feature_chainer.property_spec import PropertySpec, is_no_default
 from mloda.core.abstract_plugins.components.subtype_declaration import SubtypeDeclaration
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.input_data.api.api_input_data import ApiInputData
@@ -42,17 +42,16 @@ class FeatureGroup(ABC):
     ``PROPERTY_MAPPING`` validation, and provides a default ``input_features``
     implementation::
 
-        from mloda.provider import FeatureChainParserMixin, FeatureGroup, DefaultOptionKeys
+        from mloda.provider import FeatureChainParserMixin, FeatureGroup, PropertySpec
 
         class MyFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             PREFIX_PATTERN = r".*__([\\w]+)_my_op$"
             PROPERTY_MAPPING = {
-                "operation_type": {
-                    "add": "Addition",
-                    "sub": "Subtraction",
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: True,
-                },
+                "operation_type": PropertySpec(
+                    "Operation to apply.",
+                    allowed_values={"add": "Addition", "sub": "Subtraction"},
+                    strict_validation=True,
+                ),
             }
 
             @classmethod
@@ -75,13 +74,13 @@ class FeatureGroup(ABC):
     for the full PROPERTY_MAPPING reference.
     """
 
-    PROPERTY_MAPPING: ClassVar[Optional[dict[str, Any]]] = None
+    PROPERTY_MAPPING: ClassVar[Optional[dict[str, PropertySpec]]] = None
     """Override in subclasses to declare configurable parameters.
 
-    Each key is a parameter name. Each value is a dict containing valid
-    values, metadata flags (``DefaultOptionKeys.context``,
-    ``DefaultOptionKeys.strict_validation``, etc.), and optional validators.
-    See ``docs/in_depth/property-mapping.md`` for the full specification.
+    Each key is a parameter name. Each value is a ``PropertySpec`` carrying the
+    explanation, the value space (``allowed_values``), flags (``context``,
+    ``strict_validation``), and optional validators. See
+    ``docs/in_depth/property-mapping.md`` for the full specification.
     """
 
     SUBTYPES: ClassVar[Optional[SubtypeDeclaration]] = None
@@ -222,8 +221,8 @@ class FeatureGroup(ABC):
         key = declaration.key
         spec = (cls.PROPERTY_MAPPING or {}).get(key)
         value = options.get(key)
-        if value is None and isinstance(spec, dict):
-            value = spec.get(DefaultOptionKeys.default)
+        if value is None and spec is not None and not is_no_default(spec.default):
+            value = spec.default
         if value is None:
             return None
         if spec is not None:

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -229,6 +229,14 @@ class IdentifyFeatureGroupClass:
         msg += " Pin the feature to a supported compute framework or override supports_compute_framework."
         return msg
 
+    def _value_rejection_reason(self, feature_group: type[FeatureGroup], feature: Feature) -> Optional[str]:
+        """The candidate's own message for rejecting an option VALUE, if it has one."""
+        rejection_check = getattr(feature_group, "_strict_validation_rejection_reason", None)
+        if rejection_check is None:
+            return None
+        reason: Optional[str] = rejection_check(feature.name, feature.options)
+        return reason
+
     def _input_feature_forwarding_hint(
         self, feature: Feature, accessible_plugins: FeatureGroupEnvironmentMapping
     ) -> Optional[str]:
@@ -236,6 +244,9 @@ class IdentifyFeatureGroupClass:
         offending = sorted(str(k) for k in feature.options.group if k not in reserved)
         if not offending:
             return None
+
+        # Did any offending key arrive BY forwarding, rather than being set on this feature directly?
+        forwarded_offenders = [key for key in offending if key in feature.options.inherited_group_keys]
 
         bare = Options(
             context=dict(feature.options.context),
@@ -247,6 +258,12 @@ class IdentifyFeatureGroupClass:
             if not self._filter_feature_group_by_domain(feature_group, feature):
                 continue
             if not self._filter_feature_group_by_scope(feature_group, feature):
+                continue
+            # A rejected VALUE the caller set HERE is not a forwarding problem: carving the key out
+            # would not fix the value, and the value-rejection hint already says what is wrong. A
+            # value that arrived by forwarding is both, and carving the key out is exactly the fix,
+            # so that candidate still earns the hint.
+            if self._value_rejection_reason(feature_group, feature) is not None and not forwarded_offenders:
                 continue
             accepts_bare = feature_group.match_feature_group_criteria(feature.name, bare, self._data_access_collection)
             rejects_actual = not feature_group.match_feature_group_criteria(
@@ -277,11 +294,7 @@ class IdentifyFeatureGroupClass:
             if not self._filter_feature_group_by_scope(feature_group, feature):
                 continue
 
-            rejection_check = getattr(feature_group, "_strict_validation_rejection_reason", None)
-            if rejection_check is None:
-                continue
-
-            reason = rejection_check(feature.name, feature.options)
+            reason = self._value_rejection_reason(feature_group, feature)
             if reason is not None:
                 reasons.append((feature_group.get_class_name(), reason))
 

--- a/mloda/provider/__init__.py
+++ b/mloda/provider/__init__.py
@@ -72,7 +72,11 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
     INPUT_SEPARATOR,
 )
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
-from mloda.core.abstract_plugins.components.feature_chainer.property_spec import NO_DEFAULT, property_spec
+from mloda.core.abstract_plugins.components.feature_chainer.property_spec import (
+    NO_DEFAULT,
+    PropertySpec,
+    property_spec,
+)
 
 # Subtype declaration
 from mloda.core.abstract_plugins.components.subtype_declaration import SubtypeDeclaration
@@ -137,6 +141,7 @@ __all__ = [
     "COLUMN_SEPARATOR",
     "INPUT_SEPARATOR",
     "FeatureChainParserMixin",
+    "PropertySpec",
     "property_spec",
     "NO_DEFAULT",
     # Subtype declaration

--- a/mloda_plugins/feature_group/experimental/aggregated_feature_group/base.py
+++ b/mloda_plugins/feature_group/experimental/aggregated_feature_group/base.py
@@ -15,6 +15,7 @@ from mloda.provider import (
     FeatureChainParserMixin,
 )
 from mloda.provider import DefaultOptionKeys
+from mloda.provider import PropertySpec
 from mloda.provider import SubtypeDeclaration
 
 
@@ -110,16 +111,17 @@ class AggregatedFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 
     # Property mapping for configuration-based feature creation
     PROPERTY_MAPPING = {
-        AGGREGATION_TYPE: {
-            DefaultOptionKeys.allowed_values: AGGREGATION_TYPES,
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-        },
-        DefaultOptionKeys.in_features: {
-            "explanation": "Source feature to aggregate",
-            DefaultOptionKeys.context: True,  # Mark as context parameter
-            DefaultOptionKeys.strict_validation: False,  # Flexible validation
-        },
+        AGGREGATION_TYPE: PropertySpec(
+            "Type of aggregation to perform",
+            allowed_values=AGGREGATION_TYPES,
+            context=True,
+            strict_validation=True,
+        ),
+        DefaultOptionKeys.in_features: PropertySpec(
+            "Source feature to aggregate",
+            context=True,
+            strict_validation=False,
+        ),
     }
 
     @classmethod

--- a/mloda_plugins/feature_group/experimental/clustering/base.py
+++ b/mloda_plugins/feature_group/experimental/clustering/base.py
@@ -15,6 +15,12 @@ from mloda.provider import (
 )
 from mloda.provider import FeatureSet
 from mloda.provider import DefaultOptionKeys
+from mloda.provider import PropertySpec
+
+
+def _is_bool(value: Any) -> bool:
+    """Accept only a real bool, so 1 or "true" is rejected rather than silently coerced."""
+    return isinstance(value, bool)
 
 
 class ClusteringFeatureGroup(FeatureChainParserMixin, FeatureGroup):
@@ -112,31 +118,36 @@ class ClusteringFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 
     # Property mapping for configuration-based feature creation
     PROPERTY_MAPPING = {
-        ALGORITHM: {
-            DefaultOptionKeys.allowed_values: CLUSTERING_ALGORITHMS,
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-        },
-        K_VALUE: {
-            "explanation": "Number of clusters or 'auto' for automatic determination",
-            DefaultOptionKeys.context: True,  # Mark as context parameter
-            DefaultOptionKeys.strict_validation: True,  # Enable strict validation
-            DefaultOptionKeys.element_validator: lambda value: (
+        ALGORITHM: PropertySpec(
+            "Clustering algorithm to use",
+            allowed_values=CLUSTERING_ALGORITHMS,
+            context=True,
+            strict_validation=True,
+        ),
+        K_VALUE: PropertySpec(
+            "Number of clusters or 'auto' for automatic determination",
+            context=True,
+            strict_validation=True,
+            element_validator=lambda value: (
                 value == "auto" or (isinstance(value, (int, str)) and str(value).isdigit() and int(value) > 0)
             ),
-        },
-        DefaultOptionKeys.in_features: {
-            "explanation": "Source features to use for clustering",
-            DefaultOptionKeys.context: True,  # Mark as context parameter
-            DefaultOptionKeys.strict_validation: False,  # Flexible validation
-        },
-        OUTPUT_PROBABILITIES: {
-            "explanation": "Whether to output cluster probabilities/distances as separate columns using ~N suffix pattern",
-            DefaultOptionKeys.context: True,  # Mark as context parameter
-            DefaultOptionKeys.strict_validation: False,  # Flexible validation
-            DefaultOptionKeys.default: False,  # Default is False (don't output probabilities)
-            DefaultOptionKeys.element_validator: lambda value: isinstance(value, bool),
-        },
+        ),
+        DefaultOptionKeys.in_features: PropertySpec(
+            "Source features to use for clustering",
+            context=True,
+            strict_validation=False,
+        ),
+        # Both hooks share _is_bool. element_validator produces the rejection message and checks the
+        # declared default at construction; it runs on BOTH match paths, so it alone enforces the
+        # value space. match_guard additionally judges the raw, un-unpacked value.
+        OUTPUT_PROBABILITIES: PropertySpec(
+            "Whether to output cluster probabilities/distances as separate columns using ~N suffix pattern",
+            context=True,
+            strict_validation=True,
+            default=False,
+            element_validator=_is_bool,
+            match_guard=_is_bool,
+        ),
     }
 
     @classmethod

--- a/mloda_plugins/feature_group/experimental/data_quality/missing_value/base.py
+++ b/mloda_plugins/feature_group/experimental/data_quality/missing_value/base.py
@@ -15,6 +15,7 @@ from mloda.provider import (
 )
 from mloda.provider import FeatureSet
 from mloda.provider import DefaultOptionKeys
+from mloda.provider import PropertySpec
 
 
 class MissingValueFeatureGroup(FeatureChainParserMixin, FeatureGroup):
@@ -165,28 +166,29 @@ class MissingValueFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     MAX_IN_FEATURES = 1
 
     PROPERTY_MAPPING = {
-        IMPUTATION_METHOD: {
-            DefaultOptionKeys.allowed_values: IMPUTATION_METHODS,
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-        },
-        DefaultOptionKeys.in_features: {
-            "explanation": "Source feature to impute missing values",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-        },
-        "constant_value": {
-            "explanation": "Constant value to use for constant imputation method",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.default: None,  # Default is None, required only for constant method
-        },
-        "group_by_features": {
-            "explanation": "Optional list of features to group by before imputation",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.default: None,  # Default is None (no grouping)
-        },
+        IMPUTATION_METHOD: PropertySpec(
+            "Imputation method to apply",
+            allowed_values=IMPUTATION_METHODS,
+            context=True,
+            strict_validation=True,
+        ),
+        DefaultOptionKeys.in_features: PropertySpec(
+            "Source feature to impute missing values",
+            context=True,
+            strict_validation=False,
+        ),
+        "constant_value": PropertySpec(
+            "Constant value to use for constant imputation method",
+            context=True,
+            strict_validation=False,
+            default=None,  # Optional: only the constant method uses it
+        ),
+        "group_by_features": PropertySpec(
+            "Optional list of features to group by before imputation",
+            context=True,
+            strict_validation=False,
+            default=None,  # Optional: no grouping
+        ),
     }
 
     @classmethod

--- a/mloda_plugins/feature_group/experimental/dimensionality_reduction/base.py
+++ b/mloda_plugins/feature_group/experimental/dimensionality_reduction/base.py
@@ -4,6 +4,7 @@ Base implementation for dimensionality reduction feature groups.
 
 from __future__ import annotations
 
+import numbers
 from abc import abstractmethod
 from typing import Any, Optional
 
@@ -16,6 +17,16 @@ from mloda.provider import (
 from mloda.provider import FeatureSet
 from mloda.user import Options
 from mloda.provider import DefaultOptionKeys
+from mloda.provider import PropertySpec
+
+
+def _is_positive_int(value: Any) -> bool:
+    """Accept any positive integer (int, numpy int, decimal string), so bool, 0, -5, 2.5, "abc" and "²" are rejected."""
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, numbers.Integral):
+        return int(value) > 0
+    return isinstance(value, str) and value.isdecimal() and int(value) > 0
 
 
 class DimensionalityReductionFeatureGroup(FeatureChainParserMixin, FeatureGroup):
@@ -119,86 +130,85 @@ class DimensionalityReductionFeatureGroup(FeatureChainParserMixin, FeatureGroup)
     MAX_IN_FEATURES = None
 
     PROPERTY_MAPPING = {
-        ALGORITHM: {
-            DefaultOptionKeys.allowed_values: REDUCTION_ALGORITHMS,
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-        },
-        DIMENSION: {
-            "explanation": "Target dimension for the reduction (positive integer)",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.element_validator: lambda value: (
-                isinstance(value, (int, str)) and str(value).isdigit() and int(value) > 0
-            ),
-        },
-        DefaultOptionKeys.in_features: {
-            "explanation": "Source features to use for dimensionality reduction",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-        },
+        ALGORITHM: PropertySpec(
+            "Dimensionality reduction algorithm to use",
+            allowed_values=REDUCTION_ALGORITHMS,
+            context=True,
+            strict_validation=True,
+        ),
+        DIMENSION: PropertySpec(
+            "Target dimension for the reduction (positive integer)",
+            context=True,
+            strict_validation=True,
+            element_validator=_is_positive_int,
+        ),
+        DefaultOptionKeys.in_features: PropertySpec(
+            "Source features to use for dimensionality reduction",
+            context=True,
+            strict_validation=False,
+        ),
+        # The algorithm-specific numeric keys below share _is_positive_int across both hooks.
+        # element_validator produces the rejection message and checks the declared default at
+        # construction; it runs on BOTH match paths, so it alone enforces the value space. match_guard
+        # additionally judges the raw, un-unpacked value.
         # t-SNE specific parameters
-        TSNE_MAX_ITER: {
-            "explanation": "Maximum number of iterations for t-SNE optimization",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.default: 250,
-            DefaultOptionKeys.element_validator: lambda value: (
-                isinstance(value, (int, str)) and str(value).isdigit() and int(value) > 0
-            ),
-        },
-        TSNE_N_ITER_WITHOUT_PROGRESS: {
-            "explanation": "Maximum iterations without progress before early stopping (t-SNE)",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.default: 50,
-            DefaultOptionKeys.element_validator: lambda value: (
-                isinstance(value, (int, str)) and str(value).isdigit() and int(value) > 0
-            ),
-        },
-        TSNE_METHOD: {
-            "explanation": "t-SNE computation method",
-            DefaultOptionKeys.allowed_values: {
+        TSNE_MAX_ITER: PropertySpec(
+            "Maximum number of iterations for t-SNE optimization",
+            context=True,
+            strict_validation=True,
+            default=250,
+            element_validator=_is_positive_int,
+            match_guard=_is_positive_int,
+        ),
+        TSNE_N_ITER_WITHOUT_PROGRESS: PropertySpec(
+            "Maximum iterations without progress before early stopping (t-SNE)",
+            context=True,
+            strict_validation=True,
+            default=50,
+            element_validator=_is_positive_int,
+            match_guard=_is_positive_int,
+        ),
+        TSNE_METHOD: PropertySpec(
+            "t-SNE computation method",
+            allowed_values={
                 "barnes_hut": "Barnes-Hut approximation (faster, O(n log n))",
                 "exact": "Exact method (slower, O(n^2))",
             },
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.default: "barnes_hut",
-        },
+            context=True,
+            strict_validation=True,
+            default="barnes_hut",
+        ),
         # PCA specific parameters
-        PCA_SVD_SOLVER: {
-            "explanation": "SVD solver algorithm for PCA",
-            DefaultOptionKeys.allowed_values: {
+        PCA_SVD_SOLVER: PropertySpec(
+            "SVD solver algorithm for PCA",
+            allowed_values={
                 "auto": "Automatically choose solver based on data shape",
                 "full": "Full SVD using LAPACK",
                 "arpack": "Truncated SVD using ARPACK",
                 "randomized": "Randomized SVD",
             },
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.default: "auto",
-        },
+            context=True,
+            strict_validation=True,
+            default="auto",
+        ),
         # ICA specific parameters
-        ICA_MAX_ITER: {
-            "explanation": "Maximum number of iterations for ICA",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.default: 200,
-            DefaultOptionKeys.element_validator: lambda value: (
-                isinstance(value, (int, str)) and str(value).isdigit() and int(value) > 0
-            ),
-        },
+        ICA_MAX_ITER: PropertySpec(
+            "Maximum number of iterations for ICA",
+            context=True,
+            strict_validation=True,
+            default=200,
+            element_validator=_is_positive_int,
+            match_guard=_is_positive_int,
+        ),
         # Isomap specific parameters
-        ISOMAP_N_NEIGHBORS: {
-            "explanation": "Number of neighbors for Isomap",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.default: 5,
-            DefaultOptionKeys.element_validator: lambda value: (
-                isinstance(value, (int, str)) and str(value).isdigit() and int(value) > 0
-            ),
-        },
+        ISOMAP_N_NEIGHBORS: PropertySpec(
+            "Number of neighbors for Isomap",
+            context=True,
+            strict_validation=True,
+            default=5,
+            element_validator=_is_positive_int,
+            match_guard=_is_positive_int,
+        ),
     }
 
     @classmethod

--- a/mloda_plugins/feature_group/experimental/dimensionality_reduction/pandas.py
+++ b/mloda_plugins/feature_group/experimental/dimensionality_reduction/pandas.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import Any, TYPE_CHECKING, cast
 
-from mloda.provider import ComputeFramework, DefaultOptionKeys
+from mloda.provider import ComputeFramework
 from mloda.user.pandas import PandasDataFrame
 from mloda_plugins.feature_group.experimental.dimensionality_reduction.base import DimensionalityReductionFeatureGroup
 
@@ -143,35 +143,35 @@ class PandasDimensionalityReductionFeatureGroup(DimensionalityReductionFeatureGr
             if svd_solver is None:
                 svd_solver = DimensionalityReductionFeatureGroup.PROPERTY_MAPPING[
                     DimensionalityReductionFeatureGroup.PCA_SVD_SOLVER
-                ][DefaultOptionKeys.default]
+                ].default
             return cls._perform_pca_reduction(X_scaled, dimension, svd_solver)
         elif algorithm == "tsne":
             max_iter_val = options.get(DimensionalityReductionFeatureGroup.TSNE_MAX_ITER)
             if max_iter_val is None:
                 max_iter_val = DimensionalityReductionFeatureGroup.PROPERTY_MAPPING[
                     DimensionalityReductionFeatureGroup.TSNE_MAX_ITER
-                ][DefaultOptionKeys.default]
+                ].default
             max_iter = int(max_iter_val)
 
             n_iter_without_progress_val = options.get(DimensionalityReductionFeatureGroup.TSNE_N_ITER_WITHOUT_PROGRESS)
             if n_iter_without_progress_val is None:
                 n_iter_without_progress_val = DimensionalityReductionFeatureGroup.PROPERTY_MAPPING[
                     DimensionalityReductionFeatureGroup.TSNE_N_ITER_WITHOUT_PROGRESS
-                ][DefaultOptionKeys.default]
+                ].default
             n_iter_without_progress = int(n_iter_without_progress_val)
 
             method = options.get(DimensionalityReductionFeatureGroup.TSNE_METHOD)
             if method is None:
                 method = DimensionalityReductionFeatureGroup.PROPERTY_MAPPING[
                     DimensionalityReductionFeatureGroup.TSNE_METHOD
-                ][DefaultOptionKeys.default]
+                ].default
             return cls._perform_tsne_reduction(X_scaled, dimension, max_iter, n_iter_without_progress, method)
         elif algorithm == "ica":
             max_iter_val = options.get(DimensionalityReductionFeatureGroup.ICA_MAX_ITER)
             if max_iter_val is None:
                 max_iter_val = DimensionalityReductionFeatureGroup.PROPERTY_MAPPING[
                     DimensionalityReductionFeatureGroup.ICA_MAX_ITER
-                ][DefaultOptionKeys.default]
+                ].default
             max_iter = int(max_iter_val)
             return cls._perform_ica_reduction(X_scaled, dimension, max_iter)
         elif algorithm == "lda":
@@ -181,7 +181,7 @@ class PandasDimensionalityReductionFeatureGroup(DimensionalityReductionFeatureGr
             if n_neighbors_val is None:
                 n_neighbors_val = DimensionalityReductionFeatureGroup.PROPERTY_MAPPING[
                     DimensionalityReductionFeatureGroup.ISOMAP_N_NEIGHBORS
-                ][DefaultOptionKeys.default]
+                ].default
             n_neighbors = int(n_neighbors_val)
             return cls._perform_isomap_reduction(X_scaled, dimension, n_neighbors)
         else:

--- a/mloda_plugins/feature_group/experimental/forecasting/base.py
+++ b/mloda_plugins/feature_group/experimental/forecasting/base.py
@@ -14,8 +14,14 @@ from mloda.provider import CHAIN_SEPARATOR, FeatureChainParser, FeatureChainPars
 from mloda.user import FeatureName
 from mloda.user import Options
 from mloda.provider import DefaultOptionKeys
+from mloda.provider import PropertySpec
 from mloda_plugins.feature_group.experimental.forecasting.forecasting_artifact import ForecastingArtifact
 from mloda_plugins.feature_group.experimental.time_reference_mixin import TimeReferenceMixin
+
+
+def _is_bool(value: Any) -> bool:
+    """Accept only a real bool, so 1 or "true" is rejected rather than silently coerced."""
+    return isinstance(value, bool)
 
 
 class ForecastingFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, FeatureGroup):
@@ -125,36 +131,40 @@ class ForecastingFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featu
 
     # Property mapping for configuration-based features with group/context separation
     PROPERTY_MAPPING = {
-        ALGORITHM: {
-            DefaultOptionKeys.allowed_values: FORECASTING_ALGORITHMS,
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-        },
-        HORIZON: {
-            "explanation": "Forecast horizon (number of time units to predict)",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.element_validator: lambda x: (
-                (isinstance(x, int) or (isinstance(x, str) and x.isdigit())) and int(x) > 0
-            ),
-        },
-        TIME_UNIT: {
-            DefaultOptionKeys.allowed_values: TimeReferenceMixin.TIME_UNITS,
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-        },
-        DefaultOptionKeys.in_features: {
-            "explanation": "Source feature to generate forecasts for",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-        },
-        OUTPUT_CONFIDENCE_INTERVALS: {
-            "explanation": "Whether to output confidence intervals as separate columns using ~lower and ~upper suffix pattern",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.default: False,  # Default is False (don't output confidence intervals)
-            DefaultOptionKeys.element_validator: lambda value: isinstance(value, bool),
-        },
+        ALGORITHM: PropertySpec(
+            "Forecasting algorithm to use",
+            allowed_values=FORECASTING_ALGORITHMS,
+            context=True,
+            strict_validation=True,
+        ),
+        HORIZON: PropertySpec(
+            "Forecast horizon (number of time units to predict)",
+            context=True,
+            strict_validation=True,
+            element_validator=lambda x: (isinstance(x, int) or (isinstance(x, str) and x.isdigit())) and int(x) > 0,
+        ),
+        TIME_UNIT: PropertySpec(
+            "Time unit of the forecast horizon",
+            allowed_values=TimeReferenceMixin.TIME_UNITS,
+            context=True,
+            strict_validation=True,
+        ),
+        DefaultOptionKeys.in_features: PropertySpec(
+            "Source feature to generate forecasts for",
+            context=True,
+            strict_validation=False,
+        ),
+        # Both hooks share _is_bool. element_validator produces the rejection message and checks the
+        # declared default at construction; it runs on BOTH match paths, so it alone enforces the
+        # value space. match_guard additionally judges the raw, un-unpacked value.
+        OUTPUT_CONFIDENCE_INTERVALS: PropertySpec(
+            "Whether to output confidence intervals as separate columns using ~lower and ~upper suffix pattern",
+            context=True,
+            strict_validation=True,
+            default=False,
+            element_validator=_is_bool,
+            match_guard=_is_bool,
+        ),
     }
 
     @staticmethod

--- a/mloda_plugins/feature_group/experimental/geo_distance/base.py
+++ b/mloda_plugins/feature_group/experimental/geo_distance/base.py
@@ -17,6 +17,7 @@ from mloda.provider import (
     FeatureChainParserMixin,
 )
 from mloda.provider import DefaultOptionKeys
+from mloda.provider import PropertySpec
 
 
 class GeoDistanceFeatureGroup(FeatureChainParserMixin, FeatureGroup):
@@ -103,19 +104,20 @@ class GeoDistanceFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 
     # Property mapping for configuration-based features with group/context separation
     PROPERTY_MAPPING = {
-        DISTANCE_TYPE: {
-            DefaultOptionKeys.allowed_values: DISTANCE_TYPES,
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-        },
-        DefaultOptionKeys.in_features: {
-            "explanation": "Source features (exactly 2 point features required)",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
+        DISTANCE_TYPE: PropertySpec(
+            "Type of distance calculation to perform",
+            allowed_values=DISTANCE_TYPES,
+            context=True,
+            strict_validation=True,
+        ),
+        DefaultOptionKeys.in_features: PropertySpec(
+            "Source features (exactly 2 point features required)",
+            context=True,
+            strict_validation=True,
             # Core unpacks the sequence, so this judges ONE point feature name.
             # The arity (exactly 2) is enforced by MIN_IN_FEATURES / MAX_IN_FEATURES.
-            DefaultOptionKeys.element_validator: lambda point: isinstance(point, str),
-        },
+            element_validator=lambda point: isinstance(point, str),
+        ),
     }
 
     def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:

--- a/mloda_plugins/feature_group/experimental/node_centrality/base.py
+++ b/mloda_plugins/feature_group/experimental/node_centrality/base.py
@@ -15,6 +15,7 @@ from mloda.provider import (
 )
 from mloda.provider import FeatureSet
 from mloda.provider import DefaultOptionKeys
+from mloda.provider import PropertySpec
 
 
 class NodeCentralityFeatureGroup(FeatureChainParserMixin, FeatureGroup):
@@ -140,28 +141,30 @@ class NodeCentralityFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     # Property mapping for configuration-based feature creation
     PROPERTY_MAPPING = {
         # Context parameters (don't affect Feature Group resolution)
-        CENTRALITY_TYPE: {
-            DefaultOptionKeys.allowed_values: CENTRALITY_TYPES,
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-        },
-        GRAPH_TYPE: {
-            DefaultOptionKeys.allowed_values: GRAPH_TYPES,
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.default: "undirected",
-        },
-        WEIGHT_COLUMN: {
-            "explanation": "Column name for edge weights (optional)",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.default: None,
-        },
-        DefaultOptionKeys.in_features: {
-            "explanation": "Source feature representing the nodes for centrality calculation",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-        },
+        CENTRALITY_TYPE: PropertySpec(
+            "Centrality metric to calculate",
+            allowed_values=CENTRALITY_TYPES,
+            context=True,
+            strict_validation=True,
+        ),
+        GRAPH_TYPE: PropertySpec(
+            "Type of graph (directed or undirected)",
+            allowed_values=GRAPH_TYPES,
+            context=True,
+            strict_validation=True,
+            default="undirected",
+        ),
+        WEIGHT_COLUMN: PropertySpec(
+            "Column name for edge weights (optional)",
+            context=True,
+            strict_validation=False,
+            default=None,  # Optional: no default weight column (unweighted)
+        ),
+        DefaultOptionKeys.in_features: PropertySpec(
+            "Source feature representing the nodes for centrality calculation",
+            context=True,
+            strict_validation=False,
+        ),
     }
 
     @classmethod

--- a/mloda_plugins/feature_group/experimental/sklearn/encoding/base.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/encoding/base.py
@@ -19,6 +19,7 @@ from mloda.provider import (
 )
 from mloda.provider import BaseArtifact
 from mloda.provider import DefaultOptionKeys
+from mloda.provider import PropertySpec
 from mloda_plugins.feature_group.experimental.sklearn.sklearn_artifact import SklearnArtifact
 
 
@@ -178,16 +179,17 @@ class EncodingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 
     # Property mapping for new configuration-based approach
     PROPERTY_MAPPING = {
-        ENCODER_TYPE: {
-            DefaultOptionKeys.allowed_values: SUPPORTED_ENCODERS,
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-        },
-        DefaultOptionKeys.in_features: {
-            "explanation": "Source feature to encode",
-            DefaultOptionKeys.context: True,  # Context parameter
-            DefaultOptionKeys.strict_validation: False,  # Flexible validation
-        },
+        ENCODER_TYPE: PropertySpec(
+            "Type of encoder to apply",
+            allowed_values=SUPPORTED_ENCODERS,
+            context=True,
+            strict_validation=True,
+        ),
+        DefaultOptionKeys.in_features: PropertySpec(
+            "Source feature to encode",
+            context=True,
+            strict_validation=False,
+        ),
     }
 
     @staticmethod

--- a/mloda_plugins/feature_group/experimental/sklearn/pipeline/base.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/pipeline/base.py
@@ -19,6 +19,7 @@ from mloda.provider import (
 )
 from mloda.provider import BaseArtifact
 from mloda.provider import DefaultOptionKeys
+from mloda.provider import PropertySpec
 from mloda_plugins.feature_group.experimental.sklearn.sklearn_artifact import SklearnArtifact
 
 
@@ -90,37 +91,34 @@ class SklearnPipelineFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 
     # Property mapping for new configuration-based approach
     PROPERTY_MAPPING = {
-        PIPELINE_NAME: {
-            DefaultOptionKeys.allowed_values: PIPELINE_TYPES,
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.default: None,
+        PIPELINE_NAME: PropertySpec(
+            "Name of the predefined pipeline type to apply",
+            allowed_values=PIPELINE_TYPES,
+            context=True,
+            strict_validation=True,
+            default=None,  # Optional: pipeline_steps is the alternative
             # Required only when the other is absent.
-            DefaultOptionKeys.required_when: (
-                lambda options: options.get(SklearnPipelineFeatureGroup.PIPELINE_STEPS) is None
-            ),
-        },
-        PIPELINE_STEPS: {
-            "explanation": "List of pipeline steps as (name, transformer) tuples",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.default: None,  # Default is None as pipeline_types also work
+            required_when=(lambda options: options.get(SklearnPipelineFeatureGroup.PIPELINE_STEPS) is None),
+        ),
+        PIPELINE_STEPS: PropertySpec(
+            "List of pipeline steps as (name, transformer) tuples",
+            context=True,
+            strict_validation=False,
+            default=None,  # Optional: pipeline_name is the alternative
             # Required only when the other is absent.
-            DefaultOptionKeys.required_when: (
-                lambda options: options.get(SklearnPipelineFeatureGroup.PIPELINE_NAME) is None
-            ),
-        },
-        PIPELINE_PARAMS: {
-            "explanation": "Pipeline parameters dictionary",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.default: None,  # Default is None as pipeline_types also work
-        },
-        DefaultOptionKeys.in_features: {
-            "explanation": "Source features for sklearn pipeline (comma-separated)",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-        },
+            required_when=(lambda options: options.get(SklearnPipelineFeatureGroup.PIPELINE_NAME) is None),
+        ),
+        PIPELINE_PARAMS: PropertySpec(
+            "Pipeline parameters dictionary",
+            context=True,
+            strict_validation=False,
+            default=None,  # Optional: pipeline_types also work
+        ),
+        DefaultOptionKeys.in_features: PropertySpec(
+            "Source features for sklearn pipeline (comma-separated)",
+            context=True,
+            strict_validation=False,
+        ),
     }
 
     PREFIX_PATTERN = r".*__sklearn_pipeline_([\w]+)$"

--- a/mloda_plugins/feature_group/experimental/sklearn/scaling/base.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/scaling/base.py
@@ -17,6 +17,7 @@ from mloda.provider import (
 )
 from mloda.provider import BaseArtifact
 from mloda.provider import DefaultOptionKeys
+from mloda.provider import PropertySpec
 from mloda_plugins.feature_group.experimental.sklearn.sklearn_artifact import SklearnArtifact
 
 
@@ -88,16 +89,17 @@ class ScalingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 
     # Property mapping for new configuration-based approach
     PROPERTY_MAPPING = {
-        SCALER_TYPE: {
-            DefaultOptionKeys.allowed_values: SUPPORTED_SCALERS,
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-        },
-        DefaultOptionKeys.in_features: {
-            "explanation": "Source feature to scale",
-            DefaultOptionKeys.context: True,  # Context parameter
-            DefaultOptionKeys.strict_validation: False,  # Flexible validation
-        },
+        SCALER_TYPE: PropertySpec(
+            "Type of scaler to apply",
+            allowed_values=SUPPORTED_SCALERS,
+            context=True,
+            strict_validation=True,
+        ),
+        DefaultOptionKeys.in_features: PropertySpec(
+            "Source feature to scale",
+            context=True,
+            strict_validation=False,
+        ),
     }
 
     @staticmethod

--- a/mloda_plugins/feature_group/experimental/text_cleaning/base.py
+++ b/mloda_plugins/feature_group/experimental/text_cleaning/base.py
@@ -15,6 +15,7 @@ from mloda.provider import (
 )
 from mloda.provider import FeatureSet
 from mloda.provider import DefaultOptionKeys
+from mloda.provider import PropertySpec
 
 
 class TextCleaningFeatureGroup(FeatureChainParserMixin, FeatureGroup):
@@ -92,18 +93,19 @@ class TextCleaningFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 
     # Property mapping for configuration-based features
     PROPERTY_MAPPING = {
-        CLEANING_OPERATIONS: {
-            DefaultOptionKeys.allowed_values: SUPPORTED_OPERATIONS,
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
+        CLEANING_OPERATIONS: PropertySpec(
+            "Sequence of text cleaning operations to apply",
+            allowed_values=SUPPORTED_OPERATIONS,
+            context=True,
+            strict_validation=True,
             # The option is a sequence of operations; core unpacks it, so this judges ONE operation.
-            DefaultOptionKeys.element_validator: lambda op: op in TextCleaningFeatureGroup.SUPPORTED_OPERATIONS,
-        },
-        DefaultOptionKeys.in_features: {
-            "explanation": "Source feature to apply text cleaning operations to",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-        },
+            element_validator=lambda op: op in TextCleaningFeatureGroup.SUPPORTED_OPERATIONS,
+        ),
+        DefaultOptionKeys.in_features: PropertySpec(
+            "Source feature to apply text cleaning operations to",
+            context=True,
+            strict_validation=False,
+        ),
     }
 
     @classmethod

--- a/mloda_plugins/feature_group/experimental/time_window/base.py
+++ b/mloda_plugins/feature_group/experimental/time_window/base.py
@@ -17,6 +17,7 @@ from mloda.user import FeatureName
 from mloda.provider import FeatureSet
 from mloda.user import Options
 from mloda.provider import DefaultOptionKeys
+from mloda.provider import PropertySpec
 from mloda_plugins.feature_group.experimental.time_reference_mixin import TimeReferenceMixin
 
 
@@ -93,33 +94,31 @@ class TimeWindowFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featur
 
     # Define PROPERTY_MAPPING for the new unified parser approach
     PROPERTY_MAPPING = {
-        # Window function parameter (context parameter)
-        WINDOW_FUNCTION: {
-            DefaultOptionKeys.allowed_values: WINDOW_FUNCTIONS,
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-        },
-        # Window size parameter (context parameter)
-        WINDOW_SIZE: {
-            "explanation": "Size of the time window (must be positive integer)",
-            DefaultOptionKeys.context: True,  # Mark as context parameter
-            DefaultOptionKeys.strict_validation: True,  # Enable strict validation
-            DefaultOptionKeys.element_validator: lambda x: (
+        WINDOW_FUNCTION: PropertySpec(
+            "Window function to apply over the time window",
+            allowed_values=WINDOW_FUNCTIONS,
+            context=True,
+            strict_validation=True,
+        ),
+        WINDOW_SIZE: PropertySpec(
+            "Size of the time window (must be positive integer)",
+            context=True,
+            strict_validation=True,
+            element_validator=lambda x: (
                 (isinstance(x, int) and x > 0) or (isinstance(x, str) and x.isdigit() and int(x) > 0)
             ),
-        },
-        # Time unit parameter (context parameter)
-        TIME_UNIT: {
-            DefaultOptionKeys.allowed_values: TimeReferenceMixin.TIME_UNITS,
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-        },
-        # Source feature parameter (context parameter)
-        DefaultOptionKeys.in_features: {
-            "explanation": "Source feature to apply time window operation to",
-            DefaultOptionKeys.context: True,  # Mark as context parameter
-            DefaultOptionKeys.strict_validation: False,  # Flexible validation
-        },
+        ),
+        TIME_UNIT: PropertySpec(
+            "Time unit of the window size",
+            allowed_values=TimeReferenceMixin.TIME_UNITS,
+            context=True,
+            strict_validation=True,
+        ),
+        DefaultOptionKeys.in_features: PropertySpec(
+            "Source feature to apply time window operation to",
+            context=True,
+            strict_validation=False,
+        ),
     }
 
     # Define the regex pattern for this feature group

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_feature_chain_parser_mixin.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_feature_chain_parser_mixin.py
@@ -10,7 +10,7 @@ from mloda.user import Options
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import (
     FeatureChainParserMixin,
 )
-from mloda.provider import DefaultOptionKeys
+from mloda.provider import DefaultOptionKeys, PropertySpec
 
 
 class MockFeatureGroup(FeatureChainParserMixin):
@@ -18,11 +18,12 @@ class MockFeatureGroup(FeatureChainParserMixin):
 
     PREFIX_PATTERN = r".*__([\w]+)_test$"
     PROPERTY_MAPPING = {
-        "operation": {
-            DefaultOptionKeys.allowed_values: {"op1": "Operation 1", "op2": "Operation 2"},
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-        }
+        "operation": PropertySpec(
+            "Operation to apply",
+            allowed_values={"op1": "Operation 1", "op2": "Operation 2"},
+            context=True,
+            strict_validation=True,
+        )
     }
 
 
@@ -32,11 +33,12 @@ class MockFeatureGroupCustomSeparator(FeatureChainParserMixin):
     PREFIX_PATTERN = r".*__([\w]+)_test$"
     IN_FEATURE_SEPARATOR = ","
     PROPERTY_MAPPING = {
-        "operation": {
-            DefaultOptionKeys.allowed_values: {"op1": "Operation 1", "op2": "Operation 2"},
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-        }
+        "operation": PropertySpec(
+            "Operation to apply",
+            allowed_values={"op1": "Operation 1", "op2": "Operation 2"},
+            context=True,
+            strict_validation=True,
+        )
     }
 
 
@@ -47,11 +49,12 @@ class MockFeatureGroupWithMinMax(FeatureChainParserMixin):
     MIN_IN_FEATURES = 2
     MAX_IN_FEATURES = 3
     PROPERTY_MAPPING = {
-        "operation": {
-            DefaultOptionKeys.allowed_values: {"op1": "Operation 1"},
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-        }
+        "operation": PropertySpec(
+            "Operation to apply",
+            allowed_values={"op1": "Operation 1"},
+            context=True,
+            strict_validation=True,
+        )
     }
 
 
@@ -62,11 +65,12 @@ class MockFeatureGroupSingleInFeature(FeatureChainParserMixin):
     MIN_IN_FEATURES = 1
     MAX_IN_FEATURES = 1
     PROPERTY_MAPPING = {
-        "operation": {
-            DefaultOptionKeys.allowed_values: {"op1": "Operation 1"},
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-        }
+        "operation": PropertySpec(
+            "Operation to apply",
+            allowed_values={"op1": "Operation 1"},
+            context=True,
+            strict_validation=True,
+        )
     }
 
 
@@ -87,11 +91,12 @@ class MockFeatureGroupWithoutMinMax(FeatureChainParserMixin):
     MIN_IN_FEATURES = _HiddenAttribute()  # type: ignore[assignment]
     MAX_IN_FEATURES = _HiddenAttribute()
     PROPERTY_MAPPING = {
-        "operation": {
-            DefaultOptionKeys.allowed_values: {"op1": "Operation 1"},
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-        }
+        "operation": PropertySpec(
+            "Operation to apply",
+            allowed_values={"op1": "Operation 1"},
+            context=True,
+            strict_validation=True,
+        )
     }
 
 
@@ -100,11 +105,12 @@ class MockFeatureGroupWithValidationHook(FeatureChainParserMixin):
 
     PREFIX_PATTERN = r".*__([\w]+)_test$"
     PROPERTY_MAPPING = {
-        "operation": {
-            DefaultOptionKeys.allowed_values: {"op1": "Operation 1"},
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-        }
+        "operation": PropertySpec(
+            "Operation to apply",
+            allowed_values={"op1": "Operation 1"},
+            context=True,
+            strict_validation=True,
+        )
     }
 
     @classmethod
@@ -503,11 +509,11 @@ class TestFeatureChainParserMixinListValuedOptions:
 
         class ListValuedFeatureGroup(FeatureChainParserMixin):
             PROPERTY_MAPPING = {
-                "partition_by": {
-                    "explanation": "List of columns to partition by",
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: False,
-                },
+                "partition_by": PropertySpec(
+                    "List of columns to partition by",
+                    context=True,
+                    strict_validation=False,
+                ),
             }
 
         options = Options(context={"partition_by": ["region", "category"]})
@@ -519,11 +525,11 @@ class TestFeatureChainParserMixinListValuedOptions:
 
         class TupleValuedFeatureGroup(FeatureChainParserMixin):
             PROPERTY_MAPPING = {
-                "partition_by": {
-                    "explanation": "Columns to partition by",
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: False,
-                },
+                "partition_by": PropertySpec(
+                    "Columns to partition by",
+                    context=True,
+                    strict_validation=False,
+                ),
             }
 
         options = Options(context={"partition_by": ("region", "category")})
@@ -535,10 +541,11 @@ class TestFeatureChainParserMixinListValuedOptions:
         from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 
         property_mapping = {
-            "partition_by": {
-                DefaultOptionKeys.context: True,
-                DefaultOptionKeys.strict_validation: False,
-            },
+            "partition_by": PropertySpec(
+                "Columns to partition by",
+                context=True,
+                strict_validation=False,
+            ),
         }
         options = Options(context={"partition_by": ["col1", "col2", "col3"]})
         result = FeatureChainParser._validate_options_against_property_mapping(options, property_mapping)

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_name_path_validates_option_values.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_name_path_validates_option_values.py
@@ -10,13 +10,13 @@ from typing import Any
 
 import pytest
 
-from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import (
     FeatureChainParser,
 )
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import (
     FeatureChainParserMixin,
 )
+from mloda.core.abstract_plugins.components.feature_chainer.property_spec import PropertySpec
 from mloda.core.abstract_plugins.components.options import Options
 
 
@@ -35,31 +35,34 @@ class NamePathFeatureGroup(FeatureChainParserMixin):
 
     PREFIX_PATTERN = r".*__([\w]+)_(\d+)d$"
 
-    PROPERTY_MAPPING: dict[str, dict[Any, Any]] = {
-        "algorithm": {
-            DefaultOptionKeys.allowed_values: {"pca": "PCA", "tsne": "t-SNE"},
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-        },
-        "solver": {
-            "explanation": "strict, allowed_values, never encoded in the name",
-            DefaultOptionKeys.allowed_values: {"auto": "Auto", "arpack": "ARPACK"},
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.default: "auto",
-        },
-        "size": {
-            "explanation": "strict, element_validator, never encoded in the name",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.element_validator: _is_positive_int,
-        },
-        "notes": {
-            "explanation": "non-strict, so no value space is enforced",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.default: "",
-        },
+    PROPERTY_MAPPING: dict[str, PropertySpec] = {
+        # No declared default: the key is REQUIRED on the config path.
+        "algorithm": PropertySpec(
+            "strict, allowed_values, encoded in the name",
+            allowed_values={"pca": "PCA", "tsne": "t-SNE"},
+            context=True,
+            strict_validation=True,
+        ),
+        "solver": PropertySpec(
+            "strict, allowed_values, never encoded in the name",
+            allowed_values={"auto": "Auto", "arpack": "ARPACK"},
+            context=True,
+            strict_validation=True,
+            default="auto",
+        ),
+        # No declared default: the key is REQUIRED on the config path.
+        "size": PropertySpec(
+            "strict, element_validator, never encoded in the name",
+            context=True,
+            strict_validation=True,
+            element_validator=_is_positive_int,
+        ),
+        "notes": PropertySpec(
+            "non-strict, so no value space is enforced",
+            context=True,
+            strict_validation=False,
+            default="",
+        ),
     }
 
 
@@ -68,13 +71,13 @@ class GuardedNamePathFeatureGroup(FeatureChainParserMixin):
 
     PREFIX_PATTERN = r".*__([\w]+)_guarded$"
 
-    PROPERTY_MAPPING: dict[str, dict[Any, Any]] = {
-        "columns": {
-            "explanation": "guarded, non-strict: the guard sees the raw whole value",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.match_guard: _is_list_of_str,
-        }
+    PROPERTY_MAPPING: dict[str, PropertySpec] = {
+        "columns": PropertySpec(
+            "guarded, non-strict: the guard sees the raw whole value",
+            context=True,
+            strict_validation=False,
+            match_guard=_is_list_of_str,
+        )
     }
 
 
@@ -83,13 +86,14 @@ class MalformedNameFeatureGroup(FeatureChainParserMixin):
 
     PREFIX_PATTERN = r"^orphan_(\w+)$"
 
-    PROPERTY_MAPPING: dict[str, dict[Any, Any]] = {
-        "solver": {
-            DefaultOptionKeys.allowed_values: {"auto": "Auto", "arpack": "ARPACK"},
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.default: "auto",
-        }
+    PROPERTY_MAPPING: dict[str, PropertySpec] = {
+        "solver": PropertySpec(
+            "strict, allowed_values, with a default",
+            allowed_values={"auto": "Auto", "arpack": "ARPACK"},
+            context=True,
+            strict_validation=True,
+            default="auto",
+        )
     }
 
 

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_option_value_rejection_never_escapes.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_option_value_rejection_never_escapes.py
@@ -21,6 +21,7 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import (
     FeatureChainParserMixin,
 )
+from mloda.core.abstract_plugins.components.feature_chainer.property_spec import PropertySpec
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
@@ -58,12 +59,13 @@ class DirectParserOverrideFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     PREFIX_PATTERN = r".*__esc732_pipeline_([\w]+)$"
 
     PROPERTY_MAPPING = {
-        PIPELINE_KEY: {
-            DefaultOptionKeys.allowed_values: {"scaling": "Scaling", "imputation": "Imputation"},
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.default: None,
-        }
+        PIPELINE_KEY: PropertySpec(
+            "Pipeline to apply (esc732 fixture)",
+            allowed_values={"scaling": "Scaling", "imputation": "Imputation"},
+            context=True,
+            strict_validation=True,
+            default=None,
+        )
     }
 
     @classmethod
@@ -111,17 +113,18 @@ class RaisingTypeErrorValidatorFeatureGroup(FeatureChainParserMixin, FeatureGrou
     PREFIX_PATTERN = r".*__cleaned_esc732$"
 
     PROPERTY_MAPPING = {
-        OPERATIONS_KEY: {
-            DefaultOptionKeys.allowed_values: SUPPORTED_OPERATIONS_ESC732,
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.element_validator: lambda op: op in SUPPORTED_OPERATIONS_ESC732,
-        },
-        DefaultOptionKeys.in_features: {
-            "explanation": "Source feature (esc732 fixture)",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-        },
+        OPERATIONS_KEY: PropertySpec(
+            "Operations to apply (esc732 fixture)",
+            allowed_values=SUPPORTED_OPERATIONS_ESC732,
+            context=True,
+            strict_validation=True,
+            element_validator=lambda op: op in SUPPORTED_OPERATIONS_ESC732,
+        ),
+        DefaultOptionKeys.in_features: PropertySpec(
+            "Source feature (esc732 fixture)",
+            context=True,
+            strict_validation=False,
+        ),
     }
 
     def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
@@ -134,12 +137,12 @@ class RaisingAttributeErrorValidatorFeatureGroup(FeatureChainParserMixin, Featur
     PREFIX_PATTERN = r".*__prefixed_esc732$"
 
     PROPERTY_MAPPING = {
-        PREFIX_KEY: {
-            "explanation": "Value must start with 'ok' (esc732 fixture)",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.element_validator: lambda value: value.startswith("ok"),
-        }
+        PREFIX_KEY: PropertySpec(
+            "Value must start with 'ok' (esc732 fixture)",
+            context=True,
+            strict_validation=True,
+            element_validator=lambda value: value.startswith("ok"),
+        )
     }
 
     def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_allowed_values.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_allowed_values.py
@@ -1,10 +1,10 @@
 """Tests for the allowed_values-aware PROPERTY_MAPPING extractor/validator (issue #543).
 
 PROPERTY_MAPPING specs historically conflated allowed-value->docstring entries,
-``DefaultOptionKeys`` flag keys, and a magic plain-string ``"explanation"`` doc key
-in one namespace. ``FeatureChainParser._extract_property_values`` recovered the
-allowed-value set by subtracting a hardcoded blocklist. This module pins the
-``DefaultOptionKeys.allowed_values`` field that replaced that:
+flag keys, and a magic plain-string ``"explanation"`` doc key in one namespace.
+``FeatureChainParser._extract_property_values`` recovered the allowed-value set by
+subtracting a hardcoded blocklist. This module pins the ``PropertySpec.allowed_values``
+field that replaced that:
 
 * authors DECLARE the accepted values under ``allowed_values``,
 * ``_extract_property_values`` returns exactly that mapping, so both membership
@@ -26,15 +26,13 @@ from typing import Any
 
 import pytest
 
-from mloda.core.abstract_plugins.components.default_options_key import (
-    DefaultOptionKeys,
-)
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import (
     FeatureChainParser,
 )
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import (
     FeatureChainParserMixin,
 )
+from mloda.core.abstract_plugins.components.feature_chainer.property_spec import PropertySpec
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.components.utils import get_all_subclasses
@@ -57,19 +55,6 @@ def _no_feature_group_registry_pollution() -> Any:
     assert not leaked, f"Leaked FeatureGroup subclasses from {__name__}: {[c.__name__ for c in leaked]}"
 
 
-class TestAllowedValuesKey:
-    """``allowed_values`` is the field a spec declares its value space under.
-
-    The completeness of the surrounding key set is the spec SCHEMA now, pinned as
-    ``PROPERTY_SPEC_KEYS`` in ``test_property_mapping_spec_schema.py``.
-    """
-
-    def test_allowed_values_enum_member_exists(self) -> None:
-        """``DefaultOptionKeys.allowed_values`` exists and stringifies to ``allowed_values``."""
-        assert str(DefaultOptionKeys.allowed_values) == "allowed_values"
-        assert DefaultOptionKeys.allowed_values.value == "allowed_values"
-
-
 class TestStrictMembershipViaAllowedValues:
     """Strict membership flows through the explicit ``allowed_values`` field.
 
@@ -84,11 +69,12 @@ class TestStrictMembershipViaAllowedValues:
         class AllowedValuesFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             PREFIX_PATTERN = r".*__([\w]+)_op$"
             PROPERTY_MAPPING = {
-                "operation_type": {
-                    DefaultOptionKeys.allowed_values: {"add": "Addition", "sub": "Subtraction"},
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: True,
-                }
+                "operation_type": PropertySpec(
+                    "Arithmetic operation",
+                    allowed_values={"add": "Addition", "sub": "Subtraction"},
+                    context=True,
+                    strict_validation=True,
+                )
             }
 
             @classmethod
@@ -110,7 +96,11 @@ class TestStrictMembershipViaAllowedValues:
 
 
 class TestClassDefinitionDefaultInvariantHonorsAllowedValues:
-    """The class-definition default invariant reads accepted values from ``allowed_values``."""
+    """The default invariant reads accepted values from ``allowed_values``.
+
+    The invariant fires at ``PropertySpec`` construction, which for a class-level
+    PROPERTY_MAPPING is during class definition: the class body never finishes.
+    """
 
     def test_rejects_strict_default_outside_allowed_values(self) -> None:
         """A strict default outside the ``allowed_values`` set rejects at class definition."""
@@ -119,12 +109,13 @@ class TestClassDefinitionDefaultInvariantHonorsAllowedValues:
             class BadAllowedValuesDefault(FeatureChainParserMixin, FeatureGroup):
                 PREFIX_PATTERN = r".*__([\w]+)_op$"
                 PROPERTY_MAPPING = {
-                    "operation_type": {
-                        DefaultOptionKeys.allowed_values: {"add": "Addition", "sub": "Subtraction"},
-                        DefaultOptionKeys.context: True,
-                        DefaultOptionKeys.strict_validation: True,
-                        DefaultOptionKeys.default: "mul",
-                    }
+                    "operation_type": PropertySpec(
+                        "Arithmetic operation",
+                        allowed_values={"add": "Addition", "sub": "Subtraction"},
+                        context=True,
+                        strict_validation=True,
+                        default="mul",
+                    )
                 }
 
                 @classmethod
@@ -133,11 +124,9 @@ class TestClassDefinitionDefaultInvariantHonorsAllowedValues:
 
         message = str(exc_info.value)
         del exc_info
-        assert "BadAllowedValuesDefault" in message
-        assert "operation_type" in message
+        assert "PropertySpec" in message
         assert "mul" in message
-        assert "add" in message
-        assert "sub" in message
+        assert "allowed_values" in message
 
     def test_accepts_strict_default_in_allowed_values(self) -> None:
         """A strict default inside the ``allowed_values`` set defines without error."""
@@ -145,45 +134,46 @@ class TestClassDefinitionDefaultInvariantHonorsAllowedValues:
         class GoodAllowedValuesDefault(FeatureChainParserMixin, FeatureGroup):
             PREFIX_PATTERN = r".*__([\w]+)_op$"
             PROPERTY_MAPPING = {
-                "operation_type": {
-                    DefaultOptionKeys.allowed_values: {"add": "Addition", "sub": "Subtraction"},
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: True,
-                    DefaultOptionKeys.default: "add",
-                }
+                "operation_type": PropertySpec(
+                    "Arithmetic operation",
+                    allowed_values={"add": "Addition", "sub": "Subtraction"},
+                    context=True,
+                    strict_validation=True,
+                    default="add",
+                )
             }
 
             @classmethod
             def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
                 return data
 
-        assert GoodAllowedValuesDefault.PROPERTY_MAPPING["operation_type"][DefaultOptionKeys.default] == "add"
+        assert GoodAllowedValuesDefault.PROPERTY_MAPPING["operation_type"].default == "add"
 
 
 class TestNoSilentWidening:
-    """An extra top-level doc key is never promoted to an allowed value."""
+    """The spec's documentation text is never promoted to an allowed value."""
 
-    def test_extra_doc_key_not_treated_as_allowed_value(self) -> None:
+    def test_explanation_not_treated_as_allowed_value(self) -> None:
         """When ``allowed_values`` is present, extraction returns exactly that mapping."""
-        spec = {
-            DefaultOptionKeys.allowed_values: {"add": "Addition"},
-            "explanation": "operation_type chooses the arithmetic operation",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-        }
+        spec = PropertySpec(
+            "operation_type chooses the arithmetic operation",
+            allowed_values={"add": "Addition"},
+            context=True,
+            strict_validation=True,
+        )
 
         extracted = FeatureChainParser._extract_property_values(spec)
         assert extracted == {"add": "Addition"}
 
     def test_doc_key_name_rejected_by_strict_validation(self) -> None:
-        """The doc key name (``explanation``) is not a member, so strict validation rejects it."""
+        """The doc field name (``explanation``) is not a member, so strict validation rejects it."""
         property_mapping = {
-            "operation_type": {
-                DefaultOptionKeys.allowed_values: {"add": "Addition"},
-                "explanation": "operation_type chooses the arithmetic operation",
-                DefaultOptionKeys.context: True,
-                DefaultOptionKeys.strict_validation: True,
-            }
+            "operation_type": PropertySpec(
+                "operation_type chooses the arithmetic operation",
+                allowed_values={"add": "Addition"},
+                context=True,
+                strict_validation=True,
+            )
         }
 
         assert (

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_required_when.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_required_when.py
@@ -21,7 +21,7 @@ from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.provider import DataCreator
 from mloda.user import Feature, PluginCollector, mloda
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
-from mloda.provider import DefaultOptionKeys
+from mloda.provider import PropertySpec
 
 
 _ORDER_DEPENDENT = {"first", "last"}
@@ -39,22 +39,23 @@ class MockWithConditionalRequired(FeatureChainParserMixin):
     PREFIX_PATTERN = r".*__([\w]+)_windowed$"
 
     PROPERTY_MAPPING = {
-        "aggregation_type": {
-            DefaultOptionKeys.allowed_values: {
+        "aggregation_type": PropertySpec(
+            "Aggregation to apply",
+            allowed_values={
                 "sum": "Sum of values",
                 "avg": "Average of values",
                 "first": "First value (requires order_by)",
                 "last": "Last value (requires order_by)",
             },
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-        },
-        "order_by": {
-            "explanation": "Column to order by within each partition",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.required_when: _needs_order_by,
-        },
+            context=True,
+            strict_validation=True,
+        ),
+        "order_by": PropertySpec(
+            "Column to order by within each partition",
+            context=True,
+            strict_validation=False,
+            required_when=_needs_order_by,
+        ),
     }
 
 
@@ -86,73 +87,66 @@ class TestRequiredWhenUnit:
         assert result is True
 
     def test_extract_property_values_strips_required_when(self) -> None:
-        """required_when callable must be stripped from extracted property values."""
-        mapping_entry = {
-            "explanation": "Column to order by within each partition",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.required_when: _needs_order_by,
-        }
+        """required_when is spec metadata and never leaks into the extracted value space."""
+        mapping_entry = PropertySpec(
+            "Column to order by within each partition",
+            context=True,
+            strict_validation=False,
+            required_when=_needs_order_by,
+        )
         extracted = FeatureChainParser._extract_property_values(mapping_entry)
-        assert DefaultOptionKeys.required_when not in extracted
-        assert "explanation" not in extracted
+        assert extracted == {}
 
     def test_extract_property_values_strips_explanation(self) -> None:
-        """'explanation' is documentation metadata and must be stripped from extracted property values."""
-        mapping_entry = {
-            "explanation": "Column to order by within each partition",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-        }
+        """The explanation is documentation metadata and never leaks into the extracted value space."""
+        mapping_entry = PropertySpec(
+            "Column to order by within each partition",
+            context=True,
+            strict_validation=False,
+        )
         extracted = FeatureChainParser._extract_property_values(mapping_entry)
-        assert "explanation" not in extracted
+        assert extracted == {}
 
     def test_can_skip_required_check_with_required_when(self) -> None:
         """Properties with required_when should be skippable in the base required check."""
-        prop_with_required_when = {
-            "explanation": "test",
-            DefaultOptionKeys.required_when: _needs_order_by,
-        }
+        prop_with_required_when = PropertySpec(
+            "test",
+            context=False,
+            required_when=_needs_order_by,
+        )
         assert FeatureChainParser._can_skip_required_check(prop_with_required_when) is True
 
     def test_can_skip_required_check_with_default(self) -> None:
         """Properties with default should be skippable in the base required check."""
-        prop_with_default = {
-            "val1": "desc",
-            DefaultOptionKeys.default: "val1",
-        }
+        prop_with_default = PropertySpec(
+            "Value with a default",
+            allowed_values={"val1": "desc"},
+            default="val1",
+            context=False,
+        )
         assert FeatureChainParser._can_skip_required_check(prop_with_default) is True
 
     def test_can_skip_required_check_without_either(self) -> None:
         """Properties without default or required_when are required."""
-        prop_required = {
-            "val1": "desc",
-            DefaultOptionKeys.strict_validation: True,
-        }
+        prop_required = PropertySpec(
+            "Value without default",
+            allowed_values={"val1": "desc"},
+            context=False,
+            strict_validation=True,
+        )
         assert FeatureChainParser._can_skip_required_check(prop_required) is False
 
-    def test_non_callable_required_when_is_skipped(self) -> None:
-        """A non-callable required_when value should not crash; the option is treated as optional."""
-
-        class MockWithBadPredicate(FeatureChainParserMixin):
-            PREFIX_PATTERN = r".*__([\w]+)_windowed$"
-            PROPERTY_MAPPING = {
-                "aggregation_type": {
-                    DefaultOptionKeys.allowed_values: {"sum": "Sum"},
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: True,
-                },
-                "order_by": {
-                    "explanation": "sort column",
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: False,
-                    DefaultOptionKeys.required_when: "not_a_callable",
-                },
-            }
-
-        options = Options(context={"aggregation_type": "sum"})
-        result = MockWithBadPredicate.match_feature_group_criteria("my_feature", options)
-        assert result is True
+    def test_non_callable_required_when_rejected_at_construction(self) -> None:
+        """A non-callable required_when is rejected when the spec is built, so a
+        mapping can never carry one (the old parser-level tolerance is gone)."""
+        not_callable: Any = "not_a_callable"
+        with pytest.raises(ValueError, match="required_when must be callable"):
+            PropertySpec(
+                "sort column",
+                context=True,
+                strict_validation=False,
+                required_when=not_callable,
+            )
 
     def test_required_when_with_default_value_interaction(self) -> None:
         """When a property has both required_when and default, default takes effect in base parser.
@@ -167,18 +161,19 @@ class TestRequiredWhenUnit:
         class MockWithBothDefaultAndRequiredWhen(FeatureChainParserMixin):
             PREFIX_PATTERN = r".*__([\w]+)_windowed$"
             PROPERTY_MAPPING = {
-                "aggregation_type": {
-                    DefaultOptionKeys.allowed_values: {"sum": "Sum", "first": "First"},
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: True,
-                },
-                "order_by": {
-                    "explanation": "sort column",
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: False,
-                    DefaultOptionKeys.default: "id",
-                    DefaultOptionKeys.required_when: _always_required,
-                },
+                "aggregation_type": PropertySpec(
+                    "Aggregation to apply",
+                    allowed_values={"sum": "Sum", "first": "First"},
+                    context=True,
+                    strict_validation=True,
+                ),
+                "order_by": PropertySpec(
+                    "sort column",
+                    context=True,
+                    strict_validation=False,
+                    default="id",
+                    required_when=_always_required,
+                ),
             }
 
         # The property has a default, but required_when predicate always returns True.
@@ -255,17 +250,18 @@ class ConditionalRequiredFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     PREFIX_PATTERN = r".*__([\w]+)_windowed$"
 
     PROPERTY_MAPPING = {
-        "aggregation_type": {
-            DefaultOptionKeys.allowed_values: {"sum": "Sum of values", "first": "First value (requires order_by)"},
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-        },
-        "order_by": {
-            "explanation": "Column to order by within each partition",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.required_when: _run_all_needs_order_by,
-        },
+        "aggregation_type": PropertySpec(
+            "Aggregation to apply",
+            allowed_values={"sum": "Sum of values", "first": "First value (requires order_by)"},
+            context=True,
+            strict_validation=True,
+        ),
+        "order_by": PropertySpec(
+            "Column to order by within each partition",
+            context=True,
+            strict_validation=False,
+            required_when=_run_all_needs_order_by,
+        ),
     }
 
     @classmethod

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_sequence_unpacking.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_sequence_unpacking.py
@@ -23,7 +23,7 @@ import pytest
 
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
 from mloda.core.abstract_plugins.components.options import Options
-from mloda.provider import DefaultOptionKeys
+from mloda.provider import PropertySpec
 
 
 class _Recorder:
@@ -43,12 +43,12 @@ def _strict_element_validator_group(validator: Any) -> type[FeatureChainParserMi
 
     class ElementFeatureGroup(FeatureChainParserMixin):
         PROPERTY_MAPPING = {
-            "ops": {
-                "explanation": "Operations to apply",
-                DefaultOptionKeys.context: True,
-                DefaultOptionKeys.strict_validation: True,
-                DefaultOptionKeys.element_validator: validator,
-            }
+            "ops": PropertySpec(
+                "Operations to apply",
+                context=True,
+                strict_validation=True,
+                element_validator=validator,
+            )
         }
 
     return ElementFeatureGroup
@@ -59,12 +59,12 @@ def _strict_membership_group() -> type[FeatureChainParserMixin]:
 
     class MembershipFeatureGroup(FeatureChainParserMixin):
         PROPERTY_MAPPING = {
-            "ops": {
-                "explanation": "Operations to apply",
-                DefaultOptionKeys.allowed_values: {"a": "A", "b": "B"},
-                DefaultOptionKeys.context: True,
-                DefaultOptionKeys.strict_validation: True,
-            }
+            "ops": PropertySpec(
+                "Operations to apply",
+                allowed_values={"a": "A", "b": "B"},
+                context=True,
+                strict_validation=True,
+            )
         }
 
     return MembershipFeatureGroup
@@ -75,12 +75,12 @@ def _match_guard_group(guard: Any) -> type[FeatureChainParserMixin]:
 
     class GuardedFeatureGroup(FeatureChainParserMixin):
         PROPERTY_MAPPING = {
-            "ops": {
-                "explanation": "Operations to apply",
-                DefaultOptionKeys.context: True,
-                DefaultOptionKeys.strict_validation: False,
-                DefaultOptionKeys.match_guard: guard,
-            }
+            "ops": PropertySpec(
+                "Operations to apply",
+                context=True,
+                strict_validation=False,
+                match_guard=guard,
+            )
         }
 
     return GuardedFeatureGroup
@@ -271,13 +271,13 @@ class TestMatchGuardSeesTheRawValue:
 
         class BothFeatureGroup(FeatureChainParserMixin):
             PROPERTY_MAPPING = {
-                "ops": {
-                    "explanation": "Operations to apply",
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: True,
-                    DefaultOptionKeys.element_validator: validator,
-                    DefaultOptionKeys.match_guard: guard,
-                }
+                "ops": PropertySpec(
+                    "Operations to apply",
+                    context=True,
+                    strict_validation=True,
+                    element_validator=validator,
+                    match_guard=guard,
+                )
             }
 
         value = ("a", "b")

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_spec_schema.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_spec_schema.py
@@ -1,575 +1,112 @@
-"""A PROPERTY_MAPPING spec has a SCHEMA: unknown keys are errors, never allowed values (issue #600).
+"""A PROPERTY_MAPPING spec's schema IS the ``PropertySpec`` constructor (issue #694).
 
-The legacy flattened authoring form is retired here. It recovered a spec's allowed-value
-space by SUBTRACTING the reserved metadata keys, which means every key the parser did not
-recognize was silently absorbed as an accepted VALUE. One typo, two silent failures::
+The dict-spec era validated every spec against a curated key set (``PROPERTY_SPEC_KEYS``),
+suggested the nearest known key for a typo and named replacements for removed keys, because a
+dict absorbs any key silently: one typo'd flag used to become an accepted VALUE while strict
+validation switched itself off. With ``PropertySpec`` there is no key set left to curate. The
+constructor signature is the schema: a misspelled or retired field name is Python's own
+``TypeError``, raised at the exact line where the spec literal is written, and nothing can
+ever be absorbed as a value.
 
-    {"add": "Addition", "sub": "Subtraction", "strict_validaton": True}   # missing an 'i'
-
-    _extract_property_values(...) -> {"add": ..., "sub": ..., "strict_validaton": True}
-                                     the typo'd FLAG is now an accepted VALUE
-    _is_strict_validation(...)    -> False
-                                     strict validation is silently OFF
-
-Nothing raised, at any lifecycle moment. This module pins the hard break that makes that
-impossible to express:
-
-1. A spec's value space is DECLARED under ``DefaultOptionKeys.allowed_values``. It is never
-   inferred by subtraction, so a spec without ``allowed_values`` declares an EMPTY value
-   space (and, being non-strict, accepts anything).
-2. Because the value space is explicit, every remaining key in a spec must be a known spec
-   key. ONE general rule at class-definition time rejects any unknown key, naming the owning
-   class, the property key and the offender. For a REMOVED key the message names its
-   replacement; otherwise it suggests the nearest known key.
-3. The known-key set is the spec SCHEMA now, not a subtraction set: ``PROPERTY_SPEC_KEYS``
-   replaces ``RESERVED_PROPERTY_KEYS`` (hard rename, no alias).
-4. Now checkable: ``strict_validation: True`` requires a non-empty ``allowed_values`` OR an
-   ``element_validator``. Strict with neither accepts nothing and rejects every value. This
-   mirrors the invariant ``property_spec`` already enforces, so core and the builder agree.
+This module pins that schema surface: the field set, and the unknown-field ``TypeError``
+naming the offending keyword. The machinery deletion itself (``PROPERTY_SPEC_KEYS``,
+``REMOVED_PROPERTY_KEYS``) is pinned in ``test_property_spec_hard_break.py``; the value-shape
+construction rules live in ``test_property_spec_type.py``.
 """
 
 from __future__ import annotations
 
-import gc
+import dataclasses
 from typing import Any
 
 import pytest
 
-from mloda.core.abstract_plugins.components import default_options_key as default_options_key_module
-from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
-from mloda.core.abstract_plugins.components.feature_set import FeatureSet
-from mloda.core.abstract_plugins.components.options import Options
-from mloda.core.abstract_plugins.components.utils import get_all_subclasses
-from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.abstract_plugins.components.feature_chainer.property_spec import PropertySpec
 
-TYPO_STRICT_KEY = "strict_validaton"  # the headline typo: 'strict_validation' minus one 'i'
-STALE_ELEMENT_VALIDATOR_KEY = "validation_function"
-STALE_MATCH_GUARD_KEY = "type_validator"
+TYPO_STRICT_FIELD = "strict_validaton"  # the headline typo: 'strict_validation' minus one 'i'
+STALE_ELEMENT_VALIDATOR_FIELD = "validation_function"
+STALE_MATCH_GUARD_FIELD = "type_validator"
 
 
-@pytest.fixture(autouse=True)
-def _no_feature_group_registry_pollution() -> Any:
-    """Guarantee this module never leaks throwaway FeatureGroup subclasses.
+def _spec(*args: Any, **kwargs: Any) -> PropertySpec:
+    """Build a ``PropertySpec`` through an untyped seam.
 
-    Mirrors ``test_property_mapping_unified_model.py``: the class-definition tests below
-    define FeatureGroup subclasses, which linger in ``FeatureGroup.__subclasses__()`` until
-    a GC cycle runs and would otherwise be seen by tests that enumerate feature groups.
+    The type-invalid calls below (unknown keywords) must stay runtime tests; routing them
+    through ``Any`` keeps the module mypy --strict clean.
     """
-    yield
-    gc.collect()
-    gc.collect()
-    leaked = [c for c in get_all_subclasses(FeatureGroup) if c.__module__ == __name__]
-    assert not leaked, f"Leaked FeatureGroup subclasses from {__name__}: {[c.__name__ for c in leaked]}"
+    return PropertySpec(*args, **kwargs)
 
 
-def _positive_int(value: Any) -> bool:
-    return isinstance(value, int) and value > 0
+def _accept_anything(value: Any) -> bool:
+    return True
 
 
-class TestSpecSchemaKeySet:
-    """The known-key set is the spec SCHEMA: ``PROPERTY_SPEC_KEYS``, and only that name."""
+class TestTheConstructorIsTheSchema:
+    """The dataclass field set is the whole schema; an unknown field cannot exist."""
 
-    def test_property_spec_keys_exists_and_is_complete(self) -> None:
-        """``PROPERTY_SPEC_KEYS`` is an importable frozenset holding every known spec key."""
-        spec_keys = getattr(default_options_key_module, "PROPERTY_SPEC_KEYS", None)
+    def test_field_set_is_exactly_the_schema(self) -> None:
+        """The schema is these eight fields, nothing more: there is no key set to drift from."""
+        assert {field.name for field in dataclasses.fields(PropertySpec)} == {
+            "explanation",
+            "allowed_values",
+            "default",
+            "context",
+            "strict_validation",
+            "element_validator",
+            "match_guard",
+            "required_when",
+        }
 
-        assert spec_keys is not None, "PROPERTY_SPEC_KEYS must exist in default_options_key"
-        assert isinstance(spec_keys, frozenset)
-        for member in (
-            DefaultOptionKeys.allowed_values,
-            DefaultOptionKeys.default,
-            DefaultOptionKeys.context,
-            DefaultOptionKeys.group,
-            DefaultOptionKeys.strict_validation,
-            DefaultOptionKeys.element_validator,
-            DefaultOptionKeys.required_when,
-            DefaultOptionKeys.match_guard,
-        ):
-            assert member in spec_keys
-        assert "explanation" in spec_keys
+    def test_typo_field_is_a_constructor_type_error_naming_the_offender(self) -> None:
+        """The headline typo is a ``TypeError`` at the spec literal, naming the bad keyword.
 
-    def test_reserved_property_keys_is_gone(self) -> None:
-        """The subtraction-set name is retired: no alias, no re-export."""
-        assert not hasattr(default_options_key_module, "RESERVED_PROPERTY_KEYS"), (
-            "RESERVED_PROPERTY_KEYS is renamed to PROPERTY_SPEC_KEYS, with no alias"
-        )
-
-
-class TestUnknownSpecKeyFailsAtClassDefinition:
-    """The headline: a typo'd flag can no longer be expressed silently.
-
-    Any key that is not a known spec key raises at class definition, naming the owning
-    class, the property key and the offending key.
-    """
-
-    def test_typo_flag_key_rejected_at_class_definition(self) -> None:
-        """``strict_validaton`` (one character off) raises, and the message suggests the real key."""
-        with pytest.raises(ValueError) as exc_info:
-
-            class TypoFlagFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-                PROPERTY_MAPPING = {
-                    "operation_type": {
-                        "explanation": "The arithmetic operation to apply",
-                        DefaultOptionKeys.allowed_values: {"add": "Addition", "sub": "Subtraction"},
-                        DefaultOptionKeys.context: True,
-                        TYPO_STRICT_KEY: True,
-                    }
-                }
-
-                @classmethod
-                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                    return data
+        The old model absorbed the typo as an accepted VALUE with strict validation silently
+        off. (Python 3.12+ additionally suggests the nearest field name; that part of the
+        message is the interpreter's and is deliberately not pinned.)
+        """
+        with pytest.raises(TypeError) as exc_info:
+            _spec(
+                "The arithmetic operation to apply",
+                allowed_values={"add": "Addition", "sub": "Subtraction"},
+                **{TYPO_STRICT_FIELD: True},
+            )
 
         message = str(exc_info.value)
-        del exc_info
-        assert "TypoFlagFeatureGroup" in message
-        assert "operation_type" in message
-        assert TYPO_STRICT_KEY in message
-        assert DefaultOptionKeys.strict_validation.value in message, (
-            "the message must name the key the author meant (nearest-known-key suggestion)"
-        )
+        assert "unexpected keyword argument" in message
+        assert TYPO_STRICT_FIELD in message
 
-    def test_arbitrary_unknown_key_rejected_at_class_definition(self) -> None:
-        """An unknown key with no near miss still raises, naming class, property and offender."""
-        with pytest.raises(ValueError) as exc_info:
-
-            class UnknownKeyFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-                PROPERTY_MAPPING = {
-                    "window_size": {
-                        "explanation": "Size of the time window",
-                        DefaultOptionKeys.context: True,
-                        "documentation_url": "https://example.invalid/window_size",
-                    }
-                }
-
-                @classmethod
-                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                    return data
+    def test_arbitrary_unknown_field_is_a_constructor_type_error(self) -> None:
+        """An unknown field with no near miss is the same ``TypeError``, naming the offender."""
+        with pytest.raises(TypeError) as exc_info:
+            _spec("Size of the time window", documentation_url="https://example.invalid/window_size")
 
         message = str(exc_info.value)
-        del exc_info
-        assert "UnknownKeyFeatureGroup" in message
-        assert "window_size" in message
+        assert "unexpected keyword argument" in message
         assert "documentation_url" in message
 
-    def test_legacy_flattened_value_entries_are_unknown_keys(self) -> None:
-        """The legacy flattened form is retired: inline value entries are now unknown keys."""
-        with pytest.raises(ValueError) as exc_info:
 
-            class LegacyFlattenedFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-                PROPERTY_MAPPING = {
-                    "operation_type": {
-                        "add": "Addition",
-                        "sub": "Subtraction",
-                        DefaultOptionKeys.context: True,
-                        DefaultOptionKeys.strict_validation: True,
-                    }
-                }
+class TestRetiredFieldNames:
+    """The pre-rename callable field names are plain unknown fields now, not curated renames.
 
-                @classmethod
-                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                    return data
-
-        message = str(exc_info.value)
-        del exc_info
-        assert "LegacyFlattenedFeatureGroup" in message
-        assert "operation_type" in message
-        assert "add" in message
-        assert DefaultOptionKeys.allowed_values.value in message, (
-            "the remedy is to declare the value space under allowed_values"
-        )
-
-    def test_parser_entry_point_rejects_unknown_key(self) -> None:
-        """The rule lives in core, so validating a mapping directly raises the same way."""
-        mapping: dict[str, Any] = {
-            "operation_type": {
-                DefaultOptionKeys.allowed_values: {"add": "Addition"},
-                DefaultOptionKeys.context: True,
-                TYPO_STRICT_KEY: True,
-            }
-        }
-
-        with pytest.raises(ValueError) as exc_info:
-            FeatureChainParser.validate_property_mapping_defaults("SomeOwner", mapping)
-
-        message = str(exc_info.value)
-        del exc_info
-        assert "SomeOwner" in message
-        assert TYPO_STRICT_KEY in message
-
-    def test_typo_flag_is_never_absorbed_into_the_accepted_value_set(self) -> None:
-        """The regression this whole change exists to prevent, checked through MATCHING.
-
-        Under the old subtraction rule the typo'd flag became a member of the accepted set,
-        so a feature whose option value is literally ``"strict_validaton"`` matched, while
-        strict validation was silently off. No feature group may ever accept that.
-        """
-        matched: bool
-
-        try:
-
-            class AbsorbedTypoFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-                PROPERTY_MAPPING = {
-                    "operation_type": {
-                        "add": "Addition",
-                        "sub": "Subtraction",
-                        TYPO_STRICT_KEY: True,
-                        DefaultOptionKeys.context: True,
-                    }
-                }
-
-                @classmethod
-                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                    return data
-
-            matched = AbsorbedTypoFeatureGroup.match_feature_group_criteria(
-                "any_feature", Options(context={"operation_type": TYPO_STRICT_KEY})
-            )
-        except ValueError:
-            matched = False
-
-        assert matched is False, "an unknown spec key must never become an accepted option value"
-
-
-class TestExtractPropertyValuesReadsAllowedValuesOnly:
-    """``_extract_property_values`` returns exactly what ``allowed_values`` declares."""
-
-    def test_flattened_spec_no_longer_widens_the_value_space(self) -> None:
-        """No ``allowed_values`` means an EMPTY value space, never the leftover entries.
-
-        Unreachable through class definition now, so the parser seam is tested directly.
-        """
-        spec: dict[Any, Any] = {
-            "add": "Addition",
-            "sub": "Subtraction",
-            DefaultOptionKeys.context: True,
-        }
-
-        extracted = FeatureChainParser._extract_property_values(spec)
-
-        assert not extracted, "a spec with no allowed_values declares no value space"
-        assert "add" not in extracted
-        assert "sub" not in extracted
-
-    def test_stray_unknown_key_does_not_widen_a_declared_value_space(self) -> None:
-        """With ``allowed_values`` declared, a stray key is never appended to the value space."""
-        spec: dict[Any, Any] = {
-            "explanation": "The arithmetic operation to apply",
-            DefaultOptionKeys.allowed_values: {"add": "Addition"},
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-            TYPO_STRICT_KEY: True,
-        }
-
-        extracted = FeatureChainParser._extract_property_values(spec)
-
-        assert extracted == {"add": "Addition"}
-        assert TYPO_STRICT_KEY not in extracted
-
-    def test_empty_value_space_is_returned_for_a_spec_without_allowed_values(self) -> None:
-        """A metadata-only spec (the ``in_features`` shape) declares no value space."""
-        spec: dict[Any, Any] = {
-            "explanation": "The input features",
-            DefaultOptionKeys.context: True,
-        }
-
-        assert not FeatureChainParser._extract_property_values(spec)
-
-
-class TestKnownKeySpecsAreAccepted:
-    """The valid authoring forms keep working: this rule rejects only UNKNOWN keys."""
-
-    def test_allowed_values_plus_known_flags_defines_and_matches(self) -> None:
-        """``allowed_values`` plus known flags is the canonical strict spec."""
-
-        class ExplicitFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-            PROPERTY_MAPPING = {
-                "operation_type": {
-                    "explanation": "The arithmetic operation to apply",
-                    DefaultOptionKeys.allowed_values: {"add": "Addition", "sub": "Subtraction"},
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: True,
-                    DefaultOptionKeys.default: "add",
-                }
-            }
-
-            @classmethod
-            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                return data
-
-        assert (
-            ExplicitFeatureGroup.match_feature_group_criteria("any_feature", Options(context={"operation_type": "sub"}))
-            is True
-        )
-        assert (
-            ExplicitFeatureGroup.match_feature_group_criteria("any_feature", Options(context={"operation_type": "mul"}))
-            is False
-        )
-
-    def test_metadata_only_spec_declares_no_value_space_and_accepts_anything(self) -> None:
-        """No ``allowed_values`` and no strict (the ``in_features`` shape) stays valid."""
-
-        class MetadataOnlyFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-            PROPERTY_MAPPING = {
-                DefaultOptionKeys.in_features: {
-                    "explanation": "The input features",
-                    DefaultOptionKeys.context: True,
-                }
-            }
-
-            @classmethod
-            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                return data
-
-        assert (
-            MetadataOnlyFeatureGroup.match_feature_group_criteria(
-                "any_feature", Options(context={DefaultOptionKeys.in_features.value: "anything_at_all"})
-            )
-            is True
-        )
-
-    def test_match_guard_only_spec_defines(self) -> None:
-        """A non-strict guarded spec carries only known keys and defines cleanly."""
-
-        class GuardedFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-            PROPERTY_MAPPING = {
-                "partition_by": {
-                    "explanation": "List of columns to partition by",
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: False,
-                    DefaultOptionKeys.match_guard: _positive_int,
-                }
-            }
-
-            @classmethod
-            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                return data
-
-        assert DefaultOptionKeys.match_guard in GuardedFeatureGroup.PROPERTY_MAPPING["partition_by"]
-
-
-class TestRemovedKeysFoldIntoTheGeneralRule:
-    """The removed-key guard becomes a MESSAGE VARIANT of the unknown-key rule, not a second check."""
-
-    def test_removed_element_validator_key_names_its_replacement(self) -> None:
-        """``validation_function`` is an unknown key whose message names ``element_validator``."""
-        with pytest.raises(ValueError) as exc_info:
-
-            class StaleElementValidatorFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-                PROPERTY_MAPPING = {
-                    "operation_type": {
-                        "explanation": "The arithmetic operation to apply",
-                        DefaultOptionKeys.allowed_values: {"add": "Addition"},
-                        DefaultOptionKeys.context: True,
-                        DefaultOptionKeys.strict_validation: True,
-                        STALE_ELEMENT_VALIDATOR_KEY: _positive_int,
-                    }
-                }
-
-                @classmethod
-                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                    return data
-
-        message = str(exc_info.value)
-        del exc_info
-        assert "StaleElementValidatorFeatureGroup" in message
-        assert "operation_type" in message
-        assert STALE_ELEMENT_VALIDATOR_KEY in message
-        assert DefaultOptionKeys.element_validator.value in message
-
-    def test_removed_match_guard_key_names_its_replacement(self) -> None:
-        """``type_validator`` is an unknown key whose message names ``match_guard``."""
-        with pytest.raises(ValueError) as exc_info:
-
-            class StaleMatchGuardFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-                PROPERTY_MAPPING = {
-                    "partition_by": {
-                        "explanation": "List of columns to partition by",
-                        DefaultOptionKeys.context: True,
-                        DefaultOptionKeys.strict_validation: False,
-                        STALE_MATCH_GUARD_KEY: _positive_int,
-                    }
-                }
-
-                @classmethod
-                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                    return data
-
-        message = str(exc_info.value)
-        del exc_info
-        assert "StaleMatchGuardFeatureGroup" in message
-        assert "partition_by" in message
-        assert STALE_MATCH_GUARD_KEY in message
-        assert DefaultOptionKeys.match_guard.value in message
-
-
-class TestStrictValidationNeedsAValueSpace:
-    """``strict_validation: True`` needs something to validate AGAINST.
-
-    Strict with neither a non-empty ``allowed_values`` nor an ``element_validator`` accepts
-    nothing and rejects every value: a spec that can never match. ``property_spec`` already
-    rejects this at import time; core now agrees, so the two entry points cannot drift.
+    ``element_validator`` and ``match_guard`` are the accepted spellings (they are in the
+    field set above); their predecessors get no rename hint, just the constructor's
+    ``TypeError``.
     """
 
-    def test_strict_without_allowed_values_or_element_validator_raises(self) -> None:
-        """Strict, but nothing to validate against: raises at class definition."""
-        with pytest.raises(ValueError) as exc_info:
-
-            class EmptyStrictFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-                PROPERTY_MAPPING = {
-                    "operation_type": {
-                        "explanation": "The arithmetic operation to apply",
-                        DefaultOptionKeys.context: True,
-                        DefaultOptionKeys.strict_validation: True,
-                    }
-                }
-
-                @classmethod
-                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                    return data
+    def test_validation_function_is_an_unknown_field(self) -> None:
+        """``validation_function`` is simply not a field."""
+        with pytest.raises(TypeError) as exc_info:
+            _spec("The arithmetic operation to apply", **{STALE_ELEMENT_VALIDATOR_FIELD: _accept_anything})
 
         message = str(exc_info.value)
-        del exc_info
-        assert "EmptyStrictFeatureGroup" in message
-        assert "operation_type" in message
-        assert DefaultOptionKeys.allowed_values.value in message
-        assert DefaultOptionKeys.element_validator.value in message
+        assert "unexpected keyword argument" in message
+        assert STALE_ELEMENT_VALIDATOR_FIELD in message
 
-    def test_strict_with_empty_allowed_values_raises(self) -> None:
-        """An empty declared value space would reject every value: raises at class definition."""
-        with pytest.raises(ValueError) as exc_info:
-
-            class EmptyAllowedValuesFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-                PROPERTY_MAPPING = {
-                    "operation_type": {
-                        "explanation": "The arithmetic operation to apply",
-                        DefaultOptionKeys.allowed_values: {},
-                        DefaultOptionKeys.context: True,
-                        DefaultOptionKeys.strict_validation: True,
-                    }
-                }
-
-                @classmethod
-                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                    return data
+    def test_type_validator_is_an_unknown_field(self) -> None:
+        """``type_validator`` is simply not a field."""
+        with pytest.raises(TypeError) as exc_info:
+            _spec("List of columns to partition by", **{STALE_MATCH_GUARD_FIELD: _accept_anything})
 
         message = str(exc_info.value)
-        del exc_info
-        assert "EmptyAllowedValuesFeatureGroup" in message
-        assert "operation_type" in message
-
-    def test_parser_entry_point_rejects_strict_without_a_value_space(self) -> None:
-        """The invariant lives in core, so validating a mapping directly raises too."""
-        mapping: dict[str, Any] = {
-            "operation_type": {
-                DefaultOptionKeys.context: True,
-                DefaultOptionKeys.strict_validation: True,
-            }
-        }
-
-        with pytest.raises(ValueError, match="operation_type"):
-            FeatureChainParser.validate_property_mapping_defaults("SomeOwner", mapping)
-
-    def test_strict_with_element_validator_only_is_fine(self) -> None:
-        """An ``element_validator`` IS a value space: no ``allowed_values`` needed."""
-
-        class StrictValidatorFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-            PROPERTY_MAPPING = {
-                "window_size": {
-                    "explanation": "Size of the time window",
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: True,
-                    DefaultOptionKeys.element_validator: _positive_int,
-                }
-            }
-
-            @classmethod
-            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                return data
-
-        assert (
-            StrictValidatorFeatureGroup.match_feature_group_criteria("any_feature", Options(context={"window_size": 7}))
-            is True
-        )
-
-    def test_strict_with_non_empty_allowed_values_is_fine(self) -> None:
-        """A non-empty declared value space is the other way to satisfy the invariant."""
-
-        class StrictAllowedValuesFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-            PROPERTY_MAPPING = {
-                "operation_type": {
-                    "explanation": "The arithmetic operation to apply",
-                    DefaultOptionKeys.allowed_values: {"add": "Addition"},
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: True,
-                }
-            }
-
-            @classmethod
-            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                return data
-
-        assert (
-            StrictAllowedValuesFeatureGroup.match_feature_group_criteria(
-                "any_feature", Options(context={"operation_type": "add"})
-            )
-            is True
-        )
-
-
-class TestNonDictSpecValuesAreRejected:
-    """A spec must BE a spec dict: a bare container bypasses every class-definition rule.
-
-    ``PROPERTY_MAPPING = {"op": ["add", "sub", "strict_validaton"]}`` defines cleanly today and
-    the list is handed back verbatim as the value space, because all three rules skip non-dicts.
-    It is not a widening hole in the strict sense (a bare container has nowhere to put
-    ``strict_validation``, so it can never be strict), but it contradicts the one-authoring-form
-    contract the schema rule establishes, and it is the one shape the repo-wide guard cannot see.
-    No in-repo spec is a non-dict, so this is a clean hard break, consistent with the rest.
-    """
-
-    def test_non_dict_spec_value_rejected_at_class_definition(self) -> None:
-        """A bare list where a spec dict belongs raises, naming the class and the property key."""
-        with pytest.raises(ValueError) as exc_info:
-
-            class BareContainerFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-                PROPERTY_MAPPING = {"operation_type": ["add", "sub"]}
-
-                @classmethod
-                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                    return data
-
-        message = str(exc_info.value)
-        del exc_info
-        assert "BareContainerFeatureGroup" in message
-        assert "operation_type" in message
-
-    def test_parser_entry_point_rejects_a_non_dict_spec_value(self) -> None:
-        """The rule lives in core, so validating a mapping directly raises the same way."""
-        mapping: dict[str, Any] = {"operation_type": ["add", "sub"]}
-
-        with pytest.raises(ValueError, match="operation_type"):
-            FeatureChainParser.validate_property_mapping_defaults("SomeOwner", mapping)
-
-    def test_non_dict_spec_value_cannot_smuggle_a_typo_flag_as_an_accepted_value(self) -> None:
-        """The schema rule's whole point, checked on the shape that used to skip it."""
-        matched: bool
-
-        try:
-
-            class SmuggledTypoFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-                PROPERTY_MAPPING = {"operation_type": ["add", "sub", TYPO_STRICT_KEY]}
-
-                @classmethod
-                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                    return data
-
-            matched = SmuggledTypoFeatureGroup.match_feature_group_criteria(
-                "any_feature", Options(context={"operation_type": TYPO_STRICT_KEY})
-            )
-        except ValueError:
-            matched = False
-
-        assert matched is False, "a spec must be a spec dict, so a bare container can carry no flags at all"
+        assert "unexpected keyword argument" in message
+        assert STALE_MATCH_GUARD_FIELD in message

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_spec_shape.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_spec_shape.py
@@ -1,67 +1,47 @@
-"""A PROPERTY_MAPPING spec has a SHAPE, not just a key set (issue #600 follow-up).
+"""The PROPERTY_MAPPING shape rules survive, relocated to ``PropertySpec`` construction (issue #694).
 
-``test_property_mapping_spec_schema.py`` closed the unknown-KEY hole: every key of a spec must
-be a known spec key. That rule is airtight, but it says nothing about the SHAPE OF THE VALUE
-under each key, which reopens the same class of silent widening from the other side:
+The dict-spec era enforced these value-shape rules at class-definition time, from
+``validate_property_mapping_defaults``. The dict form is gone, but every rule survives: it now
+fires while the ``PropertySpec`` literal inside the class body is being CONSTRUCTED. For the
+author the moment is the same, module import, and stricter: the FeatureGroup class never comes
+into existence. Because there is no class yet to name, the error identifies the offending spec
+by its explanation, with the ``PropertySpec('...')`` prefix.
 
-    {DefaultOptionKeys.allowed_values: ("add"), DefaultOptionKeys.strict_validation: True}
+The five rules, one test each, written as an author would hit them (inside a FeatureGroup
+class body):
 
-A forgotten comma makes that a ``str``, not a one-tuple. It defines cleanly, and at match time
-``found_val in "add"`` is a SUBSTRING test: ``"add"``, ``"a"``, ``"ad"``, ``"dd"`` and ``""``
-are all accepted. The retired flattened form could never express this (its value space was
-always a dict), so this is net-new surface opened by making ``allowed_values`` the one channel.
+1. a str/bytes ``allowed_values`` (the forgotten-comma bug) would make membership a substring test,
+2. a non-collection ``allowed_values`` is not a value space at all,
+3. ``strict_validation`` must be a real bool, not merely truthy,
+4. ``element_validator``, ``required_when`` and ``match_guard`` must be callable,
+5. ``strict_validation=True`` needs a non-empty ``allowed_values`` or an ``element_validator``.
 
-The same truthiness-shaped hole runs through the rest of the layer:
-
-* ``strict_validation`` needing a "non-empty" value space is a TRUTHINESS test, so an EMPTY
-  generator passes (a generator object is always truthy), a NON-EMPTY one passes and is then
-  CONSUMED (matching becomes stateful and order-dependent), and a scalar passes and then makes
-  ``value in 5`` raise a ``TypeError`` that is swallowed into a silent reject-everything.
-* the callable-valued keys are checked for PRESENCE, not CALLABILITY, so a list under
-  ``element_validator`` escapes as ``TypeError: 'list' object is not callable`` out of matching,
-  and with a declared default the broad ``except Exception`` in ``check_declared_default``
-  rewrites it into a confidently WRONG message about the default.
-* ``_is_strict_validation`` is truthiness-based, so ``strict_validation: "false"`` is strict and
-  the error message asserts ``strict_validation=True`` about a spec that never said so.
-* ``property_spec`` refuses to build a NON-STRICT spec with ``allowed_values``, on the premise
-  that "allowed_values is never enforced without strict=True". That premise is false: the value
-  space of a non-strict spec is consumed by ``_find_property_key_for_value`` and
-  ``_build_effective_options`` to map a name-parsed value back to its PROPERTY_MAPPING key.
-
-This module pins the shape rules that close all of it. The ordering constraint from the schema
-module is preserved: the unknown-key rule still runs FIRST, so a spec carrying a removed key is
-still reported as a rename, not as a shape error.
+Fine-grained constructor coverage (normalization, every message variant) lives in
+``test_property_spec_type.py``; this module pins the relocation.
 """
 
 from __future__ import annotations
 
 import gc
-from collections.abc import Iterator
 from typing import Any
 
 import pytest
 
-from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
-from mloda.core.abstract_plugins.components.feature_chainer.property_spec import property_spec
+from mloda.core.abstract_plugins.components.feature_chainer.property_spec import PropertySpec
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.components.utils import get_all_subclasses
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
-
-TYPO_STRICT_KEY = "strict_validaton"  # 'strict_validation' minus one 'i'
-TYPO_CONTEXT_KEY = "contxt"  # 'context' minus one 'e'
-STALE_ELEMENT_VALIDATOR_KEY = "validation_function"
 
 
 @pytest.fixture(autouse=True)
 def _no_feature_group_registry_pollution() -> Any:
     """Guarantee this module never leaks throwaway FeatureGroup subclasses.
 
-    Mirrors ``test_property_mapping_spec_schema.py``: the class-definition tests below define
-    FeatureGroup subclasses, which linger in ``FeatureGroup.__subclasses__()`` until a GC cycle
-    runs and would otherwise be seen by tests that enumerate feature groups.
+    Mirrors ``test_property_spec_hard_break.py``: the tests below define FeatureGroup
+    subclasses, which linger in ``FeatureGroup.__subclasses__()`` until a GC cycle runs and
+    would otherwise be seen by tests that enumerate feature groups.
     """
     yield
     gc.collect()
@@ -70,157 +50,139 @@ def _no_feature_group_registry_pollution() -> Any:
     assert not leaked, f"Leaked FeatureGroup subclasses from {__name__}: {[c.__name__ for c in leaked]}"
 
 
+def _spec(*args: Any, **kwargs: Any) -> PropertySpec:
+    """Build a ``PropertySpec`` through an untyped seam.
+
+    The type-invalid constructions below (str/scalar value space, non-bool flag, non-callable
+    validators) must stay runtime tests; routing them through ``Any`` keeps the module
+    mypy --strict clean.
+    """
+    return PropertySpec(*args, **kwargs)
+
+
 def _positive_int(value: Any) -> bool:
     return isinstance(value, int) and value > 0
 
 
-def _one_shot_values() -> Iterator[str]:
-    """A NON-EMPTY generator: truthy, but a one-shot value space that empties itself."""
-    yield "add"
-    yield "sub"
+class TestShapeRulesFireInsideTheClassBody:
+    """Each rule raises while the class body evaluates, so the class never comes into existence."""
 
+    @pytest.mark.parametrize("word", ["add", b"add"], ids=["str", "bytes"])
+    def test_str_or_bytes_allowed_values_prevents_the_class(self, word: Any) -> None:
+        """Rule 1: the forgotten-comma bug would turn membership into a substring test."""
+        with pytest.raises(ValueError, match="(?i)substring"):
 
-def _no_values() -> Iterator[str]:
-    """An EMPTY generator: still truthy, so it passes a truthiness-based non-empty test."""
-    yield from ()
-
-
-class TestAllowedValuesMustBeACollection:
-    """``allowed_values`` declares a VALUE SPACE, so it must be a Collection, never a str.
-
-    A ``str`` is the dangerous case: it is a perfectly good Collection of characters, so
-    membership silently degrades into a substring test. ``bytes`` behaves the same way. Both
-    are rejected outright, because no author ever means "any substring of this word".
-    """
-
-    def test_str_allowed_values_rejected_at_class_definition(self) -> None:
-        """A ``str`` value space (the forgotten-comma bug) raises, naming the real fault."""
-        with pytest.raises(ValueError) as exc_info:
-
-            class StrAllowedValuesFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+            class Shape694SubstringFeatureGroup(FeatureChainParserMixin, FeatureGroup):
                 PROPERTY_MAPPING = {
-                    "operation_type": {
+                    "shape694_operation": PropertySpec(
+                        "The arithmetic operation to apply",
                         # A forgotten comma: ("add") is the str "add", not the tuple ("add",).
-                        DefaultOptionKeys.allowed_values: "add",
-                        DefaultOptionKeys.context: True,
-                        DefaultOptionKeys.strict_validation: True,
-                    }
+                        allowed_values=word,
+                        strict_validation=True,
+                    )
                 }
 
                 @classmethod
                 def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
                     return data
 
-        message = str(exc_info.value)
-        del exc_info
-        assert "StrAllowedValuesFeatureGroup" in message
-        assert "operation_type" in message
-        assert DefaultOptionKeys.allowed_values.value in message
-        assert "str" in message, "the message must name the offending shape, not just say 'invalid'"
+        assert all(c.__name__ != "Shape694SubstringFeatureGroup" for c in get_all_subclasses(FeatureGroup)), (
+            "the constructor raised inside the class body, so the class must never come into existence"
+        )
 
-    def test_bytes_allowed_values_rejected_at_class_definition(self) -> None:
-        """``bytes`` substring-matches exactly like ``str``, so it is rejected the same way."""
-        with pytest.raises(ValueError) as exc_info:
+    def test_non_collection_allowed_values_prevents_the_class(self) -> None:
+        """Rule 2: a scalar is not a value space, and never a swallowed TypeError at match time."""
+        with pytest.raises(ValueError, match="not a Mapping or an iterable"):
 
-            class BytesAllowedValuesFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+            class Shape694ScalarValueSpaceFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {"shape694_window": _spec("Size of the time window", allowed_values=5)}
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+    def test_non_bool_strict_validation_prevents_the_class(self) -> None:
+        """Rule 3: a truthy ``"false"`` must never silently enable strict matching."""
+        with pytest.raises(ValueError, match="must be a bool"):
+
+            class Shape694TruthyFlagFeatureGroup(FeatureChainParserMixin, FeatureGroup):
                 PROPERTY_MAPPING = {
-                    "operation_type": {
-                        DefaultOptionKeys.allowed_values: b"add",
-                        DefaultOptionKeys.context: True,
-                        DefaultOptionKeys.strict_validation: True,
-                    }
+                    "shape694_operation": _spec(
+                        "The arithmetic operation to apply",
+                        allowed_values={"add": "Addition"},
+                        strict_validation="false",
+                    )
                 }
 
                 @classmethod
                 def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
                     return data
 
-        message = str(exc_info.value)
-        del exc_info
-        assert "BytesAllowedValuesFeatureGroup" in message
-        assert DefaultOptionKeys.allowed_values.value in message
+    @pytest.mark.parametrize("field", ["element_validator", "required_when", "match_guard"])
+    def test_non_callable_validator_prevents_the_class(self, field: str) -> None:
+        """Rule 4: a non-callable validator can never escape as a TypeError out of matching."""
+        with pytest.raises(ValueError, match=f"{field} must be callable"):
 
-    @pytest.mark.parametrize("candidate", ["add", "a", "ad", "dd", ""])
-    def test_str_allowed_values_never_substring_matches(self, candidate: str) -> None:
-        """The regression itself, checked through MATCHING.
+            class Shape694NonCallableValidatorFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {"shape694_window": _spec("Size of the time window", **{field: "not callable"})}
 
-        Every one of these is accepted today: the full word, each of its substrings, and the
-        empty string. A spec that cannot be defined can never accept any of them.
-        """
-        matched: bool
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
 
-        try:
+    def test_strict_without_a_value_space_prevents_the_class(self) -> None:
+        """Rule 5: strict with nothing to validate against would reject every value."""
+        with pytest.raises(ValueError, match="needs a non-empty allowed_values or an element_validator"):
 
-            class SubstringMatchFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+            class Shape694EmptyStrictFeatureGroup(FeatureChainParserMixin, FeatureGroup):
                 PROPERTY_MAPPING = {
-                    "operation_type": {
-                        DefaultOptionKeys.allowed_values: "add",
-                        DefaultOptionKeys.context: True,
-                        DefaultOptionKeys.strict_validation: True,
-                    }
+                    "shape694_operation": PropertySpec("The arithmetic operation to apply", strict_validation=True)
                 }
 
                 @classmethod
                 def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
                     return data
 
-            matched = SubstringMatchFeatureGroup.match_feature_group_criteria(
-                "any_feature", Options(context={"operation_type": candidate})
-            )
-        except ValueError:
-            matched = False
+    def test_the_error_names_the_spec_by_its_explanation(self) -> None:
+        """With no class to name, the ``PropertySpec('...')`` prefix locates the offending spec."""
+        with pytest.raises(ValueError, match=r"PropertySpec\('The arithmetic operation to apply'\)"):
 
-        assert matched is False, "a str allowed_values must never turn membership into a substring test"
+            class Shape694PrefixFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {
+                    "shape694_operation": _spec(
+                        "The arithmetic operation to apply",
+                        allowed_values="add",
+                        strict_validation=True,
+                    )
+                }
 
-    def test_parser_entry_point_rejects_str_allowed_values(self) -> None:
-        """The rule lives in core, so validating a mapping directly raises the same way."""
-        mapping: dict[str, Any] = {
-            "operation_type": {
-                DefaultOptionKeys.allowed_values: "add",
-                DefaultOptionKeys.strict_validation: True,
-            }
-        }
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
 
-        with pytest.raises(ValueError, match="operation_type"):
-            FeatureChainParser.validate_property_mapping_defaults("SomeOwner", mapping)
 
-    def test_str_allowed_values_rejected_without_strict_validation(self) -> None:
-        """The shape rule is about the value space itself, so it does not depend on strict.
+class TestWellFormedSpecsStillDefine:
+    """The relocation rejects only malformed specs: a well-formed mapping defines and matches."""
 
-        A non-strict value space is still consumed (name-parsed value -> property key), so a
-        str there would substring-map arbitrary operation configs onto the wrong key.
-        """
-        mapping: dict[str, Any] = {
-            "operation_type": {
-                DefaultOptionKeys.allowed_values: "add",
-                DefaultOptionKeys.strict_validation: False,
-            }
-        }
+    def test_well_formed_specs_define_and_drive_matching(self) -> None:
+        """Every shape-checked field, correctly shaped, defines and enforces at match time."""
 
-        with pytest.raises(ValueError, match="operation_type"):
-            FeatureChainParser.validate_property_mapping_defaults("SomeOwner", mapping)
-
-    @pytest.mark.parametrize(
-        "value_space",
-        [
-            {"add": "Addition", "sub": "Subtraction"},
-            ("add", "sub"),
-            ["add", "sub"],
-            {"add", "sub"},
-            frozenset({"add", "sub"}),
-        ],
-        ids=["dict", "tuple", "list", "set", "frozenset"],
-    )
-    def test_every_real_collection_form_still_defines_and_matches(self, value_space: Any) -> None:
-        """The guard rejects only non-Collections: every legitimate container keeps working."""
-
-        class CollectionValueSpaceFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+        class Shape694WellFormedFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             PROPERTY_MAPPING = {
-                "operation_type": {
-                    DefaultOptionKeys.allowed_values: value_space,
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: True,
-                }
+                "shape694_operation": PropertySpec(
+                    "The arithmetic operation to apply",
+                    allowed_values={"add": "Addition", "sub": "Subtraction"},
+                    context=True,
+                    strict_validation=True,
+                    default="add",
+                ),
+                "shape694_window": PropertySpec(
+                    "Size of the time window",
+                    context=True,
+                    strict_validation=True,
+                    element_validator=_positive_int,
+                    default=7,
+                ),
             }
 
             @classmethod
@@ -228,707 +190,20 @@ class TestAllowedValuesMustBeACollection:
                 return data
 
         assert (
-            CollectionValueSpaceFeatureGroup.match_feature_group_criteria(
-                "any_feature", Options(context={"operation_type": "add"})
+            Shape694WellFormedFeatureGroup.match_feature_group_criteria(
+                "any_feature", Options(context={"shape694_operation": "sub", "shape694_window": 7})
             )
             is True
         )
         assert (
-            CollectionValueSpaceFeatureGroup.match_feature_group_criteria(
-                "any_feature", Options(context={"operation_type": "mul"})
+            Shape694WellFormedFeatureGroup.match_feature_group_criteria(
+                "any_feature", Options(context={"shape694_operation": "mul", "shape694_window": 7})
             )
             is False
         )
-
-
-class TestNonEmptyIsNotATruthinessTest:
-    """ "Strict needs a non-empty value space" must mean non-empty, not merely truthy.
-
-    A generator object and a scalar are both truthy and both pass the rule today, each in a
-    different, worse-than-empty way. The Collection guard is what makes "non-empty" checkable.
-    """
-
-    def test_empty_generator_allowed_values_rejected(self) -> None:
-        """An EMPTY generator is truthy, so it slips past the strict-needs-a-value-space rule."""
-        with pytest.raises(ValueError) as exc_info:
-
-            class EmptyGeneratorFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-                PROPERTY_MAPPING = {
-                    "operation_type": {
-                        DefaultOptionKeys.allowed_values: _no_values(),
-                        DefaultOptionKeys.context: True,
-                        DefaultOptionKeys.strict_validation: True,
-                    }
-                }
-
-                @classmethod
-                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                    return data
-
-        message = str(exc_info.value)
-        del exc_info
-        assert "EmptyGeneratorFeatureGroup" in message
-        assert DefaultOptionKeys.allowed_values.value in message
-
-    def test_non_empty_generator_allowed_values_rejected(self) -> None:
-        """A NON-EMPTY generator is a one-shot value space, so it is not a value space at all."""
-        with pytest.raises(ValueError) as exc_info:
-
-            class GeneratorFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-                PROPERTY_MAPPING = {
-                    "operation_type": {
-                        DefaultOptionKeys.allowed_values: _one_shot_values(),
-                        DefaultOptionKeys.context: True,
-                        DefaultOptionKeys.strict_validation: True,
-                    }
-                }
-
-                @classmethod
-                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                    return data
-
-        message = str(exc_info.value)
-        del exc_info
-        assert "GeneratorFeatureGroup" in message
-        assert DefaultOptionKeys.allowed_values.value in message
-
-    def test_generator_allowed_values_never_makes_matching_stateful(self) -> None:
-        """Matching the SAME value twice must give the SAME answer.
-
-        Today a generator value space is consumed by matching: the first match succeeds, the
-        second raises "not found in mapping". That makes matching order-dependent, and so
-        nondeterministic under pytest-xdist. A spec that cannot be defined cannot be stateful.
-        """
-        matches: list[bool]
-
-        try:
-
-            class StatefulGeneratorFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-                PROPERTY_MAPPING = {
-                    "operation_type": {
-                        DefaultOptionKeys.allowed_values: _one_shot_values(),
-                        DefaultOptionKeys.context: True,
-                        DefaultOptionKeys.strict_validation: True,
-                    }
-                }
-
-                @classmethod
-                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                    return data
-
-            options = Options(context={"operation_type": "add"})
-            matches = [StatefulGeneratorFeatureGroup.match_feature_group_criteria("any_feature", options)] * 1
-            matches.append(StatefulGeneratorFeatureGroup.match_feature_group_criteria("any_feature", options))
-        except ValueError:
-            matches = [False, False]
-
-        assert matches[0] == matches[1], "matching must not depend on how often the value space was consulted"
-        assert matches == [False, False], "a generator is not a value space, so the spec must not be definable"
-
-    def test_generator_allowed_values_with_a_default_is_rejected_not_burnt(self) -> None:
-        """With a declared default, ``check_declared_default`` burns the generator at definition.
-
-        Today this class defines cleanly and then rejects EVERY runtime value, including the
-        very values it declares, because the default check consumed the value space.
-        """
-        with pytest.raises(ValueError):
-
-            class BurntGeneratorFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-                PROPERTY_MAPPING = {
-                    "operation_type": {
-                        DefaultOptionKeys.allowed_values: _one_shot_values(),
-                        DefaultOptionKeys.context: True,
-                        DefaultOptionKeys.strict_validation: True,
-                        DefaultOptionKeys.default: "add",
-                    }
-                }
-
-                @classmethod
-                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                    return data
-
-    def test_scalar_allowed_values_rejected(self) -> None:
-        """A scalar is truthy, then ``value in 5`` raises a TypeError that is swallowed.
-
-        The spec silently rejects every value, including the scalar itself.
-        """
-        with pytest.raises(ValueError) as exc_info:
-
-            class ScalarAllowedValuesFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-                PROPERTY_MAPPING = {
-                    "window_size": {
-                        DefaultOptionKeys.allowed_values: 5,
-                        DefaultOptionKeys.context: True,
-                        DefaultOptionKeys.strict_validation: True,
-                    }
-                }
-
-                @classmethod
-                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                    return data
-
-        message = str(exc_info.value)
-        del exc_info
-        assert "ScalarAllowedValuesFeatureGroup" in message
-        assert "window_size" in message
-        assert DefaultOptionKeys.allowed_values.value in message
-
-    def test_strict_with_empty_collection_allowed_values_still_raises(self) -> None:
-        """The existing empty-value-space rule survives the shape guard, for every container."""
-        mapping: dict[str, Any] = {
-            "operation_type": {
-                DefaultOptionKeys.allowed_values: (),
-                DefaultOptionKeys.strict_validation: True,
-            }
-        }
-
-        with pytest.raises(ValueError, match="operation_type"):
-            FeatureChainParser.validate_property_mapping_defaults("SomeOwner", mapping)
-
-
-class TestValidatorKeysMustBeCallable:
-    """``element_validator``, ``required_when`` and ``match_guard`` are checked for CALLABILITY.
-
-    Today they are checked only for PRESENCE. ``property_spec`` DOES check callability, so core
-    and the builder disagree: a hand-written spec can carry a list where a callable belongs.
-    """
-
-    def test_non_callable_element_validator_rejected_at_class_definition(self) -> None:
-        """A list under ``element_validator`` raises at definition, naming the real fault."""
-        with pytest.raises(ValueError) as exc_info:
-
-            class NonCallableElementValidatorFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-                PROPERTY_MAPPING = {
-                    "operation_type": {
-                        DefaultOptionKeys.context: True,
-                        DefaultOptionKeys.strict_validation: True,
-                        DefaultOptionKeys.element_validator: ["add", "sub"],
-                    }
-                }
-
-                @classmethod
-                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                    return data
-
-        message = str(exc_info.value)
-        del exc_info
-        assert "NonCallableElementValidatorFeatureGroup" in message
-        assert "operation_type" in message
-        assert DefaultOptionKeys.element_validator.value in message
-        assert "callable" in message
-
-    def test_non_callable_element_validator_message_does_not_blame_the_default(self) -> None:
-        """The headline mis-diagnosis: with a default, the broad ``except Exception`` lies.
-
-        ``check_declared_default`` catches the ``TypeError: 'list' object is not callable`` and
-        reports "the key's element_validator raised an error when called with that default. Add
-        the default to the accepted values, or remove the default", none of which is the fault.
-        """
-        with pytest.raises(ValueError) as exc_info:
-
-            class BlamedDefaultFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-                PROPERTY_MAPPING = {
-                    "operation_type": {
-                        DefaultOptionKeys.context: True,
-                        DefaultOptionKeys.strict_validation: True,
-                        DefaultOptionKeys.element_validator: ["add", "sub"],
-                        DefaultOptionKeys.default: "add",
-                    }
-                }
-
-                @classmethod
-                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                    return data
-
-        message = str(exc_info.value)
-        del exc_info
-        assert DefaultOptionKeys.element_validator.value in message
-        assert "callable" in message
-        assert "Add the default to the accepted values" not in message, (
-            "a non-callable validator is not a default problem, and must not be reported as one"
-        )
-
-    def test_non_callable_element_validator_never_reaches_match_time(self) -> None:
-        """Today matching a spec with a list validator escapes ``'list' object is not callable``.
-
-        The class definition must reject it, so no ``TypeError`` can ever leave matching. An
-        escaping ``TypeError`` fails this test rather than being caught.
-        """
-        matched: bool
-
-        try:
-
-            class EscapingTypeErrorFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-                PROPERTY_MAPPING = {
-                    "operation_type": {
-                        DefaultOptionKeys.context: True,
-                        DefaultOptionKeys.strict_validation: True,
-                        DefaultOptionKeys.element_validator: ["add", "sub"],
-                    }
-                }
-
-                @classmethod
-                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                    return data
-
-            matched = EscapingTypeErrorFeatureGroup.match_feature_group_criteria(
-                "any_feature", Options(context={"operation_type": "add"})
-            )
-        except ValueError:
-            matched = False
-
-        assert matched is False
-
-    def test_non_callable_required_when_rejected_at_class_definition(self) -> None:
-        """A non-callable ``required_when`` is silently skipped with a warning today."""
-        with pytest.raises(ValueError) as exc_info:
-
-            class NonCallableRequiredWhenFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-                PROPERTY_MAPPING = {
-                    "region": {
-                        DefaultOptionKeys.context: True,
-                        DefaultOptionKeys.required_when: ["prod"],
-                    }
-                }
-
-                @classmethod
-                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                    return data
-
-        message = str(exc_info.value)
-        del exc_info
-        assert "NonCallableRequiredWhenFeatureGroup" in message
-        assert "region" in message
-        assert DefaultOptionKeys.required_when.value in message
-        assert "callable" in message
-
-    def test_non_callable_match_guard_rejected_at_class_definition(self) -> None:
-        """A non-callable ``match_guard`` silently turns into a reject-everything guard today."""
-        with pytest.raises(ValueError) as exc_info:
-
-            class NonCallableMatchGuardFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-                PROPERTY_MAPPING = {
-                    "partition_by": {
-                        DefaultOptionKeys.context: True,
-                        DefaultOptionKeys.match_guard: "not_a_callable",
-                    }
-                }
-
-                @classmethod
-                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                    return data
-
-        message = str(exc_info.value)
-        del exc_info
-        assert "NonCallableMatchGuardFeatureGroup" in message
-        assert "partition_by" in message
-        assert DefaultOptionKeys.match_guard.value in message
-        assert "callable" in message
-
-    def test_parser_entry_point_rejects_non_callable_validator(self) -> None:
-        """The rule lives in core, so validating a mapping directly raises the same way."""
-        mapping: dict[str, Any] = {
-            "operation_type": {
-                DefaultOptionKeys.strict_validation: True,
-                DefaultOptionKeys.element_validator: ["add", "sub"],
-            }
-        }
-
-        with pytest.raises(ValueError, match="callable"):
-            FeatureChainParser.validate_property_mapping_defaults("SomeOwner", mapping)
-
-    def test_callable_validators_still_define(self) -> None:
-        """The guard rejects only non-callables: real callables keep working, unchanged."""
-
-        class CallableValidatorsFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-            PROPERTY_MAPPING = {
-                "window_size": {
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: True,
-                    DefaultOptionKeys.element_validator: _positive_int,
-                    DefaultOptionKeys.match_guard: _positive_int,
-                }
-            }
-
-            @classmethod
-            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                return data
-
         assert (
-            CallableValidatorsFeatureGroup.match_feature_group_criteria(
-                "any_feature", Options(context={"window_size": 7})
+            Shape694WellFormedFeatureGroup.match_feature_group_criteria(
+                "any_feature", Options(context={"shape694_operation": "sub", "shape694_window": -3})
             )
-            is True
+            is False
         )
-
-
-class TestSchemaRuleStillRunsFirst:
-    """The unknown-key rule keeps precedence over the new shape rules.
-
-    A malformed spec's remaining keys cannot be trusted, and a REMOVED key is the one offender
-    with an exact remedy. The shape rules must slot in BEHIND the schema rule, so a stale spec
-    is still reported as a rename.
-    """
-
-    def test_removed_key_is_reported_even_when_a_shape_rule_also_fires(self) -> None:
-        """A stale key plus a bad ``allowed_values`` shape: the rename still leads."""
-        with pytest.raises(ValueError) as exc_info:
-
-            class StaleAndMisshapenFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-                PROPERTY_MAPPING = {
-                    "operation_type": {
-                        DefaultOptionKeys.allowed_values: "add",
-                        DefaultOptionKeys.context: True,
-                        DefaultOptionKeys.strict_validation: True,
-                        STALE_ELEMENT_VALIDATOR_KEY: _positive_int,
-                    }
-                }
-
-                @classmethod
-                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                    return data
-
-        message = str(exc_info.value)
-        del exc_info
-        assert STALE_ELEMENT_VALIDATOR_KEY in message
-        assert DefaultOptionKeys.element_validator.value in message
-
-    def test_unknown_key_is_reported_even_when_a_validator_is_not_callable(self) -> None:
-        """An unknown key plus a non-callable validator: the unknown key still leads."""
-        with pytest.raises(ValueError) as exc_info:
-
-            class UnknownAndNonCallableFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-                PROPERTY_MAPPING = {
-                    "operation_type": {
-                        DefaultOptionKeys.context: True,
-                        DefaultOptionKeys.strict_validation: True,
-                        DefaultOptionKeys.element_validator: ["add"],
-                        "documentation_url": "https://example.invalid/op",
-                    }
-                }
-
-                @classmethod
-                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                    return data
-
-        message = str(exc_info.value)
-        del exc_info
-        assert "documentation_url" in message
-
-
-class TestEveryUnknownKeyIsReported:
-    """The unknown-key message lists EVERY offender, not just the first one.
-
-    Fixing one typo and re-running to discover the next is a needless round trip, and with a
-    removed key present the typo is never mentioned at all.
-    """
-
-    def test_all_unknown_keys_are_listed(self) -> None:
-        """Two typo'd keys, one message: both are named."""
-        with pytest.raises(ValueError) as exc_info:
-
-            class TwoTyposFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-                PROPERTY_MAPPING = {
-                    "operation_type": {
-                        DefaultOptionKeys.allowed_values: {"add": "Addition"},
-                        TYPO_STRICT_KEY: True,
-                        TYPO_CONTEXT_KEY: True,
-                    }
-                }
-
-                @classmethod
-                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                    return data
-
-        message = str(exc_info.value)
-        del exc_info
-        assert TYPO_STRICT_KEY in message
-        assert TYPO_CONTEXT_KEY in message, "every unknown key must be reported, not just the first"
-
-    def test_removed_key_leads_but_other_unknown_keys_are_still_listed(self) -> None:
-        """A removed key still leads with its exact remedy, and the typo is named too."""
-        with pytest.raises(ValueError) as exc_info:
-
-            class StalePlusTypoFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-                PROPERTY_MAPPING = {
-                    "operation_type": {
-                        DefaultOptionKeys.allowed_values: {"add": "Addition"},
-                        DefaultOptionKeys.strict_validation: True,
-                        STALE_ELEMENT_VALIDATOR_KEY: _positive_int,
-                        TYPO_CONTEXT_KEY: True,
-                    }
-                }
-
-                @classmethod
-                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                    return data
-
-        message = str(exc_info.value)
-        del exc_info
-        assert STALE_ELEMENT_VALIDATOR_KEY in message
-        assert DefaultOptionKeys.element_validator.value in message, "the removed key keeps its exact remedy"
-        assert TYPO_CONTEXT_KEY in message, "a removed key must not hide the other unknown keys"
-
-
-class TestStrictValidationFlagMustBeBool:
-    """``strict_validation`` must be a real ``bool``, not merely truthy.
-
-    ``_is_strict_validation`` is truthiness-based, so ``strict_validation: "false"`` reads as
-    strict. The error message then asserts ``strict_validation=True`` about a spec that literally
-    says ``"false"``. Requiring a real bool is the fix rather than softening the message: a truthy
-    non-bool flag is itself a latent bug of exactly the kind this layer exists to eliminate, and
-    no spec in the repository passes a non-bool today.
-    """
-
-    @pytest.mark.parametrize("flag", ["false", "true", 1, 0, "", None], ids=repr)
-    def test_non_bool_strict_validation_flag_rejected(self, flag: Any) -> None:
-        """Any non-bool flag raises at class definition, truthy or falsy."""
-        mapping: dict[str, Any] = {
-            "operation_type": {
-                DefaultOptionKeys.allowed_values: {"add": "Addition"},
-                DefaultOptionKeys.strict_validation: flag,
-            }
-        }
-
-        with pytest.raises(ValueError, match="strict_validation"):
-            FeatureChainParser.validate_property_mapping_defaults("SomeOwner", mapping)
-
-    def test_non_bool_flag_message_does_not_assert_strict_validation_is_true(self) -> None:
-        """The message must not claim ``strict_validation=True`` about a spec saying ``"false"``."""
-        with pytest.raises(ValueError) as exc_info:
-
-            class TruthyStringStrictFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-                PROPERTY_MAPPING = {
-                    "operation_type": {
-                        DefaultOptionKeys.context: True,
-                        DefaultOptionKeys.strict_validation: "false",
-                    }
-                }
-
-                @classmethod
-                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                    return data
-
-        message = str(exc_info.value)
-        del exc_info
-        assert "TruthyStringStrictFeatureGroup" in message
-        assert DefaultOptionKeys.strict_validation.value in message
-        assert "bool" in message
-        assert "strict_validation=True" not in message, (
-            "the spec says 'false': the message must not assert a value the author never wrote"
-        )
-
-    def test_truthy_non_bool_flag_never_silently_enables_strict_matching(self) -> None:
-        """A ``"false"`` flag reads as strict today, so the spec does the OPPOSITE of what it says.
-
-        The observable tell is the ValueError the strict path raises and
-        ``match_feature_group_criteria`` swallows: ``_strict_validation_rejection_reason``
-        surfaces it. A flag saying ``"false"`` must never produce a strict rejection, and after
-        the guard it cannot: the spec does not define at all.
-        """
-        reason: str | None
-
-        try:
-
-            class SilentlyStrictFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-                PROPERTY_MAPPING = {
-                    "operation_type": {
-                        DefaultOptionKeys.allowed_values: {"add": "Addition"},
-                        DefaultOptionKeys.context: True,
-                        DefaultOptionKeys.strict_validation: "false",
-                    }
-                }
-
-                @classmethod
-                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                    return data
-
-            reason = SilentlyStrictFeatureGroup._strict_validation_rejection_reason(
-                "any_feature", Options(context={"operation_type": "mul"})
-            )
-        except ValueError:
-            reason = None
-
-        assert reason is None, "a spec whose flag literally says 'false' must never enforce strict validation"
-
-    @pytest.mark.parametrize("flag", [True, False], ids=["True", "False"])
-    def test_real_bool_flags_still_define(self, flag: bool) -> None:
-        """Both real bools keep working: the guard rejects only non-bools."""
-
-        class RealBoolStrictFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-            PROPERTY_MAPPING = {
-                "operation_type": {
-                    DefaultOptionKeys.allowed_values: {"add": "Addition"},
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: flag,
-                }
-            }
-
-            @classmethod
-            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                return data
-
-        assert (
-            RealBoolStrictFeatureGroup.match_feature_group_criteria(
-                "any_feature", Options(context={"operation_type": "add"})
-            )
-            is True
-        )
-
-
-def _region_required_in_prod(options: Options) -> bool:
-    """``region`` is only required when deploying to prod."""
-    return bool(options.get("env") == "prod")
-
-
-class TestPropertySpecBuildsNonStrictValueSpace:
-    """``property_spec`` must be able to build a NON-STRICT spec WITH ``allowed_values``.
-
-    It refuses today, on the premise "allowed_values is never enforced without strict=True".
-    That premise is false. A non-strict value space IS consumed, by two seams that call
-    ``_extract_property_values`` unconditionally:
-
-    * ``FeatureChainParserMixin._find_property_key_for_value`` (the forwarded-name-mismatch guard)
-    * ``FeatureChainParserMixin._build_effective_options`` (required_when)
-
-    Both use it to map a name-parsed ``operation_config`` back to its PROPERTY_MAPPING key.
-    Before the flattened form was retired, such a spec carried its values flattened; now
-    ``allowed_values`` is the ONLY channel, and the builder refuses the shape the repository's
-    own fixtures need (``propagate_context_feature.py`` 'env', ``chainer_context_feature.py``
-    'property3'), which is why those fixtures are hand-written dicts.
-    """
-
-    def test_property_spec_builds_a_non_strict_spec_with_allowed_values(self) -> None:
-        """The shape the fixtures need: a declared value space, no strict enforcement."""
-        spec = property_spec(
-            "Deployment environment",
-            strict=False,
-            allowed_values={"prod": "Production", "staging": "Staging"},
-        )
-
-        assert spec[DefaultOptionKeys.allowed_values] == {"prod": "Production", "staging": "Staging"}
-        assert spec[DefaultOptionKeys.strict_validation] is False
-
-    def test_built_non_strict_value_space_maps_a_name_parsed_value_to_its_property_key(self) -> None:
-        """``_find_property_key_for_value`` recovers the key from a NON-STRICT value space."""
-        mapping: dict[str, Any] = {
-            "env": property_spec(
-                "Deployment environment",
-                strict=False,
-                allowed_values={"prod": "Production", "staging": "Staging"},
-            )
-        }
-
-        assert FeatureChainParserMixin._find_property_key_for_value(mapping, "prod") == "env"
-        assert FeatureChainParserMixin._find_property_key_for_value(mapping, "nonsense") is None
-
-    def test_built_non_strict_value_space_merges_the_name_parsed_value_into_effective_options(self) -> None:
-        """``_build_effective_options`` maps the name-parsed value onto the key via that space."""
-        mapping: dict[str, Any] = {
-            "env": property_spec(
-                "Deployment environment",
-                strict=False,
-                allowed_values={"prod": "Production", "staging": "Staging"},
-            )
-        }
-
-        effective = FeatureChainParserMixin._build_effective_options(
-            "service__prod", [r".*__([\w]+)$"], mapping, Options()
-        )
-
-        assert effective.get("env") == "prod"
-
-    def test_non_strict_value_space_drives_required_when_end_to_end(self) -> None:
-        """The whole point: without the value space, ``required_when`` never sees the env.
-
-        ``region`` is required only for prod. The env arrives from the feature NAME, so it can
-        only reach the predicate if the non-strict value space maps 'prod' back onto 'env'.
-        """
-
-        class DeploymentFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-            PREFIX_PATTERN = r".*__([\w]+)_deploy$"
-            PROPERTY_MAPPING = {
-                "env": property_spec(
-                    "Deployment environment",
-                    strict=False,
-                    allowed_values={"prod": "Production", "staging": "Staging"},
-                ),
-                "region": property_spec("Target region", required_when=_region_required_in_prod),
-            }
-
-            @classmethod
-            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                return data
-
-        assert DeploymentFeatureGroup.match_feature_group_criteria("service__prod_deploy", Options()) is False, (
-            "prod deployments require a region, which required_when can only know via the value space"
-        )
-        assert (
-            DeploymentFeatureGroup.match_feature_group_criteria(
-                "service__prod_deploy", Options(context={"region": "eu"})
-            )
-            is True
-        )
-        assert DeploymentFeatureGroup.match_feature_group_criteria("service__staging_deploy", Options()) is True, (
-            "staging needs no region"
-        )
-
-    def test_non_strict_spec_still_accepts_values_outside_its_value_space(self) -> None:
-        """A non-strict value space is a mapping aid, not an enforcement: it never rejects."""
-
-        class UnenforcedValueSpaceFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-            PROPERTY_MAPPING = {
-                "env": property_spec(
-                    "Deployment environment",
-                    strict=False,
-                    allowed_values={"prod": "Production", "staging": "Staging"},
-                )
-            }
-
-            @classmethod
-            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                return data
-
-        assert (
-            UnenforcedValueSpaceFeatureGroup.match_feature_group_criteria(
-                "any_feature", Options(context={"env": "dev"})
-            )
-            is True
-        )
-
-    def test_property_spec_still_rejects_element_validator_without_strict(self) -> None:
-        """The OTHER never-enforced-without-strict rule is true, and stays.
-
-        ``element_validator`` really is dead without strict: ``_validate_property_value`` returns
-        early when the spec is not strict. Only the ``allowed_values`` premise was false.
-        """
-        with pytest.raises(ValueError, match="element_validator"):
-            property_spec("Window size", strict=False, element_validator=_positive_int)
-
-    def test_property_spec_rejects_a_str_allowed_values(self) -> None:
-        """``tuple("add")`` is ``('a', 'd', 'd')``: the builder must not silently do that."""
-        with pytest.raises(ValueError, match="allowed_values"):
-            property_spec("Operation", strict=True, allowed_values="add")
-
-    def test_property_spec_rejects_a_str_allowed_values_without_strict(self) -> None:
-        """Now that a non-strict value space is legal, it must be shape-checked for its own sake.
-
-        This must be rejected for its SHAPE. It is rejected today, but on the false premise that
-        a non-strict ``allowed_values`` is never enforced, so the message is asserted to have
-        dropped that premise.
-        """
-        with pytest.raises(ValueError) as exc_info:
-            property_spec("Operation", strict=False, allowed_values="add")
-
-        message = str(exc_info.value)
-        del exc_info
-        assert DefaultOptionKeys.allowed_values.value in message
-        assert "never enforced without strict" not in message, (
-            "a non-strict value space IS consumed (name-parsed value -> property key), "
-            "so the only fault here is the str shape"
-        )
-
-    def test_property_spec_rejects_bytes_allowed_values(self) -> None:
-        """``bytes`` substring-matches like ``str`` and is rejected the same way."""
-        with pytest.raises(ValueError, match="allowed_values"):
-            property_spec("Operation", strict=True, allowed_values=b"add")

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_type_constraints.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_type_constraints.py
@@ -14,7 +14,7 @@ from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import ComputeFramework, FeatureGroup
 from mloda.user import Feature, PluginCollector, mloda
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
-from mloda.provider import DefaultOptionKeys
+from mloda.provider import PropertySpec
 
 from tests.test_plugins.integration_plugins.test_data_creator import ATestDataCreator
 
@@ -46,17 +46,18 @@ class MockWithTypeConstraint(FeatureChainParserMixin):
     PARTITION_BY = "partition_by"
 
     PROPERTY_MAPPING = {
-        "operation": {
-            DefaultOptionKeys.allowed_values: {"sum": "Sum of values", "avg": "Average of values"},
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-        },
-        "partition_by": {
-            "explanation": "List of columns to partition by",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.match_guard: _is_list_of_strings,
-        },
+        "operation": PropertySpec(
+            "Operation to apply",
+            allowed_values={"sum": "Sum of values", "avg": "Average of values"},
+            context=True,
+            strict_validation=True,
+        ),
+        "partition_by": PropertySpec(
+            "List of columns to partition by",
+            context=True,
+            strict_validation=False,
+            match_guard=_is_list_of_strings,
+        ),
     }
 
 
@@ -66,12 +67,13 @@ class MockStrictWithMatchGuard(FeatureChainParserMixin):
     PREFIX_PATTERN = r".*__([\w]+)_strict$"
 
     PROPERTY_MAPPING = {
-        "mode": {
-            DefaultOptionKeys.allowed_values: {"fast": "Fast mode", "slow": "Slow mode"},
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.match_guard: lambda v: isinstance(v, str),
-        },
+        "mode": PropertySpec(
+            "Execution mode",
+            allowed_values={"fast": "Fast mode", "slow": "Slow mode"},
+            context=True,
+            strict_validation=True,
+            match_guard=lambda v: isinstance(v, str),
+        ),
     }
 
 
@@ -86,12 +88,13 @@ class MockStrictWithOrthogonalMatchGuard(FeatureChainParserMixin):
     PREFIX_PATTERN = r".*__([\w]+)_ortho$"
 
     PROPERTY_MAPPING = {
-        "mode": {
-            DefaultOptionKeys.allowed_values: {"fast": "Fast mode", "slow": "Slow mode", "ok": "OK mode"},
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.match_guard: _max_length_3,
-        },
+        "mode": PropertySpec(
+            "Execution mode",
+            allowed_values={"fast": "Fast mode", "slow": "Slow mode", "ok": "OK mode"},
+            context=True,
+            strict_validation=True,
+            match_guard=_max_length_3,
+        ),
     }
 
 
@@ -101,12 +104,12 @@ class MockWithRaisingValidator(FeatureChainParserMixin):
     PREFIX_PATTERN = r".*__([\w]+)_raise$"
 
     PROPERTY_MAPPING = {
-        "items": {
-            "explanation": "A list of items",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.match_guard: _raising_validator,
-        },
+        "items": PropertySpec(
+            "A list of items",
+            context=True,
+            strict_validation=False,
+            match_guard=_raising_validator,
+        ),
     }
 
 
@@ -116,11 +119,12 @@ class MockWithoutTypeConstraint(FeatureChainParserMixin):
     PREFIX_PATTERN = r".*__([\w]+)_typed$"
 
     PROPERTY_MAPPING = {
-        "operation": {
-            DefaultOptionKeys.allowed_values: {"sum": "Sum of values"},
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-        },
+        "operation": PropertySpec(
+            "Operation to apply",
+            allowed_values={"sum": "Sum of values"},
+            context=True,
+            strict_validation=True,
+        ),
     }
 
 
@@ -247,17 +251,18 @@ class MatchGuardedAggregation(FeatureChainParserMixin, FeatureGroup):
     MAX_IN_FEATURES = 1
 
     PROPERTY_MAPPING = {
-        "aggregation_type": {
-            DefaultOptionKeys.allowed_values: {"sum": "Sum of values"},
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-        },
-        "partition_by": {
-            "explanation": "List of columns to partition by",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.match_guard: _is_list_of_strings,
-        },
+        "aggregation_type": PropertySpec(
+            "Aggregation to apply",
+            allowed_values={"sum": "Sum of values"},
+            context=True,
+            strict_validation=True,
+        ),
+        "partition_by": PropertySpec(
+            "List of columns to partition by",
+            context=True,
+            strict_validation=False,
+            match_guard=_is_list_of_strings,
+        ),
     }
 
     @classmethod

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_unified_model.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_unified_model.py
@@ -1,69 +1,53 @@
-"""One coherent mental model for the PROPERTY_MAPPING validation layer (issue #600).
+"""The ``PropertySpec`` dataclass is the ONE model for PROPERTY_MAPPING validation (issue #694).
 
-Two decisions are pinned here.
+The unified-model decisions from issue #600 survive the dict-spec deletion, re-anchored on the
+type:
 
-1. Hard rename, no back-compat. The two callable-valued PROPERTY_MAPPING keys get
-   names that state what they do:
+1. The two callable validators are FIELDS of ``PropertySpec``, under the names that state what
+   they do:
 
-   * ``element_validator`` (was ``validation_function``): runs on EACH parsed element
-     after list unpacking, requires ``strict_validation=True``, and on a falsy return
-     RAISES ``ValueError`` (recovered by the mixin as a non-match, surfaced to the user
+   * ``element_validator``: runs on EACH parsed element after list unpacking, requires
+     ``strict_validation=True`` (enforced at construction, so the old tolerance for a
+     non-strict spec carrying an unenforced validator is unexpressible now), and on a falsy
+     return raises ``ValueError`` (recovered by the mixin as a non-match, surfaced to the user
      via ``_strict_validation_rejection_reason``).
-   * ``match_guard`` (was ``type_validator``): runs on the RAW option value with no list
-     unpacking, does NOT require ``strict_validation``, and on a falsy return simply
-     means "this feature group does not match" (debug log, ``False``, no error).
+   * ``match_guard``: runs on the RAW option value with no list unpacking, needs no strict
+     flag, and on a falsy return simply means "this feature group does not match" (debug log,
+     ``False``, no error).
 
-   The old names are GONE: no enum members, no aliases. A spec dict still carrying the
-   stale string key must FAIL LOUDLY at class-definition time rather than be silently
-   ignored. The stale keys are not part of the spec schema (``PROPERTY_SPEC_KEYS``), so
-   the general unknown-key rule catches them; being REMOVED keys, they get the message
-   variant that names their replacement.
+   The pre-rename names are GONE: ``validation_function`` and ``type_validator`` are unknown
+   constructor keywords (``TypeError``), through ``PropertySpec`` and the ``property_spec``
+   builder alike, and the internal helpers follow the field names.
 
-2. Shared default-check semantics. ``property_spec`` and
-   ``FeatureChainParser.validate_property_mapping_defaults`` encoded the same rules for a
-   declared default twice. There is now ONE implementation,
-   ``FeatureChainParser.check_declared_default(owner, key, spec)``, that both entry points
-   route through, so the "validator RAISED" vs "validator REJECTED" distinction cannot
-   drift between them.
+2. The declared-default check has exactly ONE implementation: the ``PropertySpec``
+   constructor. Direct construction and the ``property_spec`` builder raise the identical
+   message for the same bad default, prefixed ``PropertySpec('<explanation>')`` so the
+   offending spec is identifiable without an owning class.
 """
 
 from __future__ import annotations
 
-import gc
 from typing import Any
-from unittest.mock import patch
 
 import pytest
 
-from mloda.core.abstract_plugins.components.default_options_key import (
-    PROPERTY_SPEC_KEYS,
-    DefaultOptionKeys,
-)
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
-from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
-from mloda.core.abstract_plugins.components.utils import get_all_subclasses
-from mloda.core.abstract_plugins.feature_group import FeatureGroup
-from mloda.provider import property_spec
+from mloda.provider import PropertySpec, property_spec
 
-STALE_ELEMENT_VALIDATOR_KEY = "validation_function"
-STALE_MATCH_GUARD_KEY = "type_validator"
+STALE_ELEMENT_VALIDATOR_NAME = "validation_function"
+STALE_MATCH_GUARD_NAME = "type_validator"
 
 
-@pytest.fixture(autouse=True)
-def _no_feature_group_registry_pollution() -> Any:
-    """Guarantee this module never leaks throwaway FeatureGroup subclasses.
+def _construct(*args: Any, **kwargs: Any) -> PropertySpec:
+    """Call ``PropertySpec`` through an untyped seam, keeping the stale-keyword tests mypy-clean."""
+    return PropertySpec(*args, **kwargs)
 
-    Mirrors ``test_property_mapping_default_invariant.py``: the class-definition tests
-    below define FeatureGroup subclasses, which linger in ``FeatureGroup.__subclasses__()``
-    until a GC cycle runs and would otherwise be seen by tests that enumerate feature groups.
-    """
-    yield
-    gc.collect()
-    gc.collect()
-    leaked = [c for c in get_all_subclasses(FeatureGroup) if c.__module__ == __name__]
-    assert not leaked, f"Leaked FeatureGroup subclasses from {__name__}: {[c.__name__ for c in leaked]}"
+
+def _build(*args: Any, **kwargs: Any) -> PropertySpec:
+    """Call ``property_spec`` through an untyped seam, keeping the stale-keyword tests mypy-clean."""
+    return property_spec(*args, **kwargs)
 
 
 class _Recorder:
@@ -115,59 +99,46 @@ def _positive_int(value: Any) -> bool:
     return isinstance(value, int) and value > 0
 
 
-def _boom(value: Any) -> bool:
-    raise RuntimeError("boom")
+class TestValidatorFieldNames:
+    """``element_validator`` and ``match_guard`` are the fields; the stale names are gone."""
 
+    def test_element_validator_and_match_guard_are_property_spec_fields(self) -> None:
+        """Both validators live as first-class fields on the spec."""
+        spec = PropertySpec(
+            "Size of the time window",
+            strict_validation=True,
+            element_validator=_positive_int,
+            match_guard=_positive_int,
+        )
 
-class TestRenamedKeys:
-    """The two keys carry their new names, and the old names are gone (no aliases)."""
+        assert spec.element_validator is _positive_int
+        assert spec.match_guard is _positive_int
 
-    def test_element_validator_member_exists(self) -> None:
-        """``DefaultOptionKeys.element_validator`` exists with value ``"element_validator"``."""
-        assert DefaultOptionKeys.element_validator.value == "element_validator"
-        assert DefaultOptionKeys("element_validator") is DefaultOptionKeys.element_validator
+    def test_stale_validation_function_name_is_a_type_error(self) -> None:
+        """``validation_function`` is an unknown keyword on the constructor and the builder."""
+        with pytest.raises(TypeError):
+            _construct("op", strict_validation=True, validation_function=_positive_int)
+        with pytest.raises(TypeError):
+            _build("op", strict=True, validation_function=_positive_int)
 
-    def test_match_guard_member_exists(self) -> None:
-        """``DefaultOptionKeys.match_guard`` exists with value ``"match_guard"``."""
-        assert DefaultOptionKeys.match_guard.value == "match_guard"
-        assert DefaultOptionKeys("match_guard") is DefaultOptionKeys.match_guard
-
-    def test_old_members_are_gone(self) -> None:
-        """The old enum members no longer exist: attribute access raises ``AttributeError``."""
-        with pytest.raises(AttributeError):
-            getattr(DefaultOptionKeys, STALE_ELEMENT_VALIDATOR_KEY)
-        with pytest.raises(AttributeError):
-            getattr(DefaultOptionKeys, STALE_MATCH_GUARD_KEY)
-
-    def test_old_values_are_not_members(self) -> None:
-        """The old string values do not resolve to any member (no value alias)."""
-        with pytest.raises(ValueError):
-            DefaultOptionKeys(STALE_ELEMENT_VALIDATOR_KEY)
-        with pytest.raises(ValueError):
-            DefaultOptionKeys(STALE_MATCH_GUARD_KEY)
-
-    def test_spec_schema_carries_the_new_members(self) -> None:
-        """``PROPERTY_SPEC_KEYS`` admits the new keys, so a spec may carry them."""
-        assert DefaultOptionKeys.element_validator in PROPERTY_SPEC_KEYS
-        assert DefaultOptionKeys.match_guard in PROPERTY_SPEC_KEYS
-
-    def test_spec_schema_drops_the_old_strings(self) -> None:
-        """The stale string keys are not part of the spec schema, so they are unknown keys."""
-        assert STALE_ELEMENT_VALIDATOR_KEY not in PROPERTY_SPEC_KEYS
-        assert STALE_MATCH_GUARD_KEY not in PROPERTY_SPEC_KEYS
+    def test_stale_type_validator_name_is_a_type_error(self) -> None:
+        """``type_validator`` is an unknown keyword on the constructor and the builder."""
+        with pytest.raises(TypeError):
+            _construct("cols", type_validator=_positive_int)
+        with pytest.raises(TypeError):
+            _build("cols", type_validator=_positive_int)
 
 
 class TestRenamedInternalHelpers:
-    """The internal helpers follow the rename, so the vocabulary is consistent end to end."""
+    """The internal helpers follow the field names, so the vocabulary is consistent end to end."""
 
     def test_parser_exposes_get_element_validator(self) -> None:
-        """``FeatureChainParser._get_element_validator`` replaces ``_get_validation_function``."""
-        assert not hasattr(FeatureChainParser, "_get_validation_function")
+        """``FeatureChainParser._get_element_validator`` reads the field; the old name is gone."""
+        assert not hasattr(FeatureChainParser, f"_get_{STALE_ELEMENT_VALIDATOR_NAME}")
 
-        validator = _positive_int
-        spec = {DefaultOptionKeys.element_validator: validator}
-        assert FeatureChainParser._get_element_validator(spec) is validator
-        assert FeatureChainParser._get_element_validator({}) is None
+        spec = PropertySpec("Size of the time window", strict_validation=True, element_validator=_positive_int)
+        assert FeatureChainParser._get_element_validator(spec) is _positive_int
+        assert FeatureChainParser._get_element_validator(PropertySpec("x")) is None
 
     def test_mixin_exposes_validate_match_guards(self) -> None:
         """``FeatureChainParserMixin._validate_match_guards`` replaces ``_validate_type_validators``."""
@@ -175,179 +146,57 @@ class TestRenamedInternalHelpers:
         assert hasattr(FeatureChainParserMixin, "_validate_match_guards")
 
 
-class TestStaleKeysFailLoudly:
-    """A spec dict still carrying a stale key is rejected at class definition, never honored.
-
-    This is NOT backwards compatibility. A stale key is simply not in the spec schema, so the
-    general unknown-key rule rejects it; because it is a REMOVED key, the error names the
-    replacement instead of guessing at one. Silently ignoring it would leave the spec claiming a
-    validation it does not perform, so the rule converts that into an actionable migration error.
-    """
-
-    def test_stale_validation_function_key_rejected_at_class_definition(self) -> None:
-        """A PROPERTY_MAPPING carrying ``"validation_function"`` raises, naming ``element_validator``."""
-        with pytest.raises(ValueError) as exc_info:
-
-            class StaleValidationFunctionFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-                PROPERTY_MAPPING = {
-                    "operation_type": {
-                        DefaultOptionKeys.context: True,
-                        DefaultOptionKeys.strict_validation: True,
-                        STALE_ELEMENT_VALIDATOR_KEY: _positive_int,
-                    }
-                }
-
-                @classmethod
-                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                    return data
-
-        message = str(exc_info.value)
-        del exc_info
-        assert "StaleValidationFunctionFeatureGroup" in message
-        assert "operation_type" in message
-        assert STALE_ELEMENT_VALIDATOR_KEY in message
-        assert "element_validator" in message
-
-    def test_stale_type_validator_key_rejected_at_class_definition(self) -> None:
-        """A PROPERTY_MAPPING carrying ``"type_validator"`` raises, naming ``match_guard``."""
-        with pytest.raises(ValueError) as exc_info:
-
-            class StaleTypeValidatorFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-                PROPERTY_MAPPING = {
-                    "partition_by": {
-                        "explanation": "List of columns to partition by",
-                        DefaultOptionKeys.context: True,
-                        DefaultOptionKeys.strict_validation: False,
-                        STALE_MATCH_GUARD_KEY: _positive_int,
-                    }
-                }
-
-                @classmethod
-                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                    return data
-
-        message = str(exc_info.value)
-        del exc_info
-        assert "StaleTypeValidatorFeatureGroup" in message
-        assert "partition_by" in message
-        assert STALE_MATCH_GUARD_KEY in message
-        assert "match_guard" in message
-
-    def test_stale_key_is_reported_ahead_of_other_unknown_keys(self) -> None:
-        """A spec with several unknown keys still names the stale one: it has the exact remedy."""
-        with pytest.raises(ValueError) as exc_info:
-
-            class MultiOffenderStaleFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-                PROPERTY_MAPPING = {
-                    "operation_type": {
-                        "add": "Addition",
-                        "sub": "Subtraction",
-                        DefaultOptionKeys.context: True,
-                        DefaultOptionKeys.strict_validation: True,
-                        STALE_ELEMENT_VALIDATOR_KEY: _positive_int,
-                    }
-                }
-
-                @classmethod
-                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                    return data
-
-        message = str(exc_info.value)
-        del exc_info
-        assert STALE_ELEMENT_VALIDATOR_KEY in message
-        assert "element_validator" in message
-
-    def test_parser_entry_point_rejects_stale_spec(self) -> None:
-        """The guard lives in core, so validating a stale mapping directly also raises."""
-        mapping: dict[str, Any] = {
-            "operation_type": {
-                DefaultOptionKeys.context: True,
-                DefaultOptionKeys.strict_validation: True,
-                STALE_ELEMENT_VALIDATOR_KEY: _positive_int,
-            }
-        }
-
-        with pytest.raises(ValueError, match="element_validator"):
-            FeatureChainParser.validate_property_mapping_defaults("SomeOwner", mapping)
-
-    def test_stale_callable_is_never_absorbed_into_the_accepted_value_set(self) -> None:
-        """The regression this guard exists to prevent: the stale callable as an allowed VALUE.
-
-        A spec is not always reached through class definition, so matching is checked too. The
-        stale callable must never end up a member of the accepted set, which is what recovering
-        the value space by subtraction used to do. Matching such a spec must never succeed.
-        """
-        validator = _positive_int
-        mapping: dict[str, Any] = {
-            "operation_type": {
-                "add": "Addition",
-                DefaultOptionKeys.context: True,
-                DefaultOptionKeys.strict_validation: True,
-                STALE_ELEMENT_VALIDATOR_KEY: validator,
-            }
-        }
-
-        try:
-            matched = FeatureChainParser.match_configuration_feature_chain_parser(
-                "any_feature", Options(context={"operation_type": validator}), mapping
-            )
-        except ValueError:
-            matched = False
-
-        assert matched is False
-
-
 class TestElementValidatorSemantics:
-    """``element_validator``: per element, strict-only, falsy -> ``ValueError``."""
+    """``element_validator``: per element, strict-only by construction, falsy -> ``ValueError``."""
 
     def test_runs_on_each_element_after_list_unpacking(self) -> None:
         """A list option is unpacked: the validator sees each element, never the list."""
         validator = _PositiveIntRecorder()
 
-        class ElementFeatureGroup(FeatureChainParserMixin):
+        class Unified694ElementFeatureGroup(FeatureChainParserMixin):
             PROPERTY_MAPPING = {
-                "window_size": {
-                    "explanation": "Sizes of time windows",
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: True,
-                    DefaultOptionKeys.element_validator: validator,
-                }
+                "window_size": PropertySpec(
+                    "Sizes of time windows",
+                    context=True,
+                    strict_validation=True,
+                    element_validator=validator,
+                )
             }
 
         options = Options(context={"window_size": [1, 2, 3]})
 
-        assert ElementFeatureGroup.match_feature_group_criteria("any_feature", options) is True
+        assert Unified694ElementFeatureGroup.match_feature_group_criteria("any_feature", options) is True
         assert set(validator.calls) == {1, 2, 3}
 
     def test_rejected_element_is_a_non_match(self) -> None:
         """A falsy verdict on any element makes the whole feature group not match."""
         validator = _PositiveIntRecorder()
 
-        class RejectingElementFeatureGroup(FeatureChainParserMixin):
+        class Unified694RejectingElementFeatureGroup(FeatureChainParserMixin):
             PROPERTY_MAPPING = {
-                "window_size": {
-                    "explanation": "Sizes of time windows",
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: True,
-                    DefaultOptionKeys.element_validator: validator,
-                }
+                "window_size": PropertySpec(
+                    "Sizes of time windows",
+                    context=True,
+                    strict_validation=True,
+                    element_validator=validator,
+                )
             }
 
         options = Options(context={"window_size": [1, -3]})
 
-        assert RejectingElementFeatureGroup.match_feature_group_criteria("any_feature", options) is False
+        assert Unified694RejectingElementFeatureGroup.match_feature_group_criteria("any_feature", options) is False
         assert validator.calls, "the element_validator must have been called"
         assert all(not isinstance(call, list) for call in validator.calls), "elements, not the raw list"
 
     def test_rejection_raises_value_error_in_the_parser(self) -> None:
         """The rejection is a ``ValueError`` at the parser seam (the mixin recovers it)."""
-        mapping: dict[str, Any] = {
-            "window_size": {
-                "explanation": "Size of time window",
-                DefaultOptionKeys.context: True,
-                DefaultOptionKeys.strict_validation: True,
-                DefaultOptionKeys.element_validator: _positive_int,
-            }
+        mapping: dict[str, PropertySpec] = {
+            "window_size": PropertySpec(
+                "Size of time window",
+                context=True,
+                strict_validation=True,
+                element_validator=_positive_int,
+            )
         }
 
         with pytest.raises(ValueError, match="window_size"):
@@ -358,44 +207,25 @@ class TestElementValidatorSemantics:
     def test_rejection_is_surfaced_via_strict_validation_rejection_reason(self) -> None:
         """The discarded ``ValueError`` message reaches the user diagnostic hook."""
 
-        class SurfacedElementFeatureGroup(FeatureChainParserMixin):
+        class Unified694SurfacedElementFeatureGroup(FeatureChainParserMixin):
             PROPERTY_MAPPING = {
-                "window_size": {
-                    "explanation": "Size of time window",
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: True,
-                    DefaultOptionKeys.element_validator: _positive_int,
-                }
+                "window_size": PropertySpec(
+                    "Size of time window",
+                    context=True,
+                    strict_validation=True,
+                    element_validator=_positive_int,
+                )
             }
 
         options = Options(context={"window_size": -3})
 
-        assert SurfacedElementFeatureGroup.match_feature_group_criteria("any_feature", options) is False
+        assert Unified694SurfacedElementFeatureGroup.match_feature_group_criteria("any_feature", options) is False
 
-        reason = SurfacedElementFeatureGroup._strict_validation_rejection_reason("any_feature", options)
+        reason = Unified694SurfacedElementFeatureGroup._strict_validation_rejection_reason("any_feature", options)
 
         assert reason is not None
         assert "window_size" in reason
         assert "-3" in reason
-
-    def test_not_enforced_without_strict_validation(self) -> None:
-        """``element_validator`` is strict-only: without ``strict_validation`` it never runs."""
-        validator = _PositiveIntRecorder()
-
-        class NonStrictElementFeatureGroup(FeatureChainParserMixin):
-            PROPERTY_MAPPING = {
-                "window_size": {
-                    "explanation": "Size of time window",
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: False,
-                    DefaultOptionKeys.element_validator: validator,
-                }
-            }
-
-        options = Options(context={"window_size": -3})
-
-        assert NonStrictElementFeatureGroup.match_feature_group_criteria("any_feature", options) is True
-        assert validator.calls == []
 
 
 class TestMatchGuardSemantics:
@@ -405,74 +235,74 @@ class TestMatchGuardSemantics:
         """The guard sees the raw list, un-unpacked, with ``strict_validation`` off."""
         guard = _ListOfStringsRecorder()
 
-        class GuardedFeatureGroup(FeatureChainParserMixin):
+        class Unified694GuardedFeatureGroup(FeatureChainParserMixin):
             PROPERTY_MAPPING = {
-                "partition_by": {
-                    "explanation": "List of columns to partition by",
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: False,
-                    DefaultOptionKeys.match_guard: guard,
-                }
+                "partition_by": PropertySpec(
+                    "List of columns to partition by",
+                    context=True,
+                    strict_validation=False,
+                    match_guard=guard,
+                )
             }
 
         options = Options(context={"partition_by": ["region", "category"]})
 
-        assert GuardedFeatureGroup.match_feature_group_criteria("any_feature", options) is True
+        assert Unified694GuardedFeatureGroup.match_feature_group_criteria("any_feature", options) is True
         assert guard.calls == [["region", "category"]]
 
     def test_falsy_guard_is_a_silent_non_match(self) -> None:
         """A falsy verdict returns ``False`` from ``match_feature_group_criteria``, it does not raise."""
         guard = _ListOfStringsRecorder()
 
-        class RejectingGuardFeatureGroup(FeatureChainParserMixin):
+        class Unified694RejectingGuardFeatureGroup(FeatureChainParserMixin):
             PROPERTY_MAPPING = {
-                "partition_by": {
-                    "explanation": "List of columns to partition by",
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: False,
-                    DefaultOptionKeys.match_guard: guard,
-                }
+                "partition_by": PropertySpec(
+                    "List of columns to partition by",
+                    context=True,
+                    strict_validation=False,
+                    match_guard=guard,
+                )
             }
 
         options = Options(context={"partition_by": "region"})
 
-        assert RejectingGuardFeatureGroup.match_feature_group_criteria("any_feature", options) is False
+        assert Unified694RejectingGuardFeatureGroup.match_feature_group_criteria("any_feature", options) is False
         assert guard.calls == ["region"]
 
     def test_falsy_guard_is_not_a_strict_validation_rejection(self) -> None:
         """A guard non-match is not an option-value rejection, so it has no rejection reason."""
 
-        class QuietGuardFeatureGroup(FeatureChainParserMixin):
+        class Unified694QuietGuardFeatureGroup(FeatureChainParserMixin):
             PROPERTY_MAPPING = {
-                "partition_by": {
-                    "explanation": "List of columns to partition by",
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: False,
-                    DefaultOptionKeys.match_guard: _ListOfStringsRecorder(),
-                }
+                "partition_by": PropertySpec(
+                    "List of columns to partition by",
+                    context=True,
+                    strict_validation=False,
+                    match_guard=_ListOfStringsRecorder(),
+                )
             }
 
         options = Options(context={"partition_by": "region"})
 
-        assert QuietGuardFeatureGroup._strict_validation_rejection_reason("any_feature", options) is None
+        assert Unified694QuietGuardFeatureGroup._strict_validation_rejection_reason("any_feature", options) is None
 
     def test_raising_guard_is_caught_and_treated_as_non_match(self) -> None:
         """A guard that raises is caught: non-match, no exception escapes."""
         guard = _RaisingRecorder()
 
-        class RaisingGuardFeatureGroup(FeatureChainParserMixin):
+        class Unified694RaisingGuardFeatureGroup(FeatureChainParserMixin):
             PROPERTY_MAPPING = {
-                "items": {
-                    "explanation": "A list of items",
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: False,
-                    DefaultOptionKeys.match_guard: guard,
-                }
+                "items": PropertySpec(
+                    "A list of items",
+                    context=True,
+                    strict_validation=False,
+                    match_guard=guard,
+                )
             }
 
         options = Options(context={"items": "not_a_list"})
 
-        assert RaisingGuardFeatureGroup.match_feature_group_criteria("any_feature", options) is False
+        assert Unified694RaisingGuardFeatureGroup.match_feature_group_criteria("any_feature", options) is False
         assert guard.calls == ["not_a_list"]
 
 
@@ -484,20 +314,20 @@ class TestElementValidatorAndMatchGuardPrecedence:
         validator = _PositiveIntRecorder()
         guard = _Recorder(verdict=True)
 
-        class BothFeatureGroup(FeatureChainParserMixin):
+        class Unified694BothFeatureGroup(FeatureChainParserMixin):
             PROPERTY_MAPPING = {
-                "window_size": {
-                    "explanation": "Size of time window",
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: True,
-                    DefaultOptionKeys.element_validator: validator,
-                    DefaultOptionKeys.match_guard: guard,
-                }
+                "window_size": PropertySpec(
+                    "Size of time window",
+                    context=True,
+                    strict_validation=True,
+                    element_validator=validator,
+                    match_guard=guard,
+                )
             }
 
         options = Options(context={"window_size": -3})
 
-        assert BothFeatureGroup.match_feature_group_criteria("any_feature", options) is False
+        assert Unified694BothFeatureGroup.match_feature_group_criteria("any_feature", options) is False
         assert validator.calls == [-3]
         assert guard.calls == [], "the match_guard must not be reached once an element was rejected"
 
@@ -506,223 +336,41 @@ class TestElementValidatorAndMatchGuardPrecedence:
         validator = _PositiveIntRecorder()
         guard = _Recorder(verdict=False)
 
-        class BothPassFeatureGroup(FeatureChainParserMixin):
+        class Unified694BothPassFeatureGroup(FeatureChainParserMixin):
             PROPERTY_MAPPING = {
-                "window_size": {
-                    "explanation": "Size of time window",
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: True,
-                    DefaultOptionKeys.element_validator: validator,
-                    DefaultOptionKeys.match_guard: guard,
-                }
+                "window_size": PropertySpec(
+                    "Size of time window",
+                    context=True,
+                    strict_validation=True,
+                    element_validator=validator,
+                    match_guard=guard,
+                )
             }
 
         options = Options(context={"window_size": [1, 2]})
 
-        assert BothPassFeatureGroup.match_feature_group_criteria("any_feature", options) is False
+        assert Unified694BothPassFeatureGroup.match_feature_group_criteria("any_feature", options) is False
         assert set(validator.calls) == {1, 2}
         assert guard.calls == [[1, 2]], "the match_guard sees the raw, un-unpacked value"
 
 
-class TestCheckDeclaredDefaultSeam:
-    """``FeatureChainParser.check_declared_default`` is the ONE default-check implementation."""
+class TestOneDefaultCheckImplementation:
+    """The declared-default check has one implementation: the ``PropertySpec`` constructor."""
 
-    def test_is_a_no_op_for_a_valid_declared_default(self) -> None:
-        """A default the spec honors passes silently."""
-        spec: dict[str, Any] = {
-            DefaultOptionKeys.allowed_values: {"add": "Addition"},
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.default: "add",
-        }
+    def test_builder_and_constructor_raise_the_identical_default_message(self) -> None:
+        """Both entry points are the same code path, so the messages cannot drift."""
+        with pytest.raises(ValueError) as constructor_exc:
+            PropertySpec("op", allowed_values={"add": "Addition"}, strict_validation=True, default="mul")
+        with pytest.raises(ValueError) as builder_exc:
+            property_spec("op", strict=True, allowed_values={"add": "Addition"}, default="mul")
 
-        assert FeatureChainParser.check_declared_default("Owner", "operation_type", spec) is None
+        assert str(constructor_exc.value) == str(builder_exc.value)
 
-    def test_raises_for_a_default_outside_the_accepted_set(self) -> None:
-        """A default outside the accepted set raises, naming the owner and the key."""
-        spec: dict[str, Any] = {
-            DefaultOptionKeys.allowed_values: {"add": "Addition"},
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.default: "mul",
-        }
-
-        with pytest.raises(ValueError) as exc_info:
-            FeatureChainParser.check_declared_default("Owner", "operation_type", spec)
-
-        message = str(exc_info.value)
-        del exc_info
-        assert "Owner" in message
-        assert "operation_type" in message
-        assert "mul" in message
-
-    def test_feature_group_definition_routes_through_the_seam(self) -> None:
-        """``FeatureGroup.__init_subclass__`` delegates its default check to the shared seam."""
-        spec = {
-            DefaultOptionKeys.allowed_values: {"add": "Addition"},
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.default: "add",
-        }
-
-        with patch.object(FeatureChainParser, "check_declared_default") as spy:
-
-            class RoutedFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-                PROPERTY_MAPPING = {"operation_type": spec}
-
-                @classmethod
-                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                    return data
-
-        assert spy.call_count == 1
-        passed = list(spy.call_args.args) + list(spy.call_args.kwargs.values())
-        assert "operation_type" in passed
-        assert spec in passed
-
-    def test_property_spec_routes_through_the_seam(self) -> None:
-        """``property_spec`` delegates its default check to the same shared seam."""
-        with patch.object(FeatureChainParser, "check_declared_default") as spy:
-            property_spec("op", strict=True, allowed_values={"add": "Addition"}, default="add")
-
-        assert spy.call_count == 1
-        passed = list(spy.call_args.args) + list(spy.call_args.kwargs.values())
-        assert any(isinstance(arg, str) and "property_spec" in arg for arg in passed), (
-            "property_spec must pass an owner label identifying itself"
-        )
-
-    def test_property_spec_owner_label_carries_the_explanation(self) -> None:
-        """The shared error message identifies the offending ``property_spec`` call."""
-        with pytest.raises(ValueError) as exc_info:
+    def test_default_message_identifies_the_spec_by_its_explanation(self) -> None:
+        """The ``PropertySpec('...')`` prefix identifies the offender; no owner label needed."""
+        with pytest.raises(ValueError, match=r"PropertySpec\('op'\)") as exc_info:
             property_spec("op", strict=True, allowed_values={"add": "Addition"}, default="mul")
 
         message = str(exc_info.value)
-        del exc_info
-        assert "property_spec" in message
-        assert "op" in message
+        assert "default" in message
         assert "mul" in message
-
-
-class TestRaisedVersusRejectedThroughBothEntryPoints:
-    """The raised/rejected distinction is identical through both entry points, by construction."""
-
-    def test_class_definition_reports_a_raising_element_validator_as_raised(self) -> None:
-        """A validator that errors on the default reports "raised", chaining the original."""
-        with pytest.raises(ValueError) as exc_info:
-
-            class RaisingFnFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-                PROPERTY_MAPPING = {
-                    "operation_type": {
-                        DefaultOptionKeys.context: True,
-                        DefaultOptionKeys.strict_validation: True,
-                        DefaultOptionKeys.element_validator: _boom,
-                        DefaultOptionKeys.default: "x",
-                    }
-                }
-
-                @classmethod
-                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                    return data
-
-        message = str(exc_info.value)
-        cause_is_runtime_error = isinstance(exc_info.value.__cause__, RuntimeError)
-        del exc_info
-        assert "RaisingFnFeatureGroup" in message
-        assert "raised" in message
-        assert "rejected by" not in message
-        assert cause_is_runtime_error, "expected the original RuntimeError chained as __cause__"
-
-    def test_class_definition_reports_a_rejecting_element_validator_as_rejected(self) -> None:
-        """A validator that runs and returns falsy reports "rejected by"."""
-        with pytest.raises(ValueError) as exc_info:
-
-            class RejectingFnFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-                PROPERTY_MAPPING = {
-                    "operation_type": {
-                        DefaultOptionKeys.context: True,
-                        DefaultOptionKeys.strict_validation: True,
-                        DefaultOptionKeys.element_validator: _positive_int,
-                        DefaultOptionKeys.default: -1,
-                    }
-                }
-
-                @classmethod
-                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                    return data
-
-        message = str(exc_info.value)
-        del exc_info
-        assert "RejectingFnFeatureGroup" in message
-        assert "rejected by" in message
-        assert "raised" not in message
-
-    def test_property_spec_reports_a_raising_element_validator_as_raised(self) -> None:
-        """The same wording and the same chaining, through the ``property_spec`` entry point."""
-        with pytest.raises(ValueError) as exc_info:
-            property_spec("op", strict=True, element_validator=_boom, default=5)
-
-        message = str(exc_info.value)
-        cause_is_runtime_error = isinstance(exc_info.value.__cause__, RuntimeError)
-        del exc_info
-        assert "raised" in message
-        assert "rejected by" not in message
-        assert cause_is_runtime_error, "expected the original RuntimeError chained as __cause__"
-
-    def test_property_spec_reports_a_rejecting_element_validator_as_rejected(self) -> None:
-        """The same wording for a genuine rejection, through the ``property_spec`` entry point."""
-        with pytest.raises(ValueError) as exc_info:
-            property_spec("op", strict=True, element_validator=_positive_int, default=-1)
-
-        message = str(exc_info.value)
-        del exc_info
-        assert "rejected by" in message
-        assert "raised" not in message
-
-
-class TestPropertySpecEmitsTheNewKeys:
-    """``property_spec`` speaks the new vocabulary: new kwargs in, new keys out."""
-
-    def test_emits_element_validator_key(self) -> None:
-        """``element_validator=`` lands under ``DefaultOptionKeys.element_validator``."""
-        spec = property_spec("op", strict=True, element_validator=_positive_int)
-
-        assert spec[DefaultOptionKeys.element_validator] is _positive_int
-        assert spec[DefaultOptionKeys.strict_validation] is True
-
-    def test_emits_match_guard_key(self) -> None:
-        """``match_guard=`` lands under ``DefaultOptionKeys.match_guard``, no strict needed."""
-        guard = _ListOfStringsRecorder()
-        spec = property_spec("cols", match_guard=guard)
-
-        assert spec[DefaultOptionKeys.match_guard] is guard
-        assert spec[DefaultOptionKeys.strict_validation] is False
-
-    def test_omitted_new_keys_are_absent(self) -> None:
-        """An omitted validator/guard is absent, never present-and-``None``."""
-        spec = property_spec("op")
-
-        assert DefaultOptionKeys.element_validator not in spec
-        assert DefaultOptionKeys.match_guard not in spec
-
-    def test_stale_kwargs_are_gone(self) -> None:
-        """The old keyword arguments no longer exist: passing them fails loudly."""
-        with pytest.raises((TypeError, ValueError)):
-            property_spec("op", strict=True, validation_function=_positive_int)  # type: ignore[call-arg]
-        with pytest.raises((TypeError, ValueError)):
-            property_spec("op", type_validator=_positive_int)  # type: ignore[call-arg]
-
-    def test_authoring_invariants_still_live_in_property_spec(self) -> None:
-        """The authoring-time-only invariants stay put; only the default check moved to core.
-
-        ``allowed_values`` without strict is NOT among them: a non-strict value space is still
-        consumed (name-parsed value -> property key). ``element_validator`` without strict is,
-        because it really is never enforced. See ``test_property_mapping_spec_shape.py``.
-        """
-        with pytest.raises(ValueError):
-            property_spec("op", strict=True)
-        with pytest.raises(ValueError):
-            property_spec("op", element_validator=_positive_int)
-        with pytest.raises(ValueError):
-            property_spec("op", strict=True, element_validator=_positive_int, allowed_values=[])
-        not_callable: Any = "not callable"
-        with pytest.raises(ValueError):
-            property_spec("op", strict=True, element_validator=not_callable)
-        with pytest.raises(ValueError):
-            property_spec("op", match_guard=not_callable)

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_spec_author_time.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_spec_author_time.py
@@ -1,0 +1,56 @@
+"""Author-time type-error pins for ``PropertySpec`` and ``property_spec`` (issue #694 DoD).
+
+Each invalid construction below is a direct typed call carrying the specific ``# type: ignore[code]``
+it triggers. Because the tox gate runs mypy --strict with ``warn_unused_ignores``, an ignore that
+stops being needed fails the gate: the ignores themselves pin that mypy catches each mistake, while
+pytest pins the matching runtime rejection.
+
+The builder mirrors every case: most in-repo specs and every docs example are written with
+``property_spec``, so the guarantee only holds if its parameters are as narrow as the fields.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mloda.core.abstract_plugins.components.feature_chainer.property_spec import PropertySpec, property_spec
+
+
+class TestAuthorTimeTypeErrors:
+    """One invalid construction per test; mypy flags it at author time, runtime rejects it too."""
+
+    def test_misspelled_field_is_a_type_error_and_a_runtime_type_error(self) -> None:
+        with pytest.raises(TypeError):
+            PropertySpec("x", strict_validaton=True)  # type: ignore[call-arg]
+
+    def test_non_bool_flag_is_a_type_error_and_rejected_at_runtime(self) -> None:
+        with pytest.raises(ValueError):
+            PropertySpec("x", strict_validation="yes")  # type: ignore[arg-type]
+
+    def test_non_callable_validator_is_a_type_error_and_rejected_at_runtime(self) -> None:
+        with pytest.raises(ValueError):
+            PropertySpec("x", strict_validation=True, element_validator=123)  # type: ignore[arg-type]
+
+    def test_str_allowed_values_is_a_type_error_and_rejected_at_runtime(self) -> None:
+        with pytest.raises(ValueError):
+            PropertySpec("x", allowed_values="add")  # type: ignore[arg-type]
+
+
+class TestAuthorTimeTypeErrorsThroughTheBuilder:
+    """The same four mistakes through ``property_spec``, whose parameters mirror the fields."""
+
+    def test_misspelled_keyword_is_a_type_error_and_a_runtime_type_error(self) -> None:
+        with pytest.raises(TypeError):
+            property_spec("x", strct=True)  # type: ignore[call-arg]
+
+    def test_non_bool_strict_is_a_type_error_and_rejected_at_runtime(self) -> None:
+        with pytest.raises(ValueError):
+            property_spec("x", strict="yes")  # type: ignore[arg-type]
+
+    def test_non_callable_validator_is_a_type_error_and_rejected_at_runtime(self) -> None:
+        with pytest.raises(ValueError):
+            property_spec("x", strict=True, element_validator=123)  # type: ignore[arg-type]
+
+    def test_str_allowed_values_is_a_type_error_and_rejected_at_runtime(self) -> None:
+        with pytest.raises(ValueError):
+            property_spec("x", allowed_values="add")  # type: ignore[arg-type]

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_spec_builder.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_spec_builder.py
@@ -1,12 +1,14 @@
 """Tests for the ``property_spec`` authoring helper (issue #543).
 
-``property_spec`` builds a conventional PROPERTY_MAPPING entry from explicit
-arguments, validating the invariants that previously had to be enforced by hand:
+``property_spec`` is a thin builder over ``PropertySpec`` (issue #694): it returns a
+``PropertySpec`` instance and maps its ``strict=`` keyword onto the ``strict_validation``
+field. All spec invariants live in ``PropertySpec.__post_init__`` (pinned in
+``test_property_spec_type.py``); this module pins the builder surface:
 
-* ``strict=True`` requires a non-empty ``allowed_values`` (a strict enum with no
-  value space rejects everything),
-* a strict, non-``None`` ``default`` must be within the allowed set,
-* a one-shot iterable for ``allowed_values`` is materialized so it survives reuse.
+* the return value IS a ``PropertySpec``,
+* ``strict=`` maps to ``strict_validation=``,
+* every rejection still fires through the builder,
+* built specs equal their directly-constructed counterparts.
 
 ``allowed_values`` WITHOUT ``strict`` is legal: a non-strict value space is not
 enforced, but it is consumed, to map a name-parsed value back onto its
@@ -22,19 +24,28 @@ from typing import Any
 
 import pytest
 
-from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import (
     FeatureChainParser,
 )
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import (
     FeatureChainParserMixin,
 )
-from mloda.core.abstract_plugins.components.feature_chainer.property_spec import NO_DEFAULT, _NoDefault
+from mloda.core.abstract_plugins.components.feature_chainer.property_spec import _NoDefault, is_no_default
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.components.utils import get_all_subclasses
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
-from mloda.provider import property_spec
+from mloda.provider import NO_DEFAULT, PropertySpec, property_spec
+
+
+def _build(*args: Any, **kwargs: Any) -> PropertySpec:
+    """Call ``property_spec`` through an untyped seam.
+
+    The builder's declared ``allowed_values`` type lists the container shapes so a bare str is an
+    author-time error. Its runtime is deliberately more lenient (any iterable is materialized), and
+    the leniency tests below exercise exactly the shapes the type does not name.
+    """
+    return property_spec(*args, **kwargs)
 
 
 @pytest.fixture(autouse=True)
@@ -63,21 +74,22 @@ class TestPropertySpecImport:
 
 
 class TestPropertySpecEmission:
-    """A valid call emits a conventional spec dict."""
+    """A valid call returns a ``PropertySpec`` with the expected field values."""
 
-    def test_emits_conventional_spec_dict(self) -> None:
-        """All conventional keys are present with the expected values."""
+    def test_returns_property_spec_with_expected_fields(self) -> None:
+        """The builder returns a ``PropertySpec``; ``strict=`` sets ``strict_validation``."""
         spec = property_spec("desc", strict=True, allowed_values={"add": "Addition"}, default="add")
 
-        assert spec["explanation"] == "desc"
-        assert spec[DefaultOptionKeys.allowed_values] == {"add": "Addition"}
-        assert spec[DefaultOptionKeys.strict_validation] is True
-        assert spec[DefaultOptionKeys.context] is True
-        assert spec[DefaultOptionKeys.default] == "add"
+        assert isinstance(spec, PropertySpec)
+        assert spec.explanation == "desc"
+        assert spec.allowed_values == {"add": "Addition"}
+        assert spec.strict_validation is True
+        assert spec.context is True
+        assert spec.default == "add"
 
 
 class TestPropertySpecInvariants:
-    """Invalid combinations raise ``ValueError``."""
+    """Invalid combinations still raise ``ValueError`` through the builder."""
 
     def test_strict_without_allowed_values_raises(self) -> None:
         """``strict=True`` with no value space rejects everything, so it is illegal."""
@@ -93,7 +105,12 @@ class TestPropertySpecInvariants:
         """An omitted/``None`` default is always legal under strict validation."""
         spec = property_spec("d", strict=True, allowed_values={"add": "A"})
 
-        assert spec[DefaultOptionKeys.allowed_values] == {"add": "A"}
+        assert spec.allowed_values == {"add": "A"}
+
+    def test_builder_errors_carry_the_property_spec_prefix(self) -> None:
+        """Rejections fire in ``PropertySpec.__post_init__``, so the prefix names the type."""
+        with pytest.raises(ValueError, match=r"PropertySpec\('d'\)"):
+            property_spec("d", strict=True)
 
 
 class TestPropertySpecIterableAllowedValues:
@@ -103,16 +120,16 @@ class TestPropertySpecIterableAllowedValues:
         """A tuple of allowed values is accepted with strict validation."""
         spec = property_spec("d", strict=True, allowed_values=("add", "sub"), default="add")
 
-        emitted = spec[DefaultOptionKeys.allowed_values]
-        assert set(emitted) == {"add", "sub"}
+        assert spec.allowed_values is not None
+        assert set(spec.allowed_values) == {"add", "sub"}
 
     def test_one_shot_generator_is_materialized(self) -> None:
         """A generator must be materialized so the emitted allowed_values is re-iterable."""
-        spec = property_spec("d", strict=True, allowed_values=(x for x in ("add", "sub")), default="add")
+        spec = _build("d", strict=True, allowed_values=(x for x in ("add", "sub")), default="add")
 
-        emitted = spec[DefaultOptionKeys.allowed_values]
-        first = list(emitted)
-        second = list(emitted)
+        assert spec.allowed_values is not None
+        first = list(spec.allowed_values)
+        second = list(spec.allowed_values)
         assert first == second
         assert set(first) == {"add", "sub"}
 
@@ -153,28 +170,35 @@ class TestPropertySpecRoundTrip:
 
 
 class TestPropertySpecDefaultOmission:
-    """OMITTING the ``default`` argument must NOT emit a spurious ``default`` key.
+    """A builder call with no default must leave the ``default`` field at ``NO_DEFAULT``.
 
-    The parser's ``_can_skip_required_check`` treats the mere PRESENCE of the
-    ``default`` key as "this option is optional", so a spurious key would silently
-    make an otherwise-required property optional. The rule is keyed on the
-    ARGUMENT, not on its value: omitting ``default`` means the key is REQUIRED,
-    while an explicit ``default=None`` means optional with a ``None`` default
+    The parser's ``_can_skip_required_check`` treats a DECLARED default as "this option is
+    optional". ``NO_DEFAULT`` means no default was declared, so an otherwise-required strict
+    property stays required; a declared ``default=None`` is the optional-with-no-value form
     (see ``TestPropertySpecNoneDefault``, issue #733).
     """
 
-    def test_builder_without_default_omits_default_key(self) -> None:
-        """No default argument -> the spec carries no ``default`` key at all."""
+    def test_builder_without_default_leaves_default_at_the_sentinel(self) -> None:
+        """No default argument -> the spec's ``default`` field is ``NO_DEFAULT``."""
         spec = property_spec("op", strict=True, allowed_values={"add": "Addition", "sub": "Subtraction"})
 
-        assert DefaultOptionKeys.default not in spec
+        assert spec.default is NO_DEFAULT
+
+    def test_builder_with_declared_none_default_makes_the_key_optional(self) -> None:
+        """``default=None`` through the builder marks the key optional: an absent option matches."""
+        property_mapping = {"weight_column": property_spec("Optional weight column", default=None)}
+
+        assert (
+            FeatureChainParser.match_configuration_feature_chain_parser(
+                "any_feature", Options(context={}), property_mapping
+            )
+            is True
+        )
 
     def test_builder_without_default_makes_strict_property_required(self) -> None:
         """A defaultless strict property is REQUIRED: absent option -> no match.
 
-        With the spurious ``default`` key the parser wrongly skips the required
-        check, so an absent option matches. After the fix the option is required,
-        so an absent option yields False while a present, valid option yields True.
+        An absent option yields False while a present, valid option yields True.
         """
 
         class RequiredOpFeatureGroup(FeatureChainParserMixin, FeatureGroup):
@@ -206,29 +230,29 @@ class TestPropertySpecDefaultOmission:
             is True
         )
 
-    def test_builder_with_explicit_default_keeps_default_key(self) -> None:
+    def test_builder_with_explicit_default_keeps_default(self) -> None:
         """An explicit, valid default is preserved (we did not over-correct)."""
         spec = property_spec("op", strict=True, allowed_values={"add": "Addition"}, default="add")
 
-        assert spec[DefaultOptionKeys.default] == "add"
+        assert spec.default == "add"
 
 
 class TestPropertySpecNoneDefault:
     """``default=None`` must be expressible: optional key whose default is ``None`` (issue #733).
 
-    ``None`` is a legitimate default (the shipped hand-written specs use it for
-    ``weight_column``, ``constant_value``, ``pipeline_steps``, ...), but the builder
-    used ``None`` as its own "argument omitted" marker and dropped the key. That made
-    an optional key REQUIRED on migration. A ``NO_DEFAULT`` sentinel separates the two:
-    the key is emitted whenever the caller passes ANY default, ``None`` included.
+    ``None`` is a legitimate default (the shipped specs use it for ``weight_column``,
+    ``constant_value``, ``pipeline_steps``, ...), but the builder once used ``None`` as its own
+    "argument omitted" marker and dropped the key. That made an optional key REQUIRED on
+    migration. The ``NO_DEFAULT`` sentinel separates the two: a declared default is whatever the
+    caller passed, ``None`` included, while ``NO_DEFAULT`` means none was declared.
     """
 
-    def test_default_none_emits_default_key(self) -> None:
-        """``default=None`` emits the ``default`` key carrying ``None``."""
+    def test_default_none_is_a_declared_default(self) -> None:
+        """``default=None`` lands on the field as a DECLARED ``None``, not as ``NO_DEFAULT``."""
         spec = property_spec("d", default=None)
 
-        assert DefaultOptionKeys.default in spec
-        assert spec[DefaultOptionKeys.default] is None
+        assert spec.default is None
+        assert not is_no_default(spec.default)
 
     def test_default_none_is_optional(self) -> None:
         """A ``default=None`` spec is optional: the parser skips the required check."""
@@ -237,10 +261,10 @@ class TestPropertySpecNoneDefault:
         assert FeatureChainParser._can_skip_required_check(spec) is True
 
     def test_omitted_default_stays_required(self) -> None:
-        """No ``default`` argument -> no key, and the property stays REQUIRED (issue #562)."""
+        """No ``default`` argument -> ``NO_DEFAULT``, and the property stays REQUIRED (issue #562)."""
         spec = property_spec("d")
 
-        assert DefaultOptionKeys.default not in spec
+        assert is_no_default(spec.default)
         assert FeatureChainParser._can_skip_required_check(spec) is False
 
     def test_no_default_sentinel_importable_from_provider(self) -> None:
@@ -254,31 +278,31 @@ class TestPropertySpecNoneDefault:
         spec = property_spec("d", default=NO_DEFAULT)
 
         assert spec == property_spec("d")
-        assert DefaultOptionKeys.default not in spec
+        assert is_no_default(spec.default)
         assert FeatureChainParser._can_skip_required_check(spec) is False
 
-    def test_none_default_spec_equals_hand_written_dict(self) -> None:
-        """A ``default=None`` spec is exactly the dict a plugin author hand-writes today."""
+    def test_none_default_spec_equals_direct_construction(self) -> None:
+        """A ``default=None`` spec is exactly the ``PropertySpec`` a plugin author constructs."""
         built = property_spec("Column name for edge weights (optional)", default=None)
 
-        hand_written: dict[str, Any] = {
-            "explanation": "Column name for edge weights (optional)",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.default: None,
-        }
-        assert built == hand_written
+        hand_constructed = PropertySpec(
+            "Column name for edge weights (optional)",
+            context=True,
+            strict_validation=False,
+            default=None,
+        )
+        assert built == hand_constructed
 
     def test_strict_spec_with_none_default_builds_and_is_optional(self) -> None:
         """A STRICT spec with ``default=None`` builds and is optional (sklearn PIPELINE_NAME shape).
 
-        Core's ``check_declared_default`` exempts a ``None`` default from the membership
+        ``PropertySpec._check_declared_default`` exempts a ``None`` default from the membership
         check, so the strict value space and the ``None`` default coexist.
         """
         spec = property_spec("d", strict=True, allowed_values={"scaling": "Feature scaling"}, default=None)
 
-        assert spec[DefaultOptionKeys.default] is None
-        assert spec[DefaultOptionKeys.strict_validation] is True
+        assert spec.default is None
+        assert spec.strict_validation is True
         assert FeatureChainParser._can_skip_required_check(spec) is True
 
     def test_absent_optional_option_still_matches_through_core(self) -> None:
@@ -333,10 +357,9 @@ class TestNoDefaultSentinelIdentity:
 
     A deepcopy, a pickle round trip, or a second import of the module (editable install plus
     site-packages, ``importlib.reload``) all yield a ``_NoDefault`` instance that is a DIFFERENT
-    object than the module-level ``NO_DEFAULT``. If the builder recognizes the sentinel by
-    identity, such a copy slips through the "argument omitted" test and lands IN the spec as a
-    bogus ``default`` VALUE, which silently flips a REQUIRED key to optional: exactly the bug
-    class #733 exists to kill.
+    object than the module-level ``NO_DEFAULT``. If the sentinel is recognized by identity, such a
+    copy reads as a DECLARED ``default`` VALUE, which silently flips a REQUIRED key to optional:
+    exactly the bug class #733 exists to kill. ``is_no_default`` is a type test for that reason.
     """
 
     def test_deepcopy_returns_the_same_sentinel(self) -> None:
@@ -348,26 +371,30 @@ class TestNoDefaultSentinelIdentity:
         assert pickle.loads(pickle.dumps(NO_DEFAULT)) is NO_DEFAULT
 
     def test_deepcopied_sentinel_behaves_like_omission(self) -> None:
-        """A deepcopied sentinel emits no ``default`` key and leaves the property REQUIRED."""
+        """A deepcopied sentinel declares no default and leaves the property REQUIRED."""
         spec = property_spec("d", default=copy.deepcopy(NO_DEFAULT))
 
-        assert DefaultOptionKeys.default not in spec
+        assert is_no_default(spec.default)
         assert FeatureChainParser._can_skip_required_check(spec) is False
         assert spec == property_spec("d")
 
     def test_pickled_sentinel_behaves_like_omission(self) -> None:
-        """A pickle round-tripped sentinel emits no ``default`` key and stays REQUIRED."""
+        """A pickle round-tripped sentinel declares no default and stays REQUIRED."""
         spec = property_spec("d", default=pickle.loads(pickle.dumps(NO_DEFAULT)))
 
-        assert DefaultOptionKeys.default not in spec
+        assert is_no_default(spec.default)
         assert FeatureChainParser._can_skip_required_check(spec) is False
         assert spec == property_spec("d")
 
     def test_second_sentinel_instance_behaves_like_omission(self) -> None:
-        """A separately constructed ``_NoDefault`` (a second imported copy) means "no default" too."""
+        """A separately constructed ``_NoDefault`` (a second imported copy) means "no default" too.
+
+        It is NOT the module-level object, so only the type test can recognize it.
+        """
         spec = property_spec("d", default=_NoDefault())
 
-        assert DefaultOptionKeys.default not in spec
+        assert spec.default is not NO_DEFAULT
+        assert is_no_default(spec.default)
         assert FeatureChainParser._can_skip_required_check(spec) is False
 
     def test_sentinel_repr_is_readable(self) -> None:
@@ -416,10 +443,10 @@ class TestPropertySpecElementValidator:
         """``strict=True`` plus an ``element_validator`` needs no ``allowed_values``."""
         spec = property_spec("d", strict=True, element_validator=_positive_int)
 
-        assert spec["explanation"] == "d"
-        assert spec[DefaultOptionKeys.element_validator] is _positive_int
-        assert spec[DefaultOptionKeys.strict_validation] is True
-        assert spec[DefaultOptionKeys.context] is True
+        assert spec.explanation == "d"
+        assert spec.element_validator is _positive_int
+        assert spec.strict_validation is True
+        assert spec.context is True
 
     def test_element_validator_without_strict_raises(self) -> None:
         """A ``element_validator`` is never enforced without ``strict`` (silent no-op)."""
@@ -436,16 +463,15 @@ class TestPropertySpecElementValidator:
 class TestPropertySpecElementValidatorDefault:
     """Strict defaults are checked via the ``element_validator`` when present (issue #536).
 
-    Mirrors ``FeatureChainParser.validate_property_mapping_defaults``: when a spec
-    carries an ``element_validator``, the strict default check uses it, taking
-    precedence over membership in ``allowed_values``.
+    When a spec carries an ``element_validator``, the strict default check uses it,
+    taking precedence over membership in ``allowed_values``.
     """
 
     def test_strict_default_accepted_by_element_validator(self) -> None:
         """A default the ``element_validator`` accepts is legal without ``allowed_values``."""
         spec = property_spec("d", strict=True, element_validator=_positive_int, default=5)
 
-        assert spec[DefaultOptionKeys.default] == 5
+        assert spec.default == 5
 
     def test_strict_default_rejected_by_element_validator_raises(self) -> None:
         """A default the ``element_validator`` rejects is illegal."""
@@ -456,9 +482,9 @@ class TestPropertySpecElementValidatorDefault:
         """With both present, the default is checked via the ``element_validator``, not membership."""
         spec = property_spec("d", strict=True, allowed_values={"add": "A"}, element_validator=_is_mul, default="mul")
 
-        assert spec[DefaultOptionKeys.default] == "mul"
-        assert spec[DefaultOptionKeys.allowed_values] == {"add": "A"}
-        assert spec[DefaultOptionKeys.element_validator] is _is_mul
+        assert spec.default == "mul"
+        assert spec.allowed_values == {"add": "A"}
+        assert spec.element_validator is _is_mul
 
 
 class TestPropertySpecRequiredWhen:
@@ -469,11 +495,11 @@ class TestPropertySpecRequiredWhen:
     """
 
     def test_required_when_emitted_without_strict(self) -> None:
-        """The predicate is emitted under ``DefaultOptionKeys.required_when`` without ``strict``."""
+        """The predicate lands on the ``required_when`` field without ``strict``."""
         spec = property_spec("d", required_when=_always_required)
 
-        assert spec[DefaultOptionKeys.required_when] is _always_required
-        assert spec[DefaultOptionKeys.strict_validation] is False
+        assert spec.required_when is _always_required
+        assert spec.strict_validation is False
 
     def test_non_callable_required_when_raises(self) -> None:
         """A non-callable ``required_when`` is rejected up front."""
@@ -491,11 +517,11 @@ class TestPropertySpecMatchGuard:
     """
 
     def test_match_guard_emitted_without_strict(self) -> None:
-        """The validator is emitted under ``DefaultOptionKeys.match_guard`` without ``strict``."""
+        """The validator lands on the ``match_guard`` field without ``strict``."""
         spec = property_spec("d", match_guard=_is_list_of_strings)
 
-        assert spec[DefaultOptionKeys.match_guard] is _is_list_of_strings
-        assert spec[DefaultOptionKeys.strict_validation] is False
+        assert spec.match_guard is _is_list_of_strings
+        assert spec.strict_validation is False
 
     def test_non_callable_match_guard_raises(self) -> None:
         """A non-callable ``match_guard`` is rejected up front."""
@@ -505,38 +531,38 @@ class TestPropertySpecMatchGuard:
 
 
 class TestPropertySpecPassthroughOmission:
-    """Omitted passthroughs never appear in the emitted dict (issue #536).
+    """Omitted passthroughs stay at their ``None`` defaults (issue #536).
 
-    Emitting ``None``-valued passthrough keys would change core behavior (e.g.
-    ``_can_skip_required_check`` keys off the mere PRESENCE of
-    ``required_when``), so an omitted passthrough must be absent, not ``None``.
+    ``None`` is the documented "not declared" sentinel: core keys off
+    ``required_when is not None`` (and friends), so an omitted passthrough must
+    be ``None``, never a truthy placeholder.
     """
 
-    def test_omitted_passthroughs_are_absent(self) -> None:
-        """Only explicitly passed passthrough keys are emitted; the rest are absent."""
+    def test_omitted_passthroughs_are_none(self) -> None:
+        """Only explicitly passed passthroughs are set; the rest stay ``None``."""
         plain = property_spec("d")
-        assert DefaultOptionKeys.element_validator not in plain
-        assert DefaultOptionKeys.required_when not in plain
-        assert DefaultOptionKeys.match_guard not in plain
+        assert plain.element_validator is None
+        assert plain.required_when is None
+        assert plain.match_guard is None
 
         with_required_when = property_spec("d", required_when=_always_required)
-        assert DefaultOptionKeys.element_validator not in with_required_when
-        assert DefaultOptionKeys.match_guard not in with_required_when
+        assert with_required_when.element_validator is None
+        assert with_required_when.match_guard is None
 
         with_match_guard = property_spec("d", match_guard=_is_list_of_strings)
-        assert DefaultOptionKeys.element_validator not in with_match_guard
-        assert DefaultOptionKeys.required_when not in with_match_guard
+        assert with_match_guard.element_validator is None
+        assert with_match_guard.required_when is None
 
 
 class TestPropertySpecElementValidatorRoundTrip:
     """A strict ``element_validator`` spec matches core semantics end to end (issue #536)."""
 
     def test_class_definition_accepts_element_validator_default(self) -> None:
-        """The built entry defines without error and equals the hand-written dict.
+        """The built entry defines without error and equals the direct construction.
 
-        Core's class-definition check (``validate_property_mapping_defaults``)
-        accepts a strict default via the ``element_validator``; the helper must
-        emit exactly the dict an author would hand-write for that spec.
+        The builder must produce exactly the ``PropertySpec`` an author would
+        construct by hand for that spec, and both pass the class-definition check
+        (``validate_property_mapping_defaults``).
         """
 
         class WindowFeatureGroup(FeatureChainParserMixin, FeatureGroup):
@@ -556,28 +582,27 @@ class TestPropertySpecElementValidatorRoundTrip:
 
         built = WindowFeatureGroup.PROPERTY_MAPPING["window_size"]
 
-        hand_written: dict[str, Any] = {
-            "explanation": "Size of time window",
-            DefaultOptionKeys.element_validator: _positive_int,
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.default: 5,
-        }
-        assert built == hand_written
+        hand_constructed = PropertySpec(
+            "Size of time window",
+            element_validator=_positive_int,
+            context=True,
+            strict_validation=True,
+            default=5,
+        )
+        assert built == hand_constructed
 
         FeatureChainParser.validate_property_mapping_defaults("Built", {"window_size": built})
-        FeatureChainParser.validate_property_mapping_defaults("HandWritten", {"window_size": hand_written})
+        FeatureChainParser.validate_property_mapping_defaults("HandConstructed", {"window_size": hand_constructed})
 
 
 class TestPropertySpecRaisingElementValidator:
     """A ``element_validator`` that raises on the default is wrapped (issue #536).
 
-    Mirrors core's ``FeatureChainParser.validate_property_mapping_defaults``, which
-    distinguishes "the element_validator raised when called with the default"
-    from "the element_validator ran and rejected the default": both surface as
-    ``ValueError``, with the original exception chained as ``__cause__`` in the
-    raising case. The builder's strict-default check must behave the same way
-    instead of letting the author's exception propagate raw.
+    ``PropertySpec`` distinguishes "the element_validator raised when called with
+    the default" from "the element_validator ran and rejected the default": both
+    surface as ``ValueError``, with the original exception chained as
+    ``__cause__`` in the raising case. The builder must surface the same
+    behavior instead of letting the author's exception propagate raw.
     """
 
     def test_raising_element_validator_wraps_as_value_error_with_cause(self) -> None:
@@ -589,19 +614,25 @@ class TestPropertySpecRaisingElementValidator:
 
 
 class TestPropertySpecEmptyAllowedValues:
-    """An explicitly empty ``allowed_values`` is always an authoring mistake (issue #536).
+    """An empty ``allowed_values`` only rejects when membership is what decides.
 
-    Even when an ``element_validator`` is present (so the spec would still be
-    enforceable), an explicitly empty allowed set is dead configuration: core's
-    ``_extract_property_values`` would surface it as an empty accepted set. The
-    builder must reject it up front instead of silently emitting a dead, empty
-    ``allowed_values`` key.
+    The value-space rules exist because an empty accepted set would reject every value. With an
+    ``element_validator`` the validator, not membership, decides: ``allowed_values`` is never
+    consulted, so an empty one rejects nothing and the rules do not fire. Without a validator an
+    empty (or absent) value space is still the reject-everything spec, and is refused.
     """
 
-    def test_empty_allowed_values_with_element_validator_raises(self) -> None:
-        """``strict=True`` with ``allowed_values=[]`` raises even though a validator is present."""
-        with pytest.raises(ValueError):
-            property_spec("d", strict=True, element_validator=_positive_int, allowed_values=[])
+    def test_empty_allowed_values_with_element_validator_is_accepted(self) -> None:
+        """``strict=True`` with ``allowed_values=[]`` is legal while a validator is present."""
+        spec = property_spec("d", strict=True, element_validator=_positive_int, allowed_values=[])
+
+        assert spec.element_validator is _positive_int
+        assert spec.allowed_values == ()
+
+    def test_empty_allowed_values_without_element_validator_raises(self) -> None:
+        """Without a validator, an empty accepted set would reject every value."""
+        with pytest.raises(ValueError, match="(?i)empty allowed_values"):
+            property_spec("d", strict=True, allowed_values=[])
 
 
 class TestPropertySpecPassthroughRegressionGuards:
@@ -623,26 +654,26 @@ class TestPropertySpecPassthroughRegressionGuards:
                 default="add",
             )
 
-    def test_required_when_spec_equals_hand_written_dict(self) -> None:
-        """A ``required_when`` spec is exactly the dict an author would hand-write."""
+    def test_required_when_spec_equals_direct_construction(self) -> None:
+        """A ``required_when`` spec is exactly the ``PropertySpec`` an author would construct."""
         built = property_spec("d", required_when=_always_required)
 
-        hand_written: dict[str, Any] = {
-            "explanation": "d",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.required_when: _always_required,
-        }
-        assert built == hand_written
+        hand_constructed = PropertySpec(
+            "d",
+            context=True,
+            strict_validation=False,
+            required_when=_always_required,
+        )
+        assert built == hand_constructed
 
-    def test_match_guard_spec_equals_hand_written_dict(self) -> None:
-        """A ``match_guard`` spec is exactly the dict an author would hand-write."""
+    def test_match_guard_spec_equals_direct_construction(self) -> None:
+        """A ``match_guard`` spec is exactly the ``PropertySpec`` an author would construct."""
         built = property_spec("d", match_guard=_is_list_of_strings)
 
-        hand_written: dict[str, Any] = {
-            "explanation": "d",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.match_guard: _is_list_of_strings,
-        }
-        assert built == hand_written
+        hand_constructed = PropertySpec(
+            "d",
+            context=True,
+            strict_validation=False,
+            match_guard=_is_list_of_strings,
+        )
+        assert built == hand_constructed

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_spec_hard_break.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_spec_hard_break.py
@@ -1,0 +1,339 @@
+"""``PropertySpec`` is the ONLY PROPERTY_MAPPING spec form (issue #694, Phase B).
+
+Phase A introduced ``PropertySpec`` as a typed, frozen spec carrying the ``property_spec``
+invariants. This module pins the Phase B hard break:
+
+1. A raw dict spec in PROPERTY_MAPPING raises at class definition, naming the owning class,
+   the property key and the ``PropertySpec`` remedy. Same for a bare non-dict spec value.
+2. A PROPERTY_MAPPING whose values are ``PropertySpec`` instances defines fine, and the
+   matching pipeline behaves exactly as the dict form did: strict accept/reject, context
+   categorization of string-parsed values, ``required_when`` and ``match_guard``.
+3. ``FeatureGroup.declared_option_values`` reads a ``PropertySpec``'s ``allowed_values``.
+4. The unknown-key machinery is deleted: ``PROPERTY_SPEC_KEYS`` and ``REMOVED_PROPERTY_KEYS``
+   no longer exist (``PropertySpec``'s constructor is the schema now).
+5. ``property_spec(...)`` returns a ``PropertySpec`` (``strict=`` maps to
+   ``strict_validation=``) and its authoring rejections still fire.
+6. ``PropertySpec`` is exported from ``mloda.provider`` and is the same class.
+7. ``FeatureChainParser._can_skip_required_check`` understands ``PropertySpec``: a non-None
+   ``default`` or a ``required_when`` predicate makes the key skippable.
+"""
+
+from __future__ import annotations
+
+import gc
+import importlib
+from typing import Any
+
+import pytest
+
+from mloda.core.abstract_plugins.components import default_options_key as default_options_key_module
+from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
+from mloda.core.abstract_plugins.components.feature_chainer.property_spec import PropertySpec, property_spec
+from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.components.utils import get_all_subclasses
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+
+
+@pytest.fixture(autouse=True)
+def _no_feature_group_registry_pollution() -> Any:
+    """Guarantee this module never leaks throwaway FeatureGroup subclasses.
+
+    Mirrors ``test_property_mapping_spec_schema.py``: the class-definition tests below
+    define FeatureGroup subclasses, which linger in ``FeatureGroup.__subclasses__()`` until
+    a GC cycle runs and would otherwise be seen by tests that enumerate feature groups.
+    """
+    yield
+    gc.collect()
+    gc.collect()
+    leaked = [c for c in get_all_subclasses(FeatureGroup) if c.__module__ == __name__]
+    assert not leaked, f"Leaked FeatureGroup subclasses from {__name__}: {[c.__name__ for c in leaked]}"
+
+
+def _hardbreak694_needs_order_column(options: Options) -> bool:
+    """Predicate: the order column is required when the aggregation is order-dependent."""
+    return options.get("hardbreak694_agg") in {"first", "last"}
+
+
+def _hardbreak694_positive_int(value: Any) -> bool:
+    return isinstance(value, int) and value > 0
+
+
+class TestRawDictSpecIsAHardBreak:
+    """Item 1 and 2: PROPERTY_MAPPING accepts PropertySpec instances and NOTHING else."""
+
+    def test_raw_dict_spec_rejected_at_class_definition(self) -> None:
+        """A raw dict spec (only known keys, valid yesterday) raises, naming the remedy."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class HardBreak694RawDictFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {
+                    "hardbreak694_operation": {  # type: ignore[dict-item]  # wrong type is the point
+                        "explanation": "x",
+                        DefaultOptionKeys.context: True,
+                    }
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "HardBreak694RawDictFeatureGroup" in message
+        assert "hardbreak694_operation" in message
+        assert "PropertySpec" in message
+
+    def test_bare_non_dict_spec_rejected_at_class_definition_names_property_spec(self) -> None:
+        """A bare tuple of values raises, and the message now names ``PropertySpec``."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class HardBreak694BareTupleFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {"hardbreak694_operation": ("add", "sub")}  # type: ignore[dict-item]  # wrong type is the point
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "HardBreak694BareTupleFeatureGroup" in message
+        assert "hardbreak694_operation" in message
+        assert "PropertySpec" in message
+
+
+class TestPropertySpecMappingBehavesAsBefore:
+    """Item 3: PropertySpec entries define fine and match exactly as the dict form did."""
+
+    def test_strict_property_spec_accepts_declared_and_rejects_undeclared_value(self) -> None:
+        """A strict PropertySpec matches a declared value and non-matches an undeclared one."""
+
+        class HardBreak694StrictFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+            PROPERTY_MAPPING = {
+                "hardbreak694_operation": PropertySpec(
+                    "The arithmetic operation to apply",
+                    allowed_values={"add": "Addition", "sub": "Subtraction"},
+                    strict_validation=True,
+                )
+            }
+
+            @classmethod
+            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                return data
+
+        assert (
+            HardBreak694StrictFeatureGroup.match_feature_group_criteria(
+                "any_feature", Options(context={"hardbreak694_operation": "sub"})
+            )
+            is True
+        )
+        assert (
+            HardBreak694StrictFeatureGroup.match_feature_group_criteria(
+                "any_feature", Options(context={"hardbreak694_operation": "mul"})
+            )
+            is False
+        )
+
+    def test_context_spec_categorizes_string_parsed_value_into_context(self) -> None:
+        """A ``context=True`` PropertySpec sends a name-parsed value to the context category.
+
+        Mirrors the categorization assertions in
+        ``tests/test_plugins/integration_plugins/chainer/context/test_parameter_resolution_unit.py``
+        at a smaller scale.
+        """
+        spec = PropertySpec("The aggregation to apply", allowed_values={"first": "First value"}, context=True)
+
+        category = FeatureChainParser._determine_parameter_category("hardbreak694_agg", spec, Options())
+        assert category == DefaultOptionKeys.context
+
+        class HardBreak694ContextCategorization(FeatureChainParserMixin):
+            PREFIX_PATTERN = r".*__([\w]+)_hardbreak694$"
+            PROPERTY_MAPPING = {"hardbreak694_agg": spec}
+
+        effective = HardBreak694ContextCategorization._build_effective_options(
+            "source__first_hardbreak694",
+            [HardBreak694ContextCategorization.PREFIX_PATTERN],
+            HardBreak694ContextCategorization.PROPERTY_MAPPING,
+            Options(),
+        )
+        assert effective.get("hardbreak694_agg") == "first"
+        assert "hardbreak694_agg" in effective.context
+
+    def test_required_when_property_spec_still_gates_the_match(self) -> None:
+        """``required_when`` on a PropertySpec behaves exactly like the dict form did."""
+
+        class HardBreak694RequiredWhenFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+            PROPERTY_MAPPING = {
+                "hardbreak694_agg": PropertySpec(
+                    "The aggregation to apply",
+                    allowed_values={"sum": "Sum of values", "first": "First value (requires an order column)"},
+                    strict_validation=True,
+                ),
+                "hardbreak694_order_by": PropertySpec(
+                    "Column to order by within each partition",
+                    required_when=_hardbreak694_needs_order_column,
+                ),
+            }
+
+            @classmethod
+            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                return data
+
+        assert (
+            HardBreak694RequiredWhenFeatureGroup.match_feature_group_criteria(
+                "any_feature", Options(context={"hardbreak694_agg": "first"})
+            )
+            is False
+        )
+        assert (
+            HardBreak694RequiredWhenFeatureGroup.match_feature_group_criteria(
+                "any_feature", Options(context={"hardbreak694_agg": "first", "hardbreak694_order_by": "ts"})
+            )
+            is True
+        )
+        assert (
+            HardBreak694RequiredWhenFeatureGroup.match_feature_group_criteria(
+                "any_feature", Options(context={"hardbreak694_agg": "sum"})
+            )
+            is True
+        )
+
+    def test_match_guard_property_spec_still_gates_the_match(self) -> None:
+        """``match_guard`` on a PropertySpec behaves exactly like the dict form did."""
+
+        class HardBreak694MatchGuardFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+            PROPERTY_MAPPING = {
+                "hardbreak694_window": PropertySpec(
+                    "Size of the time window",
+                    match_guard=_hardbreak694_positive_int,
+                )
+            }
+
+            @classmethod
+            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                return data
+
+        assert (
+            HardBreak694MatchGuardFeatureGroup.match_feature_group_criteria(
+                "any_feature", Options(context={"hardbreak694_window": 7})
+            )
+            is True
+        )
+        assert (
+            HardBreak694MatchGuardFeatureGroup.match_feature_group_criteria(
+                "any_feature", Options(context={"hardbreak694_window": -3})
+            )
+            is False
+        )
+
+
+class TestDeclaredOptionValuesReadsPropertySpec:
+    """Item 4: ``declared_option_values`` returns the stringified PropertySpec value space."""
+
+    def test_declared_option_values_with_tuple_allowed_values(self) -> None:
+        """A tuple value space is stringified element-wise."""
+
+        class HardBreak694TupleValuesFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+            PROPERTY_MAPPING = {"hardbreak694_mode": PropertySpec("The mode to run in", allowed_values=("fast", 2))}
+
+            @classmethod
+            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                return data
+
+        assert HardBreak694TupleValuesFeatureGroup.declared_option_values("hardbreak694_mode") == frozenset(
+            {"fast", "2"}
+        )
+
+    def test_declared_option_values_with_mapping_allowed_values(self) -> None:
+        """A Mapping value space yields its stringified KEYS."""
+
+        class HardBreak694MappingValuesFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+            PROPERTY_MAPPING = {
+                "hardbreak694_operation": PropertySpec(
+                    "The arithmetic operation to apply",
+                    allowed_values={"add": "Addition", "sub": "Subtraction"},
+                )
+            }
+
+            @classmethod
+            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                return data
+
+        assert HardBreak694MappingValuesFeatureGroup.declared_option_values("hardbreak694_operation") == frozenset(
+            {"add", "sub"}
+        )
+
+
+class TestUnknownKeyMachineryIsGone:
+    """Item 5: the dict-spec schema machinery is deleted along with the dict form."""
+
+    def test_property_spec_keys_is_gone(self) -> None:
+        """``PROPERTY_SPEC_KEYS`` no longer exists: the PropertySpec constructor is the schema."""
+        assert not hasattr(default_options_key_module, "PROPERTY_SPEC_KEYS")
+
+    def test_removed_property_keys_is_gone(self) -> None:
+        """``REMOVED_PROPERTY_KEYS`` no longer exists: there are no spec dicts to rename keys in."""
+        assert not hasattr(default_options_key_module, "REMOVED_PROPERTY_KEYS")
+
+
+class TestPropertySpecBuilderReturnsPropertySpec:
+    """Item 6: ``property_spec`` builds a ``PropertySpec``, keeping its authoring surface."""
+
+    def test_property_spec_returns_a_property_spec_instance(self) -> None:
+        """``property_spec("x")`` returns a PropertySpec, not a dict."""
+        spec = property_spec("x")
+
+        assert isinstance(spec, PropertySpec)
+        assert spec.explanation == "x"
+
+    def test_property_spec_maps_strict_keyword_to_strict_validation_field(self) -> None:
+        """The builder keyword stays ``strict=``; the field it sets is ``strict_validation``."""
+        spec = property_spec("x", strict=True, allowed_values=("a",))
+
+        assert isinstance(spec, PropertySpec)
+        assert spec.strict_validation is True
+        assert spec.allowed_values == ("a",)
+
+    def test_property_spec_authoring_rejections_still_fire(self) -> None:
+        """Spot check: a str ``allowed_values`` is still rejected as a substring trap."""
+        substring_trap: Any = "add"  # the forgotten-comma bug: a bare str, not a container
+
+        with pytest.raises(ValueError, match="(?i)substring"):
+            property_spec("x", allowed_values=substring_trap)
+
+
+class TestProviderExportsPropertySpec:
+    """Item 7: ``PropertySpec`` is part of the provider surface."""
+
+    def test_property_spec_is_exported_from_provider_and_is_the_same_class(self) -> None:
+        """``from mloda.provider import PropertySpec`` resolves to the one core class."""
+        provider_module = importlib.import_module("mloda.provider")
+
+        exported = getattr(provider_module, "PropertySpec", None)
+        assert exported is not None, "mloda.provider must export PropertySpec"
+        assert exported is PropertySpec
+        assert "PropertySpec" in getattr(provider_module, "__all__", ())
+
+
+class TestCanSkipRequiredCheckOnPropertySpec:
+    """Item 8: the base parser's skip rule reads PropertySpec fields."""
+
+    def test_spec_with_default_is_skippable(self) -> None:
+        """A non-None ``default`` makes the key optional for the base required check."""
+        spec = PropertySpec("x", default="fallback")
+
+        assert FeatureChainParser._can_skip_required_check(spec) is True
+
+    def test_spec_with_required_when_is_skippable(self) -> None:
+        """A ``required_when`` predicate defers the decision to the mixin layer."""
+        spec = PropertySpec("x", required_when=_hardbreak694_needs_order_column)
+
+        assert FeatureChainParser._can_skip_required_check(spec) is True
+
+    def test_spec_without_default_or_required_when_is_not_skippable(self) -> None:
+        """No default and no predicate means the key stays required."""
+        spec = PropertySpec("x")
+
+        assert FeatureChainParser._can_skip_required_check(spec) is False

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_spec_type.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_spec_type.py
@@ -1,0 +1,310 @@
+"""Pins the ``PropertySpec`` construction contract (issue #694).
+
+``PropertySpec`` is the frozen dataclass replacing PROPERTY_MAPPING spec dicts. This module
+tests the type in isolation: construction defaults, immutability, ``allowed_values``
+normalization, the flag and callable shape rules, the strict-needs-a-value-space invariant,
+the ``NO_DEFAULT`` optionality sentinel and the declared-default rule (issue #530 semantics).
+The one consumer touched here is the type rule itself: the public parser entry point must
+reject a spec that is not a ``PropertySpec``.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+import pytest
+
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
+from mloda.core.abstract_plugins.components.feature_chainer.property_spec import NO_DEFAULT, PropertySpec
+from mloda.core.abstract_plugins.components.options import Options
+
+
+def _spec(*args: Any, **kwargs: Any) -> PropertySpec:
+    """Build a ``PropertySpec`` through an untyped seam.
+
+    The type-invalid calls below (missing argument, unknown keyword, wrong-typed flag) must
+    stay runtime tests; routing them through ``Any`` keeps the module mypy --strict clean.
+    """
+    return PropertySpec(*args, **kwargs)
+
+
+def _is_int(value: Any) -> bool:
+    return isinstance(value, int)
+
+
+def _explode(value: Any) -> bool:
+    raise RuntimeError(f"element_validator exploded on {value!r}")
+
+
+class TestConstructionAndFields:
+    """Minimal construction, required explanation, unknown keywords, immutability, field names."""
+
+    def test_minimal_construction_uses_documented_defaults(self) -> None:
+        """``PropertySpec("Some explanation")`` constructs with the documented defaults."""
+        spec = PropertySpec("Some explanation")
+
+        assert spec.explanation == "Some explanation"
+        assert spec.allowed_values is None
+        assert spec.default is NO_DEFAULT
+        assert spec.context is True
+        assert spec.strict_validation is False
+        assert spec.element_validator is None
+        assert spec.match_guard is None
+        assert spec.required_when is None
+
+    def test_explanation_is_required(self) -> None:
+        """``PropertySpec()`` without an explanation raises TypeError."""
+        with pytest.raises(TypeError):
+            _spec()
+
+    def test_unknown_keyword_raises_type_error(self) -> None:
+        """A typo'd keyword is Python's own constructor error, never silently absorbed."""
+        with pytest.raises(TypeError):
+            _spec("x", strict_validaton=True)
+
+    def test_instances_are_frozen(self) -> None:
+        """Assigning any field on an instance raises ``dataclasses.FrozenInstanceError``."""
+        spec = PropertySpec("x")
+
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            setattr(spec, "explanation", "changed")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            setattr(spec, "strict_validation", True)
+
+    def test_flag_field_is_named_strict_validation(self) -> None:
+        """The flag is ``strict_validation`` (bool), NOT ``strict``."""
+        spec = PropertySpec("x")
+
+        assert hasattr(spec, "strict_validation")
+        assert not hasattr(spec, "strict")
+        with pytest.raises(TypeError):
+            _spec("x", strict=True)
+
+
+class TestAllowedValuesNormalization:
+    """Non-Mapping iterables are materialized to a tuple; Mappings are kept; bad shapes raise."""
+
+    def test_list_is_materialized_to_a_tuple(self) -> None:
+        """A list becomes a tuple, preserving order."""
+        spec = PropertySpec("x", allowed_values=["a", "b"])
+
+        assert spec.allowed_values == ("a", "b")
+
+    def test_set_is_materialized_to_a_tuple(self) -> None:
+        """A set becomes a tuple carrying exactly the set's members."""
+        spec = PropertySpec("x", allowed_values={"a", "b"})
+
+        assert isinstance(spec.allowed_values, tuple)
+        assert set(spec.allowed_values) == {"a", "b"}
+
+    def test_generator_is_materialized_and_reiterable(self) -> None:
+        """A one-shot generator is consumed once and stored re-iterable."""
+        generator = (value for value in ("a", "b"))
+        spec = _spec("x", allowed_values=generator)
+
+        values = spec.allowed_values
+        assert values is not None
+        assert list(values) == ["a", "b"]
+        assert list(values) == ["a", "b"], "the stored value space must survive re-iteration"
+
+    def test_mapping_is_kept_as_given(self) -> None:
+        """A Mapping is the value-space-with-descriptions form and is kept as given."""
+        spec = PropertySpec("x", allowed_values={"a": "A"})
+
+        assert spec.allowed_values == {"a": "A"}
+
+    def test_str_allowed_values_raises_value_error(self) -> None:
+        """A bare str would make membership a SUBSTRING test: rejected up front."""
+        with pytest.raises(ValueError, match="(?i)substring"):
+            _spec("x", allowed_values="add")
+
+    def test_bytes_allowed_values_raises_value_error(self) -> None:
+        """Bytes are the same substring trap as str."""
+        with pytest.raises(ValueError, match="(?i)substring"):
+            _spec("x", allowed_values=b"add")
+
+    def test_non_iterable_scalar_raises_value_error(self) -> None:
+        """A scalar is a clear ValueError, not a bare TypeError escaping from tuple()."""
+        with pytest.raises(ValueError):
+            _spec("x", allowed_values=5)
+
+
+class TestFlagAndCallableShapeRules:
+    """The shape rules moved from class-definition time reject the same inputs here."""
+
+    @pytest.mark.parametrize("bad_flag", ["false", 1])
+    def test_strict_validation_must_be_a_real_bool(self, bad_flag: Any) -> None:
+        """A truthy non-bool under ``strict_validation`` raises, naming the expected type."""
+        with pytest.raises(ValueError, match="(?i)bool"):
+            _spec("x", allowed_values=("a",), strict_validation=bad_flag)
+
+    def test_non_callable_element_validator_raises(self) -> None:
+        """``element_validator`` must be callable."""
+        with pytest.raises(ValueError, match="(?i)callable"):
+            _spec("x", allowed_values=("a",), strict_validation=True, element_validator="not callable")
+
+    def test_non_callable_required_when_raises(self) -> None:
+        """``required_when`` must be callable."""
+        with pytest.raises(ValueError, match="(?i)callable"):
+            _spec("x", required_when="not callable")
+
+    def test_non_callable_match_guard_raises(self) -> None:
+        """``match_guard`` must be callable."""
+        with pytest.raises(ValueError, match="(?i)callable"):
+            _spec("x", match_guard="not callable")
+
+    def test_element_validator_without_strict_raises(self) -> None:
+        """An ``element_validator`` is never enforced without ``strict_validation=True``."""
+        with pytest.raises(ValueError, match="(?i)strict"):
+            PropertySpec("x", element_validator=_is_int)
+
+
+class TestStrictNeedsAValueSpace:
+    """``strict_validation=True`` needs something to validate AGAINST."""
+
+    @pytest.mark.parametrize("empty_values", [(), []])
+    def test_strict_with_empty_allowed_values_raises(self, empty_values: Any) -> None:
+        """An empty declared value space would reject every value."""
+        with pytest.raises(ValueError):
+            _spec("x", allowed_values=empty_values, strict_validation=True)
+
+    def test_strict_with_neither_value_space_raises(self) -> None:
+        """Strict with neither ``allowed_values`` nor ``element_validator`` accepts nothing."""
+        with pytest.raises(ValueError):
+            PropertySpec("x", strict_validation=True)
+
+    def test_strict_with_element_validator_only_is_valid(self) -> None:
+        """A callable ``element_validator`` IS a value space: no ``allowed_values`` needed."""
+        spec = PropertySpec("x", strict_validation=True, element_validator=_is_int)
+
+        assert spec.strict_validation is True
+        assert spec.element_validator is _is_int
+        assert spec.allowed_values is None
+
+    def test_strict_with_element_validator_ignores_an_empty_allowed_values(self) -> None:
+        """An ``element_validator`` decides instead of membership, so an empty value space is inert.
+
+        The value-space rules do not fire at all when a validator is present: nothing is rejected
+        by an empty ``allowed_values`` the match path never consults.
+        """
+        spec = PropertySpec("x", strict_validation=True, element_validator=_is_int, allowed_values=[])
+
+        assert spec.allowed_values == ()
+        assert spec.element_validator is _is_int
+
+
+class TestNoDefaultSentinel:
+    """``NO_DEFAULT`` (no declared default) vs a DECLARED ``default=None`` (optional, no value)."""
+
+    def test_omitted_default_is_the_sentinel_and_makes_the_key_required(self) -> None:
+        """A spec with no declared default is required: the parser may not skip it."""
+        spec = PropertySpec("x")
+
+        assert spec.default is NO_DEFAULT
+        assert FeatureChainParser._can_skip_required_check(spec) is False
+
+    def test_declared_none_default_makes_the_key_optional(self) -> None:
+        """``default=None`` declares an optional key with no value to apply."""
+        spec = PropertySpec("x", default=None)
+
+        assert spec.default is None
+        assert FeatureChainParser._can_skip_required_check(spec) is True
+
+    def test_declared_none_default_matches_when_the_option_is_absent(self) -> None:
+        """The optional key is not required at match time, which is what the plugins rely on."""
+        property_mapping = {"weight_column": PropertySpec("Optional weight column", default=None)}
+
+        assert (
+            FeatureChainParser.match_configuration_feature_chain_parser(
+                "any_feature", Options(context={}), property_mapping
+            )
+            is True
+        )
+
+    def test_sentinel_repr_names_itself(self) -> None:
+        """The sentinel is readable in a spec repr and in an assertion diff."""
+        assert repr(NO_DEFAULT) == "NO_DEFAULT"
+
+
+class TestParserEntryPointRequiresPropertySpec:
+    """The public parser entry point enforces the type rule, not just class definition."""
+
+    def test_match_configuration_rejects_a_dict_spec(self) -> None:
+        """A raw dict spec handed straight to the matcher is a ValueError, never an AttributeError."""
+        property_mapping: Any = {"operation_type": {"add": "Addition"}}
+
+        with pytest.raises(ValueError, match="not a PropertySpec"):
+            FeatureChainParser.match_configuration_feature_chain_parser(
+                "any_feature", Options(context={"operation_type": "add"}), property_mapping
+            )
+
+    def test_validate_property_mapping_defaults_rejects_a_dict_spec(self) -> None:
+        """The class-definition check and the entry point share one rule and one message."""
+        property_mapping: Any = {"operation_type": {"add": "Addition"}}
+
+        with pytest.raises(ValueError, match="not a PropertySpec"):
+            FeatureChainParser.validate_property_mapping_defaults("SomeOwner", property_mapping)
+
+
+class TestDeclaredDefault:
+    """The declared-default rule (issue #530 semantics) applies only under strict."""
+
+    def test_strict_default_outside_allowed_values_raises(self) -> None:
+        """A strict default must be within the declared value space."""
+        with pytest.raises(ValueError, match="(?i)default"):
+            PropertySpec("x", allowed_values=("a", "b"), strict_validation=True, default="c")
+
+    def test_strict_default_inside_allowed_values_is_valid(self) -> None:
+        """A strict default inside the declared value space constructs."""
+        spec = PropertySpec("x", allowed_values=("a", "b"), strict_validation=True, default="a")
+
+        assert spec.default == "a"
+
+    def test_strict_element_validator_rejecting_default_raises(self) -> None:
+        """A strict default rejected by the ``element_validator`` raises."""
+        with pytest.raises(ValueError):
+            PropertySpec("x", strict_validation=True, element_validator=_is_int, default="a")
+
+    def test_strict_element_validator_raising_on_default_surfaces_as_value_error(self) -> None:
+        """An ``element_validator`` that RAISES on the default still surfaces as ValueError."""
+        with pytest.raises(ValueError):
+            PropertySpec("x", strict_validation=True, element_validator=_explode, default="a")
+
+    def test_non_strict_default_outside_allowed_values_is_valid(self) -> None:
+        """The default check only applies under strict: a non-strict spec never runs it."""
+        spec = PropertySpec("x", allowed_values=("a", "b"), default="z")
+
+        assert spec.default == "z"
+
+    def test_default_none_means_no_default(self) -> None:
+        """``default=None`` declares no default, so no default check fires under strict."""
+        spec = PropertySpec("x", allowed_values=("a", "b"), strict_validation=True, default=None)
+
+        assert spec.default is None
+
+    def test_mapping_allowed_values_default_key_is_valid(self) -> None:
+        """Under strict, a Mapping value space accepts a default that is one of its KEYS."""
+        spec = PropertySpec("x", allowed_values={"a": "A"}, strict_validation=True, default="a")
+
+        assert spec.default == "a"
+
+    def test_mapping_allowed_values_default_not_a_key_raises(self) -> None:
+        """Under strict, a default outside the Mapping's KEYS raises."""
+        with pytest.raises(ValueError, match="(?i)default"):
+            PropertySpec("x", allowed_values={"a": "A"}, strict_validation=True, default="z")
+
+    @pytest.mark.parametrize("unhashable_default", [{"a": 1}, ["a"], (["a"],)])
+    def test_unhashable_default_against_a_mapping_raises_value_error(self, unhashable_default: Any) -> None:
+        """An unhashable default can never be a Mapping key: a clean ValueError, never a TypeError.
+
+        ``(["a"],)`` is the sharp case: a tuple IS an instance of ``Hashable``, but hashing it
+        raises because it contains a list. Only the membership test itself can tell.
+        """
+        with pytest.raises(ValueError, match="(?i)default"):
+            PropertySpec("x", allowed_values={"a": "A"}, strict_validation=True, default=unhashable_default)
+
+    def test_unhashable_default_against_a_tuple_value_space_raises_value_error(self) -> None:
+        """The same holds for a non-Mapping value space: membership decides, and it rejects."""
+        with pytest.raises(ValueError, match="(?i)default"):
+            PropertySpec("x", allowed_values=("a",), strict_validation=True, default={"a": 1})

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_required_when_enforced_on_override.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_required_when_enforced_on_override.py
@@ -23,7 +23,7 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
-from mloda.provider import DefaultOptionKeys
+from mloda.provider import PropertySpec
 
 OP_TYPE = "op_type"
 ORDER_BY = "order_by"
@@ -55,20 +55,21 @@ class CountingPredicate:
         return bool(options.get(OP_TYPE) == "first")
 
 
-def _mapping(predicate: CountingPredicate) -> dict[str, Any]:
+def _mapping(predicate: CountingPredicate) -> dict[str, PropertySpec]:
     """PROPERTY_MAPPING with a conditionally required order_by. op_type stays unconditionally required."""
     return {
-        OP_TYPE: {
-            DefaultOptionKeys.allowed_values: {"sum": "Sum of values", "first": "First value (requires order_by)"},
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-        },
-        ORDER_BY: {
-            "explanation": "Column to order by",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.required_when: predicate,
-        },
+        OP_TYPE: PropertySpec(
+            "Operation to apply",
+            allowed_values={"sum": "Sum of values", "first": "First value (requires order_by)"},
+            context=True,
+            strict_validation=True,
+        ),
+        ORDER_BY: PropertySpec(
+            "Column to order by",
+            context=True,
+            strict_validation=False,
+            required_when=predicate,
+        ),
     }
 
 
@@ -83,15 +84,16 @@ class NameSuppliedPredicate:
         return options.get(ORDER_BY) is None
 
 
-def _name_supplied_mapping(predicate: NameSuppliedPredicate) -> dict[str, Any]:
+def _name_supplied_mapping(predicate: NameSuppliedPredicate) -> dict[str, PropertySpec]:
     """PROPERTY_MAPPING whose conditionally required key is the one the feature name parses into."""
     return {
-        OP_TYPE: {
-            DefaultOptionKeys.allowed_values: {"sum": "Sum of values", "first": "First value"},
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.required_when: predicate,
-        },
+        OP_TYPE: PropertySpec(
+            "Operation to apply",
+            allowed_values={"sum": "Sum of values", "first": "First value"},
+            context=True,
+            strict_validation=True,
+            required_when=predicate,
+        ),
     }
 
 
@@ -262,11 +264,12 @@ class TestGuardInstallation:
         class NoRequiredWhen(FeatureChainParserMixin, FeatureGroup):
             PREFIX_PATTERN = GUARDED_PATTERN
             PROPERTY_MAPPING = {
-                OP_TYPE: {
-                    DefaultOptionKeys.allowed_values: {"sum": "Sum of values"},
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: True,
-                },
+                OP_TYPE: PropertySpec(
+                    "Operation to apply",
+                    allowed_values={"sum": "Sum of values"},
+                    context=True,
+                    strict_validation=True,
+                ),
             }
 
         assert "match_feature_group_criteria" not in NoRequiredWhen.__dict__
@@ -341,11 +344,12 @@ class TestStaticMethodMatcherRejected:
         class StaticMatcherNoContract(FeatureChainParserMixin, FeatureGroup):
             PREFIX_PATTERN = GUARDED_PATTERN
             PROPERTY_MAPPING = {
-                OP_TYPE: {
-                    DefaultOptionKeys.allowed_values: {"sum": "Sum of values"},
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: True,
-                },
+                OP_TYPE: PropertySpec(
+                    "Operation to apply",
+                    allowed_values={"sum": "Sum of values"},
+                    context=True,
+                    strict_validation=True,
+                ),
             }
 
             @staticmethod

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_resolve_operation.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_resolve_operation.py
@@ -15,7 +15,7 @@ from mloda.user import PluginCollector
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 from mloda_plugins.feature_group.experimental.aggregated_feature_group.base import AggregatedFeatureGroup
 from mloda_plugins.feature_group.experimental.aggregated_feature_group.pandas import PandasAggregatedFeatureGroup
-from mloda.provider import DefaultOptionKeys
+from mloda.provider import DefaultOptionKeys, PropertySpec
 
 from tests.test_plugins.integration_plugins.test_data_creator import ATestDataCreator
 
@@ -27,11 +27,12 @@ class MockResolverFG(FeatureChainParserMixin):
     AGGREGATION_TYPE = "aggregation_type"
 
     PROPERTY_MAPPING = {
-        "aggregation_type": {
-            DefaultOptionKeys.allowed_values: {"sum": "Sum", "avg": "Average"},
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-        },
+        "aggregation_type": PropertySpec(
+            "Aggregation to apply",
+            allowed_values={"sum": "Sum", "avg": "Average"},
+            context=True,
+            strict_validation=True,
+        ),
     }
 
 

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_strict_validation_returns_false.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_strict_validation_returns_false.py
@@ -4,17 +4,19 @@ from mloda.user import FeatureName, Options
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import (
     FeatureChainParserMixin,
 )
-from mloda.provider import DefaultOptionKeys
+from mloda.provider import PropertySpec
 
 
 class BaseMode(FeatureChainParserMixin):
     """Base class with strict validation on 'mode' key."""
 
     PROPERTY_MAPPING = {
-        "mode": {
-            DefaultOptionKeys.allowed_values: {"mode_a": "Mode A", "mode_b": "Mode B"},
-            DefaultOptionKeys.strict_validation: True,
-        }
+        "mode": PropertySpec(
+            "Mode of operation",
+            allowed_values={"mode_a": "Mode A", "mode_b": "Mode B"},
+            context=False,
+            strict_validation=True,
+        )
     }
 
 
@@ -22,7 +24,12 @@ class SubGroupA(BaseMode):
     """Subclass that only accepts mode_a."""
 
     PROPERTY_MAPPING = {
-        "mode": {DefaultOptionKeys.allowed_values: {"mode_a": "Mode A"}, DefaultOptionKeys.strict_validation: True}
+        "mode": PropertySpec(
+            "Mode of operation",
+            allowed_values={"mode_a": "Mode A"},
+            context=False,
+            strict_validation=True,
+        )
     }
 
 
@@ -30,7 +37,12 @@ class SubGroupB(BaseMode):
     """Subclass that only accepts mode_b."""
 
     PROPERTY_MAPPING = {
-        "mode": {DefaultOptionKeys.allowed_values: {"mode_b": "Mode B"}, DefaultOptionKeys.strict_validation: True}
+        "mode": PropertySpec(
+            "Mode of operation",
+            allowed_values={"mode_b": "Mode B"},
+            context=False,
+            strict_validation=True,
+        )
     }
 
 
@@ -38,10 +50,12 @@ class SubGroupWithElementValidator(BaseMode):
     """Subclass with a custom element validator."""
 
     PROPERTY_MAPPING = {
-        "mode": {
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.element_validator: lambda v: v.startswith("valid_"),
-        }
+        "mode": PropertySpec(
+            "Mode of operation",
+            context=False,
+            strict_validation=True,
+            element_validator=lambda v: v.startswith("valid_"),
+        )
     }
 
 

--- a/tests/test_core/test_abstract_plugins/test_components/test_feature_collection_forwarding.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_feature_collection_forwarding.py
@@ -25,7 +25,7 @@ import pytest
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import (
     FeatureChainParserMixin,
 )
-from mloda.provider import DefaultOptionKeys
+from mloda.provider import DefaultOptionKeys, PropertySpec
 from mloda.user import Feature
 from mloda.user import FeatureName
 from mloda.user import Features
@@ -216,11 +216,12 @@ class _ForwardingChainedGroup(FeatureChainParserMixin):
 
     PREFIX_PATTERN = r".*__([\w]+)_fwdchain$"
     PROPERTY_MAPPING = {
-        "operation": {
-            DefaultOptionKeys.allowed_values: {"op1": "Operation 1"},
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-        }
+        "operation": PropertySpec(
+            "Operation to apply",
+            allowed_values={"op1": "Operation 1"},
+            context=True,
+            strict_validation=True,
+        )
     }
 
 

--- a/tests/test_core/test_abstract_plugins/test_components/test_forwarded_name_mismatch.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_forwarded_name_mismatch.py
@@ -29,7 +29,7 @@ import pytest
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import (
     FeatureChainParserMixin,
 )
-from mloda.provider import DefaultOptionKeys
+from mloda.provider import PropertySpec
 from mloda.user import Options
 
 
@@ -40,19 +40,21 @@ STRING_FEATURE_NAME = "sales__sum_namemis579"
 class _NameMismatchChainedGroup(FeatureChainParserMixin):
     """Minimal chainer subclass following the existing mixin test fixture style.
 
-    The operation key is group-categorized on purpose (no DefaultOptionKeys.context
-    mark): only group options flow through consumer forwarding.
+    The operation key is group-categorized on purpose (context=False): only group
+    options flow through consumer forwarding.
     """
 
     PREFIX_PATTERN = r".*__(sum|max)_namemis579$"
     PROPERTY_MAPPING = {
-        OPERATION_KEY: {
-            DefaultOptionKeys.allowed_values: {
+        OPERATION_KEY: PropertySpec(
+            "Operation of the namemis579 fixture",
+            allowed_values={
                 "sum": "Sum of the in feature (namemis579 fixture)",
                 "max": "Maximum of the in feature (namemis579 fixture)",
             },
-            DefaultOptionKeys.strict_validation: True,
-        }
+            context=False,
+            strict_validation=True,
+        )
     }
 
 

--- a/tests/test_core/test_abstract_plugins/test_feature_group/test_declared_option_keys.py
+++ b/tests/test_core/test_abstract_plugins/test_feature_group/test_declared_option_keys.py
@@ -1,14 +1,14 @@
 """Tests for FeatureGroup.declared_option_keys() (issue #603).
 
 ``declared_option_keys()`` is a classmethod that returns the top-level parameter
-names declared in ``PROPERTY_MAPPING`` -- regardless of whether the mapping was
-authored as a hand-written spec dict or via the ``property_spec`` builder. It
+names declared in ``PROPERTY_MAPPING`` -- regardless of whether the specs were
+constructed directly as ``PropertySpec`` or via the ``property_spec`` builder. It
 never returns the inner allowed-value keys (e.g. "add"/"sub").
 """
 
 from typing import Any
 
-from mloda.provider import DefaultOptionKeys, FeatureGroup, property_spec
+from mloda.provider import FeatureGroup, PropertySpec, property_spec
 
 
 class DefaultMappingFeatureGroup(FeatureGroup):
@@ -22,14 +22,15 @@ class EmptyMappingFeatureGroup(FeatureGroup):
 
 
 class HandWrittenMappingFeatureGroup(FeatureGroup):
-    """Hand-written PROPERTY_MAPPING spec dict with a single declared parameter."""
+    """Directly-constructed PropertySpec with a single declared parameter."""
 
     PROPERTY_MAPPING = {
-        "operation_type": {
-            DefaultOptionKeys.allowed_values: {"add": "Addition", "sub": "Subtraction"},
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-        },
+        "operation_type": PropertySpec(
+            "the operation to apply",
+            allowed_values={"add": "Addition", "sub": "Subtraction"},
+            context=True,
+            strict_validation=True,
+        ),
     }
 
 
@@ -46,24 +47,26 @@ class BuilderMappingFeatureGroup(FeatureGroup):
 
 
 class MultiKeyMappingFeatureGroup(FeatureGroup):
-    """Multiple declared parameters, mixing hand-written and builder-form specs."""
+    """Multiple declared parameters, mixing directly-constructed and builder-form specs."""
 
     PROPERTY_MAPPING = {
-        "operation_type": {
-            DefaultOptionKeys.allowed_values: {"add": "Addition"},
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-        },
+        "operation_type": PropertySpec(
+            "the operation to apply",
+            allowed_values={"add": "Addition"},
+            context=True,
+            strict_validation=True,
+        ),
         "aggregation_type": property_spec(
             "the aggregation to apply",
             strict=True,
             allowed_values={"sum": "Sum", "mean": "Mean"},
         ),
-        "window_size": {
-            DefaultOptionKeys.allowed_values: {"3": "three"},
-            DefaultOptionKeys.context: False,
-            DefaultOptionKeys.strict_validation: False,
-        },
+        "window_size": PropertySpec(
+            "the window size",
+            allowed_values={"3": "three"},
+            context=False,
+            strict_validation=False,
+        ),
     }
 
 
@@ -82,7 +85,7 @@ def test_declared_option_keys_returns_empty_frozenset_when_property_mapping_empt
 
 
 def test_declared_option_keys_returns_top_level_keys_for_hand_written_mapping() -> None:
-    """Hand-written spec dict: only the top-level parameter name is returned.
+    """Directly-constructed spec: only the top-level parameter name is returned.
 
     Inner allowed-value keys ("add"/"sub") and metadata flags must not appear.
     """
@@ -140,18 +143,19 @@ def test_declared_option_keys_snapshot_not_tied_to_underlying_dict() -> None:
     """Mutating the original PROPERTY_MAPPING dict after the call does not
     retroactively change an already-returned frozenset (unlike a dict_keys view)."""
     mapping: dict[str, Any] = {
-        "operation_type": {
-            DefaultOptionKeys.allowed_values: {"add": "Addition"},
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-        },
+        "operation_type": PropertySpec(
+            "the operation to apply",
+            allowed_values={"add": "Addition"},
+            context=True,
+            strict_validation=True,
+        ),
     }
 
     class MutableMappingFeatureGroup(FeatureGroup):
         PROPERTY_MAPPING = mapping
 
     result = MutableMappingFeatureGroup.declared_option_keys()
-    mapping["new_param"] = {"explanation": "added after the snapshot"}
+    mapping["new_param"] = PropertySpec("added after the snapshot")
 
     assert result == frozenset({"operation_type"})
     assert "new_param" not in result

--- a/tests/test_core/test_abstract_plugins/test_property_mapping_default_invariant.py
+++ b/tests/test_core/test_abstract_plugins/test_property_mapping_default_invariant.py
@@ -1,16 +1,17 @@
-"""Tests for the class-definition-time PROPERTY_MAPPING default invariant (issue #520).
+"""The PROPERTY_MAPPING declared-default invariant (issue #530), relocated to construction.
 
-At class definition time, for every PROPERTY_MAPPING key whose spec is a dict and
-declares a non-``None`` ``DefaultOptionKeys.default``, the declared default must be
-honored by the key's own strict-validation rules (be in the accepted set or pass the
-``element_validator``). Otherwise defining the FeatureGroup subclass must raise
-``ValueError`` immediately.
+For every PROPERTY_MAPPING key that declares a non-``None`` ``default`` under strict
+validation, the declared default must be honored by the key's own rules: be within
+``allowed_values``, or pass the ``element_validator``. The check now runs when the
+``PropertySpec`` is CONSTRUCTED (issue #694), so a FeatureGroup declaring a bad default still
+fails at class definition: the spec literal in the class body raises and the class never
+comes into existence. The error identifies the spec by its explanation
+(``PropertySpec('...')``) rather than by the class, which does not exist yet.
 
-``DefaultOptionKeys.required_when`` is NOT an escape hatch: it expresses a conditional
-requirement, so when its predicate is False (or it is non-callable) and the key is
-omitted, the bad default would still apply silently. The only sound way to mark a key
-required is to declare NO default; mloda treats a key with no default and no
-``required_when`` as unconditionally required.
+``required_when`` is NOT an escape hatch: it expresses a conditional requirement, so when its
+predicate is False and the key is omitted, the bad default would still apply silently. The
+only sound way to mark a key required is to declare NO default; mloda treats a key with no
+default and no ``required_when`` as unconditionally required.
 """
 
 from __future__ import annotations
@@ -26,26 +27,35 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.utils import get_all_subclasses
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
-from mloda.provider import DefaultOptionKeys
+from mloda.provider import NO_DEFAULT, PropertySpec
 
 
 @pytest.fixture(autouse=True)
 def _no_feature_group_registry_pollution() -> Any:
     """Guarantee this module never leaks throwaway FeatureGroup subclasses.
 
-    The tests below define FeatureGroup subclasses to exercise
-    ``FeatureGroup.__init_subclass__``. Those class objects sit in reference
-    cycles, so they linger in ``FeatureGroup.__subclasses__()`` until a GC cycle
-    runs. While they linger, other tests that enumerate feature groups via
-    ``get_all_subclasses(FeatureGroup)`` trip over them. After each test we force
-    a collection to reclaim the now-unreferenced classes and assert that none of
-    this module's classes remain registered, pinning the no-pollution contract.
+    The tests below define FeatureGroup subclasses to exercise the author experience.
+    Those class objects sit in reference cycles, so they linger in
+    ``FeatureGroup.__subclasses__()`` until a GC cycle runs. While they linger, other
+    tests that enumerate feature groups via ``get_all_subclasses(FeatureGroup)`` trip
+    over them. After each test we force a collection to reclaim the now-unreferenced
+    classes and assert that none of this module's classes remain registered, pinning
+    the no-pollution contract.
     """
     yield
     gc.collect()
     gc.collect()
     leaked = [c for c in get_all_subclasses(FeatureGroup) if c.__module__ == __name__]
     assert not leaked, f"Leaked FeatureGroup subclasses from {__name__}: {[c.__name__ for c in leaked]}"
+
+
+def _spec(*args: Any, **kwargs: Any) -> PropertySpec:
+    """Build a ``PropertySpec`` through an untyped seam.
+
+    The buggy zero-argument element_validator below is intentionally type-invalid; routing
+    it through ``Any`` keeps the module mypy --strict clean.
+    """
+    return PropertySpec(*args, **kwargs)
 
 
 def _never_required(options: Any) -> bool:
@@ -61,19 +71,20 @@ def _never_required(options: Any) -> bool:
 class TestStrictEnumeratedDefaultInvariant:
     """Strict validation with an enumerated accepted set."""
 
-    def test_rejects_strict_default_outside_accepted_set(self) -> None:
-        """A strict key whose default is not in the accepted set must reject at class definition."""
+    def test_rejects_strict_default_outside_mapping_keys(self) -> None:
+        """A strict default outside a Mapping value space's KEYS raises at class definition."""
         with pytest.raises(ValueError) as exc_info:
 
             class BadDefaultFeatureGroup(FeatureChainParserMixin, FeatureGroup):
                 PREFIX_PATTERN = r".*__([\w]+)_op$"
                 PROPERTY_MAPPING = {
-                    "operation_type": {
-                        DefaultOptionKeys.allowed_values: {"add": "Addition", "sub": "Subtraction"},
-                        DefaultOptionKeys.context: True,
-                        DefaultOptionKeys.strict_validation: True,
-                        DefaultOptionKeys.default: "mul",
-                    }
+                    "operation_type": PropertySpec(
+                        "The arithmetic operation to apply",
+                        allowed_values={"add": "Addition", "sub": "Subtraction"},
+                        context=True,
+                        strict_validation=True,
+                        default="mul",
+                    )
                 }
 
                 @classmethod
@@ -81,11 +92,35 @@ class TestStrictEnumeratedDefaultInvariant:
                     return data
 
         message = str(exc_info.value)
-        assert "BadDefaultFeatureGroup" in message
-        assert "operation_type" in message
+        assert "default" in message
         assert "mul" in message
-        assert "add" in message
-        assert "sub" in message
+        assert all(c.__name__ != "BadDefaultFeatureGroup" for c in get_all_subclasses(FeatureGroup)), (
+            "the spec raised inside the class body, so the class must never come into existence"
+        )
+
+    def test_rejects_strict_default_outside_tuple_allowed_values(self) -> None:
+        """The invariant covers a tuple value space exactly like a Mapping one."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class BadTupleDefaultFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PREFIX_PATTERN = r".*__([\w]+)_op$"
+                PROPERTY_MAPPING = {
+                    "operation_type": PropertySpec(
+                        "The arithmetic operation to apply",
+                        allowed_values=("add", "sub"),
+                        context=True,
+                        strict_validation=True,
+                        default="mul",
+                    )
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        assert "default" in message
+        assert "mul" in message
 
     def test_accepts_strict_default_in_accepted_set(self) -> None:
         """A strict key whose default is in the accepted set defines without error."""
@@ -93,19 +128,20 @@ class TestStrictEnumeratedDefaultInvariant:
         class GoodDefaultFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             PREFIX_PATTERN = r".*__([\w]+)_op$"
             PROPERTY_MAPPING = {
-                "operation_type": {
-                    DefaultOptionKeys.allowed_values: {"add": "Addition", "sub": "Subtraction"},
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: True,
-                    DefaultOptionKeys.default: "add",
-                }
+                "operation_type": PropertySpec(
+                    "The arithmetic operation to apply",
+                    allowed_values={"add": "Addition", "sub": "Subtraction"},
+                    context=True,
+                    strict_validation=True,
+                    default="add",
+                )
             }
 
             @classmethod
             def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
                 return data
 
-        assert GoodDefaultFeatureGroup.PROPERTY_MAPPING["operation_type"][DefaultOptionKeys.default] == "add"
+        assert GoodDefaultFeatureGroup.PROPERTY_MAPPING["operation_type"].default == "add"
 
     def test_required_when_does_not_rescue_strict_bad_default(self) -> None:
         """``required_when`` must not exempt a strict default outside the accepted set.
@@ -113,20 +149,21 @@ class TestStrictEnumeratedDefaultInvariant:
         ``required_when`` is a conditional requirement: when its predicate is False
         and the key is omitted, the bad default still applies silently, reopening the
         exact bug the invariant closes. So a strict, non-None default outside the
-        accepted set must reject at class definition even with ``required_when`` set.
+        accepted set must reject at construction even with ``required_when`` set.
         """
         with pytest.raises(ValueError) as exc_info:
 
             class RequiredWhenBadDefaultFeatureGroup(FeatureChainParserMixin, FeatureGroup):
                 PREFIX_PATTERN = r".*__([\w]+)_op$"
                 PROPERTY_MAPPING = {
-                    "operation_type": {
-                        DefaultOptionKeys.allowed_values: {"add": "Addition", "sub": "Subtraction"},
-                        DefaultOptionKeys.context: True,
-                        DefaultOptionKeys.strict_validation: True,
-                        DefaultOptionKeys.default: "mul",
-                        DefaultOptionKeys.required_when: _never_required,
-                    }
+                    "operation_type": PropertySpec(
+                        "The arithmetic operation to apply",
+                        allowed_values={"add": "Addition", "sub": "Subtraction"},
+                        context=True,
+                        strict_validation=True,
+                        default="mul",
+                        required_when=_never_required,
+                    )
                 }
 
                 @classmethod
@@ -134,8 +171,7 @@ class TestStrictEnumeratedDefaultInvariant:
                     return data
 
         message = str(exc_info.value)
-        assert "RequiredWhenBadDefaultFeatureGroup" in message
-        assert "operation_type" in message
+        assert "default" in message
         assert "mul" in message
 
     def test_accepts_none_default_under_strict_validation(self) -> None:
@@ -150,22 +186,23 @@ class TestStrictEnumeratedDefaultInvariant:
         class NoneDefaultFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             PREFIX_PATTERN = r".*__([\w]+)_op$"
             PROPERTY_MAPPING = {
-                "operation_type": {
-                    DefaultOptionKeys.allowed_values: {
+                "operation_type": PropertySpec(
+                    "The pipeline step to run",
+                    allowed_values={
                         "feature_engineering": "Feature engineering step",
                         "scaling": "Scaling step",
                     },
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: True,
-                    DefaultOptionKeys.default: None,
-                }
+                    context=True,
+                    strict_validation=True,
+                    default=None,
+                )
             }
 
             @classmethod
             def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
                 return data
 
-        assert NoneDefaultFeatureGroup.PROPERTY_MAPPING["operation_type"][DefaultOptionKeys.default] is None
+        assert NoneDefaultFeatureGroup.PROPERTY_MAPPING["operation_type"].default is None
 
     def test_no_op_for_non_strict_spec(self) -> None:
         """When strict_validation is False, the listed values are illustrative; any default is fine."""
@@ -173,66 +210,41 @@ class TestStrictEnumeratedDefaultInvariant:
         class NonStrictFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             PREFIX_PATTERN = r".*__([\w]+)_op$"
             PROPERTY_MAPPING = {
-                "operation_type": {
-                    DefaultOptionKeys.allowed_values: {"add": "Addition", "sub": "Subtraction"},
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: False,
-                    DefaultOptionKeys.default: "mul",
-                }
+                "operation_type": PropertySpec(
+                    "The arithmetic operation to apply",
+                    allowed_values={"add": "Addition", "sub": "Subtraction"},
+                    context=True,
+                    strict_validation=False,
+                    default="mul",
+                )
             }
 
             @classmethod
             def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
                 return data
 
-        assert NonStrictFeatureGroup.PROPERTY_MAPPING["operation_type"][DefaultOptionKeys.default] == "mul"
-
-    def test_rejects_empty_accepted_set_under_strict_validation(self) -> None:
-        """A strict key with no enumerated values and no element_validator rejects a default.
-
-        Without any accepted values and without a ``element_validator``, the
-        declared default can never be honored, so defining the FeatureGroup subclass
-        must raise ``ValueError``.
-        """
-        with pytest.raises(ValueError) as exc_info:
-
-            class EmptyAcceptedSetFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-                PREFIX_PATTERN = r".*__([\w]+)_op$"
-                PROPERTY_MAPPING = {
-                    "operation_type": {
-                        DefaultOptionKeys.context: True,
-                        DefaultOptionKeys.strict_validation: True,
-                        DefaultOptionKeys.default: "x",
-                    }
-                }
-
-                @classmethod
-                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                    return data
-
-        message = str(exc_info.value)
-        assert "EmptyAcceptedSetFeatureGroup" in message
-        assert "operation_type" in message
+        assert NonStrictFeatureGroup.PROPERTY_MAPPING["operation_type"].default == "mul"
 
     def test_unhashable_default_reports_clear_error(self) -> None:
         """An unhashable strict default surfaces as ``ValueError``, not a bare ``TypeError``.
 
-        The membership check ``default not in accepted`` raises ``TypeError`` for an
-        unhashable default (e.g. a list). The invariant must translate that into a
-        clear ``ValueError`` naming the class and key rather than leaking the
-        ``TypeError``.
+        Membership in a Mapping value space tests KEYS, and an unhashable default
+        (e.g. a list) can never be a key: ``["mul"] in {...}`` would raise
+        ``TypeError``. The invariant must translate that into the regular
+        out-of-value-space ``ValueError`` rather than leaking the ``TypeError``.
         """
         with pytest.raises(ValueError) as exc_info:
 
             class UnhashableDefaultFeatureGroup(FeatureChainParserMixin, FeatureGroup):
                 PREFIX_PATTERN = r".*__([\w]+)_op$"
                 PROPERTY_MAPPING = {
-                    "operation_type": {
-                        DefaultOptionKeys.allowed_values: {"add": "Addition", "sub": "Subtraction"},
-                        DefaultOptionKeys.context: True,
-                        DefaultOptionKeys.strict_validation: True,
-                        DefaultOptionKeys.default: ["mul"],
-                    }
+                    "operation_type": PropertySpec(
+                        "The arithmetic operation to apply",
+                        allowed_values={"add": "Addition", "sub": "Subtraction"},
+                        context=True,
+                        strict_validation=True,
+                        default=["mul"],
+                    )
                 }
 
                 @classmethod
@@ -240,8 +252,8 @@ class TestStrictEnumeratedDefaultInvariant:
                     return data
 
         message = str(exc_info.value)
-        assert "UnhashableDefaultFeatureGroup" in message
-        assert "operation_type" in message
+        assert "default" in message
+        assert "mul" in message
 
 
 class TestStrictElementValidatorDefaultInvariant:
@@ -254,12 +266,13 @@ class TestStrictElementValidatorDefaultInvariant:
             class BadFnDefaultFeatureGroup(FeatureChainParserMixin, FeatureGroup):
                 PREFIX_PATTERN = r".*__([\w]+)_op$"
                 PROPERTY_MAPPING = {
-                    "operation_type": {
-                        DefaultOptionKeys.context: True,
-                        DefaultOptionKeys.strict_validation: True,
-                        DefaultOptionKeys.element_validator: lambda v: v in {"x", "y"},
-                        DefaultOptionKeys.default: "z",
-                    }
+                    "operation_type": PropertySpec(
+                        "The operation to apply",
+                        context=True,
+                        strict_validation=True,
+                        element_validator=lambda v: v in {"x", "y"},
+                        default="z",
+                    )
                 }
 
                 @classmethod
@@ -267,8 +280,7 @@ class TestStrictElementValidatorDefaultInvariant:
                     return data
 
         message = str(exc_info.value)
-        assert "BadFnDefaultFeatureGroup" in message
-        assert "operation_type" in message
+        assert "default" in message
         assert "z" in message
 
     def test_accepts_default_passing_element_validator(self) -> None:
@@ -277,19 +289,149 @@ class TestStrictElementValidatorDefaultInvariant:
         class GoodFnDefaultFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             PREFIX_PATTERN = r".*__([\w]+)_op$"
             PROPERTY_MAPPING = {
-                "operation_type": {
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: True,
-                    DefaultOptionKeys.element_validator: lambda v: v in {"x", "y"},
-                    DefaultOptionKeys.default: "x",
-                }
+                "operation_type": PropertySpec(
+                    "The operation to apply",
+                    context=True,
+                    strict_validation=True,
+                    element_validator=lambda v: v in {"x", "y"},
+                    default="x",
+                )
             }
 
             @classmethod
             def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
                 return data
 
-        assert GoodFnDefaultFeatureGroup.PROPERTY_MAPPING["operation_type"][DefaultOptionKeys.default] == "x"
+        assert GoodFnDefaultFeatureGroup.PROPERTY_MAPPING["operation_type"].default == "x"
+
+
+class TestElementValidatorRaisedVersusRejected:
+    """The error must distinguish a default REJECTED by a working validator from a validator
+    that itself RAISED when called: only the first is a verdict on the default."""
+
+    def test_buggy_element_validator_reported_as_raised_not_rejected(self) -> None:
+        """A element_validator that errors when called is reported as having raised.
+
+        ``lambda: True`` takes no arguments, so calling it with the default raises
+        ``TypeError``. That is a bug in the validator, not a verdict on the default,
+        so construction must surface a ``ValueError`` saying the element_validator
+        raised (not that the default was "rejected by" it), chaining the original
+        ``TypeError`` as the cause.
+        """
+        with pytest.raises(ValueError) as exc_info:
+
+            class BuggyFnFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PREFIX_PATTERN = r".*__([\w]+)_op$"
+                PROPERTY_MAPPING = {
+                    "operation_type": _spec(
+                        "The operation to apply",
+                        context=True,
+                        strict_validation=True,
+                        element_validator=lambda: True,
+                        default="x",
+                    )
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        assert "raised" in message
+        assert "rejected by" not in message
+        assert isinstance(exc_info.value.__cause__, TypeError), "expected the original TypeError chained as __cause__"
+
+    def test_element_validator_raising_attribute_error_reports_raised(self) -> None:
+        """A element_validator raising ``AttributeError`` surfaces as the curated ``ValueError``.
+
+        ``lambda v: v.startswith("a")`` crashes with ``AttributeError`` for the
+        non-string default ``5``. The raw ``AttributeError`` must never escape class
+        definition; construction must say the element_validator raised and chain the
+        original error as the cause.
+        """
+        with pytest.raises(ValueError) as exc_info:
+
+            class AttributeErrorFnFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PREFIX_PATTERN = r".*__([\w]+)_op$"
+                PROPERTY_MAPPING = {
+                    "operation_type": PropertySpec(
+                        "The operation to apply",
+                        context=True,
+                        strict_validation=True,
+                        element_validator=lambda v: v.startswith("a"),
+                        default=5,
+                    )
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        assert "raised" in message
+        assert "rejected by" not in message
+        assert isinstance(exc_info.value.__cause__, AttributeError), (
+            "expected the original AttributeError chained as __cause__"
+        )
+
+    def test_element_validator_raising_value_error_reports_raised(self) -> None:
+        """A element_validator raising ``ValueError`` internally is reported as having raised.
+
+        ``lambda v: int(v) > 0`` crashes with ``ValueError`` for the default
+        ``"abc"``: the function never returned a verdict, it errored. Construction
+        must not misreport this as the default being "rejected by" the validator.
+        """
+        with pytest.raises(ValueError) as exc_info:
+
+            class ValueErrorFnFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PREFIX_PATTERN = r".*__([\w]+)_op$"
+                PROPERTY_MAPPING = {
+                    "operation_type": PropertySpec(
+                        "The operation to apply",
+                        context=True,
+                        strict_validation=True,
+                        element_validator=lambda v: int(v) > 0,
+                        default="abc",
+                    )
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        assert "raised" in message
+        assert "rejected by" not in message
+        assert isinstance(exc_info.value.__cause__, ValueError), "expected the original ValueError chained as __cause__"
+
+    def test_genuine_rejection_still_labeled_as_rejection(self) -> None:
+        """A working element_validator that returns False is still reported as a rejection.
+
+        Distinguishing a buggy validator (it raised) must not erase the rejection
+        wording for the genuine case: a callable that runs and returns False has
+        rejected the default, and the message must say so.
+        """
+        with pytest.raises(ValueError) as exc_info:
+
+            class RejectingFnDefaultFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PREFIX_PATTERN = r".*__([\w]+)_op$"
+                PROPERTY_MAPPING = {
+                    "operation_type": PropertySpec(
+                        "The operation to apply",
+                        context=True,
+                        strict_validation=True,
+                        element_validator=lambda v: False,
+                        default="x",
+                    )
+                }
+
+                @classmethod
+                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                    return data
+
+        message = str(exc_info.value)
+        assert "rejected by the element_validator" in message
+        assert "raised" not in message
 
 
 class TestNoDefaultDeclared:
@@ -301,232 +443,16 @@ class TestNoDefaultDeclared:
         class NoDefaultFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             PREFIX_PATTERN = r".*__([\w]+)_op$"
             PROPERTY_MAPPING = {
-                "operation_type": {
-                    DefaultOptionKeys.allowed_values: {"add": "Addition", "sub": "Subtraction"},
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: True,
-                }
+                "operation_type": PropertySpec(
+                    "The arithmetic operation to apply",
+                    allowed_values={"add": "Addition", "sub": "Subtraction"},
+                    context=True,
+                    strict_validation=True,
+                )
             }
 
             @classmethod
             def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
                 return data
 
-        assert DefaultOptionKeys.default not in NoDefaultFeatureGroup.PROPERTY_MAPPING["operation_type"]
-
-
-class TestDefaultInvariantErrorMessaging:
-    """The ValueError raised by the invariant must give accurate, actionable advice.
-
-    The two legal remedies for a strict default outside the accepted set are: add the
-    default to the accepted values, or remove the default. ``required_when`` is NOT a
-    remedy (its predicate being False still lets the bad default apply silently), so
-    the message must never advise it. The message must also distinguish a default that
-    was genuinely rejected by a working element_validator from an element_validator
-    that itself errored when called.
-    """
-
-    def test_message_advises_only_the_two_legal_remedies(self) -> None:
-        """The message for a strict out-of-set default advises exactly the legal remedies.
-
-        It must advise adding the default to the accepted values and removing the
-        default, and must NOT advise ``required_when``: a False predicate plus an
-        omitted key still applies the bad default silently, so suggesting it would
-        steer users back into the very bug the invariant closes.
-        """
-        with pytest.raises(ValueError) as exc_info:
-
-            class RemedyAdviceFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-                PREFIX_PATTERN = r".*__([\w]+)_op$"
-                PROPERTY_MAPPING = {
-                    "operation_type": {
-                        DefaultOptionKeys.allowed_values: {"add": "Addition", "sub": "Subtraction"},
-                        DefaultOptionKeys.context: True,
-                        DefaultOptionKeys.strict_validation: True,
-                        DefaultOptionKeys.default: "mul",
-                    }
-                }
-
-                @classmethod
-                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                    return data
-
-        message = str(exc_info.value)
-        # Drop the ExceptionInfo before asserting: when an assert fails, pytest's
-        # report retains this frame, and via the captured traceback the throwaway
-        # class would stay alive and trip the no-pollution fixture.
-        del exc_info
-        assert "accepted values" in message
-        assert "remove the default" in message
-        assert "required_when" not in message
-
-    def test_message_renders_accepted_values_without_nested_quoting(self) -> None:
-        """Accepted values render as plain reprs, not repr-of-repr.
-
-        The accepted set for the key below must appear as ``['add', 'sub']`` in the
-        message, not as ``["'add'", "'sub'"]`` (stringifying each value before
-        repr-ing the list double-quotes every entry and obscures the actual values).
-        """
-        with pytest.raises(ValueError) as exc_info:
-
-            class ValueRenderingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-                PREFIX_PATTERN = r".*__([\w]+)_op$"
-                PROPERTY_MAPPING = {
-                    "operation_type": {
-                        DefaultOptionKeys.allowed_values: {"add": "Addition", "sub": "Subtraction"},
-                        DefaultOptionKeys.context: True,
-                        DefaultOptionKeys.strict_validation: True,
-                        DefaultOptionKeys.default: "mul",
-                    }
-                }
-
-                @classmethod
-                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                    return data
-
-        message = str(exc_info.value)
-        # Drop the ExceptionInfo before asserting (see remedy-advice test above).
-        del exc_info
-        assert "['add', 'sub']" in message
-
-    def test_buggy_element_validator_reported_as_raised_not_rejected(self) -> None:
-        """A element_validator that errors when called is reported as having raised.
-
-        ``lambda: True`` takes no arguments, so calling it with the default raises
-        ``TypeError``. That is a bug in the plugin's element_validator, not a
-        verdict on the default, so the invariant must still surface a ``ValueError``
-        at class definition, must say the element_validator raised (not that the
-        default was "rejected by" it), and must chain the original ``TypeError`` as
-        the cause.
-        """
-        with pytest.raises(ValueError) as exc_info:
-
-            class BuggyFnFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-                PREFIX_PATTERN = r".*__([\w]+)_op$"
-                PROPERTY_MAPPING = {
-                    "operation_type": {
-                        DefaultOptionKeys.context: True,
-                        DefaultOptionKeys.strict_validation: True,
-                        DefaultOptionKeys.element_validator: lambda: True,
-                        DefaultOptionKeys.default: "x",
-                    }
-                }
-
-                @classmethod
-                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                    return data
-
-        message = str(exc_info.value)
-        cause_is_type_error = isinstance(exc_info.value.__cause__, TypeError)
-        # Drop the ExceptionInfo before asserting (see remedy-advice test above).
-        del exc_info
-        assert "BuggyFnFeatureGroup" in message
-        assert "operation_type" in message
-        assert "rejected by" not in message
-        assert "raised" in message
-        assert cause_is_type_error, "expected the original TypeError chained as __cause__"
-
-    def test_genuine_rejection_still_labeled_as_rejection(self) -> None:
-        """A working element_validator that returns False is still reported as a rejection.
-
-        Distinguishing a buggy element_validator (it raised) must not erase the
-        rejection wording for the genuine case: a callable that runs and returns
-        False has rejected the default, and the message must say so.
-        """
-        with pytest.raises(ValueError) as exc_info:
-
-            class RejectingFnFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-                PREFIX_PATTERN = r".*__([\w]+)_op$"
-                PROPERTY_MAPPING = {
-                    "operation_type": {
-                        DefaultOptionKeys.context: True,
-                        DefaultOptionKeys.strict_validation: True,
-                        DefaultOptionKeys.element_validator: lambda v: False,
-                        DefaultOptionKeys.default: "x",
-                    }
-                }
-
-                @classmethod
-                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                    return data
-
-        message = str(exc_info.value)
-        # Drop the ExceptionInfo before asserting (see remedy-advice test above).
-        del exc_info
-        assert "RejectingFnFeatureGroup" in message
-        assert "operation_type" in message
-        assert "rejected by the key's element_validator" in message
-
-    def test_element_validator_raising_attribute_error_reports_raised(self) -> None:
-        """A element_validator raising ``AttributeError`` surfaces as the curated ``ValueError``.
-
-        ``lambda v: v.startswith("a")`` crashes with ``AttributeError`` for the
-        non-string default ``5``. That is a bug in the plugin's element_validator,
-        not a verdict on the default, so the invariant must still surface a
-        ``ValueError`` at class definition naming the class and key, must say the
-        element_validator raised (not that the default was "rejected by" it), and
-        must chain the original ``AttributeError`` as the cause. The raw
-        ``AttributeError`` must never escape class definition.
-        """
-        with pytest.raises(ValueError) as exc_info:
-
-            class AttributeErrorFnFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-                PREFIX_PATTERN = r".*__([\w]+)_op$"
-                PROPERTY_MAPPING = {
-                    "operation_type": {
-                        DefaultOptionKeys.context: True,
-                        DefaultOptionKeys.strict_validation: True,
-                        DefaultOptionKeys.element_validator: lambda v: v.startswith("a"),
-                        DefaultOptionKeys.default: 5,
-                    }
-                }
-
-                @classmethod
-                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                    return data
-
-        message = str(exc_info.value)
-        cause_is_attribute_error = isinstance(exc_info.value.__cause__, AttributeError)
-        # Drop the ExceptionInfo before asserting (see remedy-advice test above).
-        del exc_info
-        assert "AttributeErrorFnFeatureGroup" in message
-        assert "operation_type" in message
-        assert "raised" in message
-        assert "rejected by" not in message
-        assert cause_is_attribute_error, "expected the original AttributeError chained as __cause__"
-
-    def test_element_validator_raising_value_error_reports_raised(self) -> None:
-        """A element_validator raising ``ValueError`` internally is reported as having raised.
-
-        ``lambda v: int(v) > 0`` crashes with ``ValueError`` for the default
-        ``"abc"``: the function never returned a verdict, it errored. The invariant
-        must not misreport this as the default being "rejected by" the
-        element_validator; it must say the element_validator raised and chain
-        the original ``ValueError`` as the cause.
-        """
-        with pytest.raises(ValueError) as exc_info:
-
-            class ValueErrorFnFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-                PREFIX_PATTERN = r".*__([\w]+)_op$"
-                PROPERTY_MAPPING = {
-                    "operation_type": {
-                        DefaultOptionKeys.context: True,
-                        DefaultOptionKeys.strict_validation: True,
-                        DefaultOptionKeys.element_validator: lambda v: int(v) > 0,
-                        DefaultOptionKeys.default: "abc",
-                    }
-                }
-
-                @classmethod
-                def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
-                    return data
-
-        message = str(exc_info.value)
-        cause_is_value_error = isinstance(exc_info.value.__cause__, ValueError)
-        # Drop the ExceptionInfo before asserting (see remedy-advice test above).
-        del exc_info
-        assert "ValueErrorFnFeatureGroup" in message
-        assert "operation_type" in message
-        assert "raised" in message
-        assert "rejected by" not in message
-        assert cause_is_value_error, "expected the original ValueError chained as __cause__"
+        assert NoDefaultFeatureGroup.PROPERTY_MAPPING["operation_type"].default is NO_DEFAULT

--- a/tests/test_core/test_api/test_resolve_feature.py
+++ b/tests/test_core/test_api/test_resolve_feature.py
@@ -10,10 +10,10 @@ import pytest
 from typing import Any, Optional
 
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
-from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
+from mloda.core.abstract_plugins.components.feature_chainer.property_spec import property_spec
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
@@ -173,11 +173,12 @@ class ForwardMismatchResolveFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     PREFIX_PATTERN = r".*__([\w]+)_resolveprobe$"
 
     PROPERTY_MAPPING = {
-        PROBE_TYPE_KEY: {
-            DefaultOptionKeys.allowed_values: {"median": "Median value", "sum": "Sum of values"},
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-        },
+        PROBE_TYPE_KEY: property_spec(
+            "Probe operation subtype.",
+            strict=True,
+            allowed_values={"median": "Median value", "sum": "Sum of values"},
+            context=True,
+        ),
     }
 
     @classmethod

--- a/tests/test_core/test_prepare/test_identify_feature_group_error_message.py
+++ b/tests/test_core/test_prepare/test_identify_feature_group_error_message.py
@@ -15,6 +15,7 @@ from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import (
     FeatureChainParserMixin,
 )
+from mloda.core.abstract_plugins.components.feature_chainer.property_spec import property_spec
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
@@ -694,12 +695,13 @@ class StrictWindowFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     """
 
     PROPERTY_MAPPING = {
-        "window_size": {
-            "explanation": "Size of window",
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.element_validator: lambda v: isinstance(v, int) and 0 < v <= 13,
-        },
-        DefaultOptionKeys.in_features: {"explanation": "source", DefaultOptionKeys.context: True},
+        "window_size": property_spec(
+            "Size of window",
+            strict=True,
+            context=False,
+            element_validator=lambda v: isinstance(v, int) and 0 < v <= 13,
+        ),
+        DefaultOptionKeys.in_features: property_spec("source", context=True),
     }
 
     def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
@@ -713,12 +715,13 @@ class StrictMaxWindowFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     """
 
     PROPERTY_MAPPING = {
-        "max_window": {
-            "explanation": "Maximum window size",
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.element_validator: lambda v: isinstance(v, int) and 0 < v <= 13,
-        },
-        DefaultOptionKeys.in_features: {"explanation": "source", DefaultOptionKeys.context: True},
+        "max_window": property_spec(
+            "Maximum window size",
+            strict=True,
+            context=False,
+            element_validator=lambda v: isinstance(v, int) and 0 < v <= 13,
+        ),
+        DefaultOptionKeys.in_features: property_spec("source", context=True),
     }
 
     def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:

--- a/tests/test_core/test_prepare/test_sbdg_collection_value_spaces.py
+++ b/tests/test_core/test_prepare/test_sbdg_collection_value_spaces.py
@@ -18,12 +18,22 @@ membership trap), so no legal spec can carry a str value space; no string pin ne
 """
 
 from types import MappingProxyType
+from typing import Any
 
-from mloda.provider import FeatureGroup, SubtypeDeclaration, property_spec
+from mloda.provider import FeatureGroup, PropertySpec, SubtypeDeclaration, property_spec
 
 
 SBDG_SIZE_KEY = "sbdg_size"
 SBDG_PROXY_VALUES = MappingProxyType({2: "two", 3: "three", 4: "four"})
+
+
+def _build(*args: Any, **kwargs: Any) -> PropertySpec:
+    """Call ``property_spec`` through an untyped seam.
+
+    The builder's declared ``allowed_values`` type lists the container shapes; a ``range`` is one
+    of the iterables its runtime materializes but its type deliberately does not name.
+    """
+    return property_spec(*args, **kwargs)
 
 
 class SbdgProxyValuesFG(FeatureGroup):
@@ -47,7 +57,7 @@ class TestSbdgDeclaredOptionValuesAcceptsMappingProxy:
         # so a range-backed spec is already enumerable.
         class SbdgRangeValuesFG(FeatureGroup):
             PROPERTY_MAPPING = {
-                "sbdg_range_size": property_spec(
+                "sbdg_range_size": _build(
                     "Size from a range.",
                     strict=True,
                     allowed_values=range(2, 5),

--- a/tests/test_core/test_prepare/test_subtype_declaration.py
+++ b/tests/test_core/test_prepare/test_subtype_declaration.py
@@ -366,7 +366,7 @@ class TestDeclaredOptionValues:
         # subdecl_mode carries context/strict_validation flags; only allowed_values is the value space.
         values = SubDeclValueSpaceFG.declared_option_values("subdecl_mode")
         assert values == frozenset({"fast", "slow"})
-        assert not values & {str(DefaultOptionKeys.context), str(DefaultOptionKeys.strict_validation)}
+        assert not values & {str(DefaultOptionKeys.context), "strict_validation"}
 
     def test_predicate_only_key_has_empty_value_space(self) -> None:
         assert SubDeclValueSpaceFG.declared_option_values("subdecl_n") == frozenset()

--- a/tests/test_plugins/feature_group/experimental/test_dimensionality_reduction_feature_group/test_name_path_option_validation.py
+++ b/tests/test_plugins/feature_group/experimental/test_dimensionality_reduction_feature_group/test_name_path_option_validation.py
@@ -103,11 +103,18 @@ class TestNamePathElementValidatorAndPresence:
         """Required-PRESENCE stays off on the name path: the name carries algorithm and dimension."""
         assert DimensionalityReductionFeatureGroup.match_feature_group_criteria("f0__pca_2d", Options()) is True
 
-    def test_non_strict_key_with_bad_looking_value_is_accepted(self) -> None:
-        """isomap_n_neighbors is strict_validation=False, so no value space is enforced."""
+    def test_isomap_n_neighbors_bad_value_is_rejected_on_the_name_path(self) -> None:
+        """isomap_n_neighbors is strict + element_validator, so its value IS enforced (issue #724).
+
+        This key used to declare an element_validator WITHOUT strict_validation, which never ran:
+        dead config, so a bad value was accepted. ``PropertySpec`` now rejects that combination at
+        construction and the key was made strict, which is what #724 pins. The guard against
+        OVER-rejecting a genuinely unconstrained key lives in the core suite, on a purpose-built
+        non-strict key (``test_name_path_validates_option_values.py::test_non_strict_key_accepts_any_value``).
+        """
         options = Options(context={DimensionalityReductionFeatureGroup.ISOMAP_N_NEIGHBORS: "not_a_number"})
 
-        assert DimensionalityReductionFeatureGroup.match_feature_group_criteria("f0__isomap_2d", options) is True
+        assert DimensionalityReductionFeatureGroup.match_feature_group_criteria("f0__isomap_2d", options) is False
 
 
 def _forwarded_child_options(algorithm: str) -> Options:

--- a/tests/test_plugins/feature_group/experimental/test_node_centrality_feature_group/test_base_node_centrality_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/test_node_centrality_feature_group/test_base_node_centrality_feature_group.py
@@ -7,6 +7,7 @@ import pytest
 from mloda.user import Feature
 from mloda.user import FeatureName
 from mloda.user import Options
+from mloda.provider import DefaultOptionKeys
 from mloda_plugins.feature_group.experimental.node_centrality.base import NodeCentralityFeatureGroup
 from mloda_plugins.feature_group.experimental.node_centrality.pandas import PandasNodeCentralityFeatureGroup
 
@@ -25,6 +26,18 @@ class TestNodeCentralityFeatureGroup:
 
         # Invalid feature names
         assert not NodeCentralityFeatureGroup.match_feature_group_criteria("centrality_degree__user", Options())
+
+    def test_match_feature_group_criteria_configuration_without_weight_column(self) -> None:
+        """Configuration-based matching must succeed when the optional weight_column is omitted."""
+        options = Options(
+            context={
+                NodeCentralityFeatureGroup.CENTRALITY_TYPE: "degree",
+                NodeCentralityFeatureGroup.GRAPH_TYPE: "undirected",
+                DefaultOptionKeys.in_features: "source",
+            }
+        )
+
+        assert NodeCentralityFeatureGroup.match_feature_group_criteria("placeholder", options)
 
     def test_parse_centrality_prefix(self) -> None:
         """Test the parse_centrality_prefix method."""

--- a/tests/test_plugins/feature_group/experimental/test_node_centrality_feature_group/test_node_centrality_integration.py
+++ b/tests/test_plugins/feature_group/experimental/test_node_centrality_feature_group/test_node_centrality_integration.py
@@ -179,6 +179,56 @@ class TestNodeCentralityPandasIntegration:
         # Validate the node centrality features
         validate_node_centrality_features(centrality_df, ["placeholder1", "placeholder2"])
 
+    def test_node_centrality_with_configuration_without_weight_column(self) -> None:
+        """
+        Test node centrality features using the configuration-based approach on an unweighted graph.
+
+        weight_column is optional: a user with an unweighted graph simply omits the key.
+        The feature group must still match and compute.
+        """
+        # Enable the necessary feature groups
+        plugin_collector = PluginCollector.enabled_feature_groups(
+            {NodeCentralityTestDataCreator, PandasNodeCentralityFeatureGroup}
+        )
+
+        # Create a degree centrality feature WITHOUT the optional weight_column option
+        degree_feature = Feature(
+            "placeholder1",
+            Options(
+                context={
+                    NodeCentralityFeatureGroup.CENTRALITY_TYPE: "degree",
+                    DefaultOptionKeys.in_features: "source",
+                    NodeCentralityFeatureGroup.GRAPH_TYPE: "undirected",
+                }
+            ),
+        )
+
+        # Run the mloda with the configured feature
+        result = mloda.run_all(
+            [
+                "source",  # Source node feature
+                "target",  # Target node feature
+                degree_feature,
+            ],
+            compute_frameworks={PandasDataFrame},
+            plugin_collector=plugin_collector,
+        )
+
+        # Verify the results
+        assert len(result) > 0, "No results returned from mloda"
+
+        # Find the DataFrame with the node centrality feature
+        centrality_df = None
+        for df in result:
+            if "placeholder1" in df.columns:
+                centrality_df = df
+                break
+
+        assert centrality_df is not None, "DataFrame with node centrality features not found"
+
+        # Validate the node centrality feature
+        validate_node_centrality_features(centrality_df, ["placeholder1"])
+
     def test_directed_vs_undirected_graph(self) -> None:
         """Test node centrality features with different graph types."""
 

--- a/tests/test_plugins/feature_group/experimental/test_property_mapping_consistency.py
+++ b/tests/test_plugins/feature_group/experimental/test_property_mapping_consistency.py
@@ -1,9 +1,17 @@
+"""Cross-plugin PROPERTY_MAPPING consistency sweep.
+
+PROPERTY_MAPPING values are ``PropertySpec`` instances (issue #694): the dataclass
+constructor enforces the per-spec invariants (known fields, flag types, strict needs a
+value space), so this sweep pins what the type system cannot: every shipped plugin spec
+IS a ``PropertySpec``, documents itself with a non-empty explanation, and enumerated
+value spaces opt into strict validation.
+"""
+
 from typing import Any
 
 import pytest
 
-from mloda.core.abstract_plugins.components.default_options_key import PROPERTY_SPEC_KEYS
-from mloda.provider import DefaultOptionKeys
+from mloda.provider import PropertySpec
 from mloda_plugins.feature_group.experimental.aggregated_feature_group.base import AggregatedFeatureGroup
 from mloda_plugins.feature_group.experimental.clustering.base import ClusteringFeatureGroup
 from mloda_plugins.feature_group.experimental.data_quality.missing_value.base import MissingValueFeatureGroup
@@ -32,69 +40,45 @@ ALL_PLUGINS: list[type[Any]] = [
     TimeWindowFeatureGroup,
 ]
 
-DOK_VALUES: list[str] = [dok.value for dok in DefaultOptionKeys]
-
 
 @pytest.mark.parametrize("plugin_cls", ALL_PLUGINS, ids=lambda c: c.__name__)
 class TestPropertyMappingConsistency:
-    def test_every_entry_has_explicit_strict_validation(self, plugin_cls: type[Any]) -> None:
+    def test_every_spec_is_a_property_spec(self, plugin_cls: type[Any]) -> None:
+        """Raw dict specs are retired: every PROPERTY_MAPPING value is a PropertySpec."""
         mapping: dict[str, Any] = plugin_cls.PROPERTY_MAPPING
         violations: list[str] = []
-        for prop_key, entry in mapping.items():
-            if not isinstance(entry, dict):
-                continue
-            if DefaultOptionKeys.strict_validation not in entry:
+        for prop_key, spec in mapping.items():
+            if not isinstance(spec, PropertySpec):
                 violations.append(str(prop_key))
         assert violations == [], (
-            f"{plugin_cls.__name__} PROPERTY_MAPPING entries missing DefaultOptionKeys.strict_validation: {violations}"
+            f"{plugin_cls.__name__} PROPERTY_MAPPING entries that are not PropertySpec instances: {violations}"
         )
 
-    def test_no_raw_string_metadata_keys(self, plugin_cls: type[Any]) -> None:
-        mapping: dict[str, Any] = plugin_cls.PROPERTY_MAPPING
-        violations: list[tuple[str, str]] = []
-        for prop_key, entry in mapping.items():
-            if not isinstance(entry, dict):
-                continue
-            for key in entry:
-                if key in DOK_VALUES and not isinstance(key, DefaultOptionKeys):
-                    violations.append((str(prop_key), str(key)))
-        assert violations == [], (
-            f"{plugin_cls.__name__} PROPERTY_MAPPING uses raw strings where "
-            f"DefaultOptionKeys enum members should be used: {violations}"
-        )
-
-    def test_only_known_spec_keys(self, plugin_cls: type[Any]) -> None:
-        """Every key of every spec is part of the spec schema.
-
-        Derived from the single source of truth, so a plugin cannot reintroduce a bare value
-        entry (the retired flattened form) or a typo'd flag without this failing.
-        """
-        mapping: dict[str, Any] = plugin_cls.PROPERTY_MAPPING
-        violations: list[tuple[str, str]] = []
-        for prop_key, entry in mapping.items():
-            if not isinstance(entry, dict):
-                continue
-            for key in entry:
-                if key not in PROPERTY_SPEC_KEYS:
-                    violations.append((str(prop_key), str(key)))
-        assert violations == [], (
-            f"{plugin_cls.__name__} PROPERTY_MAPPING carries keys outside the spec schema "
-            f"(accepted values belong under allowed_values): {violations}"
-        )
-
-    def test_enum_entries_have_strict_validation_true(self, plugin_cls: type[Any]) -> None:
+    def test_every_spec_has_a_nonempty_explanation(self, plugin_cls: type[Any]) -> None:
+        """Every spec documents itself: the explanation is a non-empty string."""
         mapping: dict[str, Any] = plugin_cls.PROPERTY_MAPPING
         violations: list[str] = []
-        for prop_key, entry in mapping.items():
-            if not isinstance(entry, dict):
+        for prop_key, spec in mapping.items():
+            if not isinstance(spec.explanation, str) or not spec.explanation.strip():
+                violations.append(str(prop_key))
+        assert violations == [], (
+            f"{plugin_cls.__name__} PROPERTY_MAPPING entries without a non-empty explanation: {violations}"
+        )
+
+    def test_enum_specs_have_strict_validation_true(self, plugin_cls: type[Any]) -> None:
+        """A spec that enumerates its value space should enforce it.
+
+        Specs with an element_validator delegate validation to the callable, and value
+        spaces of fewer than two entries are documentation rather than an enumeration.
+        """
+        mapping: dict[str, Any] = plugin_cls.PROPERTY_MAPPING
+        violations: list[str] = []
+        for prop_key, spec in mapping.items():
+            if spec.element_validator is not None:
                 continue
-            if DefaultOptionKeys.element_validator in entry:
+            if spec.allowed_values is None or len(spec.allowed_values) < 2:
                 continue
-            allowed_values = entry.get(DefaultOptionKeys.allowed_values) or {}
-            if len(allowed_values) < 2:
-                continue
-            sv_value = entry.get(DefaultOptionKeys.strict_validation)
-            if sv_value is not True:
+            if spec.strict_validation is not True:
                 violations.append(str(prop_key))
         assert violations == [], (
             f"{plugin_cls.__name__} PROPERTY_MAPPING entries with enumerated values "

--- a/tests/test_plugins/feature_group/experimental/test_property_mapping_container_invariance.py
+++ b/tests/test_plugins/feature_group/experimental/test_property_mapping_container_invariance.py
@@ -79,8 +79,9 @@ class TestTextCleaningOperationsAreValidatedPerElement:
         element. This is what lets the plugin's lambda collapse to a membership check.
         """
         spec = TextCleaningFeatureGroup.PROPERTY_MAPPING[TextCleaningFeatureGroup.CLEANING_OPERATIONS]
-        validator = spec[DefaultOptionKeys.element_validator]
+        validator = spec.element_validator
 
+        assert validator is not None
         assert validator("normalize") is True
         assert validator("bogus_operation") is False
 

--- a/tests/test_plugins/feature_group/experimental/test_property_mapping_enforced_validators.py
+++ b/tests/test_plugins/feature_group/experimental/test_property_mapping_enforced_validators.py
@@ -1,0 +1,441 @@
+"""Enforcement tests for the six PROPERTY_MAPPING keys that declare a value constraint (issue #724).
+
+Each key must reject bad values on both match paths. Value validation does not depend on how the
+feature was created: the element_validator runs on the config-based path AND on the string-named
+one, match_feature_group_criteria returns False, and _strict_validation_rejection_reason surfaces
+the discarded message. The match_guard additionally judges the raw, un-unpacked value.
+
+A rejection on either path must be REPORTABLE: _strict_validation_rejection_reason is what
+identify_feature_group turns into the user-facing hint, so a match_guard rejection may not stay a
+silent logger.debug. The reporting must not fire for a feature group that does not match the
+feature at all, and a rejected VALUE must not be misdiagnosed as an input-feature forwarding
+problem.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, cast
+
+import pytest
+
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+from mloda.provider import DefaultOptionKeys
+from mloda.provider import FeatureChainParserMixin
+from mloda.provider import FeatureGroup
+from mloda.user import Feature
+from mloda.user import Options
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.feature_group.experimental.aggregated_feature_group.base import AggregatedFeatureGroup
+from mloda_plugins.feature_group.experimental.clustering.base import ClusteringFeatureGroup
+from mloda_plugins.feature_group.experimental.dimensionality_reduction.base import DimensionalityReductionFeatureGroup
+from mloda_plugins.feature_group.experimental.forecasting.base import ForecastingFeatureGroup
+
+
+@dataclass(frozen=True)
+class KeyCase:
+    """One PROPERTY_MAPPING key under test, with both match paths pre-wired."""
+
+    feature_group: type[FeatureChainParserMixin]
+    key: str
+    string_feature_name: str
+    base_context: dict[str, Any]
+    valid_value: Any
+    invalid_values: tuple[Any, ...]
+    reported_invalid_value: Any
+    list_value: list[Any]
+    digit_string: str | None = None
+
+    def options(self, value: Any) -> Options:
+        """Options for the string-named path: only the key under test."""
+        return Options(context={self.key: value})
+
+    def config_options(self, value: Any) -> Options:
+        """Options for the config-based path: the required option set plus the key under test."""
+        return Options(context={**self.base_context, self.key: value})
+
+    def as_feature_group(self) -> type[FeatureGroup]:
+        """The same class seen through the FeatureGroup API (every case subclasses both)."""
+        return cast(type[FeatureGroup], self.feature_group)
+
+
+CLUSTERING_CONTEXT: dict[str, Any] = {
+    ClusteringFeatureGroup.ALGORITHM: "kmeans",
+    ClusteringFeatureGroup.K_VALUE: 5,
+    DefaultOptionKeys.in_features: "customer_behavior",
+}
+
+FORECASTING_CONTEXT: dict[str, Any] = {
+    ForecastingFeatureGroup.ALGORITHM: "linear",
+    ForecastingFeatureGroup.HORIZON: 7,
+    ForecastingFeatureGroup.TIME_UNIT: "day",
+    DefaultOptionKeys.in_features: "sales",
+}
+
+DIMENSION_CONTEXT: dict[str, Any] = {
+    DimensionalityReductionFeatureGroup.ALGORITHM: "tsne",
+    DimensionalityReductionFeatureGroup.DIMENSION: 2,
+    DefaultOptionKeys.in_features: "feature0,feature1,feature2",
+}
+
+BOOL_INVALID: tuple[Any, ...] = ("maybe", 1)
+NUMERIC_INVALID: tuple[Any, ...] = (0, -5, "abc", 2.5)
+
+# A value the user-facing error must echo back. Picked so it cannot occur by accident inside a
+# feature name ("0" would also match the "feature0" in the dimensionality-reduction names).
+BOOL_REPORTED: Any = "maybe"
+NUMERIC_REPORTED: Any = -5
+
+# str.isdigit() is True for the unicode superscript two, but int("²") raises ValueError.
+SUPERSCRIPT_TWO = "²"
+
+# Matched by none of the feature groups under test: no PREFIX_PATTERN hit, and the required
+# config-based keys (algorithm, ...) are absent.
+UNRELATED_FEATURE_NAME = "an_unrelated_feature_of_no_group"
+
+CASES: list[KeyCase] = [
+    KeyCase(
+        feature_group=ClusteringFeatureGroup,
+        key=ClusteringFeatureGroup.OUTPUT_PROBABILITIES,
+        string_feature_name="customer_behavior__cluster_kmeans_5",
+        base_context=CLUSTERING_CONTEXT,
+        valid_value=True,
+        invalid_values=BOOL_INVALID,
+        reported_invalid_value=BOOL_REPORTED,
+        list_value=[True],
+    ),
+    KeyCase(
+        feature_group=ForecastingFeatureGroup,
+        key=ForecastingFeatureGroup.OUTPUT_CONFIDENCE_INTERVALS,
+        string_feature_name="sales__linear_forecast_7day",
+        base_context=FORECASTING_CONTEXT,
+        valid_value=True,
+        invalid_values=BOOL_INVALID,
+        reported_invalid_value=BOOL_REPORTED,
+        list_value=[True],
+    ),
+    KeyCase(
+        feature_group=DimensionalityReductionFeatureGroup,
+        key=DimensionalityReductionFeatureGroup.TSNE_MAX_ITER,
+        string_feature_name="feature0,feature1,feature2__tsne_2d",
+        base_context=DIMENSION_CONTEXT,
+        valid_value=250,
+        invalid_values=NUMERIC_INVALID,
+        reported_invalid_value=NUMERIC_REPORTED,
+        list_value=[250, 300],
+        digit_string="250",
+    ),
+    KeyCase(
+        feature_group=DimensionalityReductionFeatureGroup,
+        key=DimensionalityReductionFeatureGroup.TSNE_N_ITER_WITHOUT_PROGRESS,
+        string_feature_name="feature0,feature1,feature2__tsne_2d",
+        base_context=DIMENSION_CONTEXT,
+        valid_value=30,
+        invalid_values=NUMERIC_INVALID,
+        reported_invalid_value=NUMERIC_REPORTED,
+        list_value=[30, 50],
+        digit_string="30",
+    ),
+    KeyCase(
+        feature_group=DimensionalityReductionFeatureGroup,
+        key=DimensionalityReductionFeatureGroup.ICA_MAX_ITER,
+        string_feature_name="feature0,feature1,feature2__ica_2d",
+        base_context={**DIMENSION_CONTEXT, DimensionalityReductionFeatureGroup.ALGORITHM: "ica"},
+        valid_value=300,
+        invalid_values=NUMERIC_INVALID,
+        reported_invalid_value=NUMERIC_REPORTED,
+        list_value=[200, 300],
+        digit_string="300",
+    ),
+    KeyCase(
+        feature_group=DimensionalityReductionFeatureGroup,
+        key=DimensionalityReductionFeatureGroup.ISOMAP_N_NEIGHBORS,
+        string_feature_name="feature0,feature1,feature2__isomap_2d",
+        base_context={**DIMENSION_CONTEXT, DimensionalityReductionFeatureGroup.ALGORITHM: "isomap"},
+        valid_value=3,
+        invalid_values=NUMERIC_INVALID,
+        reported_invalid_value=NUMERIC_REPORTED,
+        list_value=[3, 5],
+        digit_string="3",
+    ),
+]
+
+NUMERIC_CASES: list[KeyCase] = [case for case in CASES if case.digit_string is not None]
+
+
+def _case_params() -> list[Any]:
+    """One param per key."""
+    return [pytest.param(case, id=case.key) for case in CASES]
+
+
+def _numeric_case_params() -> list[Any]:
+    """One param per numeric key."""
+    return [pytest.param(case, id=case.key) for case in NUMERIC_CASES]
+
+
+def _invalid_value_params() -> list[Any]:
+    """One param per (key, invalid value) pair."""
+    return [
+        pytest.param(case, invalid_value, id=f"{case.key}-{invalid_value!r}")
+        for case in CASES
+        for invalid_value in case.invalid_values
+    ]
+
+
+def _resolution_error(feature: Feature, feature_group: type[FeatureGroup]) -> str:
+    """Resolve the feature against a single accessible feature group and return the raised error."""
+    accessible_plugins: FeatureGroupEnvironmentMapping = {feature_group: {PandasDataFrame}}
+    with pytest.raises(ValueError) as exc_info:
+        IdentifyFeatureGroupClass(feature=feature, accessible_plugins=accessible_plugins, links=None)
+    return str(exc_info.value)
+
+
+@pytest.mark.parametrize("case, invalid_value", _invalid_value_params())
+def test_string_named_path_rejects_invalid_value(case: KeyCase, invalid_value: Any) -> None:
+    """The match_guard must reject a bad value even when the feature name matches PREFIX_PATTERN."""
+    assert (
+        case.feature_group.match_feature_group_criteria(case.string_feature_name, case.options(invalid_value)) is False
+    )
+
+
+@pytest.mark.parametrize("case", _case_params())
+def test_string_named_path_accepts_valid_value(case: KeyCase) -> None:
+    """Regression guard: existing valid string-named usages must keep matching."""
+    assert case.feature_group.match_feature_group_criteria(case.string_feature_name, case.options(case.valid_value))
+
+
+@pytest.mark.parametrize("case, invalid_value", _invalid_value_params())
+def test_config_based_path_rejects_invalid_value(case: KeyCase, invalid_value: Any) -> None:
+    """The element_validator must reject a bad value on the config-based path."""
+    options = case.config_options(invalid_value)
+    assert case.feature_group.match_feature_group_criteria("placeholder", options) is False
+
+
+@pytest.mark.parametrize("case, invalid_value", _invalid_value_params())
+def test_config_based_path_reports_rejection_reason(case: KeyCase, invalid_value: Any) -> None:
+    """The discarded ValueError must name the property key and the rejected value."""
+    options = case.config_options(invalid_value)
+    reason = case.feature_group._strict_validation_rejection_reason("placeholder", options)
+    assert reason is not None
+    assert case.key in reason
+    assert str(invalid_value) in reason
+
+
+@pytest.mark.parametrize("case", _case_params())
+def test_config_based_path_accepts_valid_value(case: KeyCase) -> None:
+    """Regression guard: the valid config-based option set must keep matching."""
+    assert case.feature_group.match_feature_group_criteria("placeholder", case.config_options(case.valid_value))
+
+
+@pytest.mark.parametrize("case", _numeric_case_params())
+def test_digit_string_is_accepted_on_string_named_path(case: KeyCase) -> None:
+    """The numeric keys accept a digit string, like the sibling DIMENSION key."""
+    assert case.feature_group.match_feature_group_criteria(case.string_feature_name, case.options(case.digit_string))
+
+
+@pytest.mark.parametrize("case", _numeric_case_params())
+def test_digit_string_is_accepted_on_config_based_path(case: KeyCase) -> None:
+    """The numeric keys accept a digit string on the config-based path too."""
+    assert case.feature_group.match_feature_group_criteria("placeholder", case.config_options(case.digit_string))
+
+
+@pytest.mark.parametrize("case", _case_params())
+def test_string_named_path_rejects_list_value(case: KeyCase) -> None:
+    """The match_guard checks the whole raw value, so a list is rejected even if its elements are valid."""
+    assert (
+        case.feature_group.match_feature_group_criteria(case.string_feature_name, case.options(case.list_value))
+        is False
+    )
+
+
+class TestMatchGuardRejectionIsReportable:
+    """A match_guard rejection must be recoverable as a message, not only a logger.debug line."""
+
+    @pytest.mark.parametrize("case, invalid_value", _invalid_value_params())
+    def test_string_named_path_reports_guard_rejection(self, case: KeyCase, invalid_value: Any) -> None:
+        """On the string-named path the guard is the only enforcement, so it must report itself."""
+        reason = case.feature_group._strict_validation_rejection_reason(
+            case.string_feature_name, case.options(invalid_value)
+        )
+        assert reason is not None
+        assert case.key in reason
+        assert str(invalid_value) in reason
+
+    @pytest.mark.parametrize("case", _case_params())
+    def test_string_named_path_reports_nothing_for_valid_value(self, case: KeyCase) -> None:
+        """No false positives: a value the guard accepts has nothing to report."""
+        reason = case.feature_group._strict_validation_rejection_reason(
+            case.string_feature_name, case.options(case.valid_value)
+        )
+        assert reason is None
+
+    @pytest.mark.parametrize("case", _case_params())
+    def test_string_named_path_reports_nothing_when_key_is_absent(self, case: KeyCase) -> None:
+        """No false positives: an absent key is not a rejection."""
+        assert case.feature_group._strict_validation_rejection_reason(case.string_feature_name, Options()) is None
+
+    @pytest.mark.parametrize("case", _case_params())
+    def test_no_guard_rejection_reported_for_unrelated_feature_name(self, case: KeyCase) -> None:
+        """A feature group that does not match the name at all must not report its guards.
+
+        The list value passes every element_validator and is rejected only by the match_guard, so a
+        guard check that ignores whether the feature group matches would report a phantom rejection.
+        """
+        options = case.options(case.list_value)
+        assert case.feature_group.match_feature_group_criteria(UNRELATED_FEATURE_NAME, options) is False
+        assert case.feature_group._strict_validation_rejection_reason(UNRELATED_FEATURE_NAME, options) is None
+
+    def test_no_guard_rejection_reported_for_option_outside_the_mapping(self) -> None:
+        """An aggregated feature carrying another group's option has nothing to report."""
+        options = Options(context={ClusteringFeatureGroup.OUTPUT_PROBABILITIES: "maybe"})
+        assert AggregatedFeatureGroup._strict_validation_rejection_reason("sales__sum_aggr", options) is None
+
+
+class TestRejectedValueNamedInResolutionError:
+    """The user-facing no-feature-group error must name the culprit option, not stay generic."""
+
+    @pytest.mark.parametrize("case", _case_params())
+    def test_string_named_rejection_names_key_and_value(self, case: KeyCase) -> None:
+        """A string-named feature rejected by a guard must not fail with a bare 'No feature groups found'."""
+        feature = Feature(case.string_feature_name, case.options(case.reported_invalid_value))
+
+        message = _resolution_error(feature, case.as_feature_group())
+
+        assert case.key in message
+        assert str(case.reported_invalid_value) in message
+        assert case.feature_group.__name__ in message
+
+    @pytest.mark.parametrize("case", _case_params())
+    def test_config_based_rejection_names_key_and_value(self, case: KeyCase) -> None:
+        """Regression guard: the config-based path already names the culprit option."""
+        feature = Feature("placeholder", case.config_options(case.reported_invalid_value))
+
+        message = _resolution_error(feature, case.as_feature_group())
+
+        assert case.key in message
+        assert str(case.reported_invalid_value) in message
+        assert case.feature_group.__name__ in message
+
+
+class TestRejectedValueIsNotAForwardingProblem:
+    """A rejected VALUE in group options must not be reported as an extra-group-option problem."""
+
+    def test_group_placed_bad_value_names_the_value_not_forwarding(self) -> None:
+        """ica_max_iter=-1 in group options is a bad value; forward_group_exclude would not fix it."""
+        feature = Feature(
+            "feature0,feature1,feature2__ica_2d",
+            Options({DimensionalityReductionFeatureGroup.ICA_MAX_ITER: -1}),
+        )
+
+        message = _resolution_error(feature, DimensionalityReductionFeatureGroup)
+
+        assert DimensionalityReductionFeatureGroup.ICA_MAX_ITER in message
+        assert "-1" in message
+        assert "extra group option" not in message
+        assert "forward_group_exclude" not in message
+        assert "Group options flow onto input features" not in message
+
+    def test_group_placed_valid_value_still_matches(self) -> None:
+        """Regression guard: a valid value in group options is not a rejection at all."""
+        options = Options({DimensionalityReductionFeatureGroup.ICA_MAX_ITER: 300})
+        assert DimensionalityReductionFeatureGroup.match_feature_group_criteria(
+            "feature0,feature1,feature2__ica_2d", options
+        )
+
+
+class TestNumericPredicateHardening:
+    """The positive-int predicate behind the four numeric keys must be type-honest."""
+
+    @pytest.mark.parametrize("case", _numeric_case_params())
+    def test_numpy_integer_is_accepted_on_both_paths(self, case: KeyCase) -> None:
+        """A numpy integer is a positive integer; rejecting it on isinstance(int) is a false negative."""
+        np = pytest.importorskip("numpy")
+        value = np.int64(int(case.valid_value))
+
+        assert case.feature_group.match_feature_group_criteria(case.string_feature_name, case.options(value))
+        assert case.feature_group.match_feature_group_criteria("placeholder", case.config_options(value))
+
+    def test_numpy_integer_is_accepted_for_the_dimension_key(self) -> None:
+        """DIMENSION shares the predicate with the numeric keys, so it must accept a numpy integer too."""
+        np = pytest.importorskip("numpy")
+        options = Options(
+            context={**DIMENSION_CONTEXT, DimensionalityReductionFeatureGroup.DIMENSION: np.int64(2)},
+        )
+
+        assert DimensionalityReductionFeatureGroup.match_feature_group_criteria("placeholder", options)
+
+    @pytest.mark.parametrize("case", _numeric_case_params())
+    def test_bool_is_rejected_on_both_paths(self, case: KeyCase) -> None:
+        """True is not an iteration count: bool must not be read as 1."""
+        assert case.feature_group.match_feature_group_criteria(case.string_feature_name, case.options(True)) is False
+        assert case.feature_group.match_feature_group_criteria("placeholder", case.config_options(True)) is False
+
+    @pytest.mark.parametrize("case", _numeric_case_params())
+    def test_superscript_digit_is_rejected_cleanly_on_string_named_path(self, case: KeyCase) -> None:
+        """The superscript passes str.isdigit() but breaks int(): the rejection must stay clean."""
+        options = case.options(SUPERSCRIPT_TWO)
+
+        assert case.feature_group.match_feature_group_criteria(case.string_feature_name, options) is False
+
+        reason = case.feature_group._strict_validation_rejection_reason(case.string_feature_name, options)
+        assert reason is not None
+        assert case.key in reason
+        assert "invalid literal for int()" not in reason
+
+    @pytest.mark.parametrize("case", _numeric_case_params())
+    def test_superscript_digit_is_rejected_cleanly_on_config_based_path(self, case: KeyCase) -> None:
+        """The config-based rejection reason must name the key, not leak int()'s internal error."""
+        options = case.config_options(SUPERSCRIPT_TWO)
+
+        assert case.feature_group.match_feature_group_criteria("placeholder", options) is False
+
+        reason = case.feature_group._strict_validation_rejection_reason("placeholder", options)
+        assert reason is not None
+        assert case.key in reason
+        assert "invalid literal for int()" not in reason
+
+
+class TestStrictValidationDoesNotMakeKeysRequired:
+    """strict_validation=True enforces the VALUE SPACE, never presence."""
+
+    @pytest.mark.parametrize("case", _case_params())
+    def test_absent_key_still_matches_on_string_named_path(self, case: KeyCase) -> None:
+        """Regression guard: the key stays optional on the string-named path."""
+        assert case.feature_group.match_feature_group_criteria(case.string_feature_name, Options())
+
+    @pytest.mark.parametrize("case", _case_params())
+    def test_absent_key_still_matches_on_config_based_path(self, case: KeyCase) -> None:
+        """Regression guard: the key stays optional on the config-based path."""
+        options = Options(context=dict(case.base_context))
+        assert case.feature_group.match_feature_group_criteria("placeholder", options)
+
+    @pytest.mark.parametrize("case", _case_params())
+    def test_explicit_none_is_treated_as_absent_on_string_named_path(self, case: KeyCase) -> None:
+        """options.get cannot tell an explicit None from an absent key, so None still matches."""
+        assert case.feature_group.match_feature_group_criteria(case.string_feature_name, case.options(None))
+
+    @pytest.mark.parametrize("case", _case_params())
+    def test_explicit_none_is_treated_as_absent_on_config_based_path(self, case: KeyCase) -> None:
+        """Same Options semantics on the config-based path."""
+        assert case.feature_group.match_feature_group_criteria("placeholder", case.config_options(None))
+
+
+class TestConfigBasedListRejection:
+    """A list value survives the element_validator (it sees the elements) and dies on the match_guard."""
+
+    @pytest.mark.parametrize("case", _case_params())
+    def test_config_based_path_rejects_list_value(self, case: KeyCase) -> None:
+        """Regression guard: the raw list is not a valid value even when every element is."""
+        options = case.config_options(case.list_value)
+        assert case.feature_group.match_feature_group_criteria("placeholder", options) is False
+
+    @pytest.mark.parametrize("case", _case_params())
+    def test_config_based_path_reports_list_rejection(self, case: KeyCase) -> None:
+        """The guard-only rejection must be reportable, like the element_validator one already is."""
+        options = case.config_options(case.list_value)
+
+        reason = case.feature_group._strict_validation_rejection_reason("placeholder", options)
+        assert reason is not None
+        assert case.key in reason
+        assert str(case.list_value) in reason

--- a/tests/test_plugins/feature_group/experimental/test_property_spec_shipped_specs.py
+++ b/tests/test_plugins/feature_group/experimental/test_property_spec_shipped_specs.py
@@ -1,31 +1,31 @@
 """The builder must reproduce every shipped optional-with-``None``-default spec (issue #733).
 
-Six specs ship hand-written today with ``default: None``, which makes them OPTIONAL
-(``_can_skip_required_check`` keys off the PRESENCE of the ``default`` key). Until the
-``NO_DEFAULT`` sentinel exists, ``property_spec(..., default=None)`` drops that key and
-silently turns them REQUIRED, so migrating one to the builder is a behavior change. These
-pins are what would have caught the ``weight_column`` regression (issue #723).
+Six specs ship with ``default=None``, which makes them OPTIONAL (``_can_skip_required_check``
+keys off a DECLARED default, and ``NO_DEFAULT`` is the "none declared" sentinel). Before the
+sentinel existed, ``property_spec(..., default=None)`` dropped the default and silently turned
+them REQUIRED, so migrating one to the builder was a behavior change. These pins are what would
+have caught the ``weight_column`` regression (issue #723).
 """
 
 from __future__ import annotations
 
-from typing import Any
+import dataclasses
 
 import pytest
 
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
-from mloda.provider import DefaultOptionKeys, property_spec
+from mloda.provider import PropertySpec, property_spec
 from mloda_plugins.feature_group.experimental.data_quality.missing_value.base import MissingValueFeatureGroup
 from mloda_plugins.feature_group.experimental.node_centrality.base import NodeCentralityFeatureGroup
 from mloda_plugins.feature_group.experimental.sklearn.pipeline.base import SklearnPipelineFeatureGroup
 
 
-def _shipped(feature_group: type[FeatureGroup], key: str) -> dict[str, Any]:
-    """Return the hand-written spec a shipped plugin declares for ``key``."""
+def _shipped(feature_group: type[FeatureGroup], key: str) -> PropertySpec:
+    """Return the spec a shipped plugin declares for ``key``."""
     mapping = feature_group.PROPERTY_MAPPING
     assert mapping is not None, f"{feature_group.__name__} declares no PROPERTY_MAPPING"
-    spec: dict[str, Any] = mapping[key]
+    spec: PropertySpec = mapping[key]
     return spec
 
 
@@ -33,16 +33,14 @@ def _shipped(feature_group: type[FeatureGroup], key: str) -> dict[str, Any]:
 # other is absent"). Two separately written lambdas are never ``==``, so a rebuilt spec can only
 # equal the shipped one if the builder is handed the SAME callable object: read the predicate off
 # the shipped spec and thread it through by identity.
-_PIPELINE_NAME_SHIPPED: dict[str, Any] = _shipped(
-    SklearnPipelineFeatureGroup, SklearnPipelineFeatureGroup.PIPELINE_NAME
-)
-_PIPELINE_STEPS_SHIPPED: dict[str, Any] = _shipped(
+_PIPELINE_NAME_SHIPPED: PropertySpec = _shipped(SklearnPipelineFeatureGroup, SklearnPipelineFeatureGroup.PIPELINE_NAME)
+_PIPELINE_STEPS_SHIPPED: PropertySpec = _shipped(
     SklearnPipelineFeatureGroup, SklearnPipelineFeatureGroup.PIPELINE_STEPS
 )
 
 
 # Shipped specs the builder must reproduce EXACTLY: (id, built, shipped).
-_EXACT_CASES: list[tuple[str, dict[str, Any], dict[str, Any]]] = [
+_EXACT_CASES: list[tuple[str, PropertySpec, PropertySpec]] = [
     (
         "node_centrality.weight_column",
         property_spec("Column name for edge weights (optional)", default=None),
@@ -63,7 +61,7 @@ _EXACT_CASES: list[tuple[str, dict[str, Any], dict[str, Any]]] = [
         property_spec(
             "List of pipeline steps as (name, transformer) tuples",
             default=None,
-            required_when=_PIPELINE_STEPS_SHIPPED[DefaultOptionKeys.required_when],
+            required_when=_PIPELINE_STEPS_SHIPPED.required_when,
         ),
         _PIPELINE_STEPS_SHIPPED,
     ),
@@ -74,20 +72,20 @@ _EXACT_CASES: list[tuple[str, dict[str, Any], dict[str, Any]]] = [
     ),
 ]
 
-# PIPELINE_NAME ships without an "explanation" key, which the builder always emits.
-_PIPELINE_NAME_BUILT: dict[str, Any] = property_spec(
+# Built with its own wording, so it matches the shipped spec on every field BUT ``explanation``.
+_PIPELINE_NAME_BUILT: PropertySpec = property_spec(
     "Name of the sklearn pipeline to apply",
     strict=True,
     allowed_values=SklearnPipelineFeatureGroup.PIPELINE_TYPES,
     default=None,
-    required_when=_PIPELINE_NAME_SHIPPED[DefaultOptionKeys.required_when],
+    required_when=_PIPELINE_NAME_SHIPPED.required_when,
 )
 
-_ALL_BUILT: list[tuple[str, dict[str, Any]]] = [(case_id, built) for case_id, built, _ in _EXACT_CASES] + [
+_ALL_BUILT: list[tuple[str, PropertySpec]] = [(case_id, built) for case_id, built, _ in _EXACT_CASES] + [
     ("sklearn_pipeline.pipeline_name", _PIPELINE_NAME_BUILT)
 ]
 
-_ALL_SHIPPED: list[tuple[str, dict[str, Any]]] = [(case_id, shipped) for case_id, _, shipped in _EXACT_CASES] + [
+_ALL_SHIPPED: list[tuple[str, PropertySpec]] = [(case_id, shipped) for case_id, _, shipped in _EXACT_CASES] + [
     ("sklearn_pipeline.pipeline_name", _PIPELINE_NAME_SHIPPED)
 ]
 
@@ -99,25 +97,26 @@ class TestShippedOptionalSpecsAreBuildable:
         ("built", "shipped"),
         [pytest.param(built, shipped, id=case_id) for case_id, built, shipped in _EXACT_CASES],
     )
-    def test_builder_reproduces_shipped_spec_exactly(self, built: dict[str, Any], shipped: dict[str, Any]) -> None:
-        """The built spec is byte-for-byte the hand-written dict the plugin ships."""
+    def test_builder_reproduces_shipped_spec_exactly(self, built: PropertySpec, shipped: PropertySpec) -> None:
+        """The built spec is field-for-field the spec the plugin ships."""
         assert built == shipped
 
-    def test_builder_reproduces_pipeline_name_up_to_added_explanation(self) -> None:
-        """PIPELINE_NAME matches once the builder's explanation is set aside.
+    def test_builder_reproduces_pipeline_name_up_to_the_explanation(self) -> None:
+        """PIPELINE_NAME matches once the wording of ``explanation`` is set aside.
 
-        Migrating it ADDS the "explanation" key the shipped dict lacks: an improvement, not a
-        behavior change (no core rule reads "explanation").
+        The two are worded differently, which is no behavior change: no core rule reads
+        ``explanation``. Every OTHER field must agree.
         """
-        without_explanation = {key: value for key, value in _PIPELINE_NAME_BUILT.items() if key != "explanation"}
+        normalized = dataclasses.replace(_PIPELINE_NAME_BUILT, explanation=_PIPELINE_NAME_SHIPPED.explanation)
 
-        assert without_explanation == _PIPELINE_NAME_SHIPPED
+        assert normalized == _PIPELINE_NAME_SHIPPED
+        assert _PIPELINE_NAME_BUILT.explanation != _PIPELINE_NAME_SHIPPED.explanation
 
     @pytest.mark.parametrize(
         "built",
         [pytest.param(built, id=case_id) for case_id, built in _ALL_BUILT],
     )
-    def test_built_spec_is_optional(self, built: dict[str, Any]) -> None:
+    def test_built_spec_is_optional(self, built: PropertySpec) -> None:
         """Each built spec stays OPTIONAL: migration must not make the option required."""
         assert FeatureChainParser._can_skip_required_check(built) is True
 
@@ -125,11 +124,10 @@ class TestShippedOptionalSpecsAreBuildable:
         "shipped",
         [pytest.param(shipped, id=case_id) for case_id, shipped in _ALL_SHIPPED],
     )
-    def test_shipped_spec_is_optional(self, shipped: dict[str, Any]) -> None:
+    def test_shipped_spec_is_optional(self, shipped: PropertySpec) -> None:
         """Each SHIPPED spec is OPTIONAL: the invariant #723 broke, pinned on what plugins declare.
 
-        ``test_built_spec_is_optional`` only checks specs this test builds. Once these plugins
-        migrate to the builder, ``built == shipped`` degrades into comparing builder output with
-        builder output, so the shipped side needs its own pin.
+        ``test_built_spec_is_optional`` only checks specs this test builds. Now that these plugins
+        declare ``PropertySpec`` directly, the shipped side needs its own pin.
         """
         assert FeatureChainParser._can_skip_required_check(shipped) is True

--- a/tests/test_plugins/feature_group/test_default_options_key_graduation.py
+++ b/tests/test_plugins/feature_group/test_default_options_key_graduation.py
@@ -21,12 +21,9 @@ class TestDefaultOptionKeysCoreLocation:
             "in_features",
             "reference_time",
             "time_travel",
-            "default",
             "context",
             "group",
             "order_by",
-            "strict_validation",
-            "element_validator",
             "strict_type_enforcement",
         ]
         for key in expected_keys:

--- a/tests/test_plugins/integration_plugins/chainer/chainer_context_feature.py
+++ b/tests/test_plugins/integration_plugins/chainer/chainer_context_feature.py
@@ -14,6 +14,7 @@ from mloda.provider import FeatureSet
 from mloda.user import Options
 from mloda.provider import FeatureChainParser
 from mloda.provider import DefaultOptionKeys
+from mloda.provider import PropertySpec
 
 
 class ChainedContextFeatureGroupTest(FeatureGroup):
@@ -21,31 +22,35 @@ class ChainedContextFeatureGroupTest(FeatureGroup):
     OPERATION_ID = "chainer_"  # Used for constructing feature names
 
     PROPERTY_MAPPING = {
-        "ident": {
-            DefaultOptionKeys.allowed_values: {"identifier1": "explanation", "identifier2": "explanation"},
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-        },
-        "property2": {
-            DefaultOptionKeys.allowed_values: {
+        "ident": PropertySpec(
+            "Identifier selecting the chainer operation variant",
+            allowed_values={"identifier1": "explanation", "identifier2": "explanation"},
+            context=True,
+            strict_validation=True,
+        ),
+        "property2": PropertySpec(
+            "Group-categorized property with a default",
+            allowed_values={
                 "value1": "explanation",
                 "value2": "explanation",
                 "specific_val_3_test": "explanation",
             },
-            DefaultOptionKeys.strict_validation: True,
-            DefaultOptionKeys.default: "value1",
-        },
-        "property3": {
-            DefaultOptionKeys.allowed_values: {"opt_val1": "explanation", "opt_val2": "explanation"},
-            DefaultOptionKeys.default: "opt_val1",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-        },
-        DefaultOptionKeys.in_features: {
-            "explanation": "explanation",
-            DefaultOptionKeys.context: True,  # Mark as context parameter
+            default="value1",
+            context=False,
+            strict_validation=True,
+        ),
+        "property3": PropertySpec(
+            "Optional context property with a default",
+            allowed_values={"opt_val1": "explanation", "opt_val2": "explanation"},
+            default="opt_val1",
+            context=True,
+            strict_validation=False,
+        ),
+        DefaultOptionKeys.in_features: PropertySpec(
+            "explanation",
+            context=True,  # Mark as context parameter
             # No strict validation for source feature -> defaults to flexible
-        },
+        ),
     }
 
     @classmethod

--- a/tests/test_plugins/integration_plugins/chainer/context/test_parameter_resolution_unit.py
+++ b/tests/test_plugins/integration_plugins/chainer/context/test_parameter_resolution_unit.py
@@ -6,6 +6,7 @@ from mloda.user import Feature
 from mloda.user import Options
 from mloda.provider import FeatureChainParser
 from mloda.provider import DefaultOptionKeys
+from mloda.provider import PropertySpec
 from tests.test_plugins.integration_plugins.chainer.chainer_context_feature import (
     ChainedContextFeatureGroupTest,
 )
@@ -25,26 +26,30 @@ class TestParameterResolutionUnit:
         """Test proper error handling when required parameters are missing."""
 
         property_mapping = {
-            "ident": {
-                DefaultOptionKeys.allowed_values: {"identifier1": "explanation", "identifier2": "explanation"},
-                DefaultOptionKeys.context: True,
-            },
-            "property2": {
-                DefaultOptionKeys.allowed_values: {
+            "ident": PropertySpec(
+                "Required identifier",
+                allowed_values={"identifier1": "explanation", "identifier2": "explanation"},
+                context=True,
+            ),
+            "property2": PropertySpec(
+                "Required group property",
+                allowed_values={
                     "value1": "explanation",
                     "value2": "explanation",
                     "specific_val_3_test": "explanation",
-                }
-            },
-            "property3": {
-                DefaultOptionKeys.allowed_values: {"opt_val1": "explanation", "opt_val2": "explanation"},
-                DefaultOptionKeys.default: "opt_val1",
-                DefaultOptionKeys.context: True,
-            },
-            DefaultOptionKeys.in_features: {
-                "explanation": "explanation",
-                DefaultOptionKeys.context: True,  # Mark as context parameter
-            },
+                },
+                context=False,
+            ),
+            "property3": PropertySpec(
+                "Optional property with a default",
+                allowed_values={"opt_val1": "explanation", "opt_val2": "explanation"},
+                default="opt_val1",
+                context=True,
+            ),
+            DefaultOptionKeys.in_features: PropertySpec(
+                "explanation",
+                context=True,  # Mark as context parameter
+            ),
         }
 
         # Test: Missing required context parameter 'ident'
@@ -265,29 +270,25 @@ class TestParameterResolutionUnit:
 
     def test_parameter_extraction_logic(self) -> None:
         """Test the _extract_property_values logic."""
-        # Test: the declared value space is returned, the metadata keys around it are not
-        property_value_with_default = {
-            DefaultOptionKeys.allowed_values: {"opt_val1": "explanation", "opt_val2": "explanation"},
-            DefaultOptionKeys.default: "opt_val1",
-            DefaultOptionKeys.context: True,
-        }
+        # Test: the declared value space is returned, the fields around it are not
+        spec_with_default = PropertySpec(
+            "Optional property with a default",
+            allowed_values={"opt_val1": "explanation", "opt_val2": "explanation"},
+            default="opt_val1",
+            context=True,
+        )
 
-        extracted = FeatureChainParser._extract_property_values(property_value_with_default)
+        extracted = FeatureChainParser._extract_property_values(spec_with_default)
         expected = {"opt_val1": "explanation", "opt_val2": "explanation"}
         assert extracted == expected, "Should return exactly the declared allowed_values"
 
-        # Test: a spec that declares no allowed_values declares an EMPTY value space. It is
-        # never recovered by subtracting the known keys, which is what used to absorb an
-        # unrecognized key as an accepted value.
-        property_value_without_allowed_values = {"value1": "explanation", "value2": "explanation"}
+        # Test: a spec that declares no allowed_values declares an EMPTY value space.
+        # (The retired dict form used to absorb unrecognized keys as accepted values;
+        # PropertySpec has no such fallback.)
+        spec_without_allowed_values = PropertySpec("Spec without a declared value space")
 
-        extracted = FeatureChainParser._extract_property_values(property_value_without_allowed_values)
+        extracted = FeatureChainParser._extract_property_values(spec_without_allowed_values)
         assert extracted == {}, "Should declare an empty value space when allowed_values is absent"
-
-        # Test: Extract values from non-dict
-        property_value_non_dict = "simple_value"
-        extracted = FeatureChainParser._extract_property_values(property_value_non_dict)
-        assert extracted == property_value_non_dict, "Should return unchanged for non-dict values"
 
     def test_validation_final_properties(self) -> None:
         """Test the _validate_final_properties logic."""
@@ -332,21 +333,19 @@ class TestParameterResolutionUnit:
 
         # Test property mapping with mixed strict/flexible validation
         property_mapping_mixed = {
-            "strict_param": {
-                DefaultOptionKeys.allowed_values: {"allowed_value1": "explanation", "allowed_value2": "explanation"},
-                DefaultOptionKeys.strict_validation: True,
-                DefaultOptionKeys.context: True,
-            },
-            "flexible_param": {
-                DefaultOptionKeys.strict_validation: False,  # Explicit flexible validation
-                DefaultOptionKeys.context: True,
-            },
-            "default_flexible_param": {
-                DefaultOptionKeys.context: True,
-            },
-            DefaultOptionKeys.in_features: {
-                DefaultOptionKeys.context: True,
-            },
+            "strict_param": PropertySpec(
+                "Strictly validated parameter",
+                allowed_values={"allowed_value1": "explanation", "allowed_value2": "explanation"},
+                context=True,
+                strict_validation=True,
+            ),
+            "flexible_param": PropertySpec(
+                "Explicitly flexible parameter",
+                context=True,
+                strict_validation=False,  # Explicit flexible validation
+            ),
+            "default_flexible_param": PropertySpec("Parameter without a validation flag", context=True),
+            DefaultOptionKeys.in_features: PropertySpec("Source features", context=True),
         }
 
         # Test: All parameters with valid values should pass
@@ -427,68 +426,71 @@ class TestParameterResolutionUnit:
     def test_strict_validation_helper_methods(self) -> None:
         """Test the _is_strict_validation helper method with default non-strict behavior."""
 
-        # Test: Property with explicit strict validation = True
-        strict_property = {
-            "value1": "explanation",
-            DefaultOptionKeys.strict_validation: True,
-        }
-        assert FeatureChainParser._is_strict_validation(strict_property) is True, (
-            "Should identify strict validation = True"
+        # Test: Spec with explicit strict validation = True
+        strict_spec = PropertySpec(
+            "Strict spec",
+            allowed_values={"value1": "explanation"},
+            strict_validation=True,
         )
+        assert FeatureChainParser._is_strict_validation(strict_spec) is True, "Should identify strict validation = True"
 
-        # Test: Property with explicit strict validation = False
-        flexible_property = {
-            "value1": "explanation",
-            DefaultOptionKeys.strict_validation: False,
-        }
-        assert FeatureChainParser._is_strict_validation(flexible_property) is False, (
+        # Test: Spec with explicit strict validation = False
+        flexible_spec = PropertySpec(
+            "Flexible spec",
+            allowed_values={"value1": "explanation"},
+            strict_validation=False,
+        )
+        assert FeatureChainParser._is_strict_validation(flexible_spec) is False, (
             "Should identify strict validation = False"
         )
 
-        # Test: Property without strict validation flag (defaults to False)
-        default_property = {
-            "value1": "explanation",
-            DefaultOptionKeys.context: True,
-        }
-        assert FeatureChainParser._is_strict_validation(default_property) is False, (
+        # Test: Spec without an explicit strict validation flag (defaults to False)
+        default_spec = PropertySpec(
+            "Spec without a validation flag",
+            allowed_values={"value1": "explanation"},
+            context=True,
+        )
+        assert FeatureChainParser._is_strict_validation(default_spec) is False, (
             "Should default to strict validation = False"
         )
 
-        # Test: Non-dict property (should default to False)
-        non_dict_property = "simple_value"
-        assert FeatureChainParser._is_strict_validation(non_dict_property) is False, (
-            "Should default to strict validation = False for non-dict"
-        )
-
-        # Test: Empty dict (should default to False)
-        empty_dict_property = {}  # type: ignore
-        assert FeatureChainParser._is_strict_validation(empty_dict_property) is False, (
-            "Should default to strict validation = False for empty dict"
+        # Test: Minimal spec (explanation only) defaults to False. The non-spec inputs
+        # the old helper tolerated (bare strings, empty dicts) are rejected at class
+        # definition now, so PropertySpec instances are the only shapes left to test.
+        minimal_spec = PropertySpec("Minimal spec")
+        assert FeatureChainParser._is_strict_validation(minimal_spec) is False, (
+            "Should default to strict validation = False for a minimal spec"
         )
 
     def test_mixed_validation_scenarios(self) -> None:
         """Test complex scenarios with mixed strict and flexible validation."""
 
         property_mapping_complex = {
-            "algorithm_type": {
-                DefaultOptionKeys.allowed_values: {"sum": "explanation", "avg": "explanation"},
-                DefaultOptionKeys.context: True,
-            },
-            "data_source": {
-                DefaultOptionKeys.allowed_values: {"production": "explanation", "staging": "explanation"},
-                DefaultOptionKeys.strict_validation: True,
-                DefaultOptionKeys.group: True,
-            },
-            "debug_mode": {
-                DefaultOptionKeys.allowed_values: {"true": "explanation", "false": "explanation"},
-                DefaultOptionKeys.strict_validation: False,
-                DefaultOptionKeys.context: True,
-            },
-            DefaultOptionKeys.in_features: {
-                "explanation": "explanation",
+            "algorithm_type": PropertySpec(
+                "Flexible algorithm selector",
+                allowed_values={"sum": "explanation", "avg": "explanation"},
+                context=True,
+            ),
+            # The retired dict spec also carried a DefaultOptionKeys.group key here; it was
+            # dead (core never read it, group is simply context=False) and PropertySpec has
+            # no such field, so it is dropped.
+            "data_source": PropertySpec(
+                "Strictly validated group parameter",
+                allowed_values={"production": "explanation", "staging": "explanation"},
+                context=False,
+                strict_validation=True,
+            ),
+            "debug_mode": PropertySpec(
+                "Explicitly flexible debug flag",
+                allowed_values={"true": "explanation", "false": "explanation"},
+                context=True,
+                strict_validation=False,
+            ),
+            DefaultOptionKeys.in_features: PropertySpec(
+                "explanation",
                 # No strict_validation flag -> defaults to False (flexible)
-                DefaultOptionKeys.context: True,
-            },
+                context=True,
+            ),
         }
 
         # Test: Valid combination should pass

--- a/tests/test_plugins/integration_plugins/chainer/propagate_context_feature.py
+++ b/tests/test_plugins/integration_plugins/chainer/propagate_context_feature.py
@@ -12,6 +12,7 @@ from mloda.provider import FeatureSet
 from mloda.user import Options
 from mloda.provider import FeatureChainParser
 from mloda.provider import DefaultOptionKeys
+from mloda.provider import PropertySpec
 
 
 class PropagateContextFeatureGroupTest(FeatureGroup):
@@ -19,21 +20,20 @@ class PropagateContextFeatureGroupTest(FeatureGroup):
     OPERATION_ID = "propctx_"
 
     PROPERTY_MAPPING = {
-        "ident": {
-            DefaultOptionKeys.allowed_values: {"identifier1": "multiplier 2", "identifier2": "multiplier 3"},
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-        },
-        "env": {
-            DefaultOptionKeys.allowed_values: {"prod": "production offset 1000", "staging": "staging offset 500"},
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.default: None,
-        },
-        DefaultOptionKeys.in_features: {
-            "explanation": "explanation",
-            DefaultOptionKeys.context: True,
-        },
+        "ident": PropertySpec(
+            "Identifier selecting the multiplier",
+            allowed_values={"identifier1": "multiplier 2", "identifier2": "multiplier 3"},
+            context=True,
+            strict_validation=True,
+        ),
+        "env": PropertySpec(
+            "Environment selecting the offset",
+            allowed_values={"prod": "production offset 1000", "staging": "staging offset 500"},
+            context=True,
+            strict_validation=False,
+            default=None,  # Optional: features without env fall back to offset 0
+        ),
+        DefaultOptionKeys.in_features: PropertySpec("explanation", context=True),
     }
 
     @classmethod

--- a/tests/test_plugins/integration_plugins/chainer/test_list_valued_options_e2e.py
+++ b/tests/test_plugins/integration_plugins/chainer/test_list_valued_options_e2e.py
@@ -12,6 +12,7 @@ from mloda.provider import FeatureGroup
 from mloda.provider import FeatureSet
 from mloda.provider import DataCreator
 from mloda.provider import BaseInputData
+from mloda.provider import PropertySpec
 from mloda.user import Feature
 from mloda.user import FeatureName
 from mloda.user import Options
@@ -54,15 +55,12 @@ class ListValuedFeatureGroup(FeatureGroup):
     """
 
     PROPERTY_MAPPING = {
-        "columns": {
-            "explanation": "List of columns to combine in order",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-        },
-        DefaultOptionKeys.in_features: {
-            "explanation": "Source features",
-            DefaultOptionKeys.context: True,
-        },
+        "columns": PropertySpec(
+            "List of columns to combine in order",
+            context=True,
+            strict_validation=False,
+        ),
+        DefaultOptionKeys.in_features: PropertySpec("Source features", context=True),
     }
 
     @classmethod

--- a/tests/test_plugins/integration_plugins/chainer/test_property_spec_validation_e2e.py
+++ b/tests/test_plugins/integration_plugins/chainer/test_property_spec_validation_e2e.py
@@ -153,7 +153,11 @@ class TestPropertySpecValidationFunctionE2E:
 
     def test_author_side_default_rejected_at_call_site(self) -> None:
         """A default rejected by the element_validator fails at the property_spec call."""
-        with pytest.raises(ValueError, match=r"default 14 .*rejected by the key's element_validator"):
+        with pytest.raises(
+            ValueError,
+            match=r"PropertySpec\('Size of the time window, at most 13'\): "
+            r"default 14 is rejected by the element_validator",
+        ):
             property_spec(
                 "Size of the time window, at most 13",
                 strict=True,

--- a/tests/test_plugins/integration_plugins/test_dual_option_consumption_warning.py
+++ b/tests/test_plugins/integration_plugins/test_dual_option_consumption_warning.py
@@ -32,6 +32,7 @@ from mloda.provider import ComputeFramework
 from mloda.provider import DataCreator
 from mloda.provider import FeatureGroup
 from mloda.provider import FeatureSet
+from mloda.provider import PropertySpec
 from mloda.user import DataAccessCollection
 from mloda.user import Feature
 from mloda.user import FeatureName
@@ -51,9 +52,7 @@ class DualWarn579SourceGroup(FeatureGroup):
     """Upstream root group that declares the mode key and records resolved options."""
 
     PROPERTY_MAPPING = {
-        MODE_KEY: {
-            "explanation": "Execution mode consumed by the dualwarn579 source group",
-        },
+        MODE_KEY: PropertySpec("Execution mode consumed by the dualwarn579 source group", context=False),
     }
 
     seen_options: ClassVar[list[dict[str, dict[str, Any]]]] = []
@@ -130,9 +129,7 @@ class DualWarn579ConsumerGroup(_DualWarn579ConsumerBase):
 
     FEATURE_NAME = "dualwarn579_consumer"
     PROPERTY_MAPPING = {
-        MODE_KEY: {
-            "explanation": "Execution mode consumed by the dualwarn579 consumer group",
-        },
+        MODE_KEY: PropertySpec("Execution mode consumed by the dualwarn579 consumer group", context=False),
     }
 
     def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
@@ -149,9 +146,7 @@ class DualWarn579StringConsumerGroup(_DualWarn579ConsumerBase):
 
     FEATURE_NAME = "dualwarn579_string_consumer"
     PROPERTY_MAPPING = {
-        MODE_KEY: {
-            "explanation": "Execution mode consumed by the dualwarn579 string consumer group",
-        },
+        MODE_KEY: PropertySpec("Execution mode consumed by the dualwarn579 string consumer group", context=False),
     }
 
     def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Any]]:
@@ -164,9 +159,7 @@ class DualWarn579RepeatConsumerGroup(_DualWarn579ConsumerBase):
     FEATURE_NAME = "dualwarn579_repeat_consumer_a"
     SECOND_FEATURE_NAME: ClassVar[str] = "dualwarn579_repeat_consumer_b"
     PROPERTY_MAPPING = {
-        MODE_KEY: {
-            "explanation": "Execution mode consumed by the dualwarn579 repeat consumer group",
-        },
+        MODE_KEY: PropertySpec("Execution mode consumed by the dualwarn579 repeat consumer group", context=False),
     }
 
     @classmethod
@@ -188,9 +181,7 @@ class DualWarn579CleanConsumerGroup(_DualWarn579ConsumerBase):
     FEATURE_NAME = "dualwarn579_clean_consumer"
     SOURCE_COLUMN = CLEAN_SOURCE_NAME
     PROPERTY_MAPPING = {
-        MODE_KEY: {
-            "explanation": "Execution mode consumed by the dualwarn579 clean consumer group",
-        },
+        MODE_KEY: PropertySpec("Execution mode consumed by the dualwarn579 clean consumer group", context=False),
     }
 
     def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
@@ -202,9 +193,7 @@ class DualWarn579ExcludeConsumerGroup(_DualWarn579ConsumerBase):
 
     FEATURE_NAME = "dualwarn579_exclude_consumer"
     PROPERTY_MAPPING = {
-        MODE_KEY: {
-            "explanation": "Execution mode consumed by the dualwarn579 exclude consumer group",
-        },
+        MODE_KEY: PropertySpec("Execution mode consumed by the dualwarn579 exclude consumer group", context=False),
     }
 
     def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
@@ -222,9 +211,7 @@ class DualWarn579SharedConsumerAGroup(_DualWarn579ConsumerBase):
 
     FEATURE_NAME = "dualwarn579_shared_consumer_a"
     PROPERTY_MAPPING = {
-        MODE_KEY: {
-            "explanation": "Execution mode consumed by the dualwarn579 shared consumer A group",
-        },
+        MODE_KEY: PropertySpec("Execution mode consumed by the dualwarn579 shared consumer A group", context=False),
     }
 
     def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
@@ -236,9 +223,7 @@ class DualWarn579SharedConsumerBGroup(_DualWarn579ConsumerBase):
 
     FEATURE_NAME = "dualwarn579_shared_consumer_b"
     PROPERTY_MAPPING = {
-        MODE_KEY: {
-            "explanation": "Execution mode consumed by the dualwarn579 shared consumer B group",
-        },
+        MODE_KEY: PropertySpec("Execution mode consumed by the dualwarn579 shared consumer B group", context=False),
     }
 
     def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:

--- a/tests/test_plugins/integration_plugins/test_forwarded_name_mismatch_e2e.py
+++ b/tests/test_plugins/integration_plugins/test_forwarded_name_mismatch_e2e.py
@@ -25,9 +25,9 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
 from mloda.provider import BaseInputData
 from mloda.provider import ComputeFramework
 from mloda.provider import DataCreator
-from mloda.provider import DefaultOptionKeys
 from mloda.provider import FeatureGroup
 from mloda.provider import FeatureSet
+from mloda.provider import PropertySpec
 from mloda.user import Feature
 from mloda.user import FeatureName
 from mloda.user import Options
@@ -64,13 +64,15 @@ class NameMis579ChainedGroup(FeatureChainParserMixin, FeatureGroup):
 
     PREFIX_PATTERN = r".*__(sum|max)_namemis579$"
     PROPERTY_MAPPING = {
-        OPERATION_KEY: {
-            DefaultOptionKeys.allowed_values: {
+        OPERATION_KEY: PropertySpec(
+            "Aggregation operation applied to the in feature (namemis579 fixture)",
+            allowed_values={
                 "sum": "Sum of the in feature (namemis579 fixture)",
                 "max": "Maximum of the in feature (namemis579 fixture)",
             },
-            DefaultOptionKeys.strict_validation: True,
-        }
+            context=False,
+            strict_validation=True,
+        )
     }
 
     @classmethod

--- a/tests/test_plugins/integration_plugins/test_input_feature_option_forwarding_e2e.py
+++ b/tests/test_plugins/integration_plugins/test_input_feature_option_forwarding_e2e.py
@@ -31,6 +31,7 @@ from mloda.provider import DefaultOptionKeys
 from mloda.provider import FeatureChainParserMixin
 from mloda.provider import FeatureGroup
 from mloda.provider import FeatureSet
+from mloda.provider import PropertySpec
 from mloda.user import DataAccessCollection
 from mloda.user import Feature
 from mloda.user import FeatureName
@@ -178,15 +179,13 @@ class ForwardingE2EChainedGroup(FeatureChainParserMixin, FeatureGroup):
 
     PREFIX_PATTERN = r".*__([\w]+)_e2echain579fwd$"
     PROPERTY_MAPPING = {
-        "operation": {
-            DefaultOptionKeys.allowed_values: {"double": "Doubles the source values"},
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: True,
-        },
-        DefaultOptionKeys.in_features: {
-            "explanation": "Source features",
-            DefaultOptionKeys.context: True,
-        },
+        "operation": PropertySpec(
+            "Operation applied to the source values",
+            allowed_values={"double": "Doubles the source values"},
+            context=True,
+            strict_validation=True,
+        ),
+        DefaultOptionKeys.in_features: PropertySpec("Source features", context=True),
     }
 
     @classmethod


### PR DESCRIPTION
Closes #694.

## What changed

`PROPERTY_MAPPING` values are now `PropertySpec` frozen dataclasses instead of `dict[str, Any]`. A spec validates itself at construction, so the invariants that used to be hand-written class-definition rules are now either type errors at author time or one `__post_init__`.

Following the issue author's own correction on the ticket, only the unknown-key machinery is deleted, not the value rules:

- **Deleted:** `PROPERTY_SPEC_KEYS`, `REMOVED_PROPERTY_KEYS`, the difflib suggestion, and the four `_reject_*` class-definition rules. A misspelled field is now Python's own `TypeError` (with its own "Did you mean" suggestion), caught by `mypy --strict` before the code runs.
- **Relocated, unchanged in behavior:** the shape, callability, strict-needs-a-value-space and declared-default (#530) rules now live in `PropertySpec.__post_init__`.
- **`validate_property_mapping_defaults`** shrinks to a single rule: every spec is a `PropertySpec`. Raw dict specs are a hard break, rejected at class definition and at the public parser entry point.
- **`property_spec(...)`** stops being a parallel authoring path that returned a dict; it is now a thin wrapper over the constructor.
- The six `DefaultOptionKeys` members that named retired spec keys are removed.

All 166 in-repo spec sites (12 plugin bases, the rest tests) are migrated.

## Optionality

The retired dict form used a **present** `default: None` key to mean "optional" (a key-presence check). A dataclass field is always present, so `PropertySpec` carries a `NO_DEFAULT` sentinel:

| Spec | Meaning |
| --- | --- |
| no `default` | required |
| `default=None` | optional, no default applied |
| `default=<value>` | optional, and the value is checked under `strict_validation` |

This reproduces the old semantics exactly, with nothing for a plugin author to remember.

## Author-time type errors

The definition of done requires mypy to catch four author mistakes. It does, on both `PropertySpec` and `property_spec`, and `tests/.../test_property_spec_author_time.py` pins that: each invalid construction carries the `# type: ignore` it triggers, so `warn_unused_ignores` (implied by `mypy --strict` in the gate) fails the build if any of them stops being a type error.

```
PropertySpec("x", strict_validaton=True)                     # call-arg: unexpected keyword argument
PropertySpec("x", strict_validation="yes")                   # arg-type: str is not bool
PropertySpec("x", strict_validation=True, element_validator=123)  # arg-type: int is not Callable
PropertySpec("x", allowed_values="add")                      # arg-type: str is not a value space
```

## Review

Two independent deep reviews (a fresh Claude agent and codex) ran against the diff. Both found the same real bug, and it is fixed and pinned by tests: `NodeCentralityFeatureGroup.weight_column` had silently become a required option, so a config-based unweighted centrality feature stopped matching ("no feature groups found"). Nothing covered it, which is why the suite stayed green. That miss is what motivated the `NO_DEFAULT` sentinel: it removes the per-site convention that made the mistake possible.

Also fixed from the reviews:
- An unhashable declared default raised a raw `TypeError` instead of the clean `ValueError` main gave (`isinstance(x, Hashable)` is not a hashability test: a tuple containing a list passes it and then blows up on `hash()`).
- A raw dict spec reaching the exported `match_configuration_feature_chain_parser` died with `AttributeError` instead of the hard-break `ValueError`, and `match_feature_group_criteria` catches only `ValueError`, so it aborted resolution rather than degrading to a non-match.
- The strict-needs-a-value-space rule fired even when an `element_validator` was present, which main allowed and which the error message misdiagnosed.

Known follow-up, deliberately not in this PR: six plugin specs carried an `element_validator` with `strict_validation: False`, where the old parser never ran it. They were dead, so the migration dropped them rather than silently starting to enforce them. Turning them on is a behavior change and deserves its own issue.

## Docs

`docs/docs/in_depth/property-mapping.md` is rewritten around the type. Its lifecycle table now runs author time (mypy) to construction to class definition to match time, and the rows that moved to author time are gone.

## Testing

`tox` passes: 5781 passed, 171 skipped, `mypy --strict` clean over `mloda/`, `mloda_plugins/` and `tests/`, ruff, licenses, bandit.


## Rebased on main (2026-07-14)

Rebased onto `efde1c8`. Four PRs landed on this exact validation surface while the branch was open, so this was a reconciliation rather than a replay. The six commits are squashed into one, and the stacked #730 (issue #724) is folded in.

What main changed here, and how it is carried:

- **#731/#740**: `required_when` is enforced by a guard installed on the class at definition time, not inside the mixin. The guard's helpers (`has_required_when_predicates`, `build_effective_options`, `check_required_when`) read specs as dicts, which against a `PropertySpec` silently means "no predicates". They are now typed attribute access, so the predicates still run. Same for the default-application path in `feature_group.py`, which identity-tested the sentinel; `is_no_default()` is a type test, matching what #738 chose for the same reason.
- **#732/#739**: present option values are validated on the string-named path too. The `_collect_option_value` / `_validate_present_option_values` structure is kept, with the raw-dict hard break applied on both entry paths so an unmigrated mapping raises `ValueError` rather than `AttributeError`.
- **#733/#738**: main independently reached the `NO_DEFAULT` sentinel on the dict builder. Both converge; the dataclass carries it, and the builder's `__reduce__` (pickle/deepcopy resolve back to the singleton) is preserved.
- **#726/#741**: facade import moves absorbed.

### One behavior call that needs a reviewer's eye

`DimensionalityReductionFeatureGroup.ISOMAP_N_NEIGHBORS` (and three sibling numeric keys) carried an `element_validator` with `strict_validation: False`, which never ran. `PropertySpec.__post_init__` rejects that dead combination at construction, so the spec could not survive unchanged, and #724 made it strict: the validators are now live and a bad value is rejected.

#739's `test_non_strict_key_with_bad_looking_value_is_accepted` used that same key as its example of an unenforced key, so its premise no longer holds. It is rewritten to the post-#724 truth rather than deleted. The property it actually guarded (a genuinely non-strict key must not be over-rejected) stays pinned in the core suite on a purpose-built key: `test_name_path_validates_option_values.py::test_non_strict_key_accepts_any_value`.

Docs: the page claimed the name-matched path "short-circuits to a match, without consulting the property mapping at all", which #739 falsified. Corrected, along with two sibling claims in plugin comments.

`tox` green: 6222 passed, 171 skipped, `mypy --strict` clean. All 18 CI checks pass.
