### PR TITLE
refactor: enforce the six plugin specs whose element_validator never ran (#724)

### DIFF
--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -85,6 +85,11 @@ than adding to it: when a key declares one, `allowed_values` is not consulted. B
 parser runs before the mixin, an element rejected by membership or by `element_validator`
 short-circuits, and `match_guard` is never reached.
 
+That short-circuit holds only when the feature name does **not** match a `PREFIX_PATTERN`. On a
+name match the parser short-circuits the other way (to a match, without consulting the property
+mapping at all), so `match_guard` is the only hook that runs on the string-named path. A key that
+must be enforced on both paths therefore declares both callables, usually with the same predicate.
+
 ## Choosing a mechanism
 
 | You want to say | Use |
@@ -101,7 +106,12 @@ The two callables differ on both axes, which is what their names say:
   accept, so they are told.
 - **`match_guard`** sees the **raw whole value**, with or without strict, and a falsy return
   is a plain **non-match**. The group is saying "not mine", so resolution moves on and
-  another feature group may still take the feature.
+  another feature group may still take the feature. On a spec that also sets
+  `strict_validation=True` the guard means "this value is wrong", so its rejection is reported to
+  the user instead of failing silently.
+
+Declaring both on one spec is the way to enforce a key on both paths: `element_validator` cannot
+run on the string-named path, and `match_guard` alone gives no message on a non-strict spec.
 
 Both must be pure functions. They may be called several times during resolution (once per
 candidate feature group).

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -35,7 +35,15 @@ When both are present on the same spec, ``element_validator`` runs
 first (during property mapping validation) on each parsed element, then
 ``match_guard`` runs on the raw value. If ``element_validator`` rejects an
 element, the match fails with a ``ValueError`` before ``match_guard`` is
-reached.
+reached. That ordering holds only when the feature name does NOT match a
+PREFIX_PATTERN: on a name match the parser short-circuits to a match and
+``match_guard`` is the only hook that runs, which is why a key that must be
+enforced on both paths declares both hooks.
+
+A guard rejection on a spec that also sets ``strict_validation=True`` is
+reportable: ``_strict_validation_rejection_reason`` turns it into a message so
+the feature group does not vanish silently. A guard on a non-strict spec keeps
+its "not mine" meaning and reports nothing.
 
 Validators must be pure functions with no side effects. They may be called
 multiple times during feature group resolution (once per candidate feature
@@ -250,33 +258,57 @@ class FeatureChainParserMixin:
 
     @classmethod
     def _strict_validation_rejection_reason(cls, feature_name: str | FeatureName, options: Options) -> str | None:
-        """Return the ValueError message that match_feature_group_criteria discards, if any.
+        """Return the rejection message that match_feature_group_criteria discards, if any.
 
-        Only surfaces ValueErrors raised by property-mapping validation (genuine
-        strict_validation rejections). A ValueError raised while parsing a
-        PREFIX_PATTERN match (malformed feature name, no chain separator) is a
-        parse error, not an option-value rejection, and is treated as nothing to
-        report. Returns None when nothing was rejected (match succeeded, or the
-        candidate is unrelated). Diagnostic-only: does not affect
+        Reports two kinds of value rejection, both gated on the feature group OTHERWISE matching
+        the feature:
+
+        1. A ValueError raised by property-mapping validation (a strict_validation rejection).
+        2. A match_guard rejection on a spec that also declares strict_validation. On the
+           string-named path the PREFIX_PATTERN match short-circuits property-mapping validation,
+           so the guard is the only enforcement there and would otherwise reject in silence.
+
+        A guard on a non-strict spec means "this feature group does not match", not "this value is
+        wrong", so it stays unreported. A ValueError raised while parsing a PREFIX_PATTERN match
+        (malformed feature name, no chain separator) is a parse error, not an option-value
+        rejection, and is likewise nothing to report. Returns None when nothing was rejected (the
+        match succeeded, or the candidate is unrelated). Diagnostic-only: does not affect
         match_feature_group_criteria's behavior.
         """
-        prefix_patterns = cls._get_prefix_patterns()
-        if prefix_patterns:
-            try:
-                if FeatureChainParser._match_pattern_based_feature(feature_name, prefix_patterns, CHAIN_SEPARATOR):
-                    return None
-            except ValueError:
-                return None
-
         property_mapping = cls._get_property_mapping()
         if property_mapping is None:
             return None
 
-        try:
-            FeatureChainParser._validate_options_against_property_mapping(options, property_mapping)
-        except ValueError as exc:
-            return str(exc)
-        return None
+        prefix_patterns = cls._get_prefix_patterns()
+        name_matches = False
+        if prefix_patterns:
+            try:
+                name_matches = FeatureChainParser._match_pattern_based_feature(
+                    feature_name, prefix_patterns, CHAIN_SEPARATOR
+                )
+            except ValueError:
+                return None
+
+        if not name_matches:
+            try:
+                matches_mapping = FeatureChainParser._validate_options_against_property_mapping(
+                    options, property_mapping
+                )
+            except ValueError as exc:
+                return str(exc)
+            # Neither the name nor the option set relates this feature group to the feature: its
+            # guards are none of the feature's business.
+            if not matches_mapping:
+                return None
+
+        rejection = cls._first_rejecting_guard(options, property_mapping)
+        if rejection is None:
+            return None
+
+        key, value = rejection
+        if not property_mapping[key].strict_validation:
+            return None
+        return f"Property value '{value}' rejected by match_guard for '{key}'"
 
     @classmethod
     def _validate_forwarded_name_mismatch(
@@ -351,26 +383,49 @@ class FeatureChainParserMixin:
         return True
 
     @classmethod
+    def _first_rejecting_guard(
+        cls, options: Options, property_mapping: dict[str, PropertySpec] | None
+    ) -> tuple[str, Any] | None:
+        """Return the (key, value) of the first match_guard that rejects its option value, or None.
+
+        A guard rejects by returning a falsy value or by raising. Shared by the match decision
+        (_validate_match_guards) and the diagnostic (_strict_validation_rejection_reason), so the
+        two can never disagree on what a guard rejected.
+        """
+        if property_mapping is None:
+            return None
+
+        for key, mapping_entry in property_mapping.items():
+            guard = mapping_entry.match_guard
+            if guard is None:
+                continue
+            value = options.get(key)
+            if value is None:
+                continue
+            try:
+                rejected = not guard(value)
+            except (TypeError, ValueError, AttributeError) as exc:
+                logger.debug("match_guard for '%s' raised %s for value %r", key, exc, value)
+                rejected = True
+            if rejected:
+                return key, value
+        return None
+
+    @classmethod
     def _validate_match_guards(
         cls, result: bool, options: Options, property_mapping: dict[str, PropertySpec] | None
     ) -> bool:
         # Enforce match_guard constraints from PROPERTY_MAPPING
-        if result and property_mapping is not None:
-            for key, mapping_entry in property_mapping.items():
-                guard = mapping_entry.match_guard
-                if guard is None:
-                    continue
-                value = options.get(key)
-                if value is None:
-                    continue
-                try:
-                    if not guard(value):
-                        logger.debug("match_guard for '%s' rejected value %r", key, value)
-                        return False
-                except (TypeError, ValueError, AttributeError) as exc:
-                    logger.debug("match_guard for '%s' raised %s for value %r", key, exc, value)
-                    return False
-        return True
+        if not result:
+            return True
+
+        rejection = cls._first_rejecting_guard(options, property_mapping)
+        if rejection is None:
+            return True
+
+        key, value = rejection
+        logger.debug("match_guard for '%s' rejected value %r", key, value)
+        return False
 
     @classmethod
     def _validate_in_features(cls, result: bool, options: Options) -> bool:

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -221,6 +221,14 @@ class IdentifyFeatureGroupClass:
         msg += " Pin the feature to a supported compute framework or override supports_compute_framework."
         return msg
 
+    def _value_rejection_reason(self, feature_group: type[FeatureGroup], feature: Feature) -> Optional[str]:
+        """The candidate's own message for rejecting an option VALUE, if it has one."""
+        rejection_check = getattr(feature_group, "_strict_validation_rejection_reason", None)
+        if rejection_check is None:
+            return None
+        reason: Optional[str] = rejection_check(feature.name, feature.options)
+        return reason
+
     def _input_feature_forwarding_hint(
         self, feature: Feature, accessible_plugins: FeatureGroupEnvironmentMapping
     ) -> Optional[str]:
@@ -239,6 +247,10 @@ class IdentifyFeatureGroupClass:
             if not self._filter_feature_group_by_domain(feature_group, feature):
                 continue
             if not self._filter_feature_group_by_scope(feature_group, feature):
+                continue
+            # A rejected VALUE is not a forwarding problem: dropping the key would not fix it, and
+            # the value-rejection hint already says what is wrong.
+            if self._value_rejection_reason(feature_group, feature) is not None:
                 continue
             accepts_bare = feature_group.match_feature_group_criteria(feature.name, bare, self._data_access_collection)
             rejects_actual = not feature_group.match_feature_group_criteria(
@@ -269,11 +281,7 @@ class IdentifyFeatureGroupClass:
             if not self._filter_feature_group_by_scope(feature_group, feature):
                 continue
 
-            rejection_check = getattr(feature_group, "_strict_validation_rejection_reason", None)
-            if rejection_check is None:
-                continue
-
-            reason = rejection_check(feature.name, feature.options)
+            reason = self._value_rejection_reason(feature_group, feature)
             if reason is not None:
                 reasons.append((feature_group.get_class_name(), reason))
 

--- a/mloda_plugins/feature_group/experimental/clustering/base.py
+++ b/mloda_plugins/feature_group/experimental/clustering/base.py
@@ -18,6 +18,11 @@ from mloda.provider import DefaultOptionKeys
 from mloda.provider import PropertySpec
 
 
+def _is_bool(value: Any) -> bool:
+    """Accept only a real bool, so 1 or "true" is rejected rather than silently coerced."""
+    return isinstance(value, bool)
+
+
 class ClusteringFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     """
     Base class for all clustering feature groups.
@@ -132,11 +137,16 @@ class ClusteringFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             context=True,
             strict_validation=False,
         ),
+        # element_validator enforces the constraint on the config-based path; match_guard is the only
+        # enforcement on the string-named path, where the PREFIX_PATTERN match short-circuits
+        # property-mapping validation and this key never appears in the feature name.
         OUTPUT_PROBABILITIES: PropertySpec(
             "Whether to output cluster probabilities/distances as separate columns using ~N suffix pattern",
             context=True,
-            strict_validation=False,
+            strict_validation=True,
             default=False,
+            element_validator=_is_bool,
+            match_guard=_is_bool,
         ),
     }
 

--- a/mloda_plugins/feature_group/experimental/clustering/base.py
+++ b/mloda_plugins/feature_group/experimental/clustering/base.py
@@ -137,9 +137,10 @@ class ClusteringFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             context=True,
             strict_validation=False,
         ),
-        # element_validator enforces the constraint on the config-based path; match_guard is the only
-        # enforcement on the string-named path, where the PREFIX_PATTERN match short-circuits
-        # property-mapping validation and this key never appears in the feature name.
+        # Both hooks share _is_bool: on the config-based path both run, and element_validator is what
+        # produces the rejection message (and checks the declared default at construction); on the
+        # string-named path the PREFIX_PATTERN match short-circuits property-mapping validation, so
+        # match_guard is the only hook left to enforce the value.
         OUTPUT_PROBABILITIES: PropertySpec(
             "Whether to output cluster probabilities/distances as separate columns using ~N suffix pattern",
             context=True,

--- a/mloda_plugins/feature_group/experimental/dimensionality_reduction/base.py
+++ b/mloda_plugins/feature_group/experimental/dimensionality_reduction/base.py
@@ -19,6 +19,11 @@ from mloda.provider import DefaultOptionKeys
 from mloda.provider import PropertySpec
 
 
+def _is_positive_int(value: Any) -> bool:
+    """Accept a positive int or a digit string, so 0, -5, 2.5 and "abc" are rejected."""
+    return isinstance(value, (int, str)) and str(value).isdigit() and int(value) > 0
+
+
 class DimensionalityReductionFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     """
     Base class for all dimensionality reduction feature groups.
@@ -130,25 +135,33 @@ class DimensionalityReductionFeatureGroup(FeatureChainParserMixin, FeatureGroup)
             "Target dimension for the reduction (positive integer)",
             context=True,
             strict_validation=True,
-            element_validator=lambda value: isinstance(value, (int, str)) and str(value).isdigit() and int(value) > 0,
+            element_validator=_is_positive_int,
         ),
         DefaultOptionKeys.in_features: PropertySpec(
             "Source features to use for dimensionality reduction",
             context=True,
             strict_validation=False,
         ),
+        # The algorithm-specific numeric keys below carry both enforcement hooks: element_validator
+        # covers the config-based path, match_guard is the only enforcement on the string-named path,
+        # where the PREFIX_PATTERN match short-circuits property-mapping validation and none of these
+        # keys ever appears in the feature name.
         # t-SNE specific parameters
         TSNE_MAX_ITER: PropertySpec(
             "Maximum number of iterations for t-SNE optimization",
             context=True,
-            strict_validation=False,
+            strict_validation=True,
             default=250,
+            element_validator=_is_positive_int,
+            match_guard=_is_positive_int,
         ),
         TSNE_N_ITER_WITHOUT_PROGRESS: PropertySpec(
             "Maximum iterations without progress before early stopping (t-SNE)",
             context=True,
-            strict_validation=False,
+            strict_validation=True,
             default=50,
+            element_validator=_is_positive_int,
+            match_guard=_is_positive_int,
         ),
         TSNE_METHOD: PropertySpec(
             "t-SNE computation method",
@@ -177,15 +190,19 @@ class DimensionalityReductionFeatureGroup(FeatureChainParserMixin, FeatureGroup)
         ICA_MAX_ITER: PropertySpec(
             "Maximum number of iterations for ICA",
             context=True,
-            strict_validation=False,
+            strict_validation=True,
             default=200,
+            element_validator=_is_positive_int,
+            match_guard=_is_positive_int,
         ),
         # Isomap specific parameters
         ISOMAP_N_NEIGHBORS: PropertySpec(
             "Number of neighbors for Isomap",
             context=True,
-            strict_validation=False,
+            strict_validation=True,
             default=5,
+            element_validator=_is_positive_int,
+            match_guard=_is_positive_int,
         ),
     }
 

--- a/mloda_plugins/feature_group/experimental/dimensionality_reduction/base.py
+++ b/mloda_plugins/feature_group/experimental/dimensionality_reduction/base.py
@@ -4,6 +4,7 @@ Base implementation for dimensionality reduction feature groups.
 
 from __future__ import annotations
 
+import numbers
 from abc import abstractmethod
 from typing import Any, Optional
 
@@ -20,8 +21,12 @@ from mloda.provider import PropertySpec
 
 
 def _is_positive_int(value: Any) -> bool:
-    """Accept a positive int or a digit string, so 0, -5, 2.5 and "abc" are rejected."""
-    return isinstance(value, (int, str)) and str(value).isdigit() and int(value) > 0
+    """Accept any positive integer (int, numpy int, decimal string), so bool, 0, -5, 2.5, "abc" and "²" are rejected."""
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, numbers.Integral):
+        return int(value) > 0
+    return isinstance(value, str) and value.isdecimal() and int(value) > 0
 
 
 class DimensionalityReductionFeatureGroup(FeatureChainParserMixin, FeatureGroup):
@@ -142,10 +147,11 @@ class DimensionalityReductionFeatureGroup(FeatureChainParserMixin, FeatureGroup)
             context=True,
             strict_validation=False,
         ),
-        # The algorithm-specific numeric keys below carry both enforcement hooks: element_validator
-        # covers the config-based path, match_guard is the only enforcement on the string-named path,
-        # where the PREFIX_PATTERN match short-circuits property-mapping validation and none of these
-        # keys ever appears in the feature name.
+        # The algorithm-specific numeric keys below share _is_positive_int across both hooks: on the
+        # config-based path both run, and element_validator is what produces the rejection message
+        # (and checks the declared default at construction); on the string-named path the
+        # PREFIX_PATTERN match short-circuits property-mapping validation, so match_guard is the only
+        # hook left to enforce the value.
         # t-SNE specific parameters
         TSNE_MAX_ITER: PropertySpec(
             "Maximum number of iterations for t-SNE optimization",

--- a/mloda_plugins/feature_group/experimental/forecasting/base.py
+++ b/mloda_plugins/feature_group/experimental/forecasting/base.py
@@ -154,9 +154,10 @@ class ForecastingFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featu
             context=True,
             strict_validation=False,
         ),
-        # element_validator enforces the constraint on the config-based path; match_guard is the only
-        # enforcement on the string-named path, where the PREFIX_PATTERN match short-circuits
-        # property-mapping validation and this key never appears in the feature name.
+        # Both hooks share _is_bool: on the config-based path both run, and element_validator is what
+        # produces the rejection message (and checks the declared default at construction); on the
+        # string-named path the PREFIX_PATTERN match short-circuits property-mapping validation, so
+        # match_guard is the only hook left to enforce the value.
         OUTPUT_CONFIDENCE_INTERVALS: PropertySpec(
             "Whether to output confidence intervals as separate columns using ~lower and ~upper suffix pattern",
             context=True,

--- a/mloda_plugins/feature_group/experimental/forecasting/base.py
+++ b/mloda_plugins/feature_group/experimental/forecasting/base.py
@@ -19,6 +19,11 @@ from mloda_plugins.feature_group.experimental.forecasting.forecasting_artifact i
 from mloda_plugins.feature_group.experimental.time_reference_mixin import TimeReferenceMixin
 
 
+def _is_bool(value: Any) -> bool:
+    """Accept only a real bool, so 1 or "true" is rejected rather than silently coerced."""
+    return isinstance(value, bool)
+
+
 class ForecastingFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, FeatureGroup):
     """
     Base class for all forecasting feature groups.
@@ -149,11 +154,16 @@ class ForecastingFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featu
             context=True,
             strict_validation=False,
         ),
+        # element_validator enforces the constraint on the config-based path; match_guard is the only
+        # enforcement on the string-named path, where the PREFIX_PATTERN match short-circuits
+        # property-mapping validation and this key never appears in the feature name.
         OUTPUT_CONFIDENCE_INTERVALS: PropertySpec(
             "Whether to output confidence intervals as separate columns using ~lower and ~upper suffix pattern",
             context=True,
-            strict_validation=False,
+            strict_validation=True,
             default=False,
+            element_validator=_is_bool,
+            match_guard=_is_bool,
         ),
     }
 

--- a/tests/test_plugins/feature_group/experimental/test_property_mapping_enforced_validators.py
+++ b/tests/test_plugins/feature_group/experimental/test_property_mapping_enforced_validators.py
@@ -5,18 +5,30 @@ Each key must reject bad values on both match paths:
   and _strict_validation_rejection_reason surfaces the discarded message.
 - string-named path: the PREFIX_PATTERN match short-circuits property-mapping validation, so only
   the match_guard runs.
+
+A rejection on either path must be REPORTABLE: _strict_validation_rejection_reason is what
+identify_feature_group turns into the user-facing hint, so a match_guard rejection may not stay a
+silent logger.debug. The reporting must not fire for a feature group that does not match the
+feature at all, and a rejected VALUE must not be misdiagnosed as an input-feature forwarding
+problem.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import Any
+from dataclasses import dataclass
+from typing import Any, cast
 
 import pytest
 
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
 from mloda.provider import DefaultOptionKeys
 from mloda.provider import FeatureChainParserMixin
+from mloda.provider import FeatureGroup
+from mloda.user import Feature
 from mloda.user import Options
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.feature_group.experimental.aggregated_feature_group.base import AggregatedFeatureGroup
 from mloda_plugins.feature_group.experimental.clustering.base import ClusteringFeatureGroup
 from mloda_plugins.feature_group.experimental.dimensionality_reduction.base import DimensionalityReductionFeatureGroup
 from mloda_plugins.feature_group.experimental.forecasting.base import ForecastingFeatureGroup
@@ -32,8 +44,9 @@ class KeyCase:
     base_context: dict[str, Any]
     valid_value: Any
     invalid_values: tuple[Any, ...]
+    reported_invalid_value: Any
     list_value: list[Any]
-    digit_string: str | None = field(default=None)
+    digit_string: str | None = None
 
     def options(self, value: Any) -> Options:
         """Options for the string-named path: only the key under test."""
@@ -42,6 +55,10 @@ class KeyCase:
     def config_options(self, value: Any) -> Options:
         """Options for the config-based path: the required option set plus the key under test."""
         return Options(context={**self.base_context, self.key: value})
+
+    def as_feature_group(self) -> type[FeatureGroup]:
+        """The same class seen through the FeatureGroup API (every case subclasses both)."""
+        return cast(type[FeatureGroup], self.feature_group)
 
 
 CLUSTERING_CONTEXT: dict[str, Any] = {
@@ -66,6 +83,18 @@ DIMENSION_CONTEXT: dict[str, Any] = {
 BOOL_INVALID: tuple[Any, ...] = ("maybe", 1)
 NUMERIC_INVALID: tuple[Any, ...] = (0, -5, "abc", 2.5)
 
+# A value the user-facing error must echo back. Picked so it cannot occur by accident inside a
+# feature name ("0" would also match the "feature0" in the dimensionality-reduction names).
+BOOL_REPORTED: Any = "maybe"
+NUMERIC_REPORTED: Any = -5
+
+# str.isdigit() is True for the unicode superscript two, but int("²") raises ValueError.
+SUPERSCRIPT_TWO = "²"
+
+# Matched by none of the feature groups under test: no PREFIX_PATTERN hit, and the required
+# config-based keys (algorithm, ...) are absent.
+UNRELATED_FEATURE_NAME = "an_unrelated_feature_of_no_group"
+
 CASES: list[KeyCase] = [
     KeyCase(
         feature_group=ClusteringFeatureGroup,
@@ -74,6 +103,7 @@ CASES: list[KeyCase] = [
         base_context=CLUSTERING_CONTEXT,
         valid_value=True,
         invalid_values=BOOL_INVALID,
+        reported_invalid_value=BOOL_REPORTED,
         list_value=[True],
     ),
     KeyCase(
@@ -83,6 +113,7 @@ CASES: list[KeyCase] = [
         base_context=FORECASTING_CONTEXT,
         valid_value=True,
         invalid_values=BOOL_INVALID,
+        reported_invalid_value=BOOL_REPORTED,
         list_value=[True],
     ),
     KeyCase(
@@ -92,6 +123,7 @@ CASES: list[KeyCase] = [
         base_context=DIMENSION_CONTEXT,
         valid_value=250,
         invalid_values=NUMERIC_INVALID,
+        reported_invalid_value=NUMERIC_REPORTED,
         list_value=[250, 300],
         digit_string="250",
     ),
@@ -102,8 +134,9 @@ CASES: list[KeyCase] = [
         base_context=DIMENSION_CONTEXT,
         valid_value=30,
         invalid_values=NUMERIC_INVALID,
+        reported_invalid_value=NUMERIC_REPORTED,
         list_value=[30, 50],
-        digit_string="250",
+        digit_string="30",
     ),
     KeyCase(
         feature_group=DimensionalityReductionFeatureGroup,
@@ -112,8 +145,9 @@ CASES: list[KeyCase] = [
         base_context={**DIMENSION_CONTEXT, DimensionalityReductionFeatureGroup.ALGORITHM: "ica"},
         valid_value=300,
         invalid_values=NUMERIC_INVALID,
+        reported_invalid_value=NUMERIC_REPORTED,
         list_value=[200, 300],
-        digit_string="250",
+        digit_string="300",
     ),
     KeyCase(
         feature_group=DimensionalityReductionFeatureGroup,
@@ -122,8 +156,9 @@ CASES: list[KeyCase] = [
         base_context={**DIMENSION_CONTEXT, DimensionalityReductionFeatureGroup.ALGORITHM: "isomap"},
         valid_value=3,
         invalid_values=NUMERIC_INVALID,
+        reported_invalid_value=NUMERIC_REPORTED,
         list_value=[3, 5],
-        digit_string="250",
+        digit_string="3",
     ),
 ]
 
@@ -147,6 +182,14 @@ def _invalid_value_params() -> list[Any]:
         for case in CASES
         for invalid_value in case.invalid_values
     ]
+
+
+def _resolution_error(feature: Feature, feature_group: type[FeatureGroup]) -> str:
+    """Resolve the feature against a single accessible feature group and return the raised error."""
+    accessible_plugins: FeatureGroupEnvironmentMapping = {feature_group: {PandasDataFrame}}
+    with pytest.raises(ValueError) as exc_info:
+        IdentifyFeatureGroupClass(feature=feature, accessible_plugins=accessible_plugins, links=None)
+    return str(exc_info.value)
 
 
 @pytest.mark.parametrize("case, invalid_value", _invalid_value_params())
@@ -205,3 +248,195 @@ def test_string_named_path_rejects_list_value(case: KeyCase) -> None:
         case.feature_group.match_feature_group_criteria(case.string_feature_name, case.options(case.list_value))
         is False
     )
+
+
+class TestMatchGuardRejectionIsReportable:
+    """A match_guard rejection must be recoverable as a message, not only a logger.debug line."""
+
+    @pytest.mark.parametrize("case, invalid_value", _invalid_value_params())
+    def test_string_named_path_reports_guard_rejection(self, case: KeyCase, invalid_value: Any) -> None:
+        """On the string-named path the guard is the only enforcement, so it must report itself."""
+        reason = case.feature_group._strict_validation_rejection_reason(
+            case.string_feature_name, case.options(invalid_value)
+        )
+        assert reason is not None
+        assert case.key in reason
+        assert str(invalid_value) in reason
+
+    @pytest.mark.parametrize("case", _case_params())
+    def test_string_named_path_reports_nothing_for_valid_value(self, case: KeyCase) -> None:
+        """No false positives: a value the guard accepts has nothing to report."""
+        reason = case.feature_group._strict_validation_rejection_reason(
+            case.string_feature_name, case.options(case.valid_value)
+        )
+        assert reason is None
+
+    @pytest.mark.parametrize("case", _case_params())
+    def test_string_named_path_reports_nothing_when_key_is_absent(self, case: KeyCase) -> None:
+        """No false positives: an absent key is not a rejection."""
+        assert case.feature_group._strict_validation_rejection_reason(case.string_feature_name, Options()) is None
+
+    @pytest.mark.parametrize("case", _case_params())
+    def test_no_guard_rejection_reported_for_unrelated_feature_name(self, case: KeyCase) -> None:
+        """A feature group that does not match the name at all must not report its guards.
+
+        The list value passes every element_validator and is rejected only by the match_guard, so a
+        guard check that ignores whether the feature group matches would report a phantom rejection.
+        """
+        options = case.options(case.list_value)
+        assert case.feature_group.match_feature_group_criteria(UNRELATED_FEATURE_NAME, options) is False
+        assert case.feature_group._strict_validation_rejection_reason(UNRELATED_FEATURE_NAME, options) is None
+
+    def test_no_guard_rejection_reported_for_option_outside_the_mapping(self) -> None:
+        """An aggregated feature carrying another group's option has nothing to report."""
+        options = Options(context={ClusteringFeatureGroup.OUTPUT_PROBABILITIES: "maybe"})
+        assert AggregatedFeatureGroup._strict_validation_rejection_reason("sales__sum_aggr", options) is None
+
+
+class TestRejectedValueNamedInResolutionError:
+    """The user-facing no-feature-group error must name the culprit option, not stay generic."""
+
+    @pytest.mark.parametrize("case", _case_params())
+    def test_string_named_rejection_names_key_and_value(self, case: KeyCase) -> None:
+        """A string-named feature rejected by a guard must not fail with a bare 'No feature groups found'."""
+        feature = Feature(case.string_feature_name, case.options(case.reported_invalid_value))
+
+        message = _resolution_error(feature, case.as_feature_group())
+
+        assert case.key in message
+        assert str(case.reported_invalid_value) in message
+        assert case.feature_group.__name__ in message
+
+    @pytest.mark.parametrize("case", _case_params())
+    def test_config_based_rejection_names_key_and_value(self, case: KeyCase) -> None:
+        """Regression guard: the config-based path already names the culprit option."""
+        feature = Feature("placeholder", case.config_options(case.reported_invalid_value))
+
+        message = _resolution_error(feature, case.as_feature_group())
+
+        assert case.key in message
+        assert str(case.reported_invalid_value) in message
+        assert case.feature_group.__name__ in message
+
+
+class TestRejectedValueIsNotAForwardingProblem:
+    """A rejected VALUE in group options must not be reported as an extra-group-option problem."""
+
+    def test_group_placed_bad_value_names_the_value_not_forwarding(self) -> None:
+        """ica_max_iter=-1 in group options is a bad value; forward_group_exclude would not fix it."""
+        feature = Feature(
+            "feature0,feature1,feature2__ica_2d",
+            Options({DimensionalityReductionFeatureGroup.ICA_MAX_ITER: -1}),
+        )
+
+        message = _resolution_error(feature, DimensionalityReductionFeatureGroup)
+
+        assert DimensionalityReductionFeatureGroup.ICA_MAX_ITER in message
+        assert "-1" in message
+        assert "extra group option" not in message
+        assert "forward_group_exclude" not in message
+        assert "Group options flow onto input features" not in message
+
+    def test_group_placed_valid_value_still_matches(self) -> None:
+        """Regression guard: a valid value in group options is not a rejection at all."""
+        options = Options({DimensionalityReductionFeatureGroup.ICA_MAX_ITER: 300})
+        assert DimensionalityReductionFeatureGroup.match_feature_group_criteria(
+            "feature0,feature1,feature2__ica_2d", options
+        )
+
+
+class TestNumericPredicateHardening:
+    """The positive-int predicate behind the four numeric keys must be type-honest."""
+
+    @pytest.mark.parametrize("case", _numeric_case_params())
+    def test_numpy_integer_is_accepted_on_both_paths(self, case: KeyCase) -> None:
+        """A numpy integer is a positive integer; rejecting it on isinstance(int) is a false negative."""
+        np = pytest.importorskip("numpy")
+        value = np.int64(int(case.valid_value))
+
+        assert case.feature_group.match_feature_group_criteria(case.string_feature_name, case.options(value))
+        assert case.feature_group.match_feature_group_criteria("placeholder", case.config_options(value))
+
+    def test_numpy_integer_is_accepted_for_the_dimension_key(self) -> None:
+        """DIMENSION shares the predicate with the numeric keys, so it must accept a numpy integer too."""
+        np = pytest.importorskip("numpy")
+        options = Options(
+            context={**DIMENSION_CONTEXT, DimensionalityReductionFeatureGroup.DIMENSION: np.int64(2)},
+        )
+
+        assert DimensionalityReductionFeatureGroup.match_feature_group_criteria("placeholder", options)
+
+    @pytest.mark.parametrize("case", _numeric_case_params())
+    def test_bool_is_rejected_on_both_paths(self, case: KeyCase) -> None:
+        """True is not an iteration count: bool must not be read as 1."""
+        assert case.feature_group.match_feature_group_criteria(case.string_feature_name, case.options(True)) is False
+        assert case.feature_group.match_feature_group_criteria("placeholder", case.config_options(True)) is False
+
+    @pytest.mark.parametrize("case", _numeric_case_params())
+    def test_superscript_digit_is_rejected_cleanly_on_string_named_path(self, case: KeyCase) -> None:
+        """The superscript passes str.isdigit() but breaks int(): the rejection must stay clean."""
+        options = case.options(SUPERSCRIPT_TWO)
+
+        assert case.feature_group.match_feature_group_criteria(case.string_feature_name, options) is False
+
+        reason = case.feature_group._strict_validation_rejection_reason(case.string_feature_name, options)
+        assert reason is not None
+        assert case.key in reason
+        assert "invalid literal for int()" not in reason
+
+    @pytest.mark.parametrize("case", _numeric_case_params())
+    def test_superscript_digit_is_rejected_cleanly_on_config_based_path(self, case: KeyCase) -> None:
+        """The config-based rejection reason must name the key, not leak int()'s internal error."""
+        options = case.config_options(SUPERSCRIPT_TWO)
+
+        assert case.feature_group.match_feature_group_criteria("placeholder", options) is False
+
+        reason = case.feature_group._strict_validation_rejection_reason("placeholder", options)
+        assert reason is not None
+        assert case.key in reason
+        assert "invalid literal for int()" not in reason
+
+
+class TestStrictValidationDoesNotMakeKeysRequired:
+    """strict_validation=True enforces the VALUE SPACE, never presence."""
+
+    @pytest.mark.parametrize("case", _case_params())
+    def test_absent_key_still_matches_on_string_named_path(self, case: KeyCase) -> None:
+        """Regression guard: the key stays optional on the string-named path."""
+        assert case.feature_group.match_feature_group_criteria(case.string_feature_name, Options())
+
+    @pytest.mark.parametrize("case", _case_params())
+    def test_absent_key_still_matches_on_config_based_path(self, case: KeyCase) -> None:
+        """Regression guard: the key stays optional on the config-based path."""
+        options = Options(context=dict(case.base_context))
+        assert case.feature_group.match_feature_group_criteria("placeholder", options)
+
+    @pytest.mark.parametrize("case", _case_params())
+    def test_explicit_none_is_treated_as_absent_on_string_named_path(self, case: KeyCase) -> None:
+        """options.get cannot tell an explicit None from an absent key, so None still matches."""
+        assert case.feature_group.match_feature_group_criteria(case.string_feature_name, case.options(None))
+
+    @pytest.mark.parametrize("case", _case_params())
+    def test_explicit_none_is_treated_as_absent_on_config_based_path(self, case: KeyCase) -> None:
+        """Same Options semantics on the config-based path."""
+        assert case.feature_group.match_feature_group_criteria("placeholder", case.config_options(None))
+
+
+class TestConfigBasedListRejection:
+    """A list value survives the element_validator (it sees the elements) and dies on the match_guard."""
+
+    @pytest.mark.parametrize("case", _case_params())
+    def test_config_based_path_rejects_list_value(self, case: KeyCase) -> None:
+        """Regression guard: the raw list is not a valid value even when every element is."""
+        options = case.config_options(case.list_value)
+        assert case.feature_group.match_feature_group_criteria("placeholder", options) is False
+
+    @pytest.mark.parametrize("case", _case_params())
+    def test_config_based_path_reports_list_rejection(self, case: KeyCase) -> None:
+        """The guard-only rejection must be reportable, like the element_validator one already is."""
+        options = case.config_options(case.list_value)
+
+        reason = case.feature_group._strict_validation_rejection_reason("placeholder", options)
+        assert reason is not None
+        assert case.key in reason
+        assert str(case.list_value) in reason

--- a/tests/test_plugins/feature_group/experimental/test_property_mapping_enforced_validators.py
+++ b/tests/test_plugins/feature_group/experimental/test_property_mapping_enforced_validators.py
@@ -1,0 +1,207 @@
+"""Enforcement tests for the six PROPERTY_MAPPING keys that declare a value constraint (issue #724).
+
+Each key must reject bad values on both match paths:
+- config-based path: the element_validator raises, match_feature_group_criteria returns False,
+  and _strict_validation_rejection_reason surfaces the discarded message.
+- string-named path: the PREFIX_PATTERN match short-circuits property-mapping validation, so only
+  the match_guard runs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from mloda.provider import DefaultOptionKeys
+from mloda.provider import FeatureChainParserMixin
+from mloda.user import Options
+from mloda_plugins.feature_group.experimental.clustering.base import ClusteringFeatureGroup
+from mloda_plugins.feature_group.experimental.dimensionality_reduction.base import DimensionalityReductionFeatureGroup
+from mloda_plugins.feature_group.experimental.forecasting.base import ForecastingFeatureGroup
+
+
+@dataclass(frozen=True)
+class KeyCase:
+    """One PROPERTY_MAPPING key under test, with both match paths pre-wired."""
+
+    feature_group: type[FeatureChainParserMixin]
+    key: str
+    string_feature_name: str
+    base_context: dict[str, Any]
+    valid_value: Any
+    invalid_values: tuple[Any, ...]
+    list_value: list[Any]
+    digit_string: str | None = field(default=None)
+
+    def options(self, value: Any) -> Options:
+        """Options for the string-named path: only the key under test."""
+        return Options(context={self.key: value})
+
+    def config_options(self, value: Any) -> Options:
+        """Options for the config-based path: the required option set plus the key under test."""
+        return Options(context={**self.base_context, self.key: value})
+
+
+CLUSTERING_CONTEXT: dict[str, Any] = {
+    ClusteringFeatureGroup.ALGORITHM: "kmeans",
+    ClusteringFeatureGroup.K_VALUE: 5,
+    DefaultOptionKeys.in_features: "customer_behavior",
+}
+
+FORECASTING_CONTEXT: dict[str, Any] = {
+    ForecastingFeatureGroup.ALGORITHM: "linear",
+    ForecastingFeatureGroup.HORIZON: 7,
+    ForecastingFeatureGroup.TIME_UNIT: "day",
+    DefaultOptionKeys.in_features: "sales",
+}
+
+DIMENSION_CONTEXT: dict[str, Any] = {
+    DimensionalityReductionFeatureGroup.ALGORITHM: "tsne",
+    DimensionalityReductionFeatureGroup.DIMENSION: 2,
+    DefaultOptionKeys.in_features: "feature0,feature1,feature2",
+}
+
+BOOL_INVALID: tuple[Any, ...] = ("maybe", 1)
+NUMERIC_INVALID: tuple[Any, ...] = (0, -5, "abc", 2.5)
+
+CASES: list[KeyCase] = [
+    KeyCase(
+        feature_group=ClusteringFeatureGroup,
+        key=ClusteringFeatureGroup.OUTPUT_PROBABILITIES,
+        string_feature_name="customer_behavior__cluster_kmeans_5",
+        base_context=CLUSTERING_CONTEXT,
+        valid_value=True,
+        invalid_values=BOOL_INVALID,
+        list_value=[True],
+    ),
+    KeyCase(
+        feature_group=ForecastingFeatureGroup,
+        key=ForecastingFeatureGroup.OUTPUT_CONFIDENCE_INTERVALS,
+        string_feature_name="sales__linear_forecast_7day",
+        base_context=FORECASTING_CONTEXT,
+        valid_value=True,
+        invalid_values=BOOL_INVALID,
+        list_value=[True],
+    ),
+    KeyCase(
+        feature_group=DimensionalityReductionFeatureGroup,
+        key=DimensionalityReductionFeatureGroup.TSNE_MAX_ITER,
+        string_feature_name="feature0,feature1,feature2__tsne_2d",
+        base_context=DIMENSION_CONTEXT,
+        valid_value=250,
+        invalid_values=NUMERIC_INVALID,
+        list_value=[250, 300],
+        digit_string="250",
+    ),
+    KeyCase(
+        feature_group=DimensionalityReductionFeatureGroup,
+        key=DimensionalityReductionFeatureGroup.TSNE_N_ITER_WITHOUT_PROGRESS,
+        string_feature_name="feature0,feature1,feature2__tsne_2d",
+        base_context=DIMENSION_CONTEXT,
+        valid_value=30,
+        invalid_values=NUMERIC_INVALID,
+        list_value=[30, 50],
+        digit_string="250",
+    ),
+    KeyCase(
+        feature_group=DimensionalityReductionFeatureGroup,
+        key=DimensionalityReductionFeatureGroup.ICA_MAX_ITER,
+        string_feature_name="feature0,feature1,feature2__ica_2d",
+        base_context={**DIMENSION_CONTEXT, DimensionalityReductionFeatureGroup.ALGORITHM: "ica"},
+        valid_value=300,
+        invalid_values=NUMERIC_INVALID,
+        list_value=[200, 300],
+        digit_string="250",
+    ),
+    KeyCase(
+        feature_group=DimensionalityReductionFeatureGroup,
+        key=DimensionalityReductionFeatureGroup.ISOMAP_N_NEIGHBORS,
+        string_feature_name="feature0,feature1,feature2__isomap_2d",
+        base_context={**DIMENSION_CONTEXT, DimensionalityReductionFeatureGroup.ALGORITHM: "isomap"},
+        valid_value=3,
+        invalid_values=NUMERIC_INVALID,
+        list_value=[3, 5],
+        digit_string="250",
+    ),
+]
+
+NUMERIC_CASES: list[KeyCase] = [case for case in CASES if case.digit_string is not None]
+
+
+def _case_params() -> list[Any]:
+    """One param per key."""
+    return [pytest.param(case, id=case.key) for case in CASES]
+
+
+def _numeric_case_params() -> list[Any]:
+    """One param per numeric key."""
+    return [pytest.param(case, id=case.key) for case in NUMERIC_CASES]
+
+
+def _invalid_value_params() -> list[Any]:
+    """One param per (key, invalid value) pair."""
+    return [
+        pytest.param(case, invalid_value, id=f"{case.key}-{invalid_value!r}")
+        for case in CASES
+        for invalid_value in case.invalid_values
+    ]
+
+
+@pytest.mark.parametrize("case, invalid_value", _invalid_value_params())
+def test_string_named_path_rejects_invalid_value(case: KeyCase, invalid_value: Any) -> None:
+    """The match_guard must reject a bad value even when the feature name matches PREFIX_PATTERN."""
+    assert (
+        case.feature_group.match_feature_group_criteria(case.string_feature_name, case.options(invalid_value)) is False
+    )
+
+
+@pytest.mark.parametrize("case", _case_params())
+def test_string_named_path_accepts_valid_value(case: KeyCase) -> None:
+    """Regression guard: existing valid string-named usages must keep matching."""
+    assert case.feature_group.match_feature_group_criteria(case.string_feature_name, case.options(case.valid_value))
+
+
+@pytest.mark.parametrize("case, invalid_value", _invalid_value_params())
+def test_config_based_path_rejects_invalid_value(case: KeyCase, invalid_value: Any) -> None:
+    """The element_validator must reject a bad value on the config-based path."""
+    options = case.config_options(invalid_value)
+    assert case.feature_group.match_feature_group_criteria("placeholder", options) is False
+
+
+@pytest.mark.parametrize("case, invalid_value", _invalid_value_params())
+def test_config_based_path_reports_rejection_reason(case: KeyCase, invalid_value: Any) -> None:
+    """The discarded ValueError must name the property key and the rejected value."""
+    options = case.config_options(invalid_value)
+    reason = case.feature_group._strict_validation_rejection_reason("placeholder", options)
+    assert reason is not None
+    assert case.key in reason
+    assert str(invalid_value) in reason
+
+
+@pytest.mark.parametrize("case", _case_params())
+def test_config_based_path_accepts_valid_value(case: KeyCase) -> None:
+    """Regression guard: the valid config-based option set must keep matching."""
+    assert case.feature_group.match_feature_group_criteria("placeholder", case.config_options(case.valid_value))
+
+
+@pytest.mark.parametrize("case", _numeric_case_params())
+def test_digit_string_is_accepted_on_string_named_path(case: KeyCase) -> None:
+    """The numeric keys accept a digit string, like the sibling DIMENSION key."""
+    assert case.feature_group.match_feature_group_criteria(case.string_feature_name, case.options(case.digit_string))
+
+
+@pytest.mark.parametrize("case", _numeric_case_params())
+def test_digit_string_is_accepted_on_config_based_path(case: KeyCase) -> None:
+    """The numeric keys accept a digit string on the config-based path too."""
+    assert case.feature_group.match_feature_group_criteria("placeholder", case.config_options(case.digit_string))
+
+
+@pytest.mark.parametrize("case", _case_params())
+def test_string_named_path_rejects_list_value(case: KeyCase) -> None:
+    """The match_guard checks the whole raw value, so a list is rejected even if its elements are valid."""
+    assert (
+        case.feature_group.match_feature_group_criteria(case.string_feature_name, case.options(case.list_value))
+        is False
+    )


### PR DESCRIPTION
Closes #724.

Stacked on #723: `PropertySpec` does not exist on `main` yet, so this targets `refactor/694-property-spec-dataclass`. Retarget to `main` once #723 merges.

## The decision

Six PROPERTY_MAPPING keys declared a value constraint while sitting at `strict_validation=False`, so the validator was dead code. The issue asked whether rejection should be a hard `ValueError` (`element_validator`) or a non-match (`match_guard`). The answer is **both**, and the reason is that the two match paths differ:

- `element_validator` runs on the config-based path only. It produces the rejection message, and it is the only hook `PropertySpec.__post_init__` uses to check a declared default at construction.
- `match_guard` runs on **both** paths. It is the only enforcement on the string-named path, where a `PREFIX_PATTERN` match short-circuits property-mapping validation. **None of these six keys ever appears in the feature name**, so string-named usage (`feature0,feature1__tsne_2d` plus `Options({tsne_max_iter: 250})`, which is how the existing tests use them) is the common path. An `element_validator` alone would have left the constraint unenforced there. It also sees the raw whole value, so a list whose elements would individually pass is rejected.

Each of the six specs now carries `strict_validation=True` with an `element_validator` and a `match_guard` sharing one named predicate per module.

## Behavior change

Option values that were silently accepted are now rejected at match time:

| Key | Now requires |
| --- | --- |
| `ClusteringFeatureGroup.output_probabilities` | a real bool (`1` and `"true"` are rejected) |
| `ForecastingFeatureGroup.output_confidence_intervals` | a real bool |
| `DimensionalityReductionFeatureGroup.tsne_max_iter` | a positive integer or decimal string |
| `DimensionalityReductionFeatureGroup.tsne_n_iter_without_progress` | same |
| `DimensionalityReductionFeatureGroup.ica_max_iter` | same |
| `DimensionalityReductionFeatureGroup.isomap_n_neighbors` | same |

`output_probabilities="maybe"` used to be accepted by the spec; it now fails to match, with a message that names the key and the value. Absent keys and explicit `None` still match: `strict_validation=True` does not make a key with a declared default required.

## Diagnostics, so a rejection is not a disappearance

Enforcing the specs exposed two gaps that would have traded a silently accepted bad value for a silently missing feature group:

- A `match_guard` rejection was only a `logger.debug`, and `_strict_validation_rejection_reason` bailed out as soon as the name matched a `PREFIX_PATTERN`, i.e. exactly where the guard is the only enforcement. It now reports guard rejections by key and value, gated on the group otherwise matching the feature and on `strict_validation`, so a guard on a non-strict spec keeps its "not mine" meaning. The match decision and the diagnostic now share one `_first_rejecting_guard` helper and cannot disagree.
- A bad value in group options was blamed on option forwarding ("extra group option(s) ... use `forward_group_exclude`"), sending the user to fix their forwarding config instead of the value. The forwarding hint now skips candidates whose rejection is a value rejection.

`_is_positive_int` accepts any `numbers.Integral` (a numpy int is no longer rejected while printing as a valid `250`), rejects `bool` explicitly rather than by accident, and uses `isdecimal()` so `"²"` cannot leak a raw `int()` error as the rejection reason. It also replaces the identical inline lambda on the sibling `dimension` key.

## Tests

New `tests/test_plugins/feature_group/experimental/test_property_mapping_enforced_validators.py` (192 tests, parametrized over the six keys): a rejected value per key on both paths, the rejection message naming key and value, the end-to-end resolution error, absent key and explicit `None` still matching, list values, digit and numpy and superscript values, and that a rejected value is not misdiagnosed as a forwarding problem.

`tox` passes: 5826 tests, ruff format and check, `mypy --strict`, license allowlist, bandit.

## Docs

`docs/docs/in_depth/property-mapping.md`: the claim that an `element_validator` rejection short-circuits before `match_guard` holds only when the name does not match a `PREFIX_PATTERN`, and a key that must be enforced on both paths declares both hooks.