### PR TITLE
minor: keep the facades plugin-free and publish backends per module under mloda.user (#726)

### DIFF
--- a/docs/docs/chapter1/compute-frameworks.md
+++ b/docs/docs/chapter1/compute-frameworks.md
@@ -86,7 +86,8 @@ In this example, we define a compute framework rule inside the feature group. Th
 import pyarrow.compute as pc
 import pyarrow as pa
 
-from mloda.user import PyArrowTable, PandasDataFrame
+from mloda.user.pyarrow import PyArrowTable
+from mloda.user.pandas import PandasDataFrame
 from mloda.provider import FeatureGroup
 
 
@@ -135,14 +136,20 @@ In this case, the feature group ExampleB will only run on the PyArrowTable frame
 
 ##### Importing a Compute Framework
 
-Every stock compute framework is importable directly from `mloda.user`, so you do not need the deep `mloda_plugins.compute_framework.base_implementations...` path:
+Every stock compute framework is published from one module per backend under `mloda.user`, so you do not need the deep `mloda_plugins.compute_framework.base_implementations...` path:
 
 ```python
-from mloda.user import PythonDictFramework, PandasDataFrame, PolarsDataFrame, PolarsLazyDataFrame
-from mloda.user import PyArrowTable, SqliteFramework, DuckDBFramework, IcebergFramework, SparkFramework
+from mloda.user.python_dict import PythonDictFramework
+from mloda.user.pandas import PandasDataFrame
+from mloda.user.polars import PolarsDataFrame, PolarsLazyDataFrame
+from mloda.user.pyarrow import PyArrowTable
+from mloda.user.sqlite import SqliteFramework
+from mloda.user.duckdb import DuckDBFramework
+from mloda.user.iceberg import IcebergFramework
+from mloda.user.spark import SparkFramework
 ```
 
-These are resolved lazily, so `import mloda.user` stays dependency-free: a framework whose backend (e.g. `pyarrow`) is not installed only raises `ModuleNotFoundError` when you actually import that class. The deep import paths keep working unchanged.
+`import mloda.user` needs no backend at all. Importing a backend module gives you the framework class whether or not its library is installed; a framework whose library is missing reports itself unavailable through `is_available()` and is excluded from discovery. The deep import paths keep working unchanged.
 
 ##### Automatic Dependency Detection
 
@@ -173,21 +180,16 @@ A feature group running on PythonDictFramework may also return row-wise data as 
 
 #### Columnar helpers
 
-`columnar_to_rows`, `homogenize_rows`, `is_columnar`, `result_rows`, `row_count`, `rows_to_columnar`, and `validate_columnar_dict` are importable from `mloda.provider` (plugin/provider code, where pivoting a columnar frame back to rows belongs) and from `mloda.user` (application code unwrapping a `run_all` result). `columnar_to_rows` is strict: it raises `ValueError` on anything that is not a valid columnar dict. `result_rows` is the blessed tolerant unwrapper for PythonDict-framework `run_all` output (columnar dicts and row-dict lists): it flattens the partition list into row dicts, and a dict that satisfies `is_columnar` is always treated as a columnar partition, never as a row. It rejects other frameworks' result objects (convert those to rows first).
+`columnar_to_rows`, `homogenize_rows`, `is_columnar`, `result_rows`, `row_count`, `rows_to_columnar`, and `validate_columnar_dict` come from `mloda.user.python_dict`, next to `PythonDictFramework` itself. `columnar_to_rows` is strict: it raises `ValueError` on anything that is not a valid columnar dict. `result_rows` is the blessed tolerant unwrapper for PythonDict-framework `run_all` output (columnar dicts and row-dict lists): it flattens the partition list into row dicts, and a dict that satisfies `is_columnar` is always treated as a columnar partition, never as a row. It rejects other frameworks' result objects (convert those to rows first).
 
 ``` python
-from mloda.user import mloda, result_rows
+from mloda.user import mloda
+from mloda.user.python_dict import result_rows
 
 rows = result_rows(mloda.run_all(...))
 ```
 
 Strictness stays in the library; `result_rows` packages the forgiving application-side policy.
-
-Plugin code can also import `PythonDictFramework` itself from `mloda.provider` instead of its deep `mloda_plugins` path:
-
-``` python
-from mloda.provider import PythonDictFramework, is_columnar, row_count
-```
 
 Example using Polars frameworks:
 ``` python

--- a/docs/docs/examples/mloda_basics/1_ml_mloda_intro.py
+++ b/docs/docs/examples/mloda_basics/1_ml_mloda_intro.py
@@ -135,7 +135,7 @@ def _(
 ):
     # Step 3: Request Data Using the Defined Access Collection and Desired Features
     from mloda.user import mloda
-    from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+    from mloda.user.pyarrow import PyArrowTable
 
     all_features = order_features + payment_features + location_features + categorical_features
     _result = mloda.run_all(
@@ -151,7 +151,7 @@ def _(
 @app.cell
 def _(all_features, data_access_collection, mloda):
     # The data is initially loaded as a Pyarrow table. However, we can easily load it also as a PandasDataFrame.
-    from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+    from mloda.user.pandas import PandasDataFrame
 
     _result = mloda.run_all(
         all_features, data_access_collection=data_access_collection, compute_frameworks={PandasDataFrame}

--- a/docs/docs/examples/mloda_basics/4_ml_data_providers_user_steward.py
+++ b/docs/docs/examples/mloda_basics/4_ml_data_providers_user_steward.py
@@ -60,7 +60,7 @@ def _():
     from mloda.user import mloda
     from mloda.user import Feature, DataAccessCollection, PluginLoader
     from mloda_plugins.feature_group.input_data.read_dbs.sqlite import SQLITEReader
-    from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+    from mloda.user.pyarrow import PyArrowTable
 
     plugin_loader = PluginLoader.all()
 

--- a/docs/docs/examples/sklearn_integration_basic.py
+++ b/docs/docs/examples/sklearn_integration_basic.py
@@ -138,7 +138,7 @@ def _(data_dict, pd):
     from mloda.user import mloda
     from mloda.provider import FeatureGroup, BaseInputData, DataCreator, FeatureSet
     from mloda.user import PluginLoader
-    from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+    from mloda.user.pandas import PandasDataFrame
 
     # In mloda, we have the concept of feature groups.
     # A feature group is an abstraction between a data framework and processes of a data transformation.

--- a/docs/docs/in_depth/access-feature-data.md
+++ b/docs/docs/in_depth/access-feature-data.md
@@ -218,7 +218,7 @@ The following example shows a simple ApiData setup.
 from typing import List
 
 from mloda.user import mloda
-from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda.user.pandas import PandasDataFrame
 
 # Pass api_data directly as a dict - the framework handles registration internally
 result = mloda.run_all(
@@ -256,7 +256,7 @@ One could imagine that for experimenting one wants to see data. Then one could u
 ```python
 from mloda.user import mloda
 from mloda.provider import FeatureGroup, BaseInputData, FeatureSet, DataCreator
-from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda.user.pandas import PandasDataFrame
 
 # Create a Creator FeatureGroup class, which delivers the data needed
 class AFeatureInputCreator(FeatureGroup):
@@ -367,7 +367,7 @@ When input features come from different sources (e.g., ApiData and DataCreator),
 ```python
 from mloda.user import Link, Index, Feature
 from mloda.provider import FeatureGroup, FeatureSet
-from mloda_plugins.feature_group.input_data.api_data.api_data import ApiInputDataFeature
+from mloda.provider import ApiInputDataFeature
 
 class JoinedFeature(FeatureGroup):
 

--- a/docs/docs/in_depth/artifacts.md
+++ b/docs/docs/in_depth/artifacts.md
@@ -59,7 +59,7 @@ Now, we run the query to the feature group to save the artifact. This example is
 
 ```python
 from mloda.user import mloda
-from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+from mloda.user.pyarrow import PyArrowTable
 
 api = mloda(["BaseExampleArtifactFeature"], {PyArrowTable})
 api.run()
@@ -101,7 +101,7 @@ single session alternates between training (save) and inference (load).
 
 ```python
 from mloda.user import mloda
-from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+from mloda.user.pyarrow import PyArrowTable
 
 # 1. Prepare once
 session = mloda.prepare(["BaseExampleArtifactFeature"], {PyArrowTable})

--- a/docs/docs/in_depth/data-quality.md
+++ b/docs/docs/in_depth/data-quality.md
@@ -23,7 +23,7 @@ from typing import Any, Optional, Set
 from mloda.user import mloda
 from mloda.provider import BaseInputData, DataCreator, FeatureGroup, FeatureSet
 from mloda.user import Options, FeatureName, Feature
-from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+from mloda.user.pyarrow import PyArrowTable
 
 
 class DocBaseValidateInputFeaturesBase(FeatureGroup):

--- a/docs/docs/in_depth/feature-group-testing.md
+++ b/docs/docs/in_depth/feature-group-testing.md
@@ -68,7 +68,7 @@ Test that your feature group works correctly with the mloda API.
 **Example:**
 ``` python
 from mloda.user import mloda
-from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda.user.pandas import PandasDataFrame
 
 features = ["source_feature", "source_feature__my_operation"]
 result = mloda.run_all(features, compute_frameworks={PandasDataFrame})

--- a/docs/docs/in_depth/filter_data.md
+++ b/docs/docs/in_depth/filter_data.md
@@ -113,7 +113,7 @@ Further, the feature is a data creator, so we create the data here itself.
 from mloda.user import mloda
 from mloda.provider import FeatureGroup, FeatureSet, ComputeFramework, BaseInputData, DataCreator
 from typing import Any, Union, Set, Type, Optional
-from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+from mloda.user.pyarrow import PyArrowTable
 
 class ExampleOrderFilter(FeatureGroup):
     @classmethod

--- a/mloda/core/abstract_plugins/components/input_data/api/api_input_data_feature.py
+++ b/mloda/core/abstract_plugins/components/input_data/api/api_input_data_feature.py
@@ -1,6 +1,9 @@
 from typing import Any, Optional
-from mloda.provider import FeatureGroup
-from mloda.provider import FeatureSet, ApiInputData, BaseInputData
+
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+from mloda.core.abstract_plugins.components.input_data.api.api_input_data import ApiInputData
+from mloda.core.abstract_plugins.components.input_data.base_input_data import BaseInputData
 
 
 class ApiInputDataFeature(FeatureGroup):
@@ -39,7 +42,7 @@ class ApiInputDataFeature(FeatureGroup):
     ```python
     from mloda.user import Feature
     from mloda.user import Options
-    from mloda.core.abstract_plugins.components.input_data.api.api_input_data import ApiInputData
+    from mloda.provider import ApiInputData
 
     feature = Feature(
         name="user_profile",
@@ -68,8 +71,6 @@ class ApiInputDataFeature(FeatureGroup):
     ### Configuration-Based with Endpoint Mapping
 
     ```python
-    from mloda.core.abstract_plugins.components.input_data.api.api_input_data import ApiInputData
-
     # Map multiple mloda response fields
     feature = Feature(
         name="customer_data",

--- a/mloda/core/abstract_plugins/plugin_loader/plugin_loader.py
+++ b/mloda/core/abstract_plugins/plugin_loader/plugin_loader.py
@@ -53,6 +53,10 @@ ENTRY_POINT_GROUPS: dict[str, type[Any]] = {
     "mloda.extenders": Extender,
 }
 
+# Plugin classes defined in mloda.core, not under the scanned mloda_plugins package. The loader
+# registers them explicitly so they are first-class registry entries like every bundled plugin.
+CORE_PLUGIN_MODULES: tuple[str, ...] = ("mloda.core.abstract_plugins.components.input_data.api.api_input_data_feature",)
+
 
 class PluginLoader:
     _disabled_groups: ClassVar[set[str]] = set()
@@ -260,11 +264,14 @@ class PluginLoader:
         register_module_plugins(module, source="loader")
 
     def load_all_plugins(self) -> None:
-        """Load all groups (top-level folders) and their plugins."""
+        """Load all groups (top-level folders) and their plugins, plus the core-defined plugin classes."""
         base_path = self._get_group_path("")
         for item in base_path.iterdir():
             if item.is_dir() and (item / "__init__.py").exists():
                 self.load_group(item.name)
+
+        for module_name in CORE_PLUGIN_MODULES:
+            register_module_plugins(importlib.import_module(module_name), source="loader")
 
     def _add_plugin_to_graph(self, plugin_name: str) -> None:
         """

--- a/mloda/provider/__init__.py
+++ b/mloda/provider/__init__.py
@@ -17,6 +17,8 @@
 # Primary-source feature groups (no input features) subclass FeatureGroup
 # directly and implement input_features and match_feature_group_criteria.
 #
+# This module is core-only. Concrete compute frameworks come from mloda.user.<backend>.
+#
 from mloda.core.abstract_plugins.feature_group import FeatureGroup as FeatureGroup
 
 # Versioning
@@ -37,7 +39,7 @@ from mloda.core.abstract_plugins.components.input_data.base_input_data import Ba
 from mloda.core.abstract_plugins.components.input_data.file_source import FileSource
 from mloda.core.abstract_plugins.components.input_data.input_data_descriptor import InputDataDescriptor
 from mloda.core.abstract_plugins.components.input_data.api.api_input_data import ApiInputData
-from mloda_plugins.feature_group.input_data.api_data.api_data import ApiInputDataFeature
+from mloda.core.abstract_plugins.components.input_data.api.api_input_data_feature import ApiInputDataFeature
 from mloda.core.abstract_plugins.components.input_data.api.base_api_data import BaseApiData
 from mloda.core.abstract_plugins.components.input_data.api.api_input_data_collection import ApiInputDataCollection
 from mloda.core.abstract_plugins.components.input_data.creator.data_creator import DataCreator
@@ -83,25 +85,6 @@ from mloda.core.abstract_plugins.components.framework_transformer.cfw_transforme
 from mloda.core.abstract_plugins.plugin_registry.plugin_registry import (
     PluginRegistryCollisionError,
     register_plugin,
-)
-
-# Columnar helpers (python_dict): stdlib-only module, so eager import is cycle-free.
-from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils import (
-    columnar_to_rows,
-    homogenize_rows,
-    is_columnar,
-    result_rows,
-    row_count,
-    rows_to_columnar,
-    validate_columnar_dict,
-)
-
-# Eager on purpose: a module-level __getattr__ would make mypy treat every unknown attribute on
-# mloda.provider as Any, silently killing the typo guard for the whole surface.
-# Only PythonDictFramework is exported here: it is the sole dependency-free framework, the other
-# eight need optional backends and cannot be imported eagerly (they stay lazy on mloda.user).
-from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
-    PythonDictFramework,
 )
 
 # Engines
@@ -163,15 +146,6 @@ __all__ = [
     # Plugin registry
     "PluginRegistryCollisionError",
     "register_plugin",
-    # Columnar helpers and framework (python_dict)
-    "columnar_to_rows",
-    "homogenize_rows",
-    "is_columnar",
-    "result_rows",
-    "row_count",
-    "rows_to_columnar",
-    "validate_columnar_dict",
-    "PythonDictFramework",
     # Engines
     "BaseFilterEngine",
     "BaseMaskEngine",

--- a/mloda/user/__init__.py
+++ b/mloda/user/__init__.py
@@ -1,6 +1,3 @@
-import importlib
-from typing import TYPE_CHECKING, Any
-
 # Version
 from mloda.core.version import get_mloda_version
 
@@ -62,79 +59,8 @@ __version__ = get_mloda_version()
 mloda = mlodaAPI
 stream_all = mlodaAPI.stream_all
 
-# Lazy compute-framework exports (issue #649): resolved on demand so that
-# ``import mloda.user`` stays dependency-free and optional backends propagate
-# ModuleNotFoundError only at access time.
-_LAZY_COMPUTE_FRAMEWORKS: dict[str, str] = {
-    "PythonDictFramework": "mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework",
-    "PandasDataFrame": "mloda_plugins.compute_framework.base_implementations.pandas.dataframe",
-    "PolarsDataFrame": "mloda_plugins.compute_framework.base_implementations.polars.dataframe",
-    "PolarsLazyDataFrame": "mloda_plugins.compute_framework.base_implementations.polars.lazy_dataframe",
-    "PyArrowTable": "mloda_plugins.compute_framework.base_implementations.pyarrow.table",
-    "SqliteFramework": "mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_framework",
-    "DuckDBFramework": "mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framework",
-    "SparkFramework": "mloda_plugins.compute_framework.base_implementations.spark.spark_framework",
-    "IcebergFramework": "mloda_plugins.compute_framework.base_implementations.iceberg.iceberg_framework",
-}
-
-# Lazy python_dict helper exports (same PEP 562 contract as the framework classes).
-_LAZY_PYTHON_DICT_UTILS: dict[str, str] = {
-    "columnar_to_rows": "mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils",
-    "homogenize_rows": "mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils",
-    "is_columnar": "mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils",
-    "result_rows": "mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils",
-    "row_count": "mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils",
-    "rows_to_columnar": "mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils",
-    "validate_columnar_dict": "mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils",
-}
-
-if TYPE_CHECKING:
-    # Static re-exports for mypy/tooling; not imported at runtime.
-    from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framework import (
-        DuckDBFramework as DuckDBFramework,
-    )
-    from mloda_plugins.compute_framework.base_implementations.iceberg.iceberg_framework import (
-        IcebergFramework as IcebergFramework,
-    )
-    from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame as PandasDataFrame
-    from mloda_plugins.compute_framework.base_implementations.polars.dataframe import PolarsDataFrame as PolarsDataFrame
-    from mloda_plugins.compute_framework.base_implementations.polars.lazy_dataframe import (
-        PolarsLazyDataFrame as PolarsLazyDataFrame,
-    )
-    from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable as PyArrowTable
-    from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
-        PythonDictFramework as PythonDictFramework,
-    )
-    from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils import (
-        columnar_to_rows as columnar_to_rows,
-        homogenize_rows as homogenize_rows,
-        is_columnar as is_columnar,
-        result_rows as result_rows,
-        row_count as row_count,
-        rows_to_columnar as rows_to_columnar,
-        validate_columnar_dict as validate_columnar_dict,
-    )
-    from mloda_plugins.compute_framework.base_implementations.spark.spark_framework import (
-        SparkFramework as SparkFramework,
-    )
-    from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_framework import (
-        SqliteFramework as SqliteFramework,
-    )
-
-
-def __getattr__(name: str) -> Any:
-    # PEP 562 lazy resolution of optional compute-framework classes and python_dict helpers.
-    module_path = _LAZY_COMPUTE_FRAMEWORKS.get(name) or _LAZY_PYTHON_DICT_UTILS.get(name)
-    if module_path is not None:
-        module = importlib.import_module(module_path)
-        return getattr(module, name)
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-def __dir__() -> list[str]:
-    # Surface the lazy names for REPL/IDE completion.
-    return sorted(set(globals()) | _LAZY_COMPUTE_FRAMEWORKS.keys() | _LAZY_PYTHON_DICT_UTILS.keys())
-
+# Core-only surface. Compute frameworks live in one module per backend: mloda.user.pandas,
+# mloda.user.python_dict, ... Importing this module needs no backend.
 
 __all__ = [
     # Version

--- a/mloda/user/duckdb.py
+++ b/mloda/user/duckdb.py
@@ -1,0 +1,7 @@
+# DuckDB compute framework. Importing this module works without duckdb installed;
+# the framework then reports itself unavailable via is_available().
+from mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framework import (
+    DuckDBFramework as DuckDBFramework,
+)
+
+__all__ = ["DuckDBFramework"]

--- a/mloda/user/iceberg.py
+++ b/mloda/user/iceberg.py
@@ -1,0 +1,7 @@
+# Iceberg compute framework. Importing this module works without pyiceberg installed;
+# the framework then reports itself unavailable via is_available().
+from mloda_plugins.compute_framework.base_implementations.iceberg.iceberg_framework import (
+    IcebergFramework as IcebergFramework,
+)
+
+__all__ = ["IcebergFramework"]

--- a/mloda/user/pandas.py
+++ b/mloda/user/pandas.py
@@ -1,0 +1,4 @@
+# Pandas compute framework. Importing this module requires pandas.
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame as PandasDataFrame
+
+__all__ = ["PandasDataFrame"]

--- a/mloda/user/polars.py
+++ b/mloda/user/polars.py
@@ -1,0 +1,8 @@
+# Polars compute frameworks (eager and lazy). Importing this module works without polars installed;
+# the frameworks then report themselves unavailable via is_available().
+from mloda_plugins.compute_framework.base_implementations.polars.dataframe import PolarsDataFrame as PolarsDataFrame
+from mloda_plugins.compute_framework.base_implementations.polars.lazy_dataframe import (
+    PolarsLazyDataFrame as PolarsLazyDataFrame,
+)
+
+__all__ = ["PolarsDataFrame", "PolarsLazyDataFrame"]

--- a/mloda/user/pyarrow.py
+++ b/mloda/user/pyarrow.py
@@ -1,0 +1,4 @@
+# PyArrow compute framework. Importing this module requires pyarrow.
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable as PyArrowTable
+
+__all__ = ["PyArrowTable"]

--- a/mloda/user/python_dict.py
+++ b/mloda/user/python_dict.py
@@ -1,0 +1,24 @@
+# PythonDict compute framework and its columnar helpers. Needs no optional backend.
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
+    PythonDictFramework as PythonDictFramework,
+)
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils import (
+    columnar_to_rows as columnar_to_rows,
+    homogenize_rows as homogenize_rows,
+    is_columnar as is_columnar,
+    result_rows as result_rows,
+    row_count as row_count,
+    rows_to_columnar as rows_to_columnar,
+    validate_columnar_dict as validate_columnar_dict,
+)
+
+__all__ = [
+    "PythonDictFramework",
+    "columnar_to_rows",
+    "homogenize_rows",
+    "is_columnar",
+    "result_rows",
+    "row_count",
+    "rows_to_columnar",
+    "validate_columnar_dict",
+]

--- a/mloda/user/spark.py
+++ b/mloda/user/spark.py
@@ -1,0 +1,7 @@
+# Spark compute framework. Importing this module works without pyspark installed;
+# the framework then reports itself unavailable via is_available().
+from mloda_plugins.compute_framework.base_implementations.spark.spark_framework import (
+    SparkFramework as SparkFramework,
+)
+
+__all__ = ["SparkFramework"]

--- a/mloda/user/sqlite.py
+++ b/mloda/user/sqlite.py
@@ -1,0 +1,6 @@
+# SQLite compute framework. Backed by the stdlib sqlite3 module.
+from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_framework import (
+    SqliteFramework as SqliteFramework,
+)
+
+__all__ = ["SqliteFramework"]

--- a/mloda_plugins/feature_group/experimental/aggregated_feature_group/pandas.py
+++ b/mloda_plugins/feature_group/experimental/aggregated_feature_group/pandas.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from mloda.provider import ComputeFramework
 
-from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda.user.pandas import PandasDataFrame
 from mloda_plugins.feature_group.experimental.aggregated_feature_group.base import AggregatedFeatureGroup
 
 

--- a/mloda_plugins/feature_group/experimental/aggregated_feature_group/polars_lazy.py
+++ b/mloda_plugins/feature_group/experimental/aggregated_feature_group/polars_lazy.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from mloda.provider import ComputeFramework
 
-from mloda_plugins.compute_framework.base_implementations.polars.lazy_dataframe import PolarsLazyDataFrame
+from mloda.user.polars import PolarsLazyDataFrame
 from mloda_plugins.feature_group.experimental.aggregated_feature_group.base import AggregatedFeatureGroup
 
 try:

--- a/mloda_plugins/feature_group/experimental/aggregated_feature_group/pyarrow.py
+++ b/mloda_plugins/feature_group/experimental/aggregated_feature_group/pyarrow.py
@@ -11,7 +11,7 @@ import pyarrow.compute as pc
 
 from mloda.provider import ComputeFramework
 
-from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+from mloda.user.pyarrow import PyArrowTable
 from mloda_plugins.feature_group.experimental.aggregated_feature_group.base import AggregatedFeatureGroup
 
 

--- a/mloda_plugins/feature_group/experimental/clustering/pandas.py
+++ b/mloda_plugins/feature_group/experimental/clustering/pandas.py
@@ -28,7 +28,7 @@ except ImportError:
 
 
 from mloda.provider import ComputeFramework
-from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda.user.pandas import PandasDataFrame
 from mloda_plugins.feature_group.experimental.clustering.base import ClusteringFeatureGroup
 
 

--- a/mloda_plugins/feature_group/experimental/data_quality/missing_value/pandas.py
+++ b/mloda_plugins/feature_group/experimental/data_quality/missing_value/pandas.py
@@ -9,7 +9,7 @@ from typing import Any, Optional
 
 from mloda.provider import ComputeFramework
 
-from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda.user.pandas import PandasDataFrame
 from mloda_plugins.feature_group.experimental.data_quality.missing_value.base import MissingValueFeatureGroup
 
 try:

--- a/mloda_plugins/feature_group/experimental/data_quality/missing_value/pyarrow.py
+++ b/mloda_plugins/feature_group/experimental/data_quality/missing_value/pyarrow.py
@@ -11,7 +11,7 @@ import pyarrow.compute as pc
 
 from mloda.provider import ComputeFramework
 
-from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+from mloda.user.pyarrow import PyArrowTable
 from mloda_plugins.feature_group.experimental.data_quality.missing_value.base import MissingValueFeatureGroup
 
 

--- a/mloda_plugins/feature_group/experimental/data_quality/missing_value/python_dict.py
+++ b/mloda_plugins/feature_group/experimental/data_quality/missing_value/python_dict.py
@@ -10,8 +10,7 @@ from typing import Any, Optional
 
 from mloda.provider import ComputeFramework
 
-from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
-from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils import row_count
+from mloda.user.python_dict import PythonDictFramework, row_count
 from mloda_plugins.feature_group.experimental.data_quality.missing_value.base import MissingValueFeatureGroup
 
 

--- a/mloda_plugins/feature_group/experimental/dimensionality_reduction/pandas.py
+++ b/mloda_plugins/feature_group/experimental/dimensionality_reduction/pandas.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import Any, TYPE_CHECKING, cast
 
 from mloda.provider import ComputeFramework, DefaultOptionKeys
-from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda.user.pandas import PandasDataFrame
 from mloda_plugins.feature_group.experimental.dimensionality_reduction.base import DimensionalityReductionFeatureGroup
 
 if TYPE_CHECKING:

--- a/mloda_plugins/feature_group/experimental/environment/installed_packages_feature_group.py
+++ b/mloda_plugins/feature_group/experimental/environment/installed_packages_feature_group.py
@@ -6,7 +6,7 @@ from mloda.provider import FeatureGroup
 
 from mloda.provider import FeatureSet
 from mloda.provider import ComputeFramework
-from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda.user.pandas import PandasDataFrame
 
 
 class InstalledPackagesFeatureGroup(FeatureGroup):

--- a/mloda_plugins/feature_group/experimental/environment/list_directory_feature_group.py
+++ b/mloda_plugins/feature_group/experimental/environment/list_directory_feature_group.py
@@ -5,7 +5,7 @@ import logging
 from mloda.provider import FeatureGroup
 from mloda.provider import FeatureSet
 from mloda.provider import ComputeFramework
-from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda.user.pandas import PandasDataFrame
 
 logger = logging.getLogger(__name__)
 

--- a/mloda_plugins/feature_group/experimental/forecasting/pandas.py
+++ b/mloda_plugins/feature_group/experimental/forecasting/pandas.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta
 
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.pandas import pandas_type_semantics
-from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda.user.pandas import PandasDataFrame
 from mloda_plugins.feature_group.experimental.forecasting.base import ForecastingFeatureGroup
 
 # Check if required packages are available

--- a/mloda_plugins/feature_group/experimental/geo_distance/pandas.py
+++ b/mloda_plugins/feature_group/experimental/geo_distance/pandas.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from mloda.provider import ComputeFramework
 
-from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda.user.pandas import PandasDataFrame
 from mloda_plugins.feature_group.experimental.geo_distance.base import GeoDistanceFeatureGroup
 
 

--- a/mloda_plugins/feature_group/experimental/node_centrality/pandas.py
+++ b/mloda_plugins/feature_group/experimental/node_centrality/pandas.py
@@ -15,7 +15,7 @@ except ImportError:
     np = None  # type: ignore
 
 from mloda.provider import CHAIN_SEPARATOR, ComputeFramework
-from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda.user.pandas import PandasDataFrame
 from mloda_plugins.feature_group.experimental.node_centrality.base import NodeCentralityFeatureGroup
 
 

--- a/mloda_plugins/feature_group/experimental/sklearn/encoding/pandas.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/encoding/pandas.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from mloda.provider import ComputeFramework
 
-from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda.user.pandas import PandasDataFrame
 from mloda_plugins.feature_group.experimental.sklearn.encoding.base import EncodingFeatureGroup
 
 

--- a/mloda_plugins/feature_group/experimental/sklearn/pipeline/pandas.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/pipeline/pandas.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from mloda.provider import ComputeFramework
 
-from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda.user.pandas import PandasDataFrame
 from mloda_plugins.feature_group.experimental.sklearn.pipeline.base import SklearnPipelineFeatureGroup
 
 

--- a/mloda_plugins/feature_group/experimental/sklearn/scaling/pandas.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/scaling/pandas.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from mloda.provider import ComputeFramework
 
-from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda.user.pandas import PandasDataFrame
 from mloda_plugins.feature_group.experimental.sklearn.scaling.base import ScalingFeatureGroup
 
 

--- a/mloda_plugins/feature_group/experimental/text_cleaning/pandas.py
+++ b/mloda_plugins/feature_group/experimental/text_cleaning/pandas.py
@@ -26,7 +26,7 @@ except ImportError:
 
 
 from mloda.provider import ComputeFramework
-from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda.user.pandas import PandasDataFrame
 from mloda_plugins.feature_group.experimental.text_cleaning.base import TextCleaningFeatureGroup
 
 

--- a/mloda_plugins/feature_group/experimental/text_cleaning/python_dict.py
+++ b/mloda_plugins/feature_group/experimental/text_cleaning/python_dict.py
@@ -11,8 +11,7 @@ from typing import Any
 
 from mloda.provider import ComputeFramework
 
-from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
-from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils import row_count
+from mloda.user.python_dict import PythonDictFramework, row_count
 from mloda_plugins.feature_group.experimental.text_cleaning.base import TextCleaningFeatureGroup
 
 # Optional NLTK support - gracefully handle if not available

--- a/mloda_plugins/feature_group/experimental/time_window/pandas.py
+++ b/mloda_plugins/feature_group/experimental/time_window/pandas.py
@@ -8,7 +8,7 @@ from typing import Any, Optional
 
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.pandas import pandas_type_semantics
-from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda.user.pandas import PandasDataFrame
 from mloda_plugins.feature_group.experimental.time_window.base import TimeWindowFeatureGroup
 
 

--- a/mloda_plugins/feature_group/experimental/time_window/pyarrow.py
+++ b/mloda_plugins/feature_group/experimental/time_window/pyarrow.py
@@ -13,7 +13,7 @@ import pyarrow.compute as pc
 from mloda.provider import ComputeFramework
 
 from mloda_plugins.compute_framework.base_implementations.pyarrow import pyarrow_type_semantics
-from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+from mloda.user.pyarrow import PyArrowTable
 from mloda_plugins.feature_group.experimental.time_window.base import TimeWindowFeatureGroup
 
 

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_api_input_data_feature_registration.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_api_input_data_feature_registration.py
@@ -1,0 +1,131 @@
+"""ApiInputDataFeature must stay discoverable through the plugin registry (issue #726).
+
+ApiInputDataFeature moved from mloda_plugins to mloda.core. PluginLoader scans the
+mloda_plugins base package only, and register_module_plugins registers a class under the
+module that DEFINES it, so nothing in the loader funnel registers a core-defined plugin
+class any more. Consequences pinned here: strict mode drops the class (an api_data run then
+fails to resolve its features), warn mode names a first-party class as unregistered, and the
+registered-only enumeration/docs lose it.
+
+Parallel-safety: assertions are membership-based, the api_data key and columns are unique to
+this module, and the autouse conftest fixture restores the default registry (and the warn-mode
+dedup set) around every test, so clearing the registry here is safe.
+"""
+
+import logging
+from typing import Any
+
+import pytest
+
+from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistry, PluginRegistryEntry
+from mloda.core.api.plugin_docs import get_feature_group_docs, list_registered
+from mloda.core.prepare.accessible_plugins import PreFilterPlugins
+from mloda.provider import ApiInputDataFeature
+from mloda.user import PluginLoader, mloda
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
+
+ENV_VAR = "MLODA_PLUGIN_REGISTRY_STRICT"
+
+API_KEY = "ApiInputRegistryProbeSource"
+ID_COLUMN = "api_input_registry_probe_id"
+VALUE_COLUMN = "api_input_registry_probe_value"
+API_DATA: dict[str, dict[str, Any]] = {API_KEY: {ID_COLUMN: [1, 2, 3], VALUE_COLUMN: ["a", "b", "c"]}}
+
+IDENTIFIER = f"{ApiInputDataFeature.__module__}:{ApiInputDataFeature.__qualname__}"
+
+
+def _loaded_registry() -> PluginRegistry:
+    """Default registry holding exactly what one full PluginLoader run discovers."""
+    registry = PluginRegistry.default()
+    registry.clear()
+    PluginLoader.all()
+    return registry
+
+
+def _api_input_data_feature_entries(registry: PluginRegistry) -> list[PluginRegistryEntry]:
+    return [entry for entry in registry.snapshot().values() if entry.cls is ApiInputDataFeature]
+
+
+def _column_values(frame: Any) -> list[Any]:
+    """Extract the probe column, tolerant of a columnar dict or a list of row dicts."""
+    if isinstance(frame, dict):
+        return list(frame[VALUE_COLUMN])
+    return [row[VALUE_COLUMN] for row in frame]
+
+
+class TestApiInputDataFeatureIsLoaderRegistered:
+    def test_plugin_loader_registers_api_input_data_feature(self) -> None:
+        registry = _loaded_registry()
+        assert registry.is_registered(ApiInputDataFeature), (
+            "PluginLoader.all() must register ApiInputDataFeature in the default PluginRegistry. "
+            f"It is defined in '{ApiInputDataFeature.__module__}', which the loader never scans, so the "
+            "class silently left the registry when it moved out of mloda_plugins."
+        )
+
+    def test_registry_entry_carries_loader_provenance(self) -> None:
+        registry = _loaded_registry()
+        entries = _api_input_data_feature_entries(registry)
+        assert len(entries) == 1, f"ApiInputDataFeature must hold exactly one registry entry, got {len(entries)}"
+
+        entry = entries[0]
+        assert entry.name == IDENTIFIER, "the entry must use the default '<module>:<qualname>' key"
+        assert entry.plugin_type is FeatureGroup
+        assert entry.source_module == ApiInputDataFeature.__module__
+        assert entry.source == "loader", (
+            "ApiInputDataFeature ships with mloda, so its provenance must be the loader, like every "
+            f"bundled plugin; got source '{entry.source}'"
+        )
+
+
+class TestApiInputDataFeatureEnumeration:
+    def test_list_registered_includes_api_input_data_feature(self) -> None:
+        _loaded_registry()
+        assert ApiInputDataFeature in list_registered(FeatureGroup), (
+            "list_registered(FeatureGroup) must list ApiInputDataFeature after PluginLoader.all()"
+        )
+
+    def test_registered_only_docs_include_api_input_data_feature(self) -> None:
+        _loaded_registry()
+        names = [fg.name for fg in get_feature_group_docs(registered_only=True)]
+        assert "ApiInputDataFeature" in names, (
+            "get_feature_group_docs(registered_only=True) must document ApiInputDataFeature; an unregistered "
+            "first-party feature group disappears from every registered-only listing"
+        )
+
+
+class TestApiInputDataFeatureUnderStrictMode:
+    def test_strict_mode_api_data_run_resolves_the_feature(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """End to end: strict mode must not filter ApiInputDataFeature out of an api_data run."""
+        monkeypatch.setenv(ENV_VAR, "strict")
+        _loaded_registry()
+
+        result = mloda.run_all(
+            [VALUE_COLUMN],
+            compute_frameworks={PythonDictFramework},
+            api_data=API_DATA,
+        )
+
+        assert len(result) == 1, f"Expected exactly one result frame, got: {result}"
+        assert _column_values(result[0]) == ["a", "b", "c"]
+
+
+class TestApiInputDataFeatureUnderWarnMode:
+    def test_warn_mode_does_not_flag_api_input_data_feature(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A bundled, first-party feature group must never show up in the unregistered warning."""
+        _loaded_registry()
+
+        collector = PluginCollector().set_strict_mode("warn")
+        with caplog.at_level(logging.WARNING):
+            PreFilterPlugins({PythonDictFramework}, collector)
+
+        message = " ".join(
+            record.getMessage()
+            for record in caplog.records
+            if record.name == "mloda.core.prepare.accessible_plugins" and "not registered" in record.getMessage()
+        )
+        assert IDENTIFIER not in message, (
+            "warn mode must not report ApiInputDataFeature as unregistered: the warning is permanent and "
+            "unfixable for users, since the class ships with mloda"
+        )

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_compute_framework_exports.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_compute_framework_exports.py
@@ -1,216 +1,367 @@
-"""Export contract for the mloda.user and mloda.provider facades (issues #649, #707, #716).
+"""Facade export contract for mloda.user, mloda.provider and mloda.steward (issue #726: facades must
+not import plugins).
 
-mloda.user resolves the 9 concrete ComputeFramework classes and the python_dict helpers via
-PEP 562 lazy ``__getattr__``: they stay OUT of ``__all__`` so ``from mloda.user import *``
-remains dependency-free in minimal installs, but ``__dir__`` surfaces them.
+The facades are plugin-free: none of them imports anything from mloda_plugins and none defines a
+module-level ``__getattr__``. Importing one pulls in no mloda_plugins module and no optional
+backend library.
 
-mloda.provider exports the python_dict symbols (PythonDictFramework plus the columnar
-helpers) EAGERLY and lists them in ``__all__``. The plugin modules import their base classes
-from the defining modules instead of the facades, so there is no import cycle to work around
-and mloda.provider must not define a module-level ``__getattr__``.
+The concrete ComputeFramework classes are published from one module per backend under
+``mloda.user`` (``mloda.user.pandas``, ``mloda.user.python_dict``, ...). Each backend module
+re-exports the identical objects from their canonical mloda_plugins source modules and lists
+them in its own ``__all__``, every shipped framework is covered by exactly one such module, and
+the plugin modules never import back from them. The eager provider exports of #707/#713/#716/#719/#721
+and the lazy ``mloda.user`` exports of #649 are gone: the symbols are no longer attributes of any facade.
 
-Every symbol resolves to the identical object defined in its canonical mloda_plugins source
-module, deep-path imports keep working, and unknown attributes still raise AttributeError.
+ApiInputDataFeature is core, not a plugin: it lives in mloda.core.abstract_plugins.components and
+stays exported from mloda.provider. The old plugin module is deleted without a back-compat shim.
 """
 
+import ast
 import importlib
+import inspect
 import subprocess  # nosec B404
 import sys
+from pathlib import Path
 from types import ModuleType
+from typing import Any
 
 import pytest
 
 import mloda.provider
 import mloda.user
+from mloda.core.abstract_plugins.components.utils import get_all_subclasses
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.user import PluginLoader
 
-# Source modules are resolved lazily so a missing optional backend fails only its own matrix row.
-# (symbol exported by mloda.user, canonical source module holding the class)
-EXPORT_MATRIX: list[tuple[str, str]] = [
-    ("PythonDictFramework", "mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework"),
-    ("PandasDataFrame", "mloda_plugins.compute_framework.base_implementations.pandas.dataframe"),
-    ("PolarsDataFrame", "mloda_plugins.compute_framework.base_implementations.polars.dataframe"),
-    ("PolarsLazyDataFrame", "mloda_plugins.compute_framework.base_implementations.polars.lazy_dataframe"),
-    ("PyArrowTable", "mloda_plugins.compute_framework.base_implementations.pyarrow.table"),
-    ("SqliteFramework", "mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_framework"),
-    ("DuckDBFramework", "mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framework"),
-    ("SparkFramework", "mloda_plugins.compute_framework.base_implementations.spark.spark_framework"),
-    ("IcebergFramework", "mloda_plugins.compute_framework.base_implementations.iceberg.iceberg_framework"),
-]
+_PYTHON_DICT_PACKAGE = "mloda_plugins.compute_framework.base_implementations.python_dict"
+_PYTHON_DICT_FRAMEWORK_MODULE = f"{_PYTHON_DICT_PACKAGE}.python_dict_framework"
+_PYTHON_DICT_UTILS_MODULE = f"{_PYTHON_DICT_PACKAGE}.python_dict_utils"
+_PANDAS_DATAFRAME_MODULE = "mloda_plugins.compute_framework.base_implementations.pandas.dataframe"
 
-_MATRIX_IDS = [symbol for symbol, _source in EXPORT_MATRIX]
+_FACADES: list[str] = ["mloda.provider", "mloda.steward", "mloda.user"]
 
-
-def _source_module(source_module: str) -> ModuleType:
-    return importlib.import_module(source_module)
-
-
-class TestComputeFrameworkExportMatrix:
-    @pytest.mark.parametrize(("symbol", "source_module"), EXPORT_MATRIX, ids=_MATRIX_IDS)
-    def test_symbol_excluded_from_all_but_discoverable_via_dir(self, symbol: str, source_module: str) -> None:
-        # Kept out of __all__ so wildcard import stays dependency-free, but surfaced by __dir__.
-        assert symbol not in mloda.user.__all__, (
-            f"mloda.user.__all__ must NOT list '{symbol}' (keeps wildcard import dependency-free)"
-        )
-        assert symbol in dir(mloda.user), f"mloda.user.__dir__ must surface '{symbol}' for discoverability"
-
-    @pytest.mark.parametrize(("symbol", "source_module"), EXPORT_MATRIX, ids=_MATRIX_IDS)
-    def test_symbol_is_identical_to_source_object(self, symbol: str, source_module: str) -> None:
-        source = _source_module(source_module)
-        assert hasattr(source, symbol), f"{source.__name__} must define '{symbol}'"
-        assert hasattr(mloda.user, symbol), f"mloda.user must expose '{symbol}'"
-        assert getattr(mloda.user, symbol) is getattr(source, symbol), (
-            f"mloda.user.{symbol} must be the identical object from {source.__name__}"
-        )
-
-    @pytest.mark.parametrize(("symbol", "source_module"), EXPORT_MATRIX, ids=_MATRIX_IDS)
-    def test_deep_path_import_yields_same_object(self, symbol: str, source_module: str) -> None:
-        # Independently import via the real deep path (mloda_plugins...<module>) and
-        # assert identity with the lazily-resolved mloda.user attribute (no breaking change).
-        deep_path_module = importlib.import_module(source_module)
-        deep_path_object = getattr(deep_path_module, symbol)
-        assert deep_path_object is getattr(mloda.user, symbol), (
-            f"deep-path {source_module}.{symbol} must be the identical object as mloda.user.{symbol}"
-        )
-
-
-class TestUnknownAttributeStillRaises:
-    def test_unknown_attribute_raises_attribute_error(self) -> None:
-        with pytest.raises(AttributeError):
-            mloda.user.DefinitelyNotAnExportedSymbol
-
-
-# python_dict helper functions follow the same lazy-export contract as the framework
-# classes: importable from mloda.user, identical to the canonical source object,
-# out of __all__, surfaced by __dir__.
-_PYTHON_DICT_UTILS_MODULE = "mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_utils"
-
-HELPER_EXPORT_MATRIX: list[tuple[str, str]] = [
-    ("columnar_to_rows", _PYTHON_DICT_UTILS_MODULE),
-    ("homogenize_rows", _PYTHON_DICT_UTILS_MODULE),
-    ("is_columnar", _PYTHON_DICT_UTILS_MODULE),
-    ("result_rows", _PYTHON_DICT_UTILS_MODULE),
-    ("rows_to_columnar", _PYTHON_DICT_UTILS_MODULE),
-    # Issue #716: the columnar surface is only complete with the shape check and the row count.
-    ("row_count", _PYTHON_DICT_UTILS_MODULE),
-    ("validate_columnar_dict", _PYTHON_DICT_UTILS_MODULE),
-]
-
-_HELPER_MATRIX_IDS = [symbol for symbol, _source in HELPER_EXPORT_MATRIX]
-
-
-class TestPythonDictHelperExportMatrix:
-    @pytest.mark.parametrize(("symbol", "source_module"), HELPER_EXPORT_MATRIX, ids=_HELPER_MATRIX_IDS)
-    def test_helper_excluded_from_all_but_discoverable_via_dir(self, symbol: str, source_module: str) -> None:
-        assert symbol not in mloda.user.__all__, (
-            f"mloda.user.__all__ must NOT list '{symbol}' (keeps wildcard import dependency-free)"
-        )
-        assert symbol in dir(mloda.user), f"mloda.user.__dir__ must surface '{symbol}' for discoverability"
-
-    @pytest.mark.parametrize(("symbol", "source_module"), HELPER_EXPORT_MATRIX, ids=_HELPER_MATRIX_IDS)
-    def test_helper_is_identical_to_source_object(self, symbol: str, source_module: str) -> None:
-        source = _source_module(source_module)
-        assert hasattr(source, symbol), f"{source.__name__} must define '{symbol}'"
-        assert hasattr(mloda.user, symbol), f"mloda.user must expose '{symbol}'"
-        assert getattr(mloda.user, symbol) is getattr(source, symbol), (
-            f"mloda.user.{symbol} must be the identical object from {source.__name__}"
-        )
-
-
-# Provider side (issue #707): pivoting a columnar frame back to rows is a provider-side
-# concern, so the same helpers are ALSO exported from mloda.provider. Unlike the lazy
-# mloda.user exports, python_dict_utils is stdlib-only and mloda.provider already imports
-# eagerly from mloda_plugins, so these are eager exports listed in __all__.
-class TestPythonDictHelperProviderExportMatrix:
-    @pytest.mark.parametrize(("symbol", "source_module"), HELPER_EXPORT_MATRIX, ids=_HELPER_MATRIX_IDS)
-    def test_helper_importable_from_provider(self, symbol: str, source_module: str) -> None:
-        assert hasattr(mloda.provider, symbol), f"mloda.provider must expose '{symbol}'"
-
-    @pytest.mark.parametrize(("symbol", "source_module"), HELPER_EXPORT_MATRIX, ids=_HELPER_MATRIX_IDS)
-    def test_helper_listed_in_provider_all(self, symbol: str, source_module: str) -> None:
-        assert symbol in mloda.provider.__all__, f"mloda.provider.__all__ must list '{symbol}' (eager export)"
-
-    @pytest.mark.parametrize(("symbol", "source_module"), HELPER_EXPORT_MATRIX, ids=_HELPER_MATRIX_IDS)
-    def test_provider_helper_is_identical_to_source_object(self, symbol: str, source_module: str) -> None:
-        source = _source_module(source_module)
-        assert hasattr(source, symbol), f"{source.__name__} must define '{symbol}'"
-        assert getattr(mloda.provider, symbol) is getattr(source, symbol), (
-            f"mloda.provider.{symbol} must be the identical object from {source.__name__}"
-        )
-
-    @pytest.mark.parametrize(("symbol", "source_module"), HELPER_EXPORT_MATRIX, ids=_HELPER_MATRIX_IDS)
-    def test_provider_and_user_surfaces_agree(self, symbol: str, source_module: str) -> None:
-        assert getattr(mloda.provider, symbol) is getattr(mloda.user, symbol), (
-            f"mloda.provider.{symbol} and mloda.user.{symbol} must be the identical object"
-        )
-
-
-# PythonDictFramework on the provider surface (issue #716): plugin authors reach the framework
-# class from the short namespace instead of the deep mloda_plugins path. The python_dict plugin
-# modules import their base classes from the DEFINING modules (not from the mloda.provider /
-# mloda.user facades), so there is no cycle and the export is eager, exactly like the helpers.
-_PYTHON_DICT_FRAMEWORK_MODULE = "mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework"
 _UNKNOWN_SYMBOL = "DefinitelyNotAnExportedSymbol"
 
-
-class TestPythonDictFrameworkProviderExport:
-    def test_framework_is_identical_to_source_object(self) -> None:
-        source = _source_module(_PYTHON_DICT_FRAMEWORK_MODULE)
-        assert hasattr(mloda.provider, "PythonDictFramework"), "mloda.provider must expose 'PythonDictFramework'"
-        assert getattr(mloda.provider, "PythonDictFramework") is source.PythonDictFramework, (
-            f"mloda.provider.PythonDictFramework must be the identical object from {_PYTHON_DICT_FRAMEWORK_MODULE}"
-        )
-
-    def test_framework_listed_in_provider_all(self) -> None:
-        assert "PythonDictFramework" in mloda.provider.__all__, (
-            "mloda.provider.__all__ must list 'PythonDictFramework' (eager export, stdlib-only plugin module)"
-        )
-
-    def test_provider_and_user_framework_surfaces_agree(self) -> None:
-        assert getattr(mloda.provider, "PythonDictFramework") is getattr(mloda.user, "PythonDictFramework"), (
-            "mloda.provider.PythonDictFramework and mloda.user.PythonDictFramework must be the identical object"
-        )
-
-    def test_unknown_attribute_raises_attribute_error(self) -> None:
-        with pytest.raises(AttributeError):
-            getattr(mloda.provider, _UNKNOWN_SYMBOL)
-
-
-class TestProviderHasNoModuleLevelGetattr:
-    def test_provider_does_not_define_module_getattr(self) -> None:
-        """A module-level __getattr__ on mloda.provider would type-check every typo as Any."""
-        assert "__getattr__" not in vars(mloda.provider), (
-            "mloda.provider must NOT define a module-level __getattr__: mypy honors it as a catch-all, so "
-            "every unknown attribute on the module type-checks as Any and the typo guard silently disappears "
-            "for the whole provider surface ('from mloda.provider import FeatureGropu' would pass mypy --strict "
-            "and only fail at runtime). Export eagerly instead; the import cycle is fixed at its source, where "
-            "the python_dict plugin modules import their base classes from the defining modules, not the facades."
-        )
-
-
-# (id, statements executed in order in a fresh interpreter)
-_IMPORT_ORDERS: list[tuple[str, str]] = [
+# (backend module under mloda.user, exported symbol, canonical mloda_plugins source module,
+#  library the plugin module imports EAGERLY; None means the row runs unconditionally)
+#
+# Only pandas and pyarrow import their backend at module level. The polars, duckdb, spark and
+# iceberg plugin modules guard their backend import in a try/except, so importing their
+# mloda.user module (and asserting the export identity) works without the library installed.
+# Skip-gating those rows would make them vacuous in the default tox env, which ships no pyspark.
+BACKEND_EXPORT_MATRIX: list[tuple[str, str, str, str | None]] = [
+    ("mloda.user.python_dict", "PythonDictFramework", _PYTHON_DICT_FRAMEWORK_MODULE, None),
+    ("mloda.user.python_dict", "columnar_to_rows", _PYTHON_DICT_UTILS_MODULE, None),
+    ("mloda.user.python_dict", "homogenize_rows", _PYTHON_DICT_UTILS_MODULE, None),
+    ("mloda.user.python_dict", "is_columnar", _PYTHON_DICT_UTILS_MODULE, None),
+    ("mloda.user.python_dict", "result_rows", _PYTHON_DICT_UTILS_MODULE, None),
+    ("mloda.user.python_dict", "row_count", _PYTHON_DICT_UTILS_MODULE, None),
+    ("mloda.user.python_dict", "rows_to_columnar", _PYTHON_DICT_UTILS_MODULE, None),
+    ("mloda.user.python_dict", "validate_columnar_dict", _PYTHON_DICT_UTILS_MODULE, None),
+    ("mloda.user.pandas", "PandasDataFrame", _PANDAS_DATAFRAME_MODULE, "pandas"),
     (
-        "plugin_module_first",
-        f"import {_PYTHON_DICT_FRAMEWORK_MODULE} as deep\nimport mloda.provider\n",
+        "mloda.user.polars",
+        "PolarsDataFrame",
+        "mloda_plugins.compute_framework.base_implementations.polars.dataframe",
+        None,
     ),
     (
-        "provider_first",
-        f"import mloda.provider\nimport {_PYTHON_DICT_FRAMEWORK_MODULE} as deep\n",
+        "mloda.user.polars",
+        "PolarsLazyDataFrame",
+        "mloda_plugins.compute_framework.base_implementations.polars.lazy_dataframe",
+        None,
+    ),
+    (
+        "mloda.user.pyarrow",
+        "PyArrowTable",
+        "mloda_plugins.compute_framework.base_implementations.pyarrow.table",
+        "pyarrow",
+    ),
+    (
+        "mloda.user.duckdb",
+        "DuckDBFramework",
+        "mloda_plugins.compute_framework.base_implementations.duckdb.duckdb_framework",
+        None,
+    ),
+    (
+        "mloda.user.sqlite",
+        "SqliteFramework",
+        "mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_framework",
+        None,
+    ),
+    (
+        "mloda.user.spark",
+        "SparkFramework",
+        "mloda_plugins.compute_framework.base_implementations.spark.spark_framework",
+        None,
+    ),
+    (
+        "mloda.user.iceberg",
+        "IcebergFramework",
+        "mloda_plugins.compute_framework.base_implementations.iceberg.iceberg_framework",
+        None,
     ),
 ]
 
-_IMPORT_ORDER_IDS = [order_id for order_id, _source in _IMPORT_ORDERS]
+_BACKEND_MATRIX_IDS = [f"{backend}:{symbol}" for backend, symbol, _source, _dependency in BACKEND_EXPORT_MATRIX]
+
+# Every symbol that used to live on the facades themselves (#649 lazy user exports, #707/#716
+# eager provider exports). None of them may be a facade attribute any more.
+_FORMER_FACADE_SYMBOLS: list[str] = sorted({symbol for _backend, symbol, _source, _dependency in BACKEND_EXPORT_MATRIX})
 
 
-class TestProviderImportOrderCycleGuard:
-    @pytest.mark.parametrize(("order_id", "imports"), _IMPORT_ORDERS, ids=_IMPORT_ORDER_IDS)
-    def test_both_import_orders_resolve_the_same_class(self, order_id: str, imports: str) -> None:
-        """Neither import order may raise ImportError on a mloda.provider <-> python_dict cycle."""
-        script = (
-            f"{imports}"
-            "assert mloda.provider.PythonDictFramework is deep.PythonDictFramework, 'not the same class object'\n"
-            "print('ok')\n"
+def _import_backend(backend_module: str, dependency: str | None) -> ModuleType:
+    """Import a mloda.user backend module, skipping only rows whose plugin imports its library eagerly."""
+    if dependency is not None:
+        pytest.importorskip(dependency)
+    return importlib.import_module(backend_module)
+
+
+def _facade_source(facade: str) -> Path:
+    """Resolve the facade's __init__.py through the imported module, not a hardcoded repo path."""
+    module = importlib.import_module(facade)
+    source = module.__file__
+    assert source is not None, f"{facade} must be a file-backed module"
+    return Path(source)
+
+
+def _is_plugin_module(module_name: str) -> bool:
+    return module_name == "mloda_plugins" or module_name.startswith("mloda_plugins.")
+
+
+def _is_user_backend_module(module_name: str) -> bool:
+    """True for a mloda.user.<backend> module; the bare mloda.user facade is not a backend module."""
+    return module_name.startswith("mloda.user.")
+
+
+def _imported_modules(source: Path) -> list[str]:
+    """Every module imported anywhere in the source, TYPE_CHECKING blocks included."""
+    tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+
+    imported: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module is not None:
+                imported.append(node.module)
+    return imported
+
+
+def _plugin_imports(source: Path) -> list[str]:
+    return [name for name in _imported_modules(source) if _is_plugin_module(name)]
+
+
+def _user_backend_imports(source: Path) -> list[str]:
+    return [name for name in _imported_modules(source) if _is_user_backend_module(name)]
+
+
+class TestFacadesArePluginFree:
+    @pytest.mark.parametrize("facade", _FACADES)
+    def test_facade_source_has_no_mloda_plugins_import(self, facade: str) -> None:
+        """AST check: a facade that imports a plugin drags the plugin tree into every core install."""
+        offenders = _plugin_imports(_facade_source(facade))
+        assert offenders == [], (
+            f"{facade}/__init__.py must not import from mloda_plugins, but imports {sorted(set(offenders))}. "
+            f"The facades are the public core surface; plugin classes are published from the per-backend "
+            f"modules under mloda.user instead."
         )
+
+    @pytest.mark.parametrize("facade", _FACADES)
+    def test_facade_does_not_define_module_getattr(self, facade: str) -> None:
+        """A module-level __getattr__ makes mypy type-check every typo on the facade as Any."""
+        module = importlib.import_module(facade)
+        assert "__getattr__" not in vars(module), (
+            f"{facade} must NOT define a module-level __getattr__: mypy honors it as a catch-all, so every "
+            f"unknown attribute type-checks as Any and the typo guard disappears for the whole surface. "
+            f"Optional backends are reached through their own module (import mloda.user.pandas), which "
+            f"raises ModuleNotFoundError on its own."
+        )
+
+    @pytest.mark.parametrize("facade", _FACADES)
+    def test_unknown_attribute_raises_attribute_error(self, facade: str) -> None:
+        module = importlib.import_module(facade)
+        with pytest.raises(AttributeError):
+            getattr(module, _UNKNOWN_SYMBOL)
+
+
+class TestBackendExportMatrix:
+    @pytest.mark.parametrize(
+        ("backend_module", "symbol", "source_module", "dependency"), BACKEND_EXPORT_MATRIX, ids=_BACKEND_MATRIX_IDS
+    )
+    def test_symbol_is_identical_to_source_object(
+        self, backend_module: str, symbol: str, source_module: str, dependency: str | None
+    ) -> None:
+        backend = _import_backend(backend_module, dependency)
+        source = importlib.import_module(source_module)
+        assert hasattr(source, symbol), f"{source_module} must define '{symbol}'"
+        assert hasattr(backend, symbol), f"{backend_module} must export '{symbol}'"
+        assert getattr(backend, symbol) is getattr(source, symbol), (
+            f"{backend_module}.{symbol} must be the identical object from {source_module}"
+        )
+
+    @pytest.mark.parametrize(
+        ("backend_module", "symbol", "source_module", "dependency"), BACKEND_EXPORT_MATRIX, ids=_BACKEND_MATRIX_IDS
+    )
+    def test_symbol_listed_in_backend_all(
+        self, backend_module: str, symbol: str, source_module: str, dependency: str | None
+    ) -> None:
+        backend = _import_backend(backend_module, dependency)
+        assert hasattr(backend, "__all__"), f"{backend_module} must define __all__"
+        assert symbol in backend.__all__, f"{backend_module}.__all__ must list '{symbol}'"
+
+
+class TestFrameworkSymbolsAreNotOnTheFacades:
+    @pytest.mark.parametrize("facade", _FACADES)
+    @pytest.mark.parametrize("symbol", _FORMER_FACADE_SYMBOLS)
+    def test_symbol_is_not_a_facade_attribute(self, facade: str, symbol: str) -> None:
+        """The framework classes and python_dict helpers moved to the per-backend modules."""
+        module = importlib.import_module(facade)
+        assert not hasattr(module, symbol), (
+            f"{facade} must NOT expose '{symbol}' any more: it is published from its mloda.user backend module "
+            f"(the facades stay free of plugin imports)."
+        )
+
+    @pytest.mark.parametrize("facade", _FACADES)
+    @pytest.mark.parametrize("symbol", _FORMER_FACADE_SYMBOLS)
+    def test_symbol_is_not_listed_in_facade_all(self, facade: str, symbol: str) -> None:
+        module = importlib.import_module(facade)
+        assert symbol not in module.__all__, f"{facade}.__all__ must NOT list '{symbol}'"
+
+
+_API_INPUT_DATA_FEATURE_MODULE = "mloda.core.abstract_plugins.components.input_data.api.api_input_data_feature"
+_OLD_API_DATA_MODULE = "mloda_plugins.feature_group.input_data.api_data.api_data"
+
+
+class TestApiInputDataFeatureIsCore:
+    def test_provider_export_is_defined_in_core(self) -> None:
+        """ApiInputDataFeature is what makes mloda.provider import a plugin today; it belongs to core."""
+        assert hasattr(mloda.provider, "ApiInputDataFeature"), "mloda.provider must keep exporting ApiInputDataFeature"
+        assert mloda.provider.ApiInputDataFeature.__module__.startswith("mloda.core"), (
+            f"mloda.provider.ApiInputDataFeature must be defined under mloda.core, but its __module__ is "
+            f"'{mloda.provider.ApiInputDataFeature.__module__}'"
+        )
+
+    def test_provider_export_is_identical_to_core_object(self) -> None:
+        source = importlib.import_module(_API_INPUT_DATA_FEATURE_MODULE)
+        assert mloda.provider.ApiInputDataFeature is source.ApiInputDataFeature, (
+            f"mloda.provider.ApiInputDataFeature must be the identical object from {_API_INPUT_DATA_FEATURE_MODULE}"
+        )
+
+    def test_export_stays_listed_in_provider_all(self) -> None:
+        assert "ApiInputDataFeature" in mloda.provider.__all__, (
+            "mloda.provider.__all__ must keep listing 'ApiInputDataFeature' (moved, not removed)"
+        )
+
+    def test_old_plugin_module_is_gone(self) -> None:
+        """The plugin module is deleted outright: no back-compat shim re-exporting the core class."""
+        with pytest.raises(ModuleNotFoundError):
+            importlib.import_module(_OLD_API_DATA_MODULE)
+
+
+# Fresh-interpreter guard: importing a facade must pull in neither plugins nor optional backends.
+# pyarrow is exempt: core's mloda/core/abstract_plugins/components/data_types.py imports it at module
+# level when installed, so tests/test_core/test_optional_pyarrow/ (pyarrow blocked in a subprocess) is
+# what proves the import stays optional.
+_FORBIDDEN_LIBRARIES: list[str] = ["pandas", "polars", "duckdb"]
+
+_NO_PLUGIN_SCRIPT = """
+import sys
+
+import {facade}
+
+leaked = sorted(m for m in sys.modules if m == "mloda_plugins" or m.startswith("mloda_plugins."))
+assert not leaked, f"import {facade} pulled in mloda_plugins modules: {{leaked}}"
+
+print("ok")
+"""
+
+_NO_LIBRARY_SCRIPT = """
+import sys
+
+import {facade}
+
+assert "{library}" not in sys.modules, "import {facade} pulled in the optional backend library {library}"
+
+print("ok")
+"""
+
+_LIBRARY_PARAMS: list[tuple[str, str]] = [(facade, library) for facade in _FACADES for library in _FORBIDDEN_LIBRARIES]
+
+_LIBRARY_IDS = [f"{facade}:{library}" for facade, library in _LIBRARY_PARAMS]
+
+
+def _run_isolation_script(script: str) -> subprocess.CompletedProcess[str]:
+    # Safe: fixed argv (sys.executable + a script built from module-level constants), no shell, no user input.
+    return subprocess.run(  # nosec B603
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+class TestFacadeImportIsDependencyFree:
+    @pytest.mark.timeout(30)
+    @pytest.mark.parametrize("facade", _FACADES)
+    def test_facade_import_pulls_in_no_plugin(self, facade: str) -> None:
+        """The point of #726: a core-only install must never load mloda_plugins through a facade."""
+        result = _run_isolation_script(_NO_PLUGIN_SCRIPT.format(facade=facade))
+
+        assert result.returncode == 0, (
+            f"import {facade} must not import any mloda_plugins module in a fresh interpreter.\n"
+            f"stderr:\n{result.stderr}"
+        )
+        assert result.stdout.strip() == "ok"
+
+    @pytest.mark.timeout(30)
+    @pytest.mark.parametrize(("facade", "library"), _LIBRARY_PARAMS, ids=_LIBRARY_IDS)
+    def test_facade_import_pulls_in_no_backend_library(self, facade: str, library: str) -> None:
+        """Importing a facade must not cost an optional backend import, whether or not it is installed."""
+        result = _run_isolation_script(_NO_LIBRARY_SCRIPT.format(facade=facade, library=library))
+
+        assert result.returncode == 0, (
+            f"import {facade} must not import '{library}' in a fresh interpreter: the facades are the core "
+            f"surface, optional backends load only through their mloda.user backend module.\n"
+            f"stderr:\n{result.stderr}"
+        )
+        assert result.stdout.strip() == "ok"
+
+
+# (backend module under mloda.user, canonical plugin module, symbol, optional library)
+_CYCLE_CASES: list[tuple[str, str, str, str | None]] = [
+    ("mloda.user.python_dict", _PYTHON_DICT_FRAMEWORK_MODULE, "PythonDictFramework", None),
+    ("mloda.user.pandas", _PANDAS_DATAFRAME_MODULE, "PandasDataFrame", "pandas"),
+]
+
+_IMPORT_ORDERS: list[str] = ["plugin_module_first", "backend_module_first"]
+
+_CYCLE_PARAMS: list[tuple[str, str, str, str | None, str]] = [
+    (backend, deep, symbol, dependency, order)
+    for backend, deep, symbol, dependency in _CYCLE_CASES
+    for order in _IMPORT_ORDERS
+]
+
+_CYCLE_IDS = [f"{backend}:{order}" for backend, _deep, _symbol, _dependency, order in _CYCLE_PARAMS]
+
+
+class TestImportOrderCycleGuard:
+    @pytest.mark.timeout(30)
+    @pytest.mark.parametrize(
+        ("backend_module", "deep_module", "symbol", "dependency", "order"), _CYCLE_PARAMS, ids=_CYCLE_IDS
+    )
+    def test_both_import_orders_resolve_the_same_class(
+        self, backend_module: str, deep_module: str, symbol: str, dependency: str | None, order: str
+    ) -> None:
+        """Neither import order may raise ImportError on a mloda.user.<backend> <-> plugin-module cycle."""
+        if dependency is not None:
+            pytest.importorskip(dependency)
+
+        deep_import = f"import {deep_module} as deep\n"
+        backend_import = f"import {backend_module} as backend\n"
+        imports = deep_import + backend_import if order == "plugin_module_first" else backend_import + deep_import
+        script = f"{imports}assert backend.{symbol} is deep.{symbol}, 'not the same class object'\nprint('ok')\n"
+
         # Safe: fixed argv (sys.executable + a script built from module-level constants), no shell, no user input.
         result = subprocess.run(  # nosec B603
             [sys.executable, "-c", script],
@@ -220,9 +371,97 @@ class TestProviderImportOrderCycleGuard:
         )
 
         assert result.returncode == 0, (
-            f"Import order '{order_id}' failed in a fresh interpreter. mloda.provider imports "
-            f"PythonDictFramework eagerly, so the python_dict plugin modules must import their base classes "
-            f"from the defining modules; a facade import there re-enters a partially initialized "
-            f"mloda.provider and raises ImportError.\nstderr:\n{result.stderr}"
+            f"Import order '{order}' failed in a fresh interpreter for {backend_module}. The plugin modules must "
+            f"import their base classes from the defining modules, not from the facades; otherwise the backend "
+            f"module re-enters a partially initialized plugin module and raises ImportError.\n"
+            f"stderr:\n{result.stderr}"
         )
         assert result.stdout.strip() == "ok"
+
+
+_COMPUTE_FRAMEWORK_PACKAGE = "mloda_plugins.compute_framework"
+
+
+def _package_directory(package: str) -> Path:
+    """Resolve a package directory through the imported package, not a hardcoded repo path."""
+    module = importlib.import_module(package)
+    source = module.__file__
+    assert source is not None, f"{package} must be a file-backed package"
+    return Path(source).parent
+
+
+_COMPUTE_FRAMEWORK_DIRECTORY = _package_directory(_COMPUTE_FRAMEWORK_PACKAGE)
+
+_COMPUTE_FRAMEWORK_SOURCES: list[Path] = sorted(_COMPUTE_FRAMEWORK_DIRECTORY.rglob("*.py"))
+
+_COMPUTE_FRAMEWORK_SOURCE_IDS = [
+    str(source.relative_to(_COMPUTE_FRAMEWORK_DIRECTORY)) for source in _COMPUTE_FRAMEWORK_SOURCES
+]
+
+
+class TestComputeFrameworkPluginsDoNotImportBackendModules:
+    @pytest.mark.parametrize("source", _COMPUTE_FRAMEWORK_SOURCES, ids=_COMPUTE_FRAMEWORK_SOURCE_IDS)
+    def test_plugin_module_does_not_import_a_user_backend_module(self, source: Path) -> None:
+        """Rot guard: the mloda.user backend modules import the plugins, never the other way round."""
+        offenders = _user_backend_imports(source)
+        assert offenders == [], (
+            f"{source} must not import from {sorted(set(offenders))}: a compute-framework internal importing "
+            f"its own facade module (polars/lazy_dataframe.py importing mloda.user.polars, say) re-enters a "
+            f"partially initialized module, because that module is what imports the plugin in the first place. "
+            f"Import the class from its canonical mloda_plugins module instead."
+        )
+
+
+def _shipped_concrete_frameworks() -> list[type[Any]]:
+    """Concrete ComputeFramework subclasses defined under mloda_plugins/compute_framework."""
+    return sorted(
+        (
+            cls
+            for cls in get_all_subclasses(ComputeFramework)
+            if cls.__module__.startswith(f"{_COMPUTE_FRAMEWORK_PACKAGE}.") and not inspect.isabstract(cls)
+        ),
+        key=lambda cls: f"{cls.__module__}:{cls.__qualname__}",
+    )
+
+
+def _backend_module_exports() -> dict[str, list[str]]:
+    """Map symbol -> mloda.user backend modules listing it in __all__, read via AST so nothing is imported."""
+    exports: dict[str, list[str]] = {}
+    for source in sorted(_package_directory("mloda.user").glob("*.py")):
+        if source.name == "__init__.py":
+            continue
+        tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Assign) or not isinstance(node.value, (ast.List, ast.Tuple)):
+                continue
+            if not any(isinstance(target, ast.Name) and target.id == "__all__" for target in node.targets):
+                continue
+            for element in node.value.elts:
+                if isinstance(element, ast.Constant) and isinstance(element.value, str):
+                    exports.setdefault(element.value, []).append(f"mloda.user.{source.stem}")
+    return exports
+
+
+class TestBackendModulesCoverEveryShippedFramework:
+    def test_every_concrete_framework_is_published_from_exactly_one_backend_module(self) -> None:
+        """Completeness: a new framework without a mloda.user backend module is unreachable for users."""
+        # Loading the group skips plugins whose eager backend import is missing, so absent classes
+        # never demand a backend module import here. The conftest fixture restores the registry.
+        PluginLoader().load_group("compute_framework")
+
+        frameworks = _shipped_concrete_frameworks()
+        assert frameworks, "sanity: loading the compute_framework group must expose concrete frameworks"
+
+        exports = _backend_module_exports()
+        for framework in frameworks:
+            backend_modules = exports.get(framework.__name__, [])
+            assert len(backend_modules) == 1, (
+                f"{framework.__module__}:{framework.__qualname__} must be re-exported from exactly one "
+                f"mloda.user backend module, but is listed in the __all__ of {backend_modules}. Every shipped "
+                f"framework needs its own mloda.user.<backend> module; that module is the only public import path."
+            )
+            backend = importlib.import_module(backend_modules[0])
+            assert getattr(backend, framework.__name__) is framework, (
+                f"{backend_modules[0]}.{framework.__name__} must be the identical class object from "
+                f"{framework.__module__}"
+            )

--- a/tests/test_core/test_optional_pyarrow/test_import_without_pyarrow.py
+++ b/tests/test_core/test_optional_pyarrow/test_import_without_pyarrow.py
@@ -52,21 +52,19 @@ assert "pyarrow" not in sys.modules, "import mloda.user must not eagerly import 
 
 from mloda.user import mloda, Feature, PluginCollector
 
-# Dependency-free lazy access: PythonDictFramework must resolve from mloda.user
-# even with pyarrow blocked, because PythonDict needs no optional backend.
-from mloda.user import PythonDictFramework
+# Dependency-free backend module: mloda.user.python_dict must import with pyarrow
+# blocked, because PythonDict needs no optional backend.
+from mloda.user.python_dict import PythonDictFramework
 
-# Accessing a pyarrow-backed framework via mloda.user must fail cleanly and only
-# at access time, raising ModuleNotFoundError (pyarrow blocked), not eagerly on
-# ``import mloda.user`` above. Resolve the package via importlib under a distinct
-# name: the local ``mloda`` above is the mlodaAPI alias, not the package module.
-_user_mod = importlib.import_module("mloda.user")
-_pyarrow_access_blocked = False
+# A pyarrow-backed backend module must fail cleanly and only when it is imported,
+# raising ModuleNotFoundError (pyarrow blocked), not eagerly on ``import mloda.user``
+# above.
+_pyarrow_import_blocked = False
 try:
-    _user_mod.PyArrowTable
+    importlib.import_module("mloda.user.pyarrow")
 except ModuleNotFoundError:
-    _pyarrow_access_blocked = True
-assert _pyarrow_access_blocked, "mloda.user.PyArrowTable must raise ModuleNotFoundError while pyarrow is blocked"
+    _pyarrow_import_blocked = True
+assert _pyarrow_import_blocked, "import mloda.user.pyarrow must raise ModuleNotFoundError while pyarrow is blocked"
 
 from mloda.provider import FeatureGroup, FeatureSet, DataCreator, BaseInputData
 


### PR DESCRIPTION
Closes #726.

## What

`mloda/provider/__init__.py` and `mloda/user/__init__.py` both imported from `mloda_plugins`, while those plugins import the facades back. Every public re-export of a plugin symbol was a latent circular import, and it forced a lazy module-level `__getattr__` on `mloda.user`, which makes mypy treat every unknown attribute on the module as `Any` (so `from mloda.user import PandasDataFram` type-checked fine and only blew up at runtime).

- Both facades now import **only** `mloda.core`, so no import order can re-enter a half-built facade. Neither defines a module-level `__getattr__`, and the typo guard is back on both surfaces.
- Concrete compute frameworks are published from **one module per backend**: `mloda.user.pandas`, `mloda.user.polars`, `mloda.user.pyarrow`, `mloda.user.duckdb`, `mloda.user.sqlite`, `mloda.user.spark`, `mloda.user.iceberg`, `mloda.user.python_dict`. The python_dict module also carries the columnar helpers. `import mloda.user` stays free of any backend; the backend arrives with `import mloda.user.<backend>`, and the import says so.
- `ApiInputDataFeature` moves into `mloda/core/`, which is what lets the provider facade drop its last plugin import. It stays exported from `mloda.provider`.
- The 20 bundled feature groups that name a framework class now import it from `mloda.user.<backend>`. Compute-framework internals keep their deep imports on purpose: routing `polars/lazy_dataframe.py` through `mloda.user.polars` would make the module re-enter itself.

## Breaking change

The framework classes and the columnar helpers are no longer attributes of `mloda.user` or `mloda.provider`:

```python
from mloda.user.pandas import PandasDataFrame                      # was: from mloda.user import PandasDataFrame
from mloda.user.python_dict import PythonDictFramework, result_rows
```

The `mloda.user` lazy exports shipped in 0.10.0, hence `minor:`. The provider-side python_dict exports (#707, #713, #719, #716) never shipped, so reverting them breaks nobody, but downstream adopters should move straight to `mloda.user.python_dict`.

## Review found a regression, which is fixed here

The plugin loader scans the `mloda_plugins` package only, and `register_module_plugins` registers a class only when its `__module__` matches the scanned module. Moving `ApiInputDataFeature` into core therefore silently dropped it from the plugin registry: under `MLODA_PLUGIN_REGISTRY_STRICT=strict` an `api_data` run failed with "No feature groups found", warn mode logged a permanent false positive naming a first-party class, and `list_registered` / `get_feature_group_docs(registered_only=True)` lost it. The loader now registers the core-defined plugin classes explicitly (`CORE_PLUGIN_MODULES`), so the entry keeps its loader provenance. Six tests pin this.

Also corrected in review: four `mloda/user/<backend>.py` comments (and a docs sentence) claimed that importing a backend module without its library raises `ModuleNotFoundError`. That is only true for pandas and pyarrow; polars, duckdb, spark and iceberg guard their backend import and report `is_available()` instead. The two pyspark-gated test skips were vacuous for the same reason and are gone, so `EXPECTED_SKIP_COUNT` stays at 171.

## Tests

- Facade rules: AST check that neither facade imports `mloda_plugins`, no module-level `__getattr__` (now also covering `mloda.steward`), and a fresh-interpreter check that importing a facade pulls in no plugin module and no backend library.
- Per-backend export matrix (identity against the canonical `mloda_plugins` object), both-import-orders cycle guard, and two rot guards: no compute-framework internal may import a `mloda.user.<backend>` module, and every shipped concrete framework must be exported from exactly one backend module.
- Registry/strict-mode coverage for `ApiInputDataFeature`.

`tox` green: 5885 passed, 171 skipped; ruff, mypy --strict and bandit clean.

## Follow-up, not in scope

`mloda/core/abstract_plugins/components/data_types.py` optimistically imports `pyarrow` at module level, so `import mloda.user` still pulls pyarrow into `sys.modules` when it happens to be installed. It remains fully optional (the pyarrow-blocked subprocess test proves the import works without it), but the facades cannot promise a backend-free `sys.modules` until that import is lazified.