### PR TITLE
fix: let property_spec express an optional key with a None default (#733)

### DIFF
--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -162,6 +162,10 @@ when provided. Its declared-default check is not a separate implementation: it c
 the same `FeatureChainParser.check_declared_default` the class-definition hook uses,
 so the two cannot drift.
 
+Omitting `default` emits no `default` key and leaves the option **required**, while an
+explicit `default=None` emits the key and makes the option **optional** with a `None`
+default.
+
 ## Strict validation needs a value space
 
 `strict_validation: True` needs something to validate against: a non-empty

--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -164,7 +164,9 @@ so the two cannot drift.
 
 Omitting `default` emits no `default` key and leaves the option **required**, while an
 explicit `default=None` emits the key and makes the option **optional** with a `None`
-default.
+default. The exported `NO_DEFAULT` sentinel spells out that omission for a wrapper that
+forwards an optional default through to `property_spec`: passing `NO_DEFAULT` means "no
+default given".
 
 ## Strict validation needs a value space
 

--- a/mloda/core/abstract_plugins/components/feature_chainer/property_spec.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/property_spec.py
@@ -13,12 +13,22 @@ from mloda.core.abstract_plugins.components.default_options_key import DefaultOp
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 
 
+class _NoDefault:
+    """Sentinel type: ``None`` is a legitimate default, so an omitted default needs its own object."""
+
+    def __repr__(self) -> str:
+        return "NO_DEFAULT"
+
+
+NO_DEFAULT = _NoDefault()
+
+
 def property_spec(
     explanation: str,
     *,
     strict: bool = False,
     allowed_values: Mapping[Any, str] | Iterable[Any] | None = None,
-    default: Any = None,
+    default: Any = NO_DEFAULT,
     context: bool = True,
     element_validator: Callable[..., Any] | None = None,
     required_when: Callable[..., Any] | None = None,
@@ -70,7 +80,7 @@ def property_spec(
         spec[DefaultOptionKeys.match_guard] = match_guard
     spec[DefaultOptionKeys.context] = context
     spec[DefaultOptionKeys.strict_validation] = strict
-    if default is not None:
+    if default is not NO_DEFAULT:
         spec[DefaultOptionKeys.default] = default
 
     # The declared-default semantics live in core, so the builder and the

--- a/mloda/core/abstract_plugins/components/feature_chainer/property_spec.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/property_spec.py
@@ -19,6 +19,10 @@ class _NoDefault:
     def __repr__(self) -> str:
         return "NO_DEFAULT"
 
+    def __reduce__(self) -> str:
+        # Pickle and deepcopy resolve back to the module-level singleton instead of cloning it.
+        return "NO_DEFAULT"
+
 
 NO_DEFAULT = _NoDefault()
 
@@ -34,6 +38,7 @@ def property_spec(
     required_when: Callable[..., Any] | None = None,
     match_guard: Callable[..., Any] | None = None,
 ) -> dict[str, Any]:
+    """Build a spec dict: omitting ``default`` keeps the key required, ``default=None`` makes it optional with ``None``."""
     # A str/bytes is iterable, so tuple("add") would silently build ('a', 'd', 'd'): reject the
     # shape before materializing it. Holds whether or not the spec is strict.
     if isinstance(allowed_values, (str, bytes)):
@@ -80,7 +85,9 @@ def property_spec(
         spec[DefaultOptionKeys.match_guard] = match_guard
     spec[DefaultOptionKeys.context] = context
     spec[DefaultOptionKeys.strict_validation] = strict
-    if default is not NO_DEFAULT:
+    # Type test, not identity: a second imported copy of this module (editable install plus
+    # site-packages, importlib.reload) has its own sentinel object.
+    if not isinstance(default, _NoDefault):
         spec[DefaultOptionKeys.default] = default
 
     # The declared-default semantics live in core, so the builder and the

--- a/mloda/provider/__init__.py
+++ b/mloda/provider/__init__.py
@@ -70,7 +70,7 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
     INPUT_SEPARATOR,
 )
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
-from mloda.core.abstract_plugins.components.feature_chainer.property_spec import property_spec
+from mloda.core.abstract_plugins.components.feature_chainer.property_spec import NO_DEFAULT, property_spec
 
 # Subtype declaration
 from mloda.core.abstract_plugins.components.subtype_declaration import SubtypeDeclaration
@@ -155,6 +155,7 @@ __all__ = [
     "INPUT_SEPARATOR",
     "FeatureChainParserMixin",
     "property_spec",
+    "NO_DEFAULT",
     # Subtype declaration
     "SubtypeDeclaration",
     # Transformers

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_spec_builder.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_spec_builder.py
@@ -15,7 +15,9 @@ PROPERTY_MAPPING key. See ``test_property_mapping_spec_shape.py``.
 
 from __future__ import annotations
 
+import copy
 import gc
+import pickle
 from typing import Any
 
 import pytest
@@ -27,6 +29,7 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import (
     FeatureChainParserMixin,
 )
+from mloda.core.abstract_plugins.components.feature_chainer.property_spec import NO_DEFAULT, _NoDefault
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.components.utils import get_all_subclasses
@@ -241,15 +244,13 @@ class TestPropertySpecNoneDefault:
         assert FeatureChainParser._can_skip_required_check(spec) is False
 
     def test_no_default_sentinel_importable_from_provider(self) -> None:
-        """``from mloda.provider import NO_DEFAULT`` works."""
+        """The provider re-exports THE sentinel, not merely some object of the same name."""
         from mloda.provider import NO_DEFAULT as imported
 
-        assert imported is not None
+        assert imported is NO_DEFAULT
 
     def test_explicit_sentinel_behaves_like_omission(self) -> None:
         """Passing ``NO_DEFAULT`` explicitly is exactly the same as omitting the argument."""
-        from mloda.provider import NO_DEFAULT
-
         spec = property_spec("d", default=NO_DEFAULT)
 
         assert spec == property_spec("d")
@@ -284,7 +285,10 @@ class TestPropertySpecNoneDefault:
         """End to end: a builder-authored ``default=None`` key is not demanded by the matcher."""
 
         class OptionalWeightFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-            PREFIX_PATTERN = r".*__([\w]+)_centrality$"
+            # A pattern unique to this module: a test FeatureGroup joins the global
+            # get_all_subclasses discovery pool, so reusing the shipped
+            # NodeCentralityFeatureGroup shape would make it a competing match.
+            PREFIX_PATTERN = r".*__([\w]+)_optweight$"
             PROPERTY_MAPPING = {
                 "centrality_type": property_spec(
                     "Centrality metric",
@@ -322,6 +326,53 @@ class TestPropertySpecNoneDefault:
             )
             is False
         )
+
+
+class TestNoDefaultSentinelIdentity:
+    """A round-tripped ``NO_DEFAULT`` must still mean "no default" (issue #733).
+
+    A deepcopy, a pickle round trip, or a second import of the module (editable install plus
+    site-packages, ``importlib.reload``) all yield a ``_NoDefault`` instance that is a DIFFERENT
+    object than the module-level ``NO_DEFAULT``. If the builder recognizes the sentinel by
+    identity, such a copy slips through the "argument omitted" test and lands IN the spec as a
+    bogus ``default`` VALUE, which silently flips a REQUIRED key to optional: exactly the bug
+    class #733 exists to kill.
+    """
+
+    def test_deepcopy_returns_the_same_sentinel(self) -> None:
+        """``copy.deepcopy`` must not clone the sentinel."""
+        assert copy.deepcopy(NO_DEFAULT) is NO_DEFAULT
+
+    def test_pickle_round_trip_returns_the_same_sentinel(self) -> None:
+        """A pickle round trip must resolve back to the one sentinel object."""
+        assert pickle.loads(pickle.dumps(NO_DEFAULT)) is NO_DEFAULT
+
+    def test_deepcopied_sentinel_behaves_like_omission(self) -> None:
+        """A deepcopied sentinel emits no ``default`` key and leaves the property REQUIRED."""
+        spec = property_spec("d", default=copy.deepcopy(NO_DEFAULT))
+
+        assert DefaultOptionKeys.default not in spec
+        assert FeatureChainParser._can_skip_required_check(spec) is False
+        assert spec == property_spec("d")
+
+    def test_pickled_sentinel_behaves_like_omission(self) -> None:
+        """A pickle round-tripped sentinel emits no ``default`` key and stays REQUIRED."""
+        spec = property_spec("d", default=pickle.loads(pickle.dumps(NO_DEFAULT)))
+
+        assert DefaultOptionKeys.default not in spec
+        assert FeatureChainParser._can_skip_required_check(spec) is False
+        assert spec == property_spec("d")
+
+    def test_second_sentinel_instance_behaves_like_omission(self) -> None:
+        """A separately constructed ``_NoDefault`` (a second imported copy) means "no default" too."""
+        spec = property_spec("d", default=_NoDefault())
+
+        assert DefaultOptionKeys.default not in spec
+        assert FeatureChainParser._can_skip_required_check(spec) is False
+
+    def test_sentinel_repr_is_readable(self) -> None:
+        """The sentinel keeps its readable repr for error messages and docs."""
+        assert repr(NO_DEFAULT) == "NO_DEFAULT"
 
 
 def _positive_int(value: Any) -> bool:

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_spec_builder.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_spec_builder.py
@@ -150,13 +150,14 @@ class TestPropertySpecRoundTrip:
 
 
 class TestPropertySpecDefaultOmission:
-    """A builder call with no default must NOT emit a spurious ``default`` key.
+    """OMITTING the ``default`` argument must NOT emit a spurious ``default`` key.
 
     The parser's ``_can_skip_required_check`` treats the mere PRESENCE of the
-    ``default`` key as "this option is optional". Emitting ``default=None``
-    therefore silently makes an otherwise-required strict property optional.
-    The fix is for ``property_spec`` to emit the ``default`` key only when the
-    caller passes a non-``None`` default.
+    ``default`` key as "this option is optional", so a spurious key would silently
+    make an otherwise-required property optional. The rule is keyed on the
+    ARGUMENT, not on its value: omitting ``default`` means the key is REQUIRED,
+    while an explicit ``default=None`` means optional with a ``None`` default
+    (see ``TestPropertySpecNoneDefault``, issue #733).
     """
 
     def test_builder_without_default_omits_default_key(self) -> None:
@@ -207,6 +208,120 @@ class TestPropertySpecDefaultOmission:
         spec = property_spec("op", strict=True, allowed_values={"add": "Addition"}, default="add")
 
         assert spec[DefaultOptionKeys.default] == "add"
+
+
+class TestPropertySpecNoneDefault:
+    """``default=None`` must be expressible: optional key whose default is ``None`` (issue #733).
+
+    ``None`` is a legitimate default (the shipped hand-written specs use it for
+    ``weight_column``, ``constant_value``, ``pipeline_steps``, ...), but the builder
+    used ``None`` as its own "argument omitted" marker and dropped the key. That made
+    an optional key REQUIRED on migration. A ``NO_DEFAULT`` sentinel separates the two:
+    the key is emitted whenever the caller passes ANY default, ``None`` included.
+    """
+
+    def test_default_none_emits_default_key(self) -> None:
+        """``default=None`` emits the ``default`` key carrying ``None``."""
+        spec = property_spec("d", default=None)
+
+        assert DefaultOptionKeys.default in spec
+        assert spec[DefaultOptionKeys.default] is None
+
+    def test_default_none_is_optional(self) -> None:
+        """A ``default=None`` spec is optional: the parser skips the required check."""
+        spec = property_spec("d", default=None)
+
+        assert FeatureChainParser._can_skip_required_check(spec) is True
+
+    def test_omitted_default_stays_required(self) -> None:
+        """No ``default`` argument -> no key, and the property stays REQUIRED (issue #562)."""
+        spec = property_spec("d")
+
+        assert DefaultOptionKeys.default not in spec
+        assert FeatureChainParser._can_skip_required_check(spec) is False
+
+    def test_no_default_sentinel_importable_from_provider(self) -> None:
+        """``from mloda.provider import NO_DEFAULT`` works."""
+        from mloda.provider import NO_DEFAULT as imported
+
+        assert imported is not None
+
+    def test_explicit_sentinel_behaves_like_omission(self) -> None:
+        """Passing ``NO_DEFAULT`` explicitly is exactly the same as omitting the argument."""
+        from mloda.provider import NO_DEFAULT
+
+        spec = property_spec("d", default=NO_DEFAULT)
+
+        assert spec == property_spec("d")
+        assert DefaultOptionKeys.default not in spec
+        assert FeatureChainParser._can_skip_required_check(spec) is False
+
+    def test_none_default_spec_equals_hand_written_dict(self) -> None:
+        """A ``default=None`` spec is exactly the dict a plugin author hand-writes today."""
+        built = property_spec("Column name for edge weights (optional)", default=None)
+
+        hand_written: dict[str, Any] = {
+            "explanation": "Column name for edge weights (optional)",
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: False,
+            DefaultOptionKeys.default: None,
+        }
+        assert built == hand_written
+
+    def test_strict_spec_with_none_default_builds_and_is_optional(self) -> None:
+        """A STRICT spec with ``default=None`` builds and is optional (sklearn PIPELINE_NAME shape).
+
+        Core's ``check_declared_default`` exempts a ``None`` default from the membership
+        check, so the strict value space and the ``None`` default coexist.
+        """
+        spec = property_spec("d", strict=True, allowed_values={"scaling": "Feature scaling"}, default=None)
+
+        assert spec[DefaultOptionKeys.default] is None
+        assert spec[DefaultOptionKeys.strict_validation] is True
+        assert FeatureChainParser._can_skip_required_check(spec) is True
+
+    def test_absent_optional_option_still_matches_through_core(self) -> None:
+        """End to end: a builder-authored ``default=None`` key is not demanded by the matcher."""
+
+        class OptionalWeightFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+            PREFIX_PATTERN = r".*__([\w]+)_centrality$"
+            PROPERTY_MAPPING = {
+                "centrality_type": property_spec(
+                    "Centrality metric",
+                    strict=True,
+                    allowed_values={"degree": "Degree", "pagerank": "PageRank"},
+                ),
+                "weight_column": property_spec("Column name for edge weights (optional)", default=None),
+            }
+
+            @classmethod
+            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                return data
+
+        property_mapping = OptionalWeightFeatureGroup.PROPERTY_MAPPING
+
+        # The optional key is ABSENT: the required key alone satisfies the match.
+        assert (
+            FeatureChainParser.match_configuration_feature_chain_parser(
+                "any_feature", Options(context={"centrality_type": "degree"}), property_mapping
+            )
+            is True
+        )
+        # Present is fine too, and the required key is still required.
+        assert (
+            FeatureChainParser.match_configuration_feature_chain_parser(
+                "any_feature",
+                Options(context={"centrality_type": "degree", "weight_column": "weight"}),
+                property_mapping,
+            )
+            is True
+        )
+        assert (
+            FeatureChainParser.match_configuration_feature_chain_parser(
+                "any_feature", Options(context={"weight_column": "weight"}), property_mapping
+            )
+            is False
+        )
 
 
 def _positive_int(value: Any) -> bool:

--- a/tests/test_plugins/feature_group/experimental/test_property_spec_shipped_specs.py
+++ b/tests/test_plugins/feature_group/experimental/test_property_spec_shipped_specs.py
@@ -73,6 +73,10 @@ _ALL_BUILT: list[tuple[str, dict[str, Any]]] = [(case_id, built) for case_id, bu
     ("sklearn_pipeline.pipeline_name", _PIPELINE_NAME_BUILT)
 ]
 
+_ALL_SHIPPED: list[tuple[str, dict[str, Any]]] = [(case_id, shipped) for case_id, _, shipped in _EXACT_CASES] + [
+    ("sklearn_pipeline.pipeline_name", _PIPELINE_NAME_SHIPPED)
+]
+
 
 class TestShippedOptionalSpecsAreBuildable:
     """Every shipped optional-with-``None``-default spec is expressible with ``property_spec``."""
@@ -102,3 +106,16 @@ class TestShippedOptionalSpecsAreBuildable:
     def test_built_spec_is_optional(self, built: dict[str, Any]) -> None:
         """Each built spec stays OPTIONAL: migration must not make the option required."""
         assert FeatureChainParser._can_skip_required_check(built) is True
+
+    @pytest.mark.parametrize(
+        "shipped",
+        [pytest.param(shipped, id=case_id) for case_id, shipped in _ALL_SHIPPED],
+    )
+    def test_shipped_spec_is_optional(self, shipped: dict[str, Any]) -> None:
+        """Each SHIPPED spec is OPTIONAL: the invariant #723 broke, pinned on what plugins declare.
+
+        ``test_built_spec_is_optional`` only checks specs this test builds. Once these plugins
+        migrate to the builder, ``built == shipped`` degrades into comparing builder output with
+        builder output, so the shipped side needs its own pin.
+        """
+        assert FeatureChainParser._can_skip_required_check(shipped) is True

--- a/tests/test_plugins/feature_group/experimental/test_property_spec_shipped_specs.py
+++ b/tests/test_plugins/feature_group/experimental/test_property_spec_shipped_specs.py
@@ -1,0 +1,104 @@
+"""The builder must reproduce every shipped optional-with-``None``-default spec (issue #733).
+
+Six specs ship hand-written today with ``default: None``, which makes them OPTIONAL
+(``_can_skip_required_check`` keys off the PRESENCE of the ``default`` key). Until the
+``NO_DEFAULT`` sentinel exists, ``property_spec(..., default=None)`` drops that key and
+silently turns them REQUIRED, so migrating one to the builder is a behavior change. These
+pins are what would have caught the ``weight_column`` regression (issue #723).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.provider import property_spec
+from mloda_plugins.feature_group.experimental.data_quality.missing_value.base import MissingValueFeatureGroup
+from mloda_plugins.feature_group.experimental.node_centrality.base import NodeCentralityFeatureGroup
+from mloda_plugins.feature_group.experimental.sklearn.pipeline.base import SklearnPipelineFeatureGroup
+
+
+def _shipped(feature_group: type[FeatureGroup], key: str) -> dict[str, Any]:
+    """Return the hand-written spec a shipped plugin declares for ``key``."""
+    mapping = feature_group.PROPERTY_MAPPING
+    assert mapping is not None, f"{feature_group.__name__} declares no PROPERTY_MAPPING"
+    spec: dict[str, Any] = mapping[key]
+    return spec
+
+
+# Shipped specs the builder must reproduce EXACTLY: (id, built, shipped).
+_EXACT_CASES: list[tuple[str, dict[str, Any], dict[str, Any]]] = [
+    (
+        "node_centrality.weight_column",
+        property_spec("Column name for edge weights (optional)", default=None),
+        _shipped(NodeCentralityFeatureGroup, NodeCentralityFeatureGroup.WEIGHT_COLUMN),
+    ),
+    (
+        "missing_value.constant_value",
+        property_spec("Constant value to use for constant imputation method", default=None),
+        _shipped(MissingValueFeatureGroup, "constant_value"),
+    ),
+    (
+        "missing_value.group_by_features",
+        property_spec("Optional list of features to group by before imputation", default=None),
+        _shipped(MissingValueFeatureGroup, "group_by_features"),
+    ),
+    (
+        "sklearn_pipeline.pipeline_steps",
+        property_spec("List of pipeline steps as (name, transformer) tuples", default=None),
+        _shipped(SklearnPipelineFeatureGroup, SklearnPipelineFeatureGroup.PIPELINE_STEPS),
+    ),
+    (
+        "sklearn_pipeline.pipeline_params",
+        property_spec("Pipeline parameters dictionary", default=None),
+        _shipped(SklearnPipelineFeatureGroup, SklearnPipelineFeatureGroup.PIPELINE_PARAMS),
+    ),
+]
+
+# PIPELINE_NAME ships without an "explanation" key, which the builder always emits.
+_PIPELINE_NAME_BUILT: dict[str, Any] = property_spec(
+    "Name of the sklearn pipeline to apply",
+    strict=True,
+    allowed_values=SklearnPipelineFeatureGroup.PIPELINE_TYPES,
+    default=None,
+)
+_PIPELINE_NAME_SHIPPED: dict[str, Any] = _shipped(
+    SklearnPipelineFeatureGroup, SklearnPipelineFeatureGroup.PIPELINE_NAME
+)
+
+_ALL_BUILT: list[tuple[str, dict[str, Any]]] = [(case_id, built) for case_id, built, _ in _EXACT_CASES] + [
+    ("sklearn_pipeline.pipeline_name", _PIPELINE_NAME_BUILT)
+]
+
+
+class TestShippedOptionalSpecsAreBuildable:
+    """Every shipped optional-with-``None``-default spec is expressible with ``property_spec``."""
+
+    @pytest.mark.parametrize(
+        ("built", "shipped"),
+        [pytest.param(built, shipped, id=case_id) for case_id, built, shipped in _EXACT_CASES],
+    )
+    def test_builder_reproduces_shipped_spec_exactly(self, built: dict[str, Any], shipped: dict[str, Any]) -> None:
+        """The built spec is byte-for-byte the hand-written dict the plugin ships."""
+        assert built == shipped
+
+    def test_builder_reproduces_pipeline_name_up_to_added_explanation(self) -> None:
+        """PIPELINE_NAME matches once the builder's explanation is set aside.
+
+        Migrating it ADDS the "explanation" key the shipped dict lacks: an improvement, not a
+        behavior change (no core rule reads "explanation").
+        """
+        without_explanation = {key: value for key, value in _PIPELINE_NAME_BUILT.items() if key != "explanation"}
+
+        assert without_explanation == _PIPELINE_NAME_SHIPPED
+
+    @pytest.mark.parametrize(
+        "built",
+        [pytest.param(built, id=case_id) for case_id, built in _ALL_BUILT],
+    )
+    def test_built_spec_is_optional(self, built: dict[str, Any]) -> None:
+        """Each built spec stays OPTIONAL: migration must not make the option required."""
+        assert FeatureChainParser._can_skip_required_check(built) is True


### PR DESCRIPTION
Closes #733.

`property_spec` used `None` as its own "no default given" marker, so it could not tell an omitted `default` from an explicit `default=None` and dropped the key in both cases. A key with no `default` key is REQUIRED (`_can_skip_required_check` reads mere key presence), so migrating an optional-with-`None`-default key to the builder silently turned it required. That is the trap behind #723: `weight_column` flipped optional to required, configuration-based unweighted centrality stopped resolving, and the suite stayed green.

## The change

A `NO_DEFAULT` sentinel as the parameter's default. Omitting `default` still means required (the #562 fix stands, it is pinned), while `default=None` now emits the key and means optional with a `None` default. The sentinel is exported from `mloda.provider` for a wrapper that forwards an optional default through.

The sentinel is matched by TYPE, not identity, and defines `__reduce__`. Otherwise a deep-copied, pickled, or re-imported sentinel (editable install plus site-packages) is a different object, slips past the check, and lands in the spec as a bogus default value, which flips a REQUIRED key to optional: the exact bug class this fixes.

No shipped plugin calls `property_spec` today, and nothing passed `default=None` before, so behavior for every existing caller is unchanged. `default=False`, `0` and `""` were emitted before and after.

## Tests

- Both directions of the rule: `default=None` is optional, an omitted `default` stays required, and an explicit `NO_DEFAULT` equals omission.
- The builder reproduces all six shipped hand-written `default: None` specs (`weight_column`, `constant_value`, `group_by_features`, and the three sklearn pipeline keys). The sklearn `pipeline_name` spec only gains the `explanation` key it never had; no core rule reads it.
- Those six SHIPPED specs are pinned optional, which keeps its teeth after the plugins migrate to the builder and comparing built to shipped degrades into comparing builder output with itself.
- The sentinel survives a copy, a pickle, and a second imported module copy.

Verified against the optional-option sweep on #729: migrating `NodeCentralityFeatureGroup` to the builder adds zero failures, and reverting only the `default=None` argument makes the sweep fail with "optional-option inventory drifted. No longer optional: ['weight_column']". Reviewed by two independent deep reviews; `tox` is green (5762 passed).
