### PR TITLE
fix: a name-matched feature never validated its option values (#732)

### DIFF
--- a/docs/docs/in_depth/feature-chain-parser.md
+++ b/docs/docs/in_depth/feature-chain-parser.md
@@ -289,7 +289,7 @@ def match_feature_group_criteria(cls, feature_name, options, data_access_collect
     return cls.match_parser_criteria(feature_name, options)
 ```
 
-`match_parser_criteria` calls `FeatureChainParser.match_configuration_feature_chain_parser` with the class's `PROPERTY_MAPPING` and patterns, and turns a rejected option value into a non-match. Calling the parser directly from a match hook lets that rejection escape as an exception and abort feature identification for every candidate.
+`match_parser_criteria` calls the parser with the class's `PROPERTY_MAPPING` and patterns and turns a rejected option value into a non-match. Calling `FeatureChainParser` directly from a match hook lets that rejection escape as an exception and abort feature identification for every candidate.
 
 ### 3. Modernize input_features Method
 

--- a/docs/docs/in_depth/feature-chain-parser.md
+++ b/docs/docs/in_depth/feature-chain-parser.md
@@ -281,18 +281,15 @@ class MyFeatureGroup(FeatureGroup):
 
 ### 2. Update match_feature_group_criteria
 
-Replace old pattern-only matching with unified parser:
+`FeatureChainParserMixin` already implements this; override it only to add your own checks, and reach the parser through `cls.match_parser_criteria`:
 
 ``` python
 @classmethod
 def match_feature_group_criteria(cls, feature_name, options, data_access_collection=None):
-    return FeatureChainParser.match_configuration_feature_chain_parser(
-        feature_name,
-        options,
-        property_mapping=cls.PROPERTY_MAPPING,
-        prefix_patterns=[cls.PREFIX_PATTERN],
-    )
+    return cls.match_parser_criteria(feature_name, options)
 ```
+
+`match_parser_criteria` calls `FeatureChainParser.match_configuration_feature_chain_parser` with the class's `PROPERTY_MAPPING` and patterns, and turns a rejected option value into a non-match. Calling the parser directly from a match hook lets that rejection escape as an exception and abort feature identification for every candidate.
 
 ### 3. Modernize input_features Method
 

--- a/docs/docs/in_depth/feature-group-matching.md
+++ b/docs/docs/in_depth/feature-group-matching.md
@@ -23,7 +23,7 @@ def match_feature_group_criteria(cls, feature_name, options, data_access_collect
     return cls.match_parser_criteria(feature_name, options)
 ```
 
-Do not call `FeatureChainParser.match_configuration_feature_chain_parser` directly from a match hook: it raises on an option value the `PROPERTY_MAPPING` rejects, and an exception out of the hook aborts feature identification for every candidate, not just yours. `match_parser_criteria` turns that rejection into the non-match verdict the engine expects, and the reason still reaches the user in the "No feature groups found" error.
+Do not call `FeatureChainParser.match_configuration_feature_chain_parser` directly from a match hook: it raises on an option value the `PROPERTY_MAPPING` rejects, and an exception out of the hook aborts feature identification for every candidate, not just yours. `match_parser_criteria` turns that rejection into a non-match, and the reason still reaches the user in the "No feature groups found" error.
 
 ### 2. PROPERTY_MAPPING Configuration
 

--- a/docs/docs/in_depth/feature-group-matching.md
+++ b/docs/docs/in_depth/feature-group-matching.md
@@ -10,7 +10,7 @@ When a feature is requested, the system checks all available feature groups to f
 
 ## Modern Unified Matching
 
-The recommended approach uses `FeatureChainParser.match_configuration_feature_chain_parser` which provides:
+The recommended approach uses `FeatureChainParserMixin`, whose default `match_feature_group_criteria` already does this. Override it only to add your own checks, and reach the parser through `cls.match_parser_criteria`, which reads `PROPERTY_MAPPING` (configuration-based matching) and `PREFIX_PATTERN` / `SUFFIX_PATTERN` (string-based matching) off the class:
 
 ### 1. Dual Approach Support
 
@@ -20,13 +20,10 @@ from mloda.user import Options
 
 @classmethod
 def match_feature_group_criteria(cls, feature_name, options, data_access_collection=None):
-    return FeatureChainParser.match_configuration_feature_chain_parser(
-        feature_name,
-        options,
-        property_mapping=cls.PROPERTY_MAPPING,  # Configuration-based matching
-        prefix_patterns=[cls.PREFIX_PATTERN],   # String-based matching (pattern defaults to CHAIN_SEPARATOR)
-    )
+    return cls.match_parser_criteria(feature_name, options)
 ```
+
+Do not call `FeatureChainParser.match_configuration_feature_chain_parser` directly from a match hook: it raises on an option value the `PROPERTY_MAPPING` rejects, and an exception out of the hook aborts feature identification for every candidate, not just yours. `match_parser_criteria` turns that rejection into the non-match verdict the engine expects, and the reason still reaches the user in the "No feature groups found" error.
 
 ### 2. PROPERTY_MAPPING Configuration
 

--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -22,8 +22,9 @@ Two rules carry most of the model:
 | Class definition | Spec shape | Every VALUE has the right shape: `allowed_values` is a Collection and not a str/bytes; validators are callable; `strict_validation` is a bool | Every spec in the mapping | `ValueError` naming the key and the real fault |
 | Class definition | Strict needs a value space | `strict_validation: True` has a non-empty `allowed_values` or an `element_validator` | Every spec in the mapping | `ValueError` at class definition |
 | Class definition | `check_declared_default` | A strict, non-`None` `default` is accepted by its own key | The declared default | `ValueError` at class definition |
-| Match time (parser) | `allowed_values` membership | Each element is in the accepted set | One element | `ValueError`, surfaced to the end user |
-| Match time (parser) | `element_validator` | Each element satisfies a predicate | One element | `ValueError`, surfaced to the end user |
+| Match time (parser) | `allowed_values` membership | Each element of a **present** option is in the accepted set | One element | `ValueError`, surfaced to the end user |
+| Match time (parser) | `element_validator` | Each element of a **present** option satisfies a predicate | One element | `ValueError`, surfaced to the end user |
+| Match time (parser) | Required presence | A key with no `default` and no `required_when` was provided | The options | Non-match (`False`), config-based path only |
 | Match time (mixin) | `match_guard` | The whole value has an acceptable shape | The raw value | Non-match (`False`) |
 | Match time (mixin) | `MIN/MAX_IN_FEATURES` | In-feature count is within bounds | The in-features | Non-match (`False`) |
 | Match time (guard) | `required_when` | A conditionally required option is present | `Options` | Non-match (`False`) |
@@ -37,6 +38,14 @@ Because the parser runs before the mixin, an element rejected by membership or b
 declares it gets its resolved `match_feature_group_criteria` wrapped at class definition,
 and the wrapper runs the predicates after that matcher returns `True`. Overriding the
 matcher therefore keeps the contract, whether the override delegates or not.
+
+Value validation does not depend on how the feature was created. Membership and
+`element_validator` run on **both** match paths: the configuration-based one (options
+only) and the string-named one (the feature name matches a `PREFIX_PATTERN`). Only
+required **presence** differs: it is enforced on the configuration-based path alone,
+because a key the feature name encodes (the operation) is satisfied by the name, not by
+an option. So `"income__pca_2d"` with no options at all still matches, while the same
+feature group with `pca_svd_solver="bogus"` in its options is rejected either way.
 
 The class-definition rules run in table order, and the order is load-bearing. The schema
 runs before the shape rules, because a spec with an unknown key is malformed and its
@@ -229,7 +238,8 @@ A direct `FeatureChainParser` call raises `ValueError` immediately. Going throug
 `FeatureChainParserMixin.match_feature_group_criteria` (the default for most feature
 groups) is different: it catches that `ValueError` and returns `False`, because during
 resolution one candidate's "no match" must not abort the search for another candidate
-that might still accept the feature.
+that might still accept the feature. This holds on both paths: a bad option value on a
+string-named feature is the same non-match as on a configuration-based one.
 
 If every candidate rejects the feature, the final "No feature groups found" error
 collects the discarded reasons and appends them:

--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -39,13 +39,12 @@ declares it gets its resolved `match_feature_group_criteria` wrapped at class de
 and the wrapper runs the predicates after that matcher returns `True`. Overriding the
 matcher therefore keeps the contract, whether the override delegates or not.
 
-Value validation does not depend on how the feature was created. Membership and
-`element_validator` run on **both** match paths: the configuration-based one (options
-only) and the string-named one (the feature name matches a `PREFIX_PATTERN`). Only
-required **presence** differs: it is enforced on the configuration-based path alone,
-because a key the feature name encodes (the operation) is satisfied by the name, not by
-an option. So `"income__pca_2d"` with no options at all still matches, while the same
-feature group with `pca_svd_solver="bogus"` in its options is rejected either way.
+Value validation does not depend on how the feature was created: membership and
+`element_validator` run on **both** match paths, the configuration-based one and the
+string-named one. Only required **presence** differs, enforced on the configuration-based
+path alone, because a key the feature name encodes is satisfied by the name. So
+`"income__pca_2d"` with no options at all still matches, while the same feature group with
+`pca_svd_solver="bogus"` in its options is rejected either way.
 
 The class-definition rules run in table order, and the order is load-bearing. The schema
 runs before the shape rules, because a spec with an unknown key is malformed and its

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -40,6 +40,15 @@ REQUIRED_WHEN_GUARD_DEPTH: contextvars.ContextVar[int] = contextvars.ContextVar(
 )
 
 
+class PropertyValueRejection(ValueError):
+    """A present option value that the PROPERTY_MAPPING rejects: a VERDICT, not a crash.
+
+    A ValueError subclass, so every existing ``except ValueError`` keeps working, and a distinct
+    type, so a caller can treat it as a non-match without also swallowing the deliberate
+    ValueErrors that carry actionable guidance (the forwarded-name mismatch).
+    """
+
+
 class FeatureChainParser:
     """
     Mixin class for parsing feature names with chaining support.
@@ -160,7 +169,7 @@ class FeatureChainParser:
         """
         Unified validation: if strict validation -> apply the element_validator OR check membership.
 
-        Raises ValueError if validation fails, otherwise returns None.
+        Raises PropertyValueRejection if validation fails, otherwise returns None.
         """
         if not cls._is_strict_validation(original_property_config):
             return  # No validation needed
@@ -168,9 +177,17 @@ class FeatureChainParser:
         element_validator = cls._get_element_validator(original_property_config)
 
         if element_validator is not None:
-            # Use the element validator if available
-            if not element_validator(found_property_val):
-                raise ValueError(f"Property value '{found_property_val}' failed validation for '{property_name}'")
+            # A validator that RAISES cannot judge the value, which is a rejection, not a crash:
+            # a membership-style validator raises TypeError on an unhashable element, and a
+            # str-only one raises AttributeError on an int. Same exceptions as _validate_match_guards.
+            try:
+                verdict = element_validator(found_property_val)
+            except (TypeError, ValueError, AttributeError):
+                verdict = False
+            if not verdict:
+                raise PropertyValueRejection(
+                    f"Property value '{found_property_val}' failed validation for '{property_name}'"
+                )
         else:
             # Fallback to membership check. An unhashable element (e.g. a dict) can never be
             # a member of the accepted set, so it is a clean rejection, not a TypeError.
@@ -179,7 +196,9 @@ class FeatureChainParser:
             except TypeError:
                 is_member = False
             if not is_member:
-                raise ValueError(f"Property value '{found_property_val}' not found in mapping for '{property_name}'")
+                raise PropertyValueRejection(
+                    f"Property value '{found_property_val}' not found in mapping for '{property_name}'"
+                )
 
     @classmethod
     def _determine_parameter_category(cls, property_name: str, property_value: Any, options: Options) -> str:
@@ -469,9 +488,9 @@ class FeatureChainParser:
     ) -> list[Any] | None:
         """Validate the VALUE of one option and return its elements, or None when it is absent.
 
-        The per-key work both validation paths share, so they cannot drift. Raises ValueError
-        when a present value is outside the key's declared value space or is rejected by its
-        element_validator.
+        The per-key work both validation paths share, so they cannot drift. Raises
+        PropertyValueRejection when a present value is outside the key's declared value space or
+        is rejected by its element_validator.
         """
         found_property_value = options.get(property_name)
         if found_property_value is None:
@@ -488,7 +507,7 @@ class FeatureChainParser:
 
         Used on the string-named path, where a key like the operation is carried by the feature
         name rather than by the options: an absent option is skipped instead of rejected. Raises
-        ValueError on a bad value.
+        PropertyValueRejection on a bad value.
         """
         for property_name in property_mapping:
             cls._collect_option_value(options, property_name, property_mapping)
@@ -505,7 +524,7 @@ class FeatureChainParser:
             True if validation passes, False when a required option is absent
 
         Raises:
-            ValueError: If a present option carries a value the mapping rejects
+            PropertyValueRejection: If a present option carries a value the mapping rejects
         """
         # None marks an absent option; a list (possibly empty) marks a present one.
         property_tracker: dict[str, list[Any] | None] = {
@@ -530,6 +549,11 @@ class FeatureChainParser:
         PRESENCE only: a name match satisfies the keys the name carries, so presence is enforced
         on the configuration-based path alone.
 
+        This method RAISES on a rejected value, so a caller that overrides
+        ``match_feature_group_criteria`` must not call it bare: use
+        ``FeatureChainParserMixin.match_parser_criteria``, which turns the rejection into the
+        non-match verdict the engine expects.
+
         Args:
             feature_name: The feature name to match
             options: Options object containing configuration
@@ -541,7 +565,9 @@ class FeatureChainParser:
             True if the feature matches either pattern-based or configuration-based parsing, False otherwise
 
         Raises:
-            ValueError: If a present option carries a value the property mapping rejects
+            PropertyValueRejection: If a present option carries a value the property mapping rejects
+            ValueError: If the feature name matches a prefix pattern but is malformed (no source
+                feature), raised by parse_feature_name
         """
 
         # string based matching

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -464,40 +464,54 @@ class FeatureChainParser:
         return True
 
     @classmethod
-    def _validate_options_against_property_mapping(cls, options: Options, property_mapping: dict[str, Any]) -> bool:
+    def _collect_option_value(
+        cls, options: Options, property_name: str, property_mapping: dict[str, Any]
+    ) -> list[Any] | None:
+        """Validate the VALUE of one option and return its elements, or None when it is absent.
+
+        The per-key work both validation paths share, so they cannot drift. Raises ValueError
+        when a present value is outside the key's declared value space or is rejected by its
+        element_validator.
         """
-        Shared validation logic for both string-based and configuration-based approaches.
+        found_property_value = options.get(property_name)
+        if found_property_value is None:
+            return None
+
+        property_config = property_mapping[property_name]
+        return cls._process_found_property_value(
+            found_property_value, cls._extract_property_values(property_config), property_name, property_config
+        )
+
+    @classmethod
+    def _validate_present_option_values(cls, options: Options, property_mapping: dict[str, Any]) -> None:
+        """Validate the values of the options that are present, without enforcing presence.
+
+        Used on the string-named path, where a key like the operation is carried by the feature
+        name rather than by the options: an absent option is skipped instead of rejected. Raises
+        ValueError on a bad value.
+        """
+        for property_name in property_mapping:
+            cls._collect_option_value(options, property_name, property_mapping)
+
+    @classmethod
+    def _validate_options_against_property_mapping(cls, options: Options, property_mapping: dict[str, Any]) -> bool:
+        """Validate present option values AND enforce required presence (configuration-based path).
 
         Args:
             options: Options object containing the parameters to validate
             property_mapping: Property mapping with validation rules
 
         Returns:
-            True if validation passes, False otherwise
+            True if validation passes, False when a required option is absent
+
+        Raises:
+            ValueError: If a present option carries a value the mapping rejects
         """
         # None marks an absent option; a list (possibly empty) marks a present one.
-        property_tracker: dict[str, list[Any] | None] = {}
-        for key in property_mapping:
-            property_tracker[key] = None
-
-        # Process each property in the mapping
-        for property_name, property_value in property_mapping.items():
-            found_property_value = options.get(property_name)
-            property_value = cls._extract_property_values(property_value)
-
-            # Handle missing properties: leave the tracker at None, so the final check
-            # decides whether the option was required.
-            if found_property_value is None:
-                continue
-
-            collected_property_value = cls._process_found_property_value(
-                found_property_value, property_value, property_name, property_mapping[property_name]
-            )
-
-            if property_tracker[property_name] is not None:
-                raise ValueError(f"Feature name has duplicate values for property '{property_name}'.")
-
-            property_tracker[property_name] = collected_property_value
+        property_tracker: dict[str, list[Any] | None] = {
+            property_name: cls._collect_option_value(options, property_name, property_mapping)
+            for property_name in property_mapping
+        }
         return cls._validate_final_properties(property_tracker, property_mapping)
 
     @classmethod
@@ -512,6 +526,10 @@ class FeatureChainParser:
         """
         Unified method for matching features using either configuration-based or pattern-based parsing.
 
+        Both paths validate the VALUES of the options that are present. They differ on required
+        PRESENCE only: a name match satisfies the keys the name carries, so presence is enforced
+        on the configuration-based path alone.
+
         Args:
             feature_name: The feature name to match
             options: Options object containing configuration
@@ -521,11 +539,16 @@ class FeatureChainParser:
 
         Returns:
             True if the feature matches either pattern-based or configuration-based parsing, False otherwise
+
+        Raises:
+            ValueError: If a present option carries a value the property mapping rejects
         """
 
         # string based matching
         if prefix_patterns is not None:
             if cls._match_pattern_based_feature(feature_name, prefix_patterns, pattern):
+                if property_mapping is not None:
+                    cls._validate_present_option_values(options, property_mapping)
                 return True
 
         # configuration-based

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -41,11 +41,9 @@ REQUIRED_WHEN_GUARD_DEPTH: contextvars.ContextVar[int] = contextvars.ContextVar(
 
 
 class PropertyValueRejection(ValueError):
-    """A present option value that the PROPERTY_MAPPING rejects: a VERDICT, not a crash.
-
-    A ValueError subclass, so every existing ``except ValueError`` keeps working, and a distinct
-    type, so a caller can treat it as a non-match without also swallowing the deliberate
-    ValueErrors that carry actionable guidance (the forwarded-name mismatch).
+    """An option value the PROPERTY_MAPPING rejects: a verdict, not a crash. Subclasses ValueError so
+    existing ``except ValueError`` handlers keep working, while the distinct type lets a caller treat it as a
+    non-match without also swallowing the ValueErrors that carry actionable guidance.
     """
 
 
@@ -177,9 +175,7 @@ class FeatureChainParser:
         element_validator = cls._get_element_validator(original_property_config)
 
         if element_validator is not None:
-            # A validator that RAISES cannot judge the value, which is a rejection, not a crash:
-            # a membership-style validator raises TypeError on an unhashable element, and a
-            # str-only one raises AttributeError on an int. Same exceptions as _validate_match_guards.
+            # A validator that raises cannot judge the value, so the value is rejected, not the run.
             try:
                 verdict = element_validator(found_property_val)
             except (TypeError, ValueError, AttributeError):
@@ -486,12 +482,7 @@ class FeatureChainParser:
     def _collect_option_value(
         cls, options: Options, property_name: str, property_mapping: dict[str, Any]
     ) -> list[Any] | None:
-        """Validate the VALUE of one option and return its elements, or None when it is absent.
-
-        The per-key work both validation paths share, so they cannot drift. Raises
-        PropertyValueRejection when a present value is outside the key's declared value space or
-        is rejected by its element_validator.
-        """
+        """Validate one option value and return its elements, or None when the option is absent."""
         found_property_value = options.get(property_name)
         if found_property_value is None:
             return None
@@ -503,25 +494,13 @@ class FeatureChainParser:
 
     @classmethod
     def _validate_present_option_values(cls, options: Options, property_mapping: dict[str, Any]) -> None:
-        """Validate the values of the options that are present, without enforcing presence.
-
-        Used on the string-named path, where a key like the operation is carried by the feature
-        name rather than by the options: an absent option is skipped instead of rejected. Raises
-        PropertyValueRejection on a bad value.
-        """
+        """Validate the values of the present options, without enforcing presence of the absent ones."""
         for property_name in property_mapping:
             cls._collect_option_value(options, property_name, property_mapping)
 
     @classmethod
     def _validate_options_against_property_mapping(cls, options: Options, property_mapping: dict[str, Any]) -> bool:
-        """Validate present option values AND enforce required presence (configuration-based path).
-
-        Args:
-            options: Options object containing the parameters to validate
-            property_mapping: Property mapping with validation rules
-
-        Returns:
-            True if validation passes, False when a required option is absent
+        """Validate present option values and enforce required presence. False when a required option is absent.
 
         Raises:
             PropertyValueRejection: If a present option carries a value the mapping rejects
@@ -545,14 +524,9 @@ class FeatureChainParser:
         """
         Unified method for matching features using either configuration-based or pattern-based parsing.
 
-        Both paths validate the VALUES of the options that are present. They differ on required
-        PRESENCE only: a name match satisfies the keys the name carries, so presence is enforced
-        on the configuration-based path alone.
-
-        This method RAISES on a rejected value, so a caller that overrides
-        ``match_feature_group_criteria`` must not call it bare: use
-        ``FeatureChainParserMixin.match_parser_criteria``, which turns the rejection into the
-        non-match verdict the engine expects.
+        Both paths validate the values of the present options; only required presence is enforced on the
+        configuration-based path alone. This raises on a rejected value, so an overridden
+        ``match_feature_group_criteria`` must reach it through ``FeatureChainParserMixin.match_parser_criteria``.
 
         Args:
             feature_name: The feature name to match
@@ -563,11 +537,6 @@ class FeatureChainParser:
 
         Returns:
             True if the feature matches either pattern-based or configuration-based parsing, False otherwise
-
-        Raises:
-            PropertyValueRejection: If a present option carries a value the property mapping rejects
-            ValueError: If the feature name matches a prefix pattern but is malformed (no source
-                feature), raised by parse_feature_name
         """
 
         # string based matching

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -9,34 +9,27 @@ They serve different purposes and run at different points in the pipeline.
 
 ``element_validator`` (``DefaultOptionKeys.element_validator``)
   - Requires ``strict_validation: True`` on the same mapping entry.
-  - Runs inside ``FeatureChainParser._validate_property_value`` on **both** match
-    paths: the configuration-based one (``_validate_options_against_property_mapping``)
-    and the string-named one (``_validate_present_option_values``). Value validation
-    (membership and ``element_validator``) never depends on how the feature was named.
-    The paths differ on required PRESENCE only, which stays off on the string-named
-    path because a key encoded in the feature name is satisfied by the name.
+  - Runs inside ``FeatureChainParser._validate_property_value`` on **both** match paths,
+    the configuration-based one and the string-named one. Only required *presence* is
+    config-based only, because a key encoded in the feature name is satisfied by the name.
   - Receives **individual parsed elements** after list unpacking
     (``_process_found_property_value`` converts lists to frozensets and
     iterates over each element).
   - On failure: raises ``PropertyValueRejection`` (a ``ValueError``) with an actionable
-    message identifying the property name and the rejected element value. A validator
-    that RAISES instead of returning False (membership against a dict raises TypeError on
-    an unhashable element) cannot judge the value, which is the same rejection.
+    message identifying the property name and the rejected element value. A validator that
+    raises rather than returning falsy cannot judge the value and is a rejection too.
   - Use case: validating that each individual element satisfies a constraint
     (e.g., ``lambda x: isinstance(x, int) and x > 0``).
 
 ``match_guard`` (``DefaultOptionKeys.match_guard``)
   - Does **not** require ``strict_validation``.
   - Runs inside ``FeatureChainParserMixin.match_feature_group_criteria``
-    **after** the parser has matched and validated the present option values.
-  - Receives the **raw whole option value** exactly as stored in Options, before any
-    list unpacking or element iteration. This is its first distinctive power: it can
-    check the SHAPE of a container whose elements each pass their own validation
-    (e.g., a list of exactly three strings).
-  - On failure: logs a debug message and returns ``False`` (non-match). This is its
-    second distinctive power: a falsy return is a plain "not mine", not an error, so
-    another feature group can still take the feature. If the guard raises an exception,
-    the exception is caught, logged, and the value is treated as invalid.
+    **after** basic matching succeeds (pattern + property mapping validation).
+  - Receives the **raw option value** exactly as stored in Options, before any
+    list unpacking or element iteration.
+  - On failure: logs a debug message and returns ``False`` (non-match). If the
+    guard raises an exception, the exception is caught, logged, and the value is
+    treated as invalid.
   - Use case: validating the shape or composite type of the whole value
     (e.g., ``lambda v: isinstance(v, list) and all(isinstance(i, str) for i in v)``).
 
@@ -202,8 +195,7 @@ class FeatureChainParserMixin:
         """
         Match feature against criteria using pattern-based or config-based parsing.
 
-        Delegates to match_parser_criteria() (the parser, with a rejected option value turned
-        into a non-match) and optionally calls _validate_string_match() hook for custom validation.
+        Delegates to match_parser_criteria() and optionally calls _validate_string_match() for custom validation.
 
         After basic matching succeeds, enforces ``match_guard`` constraints from
         PROPERTY_MAPPING entries. For each entry that defines a
@@ -259,12 +251,10 @@ class FeatureChainParserMixin:
 
     @classmethod
     def match_parser_criteria(cls, feature_name: str | FeatureName, options: Options) -> bool:
-        """Call the parser and turn its rejections into the non-match verdict, never an exception.
+        """Call the parser, turning a rejected option value or a malformed name into a non-match, never an exception.
 
-        The ONLY safe way to reach ``match_configuration_feature_chain_parser`` from an overridden
-        ``match_feature_group_criteria``: the parser raises on a rejected option value, and an
-        exception out of a match hook takes down the identification of the feature for every
-        candidate, not just this one. Shared with the mixin's own hook so the two cannot drift.
+        The only safe way to reach the parser from an overridden ``match_feature_group_criteria``: an exception out
+        of a match hook aborts the identification of the feature for every candidate, not just this one.
         """
         try:
             return FeatureChainParser.match_configuration_feature_chain_parser(
@@ -274,21 +264,14 @@ class FeatureChainParserMixin:
                 prefix_patterns=cls._get_prefix_patterns(),
             )
         except ValueError:
-            # PropertyValueRejection (a rejected value) and a malformed name that matched a
-            # prefix pattern are both non-matches, not errors.
             return False
 
     @classmethod
     def _strict_validation_rejection_reason(cls, feature_name: str | FeatureName, options: Options) -> str | None:
-        """Return the ValueError message that match_feature_group_criteria discards, if any.
+        """Return the option-value rejection message that match_feature_group_criteria discards, if any.
 
-        Mirrors the parser: a name match reports rejected option VALUES (presence is
-        carried by the name), the configuration-based path reports value rejections too.
-        A ValueError raised while parsing a PREFIX_PATTERN match (malformed feature name,
-        no chain separator) is a parse error, not an option-value rejection, and is
-        treated as nothing to report. Returns None when nothing was rejected (match
-        succeeded, or the candidate is unrelated). Diagnostic-only: does not affect
-        match_feature_group_criteria's behavior.
+        None when nothing was rejected, and also for a parse error on a malformed name, which is not an
+        option-value rejection. Diagnostic-only: does not affect match_feature_group_criteria's behavior.
         """
         property_mapping = cls._get_property_mapping()
         if property_mapping is None:

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -9,8 +9,12 @@ They serve different purposes and run at different points in the pipeline.
 
 ``element_validator`` (``DefaultOptionKeys.element_validator``)
   - Requires ``strict_validation: True`` on the same mapping entry.
-  - Runs inside ``FeatureChainParser._validate_property_value`` during
-    ``_validate_options_against_property_mapping``.
+  - Runs inside ``FeatureChainParser._validate_property_value`` on **both** match
+    paths: the configuration-based one (``_validate_options_against_property_mapping``)
+    and the string-named one (``_validate_present_option_values``). Value validation
+    (membership and ``element_validator``) never depends on how the feature was named.
+    The paths differ on required PRESENCE only, which stays off on the string-named
+    path because a key encoded in the feature name is satisfied by the name.
   - Receives **individual parsed elements** after list unpacking
     (``_process_found_property_value`` converts lists to frozensets and
     iterates over each element).
@@ -22,12 +26,15 @@ They serve different purposes and run at different points in the pipeline.
 ``match_guard`` (``DefaultOptionKeys.match_guard``)
   - Does **not** require ``strict_validation``.
   - Runs inside ``FeatureChainParserMixin.match_feature_group_criteria``
-    **after** basic matching succeeds (pattern + property mapping validation).
-  - Receives the **raw option value** exactly as stored in Options, before any
-    list unpacking or element iteration.
-  - On failure: logs a debug message and returns ``False`` (non-match). If the
-    guard raises an exception, the exception is caught, logged, and the value is
-    treated as invalid.
+    **after** the parser has matched and validated the present option values.
+  - Receives the **raw whole option value** exactly as stored in Options, before any
+    list unpacking or element iteration. This is its first distinctive power: it can
+    check the SHAPE of a container whose elements each pass their own validation
+    (e.g., a list of exactly three strings).
+  - On failure: logs a debug message and returns ``False`` (non-match). This is its
+    second distinctive power: a falsy return is a plain "not mine", not an error, so
+    another feature group can still take the feature. If the guard raises an exception,
+    the exception is caught, logged, and the value is treated as invalid.
   - Use case: validating the shape or composite type of the whole value
     (e.g., ``lambda v: isinstance(v, list) and all(isinstance(i, str) for i in v)``).
 
@@ -261,28 +268,33 @@ class FeatureChainParserMixin:
     def _strict_validation_rejection_reason(cls, feature_name: str | FeatureName, options: Options) -> str | None:
         """Return the ValueError message that match_feature_group_criteria discards, if any.
 
-        Only surfaces ValueErrors raised by property-mapping validation (genuine
-        strict_validation rejections). A ValueError raised while parsing a
-        PREFIX_PATTERN match (malformed feature name, no chain separator) is a
-        parse error, not an option-value rejection, and is treated as nothing to
-        report. Returns None when nothing was rejected (match succeeded, or the
-        candidate is unrelated). Diagnostic-only: does not affect
+        Mirrors the parser: a name match reports rejected option VALUES (presence is
+        carried by the name), the configuration-based path reports value rejections too.
+        A ValueError raised while parsing a PREFIX_PATTERN match (malformed feature name,
+        no chain separator) is a parse error, not an option-value rejection, and is
+        treated as nothing to report. Returns None when nothing was rejected (match
+        succeeded, or the candidate is unrelated). Diagnostic-only: does not affect
         match_feature_group_criteria's behavior.
         """
-        prefix_patterns = cls._get_prefix_patterns()
-        if prefix_patterns:
-            try:
-                if FeatureChainParser._match_pattern_based_feature(feature_name, prefix_patterns, CHAIN_SEPARATOR):
-                    return None
-            except ValueError:
-                return None
-
         property_mapping = cls._get_property_mapping()
         if property_mapping is None:
             return None
 
+        name_matched = False
+        prefix_patterns = cls._get_prefix_patterns()
+        if prefix_patterns:
+            try:
+                name_matched = FeatureChainParser._match_pattern_based_feature(
+                    feature_name, prefix_patterns, CHAIN_SEPARATOR
+                )
+            except ValueError:
+                return None
+
         try:
-            FeatureChainParser._validate_options_against_property_mapping(options, property_mapping)
+            if name_matched:
+                FeatureChainParser._validate_present_option_values(options, property_mapping)
+            else:
+                FeatureChainParser._validate_options_against_property_mapping(options, property_mapping)
         except ValueError as exc:
             return str(exc)
         return None

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -18,8 +18,10 @@ They serve different purposes and run at different points in the pipeline.
   - Receives **individual parsed elements** after list unpacking
     (``_process_found_property_value`` converts lists to frozensets and
     iterates over each element).
-  - On failure: raises ``ValueError`` with an actionable message identifying
-    the property name and the rejected element value.
+  - On failure: raises ``PropertyValueRejection`` (a ``ValueError``) with an actionable
+    message identifying the property name and the rejected element value. A validator
+    that RAISES instead of returning False (membership against a dict raises TypeError on
+    an unhashable element) cannot judge the value, which is the same rejection.
   - Use case: validating that each individual element satisfies a constraint
     (e.g., ``lambda x: isinstance(x, int) and x > 0``).
 
@@ -200,8 +202,8 @@ class FeatureChainParserMixin:
         """
         Match feature against criteria using pattern-based or config-based parsing.
 
-        Delegates to FeatureChainParser.match_configuration_feature_chain_parser() and
-        optionally calls _validate_string_match() hook for custom validation.
+        Delegates to match_parser_criteria() (the parser, with a rejected option value turned
+        into a non-match) and optionally calls _validate_string_match() hook for custom validation.
 
         After basic matching succeeds, enforces ``match_guard`` constraints from
         PROPERTY_MAPPING entries. For each entry that defines a
@@ -235,16 +237,7 @@ class FeatureChainParserMixin:
         prefix_patterns = cls._get_prefix_patterns()
         property_mapping = cls._get_property_mapping()
 
-        try:
-            # Use the unified parser for basic matching
-            result = FeatureChainParser.match_configuration_feature_chain_parser(
-                feature_name,
-                options,
-                property_mapping=property_mapping,
-                prefix_patterns=prefix_patterns,
-            )
-        except ValueError:
-            return False
+        result = cls.match_parser_criteria(feature_name, options)
 
         # If basic match succeeded and it's a string-based feature, call validation hook
         if result:
@@ -263,6 +256,27 @@ class FeatureChainParserMixin:
             return False
 
         return result
+
+    @classmethod
+    def match_parser_criteria(cls, feature_name: str | FeatureName, options: Options) -> bool:
+        """Call the parser and turn its rejections into the non-match verdict, never an exception.
+
+        The ONLY safe way to reach ``match_configuration_feature_chain_parser`` from an overridden
+        ``match_feature_group_criteria``: the parser raises on a rejected option value, and an
+        exception out of a match hook takes down the identification of the feature for every
+        candidate, not just this one. Shared with the mixin's own hook so the two cannot drift.
+        """
+        try:
+            return FeatureChainParser.match_configuration_feature_chain_parser(
+                feature_name,
+                options,
+                property_mapping=cls._get_property_mapping(),
+                prefix_patterns=cls._get_prefix_patterns(),
+            )
+        except ValueError:
+            # PropertyValueRejection (a rejected value) and a malformed name that matched a
+            # prefix pattern are both non-matches, not errors.
+            return False
 
     @classmethod
     def _strict_validation_rejection_reason(cls, feature_name: str | FeatureName, options: Options) -> str | None:

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -4,6 +4,7 @@ from typing import Iterable, Optional
 
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import PropertyValueRejection
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import NON_FORWARDED_KEYS, Options
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
@@ -153,7 +154,19 @@ class IdentifyFeatureGroupClass:
         feature: Feature,
         data_access_collection: Optional[DataAccessCollection],
     ) -> bool:
-        return feature_group.match_feature_group_criteria(feature.name, feature.options, data_access_collection)
+        """A rejected option value is a non-match, whoever calls the parser.
+
+        Guards every candidate, including a third-party feature group that overrides the match
+        hook and calls FeatureChainParser directly: without this, one rejecting candidate would
+        take the whole filter loop down and deny the feature to the group that legitimately owns
+        it. Only the rejection is caught; a plain ValueError (the forwarded-name-mismatch
+        guidance) still reaches the user.
+        """
+        try:
+            return feature_group.match_feature_group_criteria(feature.name, feature.options, data_access_collection)
+        except PropertyValueRejection as exc:
+            logger.debug("%s rejected an option value while matching '%s': %s", feature_group, feature.name, exc)
+            return False
 
     def _filter_feature_group_by_domain(self, feature_group: type[FeatureGroup], feature: Feature) -> bool:
         return not feature.domain or feature_group.get_domain() == feature.domain

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -154,13 +154,9 @@ class IdentifyFeatureGroupClass:
         feature: Feature,
         data_access_collection: Optional[DataAccessCollection],
     ) -> bool:
-        """A rejected option value is a non-match, whoever calls the parser.
-
-        Guards every candidate, including a third-party feature group that overrides the match
-        hook and calls FeatureChainParser directly: without this, one rejecting candidate would
-        take the whole filter loop down and deny the feature to the group that legitimately owns
-        it. Only the rejection is caught; a plain ValueError (the forwarded-name-mismatch
-        guidance) still reaches the user.
+        """A rejected option value is a non-match, whoever calls the parser: a candidate that overrides the match
+        hook and calls FeatureChainParser directly must not take the whole filter loop down. Only the rejection is
+        caught, so a plain ValueError (the forwarded-name-mismatch guidance) still reaches the user.
         """
         try:
             return feature_group.match_feature_group_criteria(feature.name, feature.options, data_access_collection)

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_name_path_validates_option_values.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_name_path_validates_option_values.py
@@ -1,25 +1,7 @@
-"""The string-named path validates the option values it carries (issue #732).
+"""The string-named match path validates the option values that are present.
 
-``match_configuration_feature_chain_parser`` returned True as soon as the feature name
-matched a PREFIX_PATTERN and never looked at ``options``. Every PROPERTY_MAPPING key that
-is NOT encoded in the name (a solver, a method, a size) therefore went unvalidated on the
-string-named path, including keys declaring ``strict_validation=True``.
-
-What this module pins:
-
-* On a name match, the option values that ARE present are validated exactly as on the
-  config-based path: membership against ``allowed_values``, or the ``element_validator``
-  when the spec declares one.
-* Required-PRESENCE stays OFF on the name path. A key the name carries (the operation) is
-  satisfied by the name, so a name-matched feature with no options at all still matches.
-  The config-based path keeps enforcing presence.
-* The verdict is a non-match, not a hard raise: the parser raises ``ValueError`` and
-  ``match_feature_group_criteria`` swallows it into ``False``, the same as on the
-  config-based path.
-* ``_strict_validation_rejection_reason`` surfaces that discarded message for a name-matched
-  feature, naming the key and the rejected value.
-* ``match_guard`` semantics are untouched: raw whole value, no ``strict_validation``
-  requirement, falsy verdict is a plain non-match with nothing to report.
+Only required presence differs from the config-based path: a key the name carries is satisfied by the
+name. A rejected value is a non-match, and the parser's message is still available as the reason.
 """
 
 from __future__ import annotations

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_name_path_validates_option_values.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_name_path_validates_option_values.py
@@ -1,0 +1,278 @@
+"""The string-named path validates the option values it carries (issue #732).
+
+``match_configuration_feature_chain_parser`` returned True as soon as the feature name
+matched a PREFIX_PATTERN and never looked at ``options``. Every PROPERTY_MAPPING key that
+is NOT encoded in the name (a solver, a method, a size) therefore went unvalidated on the
+string-named path, including keys declaring ``strict_validation=True``.
+
+What this module pins:
+
+* On a name match, the option values that ARE present are validated exactly as on the
+  config-based path: membership against ``allowed_values``, or the ``element_validator``
+  when the spec declares one.
+* Required-PRESENCE stays OFF on the name path. A key the name carries (the operation) is
+  satisfied by the name, so a name-matched feature with no options at all still matches.
+  The config-based path keeps enforcing presence.
+* The verdict is a non-match, not a hard raise: the parser raises ``ValueError`` and
+  ``match_feature_group_criteria`` swallows it into ``False``, the same as on the
+  config-based path.
+* ``_strict_validation_rejection_reason`` surfaces that discarded message for a name-matched
+  feature, naming the key and the rejected value.
+* ``match_guard`` semantics are untouched: raw whole value, no ``strict_validation``
+  requirement, falsy verdict is a plain non-match with nothing to report.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import (
+    FeatureChainParser,
+)
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import (
+    FeatureChainParserMixin,
+)
+from mloda.core.abstract_plugins.components.options import Options
+
+
+def _is_positive_int(value: Any) -> bool:
+    """Accept a strictly positive int (mirrors the plugins' positive-digit validators)."""
+    return isinstance(value, int) and value > 0
+
+
+def _is_list_of_str(value: Any) -> bool:
+    """Accept the raw whole value only when it is a list of strings."""
+    return isinstance(value, list) and all(isinstance(element, str) for element in value)
+
+
+class NamePathFeatureGroup(FeatureChainParserMixin):
+    """Name carries ``algorithm``; ``solver``, ``size`` and ``notes`` are options-only."""
+
+    PREFIX_PATTERN = r".*__([\w]+)_(\d+)d$"
+
+    PROPERTY_MAPPING: dict[str, dict[Any, Any]] = {
+        "algorithm": {
+            DefaultOptionKeys.allowed_values: {"pca": "PCA", "tsne": "t-SNE"},
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: True,
+        },
+        "solver": {
+            "explanation": "strict, allowed_values, never encoded in the name",
+            DefaultOptionKeys.allowed_values: {"auto": "Auto", "arpack": "ARPACK"},
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: True,
+            DefaultOptionKeys.default: "auto",
+        },
+        "size": {
+            "explanation": "strict, element_validator, never encoded in the name",
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: True,
+            DefaultOptionKeys.element_validator: _is_positive_int,
+        },
+        "notes": {
+            "explanation": "non-strict, so no value space is enforced",
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: False,
+            DefaultOptionKeys.default: "",
+        },
+    }
+
+
+class GuardedNamePathFeatureGroup(FeatureChainParserMixin):
+    """A match_guard key on a name-matched feature group."""
+
+    PREFIX_PATTERN = r".*__([\w]+)_guarded$"
+
+    PROPERTY_MAPPING: dict[str, dict[Any, Any]] = {
+        "columns": {
+            "explanation": "guarded, non-strict: the guard sees the raw whole value",
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: False,
+            DefaultOptionKeys.match_guard: _is_list_of_str,
+        }
+    }
+
+
+class MalformedNameFeatureGroup(FeatureChainParserMixin):
+    """PREFIX_PATTERN matches names with no chain separator, so parsing raises."""
+
+    PREFIX_PATTERN = r"^orphan_(\w+)$"
+
+    PROPERTY_MAPPING: dict[str, dict[Any, Any]] = {
+        "solver": {
+            DefaultOptionKeys.allowed_values: {"auto": "Auto", "arpack": "ARPACK"},
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: True,
+            DefaultOptionKeys.default: "auto",
+        }
+    }
+
+
+class TestNamePathRejectsBadOptionValues:
+    """A name match no longer waves the options through unvalidated."""
+
+    def test_membership_rejection_on_name_path(self) -> None:
+        """A strict allowed_values key with a value outside the set is a non-match."""
+        result = NamePathFeatureGroup.match_feature_group_criteria("f0__pca_2d", Options(context={"solver": "bogus"}))
+
+        assert result is False
+
+    def test_element_validator_rejection_on_name_path(self) -> None:
+        """A strict element_validator key rejecting the value is a non-match."""
+        result = NamePathFeatureGroup.match_feature_group_criteria("f0__pca_2d", Options(context={"size": -1}))
+
+        assert result is False
+
+    def test_name_path_verdict_equals_config_path_verdict(self) -> None:
+        """The same bad value is rejected identically on both paths: False, not a raise."""
+        config_options = Options(context={"algorithm": "pca", "size": 2, "solver": "bogus"})
+        name_options = Options(context={"solver": "bogus"})
+
+        config_result = NamePathFeatureGroup.match_feature_group_criteria("placeholder", config_options)
+        name_result = NamePathFeatureGroup.match_feature_group_criteria("f0__pca_2d", name_options)
+
+        assert config_result is False
+        assert name_result is False
+
+    def test_parser_raises_valueerror_on_name_path(self) -> None:
+        """The parser signals the rejection with a ValueError; the mixin is what swallows it."""
+        with pytest.raises(ValueError, match="bogus"):
+            FeatureChainParser.match_configuration_feature_chain_parser(
+                "f0__pca_2d",
+                Options(context={"solver": "bogus"}),
+                property_mapping=NamePathFeatureGroup.PROPERTY_MAPPING,
+                prefix_patterns=[NamePathFeatureGroup.PREFIX_PATTERN],
+            )
+
+
+class TestNamePathStillAcceptsValidOptions:
+    """Guard against over-rejecting: only bad values are rejected, nothing else."""
+
+    def test_valid_options_only_value_still_matches(self) -> None:
+        """A member of the strict value space on a name-matched feature still matches."""
+        result = NamePathFeatureGroup.match_feature_group_criteria("f0__pca_2d", Options(context={"solver": "arpack"}))
+
+        assert result is True
+
+    def test_valid_element_validator_value_still_matches(self) -> None:
+        """A value the element_validator accepts on a name-matched feature still matches."""
+        result = NamePathFeatureGroup.match_feature_group_criteria("f0__pca_2d", Options(context={"size": 3}))
+
+        assert result is True
+
+    def test_non_strict_key_accepts_any_value(self) -> None:
+        """strict_validation=False declares no value space, so nothing is enforced."""
+        result = NamePathFeatureGroup.match_feature_group_criteria(
+            "f0__pca_2d", Options(context={"notes": "!!! not a member of anything !!!"})
+        )
+
+        assert result is True
+
+    def test_plain_name_match_without_options_still_matches(self) -> None:
+        """Required-PRESENCE stays off on the name path: no options at all still matches."""
+        result = NamePathFeatureGroup.match_feature_group_criteria("f0__pca_2d", Options())
+
+        assert result is True
+
+    def test_unrelated_name_is_a_plain_non_match(self) -> None:
+        """A name that matches no pattern and carries no options is still just a non-match."""
+        result = NamePathFeatureGroup.match_feature_group_criteria("unrelated_feature", Options())
+
+        assert result is False
+
+
+class TestConfigPathPresenceUnchanged:
+    """Turning validation ON for the name path must not turn presence OFF for the config path."""
+
+    def test_config_path_still_requires_present_keys(self) -> None:
+        """A required key with no default and no name to carry it still rejects the config path."""
+        result = NamePathFeatureGroup.match_feature_group_criteria("placeholder", Options(context={"algorithm": "pca"}))
+
+        assert result is False
+
+    def test_config_path_matches_when_required_keys_present(self) -> None:
+        """All required keys present with valid values: the config path matches."""
+        result = NamePathFeatureGroup.match_feature_group_criteria(
+            "placeholder", Options(context={"algorithm": "pca", "size": 2})
+        )
+
+        assert result is True
+
+
+class TestNamePathRejectionReason:
+    """The rejection explains itself instead of vanishing into a bare False."""
+
+    def test_reason_names_key_and_value_for_membership_rejection(self) -> None:
+        """The discarded ValueError message is surfaced for a name-matched feature."""
+        options = Options(context={"solver": "bogus"})
+
+        assert NamePathFeatureGroup.match_feature_group_criteria("f0__pca_2d", options) is False
+
+        reason = NamePathFeatureGroup._strict_validation_rejection_reason("f0__pca_2d", options)
+
+        assert reason is not None
+        assert "solver" in reason
+        assert "bogus" in reason
+
+    def test_reason_names_key_and_value_for_element_validator_rejection(self) -> None:
+        """The element_validator message is surfaced for a name-matched feature too."""
+        options = Options(context={"size": -1})
+
+        reason = NamePathFeatureGroup._strict_validation_rejection_reason("f0__pca_2d", options)
+
+        assert reason is not None
+        assert "size" in reason
+        assert "-1" in reason
+
+    def test_no_reason_when_nothing_was_rejected(self) -> None:
+        """A name match with a valid value has nothing to report."""
+        options = Options(context={"solver": "arpack"})
+
+        reason = NamePathFeatureGroup._strict_validation_rejection_reason("f0__pca_2d", options)
+
+        assert reason is None
+
+    def test_no_reason_for_bare_name_match(self) -> None:
+        """A name match with no options has nothing to report."""
+        reason = NamePathFeatureGroup._strict_validation_rejection_reason("f0__pca_2d", Options())
+
+        assert reason is None
+
+    def test_no_reason_for_malformed_name_parse_error(self) -> None:
+        """A ValueError from PARSING a malformed name is not an option-value rejection."""
+        assert MalformedNameFeatureGroup.match_feature_group_criteria("orphan_thing", Options()) is False
+
+        reason = MalformedNameFeatureGroup._strict_validation_rejection_reason("orphan_thing", Options())
+
+        assert reason is None
+
+
+class TestMatchGuardSemanticsUnchanged:
+    """match_guard keeps its own contract: raw value, no strict requirement, silent non-match."""
+
+    def test_guard_sees_the_raw_whole_value(self) -> None:
+        """A list value reaches the guard whole, not unpacked into elements."""
+        result = GuardedNamePathFeatureGroup.match_feature_group_criteria(
+            "f0__x_guarded", Options(context={"columns": ["a", "b"]})
+        )
+
+        assert result is True
+
+    def test_falsy_guard_is_a_plain_non_match(self) -> None:
+        """A rejecting guard yields False without raising, even though the key is not strict."""
+        result = GuardedNamePathFeatureGroup.match_feature_group_criteria(
+            "f0__x_guarded", Options(context={"columns": "not_a_list"})
+        )
+
+        assert result is False
+
+    def test_guard_rejection_has_nothing_to_report(self) -> None:
+        """A guard rejection is not a strict_validation rejection, so there is no reason."""
+        options = Options(context={"columns": "not_a_list"})
+
+        reason = GuardedNamePathFeatureGroup._strict_validation_rejection_reason("f0__x_guarded", options)
+
+        assert reason is None

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_option_value_rejection_never_escapes.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_option_value_rejection_never_escapes.py
@@ -1,24 +1,9 @@
-"""An option-value rejection is a NON-MATCH, and it never escapes into the engine (issue #732).
+"""A value the mapping rejects, however it is rejected, is a non-match with an actionable reason.
 
-Validating the values of the options that are present on the string-named path (58b0d6d) turned
-two previously silent inputs into escaping exceptions:
+This holds for a feature group that overrides the match hook and calls the parser directly, and for an
+``element_validator`` that raises instead of returning falsy. Nothing escapes the filter loop as an exception.
 
-1. A feature group that OVERRIDES ``match_feature_group_criteria`` and calls
-   ``FeatureChainParser.match_configuration_feature_chain_parser`` DIRECTLY has no ValueError
-   swallow of its own (``SklearnPipelineFeatureGroup`` is the shipped example). The parser's
-   rejection therefore travels straight through ``IdentifyFeatureGroupClass``, out of the whole
-   run: no "No feature groups found", no hint, and every candidate in the filter loop is exposed
-   to it, so ONE bad option poisons the identification of the feature entirely.
-2. An ``element_validator`` that RAISES instead of returning False (membership against a dict with
-   an unhashable element raises TypeError) escapes the mixin, whose swallow only catches
-   ValueError, and escapes the error-message builder too.
-
-The contract pinned here: a value the mapping rejects, however it is rejected, is a non-match with
-an actionable reason naming the key and the value. Nothing reaches the caller as an exception from
-the filter loop.
-
-All fixture names carry an "esc732" marker so they cannot collide with other tests in the global
-plugin registry.
+All fixture names carry an "esc732" marker so they cannot collide with other tests in the global plugin registry.
 """
 
 from __future__ import annotations
@@ -66,10 +51,8 @@ class MockComputeFrameworkEsc732(ComputeFramework):
 
 
 class DirectParserOverrideFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-    """Mirrors SklearnPipelineFeatureGroup: overrides the match hook, calls the parser directly.
-
-    No try/except of its own, exactly like the shipped plugin. The strict key is never encoded in
-    the feature name, which is the shape the string-named path now validates.
+    """Mirrors SklearnPipelineFeatureGroup: overrides the match hook and calls the parser directly, with no
+    ValueError swallow of its own. The strict key is never encoded in the feature name.
     """
 
     PREFIX_PATTERN = r".*__esc732_pipeline_([\w]+)$"
@@ -121,9 +104,8 @@ class NeighborFeatureGroup(FeatureGroup):
 
 
 class RaisingTypeErrorValidatorFeatureGroup(FeatureChainParserMixin, FeatureGroup):
-    """Mirrors TextCleaningFeatureGroup: element_validator is membership against a dict.
-
-    An unhashable element makes the validator itself raise TypeError, rather than returning False.
+    """Mirrors TextCleaningFeatureGroup: element_validator is membership against a dict, so an unhashable
+    element makes the validator itself raise TypeError instead of returning False.
     """
 
     PREFIX_PATTERN = r".*__cleaned_esc732$"
@@ -211,11 +193,7 @@ class TestRaisingElementValidatorIsARejection:
         assert result is False
 
     def test_parser_reports_a_raising_validator_as_a_value_rejection(self) -> None:
-        """The parser converts the validator's own exception into the standard ValueError.
-
-        ValueError is the single signal both the mixin's swallow and the reason builder read; a
-        TypeError from inside the validator bypasses them and escapes.
-        """
+        """The parser converts the validator's own exception into the ValueError its callers read."""
         with pytest.raises(ValueError) as exc_info:
             FeatureChainParser.match_configuration_feature_chain_parser(
                 OPERATIONS_FEATURE,
@@ -300,11 +278,7 @@ class TestRejectionNeverEscapesTheEngine:
     """The filter loop must never leak a rejection as an exception, whoever calls the parser."""
 
     def test_direct_parser_caller_yields_the_standard_no_match_error(self) -> None:
-        """A feature group that calls the parser directly cannot break feature identification.
-
-        The user must get mloda's normal "No feature groups found" error, carrying the rejection
-        reason, rather than the parser's bare ValueError out of the engine.
-        """
+        """A direct parser caller yields the normal "No feature groups found" error carrying the reason."""
         feature = Feature(PIPELINE_FEATURE, Options(context={PIPELINE_KEY: "custom"}))
         accessible_plugins: FeatureGroupEnvironmentMapping = {
             DirectParserOverrideFeatureGroup: {MockComputeFrameworkEsc732},
@@ -322,11 +296,7 @@ class TestRejectionNeverEscapesTheEngine:
         assert "custom" in message
 
     def test_direct_parser_caller_does_not_poison_other_candidates(self) -> None:
-        """One rejecting candidate must not take the whole filter loop down with it.
-
-        The loop consults every accessible plugin, so a raising candidate would deny the feature
-        to the feature group that legitimately owns it.
-        """
+        """One rejecting candidate must not deny the feature to the group that legitimately owns it."""
         feature = Feature(PIPELINE_FEATURE, Options(context={PIPELINE_KEY: "custom"}))
         accessible_plugins: FeatureGroupEnvironmentMapping = {
             DirectParserOverrideFeatureGroup: {MockComputeFrameworkEsc732},
@@ -372,10 +342,10 @@ class TestRejectionNeverEscapesTheEngine:
 
 
 class TestParserContractUnchangedForOrdinaryRejections:
-    """The ordinary membership rejection keeps raising ValueError from the parser (58b0d6d)."""
+    """The ordinary membership rejection keeps raising ValueError from the parser."""
 
     def test_parser_raises_valueerror_for_a_direct_caller(self) -> None:
-        """The parser signals a rejected value; the CALLER is what must not let it escape."""
+        """The parser signals a rejected value; the caller is what must not let it escape."""
         with pytest.raises(ValueError) as exc_info:
             FeatureChainParser.match_configuration_feature_chain_parser(
                 PIPELINE_FEATURE,

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_option_value_rejection_never_escapes.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_option_value_rejection_never_escapes.py
@@ -1,0 +1,389 @@
+"""An option-value rejection is a NON-MATCH, and it never escapes into the engine (issue #732).
+
+Validating the values of the options that are present on the string-named path (58b0d6d) turned
+two previously silent inputs into escaping exceptions:
+
+1. A feature group that OVERRIDES ``match_feature_group_criteria`` and calls
+   ``FeatureChainParser.match_configuration_feature_chain_parser`` DIRECTLY has no ValueError
+   swallow of its own (``SklearnPipelineFeatureGroup`` is the shipped example). The parser's
+   rejection therefore travels straight through ``IdentifyFeatureGroupClass``, out of the whole
+   run: no "No feature groups found", no hint, and every candidate in the filter loop is exposed
+   to it, so ONE bad option poisons the identification of the feature entirely.
+2. An ``element_validator`` that RAISES instead of returning False (membership against a dict with
+   an unhashable element raises TypeError) escapes the mixin, whose swallow only catches
+   ValueError, and escapes the error-message builder too.
+
+The contract pinned here: a value the mapping rejects, however it is rejected, is a non-match with
+an actionable reason naming the key and the value. Nothing reaches the caller as an exception from
+the filter loop.
+
+All fixture names carry an "esc732" marker so they cannot collide with other tests in the global
+plugin registry.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import pytest
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import (
+    FeatureChainParser,
+)
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import (
+    FeatureChainParserMixin,
+)
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+
+
+PIPELINE_KEY = "pipeline_name_esc732"
+OPERATIONS_KEY = "operations_esc732"
+PREFIX_KEY = "prefix_esc732"
+
+PIPELINE_FEATURE = "income__esc732_pipeline_custom"
+OPERATIONS_FEATURE = "text__cleaned_esc732"
+PREFIX_FEATURE = "text__prefixed_esc732"
+
+# An unhashable element: `element in {dict}` raises TypeError instead of returning False.
+UNHASHABLE_VALUE: dict[str, int] = {"a": 1}
+
+SUPPORTED_OPERATIONS_ESC732: dict[str, str] = {
+    "normalize": "Normalize the text (esc732 fixture)",
+    "strip": "Strip the text (esc732 fixture)",
+}
+
+
+class MockComputeFrameworkEsc732(ComputeFramework):
+    """Mock compute framework, following the existing identify_feature_group test pattern."""
+
+
+class DirectParserOverrideFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+    """Mirrors SklearnPipelineFeatureGroup: overrides the match hook, calls the parser directly.
+
+    No try/except of its own, exactly like the shipped plugin. The strict key is never encoded in
+    the feature name, which is the shape the string-named path now validates.
+    """
+
+    PREFIX_PATTERN = r".*__esc732_pipeline_([\w]+)$"
+
+    PROPERTY_MAPPING = {
+        PIPELINE_KEY: {
+            DefaultOptionKeys.allowed_values: {"scaling": "Scaling", "imputation": "Imputation"},
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: True,
+            DefaultOptionKeys.default: None,
+        }
+    }
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        name = str(feature_name)
+        if options.get(PIPELINE_KEY) is None and "esc732_pipeline_" not in name:
+            return False
+        return FeatureChainParser.match_configuration_feature_chain_parser(
+            name,
+            options,
+            property_mapping=cls.PROPERTY_MAPPING,
+            prefix_patterns=[cls.PREFIX_PATTERN],
+        )
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class NeighborFeatureGroup(FeatureGroup):
+    """Claims the same feature name and accepts any options: the feature has a valid owner."""
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == PIPELINE_FEATURE
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class RaisingTypeErrorValidatorFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+    """Mirrors TextCleaningFeatureGroup: element_validator is membership against a dict.
+
+    An unhashable element makes the validator itself raise TypeError, rather than returning False.
+    """
+
+    PREFIX_PATTERN = r".*__cleaned_esc732$"
+
+    PROPERTY_MAPPING = {
+        OPERATIONS_KEY: {
+            DefaultOptionKeys.allowed_values: SUPPORTED_OPERATIONS_ESC732,
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: True,
+            DefaultOptionKeys.element_validator: lambda op: op in SUPPORTED_OPERATIONS_ESC732,
+        },
+        DefaultOptionKeys.in_features: {
+            "explanation": "Source feature (esc732 fixture)",
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: False,
+        },
+    }
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class RaisingAttributeErrorValidatorFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+    """element_validator that raises AttributeError on a value of the wrong type."""
+
+    PREFIX_PATTERN = r".*__prefixed_esc732$"
+
+    PROPERTY_MAPPING = {
+        PREFIX_KEY: {
+            "explanation": "Value must start with 'ok' (esc732 fixture)",
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: True,
+            DefaultOptionKeys.element_validator: lambda value: value.startswith("ok"),
+        }
+    }
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+def _identify(feature: Feature, accessible_plugins: FeatureGroupEnvironmentMapping) -> IdentifyFeatureGroupClass:
+    return IdentifyFeatureGroupClass(
+        feature=feature,
+        accessible_plugins=accessible_plugins,
+        links=None,
+        data_access_collection=None,
+    )
+
+
+class TestRaisingElementValidatorIsARejection:
+    """A validator that raises rejects the value; it does not blow up the match."""
+
+    def test_name_path_typeerror_validator_is_a_non_match(self) -> None:
+        """An unhashable element makes the membership-style validator raise: still a non-match."""
+        options = Options(context={OPERATIONS_KEY: [UNHASHABLE_VALUE]})
+
+        result = RaisingTypeErrorValidatorFeatureGroup.match_feature_group_criteria(OPERATIONS_FEATURE, options)
+
+        assert result is False
+
+    def test_config_path_typeerror_validator_is_a_non_match(self) -> None:
+        """The config-based path reaches the same verdict for the same value."""
+        options = Options(
+            context={OPERATIONS_KEY: [UNHASHABLE_VALUE], DefaultOptionKeys.in_features: "text"},
+        )
+
+        result = RaisingTypeErrorValidatorFeatureGroup.match_feature_group_criteria("placeholder_esc732", options)
+
+        assert result is False
+
+    def test_name_path_attributeerror_validator_is_a_non_match(self) -> None:
+        """A validator raising AttributeError is a rejection too, not an escape."""
+        options = Options(context={PREFIX_KEY: 5})
+
+        result = RaisingAttributeErrorValidatorFeatureGroup.match_feature_group_criteria(PREFIX_FEATURE, options)
+
+        assert result is False
+
+    def test_config_path_attributeerror_validator_is_a_non_match(self) -> None:
+        """Same verdict on the config-based path."""
+        options = Options(context={PREFIX_KEY: 5})
+
+        result = RaisingAttributeErrorValidatorFeatureGroup.match_feature_group_criteria("placeholder_esc732", options)
+
+        assert result is False
+
+    def test_parser_reports_a_raising_validator_as_a_value_rejection(self) -> None:
+        """The parser converts the validator's own exception into the standard ValueError.
+
+        ValueError is the single signal both the mixin's swallow and the reason builder read; a
+        TypeError from inside the validator bypasses them and escapes.
+        """
+        with pytest.raises(ValueError) as exc_info:
+            FeatureChainParser.match_configuration_feature_chain_parser(
+                OPERATIONS_FEATURE,
+                Options(context={OPERATIONS_KEY: [UNHASHABLE_VALUE]}),
+                property_mapping=RaisingTypeErrorValidatorFeatureGroup.PROPERTY_MAPPING,
+                prefix_patterns=[RaisingTypeErrorValidatorFeatureGroup.PREFIX_PATTERN],
+            )
+
+        message = str(exc_info.value)
+        assert OPERATIONS_KEY in message
+        assert str(UNHASHABLE_VALUE) in message
+
+
+class TestRaisingElementValidatorRejectionReason:
+    """The discarded message stays actionable: it names the key and the rejected value."""
+
+    def test_reason_for_typeerror_validator_on_name_path(self) -> None:
+        """_strict_validation_rejection_reason is diagnostic-only: it reports, it never raises."""
+        options = Options(context={OPERATIONS_KEY: [UNHASHABLE_VALUE]})
+
+        reason = RaisingTypeErrorValidatorFeatureGroup._strict_validation_rejection_reason(OPERATIONS_FEATURE, options)
+
+        assert reason is not None
+        assert OPERATIONS_KEY in reason
+        assert str(UNHASHABLE_VALUE) in reason
+
+    def test_reason_for_typeerror_validator_on_config_path(self) -> None:
+        """The config-based path reports the same rejection."""
+        options = Options(
+            context={OPERATIONS_KEY: [UNHASHABLE_VALUE], DefaultOptionKeys.in_features: "text"},
+        )
+
+        reason = RaisingTypeErrorValidatorFeatureGroup._strict_validation_rejection_reason(
+            "placeholder_esc732", options
+        )
+
+        assert reason is not None
+        assert OPERATIONS_KEY in reason
+        assert str(UNHASHABLE_VALUE) in reason
+
+    def test_reason_for_attributeerror_validator(self) -> None:
+        """An AttributeError-raising validator produces a reason, not an escape."""
+        options = Options(context={PREFIX_KEY: 5})
+
+        reason = RaisingAttributeErrorValidatorFeatureGroup._strict_validation_rejection_reason(PREFIX_FEATURE, options)
+
+        assert reason is not None
+        assert PREFIX_KEY in reason
+        assert "5" in reason
+
+
+class TestValidValuesStillMatchThroughRaisingValidators:
+    """Guard against over-rejecting: the validators still accept what they always accepted."""
+
+    def test_valid_operation_on_name_path_matches(self) -> None:
+        options = Options(context={OPERATIONS_KEY: ["normalize"]})
+
+        assert RaisingTypeErrorValidatorFeatureGroup.match_feature_group_criteria(OPERATIONS_FEATURE, options) is True
+
+    def test_valid_operation_on_config_path_matches(self) -> None:
+        options = Options(context={OPERATIONS_KEY: ["normalize"], DefaultOptionKeys.in_features: "text"})
+
+        assert RaisingTypeErrorValidatorFeatureGroup.match_feature_group_criteria("placeholder_esc732", options) is True
+
+    def test_hashable_non_member_is_still_a_plain_rejection(self) -> None:
+        """A value the validator can judge (and rejects) keeps its existing verdict."""
+        options = Options(context={OPERATIONS_KEY: ["bogus"]})
+
+        assert RaisingTypeErrorValidatorFeatureGroup.match_feature_group_criteria(OPERATIONS_FEATURE, options) is False
+
+    def test_valid_prefix_value_matches(self) -> None:
+        options = Options(context={PREFIX_KEY: "ok_value"})
+
+        assert RaisingAttributeErrorValidatorFeatureGroup.match_feature_group_criteria(PREFIX_FEATURE, options) is True
+
+    def test_bare_name_match_without_options_still_matches(self) -> None:
+        """Required-PRESENCE stays off on the name path, raising validators or not."""
+        assert RaisingTypeErrorValidatorFeatureGroup.match_feature_group_criteria(OPERATIONS_FEATURE, Options()) is True
+
+
+class TestRejectionNeverEscapesTheEngine:
+    """The filter loop must never leak a rejection as an exception, whoever calls the parser."""
+
+    def test_direct_parser_caller_yields_the_standard_no_match_error(self) -> None:
+        """A feature group that calls the parser directly cannot break feature identification.
+
+        The user must get mloda's normal "No feature groups found" error, carrying the rejection
+        reason, rather than the parser's bare ValueError out of the engine.
+        """
+        feature = Feature(PIPELINE_FEATURE, Options(context={PIPELINE_KEY: "custom"}))
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            DirectParserOverrideFeatureGroup: {MockComputeFrameworkEsc732},
+        }
+
+        with pytest.raises(ValueError) as exc_info:
+            _identify(feature, accessible_plugins)
+
+        message = str(exc_info.value)
+        assert "No feature groups found" in message, (
+            f"A rejected option value must be a non-match, not a bare parser error out of the engine, "
+            f"but got: {message}"
+        )
+        assert PIPELINE_KEY in message
+        assert "custom" in message
+
+    def test_direct_parser_caller_does_not_poison_other_candidates(self) -> None:
+        """One rejecting candidate must not take the whole filter loop down with it.
+
+        The loop consults every accessible plugin, so a raising candidate would deny the feature
+        to the feature group that legitimately owns it.
+        """
+        feature = Feature(PIPELINE_FEATURE, Options(context={PIPELINE_KEY: "custom"}))
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            DirectParserOverrideFeatureGroup: {MockComputeFrameworkEsc732},
+            NeighborFeatureGroup: {MockComputeFrameworkEsc732},
+        }
+
+        identified = _identify(feature, accessible_plugins)
+
+        feature_group, _frameworks = identified.get()
+        assert feature_group is NeighborFeatureGroup
+
+    def test_raising_element_validator_yields_the_standard_no_match_error(self) -> None:
+        """A validator that raises must not escape the engine either."""
+        feature = Feature(OPERATIONS_FEATURE, Options(context={OPERATIONS_KEY: [UNHASHABLE_VALUE]}))
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            RaisingTypeErrorValidatorFeatureGroup: {MockComputeFrameworkEsc732},
+        }
+
+        with pytest.raises(ValueError) as exc_info:
+            _identify(feature, accessible_plugins)
+
+        message = str(exc_info.value)
+        assert "No feature groups found" in message, (
+            f"A validator that raises must be a non-match, not an exception out of the engine, but got: {message}"
+        )
+        assert OPERATIONS_KEY in message
+        assert str(UNHASHABLE_VALUE) in message
+
+    def test_valid_option_value_still_resolves_through_a_direct_parser_caller(self) -> None:
+        """A valid strict value on a string-named feature still identifies its feature group."""
+        feature = Feature(
+            "income__esc732_pipeline_scaling",
+            Options(context={PIPELINE_KEY: "scaling"}),
+        )
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            DirectParserOverrideFeatureGroup: {MockComputeFrameworkEsc732},
+        }
+
+        identified = _identify(feature, accessible_plugins)
+
+        feature_group, _frameworks = identified.get()
+        assert feature_group is DirectParserOverrideFeatureGroup
+
+
+class TestParserContractUnchangedForOrdinaryRejections:
+    """The ordinary membership rejection keeps raising ValueError from the parser (58b0d6d)."""
+
+    def test_parser_raises_valueerror_for_a_direct_caller(self) -> None:
+        """The parser signals a rejected value; the CALLER is what must not let it escape."""
+        with pytest.raises(ValueError) as exc_info:
+            FeatureChainParser.match_configuration_feature_chain_parser(
+                PIPELINE_FEATURE,
+                Options(context={PIPELINE_KEY: "custom"}),
+                property_mapping=DirectParserOverrideFeatureGroup.PROPERTY_MAPPING,
+                prefix_patterns=[DirectParserOverrideFeatureGroup.PREFIX_PATTERN],
+            )
+
+        message = str(exc_info.value)
+        assert PIPELINE_KEY in message
+        assert "custom" in message

--- a/tests/test_plugins/feature_group/experimental/sklearn/test_pipeline_feature_group/test_pipeline_name_option_validation.py
+++ b/tests/test_plugins/feature_group/experimental/sklearn/test_pipeline_feature_group/test_pipeline_name_option_validation.py
@@ -1,0 +1,117 @@
+"""A rejected pipeline_name is a non-match, not an exception (issue #732 regression).
+
+``SklearnPipelineFeatureGroup`` overrides ``match_feature_group_criteria`` and calls
+``FeatureChainParser.match_configuration_feature_chain_parser`` directly, without the mixin's
+ValueError swallow. Its PIPELINE_NAME spec is strict_validation=True with allowed_values=
+PIPELINE_TYPES and is never encoded in the feature name, which is exactly the shape the
+string-named path now validates: a bogus value raises ValueError straight out of the override, and
+straight out of the engine's filter loop with it.
+
+A value outside PIPELINE_TYPES must be a NON-MATCH on both paths, with the standard
+"No feature groups found" error and the rejection reason naming the key and the value.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+from mloda.provider import DefaultOptionKeys
+from mloda.user import Options
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.feature_group.experimental.sklearn.pipeline.base import SklearnPipelineFeatureGroup
+from mloda_plugins.feature_group.experimental.sklearn.pipeline.pandas import PandasSklearnPipelineFeatureGroup
+
+
+# "custom" is deliberately NOT a member of PIPELINE_TYPES.
+BOGUS_PIPELINE_NAME = "custom"
+BOGUS_FEATURE = "income__sklearn_pipeline_custom"
+VALID_FEATURE = "income__sklearn_pipeline_scaling"
+
+
+class TestBogusPipelineNameIsANonMatch:
+    def test_pipeline_types_does_not_contain_the_bogus_value(self) -> None:
+        """Precondition: the rejected value really is outside the declared value space."""
+        assert BOGUS_PIPELINE_NAME not in SklearnPipelineFeatureGroup.PIPELINE_TYPES
+
+    def test_name_path_bogus_pipeline_name_returns_false(self) -> None:
+        """The reproduction: a string-named pipeline feature with a bogus pipeline_name."""
+        options = Options(context={SklearnPipelineFeatureGroup.PIPELINE_NAME: BOGUS_PIPELINE_NAME})
+
+        result = SklearnPipelineFeatureGroup.match_feature_group_criteria(BOGUS_FEATURE, options)
+
+        assert result is False
+
+    def test_config_path_bogus_pipeline_name_returns_false(self) -> None:
+        """The config-based path reaches the same verdict, and does not raise either."""
+        options = Options(
+            context={
+                SklearnPipelineFeatureGroup.PIPELINE_NAME: BOGUS_PIPELINE_NAME,
+                DefaultOptionKeys.in_features: "income",
+            }
+        )
+
+        result = SklearnPipelineFeatureGroup.match_feature_group_criteria("placeholder", options)
+
+        assert result is False
+
+    def test_rejection_reason_names_key_and_value(self) -> None:
+        """The discarded message stays actionable."""
+        options = Options(context={SklearnPipelineFeatureGroup.PIPELINE_NAME: BOGUS_PIPELINE_NAME})
+
+        reason = SklearnPipelineFeatureGroup._strict_validation_rejection_reason(BOGUS_FEATURE, options)
+
+        assert reason is not None
+        assert SklearnPipelineFeatureGroup.PIPELINE_NAME in reason
+        assert BOGUS_PIPELINE_NAME in reason
+
+
+class TestValidPipelineNameStillMatches:
+    """Guard against over-rejecting: only bogus values are rejected."""
+
+    def test_valid_pipeline_name_on_name_path_matches(self) -> None:
+        options = Options(context={SklearnPipelineFeatureGroup.PIPELINE_NAME: "scaling"})
+
+        assert SklearnPipelineFeatureGroup.match_feature_group_criteria(VALID_FEATURE, options) is True
+
+    def test_name_path_without_options_matches(self) -> None:
+        """The name carries the pipeline; no options at all is still a match."""
+        assert SklearnPipelineFeatureGroup.match_feature_group_criteria(VALID_FEATURE, Options()) is True
+
+    def test_config_path_with_valid_pipeline_name_matches(self) -> None:
+        options = Options(
+            context={
+                SklearnPipelineFeatureGroup.PIPELINE_NAME: "scaling",
+                DefaultOptionKeys.in_features: "income",
+            }
+        )
+
+        assert SklearnPipelineFeatureGroup.match_feature_group_criteria("placeholder", options) is True
+
+
+class TestBogusPipelineNameAtEngineLevel:
+    """The rejection must not travel out of feature identification."""
+
+    def test_engine_reports_no_feature_groups_found_with_the_reason(self) -> None:
+        feature = Feature(BOGUS_FEATURE, Options(context={SklearnPipelineFeatureGroup.PIPELINE_NAME: "custom"}))
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            PandasSklearnPipelineFeatureGroup: {PandasDataFrame},
+        }
+
+        with pytest.raises(ValueError) as exc_info:
+            IdentifyFeatureGroupClass(
+                feature=feature,
+                accessible_plugins=accessible_plugins,
+                links=None,
+                data_access_collection=None,
+            )
+
+        message = str(exc_info.value)
+        assert "No feature groups found" in message, (
+            f"A bogus pipeline_name must be a non-match with mloda's standard error, "
+            f"not a bare ValueError out of the engine, but got: {message}"
+        )
+        assert SklearnPipelineFeatureGroup.PIPELINE_NAME in message
+        assert BOGUS_PIPELINE_NAME in message

--- a/tests/test_plugins/feature_group/experimental/sklearn/test_pipeline_feature_group/test_pipeline_name_option_validation.py
+++ b/tests/test_plugins/feature_group/experimental/sklearn/test_pipeline_feature_group/test_pipeline_name_option_validation.py
@@ -1,14 +1,7 @@
-"""A rejected pipeline_name is a non-match, not an exception (issue #732 regression).
+"""A pipeline_name outside PIPELINE_TYPES is a non-match on both paths, not an exception.
 
-``SklearnPipelineFeatureGroup`` overrides ``match_feature_group_criteria`` and calls
-``FeatureChainParser.match_configuration_feature_chain_parser`` directly, without the mixin's
-ValueError swallow. Its PIPELINE_NAME spec is strict_validation=True with allowed_values=
-PIPELINE_TYPES and is never encoded in the feature name, which is exactly the shape the
-string-named path now validates: a bogus value raises ValueError straight out of the override, and
-straight out of the engine's filter loop with it.
-
-A value outside PIPELINE_TYPES must be a NON-MATCH on both paths, with the standard
-"No feature groups found" error and the rejection reason naming the key and the value.
+``SklearnPipelineFeatureGroup`` overrides the match hook and calls the parser directly, so it is the case where
+a rejection could escape the engine. The user gets "No feature groups found" with the reason instead.
 """
 
 from __future__ import annotations
@@ -37,7 +30,7 @@ class TestBogusPipelineNameIsANonMatch:
         assert BOGUS_PIPELINE_NAME not in SklearnPipelineFeatureGroup.PIPELINE_TYPES
 
     def test_name_path_bogus_pipeline_name_returns_false(self) -> None:
-        """The reproduction: a string-named pipeline feature with a bogus pipeline_name."""
+        """A string-named pipeline feature carrying a bogus pipeline_name does not match."""
         options = Options(context={SklearnPipelineFeatureGroup.PIPELINE_NAME: BOGUS_PIPELINE_NAME})
 
         result = SklearnPipelineFeatureGroup.match_feature_group_criteria(BOGUS_FEATURE, options)

--- a/tests/test_plugins/feature_group/experimental/test_dimensionality_reduction_feature_group/test_name_path_option_validation.py
+++ b/tests/test_plugins/feature_group/experimental/test_dimensionality_reduction_feature_group/test_name_path_option_validation.py
@@ -1,0 +1,103 @@
+"""Options-only algorithm parameters are validated on the string-named path too (issue #732).
+
+``pca_svd_solver`` and ``tsne_method`` are strict_validation keys with an ``allowed_values``
+space, and neither is ever encoded in the feature name. The config-based path rejected a bogus
+value for them; the string-named path accepted it, because a PREFIX_PATTERN match short-circuited
+before the options were ever read. Both paths must reach the same verdict.
+"""
+
+from __future__ import annotations
+
+from mloda.provider import DefaultOptionKeys
+from mloda.user import Options
+from mloda_plugins.feature_group.experimental.dimensionality_reduction.base import (
+    DimensionalityReductionFeatureGroup,
+)
+
+
+class TestPcaSvdSolverValidatedOnBothPaths:
+    """The reproduction from issue #732."""
+
+    def test_config_path_rejects_bogus_solver(self) -> None:
+        """Config-based path already rejects a solver outside allowed_values."""
+        options = Options(
+            context={
+                DimensionalityReductionFeatureGroup.ALGORITHM: "pca",
+                DimensionalityReductionFeatureGroup.DIMENSION: 2,
+                DefaultOptionKeys.in_features: "f0",
+                DimensionalityReductionFeatureGroup.PCA_SVD_SOLVER: "bogus",
+            }
+        )
+
+        assert DimensionalityReductionFeatureGroup.match_feature_group_criteria("placeholder", options) is False
+
+    def test_name_path_rejects_bogus_solver(self) -> None:
+        """String-named path must reject the same solver value, instead of waving it through."""
+        options = Options(context={DimensionalityReductionFeatureGroup.PCA_SVD_SOLVER: "bogus"})
+
+        assert DimensionalityReductionFeatureGroup.match_feature_group_criteria("f0,f1,f2__pca_2d", options) is False
+
+    def test_name_path_accepts_valid_solver(self) -> None:
+        """A member of the solver value space on a name-matched feature still matches."""
+        options = Options(context={DimensionalityReductionFeatureGroup.PCA_SVD_SOLVER: "arpack"})
+
+        assert DimensionalityReductionFeatureGroup.match_feature_group_criteria("f0__pca_2d", options) is True
+
+    def test_name_path_rejection_reason_names_key_and_value(self) -> None:
+        """The discarded ValueError message identifies the key and the rejected value."""
+        options = Options(context={DimensionalityReductionFeatureGroup.PCA_SVD_SOLVER: "bogus"})
+
+        reason = DimensionalityReductionFeatureGroup._strict_validation_rejection_reason("f0__pca_2d", options)
+
+        assert reason is not None
+        assert DimensionalityReductionFeatureGroup.PCA_SVD_SOLVER in reason
+        assert "bogus" in reason
+
+
+class TestTsneMethodValidatedOnBothPaths:
+    """tsne_method has the same shape: strict, allowed_values, options-only."""
+
+    def test_config_path_rejects_bogus_method(self) -> None:
+        """Config-based path rejects a t-SNE method outside allowed_values."""
+        options = Options(
+            context={
+                DimensionalityReductionFeatureGroup.ALGORITHM: "tsne",
+                DimensionalityReductionFeatureGroup.DIMENSION: 2,
+                DefaultOptionKeys.in_features: "f0",
+                DimensionalityReductionFeatureGroup.TSNE_METHOD: "bogus",
+            }
+        )
+
+        assert DimensionalityReductionFeatureGroup.match_feature_group_criteria("placeholder", options) is False
+
+    def test_name_path_rejects_bogus_method(self) -> None:
+        """String-named path must reject the same t-SNE method value."""
+        options = Options(context={DimensionalityReductionFeatureGroup.TSNE_METHOD: "bogus"})
+
+        assert DimensionalityReductionFeatureGroup.match_feature_group_criteria("f0__tsne_2d", options) is False
+
+    def test_name_path_accepts_valid_method(self) -> None:
+        """A member of the t-SNE method value space still matches."""
+        options = Options(context={DimensionalityReductionFeatureGroup.TSNE_METHOD: "exact"})
+
+        assert DimensionalityReductionFeatureGroup.match_feature_group_criteria("f0__tsne_2d", options) is True
+
+
+class TestNamePathElementValidatorAndPresence:
+    """dimension is strict + element_validator; presence stays satisfiable by the name."""
+
+    def test_name_path_rejects_invalid_dimension_option(self) -> None:
+        """An element_validator-backed key is validated on the name path as well."""
+        options = Options(context={DimensionalityReductionFeatureGroup.DIMENSION: -1})
+
+        assert DimensionalityReductionFeatureGroup.match_feature_group_criteria("f0__pca_2d", options) is False
+
+    def test_name_match_without_options_still_matches(self) -> None:
+        """Required-PRESENCE stays off on the name path: the name carries algorithm and dimension."""
+        assert DimensionalityReductionFeatureGroup.match_feature_group_criteria("f0__pca_2d", Options()) is True
+
+    def test_non_strict_key_with_bad_looking_value_is_accepted(self) -> None:
+        """isomap_n_neighbors is strict_validation=False, so no value space is enforced."""
+        options = Options(context={DimensionalityReductionFeatureGroup.ISOMAP_N_NEIGHBORS: "not_a_number"})
+
+        assert DimensionalityReductionFeatureGroup.match_feature_group_criteria("f0__isomap_2d", options) is True

--- a/tests/test_plugins/feature_group/experimental/test_dimensionality_reduction_feature_group/test_name_path_option_validation.py
+++ b/tests/test_plugins/feature_group/experimental/test_dimensionality_reduction_feature_group/test_name_path_option_validation.py
@@ -1,9 +1,7 @@
-"""Options-only algorithm parameters are validated on the string-named path too (issue #732).
+"""Options-only algorithm parameters are validated on both match paths.
 
-``pca_svd_solver`` and ``tsne_method`` are strict_validation keys with an ``allowed_values``
-space, and neither is ever encoded in the feature name. The config-based path rejected a bogus
-value for them; the string-named path accepted it, because a PREFIX_PATTERN match short-circuited
-before the options were ever read. Both paths must reach the same verdict.
+``pca_svd_solver`` and ``tsne_method`` are strict keys with an ``allowed_values`` space that the feature name
+never encodes, so a name match must reach the same verdict as the config-based one.
 """
 
 from __future__ import annotations
@@ -25,10 +23,10 @@ from mloda_plugins.feature_group.experimental.dimensionality_reduction.pandas im
 
 
 class TestPcaSvdSolverValidatedOnBothPaths:
-    """The reproduction from issue #732."""
+    """pca_svd_solver: strict, allowed_values, options-only."""
 
     def test_config_path_rejects_bogus_solver(self) -> None:
-        """Config-based path already rejects a solver outside allowed_values."""
+        """The config-based path rejects a solver outside allowed_values."""
         options = Options(
             context={
                 DimensionalityReductionFeatureGroup.ALGORITHM: "pca",
@@ -41,7 +39,7 @@ class TestPcaSvdSolverValidatedOnBothPaths:
         assert DimensionalityReductionFeatureGroup.match_feature_group_criteria("placeholder", options) is False
 
     def test_name_path_rejects_bogus_solver(self) -> None:
-        """String-named path must reject the same solver value, instead of waving it through."""
+        """The string-named path rejects the same solver value."""
         options = Options(context={DimensionalityReductionFeatureGroup.PCA_SVD_SOLVER: "bogus"})
 
         assert DimensionalityReductionFeatureGroup.match_feature_group_criteria("f0,f1,f2__pca_2d", options) is False
@@ -80,7 +78,7 @@ class TestTsneMethodValidatedOnBothPaths:
         assert DimensionalityReductionFeatureGroup.match_feature_group_criteria("placeholder", options) is False
 
     def test_name_path_rejects_bogus_method(self) -> None:
-        """String-named path must reject the same t-SNE method value."""
+        """The string-named path rejects the same t-SNE method value."""
         options = Options(context={DimensionalityReductionFeatureGroup.TSNE_METHOD: "bogus"})
 
         assert DimensionalityReductionFeatureGroup.match_feature_group_criteria("f0__tsne_2d", options) is False
@@ -120,13 +118,9 @@ def _forwarded_child_options(algorithm: str) -> Options:
 
 
 class TestForwardedAlgorithmOutsideTheChildValueSpace:
-    """``algorithm`` is shared across feature group families with DIFFERENT value spaces.
-
-    A consumer forwarding algorithm='kmeans' (a clustering algorithm) onto the child 'f0__pca_2d'
-    used to hit ``_validate_forwarded_name_mismatch`` and raise the forward_group_exclude error.
-    The forwarded value is now outside the child's OWN value space, so the parser's value rejection
-    fires first and the verdict is a non-match: the same verdict shape as every other rejected
-    value. Pin which message wins, so it cannot silently change again.
+    """``algorithm`` is shared across feature group families with different value spaces. A forwarded value
+    outside the child's own space is rejected as a value before the forwarded-name mismatch check sees it, so
+    the verdict is a non-match. Pins which of the two messages wins.
     """
 
     def test_forwarded_out_of_space_value_is_a_non_match(self) -> None:

--- a/tests/test_plugins/feature_group/experimental/test_dimensionality_reduction_feature_group/test_name_path_option_validation.py
+++ b/tests/test_plugins/feature_group/experimental/test_dimensionality_reduction_feature_group/test_name_path_option_validation.py
@@ -8,10 +8,19 @@ before the options were ever read. Both paths must reach the same verdict.
 
 from __future__ import annotations
 
+import pytest
+
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
 from mloda.provider import DefaultOptionKeys
 from mloda.user import Options
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 from mloda_plugins.feature_group.experimental.dimensionality_reduction.base import (
     DimensionalityReductionFeatureGroup,
+)
+from mloda_plugins.feature_group.experimental.dimensionality_reduction.pandas import (
+    PandasDimensionalityReductionFeatureGroup,
 )
 
 
@@ -101,3 +110,99 @@ class TestNamePathElementValidatorAndPresence:
         options = Options(context={DimensionalityReductionFeatureGroup.ISOMAP_N_NEIGHBORS: "not_a_number"})
 
         assert DimensionalityReductionFeatureGroup.match_feature_group_criteria("f0__isomap_2d", options) is True
+
+
+def _forwarded_child_options(algorithm: str) -> Options:
+    """Child options as the engine builds them: the consumer's group option flows onto the child."""
+    child = Options()
+    child.inherit_from(Options(group={DimensionalityReductionFeatureGroup.ALGORITHM: algorithm}))
+    return child
+
+
+class TestForwardedAlgorithmOutsideTheChildValueSpace:
+    """``algorithm`` is shared across feature group families with DIFFERENT value spaces.
+
+    A consumer forwarding algorithm='kmeans' (a clustering algorithm) onto the child 'f0__pca_2d'
+    used to hit ``_validate_forwarded_name_mismatch`` and raise the forward_group_exclude error.
+    The forwarded value is now outside the child's OWN value space, so the parser's value rejection
+    fires first and the verdict is a non-match: the same verdict shape as every other rejected
+    value. Pin which message wins, so it cannot silently change again.
+    """
+
+    def test_forwarded_out_of_space_value_is_a_non_match(self) -> None:
+        """A non-match, not a raise: the value rejection precedes the mismatch check."""
+        child_options = _forwarded_child_options("kmeans")
+        assert child_options.inherited_group_keys == frozenset(
+            {DimensionalityReductionFeatureGroup.ALGORITHM}
+        )  # precondition
+
+        result = DimensionalityReductionFeatureGroup.match_feature_group_criteria("f0__pca_2d", child_options)
+
+        assert result is False
+
+    def test_rejection_reason_names_key_and_value(self) -> None:
+        """The strict-validation reason explains WHICH key and WHICH value were rejected."""
+        reason = DimensionalityReductionFeatureGroup._strict_validation_rejection_reason(
+            "f0__pca_2d", _forwarded_child_options("kmeans")
+        )
+
+        assert reason is not None
+        assert DimensionalityReductionFeatureGroup.ALGORITHM in reason
+        assert "kmeans" in reason
+
+    def test_engine_error_keeps_naming_forward_group_exclude(self) -> None:
+        """End-to-end the user still gets the actionable guidance, via the group-option hint."""
+        feature = Feature("f0__pca_2d", _forwarded_child_options("kmeans"))
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            PandasDimensionalityReductionFeatureGroup: {PandasDataFrame},
+        }
+
+        with pytest.raises(ValueError) as exc_info:
+            IdentifyFeatureGroupClass(
+                feature=feature,
+                accessible_plugins=accessible_plugins,
+                links=None,
+                data_access_collection=None,
+            )
+
+        message = str(exc_info.value)
+        assert "No feature groups found" in message
+        assert "forward_group_exclude" in message
+        assert DimensionalityReductionFeatureGroup.ALGORITHM in message
+        assert "kmeans" in message
+
+
+class TestForwardedAlgorithmInsideTheChildValueSpace:
+    """A forwarded value the child DOES accept still contradicts the name: that stays a hard error."""
+
+    def test_forwarded_in_space_value_still_raises_the_mismatch_error(self) -> None:
+        """'tsne' is a valid dimensionality reduction algorithm, but the name parses to 'pca'."""
+        child_options = _forwarded_child_options("tsne")
+
+        with pytest.raises(ValueError) as exc_info:
+            DimensionalityReductionFeatureGroup.match_feature_group_criteria("f0__pca_2d", child_options)
+
+        message = str(exc_info.value)
+        assert "forward_group_exclude" in message
+        assert DimensionalityReductionFeatureGroup.ALGORITHM in message
+        assert "tsne" in message
+        assert "pca" in message
+
+    def test_engine_surfaces_actionable_guidance_for_the_in_space_mismatch(self) -> None:
+        """However the engine reports it, the user is told to carve the key out."""
+        feature = Feature("f0__pca_2d", _forwarded_child_options("tsne"))
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            PandasDimensionalityReductionFeatureGroup: {PandasDataFrame},
+        }
+
+        with pytest.raises(ValueError) as exc_info:
+            IdentifyFeatureGroupClass(
+                feature=feature,
+                accessible_plugins=accessible_plugins,
+                links=None,
+                data_access_collection=None,
+            )
+
+        message = str(exc_info.value)
+        assert "forward_group_exclude" in message
+        assert DimensionalityReductionFeatureGroup.ALGORITHM in message

--- a/tests/test_plugins/feature_group/experimental/test_geo_distance_feature_group/test_in_features_option_validation.py
+++ b/tests/test_plugins/feature_group/experimental/test_geo_distance_feature_group/test_in_features_option_validation.py
@@ -1,8 +1,6 @@
-"""geo_distance's strict in_features spec is enforced on the string-named path too (issue #732).
+"""geo_distance's strict ``in_features`` spec (each point must be a str) is enforced on both match paths.
 
-``in_features`` declares strict_validation=True with an ``element_validator`` (each point must be a
-str), and the string-named path now validates the option values that are present. A non-str point
-is a non-match with an actionable reason, never an exception.
+A non-str point is a non-match with an actionable reason, never an exception.
 """
 
 from __future__ import annotations

--- a/tests/test_plugins/feature_group/experimental/test_geo_distance_feature_group/test_in_features_option_validation.py
+++ b/tests/test_plugins/feature_group/experimental/test_geo_distance_feature_group/test_in_features_option_validation.py
@@ -1,0 +1,64 @@
+"""geo_distance's strict in_features spec is enforced on the string-named path too (issue #732).
+
+``in_features`` declares strict_validation=True with an ``element_validator`` (each point must be a
+str), and the string-named path now validates the option values that are present. A non-str point
+is a non-match with an actionable reason, never an exception.
+"""
+
+from __future__ import annotations
+
+from mloda.provider import DefaultOptionKeys
+from mloda.user import Options
+from mloda_plugins.feature_group.experimental.geo_distance.base import GeoDistanceFeatureGroup
+
+
+GEO_FEATURE = "customer_location&store_location__haversine_distance"
+
+
+class TestInFeaturesValidatedOnNamePath:
+    def test_non_str_point_is_a_non_match(self) -> None:
+        """The element_validator rejects a non-str point on the string-named path."""
+        options = Options(context={DefaultOptionKeys.in_features: [1, 2]})
+
+        assert GeoDistanceFeatureGroup.match_feature_group_criteria(GEO_FEATURE, options) is False
+
+    def test_rejection_reason_names_key_and_value(self) -> None:
+        options = Options(context={DefaultOptionKeys.in_features: [1, 2]})
+
+        reason = GeoDistanceFeatureGroup._strict_validation_rejection_reason(GEO_FEATURE, options)
+
+        assert reason is not None
+        assert str(DefaultOptionKeys.in_features) in reason
+        assert "1" in reason
+
+    def test_str_points_still_match(self) -> None:
+        """Guard against over-rejecting: valid points on a name-matched feature still match."""
+        options = Options(context={DefaultOptionKeys.in_features: ["customer_location", "store_location"]})
+
+        assert GeoDistanceFeatureGroup.match_feature_group_criteria(GEO_FEATURE, options) is True
+
+    def test_name_match_without_options_still_matches(self) -> None:
+        """The name carries the points and the distance type: no options at all still matches."""
+        assert GeoDistanceFeatureGroup.match_feature_group_criteria(GEO_FEATURE, Options()) is True
+
+
+class TestInFeaturesValidatedOnConfigPath:
+    def test_non_str_point_is_a_non_match(self) -> None:
+        options = Options(
+            context={
+                GeoDistanceFeatureGroup.DISTANCE_TYPE: "haversine",
+                DefaultOptionKeys.in_features: [1, 2],
+            }
+        )
+
+        assert GeoDistanceFeatureGroup.match_feature_group_criteria("placeholder", options) is False
+
+    def test_str_points_still_match(self) -> None:
+        options = Options(
+            context={
+                GeoDistanceFeatureGroup.DISTANCE_TYPE: "haversine",
+                DefaultOptionKeys.in_features: ["customer_location", "store_location"],
+            }
+        )
+
+        assert GeoDistanceFeatureGroup.match_feature_group_criteria("placeholder", options) is True

--- a/tests/test_plugins/feature_group/experimental/test_text_cleaning/test_cleaning_operations_option_validation.py
+++ b/tests/test_plugins/feature_group/experimental/test_text_cleaning/test_cleaning_operations_option_validation.py
@@ -1,13 +1,7 @@
-"""An element_validator that raises is a rejection, not an escape (issue #732 regression).
+"""A value the element_validator cannot accept is a non-match, whether the validator returns falsy or raises.
 
-``TextCleaningFeatureGroup`` ships ``element_validator: lambda op: op in SUPPORTED_OPERATIONS``, a
-membership test against a dict. An unhashable element (a dict) makes the validator itself raise
-TypeError. The parser calls the validator unguarded, the mixin's swallow only catches ValueError,
-and the error-message builder only catches ValueError, so the TypeError escapes both the match and
-the engine.
-
-A value the validator cannot accept is a NON-MATCH, whether the validator returns False or raises,
-with the same actionable reason naming the key and the value.
+``TextCleaningFeatureGroup`` ships ``element_validator: lambda op: op in SUPPORTED_OPERATIONS``, a membership
+test against a dict, so an unhashable element makes the validator itself raise TypeError.
 """
 
 from __future__ import annotations
@@ -45,7 +39,7 @@ def _config_path_options(operations: object) -> Options:
 
 class TestUnhashableOperationIsANonMatch:
     def test_name_path_unhashable_operation_returns_false(self) -> None:
-        """The reproduction: the validator raises TypeError; the verdict must be a non-match."""
+        """The validator raises TypeError on the name path; the verdict is a non-match."""
         result = TextCleaningFeatureGroup.match_feature_group_criteria(
             CLEANED_FEATURE, _name_path_options([UNHASHABLE_OPERATION])
         )
@@ -61,7 +55,7 @@ class TestUnhashableOperationIsANonMatch:
         assert result is False
 
     def test_rejection_reason_names_key_and_value_on_name_path(self) -> None:
-        """The reason builder is diagnostic-only: it reports the rejection, it never raises."""
+        """The reason builder reports the rejection instead of raising the validator's TypeError."""
         reason = TextCleaningFeatureGroup._strict_validation_rejection_reason(
             CLEANED_FEATURE, _name_path_options([UNHASHABLE_OPERATION])
         )

--- a/tests/test_plugins/feature_group/experimental/test_text_cleaning/test_cleaning_operations_option_validation.py
+++ b/tests/test_plugins/feature_group/experimental/test_text_cleaning/test_cleaning_operations_option_validation.py
@@ -1,0 +1,133 @@
+"""An element_validator that raises is a rejection, not an escape (issue #732 regression).
+
+``TextCleaningFeatureGroup`` ships ``element_validator: lambda op: op in SUPPORTED_OPERATIONS``, a
+membership test against a dict. An unhashable element (a dict) makes the validator itself raise
+TypeError. The parser calls the validator unguarded, the mixin's swallow only catches ValueError,
+and the error-message builder only catches ValueError, so the TypeError escapes both the match and
+the engine.
+
+A value the validator cannot accept is a NON-MATCH, whether the validator returns False or raises,
+with the same actionable reason naming the key and the value.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+from mloda.provider import DefaultOptionKeys
+from mloda.user import Options
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.feature_group.experimental.text_cleaning.base import TextCleaningFeatureGroup
+from mloda_plugins.feature_group.experimental.text_cleaning.pandas import PandasTextCleaningFeatureGroup
+
+
+CLEANED_FEATURE = "text__cleaned_text"
+
+# Unhashable: `{"a": 1} in SUPPORTED_OPERATIONS` raises TypeError instead of returning False.
+UNHASHABLE_OPERATION: dict[str, int] = {"a": 1}
+
+
+def _name_path_options(operations: object) -> Options:
+    return Options(context={TextCleaningFeatureGroup.CLEANING_OPERATIONS: operations})
+
+
+def _config_path_options(operations: object) -> Options:
+    return Options(
+        context={
+            TextCleaningFeatureGroup.CLEANING_OPERATIONS: operations,
+            DefaultOptionKeys.in_features: "text",
+        }
+    )
+
+
+class TestUnhashableOperationIsANonMatch:
+    def test_name_path_unhashable_operation_returns_false(self) -> None:
+        """The reproduction: the validator raises TypeError; the verdict must be a non-match."""
+        result = TextCleaningFeatureGroup.match_feature_group_criteria(
+            CLEANED_FEATURE, _name_path_options([UNHASHABLE_OPERATION])
+        )
+
+        assert result is False
+
+    def test_config_path_unhashable_operation_returns_false(self) -> None:
+        """The config-based path reaches the same verdict for the same value."""
+        result = TextCleaningFeatureGroup.match_feature_group_criteria(
+            "placeholder", _config_path_options([UNHASHABLE_OPERATION])
+        )
+
+        assert result is False
+
+    def test_rejection_reason_names_key_and_value_on_name_path(self) -> None:
+        """The reason builder is diagnostic-only: it reports the rejection, it never raises."""
+        reason = TextCleaningFeatureGroup._strict_validation_rejection_reason(
+            CLEANED_FEATURE, _name_path_options([UNHASHABLE_OPERATION])
+        )
+
+        assert reason is not None
+        assert TextCleaningFeatureGroup.CLEANING_OPERATIONS in reason
+        assert str(UNHASHABLE_OPERATION) in reason
+
+    def test_rejection_reason_names_key_and_value_on_config_path(self) -> None:
+        reason = TextCleaningFeatureGroup._strict_validation_rejection_reason(
+            "placeholder", _config_path_options([UNHASHABLE_OPERATION])
+        )
+
+        assert reason is not None
+        assert TextCleaningFeatureGroup.CLEANING_OPERATIONS in reason
+        assert str(UNHASHABLE_OPERATION) in reason
+
+
+class TestOrdinaryOperationVerdictsUnchanged:
+    """The validator keeps accepting what it accepted and rejecting what it could already judge."""
+
+    def test_valid_operations_on_name_path_match(self) -> None:
+        result = TextCleaningFeatureGroup.match_feature_group_criteria(
+            CLEANED_FEATURE, _name_path_options(["normalize", "remove_urls"])
+        )
+
+        assert result is True
+
+    def test_valid_operations_on_config_path_match(self) -> None:
+        result = TextCleaningFeatureGroup.match_feature_group_criteria(
+            "placeholder", _config_path_options(["normalize"])
+        )
+
+        assert result is True
+
+    def test_name_path_without_options_matches(self) -> None:
+        assert TextCleaningFeatureGroup.match_feature_group_criteria(CLEANED_FEATURE, Options()) is True
+
+    def test_hashable_unsupported_operation_is_a_non_match(self) -> None:
+        """A value the validator can judge (and rejects) keeps its verdict."""
+        result = TextCleaningFeatureGroup.match_feature_group_criteria(CLEANED_FEATURE, _name_path_options(["bogus"]))
+
+        assert result is False
+
+
+class TestUnhashableOperationAtEngineLevel:
+    """Nothing escapes into the engine."""
+
+    def test_engine_reports_no_feature_groups_found_with_the_reason(self) -> None:
+        feature = Feature(CLEANED_FEATURE, _name_path_options([UNHASHABLE_OPERATION]))
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            PandasTextCleaningFeatureGroup: {PandasDataFrame},
+        }
+
+        with pytest.raises(ValueError) as exc_info:
+            IdentifyFeatureGroupClass(
+                feature=feature,
+                accessible_plugins=accessible_plugins,
+                links=None,
+                data_access_collection=None,
+            )
+
+        message = str(exc_info.value)
+        assert "No feature groups found" in message, (
+            f"A validator that raises must be a non-match with mloda's standard error, "
+            f"not a TypeError out of the engine, but got: {message}"
+        )
+        assert TextCleaningFeatureGroup.CLEANING_OPERATIONS in message
+        assert str(UNHASHABLE_OPERATION) in message

--- a/tests/test_plugins/integration_plugins/chainer/chainer_test_feature.py
+++ b/tests/test_plugins/integration_plugins/chainer/chainer_test_feature.py
@@ -37,7 +37,10 @@ class ChainedFeatureGroupTest(ChainedContextFeatureGroupTest):
         elif has_suffix_configuration == "identifier2":
             val = 1
         else:
-            raise ValueError("Invalid suffix configuration")
+            # Name the offending suffix: this group owns the feature, so this is the only
+            # place the bad suffix is reported. It used to surface as the parser rejection
+            # that leaked out of matching the UNRELATED source feature 'Sales' (issue #732).
+            raise ValueError(f"Invalid suffix configuration: {has_suffix_configuration}")
 
         data[f"{source_feature}__{cls.OPERATION_ID}{has_suffix_configuration}"] = data[source_feature] * 2 + val
         return data

--- a/tests/test_plugins/integration_plugins/chainer/chainer_test_feature.py
+++ b/tests/test_plugins/integration_plugins/chainer/chainer_test_feature.py
@@ -37,9 +37,6 @@ class ChainedFeatureGroupTest(ChainedContextFeatureGroupTest):
         elif has_suffix_configuration == "identifier2":
             val = 1
         else:
-            # Name the offending suffix: this group owns the feature, so this is the only
-            # place the bad suffix is reported. It used to surface as the parser rejection
-            # that leaked out of matching the UNRELATED source feature 'Sales' (issue #732).
             raise ValueError(f"Invalid suffix configuration: {has_suffix_configuration}")
 
         data[f"{source_feature}__{cls.OPERATION_ID}{has_suffix_configuration}"] = data[source_feature] * 2 + val


### PR DESCRIPTION
Closes #732.

## The bug

`match_configuration_feature_chain_parser` returned `True` as soon as the feature name matched a `PREFIX_PATTERN` and never looked at the options. Every `PROPERTY_MAPPING` key not encoded in the feature name therefore went unvalidated on the string-named path, including keys declaring `strict_validation=True`:

```python
# rejected, as declared
D.match_feature_group_criteria("placeholder", Options(context={..., D.PCA_SVD_SOLVER: "bogus"}))  # False

# accepted, and "bogus" reaches PCA(svd_solver="bogus")
D.match_feature_group_criteria("f0,f1,f2__pca_2d", Options(context={D.PCA_SVD_SOLVER: "bogus"}))  # True
```

`_validate_options_against_property_mapping` did two jobs at once: validate the values of the options that are present, and enforce required presence. Job 2 genuinely must not run on the string-named path, because keys like `algorithm` and `dimension` come from the name rather than from the options. The bug was that skipping job 2 was implemented by skipping the whole function, which discarded job 1 with it.

## The change

Split the two. `_collect_option_value` is the per-key work both paths share, `_validate_present_option_values` runs value validation alone, and the configuration-based path keeps the presence check on top. A name match now validates the values of the options that are present, and required-presence stays off that path.

The verdict is the same on both paths: a non-match, with the discarded reason naming the key and the value in the "No feature groups found" hint. No new hard-error outcome was invented.

## Behavior change

**Option values that were silently ignored on the string-named path are now enforced.** This affects every `FeatureChainParserMixin` plugin. The residual delta is smaller than it looks: a consumer's group option flowing onto a child whose mapping shares the key already raised via `_validate_forwarded_name_mismatch`. What changes is directly-set option values on string-named features, which is exactly the class that was silently wrong.

Two knock-on rejections that the reviews caught, both of which turned the new verdict into a crash rather than a non-match:

- A feature group that overrides `match_feature_group_criteria` and calls the parser directly (`SklearnPipelineFeatureGroup`, and any third-party plugin following the documented pattern) let the rejection escape into the engine. Nothing guarded the filter loop, so one rejecting candidate denied the feature to the group that legitimately owned it. `PropertyValueRejection` (a `ValueError` subclass) now names that verdict, `FeatureChainParserMixin.match_parser_criteria` is the single shared place that converts it to `False`, and the engine catches it per candidate. A plain `ValueError` still escapes, so the forwarded-name-mismatch guidance keeps reaching the user.
- An `element_validator` that raises rather than returning `False` escaped as `TypeError`/`AttributeError`. Membership against a dict raises on an unhashable element, as `TextCleaningFeatureGroup`'s shipped validator does. A validator that cannot judge a value has rejected it, so it now yields the same rejection as one returning `False`, matching what the membership branch and `match_guard` already did.

A forwarded group option outside the child's own value space (`f0__pca_2d` with `algorithm="kmeans"`) is now a non-match instead of the `forward_group_exclude` hard error. The user still gets that guidance end to end, via the engine's group-option hint. Pinned by tests either way.

## Notes

- The six specs from #724 are not simplified here: #730 was merged into `refactor/694-property-spec-dataclass`, not into `main`, so no two-hook spec exists in this base (`grep match_guard mloda_plugins/` is empty). That item stays open for whichever branch lands those specs.
- Docs: `property-mapping.md` now states value validation runs on both paths and presence on the config-based path only. `feature-group-matching.md` and `feature-chain-parser.md` showed the bare-parser-call pattern in a custom matcher, which is exactly the escape above; they now show `match_parser_criteria`.
- One pre-existing test fixture's error message changed: it was passing on a parser rejection that leaked out of matching an unrelated source feature. Its assertion is untouched.

`tox` is green (5805 passed, ruff, pip-licenses, mypy --strict, bandit).