### PR TITLE
fix: enforce required_when whatever matcher a feature group keeps (#731)

### DIFF
--- a/docs/docs/in_depth/feature-chain-parser.md
+++ b/docs/docs/in_depth/feature-chain-parser.md
@@ -188,28 +188,19 @@ class TimeWindowFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 
 #### 3. Custom `match_feature_group_criteria()` Method
 
-Override for complex pre-check logic that can't be captured by the hook:
+Override for the rules a `PROPERTY_MAPPING` spec cannot express, then delegate. Conditional
+requirements belong in `required_when` instead: it is enforced by a guard installed at class
+definition, so it still runs on an override.
 
 ``` python
 class SklearnPipelineFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     @classmethod
     def match_feature_group_criteria(cls, feature_name, options, data_access_collection=None) -> bool:
-        """Custom matching with mutual exclusivity validation."""
-        has_pipeline_name = options.get(cls.PIPELINE_NAME)
-        has_pipeline_steps = options.get(cls.PIPELINE_STEPS)
-
-        # Pre-check: require pattern in name if no config provided
-        if has_pipeline_name is None and has_pipeline_steps is None:
-            if "sklearn_pipeline_" not in str(feature_name):
-                return False
-
-        # Use base matching
-        base_match = FeatureChainParser.match_configuration_feature_chain_parser(...)
-
-        # Post-check: mutual exclusivity
-        if base_match and has_pipeline_name and has_pipeline_steps:
+        """Mutual exclusivity: pipeline_name and pipeline_steps cannot both be set."""
+        if options.get(cls.PIPELINE_NAME) is not None and options.get(cls.PIPELINE_STEPS) is not None:
             return False
-        return base_match
+
+        return super().match_feature_group_criteria(feature_name, options, data_access_collection)
 ```
 
 #### 4. Operation Resolution with `_resolve_operation()`

--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -274,7 +274,13 @@ warning; non-bool truthy returns count as `True`.
 
 The enforcement is installed on the class, not on one matcher, so overriding
 `match_feature_group_criteria` does not lose it: the predicates still run after the
-override returns `True`. They are evaluated exactly once per match call.
+override returns `True`. Nested guards (an override that delegates into an already guarded
+parent) do not stack: only the outermost one evaluates, so the predicates run exactly once
+per match call. The matcher must be a `classmethod`; a `staticmethod` matcher on a class
+that declares `required_when` is rejected at class definition.
+
+The guard is installed at class definition, so mutating `PROPERTY_MAPPING` or replacing
+`match_feature_group_criteria` after the class body escapes it.
 
 ## Migrating from the flattened form
 

--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -24,14 +24,19 @@ Two rules carry most of the model:
 | Class definition | `check_declared_default` | A strict, non-`None` `default` is accepted by its own key | The declared default | `ValueError` at class definition |
 | Match time (parser) | `allowed_values` membership | Each element is in the accepted set | One element | `ValueError`, surfaced to the end user |
 | Match time (parser) | `element_validator` | Each element satisfies a predicate | One element | `ValueError`, surfaced to the end user |
-| Match time (mixin) | `required_when` | A conditionally required option is present | `Options` | Non-match (`False`) |
 | Match time (mixin) | `match_guard` | The whole value has an acceptable shape | The raw value | Non-match (`False`) |
 | Match time (mixin) | `MIN/MAX_IN_FEATURES` | In-feature count is within bounds | The in-features | Non-match (`False`) |
+| Match time (guard) | `required_when` | A conditionally required option is present | `Options` | Non-match (`False`) |
 
 Match-time mechanisms run in that order. `element_validator` **replaces** membership
 rather than adding to it: when a key declares one, `allowed_values` is not consulted.
 Because the parser runs before the mixin, an element rejected by membership or by
 `element_validator` short-circuits, and `match_guard` is never reached.
+
+`required_when` is the one mechanism that does not live inside a matcher. A class that
+declares it gets its resolved `match_feature_group_criteria` wrapped at class definition,
+and the wrapper runs the predicates after that matcher returns `True`. Overriding the
+matcher therefore keeps the contract, whether the override delegates or not.
 
 The class-definition rules run in table order, and the order is load-bearing. The schema
 runs before the shape rules, because a spec with an unknown key is malformed and its
@@ -266,6 +271,10 @@ When the predicate returns `True` and the option is absent, the match fails; ent
 with `required_when` are otherwise optional. The predicate must be a pure, callable
 `(Options) -> bool` that does not raise. Non-callable values are skipped with a
 warning; non-bool truthy returns count as `True`.
+
+The enforcement is installed on the class, not on one matcher, so overriding
+`match_feature_group_criteria` does not lose it: the predicates still run after the
+override returns `True`. They are evaluated exactly once per match call.
 
 ## Migrating from the flattened form
 

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -4,6 +4,7 @@ Feature chain parser for handling feature name chaining across feature groups.
 
 from __future__ import annotations
 
+import contextvars
 import difflib
 import functools
 import logging
@@ -19,6 +20,7 @@ from mloda.core.abstract_plugins.components.default_options_key import (
     REMOVED_PROPERTY_KEYS,
     DefaultOptionKeys,
 )
+from mloda.core.abstract_plugins.components.utils import safe_field
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +31,13 @@ INPUT_SEPARATOR = "&"  # Separates multiple input features
 
 # Marks a matcher that already carries the required_when guard, so it is never wrapped twice.
 REQUIRED_WHEN_GUARD_FLAG = "_mloda_required_when_guard"
+
+# How many guards the current match call is nested in. A guarded matcher that delegates via super()
+# reaches the guard of its parent, and only the outermost one may evaluate the predicates.
+# A ContextVar (not a plain global) keeps the count per thread and per async task.
+REQUIRED_WHEN_GUARD_DEPTH: contextvars.ContextVar[int] = contextvars.ContextVar(
+    "mloda_required_when_guard_depth", default=0
+)
 
 
 class FeatureChainParser:
@@ -68,10 +77,13 @@ class FeatureChainParser:
     def parse_feature_name(
         cls,
         feature_name: FeatureName | str,
-        prefix_patterns: list[str],
+        prefix_patterns: list[Any],
         pattern: str = CHAIN_SEPARATOR,
     ) -> tuple[str | None, str | None]:
-        """Internal method for parsing feature names - used by match_configuration_feature_chain_parser."""
+        """Internal method for parsing feature names - used by match_configuration_feature_chain_parser.
+
+        A prefix pattern is anything ``re.match`` accepts: a ``str`` or a compiled ``re.Pattern``.
+        """
         _feature_name: str = feature_name
 
         parts = _feature_name.rsplit(pattern, 1)
@@ -99,7 +111,7 @@ class FeatureChainParser:
     def _match_pattern_based_feature(
         cls,
         feature_name: str | FeatureName,
-        prefix_patterns: list[str],
+        prefix_patterns: list[Any],
         pattern: str = CHAIN_SEPARATOR,
     ) -> bool:
         """Internal method for matching pattern-based features - used by match_configuration_feature_chain_parser."""
@@ -494,7 +506,7 @@ class FeatureChainParser:
         feature_name: str | FeatureName,
         options: Options,
         property_mapping: Optional[dict[str, Any]] = None,
-        prefix_patterns: Optional[list[str]] = None,
+        prefix_patterns: Optional[list[Any]] = None,
         pattern: str = CHAIN_SEPARATOR,
     ) -> bool:
         """
@@ -532,12 +544,17 @@ class FeatureChainParser:
         return False
 
     @classmethod
-    def prefix_patterns_of(cls, owner: type[Any]) -> list[str]:
-        """Collect the name patterns a class matches on, in the order the mixin uses them."""
-        patterns = []
+    def prefix_patterns_of(cls, owner: type[Any]) -> list[Any]:
+        """Collect the name patterns a class matches on. The single implementation the mixin uses too.
+
+        A pattern is whatever ``re.match`` accepts: a ``str`` or an already compiled ``re.Pattern``.
+        Filtering by type would hide a compiled pattern from the guard while the matcher still matches
+        on it, and the guard would then reject a feature the matcher accepted.
+        """
+        patterns: list[Any] = []
         for attribute in ("PREFIX_PATTERN", "SUFFIX_PATTERN"):
             pattern = getattr(owner, attribute, None)
-            if isinstance(pattern, str):
+            if pattern is not None:
                 patterns.append(pattern)
         return patterns
 
@@ -545,7 +562,7 @@ class FeatureChainParser:
     def build_effective_options(
         cls,
         feature_name: str | FeatureName,
-        prefix_patterns: list[str],
+        prefix_patterns: list[Any],
         property_mapping: dict[str, Any],
         options: Options,
     ) -> Options:
@@ -558,7 +575,14 @@ class FeatureChainParser:
         If the feature is not string-based or no mapping key matches, returns the
         original options unchanged.
         """
-        operation_config, _source_feature = cls.parse_feature_name(feature_name, prefix_patterns, CHAIN_SEPARATOR)
+        # A matcher may parse the name with its own separator, so CHAIN_SEPARATOR can leave it
+        # unparseable. That is no name-parsed value to merge, never an exception out of a matcher.
+        nothing_parsed: tuple[str | None, str | None] = (None, None)
+        operation_config, _source_feature = safe_field(
+            lambda: cls.parse_feature_name(feature_name, prefix_patterns, CHAIN_SEPARATOR),
+            nothing_parsed,
+            catching=(ValueError,),
+        )
         if operation_config is None:
             return options
 
@@ -592,7 +616,7 @@ class FeatureChainParser:
         cls,
         owner_name: str,
         feature_name: str | FeatureName,
-        prefix_patterns: list[str],
+        prefix_patterns: list[Any],
         property_mapping: dict[str, Any] | None,
         options: Options,
     ) -> bool:
@@ -636,6 +660,27 @@ class FeatureChainParser:
         return feature_name, options
 
     @classmethod
+    def _reject_staticmethod_matcher(cls, owner: type[Any]) -> None:
+        """Reject a staticmethod matcher on a class that declares required_when.
+
+        The guard is reinstalled as a classmethod, so the class would be passed as the first
+        positional argument: a staticmethod matcher would read ``cls`` as its ``feature_name`` and the
+        feature name as its ``options``, and answer a silently wrong verdict. Fail at class definition.
+        """
+        for klass in owner.__mro__:
+            descriptor = klass.__dict__.get("match_feature_group_criteria")
+            if descriptor is None:
+                continue
+            if isinstance(descriptor, staticmethod):
+                raise ValueError(
+                    f"{owner.__name__} declares required_when in its PROPERTY_MAPPING, but its "
+                    f"match_feature_group_criteria is a staticmethod. It must be a classmethod: the "
+                    f"required_when guard is installed as a classmethod and passes the class as the first "
+                    f"argument, which a staticmethod would misread as the feature name."
+                )
+            return
+
+    @classmethod
     def install_required_when_guard(cls, owner: type[Any]) -> None:
         """Wrap a class's RESOLVED matcher so its required_when predicates run whatever matcher it kept.
 
@@ -646,11 +691,17 @@ class FeatureChainParser:
         classmethod, so it reads the PROPERTY_MAPPING and patterns of the class it is called on.
 
         A class that declares no required_when is left untouched, and an already guarded matcher
-        is never wrapped again, so the predicates are evaluated exactly once per match call.
+        is never wrapped again. Guards do nest (an override may delegate into a guarded parent), so
+        only the outermost one evaluates the predicates: exactly once per match call.
+
+        Class definition is the install site, so a PROPERTY_MAPPING mutated, or a matcher replaced,
+        AFTER the class body is not seen by the guard.
         """
         property_mapping = getattr(owner, "PROPERTY_MAPPING", None)
         if not isinstance(property_mapping, dict) or not cls.has_required_when_predicates(property_mapping):
             return
+
+        cls._reject_staticmethod_matcher(owner)
 
         matcher = getattr(owner, "match_feature_group_criteria", None)
         if matcher is None:
@@ -662,20 +713,31 @@ class FeatureChainParser:
 
         @functools.wraps(inner)
         def guarded(guarded_cls: type[Any], *args: Any, **kwargs: Any) -> bool:
-            if not inner(guarded_cls, *args, **kwargs):
-                return False
+            # The outermost guard is the one whose class the matcher was called on, so it is the one
+            # whose PROPERTY_MAPPING decides. An inner guard, reached through a delegating super()
+            # call, only answers with its matcher's verdict.
+            outermost = REQUIRED_WHEN_GUARD_DEPTH.get() == 0
+            token = REQUIRED_WHEN_GUARD_DEPTH.set(REQUIRED_WHEN_GUARD_DEPTH.get() + 1)
+            try:
+                if not inner(guarded_cls, *args, **kwargs):
+                    return False
 
-            feature_name, options = FeatureChainParser._resolve_match_arguments(args, kwargs)
-            if options is None:
-                return True
+                if not outermost:
+                    return True
 
-            return FeatureChainParser.check_required_when(
-                guarded_cls.__name__,
-                feature_name,
-                FeatureChainParser.prefix_patterns_of(guarded_cls),
-                getattr(guarded_cls, "PROPERTY_MAPPING", None),
-                options,
-            )
+                feature_name, options = FeatureChainParser._resolve_match_arguments(args, kwargs)
+                if options is None:
+                    return True
+
+                return FeatureChainParser.check_required_when(
+                    guarded_cls.__name__,
+                    feature_name,
+                    FeatureChainParser.prefix_patterns_of(guarded_cls),
+                    getattr(guarded_cls, "PROPERTY_MAPPING", None),
+                    options,
+                )
+            finally:
+                REQUIRED_WHEN_GUARD_DEPTH.reset(token)
 
         setattr(guarded, REQUIRED_WHEN_GUARD_FLAG, True)
         setattr(owner, "match_feature_group_criteria", classmethod(guarded))

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -5,6 +5,8 @@ Feature chain parser for handling feature name chaining across feature groups.
 from __future__ import annotations
 
 import difflib
+import functools
+import logging
 import re
 from collections.abc import Collection
 from typing import Any, Optional
@@ -18,10 +20,15 @@ from mloda.core.abstract_plugins.components.default_options_key import (
     DefaultOptionKeys,
 )
 
+logger = logging.getLogger(__name__)
+
 # Separator constants for feature name parsing
 CHAIN_SEPARATOR = "__"  # Separates chained transformations (source→suffix)
 COLUMN_SEPARATOR = "~"  # Separates multi-column output index
 INPUT_SEPARATOR = "&"  # Separates multiple input features
+
+# Marks a matcher that already carries the required_when guard, so it is never wrapped twice.
+REQUIRED_WHEN_GUARD_FLAG = "_mloda_required_when_guard"
 
 
 class FeatureChainParser:
@@ -110,8 +117,8 @@ class FeatureChainParser:
         Returns True when the property has a default value or uses conditional
         requirements (required_when).  In both cases the base validation loop
         should not reject the match just because the option is absent; either
-        the default will be applied later, or the required_when predicate in
-        FeatureChainParserMixin will decide.
+        the default will be applied later, or the required_when guard installed
+        at class definition will decide.
         """
         if not isinstance(property_value, dict):
             return False
@@ -515,6 +522,163 @@ class FeatureChainParser:
 
         # If neither pattern-based nor configuration-based matching succeeded, return False
         return False
+
+    @staticmethod
+    def has_required_when_predicates(property_mapping: dict[str, Any]) -> bool:
+        """Return True if any spec in property_mapping declares required_when."""
+        for spec in property_mapping.values():
+            if isinstance(spec, dict) and DefaultOptionKeys.required_when in spec:
+                return True
+        return False
+
+    @classmethod
+    def prefix_patterns_of(cls, owner: type[Any]) -> list[str]:
+        """Collect the name patterns a class matches on, in the order the mixin uses them."""
+        patterns = []
+        for attribute in ("PREFIX_PATTERN", "SUFFIX_PATTERN"):
+            pattern = getattr(owner, attribute, None)
+            if isinstance(pattern, str):
+                patterns.append(pattern)
+        return patterns
+
+    @classmethod
+    def build_effective_options(
+        cls,
+        feature_name: str | FeatureName,
+        prefix_patterns: list[str],
+        property_mapping: dict[str, Any],
+        options: Options,
+    ) -> Options:
+        """Build effective options by merging string-parsed values with explicit options.
+
+        When a feature is matched by string pattern, the operation_config value extracted
+        from the feature name is mapped to the corresponding PROPERTY_MAPPING key. This
+        ensures that required_when predicates see values from both sources.
+
+        If the feature is not string-based or no mapping key matches, returns the
+        original options unchanged.
+        """
+        operation_config, _source_feature = cls.parse_feature_name(feature_name, prefix_patterns, CHAIN_SEPARATOR)
+        if operation_config is None:
+            return options
+
+        # Find which property mapping key the operation_config value belongs to
+        for prop_key, prop_value in property_mapping.items():
+            if not isinstance(prop_value, dict):
+                continue
+            # Already present in options: no merge needed
+            if options.get(prop_key) is not None:
+                continue
+            # Check if operation_config is a valid value for this property
+            if operation_config not in cls._extract_property_values(prop_value):
+                continue
+            category = cls._determine_parameter_category(prop_key, prop_value, options)
+            merged_group = dict(options.group)
+            merged_context = dict(options.context)
+            if category == DefaultOptionKeys.context:
+                merged_context[prop_key] = operation_config
+            else:
+                merged_group[prop_key] = operation_config
+            return Options(
+                group=merged_group,
+                context=merged_context,
+                propagate_context_keys=options.propagate_context_keys,
+            )
+
+        return options
+
+    @classmethod
+    def check_required_when(
+        cls,
+        owner_name: str,
+        feature_name: str | FeatureName,
+        prefix_patterns: list[str],
+        property_mapping: dict[str, Any] | None,
+        options: Options,
+    ) -> bool:
+        """Evaluate every required_when predicate of a mapping. False means the feature is not a match."""
+        if property_mapping is None or not cls.has_required_when_predicates(property_mapping):
+            return True
+
+        effective_options = cls.build_effective_options(feature_name, prefix_patterns, property_mapping, options)
+        for key, spec in property_mapping.items():
+            if not isinstance(spec, dict):
+                continue
+            predicate = spec.get(DefaultOptionKeys.required_when)
+            if predicate is None:
+                continue
+            if not callable(predicate):
+                logger.warning("required_when for '%s' in %s is not callable, skipping.", key, owner_name)
+                continue
+            if predicate(effective_options) and effective_options.get(key) is None:
+                logger.debug(
+                    "Feature group %s requires option '%s' (predicate %s is satisfied) but it was not provided.",
+                    owner_name,
+                    key,
+                    getattr(predicate, "__name__", repr(predicate)),
+                )
+                return False
+        return True
+
+    @staticmethod
+    def _resolve_match_arguments(args: tuple[Any, ...], kwargs: dict[str, Any]) -> tuple[str | FeatureName, Any]:
+        """Recover (feature_name, options) from a matcher call without assuming an override's parameter names."""
+        values = list(args) + list(kwargs.values())
+
+        feature_name = kwargs.get("feature_name", args[0] if args else None)
+        if not isinstance(feature_name, str):
+            feature_name = next((value for value in values if isinstance(value, str)), "")
+
+        options = kwargs.get("options")
+        if not isinstance(options, Options):
+            options = next((value for value in values if isinstance(value, Options)), None)
+
+        return feature_name, options
+
+    @classmethod
+    def install_required_when_guard(cls, owner: type[Any]) -> None:
+        """Wrap a class's RESOLVED matcher so its required_when predicates run whatever matcher it kept.
+
+        Called at class-definition time from ``FeatureGroup.__init_subclass__`` and
+        ``FeatureChainParserMixin.__init_subclass__``. The predicates cannot live inside one
+        matcher: overriding ``match_feature_group_criteria`` is supported, and an override that
+        never delegates would silently drop the declared contract. The wrapper stays a
+        classmethod, so it reads the PROPERTY_MAPPING and patterns of the class it is called on.
+
+        A class that declares no required_when is left untouched, and an already guarded matcher
+        is never wrapped again, so the predicates are evaluated exactly once per match call.
+        """
+        property_mapping = getattr(owner, "PROPERTY_MAPPING", None)
+        if not isinstance(property_mapping, dict) or not cls.has_required_when_predicates(property_mapping):
+            return
+
+        matcher = getattr(owner, "match_feature_group_criteria", None)
+        if matcher is None:
+            return
+
+        inner: Any = getattr(matcher, "__func__", matcher)
+        if getattr(inner, REQUIRED_WHEN_GUARD_FLAG, False):
+            return
+
+        @functools.wraps(inner)
+        def guarded(guarded_cls: type[Any], *args: Any, **kwargs: Any) -> bool:
+            if not inner(guarded_cls, *args, **kwargs):
+                return False
+
+            feature_name, options = FeatureChainParser._resolve_match_arguments(args, kwargs)
+            if options is None:
+                return True
+
+            return FeatureChainParser.check_required_when(
+                guarded_cls.__name__,
+                feature_name,
+                FeatureChainParser.prefix_patterns_of(guarded_cls),
+                getattr(guarded_cls, "PROPERTY_MAPPING", None),
+                options,
+            )
+
+        setattr(guarded, REQUIRED_WHEN_GUARD_FLAG, True)
+        setattr(owner, "match_feature_group_criteria", classmethod(guarded))
 
     @classmethod
     def extract_in_feature(cls, feature_name: str, suffix_pattern: str) -> str:

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -334,22 +334,6 @@ class FeatureChainParserMixin:
         return None
 
     @classmethod
-    def _validate_required_when(
-        cls,
-        result: bool,
-        feature_name: str | FeatureName,
-        prefix_patterns: list[str],
-        property_mapping: dict[str, Any] | None,
-        options: Options,
-    ) -> bool:
-        """Evaluate the required_when predicates. The class-definition guard is the enforcement site."""
-        if not result:
-            return True
-        return FeatureChainParser.check_required_when(
-            cls.__name__, feature_name, prefix_patterns, property_mapping, options
-        )
-
-    @classmethod
     def _validate_match_guards(cls, result: bool, options: Options, property_mapping: dict[str, Any] | None) -> bool:
         # Enforce match_guard constraints from PROPERTY_MAPPING
         if result and property_mapping is not None:
@@ -382,13 +366,14 @@ class FeatureChainParserMixin:
                     count = 0
                 else:
                     # An in_features shape this matcher cannot count (SourceInputFeature stores join
-                    # tuples there) is a foreign feature, not a count violation: a matcher answers
-                    # True/False, so leave the verdict to the other rules instead of raising.
+                    # tuples there) is a NON-MATCH: a group that cannot even count the in_features
+                    # cannot consume them. Skipping MIN/MAX here would accept the feature and let the
+                    # group win a resolution its own cap says it must lose.
                     in_features: frozenset[Feature] | None = safe_field(
                         options.get_in_features, None, catching=(TypeError,)
                     )
                     if in_features is None:
-                        return True
+                        return False
                     count = len(in_features)
                 if count < cls.MIN_IN_FEATURES:
                     return False
@@ -397,14 +382,12 @@ class FeatureChainParserMixin:
         return True
 
     @classmethod
-    def _get_prefix_patterns(cls) -> list[str]:
-        """Get prefix/suffix patterns from class attributes."""
-        patterns = []
-        if hasattr(cls, "PREFIX_PATTERN"):
-            patterns.append(cls.PREFIX_PATTERN)
-        if hasattr(cls, "SUFFIX_PATTERN"):
-            patterns.append(cls.SUFFIX_PATTERN)
-        return patterns
+    def _get_prefix_patterns(cls) -> list[Any]:
+        """Get prefix/suffix patterns from class attributes.
+
+        Delegates to the guard's own collector, so matcher and guard can never see different patterns.
+        """
+        return FeatureChainParser.prefix_patterns_of(cls)
 
     @classmethod
     def _get_property_mapping(cls) -> Optional[dict[str, Any]]:
@@ -413,16 +396,11 @@ class FeatureChainParserMixin:
             return cast(dict[str, Any], cls.PROPERTY_MAPPING)
         return None
 
-    @staticmethod
-    def _has_required_when_predicates(property_mapping: dict[str, Any]) -> bool:
-        """Return True if any entry in property_mapping uses required_when."""
-        return FeatureChainParser.has_required_when_predicates(property_mapping)
-
     @classmethod
     def _build_effective_options(
         cls,
         feature_name: str,
-        prefix_patterns: list[str],
+        prefix_patterns: list[Any],
         property_mapping: dict[str, Any],
         options: Options,
     ) -> Options:

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -59,6 +59,7 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
     INPUT_SEPARATOR,
 )
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+from mloda.core.abstract_plugins.components.utils import safe_field
 
 logger = logging.getLogger(__name__)
 
@@ -77,7 +78,10 @@ class FeatureChainParserMixin:
     PROPERTY_MAPPING supports conditional requirements via ``DefaultOptionKeys.required_when``.
     Attach a predicate ``(Options) -> bool`` to any mapping entry. When the predicate returns
     True and the option value is absent, ``match_feature_group_criteria`` rejects the match.
-    When the predicate returns False, the option is treated as optional.
+    When the predicate returns False, the option is treated as optional. The predicates are
+    enforced by a guard installed on the class at definition time (see
+    ``FeatureChainParser.install_required_when_guard``), so overriding
+    ``match_feature_group_criteria`` keeps the contract.
 
     This works for both string-based and configuration-based feature creation. For
     string-based features, the operation value parsed from the feature name is merged
@@ -97,6 +101,12 @@ class FeatureChainParserMixin:
     IN_FEATURE_SEPARATOR: str = INPUT_SEPARATOR
     MIN_IN_FEATURES: int = 1
     MAX_IN_FEATURES: Optional[int] = None
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        # The mixin sits first in the MRO of ``class X(FeatureChainParserMixin, FeatureGroup)``,
+        # so super() is what lets FeatureGroup's own class-definition validation still run.
+        super().__init_subclass__(**kwargs)
+        FeatureChainParser.install_required_when_guard(cls)
 
     @classmethod
     def _validate_string_match(cls, _feature_name: str, _operation_config: str, _in_feature: str) -> bool:
@@ -196,6 +206,9 @@ class FeatureChainParserMixin:
         Also enforces MIN_IN_FEATURES / MAX_IN_FEATURES constraints when
         in_features is present in options.
 
+        ``required_when`` is NOT evaluated here. The guard installed at class definition
+        runs the predicates after this method (or any override of it) returns True.
+
         For string-parsed features, additionally checks consumer-forwarded option
         values against the value parsed from the feature name: if a PROPERTY_MAPPING
         key arrived via forwarding (it is in ``options.inherited_group_keys``) and its
@@ -235,9 +248,6 @@ class FeatureChainParserMixin:
                 if not cls._validate_string_match(feature_name, operation_config, source_feature):
                     return False
                 cls._validate_forwarded_name_mismatch(feature_name, operation_config, property_mapping, options)
-
-        if not cls._validate_required_when(result, feature_name, prefix_patterns, property_mapping, options):
-            return False
 
         if not cls._validate_match_guards(result, options, property_mapping):
             return False
@@ -332,33 +342,12 @@ class FeatureChainParserMixin:
         property_mapping: dict[str, Any] | None,
         options: Options,
     ) -> bool:
-        # Enforce required_when constraints from PROPERTY_MAPPING.
-        # Build effective options by merging string-parsed operation_config into
-        # the Options object so predicates see values from both sources.
-        if result and property_mapping is not None and cls._has_required_when_predicates(property_mapping):
-            effective_options = cls._build_effective_options(feature_name, prefix_patterns, property_mapping, options)
-            for key, mapping_entry in property_mapping.items():
-                if not isinstance(mapping_entry, dict):
-                    continue
-                predicate = mapping_entry.get(DefaultOptionKeys.required_when)
-                if predicate is None:
-                    continue
-                if not callable(predicate):
-                    logger.warning(
-                        "required_when for '%s' in %s is not callable, skipping.",
-                        key,
-                        cls.__name__,
-                    )
-                    continue
-                if predicate(effective_options) and effective_options.get(key) is None:
-                    logger.debug(
-                        "Feature group %s requires option '%s' (predicate %s is satisfied) but it was not provided.",
-                        cls.__name__,
-                        key,
-                        getattr(predicate, "__name__", repr(predicate)),
-                    )
-                    return False
-        return True
+        """Evaluate the required_when predicates. The class-definition guard is the enforcement site."""
+        if not result:
+            return True
+        return FeatureChainParser.check_required_when(
+            cls.__name__, feature_name, prefix_patterns, property_mapping, options
+        )
 
     @classmethod
     def _validate_match_guards(cls, result: bool, options: Options, property_mapping: dict[str, Any] | None) -> bool:
@@ -392,7 +381,15 @@ class FeatureChainParserMixin:
                     # Present but empty: zero in_features, a non-match rather than an error.
                     count = 0
                 else:
-                    count = len(options.get_in_features())
+                    # An in_features shape this matcher cannot count (SourceInputFeature stores join
+                    # tuples there) is a foreign feature, not a count violation: a matcher answers
+                    # True/False, so leave the verdict to the other rules instead of raising.
+                    in_features: frozenset[Feature] | None = safe_field(
+                        options.get_in_features, None, catching=(TypeError,)
+                    )
+                    if in_features is None:
+                        return True
+                    count = len(in_features)
                 if count < cls.MIN_IN_FEATURES:
                     return False
                 if cls.MAX_IN_FEATURES is not None and count > cls.MAX_IN_FEATURES:
@@ -419,10 +416,7 @@ class FeatureChainParserMixin:
     @staticmethod
     def _has_required_when_predicates(property_mapping: dict[str, Any]) -> bool:
         """Return True if any entry in property_mapping uses required_when."""
-        for value in property_mapping.values():
-            if isinstance(value, dict) and DefaultOptionKeys.required_when in value:
-                return True
-        return False
+        return FeatureChainParser.has_required_when_predicates(property_mapping)
 
     @classmethod
     def _build_effective_options(
@@ -432,45 +426,8 @@ class FeatureChainParserMixin:
         property_mapping: dict[str, Any],
         options: Options,
     ) -> Options:
-        """Build effective options by merging string-parsed values with explicit options.
-
-        When a feature is matched by string pattern, the operation_config value extracted
-        from the feature name is mapped to the corresponding PROPERTY_MAPPING key. This
-        ensures that required_when predicates see values from both sources.
-
-        If the feature is not string-based or no mapping key matches, returns the
-        original options unchanged.
-        """
-        operation_config, _source_feature = FeatureChainParser.parse_feature_name(
-            feature_name, prefix_patterns, CHAIN_SEPARATOR
-        )
-        if operation_config is None:
-            return options
-
-        # Find which property mapping key the operation_config value belongs to
-        for prop_key, prop_value in property_mapping.items():
-            if not isinstance(prop_value, dict):
-                continue
-            # Already present in options: no merge needed
-            if options.get(prop_key) is not None:
-                continue
-            # Check if operation_config is a valid value for this property
-            extracted = FeatureChainParser._extract_property_values(prop_value)
-            if operation_config in extracted:
-                category = FeatureChainParser._determine_parameter_category(prop_key, prop_value, options)
-                merged_group = dict(options.group)
-                merged_context = dict(options.context)
-                if category == DefaultOptionKeys.context:
-                    merged_context[prop_key] = operation_config
-                else:
-                    merged_group[prop_key] = operation_config
-                return Options(
-                    group=merged_group,
-                    context=merged_context,
-                    propagate_context_keys=options.propagate_context_keys,
-                )
-
-        return options
+        """Merge the value parsed from the feature name into the options the predicates see."""
+        return FeatureChainParser.build_effective_options(feature_name, prefix_patterns, property_mapping, options)
 
     @classmethod
     def _extract_source_features(cls, feature: Feature) -> list[str]:

--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -91,6 +91,7 @@ class FeatureGroup(ABC):
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
         FeatureChainParser.validate_property_mapping_defaults(cls.__name__, cls.PROPERTY_MAPPING)
+        FeatureChainParser.install_required_when_guard(cls)
         cls._validate_subtype_declaration()
 
     @classmethod

--- a/mloda_plugins/feature_group/experimental/sklearn/pipeline/base.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/pipeline/base.py
@@ -95,12 +95,20 @@ class SklearnPipelineFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: True,
             DefaultOptionKeys.default: None,
+            # Required only when the other is absent.
+            DefaultOptionKeys.required_when: (
+                lambda options: options.get(SklearnPipelineFeatureGroup.PIPELINE_STEPS) is None
+            ),
         },
         PIPELINE_STEPS: {
             "explanation": "List of pipeline steps as (name, transformer) tuples",
             DefaultOptionKeys.context: True,
             DefaultOptionKeys.strict_validation: False,
             DefaultOptionKeys.default: None,  # Default is None as pipeline_types also work
+            # Required only when the other is absent.
+            DefaultOptionKeys.required_when: (
+                lambda options: options.get(SklearnPipelineFeatureGroup.PIPELINE_NAME) is None
+            ),
         },
         PIPELINE_PARAMS: {
             "explanation": "Pipeline parameters dictionary",
@@ -155,8 +163,6 @@ class SklearnPipelineFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         # The regex already extracts just the pipeline name (e.g., "scaling" from "income__sklearn_pipeline_scaling")
         return prefix_part
 
-    # Note: Custom match_feature_group_criteria() required instead of inheriting from mixin
-    # because this feature group has unique pre-check logic (PIPELINE_NAME vs PIPELINE_STEPS mutual exclusivity)
     @classmethod
     def match_feature_group_criteria(
         cls,
@@ -164,32 +170,15 @@ class SklearnPipelineFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         options: Options,
         data_access_collection: Optional[Any] = None,
     ) -> bool:
-        """Check if feature name matches the expected pattern using unified parser with custom validation."""
-        # First, try the unified parser
+        """Reject the one rule a spec cannot express: PIPELINE_NAME and PIPELINE_STEPS are mutually exclusive.
 
-        has_pipeline_name = options.get(cls.PIPELINE_NAME)
-        has_pipeline_steps = options.get(cls.PIPELINE_STEPS)
-
-        feature_name = str(feature_name) if isinstance(feature_name, FeatureName) else str(feature_name)
-
-        if has_pipeline_name is None and has_pipeline_steps is None:
-            if "sklearn_pipeline_" not in feature_name:
-                return False
-
-        base_match = FeatureChainParser.match_configuration_feature_chain_parser(
-            feature_name,
-            options,
-            property_mapping=cls.PROPERTY_MAPPING,
-            prefix_patterns=[cls.PREFIX_PATTERN],
-        )
-
-        if not base_match:
+        Their conditional presence is a required_when contract on PROPERTY_MAPPING, enforced by the
+        guard installed at class definition, so the rest of the matching is the mixin's.
+        """
+        if options.get(cls.PIPELINE_NAME) is not None and options.get(cls.PIPELINE_STEPS) is not None:
             return False
 
-        # For configuration-based features, must have exactly one of PIPELINE_NAME or PIPELINE_STEPS
-        if has_pipeline_name and has_pipeline_steps:
-            return False
-        return True
+        return super().match_feature_group_criteria(feature_name, options, data_access_collection)
 
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_feature_chain_parser_mixin.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_feature_chain_parser_mixin.py
@@ -55,6 +55,21 @@ class MockFeatureGroupWithMinMax(FeatureChainParserMixin):
     }
 
 
+class MockFeatureGroupSingleInFeature(FeatureChainParserMixin):
+    """Mock Feature group that accepts exactly one in_feature."""
+
+    PREFIX_PATTERN = r".*__([\w]+)_test$"
+    MIN_IN_FEATURES = 1
+    MAX_IN_FEATURES = 1
+    PROPERTY_MAPPING = {
+        "operation": {
+            DefaultOptionKeys.allowed_values: {"op1": "Operation 1"},
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: True,
+        }
+    }
+
+
 class _HiddenAttribute:
     """Descriptor that makes hasattr return False by raising AttributeError."""
 
@@ -452,6 +467,32 @@ class TestFeatureChainParserMixinMinMaxInFeatures:
         assert not hasattr(MockFeatureGroupWithoutMinMax, "MAX_IN_FEATURES")
         result = MockFeatureGroupWithoutMinMax.match_feature_group_criteria("any_name", options)
         assert result is True
+
+    def test_rejects_in_features_shape_it_cannot_count(self) -> None:
+        """Join tuples (the shape SourceInputFeature stores) are not countable in_features: a non-match.
+
+        Skipping the MIN/MAX check for an uncountable value accepts the feature, which is the one
+        answer that cannot be right: the cap says at most one in_feature.
+        """
+        options = Options(
+            context={
+                "operation": "op1",
+                "in_features": [("a", 1), ("b", 2), ("c", 3)],
+            }
+        )
+        result = MockFeatureGroupSingleInFeature.match_feature_group_criteria("any_name", options)
+        assert result is False
+
+    def test_rejects_in_features_holding_uncountable_values(self) -> None:
+        """A plain typo (in_features=[1, 2, 3]) is uncountable too, and must not slip past the cap."""
+        options = Options(
+            context={
+                "operation": "op1",
+                "in_features": [1, 2, 3],
+            }
+        )
+        result = MockFeatureGroupSingleInFeature.match_feature_group_criteria("any_name", options)
+        assert result is False
 
 
 class TestFeatureChainParserMixinListValuedOptions:

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_required_when_enforced_on_override.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_required_when_enforced_on_override.py
@@ -1,0 +1,247 @@
+"""required_when must be enforced no matter who owns match_feature_group_criteria (issue #731).
+
+Today the predicates only run inside ``FeatureChainParserMixin.match_feature_group_criteria``.
+Overriding that method (a supported thing) silently drops the conditional-requirement contract.
+The enforcement therefore has to be installed on the class at definition time, exactly once,
+and it must reach both the mixin matcher and the default FeatureGroup matcher.
+"""
+
+from __future__ import annotations
+
+import gc
+from typing import Any
+
+import pytest
+
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import (
+    FeatureChainParser,
+)
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import (
+    FeatureChainParserMixin,
+)
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.provider import DefaultOptionKeys
+
+OP_TYPE = "op_type"
+ORDER_BY = "order_by"
+GUARDED_PATTERN = r".*__([\w]+)_guarded$"
+
+
+@pytest.fixture(autouse=True)
+def _no_feature_group_registry_pollution() -> Any:
+    """Reclaim the throwaway FeatureGroup subclasses defined inside the tests below.
+
+    They sit in reference cycles, so they linger in ``FeatureGroup.__subclasses__()`` until a GC
+    cycle runs, and other tests enumerate that registry.
+    """
+    yield
+    gc.collect()
+    gc.collect()
+
+
+class CountingPredicate:
+    """required_when predicate that records how often it ran: order_by is required for op_type 'first'."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self, options: Options) -> bool:
+        self.calls += 1
+        return bool(options.get(OP_TYPE) == "first")
+
+
+def _mapping(predicate: CountingPredicate) -> dict[str, Any]:
+    """PROPERTY_MAPPING with a conditionally required order_by. op_type stays unconditionally required."""
+    return {
+        OP_TYPE: {
+            DefaultOptionKeys.allowed_values: {"sum": "Sum of values", "first": "First value (requires order_by)"},
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: True,
+        },
+        ORDER_BY: {
+            "explanation": "Column to order by",
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: False,
+            DefaultOptionKeys.required_when: predicate,
+        },
+    }
+
+
+REQUIRES_ORDER_BY = Options(context={OP_TYPE: "first"})
+SATISFIED = Options(context={OP_TYPE: "first", ORDER_BY: "ts"})
+NOT_REQUIRED = Options(context={OP_TYPE: "sum"})
+
+
+class TestOverriddenMatcher:
+    """A feature group that overrides the matcher keeps its required_when contract."""
+
+    def test_non_delegating_override_rejects_when_required_option_absent(self) -> None:
+        """The override never calls the mixin, so the enforcement cannot live inside the mixin matcher."""
+        predicate = CountingPredicate()
+
+        class NonDelegatingOverride(FeatureChainParserMixin, FeatureGroup):
+            PREFIX_PATTERN = GUARDED_PATTERN
+            PROPERTY_MAPPING = _mapping(predicate)
+
+            @classmethod
+            def match_feature_group_criteria(
+                cls,
+                feature_name: str | FeatureName,
+                options: Options,
+                data_access_collection: Any = None,
+            ) -> bool:
+                return FeatureChainParser.match_configuration_feature_chain_parser(
+                    feature_name,
+                    options,
+                    property_mapping=cls.PROPERTY_MAPPING,
+                    prefix_patterns=[cls.PREFIX_PATTERN],
+                )
+
+        assert NonDelegatingOverride.match_feature_group_criteria("x__first_guarded", REQUIRES_ORDER_BY) is False
+        assert predicate.calls == 1
+
+    def test_non_delegating_override_accepts_when_required_option_present(self) -> None:
+        """Enforcement must not turn into blanket rejection."""
+        predicate = CountingPredicate()
+
+        class NonDelegatingOverride(FeatureChainParserMixin, FeatureGroup):
+            PREFIX_PATTERN = GUARDED_PATTERN
+            PROPERTY_MAPPING = _mapping(predicate)
+
+            @classmethod
+            def match_feature_group_criteria(
+                cls,
+                feature_name: str | FeatureName,
+                options: Options,
+                data_access_collection: Any = None,
+            ) -> bool:
+                return FeatureChainParser.match_configuration_feature_chain_parser(
+                    feature_name,
+                    options,
+                    property_mapping=cls.PROPERTY_MAPPING,
+                    prefix_patterns=[cls.PREFIX_PATTERN],
+                )
+
+        assert NonDelegatingOverride.match_feature_group_criteria("x__first_guarded", SATISFIED) is True
+        assert NonDelegatingOverride.match_feature_group_criteria("x__sum_guarded", NOT_REQUIRED) is True
+
+    def test_delegating_override_evaluates_predicate_exactly_once(self) -> None:
+        """One enforcement site: the guard, not the guard plus an inline call inside the mixin matcher."""
+        predicate = CountingPredicate()
+
+        class DelegatingOverride(FeatureChainParserMixin, FeatureGroup):
+            PREFIX_PATTERN = GUARDED_PATTERN
+            PROPERTY_MAPPING = _mapping(predicate)
+
+            @classmethod
+            def match_feature_group_criteria(
+                cls,
+                feature_name: str | FeatureName,
+                options: Options,
+                data_access_collection: Any = None,
+            ) -> bool:
+                return super().match_feature_group_criteria(feature_name, options, data_access_collection)
+
+        assert DelegatingOverride.match_feature_group_criteria("x__first_guarded", REQUIRES_ORDER_BY) is False
+        assert predicate.calls == 1
+
+    def test_subclass_of_override_is_enforced_once(self) -> None:
+        """Inheriting a guarded matcher must not stack a second guard on top of it."""
+        predicate = CountingPredicate()
+
+        class Parent(FeatureChainParserMixin, FeatureGroup):
+            PREFIX_PATTERN = GUARDED_PATTERN
+            PROPERTY_MAPPING = _mapping(predicate)
+
+            @classmethod
+            def match_feature_group_criteria(
+                cls,
+                feature_name: str | FeatureName,
+                options: Options,
+                data_access_collection: Any = None,
+            ) -> bool:
+                return FeatureChainParser.match_configuration_feature_chain_parser(
+                    feature_name,
+                    options,
+                    property_mapping=cls.PROPERTY_MAPPING,
+                    prefix_patterns=[cls.PREFIX_PATTERN],
+                )
+
+        class Child(Parent):
+            """Does not redefine the matcher: it inherits the already guarded one."""
+
+        assert Child.match_feature_group_criteria("x__first_guarded", REQUIRES_ORDER_BY) is False
+        assert predicate.calls == 1
+
+
+class TestMatcherVariants:
+    """The guard reaches every matcher a feature group can end up with."""
+
+    def test_default_feature_group_matcher_is_enforced(self) -> None:
+        """A plain FeatureGroup (no mixin) matches by class name and must still honor required_when."""
+        predicate = CountingPredicate()
+
+        class DefaultMatcherFeatureGroup(FeatureGroup):
+            PROPERTY_MAPPING = _mapping(predicate)
+
+        name = DefaultMatcherFeatureGroup.get_class_name()
+        assert DefaultMatcherFeatureGroup.match_feature_group_criteria(name, REQUIRES_ORDER_BY) is False
+        assert predicate.calls == 1
+        assert DefaultMatcherFeatureGroup.match_feature_group_criteria(name, SATISFIED) is True
+
+    def test_standalone_mixin_override_is_enforced(self) -> None:
+        """The mixin is usable without FeatureGroup, so it must install the guard itself."""
+        predicate = CountingPredicate()
+
+        class StandaloneMixinOverride(FeatureChainParserMixin):
+            PREFIX_PATTERN = GUARDED_PATTERN
+            PROPERTY_MAPPING = _mapping(predicate)
+
+            @classmethod
+            def match_feature_group_criteria(
+                cls,
+                feature_name: str | FeatureName,
+                options: Options,
+                data_access_collection: Any = None,
+            ) -> bool:
+                return True
+
+        assert StandaloneMixinOverride.match_feature_group_criteria("x__first_guarded", REQUIRES_ORDER_BY) is False
+        assert predicate.calls == 1
+        assert StandaloneMixinOverride.match_feature_group_criteria("x__first_guarded", SATISFIED) is True
+
+
+class TestGuardInstallation:
+    """The guard is installed at class definition time, and only where it is declared."""
+
+    def test_required_when_wraps_the_inherited_matcher(self) -> None:
+        """A class declaring required_when carries its own guarded matcher, even without overriding one."""
+        predicate = CountingPredicate()
+
+        class InheritsMixinMatcher(FeatureChainParserMixin, FeatureGroup):
+            PREFIX_PATTERN = GUARDED_PATTERN
+            PROPERTY_MAPPING = _mapping(predicate)
+
+        resolved = InheritsMixinMatcher.match_feature_group_criteria.__func__  # type: ignore[attr-defined]
+        assert resolved is not FeatureChainParserMixin.match_feature_group_criteria.__func__  # type: ignore[attr-defined]
+        assert InheritsMixinMatcher.match_feature_group_criteria("x__first_guarded", REQUIRES_ORDER_BY) is False
+        assert predicate.calls == 1
+
+    def test_no_required_when_leaves_the_matcher_untouched(self) -> None:
+        """No conditional requirement declared means nothing to enforce: no wrapper is installed."""
+
+        class NoRequiredWhen(FeatureChainParserMixin, FeatureGroup):
+            PREFIX_PATTERN = GUARDED_PATTERN
+            PROPERTY_MAPPING = {
+                OP_TYPE: {
+                    DefaultOptionKeys.allowed_values: {"sum": "Sum of values"},
+                    DefaultOptionKeys.context: True,
+                    DefaultOptionKeys.strict_validation: True,
+                },
+            }
+
+        assert "match_feature_group_criteria" not in NoRequiredWhen.__dict__
+        resolved = NoRequiredWhen.match_feature_group_criteria.__func__  # type: ignore[attr-defined]
+        assert resolved is FeatureChainParserMixin.match_feature_group_criteria.__func__  # type: ignore[attr-defined]

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_required_when_enforced_on_override.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_required_when_enforced_on_override.py
@@ -9,6 +9,7 @@ and it must reach both the mixin matcher and the default FeatureGroup matcher.
 from __future__ import annotations
 
 import gc
+import re
 from typing import Any
 
 import pytest
@@ -27,6 +28,8 @@ from mloda.provider import DefaultOptionKeys
 OP_TYPE = "op_type"
 ORDER_BY = "order_by"
 GUARDED_PATTERN = r".*__([\w]+)_guarded$"
+CUSTOM_SEPARATOR_PATTERN = r".*::([\w]+)_custom$"
+COMPILED_PATTERN = re.compile(r".*__([\w]+)_compiled$")
 
 
 @pytest.fixture(autouse=True)
@@ -69,9 +72,33 @@ def _mapping(predicate: CountingPredicate) -> dict[str, Any]:
     }
 
 
+class NameSuppliedPredicate:
+    """required_when predicate on the very key the feature name supplies: op_type is required unless order_by is."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self, options: Options) -> bool:
+        self.calls += 1
+        return options.get(ORDER_BY) is None
+
+
+def _name_supplied_mapping(predicate: NameSuppliedPredicate) -> dict[str, Any]:
+    """PROPERTY_MAPPING whose conditionally required key is the one the feature name parses into."""
+    return {
+        OP_TYPE: {
+            DefaultOptionKeys.allowed_values: {"sum": "Sum of values", "first": "First value"},
+            DefaultOptionKeys.context: True,
+            DefaultOptionKeys.strict_validation: True,
+            DefaultOptionKeys.required_when: predicate,
+        },
+    }
+
+
 REQUIRES_ORDER_BY = Options(context={OP_TYPE: "first"})
 SATISFIED = Options(context={OP_TYPE: "first", ORDER_BY: "ts"})
 NOT_REQUIRED = Options(context={OP_TYPE: "sum"})
+ONLY_ORDER_BY = Options(context={ORDER_BY: "ts"})
 
 
 class TestOverriddenMatcher:
@@ -245,3 +272,136 @@ class TestGuardInstallation:
         assert "match_feature_group_criteria" not in NoRequiredWhen.__dict__
         resolved = NoRequiredWhen.match_feature_group_criteria.__func__  # type: ignore[attr-defined]
         assert resolved is FeatureChainParserMixin.match_feature_group_criteria.__func__  # type: ignore[attr-defined]
+
+
+class TestGuardAnswersInsteadOfRaising:
+    """A matcher answers True or False. The guard must never turn a verdict into an exception."""
+
+    def test_custom_separator_matcher_keeps_its_verdict(self) -> None:
+        """match_configuration_feature_chain_parser takes a custom pattern; the guard reparses with '__'.
+
+        The name is unparseable under CHAIN_SEPARATOR, which only means there is no name-parsed value
+        to merge: the predicates then see the explicit options, and the matcher's verdict stands.
+        """
+        predicate = CountingPredicate()
+
+        class CustomSeparatorOverride(FeatureChainParserMixin, FeatureGroup):
+            PREFIX_PATTERN = CUSTOM_SEPARATOR_PATTERN
+            PROPERTY_MAPPING = _mapping(predicate)
+
+            @classmethod
+            def match_feature_group_criteria(
+                cls,
+                feature_name: str | FeatureName,
+                options: Options,
+                data_access_collection: Any = None,
+            ) -> bool:
+                return FeatureChainParser.match_configuration_feature_chain_parser(
+                    feature_name,
+                    options,
+                    property_mapping=cls.PROPERTY_MAPPING,
+                    prefix_patterns=[cls.PREFIX_PATTERN],
+                    pattern="::",
+                )
+
+        assert CustomSeparatorOverride.match_feature_group_criteria("x::first_custom", ONLY_ORDER_BY) is True
+        # The contract still holds on the options the guard can read: op_type 'first' needs order_by.
+        assert CustomSeparatorOverride.match_feature_group_criteria("x::first_custom", REQUIRES_ORDER_BY) is False
+
+
+class TestStaticMethodMatcherRejected:
+    """The guard reinstalls the matcher as a classmethod, so a staticmethod matcher must not reach it."""
+
+    def test_staticmethod_matcher_with_required_when_is_rejected_at_class_definition(self) -> None:
+        """Wrapping a staticmethod injects cls as the first argument, so the matcher would misread its own
+        arguments and return a silently wrong verdict. Reject loudly, at class definition."""
+        predicate = CountingPredicate()
+
+        with pytest.raises(ValueError) as excinfo:
+
+            class StaticMatcherFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+                PREFIX_PATTERN = GUARDED_PATTERN
+                PROPERTY_MAPPING = _mapping(predicate)
+
+                @staticmethod
+                def match_feature_group_criteria(
+                    feature_name: str | FeatureName,
+                    options: Options,
+                    data_access_collection: Any = None,
+                ) -> bool:
+                    return True
+
+        message = str(excinfo.value)
+        assert "StaticMatcherFeatureGroup" in message
+        assert "classmethod" in message
+
+    def test_staticmethod_matcher_without_required_when_is_left_alone(self) -> None:
+        """Nothing to enforce means nothing to install: a staticmethod matcher stays a valid choice."""
+
+        class StaticMatcherNoContract(FeatureChainParserMixin, FeatureGroup):
+            PREFIX_PATTERN = GUARDED_PATTERN
+            PROPERTY_MAPPING = {
+                OP_TYPE: {
+                    DefaultOptionKeys.allowed_values: {"sum": "Sum of values"},
+                    DefaultOptionKeys.context: True,
+                    DefaultOptionKeys.strict_validation: True,
+                },
+            }
+
+            @staticmethod
+            def match_feature_group_criteria(
+                feature_name: str | FeatureName,
+                options: Options,
+                data_access_collection: Any = None,
+            ) -> bool:
+                return True
+
+        assert StaticMatcherNoContract.match_feature_group_criteria("x__sum_guarded", NOT_REQUIRED) is True
+
+
+class TestExactlyOnceAcrossInheritance:
+    """One enforcement site per match call, including when the delegation target is itself guarded."""
+
+    def test_delegating_child_of_a_guarded_parent_evaluates_the_predicate_once(self) -> None:
+        """The parent declares required_when and keeps the inherited matcher, so the parent carries the guard.
+        A child that overrides the matcher and delegates into the parent must not stack a second guard."""
+        predicate = CountingPredicate()
+
+        class GuardedParent(FeatureChainParserMixin, FeatureGroup):
+            PREFIX_PATTERN = GUARDED_PATTERN
+            PROPERTY_MAPPING = _mapping(predicate)
+
+        class DelegatingChild(GuardedParent):
+            @classmethod
+            def match_feature_group_criteria(
+                cls,
+                feature_name: str | FeatureName,
+                options: Options,
+                data_access_collection: Any = None,
+            ) -> bool:
+                return super().match_feature_group_criteria(feature_name, options, data_access_collection)
+
+        assert DelegatingChild.match_feature_group_criteria("x__first_guarded", SATISFIED) is True
+        assert predicate.calls == 1
+        assert DelegatingChild.match_feature_group_criteria("x__first_guarded", REQUIRES_ORDER_BY) is False
+
+
+class TestPatternDiscovery:
+    """The guard must collect the same patterns the matcher matched on."""
+
+    def test_compiled_prefix_pattern_still_supplies_the_name_parsed_value(self) -> None:
+        """re.match accepts a compiled pattern, so the mixin matches on it. The guard must see it too, or the
+        name-parsed value never reaches the key that requires it and the feature is wrongly rejected."""
+        string_predicate = NameSuppliedPredicate()
+        compiled_predicate = NameSuppliedPredicate()
+
+        class StringPatternGroup(FeatureChainParserMixin, FeatureGroup):
+            PREFIX_PATTERN = COMPILED_PATTERN.pattern
+            PROPERTY_MAPPING = _name_supplied_mapping(string_predicate)
+
+        class CompiledPatternGroup(FeatureChainParserMixin, FeatureGroup):
+            PREFIX_PATTERN = COMPILED_PATTERN
+            PROPERTY_MAPPING = _name_supplied_mapping(compiled_predicate)
+
+        assert StringPatternGroup.match_feature_group_criteria("x__first_compiled", Options()) is True
+        assert CompiledPatternGroup.match_feature_group_criteria("x__first_compiled", Options()) is True

--- a/tests/test_plugins/feature_group/experimental/sklearn/test_pipeline_feature_group/test_base_pipeline_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/sklearn/test_pipeline_feature_group/test_base_pipeline_feature_group.py
@@ -280,3 +280,31 @@ class TestSklearnPipelineRequiredWhen:
         """Each option is required when the other is absent."""
         options = Options({DefaultOptionKeys.in_features: "income"})
         assert SklearnPipelineFeatureGroup.match_feature_group_criteria("x", options) is False
+
+    def test_rejects_string_name_outside_pipeline_types_even_with_options(self) -> None:
+        """Regression pin for the real blast radius of the accepted behavior change.
+
+        The rejection is not limited to the no-options case: an undeclared pipeline name never maps back
+        onto pipeline_name, so ANY string-named pipeline outside PIPELINE_TYPES is rejected, options or not.
+        This returned True before the required_when guard.
+        """
+        options = Options({DefaultOptionKeys.in_features: "income"})
+        assert (
+            SklearnPipelineFeatureGroup.match_feature_group_criteria("income__sklearn_pipeline_custom", options)
+            is False
+        )
+
+    def test_rejects_pipeline_name_with_empty_pipeline_steps(self) -> None:
+        """Regression pin: mutual exclusivity is presence-based (is not None), not truthiness.
+
+        An empty pipeline_steps list is still a present pipeline_steps, so it collides with pipeline_name.
+        Truthiness let this pair through before the required_when guard.
+        """
+        options = Options(
+            {
+                SklearnPipelineFeatureGroup.PIPELINE_NAME: "scaling",
+                SklearnPipelineFeatureGroup.PIPELINE_STEPS: [],
+                DefaultOptionKeys.in_features: "income",
+            }
+        )
+        assert SklearnPipelineFeatureGroup.match_feature_group_criteria("x", options) is False

--- a/tests/test_plugins/feature_group/experimental/sklearn/test_pipeline_feature_group/test_base_pipeline_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/sklearn/test_pipeline_feature_group/test_base_pipeline_feature_group.py
@@ -6,6 +6,7 @@ import pytest
 from unittest.mock import Mock, patch
 from mloda_plugins.feature_group.experimental.sklearn.pipeline.base import SklearnPipelineFeatureGroup
 from mloda_plugins.feature_group.experimental.sklearn.pipeline.pandas import PandasSklearnPipelineFeatureGroup
+from mloda.provider import DefaultOptionKeys
 from mloda.user import FeatureName
 from mloda.user import Options
 
@@ -212,3 +213,70 @@ class TestSklearnPipelineFeatureGroup:
         """Test that abstract base class cannot be instantiated directly."""
         with pytest.raises(TypeError, match="abstract method"):
             SklearnPipelineFeatureGroup()  # type: ignore[abstract]
+
+
+PIPELINE_STEPS_VALUE = frozenset({("scaler", "StandardScaler")})
+
+
+class TestSklearnPipelineRequiredWhen:
+    """The pipeline_name / pipeline_steps requirement is a required_when contract (issue #731).
+
+    SklearnPipelineFeatureGroup overrides match_feature_group_criteria, so the mixin's
+    required_when evaluation never reached it. The declared predicates must now be enforced
+    on the override too.
+    """
+
+    def test_rejects_name_that_only_contains_the_pipeline_infix(self) -> None:
+        """Issue repro: the name is not a chained pipeline feature and neither option is given."""
+        options = Options(context={DefaultOptionKeys.in_features: ["x"]})
+        assert SklearnPipelineFeatureGroup.match_feature_group_criteria("my_sklearn_pipeline_thing", options) is False
+
+    def test_accepts_string_name_inside_pipeline_types(self) -> None:
+        """A declared pipeline type maps back onto pipeline_name, so the predicate is satisfied."""
+        assert (
+            SklearnPipelineFeatureGroup.match_feature_group_criteria("x__sklearn_pipeline_scaling", Options()) is True
+        )
+
+    def test_rejects_string_name_outside_pipeline_types(self) -> None:
+        """Accepted behavior change: an undeclared pipeline name cannot map back onto pipeline_name,
+        so pipeline_name stays absent and its required_when predicate rejects the feature instead of
+        silently computing it with the default scaling pipeline."""
+        assert (
+            SklearnPipelineFeatureGroup.match_feature_group_criteria("x__sklearn_pipeline_custom", Options()) is False
+        )
+
+    def test_accepts_config_with_pipeline_name_only(self) -> None:
+        """pipeline_name present: the pipeline_steps predicate does not fire."""
+        options = Options(
+            {
+                SklearnPipelineFeatureGroup.PIPELINE_NAME: "scaling",
+                DefaultOptionKeys.in_features: "income",
+            }
+        )
+        assert SklearnPipelineFeatureGroup.match_feature_group_criteria("x", options) is True
+
+    def test_accepts_config_with_pipeline_steps_only(self) -> None:
+        """pipeline_steps present: the pipeline_name predicate does not fire."""
+        options = Options(
+            {
+                SklearnPipelineFeatureGroup.PIPELINE_STEPS: PIPELINE_STEPS_VALUE,
+                DefaultOptionKeys.in_features: "income",
+            }
+        )
+        assert SklearnPipelineFeatureGroup.match_feature_group_criteria("x", options) is True
+
+    def test_rejects_config_with_both_pipeline_name_and_steps(self) -> None:
+        """Mutual exclusivity is the one rule a spec cannot express; the override keeps it."""
+        options = Options(
+            {
+                SklearnPipelineFeatureGroup.PIPELINE_NAME: "scaling",
+                SklearnPipelineFeatureGroup.PIPELINE_STEPS: PIPELINE_STEPS_VALUE,
+                DefaultOptionKeys.in_features: "income",
+            }
+        )
+        assert SklearnPipelineFeatureGroup.match_feature_group_criteria("x", options) is False
+
+    def test_rejects_config_with_neither_pipeline_name_nor_steps(self) -> None:
+        """Each option is required when the other is absent."""
+        options = Options({DefaultOptionKeys.in_features: "income"})
+        assert SklearnPipelineFeatureGroup.match_feature_group_criteria("x", options) is False


### PR DESCRIPTION
Closes #731.

## Problem

`required_when` predicates were only ever evaluated inside `FeatureChainParserMixin.match_feature_group_criteria`. Overriding that entry point is documented and supported, and any group that did so silently lost the enforcement: the spec declared a conditional-requirement contract that nothing executed. `SklearnPipelineFeatureGroup` was the live case, correct only by coincidence because its hand-written pre-check happened to enforce the same rule independently.

## Change

Option 1 from the issue, the one that makes the spec authoritative.

The predicates moved from the mixin into `FeatureChainParser`, and a guard is installed on the class at definition time (from `FeatureGroup.__init_subclass__` and `FeatureChainParserMixin.__init_subclass__`) that wraps whatever matcher the class kept. It is the single enforcement site: the mixin no longer runs the predicates inline, guards do not stack when an override delegates via `super()`, and an inherited guard is never wrapped twice, so the predicates run exactly once per match call.

`SklearnPipelineFeatureGroup` now declares the contract on its spec (`pipeline_name` and `pipeline_steps` are each required only when the other is absent), drops its pre-check, and keeps only the one rule a spec cannot express: not both.

Two guard-adjacent hazards are rejected rather than tolerated: a `staticmethod` matcher on a class declaring `required_when` fails at class definition (the guard installs as a classmethod, so such a matcher would read the class as its feature name), and an `in_features` shape the group cannot count is a non-match rather than a free pass around `MIN/MAX_IN_FEATURES`.

## Behavior changes

- A string-named sklearn pipeline whose name is outside `PIPELINE_TYPES` is now rejected at match time, with or without options (`income__sklearn_pipeline_custom`). It previously matched and silently computed with a default scaling pipeline. `pipeline_name` is strict with `allowed_values=PIPELINE_TYPES`, so the same value passed as an option was already rejected; this aligns the name path with the spec.
- sklearn mutual exclusivity is `is not None` rather than truthiness, so `pipeline_name` plus an empty `pipeline_steps` list is now a non-match.
- An `in_features` value that `Options.get_in_features()` cannot convert (a `SourceInputFeature` join tuple, or a plain typo) is a non-match. It previously raised `TypeError` out of the matcher.

Each is pinned by a test.

## Review

Two independent deep reviews (Claude Opus and codex) ran against the first commit. They converged on the guard's own gaps, all fixed in the second commit: the guard could raise out of a matcher when an override parsed the name with its own separator, it mis-bound a `staticmethod` matcher, it evaluated predicates twice for a delegating child of a guarded parent, and it hid a compiled `re.Pattern` from itself.

## Gate

`tox` green: 5754 passed, 171 skipped; ruff format, ruff check, pip-licenses, `mypy --strict`, bandit all clean.