### PR TITLE
fix(tests): rebuild the sklearn specs with the required_when they now carry

### DIFF
--- a/tests/test_plugins/feature_group/experimental/test_property_spec_shipped_specs.py
+++ b/tests/test_plugins/feature_group/experimental/test_property_spec_shipped_specs.py
@@ -15,7 +15,7 @@ import pytest
 
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
-from mloda.provider import property_spec
+from mloda.provider import DefaultOptionKeys, property_spec
 from mloda_plugins.feature_group.experimental.data_quality.missing_value.base import MissingValueFeatureGroup
 from mloda_plugins.feature_group.experimental.node_centrality.base import NodeCentralityFeatureGroup
 from mloda_plugins.feature_group.experimental.sklearn.pipeline.base import SklearnPipelineFeatureGroup
@@ -27,6 +27,18 @@ def _shipped(feature_group: type[FeatureGroup], key: str) -> dict[str, Any]:
     assert mapping is not None, f"{feature_group.__name__} declares no PROPERTY_MAPPING"
     spec: dict[str, Any] = mapping[key]
     return spec
+
+
+# PIPELINE_NAME and PIPELINE_STEPS each carry a required_when predicate ("required only when the
+# other is absent"). Two separately written lambdas are never ``==``, so a rebuilt spec can only
+# equal the shipped one if the builder is handed the SAME callable object: read the predicate off
+# the shipped spec and thread it through by identity.
+_PIPELINE_NAME_SHIPPED: dict[str, Any] = _shipped(
+    SklearnPipelineFeatureGroup, SklearnPipelineFeatureGroup.PIPELINE_NAME
+)
+_PIPELINE_STEPS_SHIPPED: dict[str, Any] = _shipped(
+    SklearnPipelineFeatureGroup, SklearnPipelineFeatureGroup.PIPELINE_STEPS
+)
 
 
 # Shipped specs the builder must reproduce EXACTLY: (id, built, shipped).
@@ -48,8 +60,12 @@ _EXACT_CASES: list[tuple[str, dict[str, Any], dict[str, Any]]] = [
     ),
     (
         "sklearn_pipeline.pipeline_steps",
-        property_spec("List of pipeline steps as (name, transformer) tuples", default=None),
-        _shipped(SklearnPipelineFeatureGroup, SklearnPipelineFeatureGroup.PIPELINE_STEPS),
+        property_spec(
+            "List of pipeline steps as (name, transformer) tuples",
+            default=None,
+            required_when=_PIPELINE_STEPS_SHIPPED[DefaultOptionKeys.required_when],
+        ),
+        _PIPELINE_STEPS_SHIPPED,
     ),
     (
         "sklearn_pipeline.pipeline_params",
@@ -64,9 +80,7 @@ _PIPELINE_NAME_BUILT: dict[str, Any] = property_spec(
     strict=True,
     allowed_values=SklearnPipelineFeatureGroup.PIPELINE_TYPES,
     default=None,
-)
-_PIPELINE_NAME_SHIPPED: dict[str, Any] = _shipped(
-    SklearnPipelineFeatureGroup, SklearnPipelineFeatureGroup.PIPELINE_NAME
+    required_when=_PIPELINE_NAME_SHIPPED[DefaultOptionKeys.required_when],
 )
 
 _ALL_BUILT: list[tuple[str, dict[str, Any]]] = [(case_id, built) for case_id, built, _ in _EXACT_CASES] + [


### PR DESCRIPTION
`main` is red, and every open PR fails with it.

## What broke

Two tests fail on a clean checkout of `main`:

```
FAILED test_property_spec_shipped_specs.py::TestShippedOptionalSpecsAreBuildable::test_builder_reproduces_shipped_spec_exactly[sklearn_pipeline.pipeline_steps]
FAILED test_property_spec_shipped_specs.py::TestShippedOptionalSpecsAreBuildable::test_builder_reproduces_pipeline_name_up_to_added_explanation
```

A semantic conflict between two PRs that were each correct in isolation and never saw each other:

- #738 (issue #733) added `test_property_spec_shipped_specs.py`, which pins that every shipped optional-with-`None`-default spec is reproducible with `property_spec(...)`, by rebuilding it and asserting `built == shipped`.
- #740 (issue #731) then added a `required_when` predicate to the shipped `PIPELINE_NAME` and `PIPELINE_STEPS` specs ("required only when the other is absent").

The builder calls in the test do not pass `required_when`, so the rebuilt spec is exactly one key short of the shipped dict:

```
E   Right contains 1 more item:
E   {<DefaultOptionKeys.required_when: 'required_when'>: <function SklearnPipelineFeatureGroup.<lambda> at 0x...>}
```

## The fix

Test-side only. The contract the test pins is still true and still worth pinning: `property_spec` accepts `required_when`, so both specs remain exactly expressible with the builder. So pass it, rather than weakening the assertion or reverting the plugin.

The predicate is threaded through **by identity**, read off the shipped spec. Two separately written lambdas are never `==`, so handing the builder a new equivalent lambda could never satisfy `built == shipped`. That is non-obvious, so the code says why.

The plugin and its `required_when` lambdas are untouched. Test ids, structure, and assertions are unchanged.

## Verification

That file goes from 2 failed / 16 passed to 18 passed. Full `tox` is green (5941 passed, ruff, pip-licenses, mypy --strict, bandit), which also confirms these two tests were `main`'s only breakage.