### PR TITLE
feat: unify FeatureGroup resolution behind one authoritative resolver (#722)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,8 @@ jobs:
       env:
         PYTEST_WORKERS: 2
       run: tox ${{ matrix.toxenv }}
-      timeout-minutes: 3
+      # 3 minutes started killing green full-tox legs once #722 grew the suite past 6600 tests.
+      timeout-minutes: 5
 
   notebooks:
     # Runs the marimo example notebooks; slower than the unit-test matrix.

--- a/docs/docs/in_depth/compute-framework-integration.md
+++ b/docs/docs/in_depth/compute-framework-integration.md
@@ -56,6 +56,9 @@ The debug inspector `resolve_feature(name)` reflects the hook too: its
 pass `options=`, see [Discover Plugins](discover-plugins.md)), and a feature
 that matches a group but is unsupported on every installed framework resolves
 to `feature_group=None` with a capability error rather than appearing runnable.
+Framework availability applies the same way: a feature whose only declared
+framework is not installed resolves to `feature_group=None` on the debug path
+too, exactly like the engine refuses to run it.
 
 ### Declaring capability per subtype
 

--- a/docs/docs/in_depth/discover-plugins.md
+++ b/docs/docs/in_depth/discover-plugins.md
@@ -22,6 +22,15 @@ This is useful for:
 - Understanding which plugin handles a feature
 - Identifying conflicts when multiple FeatureGroups match
 
+`resolve_feature` also accepts a `Feature` object carrying its own options, domain,
+scope, and compute-framework pin (do not combine it with `options=` or
+`feature_group=`), plus the keyword-only `links`, `data_access_collection`, and
+`compute_frameworks` parameters to express the remaining run context. The
+standalone environment applies collector applicability, registry strict mode, and
+framework availability exactly like the engine, and every result carries
+`mode == "standalone"`. For the exact configuration of a run, use
+`mlodaAPI.diagnose(...)` or `session.resolution_report()`.
+
 ### Option-Gated Feature Groups
 
 Matching and the compute framework split both run under the options you pass.
@@ -41,7 +50,7 @@ result = resolve_feature("sales__sum_aggr", options=Options(group={"partition_by
 print(result.feature_group, result.supported_compute_frameworks)
 ```
 
-`options` and `plugin_collector` are keyword-only, so pass them by name.
+Every parameter after the first is keyword-only, so pass it by name.
 
 ### Scoping to a Feature Group
 

--- a/docs/docs/in_depth/feature-group-resolution-contract.md
+++ b/docs/docs/in_depth/feature-group-resolution-contract.md
@@ -26,7 +26,7 @@ Environment provenance distinguishes: not discovered, disabled by collector, rej
 ## Statuses and invariants
 
 - `ResolutionStatus`: RESOLVED, NOT_FOUND, AMBIGUOUS, FAILED.
-- `CandidateResolutionStatus`: WINNER, SHADOWED, REJECTED, FAILED.
+- `CandidateResolutionStatus`: WINNER, SURVIVOR (passed every filter, did not win: ambiguous or failed outcome), SHADOWED, REJECTED, FAILED.
 - `FrameworkResolutionStatus`: SUPPORTED, NOT_ENABLED, UNAVAILABLE, PIN_EXCLUDED, CAPABILITY_REJECTED, HOOK_FAILED.
 
 Invariants:

--- a/docs/docs/in_depth/feature-group-resolution-contract.md
+++ b/docs/docs/in_depth/feature-group-resolution-contract.md
@@ -1,0 +1,110 @@
+# Feature Group Resolution Contract
+
+Status: this contract was decided under issue #722 (Stage 1). The engine matcher (`IdentifyFeatureGroupClass`) and the debug matcher (`resolve_feature`) still diverge today; the known divergences are pinned by `tests/test_core/test_resolution_parity/`. Stages 2-4 of #722 implement this contract; nothing below is implemented yet unless a parity test says otherwise. Input-data reader selection (issue #727) and GlobalFilter (issue #728) are out-of-scope follow-ups.
+
+## Boundary model
+
+One authoritative pipeline:
+
+```text
+run configuration
+  -> EnvironmentBuildOutcome            (environment construction, may fail structurally)
+  -> ResolutionEnvironmentSnapshot
+  -> FeatureGroupResolver.resolve(request, environment)
+  -> ResolutionOutcome
+  -> projections
+```
+
+`FeatureGroupResolver` is the only component allowed to decide whether a FeatureGroup wins. It never raises for resolution failures; it returns structured state. The engine validates the outcome and raises a typed `FeatureResolutionError` carrying it. Diagnostic surfaces consume the same outcome; they never re-match and never call provider hooks.
+
+## Candidate universe
+
+The candidate universe is exactly the accessible mapping of the environment snapshot: discovered FeatureGroup subclasses, minus collector-disabled, minus registry-strict-mode rejections, after redefinition dedup, each with frameworks = declared intersect run-enabled intersect available. The resolver never calls `get_all_subclasses` and never re-reads registry state.
+
+Environment provenance distinguishes: not discovered, disabled by collector, rejected by policy or strict mode, unavailable, not enabled for this run, redefinition conflict, invalid provider framework declaration, accessible.
+
+## Statuses and invariants
+
+- `ResolutionStatus`: RESOLVED, NOT_FOUND, AMBIGUOUS, FAILED.
+- `CandidateResolutionStatus`: WINNER, SHADOWED, REJECTED, FAILED.
+- `FrameworkResolutionStatus`: SUPPORTED, NOT_ENABLED, UNAVAILABLE, PIN_EXCLUDED, CAPABILITY_REJECTED, HOOK_FAILED.
+
+Invariants:
+
+- A winner is present if and only if the status is RESOLVED.
+- A decision-relevant fatal provider or environment error cannot coexist with RESOLVED.
+- Candidate and framework ordering is deterministic by stable plugin identity (`module:qualname`), never set iteration.
+- Shadowed candidates stay visible, with who shadowed them and the affected framework set.
+- Public records serialize without Python class objects.
+- Every rejection carries a structured reason (criteria, domain, scope, abstract class, no accessible framework, capability rejection, framework-pin exclusion, link/index mismatch, provider-hook failure, policy exclusion, subclass shadowing), never only an error string.
+
+## Filter and hook order
+
+The decided order:
+
+1. Normalize and validate the request.
+2. Apply environment accessibility and policy.
+3. Structural scope filter.
+4. Abstract classification (abstract candidates can never win).
+5. Domain.
+6. Criteria (`match_feature_group_criteria`).
+7. Effective frameworks from the environment.
+8. Framework pin.
+9. Link/index compatibility.
+10. Per-feature capability hook (`supports_compute_framework`), on remaining frameworks only.
+11. Framework-aware subclass preference.
+12. Final uniqueness validation.
+
+Two deliberate changes from current engine behavior:
+
+- Today criteria runs before scope, so irrelevant provider code can observe, and even abort, a scoped-out request.
+- Today capability hooks run before the framework pin, so a broken hook on a pinned-away framework is engine-fatal.
+
+The new order runs cheap structural exclusions first and never invokes hooks for candidates or frameworks that are already excluded. Each provider hook is invoked at most once per candidate or per candidate/framework pair. Renderers and diagnostics never invoke hooks. Diagnostic enrichment cannot change the resolution status.
+
+## Subclass policy
+
+Framework-aware preference, the engine's current semantics: a child shadows its parent only when both survived all prior steps and their supported framework sets are equal. Shadowing records the shadowed candidate as SHADOWED. Pure-issubclass collapse (what `resolve_feature` does today) is rejected because it hides real ambiguity that the engine reports.
+
+## Failure precedence
+
+FAILED (a decision-relevant provider or environment error) beats AMBIGUOUS, which beats NOT_FOUND. An otherwise successful candidate never hides a decision-relevant failure that would abort the engine. Failures of candidates or frameworks excluded earlier by policy are not decision-relevant, and their hooks are not invoked at all.
+
+## Provider failure semantics
+
+| Signal | Engine semantics | Diagnostic semantics |
+| --- | --- | --- |
+| Ordinary non-match (`False`) | Candidate REJECTED | Silent |
+| Typed value rejection (`PropertyValueRejection`) | Candidate REJECTED with structured reason | Surfaced identically on both paths |
+| Provider contract violation (malformed framework declaration and similar) | FAILED, fail closed | FAILED, fail closed |
+| Unexpected provider exception | FAILED, fail closed, never degraded open, never converted to a non-match or an empty framework list | FAILED, fail closed |
+| Environment or policy failure | FAILED at environment construction | FAILED at environment construction |
+
+Recorded per failure: plugin identity, hook or stage, exception category, safe message. Never retained: traceback objects. The current `resolve_feature` behavior of degrading a raising capability hook open is explicitly rejected.
+
+## Projections
+
+The three personas from issue #722:
+
+| Persona | Projection |
+| --- | --- |
+| Data user | Concise actionable message: typed failure, dependency path, suggested fixes, explicit standalone vs exact-run labeling. |
+| Data provider | Candidate, hook, and framework-level decisions: the failing hook and its category, deterministic ordering, exactly-once hook invocation. |
+| Data steward | Redacted serializable report: stable plugin identity, registry and strict-mode provenance, policy exclusions, effective framework set, environment fingerprint, deterministic output. |
+
+Human-readable strings are projections of structured state. They are never matching inputs and never the only retained representation.
+
+## Serialization and redaction
+
+Stable plugin identity is `module:qualname`. Public records are plain data (strings, numbers, tuples) and serialize without importing plugin classes.
+
+Redaction: credentials, raw data-access objects, secret option values, and unsafe plugin exception content never appear in public or steward projections. The internal request may carry opaque provider values, but the resolver never mutates them.
+
+## Diagnostics modes
+
+Two labelled modes:
+
+- Standalone (default): a fresh default environment, exploratory. It records its origin and does not claim to reproduce a run.
+- Exact-run (preflight): the same configuration as `prepare()`, or the stored outcome of an actual planning pass.
+
+A session exposes its captured report; inspecting a report never re-matches. `mlodaAPI.explain` and `session.resolved_plan` stay plan-based.

--- a/docs/docs/in_depth/feature-group-resolution-contract.md
+++ b/docs/docs/in_depth/feature-group-resolution-contract.md
@@ -1,6 +1,6 @@
 # Feature Group Resolution Contract
 
-Status: this contract was decided under issue #722 (Stage 1). The engine matcher (`IdentifyFeatureGroupClass`) and the debug matcher (`resolve_feature`) still diverge today; the known divergences are pinned by `tests/test_core/test_resolution_parity/`. Stages 2-4 of #722 implement this contract; nothing below is implemented yet unless a parity test says otherwise. Input-data reader selection (issue #727) and GlobalFilter (issue #728) are out-of-scope follow-ups.
+Status: this contract was decided under issue #722 (Stage 1); Stages 2-4 are implemented. The engine matcher (`IdentifyFeatureGroupClass`) and the debug matcher (`resolve_feature`) resolve through the same `FeatureGroupResolver`, and `tests/test_core/test_resolution_parity/` expresses the target contract, except the documented presentation-only rendering differences (divergences 12, 14, and 15). Input-data reader selection (issue #727) and GlobalFilter (issue #728) remain out-of-scope follow-ups.
 
 ## Boundary model
 
@@ -64,7 +64,7 @@ The new order runs cheap structural exclusions first and never invokes hooks for
 
 ## Subclass policy
 
-Framework-aware preference, the engine's current semantics: a child shadows its parent only when both survived all prior steps and their supported framework sets are equal. Shadowing records the shadowed candidate as SHADOWED. Pure-issubclass collapse (what `resolve_feature` does today) is rejected because it hides real ambiguity that the engine reports.
+Framework-aware preference, the engine's current semantics: a child shadows its parent only when both survived all prior steps and their supported framework sets are equal. Shadowing records the shadowed candidate as SHADOWED. Pure-issubclass collapse (what `resolve_feature` did before #722) is rejected because it hides real ambiguity that the engine reports.
 
 ## Failure precedence
 
@@ -80,7 +80,7 @@ FAILED (a decision-relevant provider or environment error) beats AMBIGUOUS, whic
 | Unexpected provider exception | FAILED, fail closed, never degraded open, never converted to a non-match or an empty framework list | FAILED, fail closed |
 | Environment or policy failure | FAILED at environment construction | FAILED at environment construction |
 
-Recorded per failure: plugin identity, hook or stage, exception category, safe message. Never retained: traceback objects. The current `resolve_feature` behavior of degrading a raising capability hook open is explicitly rejected.
+Recorded per failure: plugin identity, hook or stage, exception category, safe message. Never retained: traceback objects. The pre-#722 `resolve_feature` behavior of degrading a raising capability hook open is explicitly rejected.
 
 ## Projections
 

--- a/docs/docs/in_depth/feature-group-resolution-contract.md
+++ b/docs/docs/in_depth/feature-group-resolution-contract.md
@@ -107,4 +107,6 @@ Two labelled modes:
 - Standalone (default): a fresh default environment, exploratory. It records its origin and does not claim to reproduce a run.
 - Exact-run (preflight): the same configuration as `prepare()`, or the stored outcome of an actual planning pass.
 
+Standalone mode runs the authoritative resolver exactly once against its fresh default environment to build its captured outcome. The hook-free guarantee applies to inspecting and projecting an already captured outcome, not to that single build pass.
+
 A session exposes its captured report; inspecting a report never re-matches. `mlodaAPI.explain` and `session.resolved_plan` stay plan-based.

--- a/docs/docs/in_depth/feature-group-resolution-contract.md
+++ b/docs/docs/in_depth/feature-group-resolution-contract.md
@@ -110,3 +110,15 @@ Two labelled modes:
 Standalone mode runs the authoritative resolver exactly once against its fresh default environment to build its captured outcome. The hook-free guarantee applies to inspecting and projecting an already captured outcome, not to that single build pass.
 
 A session exposes its captured report; inspecting a report never re-matches. `mlodaAPI.explain` and `session.resolved_plan` stay plan-based.
+
+## Reusable boundaries for follow-ups
+
+Issue #728 (GlobalFilter evaluation) and issue #727 (input-data reader selection) reuse these seams without adding matcher logic to `FeatureGroupResolver`:
+
+- the normalized `ResolutionRequestSnapshot` (links and the data-access collection already ride on it),
+- the environment factory (`build_resolution_environment`) and `ResolutionEnvironmentSnapshot`,
+- the structured evaluation records (`Rejection`, `PluginFailure`, candidate and framework statuses),
+- the report layer (`ResolutionReport`, `diagnose`, `resolution_report`),
+- the renderers.
+
+Their matcher-specific evaluation and integration stay out of this contract and are implemented under their own issues. `mlodaAPI.explain` and `session.resolved_plan` remain plan-based projections of the resolved plan and never re-match.

--- a/docs/docs/in_depth/feature-group-resolution-contract.md
+++ b/docs/docs/in_depth/feature-group-resolution-contract.md
@@ -26,8 +26,8 @@ Environment provenance distinguishes: not discovered, disabled by collector, rej
 ## Statuses and invariants
 
 - `ResolutionStatus`: RESOLVED, NOT_FOUND, AMBIGUOUS, FAILED.
-- `CandidateResolutionStatus`: WINNER, SURVIVOR (passed every filter, did not win: ambiguous or failed outcome), SHADOWED, REJECTED, FAILED.
-- `FrameworkResolutionStatus`: SUPPORTED, NOT_ENABLED, UNAVAILABLE, PIN_EXCLUDED, CAPABILITY_REJECTED, HOOK_FAILED.
+- `CandidateStatus`: WINNER, SURVIVOR (passed every filter, did not win: ambiguous or failed outcome), SHADOWED, REJECTED, FAILED.
+- `FrameworkStatus`: SUPPORTED, NOT_ENABLED, UNAVAILABLE, PIN_EXCLUDED, CAPABILITY_REJECTED, HOOK_FAILED, NOT_EVALUATED (never reached capability evaluation).
 
 Invariants:
 

--- a/docs/docs/in_depth/mloda-api.md
+++ b/docs/docs/in_depth/mloda-api.md
@@ -131,6 +131,26 @@ print(f"Candidates: {[fg.__name__ for fg in result.candidates]}")
 - **error** (`str | None`): Error message if resolution failed (no match or multiple conflicts).
 - **mode** (`str`): Always `"standalone"`, the diagnostics-mode label; use `mlodaAPI.diagnose(...)` or `session.resolution_report()` for exact-run diagnostics.
 
+##### diagnose and resolution_report
+
+Whole-request diagnostics. `mlodaAPI.diagnose(features, ...)` takes the same signature family as `prepare` (every parameter after `features` is keyword-only) and resolves the request into a `ResolutionReport` without executing anything. It is non-raising for resolution, environment, and resolution-relevant configuration failures (an unknown framework name, a framework pin outside the run set, unsatisfiable parallelization modes); those come back as a report with `complete=False`. `session.resolution_report()` returns the same report shape for a prepared session, taken from its planning pass; nothing is re-resolved.
+
+`ResolutionReport` fields, mirrored by `to_payload()` as plain JSON data:
+
+- **environment** (`EnvironmentBuildOutcome | None`): The plugin-environment build; for `diagnose` this is the full pre-check outcome, whose records also cover non-survivors (e.g. collector-disabled plugins), while `session.resolution_report()` synthesizes it from the engine's accessible survivors.
+- **features** (`tuple[FeatureResolutionRecord, ...]`): One record per identification in planning order, each carrying its dependency path and structured outcome.
+- **complete** (`bool`): True only when the environment built and every feature resolved.
+
+Labeling: `resolve_feature` answers "what would this feature resolve to" against a standalone environment (`mode == "standalone"`); `diagnose` and `resolution_report` describe the exact configuration of a run.
+
+``` python
+from mloda.core.api.request import mlodaAPI
+
+report = mlodaAPI.diagnose(["sales__mean_aggr"], compute_frameworks=["PandasDataFrame"])
+print(report.complete)
+print(report.to_payload())
+```
+
 ##### explain and resolved_plan
 
 The runtime counterpart to `resolve_feature`: `mlodaAPI.explain(...)` builds the execution plan for a request without running it, and `session.resolved_plan()` returns the same records for a prepared session (before or after `run()`). Both return a `list[PlanStep]` in execution-plan order. Every `explain` parameter after `features` is keyword-only.

--- a/docs/docs/in_depth/mloda-api.md
+++ b/docs/docs/in_depth/mloda-api.md
@@ -115,9 +115,13 @@ print(f"Candidates: {[fg.__name__ for fg in result.candidates]}")
 
 **Parameters:**
 
-- **feature_name** (`str`): The name of the feature to resolve.
-- **options** (`Options | None`, keyword-only): Options used for matching and for the compute framework capability split. Defaults to empty `Options`. Required to resolve FeatureGroups that gate matching on an option.
-- **plugin_collector** (`PluginCollector | None`, keyword-only): Restricts the FeatureGroups considered, and threads its `allow_redefinition` flag into deduplication.
+- **feature** (`str | Feature`): The feature name, or a `Feature` object carrying its own options, domain, scope, and compute-framework pin. A `Feature` cannot be combined with `options` or `feature_group`.
+- **options** (`Options | None`, keyword-only, name form only): Options used for matching and for the compute framework capability split. Defaults to empty `Options`. Required to resolve FeatureGroups that gate matching on an option.
+- **plugin_collector** (`PluginCollector | None`, keyword-only): Threaded into the standalone environment build: applicability, registry strict mode, and `allow_redefinition`.
+- **feature_group** (`str | type[FeatureGroup] | None`, keyword-only, name form only): Scopes resolution to a FeatureGroup subclass or its class-name string.
+- **links** (`set[Link] | None`, keyword-only): The run's links; a candidate declaring an index no link carries is excluded.
+- **data_access_collection** (`DataAccessCollection | None`, keyword-only): Threaded into matching, exactly like the engine threads it.
+- **compute_frameworks** (`set[type[ComputeFramework]] | None`, keyword-only): Restricts the standalone environment to the given frameworks, like `mlodaAPI(compute_frameworks=...)`; `None` keeps every available framework.
 
 **Returns:** `ResolvedFeature` dataclass with fields:
 
@@ -125,6 +129,7 @@ print(f"Candidates: {[fg.__name__ for fg in result.candidates]}")
 - **feature_group** (`Type[FeatureGroup] | None`): The resolved FeatureGroup class, or None if resolution failed.
 - **candidates** (`List[Type[FeatureGroup]]`): All FeatureGroups that matched before subclass filtering.
 - **error** (`str | None`): Error message if resolution failed (no match or multiple conflicts).
+- **mode** (`str`): Always `"standalone"`, the diagnostics-mode label; use `mlodaAPI.diagnose(...)` or `session.resolution_report()` for exact-run diagnostics.
 
 ##### explain and resolved_plan
 

--- a/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
+++ b/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
@@ -110,7 +110,7 @@ If both versions of the class have **identical** source code (e.g., re-running a
 
 For rapid iteration in notebooks, opt in to "newest wins" using the builder method on `PluginCollector`:
 
-**Option A** — set the override flag on a fresh collector:
+**Option A**: set the override flag on a fresh collector:
 
 ```python
 from mloda.provider import FeatureGroup
@@ -124,7 +124,7 @@ class SomeFG(FeatureGroup):
 plugin_collector = PluginCollector().set_allow_redefinition()
 ```
 
-**Option B** — compose with disable/enable filters:
+**Option B**: compose with disable/enable filters:
 
 ```python
 plugin_collector = (
@@ -196,6 +196,21 @@ group rather than the final result, are never subject to `EmptyResultError`.
 
 For full details on how the guard works and the schema-presence gate, see
 [Empty Results](../compute-framework-integration.md#empty-results).
+
+## Debugging Resolution
+
+`resolve_feature` is the standalone diagnostics mode: it resolves one feature against a fresh
+default environment under the same rules as the engine (collector applicability, registry strict
+mode, redefinition dedup, framework availability). It accepts a `Feature` object or a feature
+name; a `Feature` carries its own options, domain, scope, and compute-framework pin. The
+keyword-only parameters `links`, `data_access_collection`, and `compute_frameworks` express the
+remaining run context; `compute_frameworks` restricts the environment exactly like
+`mlodaAPI(compute_frameworks=...)`. It never raises; failures land in `result.error`, and every
+result carries `mode == "standalone"`.
+
+For the exact configuration of a run, use `mlodaAPI.diagnose(...)` or
+`session.resolution_report()` instead: they capture the resolution outcomes of a real planning
+pass rather than a fresh standalone environment.
 
 ## Related Documentation
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -37,6 +37,7 @@ nav:
       - Feature Configuration: in_depth/feature-config.md
       - Feature Chain Parser: in_depth/feature-chain-parser.md
       - Feature Group Matching: in_depth/feature-group-matching.md
+      - Feature Group Resolution Contract: in_depth/feature-group-resolution-contract.md
       - PROPERTY_MAPPING: in_depth/property-mapping.md
       - Feature Group Testing: in_depth/feature-group-testing.md
       - Feature Group Versioning: in_depth/feature-group-version.md

--- a/mloda/core/api/feature_config/models.py
+++ b/mloda/core/api/feature_config/models.py
@@ -10,9 +10,14 @@ from typing import Any, Optional
 
 
 def validate_feature_group_scope(value: Any) -> Optional[str]:
-    """Config scope is a non-empty class-name string; the class-object form is Python-only."""
-    # Local import: feature_group pulls in the plugin machinery, which this data-model module stays free of.
-    from mloda.core.abstract_plugins.feature_group import FeatureGroup
+    """Config scope is a non-empty class-name string; the class-object form is Python-only.
+
+    The string semantics (root FeatureGroup base-name rejection, strip-to-nothing) delegate to the
+    canonical ``normalize_feature_group_scope``; only the config-specific concerns stay local: configs
+    accept strings only, and every rejection is a ValueError in the config validation style.
+    """
+    # Local import: feature pulls in the plugin machinery, which this data-model module stays free of.
+    from mloda.core.abstract_plugins.components.feature import normalize_feature_group_scope
 
     if value is None:
         return None
@@ -21,14 +26,17 @@ def validate_feature_group_scope(value: Any) -> Optional[str]:
             "'feature_group' must be a feature group class-name string; "
             "the class-object form is only available in Python, not in a config"
         )
-    stripped = value.strip()
-    if not stripped:
-        raise ValueError("'feature_group' must be a non-empty feature group class-name string")
-    if stripped == FeatureGroup.get_class_name():
+    # Boundary conversion: for a string, the canonical helper raises TypeError only for the root base name.
+    try:
+        normalized = normalize_feature_group_scope(value)
+    except TypeError as exc:
         raise ValueError(
             "'feature_group' cannot be the root FeatureGroup base class name; it names no feature group family, "
             "so a concrete subclass name is required"
-        )
+        ) from exc
+    # The canonical helper strips an empty string to None; a config must reject it instead of dropping the scope.
+    if normalized is None:
+        raise ValueError("'feature_group' must be a non-empty feature group class-name string")
     return value
 
 

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -18,6 +18,8 @@ Example:
 from typing import Any, Optional
 
 from mloda.core.abstract_plugins.components.base_feature_group_version import SOURCE_INTROSPECTION_ERRORS
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.link import Link
 from mloda.core.abstract_plugins.components.subtype_declaration import SubtypeDeclaration
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
@@ -25,7 +27,7 @@ from mloda.core.abstract_plugins.components.utils import get_all_subclasses, saf
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.function_extender import Extender
 from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistry
-from mloda.core.abstract_plugins.components.feature import normalize_feature_group_scope
+from mloda.core.abstract_plugins.components.feature import Feature, normalize_feature_group_scope
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.api.plugin_info import ComputeFrameworkInfo, ExtenderInfo, FeatureGroupInfo, ResolvedFeature
@@ -34,10 +36,7 @@ from mloda.core.prepare.accessible_plugins import (
     dedup_feature_group_subclasses,
     registry_for,
 )
-from mloda.core.prepare.identify_feature_group import (
-    matches_feature_group_scope,
-    scope_callout,
-)
+from mloda.core.prepare.identify_feature_group import scope_callout
 from mloda.core.resolve.environment import (
     EnvironmentBuildError,
     EnvironmentProvenance,
@@ -52,7 +51,7 @@ from mloda.core.resolve.outcome import (
     ResolutionStatus,
 )
 from mloda.core.resolve.request import ResolutionRequestSnapshot
-from mloda.core.resolve.resolver import FeatureGroupResolver
+from mloda.core.resolve.resolver import FeatureGroupResolver, matching_conflict_candidates
 
 
 def list_registered(plugin_type: type[Any]) -> list[type[Any]]:
@@ -103,27 +102,6 @@ def _dedup_degrading_on_conflict(
         return dedup_feature_group_subclasses(feature_groups, allow_redefinition=allow_redefinition)
     except RedefinitionConflictError:
         return dedup_feature_group_subclasses(feature_groups, allow_redefinition=True)
-
-
-def _match_recording_validation_errors(
-    fg_class: type[FeatureGroup],
-    feature_name: FeatureName,
-    options: Options,
-    validation_errors: list[str],
-) -> bool:
-    """Match a feature group, degrading a validation ValueError into "not a match" and recording its message.
-
-    resolve_feature is a non-throwing debug API, but matching can raise ValueError once caller
-    options reach the feature chain parser (e.g. a forwarded option contradicting the feature name).
-    Such a candidate is not a match, and the reason is recorded so it can be surfaced in the error.
-    """
-    try:
-        return fg_class.match_feature_group_criteria(feature_name, options, None)
-    except ValueError as exc:
-        message = str(exc)
-        if message not in validation_errors:
-            validation_errors.append(message)
-        return False
 
 
 def get_feature_group_docs(
@@ -361,69 +339,101 @@ def get_extender_docs(
 
 
 def resolve_feature(
-    feature_name: str,
+    feature: str | Feature,
     *,
     options: Optional[Options] = None,
     plugin_collector: Optional[PluginCollector] = None,
     feature_group: str | type[FeatureGroup] | None = None,
+    links: Optional[set[Link]] = None,
+    data_access_collection: Optional[DataAccessCollection] = None,
+    compute_frameworks: Optional[set[type[ComputeFramework]]] = None,
 ) -> ResolvedFeature:
     """
-    Resolve a feature name to its matching FeatureGroup class.
+    Resolve a feature name or Feature object to its matching FeatureGroup class.
 
     Never raises: matching errors are reported in the returned ResolvedFeature.error.
 
     Design note: resolve_feature delegates to the shared FeatureGroupResolver against a standalone
-    default environment (collector applicability, strict mode, dedup, and framework availability applied
-    exactly like the engine). The remaining differences from the engine are request expressibility
-    (domain, links, framework pin, data access) until Stage 4.
+    environment (collector applicability, strict mode, dedup, and framework availability applied
+    exactly like the engine). Every result carries ``mode == "standalone"``; for the exact
+    configuration of a run use ``mlodaAPI.diagnose(...)`` or ``session.resolution_report()``.
 
     Args:
-        feature_name: The name of the feature to resolve.
-        options: Keyword-only. Options used for matching and capability checks. An empty or omitted Options is
-            the documented default.
+        feature: The feature name, or a Feature object carrying its own options, domain, scope,
+            and compute-framework pin. A Feature cannot be combined with the ``options`` or
+            ``feature_group`` keyword.
+        options: Keyword-only, name form only. Options used for matching and capability checks.
+            An empty or omitted Options is the documented default.
         plugin_collector: Keyword-only. Threaded into the standalone environment build (applicability,
             strict mode, ``allow_redefinition``).
-        feature_group: Keyword-only. Scope resolution to a FeatureGroup subclass or a class-name string,
-            same forms and semantics as ``Feature(..., feature_group=...)``: the string form matches the
-            named class and its subclasses; None (or a whitespace-only string) means unscoped.
+        feature_group: Keyword-only, name form only. Scope resolution to a FeatureGroup subclass or a
+            class-name string, same forms and semantics as ``Feature(..., feature_group=...)``: the string
+            form matches the named class and its subclasses; None (or a whitespace-only string) means unscoped.
+        links: Keyword-only. The run's links; a candidate declaring an index no link carries is
+            excluded, exactly like the engine's links filter.
+        data_access_collection: Keyword-only. Threaded into matching, exactly like the engine threads it.
+        compute_frameworks: Keyword-only. Restricts the standalone environment to the given frameworks,
+            exactly like ``mlodaAPI(compute_frameworks=...)`` restricts the engine's run set. None keeps
+            every available framework, the standalone default.
 
     Returns:
         ResolvedFeature containing the resolved FeatureGroup (if found),
         all matching candidates, and any error message.
     """
-    try:
-        scope = normalize_feature_group_scope(feature_group)
-    except TypeError as exc:
-        return ResolvedFeature(
-            feature_name=feature_name,
-            feature_group=None,
-            candidates=[],
-            error=str(exc),
+    if isinstance(feature, Feature):
+        if options is not None or feature_group is not None:
+            return ResolvedFeature(
+                feature_name=str(feature.name),
+                feature_group=None,
+                candidates=[],
+                error=(
+                    "Cannot combine a Feature object with the 'options' or 'feature_group' keyword: "
+                    "a Feature carries its own options, domain, scope, and framework pin."
+                ),
+            )
+        feature_name = str(feature.name)
+        scope = feature.feature_group_scope
+        resolved_options = feature.options
+        request = ResolutionRequestSnapshot.from_feature(
+            feature, links=links, data_access_collection=data_access_collection
         )
+    else:
+        try:
+            scope = normalize_feature_group_scope(feature_group)
+        except TypeError as exc:
+            return ResolvedFeature(
+                feature_name=feature,
+                feature_group=None,
+                candidates=[],
+                error=str(exc),
+            )
+        feature_name = feature
+        resolved_options = options if options is not None else Options()
+        request = ResolutionRequestSnapshot(
+            feature_name=feature_name,
+            domain=None,
+            feature_group_scope=scope,
+            framework_pin=None,
+            pinned_frameworks=(),
+            group_option_keys=frozenset(resolved_options.group),
+            context_option_keys=frozenset(resolved_options.context),
+            inherited_group_keys=resolved_options.inherited_group_keys,
+            dependency_path=(),
+            links=tuple(links) if links else (),
+            data_access_collection=data_access_collection,
+            options=resolved_options,
+        )
+
     callout = scope_callout(scope)
     scope_suffix = f" {callout}" if callout else ""
-    resolved_options = options if options is not None else Options()
 
-    # compute_frameworks=None: the factory samples availability exactly once, guarded.
-    build = build_resolution_environment(compute_frameworks=None, plugin_collector=plugin_collector)
+    # compute_frameworks=None keeps the all-available standalone default (availability sampled
+    # exactly once, guarded); a set restricts exactly like the engine's run set.
+    build = build_resolution_environment(compute_frameworks=compute_frameworks, plugin_collector=plugin_collector)
     snapshot = build.snapshot
     if snapshot is None:
         return _environment_error_result(build.errors[0], feature_name, scope, scope_suffix, resolved_options)
 
-    request = ResolutionRequestSnapshot(
-        feature_name=feature_name,
-        domain=None,
-        feature_group_scope=scope,
-        framework_pin=None,
-        pinned_frameworks=(),
-        group_option_keys=frozenset(resolved_options.group),
-        context_option_keys=frozenset(resolved_options.context),
-        inherited_group_keys=resolved_options.inherited_group_keys,
-        dependency_path=(),
-        links=(),
-        data_access_collection=None,
-        options=resolved_options,
-    )
     outcome = FeatureGroupResolver().resolve(request, snapshot)
     return _project_outcome(outcome, feature_name, resolved_options, scope_suffix)
 
@@ -438,14 +448,7 @@ def _environment_error_result(
     """Project a failed standalone environment build; only a redefinition conflict carries candidates."""
     if error.category == EnvironmentProvenance.REDEFINITION_CONFLICT.value:
         raw_conflicts = list(getattr(error.as_exception(), "conflicts", []))
-        feature_name_obj = FeatureName(feature_name)
-        validation_errors: list[str] = []
-        matching_conflicts = [
-            fg
-            for fg in raw_conflicts
-            if (scope is None or matches_feature_group_scope(fg, scope))
-            and _match_recording_validation_errors(fg, feature_name_obj, options, validation_errors)
-        ]
+        matching_conflicts = matching_conflict_candidates(raw_conflicts, FeatureName(feature_name), options, scope)
         return ResolvedFeature(
             feature_name=feature_name,
             feature_group=None,
@@ -630,6 +633,20 @@ def _not_found_result(
         )
 
     names = [c.get_class_name() for c in candidates]
+    if all(
+        any(rejection.reason is RejectionReason.LINK_INDEX for rejection in evaluation.rejections)
+        for evaluation in matched
+    ):
+        return ResolvedFeature(
+            feature_name=feature_name,
+            feature_group=None,
+            candidates=candidates,
+            error=(
+                f"Feature '{feature_name}' matches {names} but none of them supports "
+                f"an index carried by the request's links.{scope_suffix}"
+            ),
+        )
+
     return ResolvedFeature(
         feature_name=feature_name,
         feature_group=None,

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -30,6 +30,7 @@ from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.api.plugin_info import ComputeFrameworkInfo, ExtenderInfo, FeatureGroupInfo, ResolvedFeature
 from mloda.core.prepare.accessible_plugins import (
+    PreFilterPlugins,
     RedefinitionConflictError,
     dedup_feature_group_subclasses,
     registry_for,
@@ -37,8 +38,22 @@ from mloda.core.prepare.accessible_plugins import (
 from mloda.core.prepare.identify_feature_group import (
     matches_feature_group_scope,
     scope_callout,
-    split_frameworks_by_capability,
 )
+from mloda.core.resolve.environment import (
+    EnvironmentBuildError,
+    EnvironmentProvenance,
+    build_resolution_environment,
+)
+from mloda.core.resolve.outcome import (
+    CandidateEvaluation,
+    CandidateStatus,
+    FrameworkStatus,
+    RejectionReason,
+    ResolutionOutcome,
+    ResolutionStatus,
+)
+from mloda.core.resolve.request import ResolutionRequestSnapshot
+from mloda.core.resolve.resolver import FeatureGroupResolver
 
 
 def list_registered(plugin_type: type[Any]) -> list[type[Any]]:
@@ -356,26 +371,19 @@ def resolve_feature(
     """
     Resolve a feature name to its matching FeatureGroup class.
 
-    This function searches all loaded FeatureGroups to find those that match
-    the given feature name. It applies subclass filtering to prefer more
-    specific (child) classes over parent classes.
-
     Never raises: matching errors are reported in the returned ResolvedFeature.error.
 
-    Design note: resolve_feature intentionally does NOT delegate to IdentifyFeatureGroupClass. It is a
-    never-raising debug API that reports candidates, capability splits, and subtype fields and degrades
-    per candidate, while IdentifyFeatureGroupClass needs an accessible-plugins environment mapping and
-    raises on failure. The scope predicate (matches_feature_group_scope) and callout renderer are shared
-    so scoped semantics cannot drift between the two paths. Beyond that the paths may still differ:
-    _filter_subclasses collapses parent/child purely by issubclass while the engine only collapses candidates
-    sharing the same supported-framework set, and the engine excludes abstract bases while resolve_feature
-    does not.
+    Design note: resolve_feature delegates to the shared FeatureGroupResolver against a standalone
+    default environment (collector applicability, strict mode, dedup, and framework availability applied
+    exactly like the engine). The remaining differences from the engine are request expressibility
+    (domain, links, framework pin, data access) until Stage 4.
 
     Args:
         feature_name: The name of the feature to resolve.
         options: Keyword-only. Options used for matching and capability checks. An empty or omitted Options is
             the documented default.
-        plugin_collector: Keyword-only. Its ``allow_redefinition`` flag is threaded into deduplication.
+        plugin_collector: Keyword-only. Threaded into the standalone environment build (applicability,
+            strict mode, ``allow_redefinition``).
         feature_group: Keyword-only. Scope resolution to a FeatureGroup subclass or a class-name string,
             same forms and semantics as ``Feature(..., feature_group=...)``: the string form matches the
             named class and its subclasses; None (or a whitespace-only string) means unscoped.
@@ -396,43 +404,174 @@ def resolve_feature(
     callout = scope_callout(scope)
     scope_suffix = f" {callout}" if callout else ""
     resolved_options = options if options is not None else Options()
-    is_default_options = not resolved_options.group and not resolved_options.context
-    options_caveat = "default options" if is_default_options else "the provided options"
-    allow_redefinition = plugin_collector.allow_redefinition if plugin_collector is not None else False
-    validation_errors: list[str] = []
-    fg_classes: set[type[FeatureGroup]] = get_all_subclasses(FeatureGroup)
-    if plugin_collector is not None:
-        fg_classes = {fg for fg in fg_classes if plugin_collector.applicable_feature_group_class(fg)}
-    try:
-        all_fgs = list(dedup_feature_group_subclasses(fg_classes, allow_redefinition=allow_redefinition))
-    except ValueError as exc:
-        raw_conflicts = list(getattr(exc, "conflicts", []))
+
+    build = build_resolution_environment(
+        compute_frameworks=PreFilterPlugins.get_cfw_subclasses(), plugin_collector=plugin_collector
+    )
+    snapshot = build.snapshot
+    if snapshot is None:
+        return _environment_error_result(build.errors[0], feature_name, scope, scope_suffix, resolved_options)
+
+    request = ResolutionRequestSnapshot(
+        feature_name=feature_name,
+        domain=None,
+        feature_group_scope=scope,
+        framework_pin=None,
+        pinned_frameworks=(),
+        group_option_keys=frozenset(resolved_options.group),
+        context_option_keys=frozenset(resolved_options.context),
+        inherited_group_keys=resolved_options.inherited_group_keys,
+        dependency_path=(),
+        links=(),
+        data_access_collection=None,
+        options=resolved_options,
+    )
+    outcome = FeatureGroupResolver().resolve(request, snapshot)
+    return _project_outcome(outcome, feature_name, resolved_options, scope_suffix)
+
+
+def _environment_error_result(
+    error: EnvironmentBuildError,
+    feature_name: str,
+    scope: str | type[FeatureGroup] | None,
+    scope_suffix: str,
+    options: Options,
+) -> ResolvedFeature:
+    """Project a failed standalone environment build; only a redefinition conflict carries candidates."""
+    if error.category == EnvironmentProvenance.REDEFINITION_CONFLICT.value:
+        raw_conflicts = list(getattr(error.as_exception(), "conflicts", []))
         feature_name_obj = FeatureName(feature_name)
+        validation_errors: list[str] = []
         matching_conflicts = [
             fg
             for fg in raw_conflicts
             if (scope is None or matches_feature_group_scope(fg, scope))
-            and _match_recording_validation_errors(fg, feature_name_obj, resolved_options, validation_errors)
+            and _match_recording_validation_errors(fg, feature_name_obj, options, validation_errors)
         ]
         return ResolvedFeature(
             feature_name=feature_name,
             feature_group=None,
             candidates=matching_conflicts,
-            error=f"{exc}{scope_suffix}",
+            error=f"{error.message}{scope_suffix}",
         )
-    candidates: list[type[FeatureGroup]] = []
+    return ResolvedFeature(
+        feature_name=feature_name,
+        feature_group=None,
+        candidates=[],
+        error=f"{error.message}{scope_suffix}",
+    )
+
+
+# Rejections recorded before a candidate matched name, scope, and criteria; such candidates are not reported.
+_CANDIDATE_STAGE_EXCLUSIONS = frozenset(
+    {
+        RejectionReason.SCOPE,
+        RejectionReason.DOMAIN,
+        RejectionReason.CRITERIA,
+        RejectionReason.VALUE_REJECTION,
+    }
+)
+
+
+def _matched_candidate_evaluations(outcome: ResolutionOutcome) -> list[CandidateEvaluation]:
+    """Evaluations that matched name, scope, and criteria, in the outcome's deterministic order."""
+    return [
+        evaluation
+        for evaluation in outcome.candidates
+        if not any(rejection.reason in _CANDIDATE_STAGE_EXCLUSIONS for rejection in evaluation.rejections)
+    ]
+
+
+def _framework_names(evaluation: CandidateEvaluation, status: FrameworkStatus) -> list[str]:
+    """Sorted class names of the evaluation's frameworks carrying the given status."""
+    return sorted(
+        framework_evaluation.framework.get_class_name()
+        for framework_evaluation in evaluation.frameworks
+        if framework_evaluation.status is status
+    )
+
+
+def _value_rejection_details(outcome: ResolutionOutcome) -> list[str]:
+    """Distinct VALUE_REJECTION details in outcome order."""
+    details: list[str] = []
+    for evaluation in outcome.candidates:
+        for rejection in evaluation.rejections:
+            if rejection.reason is not RejectionReason.VALUE_REJECTION:
+                continue
+            if rejection.detail and rejection.detail not in details:
+                details.append(rejection.detail)
+    return details
+
+
+def _project_outcome(
+    outcome: ResolutionOutcome,
+    feature_name: str,
+    options: Options,
+    scope_suffix: str,
+) -> ResolvedFeature:
+    """Project a structured resolution outcome into the debug ResolvedFeature shape."""
     feature_name_obj = FeatureName(feature_name)
+    matched = _matched_candidate_evaluations(outcome)
+    candidates = [evaluation.feature_group for evaluation in matched]
 
-    for fg in all_fgs:
-        if scope is not None and not matches_feature_group_scope(fg, scope):
-            continue
-        if _match_recording_validation_errors(fg, feature_name_obj, resolved_options, validation_errors):
-            candidates.append(fg)
+    if outcome.status is ResolutionStatus.RESOLVED:
+        winner = next(evaluation for evaluation in outcome.candidates if evaluation.status is CandidateStatus.WINNER)
+        subtype, subtype_family = _resolved_subtype_fields(winner.feature_group, feature_name_obj, options)
+        return ResolvedFeature(
+            feature_name=feature_name,
+            feature_group=winner.feature_group,
+            candidates=candidates,
+            error=None,
+            supported_compute_frameworks=_framework_names(winner, FrameworkStatus.SUPPORTED),
+            unsupported_compute_frameworks=_framework_names(winner, FrameworkStatus.CAPABILITY_REJECTED),
+            subtype=subtype,
+            subtype_family=subtype_family,
+        )
 
-    if not candidates:
+    if outcome.status is ResolutionStatus.FAILED:
+        details = " | ".join(
+            f"{failure.plugin.qualname.rsplit('.', 1)[-1]} [{failure.stage}] {failure.category}: {failure.message}"
+            for failure in outcome.failures
+        )
+        return ResolvedFeature(
+            feature_name=feature_name,
+            feature_group=None,
+            candidates=candidates,
+            error=f"Feature group resolution failed for feature '{feature_name}': {details}{scope_suffix}",
+        )
+
+    if outcome.status is ResolutionStatus.AMBIGUOUS:
+        survivor_names = [
+            evaluation.feature_group.__name__
+            for evaluation in outcome.candidates
+            if evaluation.status is CandidateStatus.SURVIVOR
+        ]
+        return ResolvedFeature(
+            feature_name=feature_name,
+            feature_group=None,
+            candidates=candidates,
+            error=f"Multiple FeatureGroups match feature name '{feature_name}': {survivor_names}{scope_suffix}",
+        )
+
+    return _not_found_result(outcome, feature_name, feature_name_obj, matched, options, scope_suffix)
+
+
+def _not_found_result(
+    outcome: ResolutionOutcome,
+    feature_name: str,
+    feature_name_obj: FeatureName,
+    matched: list[CandidateEvaluation],
+    options: Options,
+    scope_suffix: str,
+) -> ResolvedFeature:
+    """Project a NOT_FOUND outcome: no match, abstract-only, all-capability-rejected, or not runnable."""
+    candidates = [evaluation.feature_group for evaluation in matched]
+
+    if not matched:
         error = f"No FeatureGroup found for feature name: {feature_name}{scope_suffix}"
-        if validation_errors:
-            error = f"{error} Rejected during matching: {' | '.join(validation_errors)}"
+        details = _value_rejection_details(outcome)
+        if details:
+            error = f"{error} Rejected during matching: {' | '.join(details)}"
         return ResolvedFeature(
             feature_name=feature_name,
             feature_group=None,
@@ -440,35 +579,35 @@ def resolve_feature(
             error=error,
         )
 
-    # Degrade a raising plugin declaration OPEN (all available declared frameworks); resolve_feature never raises.
-    # The broad catch intentionally drops any partially computed rejection info; degrading open is the contract.
-    split_result: Optional[tuple[set[type[ComputeFramework]], set[type[ComputeFramework]]]] = safe_field(
-        lambda: split_frameworks_by_capability(candidates, feature_name_obj, resolved_options),
-        None,
-        field=f"capability split for '{feature_name}'",
-    )
-    if split_result is None:
-        open_supported: set[type[ComputeFramework]] = set()
-        for candidate in candidates:
-            defined: set[type[ComputeFramework]] = safe_field(
-                lambda candidate=candidate: set(candidate.compute_framework_definition()),  # type: ignore[misc]
-                set(),
-                field=f"open-degrade frameworks for '{feature_name}'",
-            )
-            open_supported.update(cfw for cfw in defined if cfw.is_available())
-        split_result = (open_supported, set())
-    supported, rejected = split_result
-    supported_names = sorted(c.get_class_name() for c in supported)
-    rejected_names = sorted(c.get_class_name() for c in rejected)
-    filtered = _filter_subclasses(candidates)
+    if all(
+        any(rejection.reason is RejectionReason.ABSTRACT for rejection in evaluation.rejections)
+        for evaluation in matched
+    ):
+        abstract_names = [evaluation.feature_group.get_class_name() for evaluation in matched]
+        return ResolvedFeature(
+            feature_name=feature_name,
+            feature_group=None,
+            candidates=candidates,
+            error=(
+                f"Feature '{feature_name}' matches only abstract FeatureGroup base(s) {abstract_names}, "
+                f"which cannot be instantiated.{scope_suffix}"
+            ),
+        )
 
-    if not supported and rejected:
-        subtype_unsupported: Optional[str] = None
-        subtype_family_unsupported: Optional[str] = None
-        if len(filtered) == 1:
-            subtype_unsupported, subtype_family_unsupported = _resolved_subtype_fields(
-                filtered[0], feature_name_obj, resolved_options
-            )
+    rejected_names = sorted(
+        {
+            framework_evaluation.framework.get_class_name()
+            for evaluation in matched
+            for framework_evaluation in evaluation.frameworks
+            if framework_evaluation.status is FrameworkStatus.CAPABILITY_REJECTED
+        }
+    )
+    if rejected_names:
+        options_caveat = "default options" if not options.group and not options.context else "the provided options"
+        subtype: Optional[str] = None
+        subtype_family: Optional[str] = None
+        if len(matched) == 1:
+            subtype, subtype_family = _resolved_subtype_fields(matched[0].feature_group, feature_name_obj, options)
         return ResolvedFeature(
             feature_name=feature_name,
             feature_group=None,
@@ -480,44 +619,17 @@ def resolve_feature(
             ),
             supported_compute_frameworks=[],
             unsupported_compute_frameworks=rejected_names,
-            subtype=subtype_unsupported,
-            subtype_family=subtype_family_unsupported,
-        )
-
-    if len(filtered) == 1:
-        resolved = filtered[0]
-        subtype, subtype_family = _resolved_subtype_fields(resolved, feature_name_obj, resolved_options)
-        return ResolvedFeature(
-            feature_name=feature_name,
-            feature_group=resolved,
-            candidates=candidates,
-            error=None,
-            supported_compute_frameworks=supported_names,
-            unsupported_compute_frameworks=rejected_names,
             subtype=subtype,
             subtype_family=subtype_family,
         )
 
-    conflicting_names = [fg.__name__ for fg in filtered]
+    names = [c.get_class_name() for c in candidates]
     return ResolvedFeature(
         feature_name=feature_name,
         feature_group=None,
         candidates=candidates,
-        error=f"Multiple FeatureGroups match feature name '{feature_name}': {conflicting_names}{scope_suffix}",
-        supported_compute_frameworks=supported_names,
-        unsupported_compute_frameworks=rejected_names,
+        error=(
+            f"Feature '{feature_name}' matches {names} but is not runnable on any "
+            f"available compute framework.{scope_suffix}"
+        ),
     )
-
-
-def _filter_subclasses(feature_groups: list[type[FeatureGroup]]) -> list[type[FeatureGroup]]:
-    """Prefer more specific (child) classes over parent classes."""
-    fgs_to_pop: set[type[FeatureGroup]] = set()
-
-    for i_fg in feature_groups:
-        for o_fg in feature_groups:
-            if i_fg == o_fg:
-                continue
-            if issubclass(i_fg, o_fg):
-                fgs_to_pop.add(o_fg)
-
-    return [fg for fg in feature_groups if fg not in fgs_to_pop]

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -30,7 +30,6 @@ from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.api.plugin_info import ComputeFrameworkInfo, ExtenderInfo, FeatureGroupInfo, ResolvedFeature
 from mloda.core.prepare.accessible_plugins import (
-    PreFilterPlugins,
     RedefinitionConflictError,
     dedup_feature_group_subclasses,
     registry_for,
@@ -405,9 +404,8 @@ def resolve_feature(
     scope_suffix = f" {callout}" if callout else ""
     resolved_options = options if options is not None else Options()
 
-    build = build_resolution_environment(
-        compute_frameworks=PreFilterPlugins.get_cfw_subclasses(), plugin_collector=plugin_collector
-    )
+    # compute_frameworks=None: the factory samples availability exactly once, guarded.
+    build = build_resolution_environment(compute_frameworks=None, plugin_collector=plugin_collector)
     snapshot = build.snapshot
     if snapshot is None:
         return _environment_error_result(build.errors[0], feature_name, scope, scope_suffix, resolved_options)
@@ -514,16 +512,24 @@ def _project_outcome(
     matched = _matched_candidate_evaluations(outcome)
     candidates = [evaluation.feature_group for evaluation in matched]
 
-    if outcome.status is ResolutionStatus.RESOLVED:
-        winner = next(evaluation for evaluation in outcome.candidates if evaluation.status is CandidateStatus.WINNER)
+    winner = outcome.winner
+    if outcome.status is ResolutionStatus.RESOLVED and winner is not None:
+        winner_evaluation = next(
+            (evaluation for evaluation in outcome.candidates if evaluation.status is CandidateStatus.WINNER),
+            None,
+        )
         subtype, subtype_family = _resolved_subtype_fields(winner.feature_group, feature_name_obj, options)
         return ResolvedFeature(
             feature_name=feature_name,
             feature_group=winner.feature_group,
             candidates=candidates,
             error=None,
-            supported_compute_frameworks=_framework_names(winner, FrameworkStatus.SUPPORTED),
-            unsupported_compute_frameworks=_framework_names(winner, FrameworkStatus.CAPABILITY_REJECTED),
+            supported_compute_frameworks=sorted(framework.get_class_name() for framework in winner.compute_frameworks),
+            unsupported_compute_frameworks=(
+                _framework_names(winner_evaluation, FrameworkStatus.CAPABILITY_REJECTED)
+                if winner_evaluation is not None
+                else []
+            ),
             subtype=subtype,
             subtype_family=subtype_family,
         )

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -603,26 +603,39 @@ def _not_found_result(
             ),
         )
 
+    # The capability clause covers only candidates with a capability-rejected framework; a
+    # candidate rejected earlier (e.g. by the links filter) never appears in this error.
+    capability_matched = [
+        evaluation
+        for evaluation in matched
+        if any(
+            framework_evaluation.status is FrameworkStatus.CAPABILITY_REJECTED
+            for framework_evaluation in evaluation.frameworks
+        )
+    ]
     rejected_names = sorted(
         {
             framework_evaluation.framework.get_class_name()
-            for evaluation in matched
+            for evaluation in capability_matched
             for framework_evaluation in evaluation.frameworks
             if framework_evaluation.status is FrameworkStatus.CAPABILITY_REJECTED
         }
     )
     if rejected_names:
+        capability_names = [evaluation.feature_group.get_class_name() for evaluation in capability_matched]
         options_caveat = "default options" if not options.group and not options.context else "the provided options"
         subtype: Optional[str] = None
         subtype_family: Optional[str] = None
-        if len(matched) == 1:
-            subtype, subtype_family = _resolved_subtype_fields(matched[0].feature_group, feature_name_obj, options)
+        if len(capability_matched) == 1:
+            subtype, subtype_family = _resolved_subtype_fields(
+                capability_matched[0].feature_group, feature_name_obj, options
+            )
         return ResolvedFeature(
             feature_name=feature_name,
             feature_group=None,
-            candidates=candidates,
+            candidates=[evaluation.feature_group for evaluation in capability_matched],
             error=(
-                f"Feature '{feature_name}' matches {[c.get_class_name() for c in candidates]} "
+                f"Feature '{feature_name}' matches {capability_names} "
                 f"but is unsupported on all installed compute frameworks "
                 f"(evaluated under {options_caveat}): {rejected_names}.{scope_suffix}"
             ),

--- a/mloda/core/api/plugin_info.py
+++ b/mloda/core/api/plugin_info.py
@@ -59,3 +59,5 @@ class ResolvedFeature:
     subtype: Optional[str] = None
     # Family name only when the subtype is a parametric instance (e.g. "ntile" for "ntile_2"), else None.
     subtype_family: Optional[str] = None
+    # Diagnostics-mode label: resolve_feature always resolves against the standalone environment.
+    mode: str = "standalone"

--- a/mloda/core/api/request.py
+++ b/mloda/core/api/request.py
@@ -12,7 +12,11 @@ from mloda.core.api.plan_info import PlanStep, build_plan_steps
 from mloda.core.api.run_result import ResultStream, RunResult
 from mloda.core.api.prepare.setup_compute_framework import SetupComputeFramework
 from mloda.core.prepare.accessible_plugins import filter_extenders_by_strict_mode
-from mloda.core.resolve.environment import build_resolution_environment
+from mloda.core.resolve.environment import (
+    EnvironmentBuildError,
+    EnvironmentBuildOutcome,
+    build_resolution_environment,
+)
 from mloda.core.resolve.outcome import FeatureResolutionError
 from mloda.core.resolve.report import ResolutionReport
 from mloda.core.filter.global_filter import GlobalFilter
@@ -320,16 +324,23 @@ class mlodaAPI:
     ) -> ResolutionReport:
         """Resolve the whole request into a ``ResolutionReport`` without executing anything.
 
-        Non-raising for resolution and environment failures: those come back as a structured
-        report with ``complete=False``. Every parameter after ``features`` is keyword-only.
+        Non-raising for resolution, environment, and resolution-relevant configuration
+        failures (an unknown framework name, a framework pin outside the run set,
+        unsatisfiable parallelization modes): those come back as a structured report with
+        ``complete=False``. The returned environment is the full pre-check build outcome,
+        whose records also cover non-survivors (e.g. collector-disabled plugins). Every
+        parameter after ``features`` is keyword-only.
         """
-        framework_set = SetupComputeFramework(
-            compute_frameworks, Features([]), parallelization_modes=parallelization_modes
-        ).compute_frameworks
+        # Guarded: an unknown framework name or unsatisfiable modes raise ValueError here; diagnose reports them.
+        try:
+            framework_set = SetupComputeFramework(
+                compute_frameworks, Features([]), parallelization_modes=parallelization_modes
+            ).compute_frameworks
+        except ValueError as exc:
+            return cls._configuration_failure_report(exc)
         environment = build_resolution_environment(framework_set, plugin_collector)
         if environment.errors:
             return ResolutionReport(environment=environment, features=(), complete=False)
-        # Narrow by contract: the engine attaches the partial report to every planning-time resolution error.
         try:
             session = cls.prepare(
                 features,
@@ -344,15 +355,33 @@ class mlodaAPI:
                 column_ordering=column_ordering,
                 parallelization_modes=parallelization_modes,
             )
+        # Narrow by contract: the engine attaches the partial report to every planning-time resolution error.
         except FeatureResolutionError as err:
             report = err.report
             if report is not None:
                 return report
             return ResolutionReport(environment=environment, features=(), complete=False)
-        return session.resolution_report()
+        # Guarded: prepare()'s configuration validation (e.g. a pin outside the run set) raises plain ValueError.
+        except ValueError as exc:
+            return cls._configuration_failure_report(exc)
+        return ResolutionReport(environment=environment, features=session.resolution_report().features, complete=True)
+
+    @classmethod
+    def _configuration_failure_report(cls, exc: ValueError) -> ResolutionReport:
+        """complete=False report over a run-configuration ValueError; the environment carries the error entry."""
+        error = EnvironmentBuildError(
+            category="configuration_failure", message=str(exc), exception=exc.with_traceback(None)
+        )
+        return ResolutionReport(
+            environment=EnvironmentBuildOutcome(snapshot=None, errors=(error,)), features=(), complete=False
+        )
 
     def resolution_report(self) -> ResolutionReport:
-        """Whole-request report from this session's planning pass; nothing is re-resolved."""
+        """Whole-request report from this session's planning pass; nothing is re-resolved.
+
+        The report's environment is synthesized from the engine's accessible-plugin mapping,
+        so its records cover accessible survivors only.
+        """
         if self.engine is None:
             raise ValueError("Internal error: engine not initialized. This is likely a bug in mloda.")
         return self.engine.resolution_report()

--- a/mloda/core/api/request.py
+++ b/mloda/core/api/request.py
@@ -328,8 +328,10 @@ class mlodaAPI:
         failures (an unknown framework name, a framework pin outside the run set,
         unsatisfiable parallelization modes): those come back as a structured report with
         ``complete=False``. The returned environment is the full pre-check build outcome,
-        whose records also cover non-survivors (e.g. collector-disabled plugins). Every
-        parameter after ``features`` is keyword-only.
+        whose records also cover non-survivors (e.g. collector-disabled plugins). Per-feature
+        outcome fingerprints are mapping-derived from the engine's snapshot and can differ
+        from the pre-check environment fingerprint. Every parameter after ``features`` is
+        keyword-only.
         """
         # Guarded: an unknown framework name or unsatisfiable modes raise ValueError here; diagnose reports them.
         try:
@@ -357,10 +359,8 @@ class mlodaAPI:
             )
         # Narrow by contract: the engine attaches the partial report to every planning-time resolution error.
         except FeatureResolutionError as err:
-            report = err.report
-            if report is not None:
-                return report
-            return ResolutionReport(environment=environment, features=(), complete=False)
+            failure_records = err.report.features if err.report is not None else ()
+            return ResolutionReport(environment=environment, features=failure_records, complete=False)
         # Guarded: prepare()'s configuration validation (e.g. a pin outside the run set) raises plain ValueError.
         except ValueError as exc:
             return cls._configuration_failure_report(exc)

--- a/mloda/core/api/request.py
+++ b/mloda/core/api/request.py
@@ -12,6 +12,9 @@ from mloda.core.api.plan_info import PlanStep, build_plan_steps
 from mloda.core.api.run_result import ResultStream, RunResult
 from mloda.core.api.prepare.setup_compute_framework import SetupComputeFramework
 from mloda.core.prepare.accessible_plugins import filter_extenders_by_strict_mode
+from mloda.core.resolve.environment import build_resolution_environment
+from mloda.core.resolve.outcome import FeatureResolutionError
+from mloda.core.resolve.report import ResolutionReport
 from mloda.core.filter.global_filter import GlobalFilter
 from mloda.core.runtime.run import ExecutionOrchestrator
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
@@ -298,6 +301,61 @@ class mlodaAPI:
             parallelization_modes=parallelization_modes,
         )
         return session.resolved_plan()
+
+    @classmethod
+    def diagnose(
+        cls,
+        features: Features | list[Feature | str],
+        *,
+        compute_frameworks: set[type[ComputeFramework]] | Optional[list[str]] = None,
+        links: Optional[set[Link]] = None,
+        data_access_collection: Optional[DataAccessCollection] = None,
+        global_filter: Optional[GlobalFilter] = None,
+        api_data: Optional[dict[str, dict[str, Any]]] = None,
+        plugin_collector: Optional[PluginCollector] = None,
+        copy_features: bool = True,
+        strict_type_enforcement: bool = False,
+        column_ordering: Optional[str] = None,
+        parallelization_modes: Optional[set[ParallelizationMode]] = None,
+    ) -> ResolutionReport:
+        """Resolve the whole request into a ``ResolutionReport`` without executing anything.
+
+        Non-raising for resolution and environment failures: those come back as a structured
+        report with ``complete=False``. Every parameter after ``features`` is keyword-only.
+        """
+        framework_set = SetupComputeFramework(
+            compute_frameworks, Features([]), parallelization_modes=parallelization_modes
+        ).compute_frameworks
+        environment = build_resolution_environment(framework_set, plugin_collector)
+        if environment.errors:
+            return ResolutionReport(environment=environment, features=(), complete=False)
+        # Narrow by contract: the engine attaches the partial report to every planning-time resolution error.
+        try:
+            session = cls.prepare(
+                features,
+                compute_frameworks,
+                links,
+                data_access_collection,
+                global_filter,
+                api_data=api_data,
+                plugin_collector=plugin_collector,
+                copy_features=copy_features,
+                strict_type_enforcement=strict_type_enforcement,
+                column_ordering=column_ordering,
+                parallelization_modes=parallelization_modes,
+            )
+        except FeatureResolutionError as err:
+            report = err.report
+            if report is not None:
+                return report
+            return ResolutionReport(environment=environment, features=(), complete=False)
+        return session.resolution_report()
+
+    def resolution_report(self) -> ResolutionReport:
+        """Whole-request report from this session's planning pass; nothing is re-resolved."""
+        if self.engine is None:
+            raise ValueError("Internal error: engine not initialized. This is likely a bug in mloda.")
+        return self.engine.resolution_report()
 
     def resolved_plan(self) -> list[PlanStep]:
         """Return the resolved execution plan of this session as ``PlanStep`` records.

--- a/mloda/core/core/engine.py
+++ b/mloda/core/core/engine.py
@@ -22,6 +22,7 @@ from mloda.core.prepare.graph.build_graph import BuildGraph
 from mloda.core.prepare.resolve_graph import ResolveGraph
 from mloda.core.runtime.run import ExecutionOrchestrator
 from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+from mloda.core.resolve.outcome import ResolutionOutcome
 from mloda.core.runtime.flight.runner_flight_server import ParallelRunnerFlightServer
 from mloda.core.abstract_plugins.feature_group import FeatureGroup, format_feature_group_class
 from mloda.core.abstract_plugins.components.feature import Feature
@@ -73,6 +74,8 @@ class Engine:
         self.request_feature_order: list[str] = [str(f.name) for f in features]
         self._dual_consumption_warned: set[tuple[str, str, frozenset[str]]] = set()
         self._property_mapping_keys_cache: dict[type[FeatureGroup], frozenset[str]] = {}
+        # One (dependency_path, outcome) entry per successful feature identification, in planning order.
+        self.resolution_outcomes: list[tuple[tuple[str, ...], ResolutionOutcome]] = []
         self.execution_planner = self.create_setup_execution_plan(features)
         self.tfs_connection_map = self._resolve_tfs_connection_map()
 
@@ -131,14 +134,15 @@ class Engine:
         execution_planner.create_execution_plan(planned_queue, graph, resolver.resolver_links.get_link_trekker())
         return execution_planner
 
-    def setup_features_recursion(self, features: Features) -> None:
+    def setup_features_recursion(self, features: Features, dependency_path: tuple[str, ...] = ()) -> None:
         for feature in features:
-            self._process_feature(feature, features)
+            self._process_feature(feature, features, dependency_path)
 
-    def _process_feature(self, feature: Feature, features: Features) -> None:
+    def _process_feature(self, feature: Feature, features: Features, dependency_path: tuple[str, ...] = ()) -> None:
         """Processes a single feature by delegating tasks to helper methods."""
 
-        feature_group_class, compute_frameworks = self._identify_feature_group_and_frameworks(feature)
+        feature_path = dependency_path + (str(feature.name),)
+        feature_group_class, compute_frameworks = self._identify_feature_group_and_frameworks(feature, feature_path)
         self._warn_on_dual_option_consumption(feature, feature_group_class)
         feature_group = feature_group_class()
 
@@ -150,7 +154,12 @@ class Engine:
         if added:
             parent_domain = feature.domain.name if feature.domain else None
             self._handle_input_features_recursion(
-                feature_group_class, feature.uuid, feature.options, feature.name, parent_domain=parent_domain
+                feature_group_class,
+                feature.uuid,
+                feature.options,
+                feature.name,
+                parent_domain=parent_domain,
+                dependency_path=feature_path,
             )
 
         if self.global_filter:
@@ -208,12 +217,13 @@ class Engine:
             )
 
     def _identify_feature_group_and_frameworks(
-        self, feature: Feature
+        self, feature: Feature, dependency_path: tuple[str, ...] = ()
     ) -> tuple[type[FeatureGroup], set[type[ComputeFramework]]]:
         """Identifies the feature group class and compute frameworks for a given feature."""
         identifier = IdentifyFeatureGroupClass(
-            feature, self.accessible_plugins, self.links, self.data_access_collection
+            feature, self.accessible_plugins, self.links, self.data_access_collection, dependency_path=dependency_path
         )
+        self.resolution_outcomes.append((dependency_path, identifier.outcome))
         return identifier.get()
 
     def _add_index_feature(
@@ -376,6 +386,7 @@ class Engine:
         options: Options,
         feature_name: FeatureName,
         parent_domain: Optional[str] = None,
+        dependency_path: tuple[str, ...] = (),
     ) -> None:
         """Handles recursion for input features of a feature group."""
         feature_group = feature_group_class()
@@ -399,7 +410,7 @@ class Engine:
             if features.child_uuid is None:
                 raise ValueError(f"Features {features} has no parent uuid although it should have one.")
             self.feature_link_parents[features.child_uuid] = features.parent_uuids
-            self.setup_features_recursion(features)
+            self.setup_features_recursion(features, dependency_path)
 
     def set_compute_framework(self, feature: Feature, compute_frameworks: set[type[ComputeFramework]]) -> Feature:
         """

--- a/mloda/core/core/engine.py
+++ b/mloda/core/core/engine.py
@@ -83,7 +83,15 @@ class Engine:
         # Path of the identification currently in flight; consulted only on a planning failure.
         self._pending_identification_path: tuple[str, ...] = ()
         # Built at most once per Engine: every identification shares this mapping-derived snapshot.
-        self.resolution_environment = identify_feature_group.snapshot_from_mapping(self.accessible_plugins)
+        # The collector's strict mode is the only run configuration threaded in; without a collector
+        # the metadata stays "off" so the snapshot never consults the strict-mode env (pinned).
+        strict_mode = plugin_collector.strict_mode if plugin_collector is not None else "off"
+        if strict_mode == "off":
+            self.resolution_environment = identify_feature_group.snapshot_from_mapping(self.accessible_plugins)
+        else:
+            self.resolution_environment = identify_feature_group.snapshot_from_mapping(
+                self.accessible_plugins, strict_mode
+            )
         self.environment_build_outcome = EnvironmentBuildOutcome(snapshot=self.resolution_environment, errors=())
         # Narrow re-raise of the same object: planning failures carry the partial report for diagnose().
         try:

--- a/mloda/core/core/engine.py
+++ b/mloda/core/core/engine.py
@@ -21,6 +21,7 @@ from mloda.core.prepare.execution_plan import ExecutionPlan
 from mloda.core.prepare.graph.build_graph import BuildGraph
 from mloda.core.prepare.resolve_graph import ResolveGraph
 from mloda.core.runtime.run import ExecutionOrchestrator
+from mloda.core.prepare import identify_feature_group
 from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
 from mloda.core.resolve.outcome import ResolutionOutcome
 from mloda.core.runtime.flight.runner_flight_server import ParallelRunnerFlightServer
@@ -74,8 +75,11 @@ class Engine:
         self.request_feature_order: list[str] = [str(f.name) for f in features]
         self._dual_consumption_warned: set[tuple[str, str, frozenset[str]]] = set()
         self._property_mapping_keys_cache: dict[type[FeatureGroup], frozenset[str]] = {}
-        # One (dependency_path, outcome) entry per successful feature identification, in planning order.
+        # One (dependency_path, outcome) entry per successful identification call, in planning
+        # order; a feature reached via multiple parents is retained once per occurrence.
         self.resolution_outcomes: list[tuple[tuple[str, ...], ResolutionOutcome]] = []
+        # Built at most once per Engine: every identification shares this mapping-derived snapshot.
+        self.resolution_environment = identify_feature_group.snapshot_from_mapping(self.accessible_plugins)
         self.execution_planner = self.create_setup_execution_plan(features)
         self.tfs_connection_map = self._resolve_tfs_connection_map()
 
@@ -221,7 +225,12 @@ class Engine:
     ) -> tuple[type[FeatureGroup], set[type[ComputeFramework]]]:
         """Identifies the feature group class and compute frameworks for a given feature."""
         identifier = IdentifyFeatureGroupClass(
-            feature, self.accessible_plugins, self.links, self.data_access_collection, dependency_path=dependency_path
+            feature,
+            self.accessible_plugins,
+            self.links,
+            self.data_access_collection,
+            dependency_path=dependency_path,
+            environment=self.resolution_environment,
         )
         self.resolution_outcomes.append((dependency_path, identifier.outcome))
         return identifier.get()

--- a/mloda/core/core/engine.py
+++ b/mloda/core/core/engine.py
@@ -23,7 +23,9 @@ from mloda.core.prepare.resolve_graph import ResolveGraph
 from mloda.core.runtime.run import ExecutionOrchestrator
 from mloda.core.prepare import identify_feature_group
 from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
-from mloda.core.resolve.outcome import ResolutionOutcome
+from mloda.core.resolve.environment import EnvironmentBuildOutcome
+from mloda.core.resolve.outcome import FeatureResolutionError, ResolutionOutcome
+from mloda.core.resolve.report import FeatureResolutionRecord, ResolutionReport
 from mloda.core.runtime.flight.runner_flight_server import ParallelRunnerFlightServer
 from mloda.core.abstract_plugins.feature_group import FeatureGroup, format_feature_group_class
 from mloda.core.abstract_plugins.components.feature import Feature
@@ -78,9 +80,17 @@ class Engine:
         # One (dependency_path, outcome) entry per successful identification call, in planning
         # order; a feature reached via multiple parents is retained once per occurrence.
         self.resolution_outcomes: list[tuple[tuple[str, ...], ResolutionOutcome]] = []
+        # Path of the identification currently in flight; consulted only on a planning failure.
+        self._pending_identification_path: tuple[str, ...] = ()
         # Built at most once per Engine: every identification shares this mapping-derived snapshot.
         self.resolution_environment = identify_feature_group.snapshot_from_mapping(self.accessible_plugins)
-        self.execution_planner = self.create_setup_execution_plan(features)
+        self.environment_build_outcome = EnvironmentBuildOutcome(snapshot=self.resolution_environment, errors=())
+        # Narrow re-raise of the same object: planning failures carry the partial report for diagnose().
+        try:
+            self.execution_planner = self.create_setup_execution_plan(features)
+        except FeatureResolutionError as err:
+            err.report = self._failure_resolution_report(err)
+            raise
         self.tfs_connection_map = self._resolve_tfs_connection_map()
 
     def _resolve_tfs_connection_map(self) -> dict[type[ComputeFramework], Any]:
@@ -224,6 +234,7 @@ class Engine:
         self, feature: Feature, dependency_path: tuple[str, ...] = ()
     ) -> tuple[type[FeatureGroup], set[type[ComputeFramework]]]:
         """Identifies the feature group class and compute frameworks for a given feature."""
+        self._pending_identification_path = dependency_path
         identifier = IdentifyFeatureGroupClass(
             feature,
             self.accessible_plugins,
@@ -234,6 +245,28 @@ class Engine:
         )
         self.resolution_outcomes.append((dependency_path, identifier.outcome))
         return identifier.get()
+
+    def resolution_report(self) -> ResolutionReport:
+        """Whole-request report over the memoized planning outcomes; nothing is re-resolved."""
+        return ResolutionReport(
+            environment=self.environment_build_outcome,
+            features=self._resolution_records(),
+            complete=True,
+        )
+
+    def _resolution_records(self) -> tuple[FeatureResolutionRecord, ...]:
+        return tuple(
+            FeatureResolutionRecord(dependency_path=path, outcome=outcome) for path, outcome in self.resolution_outcomes
+        )
+
+    def _failure_resolution_report(self, error: FeatureResolutionError) -> ResolutionReport:
+        """Partial report for a planning failure: successful records first, the failing one last."""
+        failing = FeatureResolutionRecord(dependency_path=self._pending_identification_path, outcome=error.outcome)
+        return ResolutionReport(
+            environment=self.environment_build_outcome,
+            features=self._resolution_records() + (failing,),
+            complete=False,
+        )
 
     def _add_index_feature(
         self,

--- a/mloda/core/prepare/accessible_plugins.py
+++ b/mloda/core/prepare/accessible_plugins.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
-import inspect
 import logging
 import sys
-from copy import deepcopy
 from typing import Any, Optional, cast
 
 from mloda.core.abstract_plugins.components.base_feature_group_version import (
@@ -302,106 +300,28 @@ class PreFilterPlugins:
         return self.accessible_plugins
 
     def _set_feature_groups(self, plugin_collector: Optional[PluginCollector] = None) -> set[type[FeatureGroup]]:
-        accessible_feature_groups = self.get_featuregroup_subclasses()
+        """Adapter over the resolve pipeline; raises exactly what the absorbed inline logic raised."""
+        # Imported inside the method: mloda.core.resolve.environment imports helpers from this module.
+        from mloda.core.resolve.environment import run_feature_group_pipeline
 
-        if plugin_collector:
-            for accessible_fg in deepcopy(accessible_feature_groups):
-                if not plugin_collector.applicable_feature_group_class(accessible_fg):
-                    accessible_feature_groups.remove(accessible_fg)
-
-        allow_redefinition = plugin_collector.allow_redefinition if plugin_collector is not None else False
-        strict_mode = plugin_collector.strict_mode if plugin_collector is not None else strict_mode_from_env()
-
-        registered: set[type[Any]] = set()
-        if strict_mode != "off":
-            registered = registry_for(plugin_collector).registered_classes()
-
-        if strict_mode == "strict":
-            before_strict = accessible_feature_groups
-            accessible_feature_groups = {
-                fg for fg in accessible_feature_groups if fg in registered or inspect.isabstract(fg)
-            }
-            if plugin_collector is not None:
-                dropped_enabled = sorted(
-                    f"{fg.__module__}:{fg.__qualname__}"
-                    for fg in before_strict - accessible_feature_groups
-                    if fg in plugin_collector.enabled_feature_group_classes
-                )
-                if dropped_enabled:
-                    logger.warning(
-                        "Explicitly enabled FeatureGroups were dropped by strict mode because they are "
-                        "not registered in the plugin registry: %s.",
-                        ", ".join(dropped_enabled),
-                    )
-            had_concrete = any(not inspect.isabstract(fg) for fg in before_strict)
-            has_concrete = any(not inspect.isabstract(fg) for fg in accessible_feature_groups)
-            if had_concrete and not has_concrete:
-                raise ValueError(
-                    "Strict mode filtered out all FeatureGroups: none of the accessible FeatureGroups "
-                    "are registered in the plugin registry. Register them via mloda.user.register_plugin() or "
-                    "relax MLODA_PLUGIN_REGISTRY_STRICT to disable strict mode."
-                )
-
-        accessible_feature_groups = dedup_feature_group_subclasses(
-            accessible_feature_groups, allow_redefinition=allow_redefinition
-        )
-
-        if strict_mode == "warn":
-            unregistered = sorted(
-                f"{fg.__module__}:{fg.__qualname__}"
-                for fg in accessible_feature_groups
-                if fg not in registered
-                and not inspect.isabstract(fg)
-                and f"{fg.__module__}:{fg.__qualname__}" not in _warned_unregistered
-            )
-            if unregistered:
-                _warned_unregistered.update(unregistered)
-                logger.warning(
-                    "FeatureGroups not registered in the plugin registry: %s.",
-                    ", ".join(unregistered),
-                )
-
-        if len(accessible_feature_groups) == 0:
-            raise ValueError("No feature groups are loaded. Did you call PluginLoader.all()?")
-        return accessible_feature_groups
+        result = run_feature_group_pipeline(plugin_collector)
+        if result.error is not None:
+            raise result.error.as_exception()
+        return set(result.survivors)
 
     def _set_compute_frameworks(
         self,
         compute_frameworks: set[type[ComputeFramework]],
         plugin_collector: Optional[PluginCollector] = None,
     ) -> set[type[ComputeFramework]]:
-        compute_frameworks = compute_frameworks.intersection(self.get_cfw_subclasses())
+        """Adapter over the resolve pipeline; raises exactly what the absorbed inline logic raised."""
+        # Imported inside the method: mloda.core.resolve.environment imports helpers from this module.
+        from mloda.core.resolve.environment import run_compute_framework_pipeline
 
-        strict_mode = plugin_collector.strict_mode if plugin_collector is not None else strict_mode_from_env()
-        if strict_mode == "off":
-            return compute_frameworks
-
-        registered = registry_for(plugin_collector).registered_classes()
-        # Bundled plugin frameworks ship with mloda, like abstract classes: never filtered or flagged.
-        unregistered = {
-            cfw
-            for cfw in compute_frameworks
-            if cfw not in registered and not inspect.isabstract(cfw) and not _is_bundled_plugin(cfw)
-        }
-        unregistered_names = sorted(f"{cfw.__module__}:{cfw.__qualname__}" for cfw in unregistered)
-
-        if strict_mode == "warn":
-            new_names = [name for name in unregistered_names if name not in _warned_unregistered]
-            if new_names:
-                _warned_unregistered.update(new_names)
-                logger.warning("ComputeFrameworks not registered in the plugin registry: %s.", ", ".join(new_names))
-            return compute_frameworks
-
-        surviving = compute_frameworks - unregistered
-        had_concrete = any(not inspect.isabstract(cfw) for cfw in compute_frameworks)
-        has_concrete = any(not inspect.isabstract(cfw) for cfw in surviving)
-        if had_concrete and not has_concrete:
-            raise ValueError(
-                "Strict mode filtered out all ComputeFrameworks: none of the requested ComputeFrameworks "
-                "are registered in the plugin registry. Register them via mloda.user.register_plugin() or "
-                "relax MLODA_PLUGIN_REGISTRY_STRICT to disable strict mode."
-            )
-        return surviving
+        result = run_compute_framework_pipeline(compute_frameworks, plugin_collector)
+        if result.error is not None:
+            raise result.error.as_exception()
+        return set(result.enabled)
 
     def resolve_feature_group_compute_framework_limitations(
         self, feature_groups: set[type[FeatureGroup]], compute_frameworks: set[type[ComputeFramework]]

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -14,6 +14,7 @@ from mloda.core.resolve.environment import ResolutionEnvironmentSnapshot
 from mloda.core.resolve.outcome import (
     CandidateStatus,
     FeatureResolutionError,
+    FrameworkStatus,
     RejectionReason,
     ResolutionOutcome,
     ResolutionStatus,
@@ -168,21 +169,55 @@ class IdentifyFeatureGroupClass:
         scope = feature.feature_group_scope
         return scope is None or matches_feature_group_scope(feature_group, scope)
 
-    # The hint helpers below re-invoke provider hooks on the failure path only, as
-    # post-decision enrichment; Stage 4 replaces them with structured rendering.
+    # The hint helpers below run on the failure path only, as post-decision enrichment.
+    # Capability verdicts already recorded in the outcome are reused, never re-invoked;
+    # remaining declared-basis hook calls are guarded so a raise degrades the hint.
     def _capability_rejection_message(self, feature: Feature) -> Optional[str]:
-        supported, rejected = split_frameworks_by_capability(
-            self._criteria_matched_feature_groups, feature.name, feature.options
-        )
+        supported: set[str] = set()
+        rejected: set[str] = set()
+        for candidate in self.outcome.candidates:
+            if candidate.feature_group not in self._criteria_matched_feature_groups:
+                continue
+            verdicts: dict[type[ComputeFramework], FrameworkStatus] = {
+                evaluation.framework: evaluation.status for evaluation in candidate.frameworks
+            }
+            for framework, status in verdicts.items():
+                if status is FrameworkStatus.SUPPORTED:
+                    supported.add(framework.get_class_name())
+                elif status is FrameworkStatus.CAPABILITY_REJECTED:
+                    rejected.add(framework.get_class_name())
+            # Guarded: the declared-basis enrichment below runs provider hooks on the failure path.
+            try:
+                declared = candidate.feature_group.compute_framework_definition()
+            except Exception:
+                logger.debug("Capability hint skipped a raising framework declaration of %s", candidate.identity)
+                continue
+            for framework in declared:
+                if verdicts.get(framework) in (FrameworkStatus.SUPPORTED, FrameworkStatus.CAPABILITY_REJECTED):
+                    continue
+                # Guarded: availability and capability hooks are provider code; a raise drops the framework.
+                try:
+                    if not framework.is_available():
+                        continue
+                    accepts = candidate.feature_group.supports_compute_framework(
+                        feature.name, feature.options, framework
+                    )
+                except Exception:
+                    logger.debug("Capability hint dropped a raising framework hook of %s", candidate.identity)
+                    continue
+                if accepts:
+                    supported.add(framework.get_class_name())
+                else:
+                    rejected.add(framework.get_class_name())
 
         if not rejected:
             return None
 
-        rejected_names = sorted(fw.get_class_name() for fw in rejected)
+        rejected_names = sorted(rejected)
         msg = f"Unsupported compute framework(s) for feature '{str(feature.name)}': {rejected_names}."
 
         if supported:
-            supported_names = sorted(fw.get_class_name() for fw in supported)
+            supported_names = sorted(supported)
             msg += f" Supported on: {supported_names}."
 
         msg += " Pin the feature to a supported compute framework or override supports_compute_framework."
@@ -214,20 +249,28 @@ class IdentifyFeatureGroupClass:
 
         culprits: list[type[FeatureGroup]] = []
         for feature_group in accessible_plugins:
-            if not self._filter_feature_group_by_domain(feature_group, feature):
+            # Guarded: the re-match below runs provider hooks on the failure path; a raising
+            # candidate degrades out of the hint so the no-match error survives unchanged.
+            try:
+                if not self._filter_feature_group_by_domain(feature_group, feature):
+                    continue
+                if not self._filter_feature_group_by_scope(feature_group, feature):
+                    continue
+                # A rejected VALUE the caller set HERE is not a forwarding problem: carving the key out
+                # would not fix the value, and the value-rejection hint already says what is wrong. A
+                # value that arrived by forwarding is both, and carving the key out is exactly the fix,
+                # so that candidate still earns the hint.
+                if self._value_rejection_reason(feature_group, feature) is not None and not forwarded_offenders:
+                    continue
+                accepts_bare = feature_group.match_feature_group_criteria(
+                    feature.name, bare, self._data_access_collection
+                )
+                rejects_actual = not feature_group.match_feature_group_criteria(
+                    feature.name, feature.options, self._data_access_collection
+                )
+            except Exception:
+                logger.debug("Forwarding hint dropped raising candidate %s", feature_group.get_class_name())
                 continue
-            if not self._filter_feature_group_by_scope(feature_group, feature):
-                continue
-            # A rejected VALUE the caller set HERE is not a forwarding problem: carving the key out
-            # would not fix the value, and the value-rejection hint already says what is wrong. A
-            # value that arrived by forwarding is both, and carving the key out is exactly the fix,
-            # so that candidate still earns the hint.
-            if self._value_rejection_reason(feature_group, feature) is not None and not forwarded_offenders:
-                continue
-            accepts_bare = feature_group.match_feature_group_criteria(feature.name, bare, self._data_access_collection)
-            rejects_actual = not feature_group.match_feature_group_criteria(
-                feature.name, feature.options, self._data_access_collection
-            )
             if accepts_bare and rejects_actual:
                 culprits.append(feature_group)
 
@@ -248,12 +291,18 @@ class IdentifyFeatureGroupClass:
     ) -> Optional[str]:
         reasons: list[tuple[str, str]] = []
         for feature_group in accessible_plugins:
-            if not self._filter_feature_group_by_domain(feature_group, feature):
-                continue
-            if not self._filter_feature_group_by_scope(feature_group, feature):
-                continue
+            # Guarded: domain and rejection-reason hooks are provider code on the failure path;
+            # a raising candidate degrades out of the hint.
+            try:
+                if not self._filter_feature_group_by_domain(feature_group, feature):
+                    continue
+                if not self._filter_feature_group_by_scope(feature_group, feature):
+                    continue
 
-            reason = self._value_rejection_reason(feature_group, feature)
+                reason = self._value_rejection_reason(feature_group, feature)
+            except Exception:
+                logger.debug("Value-rejection hint dropped raising candidate %s", feature_group.get_class_name())
+                continue
             if reason is not None:
                 reasons.append((feature_group.get_class_name(), reason))
 
@@ -280,8 +329,13 @@ class IdentifyFeatureGroupClass:
                 continue
             if not any(issubclass(candidate, abstract_fg) for abstract_fg in self._abstract_matched_feature_groups):
                 continue
-            for cfw in candidate.compute_framework_definition():
-                frameworks.add(cfw.get_class_name())
+            # Guarded: the framework declaration is provider code on the failure path; a raise drops the candidate.
+            try:
+                for cfw in candidate.compute_framework_definition():
+                    frameworks.add(cfw.get_class_name())
+            except Exception:
+                logger.debug("Abstract-only hint dropped raising candidate %s", candidate.get_class_name())
+                continue
 
         feature_name = str(feature.name)
         if not frameworks:
@@ -337,9 +391,14 @@ class IdentifyFeatureGroupClass:
         known_names: list[str] = []
         for fg_class in accessible_plugins:
             known_names.append(fg_class.get_class_name())
-            known_names.extend(fg_class.feature_names_supported())
-            if fg_class.prefix():
-                known_names.append(fg_class.prefix())
+            # Guarded: name and prefix declarations are provider code on the failure path; a raise drops them.
+            try:
+                known_names.extend(fg_class.feature_names_supported())
+                if fg_class.prefix():
+                    known_names.append(fg_class.prefix())
+            except Exception:
+                logger.debug("Suggestion list dropped raising candidate %s", fg_class.get_class_name())
+                continue
 
         similar = get_close_matches(feature_name, known_names, n=5, cutoff=0.5)
         if similar:

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -4,17 +4,44 @@ from typing import Iterable, Optional
 
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import PropertyValueRejection
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import NON_FORWARDED_KEYS, Options
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
-from mloda.core.abstract_plugins.feature_group import FeatureGroup, format_feature_group_class
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.link import Link
+from mloda.core.resolve.outcome import (
+    CandidateStatus,
+    FeatureResolutionError,
+    RejectionReason,
+    ResolutionOutcome,
+    ResolutionStatus,
+)
+from mloda.core.resolve.request import ResolutionRequestSnapshot
+from mloda.core.resolve.resolver import FeatureGroupResolver, matches_feature_group_scope, snapshot_from_mapping
 
 import logging
 
 logger = logging.getLogger(__name__)
+
+
+__all__ = [
+    "IdentifyFeatureGroupClass",
+    "matches_feature_group_scope",
+    "scope_callout",
+    "split_frameworks_by_capability",
+]
+
+
+# Rejections a candidate can only collect after passing scope, domain, criteria, and abstract.
+_FRAMEWORK_STAGE_REASONS = frozenset(
+    {
+        RejectionReason.NO_ACCESSIBLE_FRAMEWORK,
+        RejectionReason.FRAMEWORK_PIN,
+        RejectionReason.LINK_INDEX,
+        RejectionReason.CAPABILITY,
+    }
+)
 
 
 def split_frameworks_by_capability(
@@ -42,24 +69,6 @@ def split_frameworks_by_capability(
     return supported, rejected
 
 
-def matches_feature_group_scope(feature_group: type[FeatureGroup], scope: str | type[FeatureGroup]) -> bool:
-    """Is the candidate inside the requested scope, for both the class-object and the string form.
-
-    The string form matches the named class and its subclasses by walking the candidate's ancestry
-    (MRO), so a config that can only carry a name keeps the same subclass-preferring semantics. The
-    root FeatureGroup base is excluded from that walk because every candidate carries it, which would
-    make it a wildcard.
-    """
-    if isinstance(scope, type):
-        return issubclass(feature_group, scope)
-    # Name first: get_class_name() is @final and just returns __name__, while issubclass() on an ABCMeta
-    # class is the expensive check, so the name gate keeps it off nearly every MRO entry.
-    return any(
-        ancestor.__name__ == scope and ancestor is not FeatureGroup and issubclass(ancestor, FeatureGroup)
-        for ancestor in feature_group.__mro__
-    )
-
-
 def scope_callout(scope: str | type[FeatureGroup] | None) -> str | None:
     """Render the shared scope callout, or None when the scope is unset."""
     if scope is None:
@@ -69,100 +78,85 @@ def scope_callout(scope: str | type[FeatureGroup] | None) -> str | None:
 
 
 class IdentifyFeatureGroupClass:
+    """Engine adapter over the authoritative FeatureGroupResolver.
+
+    Resolution decisions live in the resolver; this class projects the structured
+    outcome into the engine's mapping shape and the established error message texts.
+    """
+
     def __init__(
         self,
         feature: Feature,
         accessible_plugins: FeatureGroupEnvironmentMapping,
         links: Optional[set[Link]],
         data_access_collection: Optional[DataAccessCollection] = None,
+        dependency_path: tuple[str, ...] = (),
     ):
-        self._criteria_matched_feature_groups: set[type[FeatureGroup]] = set()
-        self._abstract_matched_feature_groups: set[type[FeatureGroup]] = set()
-
-        feature_group = self._filter_loop(feature, accessible_plugins, links, data_access_collection)
-
+        request = ResolutionRequestSnapshot.from_feature(
+            feature,
+            links=links,
+            data_access_collection=data_access_collection,
+            dependency_path=dependency_path,
+        )
+        self.outcome: ResolutionOutcome = FeatureGroupResolver().resolve(
+            request, snapshot_from_mapping(accessible_plugins)
+        )
         self._data_access_collection = data_access_collection
-        self.validate(feature_group, feature, accessible_plugins)
-        self.feature_group_compute_framework_mapping = feature_group
 
-    def _filter_loop(
-        self,
-        feature: Feature,
-        accessible_plugins: FeatureGroupEnvironmentMapping,
-        links: Optional[set[Link]],
-        data_access_collection: Optional[DataAccessCollection] = None,
-    ) -> FeatureGroupEnvironmentMapping:
-        _identified_feature_groups: FeatureGroupEnvironmentMapping = {}
+        self._criteria_matched_feature_groups: set[type[FeatureGroup]] = {
+            candidate.feature_group
+            for candidate in self.outcome.candidates
+            if candidate.status is CandidateStatus.REJECTED
+            and {rejection.reason for rejection in candidate.rejections} <= _FRAMEWORK_STAGE_REASONS
+        }
+        self._abstract_matched_feature_groups: set[type[FeatureGroup]] = {
+            candidate.feature_group
+            for candidate in self.outcome.candidates
+            if any(rejection.reason is RejectionReason.ABSTRACT for rejection in candidate.rejections)
+        }
 
-        for feature_group, compute_frameworks in accessible_plugins.items():
-            if not self._filter_feature_group_by_criteria(feature_group, feature, data_access_collection):
-                continue
-
-            if not self._filter_feature_group_by_domain(feature_group, feature):
-                continue
-
-            if not self._filter_feature_group_by_scope(feature_group, feature):
-                continue
-
-            # Abstract bases can match name+domain+scope but cannot be instantiated; never let one win.
-            if inspect.isabstract(feature_group):
-                self._abstract_matched_feature_groups.add(feature_group)
-                continue
-
-            self._criteria_matched_feature_groups.add(feature_group)
-
-            supported_frameworks = {
-                cfw
-                for cfw in compute_frameworks
-                if feature_group.supports_compute_framework(feature.name, feature.options, cfw)
+        winner = self.outcome.winner
+        if winner is not None:
+            self.feature_group_compute_framework_mapping: FeatureGroupEnvironmentMapping = {
+                winner.feature_group: set(winner.compute_frameworks)
             }
+            return
 
-            if not self._filter_feature_group_by_framework(supported_frameworks, feature):
-                continue
+        if self.outcome.status is ResolutionStatus.FAILED:
+            raise FeatureResolutionError(self._build_failed_error(feature), self.outcome)
 
-            if not self._filter_feature_group_by_links(feature_group, links):
-                continue
+        if self.outcome.status is ResolutionStatus.AMBIGUOUS:
+            raise FeatureResolutionError(self._build_multiple_error(feature), self.outcome)
 
-            if supported_frameworks:
-                _identified_feature_groups[feature_group] = supported_frameworks
+        raise FeatureResolutionError(self._build_no_feature_group_error(feature, accessible_plugins), self.outcome)
 
-        _identified_feature_groups = self.filter_subclasses(_identified_feature_groups)
-        return _identified_feature_groups
+    def get(self) -> tuple[type[FeatureGroup], set[type[ComputeFramework]]]:
+        return next(iter(self.feature_group_compute_framework_mapping.items()))
 
-    def _filter_feature_group_by_links(self, feature_group: type[FeatureGroup], links: Optional[set[Link]]) -> bool:
-        # Case index columns not given, so no validation possible
-        if feature_group.index_columns() is None:
-            return True
+    def _build_failed_error(self, feature: Feature) -> str:
+        details = "\n".join(
+            f"  - {failure.plugin.render()} [{failure.stage}] {failure.category}: {failure.message}"
+            for failure in self.outcome.failures
+        )
+        return f"Feature group resolution failed for feature '{feature.name}':\n{details}"
 
-        # Case no links given, so no validation possible
-        if links is None:
-            return True
+    def _build_multiple_error(self, feature: Feature) -> str:
+        from mloda.core.abstract_plugins.feature_group import format_feature_group_classes
 
-        # Validate that at least one index is supported by the feature group
-        for link in links:
-            if feature_group.supports_index(link.left_index):
-                return True
+        ambiguous = [
+            candidate.feature_group
+            for candidate in self.outcome.candidates
+            if candidate.status is CandidateStatus.SURVIVOR
+        ]
+        callout = scope_callout(feature.feature_group_scope)
+        scope_line = f"{callout}\n" if callout else ""
 
-            if feature_group.supports_index(link.right_index):
-                return True
-
-        return False
-
-    def _filter_feature_group_by_criteria(
-        self,
-        feature_group: type[FeatureGroup],
-        feature: Feature,
-        data_access_collection: Optional[DataAccessCollection],
-    ) -> bool:
-        """A rejected option value is a non-match, whoever calls the parser: a candidate that overrides the match
-        hook and calls FeatureChainParser directly must not take the whole filter loop down. Only the rejection is
-        caught, so a plain ValueError (the forwarded-name-mismatch guidance) still reaches the user.
-        """
-        try:
-            return feature_group.match_feature_group_criteria(feature.name, feature.options, data_access_collection)
-        except PropertyValueRejection as exc:
-            logger.debug("%s rejected an option value while matching '%s': %s", feature_group, feature.name, exc)
-            return False
+        return (
+            f"Multiple feature groups found for feature '{feature.name}':\n"
+            f"{format_feature_group_classes(ambiguous, include_domain=True)}\n"
+            f"{scope_line}"
+            "For troubleshooting guide, see: https://mloda-ai.github.io/mloda/in_depth/troubleshooting/feature-group-resolution-errors/"
+        )
 
     def _filter_feature_group_by_domain(self, feature_group: type[FeatureGroup], feature: Feature) -> bool:
         return not feature.domain or feature_group.get_domain() == feature.domain
@@ -171,46 +165,8 @@ class IdentifyFeatureGroupClass:
         scope = feature.feature_group_scope
         return scope is None or matches_feature_group_scope(feature_group, scope)
 
-    def _filter_feature_group_by_framework(
-        self,
-        compute_frameworks: set[type[ComputeFramework]],
-        feature: Feature,
-    ) -> bool:
-        if feature.compute_frameworks is None:
-            return True
-
-        if len(feature.compute_frameworks) > 1:
-            raise ValueError(f"Feature should only have one compute framework when set by user {feature.name}.")
-
-        return feature.get_compute_framework() in compute_frameworks
-
-    def validate(
-        self,
-        feature_group: FeatureGroupEnvironmentMapping,
-        feature: Feature,
-        accessible_plugins: FeatureGroupEnvironmentMapping,
-    ) -> None:
-        if not feature_group or len(feature_group) == 0:
-            raise ValueError(self._build_no_feature_group_error(feature, accessible_plugins))
-        if len(feature_group) > 1:
-            from mloda.core.abstract_plugins.feature_group import format_feature_group_classes
-
-            callout = scope_callout(feature.feature_group_scope)
-            scope_line = f"{callout}\n" if callout else ""
-
-            raise ValueError(
-                f"Multiple feature groups found for feature '{feature.name}':\n"
-                f"{format_feature_group_classes(feature_group.keys(), include_domain=True)}\n"
-                f"{scope_line}"
-                "For troubleshooting guide, see: https://mloda-ai.github.io/mloda/in_depth/troubleshooting/feature-group-resolution-errors/"
-            )
-
-        feature_group_class, compute_frameworks = next(iter(feature_group.items()))
-        if not compute_frameworks:
-            raise ValueError(
-                f"Feature {feature.name} {format_feature_group_class(feature_group_class)} has no compute framework."
-            )
-
+    # The hint helpers below re-invoke provider hooks on the failure path only, as
+    # post-decision enrichment; Stage 4 replaces them with structured rendering.
     def _capability_rejection_message(self, feature: Feature) -> Optional[str]:
         supported, rejected = split_frameworks_by_capability(
             self._criteria_matched_feature_groups, feature.name, feature.options
@@ -393,30 +349,3 @@ class IdentifyFeatureGroupClass:
             "https://mloda-ai.github.io/mloda/in_depth/troubleshooting/feature-group-resolution-errors/"
         )
         return msg
-
-    def get(self) -> tuple[type[FeatureGroup], set[type[ComputeFramework]]]:
-        return next(iter(self.feature_group_compute_framework_mapping.items()))
-
-    def filter_subclasses(
-        self, _identified_feature_groups: FeatureGroupEnvironmentMapping
-    ) -> FeatureGroupEnvironmentMapping:
-        """
-        This functionality ensures that only subclass feature groups are kept.
-        """
-        fgs_to_pop: set[type[FeatureGroup]] = set()
-
-        for i_feature_group, i_compute_frameworks in _identified_feature_groups.items():
-            for o_feature_group, o_compute_frameworks in _identified_feature_groups.items():
-                if i_compute_frameworks != o_compute_frameworks:
-                    continue
-
-                if i_feature_group == o_feature_group:
-                    continue
-
-                if issubclass(i_feature_group, o_feature_group):
-                    fgs_to_pop.add(o_feature_group)
-
-        for fg in fgs_to_pop:
-            _identified_feature_groups.pop(fg)
-
-        return _identified_feature_groups

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -10,6 +10,7 @@ from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.link import Link
+from mloda.core.resolve.environment import ResolutionEnvironmentSnapshot
 from mloda.core.resolve.outcome import (
     CandidateStatus,
     FeatureResolutionError,
@@ -29,6 +30,7 @@ __all__ = [
     "IdentifyFeatureGroupClass",
     "matches_feature_group_scope",
     "scope_callout",
+    "snapshot_from_mapping",
     "split_frameworks_by_capability",
 ]
 
@@ -91,6 +93,7 @@ class IdentifyFeatureGroupClass:
         links: Optional[set[Link]],
         data_access_collection: Optional[DataAccessCollection] = None,
         dependency_path: tuple[str, ...] = (),
+        environment: Optional[ResolutionEnvironmentSnapshot] = None,
     ):
         request = ResolutionRequestSnapshot.from_feature(
             feature,
@@ -98,9 +101,9 @@ class IdentifyFeatureGroupClass:
             data_access_collection=data_access_collection,
             dependency_path=dependency_path,
         )
-        self.outcome: ResolutionOutcome = FeatureGroupResolver().resolve(
-            request, snapshot_from_mapping(accessible_plugins)
-        )
+        if environment is None:
+            environment = snapshot_from_mapping(accessible_plugins)
+        self.outcome: ResolutionOutcome = FeatureGroupResolver().resolve(request, environment)
         self._data_access_collection = data_access_collection
 
         self._criteria_matched_feature_groups: set[type[FeatureGroup]] = {

--- a/mloda/core/resolve/environment.py
+++ b/mloda/core/resolve/environment.py
@@ -1,0 +1,399 @@
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import (
+    PluginCollector,
+    strict_mode_from_env,
+)
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.prepare import accessible_plugins as _prefilter
+from mloda.core.prepare.accessible_plugins import (
+    FeatureGroupEnvironmentMapping,
+    PreFilterPlugins,
+    RedefinitionConflictError,
+    dedup_feature_group_subclasses,
+    registry_for,
+)
+from mloda.core.resolve.identity import PluginIdentity
+
+
+_STRICT_MODE_FEATURE_GROUPS_MESSAGE = (
+    "Strict mode filtered out all FeatureGroups: none of the accessible FeatureGroups "
+    "are registered in the plugin registry. Register them via mloda.user.register_plugin() or "
+    "relax MLODA_PLUGIN_REGISTRY_STRICT to disable strict mode."
+)
+
+_STRICT_MODE_COMPUTE_FRAMEWORKS_MESSAGE = (
+    "Strict mode filtered out all ComputeFrameworks: none of the requested ComputeFrameworks "
+    "are registered in the plugin registry. Register them via mloda.user.register_plugin() or "
+    "relax MLODA_PLUGIN_REGISTRY_STRICT to disable strict mode."
+)
+
+_NO_FEATURE_GROUPS_MESSAGE = "No feature groups are loaded. Did you call PluginLoader.all()?"
+
+
+class EnvironmentProvenance(Enum):
+    """Why a plugin ended up in, or out of, the resolution environment."""
+
+    DISCOVERED = "discovered"
+    DISABLED_BY_COLLECTOR = "disabled_by_collector"
+    POLICY_REJECTED = "policy_rejected"
+    UNAVAILABLE = "unavailable"
+    NOT_ENABLED = "not_enabled"
+    REDEFINITION_CONFLICT = "redefinition_conflict"
+    INVALID_DECLARATION = "invalid_declaration"
+    ACCESSIBLE = "accessible"
+
+
+@dataclass(frozen=True)
+class FrameworkRecord:
+    """One declared compute framework of a feature group and its classification."""
+
+    identity: PluginIdentity
+    provenance: EnvironmentProvenance
+
+
+@dataclass(frozen=True)
+class FeatureGroupRecord:
+    """One discovered feature group, its classification, and its framework records."""
+
+    identity: PluginIdentity
+    provenance: EnvironmentProvenance
+    frameworks: tuple[FrameworkRecord, ...]
+
+
+@dataclass(frozen=True)
+class EnvironmentBuildError:
+    """One fatal condition met while building the environment.
+
+    ``exception`` carries the original provider or dedup exception (never serialized)
+    so adapters can re-raise exactly what the absorbed inline logic raised.
+    """
+
+    category: str
+    message: str
+    conflict_identities: tuple[PluginIdentity, ...] = ()
+    exception: Exception | None = None
+
+    def as_exception(self) -> Exception:
+        """Return the carried original exception, else a ValueError over the message."""
+        if self.exception is not None:
+            return self.exception
+        return ValueError(self.message)
+
+    def to_payload(self) -> dict[str, Any]:
+        """Plain-data projection; the carried exception never appears."""
+        return {
+            "category": self.category,
+            "message": self.message,
+            "conflict_identities": [identity.render() for identity in self.conflict_identities],
+        }
+
+
+@dataclass(frozen=True)
+class ResolutionEnvironmentSnapshot:
+    """Immutable, deterministic view of the plugin environment for one build."""
+
+    records: tuple[FeatureGroupRecord, ...]
+    accessible: tuple[tuple[type[FeatureGroup], tuple[type[ComputeFramework], ...]], ...]
+    strict_mode: str
+    requested_frameworks: tuple[PluginIdentity, ...]
+    enabled_frameworks: tuple[PluginIdentity, ...]
+    fingerprint: str
+
+    def accessible_mapping(self) -> FeatureGroupEnvironmentMapping:
+        """Fresh mutable mapping per call, equal to PreFilterPlugins.get_accessible_plugins()."""
+        return {feature_group: set(frameworks) for feature_group, frameworks in self.accessible}
+
+    def to_payload(self) -> dict[str, Any]:
+        """Plain JSON data; plugin classes are rendered as identity strings."""
+        return {
+            "strict_mode": self.strict_mode,
+            "fingerprint": self.fingerprint,
+            "requested_frameworks": [identity.render() for identity in self.requested_frameworks],
+            "enabled_frameworks": [identity.render() for identity in self.enabled_frameworks],
+            "records": [
+                {
+                    "identity": record.identity.render(),
+                    "provenance": record.provenance.value,
+                    "frameworks": [
+                        {"identity": framework.identity.render(), "provenance": framework.provenance.value}
+                        for framework in record.frameworks
+                    ],
+                }
+                for record in self.records
+            ],
+            "accessible": [
+                {
+                    "feature_group": PluginIdentity.from_class(feature_group).render(),
+                    "frameworks": [PluginIdentity.from_class(framework).render() for framework in frameworks],
+                }
+                for feature_group, frameworks in self.accessible
+            ],
+        }
+
+
+@dataclass(frozen=True)
+class EnvironmentBuildOutcome:
+    """Snapshot on success, structured errors otherwise; never both."""
+
+    snapshot: ResolutionEnvironmentSnapshot | None
+    errors: tuple[EnvironmentBuildError, ...] = ()
+
+    def to_payload(self) -> dict[str, Any]:
+        """Plain JSON data for the whole outcome."""
+        return {
+            "snapshot": self.snapshot.to_payload() if self.snapshot is not None else None,
+            "errors": [error.to_payload() for error in self.errors],
+        }
+
+
+@dataclass(frozen=True)
+class FeatureGroupPipelineResult:
+    """Survivors and per-class drops of the feature-group pipeline, or a fatal error."""
+
+    survivors: tuple[type[FeatureGroup], ...]
+    dropped: tuple[tuple[type[FeatureGroup], EnvironmentProvenance], ...]
+    error: EnvironmentBuildError | None
+
+
+@dataclass(frozen=True)
+class ComputeFrameworkPipelineResult:
+    """Enabled frameworks after intersection and strict filtering, or a fatal error."""
+
+    enabled: frozenset[type[ComputeFramework]]
+    error: EnvironmentBuildError | None
+
+
+def _strict_mode(plugin_collector: PluginCollector | None) -> str:
+    return plugin_collector.strict_mode if plugin_collector is not None else strict_mode_from_env()
+
+
+def run_feature_group_pipeline(plugin_collector: PluginCollector | None = None) -> FeatureGroupPipelineResult:
+    """Discover, collector-filter, strict-filter, and dedup feature groups.
+
+    Mirrors the absorbed PreFilterPlugins._set_feature_groups step for step,
+    returning structured drops and errors instead of raising.
+    """
+    discovered = set(PreFilterPlugins.get_featuregroup_subclasses())
+    dropped: list[tuple[type[FeatureGroup], EnvironmentProvenance]] = []
+
+    working = set(discovered)
+    if plugin_collector is not None:
+        for feature_group in sorted(discovered, key=PluginIdentity.from_class):
+            if not plugin_collector.applicable_feature_group_class(feature_group):
+                working.discard(feature_group)
+                dropped.append((feature_group, EnvironmentProvenance.DISABLED_BY_COLLECTOR))
+
+    allow_redefinition = plugin_collector.allow_redefinition if plugin_collector is not None else False
+    strict_mode = _strict_mode(plugin_collector)
+
+    registered: set[type[Any]] = set()
+    if strict_mode != "off":
+        registered = registry_for(plugin_collector).registered_classes()
+
+    if strict_mode == "strict":
+        before_strict = working
+        working = {fg for fg in before_strict if fg in registered or inspect.isabstract(fg)}
+        for feature_group in sorted(before_strict - working, key=PluginIdentity.from_class):
+            dropped.append((feature_group, EnvironmentProvenance.POLICY_REJECTED))
+        if plugin_collector is not None:
+            dropped_enabled = sorted(
+                f"{fg.__module__}:{fg.__qualname__}"
+                for fg in before_strict - working
+                if fg in plugin_collector.enabled_feature_group_classes
+            )
+            if dropped_enabled:
+                _prefilter.logger.warning(
+                    "Explicitly enabled FeatureGroups were dropped by strict mode because they are "
+                    "not registered in the plugin registry: %s.",
+                    ", ".join(dropped_enabled),
+                )
+        had_concrete = any(not inspect.isabstract(fg) for fg in before_strict)
+        has_concrete = any(not inspect.isabstract(fg) for fg in working)
+        if had_concrete and not has_concrete:
+            error = EnvironmentBuildError(
+                category="strict_mode_feature_groups", message=_STRICT_MODE_FEATURE_GROUPS_MESSAGE
+            )
+            return FeatureGroupPipelineResult(survivors=(), dropped=tuple(dropped), error=error)
+
+    # Dedup raises on same-identity classes with differing source; the factory returns it structurally.
+    try:
+        working = dedup_feature_group_subclasses(working, allow_redefinition=allow_redefinition)
+    except RedefinitionConflictError as exc:
+        error = EnvironmentBuildError(
+            category="redefinition_conflict",
+            message=str(exc),
+            conflict_identities=tuple(sorted(PluginIdentity.from_class(cls) for cls in exc.conflicts)),
+            exception=exc,
+        )
+        return FeatureGroupPipelineResult(survivors=(), dropped=tuple(dropped), error=error)
+
+    if strict_mode == "warn":
+        unregistered = sorted(
+            f"{fg.__module__}:{fg.__qualname__}"
+            for fg in working
+            if fg not in registered
+            and not inspect.isabstract(fg)
+            and f"{fg.__module__}:{fg.__qualname__}" not in _prefilter._warned_unregistered
+        )
+        if unregistered:
+            _prefilter._warned_unregistered.update(unregistered)
+            _prefilter.logger.warning(
+                "FeatureGroups not registered in the plugin registry: %s.",
+                ", ".join(unregistered),
+            )
+
+    if len(working) == 0:
+        error = EnvironmentBuildError(category="no_feature_groups", message=_NO_FEATURE_GROUPS_MESSAGE)
+        return FeatureGroupPipelineResult(survivors=(), dropped=tuple(dropped), error=error)
+
+    survivors = tuple(sorted(working, key=PluginIdentity.from_class))
+    return FeatureGroupPipelineResult(survivors=survivors, dropped=tuple(dropped), error=None)
+
+
+def run_compute_framework_pipeline(
+    compute_frameworks: set[type[ComputeFramework]],
+    plugin_collector: PluginCollector | None = None,
+) -> ComputeFrameworkPipelineResult:
+    """Intersect the requested frameworks with the available ones and apply strict mode.
+
+    Mirrors the absorbed PreFilterPlugins._set_compute_frameworks step for step.
+    """
+    enabled = compute_frameworks.intersection(PreFilterPlugins.get_cfw_subclasses())
+
+    strict_mode = _strict_mode(plugin_collector)
+    if strict_mode == "off":
+        return ComputeFrameworkPipelineResult(enabled=frozenset(enabled), error=None)
+
+    registered = registry_for(plugin_collector).registered_classes()
+    # Bundled plugin frameworks ship with mloda, like abstract classes: never filtered or flagged.
+    unregistered = {
+        cfw
+        for cfw in enabled
+        if cfw not in registered and not inspect.isabstract(cfw) and not _prefilter._is_bundled_plugin(cfw)
+    }
+    unregistered_names = sorted(f"{cfw.__module__}:{cfw.__qualname__}" for cfw in unregistered)
+
+    if strict_mode == "warn":
+        new_names = [name for name in unregistered_names if name not in _prefilter._warned_unregistered]
+        if new_names:
+            _prefilter._warned_unregistered.update(new_names)
+            _prefilter.logger.warning(
+                "ComputeFrameworks not registered in the plugin registry: %s.", ", ".join(new_names)
+            )
+        return ComputeFrameworkPipelineResult(enabled=frozenset(enabled), error=None)
+
+    surviving = enabled - unregistered
+    had_concrete = any(not inspect.isabstract(cfw) for cfw in enabled)
+    has_concrete = any(not inspect.isabstract(cfw) for cfw in surviving)
+    if had_concrete and not has_concrete:
+        error = EnvironmentBuildError(
+            category="strict_mode_compute_frameworks", message=_STRICT_MODE_COMPUTE_FRAMEWORKS_MESSAGE
+        )
+        return ComputeFrameworkPipelineResult(enabled=frozenset(), error=error)
+    return ComputeFrameworkPipelineResult(enabled=frozenset(surviving), error=None)
+
+
+def _fingerprint(
+    strict_mode: str,
+    requested: tuple[PluginIdentity, ...],
+    enabled: tuple[PluginIdentity, ...],
+    records: tuple[FeatureGroupRecord, ...],
+) -> str:
+    """sha256 hex over a canonical string of identities, provenance, and run configuration."""
+    canonical = json.dumps(
+        {
+            "strict_mode": strict_mode,
+            "requested_frameworks": [identity.render() for identity in requested],
+            "enabled_frameworks": [identity.render() for identity in enabled],
+            "records": [
+                [
+                    record.identity.render(),
+                    record.provenance.value,
+                    [[framework.identity.render(), framework.provenance.value] for framework in record.frameworks],
+                ]
+                for record in records
+            ],
+        },
+        sort_keys=True,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def build_resolution_environment(
+    compute_frameworks: set[type[ComputeFramework]],
+    plugin_collector: PluginCollector | None = None,
+) -> EnvironmentBuildOutcome:
+    """Run the PreFilterPlugins classification pipeline, returning structured state.
+
+    Same evaluation order as PreFilterPlugins; on the conditions where it raises,
+    the outcome carries an error with the exact current message and no snapshot.
+    """
+    strict_mode = _strict_mode(plugin_collector)
+    requested = tuple(sorted(PluginIdentity.from_class(cfw) for cfw in compute_frameworks))
+
+    feature_group_result = run_feature_group_pipeline(plugin_collector)
+    if feature_group_result.error is not None:
+        return EnvironmentBuildOutcome(snapshot=None, errors=(feature_group_result.error,))
+
+    framework_result = run_compute_framework_pipeline(compute_frameworks, plugin_collector)
+    if framework_result.error is not None:
+        return EnvironmentBuildOutcome(snapshot=None, errors=(framework_result.error,))
+
+    enabled_classes = framework_result.enabled
+    enabled = tuple(sorted(PluginIdentity.from_class(cfw) for cfw in enabled_classes))
+
+    records_by_identity: dict[PluginIdentity, FeatureGroupRecord] = {}
+    for feature_group, provenance in feature_group_result.dropped:
+        identity = PluginIdentity.from_class(feature_group)
+        records_by_identity[identity] = FeatureGroupRecord(identity=identity, provenance=provenance, frameworks=())
+
+    accessible_entries: list[tuple[type[FeatureGroup], tuple[type[ComputeFramework], ...]]] = []
+    for feature_group in feature_group_result.survivors:
+        identity = PluginIdentity.from_class(feature_group)
+        # Provider declarations are third-party code; a raise becomes a structured invalid_declaration error.
+        try:
+            declared = feature_group.compute_framework_definition()
+        except Exception as exc:
+            error = EnvironmentBuildError(category="invalid_declaration", message=str(exc), exception=exc)
+            return EnvironmentBuildOutcome(snapshot=None, errors=(error,))
+
+        framework_records: list[FrameworkRecord] = []
+        accessible_frameworks: list[type[ComputeFramework]] = []
+        for framework in sorted(declared, key=PluginIdentity.from_class):
+            if not framework.is_available():
+                framework_provenance = EnvironmentProvenance.UNAVAILABLE
+            elif framework in enabled_classes:
+                framework_provenance = EnvironmentProvenance.ACCESSIBLE
+                accessible_frameworks.append(framework)
+            elif framework in compute_frameworks:
+                framework_provenance = EnvironmentProvenance.POLICY_REJECTED
+            else:
+                framework_provenance = EnvironmentProvenance.NOT_ENABLED
+            framework_records.append(
+                FrameworkRecord(identity=PluginIdentity.from_class(framework), provenance=framework_provenance)
+            )
+
+        records_by_identity[identity] = FeatureGroupRecord(
+            identity=identity, provenance=EnvironmentProvenance.ACCESSIBLE, frameworks=tuple(framework_records)
+        )
+        accessible_entries.append((feature_group, tuple(accessible_frameworks)))
+
+    records = tuple(records_by_identity[identity] for identity in sorted(records_by_identity))
+    snapshot = ResolutionEnvironmentSnapshot(
+        records=records,
+        accessible=tuple(accessible_entries),
+        strict_mode=strict_mode,
+        requested_frameworks=requested,
+        enabled_frameworks=enabled,
+        fingerprint=_fingerprint(strict_mode, requested, enabled, records),
+    )
+    return EnvironmentBuildOutcome(snapshot=snapshot, errors=())

--- a/mloda/core/resolve/environment.py
+++ b/mloda/core/resolve/environment.py
@@ -358,13 +358,20 @@ def build_resolution_environment(
 ) -> EnvironmentBuildOutcome:
     """Run the PreFilterPlugins classification pipeline, returning structured state.
 
-    Same evaluation order as PreFilterPlugins; on the conditions where it raises,
-    the outcome carries an error with the exact current message and no snapshot.
-    Availability is sampled exactly once inside this pipeline for both the
-    ``compute_frameworks=None`` ("all available frameworks") and the explicit-set
-    branch, and a raising ``is_available`` probe becomes a structured
-    availability_failure error instead of a raise.
+    On the conditions where PreFilterPlugins raises, the outcome carries an error
+    with the exact current message and no snapshot. The feature-group pipeline runs
+    BEFORE availability sampling, so a feature-group fatal (strict mode, redefinition)
+    takes precedence over an availability_failure. Availability is sampled exactly
+    once inside this pipeline for both the ``compute_frameworks=None`` ("all available
+    frameworks") and the explicit-set branch, and a raising ``is_available`` probe
+    becomes a structured availability_failure error instead of a raise.
     """
+    strict_mode = _strict_mode(plugin_collector)
+
+    feature_group_result = run_feature_group_pipeline(plugin_collector)
+    if feature_group_result.error is not None:
+        return EnvironmentBuildOutcome(snapshot=None, errors=(feature_group_result.error,))
+
     # Guarded: availability probes are third-party code; a raise must fail structurally here.
     try:
         sampled = frozenset(PreFilterPlugins.get_cfw_subclasses())
@@ -378,12 +385,7 @@ def build_resolution_environment(
     if compute_frameworks is None:
         compute_frameworks = set(sampled)
 
-    strict_mode = _strict_mode(plugin_collector)
     requested = tuple(sorted(PluginIdentity.from_class(cfw) for cfw in compute_frameworks))
-
-    feature_group_result = run_feature_group_pipeline(plugin_collector)
-    if feature_group_result.error is not None:
-        return EnvironmentBuildOutcome(snapshot=None, errors=(feature_group_result.error,))
 
     framework_result = run_compute_framework_pipeline(compute_frameworks, plugin_collector, available=sampled)
     if framework_result.error is not None:

--- a/mloda/core/resolve/environment.py
+++ b/mloda/core/resolve/environment.py
@@ -42,6 +42,7 @@ _NO_FEATURE_GROUPS_MESSAGE = "No feature groups are loaded. Did you call PluginL
 class EnvironmentProvenance(Enum):
     """Why a plugin ended up in, or out of, the resolution environment."""
 
+    # Reserved for the Stage 3 full-universe candidate records.
     DISCOVERED = "discovered"
     DISABLED_BY_COLLECTOR = "disabled_by_collector"
     POLICY_REJECTED = "policy_rejected"
@@ -89,12 +90,20 @@ class EnvironmentBuildError:
         return ValueError(self.message)
 
     def to_payload(self) -> dict[str, Any]:
-        """Plain-data projection; the carried exception never appears."""
-        return {
+        """Plain-data projection, redacted: raw provider text never appears.
+
+        Errors carrying an exception name only its type; errors without one carry
+        mloda-generated safe text, so their message stays.
+        """
+        payload: dict[str, Any] = {
             "category": self.category,
-            "message": self.message,
             "conflict_identities": [identity.render() for identity in self.conflict_identities],
         }
+        if self.exception is not None:
+            payload["exception_type"] = type(self.exception).__name__
+        else:
+            payload["message"] = self.message
+        return payload
 
 
 @dataclass(frozen=True)
@@ -166,10 +175,14 @@ class FeatureGroupPipelineResult:
 
 @dataclass(frozen=True)
 class ComputeFrameworkPipelineResult:
-    """Enabled frameworks after intersection and strict filtering, or a fatal error."""
+    """Enabled frameworks after intersection and strict filtering, or a fatal error.
+
+    ``available`` is the single per-build availability sampling; classification reuses it.
+    """
 
     enabled: frozenset[type[ComputeFramework]]
     error: EnvironmentBuildError | None
+    available: frozenset[type[ComputeFramework]] = frozenset()
 
 
 def _strict_mode(plugin_collector: PluginCollector | None) -> str:
@@ -229,10 +242,10 @@ def run_feature_group_pipeline(plugin_collector: PluginCollector | None = None) 
         working = dedup_feature_group_subclasses(working, allow_redefinition=allow_redefinition)
     except RedefinitionConflictError as exc:
         error = EnvironmentBuildError(
-            category="redefinition_conflict",
+            category=EnvironmentProvenance.REDEFINITION_CONFLICT.value,
             message=str(exc),
-            conflict_identities=tuple(sorted(PluginIdentity.from_class(cls) for cls in exc.conflicts)),
-            exception=exc,
+            conflict_identities=tuple(sorted({PluginIdentity.from_class(cls) for cls in exc.conflicts})),
+            exception=exc.with_traceback(None),
         )
         return FeatureGroupPipelineResult(survivors=(), dropped=tuple(dropped), error=error)
 
@@ -267,11 +280,12 @@ def run_compute_framework_pipeline(
 
     Mirrors the absorbed PreFilterPlugins._set_compute_frameworks step for step.
     """
-    enabled = compute_frameworks.intersection(PreFilterPlugins.get_cfw_subclasses())
+    available = frozenset(PreFilterPlugins.get_cfw_subclasses())
+    enabled = compute_frameworks.intersection(available)
 
     strict_mode = _strict_mode(plugin_collector)
     if strict_mode == "off":
-        return ComputeFrameworkPipelineResult(enabled=frozenset(enabled), error=None)
+        return ComputeFrameworkPipelineResult(enabled=frozenset(enabled), error=None, available=available)
 
     registered = registry_for(plugin_collector).registered_classes()
     # Bundled plugin frameworks ship with mloda, like abstract classes: never filtered or flagged.
@@ -289,7 +303,7 @@ def run_compute_framework_pipeline(
             _prefilter.logger.warning(
                 "ComputeFrameworks not registered in the plugin registry: %s.", ", ".join(new_names)
             )
-        return ComputeFrameworkPipelineResult(enabled=frozenset(enabled), error=None)
+        return ComputeFrameworkPipelineResult(enabled=frozenset(enabled), error=None, available=available)
 
     surviving = enabled - unregistered
     had_concrete = any(not inspect.isabstract(cfw) for cfw in enabled)
@@ -298,8 +312,15 @@ def run_compute_framework_pipeline(
         error = EnvironmentBuildError(
             category="strict_mode_compute_frameworks", message=_STRICT_MODE_COMPUTE_FRAMEWORKS_MESSAGE
         )
-        return ComputeFrameworkPipelineResult(enabled=frozenset(), error=error)
-    return ComputeFrameworkPipelineResult(enabled=frozenset(surviving), error=None)
+        return ComputeFrameworkPipelineResult(enabled=frozenset(), error=error, available=available)
+    return ComputeFrameworkPipelineResult(enabled=frozenset(surviving), error=None, available=available)
+
+
+def _member_identity(member: Any) -> PluginIdentity:
+    """Identity of a declared rule member, defensive: junk members may lack module/qualname."""
+    module = getattr(member, "__module__", type(member).__module__)
+    qualname = getattr(member, "__qualname__", type(member).__qualname__)
+    return PluginIdentity(module=str(module), qualname=str(qualname))
 
 
 def _fingerprint(
@@ -349,6 +370,8 @@ def build_resolution_environment(
         return EnvironmentBuildOutcome(snapshot=None, errors=(framework_result.error,))
 
     enabled_classes = framework_result.enabled
+    # Classification reuses the pipeline's one availability sampling; is_available never runs again.
+    available_classes = framework_result.available
     enabled = tuple(sorted(PluginIdentity.from_class(cfw) for cfw in enabled_classes))
 
     records_by_identity: dict[PluginIdentity, FeatureGroupRecord] = {}
@@ -363,13 +386,27 @@ def build_resolution_environment(
         try:
             declared = feature_group.compute_framework_definition()
         except Exception as exc:
-            error = EnvironmentBuildError(category="invalid_declaration", message=str(exc), exception=exc)
+            error = EnvironmentBuildError(
+                category=EnvironmentProvenance.INVALID_DECLARATION.value,
+                message=str(exc),
+                exception=exc.with_traceback(None),
+            )
             return EnvironmentBuildOutcome(snapshot=None, errors=(error,))
 
         framework_records: list[FrameworkRecord] = []
         accessible_frameworks: list[type[ComputeFramework]] = []
-        for framework in sorted(declared, key=PluginIdentity.from_class):
-            if not framework.is_available():
+        # The declared type lies for junk members (anything a provider put in the rule set).
+        members: list[Any] = sorted(declared, key=_member_identity)
+        for member in members:
+            identity_record = _member_identity(member)
+            if not (isinstance(member, type) and issubclass(member, ComputeFramework)):
+                # Junk members are recorded, never fatal; PreFilterPlugins keeps dropping them silently.
+                framework_records.append(
+                    FrameworkRecord(identity=identity_record, provenance=EnvironmentProvenance.INVALID_DECLARATION)
+                )
+                continue
+            framework: type[ComputeFramework] = member
+            if framework not in available_classes:
                 framework_provenance = EnvironmentProvenance.UNAVAILABLE
             elif framework in enabled_classes:
                 framework_provenance = EnvironmentProvenance.ACCESSIBLE
@@ -378,9 +415,7 @@ def build_resolution_environment(
                 framework_provenance = EnvironmentProvenance.POLICY_REJECTED
             else:
                 framework_provenance = EnvironmentProvenance.NOT_ENABLED
-            framework_records.append(
-                FrameworkRecord(identity=PluginIdentity.from_class(framework), provenance=framework_provenance)
-            )
+            framework_records.append(FrameworkRecord(identity=identity_record, provenance=framework_provenance))
 
         records_by_identity[identity] = FeatureGroupRecord(
             identity=identity, provenance=EnvironmentProvenance.ACCESSIBLE, frameworks=tuple(framework_records)

--- a/mloda/core/resolve/environment.py
+++ b/mloda/core/resolve/environment.py
@@ -275,12 +275,15 @@ def run_feature_group_pipeline(plugin_collector: PluginCollector | None = None) 
 def run_compute_framework_pipeline(
     compute_frameworks: set[type[ComputeFramework]],
     plugin_collector: PluginCollector | None = None,
+    available: frozenset[type[ComputeFramework]] | None = None,
 ) -> ComputeFrameworkPipelineResult:
     """Intersect the requested frameworks with the available ones and apply strict mode.
 
     Mirrors the absorbed PreFilterPlugins._set_compute_frameworks step for step.
+    ``available`` reuses a caller-side availability sampling; None samples here.
     """
-    available = frozenset(PreFilterPlugins.get_cfw_subclasses())
+    if available is None:
+        available = frozenset(PreFilterPlugins.get_cfw_subclasses())
     enabled = compute_frameworks.intersection(available)
 
     strict_mode = _strict_mode(plugin_collector)
@@ -350,14 +353,31 @@ def _fingerprint(
 
 
 def build_resolution_environment(
-    compute_frameworks: set[type[ComputeFramework]],
+    compute_frameworks: set[type[ComputeFramework]] | None = None,
     plugin_collector: PluginCollector | None = None,
 ) -> EnvironmentBuildOutcome:
     """Run the PreFilterPlugins classification pipeline, returning structured state.
 
     Same evaluation order as PreFilterPlugins; on the conditions where it raises,
     the outcome carries an error with the exact current message and no snapshot.
+    ``compute_frameworks=None`` means "all available frameworks": availability is
+    sampled exactly once inside this pipeline, and a raising ``is_available`` probe
+    becomes a structured availability_failure error instead of a raise.
     """
+    sampled: frozenset[type[ComputeFramework]] | None = None
+    if compute_frameworks is None:
+        # Guarded: availability probes are third-party code; a raise must fail structurally here.
+        try:
+            sampled = frozenset(PreFilterPlugins.get_cfw_subclasses())
+        except Exception as exc:
+            error = EnvironmentBuildError(
+                category="availability_failure",
+                message=str(exc),
+                exception=exc.with_traceback(None),
+            )
+            return EnvironmentBuildOutcome(snapshot=None, errors=(error,))
+        compute_frameworks = set(sampled)
+
     strict_mode = _strict_mode(plugin_collector)
     requested = tuple(sorted(PluginIdentity.from_class(cfw) for cfw in compute_frameworks))
 
@@ -365,7 +385,7 @@ def build_resolution_environment(
     if feature_group_result.error is not None:
         return EnvironmentBuildOutcome(snapshot=None, errors=(feature_group_result.error,))
 
-    framework_result = run_compute_framework_pipeline(compute_frameworks, plugin_collector)
+    framework_result = run_compute_framework_pipeline(compute_frameworks, plugin_collector, available=sampled)
     if framework_result.error is not None:
         return EnvironmentBuildOutcome(snapshot=None, errors=(framework_result.error,))
 

--- a/mloda/core/resolve/environment.py
+++ b/mloda/core/resolve/environment.py
@@ -360,22 +360,22 @@ def build_resolution_environment(
 
     Same evaluation order as PreFilterPlugins; on the conditions where it raises,
     the outcome carries an error with the exact current message and no snapshot.
-    ``compute_frameworks=None`` means "all available frameworks": availability is
-    sampled exactly once inside this pipeline, and a raising ``is_available`` probe
-    becomes a structured availability_failure error instead of a raise.
+    Availability is sampled exactly once inside this pipeline for both the
+    ``compute_frameworks=None`` ("all available frameworks") and the explicit-set
+    branch, and a raising ``is_available`` probe becomes a structured
+    availability_failure error instead of a raise.
     """
-    sampled: frozenset[type[ComputeFramework]] | None = None
+    # Guarded: availability probes are third-party code; a raise must fail structurally here.
+    try:
+        sampled = frozenset(PreFilterPlugins.get_cfw_subclasses())
+    except Exception as exc:
+        error = EnvironmentBuildError(
+            category="availability_failure",
+            message=str(exc),
+            exception=exc.with_traceback(None),
+        )
+        return EnvironmentBuildOutcome(snapshot=None, errors=(error,))
     if compute_frameworks is None:
-        # Guarded: availability probes are third-party code; a raise must fail structurally here.
-        try:
-            sampled = frozenset(PreFilterPlugins.get_cfw_subclasses())
-        except Exception as exc:
-            error = EnvironmentBuildError(
-                category="availability_failure",
-                message=str(exc),
-                exception=exc.with_traceback(None),
-            )
-            return EnvironmentBuildOutcome(snapshot=None, errors=(error,))
         compute_frameworks = set(sampled)
 
     strict_mode = _strict_mode(plugin_collector)

--- a/mloda/core/resolve/identity.py
+++ b/mloda/core/resolve/identity.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True, order=True)
+class PluginIdentity:
+    """Stable plugin identity: defining module plus qualified class name."""
+
+    module: str
+    qualname: str
+
+    @classmethod
+    def from_class(cls, plugin_class: type[Any]) -> PluginIdentity:
+        """Build the identity of a plugin class."""
+        return cls(module=plugin_class.__module__, qualname=plugin_class.__qualname__)
+
+    def render(self) -> str:
+        """Render the canonical "module:qualname" string."""
+        return f"{self.module}:{self.qualname}"

--- a/mloda/core/resolve/outcome.py
+++ b/mloda/core/resolve/outcome.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.resolve.identity import PluginIdentity
+
+if TYPE_CHECKING:
+    from mloda.core.resolve.report import ResolutionReport
 
 
 class ResolutionStatus(Enum):
@@ -171,3 +174,5 @@ class FeatureResolutionError(ValueError):
     def __init__(self, message: str, outcome: ResolutionOutcome) -> None:
         super().__init__(message)
         self.outcome = outcome
+        # Attached by the engine when this error escapes planning; None everywhere else.
+        self.report: ResolutionReport | None = None

--- a/mloda/core/resolve/outcome.py
+++ b/mloda/core/resolve/outcome.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.resolve.identity import PluginIdentity
+
+
+class ResolutionStatus(Enum):
+    """Final verdict of one resolve() call."""
+
+    RESOLVED = "resolved"
+    NOT_FOUND = "not_found"
+    AMBIGUOUS = "ambiguous"
+    FAILED = "failed"
+
+
+class CandidateStatus(Enum):
+    """Per-candidate verdict inside one resolve() call."""
+
+    WINNER = "winner"
+    SURVIVOR = "survivor"
+    SHADOWED = "shadowed"
+    REJECTED = "rejected"
+    FAILED = "failed"
+
+
+class FrameworkStatus(Enum):
+    """Per-candidate, per-framework verdict."""
+
+    SUPPORTED = "supported"
+    NOT_ENABLED = "not_enabled"
+    UNAVAILABLE = "unavailable"
+    PIN_EXCLUDED = "pin_excluded"
+    CAPABILITY_REJECTED = "capability_rejected"
+    HOOK_FAILED = "hook_failed"
+
+
+class RejectionReason(Enum):
+    """Structured reason attached to every candidate rejection."""
+
+    CRITERIA = "criteria"
+    DOMAIN = "domain"
+    SCOPE = "scope"
+    ABSTRACT = "abstract"
+    NO_ACCESSIBLE_FRAMEWORK = "no_accessible_framework"
+    CAPABILITY = "capability"
+    FRAMEWORK_PIN = "framework_pin"
+    LINK_INDEX = "link_index"
+    VALUE_REJECTION = "value_rejection"
+    PROVIDER_FAILURE = "provider_failure"
+    SUBCLASS_SHADOWED = "subclass_shadowed"
+
+
+@dataclass(frozen=True)
+class Rejection:
+    """One structured rejection: a reason plus optional safe detail text."""
+
+    reason: RejectionReason
+    detail: str = ""
+
+    def to_payload(self) -> dict[str, Any]:
+        return {"reason": self.reason.value, "detail": self.detail}
+
+
+@dataclass(frozen=True)
+class PluginFailure:
+    """One provider failure as plain data; never carries the exception object."""
+
+    plugin: PluginIdentity
+    stage: str
+    category: str
+    message: str
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "plugin": self.plugin.render(),
+            "stage": self.stage,
+            "category": self.category,
+            "message": self.message,
+        }
+
+
+@dataclass(frozen=True)
+class FrameworkEvaluation:
+    """Verdict for one framework of one candidate."""
+
+    framework: type[ComputeFramework]
+    identity: PluginIdentity
+    status: FrameworkStatus
+    failure: PluginFailure | None = None
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "identity": self.identity.render(),
+            "status": self.status.value,
+            "failure": self.failure.to_payload() if self.failure is not None else None,
+        }
+
+
+@dataclass(frozen=True)
+class CandidateEvaluation:
+    """Full evaluation record of one accessible candidate."""
+
+    feature_group: type[FeatureGroup]
+    identity: PluginIdentity
+    status: CandidateStatus
+    frameworks: tuple[FrameworkEvaluation, ...] = ()
+    rejections: tuple[Rejection, ...] = ()
+    shadowed_by: PluginIdentity | None = None
+    failure: PluginFailure | None = None
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "identity": self.identity.render(),
+            "status": self.status.value,
+            "frameworks": [evaluation.to_payload() for evaluation in self.frameworks],
+            "rejections": [rejection.to_payload() for rejection in self.rejections],
+            "shadowed_by": self.shadowed_by.render() if self.shadowed_by is not None else None,
+            "failure": self.failure.to_payload() if self.failure is not None else None,
+        }
+
+
+@dataclass(frozen=True)
+class ResolvedCandidate:
+    """The winner: the feature group and its supported frameworks for this feature."""
+
+    feature_group: type[FeatureGroup]
+    identity: PluginIdentity
+    compute_frameworks: tuple[type[ComputeFramework], ...]
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "feature_group": self.identity.render(),
+            "compute_frameworks": [
+                PluginIdentity.from_class(framework).render() for framework in self.compute_frameworks
+            ],
+        }
+
+
+@dataclass(frozen=True)
+class ResolutionOutcome:
+    """Structured result of one resolve() call; a winner exists iff status is RESOLVED."""
+
+    status: ResolutionStatus
+    winner: ResolvedCandidate | None
+    candidates: tuple[CandidateEvaluation, ...]
+    failures: tuple[PluginFailure, ...]
+    environment_fingerprint: str
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "status": self.status.value,
+            "winner": self.winner.to_payload() if self.winner is not None else None,
+            "candidates": [candidate.to_payload() for candidate in self.candidates],
+            "failures": [failure.to_payload() for failure in self.failures],
+            "environment_fingerprint": self.environment_fingerprint,
+        }
+
+
+class FeatureResolutionError(ValueError):
+    """Engine-facing resolution error carrying the structured outcome."""
+
+    def __init__(self, message: str, outcome: ResolutionOutcome) -> None:
+        super().__init__(message)
+        self.outcome = outcome

--- a/mloda/core/resolve/outcome.py
+++ b/mloda/core/resolve/outcome.py
@@ -37,6 +37,7 @@ class FrameworkStatus(Enum):
     PIN_EXCLUDED = "pin_excluded"
     CAPABILITY_REJECTED = "capability_rejected"
     HOOK_FAILED = "hook_failed"
+    NOT_EVALUATED = "not_evaluated"
 
 
 class RejectionReason(Enum):
@@ -68,7 +69,11 @@ class Rejection:
 
 @dataclass(frozen=True)
 class PluginFailure:
-    """One provider failure as plain data; never carries the exception object."""
+    """One provider failure as plain data; never carries the exception object.
+
+    ``message`` keeps the raw provider text for the rendered user-facing errors;
+    ``to_payload()`` redacts it and carries only identity, stage, and category.
+    """
 
     plugin: PluginIdentity
     stage: str
@@ -80,7 +85,6 @@ class PluginFailure:
             "plugin": self.plugin.render(),
             "stage": self.stage,
             "category": self.category,
-            "message": self.message,
         }
 
 

--- a/mloda/core/resolve/outcome.py
+++ b/mloda/core/resolve/outcome.py
@@ -59,15 +59,24 @@ class RejectionReason(Enum):
     SUBCLASS_SHADOWED = "subclass_shadowed"
 
 
+# Reasons whose detail carries raw provider text; the payload drops it, the field keeps it.
+_RAW_DETAIL_REASONS = frozenset({RejectionReason.VALUE_REJECTION, RejectionReason.PROVIDER_FAILURE})
+
+
 @dataclass(frozen=True)
 class Rejection:
-    """One structured rejection: a reason plus optional safe detail text."""
+    """One structured rejection: a reason plus optional detail text.
+
+    ``detail`` stays raw in memory (rendered errors depend on it); ``to_payload()``
+    redacts it for the reasons that carry raw provider text.
+    """
 
     reason: RejectionReason
     detail: str = ""
 
     def to_payload(self) -> dict[str, Any]:
-        return {"reason": self.reason.value, "detail": self.detail}
+        detail = "" if self.reason in _RAW_DETAIL_REASONS else self.detail
+        return {"reason": self.reason.value, "detail": detail}
 
 
 @dataclass(frozen=True)

--- a/mloda/core/resolve/render.py
+++ b/mloda/core/resolve/render.py
@@ -1,0 +1,51 @@
+"""Persona renderers over a captured ResolutionOutcome.
+
+Pure projections: they never invoke provider hooks, never build environments,
+and never import from mloda.core.api.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mloda.core.resolve.outcome import CandidateStatus, ResolutionOutcome, ResolutionStatus
+
+
+def render_user_view(outcome: ResolutionOutcome) -> str:
+    """Concise user summary: the status, the winner or failing plugin, and one next step."""
+    lines = [f"Status: {outcome.status.value}"]
+    if outcome.status is ResolutionStatus.RESOLVED and outcome.winner is not None:
+        lines.append(f"Feature group: {outcome.winner.identity.qualname}")
+        lines.append("Next step: request the feature; this environment resolves it unambiguously.")
+    elif outcome.status is ResolutionStatus.AMBIGUOUS:
+        survivors = ", ".join(
+            candidate.identity.qualname
+            for candidate in outcome.candidates
+            if candidate.status is CandidateStatus.SURVIVOR
+        )
+        lines.append(f"Surviving candidates: {survivors}")
+        lines.append("Next step: narrow the request with a feature_group scope, a domain, or a framework pin.")
+    elif outcome.status is ResolutionStatus.FAILED:
+        failing = ", ".join(sorted({failure.plugin.qualname for failure in outcome.failures}))
+        lines.append(f"Failing plugin: {failing}")
+        lines.append("Next step: fix or disable the failing plugin; a provider hook raised during resolution.")
+    else:
+        lines.append("Next step: check the feature name and load the providing plugin (PluginLoader.all()).")
+    return "\n".join(lines)
+
+
+def render_provider_view(outcome: ResolutionOutcome) -> str:
+    """Per-candidate provider detail: identity, verdict, and every per-framework status."""
+    lines = [f"Status: {outcome.status.value}"]
+    for candidate in outcome.candidates:
+        lines.append(f"{candidate.identity.render()}: {candidate.status.value}")
+        for evaluation in candidate.frameworks:
+            lines.append(f"  {evaluation.identity.render()}: {evaluation.status.value}")
+        for rejection in candidate.rejections:
+            lines.append(f"  rejection: {rejection.reason.value}")
+    return "\n".join(lines)
+
+
+def render_steward_view(outcome: ResolutionOutcome) -> dict[str, Any]:
+    """Audit projection: the outcome's redacted plain-data payload, fingerprint included."""
+    return outcome.to_payload()

--- a/mloda/core/resolve/render.py
+++ b/mloda/core/resolve/render.py
@@ -27,15 +27,19 @@ def render_user_view(outcome: ResolutionOutcome) -> str:
         lines.append("Next step: narrow the request with a feature_group scope, a domain, or a framework pin.")
     elif outcome.status is ResolutionStatus.FAILED:
         failing = ", ".join(sorted({failure.plugin.qualname for failure in outcome.failures}))
-        lines.append(f"Failing plugin: {failing}")
-        lines.append("Next step: fix or disable the failing plugin; a provider hook raised during resolution.")
+        if all(failure.stage == "validate_request" for failure in outcome.failures):
+            lines.append(f"Failing request validation: {failing}")
+            lines.append("Next step: fix the request; keep at most one compute framework pin per feature.")
+        else:
+            lines.append(f"Failing plugin: {failing}")
+            lines.append("Next step: fix or disable the failing plugin; a provider hook raised during resolution.")
     else:
         lines.append("Next step: check the feature name and load the providing plugin (PluginLoader.all()).")
     return "\n".join(lines)
 
 
 def render_provider_view(outcome: ResolutionOutcome) -> str:
-    """Per-candidate provider detail: identity, verdict, and every per-framework status."""
+    """Per-candidate provider detail: identity, verdict, per-framework status, and failure metadata."""
     lines = [f"Status: {outcome.status.value}"]
     for candidate in outcome.candidates:
         lines.append(f"{candidate.identity.render()}: {candidate.status.value}")
@@ -43,6 +47,10 @@ def render_provider_view(outcome: ResolutionOutcome) -> str:
             lines.append(f"  {evaluation.identity.render()}: {evaluation.status.value}")
         for rejection in candidate.rejections:
             lines.append(f"  rejection: {rejection.reason.value}")
+        if candidate.failure is not None:
+            lines.append(f"  failure: {candidate.failure.stage} ({candidate.failure.category})")
+    for failure in outcome.failures:
+        lines.append(f"failure: {failure.plugin.render()} {failure.stage} ({failure.category})")
     return "\n".join(lines)
 
 

--- a/mloda/core/resolve/report.py
+++ b/mloda/core/resolve/report.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from mloda.core.resolve.environment import EnvironmentBuildOutcome
+from mloda.core.resolve.outcome import ResolutionOutcome
+
+
+@dataclass(frozen=True)
+class FeatureResolutionRecord:
+    """One identification of the planning pass: dependency path plus its structured outcome."""
+
+    dependency_path: tuple[str, ...]
+    outcome: ResolutionOutcome
+
+    def to_payload(self) -> dict[str, Any]:
+        return {"dependency_path": list(self.dependency_path), "outcome": self.outcome.to_payload()}
+
+
+@dataclass(frozen=True)
+class ResolutionReport:
+    """Whole-request diagnostics: the environment build plus every per-feature outcome."""
+
+    environment: EnvironmentBuildOutcome | None
+    features: tuple[FeatureResolutionRecord, ...]
+    complete: bool
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "environment": self.environment.to_payload() if self.environment is not None else None,
+            "features": [record.to_payload() for record in self.features],
+            "complete": self.complete,
+        }

--- a/mloda/core/resolve/request.py
+++ b/mloda/core/resolve/request.py
@@ -14,9 +14,11 @@ from mloda.core.resolve.identity import PluginIdentity
 
 @dataclass(frozen=True)
 class ResolutionRequestSnapshot:
-    """Immutable capture of one feature request as per-feature matching consumes it.
+    """Capture of one feature request as per-feature matching consumes it.
 
-    ``options`` is the SAME Options object as the feature: an opaque hook input the resolver never mutates.
+    The matching-decision fields and the payload are immutable captures. ``options`` (the SAME
+    Options object as the feature) and ``data_access_collection`` are retained live as opaque
+    hook inputs the resolver never mutates.
     """
 
     feature_name: str

--- a/mloda/core/resolve/request.py
+++ b/mloda/core/resolve/request.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.link import Link
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.resolve.identity import PluginIdentity
+
+
+@dataclass(frozen=True)
+class ResolutionRequestSnapshot:
+    """Immutable capture of one feature request as per-feature matching consumes it.
+
+    ``options`` is the SAME Options object as the feature: an opaque hook input the resolver never mutates.
+    """
+
+    feature_name: str
+    domain: str | None
+    feature_group_scope: str | type[FeatureGroup] | None
+    framework_pin: str | None
+    pinned_frameworks: tuple[type[ComputeFramework], ...]
+    group_option_keys: frozenset[str]
+    context_option_keys: frozenset[str]
+    inherited_group_keys: frozenset[str]
+    dependency_path: tuple[str, ...]
+    links: tuple[Link, ...]
+    data_access_collection: DataAccessCollection | None
+    options: Options
+
+    @classmethod
+    def from_feature(
+        cls,
+        feature: Feature,
+        links: set[Link] | frozenset[Link] | None = None,
+        data_access_collection: DataAccessCollection | None = None,
+        dependency_path: tuple[str, ...] = (),
+    ) -> ResolutionRequestSnapshot:
+        """Capture the matching-relevant request fields of ``feature`` at call time."""
+        pinned: tuple[type[ComputeFramework], ...] = ()
+        if feature.compute_frameworks:
+            pinned = tuple(sorted(feature.compute_frameworks, key=PluginIdentity.from_class))
+        return cls(
+            feature_name=str(feature.name),
+            domain=feature.domain.name if feature.domain is not None else None,
+            feature_group_scope=feature.feature_group_scope,
+            framework_pin=pinned[0].__name__ if len(pinned) == 1 else None,
+            pinned_frameworks=pinned,
+            group_option_keys=frozenset(feature.options.group),
+            context_option_keys=frozenset(feature.options.context),
+            inherited_group_keys=feature.options.inherited_group_keys,
+            dependency_path=tuple(dependency_path),
+            links=tuple(links) if links else (),
+            data_access_collection=data_access_collection,
+            options=feature.options,
+        )
+
+    def to_payload(self) -> dict[str, Any]:
+        """Plain JSON data: option KEYS only, link count only; values, Options, and the collection are redacted."""
+        scope = self.feature_group_scope
+        scope_payload = scope if scope is None or isinstance(scope, str) else PluginIdentity.from_class(scope).render()
+        return {
+            "feature_name": self.feature_name,
+            "domain": self.domain,
+            "feature_group_scope": scope_payload,
+            "framework_pin": self.framework_pin,
+            "group_option_keys": sorted(self.group_option_keys),
+            "context_option_keys": sorted(self.context_option_keys),
+            "inherited_group_keys": sorted(self.inherited_group_keys),
+            "dependency_path": list(self.dependency_path),
+            "links": len(self.links),
+        }

--- a/mloda/core/resolve/resolver.py
+++ b/mloda/core/resolve/resolver.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass, field
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import PropertyValueRejection
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.link import Link
-from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import strict_mode_from_env
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
@@ -55,11 +54,15 @@ def matches_feature_group_scope(feature_group: type[FeatureGroup], scope: str | 
     )
 
 
-def snapshot_from_mapping(mapping: FeatureGroupEnvironmentMapping) -> ResolutionEnvironmentSnapshot:
+def snapshot_from_mapping(
+    mapping: FeatureGroupEnvironmentMapping, strict_mode: str = "off"
+) -> ResolutionEnvironmentSnapshot:
     """Accessible-only snapshot over an engine mapping.
 
     Enabled and requested frameworks are the union of the mapping's framework sets; every
     record carries ACCESSIBLE provenance because the engine mapping only holds survivors.
+    ``strict_mode`` is caller-provided metadata; the mapping already encodes the survivors
+    of any strict filtering, so the snapshot never re-reads run configuration from the env.
     """
     accessible_entries: list[tuple[type[FeatureGroup], tuple[type[ComputeFramework], ...]]] = []
     records: list[FeatureGroupRecord] = []
@@ -82,7 +85,6 @@ def snapshot_from_mapping(mapping: FeatureGroupEnvironmentMapping) -> Resolution
             )
         )
     enabled = tuple(sorted(PluginIdentity.from_class(framework) for framework in framework_union))
-    strict_mode = strict_mode_from_env()
     record_tuple = tuple(records)
     return ResolutionEnvironmentSnapshot(
         records=record_tuple,
@@ -215,9 +217,14 @@ class FeatureGroupResolver:
         # reason keeps meaning "a genuine match that can never be instantiated".
         is_abstract = inspect.isabstract(feature_group)
 
-        if request.domain is not None and feature_group.get_domain().name != request.domain:
-            state.rejections.append(Rejection(RejectionReason.DOMAIN))
-            return state
+        if request.domain is not None:
+            try:
+                domain_name = feature_group.get_domain().name
+            except Exception as exc:  # Fail closed: a raising domain hook is decision-relevant.
+                return self._fail_state(state, "get_domain", exc)
+            if domain_name != request.domain:
+                state.rejections.append(Rejection(RejectionReason.DOMAIN))
+                return state
 
         try:
             matched = feature_group.match_feature_group_criteria(
@@ -228,16 +235,7 @@ class FeatureGroupResolver:
             state.rejections.append(Rejection(RejectionReason.VALUE_REJECTION, detail=str(exc)))
             return state
         except Exception as exc:  # Fail closed: any provider exception is decision-relevant.
-            failure = PluginFailure(
-                plugin=state.identity,
-                stage="match_feature_group_criteria",
-                category=type(exc).__name__,
-                message=str(exc),
-            )
-            state.status = CandidateStatus.FAILED
-            state.failure = failure
-            state.failures = (failure,)
-            return state
+            return self._fail_state(state, "match_feature_group_criteria", exc)
         if not matched:
             state.rejections.append(Rejection(RejectionReason.CRITERIA))
             return state
@@ -269,15 +267,19 @@ class FeatureGroupResolver:
                 state.rejections.append(Rejection(RejectionReason.FRAMEWORK_PIN))
                 return state
 
-        if not self._supports_request_links(feature_group, request.links):
+        links_supported, link_failure = self._supports_request_links(feature_group, request.links, state.identity)
+        if link_failure is not None:
+            state.frameworks = tuple(evaluations)
+            return self._record_failure(state, link_failure)
+        if not links_supported:
             # Capability is never consulted for a link-rejected candidate; the surviving
-            # frameworks were accessible and pin-compatible, which SUPPORTED records here.
+            # frameworks carry NOT_EVALUATED because they never reached that evaluation.
             for framework in remaining:
                 evaluations.append(
                     FrameworkEvaluation(
                         framework=framework,
                         identity=PluginIdentity.from_class(framework),
-                        status=FrameworkStatus.SUPPORTED,
+                        status=FrameworkStatus.NOT_EVALUATED,
                     )
                 )
             state.frameworks = tuple(evaluations)
@@ -334,17 +336,51 @@ class FeatureGroupResolver:
         state.status = CandidateStatus.SURVIVOR
         return state
 
-    def _supports_request_links(self, feature_group: type[FeatureGroup], links: tuple[Link, ...]) -> bool:
-        if feature_group.index_columns() is None:
-            return True
+    def _fail_state(self, state: _CandidateState, stage: str, exc: Exception) -> _CandidateState:
+        """Freeze a raising provider hook into the candidate's fail-closed FAILED state."""
+        failure = PluginFailure(
+            plugin=state.identity,
+            stage=stage,
+            category=type(exc).__name__,
+            message=str(exc),
+        )
+        return self._record_failure(state, failure)
+
+    def _record_failure(self, state: _CandidateState, failure: PluginFailure) -> _CandidateState:
+        state.status = CandidateStatus.FAILED
+        state.failure = failure
+        state.failures = (failure,)
+        return state
+
+    def _supports_request_links(
+        self, feature_group: type[FeatureGroup], links: tuple[Link, ...], identity: PluginIdentity
+    ) -> tuple[bool, PluginFailure | None]:
+        """Link/index compatibility verdict, plus a failure when an index hook raised.
+
+        index_columns() runs BEFORE the empty-links short-circuit on purpose: a raising
+        index declaration fails closed even for a link-less request.
+        """
+        try:
+            index_columns = feature_group.index_columns()
+        except Exception as exc:  # Fail closed: a raising index declaration is decision-relevant.
+            return False, PluginFailure(
+                plugin=identity, stage="index_columns", category=type(exc).__name__, message=str(exc)
+            )
+        if index_columns is None:
+            return True, None
         if not links:
-            return True
+            return True, None
         for link in links:
-            if feature_group.supports_index(link.left_index):
-                return True
-            if feature_group.supports_index(link.right_index):
-                return True
-        return False
+            for index in (link.left_index, link.right_index):
+                try:
+                    supported = feature_group.supports_index(index)
+                except Exception as exc:  # Fail closed: a raising index capability hook is decision-relevant.
+                    return False, PluginFailure(
+                        plugin=identity, stage="supports_index", category=type(exc).__name__, message=str(exc)
+                    )
+                if supported:
+                    return True, None
+        return False, None
 
     def _apply_shadowing(self, states: list[_CandidateState]) -> None:
         """Framework-aware subclass preference: a child shadows its parent only when both

--- a/mloda/core/resolve/resolver.py
+++ b/mloda/core/resolve/resolver.py
@@ -1,0 +1,365 @@
+from __future__ import annotations
+
+import inspect
+import logging
+from dataclasses import dataclass, field
+
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import PropertyValueRejection
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.link import Link
+from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import strict_mode_from_env
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from mloda.core.resolve.environment import (
+    EnvironmentProvenance,
+    FeatureGroupRecord,
+    FrameworkRecord,
+    ResolutionEnvironmentSnapshot,
+    _fingerprint,
+)
+from mloda.core.resolve.identity import PluginIdentity
+from mloda.core.resolve.outcome import (
+    CandidateEvaluation,
+    CandidateStatus,
+    FrameworkEvaluation,
+    FrameworkStatus,
+    PluginFailure,
+    Rejection,
+    RejectionReason,
+    ResolutionOutcome,
+    ResolutionStatus,
+    ResolvedCandidate,
+)
+from mloda.core.resolve.request import ResolutionRequestSnapshot
+
+
+logger = logging.getLogger(__name__)
+
+
+def matches_feature_group_scope(feature_group: type[FeatureGroup], scope: str | type[FeatureGroup]) -> bool:
+    """Is the candidate inside the requested scope, for both the class-object and the string form.
+
+    The string form matches the named class and its subclasses by walking the candidate's ancestry
+    (MRO), so a config that can only carry a name keeps the same subclass-preferring semantics. The
+    root FeatureGroup base is excluded from that walk because every candidate carries it, which would
+    make it a wildcard.
+    """
+    if isinstance(scope, type):
+        return issubclass(feature_group, scope)
+    # Name first: get_class_name() is @final and just returns __name__, while issubclass() on an ABCMeta
+    # class is the expensive check, so the name gate keeps it off nearly every MRO entry.
+    return any(
+        ancestor.__name__ == scope and ancestor is not FeatureGroup and issubclass(ancestor, FeatureGroup)
+        for ancestor in feature_group.__mro__
+    )
+
+
+def snapshot_from_mapping(mapping: FeatureGroupEnvironmentMapping) -> ResolutionEnvironmentSnapshot:
+    """Accessible-only snapshot over an engine mapping.
+
+    Enabled and requested frameworks are the union of the mapping's framework sets; every
+    record carries ACCESSIBLE provenance because the engine mapping only holds survivors.
+    """
+    accessible_entries: list[tuple[type[FeatureGroup], tuple[type[ComputeFramework], ...]]] = []
+    records: list[FeatureGroupRecord] = []
+    framework_union: set[type[ComputeFramework]] = set()
+    for feature_group in sorted(mapping, key=PluginIdentity.from_class):
+        frameworks = tuple(sorted(mapping[feature_group], key=PluginIdentity.from_class))
+        framework_union.update(frameworks)
+        accessible_entries.append((feature_group, frameworks))
+        records.append(
+            FeatureGroupRecord(
+                identity=PluginIdentity.from_class(feature_group),
+                provenance=EnvironmentProvenance.ACCESSIBLE,
+                frameworks=tuple(
+                    FrameworkRecord(
+                        identity=PluginIdentity.from_class(framework),
+                        provenance=EnvironmentProvenance.ACCESSIBLE,
+                    )
+                    for framework in frameworks
+                ),
+            )
+        )
+    enabled = tuple(sorted(PluginIdentity.from_class(framework) for framework in framework_union))
+    strict_mode = strict_mode_from_env()
+    record_tuple = tuple(records)
+    return ResolutionEnvironmentSnapshot(
+        records=record_tuple,
+        accessible=tuple(accessible_entries),
+        strict_mode=strict_mode,
+        requested_frameworks=enabled,
+        enabled_frameworks=enabled,
+        fingerprint=_fingerprint(strict_mode, enabled, enabled, record_tuple),
+    )
+
+
+@dataclass
+class _CandidateState:
+    """Mutable working state for one candidate; frozen into a CandidateEvaluation at the end."""
+
+    feature_group: type[FeatureGroup]
+    identity: PluginIdentity
+    status: CandidateStatus
+    frameworks: tuple[FrameworkEvaluation, ...] = ()
+    rejections: list[Rejection] = field(default_factory=list)
+    shadowed_by: PluginIdentity | None = None
+    failure: PluginFailure | None = None
+    failures: tuple[PluginFailure, ...] = ()
+
+    def supported_frameworks(self) -> tuple[type[ComputeFramework], ...]:
+        return tuple(
+            evaluation.framework for evaluation in self.frameworks if evaluation.status is FrameworkStatus.SUPPORTED
+        )
+
+    def freeze(self) -> CandidateEvaluation:
+        return CandidateEvaluation(
+            feature_group=self.feature_group,
+            identity=self.identity,
+            status=self.status,
+            frameworks=self.frameworks,
+            rejections=tuple(self.rejections),
+            shadowed_by=self.shadowed_by,
+            failure=self.failure,
+        )
+
+
+class FeatureGroupResolver:
+    """Authoritative per-feature resolution: one request against one environment snapshot.
+
+    resolve() never raises for resolution failures; provider exceptions become fail-closed
+    FAILED outcomes. Filter order follows the decided contract in
+    docs/docs/in_depth/feature-group-resolution-contract.md.
+    """
+
+    def resolve(
+        self, request: ResolutionRequestSnapshot, environment: ResolutionEnvironmentSnapshot
+    ) -> ResolutionOutcome:
+        request_failure = self._validate_request(request)
+        if request_failure is not None:
+            return ResolutionOutcome(
+                status=ResolutionStatus.FAILED,
+                winner=None,
+                candidates=(),
+                failures=(request_failure,),
+                environment_fingerprint=environment.fingerprint,
+            )
+
+        feature_name = FeatureName(request.feature_name)
+        states = [
+            self._evaluate_candidate(feature_group, frameworks, request, feature_name)
+            for feature_group, frameworks in sorted(
+                environment.accessible, key=lambda entry: PluginIdentity.from_class(entry[0])
+            )
+        ]
+
+        self._apply_shadowing(states)
+
+        failures = tuple(failure for state in states for failure in state.failures)
+        survivors = [state for state in states if state.status is CandidateStatus.SURVIVOR]
+
+        winner: ResolvedCandidate | None = None
+        if failures:
+            status = ResolutionStatus.FAILED
+        elif len(survivors) == 1:
+            status = ResolutionStatus.RESOLVED
+            winning = survivors[0]
+            winning.status = CandidateStatus.WINNER
+            winner = ResolvedCandidate(
+                feature_group=winning.feature_group,
+                identity=winning.identity,
+                compute_frameworks=winning.supported_frameworks(),
+            )
+        elif survivors:
+            status = ResolutionStatus.AMBIGUOUS
+        else:
+            status = ResolutionStatus.NOT_FOUND
+
+        return ResolutionOutcome(
+            status=status,
+            winner=winner,
+            candidates=tuple(state.freeze() for state in states),
+            failures=failures,
+            environment_fingerprint=environment.fingerprint,
+        )
+
+    def _validate_request(self, request: ResolutionRequestSnapshot) -> PluginFailure | None:
+        if len(request.pinned_frameworks) > 1:
+            return PluginFailure(
+                plugin=PluginIdentity.from_class(request.pinned_frameworks[0]),
+                stage="validate_request",
+                category="ValueError",
+                message=f"Feature should only have one compute framework when set by user {request.feature_name}.",
+            )
+        return None
+
+    def _evaluate_candidate(
+        self,
+        feature_group: type[FeatureGroup],
+        frameworks: tuple[type[ComputeFramework], ...],
+        request: ResolutionRequestSnapshot,
+        feature_name: FeatureName,
+    ) -> _CandidateState:
+        state = _CandidateState(
+            feature_group=feature_group,
+            identity=PluginIdentity.from_class(feature_group),
+            status=CandidateStatus.REJECTED,
+        )
+
+        scope = request.feature_group_scope
+        if scope is not None and not matches_feature_group_scope(feature_group, scope):
+            state.rejections.append(Rejection(RejectionReason.SCOPE))
+            return state
+
+        # Abstract classification: recorded here, rejected after criteria so the ABSTRACT
+        # reason keeps meaning "a genuine match that can never be instantiated".
+        is_abstract = inspect.isabstract(feature_group)
+
+        if request.domain is not None and feature_group.get_domain().name != request.domain:
+            state.rejections.append(Rejection(RejectionReason.DOMAIN))
+            return state
+
+        try:
+            matched = feature_group.match_feature_group_criteria(
+                feature_name, request.options, request.data_access_collection
+            )
+        except PropertyValueRejection as exc:
+            logger.debug("%s rejected an option value while matching '%s': %s", feature_group, feature_name, exc)
+            state.rejections.append(Rejection(RejectionReason.VALUE_REJECTION, detail=str(exc)))
+            return state
+        except Exception as exc:  # Fail closed: any provider exception is decision-relevant.
+            failure = PluginFailure(
+                plugin=state.identity,
+                stage="match_feature_group_criteria",
+                category=type(exc).__name__,
+                message=str(exc),
+            )
+            state.status = CandidateStatus.FAILED
+            state.failure = failure
+            state.failures = (failure,)
+            return state
+        if not matched:
+            state.rejections.append(Rejection(RejectionReason.CRITERIA))
+            return state
+
+        if is_abstract:
+            state.rejections.append(Rejection(RejectionReason.ABSTRACT))
+            return state
+
+        if not frameworks:
+            state.rejections.append(Rejection(RejectionReason.NO_ACCESSIBLE_FRAMEWORK))
+            return state
+
+        remaining = list(frameworks)
+        evaluations: list[FrameworkEvaluation] = []
+        if request.pinned_frameworks:
+            pinned = request.pinned_frameworks
+            for framework in frameworks:
+                if framework not in pinned:
+                    evaluations.append(
+                        FrameworkEvaluation(
+                            framework=framework,
+                            identity=PluginIdentity.from_class(framework),
+                            status=FrameworkStatus.PIN_EXCLUDED,
+                        )
+                    )
+            remaining = [framework for framework in frameworks if framework in pinned]
+            if not remaining:
+                state.frameworks = tuple(evaluations)
+                state.rejections.append(Rejection(RejectionReason.FRAMEWORK_PIN))
+                return state
+
+        if not self._supports_request_links(feature_group, request.links):
+            # Capability is never consulted for a link-rejected candidate; the surviving
+            # frameworks were accessible and pin-compatible, which SUPPORTED records here.
+            for framework in remaining:
+                evaluations.append(
+                    FrameworkEvaluation(
+                        framework=framework,
+                        identity=PluginIdentity.from_class(framework),
+                        status=FrameworkStatus.SUPPORTED,
+                    )
+                )
+            state.frameworks = tuple(evaluations)
+            state.rejections.append(Rejection(RejectionReason.LINK_INDEX))
+            return state
+
+        failures: list[PluginFailure] = []
+        supported = False
+        for framework in remaining:
+            framework_identity = PluginIdentity.from_class(framework)
+            try:
+                accepts = feature_group.supports_compute_framework(feature_name, request.options, framework)
+            except Exception as exc:  # Fail closed: a raising capability hook is decision-relevant.
+                failure = PluginFailure(
+                    plugin=state.identity,
+                    stage="supports_compute_framework",
+                    category=type(exc).__name__,
+                    message=str(exc),
+                )
+                failures.append(failure)
+                evaluations.append(
+                    FrameworkEvaluation(
+                        framework=framework,
+                        identity=framework_identity,
+                        status=FrameworkStatus.HOOK_FAILED,
+                        failure=failure,
+                    )
+                )
+                continue
+            if accepts:
+                supported = True
+                evaluations.append(
+                    FrameworkEvaluation(
+                        framework=framework, identity=framework_identity, status=FrameworkStatus.SUPPORTED
+                    )
+                )
+            else:
+                evaluations.append(
+                    FrameworkEvaluation(
+                        framework=framework, identity=framework_identity, status=FrameworkStatus.CAPABILITY_REJECTED
+                    )
+                )
+
+        state.frameworks = tuple(evaluations)
+        if failures:
+            state.status = CandidateStatus.FAILED
+            state.failure = failures[0]
+            state.failures = tuple(failures)
+            return state
+        if not supported:
+            state.rejections.append(Rejection(RejectionReason.CAPABILITY))
+            return state
+
+        state.status = CandidateStatus.SURVIVOR
+        return state
+
+    def _supports_request_links(self, feature_group: type[FeatureGroup], links: tuple[Link, ...]) -> bool:
+        if feature_group.index_columns() is None:
+            return True
+        if not links:
+            return True
+        for link in links:
+            if feature_group.supports_index(link.left_index):
+                return True
+            if feature_group.supports_index(link.right_index):
+                return True
+        return False
+
+    def _apply_shadowing(self, states: list[_CandidateState]) -> None:
+        """Framework-aware subclass preference: a child shadows its parent only when both
+        survived every filter and their supported framework sets are equal."""
+        survivors = [state for state in states if state.status is CandidateStatus.SURVIVOR]
+        for parent in survivors:
+            parent_supported = set(parent.supported_frameworks())
+            for child in survivors:
+                if child is parent:
+                    continue
+                if not issubclass(child.feature_group, parent.feature_group):
+                    continue
+                if set(child.supported_frameworks()) != parent_supported:
+                    continue
+                parent.status = CandidateStatus.SHADOWED
+                parent.shadowed_by = child.identity
+                parent.rejections.append(Rejection(RejectionReason.SUBCLASS_SHADOWED))
+                break

--- a/mloda/core/resolve/resolver.py
+++ b/mloda/core/resolve/resolver.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import PropertyValueRejection
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.link import Link
+from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
@@ -52,6 +53,31 @@ def matches_feature_group_scope(feature_group: type[FeatureGroup], scope: str | 
         ancestor.__name__ == scope and ancestor is not FeatureGroup and issubclass(ancestor, FeatureGroup)
         for ancestor in feature_group.__mro__
     )
+
+
+def matching_conflict_candidates(
+    conflicts: list[type[FeatureGroup]],
+    feature_name: FeatureName,
+    options: Options,
+    scope: str | type[FeatureGroup] | None,
+) -> list[type[FeatureGroup]]:
+    """Scope- and criteria-matched candidates among redefinition-conflicting classes.
+
+    Serves the non-throwing debug projection of a redefinition conflict: matching can raise
+    ValueError once caller options reach the feature chain parser, and such a candidate is
+    simply not a match.
+    """
+    matched: list[type[FeatureGroup]] = []
+    for feature_group in conflicts:
+        if scope is not None and not matches_feature_group_scope(feature_group, scope):
+            continue
+        try:
+            is_match = feature_group.match_feature_group_criteria(feature_name, options, None)
+        except ValueError:
+            continue
+        if is_match:
+            matched.append(feature_group)
+    return matched
 
 
 def snapshot_from_mapping(

--- a/tests/test_core/test_api/test_sbdg_resolve_feature_broken_rule.py
+++ b/tests/test_core/test_api/test_sbdg_resolve_feature_broken_rule.py
@@ -1,17 +1,16 @@
-"""Failing test pinning resolve_feature's never-raises contract against a broken
-compute_framework_definition (sbdg defect 1).
+"""Target-contract tests for resolve_feature against a broken compute_framework_rule
+(issue #722 Stage 3b).
 
-The capability split in mloda/core/api/plugin_docs.py (around lines 411-425) is
-safe_field-guarded, but the open-degrade fallback then calls
-candidate.compute_framework_definition() UNGUARDED. A FeatureGroup whose
-compute_framework_rule() raises therefore fails the split (degrading it to None),
-and the fallback re-raises the very exception the guard just swallowed.
-
-Expected failure today: resolve_feature propagates RuntimeError("sbdg rule exploded")
-instead of returning a ResolvedFeature.
+The rewired resolve_feature shares the engine's standalone environment build
+(build_resolution_environment). A FeatureGroup whose compute_framework_rule() raises
+fails that build with an invalid-declaration error, exactly like the same declaration
+kills every engine run today. resolve_feature stays never-raising: the environment
+error is returned as ResolvedFeature.error with feature_group=None instead of the old
+open-degraded resolution that named the broken class as the winner.
 
 The broken class is scoped per test (del + gc.collect(), same pattern as
-test_plugin_docs.py) so it does not leak into the session-wide subclass registry.
+test_plugin_docs.py) so it does not leak into the session-wide subclass registry and
+poison other standalone environment builds.
 """
 
 import gc
@@ -56,7 +55,7 @@ def _make_broken_rule_fg() -> type[FeatureGroup]:
 
 
 class TestSbdgResolveFeatureBrokenRule:
-    """resolve_feature never raises, even when the open-degrade fallback path is hit."""
+    """resolve_feature never raises; a broken declaration fails the environment build instead."""
 
     def test_resolve_feature_does_not_propagate_the_rule_exception(self) -> None:
         broken_fg = _make_broken_rule_fg()
@@ -68,14 +67,18 @@ class TestSbdgResolveFeatureBrokenRule:
             del broken_fg
             gc.collect()
 
-    def test_degenerate_resolution_still_names_the_matching_group(self) -> None:
+    def test_broken_rule_fails_the_environment_build_with_an_error(self) -> None:
         broken_fg = _make_broken_rule_fg()
         try:
             result = resolve_feature(SBDG_BROKEN_RULE_FEATURE)
             assert result.feature_name == SBDG_BROKEN_RULE_FEATURE
-            assert broken_fg in result.candidates
-            # Degenerate path: capability info may be empty, but the resolution itself survives.
-            assert result.feature_group is broken_fg
+            # TARGET CONTRACT: the invalid declaration fails the standalone environment build,
+            # so there is no winner and no fabricated candidate list; the error carries the
+            # original declaration failure message.
+            assert result.feature_group is None
+            assert result.error is not None
+            assert "sbdg rule exploded" in result.error
+            assert result.candidates == []
             del result
         finally:
             del broken_fg

--- a/tests/test_core/test_api/test_subtype_docs_degradation.py
+++ b/tests/test_core/test_api/test_subtype_docs_degradation.py
@@ -1,14 +1,12 @@
-"""Failing tests pinning louder degradation of the subtype surfaces (issue #639 follow-up).
+"""Target-contract tests for the failure surfaces of the subtype personas (issue #722 Stage 3b).
 
-Pins: a raising supports_compute_framework override degrades the resolve_feature
-capability split OPEN (all declared frameworks supported) with a warning, and a
-bogus 'supported' framework name surfaces as subtype_error in the docs.
+Pins: a raising supports_compute_framework override is a fail-closed provider failure in
+the rewired resolve_feature (feature_group=None, error names the plugin and carries the
+original hook message; no open-degrade), and a bogus 'supported' framework name surfaces
+as subtype_error in the docs.
 """
 
-import logging
 from typing import Optional
-
-import pytest
 
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.feature import Feature
@@ -85,22 +83,25 @@ def _sbfix_doc_for(name: str) -> FeatureGroupInfo:
     return exact[0]
 
 
-class TestSbfixRaisingHookDegradesOpen:
-    """A raising capability hook degrades the split OPEN, not empty, and warns."""
+class TestSbfixRaisingHookFailsClosed:
+    """A raising capability hook is a fail-closed provider failure, never an open-degrade."""
 
-    def test_resolves_with_all_declared_frameworks_supported(self) -> None:
+    def test_fails_closed_with_provider_error(self) -> None:
         result = resolve_feature(SBFIX_HOOK_FEATURE)
-        assert result.feature_group is SbfixRaisingHookFG
-        assert result.error is None
-        assert result.supported_compute_frameworks == ["PythonDictFramework"]
-        assert result.unsupported_compute_frameworks == []
+        # TARGET CONTRACT (#722 Stage 3b): the broken hook makes resolution FAIL instead of
+        # reading as runnable everywhere; the matching candidate stays visible.
+        assert result.feature_group is None
+        assert result.error is not None
+        assert "sbfix hook exploded" in result.error
+        assert "SbfixRaisingHookFG" in result.error
+        assert SbfixRaisingHookFG in result.candidates
 
-    def test_degradation_is_logged_as_warning(self, caplog: pytest.LogCaptureFixture) -> None:
-        with caplog.at_level(logging.WARNING):
-            result = resolve_feature(SBFIX_HOOK_FEATURE)
-        assert result.feature_group is SbfixRaisingHookFG
-        assert "degraded" in caplog.text.lower()
-        assert "sbfix hook exploded" in caplog.text
+    def test_failure_reports_no_fabricated_capability_split(self) -> None:
+        result = resolve_feature(SBFIX_HOOK_FEATURE)
+        # TARGET CONTRACT (#722 Stage 3b): no framework is claimed as supported when the
+        # capability hook itself failed; resolve_feature still never raises.
+        assert result.feature_group is None
+        assert result.supported_compute_frameworks == []
 
 
 class TestSbfixBogusSupportedSurfacedInDocs:

--- a/tests/test_core/test_prepare/test_identify_feature_group_error_message.py
+++ b/tests/test_core/test_prepare/test_identify_feature_group_error_message.py
@@ -22,6 +22,8 @@ from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
 from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+from mloda.core.resolve.identity import PluginIdentity
+from mloda.core.resolve.outcome import CandidateStatus, FeatureResolutionError, RejectionReason
 
 
 class MockComputeFramework(ComputeFramework):
@@ -382,129 +384,57 @@ class NoComputeFrameworkFeatureGroup(FeatureGroup):
 
 
 class TestNoComputeFrameworkErrorMessageFormat:
-    """Tests for the error message format when a feature group has no compute framework.
+    """Tests for the failure shape when a matched feature group has no compute framework.
 
-    The 'no compute framework' error is raised in the validate() method when a
-    single feature group is found but its compute_frameworks set is empty.
-
-    We use unittest.mock to patch the _filter_loop method to return a feature
-    group with empty compute_frameworks, since the normal filtering logic
-    excludes feature groups with no frameworks.
+    The old dedicated 'has no compute framework' ValueError lived in a validate()
+    branch that was only reachable by mocking the internal _filter_loop method.
+    The authoritative resolver (issue #722 Stage 3a) rejects such a candidate
+    structurally instead: the candidate is visible in the outcome as REJECTED with
+    NO_ACCESSIBLE_FRAMEWORK, and the raised error is the regular no-match message.
     """
 
-    def test_no_compute_framework_error_contains_module_path(self) -> None:
-        """Test that the 'no compute framework' error includes module path.
-
-        The error message should contain the module path in parentheses like:
-          NoComputeFrameworkFeatureGroup (tests.test_core.test_prepare.test_identify_feature_group_error_message)
-        """
-        from unittest.mock import patch
-
+    def _raise_for_empty_framework_set(self) -> FeatureResolutionError:
         feature = Feature("no_compute_framework_test_feature")
 
         accessible_plugins: FeatureGroupEnvironmentMapping = {
-            NoComputeFrameworkFeatureGroup: {MockComputeFramework},
+            NoComputeFrameworkFeatureGroup: set(),
         }
 
-        def mock_filter_loop(
-            self: IdentifyFeatureGroupClass, *args: object, **kwargs: object
-        ) -> FeatureGroupEnvironmentMapping:
-            return {NoComputeFrameworkFeatureGroup: set()}
+        with pytest.raises(FeatureResolutionError) as exc_info:
+            IdentifyFeatureGroupClass(
+                feature=feature,
+                accessible_plugins=accessible_plugins,
+                links=None,
+                data_access_collection=None,
+            )
+        return exc_info.value
 
-        with patch.object(IdentifyFeatureGroupClass, "_filter_loop", mock_filter_loop):
-            with pytest.raises(ValueError) as exc_info:
-                IdentifyFeatureGroupClass(
-                    feature=feature,
-                    accessible_plugins=accessible_plugins,
-                    links=None,
-                    data_access_collection=None,
-                )
+    def test_empty_framework_set_raises_no_match_error(self) -> None:
+        """An empty framework set surfaces through the regular no-match error."""
+        error = self._raise_for_empty_framework_set()
 
-        error_message = str(exc_info.value)
+        assert "No feature groups found" in str(error)
 
-        assert "no compute framework" in error_message.lower(), (
-            f"Error should be about 'no compute framework', but got: {error_message}"
+    def test_empty_framework_set_is_structured_rejection(self) -> None:
+        """The candidate stays visible as REJECTED with NO_ACCESSIBLE_FRAMEWORK."""
+        error = self._raise_for_empty_framework_set()
+
+        identity = PluginIdentity.from_class(NoComputeFrameworkFeatureGroup)
+        matches = [candidate for candidate in error.outcome.candidates if candidate.identity == identity]
+        assert len(matches) == 1
+        candidate = matches[0]
+        assert candidate.status is CandidateStatus.REJECTED
+        assert RejectionReason.NO_ACCESSIBLE_FRAMEWORK in {rejection.reason for rejection in candidate.rejections}
+
+    def test_empty_framework_set_candidate_identity_names_class_and_module(self) -> None:
+        """The structured record carries the class name and module path the old text carried."""
+        error = self._raise_for_empty_framework_set()
+
+        rendered = [candidate.identity.render() for candidate in error.outcome.candidates]
+        expected = (
+            "tests.test_core.test_prepare.test_identify_feature_group_error_message:NoComputeFrameworkFeatureGroup"
         )
-        assert "(tests.test_core.test_prepare.test_identify_feature_group_error_message)" in error_message, (
-            f"Error message should contain module path in parentheses, but got: {error_message}"
-        )
-
-    def test_no_compute_framework_error_contains_class_name(self) -> None:
-        """Test that the 'no compute framework' error includes the class name.
-
-        The error message should contain the class name.
-        """
-        from unittest.mock import patch
-
-        feature = Feature("no_compute_framework_test_feature")
-
-        accessible_plugins: FeatureGroupEnvironmentMapping = {
-            NoComputeFrameworkFeatureGroup: {MockComputeFramework},
-        }
-
-        def mock_filter_loop(
-            self: IdentifyFeatureGroupClass, *args: object, **kwargs: object
-        ) -> FeatureGroupEnvironmentMapping:
-            return {NoComputeFrameworkFeatureGroup: set()}
-
-        with patch.object(IdentifyFeatureGroupClass, "_filter_loop", mock_filter_loop):
-            with pytest.raises(ValueError) as exc_info:
-                IdentifyFeatureGroupClass(
-                    feature=feature,
-                    accessible_plugins=accessible_plugins,
-                    links=None,
-                    data_access_collection=None,
-                )
-
-        error_message = str(exc_info.value)
-
-        assert "no compute framework" in error_message.lower(), (
-            f"Error should be about 'no compute framework', but got: {error_message}"
-        )
-        assert "NoComputeFrameworkFeatureGroup" in error_message, (
-            f"Error message should contain class name 'NoComputeFrameworkFeatureGroup', but got: {error_message}"
-        )
-
-    def test_no_compute_framework_error_uses_formatted_pattern(self) -> None:
-        """Test that the error uses the 'ClassName (module.path)' format.
-
-        The error should use format_feature_group_class() which returns:
-          ClassName (module.path)
-        """
-        from unittest.mock import patch
-
-        feature = Feature("no_compute_framework_test_feature")
-
-        accessible_plugins: FeatureGroupEnvironmentMapping = {
-            NoComputeFrameworkFeatureGroup: {MockComputeFramework},
-        }
-
-        def mock_filter_loop(
-            self: IdentifyFeatureGroupClass, *args: object, **kwargs: object
-        ) -> FeatureGroupEnvironmentMapping:
-            return {NoComputeFrameworkFeatureGroup: set()}
-
-        with patch.object(IdentifyFeatureGroupClass, "_filter_loop", mock_filter_loop):
-            with pytest.raises(ValueError) as exc_info:
-                IdentifyFeatureGroupClass(
-                    feature=feature,
-                    accessible_plugins=accessible_plugins,
-                    links=None,
-                    data_access_collection=None,
-                )
-
-        error_message = str(exc_info.value)
-
-        assert "no compute framework" in error_message.lower(), (
-            f"Error should be about 'no compute framework', but got: {error_message}"
-        )
-
-        expected_pattern = (
-            "NoComputeFrameworkFeatureGroup (tests.test_core.test_prepare.test_identify_feature_group_error_message)"
-        )
-        assert expected_pattern in error_message, (
-            f"Error message should contain formatted class '{expected_pattern}', but got: {error_message}"
-        )
+        assert expected in rendered
 
 
 class KnowledgeGraphLikeFeatureGroup(FeatureGroup):

--- a/tests/test_core/test_resolution_parity/test_parity_candidate_filters.py
+++ b/tests/test_core/test_resolution_parity/test_parity_candidate_filters.py
@@ -1,25 +1,26 @@
-"""Paired engine/diagnostic characterization tests for issue #722 Stage 1.
+"""Paired engine/diagnostic tests for issue #722, flipped to the Stage 3b target contract.
 
 Each covered divergence between the engine path (IdentifyFeatureGroupClass) and the
-diagnostic path (resolve_feature) is pinned by a pair of tests sharing one probe family.
-Assertions marked "PINS CURRENT DIVERGENCE" pin behavior that Stage 3 will change;
-assertions marked "TARGET CONTRACT" already express the final contract.
+diagnostic path (resolve_feature) is covered by a pair of tests sharing one probe family.
+Stage 3b rewires resolve_feature onto the same FeatureGroupResolver as the engine, so the
+debug-side tests below now assert the TARGET CONTRACT and FAIL until that rewire lands.
+Where a difference legitimately remains it is marked as presentation-only or Stage 4.
 
 Index (divergence -> tests):
 - #1  lone abstract match:
-      test_engine_rejects_lone_abstract_match / test_resolve_feature_returns_lone_abstract_match
+      test_engine_rejects_lone_abstract_match / test_resolve_feature_rejects_lone_abstract_match
 - #3  framework attribution:
       test_engine_parent_child_differing_framework_sets_stays_ambiguous /
-      test_resolve_feature_parent_child_unions_framework_attribution
+      test_resolve_feature_parent_child_attributes_no_union_framework_set
 - #4  subclass collapse:
       test_engine_parent_child_differing_framework_sets_stays_ambiguous /
-      test_resolve_feature_parent_child_collapses_by_subclass; parity case:
+      test_resolve_feature_parent_child_differing_framework_sets_is_ambiguous; parity case:
       test_engine_prefers_child_when_framework_sets_are_identical /
       test_resolve_feature_prefers_child_when_framework_sets_are_identical
 - #16 raising capability hook:
       test_engine_propagates_capability_hook_runtime_error /
-      test_resolve_feature_degrades_capability_hook_error_open
-- #17 PropertyValueRejection visibility:
+      test_resolve_feature_fails_closed_on_capability_hook_error
+- #17 PropertyValueRejection visibility (presentation-only difference):
       test_property_value_rejection_is_a_value_error (premise),
       test_engine_swallows_property_value_rejection_silently /
       test_resolve_feature_surfaces_property_value_rejection
@@ -237,16 +238,18 @@ def test_engine_rejects_lone_abstract_match() -> None:
     assert "Only abstract feature group base(s) matched" in str(exc_info.value)
 
 
-def test_resolve_feature_returns_lone_abstract_match() -> None:
-    """resolve_feature resolves the same lone abstract base cleanly."""
+def test_resolve_feature_rejects_lone_abstract_match() -> None:
+    """resolve_feature refuses the same lone abstract base and says why."""
     assert inspect.isabstract(AbstractOnlyProbe722A), "fixture must be abstract"
 
     collector = PluginCollector.enabled_feature_groups({AbstractOnlyProbe722A})
     result = resolve_feature(ABSTRACT_ONLY_FEATURE, plugin_collector=collector)
 
-    # PINS CURRENT DIVERGENCE (#1): the uninstantiable abstract base wins; target is no abstract winner.
-    assert result.feature_group is AbstractOnlyProbe722A
-    assert result.error is None
+    # TARGET CONTRACT (#1): an abstract base never wins on either path; the error mentions that
+    # only abstract base(s) matched while the rejected candidate stays visible in candidates.
+    assert result.feature_group is None
+    assert result.error is not None
+    assert "abstract" in result.error.lower()
     assert result.candidates == [AbstractOnlyProbe722A]
 
 
@@ -275,28 +278,32 @@ def test_engine_parent_child_differing_framework_sets_stays_ambiguous() -> None:
     assert "ChildProbe722A" in message
 
 
-def test_resolve_feature_parent_child_collapses_by_subclass() -> None:
-    """resolve_feature collapses the same parent/child pair the engine calls ambiguous."""
+def test_resolve_feature_parent_child_differing_framework_sets_is_ambiguous() -> None:
+    """resolve_feature reports the same parent/child pair ambiguous, exactly like the engine."""
     collector = PluginCollector.enabled_feature_groups({ParentProbe722A, ChildProbe722A})
     result = resolve_feature(PARENT_CHILD_FEATURE, plugin_collector=collector)
 
-    # PINS CURRENT DIVERGENCE (#4): _filter_subclasses collapses purely by issubclass; the engine stays ambiguous.
-    assert result.feature_group is ChildProbe722A
-    assert result.error is None
+    # TARGET CONTRACT (#4): framework-aware shadowing only collapses equal supported sets, so
+    # the differing-set pair stays ambiguous on both paths; no pure-issubclass collapse.
+    assert result.feature_group is None
+    assert result.error is not None
+    assert "Multiple FeatureGroups match" in result.error
+    assert "ParentProbe722A" in result.error
+    assert "ChildProbe722A" in result.error
     assert set(result.candidates) == {ParentProbe722A, ChildProbe722A}
 
 
-def test_resolve_feature_parent_child_unions_framework_attribution() -> None:
-    """resolve_feature attributes the parent-only framework to the child winner."""
+def test_resolve_feature_parent_child_attributes_no_union_framework_set() -> None:
+    """resolve_feature no longer credits anyone with the union of all candidates' frameworks."""
     collector = PluginCollector.enabled_feature_groups({ParentProbe722A, ChildProbe722A})
     result = resolve_feature(PARENT_CHILD_FEATURE, plugin_collector=collector)
 
-    assert result.feature_group is ChildProbe722A
-    # PINS CURRENT DIVERGENCE (#3): the capability split is unioned across ALL candidates, so
-    # CfwQ722A is reported as supported although the winner ChildProbe722A never declares it.
-    assert CfwP722A.get_class_name() in result.supported_compute_frameworks
-    assert CfwQ722A.get_class_name() in result.supported_compute_frameworks
-    assert result.unsupported_compute_frameworks == []
+    # TARGET CONTRACT (#3): framework attribution is per-winner only. The differing-set pair has
+    # no winner (see divergence #4 above), so no candidate is credited with CfwQ722A here; the
+    # positive per-winner pin lives in tests/test_core/test_resolve/test_resolve_feature_rewire.py
+    # (probe722g_attribution).
+    assert result.feature_group is None
+    assert result.error is not None
 
 
 # ---------------------------------------------------------------------------
@@ -341,15 +348,15 @@ def test_resolve_feature_prefers_child_when_framework_sets_are_identical() -> No
 
 
 def test_engine_propagates_capability_hook_runtime_error() -> None:
-    """A raising capability hook aborts the engine with the raw provider error."""
+    """A raising capability hook fails the engine closed with a structured ValueError."""
     feature = Feature(CAPABILITY_RAISES_FEATURE)
     accessible_plugins: FeatureGroupEnvironmentMapping = {
         CapabilityRaisesProbe722A: {CfwCapOne722A, CfwCapTwo722A},
     }
 
-    # PINS CURRENT DIVERGENCE (#16): the raw RuntimeError propagates and aborts the run;
-    # target is a fail-closed structured provider failure.
-    with pytest.raises(RuntimeError, match=CAPABILITY_ERROR_TEXT):
+    # TARGET CONTRACT (#16 engine side): provider failure is fail-closed and structured,
+    # no longer a raw propagated RuntimeError; FeatureResolutionError is a ValueError.
+    with pytest.raises(ValueError, match=CAPABILITY_ERROR_TEXT):
         IdentifyFeatureGroupClass(
             feature=feature,
             accessible_plugins=accessible_plugins,
@@ -358,20 +365,20 @@ def test_engine_propagates_capability_hook_runtime_error() -> None:
         )
 
 
-def test_resolve_feature_degrades_capability_hook_error_open() -> None:
-    """resolve_feature degrades the same raising hook OPEN and reports a clean resolution."""
+def test_resolve_feature_fails_closed_on_capability_hook_error() -> None:
+    """resolve_feature fails the same raising hook closed with the provider's message."""
     collector = PluginCollector.enabled_feature_groups({CapabilityRaisesProbe722A})
     result = resolve_feature(CAPABILITY_RAISES_FEATURE, plugin_collector=collector)
 
-    # PINS CURRENT DIVERGENCE (#16): safe_field degrades the capability split open, so the broken
-    # declaration reads as runnable everywhere; target is a fail-closed structured provider failure.
-    assert result.feature_group is CapabilityRaisesProbe722A
-    assert result.error is None
-    assert set(result.supported_compute_frameworks) == {
-        CfwCapOne722A.get_class_name(),
-        CfwCapTwo722A.get_class_name(),
-    }
-    assert result.unsupported_compute_frameworks == []
+    # TARGET CONTRACT (#16): a raising capability hook is a fail-closed provider failure on both
+    # paths; no open-degrade, no fabricated runnable-everywhere claim. The error names the
+    # failing plugin and carries the original provider message.
+    assert result.feature_group is None
+    assert result.error is not None
+    assert CAPABILITY_ERROR_TEXT in result.error
+    assert "CapabilityRaisesProbe722A" in result.error
+    assert result.supported_compute_frameworks == []
+    assert CapabilityRaisesProbe722A in result.candidates
 
 
 # ---------------------------------------------------------------------------
@@ -397,7 +404,8 @@ def test_engine_swallows_property_value_rejection_silently() -> None:
             data_access_collection=None,
         )
     message = str(exc_info.value)
-    # PINS CURRENT DIVERGENCE (#17): the rejection reason is invisible on the engine path.
+    # PRESENTATION-ONLY DIFFERENCE (#17): both paths consume the same VALUE_REJECTION outcome;
+    # the engine's error renderer omits the rejection detail while the debug renderer surfaces it.
     assert PROPERTY_REJECTION_TEXT not in message
 
 
@@ -409,6 +417,7 @@ def test_resolve_feature_surfaces_property_value_rejection() -> None:
     assert result.feature_group is None
     assert result.candidates == []
     assert result.error is not None
-    # PINS CURRENT DIVERGENCE (#17): the same rejection is an error string on the diagnostic path.
+    # PRESENTATION-ONLY DIFFERENCE (#17): both paths consume the same VALUE_REJECTION outcome;
+    # the debug renderer keeps surfacing the rejection detail the engine renderer omits.
     assert PROPERTY_REJECTION_TEXT in result.error
     assert "Rejected during matching" in result.error

--- a/tests/test_core/test_resolution_parity/test_parity_candidate_filters.py
+++ b/tests/test_core/test_resolution_parity/test_parity_candidate_filters.py
@@ -1,0 +1,414 @@
+"""Paired engine/diagnostic characterization tests for issue #722 Stage 1.
+
+Each covered divergence between the engine path (IdentifyFeatureGroupClass) and the
+diagnostic path (resolve_feature) is pinned by a pair of tests sharing one probe family.
+Assertions marked "PINS CURRENT DIVERGENCE" pin behavior that Stage 3 will change;
+assertions marked "TARGET CONTRACT" already express the final contract.
+
+Index (divergence -> tests):
+- #1  lone abstract match:
+      test_engine_rejects_lone_abstract_match / test_resolve_feature_returns_lone_abstract_match
+- #3  framework attribution:
+      test_engine_parent_child_differing_framework_sets_stays_ambiguous /
+      test_resolve_feature_parent_child_unions_framework_attribution
+- #4  subclass collapse:
+      test_engine_parent_child_differing_framework_sets_stays_ambiguous /
+      test_resolve_feature_parent_child_collapses_by_subclass; parity case:
+      test_engine_prefers_child_when_framework_sets_are_identical /
+      test_resolve_feature_prefers_child_when_framework_sets_are_identical
+- #16 raising capability hook:
+      test_engine_propagates_capability_hook_runtime_error /
+      test_resolve_feature_degrades_capability_hook_error_open
+- #17 PropertyValueRejection visibility:
+      test_property_value_rejection_is_a_value_error (premise),
+      test_engine_swallows_property_value_rejection_silently /
+      test_resolve_feature_surfaces_property_value_rejection
+"""
+
+import inspect
+from abc import abstractmethod
+from typing import Optional
+
+import pytest
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import PropertyValueRejection
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.api.plugin_docs import resolve_feature
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+from mloda.user import PluginCollector
+
+
+ABSTRACT_ONLY_FEATURE = "probe722a_abstract_only"
+PARENT_CHILD_FEATURE = "probe722a_parent_child"
+SAME_FW_FEATURE = "probe722a_same_fw_family"
+CAPABILITY_RAISES_FEATURE = "probe722a_capability_raises"
+PROPERTY_REJECTION_FEATURE = "probe722a_property_rejection"
+
+CAPABILITY_ERROR_TEXT = "broken capability 722a"
+PROPERTY_REJECTION_TEXT = "rejected value 722a: probe option out of range"
+
+
+class CfwAbstract722A(ComputeFramework):
+    """Framework declared by the abstract-only probe."""
+
+
+class CfwP722A(ComputeFramework):
+    """First framework of the parent/child family; declared by parent and child."""
+
+
+class CfwQ722A(ComputeFramework):
+    """Second framework of the parent/child family; declared by the parent only."""
+
+
+class CfwSame722A(ComputeFramework):
+    """Shared framework of the identical-set parity family."""
+
+
+class CfwCapOne722A(ComputeFramework):
+    """First framework declared by the raising-capability probe."""
+
+
+class CfwCapTwo722A(ComputeFramework):
+    """Second framework declared by the raising-capability probe."""
+
+
+class CfwReject722A(ComputeFramework):
+    """Framework declared by the property-rejection probe."""
+
+
+class AbstractOnlyProbe722A(FeatureGroup):
+    """Abstract probe: matches only its own feature name and cannot be instantiated."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwAbstract722A}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == ABSTRACT_ONLY_FEATURE
+
+    @classmethod
+    @abstractmethod
+    def _probe_hook_722a(cls) -> str:
+        """Abstract hook that keeps this probe abstract."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class ParentProbe722A(FeatureGroup):
+    """Parent probe: declares two frameworks and matches only the shared parent/child name."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwP722A, CfwQ722A}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == PARENT_CHILD_FEATURE
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class ChildProbe722A(ParentProbe722A):
+    """Child probe: narrows the declaration to a single framework."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwP722A}
+
+
+class SameFwParentProbe722A(FeatureGroup):
+    """Parity parent: one framework, matches only the identical-set family name."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwSame722A}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == SAME_FW_FEATURE
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class SameFwChildProbe722A(SameFwParentProbe722A):
+    """Parity child: inherits the identical framework set from its parent."""
+
+
+class CapabilityRaisesProbe722A(FeatureGroup):
+    """Probe whose capability hook raises, gated on its own feature name."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwCapOne722A, CfwCapTwo722A}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == CAPABILITY_RAISES_FEATURE
+
+    @classmethod
+    def supports_compute_framework(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        compute_framework: type[ComputeFramework],
+    ) -> bool:
+        # Gated on the probe name so process-global scans in other tests never trip the raise.
+        if str(feature_name) == CAPABILITY_RAISES_FEATURE:
+            raise RuntimeError(CAPABILITY_ERROR_TEXT)
+        return True
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class PropertyRejectionProbe722A(FeatureGroup):
+    """Probe whose match hook raises PropertyValueRejection for its own feature name only."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwReject722A}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        # Gated on the probe name so process-global scans in other tests never trip the raise.
+        if str(feature_name) == PROPERTY_REJECTION_FEATURE:
+            raise PropertyValueRejection(PROPERTY_REJECTION_TEXT)
+        return False
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Divergence 1: a lone abstract base matching a unique name
+# ---------------------------------------------------------------------------
+
+
+def test_engine_rejects_lone_abstract_match() -> None:
+    """The engine refuses a lone abstract match with the abstract-only error."""
+    assert inspect.isabstract(AbstractOnlyProbe722A), "fixture must be abstract"
+
+    feature = Feature(ABSTRACT_ONLY_FEATURE)
+    accessible_plugins: FeatureGroupEnvironmentMapping = {AbstractOnlyProbe722A: {CfwAbstract722A}}
+
+    # TARGET CONTRACT: an abstract base never wins on the engine path.
+    with pytest.raises(ValueError, match="Only abstract feature group base") as exc_info:
+        IdentifyFeatureGroupClass(
+            feature=feature,
+            accessible_plugins=accessible_plugins,
+            links=None,
+            data_access_collection=None,
+        )
+    assert "Only abstract feature group base(s) matched" in str(exc_info.value)
+
+
+def test_resolve_feature_returns_lone_abstract_match() -> None:
+    """resolve_feature resolves the same lone abstract base cleanly."""
+    assert inspect.isabstract(AbstractOnlyProbe722A), "fixture must be abstract"
+
+    collector = PluginCollector.enabled_feature_groups({AbstractOnlyProbe722A})
+    result = resolve_feature(ABSTRACT_ONLY_FEATURE, plugin_collector=collector)
+
+    # PINS CURRENT DIVERGENCE (#1): the uninstantiable abstract base wins; target is no abstract winner.
+    assert result.feature_group is AbstractOnlyProbe722A
+    assert result.error is None
+    assert result.candidates == [AbstractOnlyProbe722A]
+
+
+# ---------------------------------------------------------------------------
+# Divergences 3 and 4: parent/child with DIFFERENT declared framework sets
+# ---------------------------------------------------------------------------
+
+
+def test_engine_parent_child_differing_framework_sets_stays_ambiguous() -> None:
+    """Engine half of divergences #3/#4: differing framework sets block the subclass collapse."""
+    feature = Feature(PARENT_CHILD_FEATURE)
+    accessible_plugins: FeatureGroupEnvironmentMapping = {
+        ParentProbe722A: {CfwP722A, CfwQ722A},
+        ChildProbe722A: {CfwP722A},
+    }
+
+    with pytest.raises(ValueError, match="Multiple feature groups found") as exc_info:
+        IdentifyFeatureGroupClass(
+            feature=feature,
+            accessible_plugins=accessible_plugins,
+            links=None,
+            data_access_collection=None,
+        )
+    message = str(exc_info.value)
+    assert "ParentProbe722A" in message
+    assert "ChildProbe722A" in message
+
+
+def test_resolve_feature_parent_child_collapses_by_subclass() -> None:
+    """resolve_feature collapses the same parent/child pair the engine calls ambiguous."""
+    collector = PluginCollector.enabled_feature_groups({ParentProbe722A, ChildProbe722A})
+    result = resolve_feature(PARENT_CHILD_FEATURE, plugin_collector=collector)
+
+    # PINS CURRENT DIVERGENCE (#4): _filter_subclasses collapses purely by issubclass; the engine stays ambiguous.
+    assert result.feature_group is ChildProbe722A
+    assert result.error is None
+    assert set(result.candidates) == {ParentProbe722A, ChildProbe722A}
+
+
+def test_resolve_feature_parent_child_unions_framework_attribution() -> None:
+    """resolve_feature attributes the parent-only framework to the child winner."""
+    collector = PluginCollector.enabled_feature_groups({ParentProbe722A, ChildProbe722A})
+    result = resolve_feature(PARENT_CHILD_FEATURE, plugin_collector=collector)
+
+    assert result.feature_group is ChildProbe722A
+    # PINS CURRENT DIVERGENCE (#3): the capability split is unioned across ALL candidates, so
+    # CfwQ722A is reported as supported although the winner ChildProbe722A never declares it.
+    assert CfwP722A.get_class_name() in result.supported_compute_frameworks
+    assert CfwQ722A.get_class_name() in result.supported_compute_frameworks
+    assert result.unsupported_compute_frameworks == []
+
+
+# ---------------------------------------------------------------------------
+# Divergence 4 parity case: parent/child with IDENTICAL framework sets
+# ---------------------------------------------------------------------------
+
+
+def test_engine_prefers_child_when_framework_sets_are_identical() -> None:
+    """With identical framework sets, the engine collapses parent/child to the child."""
+    feature = Feature(SAME_FW_FEATURE)
+    accessible_plugins: FeatureGroupEnvironmentMapping = {
+        SameFwParentProbe722A: {CfwSame722A},
+        SameFwChildProbe722A: {CfwSame722A},
+    }
+
+    identifier = IdentifyFeatureGroupClass(
+        feature=feature,
+        accessible_plugins=accessible_plugins,
+        links=None,
+        data_access_collection=None,
+    )
+    resolved_feature_group, compute_frameworks = identifier.get()
+    # TARGET CONTRACT: identical framework sets collapse to the child on both paths.
+    assert resolved_feature_group is SameFwChildProbe722A
+    assert compute_frameworks == {CfwSame722A}
+
+
+def test_resolve_feature_prefers_child_when_framework_sets_are_identical() -> None:
+    """With identical framework sets, resolve_feature agrees with the engine on the child."""
+    collector = PluginCollector.enabled_feature_groups({SameFwParentProbe722A, SameFwChildProbe722A})
+    result = resolve_feature(SAME_FW_FEATURE, plugin_collector=collector)
+
+    # TARGET CONTRACT: identical framework sets collapse to the child on both paths.
+    assert result.feature_group is SameFwChildProbe722A
+    assert result.error is None
+    assert result.supported_compute_frameworks == [CfwSame722A.get_class_name()]
+
+
+# ---------------------------------------------------------------------------
+# Divergence 16: a raising supports_compute_framework hook
+# ---------------------------------------------------------------------------
+
+
+def test_engine_propagates_capability_hook_runtime_error() -> None:
+    """A raising capability hook aborts the engine with the raw provider error."""
+    feature = Feature(CAPABILITY_RAISES_FEATURE)
+    accessible_plugins: FeatureGroupEnvironmentMapping = {
+        CapabilityRaisesProbe722A: {CfwCapOne722A, CfwCapTwo722A},
+    }
+
+    # PINS CURRENT DIVERGENCE (#16): the raw RuntimeError propagates and aborts the run;
+    # target is a fail-closed structured provider failure.
+    with pytest.raises(RuntimeError, match=CAPABILITY_ERROR_TEXT):
+        IdentifyFeatureGroupClass(
+            feature=feature,
+            accessible_plugins=accessible_plugins,
+            links=None,
+            data_access_collection=None,
+        )
+
+
+def test_resolve_feature_degrades_capability_hook_error_open() -> None:
+    """resolve_feature degrades the same raising hook OPEN and reports a clean resolution."""
+    collector = PluginCollector.enabled_feature_groups({CapabilityRaisesProbe722A})
+    result = resolve_feature(CAPABILITY_RAISES_FEATURE, plugin_collector=collector)
+
+    # PINS CURRENT DIVERGENCE (#16): safe_field degrades the capability split open, so the broken
+    # declaration reads as runnable everywhere; target is a fail-closed structured provider failure.
+    assert result.feature_group is CapabilityRaisesProbe722A
+    assert result.error is None
+    assert set(result.supported_compute_frameworks) == {
+        CfwCapOne722A.get_class_name(),
+        CfwCapTwo722A.get_class_name(),
+    }
+    assert result.unsupported_compute_frameworks == []
+
+
+# ---------------------------------------------------------------------------
+# Divergence 17: PropertyValueRejection raised by match_feature_group_criteria
+# ---------------------------------------------------------------------------
+
+
+def test_property_value_rejection_is_a_value_error() -> None:
+    """Premise: PropertyValueRejection subclasses ValueError, which is why both paths catch it."""
+    assert issubclass(PropertyValueRejection, ValueError)
+
+
+def test_engine_swallows_property_value_rejection_silently() -> None:
+    """The engine treats the rejection as a silent non-match; its error omits the rejection text."""
+    feature = Feature(PROPERTY_REJECTION_FEATURE)
+    accessible_plugins: FeatureGroupEnvironmentMapping = {PropertyRejectionProbe722A: {CfwReject722A}}
+
+    with pytest.raises(ValueError, match="No feature groups found") as exc_info:
+        IdentifyFeatureGroupClass(
+            feature=feature,
+            accessible_plugins=accessible_plugins,
+            links=None,
+            data_access_collection=None,
+        )
+    message = str(exc_info.value)
+    # PINS CURRENT DIVERGENCE (#17): the rejection reason is invisible on the engine path.
+    assert PROPERTY_REJECTION_TEXT not in message
+
+
+def test_resolve_feature_surfaces_property_value_rejection() -> None:
+    """resolve_feature records the same rejection and surfaces it in the returned error."""
+    collector = PluginCollector.enabled_feature_groups({PropertyRejectionProbe722A})
+    result = resolve_feature(PROPERTY_REJECTION_FEATURE, plugin_collector=collector)
+
+    assert result.feature_group is None
+    assert result.candidates == []
+    assert result.error is not None
+    # PINS CURRENT DIVERGENCE (#17): the same rejection is an error string on the diagnostic path.
+    assert PROPERTY_REJECTION_TEXT in result.error
+    assert "Rejected during matching" in result.error

--- a/tests/test_core/test_resolution_parity/test_parity_environment.py
+++ b/tests/test_core/test_resolution_parity/test_parity_environment.py
@@ -1,0 +1,337 @@
+"""Paired engine/diagnostic characterization tests for issue #722 Stage 1 (environment-level divergences).
+
+Every test PASSES against current code, pinning today's behavior. Assertions marked
+"PINS CURRENT DIVERGENCE (#N)" pin behavior that later stages of #722 will change.
+Assertions marked "TARGET CONTRACT" pin engine behavior that stays authoritative.
+
+Index (divergence number in issue #722 -> test names):
+- #2 (unavailable-framework false positive):
+    test_engine_unavailable_only_framework_raises_no_feature_groups (TARGET CONTRACT)
+    test_resolve_feature_unavailable_only_framework_reads_as_runnable (PINS #2)
+- #8 (run framework set ignored by debug):
+    test_engine_resolution_limited_to_run_framework_set (TARGET CONTRACT)
+    test_resolve_feature_reports_frameworks_outside_run_set (PINS #8)
+- #9 (registry strict mode ignored by debug):
+    test_engine_strict_mode_with_empty_registry_raises (TARGET CONTRACT)
+    test_resolve_feature_never_applies_strict_mode (PINS #9)
+- #13 (redefinition conflict, three semantics):
+    test_engine_redefinition_conflict_raises (PINS #13)
+    test_resolve_feature_redefinition_conflict_reports_error_with_candidates (PINS #13)
+    test_get_feature_group_docs_redefinition_conflict_degrades_silently (PINS #13)
+"""
+
+from __future__ import annotations
+
+import linecache
+import sys
+import textwrap
+from typing import Any, Iterator, cast
+
+import pytest
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistry
+from mloda.core.api.plugin_docs import get_feature_group_docs, resolve_feature
+from mloda.core.prepare.accessible_plugins import (
+    PreFilterPlugins,
+    RedefinitionConflictError,
+    dedup_feature_group_subclasses,
+)
+from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+
+
+# ---------------------------------------------------------------------------
+# Mock compute frameworks (unique names, suffix 722C)
+# ---------------------------------------------------------------------------
+
+
+class CfwUnavailable722C(ComputeFramework):
+    """Framework whose backing dependency is never installed."""
+
+    @staticmethod
+    def is_available() -> bool:
+        return False
+
+
+class CfwEnabled722C(ComputeFramework):
+    """Available framework, the one enabled for the run."""
+
+
+class CfwOther722C(ComputeFramework):
+    """Available framework, NOT enabled for the run."""
+
+
+class CfwStrictRun722C(ComputeFramework):
+    """Available framework carrying the strict-mode run."""
+
+
+# ---------------------------------------------------------------------------
+# Probe feature groups (match ONLY their own probe722c_* names)
+# ---------------------------------------------------------------------------
+
+
+class ProbeUnavailable722C(FeatureGroup):
+    """Declares ONLY the unavailable framework."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwUnavailable722C}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == "probe722c_unavailable"
+
+
+class ProbeTwoFw722C(FeatureGroup):
+    """Declares two available frameworks; the run enables only one of them."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwEnabled722C, CfwOther722C}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == "probe722c_twofw"
+
+
+class ProbeStrict722C(FeatureGroup):
+    """Concrete probe that is never registered in the injected registry."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwStrictRun722C}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == "probe722c_strict"
+
+
+# ---------------------------------------------------------------------------
+# Jupyter-cell simulation helpers for divergence #13
+# (construction pattern mirrors tests/test_core/test_prepare/test_feature_group_dedup.py)
+# ---------------------------------------------------------------------------
+
+# Keeps exec'd classes alive across assertions, like IPython's Out[N] history.
+_REF_STORE: list[Any] = []
+
+
+def _exec_fg_in_main(class_name: str, body: str, cell_label: str) -> type[FeatureGroup]:
+    """Exec a FeatureGroup subclass into __main__ with linecache-backed source (Jupyter cell simulation)."""
+    main_mod = sys.modules["__main__"]
+    src = textwrap.dedent(body)
+    filename = f"<{cell_label}>"
+    linecache.cache[filename] = (len(src), None, src.splitlines(keepends=True), filename)
+    exec(compile(src, filename, "exec"), main_mod.__dict__)  # nosec B102
+    return cast(type[FeatureGroup], main_mod.__dict__[class_name])
+
+
+def _make_fg_source(class_name: str, feature_name: str, extra_body: str = "") -> str:
+    return f"""
+from mloda.core.abstract_plugins.feature_group import FeatureGroup as _FG_BASE_
+
+class {class_name}(_FG_BASE_):
+    @classmethod
+    def feature_names_supported(cls):
+        return {{"{feature_name}"}}
+{extra_body}
+"""
+
+
+def _make_conflicting_pair(qualname: str, feature_name: str) -> tuple[type[FeatureGroup], type[FeatureGroup]]:
+    """Two classes sharing (module, qualname) with DIFFERENT source; v2 is live in __main__."""
+    src_v1 = _make_fg_source(qualname, feature_name)
+    src_v2 = _make_fg_source(qualname, feature_name, extra_body="    def extra_method(self):\n        return 722\n")
+    v1 = _exec_fg_in_main(qualname, src_v1, f"cell-{qualname}-v1")
+    v2 = _exec_fg_in_main(qualname, src_v2, f"cell-{qualname}-v2")
+    _REF_STORE.extend([v1, v2])
+    return v1, v2
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_main_module_attrs() -> Iterator[None]:
+    """Snapshot __main__ attrs and restore after each test (xdist safety, mirrors test_feature_group_dedup)."""
+    main_mod = sys.modules["__main__"]
+    snapshot = set(main_mod.__dict__.keys())
+    yield
+    for key in set(main_mod.__dict__.keys()) - snapshot:
+        main_mod.__dict__.pop(key, None)
+
+
+# ---------------------------------------------------------------------------
+# Divergence #2: a feature whose ONLY framework is unavailable
+# ---------------------------------------------------------------------------
+
+
+def test_engine_unavailable_only_framework_raises_no_feature_groups() -> None:
+    """TARGET CONTRACT: the engine environment drops unavailable frameworks and resolution fails."""
+    assert CfwUnavailable722C.is_available() is False  # premise guard
+
+    collector = PluginCollector.enabled_feature_groups({ProbeUnavailable722C})
+    accessible = PreFilterPlugins(
+        compute_frameworks={CfwUnavailable722C}, plugin_collector=collector
+    ).get_accessible_plugins()
+
+    # TARGET CONTRACT: get_cfw_subclasses drops unavailable frameworks; the probe maps to an EMPTY set.
+    assert accessible == {ProbeUnavailable722C: set()}
+
+    # TARGET CONTRACT: the engine refuses to resolve the feature.
+    with pytest.raises(ValueError, match="No feature groups found"):
+        IdentifyFeatureGroupClass(
+            feature=Feature("probe722c_unavailable"),
+            accessible_plugins=accessible,
+            links=None,
+        )
+
+
+def test_resolve_feature_unavailable_only_framework_reads_as_runnable() -> None:
+    """resolve_feature reports success for a feature the engine can never run."""
+    assert CfwUnavailable722C.is_available() is False  # premise guard
+
+    collector = PluginCollector.enabled_feature_groups({ProbeUnavailable722C})
+    result = resolve_feature("probe722c_unavailable", plugin_collector=collector)
+
+    # PINS CURRENT DIVERGENCE (#2): a feature whose only framework is not installed reads as runnable.
+    assert result.feature_group is ProbeUnavailable722C
+    assert result.error is None
+    # PINS CURRENT DIVERGENCE (#2): the capability split skips unavailable frameworks entirely, so both
+    # sides are empty and the all-rejected guard never fires.
+    assert result.supported_compute_frameworks == []
+    assert result.unsupported_compute_frameworks == []
+
+
+# ---------------------------------------------------------------------------
+# Divergence #8: the run's compute-framework set
+# ---------------------------------------------------------------------------
+
+
+def test_engine_resolution_limited_to_run_framework_set() -> None:
+    """TARGET CONTRACT: the engine intersects declared frameworks with the run's set."""
+    assert CfwEnabled722C.is_available() is True  # premise guard
+    assert CfwOther722C.is_available() is True  # premise guard
+
+    collector = PluginCollector.enabled_feature_groups({ProbeTwoFw722C})
+    accessible = PreFilterPlugins(
+        compute_frameworks={CfwEnabled722C}, plugin_collector=collector
+    ).get_accessible_plugins()
+
+    # TARGET CONTRACT: only the run-enabled framework survives the environment build.
+    assert accessible == {ProbeTwoFw722C: {CfwEnabled722C}}
+
+    identifier = IdentifyFeatureGroupClass(
+        feature=Feature("probe722c_twofw"),
+        accessible_plugins=accessible,
+        links=None,
+    )
+    resolved, frameworks = identifier.get()
+    assert resolved is ProbeTwoFw722C
+    # TARGET CONTRACT: per-feature resolution carries only the run's framework set.
+    assert frameworks == {CfwEnabled722C}
+
+
+def test_resolve_feature_reports_frameworks_outside_run_set() -> None:
+    """resolve_feature has no notion of a run set and reports every installed declared framework."""
+    collector = PluginCollector.enabled_feature_groups({ProbeTwoFw722C})
+    result = resolve_feature("probe722c_twofw", plugin_collector=collector)
+
+    assert result.feature_group is ProbeTwoFw722C
+    assert result.error is None
+    # PINS CURRENT DIVERGENCE (#8): debug resolves against every installed framework, not the run's set;
+    # CfwOther722C shows up although no run enabled it.
+    assert result.supported_compute_frameworks == ["CfwEnabled722C", "CfwOther722C"]
+    assert result.unsupported_compute_frameworks == []
+
+
+# ---------------------------------------------------------------------------
+# Divergence #9: registry strict mode
+# ---------------------------------------------------------------------------
+
+
+def _strict_collector_with_empty_registry() -> PluginCollector:
+    """Enable only the strict probe, strict mode on, EMPTY injected registry (global registry untouched)."""
+    collector = PluginCollector.enabled_feature_groups({ProbeStrict722C})
+    return collector.set_strict_mode("strict").set_registry(PluginRegistry())
+
+
+def test_engine_strict_mode_with_empty_registry_raises() -> None:
+    """TARGET CONTRACT: strict mode drops the unregistered concrete probe and the environment build fails."""
+    collector = _strict_collector_with_empty_registry()
+
+    with pytest.raises(ValueError, match="Strict mode filtered out all FeatureGroups"):
+        PreFilterPlugins(compute_frameworks={CfwStrictRun722C}, plugin_collector=collector)
+
+
+def test_resolve_feature_never_applies_strict_mode() -> None:
+    """resolve_feature honors only the collector's enable set and allow_redefinition, never strict mode."""
+    collector = _strict_collector_with_empty_registry()
+    result = resolve_feature("probe722c_strict", plugin_collector=collector)
+
+    # PINS CURRENT DIVERGENCE (#9): debug cannot reproduce strict-mode reality even with the same collector.
+    assert result.feature_group is ProbeStrict722C
+    assert result.error is None
+    assert result.supported_compute_frameworks == ["CfwStrictRun722C"]
+
+
+# ---------------------------------------------------------------------------
+# Divergence #13: one redefinition conflict, three different semantics
+# ---------------------------------------------------------------------------
+
+
+def test_engine_redefinition_conflict_raises() -> None:
+    """Engine semantic: dedup raises RedefinitionConflictError (a ValueError) and construction dies."""
+    v1, v2 = _make_conflicting_pair("ProbeRedefDedup722C", "probe722c_redef")
+
+    # PINS CURRENT DIVERGENCE (#13): one conflict, three different semantics; the engine RAISES.
+    with pytest.raises(RedefinitionConflictError) as exc_info:
+        dedup_feature_group_subclasses({v1, v2}, allow_redefinition=False)
+    assert "redefined with different source code" in str(exc_info.value)
+    assert isinstance(exc_info.value, ValueError)
+
+    # Engine environment construction hits the same conflict.
+    collector = PluginCollector.enabled_feature_groups({v1, v2})
+    with pytest.raises(ValueError, match="redefined with different source code"):
+        PreFilterPlugins(compute_frameworks={CfwEnabled722C}, plugin_collector=collector)
+
+
+def test_resolve_feature_redefinition_conflict_reports_error_with_candidates() -> None:
+    """Debug semantic: same conflict degrades to an error string with the conflicting candidates."""
+    v1, v2 = _make_conflicting_pair("ProbeRedefResolve722C", "probe722c_redef")
+    collector = PluginCollector.enabled_feature_groups({v1, v2})
+
+    result = resolve_feature("probe722c_redef", plugin_collector=collector)
+
+    # PINS CURRENT DIVERGENCE (#13): one conflict, three different semantics; debug returns an error field.
+    assert result.feature_group is None
+    assert result.error is not None
+    assert "redefined with different source code" in result.error
+    assert set(result.candidates) == {v1, v2}
+
+
+def test_get_feature_group_docs_redefinition_conflict_degrades_silently() -> None:
+    """Docs semantic: same conflict is silently collapsed to the live class; the call does not raise."""
+    v1, v2 = _make_conflicting_pair("ProbeRedefDocs722C", "probe722c_redef")
+    collector = PluginCollector.enabled_feature_groups({v1, v2})
+
+    # PINS CURRENT DIVERGENCE (#13): one conflict, three different semantics; docs degrade, NO raise.
+    result = get_feature_group_docs(plugin_collector=collector)
+    assert isinstance(result, list)

--- a/tests/test_core/test_resolution_parity/test_parity_environment.py
+++ b/tests/test_core/test_resolution_parity/test_parity_environment.py
@@ -1,17 +1,17 @@
-"""Paired engine/diagnostic tests for issue #722 (environment-level), flipped to the Stage 3b target.
+"""Paired engine/diagnostic tests for issue #722 (environment-level), flipped to the Stage 4 target.
 
-Stage 3b rewires resolve_feature onto a standalone environment built by
-build_resolution_environment with all available compute frameworks, so the debug-side
-tests below assert the TARGET CONTRACT and FAIL until that rewire lands. Where a
-difference legitimately remains it is marked as a standalone request difference (Stage 4).
+Stage 3b rewired resolve_feature onto a standalone environment built by
+build_resolution_environment with all available compute frameworks; Stage 4 adds the
+compute_frameworks parameter that restricts that environment to a run's exact framework
+set. The div-8 debug test below asserts the TARGET CONTRACT and FAILS until Stage 4 lands.
 
 Index (divergence number in issue #722 -> test names):
 - #2 (unavailable-framework honesty):
     test_engine_unavailable_only_framework_raises_no_feature_groups (TARGET CONTRACT)
     test_resolve_feature_unavailable_only_framework_reports_not_runnable (TARGET CONTRACT)
-- #8 (run framework set, standalone request difference until Stage 4):
+- #8 (run framework set, TARGET CONTRACT via the Stage 4 compute_frameworks parameter):
     test_engine_resolution_limited_to_run_framework_set (TARGET CONTRACT)
-    test_resolve_feature_reports_frameworks_outside_run_set (standalone difference, Stage 4)
+    test_resolve_feature_compute_frameworks_parameter_limits_run_set (TARGET CONTRACT)
 - #9 (registry strict mode now shared):
     test_engine_strict_mode_with_empty_registry_raises (TARGET CONTRACT)
     test_resolve_feature_applies_collector_strict_mode (TARGET CONTRACT)
@@ -251,17 +251,24 @@ def test_engine_resolution_limited_to_run_framework_set() -> None:
     assert frameworks == {CfwEnabled722C}
 
 
-def test_resolve_feature_reports_frameworks_outside_run_set() -> None:
-    """resolve_feature has no notion of a run set and reports every installed declared framework."""
+def test_resolve_feature_compute_frameworks_parameter_limits_run_set() -> None:
+    """The compute_frameworks parameter restricts the standalone environment to the run's set."""
     collector = PluginCollector.enabled_feature_groups({ProbeTwoFw722C})
-    result = resolve_feature("probe722c_twofw", plugin_collector=collector)
+
+    # Premise guard: without a run set the standalone default reports every installed
+    # declared framework, exactly like an all-frameworks engine environment.
+    unrestricted = resolve_feature("probe722c_twofw", plugin_collector=collector)
+    assert unrestricted.feature_group is ProbeTwoFw722C
+    assert unrestricted.supported_compute_frameworks == ["CfwEnabled722C", "CfwOther722C"]
+
+    result = resolve_feature("probe722c_twofw", compute_frameworks={CfwEnabled722C}, plugin_collector=collector)
 
     assert result.feature_group is ProbeTwoFw722C
     assert result.error is None
-    # STANDALONE REQUEST DIFFERENCE (#8, Stage 4): the standalone environment legitimately enables
-    # every available framework; a run's exact framework set stays unexpressible here until the
-    # Stage 4 exact-run mode, so CfwOther722C is honestly reported alongside CfwEnabled722C.
-    assert result.supported_compute_frameworks == ["CfwEnabled722C", "CfwOther722C"]
+    # TARGET CONTRACT (#8, Stage 4): compute_frameworks restricts the standalone environment
+    # exactly like mlodaAPI(compute_frameworks=...) restricts the engine's run set, so only
+    # the enabled framework is reported.
+    assert result.supported_compute_frameworks == ["CfwEnabled722C"]
     assert result.unsupported_compute_frameworks == []
 
 

--- a/tests/test_core/test_resolution_parity/test_parity_environment.py
+++ b/tests/test_core/test_resolution_parity/test_parity_environment.py
@@ -1,23 +1,24 @@
-"""Paired engine/diagnostic characterization tests for issue #722 Stage 1 (environment-level divergences).
+"""Paired engine/diagnostic tests for issue #722 (environment-level), flipped to the Stage 3b target.
 
-Every test PASSES against current code, pinning today's behavior. Assertions marked
-"PINS CURRENT DIVERGENCE (#N)" pin behavior that later stages of #722 will change.
-Assertions marked "TARGET CONTRACT" pin engine behavior that stays authoritative.
+Stage 3b rewires resolve_feature onto a standalone environment built by
+build_resolution_environment with all available compute frameworks, so the debug-side
+tests below assert the TARGET CONTRACT and FAIL until that rewire lands. Where a
+difference legitimately remains it is marked as a standalone request difference (Stage 4).
 
 Index (divergence number in issue #722 -> test names):
-- #2 (unavailable-framework false positive):
+- #2 (unavailable-framework honesty):
     test_engine_unavailable_only_framework_raises_no_feature_groups (TARGET CONTRACT)
-    test_resolve_feature_unavailable_only_framework_reads_as_runnable (PINS #2)
-- #8 (run framework set ignored by debug):
+    test_resolve_feature_unavailable_only_framework_reports_not_runnable (TARGET CONTRACT)
+- #8 (run framework set, standalone request difference until Stage 4):
     test_engine_resolution_limited_to_run_framework_set (TARGET CONTRACT)
-    test_resolve_feature_reports_frameworks_outside_run_set (PINS #8)
-- #9 (registry strict mode ignored by debug):
+    test_resolve_feature_reports_frameworks_outside_run_set (standalone difference, Stage 4)
+- #9 (registry strict mode now shared):
     test_engine_strict_mode_with_empty_registry_raises (TARGET CONTRACT)
-    test_resolve_feature_never_applies_strict_mode (PINS #9)
-- #13 (redefinition conflict, three semantics):
-    test_engine_redefinition_conflict_raises (PINS #13)
-    test_resolve_feature_redefinition_conflict_reports_error_with_candidates (PINS #13)
-    test_get_feature_group_docs_redefinition_conflict_degrades_silently (PINS #13)
+    test_resolve_feature_applies_collector_strict_mode (TARGET CONTRACT)
+- #13 (redefinition conflict, shared environment outcome):
+    test_engine_redefinition_conflict_raises (TARGET CONTRACT)
+    test_resolve_feature_redefinition_conflict_reports_error_with_candidates (TARGET CONTRACT)
+    test_get_feature_group_docs_redefinition_conflict_degrades_silently (docs surface, unchanged)
 """
 
 from __future__ import annotations
@@ -206,20 +207,19 @@ def test_engine_unavailable_only_framework_raises_no_feature_groups() -> None:
         )
 
 
-def test_resolve_feature_unavailable_only_framework_reads_as_runnable() -> None:
-    """resolve_feature reports success for a feature the engine can never run."""
+def test_resolve_feature_unavailable_only_framework_reports_not_runnable() -> None:
+    """resolve_feature is honest about a feature the engine can never run."""
     assert CfwUnavailable722C.is_available() is False  # premise guard
 
     collector = PluginCollector.enabled_feature_groups({ProbeUnavailable722C})
     result = resolve_feature("probe722c_unavailable", plugin_collector=collector)
 
-    # PINS CURRENT DIVERGENCE (#2): a feature whose only framework is not installed reads as runnable.
-    assert result.feature_group is ProbeUnavailable722C
-    assert result.error is None
-    # PINS CURRENT DIVERGENCE (#2): the capability split skips unavailable frameworks entirely, so both
-    # sides are empty and the all-rejected guard never fires.
+    # TARGET CONTRACT (#2): the standalone environment drops unavailable frameworks exactly like
+    # the engine's, so the probe has no accessible framework and the feature is reported as not
+    # runnable on any available framework instead of silently runnable.
+    assert result.feature_group is None
+    assert result.error is not None
     assert result.supported_compute_frameworks == []
-    assert result.unsupported_compute_frameworks == []
 
 
 # ---------------------------------------------------------------------------
@@ -258,8 +258,9 @@ def test_resolve_feature_reports_frameworks_outside_run_set() -> None:
 
     assert result.feature_group is ProbeTwoFw722C
     assert result.error is None
-    # PINS CURRENT DIVERGENCE (#8): debug resolves against every installed framework, not the run's set;
-    # CfwOther722C shows up although no run enabled it.
+    # STANDALONE REQUEST DIFFERENCE (#8, Stage 4): the standalone environment legitimately enables
+    # every available framework; a run's exact framework set stays unexpressible here until the
+    # Stage 4 exact-run mode, so CfwOther722C is honestly reported alongside CfwEnabled722C.
     assert result.supported_compute_frameworks == ["CfwEnabled722C", "CfwOther722C"]
     assert result.unsupported_compute_frameworks == []
 
@@ -283,15 +284,16 @@ def test_engine_strict_mode_with_empty_registry_raises() -> None:
         PreFilterPlugins(compute_frameworks={CfwStrictRun722C}, plugin_collector=collector)
 
 
-def test_resolve_feature_never_applies_strict_mode() -> None:
-    """resolve_feature honors only the collector's enable set and allow_redefinition, never strict mode."""
+def test_resolve_feature_applies_collector_strict_mode() -> None:
+    """resolve_feature honors the collector's strict mode through the shared environment build."""
     collector = _strict_collector_with_empty_registry()
     result = resolve_feature("probe722c_strict", plugin_collector=collector)
 
-    # PINS CURRENT DIVERGENCE (#9): debug cannot reproduce strict-mode reality even with the same collector.
-    assert result.feature_group is ProbeStrict722C
-    assert result.error is None
-    assert result.supported_compute_frameworks == ["CfwStrictRun722C"]
+    # TARGET CONTRACT (#9): the standalone environment applies strict mode exactly like the
+    # engine's; with an empty registry the build fails and the environment error is returned.
+    assert result.feature_group is None
+    assert result.error is not None
+    assert "Strict mode filtered out all FeatureGroups" in result.error
 
 
 # ---------------------------------------------------------------------------
@@ -303,7 +305,8 @@ def test_engine_redefinition_conflict_raises() -> None:
     """Engine semantic: dedup raises RedefinitionConflictError (a ValueError) and construction dies."""
     v1, v2 = _make_conflicting_pair("ProbeRedefDedup722C", "probe722c_redef")
 
-    # PINS CURRENT DIVERGENCE (#13): one conflict, three different semantics; the engine RAISES.
+    # TARGET CONTRACT (#13): the engine environment build keeps raising on a genuine conflict;
+    # both paths project the same environment build outcome, the engine as a raise.
     with pytest.raises(RedefinitionConflictError) as exc_info:
         dedup_feature_group_subclasses({v1, v2}, allow_redefinition=False)
     assert "redefined with different source code" in str(exc_info.value)
@@ -322,7 +325,8 @@ def test_resolve_feature_redefinition_conflict_reports_error_with_candidates() -
 
     result = resolve_feature("probe722c_redef", plugin_collector=collector)
 
-    # PINS CURRENT DIVERGENCE (#13): one conflict, three different semantics; debug returns an error field.
+    # TARGET CONTRACT (#13): both paths project the same environment build outcome; the debug
+    # path returns it as an error field with the scope- and name-matching conflicting candidates.
     assert result.feature_group is None
     assert result.error is not None
     assert "redefined with different source code" in result.error
@@ -338,6 +342,7 @@ def test_get_feature_group_docs_redefinition_conflict_degrades_silently() -> Non
     with pytest.raises(RedefinitionConflictError):
         dedup_feature_group_subclasses({v1, v2}, allow_redefinition=False)
 
-    # PINS CURRENT DIVERGENCE (#13): one conflict, three different semantics; docs degrade, NO raise.
+    # DOCS SURFACE (#13, unchanged by Stage 3b): get_feature_group_docs deliberately degrades a
+    # conflict to the live class; only the engine and resolve_feature share the environment outcome.
     result = get_feature_group_docs(plugin_collector=collector)
     assert isinstance(result, list)

--- a/tests/test_core/test_resolution_parity/test_parity_environment.py
+++ b/tests/test_core/test_resolution_parity/test_parity_environment.py
@@ -132,7 +132,9 @@ class ProbeStrict722C(FeatureGroup):
 # (construction pattern mirrors tests/test_core/test_prepare/test_feature_group_dedup.py)
 # ---------------------------------------------------------------------------
 
-# Keeps exec'd classes alive across assertions, like IPython's Out[N] history.
+# Keeps exec'd classes alive across assertions, like IPython's Out[N] history. Leaking them for the process
+# lifetime is safe: the autouse cleanup unbinds them from __main__, so they are no longer live-in-module and
+# dedup preserves instead of re-raising, and they only match the unique name probe722c_redef.
 _REF_STORE: list[Any] = []
 
 
@@ -331,6 +333,10 @@ def test_get_feature_group_docs_redefinition_conflict_degrades_silently() -> Non
     """Docs semantic: same conflict is silently collapsed to the live class; the call does not raise."""
     v1, v2 = _make_conflicting_pair("ProbeRedefDocs722C", "probe722c_redef")
     collector = PluginCollector.enabled_feature_groups({v1, v2})
+
+    # Premise guard: dedup raises on this fixture, proving the degrade path below handles a genuine conflict.
+    with pytest.raises(RedefinitionConflictError):
+        dedup_feature_group_subclasses({v1, v2}, allow_redefinition=False)
 
     # PINS CURRENT DIVERGENCE (#13): one conflict, three different semantics; docs degrade, NO raise.
     result = get_feature_group_docs(plugin_collector=collector)

--- a/tests/test_core/test_resolution_parity/test_parity_request_context.py
+++ b/tests/test_core/test_resolution_parity/test_parity_request_context.py
@@ -1,33 +1,35 @@
-"""Paired engine/diagnostic characterization tests for issue #722 Stage 1.
+"""Paired engine/diagnostic tests for issue #722 (request context), flipped to the Stage 3b target.
 
-Every test PASSES against current code: each pair pins one divergence between the
-engine resolution path (IdentifyFeatureGroupClass) and the debug resolution path
-(resolve_feature). Assertions marked "PINS CURRENT DIVERGENCE" pin behavior that
-Stage 3/4 will change; assertions marked "TARGET CONTRACT" pin behavior to keep.
+Stage 3b rewires resolve_feature onto the same FeatureGroupResolver as the engine with a
+standalone request carrying only feature_name, options, and scope. The div-11 debug test
+below asserts the TARGET CONTRACT and FAILS until that rewire lands. Divergences #5, #6,
+#7, and #10 remain standalone request differences (domain, links, framework pin, and data
+access collection stay unexpressible until Stage 4's request redesign); #12, #14, and #15
+remain presentation-only rendering differences.
 
 Index (divergence -> engine test / resolve_feature test):
-- #5 domain:
+- #5 domain (standalone request difference, Stage 4):
     test_engine_domain_disambiguates_shared_name
     test_resolve_feature_has_no_domain_parameter_reports_false_conflict
-- #6 links/index:
+- #6 links/index (standalone request difference, Stage 4):
     test_engine_links_filter_excludes_unsupported_index_probe
     test_resolve_feature_has_no_links_parameter_resolves_phantom
-- #7 compute-framework pin:
+- #7 compute-framework pin (standalone request difference, Stage 4):
     test_engine_compute_framework_pin_disambiguates_siblings
     test_resolve_feature_has_no_framework_pin_reports_conflict
-- #10 data access collection:
+- #10 data access collection (standalone request difference, Stage 4):
     test_engine_data_access_collection_enables_reader_probe
     test_resolve_feature_hardcodes_none_data_access_collection
-- #11 ValueError from matching:
+- #11 ValueError from matching (TARGET CONTRACT, fail-closed on both paths):
     test_engine_matching_value_error_propagates_despite_clean_winner
-    test_resolve_feature_hides_matching_value_error_behind_clean_winner
-- #12 option-aware hints:
+    test_resolve_feature_fails_closed_on_matching_value_error
+- #12 option-aware hints (presentation-only, Stage 4 rendering):
     test_engine_no_match_error_carries_extra_group_option_hint
     test_resolve_feature_no_match_error_lacks_group_option_hint
-- #14 multiple-match text:
+- #14 multiple-match text (presentation-only, Stage 4 rendering):
     test_engine_multiple_match_error_carries_module_paths_and_url
     test_resolve_feature_multiple_match_error_bare_names_only
-- #15 not-found text:
+- #15 not-found text (presentation-only, Stage 4 rendering):
     test_engine_not_found_error_carries_suggestions_and_url
     test_resolve_feature_not_found_error_is_single_bare_line
 """
@@ -167,7 +169,8 @@ def test_resolve_feature_has_no_domain_parameter_reports_false_conflict() -> Non
 
     result = resolve_feature(DOMAIN_FEATURE, plugin_collector=collector)
 
-    # PINS CURRENT DIVERGENCE (#5): debug reports a conflict the run does not have.
+    # STANDALONE REQUEST DIFFERENCE (#5, Stage 4): the domain stays unexpressible in the
+    # standalone request until Stage 4's request redesign, so both probes survive here.
     assert result.feature_group is None
     assert result.error is not None
     assert "Multiple FeatureGroups match" in result.error
@@ -239,7 +242,8 @@ def test_resolve_feature_has_no_links_parameter_resolves_phantom() -> None:
 
     result = resolve_feature(INDEXED_FEATURE, plugin_collector=collector)
 
-    # PINS CURRENT DIVERGENCE (#6): phantom resolution; the links filter is unexpressible here.
+    # STANDALONE REQUEST DIFFERENCE (#6, Stage 4): the run's links stay unexpressible in the
+    # standalone request until Stage 4's request redesign, so the probe resolves cleanly.
     assert result.feature_group is ProbeIndexed722B
     assert result.error is None
 
@@ -317,7 +321,8 @@ def test_resolve_feature_has_no_framework_pin_reports_conflict() -> None:
 
     result = resolve_feature(PIN_FEATURE, plugin_collector=collector)
 
-    # PINS CURRENT DIVERGENCE (#7): the documented remedy (a framework pin) is unexpressible here.
+    # STANDALONE REQUEST DIFFERENCE (#7, Stage 4): a framework pin stays unexpressible in the
+    # standalone request until Stage 4's request redesign, so the siblings stay ambiguous.
     assert result.feature_group is None
     assert result.error is not None
     assert "Multiple FeatureGroups match" in result.error
@@ -371,7 +376,8 @@ def test_resolve_feature_hardcodes_none_data_access_collection() -> None:
 
     result = resolve_feature(DAC_FEATURE, plugin_collector=collector)
 
-    # PINS CURRENT DIVERGENCE (#10): reader/input_data groups fail to resolve in the debug tool.
+    # STANDALONE REQUEST DIFFERENCE (#10, Stage 4): a data access collection stays unexpressible
+    # in the standalone request until Stage 4's request redesign, so reader probes never match.
     assert result.feature_group is None
     assert result.error is not None
     assert "No FeatureGroup found" in result.error
@@ -426,7 +432,8 @@ def test_engine_matching_value_error_propagates_despite_clean_winner() -> None:
     )
     assert identifier.get()[0] is ProbeWinner722B
 
-    # PINS CURRENT DIVERGENCE (#11): the run aborts even though another candidate matched.
+    # TARGET CONTRACT (#11): a plain ValueError from any candidate's matching is fail-closed on
+    # the engine path; a clean rival never hides a decision-relevant provider failure.
     with pytest.raises(ValueError, match="boom 722b"):
         IdentifyFeatureGroupClass(
             feature=Feature(BOOM_FEATURE),
@@ -435,16 +442,18 @@ def test_engine_matching_value_error_propagates_despite_clean_winner() -> None:
         )
 
 
-def test_resolve_feature_hides_matching_value_error_behind_clean_winner() -> None:
-    """resolve_feature degrades the raising candidate to a non-match and crowns the winner."""
+def test_resolve_feature_fails_closed_on_matching_value_error() -> None:
+    """resolve_feature fails closed on the raising candidate; the clean winner cannot hide it."""
     collector = PluginCollector.enabled_feature_groups({ProbeBoom722B, ProbeWinner722B})
 
     result = resolve_feature(BOOM_FEATURE, plugin_collector=collector)
 
-    # PINS CURRENT DIVERGENCE (#11): debug reports a clean winner while the engine crashes.
-    assert result.feature_group is ProbeWinner722B
-    assert result.error is None
-    assert ProbeBoom722B not in result.candidates
+    # TARGET CONTRACT (#11): a plain ValueError from matching is a decision-relevant provider
+    # failure on both paths; the error names the failing plugin and its original message.
+    assert result.feature_group is None
+    assert result.error is not None
+    assert "boom 722b" in result.error
+    assert "ProbeBoom722B" in result.error
 
 
 # ---------------------------------------------------------------------------
@@ -490,7 +499,8 @@ def test_resolve_feature_no_match_error_lacks_group_option_hint() -> None:
     result = resolve_feature(PICKY_FEATURE, options=Options(group={"junk722b": 1}), plugin_collector=collector)
 
     assert result.feature_group is None
-    # PINS CURRENT DIVERGENCE (#12): the engine's option hints cannot be reproduced by the debug tool.
+    # PRESENTATION-ONLY DIFFERENCE (#12, Stage 4 rendering): both paths project the same
+    # no-match outcome; the engine's renderer adds option hints the debug renderer does not.
     assert result.error == f"No FeatureGroup found for feature name: {PICKY_FEATURE}"
     assert "extra group option(s)" not in result.error
 
@@ -553,7 +563,8 @@ def test_resolve_feature_multiple_match_error_bare_names_only() -> None:
     assert "Multiple FeatureGroups match feature name" in result.error
     assert "ProbeMultiA722B" in result.error
     assert "ProbeMultiB722B" in result.error
-    # PINS CURRENT DIVERGENCE (#14): no module paths and no troubleshooting URL in the debug error.
+    # PRESENTATION-ONLY DIFFERENCE (#14, Stage 4 rendering): both paths project the same
+    # ambiguous outcome; the engine's renderer adds module paths and the troubleshooting URL.
     assert MODULE_PATH not in result.error
     assert TROUBLESHOOTING_URL not in result.error
 
@@ -605,7 +616,8 @@ def test_resolve_feature_not_found_error_is_single_bare_line() -> None:
 
     assert result.feature_group is None
     assert result.error is not None
-    # PINS CURRENT DIVERGENCE (#15): the engine points users at a tool returning strictly less information.
+    # PRESENTATION-ONLY DIFFERENCE (#15, Stage 4 rendering): both paths project the same
+    # not-found outcome; the engine's renderer adds suggestions and the troubleshooting URL.
     assert result.error == f"No FeatureGroup found for feature name: {NEEDLE_TYPO}"
     assert "Did you mean" not in result.error
     assert TROUBLESHOOTING_URL not in result.error

--- a/tests/test_core/test_resolution_parity/test_parity_request_context.py
+++ b/tests/test_core/test_resolution_parity/test_parity_request_context.py
@@ -1,25 +1,24 @@
-"""Paired engine/diagnostic tests for issue #722 (request context), flipped to the Stage 3b target.
+"""Paired engine/diagnostic tests for issue #722 (request context), flipped to the Stage 4 target.
 
-Stage 3b rewires resolve_feature onto the same FeatureGroupResolver as the engine with a
-standalone request carrying only feature_name, options, and scope. The div-11 debug test
-below asserts the TARGET CONTRACT and FAILS until that rewire lands. Divergences #5, #6,
-#7, and #10 remain standalone request differences (domain, links, framework pin, and data
-access collection stay unexpressible until Stage 4's request redesign); #12, #14, and #15
-remain presentation-only rendering differences.
+Stage 3b rewired resolve_feature onto the same FeatureGroupResolver as the engine; Stage 4
+makes the standalone request fully expressible (Feature objects carrying domain, scope, and
+framework pin, plus links and data_access_collection parameters). The debug halves of
+divergences #5, #6, #7, and #10 below assert the TARGET CONTRACT and FAIL until Stage 4
+lands. #12, #14, and #15 remain presentation-only rendering differences.
 
 Index (divergence -> engine test / resolve_feature test):
-- #5 domain (standalone request difference, Stage 4):
+- #5 domain (TARGET CONTRACT, Stage 4 Feature-object request):
     test_engine_domain_disambiguates_shared_name
-    test_resolve_feature_has_no_domain_parameter_reports_false_conflict
-- #6 links/index (standalone request difference, Stage 4):
+    test_resolve_feature_feature_object_domain_disambiguates_shared_name
+- #6 links/index (TARGET CONTRACT, Stage 4 links parameter):
     test_engine_links_filter_excludes_unsupported_index_probe
-    test_resolve_feature_has_no_links_parameter_resolves_phantom
-- #7 compute-framework pin (standalone request difference, Stage 4):
+    test_resolve_feature_links_parameter_excludes_unsupported_index_probe
+- #7 compute-framework pin (TARGET CONTRACT, Stage 4 Feature-object pin):
     test_engine_compute_framework_pin_disambiguates_siblings
-    test_resolve_feature_has_no_framework_pin_reports_conflict
-- #10 data access collection (standalone request difference, Stage 4):
+    test_resolve_feature_feature_object_pin_disambiguates_siblings
+- #10 data access collection (TARGET CONTRACT, Stage 4 parameter):
     test_engine_data_access_collection_enables_reader_probe
-    test_resolve_feature_hardcodes_none_data_access_collection
+    test_resolve_feature_data_access_collection_parameter_enables_reader_probe
 - #11 ValueError from matching (TARGET CONTRACT, fail-closed on both paths):
     test_engine_matching_value_error_propagates_despite_clean_winner
     test_resolve_feature_fails_closed_on_matching_value_error
@@ -163,19 +162,22 @@ def test_engine_domain_disambiguates_shared_name() -> None:
     assert resolved is ProbeDomainA722B
 
 
-def test_resolve_feature_has_no_domain_parameter_reports_false_conflict() -> None:
-    """resolve_feature cannot express the run's domain, so it reports a conflict."""
+def test_resolve_feature_feature_object_domain_disambiguates_shared_name() -> None:
+    """A Feature object carries its domain into resolve_feature, matching the engine verdict."""
     collector = PluginCollector.enabled_feature_groups({ProbeDomainA722B, ProbeDomainB722B})
 
-    result = resolve_feature(DOMAIN_FEATURE, plugin_collector=collector)
+    # Premise guard: without a domain both probes survive, exactly like the engine.
+    undomained = resolve_feature(DOMAIN_FEATURE, plugin_collector=collector)
+    assert undomained.feature_group is None
+    assert undomained.error is not None
+    assert "Multiple FeatureGroups match" in undomained.error
 
-    # STANDALONE REQUEST DIFFERENCE (#5, Stage 4): the domain stays unexpressible in the
-    # standalone request until Stage 4's request redesign, so both probes survive here.
-    assert result.feature_group is None
-    assert result.error is not None
-    assert "Multiple FeatureGroups match" in result.error
-    assert "ProbeDomainA722B" in result.error
-    assert "ProbeDomainB722B" in result.error
+    result = resolve_feature(Feature(DOMAIN_FEATURE, domain=DOMAIN_A), plugin_collector=collector)
+
+    # TARGET CONTRACT (#5, Stage 4): a Feature object expresses the run's domain, so
+    # resolve_feature resolves the domain-A probe exactly like the engine.
+    assert result.feature_group is ProbeDomainA722B
+    assert result.error is None
 
 
 # ---------------------------------------------------------------------------
@@ -236,16 +238,21 @@ def test_engine_links_filter_excludes_unsupported_index_probe() -> None:
         )
 
 
-def test_resolve_feature_has_no_links_parameter_resolves_phantom() -> None:
-    """resolve_feature cannot express the run's links, so the probe resolves cleanly."""
+def test_resolve_feature_links_parameter_excludes_unsupported_index_probe() -> None:
+    """The links parameter carries the run's links, so the indexed probe stops resolving."""
     collector = PluginCollector.enabled_feature_groups({ProbeIndexed722B})
 
-    result = resolve_feature(INDEXED_FEATURE, plugin_collector=collector)
+    # Premise guard: without links the probe resolves, exactly like the engine.
+    unlinked = resolve_feature(INDEXED_FEATURE, plugin_collector=collector)
+    assert unlinked.feature_group is ProbeIndexed722B
+    assert unlinked.error is None
 
-    # STANDALONE REQUEST DIFFERENCE (#6, Stage 4): the run's links stay unexpressible in the
-    # standalone request until Stage 4's request redesign, so the probe resolves cleanly.
-    assert result.feature_group is ProbeIndexed722B
-    assert result.error is None
+    result = resolve_feature(INDEXED_FEATURE, links={_foreign_link()}, plugin_collector=collector)
+
+    # TARGET CONTRACT (#6, Stage 4): the run's links are expressible, so the probe whose
+    # index no link carries is reported as not resolvable, exactly like the engine.
+    assert result.feature_group is None
+    assert result.error is not None
 
 
 # ---------------------------------------------------------------------------
@@ -315,19 +322,25 @@ def test_engine_compute_framework_pin_disambiguates_siblings() -> None:
     assert compute_frameworks == {CfwPinX722B}
 
 
-def test_resolve_feature_has_no_framework_pin_reports_conflict() -> None:
-    """resolve_feature cannot express a framework pin, so the siblings stay ambiguous."""
+def test_resolve_feature_feature_object_pin_disambiguates_siblings() -> None:
+    """A framework pin on the Feature object resolves the sibling ambiguity, like the engine."""
     collector = PluginCollector.enabled_feature_groups({ProbePinX722B, ProbePinY722B})
 
-    result = resolve_feature(PIN_FEATURE, plugin_collector=collector)
+    # Premise guard: unpinned, the siblings stay ambiguous, exactly like the engine.
+    unpinned = resolve_feature(PIN_FEATURE, plugin_collector=collector)
+    assert unpinned.feature_group is None
+    assert unpinned.error is not None
+    assert "Multiple FeatureGroups match" in unpinned.error
 
-    # STANDALONE REQUEST DIFFERENCE (#7, Stage 4): a framework pin stays unexpressible in the
-    # standalone request until Stage 4's request redesign, so the siblings stay ambiguous.
-    assert result.feature_group is None
-    assert result.error is not None
-    assert "Multiple FeatureGroups match" in result.error
-    assert "ProbePinX722B" in result.error
-    assert "ProbePinY722B" in result.error
+    result = resolve_feature(
+        Feature(PIN_FEATURE, compute_framework=CfwPinX722B.get_class_name()), plugin_collector=collector
+    )
+
+    # TARGET CONTRACT (#7, Stage 4): the Feature's framework pin is expressible, so
+    # resolve_feature resolves the pinned sibling exactly like the engine.
+    assert result.feature_group is ProbePinX722B
+    assert result.error is None
+    assert result.supported_compute_frameworks == [CfwPinX722B.get_class_name()]
 
 
 # ---------------------------------------------------------------------------
@@ -370,17 +383,26 @@ def test_engine_data_access_collection_enables_reader_probe() -> None:
     assert resolved is ProbeDac722B
 
 
-def test_resolve_feature_hardcodes_none_data_access_collection() -> None:
-    """resolve_feature always passes data_access_collection=None into matching."""
+def test_resolve_feature_data_access_collection_parameter_enables_reader_probe() -> None:
+    """The data_access_collection parameter reaches matching, exactly like the engine threads it."""
     collector = PluginCollector.enabled_feature_groups({ProbeDac722B})
 
-    result = resolve_feature(DAC_FEATURE, plugin_collector=collector)
+    # Premise guard: without a collection the probe does not match, exactly like the engine.
+    without = resolve_feature(DAC_FEATURE, plugin_collector=collector)
+    assert without.feature_group is None
+    assert without.error is not None
+    assert "No FeatureGroup found" in without.error
 
-    # STANDALONE REQUEST DIFFERENCE (#10, Stage 4): a data access collection stays unexpressible
-    # in the standalone request until Stage 4's request redesign, so reader probes never match.
-    assert result.feature_group is None
-    assert result.error is not None
-    assert "No FeatureGroup found" in result.error
+    result = resolve_feature(
+        DAC_FEATURE,
+        data_access_collection=DataAccessCollection(files={"probe722b": "probe722b.csv"}),
+        plugin_collector=collector,
+    )
+
+    # TARGET CONTRACT (#10, Stage 4): the run's data access collection is expressible, so
+    # resolve_feature resolves the reader probe exactly like the engine.
+    assert result.feature_group is ProbeDac722B
+    assert result.error is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_core/test_resolution_parity/test_parity_request_context.py
+++ b/tests/test_core/test_resolution_parity/test_parity_request_context.py
@@ -1,0 +1,603 @@
+"""Paired engine/diagnostic characterization tests for issue #722 Stage 1.
+
+Every test PASSES against current code: each pair pins one divergence between the
+engine resolution path (IdentifyFeatureGroupClass) and the debug resolution path
+(resolve_feature). Assertions marked "PINS CURRENT DIVERGENCE" pin behavior that
+Stage 3/4 will change; assertions marked "TARGET CONTRACT" pin behavior to keep.
+
+Index (divergence -> engine test / resolve_feature test):
+- #5 domain:
+    test_engine_domain_disambiguates_shared_name
+    test_resolve_feature_has_no_domain_parameter_reports_false_conflict
+- #6 links/index:
+    test_engine_links_filter_excludes_unsupported_index_probe
+    test_resolve_feature_has_no_links_parameter_resolves_phantom
+- #7 compute-framework pin:
+    test_engine_compute_framework_pin_disambiguates_siblings
+    test_resolve_feature_has_no_framework_pin_reports_conflict
+- #10 data access collection:
+    test_engine_data_access_collection_enables_reader_probe
+    test_resolve_feature_hardcodes_none_data_access_collection
+- #11 ValueError from matching:
+    test_engine_matching_value_error_propagates_despite_clean_winner
+    test_resolve_feature_hides_matching_value_error_behind_clean_winner
+- #12 option-aware hints:
+    test_engine_no_match_error_carries_extra_group_option_hint
+    test_resolve_feature_no_match_error_lacks_group_option_hint
+- #14 multiple-match text:
+    test_engine_multiple_match_error_carries_module_paths_and_url
+    test_resolve_feature_multiple_match_error_bare_names_only
+- #15 not-found text:
+    test_engine_not_found_error_carries_suggestions_and_url
+    test_resolve_feature_not_found_error_is_single_bare_line
+"""
+
+from typing import Optional
+
+import pytest
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.domain import Domain
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.index.index import Index
+from mloda.core.abstract_plugins.components.link import JoinSpec, Link
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.api.plugin_docs import resolve_feature
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+from mloda.user import PluginCollector
+
+
+TROUBLESHOOTING_URL = "https://mloda-ai.github.io/mloda/in_depth/troubleshooting/feature-group-resolution-errors/"
+MODULE_PATH = "tests.test_core.test_resolution_parity.test_parity_request_context"
+
+DOMAIN_FEATURE = "probe722b_domain"
+DOMAIN_A = "probe722b_domain_a"
+DOMAIN_B = "probe722b_domain_b"
+INDEXED_FEATURE = "probe722b_indexed"
+PIN_FEATURE = "probe722b_pin"
+DAC_FEATURE = "probe722b_dac"
+BOOM_FEATURE = "probe722b_boom"
+PICKY_FEATURE = "probe722b_picky"
+MULTI_FEATURE = "probe722b_multi"
+NEEDLE_FEATURE = "probe722b_needle"
+NEEDLE_TYPO = "probe722b_needls"
+
+
+class CfwParity722B(ComputeFramework):
+    """Framework for hand-built engine mappings in this module."""
+
+
+class CfwPinX722B(ComputeFramework):
+    """Uniquely named framework, pinnable by name from a Feature."""
+
+
+class CfwPinY722B(ComputeFramework):
+    """Rival uniquely named framework for the sibling probe."""
+
+
+class _ParityProbeBase722B(FeatureGroup):
+    """Shared probe base: never matches anything itself."""
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return False
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Divergence 5: domain
+# ---------------------------------------------------------------------------
+
+
+class ProbeDomainA722B(_ParityProbeBase722B):
+    """Matches the shared domain feature name; lives in domain A."""
+
+    @classmethod
+    def get_domain(cls) -> Domain:
+        return Domain(DOMAIN_A)
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == DOMAIN_FEATURE
+
+
+class ProbeDomainB722B(_ParityProbeBase722B):
+    """Matches the shared domain feature name; lives in domain B."""
+
+    @classmethod
+    def get_domain(cls) -> Domain:
+        return Domain(DOMAIN_B)
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == DOMAIN_FEATURE
+
+
+def _domain_pair() -> FeatureGroupEnvironmentMapping:
+    return {
+        ProbeDomainA722B: {CfwParity722B},
+        ProbeDomainB722B: {CfwParity722B},
+    }
+
+
+def test_engine_domain_disambiguates_shared_name() -> None:
+    """The engine's domain filter resolves a name two groups share."""
+    # Premise guard: without a domain both probes match.
+    with pytest.raises(ValueError, match="Multiple feature groups found"):
+        IdentifyFeatureGroupClass(
+            feature=Feature(DOMAIN_FEATURE),
+            accessible_plugins=_domain_pair(),
+            links=None,
+        )
+
+    identifier = IdentifyFeatureGroupClass(
+        feature=Feature(DOMAIN_FEATURE, domain=DOMAIN_A),
+        accessible_plugins=_domain_pair(),
+        links=None,
+    )
+    resolved, _ = identifier.get()
+    # TARGET CONTRACT
+    assert resolved is ProbeDomainA722B
+
+
+def test_resolve_feature_has_no_domain_parameter_reports_false_conflict() -> None:
+    """resolve_feature cannot express the run's domain, so it reports a conflict."""
+    collector = PluginCollector.enabled_feature_groups({ProbeDomainA722B, ProbeDomainB722B})
+
+    result = resolve_feature(DOMAIN_FEATURE, plugin_collector=collector)
+
+    # PINS CURRENT DIVERGENCE (#5): debug reports a conflict the run does not have.
+    assert result.feature_group is None
+    assert result.error is not None
+    assert "Multiple FeatureGroups match" in result.error
+    assert "ProbeDomainA722B" in result.error
+    assert "ProbeDomainB722B" in result.error
+
+
+# ---------------------------------------------------------------------------
+# Divergence 6: links/index
+# ---------------------------------------------------------------------------
+
+
+class ProbeLinkLeft722B(_ParityProbeBase722B):
+    """Anchors the left side of the foreign link; never matches a name."""
+
+
+class ProbeLinkRight722B(_ParityProbeBase722B):
+    """Anchors the right side of the foreign link; never matches a name."""
+
+
+class ProbeIndexed722B(_ParityProbeBase722B):
+    """Declares an index no link in the run carries."""
+
+    @classmethod
+    def index_columns(cls) -> Optional[list[Index]]:
+        return [Index(("probe722b_row_id",))]
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == INDEXED_FEATURE
+
+
+def _foreign_link() -> Link:
+    """A link between two other groups whose indexes the indexed probe does not support."""
+    return Link.inner(
+        JoinSpec(ProbeLinkLeft722B, "probe722b_left_id"),
+        JoinSpec(ProbeLinkRight722B, "probe722b_right_id"),
+    )
+
+
+def test_engine_links_filter_excludes_unsupported_index_probe() -> None:
+    """The engine filters out an indexed group when no run link carries its index."""
+    # Premise guard: without links the probe resolves.
+    identifier = IdentifyFeatureGroupClass(
+        feature=Feature(INDEXED_FEATURE),
+        accessible_plugins={ProbeIndexed722B: {CfwParity722B}},
+        links=None,
+    )
+    resolved, _ = identifier.get()
+    assert resolved is ProbeIndexed722B
+
+    # TARGET CONTRACT: the run's links filter eliminates the probe.
+    with pytest.raises(ValueError, match="No feature groups found"):
+        IdentifyFeatureGroupClass(
+            feature=Feature(INDEXED_FEATURE),
+            accessible_plugins={ProbeIndexed722B: {CfwParity722B}},
+            links={_foreign_link()},
+        )
+
+
+def test_resolve_feature_has_no_links_parameter_resolves_phantom() -> None:
+    """resolve_feature cannot express the run's links, so the probe resolves cleanly."""
+    collector = PluginCollector.enabled_feature_groups({ProbeIndexed722B})
+
+    result = resolve_feature(INDEXED_FEATURE, plugin_collector=collector)
+
+    # PINS CURRENT DIVERGENCE (#6): phantom resolution; the links filter is unexpressible here.
+    assert result.feature_group is ProbeIndexed722B
+    assert result.error is None
+
+
+# ---------------------------------------------------------------------------
+# Divergence 7: compute-framework pin
+# ---------------------------------------------------------------------------
+
+
+class ProbePinX722B(_ParityProbeBase722B):
+    """Sibling probe on CfwPinX722B, matching the shared pin feature name."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwPinX722B}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == PIN_FEATURE
+
+
+class ProbePinY722B(_ParityProbeBase722B):
+    """Sibling probe on CfwPinY722B, matching the same pin feature name."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwPinY722B}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == PIN_FEATURE
+
+
+def _pin_pair() -> FeatureGroupEnvironmentMapping:
+    return {
+        ProbePinX722B: {CfwPinX722B},
+        ProbePinY722B: {CfwPinY722B},
+    }
+
+
+def test_engine_compute_framework_pin_disambiguates_siblings() -> None:
+    """A framework pin on the Feature resolves the per-framework sibling ambiguity."""
+    # Premise guard: unpinned, the siblings are ambiguous.
+    with pytest.raises(ValueError, match="Multiple feature groups found"):
+        IdentifyFeatureGroupClass(
+            feature=Feature(PIN_FEATURE),
+            accessible_plugins=_pin_pair(),
+            links=None,
+        )
+
+    identifier = IdentifyFeatureGroupClass(
+        feature=Feature(PIN_FEATURE, compute_framework=CfwPinX722B.get_class_name()),
+        accessible_plugins=_pin_pair(),
+        links=None,
+    )
+    resolved, compute_frameworks = identifier.get()
+    # TARGET CONTRACT
+    assert resolved is ProbePinX722B
+    assert compute_frameworks == {CfwPinX722B}
+
+
+def test_resolve_feature_has_no_framework_pin_reports_conflict() -> None:
+    """resolve_feature cannot express a framework pin, so the siblings stay ambiguous."""
+    collector = PluginCollector.enabled_feature_groups({ProbePinX722B, ProbePinY722B})
+
+    result = resolve_feature(PIN_FEATURE, plugin_collector=collector)
+
+    # PINS CURRENT DIVERGENCE (#7): the documented remedy (a framework pin) is unexpressible here.
+    assert result.feature_group is None
+    assert result.error is not None
+    assert "Multiple FeatureGroups match" in result.error
+    assert "ProbePinX722B" in result.error
+    assert "ProbePinY722B" in result.error
+
+
+# ---------------------------------------------------------------------------
+# Divergence 10: data access collection
+# ---------------------------------------------------------------------------
+
+
+class ProbeDac722B(_ParityProbeBase722B):
+    """Matches its name only when a data access collection is present."""
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == DAC_FEATURE and data_access_collection is not None
+
+
+def test_engine_data_access_collection_enables_reader_probe() -> None:
+    """The engine threads the run's data access collection into matching."""
+    # Premise guard: without a collection the probe does not match.
+    with pytest.raises(ValueError, match="No feature groups found"):
+        IdentifyFeatureGroupClass(
+            feature=Feature(DAC_FEATURE),
+            accessible_plugins={ProbeDac722B: {CfwParity722B}},
+            links=None,
+            data_access_collection=None,
+        )
+
+    identifier = IdentifyFeatureGroupClass(
+        feature=Feature(DAC_FEATURE),
+        accessible_plugins={ProbeDac722B: {CfwParity722B}},
+        links=None,
+        data_access_collection=DataAccessCollection(files={"probe722b": "probe722b.csv"}),
+    )
+    resolved, _ = identifier.get()
+    # TARGET CONTRACT
+    assert resolved is ProbeDac722B
+
+
+def test_resolve_feature_hardcodes_none_data_access_collection() -> None:
+    """resolve_feature always passes data_access_collection=None into matching."""
+    collector = PluginCollector.enabled_feature_groups({ProbeDac722B})
+
+    result = resolve_feature(DAC_FEATURE, plugin_collector=collector)
+
+    # PINS CURRENT DIVERGENCE (#10): reader/input_data groups fail to resolve in the debug tool.
+    assert result.feature_group is None
+    assert result.error is not None
+    assert "No FeatureGroup found" in result.error
+
+
+# ---------------------------------------------------------------------------
+# Divergence 11: ValueError raised by matching
+# ---------------------------------------------------------------------------
+
+
+class ProbeBoom722B(_ParityProbeBase722B):
+    """Raises ValueError from matching, gated on its unique shared name."""
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        if str(feature_name) == BOOM_FEATURE:
+            raise ValueError("boom 722b: matching rejected the request")
+        return False
+
+
+class ProbeWinner722B(_ParityProbeBase722B):
+    """Matches the boom feature name cleanly."""
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == BOOM_FEATURE
+
+
+def test_engine_matching_value_error_propagates_despite_clean_winner() -> None:
+    """A plain ValueError from any candidate's matching aborts the whole engine run."""
+    # The winner is inserted first; the raising candidate later in the loop still aborts.
+    accessible_plugins: FeatureGroupEnvironmentMapping = {
+        ProbeWinner722B: {CfwParity722B},
+        ProbeBoom722B: {CfwParity722B},
+    }
+
+    # PINS CURRENT DIVERGENCE (#11): the run aborts even though another candidate matched.
+    with pytest.raises(ValueError, match="boom 722b"):
+        IdentifyFeatureGroupClass(
+            feature=Feature(BOOM_FEATURE),
+            accessible_plugins=accessible_plugins,
+            links=None,
+        )
+
+
+def test_resolve_feature_hides_matching_value_error_behind_clean_winner() -> None:
+    """resolve_feature degrades the raising candidate to a non-match and crowns the winner."""
+    collector = PluginCollector.enabled_feature_groups({ProbeBoom722B, ProbeWinner722B})
+
+    result = resolve_feature(BOOM_FEATURE, plugin_collector=collector)
+
+    # PINS CURRENT DIVERGENCE (#11): debug reports a clean winner while the engine crashes.
+    assert result.feature_group is ProbeWinner722B
+    assert result.error is None
+    assert ProbeBoom722B not in result.candidates
+
+
+# ---------------------------------------------------------------------------
+# Divergence 12: option-aware hints
+# ---------------------------------------------------------------------------
+
+
+class ProbePicky722B(_ParityProbeBase722B):
+    """Accepts its name only with no group options; never raises."""
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == PICKY_FEATURE and not options.group
+
+
+def test_engine_no_match_error_carries_extra_group_option_hint() -> None:
+    """The engine's no-match error names the group options that broke the match."""
+    feature = Feature(PICKY_FEATURE, Options(group={"junk722b": 1}))
+
+    with pytest.raises(ValueError, match="No feature groups found") as exc_info:
+        IdentifyFeatureGroupClass(
+            feature=feature,
+            accessible_plugins={ProbePicky722B: {CfwParity722B}},
+            links=None,
+        )
+
+    message = str(exc_info.value)
+    # TARGET CONTRACT: the forwarding hint fires for directly-set keys too.
+    assert "extra group option(s)" in message
+    assert "junk722b" in message
+    assert "ProbePicky722B" in message
+
+
+def test_resolve_feature_no_match_error_lacks_group_option_hint() -> None:
+    """resolve_feature reports only the bare no-match line for the same request."""
+    collector = PluginCollector.enabled_feature_groups({ProbePicky722B})
+
+    result = resolve_feature(PICKY_FEATURE, options=Options(group={"junk722b": 1}), plugin_collector=collector)
+
+    assert result.feature_group is None
+    # PINS CURRENT DIVERGENCE (#12): the engine's option hints cannot be reproduced by the debug tool.
+    assert result.error == f"No FeatureGroup found for feature name: {PICKY_FEATURE}"
+    assert "extra group option(s)" not in result.error
+
+
+# ---------------------------------------------------------------------------
+# Divergence 14: multiple-match text
+# ---------------------------------------------------------------------------
+
+
+class ProbeMultiA722B(_ParityProbeBase722B):
+    """First of two unrelated probes matching the multi feature name."""
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == MULTI_FEATURE
+
+
+class ProbeMultiB722B(_ParityProbeBase722B):
+    """Second of two unrelated probes matching the multi feature name."""
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == MULTI_FEATURE
+
+
+def test_engine_multiple_match_error_carries_module_paths_and_url() -> None:
+    """The engine's ambiguity error carries module paths and ends with the troubleshooting URL."""
+    with pytest.raises(ValueError, match="Multiple feature groups found") as exc_info:
+        IdentifyFeatureGroupClass(
+            feature=Feature(MULTI_FEATURE),
+            accessible_plugins={ProbeMultiA722B: {CfwParity722B}, ProbeMultiB722B: {CfwParity722B}},
+            links=None,
+        )
+
+    message = str(exc_info.value)
+    # TARGET CONTRACT: formatted candidates with module paths, URL last.
+    assert f"ProbeMultiA722B ({MODULE_PATH})" in message
+    assert f"ProbeMultiB722B ({MODULE_PATH})" in message
+    assert message.endswith(TROUBLESHOOTING_URL)
+
+
+def test_resolve_feature_multiple_match_error_bare_names_only() -> None:
+    """resolve_feature's ambiguity error carries bare class names, no module paths, no URL."""
+    collector = PluginCollector.enabled_feature_groups({ProbeMultiA722B, ProbeMultiB722B})
+
+    result = resolve_feature(MULTI_FEATURE, plugin_collector=collector)
+
+    assert result.feature_group is None
+    assert result.error is not None
+    assert "Multiple FeatureGroups match feature name" in result.error
+    assert "ProbeMultiA722B" in result.error
+    assert "ProbeMultiB722B" in result.error
+    # PINS CURRENT DIVERGENCE (#14): no module paths and no troubleshooting URL in the debug error.
+    assert MODULE_PATH not in result.error
+    assert TROUBLESHOOTING_URL not in result.error
+
+
+# ---------------------------------------------------------------------------
+# Divergence 15: not-found text
+# ---------------------------------------------------------------------------
+
+
+class ProbeNeedle722B(_ParityProbeBase722B):
+    """Supports the needle name; feature_names_supported feeds the difflib suggestion."""
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return {NEEDLE_FEATURE}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == NEEDLE_FEATURE
+
+
+def test_engine_not_found_error_carries_suggestions_and_url() -> None:
+    """The engine's not-found error suggests close names, points at resolve_feature, ends with the URL."""
+    with pytest.raises(ValueError, match="No feature groups found") as exc_info:
+        IdentifyFeatureGroupClass(
+            feature=Feature(NEEDLE_TYPO),
+            accessible_plugins={ProbeNeedle722B: {CfwParity722B}},
+            links=None,
+        )
+
+    message = str(exc_info.value)
+    # TARGET CONTRACT: suggestion, debug pointer, URL last.
+    assert "Did you mean" in message
+    assert NEEDLE_FEATURE in message
+    assert "Use resolve_feature(" in message
+    assert message.endswith(TROUBLESHOOTING_URL)
+
+
+def test_resolve_feature_not_found_error_is_single_bare_line() -> None:
+    """resolve_feature's not-found error is one bare line without suggestions or URL."""
+    collector = PluginCollector.enabled_feature_groups({ProbeNeedle722B})
+
+    result = resolve_feature(NEEDLE_TYPO, plugin_collector=collector)
+
+    assert result.feature_group is None
+    assert result.error is not None
+    # PINS CURRENT DIVERGENCE (#15): the engine points users at a tool returning strictly less information.
+    assert result.error == f"No FeatureGroup found for feature name: {NEEDLE_TYPO}"
+    assert "Did you mean" not in result.error
+    assert TROUBLESHOOTING_URL not in result.error

--- a/tests/test_core/test_resolution_parity/test_parity_request_context.py
+++ b/tests/test_core/test_resolution_parity/test_parity_request_context.py
@@ -418,6 +418,14 @@ def test_engine_matching_value_error_propagates_despite_clean_winner() -> None:
         ProbeBoom722B: {CfwParity722B},
     }
 
+    # Premise guard: on its own the winner probe resolves cleanly, so the ValueError overrides a clean winner.
+    identifier = IdentifyFeatureGroupClass(
+        feature=Feature(BOOM_FEATURE),
+        accessible_plugins={ProbeWinner722B: {CfwParity722B}},
+        links=None,
+    )
+    assert identifier.get()[0] is ProbeWinner722B
+
     # PINS CURRENT DIVERGENCE (#11): the run aborts even though another candidate matched.
     with pytest.raises(ValueError, match="boom 722b"):
         IdentifyFeatureGroupClass(

--- a/tests/test_core/test_resolve/test_environment_factory.py
+++ b/tests/test_core/test_resolve/test_environment_factory.py
@@ -1,0 +1,570 @@
+"""Failing tests for issue #722 Stage 2: the immutable environment state API.
+
+Defines the contract of ``mloda.core.resolve.environment``:
+``build_resolution_environment`` runs the same classification pipeline as
+``PreFilterPlugins`` (collector applicability, strict mode via injected registry,
+dedup, availability, run-framework intersection) but returns structured state
+instead of raising. On the conditions where ``PreFilterPlugins`` raises, the
+outcome carries errors with the exact current message text and no snapshot.
+``PreFilterPlugins`` becomes an adapter over this factory with unchanged
+raising behavior.
+
+RED phase: ``mloda.core.resolve`` does not exist yet, so this module fails at
+collection with ``ModuleNotFoundError``.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import gc
+import json
+import linecache
+import sys
+import textwrap
+from typing import Any, Iterator, cast
+
+import pytest
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistry
+from mloda.core.prepare.accessible_plugins import PreFilterPlugins, RedefinitionConflictError
+from mloda.core.resolve.environment import (
+    EnvironmentBuildOutcome,
+    EnvironmentProvenance,
+    FeatureGroupRecord,
+    FrameworkRecord,
+    ResolutionEnvironmentSnapshot,
+    build_resolution_environment,
+)
+from mloda.core.resolve.identity import PluginIdentity
+
+
+ACCESSIBLE_FEATURE = "probe722d_accessible"
+DISABLED_FEATURE = "probe722d_disabled"
+REGISTERED_A_FEATURE = "probe722d_registered_a"
+UNREGISTERED_B_FEATURE = "probe722d_unregistered_b"
+THREE_FW_FEATURE = "probe722d_threefw"
+STRICT_ONLY_FEATURE = "probe722d_strict_only"
+TWO_FW_FEATURE = "probe722d_twofw"
+BROKEN_FEATURE = "probe722d_broken"
+REDEF_FEATURE = "probe722d_redef"
+
+
+# ---------------------------------------------------------------------------
+# Mock compute frameworks (unique names, suffix 722D)
+# ---------------------------------------------------------------------------
+
+
+class CfwAvail722D(ComputeFramework):
+    """Available framework enabled for most builds in this module."""
+
+
+class CfwSecond722D(ComputeFramework):
+    """Available framework enabled only by the fingerprint-sensitivity build."""
+
+
+class CfwNotEnabled722D(ComputeFramework):
+    """Available framework never passed into a build in this module."""
+
+
+class CfwUnavailable722D(ComputeFramework):
+    """Framework whose backing dependency is never installed."""
+
+    @staticmethod
+    def is_available() -> bool:
+        return False
+
+
+class CfwStrictRun722D(ComputeFramework):
+    """Available framework carrying the strict-mode builds."""
+
+
+# ---------------------------------------------------------------------------
+# Probe feature groups (match ONLY their own probe722d_* names)
+# ---------------------------------------------------------------------------
+
+
+class ProbeAccessible722D(FeatureGroup):
+    """Collector-enabled probe with one available, run-enabled framework."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwAvail722D}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == ACCESSIBLE_FEATURE
+
+
+class ProbeDisabled722D(FeatureGroup):
+    """Probe deliberately left out of the collector's enabled set."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwAvail722D}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == DISABLED_FEATURE
+
+
+class ProbeRegisteredA722D(FeatureGroup):
+    """Probe registered in the injected strict-mode registry."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwStrictRun722D}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == REGISTERED_A_FEATURE
+
+
+class ProbeUnregisteredB722D(FeatureGroup):
+    """Probe NOT registered in the injected strict-mode registry."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwStrictRun722D}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == UNREGISTERED_B_FEATURE
+
+
+class ProbeThreeFw722D(FeatureGroup):
+    """Declares one enabled, one unavailable, and one not-enabled framework."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwAvail722D, CfwUnavailable722D, CfwNotEnabled722D}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == THREE_FW_FEATURE
+
+
+class ProbeStrictOnly722D(FeatureGroup):
+    """Concrete probe that is never registered; strict mode drops it fatally."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwStrictRun722D}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == STRICT_ONLY_FEATURE
+
+
+class ProbeTwoFw722D(FeatureGroup):
+    """Declares two available frameworks for the fingerprint-sensitivity test."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwAvail722D, CfwSecond722D}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == TWO_FW_FEATURE
+
+
+def _make_broken_declaration_fg() -> type[FeatureGroup]:
+    """Probe whose compute_framework_definition raises when consulted.
+
+    Scoped per test (locals die at return, gc fixture collects after), so the
+    broken declaration never leaks into collector-less builds of other tests.
+    """
+    gc.collect()
+
+    class ProbeBrokenDeclaration722D(FeatureGroup):
+        @classmethod
+        def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+            raise ValueError("broken definition 722d")
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: DataAccessCollection | None = None,
+        ) -> bool:
+            return str(feature_name) == BROKEN_FEATURE
+
+    return ProbeBrokenDeclaration722D
+
+
+# ---------------------------------------------------------------------------
+# Jupyter-cell simulation helpers for the redefinition conflict
+# (transplanted from tests/test_core/test_resolution_parity/test_parity_environment.py)
+# ---------------------------------------------------------------------------
+
+# Keeps exec'd classes alive across assertions, like IPython's Out[N] history. Leaking them for the process
+# lifetime is safe: the autouse cleanup unbinds them from __main__, so they are no longer live-in-module and
+# dedup preserves instead of re-raising, and they only match the unique name probe722d_redef.
+_REF_STORE: list[Any] = []
+
+
+def _exec_fg_in_main(class_name: str, body: str, cell_label: str) -> type[FeatureGroup]:
+    """Exec a FeatureGroup subclass into __main__ with linecache-backed source (Jupyter cell simulation)."""
+    main_mod = sys.modules["__main__"]
+    src = textwrap.dedent(body)
+    filename = f"<{cell_label}>"
+    linecache.cache[filename] = (len(src), None, src.splitlines(keepends=True), filename)
+    exec(compile(src, filename, "exec"), main_mod.__dict__)  # nosec B102
+    return cast(type[FeatureGroup], main_mod.__dict__[class_name])
+
+
+def _make_fg_source(class_name: str, feature_name: str, extra_body: str = "") -> str:
+    return f"""
+from mloda.core.abstract_plugins.feature_group import FeatureGroup as _FG_BASE_
+
+class {class_name}(_FG_BASE_):
+    @classmethod
+    def feature_names_supported(cls):
+        return {{"{feature_name}"}}
+{extra_body}
+"""
+
+
+def _make_conflicting_pair(qualname: str, feature_name: str) -> tuple[type[FeatureGroup], type[FeatureGroup]]:
+    """Two classes sharing (module, qualname) with DIFFERENT source; v2 is live in __main__."""
+    src_v1 = _make_fg_source(qualname, feature_name)
+    src_v2 = _make_fg_source(qualname, feature_name, extra_body="    def extra_method(self):\n        return 722\n")
+    v1 = _exec_fg_in_main(qualname, src_v1, f"cell-{qualname}-v1")
+    v2 = _exec_fg_in_main(qualname, src_v2, f"cell-{qualname}-v2")
+    _REF_STORE.extend([v1, v2])
+    return v1, v2
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_main_module_attrs() -> Iterator[None]:
+    """Snapshot __main__ attrs and restore after each test (xdist safety, mirrors test_feature_group_dedup)."""
+    main_mod = sys.modules["__main__"]
+    snapshot = set(main_mod.__dict__.keys())
+    yield
+    for key in set(main_mod.__dict__.keys()) - snapshot:
+        main_mod.__dict__.pop(key, None)
+
+
+@pytest.fixture
+def _collect_after() -> Iterator[None]:
+    """Collect the per-test broken class once the test's frames are gone."""
+    yield
+    gc.collect()
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _off_collector(*probes: type[FeatureGroup]) -> PluginCollector:
+    return PluginCollector.enabled_feature_groups(set(probes)).set_strict_mode("off")
+
+
+def _strict_collector(registry: PluginRegistry, *probes: type[FeatureGroup]) -> PluginCollector:
+    return PluginCollector.enabled_feature_groups(set(probes)).set_strict_mode("strict").set_registry(registry)
+
+
+def _snapshot_or_fail(outcome: EnvironmentBuildOutcome) -> ResolutionEnvironmentSnapshot:
+    assert outcome.errors == ()
+    assert outcome.snapshot is not None
+    return outcome.snapshot
+
+
+def _record_for(snapshot: ResolutionEnvironmentSnapshot, plugin_class: type[FeatureGroup]) -> FeatureGroupRecord:
+    identity = PluginIdentity.from_class(plugin_class)
+    matches = [record for record in snapshot.records if record.identity == identity]
+    assert len(matches) == 1, f"expected exactly one record for {identity}, got {len(matches)}"
+    return matches[0]
+
+
+def _framework_record(record: FeatureGroupRecord, framework: type[ComputeFramework]) -> FrameworkRecord:
+    identity = PluginIdentity.from_class(framework)
+    matches = [framework_record for framework_record in record.frameworks if framework_record.identity == identity]
+    assert len(matches) == 1, f"expected exactly one framework record for {identity}, got {len(matches)}"
+    return matches[0]
+
+
+# ---------------------------------------------------------------------------
+# Provenance classification
+# ---------------------------------------------------------------------------
+
+
+def test_accessible_probe_is_classified_accessible() -> None:
+    """A collector-enabled probe with an available run-enabled framework is ACCESSIBLE end to end."""
+    collector = _off_collector(ProbeAccessible722D)
+
+    outcome = build_resolution_environment(compute_frameworks={CfwAvail722D}, plugin_collector=collector)
+    snapshot = _snapshot_or_fail(outcome)
+
+    record = _record_for(snapshot, ProbeAccessible722D)
+    assert record.provenance is EnvironmentProvenance.ACCESSIBLE
+    assert EnvironmentProvenance.ACCESSIBLE.value == "accessible"
+    assert record.identity.render() == f"{ProbeAccessible722D.__module__}:{ProbeAccessible722D.__qualname__}"
+
+    assert _framework_record(record, CfwAvail722D).provenance is EnvironmentProvenance.ACCESSIBLE
+
+    accessible_entries = [entry for entry in snapshot.accessible if entry[0] is ProbeAccessible722D]
+    assert len(accessible_entries) == 1
+    assert accessible_entries[0][1] == (CfwAvail722D,)
+
+    assert snapshot.strict_mode == "off"
+    assert snapshot.requested_frameworks == (PluginIdentity.from_class(CfwAvail722D),)
+    assert snapshot.enabled_frameworks == (PluginIdentity.from_class(CfwAvail722D),)
+
+
+def test_collector_excluded_probe_is_disabled_by_collector() -> None:
+    """A probe excluded by the collector is DISABLED_BY_COLLECTOR and absent from accessible."""
+    collector = _off_collector(ProbeAccessible722D)
+
+    snapshot = _snapshot_or_fail(
+        build_resolution_environment(compute_frameworks={CfwAvail722D}, plugin_collector=collector)
+    )
+
+    record = _record_for(snapshot, ProbeDisabled722D)
+    assert record.provenance is EnvironmentProvenance.DISABLED_BY_COLLECTOR
+    assert all(entry[0] is not ProbeDisabled722D for entry in snapshot.accessible)
+    assert ProbeDisabled722D not in snapshot.accessible_mapping()
+
+
+def test_strict_mode_rejects_unregistered_probe_as_policy_rejected() -> None:
+    """Strict mode with an injected registry rejects only the unregistered probe, without a fatal error."""
+    registry = PluginRegistry()
+    registry.register(ProbeRegisteredA722D)
+    registry.register(CfwStrictRun722D)
+    collector = _strict_collector(registry, ProbeRegisteredA722D, ProbeUnregisteredB722D)
+
+    outcome = build_resolution_environment(compute_frameworks={CfwStrictRun722D}, plugin_collector=collector)
+    snapshot = _snapshot_or_fail(outcome)
+
+    assert _record_for(snapshot, ProbeUnregisteredB722D).provenance is EnvironmentProvenance.POLICY_REJECTED
+    assert _record_for(snapshot, ProbeRegisteredA722D).provenance is EnvironmentProvenance.ACCESSIBLE
+    assert snapshot.strict_mode == "strict"
+
+    mapping = snapshot.accessible_mapping()
+    assert mapping.get(ProbeRegisteredA722D) == {CfwStrictRun722D}
+    assert ProbeUnregisteredB722D not in mapping
+
+
+def test_framework_records_distinguish_unavailable_and_not_enabled() -> None:
+    """Framework records split per cause: accessible vs unavailable vs not enabled for this run."""
+    assert CfwUnavailable722D.is_available() is False  # premise guard
+    assert CfwNotEnabled722D.is_available() is True  # premise guard
+
+    collector = _off_collector(ProbeThreeFw722D)
+    snapshot = _snapshot_or_fail(
+        build_resolution_environment(compute_frameworks={CfwAvail722D}, plugin_collector=collector)
+    )
+
+    record = _record_for(snapshot, ProbeThreeFw722D)
+    assert _framework_record(record, CfwAvail722D).provenance is EnvironmentProvenance.ACCESSIBLE
+    assert _framework_record(record, CfwUnavailable722D).provenance is EnvironmentProvenance.UNAVAILABLE
+    assert _framework_record(record, CfwNotEnabled722D).provenance is EnvironmentProvenance.NOT_ENABLED
+
+    assert snapshot.accessible_mapping()[ProbeThreeFw722D] == {CfwAvail722D}
+
+
+# ---------------------------------------------------------------------------
+# Fatal parity with PreFilterPlugins (structured errors, exact message text)
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_declaration_is_structured_and_prefilter_raises_same_error(_collect_after: None) -> None:
+    """A broken compute_framework_definition becomes a structured invalid_declaration error."""
+    broken = _make_broken_declaration_fg()
+    collector = PluginCollector.enabled_feature_groups({broken}).set_strict_mode("off")
+
+    with pytest.raises(ValueError, match="broken definition 722d") as excinfo:
+        PreFilterPlugins(compute_frameworks={CfwAvail722D}, plugin_collector=collector)
+
+    outcome = build_resolution_environment(compute_frameworks={CfwAvail722D}, plugin_collector=collector)
+
+    assert outcome.snapshot is None
+    invalid = [error for error in outcome.errors if error.category == "invalid_declaration"]
+    assert len(invalid) == 1
+    assert invalid[0].message == str(excinfo.value)
+
+
+def test_strict_mode_fatal_error_matches_prefilter_message() -> None:
+    """Strict mode dropping every concrete probe yields the exact PreFilterPlugins message, structured."""
+    collector = _strict_collector(PluginRegistry(), ProbeStrictOnly722D)
+
+    with pytest.raises(ValueError, match="Strict mode filtered out all FeatureGroups") as excinfo:
+        PreFilterPlugins(compute_frameworks={CfwStrictRun722D}, plugin_collector=collector)
+
+    outcome = build_resolution_environment(compute_frameworks={CfwStrictRun722D}, plugin_collector=collector)
+
+    assert outcome.snapshot is None
+    fatal = [error for error in outcome.errors if error.category == "strict_mode_feature_groups"]
+    assert len(fatal) == 1
+    assert fatal[0].message == str(excinfo.value)
+
+
+def test_redefinition_conflict_is_structured_and_prefilter_raises() -> None:
+    """A same-qualname different-source pair yields a redefinition_conflict error carrying identities."""
+    v1, v2 = _make_conflicting_pair("ProbeRedefEnv722D", REDEF_FEATURE)
+    collector = PluginCollector.enabled_feature_groups({v1, v2}).set_strict_mode("off")
+
+    outcome = build_resolution_environment(compute_frameworks={CfwAvail722D}, plugin_collector=collector)
+
+    assert outcome.snapshot is None
+    conflicts = [error for error in outcome.errors if error.category == "redefinition_conflict"]
+    assert len(conflicts) == 1
+    assert conflicts[0].conflict_identities != ()
+    assert all(identity.qualname == "ProbeRedefEnv722D" for identity in conflicts[0].conflict_identities)
+
+    with pytest.raises(RedefinitionConflictError):
+        PreFilterPlugins(compute_frameworks={CfwAvail722D}, plugin_collector=collector)
+
+
+# ---------------------------------------------------------------------------
+# Mapping parity, determinism, fingerprint
+# ---------------------------------------------------------------------------
+
+
+def test_accessible_mapping_matches_prefilter_plugins() -> None:
+    """On a healthy environment the snapshot mapping equals PreFilterPlugins' mapping exactly."""
+    collector = _off_collector(ProbeAccessible722D, ProbeThreeFw722D)
+
+    snapshot = _snapshot_or_fail(
+        build_resolution_environment(compute_frameworks={CfwAvail722D}, plugin_collector=collector)
+    )
+    expected = PreFilterPlugins(compute_frameworks={CfwAvail722D}, plugin_collector=collector).get_accessible_plugins()
+
+    assert snapshot.accessible_mapping() == expected
+
+
+def test_building_twice_is_deterministic() -> None:
+    """Identical inputs yield equal record tuples and equal 64-char sha256 hex fingerprints."""
+    collector = _off_collector(ProbeAccessible722D, ProbeThreeFw722D)
+
+    first = _snapshot_or_fail(
+        build_resolution_environment(compute_frameworks={CfwAvail722D}, plugin_collector=collector)
+    )
+    second = _snapshot_or_fail(
+        build_resolution_environment(compute_frameworks={CfwAvail722D}, plugin_collector=collector)
+    )
+
+    assert first.records == second.records
+    assert first.fingerprint == second.fingerprint
+    assert len(first.fingerprint) == 64
+    assert set(first.fingerprint) <= set("0123456789abcdef")
+
+
+def test_fingerprint_changes_with_second_enabled_framework() -> None:
+    """Enabling a second run framework changes the environment fingerprint."""
+    collector = _off_collector(ProbeTwoFw722D)
+
+    narrow = _snapshot_or_fail(
+        build_resolution_environment(compute_frameworks={CfwAvail722D}, plugin_collector=collector)
+    )
+    wide = _snapshot_or_fail(
+        build_resolution_environment(compute_frameworks={CfwAvail722D, CfwSecond722D}, plugin_collector=collector)
+    )
+
+    assert narrow.fingerprint != wide.fingerprint
+
+
+# ---------------------------------------------------------------------------
+# Serialization and immutability
+# ---------------------------------------------------------------------------
+
+
+def test_outcome_payload_is_json_serializable_without_class_objects() -> None:
+    """to_payload() is plain data: json.dumps succeeds and no class reprs leak through."""
+    collector = _off_collector(ProbeAccessible722D, ProbeThreeFw722D)
+
+    outcome = build_resolution_environment(compute_frameworks={CfwAvail722D}, plugin_collector=collector)
+    dumped = json.dumps(outcome.to_payload())
+
+    assert "<class" not in dumped
+    assert "object at 0x" not in dumped
+
+
+def test_accessible_mapping_returns_fresh_dict_and_snapshot_is_frozen() -> None:
+    """Mutating a returned mapping never leaks into the snapshot; fields cannot be reassigned."""
+    collector = _off_collector(ProbeAccessible722D)
+    snapshot = _snapshot_or_fail(
+        build_resolution_environment(compute_frameworks={CfwAvail722D}, plugin_collector=collector)
+    )
+
+    mapping = snapshot.accessible_mapping()
+    assert ProbeAccessible722D in mapping
+    mapping.pop(ProbeAccessible722D)
+
+    assert ProbeAccessible722D in snapshot.accessible_mapping()
+
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        setattr(snapshot, "fingerprint", "forged-722d")
+
+
+def test_snapshot_ignores_later_class_definitions() -> None:
+    """A snapshot never re-discovers: a class defined after the build stays invisible to it."""
+    collector = _off_collector(ProbeAccessible722D)
+    snapshot = _snapshot_or_fail(
+        build_resolution_environment(compute_frameworks={CfwAvail722D}, plugin_collector=collector)
+    )
+    records_before = snapshot.records
+    mapping_before = snapshot.accessible_mapping()
+
+    def _late_matches(
+        cls: type[FeatureGroup],
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == ACCESSIBLE_FEATURE
+
+    late_class = cast(
+        type[FeatureGroup],
+        type("ProbeLateArrival722D", (FeatureGroup,), {"match_feature_group_criteria": classmethod(_late_matches)}),
+    )
+
+    assert snapshot.records == records_before
+    assert PluginIdentity.from_class(late_class) not in {record.identity for record in snapshot.records}
+    assert snapshot.accessible_mapping() == mapping_before
+    assert late_class not in snapshot.accessible_mapping()
+
+    del late_class
+    gc.collect()

--- a/tests/test_core/test_resolve/test_environment_hardening.py
+++ b/tests/test_core/test_resolve/test_environment_hardening.py
@@ -1,0 +1,406 @@
+"""Failing tests for issue #722 Stage 2 hardening (post-review fix round).
+
+Pins review-mandated hardening of ``mloda.core.resolve.environment``:
+
+1. Error-path payloads are JSON-serializable AND redacted: the raw provider
+   message stays on the internal ``message`` field (it feeds the adapter
+   re-raise) but never leaks into ``to_payload()``; the payload names the
+   category and the exception type instead.
+2. Junk members in a ``compute_framework_rule`` set become framework records
+   with ``INVALID_DECLARATION`` provenance instead of crashing the build,
+   while the legacy ``PreFilterPlugins`` mapping stays tolerant.
+3. Carried exceptions are stripped of tracebacks (no frame-graph retention),
+   while the adapter still re-raises the original exception type.
+4. Framework availability is sampled at most once per framework per build.
+5. Snapshots never re-discover, even for a collector-less build
+   (TARGET CONTRACT, passes today).
+6. ``conflict_identities`` carries no duplicate identities.
+
+RED phase: tests 1, 2, 3a, 3b, 4, and 6 fail against the current
+implementation; test 5 passes and pins the target contract.
+"""
+
+from __future__ import annotations
+
+import gc
+import json
+import linecache
+import sys
+import textwrap
+from typing import Any, Iterator, cast
+
+import pytest
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.prepare.accessible_plugins import PreFilterPlugins, RedefinitionConflictError
+from mloda.core.resolve.environment import (
+    EnvironmentBuildOutcome,
+    EnvironmentProvenance,
+    build_resolution_environment,
+)
+from mloda.core.resolve.identity import PluginIdentity
+
+
+REDACTION_FEATURE = "probe722e_redacted"
+JUNK_FEATURE = "probe722e_junk"
+COUNTING_FEATURE = "probe722e_counting"
+LATE_FEATURE = "probe722e_late"
+REDEF_FEATURE = "probe722e_redef"
+
+# Fake credential-shaped provider message used to prove payload redaction; never a real secret.
+_FAKE_SECRET_MESSAGE_722E = "token=super-secret-722e"  # nosec B105
+
+
+# ---------------------------------------------------------------------------
+# Mock compute frameworks (unique names, suffix 722E)
+# ---------------------------------------------------------------------------
+
+
+class CfwValid722E(ComputeFramework):
+    """Available framework enabled by most builds in this module."""
+
+
+# Counts every is_available() call on the counting framework; cleared per test (xdist-safe:
+# workers are separate processes, and within one worker the owning test resets it first).
+_AVAILABILITY_CALLS_722E: list[str] = []
+
+
+class CfwCounting722E(ComputeFramework):
+    """Available framework whose availability probe counts its own invocations."""
+
+    @staticmethod
+    def is_available() -> bool:
+        _AVAILABILITY_CALLS_722E.append("call")
+        return True
+
+
+# A declaration member that is NOT a ComputeFramework subclass. It passes the base
+# compute_framework_definition plumbing (which only checks the rule is a set) and
+# reaches the per-FG classification in build_resolution_environment.
+_JUNK_DECLARATION_MEMBER_722E = cast(type[ComputeFramework], 42)
+
+
+# ---------------------------------------------------------------------------
+# Probe feature groups (match ONLY their own probe722e_* names)
+# ---------------------------------------------------------------------------
+
+
+class ProbeCounting722E(FeatureGroup):
+    """Probe declaring only the counting framework, for the single-sampling pin."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwCounting722E}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == COUNTING_FEATURE
+
+
+def _make_secret_raising_fg() -> type[FeatureGroup]:
+    """Probe whose compute_framework_rule raises with a credential-shaped message.
+
+    Scoped per test (locals die at return, gc fixture collects after), so the
+    broken declaration never leaks into collector-less builds of other tests.
+    """
+    gc.collect()
+
+    class ProbeSecretDeclaration722E(FeatureGroup):
+        @classmethod
+        def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+            raise ValueError(_FAKE_SECRET_MESSAGE_722E)
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: DataAccessCollection | None = None,
+        ) -> bool:
+            return str(feature_name) == REDACTION_FEATURE
+
+    return ProbeSecretDeclaration722E
+
+
+def _make_junk_declaration_fg() -> type[FeatureGroup]:
+    """Probe declaring one valid framework plus a member that is no framework at all.
+
+    Scoped per test like the secret-raising probe, so the junk declaration never
+    leaks into collector-less builds of other tests.
+    """
+    gc.collect()
+
+    class ProbeJunkDeclaration722E(FeatureGroup):
+        @classmethod
+        def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+            return {CfwValid722E, _JUNK_DECLARATION_MEMBER_722E}
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: DataAccessCollection | None = None,
+        ) -> bool:
+            return str(feature_name) == JUNK_FEATURE
+
+    return ProbeJunkDeclaration722E
+
+
+# ---------------------------------------------------------------------------
+# Jupyter-cell simulation helpers for the redefinition conflict
+# (transplanted from tests/test_core/test_resolution_parity/test_parity_environment.py)
+# ---------------------------------------------------------------------------
+
+# Keeps exec'd classes alive across assertions, like IPython's Out[N] history. Leaking them for the process
+# lifetime is safe: the autouse cleanup unbinds them from __main__, so they are no longer live-in-module and
+# dedup preserves instead of re-raising, and they only match the unique name probe722e_redef.
+_REF_STORE: list[Any] = []
+
+
+def _exec_fg_in_main(class_name: str, body: str, cell_label: str) -> type[FeatureGroup]:
+    """Exec a FeatureGroup subclass into __main__ with linecache-backed source (Jupyter cell simulation)."""
+    main_mod = sys.modules["__main__"]
+    src = textwrap.dedent(body)
+    filename = f"<{cell_label}>"
+    linecache.cache[filename] = (len(src), None, src.splitlines(keepends=True), filename)
+    exec(compile(src, filename, "exec"), main_mod.__dict__)  # nosec B102
+    return cast(type[FeatureGroup], main_mod.__dict__[class_name])
+
+
+def _make_fg_source(class_name: str, feature_name: str, extra_body: str = "") -> str:
+    return f"""
+from mloda.core.abstract_plugins.feature_group import FeatureGroup as _FG_BASE_
+
+class {class_name}(_FG_BASE_):
+    @classmethod
+    def feature_names_supported(cls):
+        return {{"{feature_name}"}}
+{extra_body}
+"""
+
+
+def _make_conflicting_pair(qualname: str, feature_name: str) -> tuple[type[FeatureGroup], type[FeatureGroup]]:
+    """Two classes sharing (module, qualname) with DIFFERENT source; v2 is live in __main__."""
+    src_v1 = _make_fg_source(qualname, feature_name)
+    src_v2 = _make_fg_source(qualname, feature_name, extra_body="    def extra_method(self):\n        return 722\n")
+    v1 = _exec_fg_in_main(qualname, src_v1, f"cell-{qualname}-v1")
+    v2 = _exec_fg_in_main(qualname, src_v2, f"cell-{qualname}-v2")
+    _REF_STORE.extend([v1, v2])
+    return v1, v2
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_main_module_attrs() -> Iterator[None]:
+    """Snapshot __main__ attrs and restore after each test (xdist safety, mirrors test_feature_group_dedup)."""
+    main_mod = sys.modules["__main__"]
+    snapshot = set(main_mod.__dict__.keys())
+    yield
+    for key in set(main_mod.__dict__.keys()) - snapshot:
+        main_mod.__dict__.pop(key, None)
+
+
+@pytest.fixture
+def _collect_after() -> Iterator[None]:
+    """Collect the per-test broken class once the test's frames are gone."""
+    yield
+    gc.collect()
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _off_collector(*probes: type[FeatureGroup]) -> PluginCollector:
+    return PluginCollector.enabled_feature_groups(set(probes)).set_strict_mode("off")
+
+
+def _build_conflict_outcome(qualname: str) -> tuple[EnvironmentBuildOutcome, PluginCollector]:
+    """Build the environment over a fresh same-qualname different-source pair."""
+    v1, v2 = _make_conflicting_pair(qualname, REDEF_FEATURE)
+    collector = PluginCollector.enabled_feature_groups({v1, v2}).set_strict_mode("off")
+    outcome = build_resolution_environment(compute_frameworks={CfwValid722E}, plugin_collector=collector)
+    return outcome, collector
+
+
+# ---------------------------------------------------------------------------
+# 1. Error-path payload is serializable and redacted
+# ---------------------------------------------------------------------------
+
+
+def test_error_payload_is_serializable_and_redacted(_collect_after: None) -> None:
+    """The internal message stays exact for the adapter; the payload never carries the raw provider text."""
+    broken = _make_secret_raising_fg()
+    collector = _off_collector(broken)
+
+    outcome = build_resolution_environment(compute_frameworks={CfwValid722E}, plugin_collector=collector)
+
+    assert outcome.snapshot is None
+    assert len(outcome.errors) == 1
+    error = outcome.errors[0]
+    assert error.category == "invalid_declaration"
+    assert error.message == _FAKE_SECRET_MESSAGE_722E
+
+    dumped = json.dumps(outcome.to_payload())
+    assert "super-secret-722e" not in dumped
+    assert "object at 0x" not in dumped
+    assert "Traceback" not in dumped
+    assert "invalid_declaration" in dumped
+    assert "ValueError" in dumped
+
+
+# ---------------------------------------------------------------------------
+# 2. Junk declaration members do not crash the build
+# ---------------------------------------------------------------------------
+
+
+def test_junk_declaration_member_is_recorded_not_crashing(_collect_after: None) -> None:
+    """A non-framework rule member becomes an INVALID_DECLARATION record; the valid one stays accessible."""
+    probe = _make_junk_declaration_fg()
+    collector = _off_collector(probe)
+
+    outcome = build_resolution_environment(compute_frameworks={CfwValid722E}, plugin_collector=collector)
+
+    assert outcome.errors == ()
+    assert outcome.snapshot is not None
+    snapshot = outcome.snapshot
+
+    identity = PluginIdentity.from_class(probe)
+    matches = [record for record in snapshot.records if record.identity == identity]
+    assert len(matches) == 1
+    record = matches[0]
+
+    assert len(record.frameworks) == 2
+    invalid = [fw for fw in record.frameworks if fw.provenance is EnvironmentProvenance.INVALID_DECLARATION]
+    assert len(invalid) == 1
+    accessible = [fw for fw in record.frameworks if fw.provenance is EnvironmentProvenance.ACCESSIBLE]
+    assert len(accessible) == 1
+    assert accessible[0].identity == PluginIdentity.from_class(CfwValid722E)
+
+    entries = [entry for entry in snapshot.accessible if entry[0] is probe]
+    assert len(entries) == 1
+    assert entries[0][1] == (CfwValid722E,)
+
+    # Legacy parity (passes today, pinned here to keep the invariant): the adapter
+    # tolerates the junk member and maps the probe to the valid framework only.
+    mapping = PreFilterPlugins(compute_frameworks={CfwValid722E}, plugin_collector=collector).get_accessible_plugins()
+    assert mapping == {probe: {CfwValid722E}}
+
+
+# ---------------------------------------------------------------------------
+# 3. Stored exceptions carry no traceback
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_declaration_exception_carries_no_traceback(_collect_after: None) -> None:
+    """The carried provider exception keeps its type but is stripped of its traceback."""
+    broken = _make_secret_raising_fg()
+    collector = _off_collector(broken)
+
+    outcome = build_resolution_environment(compute_frameworks={CfwValid722E}, plugin_collector=collector)
+
+    assert len(outcome.errors) == 1
+    error = outcome.errors[0]
+    assert error.category == "invalid_declaration"
+    assert error.exception is not None
+    assert type(error.exception) is ValueError
+    assert error.exception.__traceback__ is None
+
+
+def test_redefinition_conflict_exception_carries_no_traceback_and_adapter_reraises() -> None:
+    """The carried dedup exception is traceback-free while the adapter still raises the original type."""
+    outcome, collector = _build_conflict_outcome("ProbeRedefNoTb722E")
+
+    assert outcome.snapshot is None
+    conflicts = [error for error in outcome.errors if error.category == "redefinition_conflict"]
+    assert len(conflicts) == 1
+
+    with pytest.raises(RedefinitionConflictError):
+        PreFilterPlugins(compute_frameworks={CfwValid722E}, plugin_collector=collector)
+
+    assert conflicts[0].exception is not None
+    assert isinstance(conflicts[0].exception, RedefinitionConflictError)
+    assert conflicts[0].exception.__traceback__ is None
+
+
+# ---------------------------------------------------------------------------
+# 4. is_available sampled at most once per framework per build
+# ---------------------------------------------------------------------------
+
+
+def test_is_available_sampled_at_most_once_per_framework_per_build() -> None:
+    """One build consults a framework's availability once; classification reuses the sampled result."""
+    collector = _off_collector(ProbeCounting722E)
+    _AVAILABILITY_CALLS_722E.clear()
+
+    outcome = build_resolution_environment(compute_frameworks={CfwCounting722E}, plugin_collector=collector)
+
+    assert outcome.snapshot is not None  # premise guard: the build itself succeeds
+    assert len(_AVAILABILITY_CALLS_722E) == 1
+
+
+# ---------------------------------------------------------------------------
+# 5. Stronger no-rediscovery pin (TARGET CONTRACT, passes today)
+# ---------------------------------------------------------------------------
+
+
+def test_collectorless_snapshot_ignores_later_class_definitions() -> None:
+    """TARGET CONTRACT: even without a collector, a snapshot never re-discovers late classes."""
+    gc.collect()  # flush any per-test broken probes lingering from earlier tests in this worker
+
+    outcome = build_resolution_environment(compute_frameworks={CfwValid722E}, plugin_collector=None)
+    assert outcome.errors == ()
+    assert outcome.snapshot is not None
+    snapshot = outcome.snapshot
+
+    records_before = len(snapshot.records)
+    mapping_before = snapshot.accessible_mapping()
+
+    def _late_matches(
+        cls: type[FeatureGroup],
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == LATE_FEATURE
+
+    late_class = cast(
+        type[FeatureGroup],
+        type("ProbeLateArrival722E", (FeatureGroup,), {"match_feature_group_criteria": classmethod(_late_matches)}),
+    )
+
+    assert len(snapshot.records) == records_before
+    assert PluginIdentity.from_class(late_class) not in {record.identity for record in snapshot.records}
+    fresh_mapping = snapshot.accessible_mapping()
+    assert fresh_mapping == mapping_before
+    assert late_class not in fresh_mapping
+
+    del late_class
+    gc.collect()
+
+
+# ---------------------------------------------------------------------------
+# 6. Duplicate conflict identities are deduplicated
+# ---------------------------------------------------------------------------
+
+
+def test_conflict_identities_carry_no_duplicates() -> None:
+    """conflict_identities lists each conflicting identity once, even for same-identity class pairs."""
+    outcome, _collector = _build_conflict_outcome("ProbeRedefDedup722E")
+
+    conflicts = [error for error in outcome.errors if error.category == "redefinition_conflict"]
+    assert len(conflicts) == 1
+    identities = conflicts[0].conflict_identities
+    assert identities != ()
+    assert len(identities) == len(set(identities))

--- a/tests/test_core/test_resolve/test_final_review_pins.py
+++ b/tests/test_core/test_resolve/test_final_review_pins.py
@@ -1,0 +1,505 @@
+"""Failing tests for issue #722 final review fix round.
+
+Pins three accepted findings from the final review:
+
+A.  The engine's failure-path enrichment re-invokes provider hooks after the decision
+    was already made (mloda/core/prepare/identify_feature_group.py):
+    1. _capability_rejection_message calls split_frameworks_by_capability, re-invoking
+       compute_framework_definition / is_available / supports_compute_framework on the
+       failure path. A capability hook that returns False on its first call and raises
+       on later calls leaks that raise through IdentifyFeatureGroupClass instead of the
+       established capability rejection error (test 1), and even a well-behaved hook
+       runs twice per candidate/framework (test 2, today the counter reads 2).
+    2. _input_feature_forwarding_hint re-invokes match_feature_group_criteria with bare
+       AND actual options while building the no-match error. Investigated for the Red
+       phase: the resolver consumes the FIRST junk-key call (CRITERIA rejection), the
+       hint's accepts_bare call carries no junk key, and its rejects_actual call is the
+       SECOND junk-key call, so the raising path IS hit for this shape and the raise
+       leaks today (test 3).
+B.  build_resolution_environment samples framework availability BEFORE
+    run_feature_group_pipeline, so an armed raising is_available probe masks the
+    strict-mode feature-group fatal; the strict-mode message must take precedence
+    (test 4).
+C.  mlodaAPI.diagnose's failure branch returns err.report, whose environment is the
+    engine's synthesized survivors-only outcome; it must carry the full pre-check
+    environment, including the DISABLED_BY_COLLECTOR record of a collector-disabled
+    probe, alongside the failing feature record (test 5).
+
+RED phase: all five tests fail against the current implementation.
+- Test 1 fails with the leaked RuntimeError("second call 722m") escaping
+  IdentifyFeatureGroupClass instead of FeatureResolutionError.
+- Test 2 fails on the invocation counter: 2 today, pinned to exactly 1.
+- Test 3 fails with the leaked RuntimeError("forward rematch boom 722m") escaping the
+  no-match error building.
+- Test 4 fails on the message: availability_failure text today, strict-mode text pinned.
+- Test 5 fails on provenance: the survivors-only snapshot has no record for the
+  disabled probe.
+
+PINNED CHOICES (report these to the Green agent):
+- Tests 1 and 2 pin the established capability rejection text ("Unsupported compute
+  framework(s) for feature ...") and that the rejected framework is named; HOW the
+  message is built (structured outcome data vs a guarded re-invocation) stays free,
+  but test 2 forbids a second hook invocation.
+- Test 3 pins only that the error remains the no-match FeatureResolutionError and that
+  the provider raise does not leak; whether the forwarding hint still appears stays free.
+- Test 4 pins the exact leading clause "Strict mode filtered out all FeatureGroups" and
+  that the availability boom text is absent; error ordering inside the outcome stays free.
+- Test 5 pins complete=False, the failing feature record (dependency path ends with the
+  missing feature, outcome NOT_FOUND), and the DISABLED_BY_COLLECTOR record.
+
+Probe names use the unique probe722m_ prefix; probe classes carry the 722M suffix so
+process-global scans in other tests never trip these fixtures. Hooks that must raise do
+so only while ARMED by their test and are disarmed by fixture teardown, following the
+Stage 3/4 hardening fixture pattern (xdist-safe: per-process state, name-gated hooks).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Iterator
+
+import pytest
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistry
+from mloda.core.api.plugin_docs import resolve_feature
+from mloda.core.api.plugin_info import ResolvedFeature
+from mloda.core.api.request import mlodaAPI
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+from mloda.core.resolve.environment import EnvironmentProvenance
+from mloda.core.resolve.identity import PluginIdentity
+from mloda.core.resolve.outcome import FeatureResolutionError, ResolutionStatus
+from mloda.core.resolve.report import ResolutionReport
+from mloda.provider import BaseInputData, DataCreator, FeatureSet
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
+    PythonDictFramework,
+)
+
+
+CAP_BOOM_FEATURE = "probe722m_cap_boom"
+CAP_ONCE_FEATURE = "probe722m_cap_once"
+FORWARD_FEATURE = "probe722m_forward"
+PRECEDENCE_FEATURE = "probe722m_precedence"
+DIAG_ENV_FEATURE = "probe722m_diag_env"
+DIAG_MISSING_FEATURE = "probe722m_diag_missing"
+
+JUNK_KEY = "junk722m"
+
+SECOND_CALL_TEXT = "second call 722m"
+FORWARD_BOOM_TEXT = "forward rematch boom 722m"
+AVAIL_PREC_BOOM_TEXT = "avail precedence boom 722m"
+
+CAPABILITY_REJECTION_TEXT = "Unsupported compute framework(s) for feature"
+NO_MATCH_TEXT = "No feature groups found for feature name"
+# Exact leading clause of _STRICT_MODE_FEATURE_GROUPS_MESSAGE in mloda/core/resolve/environment.py.
+STRICT_MODE_TEXT = "Strict mode filtered out all FeatureGroups"
+
+
+# ---------------------------------------------------------------------------
+# Armed-hook state (Stage 3/4 fixture pattern; per-process, xdist-safe)
+# ---------------------------------------------------------------------------
+
+# Hook keys armed per test via the arm_hook_722m fixture; disarmed on teardown. While
+# disarmed, every hook below degrades to an inert default, so the module-level classes
+# stay harmless in every other test of the process.
+_ARMED_HOOKS_722M: set[str] = set()
+
+# supports_compute_framework invocations of the second-call probe, keyed by framework
+# class name; cleared by the owning test before each engine/debug pass.
+_CAP_SECOND_CALL_COUNTS_722M: dict[str, int] = {}
+
+# supports_compute_framework invocations of the counting probe; cleared per test.
+_CAP_ONCE_CALLS_722M: list[str] = []
+
+# match_feature_group_criteria invocations of the forwarding probe that carried the
+# junk group key; cleared per test.
+_FORWARD_JUNK_CALLS_722M: list[str] = []
+
+
+@pytest.fixture
+def arm_hook_722m() -> Iterator[Callable[[str], None]]:
+    """Arm raising hooks for one test; teardown disarms them even when the raise propagated."""
+    armed_keys: list[str] = []
+
+    def _arm(key: str) -> None:
+        _ARMED_HOOKS_722M.add(key)
+        armed_keys.append(key)
+
+    yield _arm
+    for key in armed_keys:
+        _ARMED_HOOKS_722M.discard(key)
+
+
+# ---------------------------------------------------------------------------
+# Mock compute frameworks (unique names, suffix 722M)
+# ---------------------------------------------------------------------------
+
+
+class CfwCapBoom722M(ComputeFramework):
+    """Framework declared by the second-call capability probe."""
+
+
+class CfwCapOnce722M(ComputeFramework):
+    """Framework declared by the counting capability probe."""
+
+
+class CfwForward722M(ComputeFramework):
+    """Framework declared by the forwarding-hint probe."""
+
+
+class CfwRaisingAvailPrec722M(ComputeFramework):
+    """Framework whose is_available() raises while armed; unavailable otherwise.
+
+    EVERY availability sampling in the process hits this hook, so the raise is armed
+    only for the precedence test and the class is otherwise a plain unavailable
+    framework.
+    """
+
+    @staticmethod
+    def is_available() -> bool:
+        if "avail_precedence" in _ARMED_HOOKS_722M:
+            raise RuntimeError(AVAIL_PREC_BOOM_TEXT)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Probe feature groups (match ONLY their own probe722m_* names)
+# ---------------------------------------------------------------------------
+
+
+class _Probe722MBase(FeatureGroup):
+    """Shared probe base: never matches anything itself."""
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return False
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        return None
+
+
+class ProbeCapSecondCallBoom722M(_Probe722MBase):
+    """Capability hook: False on the FIRST call per framework, raises on later calls while armed."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwCapBoom722M}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == CAP_BOOM_FEATURE
+
+    @classmethod
+    def supports_compute_framework(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        compute_framework: type[ComputeFramework],
+    ) -> bool:
+        # Gated on the probe name AND the armed flag so nothing else ever trips the raise.
+        if str(feature_name) != CAP_BOOM_FEATURE or "cap_second_call" not in _ARMED_HOOKS_722M:
+            return False
+        key = compute_framework.get_class_name()
+        count = _CAP_SECOND_CALL_COUNTS_722M.get(key, 0) + 1
+        _CAP_SECOND_CALL_COUNTS_722M[key] = count
+        if count > 1:
+            raise RuntimeError(SECOND_CALL_TEXT)
+        return False
+
+
+class ProbeCapCountingOnce722M(_Probe722MBase):
+    """Capability hook: always False, counting its own invocations; never raises."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwCapOnce722M}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == CAP_ONCE_FEATURE
+
+    @classmethod
+    def supports_compute_framework(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        compute_framework: type[ComputeFramework],
+    ) -> bool:
+        if str(feature_name) == CAP_ONCE_FEATURE:
+            _CAP_ONCE_CALLS_722M.append(compute_framework.get_class_name())
+        return False
+
+
+class ProbeForwardHintBoom722M(_Probe722MBase):
+    """Accepts bare options for its name; junk-key options: False on the first call,
+    raises on later calls while armed (inert False while disarmed)."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwForward722M}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        if str(feature_name) != FORWARD_FEATURE:
+            return False
+        if JUNK_KEY not in options.group:
+            return True
+        if "forward_junk" not in _ARMED_HOOKS_722M:
+            return False
+        _FORWARD_JUNK_CALLS_722M.append("call")
+        if len(_FORWARD_JUNK_CALLS_722M) > 1:
+            raise RuntimeError(FORWARD_BOOM_TEXT)
+        return False
+
+
+class ProbeStrictPrecedence722M(_Probe722MBase):
+    """Concrete probe the strict-mode precedence collector enables; strict mode drops it."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PythonDictFramework}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == PRECEDENCE_FEATURE
+
+
+class SourceDiagEnabled722M(FeatureGroup):
+    """DataCreator source on PythonDictFramework; the collector-enabled diagnose probe."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PythonDictFramework}
+
+    @classmethod
+    def input_data(cls) -> BaseInputData | None:
+        return DataCreator(supports_features={DIAG_ENV_FEATURE})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {DIAG_ENV_FEATURE: [1, 2, 3]}
+
+
+class ProbeDiagDisabled722M(_Probe722MBase):
+    """Concrete probe the diagnose-provenance collector deliberately disables."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PythonDictFramework}
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _off_collector(*probes: type[FeatureGroup]) -> PluginCollector:
+    return PluginCollector.enabled_feature_groups(set(probes)).set_strict_mode("off")
+
+
+# ---------------------------------------------------------------------------
+# 1. Second-call capability hook cannot leak from the failure-path enrichment
+# ---------------------------------------------------------------------------
+
+
+def test_probe722m_capability_second_call_raise_does_not_leak_from_error_building(
+    arm_hook_722m: Callable[[str], None],
+) -> None:
+    """The engine's capability rejection error is built without leaking a raise from a
+    second hook invocation; the debug path stays non-raising for the same probe.
+
+    Today _capability_rejection_message re-invokes supports_compute_framework via
+    split_frameworks_by_capability, so the second call raises and the RuntimeError
+    escapes IdentifyFeatureGroupClass instead of the FeatureResolutionError.
+    """
+    arm_hook_722m("cap_second_call")
+    _CAP_SECOND_CALL_COUNTS_722M.clear()
+    mapping: FeatureGroupEnvironmentMapping = {ProbeCapSecondCallBoom722M: {CfwCapBoom722M}}
+
+    with pytest.raises(FeatureResolutionError) as excinfo:
+        IdentifyFeatureGroupClass(
+            feature=Feature(CAP_BOOM_FEATURE),
+            accessible_plugins=mapping,
+            links=None,
+        )
+
+    message = str(excinfo.value)
+    assert CAPABILITY_REJECTION_TEXT in message
+    assert CfwCapBoom722M.get_class_name() in message
+    assert SECOND_CALL_TEXT not in message
+
+    # The debug path over the same probe must also stay non-raising (fresh counter,
+    # so the hook's first call capability-rejects the framework again).
+    _CAP_SECOND_CALL_COUNTS_722M.clear()
+    result = resolve_feature(CAP_BOOM_FEATURE, plugin_collector=_off_collector(ProbeCapSecondCallBoom722M))
+    assert isinstance(result, ResolvedFeature)
+    assert result.feature_group is None
+    assert result.error is not None
+
+
+# ---------------------------------------------------------------------------
+# 2. Capability hooks run exactly once per candidate/framework on the failure path
+# ---------------------------------------------------------------------------
+
+
+def test_probe722m_capability_hook_invoked_exactly_once_on_failure_path() -> None:
+    """One engine identification invokes supports_compute_framework exactly once per
+    candidate/framework, even when the capability rejection error is being built.
+
+    Today it is 2: once in the resolver and once more in split_frameworks_by_capability
+    while _build_no_feature_group_error renders the message.
+    """
+    _CAP_ONCE_CALLS_722M.clear()
+    mapping: FeatureGroupEnvironmentMapping = {ProbeCapCountingOnce722M: {CfwCapOnce722M}}
+
+    with pytest.raises(FeatureResolutionError, match="Unsupported compute framework"):
+        IdentifyFeatureGroupClass(
+            feature=Feature(CAP_ONCE_FEATURE),
+            accessible_plugins=mapping,
+            links=None,
+        )
+
+    assert len(_CAP_ONCE_CALLS_722M) == 1, (
+        f"supports_compute_framework ran {len(_CAP_ONCE_CALLS_722M)} times; "
+        f"the failure path must not re-invoke the capability hook"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Forwarding-hint re-match cannot leak from the no-match error building
+# ---------------------------------------------------------------------------
+
+
+def test_probe722m_forwarding_hint_rematch_raise_does_not_leak(
+    arm_hook_722m: Callable[[str], None],
+) -> None:
+    """The no-match error is built without leaking a raise from the forwarding-hint
+    re-match; the error remains the no-match FeatureResolutionError.
+
+    Investigated for the Red phase: the resolver's criteria evaluation consumes the
+    FIRST junk-key call (CRITERIA rejection), _input_feature_forwarding_hint's
+    accepts_bare call carries no junk key (returns True), and its rejects_actual call
+    is the SECOND junk-key call, which raises. Today that RuntimeError escapes
+    IdentifyFeatureGroupClass instead of the no-match error.
+    """
+    arm_hook_722m("forward_junk")
+    _FORWARD_JUNK_CALLS_722M.clear()
+    mapping: FeatureGroupEnvironmentMapping = {ProbeForwardHintBoom722M: {CfwForward722M}}
+
+    with pytest.raises(FeatureResolutionError) as excinfo:
+        IdentifyFeatureGroupClass(
+            feature=Feature(FORWARD_FEATURE, options={JUNK_KEY: "junk-value"}),
+            accessible_plugins=mapping,
+            links=None,
+        )
+
+    message = str(excinfo.value)
+    assert NO_MATCH_TEXT in message
+    assert FORWARD_FEATURE in message
+    assert FORWARD_BOOM_TEXT not in message
+
+
+# ---------------------------------------------------------------------------
+# 4. Environment error precedence: strict-mode fatal over availability failure
+# ---------------------------------------------------------------------------
+
+
+def test_probe722m_strict_mode_error_takes_precedence_over_availability_failure(
+    arm_hook_722m: Callable[[str], None],
+) -> None:
+    """A strict-mode feature-group fatal outranks a raising availability probe.
+
+    Today build_resolution_environment samples availability BEFORE running the
+    feature-group pipeline, so the armed is_available raise becomes the
+    availability_failure error and masks the strict-mode message.
+    """
+    arm_hook_722m("avail_precedence")
+    collector = (
+        PluginCollector.enabled_feature_groups({ProbeStrictPrecedence722M})
+        .set_strict_mode("strict")
+        .set_registry(PluginRegistry())
+    )
+
+    result = resolve_feature(PRECEDENCE_FEATURE, plugin_collector=collector)
+
+    assert isinstance(result, ResolvedFeature)
+    assert result.feature_group is None
+    assert result.error is not None
+    assert STRICT_MODE_TEXT in result.error
+    assert AVAIL_PREC_BOOM_TEXT not in result.error
+
+
+# ---------------------------------------------------------------------------
+# 5. diagnose failure branch carries the full pre-check environment
+# ---------------------------------------------------------------------------
+
+
+def test_probe722m_diagnose_failure_branch_carries_full_precheck_environment() -> None:
+    """The failure-branch diagnose report keeps the DISABLED_BY_COLLECTOR record of a
+    collector-disabled probe alongside the failing feature record.
+
+    Today the FeatureResolutionError branch returns err.report, whose environment is
+    the engine's synthesized survivors-only outcome, so the disabled probe has no
+    record at all.
+    """
+    report = mlodaAPI.diagnose(
+        [Feature(DIAG_MISSING_FEATURE)],
+        compute_frameworks={PythonDictFramework},
+        plugin_collector=_off_collector(SourceDiagEnabled722M),
+    )
+
+    assert isinstance(report, ResolutionReport)
+    assert report.complete is False
+
+    failing = [
+        record
+        for record in report.features
+        if record.dependency_path and record.dependency_path[-1] == DIAG_MISSING_FEATURE
+    ]
+    assert len(failing) == 1, "the failing feature record must be present in the report"
+    assert failing[0].outcome.status is ResolutionStatus.NOT_FOUND
+
+    assert report.environment is not None
+    snapshot = report.environment.snapshot
+    assert snapshot is not None
+
+    enabled_identity = PluginIdentity.from_class(SourceDiagEnabled722M)
+    enabled_records = [record for record in snapshot.records if record.identity == enabled_identity]
+    assert len(enabled_records) == 1  # premise guard: the enabled probe is in the environment
+    assert enabled_records[0].provenance is EnvironmentProvenance.ACCESSIBLE
+
+    disabled_identity = PluginIdentity.from_class(ProbeDiagDisabled722M)
+    disabled_records = [record for record in snapshot.records if record.identity == disabled_identity]
+    assert len(disabled_records) == 1, "the disabled probe must keep an environment record"
+    assert disabled_records[0].provenance is EnvironmentProvenance.DISABLED_BY_COLLECTOR

--- a/tests/test_core/test_resolve/test_request_snapshot.py
+++ b/tests/test_core/test_resolve/test_request_snapshot.py
@@ -1,0 +1,189 @@
+"""Failing tests for issue #722 Stage 2: the immutable request state API.
+
+Defines the contract of ``mloda.core.resolve.request``:
+``ResolutionRequestSnapshot.from_feature`` captures what per-feature matching
+consumes (name, domain, scope, framework pin, option key sets, dependency path)
+at build time, carries ``Options`` as an opaque hook input that the resolver
+never mutates, and ``to_payload()`` redacts option values, the ``Options``
+object, the ``DataAccessCollection``, and link internals.
+
+RED phase: ``mloda.core.resolve`` does not exist yet, so this module fails at
+collection with ``ModuleNotFoundError``.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+
+import pytest
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.link import JoinSpec, Link
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.resolve.request import ResolutionRequestSnapshot
+
+
+class CfwRequestPin722D(ComputeFramework):
+    """Uniquely named framework, pinnable by name from a Feature."""
+
+
+class _RequestProbeBase722D(FeatureGroup):
+    """Shared probe base: never matches anything itself."""
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return False
+
+
+class ProbeLinkLeft722D(_RequestProbeBase722D):
+    """Anchors the left side of the request link; never matches a name."""
+
+
+class ProbeLinkRight722D(_RequestProbeBase722D):
+    """Anchors the right side of the request link; never matches a name."""
+
+
+def _probe_link() -> Link:
+    return Link.inner(
+        JoinSpec(ProbeLinkLeft722D, "probe722d_left_id"),
+        JoinSpec(ProbeLinkRight722D, "probe722d_right_id"),
+    )
+
+
+def test_from_feature_captures_request_fields() -> None:
+    """from_feature captures name, domain, scope, framework pin, and option key sets."""
+    feature = Feature(
+        "probe722d_request_full",
+        Options(group={"group_key_722d": "gval"}, context={"context_key_722d": "cval"}),
+        domain="domain_722d",
+        compute_framework="CfwRequestPin722D",
+        feature_group="ProbeScopeTarget722D",
+    )
+
+    snapshot = ResolutionRequestSnapshot.from_feature(feature)
+
+    assert snapshot.feature_name == "probe722d_request_full"
+    assert snapshot.domain == "domain_722d"
+    assert snapshot.feature_group_scope == "ProbeScopeTarget722D"
+    assert snapshot.framework_pin == "CfwRequestPin722D"
+    assert snapshot.pinned_frameworks == (CfwRequestPin722D,)
+    assert snapshot.group_option_keys == frozenset({"group_key_722d"})
+    assert snapshot.context_option_keys == frozenset({"context_key_722d"})
+    assert snapshot.inherited_group_keys == frozenset()
+    assert snapshot.dependency_path == ()
+    assert snapshot.links == ()
+    assert snapshot.data_access_collection is None
+
+
+def test_from_feature_captures_inherited_group_keys() -> None:
+    """Keys forwarded by Options.inherit_from (the Features.merge_options mechanism) are captured."""
+    consumer = Options(group={"forwarded_722d": "shared-value"})
+    child = Options()
+    forwarded = child.inherit_from(consumer)
+    assert forwarded == frozenset({"forwarded_722d"})  # premise guard
+    assert child.inherited_group_keys == frozenset({"forwarded_722d"})  # premise guard
+
+    feature = Feature("probe722d_inherited", child)
+    snapshot = ResolutionRequestSnapshot.from_feature(feature)
+
+    assert snapshot.inherited_group_keys == frozenset({"forwarded_722d"})
+    assert snapshot.group_option_keys == frozenset({"forwarded_722d"})
+
+
+def test_snapshot_is_isolated_from_later_feature_mutation() -> None:
+    """Captured fields do not change when the feature or its options mutate afterwards."""
+    options = Options(group={"initial_key_722d": 1})
+    feature = Feature("probe722d_mutation", options)
+
+    snapshot = ResolutionRequestSnapshot.from_feature(feature)
+
+    feature.name = FeatureName("probe722d_mutation_renamed")
+    options.add_to_group("late_key_722d", 2)
+
+    assert snapshot.feature_name == "probe722d_mutation"
+    assert snapshot.group_option_keys == frozenset({"initial_key_722d"})
+
+
+def test_snapshot_is_frozen() -> None:
+    """Snapshot fields cannot be reassigned."""
+    feature = Feature("probe722d_frozen")
+    snapshot = ResolutionRequestSnapshot.from_feature(feature)
+
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        setattr(snapshot, "feature_name", "probe722d_forged")
+
+
+def test_payload_redacts_option_values_and_data_access() -> None:
+    """to_payload carries option KEYS but never values, the collection, or link internals."""
+    feature = Feature("probe722d_redaction", Options(group={"password_722d": "hunter2-722d"}))  # nosec B105
+    collection = DataAccessCollection(files={"probe722d_secret_file.csv"})
+
+    snapshot = ResolutionRequestSnapshot.from_feature(feature, links={_probe_link()}, data_access_collection=collection)
+    assert snapshot.data_access_collection is collection
+    assert len(snapshot.links) == 1
+
+    payload = snapshot.to_payload()
+    dumped = json.dumps(payload)
+
+    assert "password_722d" in dumped
+    assert "hunter2-722d" not in dumped
+    assert "data_access_collection" not in payload
+    assert isinstance(payload["links"], int)
+    assert payload["links"] == 1
+
+
+def test_dependency_path_round_trips_into_payload() -> None:
+    """The dependency path is captured as a tuple and rendered as a list in the payload."""
+    feature = Feature("probe722d_dependency")
+
+    snapshot = ResolutionRequestSnapshot.from_feature(feature, dependency_path=("root_722d", "child_722d"))
+
+    assert snapshot.dependency_path == ("root_722d", "child_722d")
+    assert snapshot.to_payload()["dependency_path"] == ["root_722d", "child_722d"]
+
+
+def test_options_are_carried_as_the_same_object() -> None:
+    """snapshot.options IS feature.options: an opaque hook input the resolver never mutates."""
+    feature = Feature("probe722d_opaque", Options(group={"opaque_key_722d": "opaque-value-722d"}))
+
+    snapshot = ResolutionRequestSnapshot.from_feature(feature)
+
+    assert snapshot.options is feature.options
+
+
+def test_payload_option_key_lists_are_sorted() -> None:
+    """Payload option key lists are deterministic: sorted, under stable payload keys."""
+    feature = Feature(
+        "probe722d_sorted",
+        Options(
+            group={"b_group_722d": 1, "a_group_722d": 2},
+            context={"d_context_722d": 3, "c_context_722d": 4},
+        ),
+    )
+
+    payload = ResolutionRequestSnapshot.from_feature(feature).to_payload()
+
+    assert payload["group_option_keys"] == ["a_group_722d", "b_group_722d"]
+    assert payload["context_option_keys"] == ["c_context_722d", "d_context_722d"]
+    expected_keys = {
+        "feature_name",
+        "domain",
+        "feature_group_scope",
+        "framework_pin",
+        "group_option_keys",
+        "context_option_keys",
+        "inherited_group_keys",
+        "dependency_path",
+        "links",
+    }
+    assert expected_keys <= set(payload.keys())

--- a/tests/test_core/test_resolve/test_resolution_report.py
+++ b/tests/test_core/test_resolve/test_resolution_report.py
@@ -1,0 +1,491 @@
+"""Failing target-contract tests for the whole-request diagnostics/report layer (issue #722 Stage 4a).
+
+TARGET API (does not exist yet; every test here FAILS until the Green implementation lands):
+
+mloda.core.resolve.report:
+- @dataclass(frozen=True) FeatureResolutionRecord(dependency_path: tuple[str, ...], outcome: ResolutionOutcome)
+- @dataclass(frozen=True) ResolutionReport(environment: EnvironmentBuildOutcome | None,
+  features: tuple[FeatureResolutionRecord, ...], complete: bool) with to_payload() -> plain JSON data.
+
+mlodaAPI (mloda/core/api/request.py):
+- classmethod diagnose(...prepare signature family...) -> ResolutionReport, NON-RAISING for
+  resolution/environment failures.
+- instance method resolution_report() -> ResolutionReport on a prepared session, taken from the
+  engine's planning pass without re-matching.
+- FeatureResolutionError raised through prepare()/run_all() engine construction additionally
+  carries .report (a ResolutionReport with the partial records, complete=False).
+
+PINNED CHOICES beyond the issue brief (report these to the Green agent):
+- Records are ordered in PLANNING ORDER and dependency_path INCLUDES the feature's own name,
+  exactly like Engine.resolution_outcomes today: root (name,), child (root, child).
+- On a successful diagnose()/resolution_report(), ``environment`` is NOT None: it carries an
+  EnvironmentBuildOutcome with a snapshot and no errors (the report describes the whole request).
+- ResolutionReport.to_payload() keys: "environment" (EnvironmentBuildOutcome.to_payload() or None),
+  "features" (list of {"dependency_path": list[str], "outcome": ResolutionOutcome.to_payload()}),
+  "complete" (bool).
+- Engine-path environment failures keep today's raise types: plain ValueError for
+  strict-mode-filtered-all (pinned via pytest.raises(ValueError, match=...), so a
+  FeatureResolutionError subclass upgrade stays allowed) and RedefinitionConflictError for a
+  redefinition conflict (pinned exactly; no report assertions on that path).
+
+Probe names use the unique probe722i_ prefix; probe classes carry the 722I suffix so
+process-global scans in other tests never trip these fixtures.
+"""
+
+from __future__ import annotations
+
+import json
+import linecache
+import sys
+import textwrap
+from typing import Any, Iterator, cast
+
+import pytest
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistry
+from mloda.core.api.plan_info import PlanStep
+from mloda.core.api.request import mlodaAPI
+from mloda.core.prepare.accessible_plugins import RedefinitionConflictError
+from mloda.core.resolve.environment import EnvironmentBuildOutcome, ResolutionEnvironmentSnapshot
+from mloda.core.resolve.outcome import FeatureResolutionError, ResolutionOutcome, ResolutionStatus
+from mloda.core.resolve.report import FeatureResolutionRecord, ResolutionReport
+from mloda.core.resolve.request import ResolutionRequestSnapshot
+from mloda.core.resolve.resolver import FeatureGroupResolver
+from mloda.provider import BaseInputData, DataCreator, FeatureSet
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
+    PythonDictFramework,
+)
+
+
+BASE_FEATURE = "probe722i_base"
+DERIVED_FEATURE = "probe722i_derived"
+MISSING_FEATURE = "probe722i_missing"
+STRICT_FEATURE = "probe722i_strict"
+REDEF_FEATURE = "probe722i_redef"
+
+STRICT_MODE_TEXT = "Strict mode filtered out all FeatureGroups"
+NO_FEATURE_GROUPS_TEXT = "No feature groups found"
+
+
+# ---------------------------------------------------------------------------
+# Probe fixtures (DataCreator-backed, PluginCollector-scoped)
+# ---------------------------------------------------------------------------
+
+
+class SourceBase722I(FeatureGroup):
+    """Root source for the report probes; matches ONLY probe722i_base via its DataCreator."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PythonDictFramework}
+
+    @classmethod
+    def input_data(cls) -> BaseInputData | None:
+        return DataCreator(supports_features={BASE_FEATURE})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {BASE_FEATURE: [1, 2, 3]}
+
+
+class DerivedOnBase722I(FeatureGroup):
+    """Derived probe with an input_features dependency on the base source."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PythonDictFramework}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == DERIVED_FEATURE
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        return {Feature(BASE_FEATURE)}
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {DERIVED_FEATURE: [2, 4, 6]}
+
+
+class CfwStrict722I(ComputeFramework):
+    """Available framework carrying the strict-mode probe."""
+
+
+class ProbeStrict722I(FeatureGroup):
+    """Concrete probe that is never registered in the injected empty registry."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwStrict722I}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == STRICT_FEATURE
+
+
+def _success_collector() -> PluginCollector:
+    return PluginCollector.enabled_feature_groups({SourceBase722I, DerivedOnBase722I})
+
+
+def _success_features() -> list[Feature | str]:
+    return [Feature(BASE_FEATURE), Feature(DERIVED_FEATURE)]
+
+
+def _strict_collector_with_empty_registry() -> PluginCollector:
+    """Enable only the strict probe, strict mode on, EMPTY injected registry (global registry untouched)."""
+    collector = PluginCollector.enabled_feature_groups({ProbeStrict722I})
+    return collector.set_strict_mode("strict").set_registry(PluginRegistry())
+
+
+# ---------------------------------------------------------------------------
+# Jupyter-cell simulation helpers for the redefinition-conflict path
+# (construction pattern mirrors tests/test_core/test_resolution_parity/test_parity_environment.py)
+# ---------------------------------------------------------------------------
+
+# Keeps exec'd classes alive across assertions, like IPython's Out[N] history. Leaking them for the
+# process lifetime is safe: the autouse cleanup unbinds them from __main__, so they are no longer
+# live-in-module and dedup preserves instead of re-raising, and they only match probe722i_redef.
+_REF_STORE: list[Any] = []
+
+
+def _exec_fg_in_main(class_name: str, body: str, cell_label: str) -> type[FeatureGroup]:
+    """Exec a FeatureGroup subclass into __main__ with linecache-backed source (Jupyter cell simulation)."""
+    main_mod = sys.modules["__main__"]
+    src = textwrap.dedent(body)
+    filename = f"<{cell_label}>"
+    linecache.cache[filename] = (len(src), None, src.splitlines(keepends=True), filename)
+    exec(compile(src, filename, "exec"), main_mod.__dict__)  # nosec B102
+    return cast(type[FeatureGroup], main_mod.__dict__[class_name])
+
+
+def _make_fg_source(class_name: str, feature_name: str, extra_body: str = "") -> str:
+    return f"""
+from mloda.core.abstract_plugins.feature_group import FeatureGroup as _FG_BASE_
+
+class {class_name}(_FG_BASE_):
+    @classmethod
+    def feature_names_supported(cls):
+        return {{"{feature_name}"}}
+{extra_body}
+"""
+
+
+def _make_conflicting_pair(qualname: str, feature_name: str) -> tuple[type[FeatureGroup], type[FeatureGroup]]:
+    """Two classes sharing (module, qualname) with DIFFERENT source; v2 is live in __main__."""
+    src_v1 = _make_fg_source(qualname, feature_name)
+    src_v2 = _make_fg_source(qualname, feature_name, extra_body="    def extra_method(self):\n        return 722\n")
+    v1 = _exec_fg_in_main(qualname, src_v1, f"cell-{qualname}-v1")
+    v2 = _exec_fg_in_main(qualname, src_v2, f"cell-{qualname}-v2")
+    _REF_STORE.extend([v1, v2])
+    return v1, v2
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_main_module_attrs() -> Iterator[None]:
+    """Snapshot __main__ attrs and restore after each test (xdist safety, mirrors test_parity_environment)."""
+    main_mod = sys.modules["__main__"]
+    snapshot = set(main_mod.__dict__.keys())
+    yield
+    for key in set(main_mod.__dict__.keys()) - snapshot:
+        main_mod.__dict__.pop(key, None)
+
+
+# ---------------------------------------------------------------------------
+# 1. diagnose success: recursive records, complete=True
+# ---------------------------------------------------------------------------
+
+
+def test_probe722i_diagnose_success_records_every_identification() -> None:
+    """A two-feature request yields one RESOLVED record per identification in planning order."""
+    report = mlodaAPI.diagnose(
+        _success_features(),
+        compute_frameworks={PythonDictFramework},
+        plugin_collector=_success_collector(),
+    )
+
+    assert isinstance(report, ResolutionReport)
+    assert report.complete is True
+    assert isinstance(report.features, tuple)
+
+    paths = [record.dependency_path for record in report.features]
+    assert paths == [
+        (BASE_FEATURE,),
+        (DERIVED_FEATURE,),
+        (DERIVED_FEATURE, BASE_FEATURE),
+    ]
+    assert all(record.outcome.status is ResolutionStatus.RESOLVED for record in report.features)
+
+    by_path = {record.dependency_path: record for record in report.features}
+    root_winner = by_path[(BASE_FEATURE,)].outcome.winner
+    assert root_winner is not None
+    assert root_winner.feature_group is SourceBase722I
+    derived_winner = by_path[(DERIVED_FEATURE,)].outcome.winner
+    assert derived_winner is not None
+    assert derived_winner.feature_group is DerivedOnBase722I
+    child_winner = by_path[(DERIVED_FEATURE, BASE_FEATURE)].outcome.winner
+    assert child_winner is not None
+    assert child_winner.feature_group is SourceBase722I
+
+    # PINNED: a successful report still describes the environment it resolved against.
+    assert report.environment is not None
+    assert isinstance(report.environment, EnvironmentBuildOutcome)
+    assert report.environment.errors == ()
+    assert report.environment.snapshot is not None
+
+
+def test_probe722i_diagnose_success_payload_is_plain_json() -> None:
+    """to_payload() is json.dumps-able, delegates to member payloads, and leaks no class objects."""
+    report = mlodaAPI.diagnose(
+        _success_features(),
+        compute_frameworks={PythonDictFramework},
+        plugin_collector=_success_collector(),
+    )
+
+    payload = report.to_payload()
+    text = json.dumps(payload)
+    assert "<class" not in text
+
+    assert payload["complete"] is True
+    assert report.environment is not None
+    assert payload["environment"] == report.environment.to_payload()
+    features_payload = payload["features"]
+    assert [entry["dependency_path"] for entry in features_payload] == [
+        list(record.dependency_path) for record in report.features
+    ]
+    assert [entry["outcome"] for entry in features_payload] == [
+        record.outcome.to_payload() for record in report.features
+    ]
+
+
+# ---------------------------------------------------------------------------
+# 2. diagnose feature failure: non-raising, partial records retained
+# ---------------------------------------------------------------------------
+
+
+def test_probe722i_diagnose_feature_failure_is_non_raising_and_keeps_partial_records() -> None:
+    """A feature matching nothing yields complete=False with earlier successes retained."""
+    report = mlodaAPI.diagnose(
+        [Feature(BASE_FEATURE), Feature(MISSING_FEATURE)],
+        compute_frameworks={PythonDictFramework},
+        plugin_collector=_success_collector(),
+    )
+
+    assert isinstance(report, ResolutionReport)
+    assert report.complete is False
+    assert len(report.features) == 2
+
+    first, last = report.features
+    assert first.dependency_path == (BASE_FEATURE,)
+    assert first.outcome.status is ResolutionStatus.RESOLVED
+    assert last.dependency_path == (MISSING_FEATURE,)
+    assert last.outcome.status is ResolutionStatus.NOT_FOUND
+
+    # The environment built fine; only the feature failed.
+    assert report.environment is not None
+    assert report.environment.snapshot is not None
+
+
+# ---------------------------------------------------------------------------
+# 3. diagnose environment failure: non-raising, environment errors carried
+# ---------------------------------------------------------------------------
+
+
+def test_probe722i_diagnose_environment_failure_is_non_raising() -> None:
+    """A strict-mode empty-registry build yields complete=False with the strict-mode error, no features."""
+    report = mlodaAPI.diagnose(
+        [Feature(STRICT_FEATURE)],
+        compute_frameworks={CfwStrict722I},
+        plugin_collector=_strict_collector_with_empty_registry(),
+    )
+
+    assert isinstance(report, ResolutionReport)
+    assert report.complete is False
+    assert report.features == ()
+    assert report.environment is not None
+    assert report.environment.snapshot is None
+    messages = [error.message for error in report.environment.errors]
+    assert any(STRICT_MODE_TEXT in message for message in messages)
+
+
+# ---------------------------------------------------------------------------
+# 4. session.resolution_report(): planning-pass records, zero re-matching
+# ---------------------------------------------------------------------------
+
+
+def test_probe722i_session_resolution_report_reuses_planning_pass(monkeypatch: pytest.MonkeyPatch) -> None:
+    """resolution_report() serves the engine's planning outcomes; calling it twice never re-resolves."""
+    session = mlodaAPI.prepare(
+        _success_features(),
+        compute_frameworks={PythonDictFramework},
+        plugin_collector=_success_collector(),
+    )
+    engine = session.engine
+    assert engine is not None
+    expected = tuple(
+        FeatureResolutionRecord(dependency_path=path, outcome=outcome) for path, outcome in engine.resolution_outcomes
+    )
+    assert len(expected) == 3  # premise guard: root, derived, and the derived's input were identified
+
+    calls = {"resolve": 0}
+    original_resolve = FeatureGroupResolver.resolve
+
+    def _counting_resolve(
+        self: FeatureGroupResolver,
+        request: ResolutionRequestSnapshot,
+        environment: ResolutionEnvironmentSnapshot,
+    ) -> ResolutionOutcome:
+        calls["resolve"] += 1
+        return original_resolve(self, request, environment)
+
+    monkeypatch.setattr(FeatureGroupResolver, "resolve", _counting_resolve)
+
+    first = session.resolution_report()
+    second = session.resolution_report()
+
+    assert calls["resolve"] == 0
+    assert first.complete is True
+    assert first.features == expected
+    assert second.features == expected
+    assert first.environment is not None
+    assert first.environment.snapshot is not None
+
+
+# ---------------------------------------------------------------------------
+# 5. prepare() failure carries the partial report on the raised error
+# ---------------------------------------------------------------------------
+
+
+def test_probe722i_prepare_failure_error_carries_report() -> None:
+    """The FeatureResolutionError raised through prepare() carries a partial ResolutionReport."""
+    with pytest.raises(FeatureResolutionError) as exc_info:
+        mlodaAPI.prepare(
+            [Feature(MISSING_FEATURE)],
+            compute_frameworks={PythonDictFramework},
+            plugin_collector=_success_collector(),
+        )
+
+    error = exc_info.value
+    assert NO_FEATURE_GROUPS_TEXT in str(error)  # message shape unchanged
+
+    report = error.report
+    assert isinstance(report, ResolutionReport)
+    assert report.complete is False
+    assert len(report.features) == 1
+    record = report.features[0]
+    assert record.dependency_path == (MISSING_FEATURE,)
+    assert record.outcome.status is ResolutionStatus.NOT_FOUND
+    assert record.outcome == error.outcome
+
+
+# ---------------------------------------------------------------------------
+# 6. Environment-failure raise-type preservation through the engine path
+# ---------------------------------------------------------------------------
+
+
+def test_probe722i_engine_path_strict_mode_raise_stays_value_error() -> None:
+    """The engine-path strict-mode failure keeps satisfying pytest.raises(ValueError, match=...).
+
+    INVESTIGATION RESULT: no existing test pins the exact exception type through Engine/mlodaAPI
+    construction; today this path raises a plain ValueError (EnvironmentBuildError.as_exception()
+    over the strict-mode message). pytest.raises(ValueError) also admits a FeatureResolutionError
+    subclass, so the report-carrying assertion stays conditional per the Stage 4a brief.
+    """
+    with pytest.raises(ValueError, match=STRICT_MODE_TEXT) as exc_info:
+        mlodaAPI.prepare(
+            [Feature(STRICT_FEATURE)],
+            compute_frameworks={CfwStrict722I},
+            plugin_collector=_strict_collector_with_empty_registry(),
+        )
+
+    error = exc_info.value
+    if isinstance(error, FeatureResolutionError):
+        assert isinstance(error.report, ResolutionReport)
+        assert error.report.complete is False
+
+
+def test_probe722i_engine_path_redefinition_conflict_type_preserved() -> None:
+    """A redefinition conflict through mlodaAPI construction keeps raising RedefinitionConflictError.
+
+    INVESTIGATION RESULT: existing RedefinitionConflictError pins under tests/ all go through
+    PreFilterPlugins or dedup_feature_group_subclasses directly; the engine path re-raises the
+    carried original exception, so callers catching RedefinitionConflictError must keep working.
+    No report assertion here: the raised type is not FeatureResolutionError.
+    """
+    v1, v2 = _make_conflicting_pair("ProbeRedefReport722I", REDEF_FEATURE)
+    collector = PluginCollector.enabled_feature_groups({v1, v2})
+
+    with pytest.raises(RedefinitionConflictError, match="redefined with different source code"):
+        mlodaAPI.prepare(
+            [Feature(REDEF_FEATURE)],
+            compute_frameworks={PythonDictFramework},
+            plugin_collector=collector,
+        )
+
+
+# ---------------------------------------------------------------------------
+# 7. Determinism: identical diagnose() calls give payload-equal reports
+# ---------------------------------------------------------------------------
+
+
+def test_probe722i_diagnose_payloads_are_deterministic() -> None:
+    """Two identical diagnose() calls serialize to the same canonical JSON."""
+    first = mlodaAPI.diagnose(
+        _success_features(),
+        compute_frameworks={PythonDictFramework},
+        plugin_collector=_success_collector(),
+    )
+    second = mlodaAPI.diagnose(
+        _success_features(),
+        compute_frameworks={PythonDictFramework},
+        plugin_collector=_success_collector(),
+    )
+
+    assert json.dumps(first.to_payload(), sort_keys=True) == json.dumps(second.to_payload(), sort_keys=True)
+
+
+# ---------------------------------------------------------------------------
+# 8. Coexistence smoke: report and plan surfaces on one session, explain unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_probe722i_resolution_report_coexists_with_plan_surfaces() -> None:
+    """resolution_report() and resolved_plan() serve one session; explain() stays plan-based."""
+    session = mlodaAPI.prepare(
+        _success_features(),
+        compute_frameworks={PythonDictFramework},
+        plugin_collector=_success_collector(),
+    )
+
+    report = session.resolution_report()
+    plan = session.resolved_plan()
+
+    assert report.complete is True
+    assert plan, "resolved_plan must keep returning a non-empty step list"
+    assert all(isinstance(step, PlanStep) for step in plan)
+    plan_names = {name for step in plan for name in step.feature_names}
+    assert {BASE_FEATURE, DERIVED_FEATURE} <= plan_names
+
+    explained = mlodaAPI.explain(
+        _success_features(),
+        compute_frameworks={PythonDictFramework},
+        plugin_collector=_success_collector(),
+    )
+    explained_names = {name for step in explained for name in step.feature_names}
+    assert {BASE_FEATURE, DERIVED_FEATURE} <= explained_names

--- a/tests/test_core/test_resolve/test_resolve_feature_rewire.py
+++ b/tests/test_core/test_resolve/test_resolve_feature_rewire.py
@@ -1,0 +1,268 @@
+"""Direct target-contract tests for the rewired resolve_feature (issue #722 Stage 3b).
+
+Stage 3b rewires the debug API resolve_feature (mloda/core/api/plugin_docs.py) onto the
+same authoritative FeatureGroupResolver as the engine, against a STANDALONE environment
+built by build_resolution_environment over all available compute frameworks
+(PreFilterPlugins.get_cfw_subclasses()) and the caller's plugin collector.
+
+These tests FAIL until the rewire lands; the engine halves already pass (Stage 3a).
+Probe names use the unique probe722g_ prefix so process-global scans in other tests
+never trip these fixtures.
+"""
+
+from __future__ import annotations
+
+import inspect
+from abc import abstractmethod
+
+import pytest
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistry
+from mloda.core.api.plugin_docs import resolve_feature
+from mloda.core.api.plugin_info import ResolvedFeature
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping, PreFilterPlugins
+from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+
+
+STRICT_FEATURE = "probe722g_strict"
+ATTRIBUTION_FEATURE = "probe722g_attribution"
+BOOM_FEATURE = "probe722g_boom"
+
+BOOM_ERROR_TEXT = "boom 722g criteria"
+STRICT_MODE_TEXT = "Strict mode filtered out all FeatureGroups"
+
+
+class CfwOne722G(ComputeFramework):
+    """First framework of the attribution family; declared by parent and child."""
+
+
+class CfwTwo722G(ComputeFramework):
+    """Second framework of the attribution family; declared by the abstract parent only."""
+
+
+class CfwStrict722G(ComputeFramework):
+    """Framework carrying the strict-mode probes."""
+
+
+class CfwBoom722G(ComputeFramework):
+    """Framework declared by the provider-failure probes."""
+
+
+class StrictProbe722G(FeatureGroup):
+    """Concrete probe that is never registered in the injected empty registry."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwStrict722G}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == STRICT_FEATURE
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        return None
+
+
+class AbstractAttributionParent722G(FeatureGroup):
+    """Abstract parent: declares two frameworks and matches the shared attribution name."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwOne722G, CfwTwo722G}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == ATTRIBUTION_FEATURE
+
+    @classmethod
+    @abstractmethod
+    def _probe_hook_722g(cls) -> str:
+        """Abstract hook that keeps this probe abstract."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        return None
+
+
+class AttributionChild722G(AbstractAttributionParent722G):
+    """Concrete child: narrows the declaration to a strict subset of the parent's."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwOne722G}
+
+    @classmethod
+    def _probe_hook_722g(cls) -> str:
+        return "concrete 722g"
+
+
+class BoomCriteriaProbe722G(FeatureGroup):
+    """Raises a plain ValueError from matching, gated on its unique shared name."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwBoom722G}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        # A plain ValueError (NOT a PropertyValueRejection) is a decision-relevant provider
+        # failure; gated on the probe name so process-global scans never trip the raise.
+        if str(feature_name) == BOOM_FEATURE:
+            raise ValueError(BOOM_ERROR_TEXT)
+        return False
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        return None
+
+
+class CleanRivalProbe722G(FeatureGroup):
+    """Matches the boom feature name cleanly."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwBoom722G}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == BOOM_FEATURE
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        return None
+
+
+def _strict_collector_with_empty_registry() -> PluginCollector:
+    """Enable only the strict probe, strict mode on, EMPTY injected registry (global registry untouched)."""
+    collector = PluginCollector.enabled_feature_groups({StrictProbe722G})
+    return collector.set_strict_mode("strict").set_registry(PluginRegistry())
+
+
+# ---------------------------------------------------------------------------
+# (a) Environment build failure: strict mode filters everything out
+# ---------------------------------------------------------------------------
+
+
+def test_probe722g_environment_build_failure_returns_error_instead_of_raising() -> None:
+    """A failing standalone environment build becomes ResolvedFeature.error, never a raise."""
+    collector = _strict_collector_with_empty_registry()
+
+    result = resolve_feature(STRICT_FEATURE, plugin_collector=collector)
+
+    assert isinstance(result, ResolvedFeature)
+    assert result.feature_name == STRICT_FEATURE
+    assert result.feature_group is None
+    assert result.error is not None
+    assert STRICT_MODE_TEXT in result.error
+
+
+# ---------------------------------------------------------------------------
+# (b) Per-winner framework attribution, no union across candidates
+# ---------------------------------------------------------------------------
+
+
+def test_probe722g_winner_attribution_is_per_candidate_not_union() -> None:
+    """The child winner is credited with ITS OWN supported frameworks only, on both paths."""
+    assert inspect.isabstract(AbstractAttributionParent722G), "fixture parent must be abstract"
+    assert not inspect.isabstract(AttributionChild722G), "fixture child must be concrete"
+
+    # Engine parity on an equivalent mapping: the abstract parent is rejected, the child wins
+    # with exactly its own framework set.
+    accessible_plugins: FeatureGroupEnvironmentMapping = {
+        AbstractAttributionParent722G: {CfwOne722G, CfwTwo722G},
+        AttributionChild722G: {CfwOne722G},
+    }
+    identifier = IdentifyFeatureGroupClass(
+        feature=Feature(ATTRIBUTION_FEATURE),
+        accessible_plugins=accessible_plugins,
+        links=None,
+    )
+    resolved, compute_frameworks = identifier.get()
+    assert resolved is AttributionChild722G
+    assert compute_frameworks == {CfwOne722G}
+
+    # Debug path: same winner, and the parent-only CfwTwo722G is NOT unioned into the winner's
+    # supported list.
+    collector = PluginCollector.enabled_feature_groups({AbstractAttributionParent722G, AttributionChild722G})
+    result = resolve_feature(ATTRIBUTION_FEATURE, plugin_collector=collector)
+
+    assert result.feature_group is AttributionChild722G
+    assert result.error is None
+    assert result.supported_compute_frameworks == [CfwOne722G.get_class_name()]
+    assert CfwTwo722G.get_class_name() not in result.supported_compute_frameworks
+    assert result.unsupported_compute_frameworks == []
+
+
+# ---------------------------------------------------------------------------
+# (c) Provider failure is fail-closed on both paths with the same provider message
+# ---------------------------------------------------------------------------
+
+
+def test_probe722g_provider_failure_fails_closed_on_both_paths() -> None:
+    """A raising criteria hook fails both paths with the original provider message."""
+    accessible_plugins: FeatureGroupEnvironmentMapping = {
+        BoomCriteriaProbe722G: {CfwBoom722G},
+        CleanRivalProbe722G: {CfwBoom722G},
+    }
+
+    # Engine path: fail-closed despite the clean rival.
+    with pytest.raises(ValueError, match=BOOM_ERROR_TEXT):
+        IdentifyFeatureGroupClass(
+            feature=Feature(BOOM_FEATURE),
+            accessible_plugins=accessible_plugins,
+            links=None,
+        )
+
+    # Debug path: same fail-closed verdict carrying the same provider message.
+    collector = PluginCollector.enabled_feature_groups({BoomCriteriaProbe722G, CleanRivalProbe722G})
+    result = resolve_feature(BOOM_FEATURE, plugin_collector=collector)
+
+    assert result.feature_group is None
+    assert result.error is not None
+    assert BOOM_ERROR_TEXT in result.error
+    assert "BoomCriteriaProbe722G" in result.error
+
+
+# ---------------------------------------------------------------------------
+# (d) Strict-mode collector parity: identical message text on both paths
+# ---------------------------------------------------------------------------
+
+
+def test_probe722g_strict_collector_produces_identical_message_on_both_paths() -> None:
+    """The same strict collector yields an engine raise and a debug error with the SAME text."""
+    collector = _strict_collector_with_empty_registry()
+
+    with pytest.raises(ValueError) as exc_info:
+        PreFilterPlugins(compute_frameworks={CfwStrict722G}, plugin_collector=collector)
+    engine_message = str(exc_info.value)
+    assert STRICT_MODE_TEXT in engine_message
+
+    result = resolve_feature(STRICT_FEATURE, plugin_collector=collector)
+
+    assert result.feature_group is None
+    # Unscoped call: no scope suffix, so the debug error is exactly the environment message.
+    assert result.error == engine_message

--- a/tests/test_core/test_resolve/test_resolver.py
+++ b/tests/test_core/test_resolve/test_resolver.py
@@ -1,0 +1,952 @@
+"""Target-contract tests for the authoritative FeatureGroupResolver (issue #722 Stage 3a).
+
+These tests define ``mloda.core.resolve.outcome`` and ``mloda.core.resolve.resolver``,
+which do not exist yet: every test in this module fails on import until the Green
+phase implements them. The contract under test is decided in
+docs/docs/in_depth/feature-group-resolution-contract.md:
+
+- resolve() never raises for resolution failures; it returns a structured
+  ResolutionOutcome. Provider exceptions become fail-closed FAILED outcomes.
+- A winner is present if and only if the status is RESOLVED.
+- Candidate ordering is deterministic by stable plugin identity.
+- Public records serialize as plain data: no class objects, no Options values,
+  no exception objects, no tracebacks.
+- The engine adapter (IdentifyFeatureGroupClass) raises FeatureResolutionError,
+  a ValueError subclass carrying the outcome.
+
+Ordering and exactly-once hook discipline are covered by test_resolver_order.py.
+"""
+
+import inspect
+import json
+from abc import abstractmethod
+
+import pytest
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.domain import Domain
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import PropertyValueRejection
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.index.index import Index
+from mloda.core.abstract_plugins.components.link import JoinSpec, Link
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+from mloda.core.resolve.identity import PluginIdentity
+from mloda.core.resolve.outcome import (
+    CandidateEvaluation,
+    CandidateStatus,
+    FeatureResolutionError,
+    FrameworkEvaluation,
+    FrameworkStatus,
+    RejectionReason,
+    ResolutionOutcome,
+    ResolutionStatus,
+)
+from mloda.core.resolve.request import ResolutionRequestSnapshot
+from mloda.core.resolve.resolver import FeatureGroupResolver, snapshot_from_mapping
+
+
+CLEAN_FEATURE = "probe722f_clean"
+AMBIGUOUS_FEATURE = "probe722f_ambiguous"
+SHADOW_FEATURE = "probe722f_shadow"
+SPLIT_FEATURE = "probe722f_split"
+ABSTRACT_FEATURE = "probe722f_abstract_only"
+NO_FRAMEWORK_FEATURE = "probe722f_no_framework"
+DOMAIN_FEATURE = "probe722f_domain"
+PIN_FEATURE = "probe722f_pin"
+LINKED_FEATURE = "probe722f_linked"
+VALUE_REJECTION_FEATURE = "probe722f_value_rejection"
+BOOM_FEATURE = "probe722f_boom"
+CAPABILITY_RAISES_FEATURE = "probe722f_capability_raises"
+CAPABILITY_FALSE_FEATURE = "probe722f_capability_false"
+MULTI_PIN_FEATURE = "probe722f_multi_pin"
+UNKNOWN_FEATURE = "probe722f_totally_unknown"
+
+DOMAIN_MATCH = "probe722f_dom_sales"
+DOMAIN_OTHER = "probe722f_dom_marketing"
+
+VALUE_REJECTION_TEXT = "rejected value 722f: probe option out of range"
+BOOM_ERROR_TEXT = "boom 722f"
+CAPABILITY_ERROR_TEXT = "broken capability 722f"
+MULTI_PIN_TEXT = "should only have one compute framework"
+
+
+class CfwAlpha722F(ComputeFramework):
+    """General-purpose framework for single-framework probe mappings."""
+
+
+class CfwShadow722F(ComputeFramework):
+    """Shared framework of the equal-set shadowing family."""
+
+
+class CfwP722F(ComputeFramework):
+    """First framework of the differing-set family; declared by parent and child."""
+
+
+class CfwQ722F(ComputeFramework):
+    """Second framework of the differing-set family; declared by the parent only."""
+
+
+class CfwPinX722F(ComputeFramework):
+    """Uniquely named framework, pinnable by name from a Feature."""
+
+
+class CfwPinY722F(ComputeFramework):
+    """Rival uniquely named framework for the pin sibling probe."""
+
+
+class CfwCap722F(ComputeFramework):
+    """Framework declared by the capability probes."""
+
+
+class CfwMultiOne722F(ComputeFramework):
+    """First framework of the illegal multi-pin request."""
+
+
+class CfwMultiTwo722F(ComputeFramework):
+    """Second framework of the illegal multi-pin request."""
+
+
+class _ResolverProbeBase722F(FeatureGroup):
+    """Shared probe base: never matches anything itself."""
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return False
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        return None
+
+
+class CleanProbe722F(_ResolverProbeBase722F):
+    """Single clean candidate: matches its own name on one framework."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwAlpha722F}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == CLEAN_FEATURE
+
+
+class AmbiguousOneProbe722F(_ResolverProbeBase722F):
+    """First of two unrelated probes matching the ambiguous feature name."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwAlpha722F}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == AMBIGUOUS_FEATURE
+
+
+class AmbiguousTwoProbe722F(_ResolverProbeBase722F):
+    """Second of two unrelated probes matching the ambiguous feature name."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwAlpha722F}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == AMBIGUOUS_FEATURE
+
+
+class ShadowParentProbe722F(_ResolverProbeBase722F):
+    """Parent of the equal-framework-set family; shadowed by its child."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwShadow722F}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == SHADOW_FEATURE
+
+
+class ShadowChildProbe722F(ShadowParentProbe722F):
+    """Child with the identical framework set; shadows the parent."""
+
+
+class SplitParentProbe722F(_ResolverProbeBase722F):
+    """Parent declaring two frameworks; the child narrows to one."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwP722F, CfwQ722F}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == SPLIT_FEATURE
+
+
+class SplitChildProbe722F(SplitParentProbe722F):
+    """Child narrowing the declaration to a single framework."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwP722F}
+
+
+class AbstractProbe722F(_ResolverProbeBase722F):
+    """Abstract probe: matches its own name but can never be instantiated."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwAlpha722F}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == ABSTRACT_FEATURE
+
+    @classmethod
+    @abstractmethod
+    def _probe_hook_722f(cls) -> str:
+        """Abstract hook that keeps this probe abstract."""
+
+
+class NoFrameworkProbe722F(_ResolverProbeBase722F):
+    """Matches its name, but the environment mapping strips all its frameworks."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwAlpha722F}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == NO_FRAMEWORK_FEATURE
+
+
+class DomainProbe722F(_ResolverProbeBase722F):
+    """Matches its name and lives in the matching probe domain."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwAlpha722F}
+
+    @classmethod
+    def get_domain(cls) -> Domain:
+        return Domain(DOMAIN_MATCH)
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == DOMAIN_FEATURE
+
+
+class PinSiblingX722F(_ResolverProbeBase722F):
+    """Sibling probe on CfwPinX722F, matching the shared pin feature name."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwPinX722F}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == PIN_FEATURE
+
+
+class PinSiblingY722F(_ResolverProbeBase722F):
+    """Sibling probe on CfwPinY722F, matching the same pin feature name."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwPinY722F}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == PIN_FEATURE
+
+
+class LinkLeftProbe722F(_ResolverProbeBase722F):
+    """Anchors the left side of the foreign link; never matches a name."""
+
+
+class LinkRightProbe722F(_ResolverProbeBase722F):
+    """Anchors the right side of the foreign link; never matches a name."""
+
+
+class LinkedProbe722F(_ResolverProbeBase722F):
+    """Declares an index no link in the request carries."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwAlpha722F}
+
+    @classmethod
+    def index_columns(cls) -> list[Index] | None:
+        return [Index(("probe722f_row_id",))]
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == LINKED_FEATURE
+
+
+class ValueRejectionProbe722F(_ResolverProbeBase722F):
+    """Raises PropertyValueRejection from matching, gated on its shared feature name."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwAlpha722F}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        # Gated on the probe name so process-global scans in other tests never trip the raise.
+        if str(feature_name) == VALUE_REJECTION_FEATURE:
+            raise PropertyValueRejection(VALUE_REJECTION_TEXT)
+        return False
+
+
+class ValueRejectionWinnerProbe722F(_ResolverProbeBase722F):
+    """Matches the value-rejection feature name cleanly."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwAlpha722F}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == VALUE_REJECTION_FEATURE
+
+
+class BoomProbe722F(_ResolverProbeBase722F):
+    """Raises a plain ValueError from matching, gated on its shared feature name."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwAlpha722F}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        # Gated on the probe name so process-global scans in other tests never trip the raise.
+        if str(feature_name) == BOOM_FEATURE:
+            raise ValueError(BOOM_ERROR_TEXT)
+        return False
+
+
+class BoomWinnerProbe722F(_ResolverProbeBase722F):
+    """Matches the boom feature name cleanly."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwAlpha722F}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == BOOM_FEATURE
+
+
+class CapabilityRaisesProbe722F(_ResolverProbeBase722F):
+    """Probe whose capability hook raises on its only (remaining) framework."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwCap722F}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == CAPABILITY_RAISES_FEATURE
+
+    @classmethod
+    def supports_compute_framework(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        compute_framework: type[ComputeFramework],
+    ) -> bool:
+        # Gated on the probe name so process-global scans in other tests never trip the raise.
+        if str(feature_name) == CAPABILITY_RAISES_FEATURE:
+            raise RuntimeError(CAPABILITY_ERROR_TEXT)
+        return True
+
+
+class CapabilityFalseProbe722F(_ResolverProbeBase722F):
+    """Probe whose capability hook rejects every framework by returning False."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwCap722F}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == CAPABILITY_FALSE_FEATURE
+
+    @classmethod
+    def supports_compute_framework(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        compute_framework: type[ComputeFramework],
+    ) -> bool:
+        if str(feature_name) == CAPABILITY_FALSE_FEATURE:
+            return False
+        return True
+
+
+class MultiPinProbe722F(_ResolverProbeBase722F):
+    """Matches the multi-pin feature name; the request itself is the illegal part."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwMultiOne722F, CfwMultiTwo722F}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == MULTI_PIN_FEATURE
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve(
+    mapping: FeatureGroupEnvironmentMapping,
+    feature: Feature,
+    links: set[Link] | None = None,
+) -> ResolutionOutcome:
+    request = ResolutionRequestSnapshot.from_feature(feature, links=links)
+    return FeatureGroupResolver().resolve(request, snapshot_from_mapping(mapping))
+
+
+def _candidate(outcome: ResolutionOutcome, feature_group: type[FeatureGroup]) -> CandidateEvaluation:
+    identity = PluginIdentity.from_class(feature_group)
+    matches = [candidate for candidate in outcome.candidates if candidate.identity == identity]
+    assert len(matches) == 1, f"expected exactly one evaluation for {identity.render()}, got {len(matches)}"
+    return matches[0]
+
+
+def _framework_evaluation(candidate: CandidateEvaluation, framework: type[ComputeFramework]) -> FrameworkEvaluation:
+    matches = [evaluation for evaluation in candidate.frameworks if evaluation.framework is framework]
+    assert len(matches) == 1, f"expected exactly one evaluation for {framework.__name__}, got {len(matches)}"
+    return matches[0]
+
+
+def _reasons(candidate: CandidateEvaluation) -> set[RejectionReason]:
+    return {rejection.reason for rejection in candidate.rejections}
+
+
+# ---------------------------------------------------------------------------
+# Statuses: RESOLVED, AMBIGUOUS, NOT_FOUND
+# ---------------------------------------------------------------------------
+
+
+def test_single_clean_candidate_resolves() -> None:
+    """A single clean candidate resolves with WINNER and SUPPORTED evaluations."""
+    mapping: FeatureGroupEnvironmentMapping = {CleanProbe722F: {CfwAlpha722F}}
+    outcome = _resolve(mapping, Feature(CLEAN_FEATURE))
+
+    assert outcome.status is ResolutionStatus.RESOLVED
+    assert outcome.winner is not None
+    assert outcome.winner.feature_group is CleanProbe722F
+    assert outcome.winner.compute_frameworks == (CfwAlpha722F,)
+    assert outcome.failures == ()
+
+    candidate = _candidate(outcome, CleanProbe722F)
+    assert candidate.status is CandidateStatus.WINNER
+    assert candidate.rejections == ()
+    evaluation = _framework_evaluation(candidate, CfwAlpha722F)
+    assert evaluation.status is FrameworkStatus.SUPPORTED
+    assert evaluation.identity == PluginIdentity.from_class(CfwAlpha722F)
+
+
+def test_two_unrelated_candidates_same_name_are_ambiguous() -> None:
+    """Two unrelated candidates on the same name stay AMBIGUOUS; both are SURVIVOR."""
+    mapping: FeatureGroupEnvironmentMapping = {
+        AmbiguousOneProbe722F: {CfwAlpha722F},
+        AmbiguousTwoProbe722F: {CfwAlpha722F},
+    }
+    outcome = _resolve(mapping, Feature(AMBIGUOUS_FEATURE))
+
+    assert outcome.status is ResolutionStatus.AMBIGUOUS
+    assert outcome.winner is None
+    assert _candidate(outcome, AmbiguousOneProbe722F).status is CandidateStatus.SURVIVOR
+    assert _candidate(outcome, AmbiguousTwoProbe722F).status is CandidateStatus.SURVIVOR
+
+
+def test_child_shadows_parent_with_equal_framework_sets() -> None:
+    """A child with the identical framework set wins; the parent is SHADOWED, visibly."""
+    mapping: FeatureGroupEnvironmentMapping = {
+        ShadowParentProbe722F: {CfwShadow722F},
+        ShadowChildProbe722F: {CfwShadow722F},
+    }
+    outcome = _resolve(mapping, Feature(SHADOW_FEATURE))
+
+    assert outcome.status is ResolutionStatus.RESOLVED
+    assert outcome.winner is not None
+    assert outcome.winner.feature_group is ShadowChildProbe722F
+
+    child = _candidate(outcome, ShadowChildProbe722F)
+    assert child.status is CandidateStatus.WINNER
+
+    parent = _candidate(outcome, ShadowParentProbe722F)
+    assert parent.status is CandidateStatus.SHADOWED
+    assert parent.shadowed_by == PluginIdentity.from_class(ShadowChildProbe722F)
+    assert RejectionReason.SUBCLASS_SHADOWED in _reasons(parent)
+
+
+def test_parent_child_differing_framework_sets_stay_ambiguous_with_per_candidate_attribution() -> None:
+    """Differing framework sets block shadowing; each candidate lists only ITS frameworks.
+
+    The false-positive-3 core: the parent-only framework must never be attributed
+    to the child candidate.
+    """
+    mapping: FeatureGroupEnvironmentMapping = {
+        SplitParentProbe722F: {CfwP722F, CfwQ722F},
+        SplitChildProbe722F: {CfwP722F},
+    }
+    outcome = _resolve(mapping, Feature(SPLIT_FEATURE))
+
+    assert outcome.status is ResolutionStatus.AMBIGUOUS
+    assert outcome.winner is None
+
+    parent = _candidate(outcome, SplitParentProbe722F)
+    assert parent.status is CandidateStatus.SURVIVOR
+    assert len(parent.frameworks) == 2
+    assert _framework_evaluation(parent, CfwP722F).status is FrameworkStatus.SUPPORTED
+    assert _framework_evaluation(parent, CfwQ722F).status is FrameworkStatus.SUPPORTED
+
+    child = _candidate(outcome, SplitChildProbe722F)
+    assert child.status is CandidateStatus.SURVIVOR
+    assert [evaluation.framework for evaluation in child.frameworks] == [CfwP722F]
+    assert _framework_evaluation(child, CfwP722F).status is FrameworkStatus.SUPPORTED
+
+
+def test_lone_abstract_candidate_is_not_found_with_abstract_rejection() -> None:
+    """An abstract candidate can never win; the lone abstract match is NOT_FOUND."""
+    assert inspect.isabstract(AbstractProbe722F), "fixture must be abstract"
+
+    mapping: FeatureGroupEnvironmentMapping = {AbstractProbe722F: {CfwAlpha722F}}
+    outcome = _resolve(mapping, Feature(ABSTRACT_FEATURE))
+
+    assert outcome.status is ResolutionStatus.NOT_FOUND
+    assert outcome.winner is None
+    candidate = _candidate(outcome, AbstractProbe722F)
+    assert candidate.status is CandidateStatus.REJECTED
+    assert RejectionReason.ABSTRACT in _reasons(candidate)
+
+
+def test_candidate_with_empty_framework_set_is_not_found_with_no_accessible_framework() -> None:
+    """The false-positive-2 core: an empty framework set is a structured rejection."""
+    mapping: FeatureGroupEnvironmentMapping = {NoFrameworkProbe722F: set()}
+    outcome = _resolve(mapping, Feature(NO_FRAMEWORK_FEATURE))
+
+    assert outcome.status is ResolutionStatus.NOT_FOUND
+    assert outcome.winner is None
+    candidate = _candidate(outcome, NoFrameworkProbe722F)
+    assert candidate.status is CandidateStatus.REJECTED
+    assert RejectionReason.NO_ACCESSIBLE_FRAMEWORK in _reasons(candidate)
+
+
+def test_domain_mismatch_rejects_and_matching_domain_resolves() -> None:
+    """A domain mismatch is a DOMAIN rejection; the matching domain resolves."""
+    mapping: FeatureGroupEnvironmentMapping = {DomainProbe722F: {CfwAlpha722F}}
+
+    mismatched = _resolve(mapping, Feature(DOMAIN_FEATURE, domain=DOMAIN_OTHER))
+    assert mismatched.status is ResolutionStatus.NOT_FOUND
+    assert mismatched.winner is None
+    candidate = _candidate(mismatched, DomainProbe722F)
+    assert candidate.status is CandidateStatus.REJECTED
+    assert RejectionReason.DOMAIN in _reasons(candidate)
+
+    matched = _resolve(mapping, Feature(DOMAIN_FEATURE, domain=DOMAIN_MATCH))
+    assert matched.status is ResolutionStatus.RESOLVED
+    assert matched.winner is not None
+    assert matched.winner.feature_group is DomainProbe722F
+
+
+# ---------------------------------------------------------------------------
+# Framework pin and link/index filters
+# ---------------------------------------------------------------------------
+
+
+def test_framework_pin_selects_sibling_and_marks_other_pin_excluded() -> None:
+    """A framework pin resolves per-framework siblings; the loser is structured.
+
+    Pinned shape: the losing candidate is REJECTED with a FRAMEWORK_PIN rejection,
+    and its pinned-away framework evaluation carries status PIN_EXCLUDED.
+    """
+    mapping: FeatureGroupEnvironmentMapping = {
+        PinSiblingX722F: {CfwPinX722F},
+        PinSiblingY722F: {CfwPinY722F},
+    }
+    feature = Feature(PIN_FEATURE, compute_framework=CfwPinX722F.get_class_name())
+    outcome = _resolve(mapping, feature)
+
+    assert outcome.status is ResolutionStatus.RESOLVED
+    assert outcome.winner is not None
+    assert outcome.winner.feature_group is PinSiblingX722F
+    assert outcome.winner.compute_frameworks == (CfwPinX722F,)
+
+    winner = _candidate(outcome, PinSiblingX722F)
+    assert winner.status is CandidateStatus.WINNER
+    assert _framework_evaluation(winner, CfwPinX722F).status is FrameworkStatus.SUPPORTED
+
+    loser = _candidate(outcome, PinSiblingY722F)
+    assert loser.status is CandidateStatus.REJECTED
+    assert RejectionReason.FRAMEWORK_PIN in _reasons(loser)
+    assert _framework_evaluation(loser, CfwPinY722F).status is FrameworkStatus.PIN_EXCLUDED
+
+
+def test_link_index_mismatch_rejects_candidate() -> None:
+    """A candidate whose index columns support no request link is a LINK_INDEX rejection."""
+    mapping: FeatureGroupEnvironmentMapping = {LinkedProbe722F: {CfwAlpha722F}}
+
+    # Premise guard: without links the probe resolves.
+    without_links = _resolve(mapping, Feature(LINKED_FEATURE))
+    assert without_links.status is ResolutionStatus.RESOLVED
+
+    link = Link.inner(
+        JoinSpec(LinkLeftProbe722F, "probe722f_left_id"),
+        JoinSpec(LinkRightProbe722F, "probe722f_right_id"),
+    )
+    outcome = _resolve(mapping, Feature(LINKED_FEATURE), links={link})
+
+    assert outcome.status is ResolutionStatus.NOT_FOUND
+    assert outcome.winner is None
+    candidate = _candidate(outcome, LinkedProbe722F)
+    assert candidate.status is CandidateStatus.REJECTED
+    assert RejectionReason.LINK_INDEX in _reasons(candidate)
+
+
+# ---------------------------------------------------------------------------
+# Provider failure semantics
+# ---------------------------------------------------------------------------
+
+
+def test_property_value_rejection_is_structured_and_not_fatal() -> None:
+    """PropertyValueRejection is a structured VALUE_REJECTION; a clean rival still wins."""
+    mapping: FeatureGroupEnvironmentMapping = {
+        ValueRejectionProbe722F: {CfwAlpha722F},
+        ValueRejectionWinnerProbe722F: {CfwAlpha722F},
+    }
+    outcome = _resolve(mapping, Feature(VALUE_REJECTION_FEATURE))
+
+    assert outcome.status is ResolutionStatus.RESOLVED
+    assert outcome.winner is not None
+    assert outcome.winner.feature_group is ValueRejectionWinnerProbe722F
+    assert outcome.failures == ()
+
+    rejected = _candidate(outcome, ValueRejectionProbe722F)
+    assert rejected.status is CandidateStatus.REJECTED
+    rejections_by_reason = {rejection.reason: rejection for rejection in rejected.rejections}
+    assert RejectionReason.VALUE_REJECTION in rejections_by_reason
+    assert VALUE_REJECTION_TEXT in rejections_by_reason[RejectionReason.VALUE_REJECTION].detail
+
+
+def test_plain_value_error_from_criteria_fails_closed_despite_clean_winner() -> None:
+    """Any non-rejection exception from criteria is fatal; a clean winner cannot hide it."""
+    mapping: FeatureGroupEnvironmentMapping = {
+        BoomProbe722F: {CfwAlpha722F},
+        BoomWinnerProbe722F: {CfwAlpha722F},
+    }
+    outcome = _resolve(mapping, Feature(BOOM_FEATURE))
+
+    assert outcome.status is ResolutionStatus.FAILED
+    assert outcome.winner is None
+
+    failing = _candidate(outcome, BoomProbe722F)
+    assert failing.status is CandidateStatus.FAILED
+    assert failing.failure is not None
+    assert failing.failure.category == "ValueError"
+    assert failing.failure.message == BOOM_ERROR_TEXT
+    assert failing.failure.plugin == PluginIdentity.from_class(BoomProbe722F)
+
+    clean = _candidate(outcome, BoomWinnerProbe722F)
+    assert clean.status is CandidateStatus.SURVIVOR
+
+    assert len(outcome.failures) >= 1
+    assert any(failure.category == "ValueError" and failure.message == BOOM_ERROR_TEXT for failure in outcome.failures)
+
+
+def test_capability_hook_raise_on_remaining_framework_fails_closed() -> None:
+    """A raising capability hook on a remaining framework is HOOK_FAILED, never degraded open."""
+    mapping: FeatureGroupEnvironmentMapping = {CapabilityRaisesProbe722F: {CfwCap722F}}
+    outcome = _resolve(mapping, Feature(CAPABILITY_RAISES_FEATURE))
+
+    assert outcome.status is ResolutionStatus.FAILED
+    assert outcome.winner is None
+
+    candidate = _candidate(outcome, CapabilityRaisesProbe722F)
+    assert candidate.status is CandidateStatus.FAILED
+    assert candidate.failure is not None
+    assert _framework_evaluation(candidate, CfwCap722F).status is FrameworkStatus.HOOK_FAILED
+
+    assert len(outcome.failures) >= 1
+    assert any(
+        failure.category == "RuntimeError" and failure.message == CAPABILITY_ERROR_TEXT for failure in outcome.failures
+    )
+
+    # The outcome carries no exception object and no traceback: it serializes as plain data.
+    dumped = json.dumps(outcome.to_payload())
+    assert "Traceback" not in dumped
+    assert "object at 0x" not in dumped
+
+
+def test_capability_hook_false_rejects_framework_and_candidate() -> None:
+    """A capability hook returning False is CAPABILITY_REJECTED, silent and non-fatal."""
+    mapping: FeatureGroupEnvironmentMapping = {CapabilityFalseProbe722F: {CfwCap722F}}
+    outcome = _resolve(mapping, Feature(CAPABILITY_FALSE_FEATURE))
+
+    assert outcome.status is ResolutionStatus.NOT_FOUND
+    assert outcome.winner is None
+    assert outcome.failures == ()
+
+    candidate = _candidate(outcome, CapabilityFalseProbe722F)
+    assert candidate.status is CandidateStatus.REJECTED
+    assert RejectionReason.CAPABILITY in _reasons(candidate)
+    assert _framework_evaluation(candidate, CfwCap722F).status is FrameworkStatus.CAPABILITY_REJECTED
+
+
+def test_multiple_pinned_frameworks_fail_resolution() -> None:
+    """A request pinning more than one framework is FAILED with the engine's text."""
+    mapping: FeatureGroupEnvironmentMapping = {MultiPinProbe722F: {CfwMultiOne722F, CfwMultiTwo722F}}
+    feature = Feature(MULTI_PIN_FEATURE)
+    pinned: set[type[ComputeFramework]] = {CfwMultiOne722F, CfwMultiTwo722F}
+    feature.compute_frameworks = pinned
+    request = ResolutionRequestSnapshot.from_feature(feature)
+    assert len(request.pinned_frameworks) == 2, "premise: the request must carry two pinned frameworks"
+
+    outcome = FeatureGroupResolver().resolve(request, snapshot_from_mapping(mapping))
+
+    assert outcome.status is ResolutionStatus.FAILED
+    assert outcome.winner is None
+    assert len(outcome.failures) >= 1
+    haystack = json.dumps(outcome.to_payload()) + " ".join(failure.message for failure in outcome.failures)
+    assert MULTI_PIN_TEXT in haystack
+
+
+# ---------------------------------------------------------------------------
+# Invariants, determinism, serialization
+# ---------------------------------------------------------------------------
+
+
+def _invariant_scenarios() -> list[tuple[FeatureGroupEnvironmentMapping, Feature]]:
+    multi_pin_feature = Feature(MULTI_PIN_FEATURE)
+    multi_pinned: set[type[ComputeFramework]] = {CfwMultiOne722F, CfwMultiTwo722F}
+    multi_pin_feature.compute_frameworks = multi_pinned
+    return [
+        ({CleanProbe722F: {CfwAlpha722F}}, Feature(CLEAN_FEATURE)),
+        (
+            {AmbiguousOneProbe722F: {CfwAlpha722F}, AmbiguousTwoProbe722F: {CfwAlpha722F}},
+            Feature(AMBIGUOUS_FEATURE),
+        ),
+        (
+            {ShadowParentProbe722F: {CfwShadow722F}, ShadowChildProbe722F: {CfwShadow722F}},
+            Feature(SHADOW_FEATURE),
+        ),
+        (
+            {SplitParentProbe722F: {CfwP722F, CfwQ722F}, SplitChildProbe722F: {CfwP722F}},
+            Feature(SPLIT_FEATURE),
+        ),
+        ({AbstractProbe722F: {CfwAlpha722F}}, Feature(ABSTRACT_FEATURE)),
+        ({NoFrameworkProbe722F: set()}, Feature(NO_FRAMEWORK_FEATURE)),
+        (
+            {ValueRejectionProbe722F: {CfwAlpha722F}, ValueRejectionWinnerProbe722F: {CfwAlpha722F}},
+            Feature(VALUE_REJECTION_FEATURE),
+        ),
+        (
+            {BoomProbe722F: {CfwAlpha722F}, BoomWinnerProbe722F: {CfwAlpha722F}},
+            Feature(BOOM_FEATURE),
+        ),
+        ({CapabilityRaisesProbe722F: {CfwCap722F}}, Feature(CAPABILITY_RAISES_FEATURE)),
+        (
+            {PinSiblingX722F: {CfwPinX722F}, PinSiblingY722F: {CfwPinY722F}},
+            Feature(PIN_FEATURE, compute_framework=CfwPinX722F.get_class_name()),
+        ),
+        ({MultiPinProbe722F: {CfwMultiOne722F, CfwMultiTwo722F}}, multi_pin_feature),
+    ]
+
+
+def test_outcomes_hold_invariants_and_are_deterministic() -> None:
+    """Every outcome holds the contract invariants and resolves deterministically.
+
+    Invariants: a winner exists if and only if the status is RESOLVED; candidates
+    are sorted by plugin identity; two identical resolve calls agree on candidate
+    ordering and payload; the payload is JSON with no class reprs.
+    """
+    for mapping, feature in _invariant_scenarios():
+        environment = snapshot_from_mapping(mapping)
+        request = ResolutionRequestSnapshot.from_feature(feature)
+        first = FeatureGroupResolver().resolve(request, environment)
+        second = FeatureGroupResolver().resolve(request, environment)
+
+        assert (first.winner is not None) == (first.status is ResolutionStatus.RESOLVED)
+
+        identities = [candidate.identity for candidate in first.candidates]
+        assert identities == sorted(identities)
+        assert [candidate.identity for candidate in second.candidates] == identities
+
+        first_payload = json.dumps(first.to_payload(), sort_keys=True)
+        second_payload = json.dumps(second.to_payload(), sort_keys=True)
+        assert first_payload == second_payload
+        assert "<class" not in first_payload
+        assert "object at 0x" not in first_payload
+
+        assert isinstance(first.environment_fingerprint, str)
+        assert first.environment_fingerprint != ""
+
+
+# ---------------------------------------------------------------------------
+# FeatureResolutionError and the IdentifyFeatureGroupClass adapter
+# ---------------------------------------------------------------------------
+
+
+def test_feature_resolution_error_is_value_error_carrying_outcome() -> None:
+    """FeatureResolutionError subclasses ValueError and carries the structured outcome."""
+    accessible: FeatureGroupEnvironmentMapping = {
+        AmbiguousOneProbe722F: {CfwAlpha722F},
+        AmbiguousTwoProbe722F: {CfwAlpha722F},
+    }
+    with pytest.raises(FeatureResolutionError) as exc_info:
+        IdentifyFeatureGroupClass(
+            feature=Feature(AMBIGUOUS_FEATURE),
+            accessible_plugins=accessible,
+            links=None,
+        )
+    error = exc_info.value
+    assert isinstance(error, ValueError)
+    assert isinstance(error.outcome, ResolutionOutcome)
+
+
+def test_identify_adapter_ambiguity_raises_feature_resolution_error() -> None:
+    """The adapter's ambiguity error keeps today's text and is a FeatureResolutionError."""
+    accessible: FeatureGroupEnvironmentMapping = {
+        AmbiguousOneProbe722F: {CfwAlpha722F},
+        AmbiguousTwoProbe722F: {CfwAlpha722F},
+    }
+    with pytest.raises(ValueError, match="Multiple feature groups found") as exc_info:
+        IdentifyFeatureGroupClass(
+            feature=Feature(AMBIGUOUS_FEATURE),
+            accessible_plugins=accessible,
+            links=None,
+        )
+    assert isinstance(exc_info.value, FeatureResolutionError)
+
+
+def test_identify_adapter_no_match_raises_feature_resolution_error() -> None:
+    """The adapter's no-match error keeps today's text and is a FeatureResolutionError."""
+    accessible: FeatureGroupEnvironmentMapping = {CleanProbe722F: {CfwAlpha722F}}
+    with pytest.raises(ValueError, match="No feature groups found") as exc_info:
+        IdentifyFeatureGroupClass(
+            feature=Feature(UNKNOWN_FEATURE),
+            accessible_plugins=accessible,
+            links=None,
+        )
+    assert isinstance(exc_info.value, FeatureResolutionError)
+
+
+def test_identify_adapter_success_returns_mapping_and_exposes_outcome() -> None:
+    """On success the adapter's .get() keeps today's shape and exposes the outcome."""
+    accessible: FeatureGroupEnvironmentMapping = {CleanProbe722F: {CfwAlpha722F}}
+    identifier = IdentifyFeatureGroupClass(
+        feature=Feature(CLEAN_FEATURE),
+        accessible_plugins=accessible,
+        links=None,
+        data_access_collection=None,
+    )
+    feature_group, compute_frameworks = identifier.get()
+    assert feature_group is CleanProbe722F
+    assert compute_frameworks == {CfwAlpha722F}
+    assert isinstance(identifier.outcome, ResolutionOutcome)
+    assert identifier.outcome.status is ResolutionStatus.RESOLVED

--- a/tests/test_core/test_resolve/test_resolver_hardening.py
+++ b/tests/test_core/test_resolve/test_resolver_hardening.py
@@ -1,0 +1,732 @@
+"""Failing tests for issue #722 Stage 3 hardening (post-review fix round).
+
+Pins review-mandated hardening of the resolver stack (``mloda.core.resolve.resolver``,
+``mloda.core.resolve.outcome``, ``mloda.core.api.plugin_docs.resolve_feature``, and the
+engine adapter / Engine call path):
+
+1.  ResolutionOutcome payloads are redacted: the raw provider message stays on the
+    internal ``PluginFailure.message`` field (it feeds the rendered errors) but never
+    leaks into ``to_payload()``.
+2.  A raising ``get_domain`` hook is guarded fail-closed into a FAILED outcome.
+3.  A raising ``index_columns`` hook is guarded fail-closed into a FAILED outcome.
+    Investigated: ``_supports_request_links`` consults ``index_columns()`` BEFORE the
+    empty-links short-circuit, so the raise propagates even for a link-less request;
+    both the no-links and with-links requests pin the guard.
+4.  A raising ``supports_index`` hook is guarded fail-closed into a FAILED outcome.
+5.  links=() and links=None are equivalent (TARGET CONTRACT, passes today).
+6.  A LINK_INDEX-rejected candidate records NOT_EVALUATED framework evaluations,
+    never SUPPORTED (new FrameworkStatus member).
+7.  resolve_feature samples framework availability exactly once per call.
+8.  resolve_feature never raises when an ``is_available`` probe raises.
+9.  A mapping-derived snapshot never consults the strict-mode env var. Investigated:
+    ``strict_mode_from_env`` RAISES ValueError on an invalid value, so this pins that
+    ``IdentifyFeatureGroupClass`` over a hand-built mapping still works under an
+    invalid env value.
+10. One Engine builds its mapping-derived environment snapshot at most once, not
+    once per requested feature.
+
+RED phase: tests 1, 2, 3, 4, 6, 7, 8, 9, and 10 fail against the current
+implementation; test 5 passes and pins the target contract.
+
+Probe names use the unique probe722h_ prefix so process-global scans in other tests
+never trip these fixtures. Hooks that cannot be name-gated (get_domain, index_columns,
+supports_index, is_available) raise only while ARMED by their test and are disarmed by
+fixture teardown: in the RED phase their raise propagates through pytest, which parks
+the exception (and the frames referencing the probe class) in sys.last_exc, so a
+gc-scoped class would stay alive and poison later tests on the same xdist worker.
+"""
+
+from __future__ import annotations
+
+import gc
+import json
+from typing import Callable, Iterator
+from unittest.mock import patch
+
+import pytest
+
+import mloda.core.prepare.identify_feature_group as identify_module
+import mloda.core.resolve.resolver as resolver_module
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.domain import Domain
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_collection import Features
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.index.index import Index
+from mloda.core.abstract_plugins.components.link import JoinSpec, Link
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import (
+    PluginCollector,
+    strict_mode_from_env,
+)
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.api.plugin_docs import resolve_feature
+from mloda.core.api.plugin_info import ResolvedFeature
+from mloda.core.core.engine import Engine
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+from mloda.core.resolve.environment import ResolutionEnvironmentSnapshot
+from mloda.core.resolve.identity import PluginIdentity
+from mloda.core.resolve.outcome import (
+    CandidateEvaluation,
+    CandidateStatus,
+    FrameworkEvaluation,
+    FrameworkStatus,
+    PluginFailure,
+    RejectionReason,
+    ResolutionOutcome,
+    ResolutionStatus,
+)
+from mloda.core.resolve.request import ResolutionRequestSnapshot
+from mloda.core.resolve.resolver import FeatureGroupResolver, snapshot_from_mapping
+
+
+CLEAN_FEATURE = "probe722h_clean"
+REDACTION_FEATURE = "probe722h_secret"
+DOMAIN_FEATURE = "probe722h_domain"
+INDEX_BOOM_FEATURE = "probe722h_index_boom"
+SUPPORTS_BOOM_FEATURE = "probe722h_supports_boom"
+LINKS_EQUAL_FEATURE = "probe722h_links_equal"
+NOT_EVALUATED_FEATURE = "probe722h_not_evaluated"
+COUNTING_FEATURE = "probe722h_counting"
+ENGINE_FEATURE_ONE = "probe722h_engine_one"
+ENGINE_FEATURE_TWO = "probe722h_engine_two"
+
+DOMAIN_722H = "probe722h_dom_ops"
+
+# Fake credential-shaped provider message used to prove payload redaction; never a real secret.
+_FAKE_CREDENTIAL_MESSAGE_722H = "credential=hush-722h"  # nosec B105
+DOMAIN_BOOM_TEXT = "domain boom 722h"
+INDEX_BOOM_TEXT = "index boom 722h"
+SUPPORTS_BOOM_TEXT = "supports boom 722h"
+AVAIL_BOOM_TEXT = "avail boom 722h"
+RAISING_AVAIL_CLASS_NAME = "CfwRaisingAvail722H"
+
+
+# ---------------------------------------------------------------------------
+# Mock compute frameworks (unique names, suffix 722H)
+# ---------------------------------------------------------------------------
+
+
+class CfwAlpha722H(ComputeFramework):
+    """General-purpose framework for the hand-built resolver mappings."""
+
+
+class CfwEngine722H(ComputeFramework):
+    """Framework carried by the Engine memoization probe."""
+
+
+# Counts every is_available() call on the counting framework; cleared per test (xdist-safe:
+# workers are separate processes, and within one worker the owning test resets it first).
+_RESOLVE_AVAILABILITY_CALLS_722H: list[str] = []
+
+
+class CfwCountingResolve722H(ComputeFramework):
+    """Available framework whose availability probe counts its own invocations."""
+
+    @staticmethod
+    def is_available() -> bool:
+        _RESOLVE_AVAILABILITY_CALLS_722H.append("call")
+        return True
+
+
+# Hook keys armed per test via the arm_hook_722h fixture; disarmed on teardown. While
+# disarmed, every hook below degrades to an inert default, so the module-level classes
+# stay harmless in every other test of the process (xdist-safe: per-process state).
+_ARMED_HOOKS_722H: set[str] = set()
+
+
+class CfwRaisingAvail722H(ComputeFramework):
+    """Framework whose is_available() raises while armed; unavailable otherwise.
+
+    EVERY availability sampling in the process hits this hook, so the raise is armed
+    only for the one test pinning it and the class is otherwise a plain unavailable
+    framework.
+    """
+
+    @staticmethod
+    def is_available() -> bool:
+        if "is_available" in _ARMED_HOOKS_722H:
+            raise RuntimeError(AVAIL_BOOM_TEXT)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Probe feature groups (match ONLY their own probe722h_* names)
+# ---------------------------------------------------------------------------
+
+
+class _HardeningProbeBase722H(FeatureGroup):
+    """Shared probe base: never matches anything itself."""
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return False
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        return None
+
+
+class CleanProbe722H(_HardeningProbeBase722H):
+    """Single clean candidate: matches its own name on one framework."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwAlpha722H}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == CLEAN_FEATURE
+
+
+class SecretCriteriaBoom722H(_HardeningProbeBase722H):
+    """Raises a ValueError carrying a credential-shaped message, gated on its name."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwAlpha722H}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        # Gated on the probe name so process-global scans in other tests never trip the raise.
+        if str(feature_name) == REDACTION_FEATURE:
+            raise ValueError(_FAKE_CREDENTIAL_MESSAGE_722H)
+        return False
+
+
+class DomainRival722H(_HardeningProbeBase722H):
+    """Clean rival in the probe domain; must not hide the domain-hook failure."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwAlpha722H}
+
+    @classmethod
+    def get_domain(cls) -> Domain:
+        return Domain(DOMAIN_722H)
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == DOMAIN_FEATURE
+
+
+class IndexedConsistencyProbe722H(_HardeningProbeBase722H):
+    """Indexed candidate for the links=() equals links=None consistency pin."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwAlpha722H}
+
+    @classmethod
+    def index_columns(cls) -> list[Index] | None:
+        return [Index(("probe722h_row_id",))]
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == LINKS_EQUAL_FEATURE
+
+
+class NotEvaluatedProbe722H(_HardeningProbeBase722H):
+    """Declares an index no request link carries: rejected at the LINK_INDEX stage."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwAlpha722H}
+
+    @classmethod
+    def index_columns(cls) -> list[Index] | None:
+        return [Index(("probe722h_ne_key",))]
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == NOT_EVALUATED_FEATURE
+
+
+class CountingResolveProbe722H(_HardeningProbeBase722H):
+    """Probe declaring only the counting framework, for the single-sampling pin."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwCountingResolve722H}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == COUNTING_FEATURE
+
+
+class EngineProbe722H(_HardeningProbeBase722H):
+    """Root probe matching both engine feature names on one framework."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwEngine722H}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) in (ENGINE_FEATURE_ONE, ENGINE_FEATURE_TWO)
+
+
+class LinkAnchorLeft722H(_HardeningProbeBase722H):
+    """Anchors the left side of the foreign link; never matches a name."""
+
+
+class LinkAnchorRight722H(_HardeningProbeBase722H):
+    """Anchors the right side of the foreign link; never matches a name."""
+
+
+class ProbeDomainBoom722H(_HardeningProbeBase722H):
+    """Probe whose get_domain() raises while armed; the hook cannot be name-gated."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwAlpha722H}
+
+    @classmethod
+    def get_domain(cls) -> Domain:
+        if "get_domain" in _ARMED_HOOKS_722H:
+            raise RuntimeError(DOMAIN_BOOM_TEXT)
+        return Domain.get_default_domain()
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == DOMAIN_FEATURE
+
+
+class ProbeIndexBoom722H(_HardeningProbeBase722H):
+    """Probe whose index_columns() raises while armed; the hook cannot be name-gated."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwAlpha722H}
+
+    @classmethod
+    def index_columns(cls) -> list[Index] | None:
+        if "index_columns" in _ARMED_HOOKS_722H:
+            raise RuntimeError(INDEX_BOOM_TEXT)
+        return None
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == INDEX_BOOM_FEATURE
+
+
+class ProbeSupportsIndexBoom722H(_HardeningProbeBase722H):
+    """Probe with valid index_columns but a supports_index() raising while armed."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwAlpha722H}
+
+    @classmethod
+    def index_columns(cls) -> list[Index] | None:
+        return [Index(("probe722h_si_key",))]
+
+    @classmethod
+    def supports_index(cls, index: Index) -> bool | None:
+        if "supports_index" in _ARMED_HOOKS_722H:
+            raise RuntimeError(SUPPORTS_BOOM_TEXT)
+        return False
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == SUPPORTS_BOOM_FEATURE
+
+
+@pytest.fixture
+def arm_hook_722h() -> Iterator[Callable[[str], None]]:
+    """Arm raising hooks for one test; teardown disarms them even when the raise propagated."""
+    armed_keys: list[str] = []
+
+    def _arm(key: str) -> None:
+        _ARMED_HOOKS_722H.add(key)
+        armed_keys.append(key)
+
+    yield _arm
+    for key in armed_keys:
+        _ARMED_HOOKS_722H.discard(key)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve(
+    mapping: FeatureGroupEnvironmentMapping,
+    feature: Feature,
+    links: set[Link] | None = None,
+) -> ResolutionOutcome:
+    request = ResolutionRequestSnapshot.from_feature(feature, links=links)
+    return FeatureGroupResolver().resolve(request, snapshot_from_mapping(mapping))
+
+
+def _candidate(outcome: ResolutionOutcome, feature_group: type[FeatureGroup]) -> CandidateEvaluation:
+    identity = PluginIdentity.from_class(feature_group)
+    matches = [candidate for candidate in outcome.candidates if candidate.identity == identity]
+    assert len(matches) == 1, f"expected exactly one evaluation for {identity.render()}, got {len(matches)}"
+    return matches[0]
+
+
+def _framework_evaluation(candidate: CandidateEvaluation, framework: type[ComputeFramework]) -> FrameworkEvaluation:
+    matches = [evaluation for evaluation in candidate.frameworks if evaluation.framework is framework]
+    assert len(matches) == 1, f"expected exactly one evaluation for {framework.__name__}, got {len(matches)}"
+    return matches[0]
+
+
+def _reasons(candidate: CandidateEvaluation) -> set[RejectionReason]:
+    return {rejection.reason for rejection in candidate.rejections}
+
+
+def _sole_failure(outcome: ResolutionOutcome) -> PluginFailure:
+    assert len(outcome.failures) == 1, f"expected exactly one failure, got {len(outcome.failures)}"
+    return outcome.failures[0]
+
+
+def _foreign_link() -> Link:
+    return Link.inner(
+        JoinSpec(LinkAnchorLeft722H, "probe722h_left_id"),
+        JoinSpec(LinkAnchorRight722H, "probe722h_right_id"),
+    )
+
+
+def _off_collector(*probes: type[FeatureGroup]) -> PluginCollector:
+    return PluginCollector.enabled_feature_groups(set(probes)).set_strict_mode("off")
+
+
+# ---------------------------------------------------------------------------
+# 1. Outcome payload is redacted
+# ---------------------------------------------------------------------------
+
+
+def test_outcome_payload_redacts_provider_message() -> None:
+    """The raw provider text stays on the internal message field; to_payload() never carries it."""
+    mapping: FeatureGroupEnvironmentMapping = {SecretCriteriaBoom722H: {CfwAlpha722H}}
+    outcome = _resolve(mapping, Feature(REDACTION_FEATURE))
+
+    assert outcome.status is ResolutionStatus.FAILED
+    failure = _sole_failure(outcome)
+    # Internal field keeps the raw text: it feeds the rendered engine and debug errors.
+    assert failure.message == _FAKE_CREDENTIAL_MESSAGE_722H
+    assert failure.stage == "match_feature_group_criteria"
+    assert failure.category == "ValueError"
+    assert failure.plugin == PluginIdentity.from_class(SecretCriteriaBoom722H)
+
+    dumped = json.dumps(outcome.to_payload())
+    assert "hush-722h" not in dumped
+    assert "SecretCriteriaBoom722H" in dumped
+    assert "match_feature_group_criteria" in dumped
+    assert "ValueError" in dumped
+
+
+# ---------------------------------------------------------------------------
+# 2. get_domain is guarded
+# ---------------------------------------------------------------------------
+
+
+def test_raising_get_domain_fails_closed_without_propagating(arm_hook_722h: Callable[[str], None]) -> None:
+    """A raising get_domain becomes a structured FAILED outcome; a clean rival cannot hide it."""
+    arm_hook_722h("get_domain")
+    mapping: FeatureGroupEnvironmentMapping = {
+        ProbeDomainBoom722H: {CfwAlpha722H},
+        DomainRival722H: {CfwAlpha722H},
+    }
+
+    outcome = _resolve(mapping, Feature(DOMAIN_FEATURE, domain=DOMAIN_722H))
+
+    assert outcome.status is ResolutionStatus.FAILED
+    assert outcome.winner is None
+
+    failing = _candidate(outcome, ProbeDomainBoom722H)
+    assert failing.status is CandidateStatus.FAILED
+    assert failing.failure is not None
+    assert failing.failure.category == "RuntimeError"
+    assert DOMAIN_BOOM_TEXT in failing.failure.message
+    assert failing.failure.plugin == PluginIdentity.from_class(ProbeDomainBoom722H)
+
+    assert any(
+        failure.category == "RuntimeError" and DOMAIN_BOOM_TEXT in failure.message for failure in outcome.failures
+    )
+
+    # The clean rival survives its own evaluation but must not hide the failure.
+    assert _candidate(outcome, DomainRival722H).status is CandidateStatus.SURVIVOR
+
+
+# ---------------------------------------------------------------------------
+# 3. index_columns is guarded
+# ---------------------------------------------------------------------------
+
+
+def test_raising_index_columns_fails_closed_without_propagating(arm_hook_722h: Callable[[str], None]) -> None:
+    """A raising index_columns becomes a structured FAILED outcome, with and without links.
+
+    Investigated for the Red phase: _supports_request_links calls index_columns() BEFORE
+    the empty-links short-circuit, so the hook is consulted even for a link-less request.
+    Both requests therefore pin the same fail-closed guard.
+    """
+    arm_hook_722h("index_columns")
+    mapping: FeatureGroupEnvironmentMapping = {ProbeIndexBoom722H: {CfwAlpha722H}}
+
+    for links in (None, {_foreign_link()}):
+        outcome = _resolve(mapping, Feature(INDEX_BOOM_FEATURE), links=links)
+
+        assert outcome.status is ResolutionStatus.FAILED
+        assert outcome.winner is None
+
+        failing = _candidate(outcome, ProbeIndexBoom722H)
+        assert failing.status is CandidateStatus.FAILED
+        assert failing.failure is not None
+        assert failing.failure.category == "RuntimeError"
+        assert INDEX_BOOM_TEXT in failing.failure.message
+
+        assert any(
+            failure.category == "RuntimeError" and INDEX_BOOM_TEXT in failure.message for failure in outcome.failures
+        )
+
+
+# ---------------------------------------------------------------------------
+# 4. supports_index is guarded
+# ---------------------------------------------------------------------------
+
+
+def test_raising_supports_index_fails_closed_without_propagating(arm_hook_722h: Callable[[str], None]) -> None:
+    """A raising supports_index on a linked request becomes a structured FAILED outcome."""
+    arm_hook_722h("supports_index")
+    mapping: FeatureGroupEnvironmentMapping = {ProbeSupportsIndexBoom722H: {CfwAlpha722H}}
+
+    outcome = _resolve(mapping, Feature(SUPPORTS_BOOM_FEATURE), links={_foreign_link()})
+
+    assert outcome.status is ResolutionStatus.FAILED
+    assert outcome.winner is None
+
+    failing = _candidate(outcome, ProbeSupportsIndexBoom722H)
+    assert failing.status is CandidateStatus.FAILED
+    assert failing.failure is not None
+    assert failing.failure.category == "RuntimeError"
+    assert SUPPORTS_BOOM_TEXT in failing.failure.message
+    assert failing.failure.plugin == PluginIdentity.from_class(ProbeSupportsIndexBoom722H)
+
+    assert any(
+        failure.category == "RuntimeError" and SUPPORTS_BOOM_TEXT in failure.message for failure in outcome.failures
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. links=() equals links=None (TARGET CONTRACT, passes today)
+# ---------------------------------------------------------------------------
+
+
+def test_empty_link_set_resolves_like_no_links() -> None:
+    """TARGET CONTRACT: an explicit empty link set behaves exactly like links=None.
+
+    The old engine rejected indexed feature groups when the request carried an explicit
+    empty link set while accepting links=None; the resolver deliberately treats both as
+    "no links" (consistency change decided in the Stage 3 review).
+    """
+    mapping: FeatureGroupEnvironmentMapping = {IndexedConsistencyProbe722H: {CfwAlpha722H}}
+
+    with_none = _resolve(mapping, Feature(LINKS_EQUAL_FEATURE), links=None)
+    with_empty = _resolve(mapping, Feature(LINKS_EQUAL_FEATURE), links=set())
+
+    assert with_none.status is with_empty.status
+    assert with_none.status is ResolutionStatus.RESOLVED
+    assert with_none.winner is not None
+    assert with_empty.winner is not None
+    assert with_none.winner.feature_group is IndexedConsistencyProbe722H
+    assert with_empty.winner.feature_group is IndexedConsistencyProbe722H
+
+
+# ---------------------------------------------------------------------------
+# 6. LINK_INDEX rejection records NOT_EVALUATED frameworks
+# ---------------------------------------------------------------------------
+
+
+def test_link_index_rejected_candidate_frameworks_are_not_evaluated() -> None:
+    """Frameworks that were never capability-evaluated must not be recorded as SUPPORTED."""
+    mapping: FeatureGroupEnvironmentMapping = {NotEvaluatedProbe722H: {CfwAlpha722H}}
+    outcome = _resolve(mapping, Feature(NOT_EVALUATED_FEATURE), links={_foreign_link()})
+
+    assert outcome.status is ResolutionStatus.NOT_FOUND
+    candidate = _candidate(outcome, NotEvaluatedProbe722H)
+    assert candidate.status is CandidateStatus.REJECTED
+    assert RejectionReason.LINK_INDEX in _reasons(candidate)
+
+    # getattr keeps the module mypy-clean until the Green phase adds the member.
+    not_evaluated = getattr(FrameworkStatus, "NOT_EVALUATED", None)
+    assert not_evaluated is not None, "FrameworkStatus must grow a NOT_EVALUATED member"
+    assert not_evaluated.value == "not_evaluated"
+
+    evaluation = _framework_evaluation(candidate, CfwAlpha722H)
+    assert evaluation.status is not FrameworkStatus.SUPPORTED
+    assert evaluation.status is not_evaluated
+
+
+# ---------------------------------------------------------------------------
+# 7. resolve_feature samples availability exactly once
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_feature_samples_availability_exactly_once() -> None:
+    """One resolve_feature call consults a framework's is_available exactly once.
+
+    Today it is 2: once in the plugin_docs pre-sampling (the compute_frameworks argument)
+    and once inside the environment factory pipeline.
+    """
+    collector = _off_collector(CountingResolveProbe722H)
+    _RESOLVE_AVAILABILITY_CALLS_722H.clear()
+
+    result = resolve_feature(COUNTING_FEATURE, plugin_collector=collector)
+
+    assert result.error is None  # premise guard: the probe resolves cleanly
+    assert result.feature_group is CountingResolveProbe722H
+    assert len(_RESOLVE_AVAILABILITY_CALLS_722H) == 1
+
+
+# ---------------------------------------------------------------------------
+# 8. resolve_feature never raises on a raising is_available
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_feature_never_raises_on_raising_is_available(arm_hook_722h: Callable[[str], None]) -> None:
+    """A raising availability probe becomes ResolvedFeature.error, never a raise."""
+    arm_hook_722h("is_available")
+    assert CfwRaisingAvail722H.__name__ == RAISING_AVAIL_CLASS_NAME  # premise guard for the error assert below
+    collector = _off_collector(CleanProbe722H)
+
+    result = resolve_feature(CLEAN_FEATURE, plugin_collector=collector)
+
+    assert isinstance(result, ResolvedFeature)
+    assert result.feature_group is None
+    assert result.error is not None
+    # The rendered error must identify the failing availability probe (raw internal text
+    # or the framework identity; payload redaction concerns to_payload only).
+    assert AVAIL_BOOM_TEXT in result.error or RAISING_AVAIL_CLASS_NAME in result.error
+
+
+# ---------------------------------------------------------------------------
+# 9. Mapping-derived snapshots never consult the strict-mode env
+# ---------------------------------------------------------------------------
+
+
+def test_mapping_snapshot_does_not_consult_strict_mode_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The engine adapter works under an invalid strict-mode env value.
+
+    strict_mode_from_env RAISES on invalid values (premise guard below), so a
+    mapping-derived snapshot that consulted the env would explode here. The mapping
+    already encodes the survivors of any strict filtering; the snapshot must not
+    re-read run configuration from the environment.
+    """
+    monkeypatch.setenv("MLODA_PLUGIN_REGISTRY_STRICT", "definitely-invalid-722h")
+
+    with pytest.raises(ValueError, match="Invalid strict mode"):
+        strict_mode_from_env()
+
+    mapping: FeatureGroupEnvironmentMapping = {CleanProbe722H: {CfwAlpha722H}}
+    identifier = IdentifyFeatureGroupClass(
+        feature=Feature(CLEAN_FEATURE),
+        accessible_plugins=mapping,
+        links=None,
+    )
+    feature_group, compute_frameworks = identifier.get()
+    assert feature_group is CleanProbe722H
+    assert compute_frameworks == {CfwAlpha722H}
+    assert identifier.outcome.status is ResolutionStatus.RESOLVED
+
+
+# ---------------------------------------------------------------------------
+# 10. Engine builds the environment snapshot at most once
+# ---------------------------------------------------------------------------
+
+
+def test_engine_builds_environment_snapshot_at_most_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    """One Engine derives its snapshot from the mapping at most once, not once per feature.
+
+    Observable: snapshot_from_mapping invocations, counted at BOTH live bindings (the
+    defining resolver module and the identify_feature_group import), with the wrapper
+    delegating to this module's original binding so nothing is double-counted.
+    """
+    gc.collect()
+    calls: list[str] = []
+
+    def counting_snapshot(mapping_arg: FeatureGroupEnvironmentMapping) -> ResolutionEnvironmentSnapshot:
+        calls.append("call")
+        return snapshot_from_mapping(mapping_arg)
+
+    monkeypatch.setattr(resolver_module, "snapshot_from_mapping", counting_snapshot)
+    monkeypatch.setattr(identify_module, "snapshot_from_mapping", counting_snapshot)
+
+    mapping: FeatureGroupEnvironmentMapping = {EngineProbe722H: {CfwEngine722H}}
+    collector = _off_collector(EngineProbe722H)
+    features = Features([Feature(ENGINE_FEATURE_ONE), Feature(ENGINE_FEATURE_TWO)])
+
+    with (
+        patch(
+            "mloda.core.prepare.accessible_plugins.PreFilterPlugins.resolve_feature_group_compute_framework_limitations"
+        ) as mocked_limitations,
+        patch("mloda.core.core.engine.Engine.create_setup_execution_plan"),
+    ):
+        mocked_limitations.return_value = mapping
+        engine = Engine(features, {CfwEngine722H}, None, plugin_collector=collector)
+        engine.setup_features_recursion(features)
+
+    # Premise guards: both requested features resolved through the same environment.
+    assert len(engine.resolution_outcomes) == 2
+    assert EngineProbe722H in engine.feature_group_collection
+    assert len(engine.feature_group_collection[EngineProbe722H]) == 2
+
+    assert len(calls) <= 1, f"snapshot_from_mapping ran {len(calls)} times; one Engine must build it at most once"

--- a/tests/test_core/test_resolve/test_resolver_order.py
+++ b/tests/test_core/test_resolve/test_resolver_order.py
@@ -1,0 +1,342 @@
+"""Filter-order and exactly-once hook tests for FeatureGroupResolver (issue #722 Stage 3a).
+
+These tests define ``mloda.core.resolve.outcome`` and ``mloda.core.resolve.resolver``,
+which do not exist yet: every test in this module fails on import until the Green
+phase implements them. They pin the two deliberate order changes of the decided
+contract (docs/docs/in_depth/feature-group-resolution-contract.md):
+
+- Scope, domain, and abstract classification run BEFORE criteria, so irrelevant
+  provider code never observes a structurally excluded request.
+- The framework pin runs BEFORE capability hooks, so a broken hook on a
+  pinned-away framework can never be engine-fatal.
+
+Plus the exactly-once discipline: each provider hook fires at most once per
+candidate, or per candidate/framework pair, on the success path.
+"""
+
+from typing import ClassVar
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.domain import Domain
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from mloda.core.resolve.identity import PluginIdentity
+from mloda.core.resolve.outcome import (
+    CandidateEvaluation,
+    CandidateStatus,
+    FrameworkEvaluation,
+    FrameworkStatus,
+    RejectionReason,
+    ResolutionOutcome,
+    ResolutionStatus,
+)
+from mloda.core.resolve.request import ResolutionRequestSnapshot
+from mloda.core.resolve.resolver import FeatureGroupResolver, snapshot_from_mapping
+
+
+SCOPE_ORDER_FEATURE = "probe722f_scope_order"
+DOMAIN_ORDER_FEATURE = "probe722f_domain_order"
+PIN_CAPABILITY_FEATURE = "probe722f_pin_capability"
+HOOK_ONCE_FEATURE = "probe722f_hook_once"
+
+DOMAIN_ORDER_MATCH = "probe722f_order_dom_a"
+DOMAIN_ORDER_OTHER = "probe722f_order_dom_b"
+
+PINNED_AWAY_ERROR_TEXT = "broken pinned-away capability 722f"
+
+
+class CfwOrder722F(ComputeFramework):
+    """Framework for the scope-order and domain-order probes."""
+
+
+class CfwPinKeep722F(ComputeFramework):
+    """The framework the pin-before-capability request pins."""
+
+
+class CfwPinDrop722F(ComputeFramework):
+    """The pinned-away framework whose capability hook would raise."""
+
+
+class CfwHookA722F(ComputeFramework):
+    """First framework of the hook-once family."""
+
+
+class CfwHookB722F(ComputeFramework):
+    """Second framework of the hook-once family."""
+
+
+class _OrderProbeBase722F(FeatureGroup):
+    """Shared probe base: never matches anything itself."""
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return False
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        return None
+
+
+class ScopeOrderProbe722F(_OrderProbeBase722F):
+    """Counting criteria probe: records every criteria call for its own feature name."""
+
+    criteria_calls: ClassVar[list[str]] = []
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwOrder722F}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        # Gated on the probe name so process-global scans in other tests never count.
+        if str(feature_name) == SCOPE_ORDER_FEATURE:
+            cls.criteria_calls.append(str(feature_name))
+            return True
+        return False
+
+
+class DomainOrderProbe722F(_OrderProbeBase722F):
+    """Counting criteria probe living in its own domain."""
+
+    criteria_calls: ClassVar[list[str]] = []
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwOrder722F}
+
+    @classmethod
+    def get_domain(cls) -> Domain:
+        return Domain(DOMAIN_ORDER_MATCH)
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        # Gated on the probe name so process-global scans in other tests never count.
+        if str(feature_name) == DOMAIN_ORDER_FEATURE:
+            cls.criteria_calls.append(str(feature_name))
+            return True
+        return False
+
+
+class PinCapabilityProbe722F(_OrderProbeBase722F):
+    """Declares a pinned-kept and a pinned-away framework; the hook RAISES for the pinned-away one."""
+
+    capability_calls: ClassVar[list[str]] = []
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwPinKeep722F, CfwPinDrop722F}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == PIN_CAPABILITY_FEATURE
+
+    @classmethod
+    def supports_compute_framework(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        compute_framework: type[ComputeFramework],
+    ) -> bool:
+        # Gated on the probe name so process-global scans in other tests never trip the raise.
+        if str(feature_name) != PIN_CAPABILITY_FEATURE:
+            return True
+        cls.capability_calls.append(compute_framework.__name__)
+        if compute_framework is CfwPinDrop722F:
+            raise RuntimeError(PINNED_AWAY_ERROR_TEXT)
+        return True
+
+
+class HookOnceParentProbe722F(_OrderProbeBase722F):
+    """Counting parent of the hook-once family; counters are shared and keyed by class name."""
+
+    criteria_calls: ClassVar[dict[str, int]] = {}
+    capability_calls: ClassVar[dict[str, list[str]]] = {}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwHookA722F, CfwHookB722F}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        # Gated on the probe name so process-global scans in other tests never count.
+        if str(feature_name) == HOOK_ONCE_FEATURE:
+            cls.criteria_calls[cls.__name__] = cls.criteria_calls.get(cls.__name__, 0) + 1
+            return True
+        return False
+
+    @classmethod
+    def supports_compute_framework(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        compute_framework: type[ComputeFramework],
+    ) -> bool:
+        if str(feature_name) == HOOK_ONCE_FEATURE:
+            cls.capability_calls.setdefault(cls.__name__, []).append(compute_framework.__name__)
+        return True
+
+
+class HookOnceChildProbe722F(HookOnceParentProbe722F):
+    """Counting child with the identical framework set; shadows the parent."""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve(mapping: FeatureGroupEnvironmentMapping, feature: Feature) -> ResolutionOutcome:
+    request = ResolutionRequestSnapshot.from_feature(feature)
+    return FeatureGroupResolver().resolve(request, snapshot_from_mapping(mapping))
+
+
+def _candidate(outcome: ResolutionOutcome, feature_group: type[FeatureGroup]) -> CandidateEvaluation:
+    identity = PluginIdentity.from_class(feature_group)
+    matches = [candidate for candidate in outcome.candidates if candidate.identity == identity]
+    assert len(matches) == 1, f"expected exactly one evaluation for {identity.render()}, got {len(matches)}"
+    return matches[0]
+
+
+def _framework_evaluation(candidate: CandidateEvaluation, framework: type[ComputeFramework]) -> FrameworkEvaluation:
+    matches = [evaluation for evaluation in candidate.frameworks if evaluation.framework is framework]
+    assert len(matches) == 1, f"expected exactly one evaluation for {framework.__name__}, got {len(matches)}"
+    return matches[0]
+
+
+def _reasons(candidate: CandidateEvaluation) -> set[RejectionReason]:
+    return {rejection.reason for rejection in candidate.rejections}
+
+
+# ---------------------------------------------------------------------------
+# Scope and domain run BEFORE criteria
+# ---------------------------------------------------------------------------
+
+
+def test_scope_rejection_precedes_criteria_hook() -> None:
+    """A scoped-out candidate is rejected structurally; its criteria hook never fires."""
+    mapping: FeatureGroupEnvironmentMapping = {ScopeOrderProbe722F: {CfwOrder722F}}
+
+    # Premise guard: unscoped, the counting hook fires exactly once and the probe resolves.
+    ScopeOrderProbe722F.criteria_calls.clear()
+    unscoped = _resolve(mapping, Feature(SCOPE_ORDER_FEATURE))
+    assert unscoped.status is ResolutionStatus.RESOLVED
+    assert len(ScopeOrderProbe722F.criteria_calls) == 1
+
+    ScopeOrderProbe722F.criteria_calls.clear()
+    scoped_out = _resolve(mapping, Feature(SCOPE_ORDER_FEATURE, feature_group="UnrelatedScope722F"))
+
+    assert scoped_out.status is ResolutionStatus.NOT_FOUND
+    assert scoped_out.winner is None
+    candidate = _candidate(scoped_out, ScopeOrderProbe722F)
+    assert candidate.status is CandidateStatus.REJECTED
+    assert RejectionReason.SCOPE in _reasons(candidate)
+    assert ScopeOrderProbe722F.criteria_calls == [], "scope runs before criteria: the hook must never fire"
+
+
+def test_domain_rejection_precedes_criteria_hook() -> None:
+    """A domain-mismatched candidate is rejected structurally; its criteria hook never fires."""
+    mapping: FeatureGroupEnvironmentMapping = {DomainOrderProbe722F: {CfwOrder722F}}
+
+    # Premise guard: with the matching domain, the counting hook fires exactly once.
+    DomainOrderProbe722F.criteria_calls.clear()
+    matched = _resolve(mapping, Feature(DOMAIN_ORDER_FEATURE, domain=DOMAIN_ORDER_MATCH))
+    assert matched.status is ResolutionStatus.RESOLVED
+    assert len(DomainOrderProbe722F.criteria_calls) == 1
+
+    DomainOrderProbe722F.criteria_calls.clear()
+    mismatched = _resolve(mapping, Feature(DOMAIN_ORDER_FEATURE, domain=DOMAIN_ORDER_OTHER))
+
+    assert mismatched.status is ResolutionStatus.NOT_FOUND
+    assert mismatched.winner is None
+    candidate = _candidate(mismatched, DomainOrderProbe722F)
+    assert candidate.status is CandidateStatus.REJECTED
+    assert RejectionReason.DOMAIN in _reasons(candidate)
+    assert DomainOrderProbe722F.criteria_calls == [], "domain runs before criteria: the hook must never fire"
+
+
+# ---------------------------------------------------------------------------
+# The framework pin runs BEFORE capability hooks
+# ---------------------------------------------------------------------------
+
+
+def test_pin_excluded_framework_never_reaches_capability_hook() -> None:
+    """A raising hook on a pinned-away framework is never invoked and never fatal."""
+    PinCapabilityProbe722F.capability_calls.clear()
+    mapping: FeatureGroupEnvironmentMapping = {PinCapabilityProbe722F: {CfwPinKeep722F, CfwPinDrop722F}}
+    feature = Feature(PIN_CAPABILITY_FEATURE, compute_framework=CfwPinKeep722F.get_class_name())
+    outcome = _resolve(mapping, feature)
+
+    assert outcome.status is ResolutionStatus.RESOLVED
+    assert outcome.winner is not None
+    assert outcome.winner.feature_group is PinCapabilityProbe722F
+    assert outcome.winner.compute_frameworks == (CfwPinKeep722F,)
+    assert outcome.failures == ()
+    assert PinCapabilityProbe722F.capability_calls == [CfwPinKeep722F.__name__], (
+        "the pin runs before capability hooks: the pinned-away framework must never reach the hook"
+    )
+
+    candidate = _candidate(outcome, PinCapabilityProbe722F)
+    assert candidate.status is CandidateStatus.WINNER
+    assert _framework_evaluation(candidate, CfwPinKeep722F).status is FrameworkStatus.SUPPORTED
+    dropped = _framework_evaluation(candidate, CfwPinDrop722F)
+    assert dropped.status is FrameworkStatus.PIN_EXCLUDED
+    assert dropped.failure is None
+
+
+# ---------------------------------------------------------------------------
+# Exactly-once hook discipline on the success path
+# ---------------------------------------------------------------------------
+
+
+def test_hooks_run_exactly_once_per_candidate_and_framework() -> None:
+    """Criteria fires once per candidate; capability once per candidate/framework pair."""
+    HookOnceParentProbe722F.criteria_calls.clear()
+    HookOnceParentProbe722F.capability_calls.clear()
+    mapping: FeatureGroupEnvironmentMapping = {
+        HookOnceParentProbe722F: {CfwHookA722F, CfwHookB722F},
+        HookOnceChildProbe722F: {CfwHookA722F, CfwHookB722F},
+    }
+    outcome = _resolve(mapping, Feature(HOOK_ONCE_FEATURE))
+
+    assert outcome.status is ResolutionStatus.RESOLVED
+    assert outcome.winner is not None
+    assert outcome.winner.feature_group is HookOnceChildProbe722F
+
+    assert HookOnceParentProbe722F.criteria_calls == {
+        "HookOnceParentProbe722F": 1,
+        "HookOnceChildProbe722F": 1,
+    }
+
+    expected_frameworks = sorted([CfwHookA722F.__name__, CfwHookB722F.__name__])
+    capability_calls = HookOnceParentProbe722F.capability_calls
+    assert set(capability_calls) == {"HookOnceParentProbe722F", "HookOnceChildProbe722F"}
+    assert sorted(capability_calls["HookOnceParentProbe722F"]) == expected_frameworks
+    assert sorted(capability_calls["HookOnceChildProbe722F"]) == expected_frameworks

--- a/tests/test_core/test_resolve/test_stage4_hardening.py
+++ b/tests/test_core/test_resolve/test_stage4_hardening.py
@@ -1,0 +1,639 @@
+"""Failing tests for issue #722 Stage 4 hardening (final post-review fix round).
+
+Pins review-mandated fixes across the diagnostics stack:
+
+1.  mlodaAPI.diagnose never raises on a feature pinned outside the run set. Investigated:
+    the pre-check builds SetupComputeFramework over Features([]) BEFORE the try, and the
+    try catches only FeatureResolutionError, so the ValueError raised by prepare()'s
+    per-feature run-set validation escapes today.
+2.  mlodaAPI.diagnose never raises on an unknown framework name. Investigated: the
+    unknown-name ValueError comes from the pre-check line itself, before the try.
+3.  A VALUE_REJECTION detail is redacted from ResolutionOutcome.to_payload() while the
+    in-memory Rejection.detail keeps the raw provider text (it feeds rendered errors).
+4.  resolve_feature with an EXPLICIT compute_frameworks set never raises on a raising
+    is_available probe. Investigated: build_resolution_environment guards availability
+    sampling only on the compute_frameworks=None branch; the explicit-set branch lets
+    run_compute_framework_pipeline sample unguarded. TARGET CONTRACT pin (passes today):
+    PreFilterPlugins with an explicit set still propagates the raise, engine semantics
+    unchanged.
+5.  diagnose() returns the full pre-check environment: a collector-disabled probe keeps
+    its DISABLED_BY_COLLECTOR record, instead of the engine's survivors-only snapshot.
+6.  The engine's mapping-derived snapshot carries the collector's effective strict mode.
+    Investigated: Engine.__init__ calls snapshot_from_mapping without strict_mode, so
+    session.resolution_report().environment.snapshot.strict_mode is "off" today even for
+    a collector explicitly set to "warn".
+7.  render_provider_view carries failure metadata: the failure stage string and category
+    for a raising criteria hook, and the stage of the multi-pin request-validation
+    failure. Today the provider view prints only statuses and rejection reasons.
+8.  render_user_view for the multi-pin request-validation failure must not claim a
+    provider hook raised; its next-step line names the pin or the request instead.
+9.  Mixed-rejection presentation: with one candidate rejected only by LINK_INDEX and one
+    rejected only by capability, the "unsupported on all installed compute frameworks"
+    error must not list the link-rejected candidate. TARGET CONTRACT pin (passes today):
+    the sole-candidate texts stay untouched.
+
+RED phase: tests 1, 2, 3, 4a, 5, 6, 7, 8, and 9a fail against the current
+implementation; tests 4b and 9b pass and pin target contracts.
+
+PINNED CHOICES beyond the issue brief (report these to the Green agent):
+- Tests 1 and 2 pin ONLY that no exception escapes, the report is a ResolutionReport,
+  and complete is False; whether the environment or a feature record carries the error
+  stays free.
+- Test 3 pins that the payload keeps the "value_rejection" reason while dropping the
+  detail text, and that the in-memory detail field equals the raw provider text.
+- Test 4a pins that the returned error identifies the failing availability probe (raw
+  internal text or the framework class name), mirroring the Stage 3 None-branch pin.
+- Test 6 pins snapshot.strict_mode == "warn" for a collector explicitly set to "warn".
+- Test 8 pins that "provider hook" appears nowhere in the user view and that a
+  next-step line contains "pin" or "request" (case-insensitive loose substrings).
+- Test 9a pins that the link-rejected candidate's class name is absent from the ENTIRE
+  error string, not merely from the candidate list clause.
+
+Probe names use the unique probe722k_ prefix; probe classes carry the 722K suffix so
+process-global scans in other tests never trip these fixtures. The is_available hook
+cannot be name-gated: it raises only while ARMED by its test and is disarmed by fixture
+teardown, exactly like the Stage 3 hardening fixtures (xdist-safe: per-process state).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Callable, Iterator
+
+import pytest
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import PropertyValueRejection
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.index.index import Index
+from mloda.core.abstract_plugins.components.link import JoinSpec, Link
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.api.plugin_docs import resolve_feature
+from mloda.core.api.plugin_info import ResolvedFeature
+from mloda.core.api.request import mlodaAPI
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping, PreFilterPlugins
+from mloda.core.resolve.environment import EnvironmentProvenance
+from mloda.core.resolve.identity import PluginIdentity
+from mloda.core.resolve.outcome import RejectionReason, ResolutionOutcome, ResolutionStatus
+from mloda.core.resolve.render import render_provider_view, render_user_view
+from mloda.core.resolve.report import ResolutionReport
+from mloda.core.resolve.request import ResolutionRequestSnapshot
+from mloda.core.resolve.resolver import FeatureGroupResolver, snapshot_from_mapping
+from mloda.provider import BaseInputData, DataCreator, FeatureSet
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
+    PythonDictFramework,
+)
+
+
+PINNED_FEATURE = "probe722k_pinned"
+VALUE_REJECT_FEATURE = "probe722k_value_reject"
+CLEAN_FEATURE = "probe722k_clean"
+ENV_FEATURE = "probe722k_env"
+CRITERIA_BOOM_FEATURE = "probe722k_criteria_boom"
+MULTI_PIN_FEATURE = "probe722k_multi_pin"
+MIXED_FEATURE = "probe722k_mixed"
+
+# Fake secret-shaped rejection detail used to prove payload redaction; never a real secret.
+VALUE_SECRET_TEXT = "rejected value secret-722k"  # nosec B105
+CRITERIA_BOOM_TEXT = "criteria boom 722k"
+AVAIL_BOOM_TEXT = "avail boom 722k"
+RAISING_AVAIL_CLASS_NAME = "CfwRaisingAvail722K"
+
+CAPABILITY_CLAUSE_TEXT = "unsupported on all installed compute frameworks"
+LINK_CLAUSE_TEXT = "an index carried by the request's links"
+
+
+# ---------------------------------------------------------------------------
+# Mock compute frameworks (unique names, suffix 722K)
+# ---------------------------------------------------------------------------
+
+
+class CfwA722K(ComputeFramework):
+    """Framework the pinned diagnose probe declares; excluded from the run set."""
+
+
+class CfwB722K(ComputeFramework):
+    """Framework forming the run set that excludes CfwA722K."""
+
+
+class CfwGood722K(ComputeFramework):
+    """Well-behaved framework for the explicit-set availability probes."""
+
+
+class CfwMixed722K(ComputeFramework):
+    """Framework shared by the mixed-rejection probes."""
+
+
+# Hook keys armed per test via the arm_hook_722k fixture; disarmed on teardown. While
+# disarmed, the hook degrades to an inert default, so the module-level class stays
+# harmless in every other test of the process (xdist-safe: per-process state).
+_ARMED_HOOKS_722K: set[str] = set()
+
+
+class CfwRaisingAvail722K(ComputeFramework):
+    """Framework whose is_available() raises while armed; unavailable otherwise.
+
+    EVERY availability sampling in the process hits this hook, so the raise is armed
+    only for the tests pinning it and the class is otherwise a plain unavailable
+    framework.
+    """
+
+    @staticmethod
+    def is_available() -> bool:
+        if "is_available" in _ARMED_HOOKS_722K:
+            raise RuntimeError(AVAIL_BOOM_TEXT)
+        return False
+
+
+@pytest.fixture
+def arm_hook_722k() -> Iterator[Callable[[str], None]]:
+    """Arm raising hooks for one test; teardown disarms them even when the raise propagated."""
+    armed_keys: list[str] = []
+
+    def _arm(key: str) -> None:
+        _ARMED_HOOKS_722K.add(key)
+        armed_keys.append(key)
+
+    yield _arm
+    for key in armed_keys:
+        _ARMED_HOOKS_722K.discard(key)
+
+
+# ---------------------------------------------------------------------------
+# Probe feature groups (match ONLY their own probe722k_* names)
+# ---------------------------------------------------------------------------
+
+
+class _Probe722KBase(FeatureGroup):
+    """Shared probe base: never matches anything itself."""
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return False
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        return None
+
+
+class SourcePinnedA722K(FeatureGroup):
+    """DataCreator source on CfwA722K; matches ONLY probe722k_pinned via its DataCreator."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwA722K}
+
+    @classmethod
+    def input_data(cls) -> BaseInputData | None:
+        return DataCreator(supports_features={PINNED_FEATURE})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {PINNED_FEATURE: [1, 2, 3]}
+
+
+class SourceEnvEnabled722K(FeatureGroup):
+    """DataCreator source on PythonDictFramework; the collector-enabled environment probe."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PythonDictFramework}
+
+    @classmethod
+    def input_data(cls) -> BaseInputData | None:
+        return DataCreator(supports_features={ENV_FEATURE})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {ENV_FEATURE: [1, 2, 3]}
+
+
+class ProbeEnvDisabled722K(_Probe722KBase):
+    """Concrete probe the environment-provenance collector deliberately disables."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PythonDictFramework}
+
+
+class ValueRejectingProbe722K(_Probe722KBase):
+    """Raises PropertyValueRejection with a secret-shaped detail, gated on its name."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwA722K}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        if str(feature_name) == VALUE_REJECT_FEATURE:
+            raise PropertyValueRejection(VALUE_SECRET_TEXT)
+        return False
+
+
+class CriteriaBoomProbe722K(_Probe722KBase):
+    """Raises RuntimeError from its criteria hook, gated on its name."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwA722K}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        if str(feature_name) == CRITERIA_BOOM_FEATURE:
+            raise RuntimeError(CRITERIA_BOOM_TEXT)
+        return False
+
+
+class CleanProbe722K(_Probe722KBase):
+    """Single clean candidate on the well-behaved framework."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwGood722K}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == CLEAN_FEATURE
+
+
+class ProbeMixedLinkRejected722K(_Probe722KBase):
+    """Declares an index no request link carries: rejected ONLY at the LINK_INDEX stage."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwMixed722K}
+
+    @classmethod
+    def index_columns(cls) -> list[Index] | None:
+        return [Index(("probe722k_mixed_key",))]
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == MIXED_FEATURE
+
+
+class ProbeMixedCapRejected722K(_Probe722KBase):
+    """Rejects its framework via the capability hook: rejected ONLY at the CAPABILITY stage."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwMixed722K}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == MIXED_FEATURE
+
+    @classmethod
+    def supports_compute_framework(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        compute_framework: type[ComputeFramework],
+    ) -> bool:
+        # Gated on the probe name so process-global scans in other tests never trip the rejection.
+        return str(feature_name) != MIXED_FEATURE
+
+
+class ProbeMixedAnchorLeft722K(_Probe722KBase):
+    """Anchors the left side of the foreign link; never matches a name."""
+
+
+class ProbeMixedAnchorRight722K(_Probe722KBase):
+    """Anchors the right side of the foreign link; never matches a name."""
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _off_collector(*probes: type[FeatureGroup]) -> PluginCollector:
+    return PluginCollector.enabled_feature_groups(set(probes)).set_strict_mode("off")
+
+
+def _mixed_link() -> Link:
+    """A link between two other groups whose indexes the indexed probe does not support."""
+    return Link.inner(
+        JoinSpec(ProbeMixedAnchorLeft722K, "probe722k_left_id"),
+        JoinSpec(ProbeMixedAnchorRight722K, "probe722k_right_id"),
+    )
+
+
+def _resolve(
+    mapping: FeatureGroupEnvironmentMapping,
+    feature: Feature,
+    links: set[Link] | None = None,
+) -> ResolutionOutcome:
+    request = ResolutionRequestSnapshot.from_feature(feature, links=links)
+    return FeatureGroupResolver().resolve(request, snapshot_from_mapping(mapping))
+
+
+def _criteria_failed_outcome() -> ResolutionOutcome:
+    """FAILED outcome from a raising match_feature_group_criteria hook."""
+    outcome = _resolve({CriteriaBoomProbe722K: {CfwA722K}}, Feature(CRITERIA_BOOM_FEATURE))
+    assert outcome.status is ResolutionStatus.FAILED  # premise guard
+    assert any(failure.stage == "match_feature_group_criteria" for failure in outcome.failures)  # premise guard
+    return outcome
+
+
+def _multi_pin_outcome() -> ResolutionOutcome:
+    """FAILED outcome from the multi-pin request validation, before any candidate runs."""
+    options = Options()
+    request = ResolutionRequestSnapshot(
+        feature_name=MULTI_PIN_FEATURE,
+        domain=None,
+        feature_group_scope=None,
+        framework_pin=None,
+        pinned_frameworks=(CfwA722K, CfwB722K),
+        group_option_keys=frozenset(),
+        context_option_keys=frozenset(),
+        inherited_group_keys=options.inherited_group_keys,
+        dependency_path=(),
+        links=(),
+        data_access_collection=None,
+        options=options,
+    )
+    outcome = FeatureGroupResolver().resolve(request, snapshot_from_mapping({CleanProbe722K: {CfwGood722K}}))
+    assert outcome.status is ResolutionStatus.FAILED  # premise guard
+    assert len(outcome.failures) == 1  # premise guard
+    assert outcome.failures[0].stage == "validate_request"  # premise guard
+    return outcome
+
+
+# ---------------------------------------------------------------------------
+# 1. diagnose never raises on a feature pinned outside the run set
+# ---------------------------------------------------------------------------
+
+
+def test_probe722k_diagnose_never_raises_on_feature_pinned_outside_run_set() -> None:
+    """A framework pin outside the run set yields a complete=False report, never a raise.
+
+    Investigated: the pin survives the diagnose pre-check because that pre-check runs
+    SetupComputeFramework over Features([]); the ValueError then raised by prepare()'s
+    per-feature run-set validation is not a FeatureResolutionError, so it escapes today.
+    """
+    report = mlodaAPI.diagnose(
+        [Feature(PINNED_FEATURE, compute_framework=CfwA722K.get_class_name())],
+        compute_frameworks={CfwB722K},
+        plugin_collector=_off_collector(SourcePinnedA722K),
+    )
+
+    assert report is not None
+    assert isinstance(report, ResolutionReport)
+    assert report.complete is False
+
+
+# ---------------------------------------------------------------------------
+# 2. diagnose never raises on an unknown framework name
+# ---------------------------------------------------------------------------
+
+
+def test_probe722k_diagnose_never_raises_on_unknown_framework_name() -> None:
+    """An unknown compute framework name yields a complete=False report, never a raise.
+
+    Investigated: the unknown-name ValueError comes from the SetupComputeFramework
+    pre-check line itself, BEFORE the try that narrows to FeatureResolutionError.
+    """
+    report = mlodaAPI.diagnose(
+        [Feature(PINNED_FEATURE)],
+        compute_frameworks=["NoSuchFramework722K"],
+        plugin_collector=_off_collector(SourcePinnedA722K),
+    )
+
+    assert report is not None
+    assert isinstance(report, ResolutionReport)
+    assert report.complete is False
+
+
+# ---------------------------------------------------------------------------
+# 3. VALUE_REJECTION payload redaction
+# ---------------------------------------------------------------------------
+
+
+def test_probe722k_value_rejection_payload_redacts_detail() -> None:
+    """The raw rejection text stays on the in-memory detail; to_payload() never carries it."""
+    outcome = _resolve({ValueRejectingProbe722K: {CfwA722K}}, Feature(VALUE_REJECT_FEATURE))
+
+    assert outcome.status is ResolutionStatus.NOT_FOUND  # premise guard
+    identity = PluginIdentity.from_class(ValueRejectingProbe722K)
+    candidates = [candidate for candidate in outcome.candidates if candidate.identity == identity]
+    assert len(candidates) == 1
+    rejections = [
+        rejection for rejection in candidates[0].rejections if rejection.reason is RejectionReason.VALUE_REJECTION
+    ]
+    assert len(rejections) == 1
+    # The in-memory detail keeps the raw provider text: the rendered errors depend on it.
+    assert rejections[0].detail == VALUE_SECRET_TEXT
+
+    dumped = json.dumps(outcome.to_payload())
+    assert RejectionReason.VALUE_REJECTION.value in dumped  # the structured reason stays visible
+    assert "secret-722k" not in dumped
+
+
+# ---------------------------------------------------------------------------
+# 4. Explicit-set availability guard
+# ---------------------------------------------------------------------------
+
+
+def test_probe722k_resolve_feature_explicit_set_never_raises_on_raising_availability(
+    arm_hook_722k: Callable[[str], None],
+) -> None:
+    """With an EXPLICIT compute_frameworks set, a raising is_available probe becomes
+    ResolvedFeature.error, never a raise.
+
+    Investigated: build_resolution_environment guards availability sampling only when
+    compute_frameworks is None; the explicit-set branch reaches
+    run_compute_framework_pipeline with available=None, which samples unguarded.
+    """
+    arm_hook_722k("is_available")
+    assert CfwRaisingAvail722K.__name__ == RAISING_AVAIL_CLASS_NAME  # premise guard for the error assert below
+    collector = _off_collector(CleanProbe722K)
+
+    result = resolve_feature(CLEAN_FEATURE, compute_frameworks={CfwGood722K}, plugin_collector=collector)
+
+    assert isinstance(result, ResolvedFeature)
+    assert result.feature_group is None
+    assert result.error is not None
+    # The rendered error must identify the failing availability probe (raw internal text
+    # or the framework identity), mirroring the Stage 3 None-branch pin.
+    assert AVAIL_BOOM_TEXT in result.error or RAISING_AVAIL_CLASS_NAME in result.error
+
+
+def test_probe722k_prefilter_explicit_set_availability_raise_still_propagates(
+    arm_hook_722k: Callable[[str], None],
+) -> None:
+    """TARGET CONTRACT (passes today): the ENGINE path keeps propagating the raise.
+
+    PreFilterPlugins with an explicit framework set samples availability through the
+    shared pipeline; its raise-through semantics are pinned unchanged so the diagnostics
+    guard cannot silently swallow engine-path failures.
+    """
+    arm_hook_722k("is_available")
+    collector = _off_collector(CleanProbe722K)
+
+    with pytest.raises(RuntimeError, match=AVAIL_BOOM_TEXT):
+        PreFilterPlugins({CfwGood722K}, collector)
+
+
+# ---------------------------------------------------------------------------
+# 5. diagnose environment provenance: full pre-check outcome, not survivors-only
+# ---------------------------------------------------------------------------
+
+
+def test_probe722k_diagnose_environment_records_disabled_probes() -> None:
+    """The diagnose report's environment keeps the DISABLED_BY_COLLECTOR record of a
+    probe the collector disabled, proving the full pre-check outcome is returned and
+    not the engine's synthesized survivors-only snapshot."""
+    report = mlodaAPI.diagnose(
+        [Feature(ENV_FEATURE)],
+        compute_frameworks={PythonDictFramework},
+        plugin_collector=_off_collector(SourceEnvEnabled722K),
+    )
+
+    assert report.complete is True  # premise guard: the request itself resolves
+    assert report.environment is not None
+    snapshot = report.environment.snapshot
+    assert snapshot is not None
+
+    disabled_identity = PluginIdentity.from_class(ProbeEnvDisabled722K)
+    disabled_records = [record for record in snapshot.records if record.identity == disabled_identity]
+    assert len(disabled_records) == 1, "the disabled probe must keep an environment record"
+    assert disabled_records[0].provenance is EnvironmentProvenance.DISABLED_BY_COLLECTOR
+
+    enabled_identity = PluginIdentity.from_class(SourceEnvEnabled722K)
+    enabled_records = [record for record in snapshot.records if record.identity == enabled_identity]
+    assert len(enabled_records) == 1
+    assert enabled_records[0].provenance is EnvironmentProvenance.ACCESSIBLE
+
+
+# ---------------------------------------------------------------------------
+# 6. Engine snapshot strict-mode metadata
+# ---------------------------------------------------------------------------
+
+
+def test_probe722k_session_report_snapshot_carries_collector_strict_mode() -> None:
+    """The session report's snapshot carries the collector's effective strict mode.
+
+    INVESTIGATION RESULT: Engine.__init__ builds its mapping-derived snapshot via
+    snapshot_from_mapping(self.accessible_plugins) without passing strict_mode, so the
+    snapshot reads "off" today even though the collector explicitly runs in "warn".
+    """
+    collector = PluginCollector.enabled_feature_groups({SourceEnvEnabled722K}).set_strict_mode("warn")
+    session = mlodaAPI.prepare(
+        [Feature(ENV_FEATURE)],
+        compute_frameworks={PythonDictFramework},
+        plugin_collector=collector,
+    )
+
+    report = session.resolution_report()
+    assert report.environment is not None
+    snapshot = report.environment.snapshot
+    assert snapshot is not None
+    assert snapshot.strict_mode == "warn"
+
+
+# ---------------------------------------------------------------------------
+# 7. Provider renderer failure metadata
+# ---------------------------------------------------------------------------
+
+
+def test_probe722k_provider_view_carries_failure_stage_and_category() -> None:
+    """The provider view names the failing stage and category of a FAILED outcome."""
+    criteria_text = render_provider_view(_criteria_failed_outcome())
+    assert "match_feature_group_criteria" in criteria_text
+    assert "RuntimeError" in criteria_text
+
+    multi_pin_text = render_provider_view(_multi_pin_outcome())
+    assert "validate_request" in multi_pin_text
+
+
+# ---------------------------------------------------------------------------
+# 8. User renderer next-step accuracy
+# ---------------------------------------------------------------------------
+
+
+def test_probe722k_user_view_multi_pin_does_not_blame_provider_hook() -> None:
+    """The user view of the multi-pin failure never claims a provider hook raised;
+    its next-step line points at the pin or the request instead."""
+    text = render_user_view(_multi_pin_outcome())
+
+    assert "provider hook" not in text.lower()
+
+    next_step_lines = [line for line in text.splitlines() if line.lower().startswith("next step")]
+    assert next_step_lines, "the user view must keep a next-step line"
+    assert any("pin" in line.lower() or "request" in line.lower() for line in next_step_lines)
+
+
+# ---------------------------------------------------------------------------
+# 9. Mixed-rejection presentation
+# ---------------------------------------------------------------------------
+
+
+def test_probe722k_mixed_rejection_capability_clause_excludes_link_rejected_candidate() -> None:
+    """The capability error of a mixed rejection never lists the link-rejected candidate.
+
+    One candidate is rejected ONLY by LINK_INDEX (indexed, foreign links provided), the
+    other ONLY by capability; the "unsupported on all installed compute frameworks"
+    text must not name the link-rejected class anywhere in the error.
+    """
+    collector = _off_collector(ProbeMixedLinkRejected722K, ProbeMixedCapRejected722K)
+
+    result = resolve_feature(MIXED_FEATURE, links={_mixed_link()}, plugin_collector=collector)
+
+    assert result.feature_group is None
+    assert result.error is not None
+    assert CAPABILITY_CLAUSE_TEXT in result.error  # premise guard: the capability clause is chosen
+    assert ProbeMixedCapRejected722K.get_class_name() in result.error
+    assert ProbeMixedLinkRejected722K.get_class_name() not in result.error
+
+
+def test_probe722k_sole_candidate_rejection_texts_unchanged() -> None:
+    """TARGET CONTRACT (passes today): the sole-candidate error texts stay untouched."""
+    cap_only = resolve_feature(
+        MIXED_FEATURE, links={_mixed_link()}, plugin_collector=_off_collector(ProbeMixedCapRejected722K)
+    )
+    assert cap_only.feature_group is None
+    assert cap_only.error is not None
+    assert CAPABILITY_CLAUSE_TEXT in cap_only.error
+    assert ProbeMixedCapRejected722K.get_class_name() in cap_only.error
+
+    link_only = resolve_feature(
+        MIXED_FEATURE, links={_mixed_link()}, plugin_collector=_off_collector(ProbeMixedLinkRejected722K)
+    )
+    assert link_only.feature_group is None
+    assert link_only.error is not None
+    assert LINK_CLAUSE_TEXT in link_only.error
+    assert ProbeMixedLinkRejected722K.get_class_name() in link_only.error

--- a/tests/test_core/test_resolve/test_stage4_surface.py
+++ b/tests/test_core/test_resolve/test_stage4_surface.py
@@ -1,0 +1,747 @@
+"""Target-contract tests for the final Stage 4 surface of issue #722 (Stage 4b).
+
+Stage 4b completes the resolve_feature request surface and the persona renderers:
+
+- resolve_feature accepts ``str | Feature`` as its first argument plus the keyword-only
+  parameters ``links``, ``data_access_collection``, and ``compute_frameworks``. A Feature
+  object carries its own options, domain, scope, and framework pin; combining a Feature
+  with the ``options`` or ``feature_group`` keyword returns an error ResolvedFeature
+  (never a raise). ``compute_frameworks=None`` keeps the all-available standalone default;
+  a set restricts the run set exactly like ``mlodaAPI(compute_frameworks=...)``.
+- ResolvedFeature carries ``mode == "standalone"``, the explicit diagnostics-mode label.
+- ``mloda.core.resolve.render`` exposes pure persona renderers over a captured
+  ResolutionOutcome: render_user_view (str), render_provider_view (str),
+  render_steward_view (JSON-serializable dict). Renderers NEVER invoke provider hooks.
+- ``mloda/core/api/plugin_docs.py`` structurally stops referencing the matching hooks
+  (match_feature_group_criteria, supports_compute_framework, split_frameworks_by_capability);
+  the redefinition-branch candidate filtering moves into the resolve layer, behavior preserved.
+
+Every test except the redefinition-conflict pin FAILS until the Green phase lands.
+Probe names use the unique probe722j_ prefix so process-global scans in other tests
+never trip these fixtures.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import linecache
+import sys
+import textwrap
+from typing import Any, ClassVar, Iterator, cast
+
+import pytest
+
+import mloda.core.api.plugin_docs as plugin_docs_module
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.domain import Domain
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.index.index import Index
+from mloda.core.abstract_plugins.components.link import JoinSpec, Link
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.api.plugin_docs import resolve_feature
+from mloda.core.api.plugin_info import ResolvedFeature
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+from mloda.core.resolve.identity import PluginIdentity
+from mloda.core.resolve.outcome import FrameworkStatus, ResolutionOutcome, ResolutionStatus
+from mloda.core.resolve.request import ResolutionRequestSnapshot
+from mloda.core.resolve.resolver import FeatureGroupResolver, snapshot_from_mapping
+
+
+DOMAIN_FEATURE = "probe722j_domain"
+DOMAIN_A = "probe722j_domain_a"
+INDEXED_FEATURE = "probe722j_indexed"
+PIN_FEATURE = "probe722j_pin"
+DAC_FEATURE = "probe722j_dac"
+TWO_FRAMEWORK_FEATURE = "probe722j_twofw"
+MODE_FEATURE = "probe722j_mode"
+MODE_MISSING_FEATURE = "probe722j_mode_missing"
+RENDER_WIN_FEATURE = "probe722j_render_win"
+RENDER_AMBIGUOUS_FEATURE = "probe722j_render_ambiguous"
+RENDER_FAIL_FEATURE = "probe722j_render_fail"
+REDEF_FEATURE = "probe722j_redef"
+REDEF_OTHER_NAME = "probe722j_redef_other"
+
+STEWARD_SECRET_TEXT = "steward secret 722j"  # nosec B105
+CONFLICT_TEXT = "cannot combine"
+REDEFINITION_TEXT = "redefined with different source code"
+
+
+# ---------------------------------------------------------------------------
+# Mock compute frameworks (unique names, suffix 722J)
+# ---------------------------------------------------------------------------
+
+
+class CfwSurface722J(ComputeFramework):
+    """General-purpose framework for the request-surface probes."""
+
+
+class CfwPinA722J(ComputeFramework):
+    """Uniquely named framework, pinnable by name from a Feature object."""
+
+
+class CfwPinB722J(ComputeFramework):
+    """Rival uniquely named framework for the sibling probe."""
+
+
+class CfwOnly722J(ComputeFramework):
+    """The framework the restricted run set keeps."""
+
+
+class CfwOther722J(ComputeFramework):
+    """The framework the restricted run set excludes."""
+
+
+class CfwRender722J(ComputeFramework):
+    """Framework carrying the renderer probes."""
+
+
+# ---------------------------------------------------------------------------
+# Probe feature groups (match ONLY their own probe722j_* names)
+# ---------------------------------------------------------------------------
+
+
+class _SurfaceProbeBase722J(FeatureGroup):
+    """Shared probe base: never matches anything itself."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwSurface722J}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return False
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        return None
+
+
+class ProbeDomainA722J(_SurfaceProbeBase722J):
+    """Matches the shared domain feature name; lives in domain A."""
+
+    @classmethod
+    def get_domain(cls) -> Domain:
+        return Domain(DOMAIN_A)
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == DOMAIN_FEATURE
+
+
+class ProbeDomainB722J(_SurfaceProbeBase722J):
+    """Matches the shared domain feature name; lives in domain B."""
+
+    @classmethod
+    def get_domain(cls) -> Domain:
+        return Domain("probe722j_domain_b")
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == DOMAIN_FEATURE
+
+
+class ProbeLinkLeft722J(_SurfaceProbeBase722J):
+    """Anchors the left side of the foreign link; never matches a name."""
+
+
+class ProbeLinkRight722J(_SurfaceProbeBase722J):
+    """Anchors the right side of the foreign link; never matches a name."""
+
+
+class ProbeIndexed722J(_SurfaceProbeBase722J):
+    """Declares an index no link in the request carries."""
+
+    @classmethod
+    def index_columns(cls) -> list[Index] | None:
+        return [Index(("probe722j_row_id",))]
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == INDEXED_FEATURE
+
+
+class ProbePinA722J(_SurfaceProbeBase722J):
+    """Sibling probe on CfwPinA722J, matching the shared pin feature name."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwPinA722J}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == PIN_FEATURE
+
+
+class ProbePinB722J(_SurfaceProbeBase722J):
+    """Sibling probe on CfwPinB722J, matching the same pin feature name."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwPinB722J}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == PIN_FEATURE
+
+
+class ProbeDac722J(_SurfaceProbeBase722J):
+    """Matches its name only when a data access collection is present."""
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == DAC_FEATURE and data_access_collection is not None
+
+
+class ProbeTwoFw722J(_SurfaceProbeBase722J):
+    """Declares two available frameworks; the restricted run set enables only one."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwOnly722J, CfwOther722J}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == TWO_FRAMEWORK_FEATURE
+
+
+class ProbeMode722J(_SurfaceProbeBase722J):
+    """Plain clean probe for the mode-label and conflict tests."""
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == MODE_FEATURE
+
+
+# ---------------------------------------------------------------------------
+# Counting renderer probes: every criteria/capability hook call bumps the counters,
+# so the purity test can prove the renderers never invoke provider hooks.
+# ---------------------------------------------------------------------------
+
+_RENDER_HOOK_CALLS: dict[str, int] = {"criteria": 0, "capability": 0}
+
+
+class _RenderProbeBase722J(FeatureGroup):
+    """Counting probe base: matches only its own RENDER_NAME."""
+
+    RENDER_NAME: ClassVar[str] = ""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CfwRender722J}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        _RENDER_HOOK_CALLS["criteria"] += 1
+        return str(feature_name) == cls.RENDER_NAME
+
+    @classmethod
+    def supports_compute_framework(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        compute_framework: type[ComputeFramework],
+    ) -> bool:
+        _RENDER_HOOK_CALLS["capability"] += 1
+        return True
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        return None
+
+
+class RenderWinner722J(_RenderProbeBase722J):
+    """Sole candidate of the RESOLVED renderer outcome."""
+
+    RENDER_NAME: ClassVar[str] = RENDER_WIN_FEATURE
+
+
+class RenderRivalA722J(_RenderProbeBase722J):
+    """First survivor of the AMBIGUOUS renderer outcome."""
+
+    RENDER_NAME: ClassVar[str] = RENDER_AMBIGUOUS_FEATURE
+
+
+class RenderRivalB722J(_RenderProbeBase722J):
+    """Second survivor of the AMBIGUOUS renderer outcome."""
+
+    RENDER_NAME: ClassVar[str] = RENDER_AMBIGUOUS_FEATURE
+
+
+class RenderBoomCap722J(_RenderProbeBase722J):
+    """Capability hook raises, producing the FAILED renderer outcome; gated on its name."""
+
+    RENDER_NAME: ClassVar[str] = RENDER_FAIL_FEATURE
+
+    @classmethod
+    def supports_compute_framework(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        compute_framework: type[ComputeFramework],
+    ) -> bool:
+        _RENDER_HOOK_CALLS["capability"] += 1
+        if str(feature_name) == RENDER_FAIL_FEATURE:
+            raise ValueError(STEWARD_SECRET_TEXT)
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _foreign_link() -> Link:
+    """A link between two other groups whose indexes the indexed probe does not support."""
+    return Link.inner(
+        JoinSpec(ProbeLinkLeft722J, "probe722j_left_id"),
+        JoinSpec(ProbeLinkRight722J, "probe722j_right_id"),
+    )
+
+
+def _render_outcome(feature_name: str, mapping: FeatureGroupEnvironmentMapping) -> ResolutionOutcome:
+    """One captured outcome over a hand-built mapping, built by the authoritative resolver."""
+    request = ResolutionRequestSnapshot.from_feature(Feature(feature_name))
+    return FeatureGroupResolver().resolve(request, snapshot_from_mapping(mapping))
+
+
+def _resolved_outcome() -> ResolutionOutcome:
+    outcome = _render_outcome(RENDER_WIN_FEATURE, {RenderWinner722J: {CfwRender722J}})
+    assert outcome.status is ResolutionStatus.RESOLVED  # premise guard
+    return outcome
+
+
+def _ambiguous_outcome() -> ResolutionOutcome:
+    outcome = _render_outcome(
+        RENDER_AMBIGUOUS_FEATURE,
+        {RenderRivalA722J: {CfwRender722J}, RenderRivalB722J: {CfwRender722J}},
+    )
+    assert outcome.status is ResolutionStatus.AMBIGUOUS  # premise guard
+    return outcome
+
+
+def _failed_outcome() -> ResolutionOutcome:
+    outcome = _render_outcome(RENDER_FAIL_FEATURE, {RenderBoomCap722J: {CfwRender722J}})
+    assert outcome.status is ResolutionStatus.FAILED  # premise guard
+    return outcome
+
+
+# ---------------------------------------------------------------------------
+# Jupyter-cell simulation helpers for the redefinition-conflict pin
+# (construction pattern mirrors tests/test_core/test_resolution_parity/test_parity_environment.py)
+# ---------------------------------------------------------------------------
+
+# Keeps exec'd classes alive across assertions, like IPython's Out[N] history. Leaking them for the process
+# lifetime is safe: the autouse cleanup unbinds them from __main__, so they are no longer live-in-module and
+# dedup preserves instead of re-raising, and they only match the unique name probe722j_redef.
+_REF_STORE: list[Any] = []
+
+
+def _exec_fg_in_main(class_name: str, body: str, cell_label: str) -> type[FeatureGroup]:
+    """Exec a FeatureGroup subclass into __main__ with linecache-backed source (Jupyter cell simulation)."""
+    main_mod = sys.modules["__main__"]
+    src = textwrap.dedent(body)
+    filename = f"<{cell_label}>"
+    linecache.cache[filename] = (len(src), None, src.splitlines(keepends=True), filename)
+    exec(compile(src, filename, "exec"), main_mod.__dict__)  # nosec B102
+    return cast(type[FeatureGroup], main_mod.__dict__[class_name])
+
+
+def _make_fg_source(class_name: str, feature_name: str, extra_body: str = "") -> str:
+    return f"""
+from mloda.core.abstract_plugins.feature_group import FeatureGroup as _FG_BASE_
+
+class {class_name}(_FG_BASE_):
+    @classmethod
+    def feature_names_supported(cls):
+        return {{"{feature_name}"}}
+{extra_body}
+"""
+
+
+def _make_conflicting_pair(qualname: str, feature_name: str) -> tuple[type[FeatureGroup], type[FeatureGroup]]:
+    """Two classes sharing (module, qualname) with DIFFERENT source; v2 is live in __main__."""
+    src_v1 = _make_fg_source(qualname, feature_name)
+    src_v2 = _make_fg_source(qualname, feature_name, extra_body="    def extra_method(self):\n        return 722\n")
+    v1 = _exec_fg_in_main(qualname, src_v1, f"cell-{qualname}-v1")
+    v2 = _exec_fg_in_main(qualname, src_v2, f"cell-{qualname}-v2")
+    _REF_STORE.extend([v1, v2])
+    return v1, v2
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_main_module_attrs() -> Iterator[None]:
+    """Snapshot __main__ attrs and restore after each test (xdist safety, mirrors test_parity_environment)."""
+    main_mod = sys.modules["__main__"]
+    snapshot = set(main_mod.__dict__.keys())
+    yield
+    for key in set(main_mod.__dict__.keys()) - snapshot:
+        main_mod.__dict__.pop(key, None)
+
+
+# ---------------------------------------------------------------------------
+# 1. Feature-object expressibility parity: domain
+# ---------------------------------------------------------------------------
+
+
+def test_probe722j_feature_object_domain_matches_engine_verdict() -> None:
+    """A Feature object carries its domain into resolve_feature; verdict matches the engine."""
+    mapping: FeatureGroupEnvironmentMapping = {
+        ProbeDomainA722J: {CfwSurface722J},
+        ProbeDomainB722J: {CfwSurface722J},
+    }
+    identifier = IdentifyFeatureGroupClass(
+        feature=Feature(DOMAIN_FEATURE, domain=DOMAIN_A),
+        accessible_plugins=mapping,
+        links=None,
+    )
+    engine_resolved, _ = identifier.get()
+    assert engine_resolved is ProbeDomainA722J  # premise guard: the engine verdict
+
+    collector = PluginCollector.enabled_feature_groups({ProbeDomainA722J, ProbeDomainB722J})
+    result = resolve_feature(Feature(DOMAIN_FEATURE, domain=DOMAIN_A), plugin_collector=collector)
+
+    # TARGET CONTRACT: the Feature's domain is expressible, resolving the domain-A probe
+    # exactly like the engine.
+    assert result.feature_group is engine_resolved
+    assert result.error is None
+
+
+# ---------------------------------------------------------------------------
+# 2. Links parity
+# ---------------------------------------------------------------------------
+
+
+def test_probe722j_links_parameter_excludes_unsupported_index_probe() -> None:
+    """The links parameter carries the run's links; the indexed probe stops resolving."""
+    collector = PluginCollector.enabled_feature_groups({ProbeIndexed722J})
+
+    # Premise guard: without links the indexed probe resolves cleanly.
+    unlinked = resolve_feature(INDEXED_FEATURE, plugin_collector=collector)
+    assert unlinked.feature_group is ProbeIndexed722J
+    assert unlinked.error is None
+
+    result = resolve_feature(INDEXED_FEATURE, links={_foreign_link()}, plugin_collector=collector)
+
+    # TARGET CONTRACT: the probe whose index no request link carries is reported as not
+    # resolvable, exactly like the engine's links filter.
+    assert result.feature_group is None
+    assert result.error is not None
+
+
+# ---------------------------------------------------------------------------
+# 3. Pin parity
+# ---------------------------------------------------------------------------
+
+
+def test_probe722j_feature_object_pin_disambiguates_framework_siblings() -> None:
+    """A framework pin on the Feature object resolves the per-framework sibling ambiguity."""
+    collector = PluginCollector.enabled_feature_groups({ProbePinA722J, ProbePinB722J})
+
+    # Premise guard: unpinned, the framework siblings stay ambiguous.
+    unpinned = resolve_feature(PIN_FEATURE, plugin_collector=collector)
+    assert unpinned.feature_group is None
+    assert unpinned.error is not None
+    assert "Multiple FeatureGroups match" in unpinned.error
+
+    result = resolve_feature(
+        Feature(PIN_FEATURE, compute_framework=CfwPinA722J.get_class_name()), plugin_collector=collector
+    )
+
+    # TARGET CONTRACT: the pin resolves the pinned sibling with exactly its framework.
+    assert result.feature_group is ProbePinA722J
+    assert result.error is None
+    assert result.supported_compute_frameworks == [CfwPinA722J.get_class_name()]
+
+
+# ---------------------------------------------------------------------------
+# 4. Data access collection parity
+# ---------------------------------------------------------------------------
+
+
+def test_probe722j_data_access_collection_parameter_enables_reader_probe() -> None:
+    """The data_access_collection parameter reaches matching, exactly like the engine threads it."""
+    collector = PluginCollector.enabled_feature_groups({ProbeDac722J})
+
+    # Premise guard: without a collection the reader probe does not match.
+    without = resolve_feature(DAC_FEATURE, plugin_collector=collector)
+    assert without.feature_group is None
+    assert without.error is not None
+    assert "No FeatureGroup found" in without.error
+
+    result = resolve_feature(
+        DAC_FEATURE,
+        data_access_collection=DataAccessCollection(files={"probe722j": "probe722j.csv"}),
+        plugin_collector=collector,
+    )
+
+    # TARGET CONTRACT: with the collection the reader probe resolves.
+    assert result.feature_group is ProbeDac722J
+    assert result.error is None
+
+
+# ---------------------------------------------------------------------------
+# 5. Run-set parity
+# ---------------------------------------------------------------------------
+
+
+def test_probe722j_compute_frameworks_parameter_restricts_run_set() -> None:
+    """The compute_frameworks parameter restricts the standalone run set to the given frameworks."""
+    collector = PluginCollector.enabled_feature_groups({ProbeTwoFw722J})
+
+    # Premise guard: the standalone default reports every installed declared framework.
+    unrestricted = resolve_feature(TWO_FRAMEWORK_FEATURE, plugin_collector=collector)
+    assert unrestricted.feature_group is ProbeTwoFw722J
+    assert unrestricted.supported_compute_frameworks == [
+        CfwOnly722J.get_class_name(),
+        CfwOther722J.get_class_name(),
+    ]
+
+    result = resolve_feature(TWO_FRAMEWORK_FEATURE, compute_frameworks={CfwOnly722J}, plugin_collector=collector)
+
+    # TARGET CONTRACT: compute_frameworks restricts the standalone environment exactly like
+    # mlodaAPI(compute_frameworks=...) restricts the engine's run set.
+    assert result.feature_group is ProbeTwoFw722J
+    assert result.error is None
+    assert result.supported_compute_frameworks == [CfwOnly722J.get_class_name()]
+    assert result.unsupported_compute_frameworks == []
+
+
+# ---------------------------------------------------------------------------
+# 6. Feature object combined with the options or feature_group keyword
+# ---------------------------------------------------------------------------
+
+
+def test_probe722j_feature_object_with_options_keyword_is_conflict_error() -> None:
+    """A Feature carries its own options; adding the options keyword is an error result, never a raise."""
+    collector = PluginCollector.enabled_feature_groups({ProbeMode722J})
+
+    result = resolve_feature(
+        Feature(MODE_FEATURE),
+        options=Options(group={"probe722j_extra": 1}),
+        plugin_collector=collector,
+    )
+
+    # TARGET CONTRACT: the conflict is reported in the non-throwing debug shape.
+    assert isinstance(result, ResolvedFeature)
+    assert result.feature_group is None
+    assert result.error is not None
+    assert CONFLICT_TEXT in result.error.lower()
+
+
+def test_probe722j_feature_object_with_feature_group_keyword_is_conflict_error() -> None:
+    """A Feature carries its own scope; adding the feature_group keyword is an error result, never a raise."""
+    collector = PluginCollector.enabled_feature_groups({ProbeMode722J})
+
+    result = resolve_feature(Feature(MODE_FEATURE), feature_group=ProbeMode722J, plugin_collector=collector)
+
+    # TARGET CONTRACT: the conflict is reported in the non-throwing debug shape.
+    assert isinstance(result, ResolvedFeature)
+    assert result.feature_group is None
+    assert result.error is not None
+    assert CONFLICT_TEXT in result.error.lower()
+
+
+# ---------------------------------------------------------------------------
+# 7. Diagnostics-mode label
+# ---------------------------------------------------------------------------
+
+
+def test_probe722j_resolved_feature_carries_standalone_mode_label() -> None:
+    """Every ResolvedFeature is labelled with the standalone diagnostics mode."""
+    # TARGET CONTRACT: the field defaults to the standalone label.
+    bare = ResolvedFeature(feature_name="probe722j_bare", feature_group=None, candidates=[], error=None)
+    assert bare.mode == "standalone"
+
+    collector = PluginCollector.enabled_feature_groups({ProbeMode722J})
+
+    success = resolve_feature(MODE_FEATURE, plugin_collector=collector)
+    assert success.feature_group is ProbeMode722J
+    assert success.mode == "standalone"
+
+    missing = resolve_feature(MODE_MISSING_FEATURE, plugin_collector=collector)
+    assert missing.feature_group is None
+    assert missing.error is not None
+    assert missing.mode == "standalone"
+
+
+# ---------------------------------------------------------------------------
+# 8. Persona renderers over captured outcomes
+# ---------------------------------------------------------------------------
+
+
+def test_probe722j_render_user_view_names_status_and_winner_or_failure() -> None:
+    """The user view mentions the status and the winner or the failing plugin."""
+    from mloda.core.resolve.render import render_user_view
+
+    resolved_text = render_user_view(_resolved_outcome())
+    assert ResolutionStatus.RESOLVED.value in resolved_text.lower()
+    assert "RenderWinner722J" in resolved_text
+
+    ambiguous_text = render_user_view(_ambiguous_outcome())
+    assert ResolutionStatus.AMBIGUOUS.value in ambiguous_text.lower()
+
+    failed_text = render_user_view(_failed_outcome())
+    assert ResolutionStatus.FAILED.value in failed_text.lower()
+    assert "RenderBoomCap722J" in failed_text
+
+
+def test_probe722j_render_provider_view_lists_candidates_and_framework_statuses() -> None:
+    """The provider view carries every candidate identity render and the framework status values."""
+    from mloda.core.resolve.render import render_provider_view
+
+    resolved_text = render_provider_view(_resolved_outcome())
+    assert PluginIdentity.from_class(RenderWinner722J).render() in resolved_text
+    assert FrameworkStatus.SUPPORTED.value in resolved_text.lower()
+
+    ambiguous_text = render_provider_view(_ambiguous_outcome())
+    assert PluginIdentity.from_class(RenderRivalA722J).render() in ambiguous_text
+    assert PluginIdentity.from_class(RenderRivalB722J).render() in ambiguous_text
+    assert FrameworkStatus.SUPPORTED.value in ambiguous_text.lower()
+
+    failed_text = render_provider_view(_failed_outcome())
+    assert PluginIdentity.from_class(RenderBoomCap722J).render() in failed_text
+    assert FrameworkStatus.HOOK_FAILED.value in failed_text.lower()
+
+
+def test_probe722j_render_steward_view_is_deterministic_serializable_and_redacted() -> None:
+    """The steward view is a deterministic JSON dict carrying the fingerprint, never raw provider text."""
+    from mloda.core.resolve.render import render_steward_view
+
+    resolved = _resolved_outcome()
+    view = render_steward_view(resolved)
+    assert isinstance(view, dict)
+    first = json.dumps(view, sort_keys=True)
+    second = json.dumps(render_steward_view(resolved), sort_keys=True)
+    assert first == second
+    assert resolved.environment_fingerprint in first
+    assert PluginIdentity.from_class(RenderWinner722J).render() in first
+    assert ResolutionStatus.RESOLVED.value in first
+
+    failed = _failed_outcome()
+    failed_dump = json.dumps(render_steward_view(failed), sort_keys=True)
+    assert failed.environment_fingerprint in failed_dump
+    assert "ValueError" in failed_dump  # the failure category stays visible
+    assert STEWARD_SECRET_TEXT not in failed_dump  # the raw provider message is redacted
+
+
+def test_probe722j_renderers_never_invoke_provider_hooks() -> None:
+    """All three renderers are pure projections: zero criteria/capability hook invocations."""
+    from mloda.core.resolve.render import render_provider_view, render_steward_view, render_user_view
+
+    baseline = dict(_RENDER_HOOK_CALLS)
+    outcomes = [_resolved_outcome(), _ambiguous_outcome(), _failed_outcome()]
+    after_build = dict(_RENDER_HOOK_CALLS)
+    # Premise guard: the single build pass DOES invoke the hooks; only rendering must not.
+    assert after_build["criteria"] > baseline["criteria"]
+    assert after_build["capability"] > baseline["capability"]
+
+    for outcome in outcomes:
+        render_user_view(outcome)
+        render_provider_view(outcome)
+        render_steward_view(outcome)
+
+    assert dict(_RENDER_HOOK_CALLS) == after_build
+
+
+# ---------------------------------------------------------------------------
+# 9. Structural guarantee: plugin_docs never references the matching hooks
+# ---------------------------------------------------------------------------
+
+
+def test_probe722j_plugin_docs_source_carries_no_matching_hook_references() -> None:
+    """plugin_docs.py delegates all matching to the resolve layer; no hook name appears in its source."""
+    source = inspect.getsource(plugin_docs_module)
+
+    assert "match_feature_group_criteria" not in source
+    assert "supports_compute_framework" not in source
+    assert "split_frameworks_by_capability" not in source
+
+
+# ---------------------------------------------------------------------------
+# 10. Redefinition-conflict projection preserved after the move (may pass today)
+# ---------------------------------------------------------------------------
+
+
+def test_probe722j_redefinition_conflict_error_keeps_scope_and_name_matched_candidates() -> None:
+    """TARGET CONTRACT pin: the conflict projection survives the move out of plugin_docs.
+
+    The redefinition-branch candidate filtering moves into the resolve layer in Stage 4;
+    this pin keeps the observable behavior fixed: the conflict error text is returned with
+    exactly the scope- and name-matched conflicting candidates.
+    """
+    v1, v2 = _make_conflicting_pair("ProbeRedefSurface722J", REDEF_FEATURE)
+    collector = PluginCollector.enabled_feature_groups({v1, v2})
+
+    result = resolve_feature(REDEF_FEATURE, plugin_collector=collector)
+    assert result.feature_group is None
+    assert result.error is not None
+    assert REDEFINITION_TEXT in result.error
+    assert set(result.candidates) == {v1, v2}
+
+    # Name filter: a non-matching feature name keeps the conflict error but drops the candidates.
+    other = resolve_feature(REDEF_OTHER_NAME, plugin_collector=collector)
+    assert other.feature_group is None
+    assert other.error is not None
+    assert REDEFINITION_TEXT in other.error
+    assert other.candidates == []
+
+    # Scope filter: a scope matching neither conflicting class drops the candidates too.
+    scoped = resolve_feature(REDEF_FEATURE, feature_group="ProbeSomewhereElse722J", plugin_collector=collector)
+    assert scoped.feature_group is None
+    assert scoped.error is not None
+    assert REDEFINITION_TEXT in scoped.error
+    assert scoped.candidates == []


### PR DESCRIPTION
## Summary

Feature-group matching was implemented twice: the engine's IdentifyFeatureGroupClass and the debug API resolve_feature disagreed in 17 catalogued ways, three of them verified user-visible false positives (an abstract base winning in the debug tool, a feature whose only framework is not installed reading as runnable, and cross-candidate framework attribution). This PR lands all four stages plus the final checkpoint of #722: one canonical FeatureGroupResolver produces structured outcomes, and every surface (engine, resolve_feature, diagnostics, renderers) projects that captured state instead of re-matching.

## What changed

- Stage 1: paired engine/diagnostic characterization tests pin all 17 divergences; the decided contract (candidate universe, statuses, invariants, filter and hook order, subclass policy, failure precedence, provider failure semantics, projections, redaction) is documented in docs/docs/in_depth/feature-group-resolution-contract.md.
- Stage 2: new mloda.core.resolve package with PluginIdentity, provenance-classified EnvironmentBuildOutcome, an immutable ResolutionEnvironmentSnapshot with deterministic fingerprints, and ResolutionRequestSnapshot; PreFilterPlugins delegates to the shared pipeline with byte-identical behavior.
- Stage 3: FeatureGroupResolver is the sole winner-selector, implementing the decided order (scope, abstract, domain, criteria, frameworks, pin, links, capability, framework-aware shadowing, uniqueness) with each provider hook invoked at most once per candidate or candidate/framework pair on the decision path. The engine raises a typed FeatureResolutionError (a ValueError) with unchanged message texts and retains every outcome with its dependency path. The three false positives are fixed and provider failures are fail-closed on both paths.
- Stage 4: ResolutionReport plus mlodaAPI.diagnose (non-raising exact-run preflight) and session.resolution_report (no re-matching on inspection); resolve_feature accepts a Feature object or name plus links, data_access_collection, and compute_frameworks, closing the remaining request expressibility gaps; shared user, provider, and steward renderers; plugin_docs.py no longer contains matching logic.
- Final checkpoint: feature-config scope validation delegates to the canonical normalizer; the contract doc names the seams issues #727 and #728 reuse.

## Breaking changes

- resolve_feature's first parameter is renamed from feature_name to feature (it now accepts str | Feature); keyword callers of the old name must update. The issue explicitly waives backward compatibility for this surface and forbids compatibility adapters.
- resolve_feature now applies strict mode, availability, and collector policy (the same environment the engine uses), so results that previously looked runnable can now honestly fail; abstract bases never win; framework attribution is per candidate.
- A raising provider hook is fail-closed everywhere instead of degrading open, and the engine wraps provider failures in FeatureResolutionError (a ValueError subclass) rather than propagating raw exceptions.

## Review and testing

Every stage passed the full tox gate (pytest with xdist, ruff format and check, license allowlist, mypy strict, bandit) and two independent per-stage deep reviews; all accepted findings were fixed and re-gated (36 findings triaged across the run, 3 rejected with reasons). Final state: 6611 tests passed, 162 skipped. The branch was rebased on main after #744 merged, with tox green on the rebase.

Closes #722. Follow-ups stay scoped to their own issues: GlobalFilter (#728) and input-data reader selection (#727).