### PR TITLE
refactor: rename tfs_collecion to tfs_collection

### DIFF
--- a/mloda/core/core/engine.py
+++ b/mloda/core/core/engine.py
@@ -86,7 +86,7 @@ class Engine:
         connection_map: dict[type[ComputeFramework], Any] = {}
         if self.data_access_collection is None:
             return connection_map
-        for tfs in self.execution_planner.tfs_collecion:
+        for tfs in self.execution_planner.tfs_collection:
             cfw_class = tfs.to_framework
             if cfw_class in connection_map:
                 continue

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -37,7 +37,7 @@ class ExecutionPlan:
         global_filter: Optional[GlobalFilter] = None,
         api_input_data_collection: Optional[ApiInputDataCollection] = None,
     ) -> None:
-        self.tfs_collecion: set[TransformFrameworkStep] = set()
+        self.tfs_collection: set[TransformFrameworkStep] = set()
         self.joinstep_collection = JoinStepCollection()
         self.global_filter = global_filter
         self.api_input_data_collection = api_input_data_collection
@@ -188,8 +188,8 @@ class ExecutionPlan:
                 if ep.destination_framework != ep.source_framework:
                     new_tfs = self.fill_tfs_by_joinstep(ep)
 
-                    if new_tfs not in self.tfs_collecion:
-                        self.tfs_collecion.add(new_tfs)
+                    if new_tfs not in self.tfs_collection:
+                        self.tfs_collection.add(new_tfs)
                         new_execution_plan.append(new_tfs)
                         ep.required_uuids.add(new_tfs.uuid)
 
@@ -271,8 +271,8 @@ class ExecutionPlan:
                             from_feature_group=parent_node_property.feature_group_class,
                             to_feature_group=ep.feature_group,
                         )
-                        if new_tfs not in self.tfs_collecion:
-                            self.tfs_collecion.add(new_tfs)
+                        if new_tfs not in self.tfs_collection:
+                            self.tfs_collection.add(new_tfs)
                             new_execution_plan.append(new_tfs)
                             ep.required_uuids.add(new_tfs.uuid)
 


### PR DESCRIPTION
## Summary
Rename the misspelled attribute `tfs_collecion` to `tfs_collection` as described in issue #745.

## Changes
- `mloda/core/prepare/execution_plan.py`: renamed attribute definition (line 40) and 4 usages (lines 191, 192, 274, 275)
- `mloda/core/core/engine.py`: updated consumer reference (line 89)

## Verification
- ✅ No remaining occurrences of `tfs_collecion` in the repository
- ✅ Python syntax check passed (`py_compile`)
- ✅ Single commit (Gate-3 ✅)

Closes #745