### PR TITLE
fix: contain every option-value rejection path so a raising validator cannot abort identification

### DIFF
--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -35,6 +35,14 @@ REQUIRED_WHEN_GUARD_DEPTH: contextvars.ContextVar[int] = contextvars.ContextVar(
     "mloda_required_when_guard_depth", default=0
 )
 
+# Exception classes a user callable raises when it merely cannot judge a value.
+_EXPECTED_JUDGMENT_ERRORS: tuple[type[Exception], ...] = (TypeError, ValueError, AttributeError)
+
+
+def _contained_raise_log_level(exc: BaseException) -> int:
+    """DEBUG for expected judgment failures, WARNING for classes that suggest a broken callable."""
+    return logging.DEBUG if isinstance(exc, _EXPECTED_JUDGMENT_ERRORS) else logging.WARNING
+
 
 class PropertyValueRejection(ValueError):
     """An option value the PROPERTY_MAPPING rejects: a verdict, not a crash. Subclasses ValueError so
@@ -168,20 +176,23 @@ class FeatureChainParser:
 
         if element_validator is not None:
             # A validator that raises cannot judge the value, so the value is rejected, not the run.
+            raised: Exception | None = None
             try:
                 verdict = element_validator(found_property_val)
             except Exception as exc:
-                logger.debug(
+                logger.log(
+                    _contained_raise_log_level(exc),
                     "element_validator for '%s' raised %s for value %r; treating value as rejected.",
                     property_name,
                     exc,
                     found_property_val,
                 )
+                raised = exc
                 verdict = False
             if not verdict:
                 raise PropertyValueRejection(
                     f"Property value '{found_property_val}' failed validation for '{property_name}'"
-                )
+                ) from raised
         else:
             # Fallback to membership check. An unhashable element (e.g. a dict) can never be
             # a member of the accepted set, so it is a clean rejection, not a TypeError.
@@ -500,10 +511,12 @@ class FeatureChainParser:
         # Building effective options may itself raise, so a raise here is contained as a non-match too.
         try:
             effective_options = cls.build_effective_options(feature_name, prefix_patterns, property_mapping, options)
-        except Exception:
-            logger.debug(
-                "building effective options for required_when on %s raised; treating feature group as a non-match.",
+        except Exception as exc:
+            logger.log(
+                _contained_raise_log_level(exc),
+                "building effective options for required_when on %s raised %s; treating feature group as a non-match.",
                 owner_name,
+                exc,
             )
             return False
         for key, spec in property_mapping.items():
@@ -516,11 +529,13 @@ class FeatureChainParser:
             # A predicate that raises cannot judge the value, so the feature group is a non-match, not the run.
             try:
                 is_required = bool(predicate(effective_options))
-            except Exception:
-                logger.debug(
-                    "required_when predicate %s for '%s' raised; treating feature group %s as a non-match.",
+            except Exception as exc:
+                logger.log(
+                    _contained_raise_log_level(exc),
+                    "required_when predicate %s for '%s' raised %s; treating feature group %s as a non-match.",
                     getattr(predicate, "__name__", repr(predicate)),
                     key,
+                    exc,
                     owner_name,
                 )
                 return False

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -180,13 +180,19 @@ class FeatureChainParser:
             try:
                 verdict = element_validator(found_property_val)
             except Exception as exc:
-                logger.log(
-                    _contained_raise_log_level(exc),
-                    "element_validator for '%s' raised %s for value %r; treating value as rejected.",
-                    property_name,
-                    exc,
-                    found_property_val,
-                )
+                level = _contained_raise_log_level(exc)
+                if level == logging.DEBUG:
+                    logger.debug(
+                        "element_validator for '%s' raised %s for value %r; treating value as rejected.",
+                        property_name,
+                        exc,
+                        found_property_val,
+                    )
+                else:
+                    # The raw value stays out of WARNING logs; rerun with debug logging to see it.
+                    logger.warning(
+                        "element_validator for '%s' raised %s; treating value as rejected.", property_name, exc
+                    )
                 raised = exc
                 verdict = False
             if not verdict:

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -170,7 +170,13 @@ class FeatureChainParser:
             # A validator that raises cannot judge the value, so the value is rejected, not the run.
             try:
                 verdict = element_validator(found_property_val)
-            except (TypeError, ValueError, AttributeError):
+            except Exception as exc:
+                logger.debug(
+                    "element_validator for '%s' raised %s for value %r; treating value as rejected.",
+                    property_name,
+                    exc,
+                    found_property_val,
+                )
                 verdict = False
             if not verdict:
                 raise PropertyValueRejection(
@@ -491,7 +497,15 @@ class FeatureChainParser:
         if property_mapping is None or not cls.has_required_when_predicates(property_mapping):
             return True
 
-        effective_options = cls.build_effective_options(feature_name, prefix_patterns, property_mapping, options)
+        # Building effective options may itself raise, so a raise here is contained as a non-match too.
+        try:
+            effective_options = cls.build_effective_options(feature_name, prefix_patterns, property_mapping, options)
+        except Exception:
+            logger.debug(
+                "building effective options for required_when on %s raised; treating feature group as a non-match.",
+                owner_name,
+            )
+            return False
         for key, spec in property_mapping.items():
             if not isinstance(spec, PropertySpec):
                 continue
@@ -499,7 +513,18 @@ class FeatureChainParser:
             predicate = spec.required_when
             if predicate is None:
                 continue
-            if predicate(effective_options) and effective_options.get(key) is None:
+            # A predicate that raises cannot judge the value, so the feature group is a non-match, not the run.
+            try:
+                is_required = bool(predicate(effective_options))
+            except Exception:
+                logger.debug(
+                    "required_when predicate %s for '%s' raised; treating feature group %s as a non-match.",
+                    getattr(predicate, "__name__", repr(predicate)),
+                    key,
+                    owner_name,
+                )
+                return False
+            if is_required and effective_options.get(key) is None:
                 logger.debug(
                     "Feature group %s requires option '%s' (predicate %s is satisfied) but it was not provided.",
                     owner_name,

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -99,7 +99,7 @@ class FeatureChainParserMixin:
     Predicate contract:
     - Signature: ``(Options) -> bool``
     - Must be callable (enforced at ``PropertySpec`` construction)
-    - Must not raise exceptions
+    - A predicate that raises is contained: the feature group is treated as a non-match
     - Must be a pure function (no side effects)
     - Non-bool truthy return values are treated as True
 
@@ -396,7 +396,7 @@ class FeatureChainParserMixin:
                 continue
             try:
                 rejected = not guard(value)
-            except (TypeError, ValueError, AttributeError) as exc:
+            except Exception as exc:
                 logger.debug("match_guard for '%s' raised %s for value %r", key, exc, value)
                 rejected = True
             if rejected:

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -399,9 +399,12 @@ class FeatureChainParserMixin:
             try:
                 rejected = not guard(value)
             except Exception as exc:
-                logger.log(
-                    _contained_raise_log_level(exc), "match_guard for '%s' raised %s for value %r", key, exc, value
-                )
+                level = _contained_raise_log_level(exc)
+                if level == logging.DEBUG:
+                    logger.debug("match_guard for '%s' raised %s for value %r", key, exc, value)
+                else:
+                    # The raw value stays out of WARNING logs; rerun with debug logging to see it.
+                    logger.warning("match_guard for '%s' raised %s", key, exc)
                 rejected = True
             if rejected:
                 return key, value

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -64,6 +64,7 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
     FeatureChainParser,
     CHAIN_SEPARATOR,
     INPUT_SEPARATOR,
+    _contained_raise_log_level,
 )
 from mloda.core.abstract_plugins.components.feature_chainer.property_spec import PropertySpec
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
@@ -100,6 +101,7 @@ class FeatureChainParserMixin:
     - Signature: ``(Options) -> bool``
     - Must be callable (enforced at ``PropertySpec`` construction)
     - A predicate that raises is contained: the feature group is treated as a non-match
+      (unexpected exception classes log a warning)
     - Must be a pure function (no side effects)
     - Non-bool truthy return values are treated as True
 
@@ -397,7 +399,9 @@ class FeatureChainParserMixin:
             try:
                 rejected = not guard(value)
             except Exception as exc:
-                logger.debug("match_guard for '%s' raised %s for value %r", key, exc, value)
+                logger.log(
+                    _contained_raise_log_level(exc), "match_guard for '%s' raised %s for value %r", key, exc, value
+                )
                 rejected = True
             if rejected:
                 return key, value

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_option_value_rejection_never_escapes.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_option_value_rejection_never_escapes.py
@@ -742,6 +742,11 @@ class TestContainedRaiseLogTiers:
         warnings = _records_at_or_above(caplog, PARSER_LOGGER_NAME, logging.WARNING)
         assert warnings, "a KeyError-raising validator looks broken and must log at WARNING"
         assert any(VALIDATOR_KEY_ESC763 in record.getMessage() for record in warnings)
+        # The exception text stays for triage; the option value itself is redacted at WARNING (production-visible).
+        assert any("element_validator cannot judge the poison value" in record.getMessage() for record in warnings)
+        assert all(POISON_VALUE_ESC763 not in record.getMessage() for record in warnings), (
+            "option values may carry secrets and must not appear in WARNING-tier containment messages"
+        )
 
     def test_typeerror_validator_raise_logs_at_debug_only(self, caplog: pytest.LogCaptureFixture) -> None:
         """A validator raising TypeError is an expected judgment failure: contained at DEBUG, never WARNING."""
@@ -758,6 +763,11 @@ class TestContainedRaiseLogTiers:
         assert _records_at_or_above(caplog, PARSER_LOGGER_NAME, logging.WARNING) == []
         debug_records = _records_at_exactly(caplog, PARSER_LOGGER_NAME, logging.DEBUG)
         assert debug_records, "the contained TypeError must still log its rejection at DEBUG"
+        # DEBUG is the debugging tier: the containment record keeps both the key and the value visible.
+        assert any(
+            VALIDATOR_KEY_ESC763 in record.getMessage() and TYPE_POISON_VALUE_TIER763 in record.getMessage()
+            for record in debug_records
+        ), "the DEBUG containment record must name the property key and keep the rejected value visible"
 
     def test_keyerror_guard_raise_logs_at_warning(self, caplog: pytest.LogCaptureFixture) -> None:
         """A guard raising KeyError is still a non-match, but the containment surfaces at WARNING."""
@@ -770,6 +780,11 @@ class TestContainedRaiseLogTiers:
         warnings = _records_at_or_above(caplog, MIXIN_LOGGER_NAME, logging.WARNING)
         assert warnings, "a KeyError-raising guard looks broken and must log at WARNING"
         assert any(GUARD_KEY_ESC763 in record.getMessage() for record in warnings)
+        # The exception text stays for triage; the option value itself is redacted at WARNING (production-visible).
+        assert any("match_guard cannot judge the poison value" in record.getMessage() for record in warnings)
+        assert all(POISON_VALUE_ESC763 not in record.getMessage() for record in warnings), (
+            "option values may carry secrets and must not appear in WARNING-tier containment messages"
+        )
 
     def test_typeerror_guard_raise_logs_at_debug_only(self, caplog: pytest.LogCaptureFixture) -> None:
         """A guard raising TypeError is an expected judgment failure: contained at DEBUG, never WARNING."""
@@ -782,6 +797,11 @@ class TestContainedRaiseLogTiers:
         assert _records_at_or_above(caplog, MIXIN_LOGGER_NAME, logging.WARNING) == []
         debug_records = _records_at_exactly(caplog, MIXIN_LOGGER_NAME, logging.DEBUG)
         assert debug_records, "the contained TypeError must still log its rejection at DEBUG"
+        # DEBUG is the debugging tier: the containment record keeps both the key and the value visible.
+        assert any(
+            GUARD_KEY_ESC763 in record.getMessage() and TYPE_POISON_VALUE_TIER763 in record.getMessage()
+            for record in debug_records
+        ), "the DEBUG containment record must name the option key and keep the rejected value visible"
 
     def test_keyerror_required_when_raise_logs_at_warning(self, caplog: pytest.LogCaptureFixture) -> None:
         """A predicate raising KeyError is still a non-match, but the containment surfaces at WARNING."""
@@ -813,6 +833,10 @@ class TestContainedRaiseLogTiers:
         assert _records_at_or_above(caplog, PARSER_LOGGER_NAME, logging.WARNING) == []
         debug_records = _records_at_exactly(caplog, PARSER_LOGGER_NAME, logging.DEBUG)
         assert debug_records, "the contained TypeError must still log its rejection at DEBUG"
+        owner = RaisingKeyErrorRequiredWhenFeatureGroupEsc763.__name__
+        assert any(
+            REQUIRED_WHEN_KEY_ESC763 in record.getMessage() or owner in record.getMessage() for record in debug_records
+        ), "the DEBUG containment record must name the guarded key or the owning feature group"
 
     def test_keyerror_build_effective_options_raise_logs_at_warning(
         self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
@@ -856,6 +880,10 @@ class TestContainedRaiseLogTiers:
         assert _records_at_or_above(caplog, PARSER_LOGGER_NAME, logging.WARNING) == []
         debug_records = _records_at_exactly(caplog, PARSER_LOGGER_NAME, logging.DEBUG)
         assert debug_records, "the contained ValueError must still log its rejection at DEBUG"
+        owner = RaisingKeyErrorRequiredWhenFeatureGroupEsc763.__name__
+        assert any(owner in record.getMessage() for record in debug_records), (
+            "the DEBUG containment record must name the feature group whose match was denied"
+        )
 
 
 class TestValidatorCauseChaining:

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_option_value_rejection_never_escapes.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_option_value_rejection_never_escapes.py
@@ -8,7 +8,7 @@ All fixture names carry an "esc732" marker so they cannot collide with other tes
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Any, Optional
 
 import pytest
 
@@ -17,6 +17,7 @@ from mloda.core.abstract_plugins.components.default_options_key import DefaultOp
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import (
     FeatureChainParser,
+    PropertyValueRejection,
 )
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import (
     FeatureChainParserMixin,
@@ -45,6 +46,54 @@ SUPPORTED_OPERATIONS_ESC732: dict[str, str] = {
     "normalize": "Normalize the text (esc732 fixture)",
     "strip": "Strip the text (esc732 fixture)",
 }
+
+
+# The esc763 fixtures pin issue #763: a user callable that raises a NON-(TypeError/ValueError/AttributeError)
+# exception (here KeyError) means "cannot judge this value" = a rejection, never an escape that aborts the
+# identification of the OTHER candidate feature groups. Fresh marker so these cannot collide in the registry.
+VALIDATOR_KEY_ESC763 = "validator_key_esc763"
+GUARD_KEY_ESC763 = "guard_key_esc763"
+REQUIRED_WHEN_KEY_ESC763 = "required_when_key_esc763"
+DRIVER_KEY_ESC763 = "required_when_driver_esc763"
+
+VALIDATOR_FEATURE_ESC763 = "text__validated_esc763"
+GUARD_FEATURE_ESC763 = "text__guarded_esc763"
+REQUIRED_WHEN_FEATURE_ESC763 = "text__required_esc763"
+
+# A value the callables cannot judge: looking at it raises KeyError, exactly the class the containment misses today.
+POISON_VALUE_ESC763 = "poison_esc763"
+# A value the callables CAN judge and accept: proves the fix does not over-reject.
+GOOD_VALUE_ESC763 = "good_esc763"
+# required_when driver modes: "needs" makes the key required, "optional" leaves it optional.
+NEEDS_MODE_ESC763 = "needs_esc763"
+OPTIONAL_MODE_ESC763 = "optional_esc763"
+
+
+def _keyerror_element_validator_esc763(value: Any) -> bool:
+    """Judge one element; the poison value cannot be judged, so raise KeyError (an uncaught class)."""
+    if value == POISON_VALUE_ESC763:
+        raise KeyError("esc763 element_validator cannot judge the poison value")
+    return bool(value == GOOD_VALUE_ESC763)
+
+
+def _keyerror_match_guard_esc763(value: Any) -> bool:
+    """Guard the raw value; the poison value cannot be judged, so raise KeyError (an uncaught class)."""
+    if value == POISON_VALUE_ESC763:
+        raise KeyError("esc763 match_guard cannot judge the poison value")
+    return bool(value == GOOD_VALUE_ESC763)
+
+
+def _keyerror_required_when_esc763(options: Options) -> bool:
+    """Decide if the guarded key is required; a poison driver cannot be judged, so raise KeyError."""
+    driver = options.get(DRIVER_KEY_ESC763)
+    if driver == POISON_VALUE_ESC763:
+        raise KeyError("esc763 required_when cannot judge the poison driver value")
+    return bool(driver == NEEDS_MODE_ESC763)
+
+
+def _raise_build_effective_options_esc763(cls: Any, *args: Any, **kwargs: Any) -> Options:
+    """Force build_effective_options to raise a plain ValueError: the escape #763 must contain."""
+    raise ValueError("esc763 build_effective_options boom")
 
 
 class MockComputeFrameworkEsc732(ComputeFramework):
@@ -144,6 +193,98 @@ class RaisingAttributeErrorValidatorFeatureGroup(FeatureChainParserMixin, Featur
             element_validator=lambda value: value.startswith("ok"),
         )
     }
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class RaisingKeyErrorValidatorFeatureGroupEsc763(FeatureChainParserMixin, FeatureGroup):
+    """element_validator raises KeyError (not a caught TypeError/ValueError/AttributeError) on a poison value."""
+
+    PREFIX_PATTERN = r".*__validated_esc763$"
+
+    PROPERTY_MAPPING = {
+        VALIDATOR_KEY_ESC763: PropertySpec(
+            "A value the validator cannot judge raises KeyError (esc763 fixture)",
+            context=True,
+            strict_validation=True,
+            element_validator=_keyerror_element_validator_esc763,
+        )
+    }
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class RaisingKeyErrorGuardFeatureGroupEsc763(FeatureChainParserMixin, FeatureGroup):
+    """match_guard raises KeyError (not a caught class) on a poison value; needs no strict_validation."""
+
+    PREFIX_PATTERN = r".*__guarded_esc763$"
+
+    PROPERTY_MAPPING = {
+        GUARD_KEY_ESC763: PropertySpec(
+            "A value the guard cannot judge raises KeyError (esc763 fixture)",
+            context=True,
+            match_guard=_keyerror_match_guard_esc763,
+        )
+    }
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class RaisingKeyErrorRequiredWhenFeatureGroupEsc763(FeatureChainParserMixin, FeatureGroup):
+    """required_when predicate raises KeyError (not a caught class) on a poison driver value.
+
+    Its single required_when key is skippable, so an unscoped matcher would claim any feature whose
+    options omit the driver and pollute the global registry. The gated override below scopes it to its
+    own feature; the class-definition guard still wraps the override, so the raising predicate runs.
+    """
+
+    PREFIX_PATTERN = r".*__required_esc763$"
+
+    PROPERTY_MAPPING = {
+        REQUIRED_WHEN_KEY_ESC763: PropertySpec(
+            "Guarded by a required_when predicate that can raise KeyError (esc763 fixture)",
+            context=True,
+            required_when=_keyerror_required_when_esc763,
+        )
+    }
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        name = str(feature_name)
+        # Classmethod is mandatory: required_when forbids a staticmethod matcher. Claim only this
+        # fixture's own feature so the auto-registered class never owns an unrelated feature.
+        if name != REQUIRED_WHEN_FEATURE_ESC763 and options.get(DRIVER_KEY_ESC763) is None:
+            return False
+        return FeatureChainParser.match_configuration_feature_chain_parser(
+            name,
+            options,
+            property_mapping=cls.PROPERTY_MAPPING,
+            prefix_patterns=[cls.PREFIX_PATTERN],
+        )
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class RequiredWhenNeighborFeatureGroupEsc763(FeatureGroup):
+    """Claims REQUIRED_WHEN_FEATURE_ESC763 and accepts any options: the valid owner the raising candidate must not deny."""
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == REQUIRED_WHEN_FEATURE_ESC763
 
     def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
         return None
@@ -360,3 +501,189 @@ class TestParserContractUnchangedForOrdinaryRejections:
         message = str(exc_info.value)
         assert PIPELINE_KEY in message
         assert "custom" in message
+
+
+class TestKeyErrorElementValidatorIsARejection:
+    """issue #763: a validator raising a non-(TypeError/ValueError/AttributeError) is a rejection, not an escape."""
+
+    def test_keyerror_validator_on_name_path_is_a_non_match(self) -> None:
+        """A validator that raises KeyError is a non-match, not an exception out of the matcher."""
+        options = Options(context={VALIDATOR_KEY_ESC763: [POISON_VALUE_ESC763]})
+
+        result = RaisingKeyErrorValidatorFeatureGroupEsc763.match_feature_group_criteria(
+            VALIDATOR_FEATURE_ESC763, options
+        )
+
+        assert result is False
+
+    def test_parser_reports_a_keyerror_validator_as_a_value_rejection(self) -> None:
+        """The parser converts the validator's KeyError into the PropertyValueRejection its callers read."""
+        with pytest.raises(PropertyValueRejection) as exc_info:
+            FeatureChainParser.match_configuration_feature_chain_parser(
+                VALIDATOR_FEATURE_ESC763,
+                Options(context={VALIDATOR_KEY_ESC763: [POISON_VALUE_ESC763]}),
+                property_mapping=RaisingKeyErrorValidatorFeatureGroupEsc763.PROPERTY_MAPPING,
+                prefix_patterns=[RaisingKeyErrorValidatorFeatureGroupEsc763.PREFIX_PATTERN],
+            )
+
+        message = str(exc_info.value)
+        assert VALIDATOR_KEY_ESC763 in message
+        assert POISON_VALUE_ESC763 in message
+
+    def test_reason_for_keyerror_validator_is_reported_not_raised(self) -> None:
+        """_strict_validation_rejection_reason reports the KeyError rejection; it never raises."""
+        options = Options(context={VALIDATOR_KEY_ESC763: [POISON_VALUE_ESC763]})
+
+        reason = RaisingKeyErrorValidatorFeatureGroupEsc763._strict_validation_rejection_reason(
+            VALIDATOR_FEATURE_ESC763, options
+        )
+
+        assert reason is not None
+        assert VALIDATOR_KEY_ESC763 in reason
+        assert POISON_VALUE_ESC763 in reason
+
+
+class TestKeyErrorMatchGuardIsARejection:
+    """A match_guard raising a non-caught exception is a non-match, not an escape."""
+
+    def test_keyerror_guard_is_a_non_match(self) -> None:
+        """A guard that raises KeyError rejects the value; it does not blow up the match."""
+        options = Options(context={GUARD_KEY_ESC763: POISON_VALUE_ESC763})
+
+        result = RaisingKeyErrorGuardFeatureGroupEsc763.match_feature_group_criteria(GUARD_FEATURE_ESC763, options)
+
+        assert result is False
+
+
+class TestKeyErrorRequiredWhenPredicateIsARejection:
+    """A required_when predicate raising a non-caught exception is a non-match, not an escape."""
+
+    def test_keyerror_required_when_predicate_is_a_non_match(self) -> None:
+        """A predicate that raises KeyError is a non-match, not an exception out of the matcher."""
+        options = Options(context={DRIVER_KEY_ESC763: POISON_VALUE_ESC763})
+
+        result = RaisingKeyErrorRequiredWhenFeatureGroupEsc763.match_feature_group_criteria(
+            REQUIRED_WHEN_FEATURE_ESC763, options
+        )
+
+        assert result is False
+
+
+class TestKeyErrorRejectionNeverEscapesTheEngine:
+    """The definition-time required_when guard must never leak a KeyError out of the filter loop."""
+
+    def test_keyerror_required_when_yields_the_standard_no_match_error(self) -> None:
+        """A required_when predicate that raises must be a non-match, not an exception out of the engine."""
+        feature = Feature(REQUIRED_WHEN_FEATURE_ESC763, Options(context={DRIVER_KEY_ESC763: POISON_VALUE_ESC763}))
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            RaisingKeyErrorRequiredWhenFeatureGroupEsc763: {MockComputeFrameworkEsc732},
+        }
+
+        with pytest.raises(ValueError) as exc_info:
+            _identify(feature, accessible_plugins)
+
+        message = str(exc_info.value)
+        assert "No feature groups found" in message, (
+            f"A predicate that raises must be a non-match, not an exception out of the engine, but got: {message}"
+        )
+
+    def test_keyerror_required_when_does_not_poison_other_candidates(self) -> None:
+        """One raising candidate must not deny the feature to the group that legitimately owns it."""
+        feature = Feature(REQUIRED_WHEN_FEATURE_ESC763, Options(context={DRIVER_KEY_ESC763: POISON_VALUE_ESC763}))
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            RaisingKeyErrorRequiredWhenFeatureGroupEsc763: {MockComputeFrameworkEsc732},
+            RequiredWhenNeighborFeatureGroupEsc763: {MockComputeFrameworkEsc732},
+        }
+
+        identified = _identify(feature, accessible_plugins)
+
+        feature_group, _frameworks = identified.get()
+        assert feature_group is RequiredWhenNeighborFeatureGroupEsc763
+
+
+class TestKeyErrorPathsDoNotOverReject:
+    """Guard against over-rejecting: a value the callables CAN judge and accept still matches (passes pre-fix)."""
+
+    def test_valid_value_through_keyerror_validator_matches(self) -> None:
+        options = Options(context={VALIDATOR_KEY_ESC763: [GOOD_VALUE_ESC763]})
+
+        assert (
+            RaisingKeyErrorValidatorFeatureGroupEsc763.match_feature_group_criteria(VALIDATOR_FEATURE_ESC763, options)
+            is True
+        )
+
+    def test_valid_value_through_keyerror_guard_matches(self) -> None:
+        options = Options(context={GUARD_KEY_ESC763: GOOD_VALUE_ESC763})
+
+        assert (
+            RaisingKeyErrorGuardFeatureGroupEsc763.match_feature_group_criteria(GUARD_FEATURE_ESC763, options) is True
+        )
+
+    def test_untriggered_required_when_predicate_still_matches(self) -> None:
+        """When the predicate returns False (option not required), the feature still matches."""
+        options = Options(context={DRIVER_KEY_ESC763: OPTIONAL_MODE_ESC763})
+
+        assert (
+            RaisingKeyErrorRequiredWhenFeatureGroupEsc763.match_feature_group_criteria(
+                REQUIRED_WHEN_FEATURE_ESC763, options
+            )
+            is True
+        )
+
+    def test_triggered_required_when_with_option_present_still_matches(self) -> None:
+        """When the predicate returns True but the required option is present, the feature still matches."""
+        options = Options(
+            context={DRIVER_KEY_ESC763: NEEDS_MODE_ESC763, REQUIRED_WHEN_KEY_ESC763: GOOD_VALUE_ESC763},
+        )
+
+        assert (
+            RaisingKeyErrorRequiredWhenFeatureGroupEsc763.match_feature_group_criteria(
+                REQUIRED_WHEN_FEATURE_ESC763, options
+            )
+            is True
+        )
+
+
+class TestBuildEffectiveOptionsRaiseIsContained:
+    """issue #763: a raise from build_effective_options inside the required_when guard is a non-match, not an escape.
+
+    The driver is OPTIONAL_MODE_ESC763, so the predicate itself returns False (would match True): the monkeypatched
+    build_effective_options, called before the predicate loop and outside its try/except, is the sole raise source.
+    """
+
+    def test_build_effective_options_raise_is_a_non_match(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A ValueError from build_effective_options is contained as a non-match, not an escape out of the matcher."""
+        monkeypatch.setattr(
+            FeatureChainParser,
+            "build_effective_options",
+            classmethod(_raise_build_effective_options_esc763),
+        )
+        options = Options(context={DRIVER_KEY_ESC763: OPTIONAL_MODE_ESC763})
+
+        result = RaisingKeyErrorRequiredWhenFeatureGroupEsc763.match_feature_group_criteria(
+            REQUIRED_WHEN_FEATURE_ESC763, options
+        )
+
+        assert result is False
+
+    def test_build_effective_options_raise_yields_the_standard_no_match_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The engine turns that contained raise into the standard no-match error, not a bare escape."""
+        monkeypatch.setattr(
+            FeatureChainParser,
+            "build_effective_options",
+            classmethod(_raise_build_effective_options_esc763),
+        )
+        feature = Feature(REQUIRED_WHEN_FEATURE_ESC763, Options(context={DRIVER_KEY_ESC763: OPTIONAL_MODE_ESC763}))
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            RaisingKeyErrorRequiredWhenFeatureGroupEsc763: {MockComputeFrameworkEsc732},
+        }
+
+        with pytest.raises(ValueError) as exc_info:
+            _identify(feature, accessible_plugins)
+
+        message = str(exc_info.value)
+        assert "No feature groups found" in message, (
+            f"A build_effective_options raise must be a non-match, not an exception out of the engine, but got: {message}"
+        )

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_option_value_rejection_never_escapes.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_option_value_rejection_never_escapes.py
@@ -8,6 +8,7 @@ All fixture names carry an "esc732" marker so they cannot collide with other tes
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Optional
 
 import pytest
@@ -68,32 +69,53 @@ GOOD_VALUE_ESC763 = "good_esc763"
 NEEDS_MODE_ESC763 = "needs_esc763"
 OPTIONAL_MODE_ESC763 = "optional_esc763"
 
+# The tier763 markers pin the two-tier logging contract on the same containment sites: an expected judgment
+# failure (TypeError, ValueError, AttributeError) stays at DEBUG, while any other exception class means the
+# callable itself looks broken and must surface at WARNING. Containment (reject / non-match) is unchanged.
+TYPE_POISON_VALUE_TIER763 = "type_poison_tier763"
+CAUSE_KEY_TIER763 = "cause_key_tier763"
+
+# Both modules create their logger via logging.getLogger(__name__), so the class's module IS the logger name.
+PARSER_LOGGER_NAME = FeatureChainParser.__module__
+MIXIN_LOGGER_NAME = FeatureChainParserMixin.__module__
+
 
 def _keyerror_element_validator_esc763(value: Any) -> bool:
-    """Judge one element; the poison value cannot be judged, so raise KeyError (an uncaught class)."""
+    """Judge one element; the poison value raises KeyError (broken-looking), the tier value TypeError (expected)."""
     if value == POISON_VALUE_ESC763:
         raise KeyError("esc763 element_validator cannot judge the poison value")
+    if value == TYPE_POISON_VALUE_TIER763:
+        raise TypeError("tier763 element_validator expected judgment failure")
     return bool(value == GOOD_VALUE_ESC763)
 
 
 def _keyerror_match_guard_esc763(value: Any) -> bool:
-    """Guard the raw value; the poison value cannot be judged, so raise KeyError (an uncaught class)."""
+    """Guard the raw value; the poison value raises KeyError (broken-looking), the tier value TypeError (expected)."""
     if value == POISON_VALUE_ESC763:
         raise KeyError("esc763 match_guard cannot judge the poison value")
+    if value == TYPE_POISON_VALUE_TIER763:
+        raise TypeError("tier763 match_guard expected judgment failure")
     return bool(value == GOOD_VALUE_ESC763)
 
 
 def _keyerror_required_when_esc763(options: Options) -> bool:
-    """Decide if the guarded key is required; a poison driver cannot be judged, so raise KeyError."""
+    """Decide if the guarded key is required; a poison driver raises KeyError, the tier driver TypeError."""
     driver = options.get(DRIVER_KEY_ESC763)
     if driver == POISON_VALUE_ESC763:
         raise KeyError("esc763 required_when cannot judge the poison driver value")
+    if driver == TYPE_POISON_VALUE_TIER763:
+        raise TypeError("tier763 required_when expected judgment failure")
     return bool(driver == NEEDS_MODE_ESC763)
 
 
 def _raise_build_effective_options_esc763(cls: Any, *args: Any, **kwargs: Any) -> Options:
     """Force build_effective_options to raise a plain ValueError: the escape #763 must contain."""
     raise ValueError("esc763 build_effective_options boom")
+
+
+def _raise_keyerror_build_effective_options_tier763(cls: Any, *args: Any, **kwargs: Any) -> Options:
+    """Force build_effective_options to raise KeyError: a broken-looking class that must surface at WARNING."""
+    raise KeyError("tier763 build_effective_options boom")
 
 
 class MockComputeFrameworkEsc732(ComputeFramework):
@@ -297,6 +319,16 @@ def _identify(feature: Feature, accessible_plugins: FeatureGroupEnvironmentMappi
         links=None,
         data_access_collection=None,
     )
+
+
+def _records_at_or_above(caplog: pytest.LogCaptureFixture, logger_name: str, levelno: int) -> list[logging.LogRecord]:
+    """Records the named logger emitted at or above the given level."""
+    return [record for record in caplog.records if record.name == logger_name and record.levelno >= levelno]
+
+
+def _records_at_exactly(caplog: pytest.LogCaptureFixture, logger_name: str, levelno: int) -> list[logging.LogRecord]:
+    """Records the named logger emitted at exactly the given level."""
+    return [record for record in caplog.records if record.name == logger_name and record.levelno == levelno]
 
 
 class TestRaisingElementValidatorIsARejection:
@@ -687,3 +719,206 @@ class TestBuildEffectiveOptionsRaiseIsContained:
         assert "No feature groups found" in message, (
             f"A build_effective_options raise must be a non-match, not an exception out of the engine, but got: {message}"
         )
+
+
+class TestContainedRaiseLogTiers:
+    """Two-tier logging for contained raises: an expected judgment failure (TypeError, ValueError,
+    AttributeError) stays at DEBUG, any other exception class looks like a broken callable and must
+    surface at WARNING. Containment itself (reject / non-match, never escape) is unchanged either way.
+    """
+
+    def test_keyerror_validator_raise_logs_at_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A validator raising KeyError still rejects the value, but the containment surfaces at WARNING."""
+        caplog.set_level(logging.DEBUG, logger=PARSER_LOGGER_NAME)
+
+        with pytest.raises(PropertyValueRejection):
+            FeatureChainParser.match_configuration_feature_chain_parser(
+                VALIDATOR_FEATURE_ESC763,
+                Options(context={VALIDATOR_KEY_ESC763: [POISON_VALUE_ESC763]}),
+                property_mapping=RaisingKeyErrorValidatorFeatureGroupEsc763.PROPERTY_MAPPING,
+                prefix_patterns=[RaisingKeyErrorValidatorFeatureGroupEsc763.PREFIX_PATTERN],
+            )
+
+        warnings = _records_at_or_above(caplog, PARSER_LOGGER_NAME, logging.WARNING)
+        assert warnings, "a KeyError-raising validator looks broken and must log at WARNING"
+        assert any(VALIDATOR_KEY_ESC763 in record.getMessage() for record in warnings)
+
+    def test_typeerror_validator_raise_logs_at_debug_only(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A validator raising TypeError is an expected judgment failure: contained at DEBUG, never WARNING."""
+        caplog.set_level(logging.DEBUG, logger=PARSER_LOGGER_NAME)
+
+        with pytest.raises(PropertyValueRejection):
+            FeatureChainParser.match_configuration_feature_chain_parser(
+                VALIDATOR_FEATURE_ESC763,
+                Options(context={VALIDATOR_KEY_ESC763: [TYPE_POISON_VALUE_TIER763]}),
+                property_mapping=RaisingKeyErrorValidatorFeatureGroupEsc763.PROPERTY_MAPPING,
+                prefix_patterns=[RaisingKeyErrorValidatorFeatureGroupEsc763.PREFIX_PATTERN],
+            )
+
+        assert _records_at_or_above(caplog, PARSER_LOGGER_NAME, logging.WARNING) == []
+        debug_records = _records_at_exactly(caplog, PARSER_LOGGER_NAME, logging.DEBUG)
+        assert debug_records, "the contained TypeError must still log its rejection at DEBUG"
+
+    def test_keyerror_guard_raise_logs_at_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A guard raising KeyError is still a non-match, but the containment surfaces at WARNING."""
+        caplog.set_level(logging.DEBUG, logger=MIXIN_LOGGER_NAME)
+        options = Options(context={GUARD_KEY_ESC763: POISON_VALUE_ESC763})
+
+        result = RaisingKeyErrorGuardFeatureGroupEsc763.match_feature_group_criteria(GUARD_FEATURE_ESC763, options)
+
+        assert result is False
+        warnings = _records_at_or_above(caplog, MIXIN_LOGGER_NAME, logging.WARNING)
+        assert warnings, "a KeyError-raising guard looks broken and must log at WARNING"
+        assert any(GUARD_KEY_ESC763 in record.getMessage() for record in warnings)
+
+    def test_typeerror_guard_raise_logs_at_debug_only(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A guard raising TypeError is an expected judgment failure: contained at DEBUG, never WARNING."""
+        caplog.set_level(logging.DEBUG, logger=MIXIN_LOGGER_NAME)
+        options = Options(context={GUARD_KEY_ESC763: TYPE_POISON_VALUE_TIER763})
+
+        result = RaisingKeyErrorGuardFeatureGroupEsc763.match_feature_group_criteria(GUARD_FEATURE_ESC763, options)
+
+        assert result is False
+        assert _records_at_or_above(caplog, MIXIN_LOGGER_NAME, logging.WARNING) == []
+        debug_records = _records_at_exactly(caplog, MIXIN_LOGGER_NAME, logging.DEBUG)
+        assert debug_records, "the contained TypeError must still log its rejection at DEBUG"
+
+    def test_keyerror_required_when_raise_logs_at_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A predicate raising KeyError is still a non-match, but the containment surfaces at WARNING."""
+        caplog.set_level(logging.DEBUG, logger=PARSER_LOGGER_NAME)
+        options = Options(context={DRIVER_KEY_ESC763: POISON_VALUE_ESC763})
+
+        result = RaisingKeyErrorRequiredWhenFeatureGroupEsc763.match_feature_group_criteria(
+            REQUIRED_WHEN_FEATURE_ESC763, options
+        )
+
+        assert result is False
+        warnings = _records_at_or_above(caplog, PARSER_LOGGER_NAME, logging.WARNING)
+        assert warnings, "a KeyError-raising predicate looks broken and must log at WARNING"
+        owner = RaisingKeyErrorRequiredWhenFeatureGroupEsc763.__name__
+        assert any(
+            owner in record.getMessage() or REQUIRED_WHEN_KEY_ESC763 in record.getMessage() for record in warnings
+        )
+
+    def test_typeerror_required_when_raise_logs_at_debug_only(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A predicate raising TypeError is an expected judgment failure: contained at DEBUG, never WARNING."""
+        caplog.set_level(logging.DEBUG, logger=PARSER_LOGGER_NAME)
+        options = Options(context={DRIVER_KEY_ESC763: TYPE_POISON_VALUE_TIER763})
+
+        result = RaisingKeyErrorRequiredWhenFeatureGroupEsc763.match_feature_group_criteria(
+            REQUIRED_WHEN_FEATURE_ESC763, options
+        )
+
+        assert result is False
+        assert _records_at_or_above(caplog, PARSER_LOGGER_NAME, logging.WARNING) == []
+        debug_records = _records_at_exactly(caplog, PARSER_LOGGER_NAME, logging.DEBUG)
+        assert debug_records, "the contained TypeError must still log its rejection at DEBUG"
+
+    def test_keyerror_build_effective_options_raise_logs_at_warning(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """build_effective_options raising KeyError is still a non-match, but the containment surfaces at WARNING."""
+        caplog.set_level(logging.DEBUG, logger=PARSER_LOGGER_NAME)
+        monkeypatch.setattr(
+            FeatureChainParser,
+            "build_effective_options",
+            classmethod(_raise_keyerror_build_effective_options_tier763),
+        )
+        options = Options(context={DRIVER_KEY_ESC763: OPTIONAL_MODE_ESC763})
+
+        result = RaisingKeyErrorRequiredWhenFeatureGroupEsc763.match_feature_group_criteria(
+            REQUIRED_WHEN_FEATURE_ESC763, options
+        )
+
+        assert result is False
+        warnings = _records_at_or_above(caplog, PARSER_LOGGER_NAME, logging.WARNING)
+        assert warnings, "a KeyError out of build_effective_options looks broken and must log at WARNING"
+        owner = RaisingKeyErrorRequiredWhenFeatureGroupEsc763.__name__
+        assert any(owner in record.getMessage() for record in warnings)
+
+    def test_valueerror_build_effective_options_raise_logs_at_debug_only(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """build_effective_options raising ValueError is an expected failure: contained at DEBUG, never WARNING."""
+        caplog.set_level(logging.DEBUG, logger=PARSER_LOGGER_NAME)
+        monkeypatch.setattr(
+            FeatureChainParser,
+            "build_effective_options",
+            classmethod(_raise_build_effective_options_esc763),
+        )
+        options = Options(context={DRIVER_KEY_ESC763: OPTIONAL_MODE_ESC763})
+
+        result = RaisingKeyErrorRequiredWhenFeatureGroupEsc763.match_feature_group_criteria(
+            REQUIRED_WHEN_FEATURE_ESC763, options
+        )
+
+        assert result is False
+        assert _records_at_or_above(caplog, PARSER_LOGGER_NAME, logging.WARNING) == []
+        debug_records = _records_at_exactly(caplog, PARSER_LOGGER_NAME, logging.DEBUG)
+        assert debug_records, "the contained ValueError must still log its rejection at DEBUG"
+
+
+class TestValidatorCauseChaining:
+    """The PropertyValueRejection a raising validator produces chains the validator's own raise as __cause__.
+
+    The inline mapping records the exact exception instance the validator raised, so the tests assert
+    identity, not just class and message. No FeatureGroup class is defined, so nothing enters the registry.
+    """
+
+    def test_keyerror_validator_cause_is_the_original_exception(self) -> None:
+        """The rejection's __cause__ is the very KeyError instance the validator raised."""
+        raised: list[KeyError] = []
+
+        def validator(value: Any) -> bool:
+            exc = KeyError("tier763 validator cannot judge this value")
+            raised.append(exc)
+            raise exc
+
+        mapping = {
+            CAUSE_KEY_TIER763: PropertySpec(
+                "Raise whose instance must become __cause__ (tier763 fixture)",
+                context=True,
+                strict_validation=True,
+                element_validator=validator,
+            )
+        }
+
+        with pytest.raises(PropertyValueRejection) as exc_info:
+            FeatureChainParser.match_configuration_feature_chain_parser(
+                VALIDATOR_FEATURE_ESC763,
+                Options(context={CAUSE_KEY_TIER763: [POISON_VALUE_ESC763]}),
+                property_mapping=mapping,
+                prefix_patterns=[RaisingKeyErrorValidatorFeatureGroupEsc763.PREFIX_PATTERN],
+            )
+
+        assert len(raised) == 1
+        assert exc_info.value.__cause__ is raised[0]
+
+    def test_typeerror_validator_cause_is_the_original_exception(self) -> None:
+        """The rejection's __cause__ is the very TypeError instance the validator raised."""
+        raised: list[TypeError] = []
+
+        def validator(value: Any) -> bool:
+            exc = TypeError("tier763 validator expected judgment failure")
+            raised.append(exc)
+            raise exc
+
+        mapping = {
+            CAUSE_KEY_TIER763: PropertySpec(
+                "Raise whose instance must become __cause__ (tier763 fixture)",
+                context=True,
+                strict_validation=True,
+                element_validator=validator,
+            )
+        }
+
+        with pytest.raises(PropertyValueRejection) as exc_info:
+            FeatureChainParser.match_configuration_feature_chain_parser(
+                VALIDATOR_FEATURE_ESC763,
+                Options(context={CAUSE_KEY_TIER763: [TYPE_POISON_VALUE_TIER763]}),
+                property_mapping=mapping,
+                prefix_patterns=[RaisingKeyErrorValidatorFeatureGroupEsc763.PREFIX_PATTERN],
+            )
+
+        assert len(raised) == 1
+        assert exc_info.value.__cause__ is raised[0]


### PR DESCRIPTION
Closes #763. Finding 1 of #750, epic #761 phase 1.

## Problem

A raising option-value validator could abort feature identification for **every** candidate feature group. Rejection containment covered only `(TypeError, ValueError, AttributeError)` on the `element_validator` and `match_guard` paths, `required_when` predicates ran with no protection, and the class-definition guard evaluated `required_when` outside `match_parser_criteria`'s `except ValueError`. Upstream, `IdentifyFeatureGroupClass._filter_feature_group_by_criteria` catches only `PropertyValueRejection`, so any other exception (e.g. `KeyError`) escaped and killed the whole run.

## Containment story (one documented rule)

A user-supplied callable in the match path that raises **any** exception means "cannot judge this value", so the value or feature is a rejection / non-match, never an escape. The engine's typed `PropertyValueRejection` catch stays narrow, so the intentional forwarded-name-mismatch `ValueError` (and other actionable guidance) still reaches the user.

Applied at every callable site:

- `element_validator` (`feature_chain_parser.py`): broaden the catch to any exception, then raise `PropertyValueRejection`; also log the raised exception at debug for parity.
- `match_guard` (`feature_chain_parser_mixin.py`): broaden the catch to any exception, treat as non-match.
- `required_when` predicate (`feature_chain_parser.py`): previously unprotected; a raising predicate now makes the feature group a non-match.
- class-definition guard: building the effective options is contained the same way, so nothing the installed guard does can abort identification.

## Tests

Extends `test_option_value_rejection_never_escapes.py` to pin every path with a non-`(TypeError/ValueError/AttributeError)` exception: element_validator, match_guard, required_when predicate, the definition guard end-to-end (standard "No feature groups found", neighbor not poisoned), and `build_effective_options` raising. Over-rejection guards confirm valid values still match.

## Validation

`tox` green: `6345 passed, 170 skipped`, ruff format/check, mypy --strict, bandit, and the license allowlist all pass. Two independent deep reviews (Claude Opus + codex) gated the change; the accepted findings (full guard-path containment and element_validator log parity) are folded in.