### PR TITLE
fix: resolve_feature delegates matching to the engine seam (#755)

### DIFF
--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -25,19 +25,20 @@ from mloda.core.abstract_plugins.components.utils import get_all_subclasses, saf
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.function_extender import Extender
 from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistry
-from mloda.core.abstract_plugins.components.feature import normalize_feature_group_scope
+from mloda.core.abstract_plugins.components.feature import Feature, normalize_feature_group_scope
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.api.plugin_info import ComputeFrameworkInfo, ExtenderInfo, FeatureGroupInfo, ResolvedFeature
 from mloda.core.prepare.accessible_plugins import (
+    FeatureGroupEnvironmentMapping,
     RedefinitionConflictError,
     dedup_feature_group_subclasses,
     registry_for,
 )
 from mloda.core.prepare.identify_feature_group import (
+    IdentifyFeatureGroupClass,
     matches_feature_group_scope,
     scope_callout,
-    split_frameworks_by_capability,
 )
 
 
@@ -362,14 +363,10 @@ def resolve_feature(
 
     Never raises: matching errors are reported in the returned ResolvedFeature.error.
 
-    Design note: resolve_feature intentionally does NOT delegate to IdentifyFeatureGroupClass. It is a
-    never-raising debug API that reports candidates, capability splits, and subtype fields and degrades
-    per candidate, while IdentifyFeatureGroupClass needs an accessible-plugins environment mapping and
-    raises on failure. The scope predicate (matches_feature_group_scope) and callout renderer are shared
-    so scoped semantics cannot drift between the two paths. Beyond that the paths may still differ:
-    _filter_subclasses collapses parent/child purely by issubclass while the engine only collapses candidates
-    sharing the same supported-framework set, and the engine excludes abstract bases while resolve_feature
-    does not.
+    Design note: resolve_feature DELEGATES matching to the #754 evaluation seam
+    IdentifyFeatureGroupClass.evaluate. It only builds the accessible-plugins environment locally
+    (applicability filter, dedup/redefinition-conflict handling) and degrades to never raise; the seam
+    owns name/domain/scope/abstract/subclass filtering, the winner, candidates, and the failure texts.
 
     Args:
         feature_name: The name of the feature to resolve.
@@ -396,8 +393,6 @@ def resolve_feature(
     callout = scope_callout(scope)
     scope_suffix = f" {callout}" if callout else ""
     resolved_options = options if options is not None else Options()
-    is_default_options = not resolved_options.group and not resolved_options.context
-    options_caveat = "default options" if is_default_options else "the provided options"
     allow_redefinition = plugin_collector.allow_redefinition if plugin_collector is not None else False
     validation_errors: list[str] = []
     fg_classes: set[type[FeatureGroup]] = get_all_subclasses(FeatureGroup)
@@ -420,104 +415,66 @@ def resolve_feature(
             candidates=matching_conflicts,
             error=f"{exc}{scope_suffix}",
         )
-    candidates: list[type[FeatureGroup]] = []
     feature_name_obj = FeatureName(feature_name)
+    feature = Feature(feature_name, options=resolved_options, feature_group=scope)
 
+    # Full environment, mirroring PreFilterPlugins: every applicable group mapped to its available declared
+    # frameworks. Guard a raising declaration to an empty set so resolve_feature never raises here.
+    accessible_plugins: FeatureGroupEnvironmentMapping = {}
     for fg in all_fgs:
-        if scope is not None and not matches_feature_group_scope(fg, scope):
-            continue
-        if _match_recording_validation_errors(fg, feature_name_obj, resolved_options, validation_errors):
-            candidates.append(fg)
-
-    if not candidates:
-        error = f"No FeatureGroup found for feature name: {feature_name}{scope_suffix}"
-        if validation_errors:
-            error = f"{error} Rejected during matching: {' | '.join(validation_errors)}"
-        return ResolvedFeature(
-            feature_name=feature_name,
-            feature_group=None,
-            candidates=[],
-            error=error,
+        accessible_plugins[fg] = safe_field(
+            lambda fg=fg: {cfw for cfw in fg.compute_framework_definition() if cfw.is_available()},  # type: ignore[misc]
+            set(),
+            field=f"framework environment for '{feature_name}'",
         )
 
-    # Degrade a raising plugin declaration OPEN (all available declared frameworks); resolve_feature never raises.
-    # The broad catch intentionally drops any partially computed rejection info; degrading open is the contract.
-    split_result: Optional[tuple[set[type[ComputeFramework]], set[type[ComputeFramework]]]] = safe_field(
-        lambda: split_frameworks_by_capability(candidates, feature_name_obj, resolved_options),
+    # The seam does the name/domain/scope/abstract/subclass filtering. Matching or a capability hook can raise;
+    # resolve_feature must not, so degrade any raise into an error result (never-raising contract).
+    evaluation = safe_field_with_error(
+        lambda: IdentifyFeatureGroupClass.evaluate(
+            feature, accessible_plugins, links=None, data_access_collection=None
+        ),
         None,
-        field=f"capability split for '{feature_name}'",
     )
-    if split_result is None:
-        open_supported: set[type[ComputeFramework]] = set()
-        for candidate in candidates:
-            defined: set[type[ComputeFramework]] = safe_field(
-                lambda candidate=candidate: set(candidate.compute_framework_definition()),  # type: ignore[misc]
-                set(),
-                field=f"open-degrade frameworks for '{feature_name}'",
-            )
-            open_supported.update(cfw for cfw in defined if cfw.is_available())
-        split_result = (open_supported, set())
-    supported, rejected = split_result
-    supported_names = sorted(c.get_class_name() for c in supported)
-    rejected_names = sorted(c.get_class_name() for c in rejected)
-    filtered = _filter_subclasses(candidates)
+    result, eval_error = evaluation
+    if result is None:
+        return ResolvedFeature(feature_name, None, [], error=f"{eval_error}{scope_suffix}")
 
-    if not supported and rejected:
-        subtype_unsupported: Optional[str] = None
-        subtype_family_unsupported: Optional[str] = None
-        if len(filtered) == 1:
-            subtype_unsupported, subtype_family_unsupported = _resolved_subtype_fields(
-                filtered[0], feature_name_obj, resolved_options
-            )
-        return ResolvedFeature(
-            feature_name=feature_name,
-            feature_group=None,
-            candidates=candidates,
-            error=(
-                f"Feature '{feature_name}' matches {[c.get_class_name() for c in candidates]} "
-                f"but is unsupported on all installed compute frameworks "
-                f"(evaluated under {options_caveat}): {rejected_names}.{scope_suffix}"
-            ),
-            supported_compute_frameworks=[],
-            unsupported_compute_frameworks=rejected_names,
-            subtype=subtype_unsupported,
-            subtype_family=subtype_family_unsupported,
-        )
+    candidates = sorted(result.criteria_matched, key=lambda c: c.get_class_name())
 
-    if len(filtered) == 1:
-        resolved = filtered[0]
-        subtype, subtype_family = _resolved_subtype_fields(resolved, feature_name_obj, resolved_options)
+    if result.failure_kind is None:
+        winner, supported_frameworks = next(iter(result.identified.items()))
+        available = accessible_plugins.get(winner, set())
+        supported_names = sorted(c.get_class_name() for c in supported_frameworks)
+        unsupported_names = sorted(c.get_class_name() for c in (available - supported_frameworks))
+        subtype, subtype_family = _resolved_subtype_fields(winner, feature_name_obj, resolved_options)
         return ResolvedFeature(
-            feature_name=feature_name,
-            feature_group=resolved,
-            candidates=candidates,
-            error=None,
+            feature_name,
+            winner,
+            candidates,
+            None,
             supported_compute_frameworks=supported_names,
-            unsupported_compute_frameworks=rejected_names,
+            unsupported_compute_frameworks=unsupported_names,
             subtype=subtype,
             subtype_family=subtype_family,
         )
 
-    conflicting_names = [fg.__name__ for fg in filtered]
-    return ResolvedFeature(
-        feature_name=feature_name,
-        feature_group=None,
-        candidates=candidates,
-        error=f"Multiple FeatureGroups match feature name '{feature_name}': {conflicting_names}{scope_suffix}",
-        supported_compute_frameworks=supported_names,
-        unsupported_compute_frameworks=rejected_names,
+    error = _engine_failure_message(feature, accessible_plugins, feature_name, scope_suffix)
+    return ResolvedFeature(feature_name, None, candidates, error=error)
+
+
+def _engine_failure_message(
+    feature: Feature,
+    accessible_plugins: FeatureGroupEnvironmentMapping,
+    feature_name: str,
+    scope_suffix: str,
+) -> str:
+    """Return the engine's failure message for these inputs, degrading to a generic message if the
+    engine's own builders touch a broken plugin declaration (resolve_feature never raises)."""
+    _, error = safe_field_with_error(
+        lambda: IdentifyFeatureGroupClass(feature, accessible_plugins, links=None, data_access_collection=None),
+        None,
     )
-
-
-def _filter_subclasses(feature_groups: list[type[FeatureGroup]]) -> list[type[FeatureGroup]]:
-    """Prefer more specific (child) classes over parent classes."""
-    fgs_to_pop: set[type[FeatureGroup]] = set()
-
-    for i_fg in feature_groups:
-        for o_fg in feature_groups:
-            if i_fg == o_fg:
-                continue
-            if issubclass(i_fg, o_fg):
-                fgs_to_pop.add(o_fg)
-
-    return [fg for fg in feature_groups if fg not in fgs_to_pop]
+    if error is not None:
+        return error
+    return f"No feature groups found for feature name: '{feature_name}'.{scope_suffix}"

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -92,24 +92,15 @@ def _dedup_degrading_on_conflict(
         return dedup_feature_group_subclasses(feature_groups, allow_redefinition=True)
 
 
-def _match_recording_validation_errors(
-    fg_class: type[FeatureGroup],
-    feature_name: FeatureName,
-    options: Options,
-    validation_errors: list[str],
-) -> bool:
-    """Match a feature group, degrading a validation ValueError into "not a match" and recording its message.
+def _matches_criteria_guarded(fg_class: type[FeatureGroup], feature_name: FeatureName, options: Options) -> bool:
+    """Match a feature group for the redefinition-conflict branch, treating any raise as 'not a match'.
 
-    resolve_feature is a non-throwing debug API, but matching can raise ValueError once caller
-    options reach the feature chain parser (e.g. a forwarded option contradicting the feature name).
-    Such a candidate is not a match, and the reason is recorded so it can be surfaced in the error.
+    resolve_feature is a non-throwing debug API: a conflicting candidate whose match hook raises must
+    not take the whole call down.
     """
     try:
         return fg_class.match_feature_group_criteria(feature_name, options, None)
-    except ValueError as exc:
-        message = str(exc)
-        if message not in validation_errors:
-            validation_errors.append(message)
+    except Exception:  # noqa: BLE001  (never-raising debug API)
         return False
 
 
@@ -394,7 +385,6 @@ def resolve_feature(
     scope_suffix = f" {callout}" if callout else ""
     resolved_options = options if options is not None else Options()
     allow_redefinition = plugin_collector.allow_redefinition if plugin_collector is not None else False
-    validation_errors: list[str] = []
     fg_classes: set[type[FeatureGroup]] = get_all_subclasses(FeatureGroup)
     if plugin_collector is not None:
         fg_classes = {fg for fg in fg_classes if plugin_collector.applicable_feature_group_class(fg)}
@@ -407,7 +397,7 @@ def resolve_feature(
             fg
             for fg in raw_conflicts
             if (scope is None or matches_feature_group_scope(fg, scope))
-            and _match_recording_validation_errors(fg, feature_name_obj, resolved_options, validation_errors)
+            and _matches_criteria_guarded(fg, feature_name_obj, resolved_options)
         ]
         return ResolvedFeature(
             feature_name=feature_name,
@@ -416,7 +406,12 @@ def resolve_feature(
             error=f"{exc}{scope_suffix}",
         )
     feature_name_obj = FeatureName(feature_name)
-    feature = Feature(feature_name, options=resolved_options, feature_group=scope)
+    feature, feature_error = safe_field_with_error(
+        lambda: Feature(feature_name, options=resolved_options, feature_group=scope),
+        None,
+    )
+    if feature is None:
+        return ResolvedFeature(feature_name, None, [], error=f"{feature_error}{scope_suffix}")
 
     # Full environment, mirroring PreFilterPlugins: every applicable group mapped to its available declared
     # frameworks. Guard a raising declaration to an empty set so resolve_feature never raises here.
@@ -469,12 +464,17 @@ def _engine_failure_message(
     feature_name: str,
     scope_suffix: str,
 ) -> str:
-    """Return the engine's failure message for these inputs, degrading to a generic message if the
-    engine's own builders touch a broken plugin declaration (resolve_feature never raises)."""
-    _, error = safe_field_with_error(
-        lambda: IdentifyFeatureGroupClass(feature, accessible_plugins, links=None, data_access_collection=None),
-        None,
-    )
-    if error is not None:
-        return error
-    return f"No feature groups found for feature name: '{feature_name}'.{scope_suffix}"
+    """Return the engine's failure message for these inputs.
+
+    The engine builders raise a ValueError carrying the failure text (already including any scope
+    callout); a broken plugin declaration touched while building that text degrades to a generic
+    message so resolve_feature never raises.
+    """
+    generic = f"No feature groups found for feature name: '{feature_name}'.{scope_suffix}"
+    try:
+        IdentifyFeatureGroupClass(feature, accessible_plugins, links=None, data_access_collection=None)
+    except ValueError as exc:
+        return str(exc)
+    except Exception:  # noqa: BLE001  (broken plugin declaration inside the builder; degrade)
+        return generic
+    return generic

--- a/tests/test_core/test_api/test_resolve_feature.py
+++ b/tests/test_core/test_api/test_resolve_feature.py
@@ -7,6 +7,7 @@ and candidate tracking.
 """
 
 import gc
+import inspect
 import linecache
 import sys
 import textwrap
@@ -422,26 +423,27 @@ class TestResolveFeatureCandidates:
     """Tests for resolve_feature candidates list."""
 
     def test_resolve_feature_candidates_contains_all_matches(self) -> None:
-        """Test that candidates list contains all FeatureGroups that matched criteria."""
+        """Test that candidates lists a concrete FeatureGroup that matched criteria."""
         from mloda.core.abstract_plugins.components.utils import get_all_subclasses
 
         all_fgs = list(get_all_subclasses(FeatureGroup))
         assert len(all_fgs) > 0, "Need at least one FeatureGroup for this test"
 
-        # Find a feature group that matches by its class name
-        target_fg = None
+        # A concrete group that matches its own class name and yields candidates. Abstract bases are
+        # no longer candidates under the engine-delegated contract (#755), so skip them; and pick one
+        # whose resolution actually produces candidates so the test is order-independent under xdist.
+        target_candidates: list[type[FeatureGroup]] = []
         for fg in all_fgs:
-            if fg.match_feature_group_criteria(FeatureName(fg.get_class_name()), Options(), None):
-                target_fg = fg
+            if inspect.isabstract(fg):
+                continue
+            if not fg.match_feature_group_criteria(FeatureName(fg.get_class_name()), Options(), None):
+                continue
+            candidates = resolve_feature(fg.get_class_name()).candidates
+            if candidates:
+                target_candidates = candidates
                 break
 
-        assert target_fg is not None, "Need a FeatureGroup that matches its class name"
-        target_name = target_fg.get_class_name()
-
-        result = resolve_feature(target_name)
-
-        # Candidates should include at least the matched feature group
-        assert len(result.candidates) >= 1
+        assert len(target_candidates) >= 1, "Need a concrete FeatureGroup that resolves to candidates"
 
     def test_resolve_feature_candidates_are_feature_group_types(self) -> None:
         """Test that all candidates are Type[FeatureGroup]."""

--- a/tests/test_core/test_api/test_resolve_feature.py
+++ b/tests/test_core/test_api/test_resolve_feature.py
@@ -561,9 +561,9 @@ class TestResolveFeatureCapabilityAware:
     def test_all_rejected_resolution_fails_with_capability_error(self) -> None:
         """When every framework in the definition rejects the op, resolution fails.
 
-        feature_group is None, error names the unsupported framework(s) and includes
-        the 'default options' caveat, and the split lists both frameworks as
-        unsupported with none supported.
+        After #755 the error is the engine's capability-rejection message: it names the
+        unsupported framework(s) and points at supports_compute_framework, with no concept
+        of a 'default options' caveat.
         """
         result = resolve_feature(ALL_REJECTED_CAP_FEATURE)
 
@@ -574,15 +574,16 @@ class TestResolveFeatureCapabilityAware:
         assert "unsupported" in lowered, f"Error must signal 'unsupported', got: {result.error}"
         assert "PandasDataFrame" in result.error, f"Error must name PandasDataFrame, got: {result.error}"
         assert "PythonDictFramework" in result.error, f"Error must name PythonDictFramework, got: {result.error}"
-        assert "default options" in result.error, (
-            f"Error must include the 'default options' caveat, got: {result.error}"
+        # Engine wording: names the capability hook and drops the debug-only phrasings.
+        assert "Pin the feature to a supported compute framework" in result.error, (
+            f"Error must carry the engine's capability-rejection guidance, got: {result.error}"
         )
-
-        # The split lists both frameworks as unsupported and none as supported (subset membership only).
-        assert "PythonDictFramework" in result.unsupported_compute_frameworks
-        assert "PandasDataFrame" in result.unsupported_compute_frameworks
-        assert "PandasDataFrame" not in result.supported_compute_frameworks
-        assert "PythonDictFramework" not in result.supported_compute_frameworks
+        assert "default options" not in result.error, (
+            f"Engine error has no 'default options' caveat, got: {result.error}"
+        )
+        assert "unsupported on all installed compute frameworks" not in result.error, (
+            f"Engine error does not use the debug-only phrasing, got: {result.error}"
+        )
 
 
 class TestResolveFeatureWithOptions:
@@ -662,22 +663,27 @@ class TestResolveFeatureWithOptions:
         assert result.candidates == [OptionGatedResolveFeatureGroup]
         assert result.error is None
 
-    def test_all_rejected_error_keeps_default_options_caveat_without_options(self) -> None:
-        """Without caller options, the all-rejected error still names the default-options caveat."""
+    def test_all_rejected_error_names_frameworks_without_options(self) -> None:
+        """Without caller options, the all-rejected error names the frameworks and has no default-options caveat."""
         result = resolve_feature(ALL_REJECTED_CAP_FEATURE)
 
         assert result.feature_group is None
         assert result.error is not None
-        assert "default options" in result.error
+        # After #755 the engine builds the message; it has no 'default options' concept.
+        assert "default options" not in result.error, (
+            f"Engine error has no 'default options' caveat, got: {result.error}"
+        )
+        assert "PandasDataFrame" in result.error
+        assert "PythonDictFramework" in result.error
 
-    def test_all_rejected_error_drops_default_options_caveat_with_options(self) -> None:
-        """With caller options, the all-rejected error must not claim it evaluated default options."""
+    def test_all_rejected_error_names_frameworks_with_options(self) -> None:
+        """With caller options, the all-rejected error names the frameworks and still has no default-options caveat."""
         result = resolve_feature(ALL_REJECTED_CAP_FEATURE, options=Options(group={PARTITION_BY_KEY: ["id"]}))
 
         assert result.feature_group is None
         assert result.error is not None
         assert "default options" not in result.error, (
-            f"Error must not claim default options when the caller supplied options, got: {result.error}"
+            f"Engine error has no 'default options' caveat, got: {result.error}"
         )
         assert "PandasDataFrame" in result.error
         assert "PythonDictFramework" in result.error
@@ -731,23 +737,28 @@ class TestResolveFeatureOptionsNoneEqualsEmpty:
             f"vs {implicit.error!r}"
         )
 
-    def test_explicit_empty_options_keeps_default_options_caveat(self) -> None:
-        """An explicitly-passed empty Options is the documented default, so it keeps the default-options caveat."""
+    def test_explicit_empty_options_error_names_frameworks(self) -> None:
+        """An explicitly-passed empty Options yields the engine message: frameworks named, no caveat."""
         result = resolve_feature(ALL_REJECTED_CAP_FEATURE, options=Options())
 
         assert result.error is not None
-        assert "default options" in result.error, (
-            f"An empty Options is the default, so the caveat must stay, got: {result.error}"
+        # After #755 the engine builds the message; it has no 'default options' concept.
+        assert "default options" not in result.error, (
+            f"Engine error has no 'default options' caveat, got: {result.error}"
         )
+        assert "PandasDataFrame" in result.error
+        assert "PythonDictFramework" in result.error
 
-    def test_non_empty_options_still_drops_default_options_caveat(self) -> None:
-        """Only a non-empty Options drops the default-options wording."""
+    def test_non_empty_options_error_names_frameworks(self) -> None:
+        """A non-empty Options yields the same engine message: frameworks named, no caveat."""
         result = resolve_feature(ALL_REJECTED_CAP_FEATURE, options=Options(group={PARTITION_BY_KEY: ["id"]}))
 
         assert result.error is not None
         assert "default options" not in result.error, (
-            f"Non-empty caller options must drop the default-options caveat, got: {result.error}"
+            f"Engine error has no 'default options' caveat, got: {result.error}"
         )
+        assert "PandasDataFrame" in result.error
+        assert "PythonDictFramework" in result.error
 
 
 class TestResolveFeatureKeywordOnlyArguments:
@@ -807,7 +818,7 @@ class TestResolveFeatureScopedResolve:
 
         assert result.feature_group is None
         assert result.error is not None
-        assert "Multiple FeatureGroups match" in result.error
+        assert "Multiple feature groups found" in result.error
 
     def test_sibling_class_name_string_scope_resolves_that_sibling(self) -> None:
         """A class-name string scope narrows the ambiguous siblings to exactly the named one."""
@@ -844,7 +855,7 @@ class TestResolveFeatureScopedNoMatch:
         assert result.feature_group is None
         assert result.candidates == []
         assert result.error is not None
-        assert "No FeatureGroup found" in result.error
+        assert "No feature groups found for feature name" in result.error
         assert "Scoped to feature group: 'UnrelatedScopedResolve693FeatureGroup'." in result.error
 
     def test_class_object_scope_excluding_all_matches_reports_scoped_no_match(self) -> None:
@@ -854,7 +865,7 @@ class TestResolveFeatureScopedNoMatch:
         assert result.feature_group is None
         assert result.candidates == []
         assert result.error is not None
-        assert "No FeatureGroup found" in result.error
+        assert "No feature groups found for feature name" in result.error
         assert "Scoped to feature group: 'UnrelatedScopedResolve693FeatureGroup'." in result.error
 
 
@@ -867,7 +878,10 @@ class TestResolveFeatureScopedCapabilityRejection:
 
         assert result.feature_group is None
         assert result.error is not None
-        assert "unsupported on all installed compute frameworks" in result.error
+        # After #755 the engine builds the capability-rejection message; the scope callout is retained.
+        assert "Pin the feature to a supported compute framework" in result.error
+        assert "PandasDataFrame" in result.error
+        assert "PythonDictFramework" in result.error
         assert "Scoped to feature group: 'AllRejectedCapResolveFeatureGroup'." in result.error
 
 
@@ -880,7 +894,7 @@ class TestResolveFeatureScopedAmbiguity:
 
         assert result.feature_group is None
         assert result.error is not None
-        assert "Multiple FeatureGroups match" in result.error
+        assert "Multiple feature groups found" in result.error
         assert "Scoped to feature group: 'ScopedResolveFamilyBase693'." in result.error
 
 

--- a/tests/test_core/test_api/test_resolve_feature.py
+++ b/tests/test_core/test_api/test_resolve_feature.py
@@ -6,6 +6,11 @@ to its matching FeatureGroup class, with support for subclass filtering
 and candidate tracking.
 """
 
+import gc
+import linecache
+import sys
+import textwrap
+
 import pytest
 from typing import Any, Optional
 
@@ -722,6 +727,25 @@ class TestResolveFeatureIsNonThrowing:
         assert result.feature_group is ForwardMismatchResolveFeatureGroup
         assert result.error is None
 
+    def test_unknown_compute_framework_option_does_not_raise(self) -> None:
+        """A bad compute_framework option makes the internal Feature() raise ValueError; it must not escape.
+
+        resolve_feature builds Feature(feature_name, options=..., feature_group=scope) internally. When the
+        caller's options name a non-existent compute framework, the Feature constructor raises ValueError
+        before any matching guard runs. The never-raising debug contract requires that error to surface in
+        ResolvedFeature.error, not propagate.
+        """
+        bad_options = Options(group={"compute_framework": "NoSuchFrameworkXYZ"})
+
+        result = resolve_feature(SPLIT_CAP_FEATURE, options=bad_options)
+
+        assert isinstance(result, ResolvedFeature)
+        assert result.feature_group is None
+        assert result.error is not None
+        assert "NoSuchFrameworkXYZ" in result.error, (
+            f"Error must surface the unknown compute framework reason, got: {result.error}"
+        )
+
 
 class TestResolveFeatureOptionsNoneEqualsEmpty:
     """options=None and options=Options() are indistinguishable, including in error wording."""
@@ -976,3 +1000,82 @@ class TestResolveFeatureScopedEngineParity:
         assert result.feature_group is None
         assert result.error is not None
         assert "Scoped to feature group: 'UnrelatedScopedResolve693FeatureGroup'." in result.error
+
+
+def _exec_conflict_fg(class_name: str, body: str, cell_label: str) -> type[FeatureGroup]:
+    """Exec a FeatureGroup subclass into ``__main__``, registering source in linecache.
+
+    Mirrors the established redefinition-conflict pattern in test_feature_group_dedup.py: the exec'd
+    class reports ``__module__ == "__main__"`` and ``inspect.getsource`` succeeds because the source
+    text is registered in linecache. Re-running with different source under the same qualname produces
+    the (module, qualname) redefinition conflict dedup raises on.
+    """
+    main_mod = sys.modules["__main__"]
+    src = textwrap.dedent(body)
+    filename = f"<{cell_label}>"
+    linecache.cache[filename] = (len(src), None, src.splitlines(keepends=True), filename)
+    exec(compile(src, filename, "exec"), main_mod.__dict__)  # nosec B102
+    return main_mod.__dict__[class_name]  # type: ignore[no-any-return]
+
+
+def _raising_match_conflict_source(qualname: str, feature_name: str, extra_body: str = "") -> str:
+    """Source for a conflicting FeatureGroup whose match hook raises a NON-ValueError (RuntimeError)."""
+    return f"""
+from mloda.core.abstract_plugins.feature_group import FeatureGroup as _FG_BASE_
+
+
+class {qualname}(_FG_BASE_):
+    @classmethod
+    def feature_names_supported(cls):
+        return {{"{feature_name}"}}
+
+    @classmethod
+    def match_feature_group_criteria(cls, feature_name, options, data_access_collection=None):
+        raise RuntimeError("raising match hook during redefinition conflict")
+{extra_body}
+"""
+
+
+@pytest.fixture()
+def _cleanup_main_after() -> Any:
+    """Snapshot ``__main__`` attributes and pop any test-added keys afterwards, even on failure.
+
+    Guarantees the exec'd conflict classes cannot leak into ``FeatureGroup.__subclasses__()`` for
+    later tests on the same xdist worker: the yield teardown runs after the test frame unwinds (so
+    local class refs are gone), pops the newly-bound ``__main__`` keys, and collects.
+    """
+    main_mod = sys.modules["__main__"]
+    snapshot = set(main_mod.__dict__.keys())
+    yield
+    for key in set(main_mod.__dict__.keys()) - snapshot:
+        main_mod.__dict__.pop(key, None)
+    gc.collect()
+
+
+class TestResolveFeatureRaisingMatchDuringConflict:
+    """A conflicting class whose match hook raises a non-ValueError must not escape resolve_feature."""
+
+    def test_raising_match_hook_during_redef_conflict_does_not_raise(self, _cleanup_main_after: Any) -> None:
+        """A RuntimeError from match_feature_group_criteria on a conflicting class must surface as an error.
+
+        The redefinition-conflict branch filters conflicts with a helper that today catches only
+        ValueError, so a conflicting class whose match hook raises RuntimeError propagates out of
+        resolve_feature. The never-raising debug contract requires it to surface in ResolvedFeature.error.
+        """
+        qualname = "RaiseMatchConflictResolveFG755"
+        feature_name = "raise_match_conflict_resolve_feature_755_xyz"
+        src_v1 = _raising_match_conflict_source(qualname, feature_name)
+        src_v2 = _raising_match_conflict_source(
+            qualname,
+            feature_name,
+            extra_body="    def extra_method(self):\n        return 755\n",
+        )
+
+        _exec_conflict_fg(qualname, src_v1, "cell-raise-match-755-v1")
+        _exec_conflict_fg(qualname, src_v2, "cell-raise-match-755-v2")
+
+        result = resolve_feature(feature_name)
+
+        assert isinstance(result, ResolvedFeature)
+        assert result.feature_group is None
+        assert result.error is not None

--- a/tests/test_core/test_api/test_sbdg_resolve_feature_broken_rule.py
+++ b/tests/test_core/test_api/test_sbdg_resolve_feature_broken_rule.py
@@ -1,14 +1,11 @@
-"""Failing test pinning resolve_feature's never-raises contract against a broken
-compute_framework_definition (sbdg defect 1).
+"""resolve_feature's never-raises + fail-closed contract against a broken compute_framework_rule.
 
-The capability split in mloda/core/api/plugin_docs.py (around lines 411-425) is
-safe_field-guarded, but the open-degrade fallback then calls
-candidate.compute_framework_definition() UNGUARDED. A FeatureGroup whose
-compute_framework_rule() raises therefore fails the split (degrading it to None),
-and the fallback re-raises the very exception the guard just swallowed.
-
-Expected failure today: resolve_feature propagates RuntimeError("sbdg rule exploded")
-instead of returning a ResolvedFeature.
+After #755 resolve_feature builds accessible_plugins = {fg: {available declared frameworks}},
+guarding a raising compute_framework_definition() so it degrades to an EMPTY framework set, then
+delegates matching to IdentifyFeatureGroupClass.evaluate(...). A FeatureGroup whose
+compute_framework_rule() raises therefore maps to an empty set: it still matches name+domain+scope
+(so it stays in candidates), but the seam never adds it to the winners because it has no supported
+framework. resolve_feature never raises and the broken group fails closed (does not win).
 
 The broken class is scoped per test (del + gc.collect(), same pattern as
 test_plugin_docs.py) so it does not leak into the session-wide subclass registry.
@@ -56,7 +53,7 @@ def _make_broken_rule_fg() -> type[FeatureGroup]:
 
 
 class TestSbdgResolveFeatureBrokenRule:
-    """resolve_feature never raises, even when the open-degrade fallback path is hit."""
+    """resolve_feature never raises, and a broken-rule group fails closed instead of winning."""
 
     def test_resolve_feature_does_not_propagate_the_rule_exception(self) -> None:
         broken_fg = _make_broken_rule_fg()
@@ -68,14 +65,16 @@ class TestSbdgResolveFeatureBrokenRule:
             del broken_fg
             gc.collect()
 
-    def test_degenerate_resolution_still_names_the_matching_group(self) -> None:
+    def test_broken_rule_group_is_candidate_but_does_not_win(self) -> None:
         broken_fg = _make_broken_rule_fg()
         try:
             result = resolve_feature(SBDG_BROKEN_RULE_FEATURE)
             assert result.feature_name == SBDG_BROKEN_RULE_FEATURE
+            # Still a criteria match (name+domain+scope), so it stays in candidates.
             assert broken_fg in result.candidates
-            # Degenerate path: capability info may be empty, but the resolution itself survives.
-            assert result.feature_group is broken_fg
+            # But its rule raises -> empty framework set -> no supported framework -> fails closed.
+            assert result.feature_group is None
+            assert result.error is not None
             del result
         finally:
             del broken_fg

--- a/tests/test_core/test_api/test_subtype_docs.py
+++ b/tests/test_core/test_api/test_subtype_docs.py
@@ -379,26 +379,37 @@ class TestSubDeclDocContractCResolvedFeatureSubtype:
 
 
 class TestSubDeclDocContractDUnsupportedEverywhere:
-    """Contract D: the unsupported-everywhere branch still reports the resolved subtype."""
+    """Contract D: the unsupported-everywhere failure surfaces the rejected frameworks via the engine's
+    error text, not via structured split fields or a resolved subtype.
 
-    def test_unsupported_everywhere_still_reports_subtype(self) -> None:
+    After #755 resolve_feature delegates the all-rejected failure to the engine, whose error names the
+    frameworks. The delegated failure path carries no structured capability split and no resolved subtype.
+    """
+
+    def test_unsupported_everywhere_surfaces_engine_error(self) -> None:
         result = resolve_feature("value__median_sbddr4")
         assert result.feature_group is None
         assert result.candidates == [SubDeclDocR4RejectingFG]
         assert result.error is not None
-        assert "unsupported" in result.error
+        # Engine wording names the frameworks and the capability hook.
+        assert "Unsupported compute framework(s)" in result.error
+        assert "PythonDictFramework" in result.error
+        assert "Pin the feature to a supported compute framework" in result.error
+        # The delegated failure path returns the ResolvedFeature defaults: no structured split, no subtype.
         assert result.supported_compute_frameworks == []
-        assert result.unsupported_compute_frameworks == ["PythonDictFramework"]
-        assert result.subtype == "median"
+        assert result.unsupported_compute_frameworks == []
+        assert result.subtype is None
         assert result.subtype_family is None
 
-    def test_unsupported_everywhere_parametric_instance_reports_family(self) -> None:
+    def test_unsupported_everywhere_parametric_instance_surfaces_engine_error(self) -> None:
         result = resolve_feature("value__ntile_3_sbddr4")
         assert result.feature_group is None
         assert result.error is not None
-        assert "unsupported" in result.error
-        assert result.subtype == "ntile_3"
-        assert result.subtype_family == "ntile"
+        assert "Unsupported compute framework(s)" in result.error
+        assert "PythonDictFramework" in result.error
+        # No structured subtype on the delegated failure path.
+        assert result.subtype is None
+        assert result.subtype_family is None
 
 
 class TestSubDeclDocContractERaisingResolverDegrades:

--- a/tests/test_core/test_api/test_subtype_docs_degradation.py
+++ b/tests/test_core/test_api/test_subtype_docs_degradation.py
@@ -1,8 +1,10 @@
-"""Failing tests pinning louder degradation of the subtype surfaces (issue #639 follow-up).
+"""Tests for the subtype surfaces around resolve_feature and the docs (issue #639 follow-up).
 
-Pins: a raising supports_compute_framework override degrades the resolve_feature
-capability split OPEN (all declared frameworks supported) with a warning, and a
-bogus 'supported' framework name surfaces as subtype_error in the docs.
+After #755 resolve_feature delegates matching to the engine seam, which does not guard
+supports_compute_framework: a raising hook propagates out of evaluate. resolve_feature catches it to
+preserve its never-raises contract and fails closed (no winner, error carries the hook's failure
+text). The old "degrade OPEN + warn" behavior is gone. A bogus 'supported' framework name still
+surfaces as subtype_error in the docs.
 """
 
 import logging
@@ -85,22 +87,23 @@ def _sbfix_doc_for(name: str) -> FeatureGroupInfo:
     return exact[0]
 
 
-class TestSbfixRaisingHookDegradesOpen:
-    """A raising capability hook degrades the split OPEN, not empty, and warns."""
+class TestSbfixRaisingHookFailsClosed:
+    """A raising capability hook fails closed: no winner, error carries the hook text, no raise."""
 
-    def test_resolves_with_all_declared_frameworks_supported(self) -> None:
+    def test_raising_hook_fails_closed_without_raising(self) -> None:
+        # The seam does not guard supports_compute_framework, so the hook raises from inside evaluate.
+        # resolve_feature catches it: no winner, and the hook's failure text surfaces in the error.
         result = resolve_feature(SBFIX_HOOK_FEATURE)
-        assert result.feature_group is SbfixRaisingHookFG
-        assert result.error is None
-        assert result.supported_compute_frameworks == ["PythonDictFramework"]
-        assert result.unsupported_compute_frameworks == []
+        assert result.feature_group is None
+        assert result.error is not None
+        assert "sbfix hook exploded" in result.error
 
-    def test_degradation_is_logged_as_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+    def test_raising_hook_is_surfaced_not_logged_as_degradation(self, caplog: pytest.LogCaptureFixture) -> None:
         with caplog.at_level(logging.WARNING):
             result = resolve_feature(SBFIX_HOOK_FEATURE)
-        assert result.feature_group is SbfixRaisingHookFG
-        assert "degraded" in caplog.text.lower()
-        assert "sbfix hook exploded" in caplog.text
+        assert result.feature_group is None
+        assert result.error is not None
+        assert "sbfix hook exploded" in result.error
 
 
 class TestSbfixBogusSupportedSurfacedInDocs:

--- a/tests/test_core/test_resolution_parity/test_verified_false_positives.py
+++ b/tests/test_core/test_resolution_parity/test_verified_false_positives.py
@@ -2,9 +2,10 @@
 
 Each of the three verified user-visible false positives between the engine matcher
 (IdentifyFeatureGroupClass) and the debug API (resolve_feature) is pinned by a pair of tests
-sharing one probe family: one engine assertion, one resolve_feature assertion. Every assertion
-here PASSES against current code. Assertions marked "PINS CURRENT DIVERGENCE (#755)" pin behavior
-that #755 (resolve_feature delegates to the engine seam) will flip to the target contract.
+sharing one probe family: one engine assertion, one resolve_feature assertion. The engine-side
+assertions pass against current code. The three resolve_feature-side tests now assert the post-#755
+target (resolve_feature delegates to the engine seam), so they FAIL against the current, still-diverging
+implementation until the delegation lands and engine and debug agree.
 
 This is deliberately NOT the full 17-way divergence matrix from #722: the presentation-only
 divergences are erased wholesale when resolve_feature delegates, so they need no individual pins.
@@ -148,18 +149,20 @@ def test_engine_rejects_lone_abstract_match() -> None:
     assert "Only abstract feature group base(s) matched" in str(exc_info.value)
 
 
-def test_resolve_feature_returns_lone_abstract_match() -> None:
-    """resolve_feature resolves the same uninstantiable abstract base as the winner."""
+def test_resolve_feature_rejects_lone_abstract_match() -> None:
+    """resolve_feature refuses a lone abstract base, matching the engine's abstract-only rejection."""
     assert inspect.isabstract(AbstractOnlyProbe753), "fixture must be abstract"
 
     collector = PluginCollector.enabled_feature_groups({AbstractOnlyProbe753})
     result = resolve_feature(ABSTRACT_ONLY_FEATURE, plugin_collector=collector)
 
-    # PINS CURRENT DIVERGENCE (#755): the uninstantiable abstract base wins on the debug path while
-    # the engine refuses it; #755 makes resolve_feature reject the abstract winner too.
-    assert result.feature_group is AbstractOnlyProbe753
-    assert result.error is None
-    assert result.candidates == [AbstractOnlyProbe753]
+    # #755 target: resolve_feature delegates to the engine seam, which excludes abstract bases from the
+    # winners and reports the abstract-only error. The uninstantiable base no longer wins on the debug path.
+    assert result.feature_group is None
+    assert result.error is not None
+    assert "Only abstract feature group base(s) matched" in result.error
+    # Abstract-only matches are not concrete candidates: criteria_matched is empty.
+    assert result.candidates == []
 
 
 # ---------------------------------------------------------------------------
@@ -189,20 +192,19 @@ def test_engine_unavailable_only_framework_raises_no_feature_groups() -> None:
         )
 
 
-def test_resolve_feature_unavailable_only_framework_reads_as_runnable() -> None:
-    """resolve_feature reports success for a feature the engine can never run."""
+def test_resolve_feature_unavailable_only_framework_fails_closed() -> None:
+    """resolve_feature fails closed for a feature whose only declared framework is not installed."""
     assert CfwUnavailable753.is_available() is False  # premise guard
 
     collector = PluginCollector.enabled_feature_groups({UnavailableOnlyProbe753})
     result = resolve_feature(UNAVAILABLE_FEATURE, plugin_collector=collector)
 
-    # PINS CURRENT DIVERGENCE (#755): a feature whose only framework is not installed reads as
-    # runnable. The capability split skips unavailable frameworks, so supported and rejected are
-    # both empty and the "if not supported and rejected" guard never fires. #755 makes this fail closed.
-    assert result.feature_group is UnavailableOnlyProbe753
-    assert result.error is None
+    # #755 target: the sole declared framework is unavailable, so the engine seam yields no winner and
+    # resolve_feature fails closed instead of reading as runnable.
+    assert result.feature_group is None
+    assert result.error is not None
+    assert "No feature groups found for feature name: 'probe753_unavailable'" in result.error
     assert result.supported_compute_frameworks == []
-    assert result.unsupported_compute_frameworks == []
 
 
 # ---------------------------------------------------------------------------
@@ -230,17 +232,19 @@ def test_engine_parent_child_differing_framework_sets_stays_ambiguous() -> None:
     assert "ChildProbe753" in message
 
 
-def test_resolve_feature_parent_child_unions_framework_attribution() -> None:
-    """resolve_feature credits the child winner with the parent-only framework it never declares."""
+def test_resolve_feature_parent_child_stays_ambiguous() -> None:
+    """resolve_feature keeps the differing-framework-set parent/child pair ambiguous, like the engine."""
     collector = PluginCollector.enabled_feature_groups({ParentProbe753, ChildProbe753})
     result = resolve_feature(PARENT_CHILD_FEATURE, plugin_collector=collector)
 
-    # PINS CURRENT DIVERGENCE (#755): _filter_subclasses collapses purely by issubclass so the child
-    # wins, and the capability split is unioned across ALL candidates, so CfwQ753 is reported as
-    # supported although the winner ChildProbe753 never declares it. #755 attributes per winner only.
-    assert result.feature_group is ChildProbe753
-    assert result.error is None
+    # #755 target: resolve_feature delegates to the engine seam. The parent and child declare differing
+    # framework sets ({CfwP753, CfwQ753} vs {CfwP753}), which blocks the seam's subclass collapse, so the
+    # pair stays ambiguous. The debug path no longer collapses to the child nor unions CfwQ753 (the
+    # parent-only framework) into the winner's attribution. Framework credit is per winner only.
+    assert result.feature_group is None
+    assert result.error is not None
+    assert "Multiple feature groups found" in result.error
+    assert "ParentProbe753" in result.error
+    assert "ChildProbe753" in result.error
     assert set(result.candidates) == {ParentProbe753, ChildProbe753}
-    assert CfwP753.get_class_name() in result.supported_compute_frameworks
-    assert CfwQ753.get_class_name() in result.supported_compute_frameworks
-    assert result.unsupported_compute_frameworks == []
+    assert CfwQ753.get_class_name() not in result.supported_compute_frameworks


### PR DESCRIPTION
Closes #755.

## What

`resolve_feature` in `mloda/core/api/plugin_docs.py` reimplemented the engine's feature-group matcher: its own candidate filtering, a capability split unioned across candidates, a pure-`issubclass` subclass collapse, and bespoke error strings. That divergence produced the three verified false positives pinned by #753. This delegates matching to the #754 evaluation seam `IdentifyFeatureGroupClass.evaluate`, so the debug tool and the real engine agree by construction.

`resolve_feature` now only builds the accessible-plugins environment locally (applicability filter, dedup / redefinition-conflict handling) and degrades so it never raises. The seam owns name/domain/scope/abstract/subclass filtering, the winner, the candidates, and the failure texts. Framework attribution is per winner only (supported = the winner's own supported frameworks; unsupported = the winner's available declared frameworks minus those). `_filter_subclasses` and the bespoke capability / open-degrade block are deleted.

## Sanctioned behavior changes (engine/debug agreement, per #722)

- An abstract base never wins; it fails with the engine's abstract-only error.
- A group whose only declared framework is unavailable fails closed instead of reading as runnable.
- A parent/child pair with differing framework sets stays ambiguous (no more collapse-to-child with the parent-only framework unioned in).
- A broken or raising capability declaration fails honestly rather than degrading open, while `resolve_feature` still never raises.
- The all-rejected failure surfaces the rejected frameworks via the engine's error text rather than structured fields or a resolved subtype (framework info moves from `unsupported_compute_frameworks` into the error string).

The paired characterization tests from #753 are flipped to assert engine/debug agreement, and the dependent debug-affordance tests (`test_sbdg_resolve_feature_broken_rule`, `test_subtype_docs_degradation`, `test_subtype_docs` Contract D) are migrated to the honest-failure contract.

## Reviews

Two independent deep reviews (a fresh Claude Opus pass and codex) gated the change. Accepted findings, fixed in the second commit:

- Guard the internally built `Feature(...)` so an unknown `compute_framework` option is returned as `error` instead of raising (never-raising hole).
- Broaden the redefinition-conflict branch's match guard so a conflicting class whose match hook raises a non-`ValueError` cannot escape.
- Drop the now-dead `validation_errors` accumulation.
- Make `_engine_failure_message` return the engine's `ValueError` text (which already carries the scope callout) and degrade a broken plugin declaration to the generic message with the scope suffix.

Both new never-raising cases are covered by added regression tests.

Rejected (noted): building the failure message from the existing `EvaluationResult` instead of re-running the engine would need the engine's error builders exposed off `EvaluationResult`, a #754 follow-up; the double-run is acceptable for a debug API.

## Testing

`tox` passes: full pytest suite, `ruff format --check`, `ruff check`, license allowlist, `mypy --strict`, and `bandit` all green.