### PR TITLE
fix: unpack singleton collections in the forwarded-name mismatch guard

### DIFF
--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -352,7 +352,12 @@ class FeatureChainParserMixin:
         if prop_key is None or prop_key not in options.inherited_group_keys:
             return
         inherited_value = options.get(prop_key)
-        if inherited_value is None or str(inherited_value) == operation_config:
+        if inherited_value is None:
+            return
+        # A singleton collection equals its sole element, exactly as _unpack_property_value treats it
+        # everywhere else; only a differing or multi-value forward is a real mismatch.
+        unpacked = FeatureChainParser._unpack_property_value(inherited_value)
+        if len(unpacked) == 1 and str(unpacked[0]) == operation_config:
             return
         message = (
             f"Feature '{feature_name}': option '{prop_key}' was forwarded from a consumer with value "

--- a/tests/test_core/test_abstract_plugins/test_components/test_forwarded_name_mismatch.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_forwarded_name_mismatch.py
@@ -23,6 +23,7 @@ other tests in the global plugin registry.
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 import pytest
 
@@ -58,7 +59,7 @@ class _NameMismatchChainedGroup(FeatureChainParserMixin):
     }
 
 
-def _inherited_child_options(consumer_group: dict[str, str]) -> Options:
+def _inherited_child_options(consumer_group: dict[str, Any]) -> Options:
     """Build child options exactly like the engine does: inherit_from the consumer."""
     child_options = Options()
     child_options.inherit_from(Options(group=consumer_group))
@@ -146,3 +147,69 @@ class TestForwardedNameMismatch:
         result = _NameMismatchChainedGroup.match_feature_group_criteria(STRING_FEATURE_NAME, child_options)
 
         assert result is True
+
+
+class TestForwardedSingletonUnpack:
+    """Issue #764: a forwarded SINGLETON collection whose sole element equals the name-parsed
+    value must match, because _unpack_property_value treats ['sum'] and 'sum' as equivalent
+    everywhere else. A genuine mismatch, and a non-singleton collection, must still raise.
+    """
+
+    def test_forwarded_singleton_list_equal_value_matches(self) -> None:
+        """A forwarded one-element list equal to the name value unpacks to it and matches."""
+        child_options = _inherited_child_options({OPERATION_KEY: ["sum"]})
+        assert child_options.inherited_group_keys == frozenset({OPERATION_KEY})  # precondition
+
+        result = _NameMismatchChainedGroup.match_feature_group_criteria(STRING_FEATURE_NAME, child_options)
+
+        assert result is True
+
+    def test_forwarded_singleton_tuple_equal_value_matches(self) -> None:
+        """A forwarded one-element tuple equal to the name value unpacks to it and matches."""
+        child_options = _inherited_child_options({OPERATION_KEY: ("sum",)})
+        assert child_options.inherited_group_keys == frozenset({OPERATION_KEY})  # precondition
+
+        result = _NameMismatchChainedGroup.match_feature_group_criteria(STRING_FEATURE_NAME, child_options)
+
+        assert result is True
+
+    def test_forwarded_singleton_set_equal_value_matches(self) -> None:
+        """A forwarded one-element set equal to the name value unpacks to it and matches."""
+        child_options = _inherited_child_options({OPERATION_KEY: {"sum"}})
+        assert child_options.inherited_group_keys == frozenset({OPERATION_KEY})  # precondition
+
+        result = _NameMismatchChainedGroup.match_feature_group_criteria(STRING_FEATURE_NAME, child_options)
+
+        assert result is True
+
+    def test_forwarded_singleton_list_differing_value_still_raises(self) -> None:
+        """A forwarded one-element list contradicting the name value stays a genuine mismatch."""
+        child_options = _inherited_child_options({OPERATION_KEY: ["max"]})
+        assert child_options.inherited_group_keys == frozenset({OPERATION_KEY})  # precondition
+
+        with pytest.raises(ValueError) as exc_info:
+            _NameMismatchChainedGroup.match_feature_group_criteria(STRING_FEATURE_NAME, child_options)
+
+        message = str(exc_info.value)
+        assert "max" in message
+        assert "forward_group_exclude" in message
+
+    def test_forwarded_multi_element_list_still_raises(self) -> None:
+        """A multi-element forwarded list is not a singleton and contradicts the scalar name value."""
+        child_options = _inherited_child_options({OPERATION_KEY: ["sum", "max"]})
+        assert child_options.inherited_group_keys == frozenset({OPERATION_KEY})  # precondition
+
+        with pytest.raises(ValueError) as exc_info:
+            _NameMismatchChainedGroup.match_feature_group_criteria(STRING_FEATURE_NAME, child_options)
+
+        assert "forward_group_exclude" in str(exc_info.value)
+
+    def test_forwarded_empty_collection_still_raises(self) -> None:
+        """An empty forwarded collection unpacks to length 0, not a singleton, so it still raises."""
+        child_options = _inherited_child_options({OPERATION_KEY: []})
+        assert child_options.inherited_group_keys == frozenset({OPERATION_KEY})  # precondition
+
+        with pytest.raises(ValueError) as exc_info:
+            _NameMismatchChainedGroup.match_feature_group_criteria(STRING_FEATURE_NAME, child_options)
+
+        assert "forward_group_exclude" in str(exc_info.value)


### PR DESCRIPTION
Closes #764.

## Problem

The forwarded-name mismatch guard (`_validate_forwarded_name_mismatch`) compared `str(inherited_value)` against the name-parsed value. A forwarded singleton collection (`["sum"]`, `("sum",)`, `{"sum"}`) stringifies to `"['sum']"` and never equalled the name-encoded `"sum"`, so it raised a spurious mismatch `ValueError`, even though `_unpack_property_value` treats `["sum"]` and `"sum"` as equivalent everywhere else. Finding 2 of #750, epic #761 phase 1.

## Fix

Unpack `inherited_value` through the canonical `FeatureChainParser._unpack_property_value` and treat the forward as a match only when it yields exactly one element whose `str()` equals the name-parsed value. This subsumes the old scalar comparison unchanged. Differing, multi-value, and empty collections still raise as genuine mismatches.

## Tests

New `TestForwardedSingletonUnpack` in `test_forwarded_name_mismatch.py`:

- list / tuple / set singletons equal to the name value now match
- differing singleton (`["max"]`), multi-element (`["sum", "max"]`, len 2), and empty (`[]`, len 0) collections still raise, each asserting the guard message

The existing helper `_inherited_child_options` is widened to `dict[str, Any]` (the type `Options.__init__` already accepts) so collection-valued forwards type-check.

## Validation

Full `tox` gate green: pytest (6363 passed, 170 skipped), ruff format + check, license allowlist, `mypy --strict`, bandit.
