### PR TITLE
fix: resolve_subtype handles compiled PREFIX_PATTERNs instead of failing open

### DIFF
--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -207,11 +207,7 @@ class FeatureGroup(ABC):
 
         source, separator, _ = name.rpartition(CHAIN_SEPARATOR)
         if separator and source:
-            patterns = [
-                pattern
-                for pattern in (getattr(cls, "PREFIX_PATTERN", None), getattr(cls, "SUFFIX_PATTERN", None))
-                if isinstance(pattern, str)
-            ]
+            patterns = FeatureChainParser.prefix_patterns_of(cls)
             if patterns:
                 # Malformed patterns degrade to the options fallback instead of raising.
                 parsed = safe_field(lambda: FeatureChainParser.parse_feature_name(name, patterns)[0], None)

--- a/tests/test_core/test_prepare/test_subtype_matching.py
+++ b/tests/test_core/test_prepare/test_subtype_matching.py
@@ -21,6 +21,8 @@ MATCH_BETA_SUPPORTED = frozenset({"sum", "lag"})
 MATCH_PLAIN_FEATURE = "subdeclm_plain_feature"
 COMPILED_KEY = "subdeclmc_window_function"
 COMPILED_BETA_SUPPORTED = frozenset({"sum", "lag"})
+COMPILED_SUFFIX_KEY = "subdeclmcs_window_function"
+COMPILED_SUFFIX_BETA_SUPPORTED = frozenset({"sum", "lag"})
 RANK_UNIVERSE = frozenset({"dense", "ordinal", "ntile"})
 FRAME_LITERALS = frozenset({"rows_1", "rows_7"})
 FRAME_UNIVERSE = FRAME_LITERALS | {"rows"}
@@ -67,6 +69,28 @@ class SubDeclMatchCompiledWindowFG(FeatureChainParserMixin, FeatureGroup):
     PREFIX_PATTERN = re.compile(r".*__([\w]+)_subdeclmcompiled$")
     PROPERTY_MAPPING = {
         COMPILED_KEY: property_spec(
+            "Window function subtype.",
+            strict=True,
+            allowed_values={"median": "Median", "sum": "Sum", "lag": "Lag"},
+        ),
+    }
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {SubDeclMatchFwAlpha, SubDeclMatchFwBeta}
+
+
+class SubDeclMatchCompiledSuffixFG(FeatureChainParserMixin, FeatureGroup):
+    """Compiled-SUFFIX_PATTERN twin: prefix_patterns_of gathers SUFFIX_PATTERN too, so it must resolve alike."""
+
+    SUBTYPES = SubtypeDeclaration(
+        key=COMPILED_SUFFIX_KEY,
+        parametric_families={"ntile": "N-tile bucketing"},
+        supported={SubDeclMatchFwBeta.get_class_name(): COMPILED_SUFFIX_BETA_SUPPORTED},
+    )
+    SUFFIX_PATTERN = re.compile(r".*__([\w]+)_subdeclmsuffix$")
+    PROPERTY_MAPPING = {
+        COMPILED_SUFFIX_KEY: property_spec(
             "Window function subtype.",
             strict=True,
             allowed_values={"median": "Median", "sum": "Sum", "lag": "Lag"},
@@ -376,6 +400,24 @@ class TestCompiledPrefixPatternParity:
         }
 
         _, compute_frameworks = _identify(feature, accessible_plugins).get()
+        # Pin resolution directly: pre-fix the dropped compiled pattern returns None, so routing merely fails open.
+        assert SubDeclMatchCompiledWindowFG.resolve_subtype("value__sum_subdeclmcompiled", Options()) == "sum"
         assert compute_frameworks == {SubDeclMatchFwAlpha, SubDeclMatchFwBeta}, (
             f"'sum' is supported on SubDeclMatchFwBeta and must run on both frameworks; got {compute_frameworks}"
+        )
+
+    def test_compiled_suffix_pattern_resolves_and_routes_like_prefix(self) -> None:
+        # resolve_subtype gathers SUFFIX_PATTERN via prefix_patterns_of, so a compiled suffix must resolve alike.
+        assert SubDeclMatchCompiledSuffixFG.resolve_subtype("value__median_subdeclmsuffix", Options()) == "median"
+
+        feature = Feature("value__median_subdeclmsuffix")
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            SubDeclMatchCompiledSuffixFG: {SubDeclMatchFwAlpha, SubDeclMatchFwBeta},
+        }
+
+        feature_group_class, compute_frameworks = _identify(feature, accessible_plugins).get()
+        assert feature_group_class is SubDeclMatchCompiledSuffixFG
+        assert compute_frameworks == {SubDeclMatchFwAlpha}, (
+            f"'median' is unsupported on SubDeclMatchFwBeta and must be routed around even when the compiled "
+            f"pattern is a SUFFIX_PATTERN; the dropped pattern fails open and keeps {compute_frameworks}"
         )

--- a/tests/test_core/test_prepare/test_subtype_matching.py
+++ b/tests/test_core/test_prepare/test_subtype_matching.py
@@ -19,6 +19,8 @@ MATCH_KEY = "subdeclm_window_function"
 MATCH_WINDOW_UNIVERSE = frozenset({"median", "sum", "lag", "ntile"})
 MATCH_BETA_SUPPORTED = frozenset({"sum", "lag"})
 MATCH_PLAIN_FEATURE = "subdeclm_plain_feature"
+COMPILED_KEY = "subdeclmc_window_function"
+COMPILED_BETA_SUPPORTED = frozenset({"sum", "lag"})
 RANK_UNIVERSE = frozenset({"dense", "ordinal", "ntile"})
 FRAME_LITERALS = frozenset({"rows_1", "rows_7"})
 FRAME_UNIVERSE = FRAME_LITERALS | {"rows"}
@@ -43,6 +45,28 @@ class SubDeclMatchWindowFG(FeatureChainParserMixin, FeatureGroup):
     PREFIX_PATTERN = r".*__([\w]+)_subdeclmw$"
     PROPERTY_MAPPING = {
         MATCH_KEY: property_spec(
+            "Window function subtype.",
+            strict=True,
+            allowed_values={"median": "Median", "sum": "Sum", "lag": "Lag"},
+        ),
+    }
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {SubDeclMatchFwAlpha, SubDeclMatchFwBeta}
+
+
+class SubDeclMatchCompiledWindowFG(FeatureChainParserMixin, FeatureGroup):
+    """Compiled-pattern twin of SubDeclMatchWindowFG; a compiled PREFIX_PATTERN must resolve like a str one."""
+
+    SUBTYPES = SubtypeDeclaration(
+        key=COMPILED_KEY,
+        parametric_families={"ntile": "N-tile bucketing"},
+        supported={SubDeclMatchFwBeta.get_class_name(): COMPILED_BETA_SUPPORTED},
+    )
+    PREFIX_PATTERN = re.compile(r".*__([\w]+)_subdeclmcompiled$")
+    PROPERTY_MAPPING = {
+        COMPILED_KEY: property_spec(
             "Window function subtype.",
             strict=True,
             allowed_values={"median": "Median", "sum": "Sum", "lag": "Lag"},
@@ -316,3 +340,42 @@ class TestSubDeclMatchPlanningNeverRaises:
         )
         assert supported == {SubDeclMatchFwAlpha, SubDeclMatchFwBeta}
         assert rejected == set()
+
+
+class TestCompiledPrefixPatternParity:
+    """A compiled PREFIX_PATTERN must resolve and route exactly like its string sibling (issue #765)."""
+
+    def test_compiled_pattern_resolves_same_subtype_as_string_sibling(self) -> None:
+        # The matcher accepts the feature on both forms; resolution must not fail open on the compiled one.
+        assert SubDeclMatchCompiledWindowFG.match_feature_group_criteria("value__median_subdeclmcompiled", Options())
+        string_subtype = SubDeclMatchWindowFG.resolve_subtype("value__median_subdeclmw", Options())
+        compiled_subtype = SubDeclMatchCompiledWindowFG.resolve_subtype("value__median_subdeclmcompiled", Options())
+        assert string_subtype == "median"
+        assert compiled_subtype == string_subtype, (
+            f"A compiled PREFIX_PATTERN must resolve the subtype like the string form '{string_subtype}'; "
+            f"the guard drops the re.Pattern and returns {compiled_subtype}."
+        )
+
+    def test_unsupported_subtype_routes_around_incapable_framework(self) -> None:
+        feature = Feature("value__median_subdeclmcompiled")
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            SubDeclMatchCompiledWindowFG: {SubDeclMatchFwAlpha, SubDeclMatchFwBeta},
+        }
+
+        feature_group_class, compute_frameworks = _identify(feature, accessible_plugins).get()
+        assert feature_group_class is SubDeclMatchCompiledWindowFG
+        assert compute_frameworks == {SubDeclMatchFwAlpha}, (
+            f"'median' is unsupported on SubDeclMatchFwBeta and must be routed around even when PREFIX_PATTERN "
+            f"is compiled; the dropped pattern fails open and keeps {compute_frameworks}"
+        )
+
+    def test_supported_subtype_runs_on_both_frameworks(self) -> None:
+        feature = Feature("value__sum_subdeclmcompiled")
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            SubDeclMatchCompiledWindowFG: {SubDeclMatchFwAlpha, SubDeclMatchFwBeta},
+        }
+
+        _, compute_frameworks = _identify(feature, accessible_plugins).get()
+        assert compute_frameworks == {SubDeclMatchFwAlpha, SubDeclMatchFwBeta}, (
+            f"'sum' is supported on SubDeclMatchFwBeta and must run on both frameworks; got {compute_frameworks}"
+        )


### PR DESCRIPTION
Closes #765. Part of epic #761, phase 1.

## Problem

A compiled `PREFIX_PATTERN` silently disabled subtype enforcement. The matcher collects name patterns via `FeatureChainParser.prefix_patterns_of`, which does not filter by type, so a compiled `re.Pattern` matched the feature. But `resolve_subtype` collected patterns with an inline `isinstance(pattern, str)` filter, dropped the compiled pattern, returned `None`, and the declared subtype support matrix went unenforced (failed open). The two functions disagreed on which patterns exist.

## Fix

`resolve_subtype` now collects through the same canonical `FeatureChainParser.prefix_patterns_of(cls)` the matcher uses, so matcher and resolver never see different patterns. `parse_feature_name` already accepts a str or a compiled pattern (it uses `re.match`), and the malformed-pattern degrade-to-fallback path via `safe_field` is unchanged. No shipped plugin uses a compiled pattern, so there is no behavior change for existing plugins and no migration.

One line changed in `mloda/core/abstract_plugins/feature_group.py`:

```python
patterns = FeatureChainParser.prefix_patterns_of(cls)
```

replaces the inline `isinstance(pattern, str)`-filtered comprehension.

## Tests

`tests/test_core/test_prepare/test_subtype_matching.py`:

- A compiled-`PREFIX_PATTERN` feature group resolves subtypes identically to its string sibling, and the support matrix is enforced at match time (unsupported subtype routed around the incapable framework, supported subtype runs on both). Both assertions fail on the pre-fix code (fail-open) and pass after.
- A compiled-`SUFFIX_PATTERN` twin pins the symmetric path, since `prefix_patterns_of` gathers both pattern kinds.

Full `tox` gate green: pytest, ruff format/check, mypy `--strict`, bandit, license allowlist.
