### PR TITLE
feat: let resolve_feature express the full resolution request (#756)

### DIFF
--- a/mloda/core/api/feature_config/models.py
+++ b/mloda/core/api/feature_config/models.py
@@ -12,7 +12,7 @@ from typing import Any, Optional
 def validate_feature_group_scope(value: Any) -> Optional[str]:
     """Config scope is a non-empty class-name string; the class-object form is Python-only."""
     # Local import: feature_group pulls in the plugin machinery, which this data-model module stays free of.
-    from mloda.core.abstract_plugins.feature_group import FeatureGroup
+    from mloda.core.abstract_plugins.components.feature import normalize_feature_group_scope
 
     if value is None:
         return None
@@ -24,11 +24,13 @@ def validate_feature_group_scope(value: Any) -> Optional[str]:
     stripped = value.strip()
     if not stripped:
         raise ValueError("'feature_group' must be a non-empty feature group class-name string")
-    if stripped == FeatureGroup.get_class_name():
+    # Delegate the root-base-name rejection to the canonical predicate; translate its TypeError to a config ValueError.
+    try:
+        normalize_feature_group_scope(stripped)
+    except TypeError:
         raise ValueError(
-            "'feature_group' cannot be the root FeatureGroup base class name; it names no feature group family, "
-            "so a concrete subclass name is required"
-        )
+            "'feature_group' cannot be the root FeatureGroup base class name; a concrete subclass name is required"
+        ) from None
     return value
 
 

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -25,8 +25,11 @@ from mloda.core.abstract_plugins.components.utils import get_all_subclasses, saf
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.function_extender import Extender
 from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistry
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.domain import Domain
 from mloda.core.abstract_plugins.components.feature import Feature, normalize_feature_group_scope
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.link import Link
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.api.plugin_info import ComputeFrameworkInfo, ExtenderInfo, FeatureGroupInfo, ResolvedFeature
 from mloda.core.prepare.accessible_plugins import (
@@ -92,14 +95,27 @@ def _dedup_degrading_on_conflict(
         return dedup_feature_group_subclasses(feature_groups, allow_redefinition=True)
 
 
-def _matches_criteria_guarded(fg_class: type[FeatureGroup], feature_name: FeatureName, options: Options) -> bool:
+def _matches_criteria_guarded(
+    fg_class: type[FeatureGroup],
+    feature_name: FeatureName,
+    options: Options,
+    data_access_collection: Optional[DataAccessCollection] = None,
+) -> bool:
     """Match a feature group for the redefinition-conflict branch, treating any raise as 'not a match'.
 
     resolve_feature is a non-throwing debug API: a conflicting candidate whose match hook raises must
     not take the whole call down.
     """
     try:
-        return fg_class.match_feature_group_criteria(feature_name, options, None)
+        return fg_class.match_feature_group_criteria(feature_name, options, data_access_collection)
+    except Exception:  # noqa: BLE001  (never-raising debug API)
+        return False
+
+
+def _matches_domain_guarded(fg_class: type[FeatureGroup], feature_domain: Optional[Domain]) -> bool:
+    """Domain gate for the conflict branch, mirroring the engine; a raising get_domain() is 'not a match'."""
+    try:
+        return feature_domain is None or fg_class.get_domain() == feature_domain
     except Exception:  # noqa: BLE001  (never-raising debug API)
         return False
 
@@ -339,51 +355,79 @@ def get_extender_docs(
 
 
 def resolve_feature(
-    feature_name: str,
+    feature: str | Feature,
     *,
     options: Optional[Options] = None,
     plugin_collector: Optional[PluginCollector] = None,
     feature_group: str | type[FeatureGroup] | None = None,
+    links: Optional[set[Link]] = None,
+    data_access_collection: Optional[DataAccessCollection] = None,
 ) -> ResolvedFeature:
     """
-    Resolve a feature name to its matching FeatureGroup class.
+    Resolve a feature name (or a Feature object) to its matching FeatureGroup class.
 
     This function searches all loaded FeatureGroups to find those that match
     the given feature name. It applies subclass filtering to prefer more
     specific (child) classes over parent classes.
 
-    Never raises: matching errors are reported in the returned ResolvedFeature.error.
+    Never raises for matching errors: those are reported in the returned ResolvedFeature.error.
+    Signature misuse (options/feature_group alongside a Feature) is a programmer error and raises TypeError.
 
     Design note: resolve_feature DELEGATES matching to the #754 evaluation seam
     IdentifyFeatureGroupClass.evaluate. It only builds the accessible-plugins environment locally
     (applicability filter, dedup/redefinition-conflict handling) and degrades to never raise; the seam
     owns name/domain/scope/abstract/subclass filtering, the winner, candidates, and the failure texts.
 
+    Engine inputs now covered: name, options, domain and compute-framework pin (carried on the Feature),
+    scope (via the Feature's feature_group_scope or the feature_group argument for the string form), and
+    the ``links`` / ``data_access_collection`` arguments threaded into the seam. No engine input is left out.
+
     Args:
-        feature_name: The name of the feature to resolve.
-        options: Keyword-only. Options used for matching and capability checks. An empty or omitted Options is
-            the documented default.
+        feature: A feature name string, or a Feature object used directly as the single source of truth for
+            name, options, domain, compute-framework pin and scope.
+        options: Keyword-only. Options used for matching and capability checks (string form only). An empty or
+            omitted Options is the documented default. Passing it alongside a Feature raises TypeError.
         plugin_collector: Keyword-only. Its ``allow_redefinition`` flag is threaded into deduplication.
-        feature_group: Keyword-only. Scope resolution to a FeatureGroup subclass or a class-name string,
-            same forms and semantics as ``Feature(..., feature_group=...)``: the string form matches the
-            named class and its subclasses; None (or a whitespace-only string) means unscoped.
+        feature_group: Keyword-only. Scope resolution to a FeatureGroup subclass or a class-name string
+            (string form only), same forms and semantics as ``Feature(..., feature_group=...)``: the string
+            form matches the named class and its subclasses; None (or a whitespace-only string) means unscoped.
+            Passing it alongside a Feature raises TypeError.
+        links: Keyword-only. Threaded to the seam's link filter.
+        data_access_collection: Keyword-only. Threaded to the seam so reader / input-data groups can resolve.
 
     Returns:
         ResolvedFeature containing the resolved FeatureGroup (if found),
         all matching candidates, and any error message.
     """
-    try:
-        scope = normalize_feature_group_scope(feature_group)
-    except TypeError as exc:
-        return ResolvedFeature(
-            feature_name=feature_name,
-            feature_group=None,
-            candidates=[],
-            error=str(exc),
-        )
+    if isinstance(feature, Feature):
+        if options is not None or feature_group is not None:
+            raise TypeError(
+                "resolve_feature(Feature(...)) is the single source of truth for name, options and scope; "
+                "set them on the Feature, do not also pass 'options' or 'feature_group'"
+            )
+        feature_obj: Optional[Feature] = feature
+        feature_name = str(feature.name)
+        scope = feature.feature_group_scope
+        resolved_options = feature.options
+        feature_domain: Optional[Domain] = feature.domain
+    else:
+        feature_obj = None
+        feature_name = feature
+        try:
+            scope = normalize_feature_group_scope(feature_group)
+        except TypeError as exc:
+            return ResolvedFeature(
+                feature_name=feature_name,
+                feature_group=None,
+                candidates=[],
+                error=str(exc),
+            )
+        resolved_options = options if options is not None else Options()
+        raw_domain = resolved_options.get("domain")
+        feature_domain = Domain(raw_domain) if raw_domain else None
+
     callout = scope_callout(scope)
     scope_suffix = f" {callout}" if callout else ""
-    resolved_options = options if options is not None else Options()
     allow_redefinition = plugin_collector.allow_redefinition if plugin_collector is not None else False
     fg_classes: set[type[FeatureGroup]] = get_all_subclasses(FeatureGroup)
     if plugin_collector is not None:
@@ -397,7 +441,8 @@ def resolve_feature(
             fg
             for fg in raw_conflicts
             if (scope is None or matches_feature_group_scope(fg, scope))
-            and _matches_criteria_guarded(fg, feature_name_obj, resolved_options)
+            and _matches_criteria_guarded(fg, feature_name_obj, resolved_options, data_access_collection)
+            and _matches_domain_guarded(fg, feature_domain)
         ]
         return ResolvedFeature(
             feature_name=feature_name,
@@ -406,12 +451,13 @@ def resolve_feature(
             error=f"{exc}{scope_suffix}",
         )
     feature_name_obj = FeatureName(feature_name)
-    feature, feature_error = safe_field_with_error(
-        lambda: Feature(feature_name, options=resolved_options, feature_group=scope),
-        None,
-    )
-    if feature is None:
-        return ResolvedFeature(feature_name, None, [], error=f"{feature_error}{scope_suffix}")
+    if feature_obj is None:
+        feature_obj, feature_error = safe_field_with_error(
+            lambda: Feature(feature_name, options=resolved_options, feature_group=scope),
+            None,
+        )
+        if feature_obj is None:
+            return ResolvedFeature(feature_name, None, [], error=f"{feature_error}{scope_suffix}")
 
     # Full environment, mirroring PreFilterPlugins: every applicable group mapped to its available declared
     # frameworks. Guard a raising declaration to an empty set so resolve_feature never raises here.
@@ -427,7 +473,7 @@ def resolve_feature(
     # resolve_feature must not, so degrade any raise into an error result (never-raising contract).
     evaluation = safe_field_with_error(
         lambda: IdentifyFeatureGroupClass.evaluate(
-            feature, accessible_plugins, links=None, data_access_collection=None
+            feature_obj, accessible_plugins, links=links, data_access_collection=data_access_collection
         ),
         None,
     )
@@ -454,7 +500,9 @@ def resolve_feature(
             subtype_family=subtype_family,
         )
 
-    error = _engine_failure_message(feature, accessible_plugins, feature_name, scope_suffix)
+    error = _engine_failure_message(
+        feature_obj, accessible_plugins, feature_name, scope_suffix, links, data_access_collection
+    )
     return ResolvedFeature(feature_name, None, candidates, error=error)
 
 
@@ -463,6 +511,8 @@ def _engine_failure_message(
     accessible_plugins: FeatureGroupEnvironmentMapping,
     feature_name: str,
     scope_suffix: str,
+    links: Optional[set[Link]],
+    data_access_collection: Optional[DataAccessCollection],
 ) -> str:
     """Return the engine's failure message for these inputs.
 
@@ -472,7 +522,9 @@ def _engine_failure_message(
     """
     generic = f"No feature groups found for feature name: '{feature_name}'.{scope_suffix}"
     try:
-        IdentifyFeatureGroupClass(feature, accessible_plugins, links=None, data_access_collection=None)
+        IdentifyFeatureGroupClass(
+            feature, accessible_plugins, links=links, data_access_collection=data_access_collection
+        )
     except ValueError as exc:
         return str(exc)
     except Exception:  # noqa: BLE001  (broken plugin declaration inside the builder; degrade)

--- a/tests/test_core/test_api/test_resolve_feature.py
+++ b/tests/test_core/test_api/test_resolve_feature.py
@@ -16,6 +16,7 @@ import pytest
 from typing import Any, Optional
 
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.abstract_plugins.components.domain import Domain
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
@@ -1081,3 +1082,74 @@ class TestResolveFeatureRaisingMatchDuringConflict:
         assert isinstance(result, ResolvedFeature)
         assert result.feature_group is None
         assert result.error is not None
+
+
+def _domain_conflict_source(qualname: str, feature_name: str, domain: str, extra_body: str = "") -> str:
+    """Source for a conflicting FeatureGroup that matches by name and declares a specific domain.
+
+    Non-raising, name-based match; ``get_domain`` returns a concrete ``Domain`` so the engine's domain
+    filter (``_filter_feature_group_by_domain``) governs whether the class reaches ``criteria_matched``.
+    """
+    return f"""
+from mloda.core.abstract_plugins.feature_group import FeatureGroup as _FG_BASE_
+from mloda.core.abstract_plugins.components.domain import Domain as _DOMAIN_
+
+
+class {qualname}(_FG_BASE_):
+    @classmethod
+    def feature_names_supported(cls):
+        return {{"{feature_name}"}}
+
+    @classmethod
+    def match_feature_group_criteria(cls, feature_name, options, data_access_collection=None):
+        return str(feature_name) == "{feature_name}"
+
+    @classmethod
+    def get_domain(cls):
+        return _DOMAIN_("{domain}")
+{extra_body}
+"""
+
+
+class TestResolveFeatureConflictBranchDomainParity:
+    """The redefinition-conflict branch must apply the feature's domain when building candidates (#756).
+
+    The engine adds a class to ``criteria_matched`` (which ``ResolvedFeature.candidates`` mirrors) only
+    AFTER it passes ``_filter_feature_group_by_domain``. The conflict branch of resolve_feature filters
+    conflicts by scope and match criteria only, omitting the domain, so a conflicting class whose domain
+    does not match the feature's domain is wrongly kept as a candidate.
+    """
+
+    def test_conflict_branch_excludes_nonmatching_domain_candidate(self, _cleanup_main_after: Any) -> None:
+        """A conflicting class whose domain differs from the feature's domain must not be a candidate."""
+        qualname = "DomainConflictResolveFG756"
+        feature_name = "domain_conflict_resolve_feature_756_xyz"
+        conflict_domain = "conflict_domain_756"
+        other_domain = "a_different_domain_than_the_conflict_class_756"
+
+        src_v1 = _domain_conflict_source(qualname, feature_name, conflict_domain)
+        src_v2 = _domain_conflict_source(
+            qualname,
+            feature_name,
+            conflict_domain,
+            extra_body="    def extra_method(self):\n        return 756\n",
+        )
+
+        _exec_conflict_fg(qualname, src_v1, "cell-domain-conflict-756-v1")
+        conflict_cls = _exec_conflict_fg(qualname, src_v2, "cell-domain-conflict-756-v2")
+
+        # Sanity: the exec'd conflict class declares the conflict domain.
+        assert conflict_cls.get_domain() == Domain(conflict_domain)
+
+        # Domain mismatch: the feature carries a domain the conflict class does not declare. The engine
+        # would exclude it, so the conflict branch must too. Today it is wrongly kept in candidates.
+        mismatch = resolve_feature(Feature(feature_name, domain=other_domain))
+
+        assert mismatch.feature_group is None
+        assert mismatch.error is not None
+        assert conflict_cls not in mismatch.candidates
+
+        # Guard proving the exclusion is domain-driven, not always-empty: a matching domain keeps the class.
+        match = resolve_feature(Feature(feature_name, domain=conflict_domain))
+
+        assert conflict_cls in match.candidates

--- a/tests/test_core/test_api/test_resolve_feature_full_request.py
+++ b/tests/test_core/test_api/test_resolve_feature_full_request.py
@@ -1,0 +1,518 @@
+"""Failing tests (TDD Red, issue #756) for resolve_feature expressing the full engine-matcher request.
+
+Target contract for resolve_feature (to be implemented in the Green phase):
+
+    def resolve_feature(
+        feature: str | Feature,
+        *,
+        options: Optional[Options] = None,
+        plugin_collector: Optional[PluginCollector] = None,
+        feature_group: str | type[FeatureGroup] | None = None,
+        links: Optional[set[Link]] = None,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> ResolvedFeature: ...
+
+The full request the engine seam ``IdentifyFeatureGroupClass.evaluate`` consumes is
+(feature, accessible_plugins, links, data_access_collection). Today resolve_feature hardcodes
+``links=None`` and ``data_access_collection=None`` and cannot carry a domain or a compute-framework
+pin, so it cannot express that full request. These tests pin the missing pieces:
+
+  1. a ``Feature`` object accepted directly as the first argument;
+  2. passing ``options``/``feature_group`` alongside a ``Feature`` is misuse -> ``TypeError``;
+  3. a domain carried on the ``Feature`` gates resolution via ``_filter_feature_group_by_domain``;
+  4. a compute-framework pin on the ``Feature`` flows to ``_filter_feature_group_by_framework``;
+  5. ``links`` are threaded to ``_filter_feature_group_by_links`` (paired engine/debug parity);
+  6. a ``data_access_collection`` is threaded so reader/input-data groups resolve (paired parity);
+  7. the never-raising contract survives the new params.
+
+Against the current signature ``resolve_feature(feature_name: str, *, options, plugin_collector,
+feature_group)`` every test here FAILS for the right reason: the str-only first argument does not
+accept a ``Feature``, and ``links`` / ``data_access_collection`` are not parameters at all.
+"""
+
+from typing import Any, Optional
+
+import pytest
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.domain import Domain
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.index.index import Index
+from mloda.core.abstract_plugins.components.link import JoinSpec, Link
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.api.plugin_docs import resolve_feature
+from mloda.core.api.plugin_info import ResolvedFeature
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+from mloda.user import PluginCollector, PluginLoader
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
+    PythonDictFramework,
+)
+
+
+PLAIN_FEATURE = "PlainResolve756Feature"
+DOMAIN_FEATURE = "DomainResolve756Feature"
+FRAMEWORK_FEATURE = "FrameworkPinResolve756Feature"
+LINK_FEATURE = "LinkResolve756Feature"
+DATA_ACCESS_FEATURE = "DataAccessResolve756Feature"
+RAISING_DAC_FEATURE = "RaisingDacResolve756Feature"
+
+DOMAIN_A = "resolve756_domain_a"
+DOMAIN_B = "resolve756_domain_b"
+LINK_INDEX_COLUMN = "resolve756_link_idx"
+UNSUPPORTED_INDEX_COLUMN = "resolve756_unsupported_idx"
+EXPECTED_FILE_HANDLE = "resolve756_source.csv"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def load_plugins() -> None:
+    """Load all plugins before running tests in this module."""
+    PluginLoader.all()
+
+
+class PlainResolve756FeatureGroup(FeatureGroup):
+    """A plain, unambiguously resolvable fixture matching its own feature name."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame, PythonDictFramework}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == PLAIN_FEATURE
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class DomainAResolve756FeatureGroup(FeatureGroup):
+    """Matches DOMAIN_FEATURE and lives in DOMAIN_A."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame, PythonDictFramework}
+
+    @classmethod
+    def get_domain(cls) -> Domain:
+        return Domain(DOMAIN_A)
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == DOMAIN_FEATURE
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class DomainBResolve756FeatureGroup(FeatureGroup):
+    """Matches the SAME DOMAIN_FEATURE name but lives in DOMAIN_B, so only a domain pin can disambiguate."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame, PythonDictFramework}
+
+    @classmethod
+    def get_domain(cls) -> Domain:
+        return Domain(DOMAIN_B)
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == DOMAIN_FEATURE
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class FrameworkPinResolve756FeatureGroup(FeatureGroup):
+    """Declares two available frameworks so a compute-framework pin can select one."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame, PythonDictFramework}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == FRAMEWORK_FEATURE
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class LinkResolve756FeatureGroup(FeatureGroup):
+    """Declares a real Index so the seam's link filter actually validates a supplied Link set."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame, PythonDictFramework}
+
+    @classmethod
+    def index_columns(cls) -> Optional[list[Index]]:
+        return [Index((LINK_INDEX_COLUMN,))]
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == LINK_FEATURE
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class DataAccessResolve756FeatureGroup(FeatureGroup):
+    """Only matches when a DataAccessCollection carrying the expected file handle is supplied."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame, PythonDictFramework}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        if str(feature_name) != DATA_ACCESS_FEATURE:
+            return False
+        if data_access_collection is None:
+            return False
+        return EXPECTED_FILE_HANDLE in set(data_access_collection.files.values())
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class RaisingDacResolve756FeatureGroup(FeatureGroup):
+    """Reader-style fixture whose match hook raises once a DataAccessCollection is supplied."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame, PythonDictFramework}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        if str(feature_name) != RAISING_DAC_FEATURE:
+            return False
+        if data_access_collection is not None:
+            raise RuntimeError("resolve756 reader-style match hook blew up on a data access collection")
+        return False
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+def _supported_link() -> Link:
+    """A Link whose indexes the LinkResolve756 group supports (derived from its own index_columns)."""
+    return Link.inner_on(LinkResolve756FeatureGroup, LinkResolve756FeatureGroup)
+
+
+def _unsupported_link() -> Link:
+    """A Link whose indexes the LinkResolve756 group does NOT support."""
+    spec = JoinSpec(LinkResolve756FeatureGroup, UNSUPPORTED_INDEX_COLUMN)
+    return Link.inner(spec, spec)
+
+
+class TestResolveFeatureAcceptsFeatureObject:
+    """resolve_feature accepts a Feature object as its first argument (issue #756)."""
+
+    def test_feature_object_resolves_like_the_string_form(self) -> None:
+        """resolve_feature(Feature("Name")) resolves identically to resolve_feature("Name")."""
+        collector = PluginCollector.enabled_feature_groups({PlainResolve756FeatureGroup})
+
+        from_string = resolve_feature(PLAIN_FEATURE, plugin_collector=collector)
+        from_feature = resolve_feature(Feature(PLAIN_FEATURE), plugin_collector=collector)
+
+        assert from_string.feature_group is PlainResolve756FeatureGroup
+        assert from_feature.feature_group is PlainResolve756FeatureGroup
+        assert from_feature.feature_name == PLAIN_FEATURE
+        assert from_feature.error is None
+        assert from_feature.feature_group is from_string.feature_group
+
+
+class TestResolveFeatureFeatureObjectMisuse:
+    """Passing options/feature_group alongside a Feature is programmer misuse: single source of truth."""
+
+    def test_feature_object_with_options_raises_type_error(self) -> None:
+        """resolve_feature(Feature(...), options=...) must raise TypeError, not silently ignore the Feature."""
+        resolve_feature_untyped: Any = resolve_feature
+
+        with pytest.raises(TypeError):
+            resolve_feature_untyped(Feature(PLAIN_FEATURE), options=Options())
+
+    def test_feature_object_with_feature_group_raises_type_error(self) -> None:
+        """resolve_feature(Feature(...), feature_group=...) must raise TypeError for the same reason."""
+        resolve_feature_untyped: Any = resolve_feature
+
+        with pytest.raises(TypeError):
+            resolve_feature_untyped(Feature(PLAIN_FEATURE), feature_group="PlainResolve756FeatureGroup")
+
+
+class TestResolveFeatureDomainViaFeature:
+    """A domain carried on the Feature gates resolution through _filter_feature_group_by_domain (#756)."""
+
+    def test_unscoped_name_is_ambiguous_across_domains(self) -> None:
+        """Premise: without a domain pin both same-named groups match, so resolution is ambiguous.
+
+        This proves the only differentiator between the two fixtures is their domain, hence the domain
+        filter is what any successful pin must be gating on.
+        """
+        collector = PluginCollector.enabled_feature_groups(
+            {DomainAResolve756FeatureGroup, DomainBResolve756FeatureGroup}
+        )
+
+        result = resolve_feature(Feature(DOMAIN_FEATURE), plugin_collector=collector)
+
+        assert result.feature_group is None
+        assert result.error is not None
+        assert "Multiple feature groups found" in result.error
+
+    def test_matching_domain_pin_resolves_exactly_one(self) -> None:
+        """A Feature pinned to DOMAIN_A disambiguates to the DOMAIN_A group only."""
+        collector = PluginCollector.enabled_feature_groups(
+            {DomainAResolve756FeatureGroup, DomainBResolve756FeatureGroup}
+        )
+
+        result = resolve_feature(Feature(DOMAIN_FEATURE, domain=DOMAIN_A), plugin_collector=collector)
+
+        assert result.feature_group is DomainAResolve756FeatureGroup
+        assert result.error is None
+        assert DomainBResolve756FeatureGroup not in result.candidates
+
+    def test_non_matching_domain_pin_fails_closed(self) -> None:
+        """A Feature pinned to a domain no group carries fails to resolve."""
+        collector = PluginCollector.enabled_feature_groups(
+            {DomainAResolve756FeatureGroup, DomainBResolve756FeatureGroup}
+        )
+
+        result = resolve_feature(
+            Feature(DOMAIN_FEATURE, domain="resolve756_nonexistent_domain"), plugin_collector=collector
+        )
+
+        assert result.feature_group is None
+        assert result.error is not None
+        # When a Feature is passed, feature_name is str(feature.name); this fails today because the
+        # str-only first arg does not accept a Feature and cannot carry the domain pin.
+        assert result.feature_name == DOMAIN_FEATURE
+
+
+class TestResolveFeatureFrameworkPinViaFeature:
+    """A compute-framework pin on the Feature flows to _filter_feature_group_by_framework (#756)."""
+
+    def test_matching_framework_pin_resolves_and_reports_it(self) -> None:
+        """A Feature pinned to PandasDataFrame resolves and reports PandasDataFrame as supported."""
+        collector = PluginCollector.enabled_feature_groups({FrameworkPinResolve756FeatureGroup})
+
+        result = resolve_feature(
+            Feature(FRAMEWORK_FEATURE, compute_framework="PandasDataFrame"), plugin_collector=collector
+        )
+
+        assert result.feature_group is FrameworkPinResolve756FeatureGroup
+        assert result.error is None
+        assert "PandasDataFrame" in result.supported_compute_frameworks
+
+    def test_undeclared_framework_pin_fails_closed(self) -> None:
+        """A Feature pinned to a framework the group does not declare fails to resolve."""
+        collector = PluginCollector.enabled_feature_groups({FrameworkPinResolve756FeatureGroup})
+
+        result = resolve_feature(
+            Feature(FRAMEWORK_FEATURE, compute_framework="SqliteFramework"), plugin_collector=collector
+        )
+
+        assert result.feature_group is None
+        assert result.error is not None
+        # When a Feature is passed, feature_name is str(feature.name); this fails today because the
+        # str-only first arg does not accept a Feature and cannot carry the framework pin.
+        assert result.feature_name == FRAMEWORK_FEATURE
+
+    def test_framework_pin_matches_engine_seam(self) -> None:
+        """The framework pin flows to the seam: engine and resolve_feature agree on match and no-match."""
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            FrameworkPinResolve756FeatureGroup: {PandasDataFrame, PythonDictFramework}
+        }
+
+        # Declared pin: the engine identifies the group, and resolve_feature resolves it.
+        pinned_declared = Feature(FRAMEWORK_FEATURE, compute_framework="PandasDataFrame")
+        engine_declared = IdentifyFeatureGroupClass(
+            feature=pinned_declared,
+            accessible_plugins=accessible_plugins,
+            links=None,
+            data_access_collection=None,
+        )
+        assert engine_declared.get()[0] is FrameworkPinResolve756FeatureGroup
+
+        collector = PluginCollector.enabled_feature_groups({FrameworkPinResolve756FeatureGroup})
+        debug_declared = resolve_feature(
+            Feature(FRAMEWORK_FEATURE, compute_framework="PandasDataFrame"), plugin_collector=collector
+        )
+        assert debug_declared.feature_group is FrameworkPinResolve756FeatureGroup
+
+        # Undeclared pin: the engine refuses (ValueError), and resolve_feature fails closed.
+        pinned_undeclared = Feature(FRAMEWORK_FEATURE, compute_framework="SqliteFramework")
+        with pytest.raises(ValueError):
+            IdentifyFeatureGroupClass(
+                feature=pinned_undeclared,
+                accessible_plugins=accessible_plugins,
+                links=None,
+                data_access_collection=None,
+            )
+
+        debug_undeclared = resolve_feature(
+            Feature(FRAMEWORK_FEATURE, compute_framework="SqliteFramework"), plugin_collector=collector
+        )
+        assert debug_undeclared.feature_group is None
+
+
+class TestResolveFeatureLinksThreaded:
+    """links are threaded to the seam's _filter_feature_group_by_links (issue #756)."""
+
+    def test_no_links_is_the_resolving_baseline(self) -> None:
+        """With links=None the link filter cannot reject, so the group resolves."""
+        collector = PluginCollector.enabled_feature_groups({LinkResolve756FeatureGroup})
+
+        result = resolve_feature(LINK_FEATURE, plugin_collector=collector, links=None)
+
+        assert result.feature_group is LinkResolve756FeatureGroup
+        assert result.error is None
+
+    def test_supported_link_resolves(self) -> None:
+        """A links set whose index the group supports passes the link filter."""
+        collector = PluginCollector.enabled_feature_groups({LinkResolve756FeatureGroup})
+
+        result = resolve_feature(LINK_FEATURE, plugin_collector=collector, links={_supported_link()})
+
+        assert result.feature_group is LinkResolve756FeatureGroup
+        assert result.error is None
+
+    def test_unsupported_link_is_rejected(self) -> None:
+        """A links set whose indexes the group does not support is rejected by the link filter."""
+        collector = PluginCollector.enabled_feature_groups({LinkResolve756FeatureGroup})
+
+        result = resolve_feature(LINK_FEATURE, plugin_collector=collector, links={_unsupported_link()})
+
+        assert result.feature_group is None
+        assert result.error is not None
+
+    def test_links_match_engine_seam(self) -> None:
+        """Paired parity: engine and resolve_feature agree for both supported and unsupported link sets."""
+        accessible_plugins: FeatureGroupEnvironmentMapping = {LinkResolve756FeatureGroup: {PandasDataFrame}}
+        collector = PluginCollector.enabled_feature_groups({LinkResolve756FeatureGroup})
+
+        supported = {_supported_link()}
+        engine_supported = IdentifyFeatureGroupClass(
+            feature=Feature(LINK_FEATURE),
+            accessible_plugins=accessible_plugins,
+            links=supported,
+            data_access_collection=None,
+        )
+        assert engine_supported.get()[0] is LinkResolve756FeatureGroup
+        assert resolve_feature(LINK_FEATURE, plugin_collector=collector, links=supported).feature_group is (
+            LinkResolve756FeatureGroup
+        )
+
+        unsupported = {_unsupported_link()}
+        with pytest.raises(ValueError):
+            IdentifyFeatureGroupClass(
+                feature=Feature(LINK_FEATURE),
+                accessible_plugins=accessible_plugins,
+                links=unsupported,
+                data_access_collection=None,
+            )
+        assert resolve_feature(LINK_FEATURE, plugin_collector=collector, links=unsupported).feature_group is None
+
+
+class TestResolveFeatureDataAccessCollectionThreaded:
+    """data_access_collection is threaded so reader / input_data groups can resolve (issue #756)."""
+
+    def test_collection_flips_no_match_into_a_resolution(self) -> None:
+        """Without a collection the gated group never matches; supplying one lets it resolve.
+
+        The no-collection premise passes today, but threading the DataAccessCollection into the seam
+        (the headline DoD item) does not exist yet, so the with-collection resolution fails.
+        """
+        collector = PluginCollector.enabled_feature_groups({DataAccessResolve756FeatureGroup})
+
+        # Premise: gated group does not match when no collection is supplied.
+        without = resolve_feature(DATA_ACCESS_FEATURE, plugin_collector=collector)
+        assert without.feature_group is None
+        assert without.error is not None
+
+        # DoD: supplying the collection threads it to the seam and the gated group resolves.
+        dac = DataAccessCollection(files={EXPECTED_FILE_HANDLE})
+        with_collection = resolve_feature(DATA_ACCESS_FEATURE, plugin_collector=collector, data_access_collection=dac)
+        assert with_collection.feature_group is DataAccessResolve756FeatureGroup
+        assert with_collection.error is None
+
+    def test_data_access_collection_matches_engine_seam(self) -> None:
+        """Paired parity: the engine and resolve_feature agree with and without the collection."""
+        accessible_plugins: FeatureGroupEnvironmentMapping = {DataAccessResolve756FeatureGroup: {PandasDataFrame}}
+        collector = PluginCollector.enabled_feature_groups({DataAccessResolve756FeatureGroup})
+        dac = DataAccessCollection(files={EXPECTED_FILE_HANDLE})
+
+        engine_with = IdentifyFeatureGroupClass(
+            feature=Feature(DATA_ACCESS_FEATURE),
+            accessible_plugins=accessible_plugins,
+            links=None,
+            data_access_collection=dac,
+        )
+        assert engine_with.get()[0] is DataAccessResolve756FeatureGroup
+        assert (
+            resolve_feature(DATA_ACCESS_FEATURE, plugin_collector=collector, data_access_collection=dac).feature_group
+            is DataAccessResolve756FeatureGroup
+        )
+
+        with pytest.raises(ValueError):
+            IdentifyFeatureGroupClass(
+                feature=Feature(DATA_ACCESS_FEATURE),
+                accessible_plugins=accessible_plugins,
+                links=None,
+                data_access_collection=None,
+            )
+        assert resolve_feature(DATA_ACCESS_FEATURE, plugin_collector=collector).feature_group is None
+
+
+class TestResolveFeatureNeverRaisesWithNewParams:
+    """The never-raising contract survives the new links/data_access_collection params (issue #756)."""
+
+    def test_raising_match_hook_with_collection_surfaces_as_error(self) -> None:
+        """A reader-style match hook that raises on a collection must surface as ResolvedFeature.error."""
+        collector = PluginCollector.enabled_feature_groups({RaisingDacResolve756FeatureGroup})
+        dac = DataAccessCollection(files={EXPECTED_FILE_HANDLE})
+
+        result = resolve_feature(RAISING_DAC_FEATURE, plugin_collector=collector, data_access_collection=dac)
+
+        assert isinstance(result, ResolvedFeature)
+        assert result.feature_group is None
+        assert result.error is not None


### PR DESCRIPTION
Closes #756.

## What

`resolve_feature` is the never-raising debug seam for feature resolution. It could only express a name, options, and a scope, hardcoding `links=None` and `data_access_collection=None` with no way to carry a domain or a compute-framework pin. So it reported conflicts a real run does not have and could not resolve reader / `input_data` feature groups at all (divergences 5, 6, 7, 10 of #722).

With the #755 delegation seam in place, this is parameter plumbing into the shared seam rather than new matching logic.

## Changes

- **`resolve_feature(feature: str | Feature, ...)`**: a `Feature` is the single source of truth for name, options, domain, compute-framework pin, and scope. Passing `options`/`feature_group` alongside a `Feature` raises `TypeError` (signature misuse, distinct from the never-raising matching contract). #722 explicitly waives backward compatibility for this surface.
- **New keyword-only `links` and `data_access_collection`**, threaded into the engine seam: `IdentifyFeatureGroupClass.evaluate`, the failure-message builder, and the guarded redefinition-conflict match. Reader / `input_data` and link-gated feature groups now resolve on the debug path.
- **Domain applied in the redefinition-conflict candidate branch**, so the debug `candidates` match the engine's `criteria_matched` (name + domain + scope, before framework/link filtering) when a domain-carrying `Feature` is passed. Framework/link filters are intentionally not applied to candidates, mirroring the engine.
- **Docstring** states which engine inputs are covered, so any remaining gap is explicit.
- **feature-config models**: the duplicated root-`FeatureGroup`-base-name scope check is dropped in favor of the canonical `normalize_feature_group_scope` predicate; config-only string / non-empty checks are kept.

## Tests

New `tests/test_core/test_api/test_resolve_feature_full_request.py` (16 tests): Feature-object acceptance, `Feature`+options/feature_group misuse, domain and framework pin via `Feature`, `links` and `data_access_collection` threading with paired engine/debug parity (reader-gated and link-gated fixtures), and never-raising under the new params. Plus a redefinition-conflict domain-parity test in the existing `test_resolve_feature.py`.

## Validation

- `tox` green: 6382 passed, 170 skipped; ruff format + check, pip-licenses allowlist, `mypy --strict`, and bandit all pass.
- Two independent deep reviews (Claude Opus + codex). Accepted: apply the Feature domain in the conflict branch (parity gap), and a cosmetic root-rejection message cleanup. Rejected: keeping a `feature_name=` keyword alias (waived by #722; no in-repo caller uses it; contradicts the single-source-of-truth union).

## Definition of done

- [x] `resolve_feature` accepts domain, compute-framework pin, links, and `data_access_collection` (or a `Feature` carrying them) and threads them to the shared seam
- [x] Reader / `input_data` feature groups resolve through the debug tool
- [x] Duplicated scope validation in feature-config models removed in favor of the canonical predicate
- [x] Docstrings state which engine inputs are covered
- [x] `tox` passes