### PR TITLE
feat: resolve_feature builds its candidate universe via PreFilterPlugins (#757)

### DIFF
--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -34,6 +34,7 @@ from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.api.plugin_info import ComputeFrameworkInfo, ExtenderInfo, FeatureGroupInfo, ResolvedFeature
 from mloda.core.prepare.accessible_plugins import (
     FeatureGroupEnvironmentMapping,
+    PreFilterPlugins,
     RedefinitionConflictError,
     dedup_feature_group_subclasses,
     registry_for,
@@ -362,6 +363,7 @@ def resolve_feature(
     feature_group: str | type[FeatureGroup] | None = None,
     links: Optional[set[Link]] = None,
     data_access_collection: Optional[DataAccessCollection] = None,
+    compute_frameworks: Optional[set[type[ComputeFramework]]] = None,
 ) -> ResolvedFeature:
     """
     Resolve a feature name (or a Feature object) to its matching FeatureGroup class.
@@ -394,6 +396,7 @@ def resolve_feature(
             Passing it alongside a Feature raises TypeError.
         links: Keyword-only. Threaded to the seam's link filter.
         data_access_collection: Keyword-only. Threaded to the seam so reader / input-data groups can resolve.
+        compute_frameworks: Keyword-only. Restrict the candidate universe's compute-framework set (default: all available frameworks).
 
     Returns:
         ResolvedFeature containing the resolved FeatureGroup (if found),
@@ -428,29 +431,31 @@ def resolve_feature(
 
     callout = scope_callout(scope)
     scope_suffix = f" {callout}" if callout else ""
-    allow_redefinition = plugin_collector.allow_redefinition if plugin_collector is not None else False
-    fg_classes: set[type[FeatureGroup]] = get_all_subclasses(FeatureGroup)
-    if plugin_collector is not None:
-        fg_classes = {fg for fg in fg_classes if plugin_collector.applicable_feature_group_class(fg)}
+    feature_name_obj = FeatureName(feature_name)
+
+    restricted_frameworks = (
+        compute_frameworks if compute_frameworks is not None else get_all_subclasses(ComputeFramework)
+    )
     try:
-        all_fgs = list(dedup_feature_group_subclasses(fg_classes, allow_redefinition=allow_redefinition))
-    except ValueError as exc:
-        raw_conflicts = list(getattr(exc, "conflicts", []))
-        feature_name_obj = FeatureName(feature_name)
+        accessible_plugins: FeatureGroupEnvironmentMapping = PreFilterPlugins(
+            restricted_frameworks, plugin_collector, degrade_on_error=True
+        ).get_accessible_plugins()
+    except RedefinitionConflictError as exc:
         matching_conflicts = [
             fg
-            for fg in raw_conflicts
+            for fg in exc.conflicts
             if (scope is None or matches_feature_group_scope(fg, scope))
             and _matches_criteria_guarded(fg, feature_name_obj, resolved_options, data_access_collection)
             and _matches_domain_guarded(fg, feature_domain)
         ]
+        return ResolvedFeature(feature_name, None, matching_conflicts, error=f"{exc}{scope_suffix}")
+    except ValueError as exc:
+        return ResolvedFeature(feature_name, None, [], error=f"{exc}{scope_suffix}")
+    except Exception:  # noqa: BLE001  (never-raising debug API; broken plugin while building the environment)
         return ResolvedFeature(
-            feature_name=feature_name,
-            feature_group=None,
-            candidates=matching_conflicts,
-            error=f"{exc}{scope_suffix}",
+            feature_name, None, [], error=f"No feature groups found for feature name: '{feature_name}'.{scope_suffix}"
         )
-    feature_name_obj = FeatureName(feature_name)
+
     if feature_obj is None:
         feature_obj, feature_error = safe_field_with_error(
             lambda: Feature(feature_name, options=resolved_options, feature_group=scope),
@@ -458,16 +463,6 @@ def resolve_feature(
         )
         if feature_obj is None:
             return ResolvedFeature(feature_name, None, [], error=f"{feature_error}{scope_suffix}")
-
-    # Full environment, mirroring PreFilterPlugins: every applicable group mapped to its available declared
-    # frameworks. Guard a raising declaration to an empty set so resolve_feature never raises here.
-    accessible_plugins: FeatureGroupEnvironmentMapping = {}
-    for fg in all_fgs:
-        accessible_plugins[fg] = safe_field(
-            lambda fg=fg: {cfw for cfw in fg.compute_framework_definition() if cfw.is_available()},  # type: ignore[misc]
-            set(),
-            field=f"framework environment for '{feature_name}'",
-        )
 
     # The seam does the name/domain/scope/abstract/subclass filtering. Matching or a capability hook can raise;
     # resolve_feature must not, so degrade any raise into an error result (never-raising contract).

--- a/mloda/core/api/plugin_info.py
+++ b/mloda/core/api/plugin_info.py
@@ -59,3 +59,6 @@ class ResolvedFeature:
     subtype: Optional[str] = None
     # Family name only when the subtype is a parametric instance (e.g. "ntile" for "ntile_2"), else None.
     subtype_family: Optional[str] = None
+    # Candidate universe built from a standalone default environment (PreFilterPlugins over installed
+    # plugins), not a captured live run.
+    environment: str = "standalone-default"

--- a/mloda/core/prepare/accessible_plugins.py
+++ b/mloda/core/prepare/accessible_plugins.py
@@ -290,12 +290,15 @@ class PreFilterPlugins:
         self,
         compute_frameworks: set[type[ComputeFramework]],
         plugin_collector: Optional[PluginCollector] = None,
+        *,
+        degrade_on_error: bool = False,
     ) -> None:
+        self._degrade_on_error = degrade_on_error
         feature_groups = self._set_feature_groups(plugin_collector)
         compute_frameworks = self._set_compute_frameworks(compute_frameworks, plugin_collector)
 
         self.accessible_plugins = self.resolve_feature_group_compute_framework_limitations(
-            feature_groups, compute_frameworks
+            feature_groups, compute_frameworks, degrade_on_error=degrade_on_error
         )
 
     def get_accessible_plugins(self) -> FeatureGroupEnvironmentMapping:
@@ -404,15 +407,23 @@ class PreFilterPlugins:
         return surviving
 
     def resolve_feature_group_compute_framework_limitations(
-        self, feature_groups: set[type[FeatureGroup]], compute_frameworks: set[type[ComputeFramework]]
+        self,
+        feature_groups: set[type[FeatureGroup]],
+        compute_frameworks: set[type[ComputeFramework]],
+        *,
+        degrade_on_error: bool = False,
     ) -> FeatureGroupEnvironmentMapping:
         accessible_plugins: FeatureGroupEnvironmentMapping = {}
         for feature_group in feature_groups:
-            new_set_of_compute_frameworks = set()
-            for cp_fg in feature_group.compute_framework_definition():
-                if cp_fg in compute_frameworks:
-                    new_set_of_compute_frameworks.add(cp_fg)
-
+            if degrade_on_error:
+                definition: set[type[ComputeFramework]] = safe_field(
+                    lambda fg=feature_group: fg.compute_framework_definition(),  # type: ignore[misc]
+                    set(),
+                    field=f"compute_framework_definition of {feature_group.__module__}:{feature_group.__qualname__}",
+                )
+            else:
+                definition = feature_group.compute_framework_definition()
+            new_set_of_compute_frameworks = {cp_fg for cp_fg in definition if cp_fg in compute_frameworks}
             accessible_plugins[feature_group] = new_set_of_compute_frameworks
 
         return accessible_plugins

--- a/tests/test_core/test_api/test_resolve_feature_prefilter_universe.py
+++ b/tests/test_core/test_api/test_resolve_feature_prefilter_universe.py
@@ -1,0 +1,257 @@
+"""Failing tests (TDD Red, issue #757) for resolve_feature routing its universe through PreFilterPlugins.
+
+Today ``resolve_feature`` hand-builds its candidate universe from every installed FeatureGroup and
+only applies the collector's applicability (enabled/disabled) filter. It never applies registry strict
+mode, never intersects a caller-supplied compute-framework set, and never labels the environment it
+resolved against. That diverges from what a real run's engine sees, which is built by
+``PreFilterPlugins`` in ``mloda/core/prepare/accessible_plugins.py`` (see ``Engine.__init__``).
+
+Target contract for the Green phase (these tests encode it and must FAIL today):
+
+  1. DoD-1: a new keyword-only ``compute_frameworks: Optional[set[type[ComputeFramework]]]`` parameter.
+     Restricting to a framework a matching group does not declare empties its available set, so the
+     group fails to resolve, mirroring how ``PreFilterPlugins`` intersects the caller's framework set.
+  2. DoD-2: passing a ``plugin_collector`` yields the same universe the engine builds via
+     ``PreFilterPlugins`` - including registry strict mode, which resolve_feature ignores today.
+  3. DoD-3: ``ResolvedFeature`` gains ``environment: str = "standalone-default"``, carried on every
+     result (success and error paths).
+  4. Never-raising is preserved under the new routing.
+
+Right-reason failures today: DoD-1 tests raise ``TypeError`` (no ``compute_frameworks`` parameter);
+DoD-2 asserts a strict-mode drop resolve_feature does not yet apply; DoD-3 and DoD-4 touch the
+not-yet-existing ``environment`` field (``AttributeError``).
+"""
+
+import gc
+from typing import Optional
+
+import pytest
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.api.plugin_docs import resolve_feature
+from mloda.core.api.plugin_info import ResolvedFeature
+from mloda.core.prepare.accessible_plugins import PreFilterPlugins
+from mloda.user import PluginCollector, PluginLoader
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
+    PythonDictFramework,
+)
+
+
+PLAIN_FEATURE_757 = "PlainResolve757Feature"
+PYTHON_DICT_ONLY_FEATURE = "PythonDictOnlyResolve757Feature"
+STRICT_EXCLUDED_FEATURE = "StrictExcludedResolve757Feature"
+BROKEN_RULE_FEATURE_757 = "broken_rule_resolve_757_feature"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def load_plugins() -> None:
+    """Load all plugins before running tests in this module."""
+    PluginLoader.all()
+
+
+class PlainResolve757FeatureGroup(FeatureGroup):
+    """A plain, unambiguously resolvable fixture matching its own feature name."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame, PythonDictFramework}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == PLAIN_FEATURE_757
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class PythonDictOnlyResolve757FeatureGroup(FeatureGroup):
+    """Declares ONLY PythonDictFramework, so a Pandas-only restriction empties its available set."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PythonDictFramework}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == PYTHON_DICT_ONLY_FEATURE
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class StrictExcludedResolve757FeatureGroup(FeatureGroup):
+    """Unregistered fixture: registry strict mode drops it from the engine's universe."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame, PythonDictFramework}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == STRICT_EXCLUDED_FEATURE
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+def _make_broken_rule_fg_757() -> type[FeatureGroup]:
+    """Build a per-test broken-rule FeatureGroup, mirroring test_sbdg_resolve_feature_broken_rule.py.
+
+    Scoped per test (del + gc.collect() by the caller) so its raising compute_framework_rule cannot
+    leak into the session-wide subclass registry and break unrelated PreFilterPlugins builds.
+    """
+    gc.collect()
+
+    class BrokenRuleResolve757FG(FeatureGroup):
+        """Matches a unique name but its compute_framework_rule raises when consulted."""
+
+        @classmethod
+        def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+            raise RuntimeError("resolve757 rule exploded")
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: Optional[DataAccessCollection] = None,
+        ) -> bool:
+            return str(feature_name) == BROKEN_RULE_FEATURE_757
+
+        def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+            return None
+
+    return BrokenRuleResolve757FG
+
+
+class TestResolveFeatureComputeFrameworkRestriction:
+    """DoD-1: a keyword-only compute_frameworks set intersects each group's available frameworks (#757)."""
+
+    def test_undeclared_framework_restriction_empties_available_set_and_fails(self) -> None:
+        """Restricting to a framework the group does not declare fails resolution, like PreFilterPlugins.
+
+        The fixture declares only PythonDictFramework; restricting to {PandasDataFrame} makes the
+        intersection empty, so the group has no supported framework and cannot resolve.
+        """
+        collector = PluginCollector.enabled_feature_groups({PythonDictOnlyResolve757FeatureGroup})
+
+        # Full default environment (restriction unset): the group resolves.
+        default_result = resolve_feature(PYTHON_DICT_ONLY_FEATURE, plugin_collector=collector)
+        assert default_result.feature_group is PythonDictOnlyResolve757FeatureGroup
+        assert default_result.error is None
+
+        # Restriction to an undeclared-but-available framework empties the group's set: fails closed.
+        restricted = resolve_feature(
+            PYTHON_DICT_ONLY_FEATURE,
+            plugin_collector=collector,
+            compute_frameworks={PandasDataFrame},
+        )
+        assert restricted.feature_group is None
+        assert restricted.error is not None
+
+    def test_compute_frameworks_none_matches_the_default_environment(self) -> None:
+        """compute_frameworks=None must behave exactly like the unset, full-environment default."""
+        collector = PluginCollector.enabled_feature_groups({PythonDictOnlyResolve757FeatureGroup})
+
+        unset = resolve_feature(PYTHON_DICT_ONLY_FEATURE, plugin_collector=collector)
+        explicit_none = resolve_feature(PYTHON_DICT_ONLY_FEATURE, plugin_collector=collector, compute_frameworks=None)
+
+        assert explicit_none.feature_group is unset.feature_group
+        assert explicit_none.feature_group is PythonDictOnlyResolve757FeatureGroup
+        assert explicit_none.error == unset.error
+
+
+class TestResolveFeatureCollectorUniverseParity:
+    """DoD-2: resolve_feature's universe honors the same collector policy the engine's PreFilterPlugins does."""
+
+    def test_strict_mode_drop_matches_engine_prefilter_universe(self) -> None:
+        """A strict-mode collector drops the unregistered fixture from both the engine env and resolve_feature.
+
+        The engine builds its universe via ``PreFilterPlugins(compute_frameworks, collector)``. With
+        registry strict mode, an unregistered concrete FeatureGroup is dropped. resolve_feature must
+        honor that same policy; today it ignores strict mode and still resolves the group.
+        """
+        collector = PluginCollector().set_strict_mode("strict")
+        compute_frameworks_set = PreFilterPlugins.get_cfw_subclasses()
+
+        # This is exactly what mloda/core/core/engine.py builds.
+        engine_env = PreFilterPlugins(compute_frameworks_set, collector).get_accessible_plugins()
+        assert StrictExcludedResolve757FeatureGroup not in engine_env
+
+        # Without the strict collector the group resolves by its unique name.
+        baseline = resolve_feature(STRICT_EXCLUDED_FEATURE)
+        assert baseline.feature_group is StrictExcludedResolve757FeatureGroup
+        assert baseline.error is None
+
+        # With the strict collector, resolve_feature must apply the same drop the engine applies.
+        scoped = resolve_feature(STRICT_EXCLUDED_FEATURE, plugin_collector=collector)
+        assert scoped.feature_group is None
+        assert StrictExcludedResolve757FeatureGroup not in scoped.candidates
+        assert scoped.error is not None
+
+
+class TestResolvedFeatureEnvironmentLabel:
+    """DoD-3: ResolvedFeature gains environment: str = "standalone-default", carried on every result (#757)."""
+
+    def test_dataclass_default_is_standalone_default(self) -> None:
+        """The 4-positional-arg constructor still works and defaults environment to the literal label."""
+        result = ResolvedFeature("n", None, [], None)
+        assert result.environment == "standalone-default"
+
+    def test_resolving_result_carries_environment(self) -> None:
+        """A successful resolution reports the standalone-default environment."""
+        collector = PluginCollector.enabled_feature_groups({PlainResolve757FeatureGroup})
+
+        result = resolve_feature(PLAIN_FEATURE_757, plugin_collector=collector)
+
+        assert result.feature_group is PlainResolve757FeatureGroup
+        assert result.environment == "standalone-default"
+
+    def test_no_match_error_result_carries_environment(self) -> None:
+        """A no-match / error result also reports the standalone-default environment."""
+        result = resolve_feature("CompletelyMissing757FeatureXYZ")
+
+        assert result.feature_group is None
+        assert result.error is not None
+        assert result.environment == "standalone-default"
+
+
+class TestResolveFeatureNeverRaisesUnderNewRouting:
+    """DoD-4: the never-raising contract survives a broken-plugin / strict scenario (#757)."""
+
+    def test_broken_rule_under_strict_collector_fails_closed_without_raising(self) -> None:
+        """A broken-rule group under a strict collector fails closed and is labelled, never raising."""
+        broken_fg = _make_broken_rule_fg_757()
+        try:
+            collector = PluginCollector().set_strict_mode("strict")
+
+            result = resolve_feature(BROKEN_RULE_FEATURE_757, plugin_collector=collector)
+
+            assert isinstance(result, ResolvedFeature)
+            assert result.feature_group is None
+            assert result.error is not None
+            assert result.environment == "standalone-default"
+        finally:
+            del broken_fg
+            gc.collect()

--- a/tests/test_core/test_prepare/test_prefilter_degrade_on_error.py
+++ b/tests/test_core/test_prepare/test_prefilter_degrade_on_error.py
@@ -1,0 +1,58 @@
+"""PreFilterPlugins.degrade_on_error is opt-in: the engine path fails fast, resolve_feature degrades.
+
+A FeatureGroup whose compute_framework_rule() raises must propagate on the default (engine) path so a
+broken plugin surfaces, but degrade to an empty framework set when a caller opts in (resolve_feature).
+The broken class is scoped per test (del + gc.collect()) so it cannot leak into other tests.
+"""
+
+import gc
+
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.prepare.accessible_plugins import PreFilterPlugins
+
+
+def _make_broken_rule_fg() -> type[FeatureGroup]:
+    # Class objects are cyclic; collect leftovers from earlier tests before defining a twin.
+    gc.collect()
+
+    class PrefilterDegradeBrokenRuleFG(FeatureGroup):
+        """Its compute_framework_rule raises when consulted."""
+
+        @classmethod
+        def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+            raise RuntimeError("prefilter degrade rule exploded")
+
+    return PrefilterDegradeBrokenRuleFG
+
+
+class TestPreFilterDegradeOnError:
+    """The framework-definition guard only applies when the caller opts in."""
+
+    def test_default_engine_path_fails_fast(self) -> None:
+        broken_fg = _make_broken_rule_fg()
+        # A bound 'except ... as e' keeps a traceback that pins the broken class; use an unbound
+        # except so nothing outlives the block and the class cannot leak to other tests.
+        raised = False
+        try:
+            try:
+                PreFilterPlugins(PreFilterPlugins.get_cfw_subclasses(), None)
+            except RuntimeError:
+                raised = True
+        finally:
+            del broken_fg
+            gc.collect()
+        assert raised
+
+    def test_degrade_on_error_maps_broken_group_to_empty_set(self) -> None:
+        broken_fg = _make_broken_rule_fg()
+        try:
+            mapping = PreFilterPlugins(
+                PreFilterPlugins.get_cfw_subclasses(), None, degrade_on_error=True
+            ).get_accessible_plugins()
+            assert broken_fg in mapping
+            assert mapping[broken_fg] == set()
+            del mapping
+        finally:
+            del broken_fg
+            gc.collect()


### PR DESCRIPTION
Closes #757.

## What

`resolve_feature` now builds its candidate universe through the engine's own `PreFilterPlugins` instead of hand-assembling it from every installed framework. Strict mode, `PluginCollector` policy, availability, and an optional caller-supplied compute-framework restriction now match what a real run sees (divergences 8 and 9 of #722).

## Changes

- **`resolve_feature`**: routes its `FeatureGroupEnvironmentMapping` through `PreFilterPlugins(...).get_accessible_plugins()`; adds a keyword-only `compute_frameworks: Optional[set[type[ComputeFramework]]] = None` to restrict the universe's framework set (default: all available). The redefinition-conflict candidate branch and the never-raising contract are preserved (except order: `RedefinitionConflictError` then `ValueError` then broad `Exception`).
- **`ResolvedFeature`**: new `environment: str = "standalone-default"` field, carried on every result, so the tool stays honest that it resolved against a standalone default environment, not a captured live run.
- **`PreFilterPlugins`**: reused as-is, plus an opt-in `degrade_on_error` flag. The engine keeps its default fail-fast behavior on a broken `compute_framework_rule` (surfacing the plugin defect); `resolve_feature` opts in to a guarded, observable degrade (warns via `safe_field`) so a broken plugin stays a candidate with an empty framework set rather than taking down the debug call.

## Definition of done

- [x] `resolve_feature` obtains its mapping from `PreFilterPlugins`, incl. strict mode and collector policy, with an optional compute-framework restriction
- [x] Same `plugin_collector` yields the same candidate universe as that run's engine
- [x] The result labels its environment as standalone/default
- [x] `tox` passes (6395 passed, 170 skipped; ruff, mypy --strict, bandit green)

## Review

Two independent deep reviews (Claude Opus + codex) both flagged that an unconditional guard in the shared `PreFilterPlugins` would silently swallow a genuine broken-plugin declaration in production runs. Fixed by making the degrade opt-in (engine fail-fast preserved, debug tool degrades observably), with a regression test pinning the split.

## Tests

- `tests/test_core/test_api/test_resolve_feature_prefilter_universe.py`: compute-framework restriction, collector/strict-mode universe parity with the engine, environment label, never-raising.
- `tests/test_core/test_prepare/test_prefilter_degrade_on_error.py`: engine path fails fast on a broken rule; `degrade_on_error=True` maps it to an empty set without raising.