### PR TITLE
docs: align resolution troubleshooting and integration docs with the single matcher (#758)

### DIFF
--- a/docs/docs/in_depth/compute-framework-integration.md
+++ b/docs/docs/in_depth/compute-framework-integration.md
@@ -50,12 +50,25 @@ hook over raising a generic error from inside `calculate_feature`: the
 rejection happens during planning rather than at compute time, and the message
 is built for you.
 
-The debug inspector `resolve_feature(name)` reflects the hook too: its
-`ResolvedFeature` result carries `supported_compute_frameworks` and
-`unsupported_compute_frameworks` (evaluated under default options unless you
-pass `options=`, see [Discover Plugins](discover-plugins.md)), and a feature
-that matches a group but is unsupported on every installed framework resolves
-to `feature_group=None` with a capability error rather than appearing runnable.
+The debug inspector `resolve_feature(name)` reflects the hook too, because it
+runs the **same matcher over the same candidate universe as the engine** (it
+delegates to `IdentifyFeatureGroupClass`). Its `ResolvedFeature` result carries
+`supported_compute_frameworks` and `unsupported_compute_frameworks` (evaluated
+under default options unless you pass `options=`, see
+[Discover Plugins](discover-plugins.md)).
+
+Two distinct gaps both resolve to `feature_group=None` rather than appearing
+runnable:
+
+- **Unsupported on every framework.** The feature matches a group, but
+  `supports_compute_framework` rejects every installed framework. Resolution
+  fails with the capability error above.
+- **Uninstalled framework.** The only framework a matching group declares is not
+  installed (its backend library is absent, so `is_available()` is `False`). The
+  candidate universe drops unavailable frameworks before matching, so the group
+  maps to an empty framework set and resolution fails closed with the ordinary
+  `No feature groups found for feature name: '<name>'.` error. It does **not**
+  read as runnable on a framework you cannot actually run.
 
 ### Declaring capability per subtype
 

--- a/docs/docs/in_depth/discover-plugins.md
+++ b/docs/docs/in_depth/discover-plugins.md
@@ -22,6 +22,53 @@ This is useful for:
 - Understanding which plugin handles a feature
 - Identifying conflicts when multiple FeatureGroups match
 
+`resolve_feature` runs the **same matcher over the same candidate universe as a
+run**: it delegates to the engine's `IdentifyFeatureGroupClass` and builds its
+plugin universe the way the engine does (availability, strict-registry mode, and
+`PluginCollector` policy all apply). So the error it reports for an unresolvable
+feature is the error a run would raise, and a feature it resolves is one a run
+resolves. The remaining differences are presentation-only: `resolve_feature`
+never raises (matching failures land in `result.error`, not an exception), and
+it returns a structured `ResolvedFeature` instead of a plan.
+
+One behavioral exception to the parity: a plugin that raises while declaring its
+frameworks (a broken `compute_framework_rule` / `compute_framework_definition`)
+aborts a real run, but on the debug path it degrades to an empty framework set,
+so it stays a listed candidate that never wins instead of taking the call down.
+The debug tool keeps reporting; the run fails fast.
+
+Its environment is a **standalone default**, not a replay of a specific run:
+`ResolvedFeature.environment` reads `"standalone-default"`. The candidate
+universe defaults to every installed compute framework unless you narrow it (see
+[Expressing the full request](#expressing-the-full-request)).
+
+### Expressing the full request
+
+A run resolves a `Feature`, not just a name, so `resolve_feature` accepts one
+too. Pass a `Feature` as the single source of truth for name, `options`, domain,
+compute-framework pin, and scope; passing `options` or `feature_group` alongside
+a `Feature` raises `TypeError`.
+
+``` python
+from mloda.user import Feature, Options
+
+result = resolve_feature(Feature("sales__sum_aggr", options=Options(group={"partition_by": ["customer_id"]})))
+```
+
+Every engine input is expressible, either on the `Feature` or as a keyword-only
+argument to `resolve_feature`:
+
+- `options`, domain, compute-framework pin, scope: on the `Feature` (or, for the
+  string form, `options=` and `feature_group=`).
+- `links`: a set of `Link` objects, threaded to the matcher so link-gated groups
+  resolve.
+- `data_access_collection`: threaded to the matcher so reader / input-data groups
+  resolve.
+- `plugin_collector`: restricts the FeatureGroups considered and threads its
+  `allow_redefinition` flag into deduplication.
+- `compute_frameworks`: restricts the candidate universe's framework set
+  (default: all installed frameworks).
+
 ### Option-Gated Feature Groups
 
 Matching and the compute framework split both run under the options you pass.
@@ -41,7 +88,9 @@ result = resolve_feature("sales__sum_aggr", options=Options(group={"partition_by
 print(result.feature_group, result.supported_compute_frameworks)
 ```
 
-`options` and `plugin_collector` are keyword-only, so pass them by name.
+Every argument after `feature` (`options`, `plugin_collector`, `feature_group`,
+`links`, `data_access_collection`, `compute_frameworks`) is keyword-only, so
+pass them by name.
 
 ### Scoping to a Feature Group
 

--- a/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
+++ b/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
@@ -1,5 +1,27 @@
 # Feature Group Resolution Errors
 
+Resolution runs inside a full `mloda` request, but you do not need to build one
+to reproduce a resolution error. `resolve_feature` (from `mloda.steward`) runs
+the **same matcher over the same candidate universe** as a run and reports what a
+run would, without raising: the failure lands in `result.error` instead of an
+exception, so the message below is the message you get back.
+
+``` python
+from mloda.steward import resolve_feature
+
+result = resolve_feature("my_feature")  # or resolve_feature(Feature(...)) for a full request
+if result.error:
+    print(result.error)  # the same message a run raises
+    print([fg.__name__ for fg in result.candidates])
+```
+
+Its environment is a standalone default (`result.environment` is
+`"standalone-default"`), not a replay of a specific run. Pass a `Feature`,
+`options`, `plugin_collector`, `links`, `data_access_collection`, or
+`compute_frameworks` (a run that restricts its frameworks needs this to mirror)
+to reproduce the run you are debugging. See
+[Discover Plugins](../discover-plugins.md) for the full signature.
+
 ## Multiple Feature Groups Error
 
 ### The Problem
@@ -110,7 +132,7 @@ If both versions of the class have **identical** source code (e.g., re-running a
 
 For rapid iteration in notebooks, opt in to "newest wins" using the builder method on `PluginCollector`:
 
-**Option A** — set the override flag on a fresh collector:
+**Option A**: set the override flag on a fresh collector:
 
 ```python
 from mloda.provider import FeatureGroup
@@ -124,7 +146,7 @@ class SomeFG(FeatureGroup):
 plugin_collector = PluginCollector().set_allow_redefinition()
 ```
 
-**Option B** — compose with disable/enable filters:
+**Option B**: compose with disable/enable filters:
 
 ```python
 plugin_collector = (


### PR DESCRIPTION
Closes #758.

`resolve_feature` now delegates matching to the engine matcher (`IdentifyFeatureGroupClass`) over the same candidate universe a run builds (#755, #756, #757). These docs still described two independent matchers. This aligns them to the single-matcher reality: one matcher, one universe, remaining differences presentation-only.

## Changes

- **compute-framework-integration.md**: state the delegation, and close the uninstalled-framework contract gap (false positive 2 of #722). Two distinct gaps now resolve to `feature_group=None` rather than reading as runnable: unsupported on every framework (capability error), and an uninstalled sole framework (fails closed with `No feature groups found`).
- **discover-plugins.md**: frame `resolve_feature` as the same matcher over the same universe; document the full expressible request (Feature, options, domain, pin, scope, links, data_access_collection, plugin_collector, compute_frameworks) and the `standalone-default` environment. Notes the one non-cosmetic divergence: a plugin that raises while declaring frameworks degrades on the debug path but fails a run fast.
- **feature-group-resolution-errors.md**: add that `resolve_feature` reproduces these engine errors standalone, never raising, with the current signature; drop two pre-existing em dashes in a touched file.

## Verification

- `tox` green (6395 passed, ruff, mypy --strict, bandit all clean).
- Doc code blocks and internal link/anchor targets validated by `tests/test_documentation`.
- Two independent deep reviews (Claude Opus + codex); accepted findings applied (parity caveat, `compute_frameworks` in the mirror list, wording, em dashes).