### PR TITLE
feat: materialize declared PropertySpec defaults into runtime options (#766)

### DIFF
--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -32,7 +32,7 @@ PROPERTY_MAPPING = {
 | --- | --- | --- | --- |
 | `explanation` | `str` | required, positional | What the option means. Also names the spec in construction errors. |
 | `allowed_values` | `Mapping[Any, str]`, any other iterable, or `None` | `None` | The declared value space. A Mapping is `{value: description}` and is kept as given; any other iterable is materialized to a tuple. |
-| `default` | `Any` | `NO_DEFAULT` | Applied when the key is absent. Leaving it at `NO_DEFAULT` declares *no default*, which makes the key required. See [Optional keys](#optional-keys). |
+| `default` | `Any` | `NO_DEFAULT` | Materialized into runtime options when the key is absent (see [Applying declared defaults](#applying-declared-defaults)). Leaving it at `NO_DEFAULT` declares *no default*, which makes the key required. See [Optional keys](#optional-keys). |
 | `context` | `bool` | `True` | `True`: context parameter. `False`: group parameter, which splits feature groups. |
 | `strict_validation` | `bool` | `False` | Enforce the value space at match time. |
 | `element_validator` | `Callable \| None` | `None` | Per-element predicate. Requires `strict_validation=True`. |
@@ -211,7 +211,7 @@ Optionality is the `default` field, and the three states are distinct:
 | --- | --- |
 | `default` omitted (stays `NO_DEFAULT`) | The key declares no default and is **required**. |
 | `default=None` | The key is **optional**; no value is applied when it is absent. |
-| `default=<value>` | The key is **optional**; the value is applied when it is absent, and is checked under strict. |
+| `default=<value>` | The key is **optional**; the value is materialized when it is absent (see [Applying declared defaults](#applying-declared-defaults)), and is checked under strict. |
 
 ``` python
 from mloda.provider import PropertySpec
@@ -231,6 +231,21 @@ every field is always present, so a plain `None` cannot say both "no default dec
 
 `required_when` is for a *conditional* requirement, not for optionality: never write a
 predicate that always returns `False` to make a key optional.
+
+## Applying declared defaults
+
+A declared default is metadata until the resolved feature group materializes it.
+`FeatureGroup.options_with_defaults(options)` returns an `Options` view where every absent key
+with a concrete declared default is filled from its spec (into context or group per the spec),
+so compute reads see it. A present value is never overridden, even a falsy `0`/`False`/`""`.
+`NO_DEFAULT` and `default=None` fill nothing. A strict default is already validated at
+construction, so the materialized value is not re-checked. The view is applied *after*
+resolution, so it never changes matching or FeatureSet splitting.
+
+``` python
+opts = MyFeatureGroup.options_with_defaults(feature.options)
+graph_type = opts.get("graph_type")  # the declared default when the caller omitted it
+```
 
 ## Parameter classification
 
@@ -353,6 +368,7 @@ if it really is a whole-value check.
 | The constructor IS the schema (no key set left to curate) | `tests/.../feature_chainer/test_property_mapping_spec_schema.py` |
 | Shape rules, relocated from class definition to construction | `tests/.../feature_chainer/test_property_mapping_spec_shape.py` |
 | Declared-default invariant | `tests/test_core/test_abstract_plugins/test_property_mapping_default_invariant.py` |
+| Declared defaults materialized into runtime options | `tests/test_core/test_abstract_plugins/test_options_with_defaults.py` |
 | Container invariance, no stringification, str-as-scalar, dict-as-composite, empty containers | `tests/.../feature_chainer/test_property_mapping_sequence_unpacking.py` |
 | Present option values validated on the string-named path too; required presence stays config-only | `tests/.../feature_chainer/test_name_path_validates_option_values.py` |
 | `required_when` survives an overridden matcher, runs exactly once, and demands a classmethod | `tests/.../feature_chainer/test_required_when_enforced_on_override.py` |

--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -26,7 +26,7 @@ from mloda.core.abstract_plugins.components.match_data.match_data import MatchDa
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
-from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.components.options import Options, _isolate_forwarded_value
 from mloda.core.abstract_plugins.components.index.index import Index
 from mloda.core.abstract_plugins.components.utils import get_all_subclasses, safe_field
 
@@ -216,9 +216,7 @@ class FeatureGroup(ABC):
 
         key = declaration.key
         spec = (cls.PROPERTY_MAPPING or {}).get(key)
-        value = options.get(key)
-        if value is None and spec is not None and not is_no_default(spec.default):
-            value = spec.default
+        value = cls.options_with_defaults(options).get(key)
         if value is None:
             return None
         if spec is not None:
@@ -230,6 +228,44 @@ class FeatureGroup(ABC):
             if normalized is not None and len(normalized) == 1:
                 return str(next(iter(normalized)))
         return str(value)
+
+    @final
+    @classmethod
+    def options_with_defaults(cls, options: Options) -> Options:
+        """Return an Options with every absent PROPERTY_MAPPING key that declares a concrete default
+        materialized from its spec (context or group per the spec); present values are never overridden (#766)."""
+        mapping = cls.PROPERTY_MAPPING or {}
+        memo: dict[int, Any] = {}
+        fills_group: dict[str, Any] = {}
+        fills_context: dict[str, Any] = {}
+        for key, spec in mapping.items():
+            if options.get(key) is not None:
+                continue
+            if is_no_default(spec.default) or spec.default is None:
+                continue
+            # Isolate the class-level default so a compute-time mutation cannot corrupt the spec (mirrors
+            # inherit_from). Fill where the key already sits (present-as-None), else per the spec's
+            # classification, so the constructed Options never lands the same key in both group and context.
+            value = _isolate_forwarded_value(spec.default, memo)
+            if key in options.group:
+                fills_group[key] = value
+            elif key in options.context:
+                fills_context[key] = value
+            elif spec.context:
+                fills_context[key] = value
+            else:
+                fills_group[key] = value
+        if not fills_group and not fills_context:
+            return options
+        result = Options(
+            group={**options.group, **fills_group},
+            context={**options.context, **fills_context},
+            propagate_context_keys=options.propagate_context_keys,
+        )
+        result.inherited_group_keys = options.inherited_group_keys
+        result.inherited_context_keys = options.inherited_context_keys
+        result.last_forwarded_group_keys = options.last_forwarded_group_keys
+        return result
 
     @final
     @classmethod

--- a/mloda_plugins/feature_group/experimental/clustering/base.py
+++ b/mloda_plugins/feature_group/experimental/clustering/base.py
@@ -314,11 +314,7 @@ class ClusteringFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             cls._check_source_features_exist(data, resolved_features)
 
             # Check if we should output probabilities
-            output_probabilities = (
-                feature.options.get(cls.OUTPUT_PROBABILITIES)
-                if feature.options.get(cls.OUTPUT_PROBABILITIES) is not None
-                else False
-            )
+            output_probabilities = cls.options_with_defaults(feature.options).get(cls.OUTPUT_PROBABILITIES)
 
             # Perform clustering
             if output_probabilities:

--- a/mloda_plugins/feature_group/experimental/dimensionality_reduction/pandas.py
+++ b/mloda_plugins/feature_group/experimental/dimensionality_reduction/pandas.py
@@ -137,52 +137,25 @@ class PandasDimensionalityReductionFeatureGroup(DimensionalityReductionFeatureGr
                 f"Target dimension ({dimension}) must be less than the number of source features ({X_scaled.shape[1]})"
             )
 
+        # Materialize declared defaults so each branch reads the spec-backed value (#766)
+        options = DimensionalityReductionFeatureGroup.options_with_defaults(options)
+
         # Perform dimensionality reduction based on the algorithm
         if algorithm == "pca":
             svd_solver = options.get(DimensionalityReductionFeatureGroup.PCA_SVD_SOLVER)
-            if svd_solver is None:
-                svd_solver = DimensionalityReductionFeatureGroup.PROPERTY_MAPPING[
-                    DimensionalityReductionFeatureGroup.PCA_SVD_SOLVER
-                ].default
             return cls._perform_pca_reduction(X_scaled, dimension, svd_solver)
         elif algorithm == "tsne":
-            max_iter_val = options.get(DimensionalityReductionFeatureGroup.TSNE_MAX_ITER)
-            if max_iter_val is None:
-                max_iter_val = DimensionalityReductionFeatureGroup.PROPERTY_MAPPING[
-                    DimensionalityReductionFeatureGroup.TSNE_MAX_ITER
-                ].default
-            max_iter = int(max_iter_val)
-
-            n_iter_without_progress_val = options.get(DimensionalityReductionFeatureGroup.TSNE_N_ITER_WITHOUT_PROGRESS)
-            if n_iter_without_progress_val is None:
-                n_iter_without_progress_val = DimensionalityReductionFeatureGroup.PROPERTY_MAPPING[
-                    DimensionalityReductionFeatureGroup.TSNE_N_ITER_WITHOUT_PROGRESS
-                ].default
-            n_iter_without_progress = int(n_iter_without_progress_val)
-
+            max_iter = int(options.get(DimensionalityReductionFeatureGroup.TSNE_MAX_ITER))
+            n_iter_without_progress = int(options.get(DimensionalityReductionFeatureGroup.TSNE_N_ITER_WITHOUT_PROGRESS))
             method = options.get(DimensionalityReductionFeatureGroup.TSNE_METHOD)
-            if method is None:
-                method = DimensionalityReductionFeatureGroup.PROPERTY_MAPPING[
-                    DimensionalityReductionFeatureGroup.TSNE_METHOD
-                ].default
             return cls._perform_tsne_reduction(X_scaled, dimension, max_iter, n_iter_without_progress, method)
         elif algorithm == "ica":
-            max_iter_val = options.get(DimensionalityReductionFeatureGroup.ICA_MAX_ITER)
-            if max_iter_val is None:
-                max_iter_val = DimensionalityReductionFeatureGroup.PROPERTY_MAPPING[
-                    DimensionalityReductionFeatureGroup.ICA_MAX_ITER
-                ].default
-            max_iter = int(max_iter_val)
+            max_iter = int(options.get(DimensionalityReductionFeatureGroup.ICA_MAX_ITER))
             return cls._perform_ica_reduction(X_scaled, dimension, max_iter)
         elif algorithm == "lda":
             return cls._perform_lda_reduction(X_scaled, dimension, df)
         elif algorithm == "isomap":
-            n_neighbors_val = options.get(DimensionalityReductionFeatureGroup.ISOMAP_N_NEIGHBORS)
-            if n_neighbors_val is None:
-                n_neighbors_val = DimensionalityReductionFeatureGroup.PROPERTY_MAPPING[
-                    DimensionalityReductionFeatureGroup.ISOMAP_N_NEIGHBORS
-                ].default
-            n_neighbors = int(n_neighbors_val)
+            n_neighbors = int(options.get(DimensionalityReductionFeatureGroup.ISOMAP_N_NEIGHBORS))
             return cls._perform_isomap_reduction(X_scaled, dimension, n_neighbors)
         else:
             raise ValueError(f"Unsupported dimensionality reduction algorithm: {algorithm}")

--- a/mloda_plugins/feature_group/experimental/forecasting/base.py
+++ b/mloda_plugins/feature_group/experimental/forecasting/base.py
@@ -335,10 +335,8 @@ class ForecastingFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featu
                     raise ValueError("No artifact to load although it was requested.")
 
             # Check if we should output confidence intervals
-            output_confidence_intervals = (
-                feature.options.get(cls.OUTPUT_CONFIDENCE_INTERVALS)
-                if feature.options.get(cls.OUTPUT_CONFIDENCE_INTERVALS) is not None
-                else False
+            output_confidence_intervals = cls.options_with_defaults(feature.options).get(
+                cls.OUTPUT_CONFIDENCE_INTERVALS
             )
 
             # Perform forecasting using the original clean data

--- a/mloda_plugins/feature_group/experimental/node_centrality/base.py
+++ b/mloda_plugins/feature_group/experimental/node_centrality/base.py
@@ -229,8 +229,9 @@ class NodeCentralityFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             centrality_type, source_feature_str = cls._extract_centrality_and_source_feature(feature)
 
             # Common parameter extraction (works for both approaches)
-            graph_type = feature.options.get(cls.GRAPH_TYPE) or "undirected"
-            weight_column = feature.options.get(cls.WEIGHT_COLUMN)
+            opts = cls.options_with_defaults(feature.options)
+            graph_type = opts.get(cls.GRAPH_TYPE)
+            weight_column = opts.get(cls.WEIGHT_COLUMN)
 
             # Validate graph type
             if graph_type not in cls.GRAPH_TYPES:

--- a/tests/test_core/test_abstract_plugins/test_options_with_defaults.py
+++ b/tests/test_core/test_abstract_plugins/test_options_with_defaults.py
@@ -1,0 +1,279 @@
+"""Pin ``FeatureGroup.options_with_defaults``: materialize declared PropertySpec defaults into Options (#766).
+
+The mechanism returns an Options equal to the input PLUS, for every PROPERTY_MAPPING key that is absent
+(``options.get(key) is None``) and declares a concrete default (``not is_no_default(spec.default)`` and
+``spec.default is not None``), the value ``spec.default`` placed in ``.context`` when ``spec.context`` else
+``.group``. A present value (even a falsy 0/""/False) is never overridden, and the input is never mutated.
+
+Group 3 (``resolve_subtype`` delegating to this mechanism) is already pinned by
+``tests/test_core/test_prepare/test_subtype_option_parity.py::TestSbparPropertyMappingDefaultParity::test_resolve_subtype_applies_declared_default``
+(empty options -> declared default subtype), so it is referenced here rather than duplicated.
+"""
+
+from __future__ import annotations
+
+import gc
+from typing import Any
+
+import pytest
+
+from mloda.core.abstract_plugins.components.feature_chainer.property_spec import is_no_default
+from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.components.utils import get_all_subclasses
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.provider import PropertySpec
+from mloda_plugins.feature_group.experimental.aggregated_feature_group.base import AggregatedFeatureGroup
+from mloda_plugins.feature_group.experimental.clustering.base import ClusteringFeatureGroup
+from mloda_plugins.feature_group.experimental.data_quality.missing_value.base import MissingValueFeatureGroup
+from mloda_plugins.feature_group.experimental.dimensionality_reduction.base import DimensionalityReductionFeatureGroup
+from mloda_plugins.feature_group.experimental.forecasting.base import ForecastingFeatureGroup
+from mloda_plugins.feature_group.experimental.geo_distance.base import GeoDistanceFeatureGroup
+from mloda_plugins.feature_group.experimental.node_centrality.base import NodeCentralityFeatureGroup
+from mloda_plugins.feature_group.experimental.sklearn.encoding.base import EncodingFeatureGroup
+from mloda_plugins.feature_group.experimental.sklearn.pipeline.base import SklearnPipelineFeatureGroup
+from mloda_plugins.feature_group.experimental.sklearn.scaling.base import ScalingFeatureGroup
+from mloda_plugins.feature_group.experimental.text_cleaning.base import TextCleaningFeatureGroup
+from mloda_plugins.feature_group.experimental.time_window.base import TimeWindowFeatureGroup
+
+
+@pytest.fixture(autouse=True)
+def _no_feature_group_registry_pollution() -> Any:
+    """Guarantee this module never leaks throwaway FeatureGroup subclasses.
+
+    The tests below define FeatureGroup subclasses to exercise the author experience.
+    Those class objects sit in reference cycles, so they linger in
+    ``FeatureGroup.__subclasses__()`` until a GC cycle runs. While they linger, other
+    tests that enumerate feature groups via ``get_all_subclasses(FeatureGroup)`` trip
+    over them. After each test we force a collection to reclaim the now-unreferenced
+    classes and assert that none of this module's classes remain registered, pinning
+    the no-pollution contract.
+    """
+    yield
+    gc.collect()
+    gc.collect()
+    leaked = [c for c in get_all_subclasses(FeatureGroup) if c.__module__ == __name__]
+    assert not leaked, f"Leaked FeatureGroup subclasses from {__name__}: {[c.__name__ for c in leaked]}"
+
+
+# PROPERTY_MAPPING keys for the throwaway feature group, one per default edge under test.
+CTX_KEY = "owd_ctx_default"  # context concrete default
+GRP_KEY = "owd_grp_default"  # group concrete default (context=False)
+FALSY_KEY = "owd_falsy_default"  # non-strict default is a non-falsy string; set to a falsy present value
+NONE_KEY = "owd_none_default"  # declared default=None (optional, applies no value)
+REQ_KEY = "owd_required"  # NO_DEFAULT (required by omission)
+
+
+def _options_with_defaults(fg: type[FeatureGroup], options: Options) -> Any:
+    """Invoke ``FeatureGroup.options_with_defaults`` directly; the method now lives on the base class.
+
+    A direct typed call (``fg`` is ``type[FeatureGroup]``, the classmethod is declared on ``FeatureGroup``)
+    stays ``mypy --strict`` clean and retires the dynamic ``getattr`` seam the RED phase needed while the
+    method was still absent.
+    """
+    return fg.options_with_defaults(options)
+
+
+def _declared_default(fg: type[FeatureGroup], key: str) -> Any:
+    """The default declared for ``key`` in ``fg``'s PROPERTY_MAPPING."""
+    mapping: dict[str, PropertySpec] = fg.PROPERTY_MAPPING or {}
+    return mapping[key].default
+
+
+def _make_probe_fg() -> type[FeatureGroup]:
+    """A throwaway FeatureGroup whose PROPERTY_MAPPING exercises every default edge (no required_when)."""
+
+    class ProbeDefaultsFeatureGroup(FeatureGroup):
+        PROPERTY_MAPPING = {
+            CTX_KEY: PropertySpec("A context concrete default.", context=True, default="ctx_val"),
+            GRP_KEY: PropertySpec("A group concrete default.", context=False, default="grp_val"),
+            FALSY_KEY: PropertySpec("Non-strict default is a non-falsy string.", context=True, default="nonfalsy"),
+            NONE_KEY: PropertySpec("Optional: a declared None applies no value.", context=True, default=None),
+            REQ_KEY: PropertySpec("Required by omission (NO_DEFAULT).", context=True),
+        }
+
+        @classmethod
+        def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+            return data
+
+    return ProbeDefaultsFeatureGroup
+
+
+class TestOptionsWithDefaultsMechanism:
+    """FeatureGroup.options_with_defaults fills declared concrete defaults into runtime Options."""
+
+    def test_absent_context_default_filled_into_context(self) -> None:
+        """An absent key with a context concrete default lands in ``.context`` with that value."""
+        fg = _make_probe_fg()
+        filled = _options_with_defaults(fg, Options())
+        assert filled.get(CTX_KEY) == "ctx_val"
+        assert CTX_KEY in filled.context
+        assert CTX_KEY not in filled.group
+
+    def test_absent_group_default_filled_into_group(self) -> None:
+        """An absent ``context=False`` key with a concrete default lands in ``.group`` with that value."""
+        fg = _make_probe_fg()
+        filled = _options_with_defaults(fg, Options())
+        assert filled.get(GRP_KEY) == "grp_val"
+        assert GRP_KEY in filled.group
+        assert GRP_KEY not in filled.context
+
+    def test_present_value_overrides_declared_default(self) -> None:
+        """An explicit value wins over the declared default."""
+        fg = _make_probe_fg()
+        filled = _options_with_defaults(fg, Options(context={CTX_KEY: "explicit"}))
+        assert filled.get(CTX_KEY) == "explicit"
+
+    @pytest.mark.parametrize("falsy", [0, "", False])
+    def test_present_falsy_value_is_kept_not_defaulted(self, falsy: Any) -> None:
+        """A present falsy value (0/""/False) is kept; the default must not override it (``is None`` not ``or``)."""
+        fg = _make_probe_fg()
+        filled = _options_with_defaults(fg, Options(context={FALSY_KEY: falsy}))
+        assert filled.get(FALSY_KEY) == falsy
+        assert filled.get(FALSY_KEY) != "nonfalsy"
+
+    def test_default_none_key_is_not_filled(self) -> None:
+        """A ``default=None`` key stays absent from both group and context."""
+        fg = _make_probe_fg()
+        filled = _options_with_defaults(fg, Options())
+        assert filled.get(NONE_KEY) is None
+        assert NONE_KEY not in filled.group
+        assert NONE_KEY not in filled.context
+
+    def test_required_no_default_key_is_not_filled(self) -> None:
+        """A NO_DEFAULT (required) key is not filled."""
+        fg = _make_probe_fg()
+        filled = _options_with_defaults(fg, Options())
+        assert filled.get(REQ_KEY) is None
+        assert REQ_KEY not in filled.group
+        assert REQ_KEY not in filled.context
+
+    def test_input_options_never_mutated(self) -> None:
+        """The input Options is not mutated; no default leaks back into it."""
+        fg = _make_probe_fg()
+        original = Options()
+        group_before = dict(original.group)
+        context_before = dict(original.context)
+        _options_with_defaults(fg, original)
+        assert original.group == group_before
+        assert original.context == context_before
+        assert CTX_KEY not in original.context
+        assert GRP_KEY not in original.group
+
+    def test_returns_options_and_preserves_propagate_context_keys(self) -> None:
+        """Returns an Options; ``propagate_context_keys`` survives the call."""
+        fg = _make_probe_fg()
+        opts = Options(context={CTX_KEY: "x"}, propagate_context_keys=frozenset({CTX_KEY}))
+        filled = _options_with_defaults(fg, opts)
+        assert isinstance(filled, Options)
+        assert filled.propagate_context_keys == frozenset({CTX_KEY})
+
+    def test_fill_path_preserves_forwarding_provenance(self) -> None:
+        """The filled view keeps inherited/forwarded provenance; a public Options must not silently drop it."""
+        fg = _make_probe_fg()
+        opts = Options(context={"seed": "v"})
+        opts.inherited_group_keys = frozenset({"a"})
+        opts.inherited_context_keys = frozenset({"b"})
+        opts.last_forwarded_group_keys = frozenset({"c"})
+        filled = _options_with_defaults(fg, opts)
+        assert filled.get(CTX_KEY) == "ctx_val"  # a default WAS filled, so this is the fresh-Options path
+        assert filled.inherited_group_keys == frozenset({"a"})
+        assert filled.inherited_context_keys == frozenset({"b"})
+        assert filled.last_forwarded_group_keys == frozenset({"c"})
+
+
+# Shipped feature groups (mirrors test_property_mapping_consistency.ALL_PLUGINS) for the drift sweep.
+ALL_PLUGINS: list[type[Any]] = [
+    AggregatedFeatureGroup,
+    ClusteringFeatureGroup,
+    MissingValueFeatureGroup,
+    DimensionalityReductionFeatureGroup,
+    ForecastingFeatureGroup,
+    GeoDistanceFeatureGroup,
+    NodeCentralityFeatureGroup,
+    EncodingFeatureGroup,
+    SklearnPipelineFeatureGroup,
+    ScalingFeatureGroup,
+    TextCleaningFeatureGroup,
+    TimeWindowFeatureGroup,
+]
+
+
+class TestShippedDefaultsMaterialize:
+    """Shipped feature groups' declared concrete defaults materialize verbatim (issue #766 DoD)."""
+
+    def test_node_centrality_graph_type_default(self) -> None:
+        """NodeCentralityFeatureGroup.graph_type materializes to its declared 'undirected'."""
+        key = NodeCentralityFeatureGroup.GRAPH_TYPE
+        filled = _options_with_defaults(NodeCentralityFeatureGroup, Options())
+        assert filled.get(key) == _declared_default(NodeCentralityFeatureGroup, key) == "undirected"
+
+    def test_clustering_output_probabilities_default(self) -> None:
+        """ClusteringFeatureGroup.output_probabilities materializes to its declared False (a falsy default)."""
+        key = ClusteringFeatureGroup.OUTPUT_PROBABILITIES
+        filled = _options_with_defaults(ClusteringFeatureGroup, Options())
+        assert filled.get(key) is False
+        assert _declared_default(ClusteringFeatureGroup, key) is False
+
+    def test_forecasting_output_confidence_intervals_default(self) -> None:
+        """ForecastingFeatureGroup.output_confidence_intervals materializes to its declared False."""
+        key = ForecastingFeatureGroup.OUTPUT_CONFIDENCE_INTERVALS
+        filled = _options_with_defaults(ForecastingFeatureGroup, Options())
+        assert filled.get(key) is False
+        assert _declared_default(ForecastingFeatureGroup, key) is False
+
+    def test_dimensionality_reduction_defaults(self) -> None:
+        """All six DimensionalityReductionFeatureGroup algorithm defaults materialize verbatim."""
+        fg = DimensionalityReductionFeatureGroup
+        filled = _options_with_defaults(fg, Options())
+        expected: dict[str, Any] = {
+            fg.TSNE_MAX_ITER: 250,
+            fg.TSNE_N_ITER_WITHOUT_PROGRESS: 50,
+            fg.TSNE_METHOD: "barnes_hut",
+            fg.PCA_SVD_SOLVER: "auto",
+            fg.ICA_MAX_ITER: 200,
+            fg.ISOMAP_N_NEIGHBORS: 5,
+        }
+        for key, value in expected.items():
+            assert filled.get(key) == _declared_default(fg, key) == value
+
+    def test_every_shipped_concrete_default_materializes(self) -> None:
+        """Every shipped concrete (non-None, declared) default materializes to itself.
+
+        Iterating every key future-proofs any newly added concrete default across the shipped set.
+        """
+        checked = 0
+        for plugin_cls in ALL_PLUGINS:
+            mapping: dict[str, Any] = plugin_cls.PROPERTY_MAPPING or {}
+            filled = _options_with_defaults(plugin_cls, Options())
+            for key, spec in mapping.items():
+                if is_no_default(spec.default) or spec.default is None:
+                    continue
+                assert filled.get(key) == spec.default, (
+                    f"{plugin_cls.__name__}.{key}: options_with_defaults yielded {filled.get(key)!r}, "
+                    f"expected the declared default {spec.default!r}."
+                )
+                checked += 1
+        assert checked > 0, "the sweep asserted nothing; no shipped concrete defaults were discovered."
+
+
+class TestMutableDefaultIsolation:
+    """A materialized mutable default must be a per-call copy, so compute-time mutation cannot corrupt the spec."""
+
+    def test_materialized_mutable_default_is_isolated(self) -> None:
+        """A mutable concrete default is copied per call; compute-time mutation cannot corrupt the spec."""
+
+        class MutableDefaultFeatureGroup(FeatureGroup):
+            PROPERTY_MAPPING = {"items": PropertySpec("A mutable default.", context=True, default=[])}
+
+            @classmethod
+            def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+                return data
+
+        materialized = _options_with_defaults(MutableDefaultFeatureGroup, Options()).get("items")
+        assert materialized == []
+        materialized.append("mutated")
+        assert MutableDefaultFeatureGroup.PROPERTY_MAPPING["items"].default == [], "the declared default was corrupted"
+        assert _options_with_defaults(MutableDefaultFeatureGroup, Options()).get("items") == [], (
+            "a later call saw the leak"
+        )

--- a/tests/test_plugins/feature_group/experimental/test_node_centrality_feature_group/test_node_centrality_integration.py
+++ b/tests/test_plugins/feature_group/experimental/test_node_centrality_feature_group/test_node_centrality_integration.py
@@ -229,6 +229,39 @@ class TestNodeCentralityPandasIntegration:
         # Validate the node centrality feature
         validate_node_centrality_features(centrality_df, ["placeholder1"])
 
+    def test_graph_type_default_applied_at_compute(self) -> None:
+        """Omitting graph_type computes the same centrality as graph_type='undirected'.
+
+        End-to-end proof that the declared 'undirected' default is materialized at compute
+        (via options_with_defaults inside calculate_feature) rather than required from the user (#766).
+        """
+        plugin_collector = PluginCollector.enabled_feature_groups(
+            {NodeCentralityTestDataCreator, PandasNodeCentralityFeatureGroup}
+        )
+
+        base_context: dict[str, Any] = {
+            NodeCentralityFeatureGroup.CENTRALITY_TYPE: "degree",
+            DefaultOptionKeys.in_features: "source",
+            NodeCentralityFeatureGroup.WEIGHT_COLUMN: "weight",
+        }
+
+        def run_centrality(context: dict[str, Any]) -> list[float]:
+            result = mloda.run_all(
+                ["source", "target", "weight", Feature("placeholder1", Options(context=context))],
+                compute_frameworks={PandasDataFrame},
+                plugin_collector=plugin_collector,
+            )
+            for df in result:
+                if "placeholder1" in df.columns:
+                    return list(df["placeholder1"])
+            raise AssertionError("DataFrame with placeholder1 centrality feature not found")
+
+        omitted = run_centrality(dict(base_context))
+        explicit = run_centrality({**base_context, NodeCentralityFeatureGroup.GRAPH_TYPE: "undirected"})
+
+        assert len(omitted) > 0, "No centrality values were computed"
+        assert omitted == explicit, "Omitting graph_type did not match the explicit 'undirected' default at compute"
+
     def test_directed_vs_undirected_graph(self) -> None:
         """Test node centrality features with different graph types."""
 


### PR DESCRIPTION
Closes #766 (epic #761, phase 2).

## Problem

`PropertySpec.default` was metadata only. Compute read the raw user `Options`, so shipped plugins hand-rolled the default three divergent ways: spec-driven reads (`PROPERTY_MAPPING[k].default`), re-hardcoded literals (`or "undirected"`, `else False`), and plain `.get`. `property-mapping.md` claimed the default was "applied when the key is absent", which was false.

## Change

Add `FeatureGroup.options_with_defaults(options)`, a post-resolution `Options` view that fills every absent `PROPERTY_MAPPING` key declaring a concrete default from its spec (into context or group per the spec). Properties:

- A present value, even a falsy `0` / `False` / `""`, is never overridden (stricter and more correct than `or`).
- `NO_DEFAULT` (required) and `default=None` (optional, no value) fill nothing.
- Strict defaults are already validated at construction, so the materialized value is not re-checked.
- The view is applied after resolution, so it never changes matching or FeatureSet splitting.
- The returned `Options` is a faithful copy: forwarding provenance is preserved and mutable defaults are isolated per call, so it is safe to read or pass onward.

`resolve_subtype` now delegates its default application to the same seam, so there is one default-application rule across the codebase.

Migrated the four feature groups that hand-rolled the default (`node_centrality`, `clustering`, `forecasting`, `dimensionality_reduction`) to the mechanism, and made the `property-mapping.md` claim true rather than corrected downward.

## Tests

- `tests/test_core/test_abstract_plugins/test_options_with_defaults.py`: mechanism edges (fill absent, never override a present or falsy value, skip `NO_DEFAULT` and `default=None`, group vs context placement, input never mutated, provenance preserved, mutable-default isolation) plus a drift sweep asserting every shipped concrete default materializes to itself.
- An end-to-end node_centrality test: omitting `graph_type` produces the same result as `graph_type="undirected"`, proving compute applies the declared default.

## Validation

Full `tox` green: pytest suite, `ruff format --check`, `ruff check`, `pip-licenses` allowlist, `mypy --strict`, and `bandit`. No dependencies added.
