### PR TITLE
feat: Options.get accepts a dict-style default argument (#767)

### DIFF
--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -247,6 +247,19 @@ opts = MyFeatureGroup.options_with_defaults(feature.options)
 graph_type = opts.get("graph_type")  # the declared default when the caller omitted it
 ```
 
+`Options.get(key, default)` reads dict-style: a present key returns its stored value (even a falsy
+`0`/`False`/`""`), and the call-site `default` is returned only when the key is absent from both
+group and context. Because `options_with_defaults` has already materialized any declared default
+into the view, reading it back gives a three-level precedence, an explicit caller value first, then
+the declared spec default, then the call-site `default`. (Subtlety: `options_with_defaults` fills any
+key whose value `is None`, so an explicit `None` is replaced by a concrete spec default, while the
+other falsy values `0`/`False`/`""` are kept.)
+
+``` python
+opts = MyFeatureGroup.options_with_defaults(feature.options)
+graph_type = opts.get("graph_type", "spring")  # explicit value; else the spec default; else "spring"
+```
+
 ## Parameter classification
 
 There is no `group` field: a group parameter is `context=False`.

--- a/mloda/core/abstract_plugins/components/options.py
+++ b/mloda/core/abstract_plugins/components/options.py
@@ -96,7 +96,7 @@ class Options:
     - Options(group={...}, context={...}) - Both specified
 
     Common Methods:
-    - .get(key) - Read value (searches group, then context)
+    - .get(key[, default]) - Read value (searches group, then context; default when absent)
     - .set(key, value) - Write value (auto-placement)
     - .items() / .keys() - Iterate over all options
     - key in options - Check existence
@@ -186,16 +186,18 @@ class Options:
             return False
         return self.group == other.group
 
-    def get(self, key: str) -> Any:
-        """
-        Get a value from options, searching group first, then context.
+    def get(self, key: str, default: Any = None) -> Any:
+        """Get a value, searching group then context; return ``default`` only when the key is absent from both.
 
-        This is the recommended way to access option values when you don't need
-        to distinguish between group and context parameters.
+        Dict-style like ``dict.get``: a present key returns its stored value even when falsy
+        (``0``, ``""``, ``False``, ``None``); ``default`` is used only for an absent key. Single-argument
+        ``get(key)`` returns ``None`` for an absent key, unchanged.
         """
         if key in self.group:
             return self.group[key]
-        return self.context.get(key, None)
+        if key in self.context:
+            return self.context[key]
+        return default
 
     def __getitem__(self, key: str) -> Any:
         return self.get(key)

--- a/tests/test_core/test_abstract_plugins/test_components/test_options.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_options.py
@@ -1,5 +1,6 @@
 import copy
 from copy import deepcopy
+from typing import Any
 
 import pytest
 from mloda.user import Options
@@ -381,3 +382,55 @@ class TestOptionsNestedStructureHashing:
         )
         result = hash(options)
         assert isinstance(result, int)
+
+
+class TestOptionsGetDefault:
+    """Options.get accepts a dict-style default returned only for absent keys (#767)."""
+
+    def test_absent_key_returns_call_site_default(self) -> None:
+        """An absent key returns the call-site default."""
+        assert Options(group={"a": 1}).get("missing", "d") == "d"
+
+    def test_single_arg_absent_key_still_returns_none(self) -> None:
+        """Single-argument get on an absent key still returns None (unchanged)."""
+        assert Options(group={"a": 1}).get("missing") is None
+
+    def test_present_group_key_ignores_default(self) -> None:
+        """A present group key returns its stored value; the default is ignored."""
+        assert Options(group={"a": 1}).get("a", "d") == 1
+
+    def test_present_context_key_ignores_default(self) -> None:
+        """A present context key returns its stored value; the default is ignored."""
+        assert Options(context={"a": 1}).get("a", "d") == 1
+
+    @pytest.mark.parametrize("falsy", [0, "", False])
+    def test_present_falsy_group_value_returned_not_default(self, falsy: Any) -> None:
+        """A present falsy group value (0/""/False) is returned as-is, never the default."""
+        result = Options(group={"a": falsy}).get("a", "sentinel_default")
+        assert result == falsy
+        assert type(result) is type(falsy)
+        assert result != "sentinel_default"
+
+    @pytest.mark.parametrize("falsy", [0, "", False])
+    def test_present_falsy_context_value_returned_not_default(self, falsy: Any) -> None:
+        """A present falsy context value (0/""/False) is returned as-is, never the default."""
+        result = Options(context={"a": falsy}).get("a", "sentinel_default")
+        assert result == falsy
+        assert type(result) is type(falsy)
+        assert result != "sentinel_default"
+
+    def test_present_none_group_value_returns_none_not_default(self) -> None:
+        """A group key stored as None returns None (presence-based), never the default."""
+        assert Options(group={"a": None}).get("a", "d") is None
+
+    def test_present_none_context_value_returns_none_not_default(self) -> None:
+        """A context key stored as None returns None (presence-based), never the default."""
+        assert Options(context={"a": None}).get("a", "d") is None
+
+    def test_default_passed_positionally(self) -> None:
+        """The default is accepted as a positional second argument."""
+        assert Options().get("m", "d") == "d"
+
+    def test_default_passed_by_keyword(self) -> None:
+        """The default is accepted as a keyword argument."""
+        assert Options().get("m", default="d") == "d"

--- a/tests/test_core/test_abstract_plugins/test_options_with_defaults.py
+++ b/tests/test_core/test_abstract_plugins/test_options_with_defaults.py
@@ -277,3 +277,32 @@ class TestMutableDefaultIsolation:
         assert _options_with_defaults(MutableDefaultFeatureGroup, Options()).get("items") == [], (
             "a later call saw the leak"
         )
+
+
+class TestOptionsGetDefaultPrecedence:
+    """get(key, call_site_default) on the materialized view honors explicit > spec default > call-site (#767).
+
+    Each test binds only the materialized ``Options`` to a local (a non-asserted assignment pytest never
+    rewrites), so the throwaway probe FeatureGroup stays a transient and the module's autouse no-leak guard
+    still passes even when an assert fails.
+    """
+
+    def test_spec_default_beats_call_site_default(self) -> None:
+        """An absent key that declares a concrete default resolves to that default, not the call-site default."""
+        view = _options_with_defaults(_make_probe_fg(), Options())
+        assert view.get(CTX_KEY, "callsite") == "ctx_val"
+
+    def test_explicit_value_beats_both_defaults(self) -> None:
+        """An explicit value beats both the spec default and the call-site default."""
+        view = _options_with_defaults(_make_probe_fg(), Options(context={CTX_KEY: "explicit"}))
+        assert view.get(CTX_KEY, "callsite") == "explicit"
+
+    def test_call_site_default_is_last_resort(self) -> None:
+        """With neither explicit value nor spec default (REQ_KEY is NO_DEFAULT), the call-site default is returned."""
+        view = _options_with_defaults(_make_probe_fg(), Options())
+        assert view.get(REQ_KEY, "callsite") == "callsite"
+
+    def test_explicit_none_is_overwritten_by_spec_default(self) -> None:
+        """An explicit None is unset to options_with_defaults, so the concrete spec default still applies."""
+        view = _options_with_defaults(_make_probe_fg(), Options(context={CTX_KEY: None}))
+        assert view.get(CTX_KEY, "callsite") == "ctx_val"


### PR DESCRIPTION
Closes #767.

## What

`Options.get(key)` accepted no default, so the natural `options.get(key, default)` was a `TypeError` and plugin authors hand-rolled fallbacks at read sites. This adds a dict-style `default` parameter.

- `Options.get(key, default)` returns `default` only when the key is absent from both group and context.
- A present key returns its stored value even when falsy (`0`, `""`, `False`, `None`), presence-based like `dict.get`, so a falsy value is never mistaken for an absent one.
- Single-argument `get(key)` is unchanged (returns `None` when absent), and `__getitem__` is untouched.
- `default` is accepted positionally and by keyword.

## Precedence

Reading through `FeatureGroup.options_with_defaults(...)`, which materializes declared spec defaults (#766), gives a three-level precedence: an explicit caller value, then the declared spec default, then the call-site `default`. Documented in `property-mapping.md`. One subtlety pinned by a test: `options_with_defaults` treats a value that `is None` as unset, so an explicit `None` is replaced by a concrete spec default, while `0`/`False`/`""` are kept. The explicit-`None` opt-in refinement stays the scope of #768 (finding 11).

Part of epic #761, phase 2.

## Tests

- `test_options.py::TestOptionsGetDefault`: absent key, single-arg unchanged, present group and context keys, falsy `0`/`""`/`False` on both sides, stored `None` on both sides, positional and keyword default.
- `test_options_with_defaults.py::TestOptionsGetDefaultPrecedence`: spec default beats call-site default, explicit value beats both, call-site default as last resort, and explicit `None` overwritten by a concrete spec default.

## Validation

`tox` green: pytest (6430 passed, 170 skipped), ruff format and check, license allowlist, `mypy --strict`, bandit.
