### PR TITLE
feat: opt-in allow_explicit_none distinguishes explicit None from absent (#768)

### DIFF
--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -38,6 +38,7 @@ PROPERTY_MAPPING = {
 | `element_validator` | `Callable \| None` | `None` | Per-element predicate. Requires `strict_validation=True`. |
 | `match_guard` | `Callable \| None` | `None` | Whole-value predicate. A falsy return is a non-match. |
 | `required_when` | `Callable \| None` | `None` | `(Options) -> bool`: the key is required only when it returns truthy. |
+| `allow_explicit_none` | `bool` | `False` | Opt-in so an explicit `None` is honored (not treated as absent) and flows through validation. |
 
 `property_spec(...)` is a thin builder over the same fields. Its keyword is `strict=`,
 which sets `strict_validation`. Both it and `PropertySpec` are exported from
@@ -253,7 +254,12 @@ group and context. Because `options_with_defaults` has already materialized any 
 into the view, reading it back gives a three-level precedence, an explicit caller value first, then
 the declared spec default, then the call-site `default`. (Subtlety: `options_with_defaults` fills any
 key whose value `is None`, so an explicit `None` is replaced by a concrete spec default, while the
-other falsy values `0`/`False`/`""` are kept.)
+other falsy values `0`/`False`/`""` are kept. That "None means absent" rule is the default; a spec
+opts a single key out with `allow_explicit_none=True`, after which an explicit `None` overrides even a
+concrete default and is honored across the match-time value mechanisms: it counts as present for the
+required-presence and `required_when` checks and is seen by membership, `element_validator`, and
+`match_guard`, while every flagless spec is unchanged. The flag defaults to `False`, so the existing
+`is not None` presence tests keep working.)
 
 ``` python
 opts = MyFeatureGroup.options_with_defaults(feature.options)

--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -32,7 +32,7 @@ PROPERTY_MAPPING = {
 | --- | --- | --- | --- |
 | `explanation` | `str` | required, positional | What the option means. Also names the spec in construction errors. |
 | `allowed_values` | `Mapping[Any, str]`, any other iterable, or `None` | `None` | The declared value space. A Mapping is `{value: description}` and is kept as given; any other iterable is materialized to a tuple. |
-| `default` | `Any` | `NO_DEFAULT` | Materialized into runtime options when the key is absent (see [Applying declared defaults](#applying-declared-defaults)). Leaving it at `NO_DEFAULT` declares *no default*, which makes the key required. See [Optional keys](#optional-keys). |
+| `default` | `Any` | `NO_DEFAULT` | Materialized into runtime options when the key is absent (see [Applying declared defaults](#applying-declared-defaults)). Leaving it at `NO_DEFAULT` declares *no default*, which makes the key required. See [Optional keys](#optional-keys). A caller's explicit `None` is treated as absent, so this default replaces it, unless the key sets `allow_explicit_none=True`. |
 | `context` | `bool` | `True` | `True`: context parameter. `False`: group parameter, which splits feature groups. |
 | `strict_validation` | `bool` | `False` | Enforce the value space at match time. |
 | `element_validator` | `Callable \| None` | `None` | Per-element predicate. Requires `strict_validation=True`. |

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -343,11 +343,11 @@ class FeatureChainParser:
         cls, options: Options, property_name: str, property_mapping: dict[str, PropertySpec]
     ) -> list[Any] | None:
         """Validate one option value and return its elements, or None when the option is absent."""
-        found_property_value = options.get(property_name)
-        if found_property_value is None:
-            return None
-
         property_config = property_mapping[property_name]
+        found_property_value = options.get(property_name)
+        # An opted-in spec treats a present-as-None value as PRESENT, so it flows through validation (#768).
+        if found_property_value is None and not (property_config.allow_explicit_none and property_name in options):
+            return None
         return cls._process_found_property_value(
             found_property_value, cls._extract_property_values(property_config), property_name, property_config
         )
@@ -545,7 +545,12 @@ class FeatureChainParser:
                     owner_name,
                 )
                 return False
-            if is_required and effective_options.get(key) is None:
+            # An opted-in key present as an explicit None counts as present, so the requirement is met (#768).
+            if (
+                is_required
+                and effective_options.get(key) is None
+                and not (spec.allow_explicit_none and key in effective_options)
+            ):
                 logger.debug(
                     "Feature group %s requires option '%s' (predicate %s is satisfied) but it was not provided.",
                     owner_name,

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -399,7 +399,8 @@ class FeatureChainParserMixin:
             if guard is None:
                 continue
             value = options.get(key)
-            if value is None:
+            # An opted-in explicit None reaches the guard; every flagless spec still skips a None (#768).
+            if value is None and not (mapping_entry.allow_explicit_none and key in options):
                 continue
             try:
                 rejected = not guard(value)

--- a/mloda/core/abstract_plugins/components/feature_chainer/property_spec.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/property_spec.py
@@ -62,6 +62,7 @@ class PropertySpec:
     element_validator: Callable[[Any], Any] | None = None
     match_guard: Callable[[Any], Any] | None = None
     required_when: Callable[[Any], Any] | None = None
+    allow_explicit_none: bool = False
 
     def __post_init__(self) -> None:
         prefix = f"PropertySpec({self.explanation!r})"
@@ -86,6 +87,11 @@ class PropertySpec:
         if not isinstance(self.strict_validation, bool):
             raise ValueError(
                 f"{prefix}: strict_validation must be a bool, got {type(self.strict_validation).__name__}."
+            )
+
+        if not isinstance(self.allow_explicit_none, bool):
+            raise ValueError(
+                f"{prefix}: allow_explicit_none must be a bool, got {type(self.allow_explicit_none).__name__}."
             )
 
         if self.element_validator is not None and not callable(self.element_validator):
@@ -163,6 +169,7 @@ def property_spec(
     element_validator: Callable[[Any], Any] | None = None,
     required_when: Callable[[Any], Any] | None = None,
     match_guard: Callable[[Any], Any] | None = None,
+    allow_explicit_none: bool = False,
 ) -> PropertySpec:
     """Build a ``PropertySpec``; the ``strict=`` keyword sets the ``strict_validation`` field."""
     return PropertySpec(
@@ -174,4 +181,5 @@ def property_spec(
         element_validator=element_validator,
         match_guard=match_guard,
         required_when=required_when,
+        allow_explicit_none=allow_explicit_none,
     )

--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -239,7 +239,9 @@ class FeatureGroup(ABC):
         fills_group: dict[str, Any] = {}
         fills_context: dict[str, Any] = {}
         for key, spec in mapping.items():
-            if options.get(key) is not None:
+            # An opted-in spec honors an explicit None: presence, not non-None-ness, gates the fill (#768).
+            present = key in options if spec.allow_explicit_none else options.get(key) is not None
+            if present:
                 continue
             if is_no_default(spec.default) or spec.default is None:
                 continue

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_explicit_none_opt_in.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_explicit_none_opt_in.py
@@ -1,0 +1,175 @@
+"""An explicit None becomes a distinct, honored option value only when a spec opts in (#768).
+
+Today the option layer reads an explicit ``None`` exactly like an absent key ("None means
+absent"). ``allow_explicit_none=True`` is the per-spec opt-in that flips two behaviors for that one
+key: an explicit ``None`` now FLOWS THROUGH the parser's value validation (a strict spec can accept
+or reject it), and an explicit ``None`` counts as PRESENT for the required-presence check. Every
+flagless spec is unchanged: an explicit ``None`` still reads as absent.
+
+These tests drive the parser entry points directly with hand-built mappings: the config path
+(``match_configuration_feature_chain_parser``), the ``required_when`` guard (``check_required_when``),
+and the ``match_guard`` sweep (``_first_rejecting_guard``). They need no FeatureGroup subclass and
+leave the registry untouched (the direct-call style of ``test_property_spec_type.py``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import (
+    FeatureChainParser,
+    PropertyValueRejection,
+)
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import (
+    FeatureChainParserMixin,
+)
+from mloda.core.abstract_plugins.components.feature_chainer.property_spec import PropertySpec
+from mloda.core.abstract_plugins.components.options import Options
+
+
+def _accepts_none(value: Any) -> bool:
+    """A value space whose accepted set is ``None`` plus the positive ints (#768)."""
+    return value is None or (isinstance(value, int) and value > 0)
+
+
+def _always_required(options: Any) -> bool:
+    """A ``required_when`` predicate that always demands the option (#768)."""
+    return True
+
+
+def _rejects_none(value: Any) -> bool:
+    """A ``match_guard`` that rejects None and accepts every other value (#768)."""
+    return value is not None
+
+
+class TestExplicitNoneFlowsThroughStrictValidation:
+    """Under strict + opt-in, an explicit None is validated like any other value (#768)."""
+
+    def test_opted_in_none_outside_value_space_is_rejected(self) -> None:
+        """C1: an opted-in explicit None outside the strict value space is validated and REJECTED."""
+        property_mapping = {
+            "k": PropertySpec(
+                "k", allowed_values=("a", "b"), strict_validation=True, default="a", allow_explicit_none=True
+            )
+        }
+
+        with pytest.raises(PropertyValueRejection):
+            FeatureChainParser.match_configuration_feature_chain_parser(
+                "any_feature", Options(context={"k": None}), property_mapping
+            )
+
+    def test_flagless_none_is_absent_so_the_default_makes_it_skippable(self) -> None:
+        """C4 contrast (DoD 3): without the flag the same explicit None reads as absent and is not validated."""
+        property_mapping = {"k": PropertySpec("k", allowed_values=("a", "b"), strict_validation=True, default="a")}
+
+        assert (
+            FeatureChainParser.match_configuration_feature_chain_parser(
+                "any_feature", Options(context={"k": None}), property_mapping
+            )
+            is True
+        )
+
+    def test_opted_in_none_inside_value_space_is_accepted(self) -> None:
+        """C2: an opted-in explicit None a strict validator accepts is validated and matches."""
+        property_mapping = {
+            "k": PropertySpec("k", strict_validation=True, element_validator=_accepts_none, allow_explicit_none=True)
+        }
+
+        assert (
+            FeatureChainParser.match_configuration_feature_chain_parser(
+                "any_feature", Options(context={"k": None}), property_mapping
+            )
+            is True
+        )
+
+
+class TestExplicitNoneSatisfiesRequiredPresence:
+    """Under opt-in, an explicit None satisfies a required key's presence; absent is still absent (#768)."""
+
+    def test_opted_in_absent_key_is_still_required(self) -> None:
+        """C3: a truly absent opted-in required key is still a non-match (absent stays absent)."""
+        property_mapping = {"k": PropertySpec("k", allow_explicit_none=True)}
+
+        assert (
+            FeatureChainParser.match_configuration_feature_chain_parser(
+                "any_feature", Options(context={}), property_mapping
+            )
+            is False
+        )
+
+    def test_opted_in_explicit_none_satisfies_presence(self) -> None:
+        """C3: an explicit None satisfies the required key once the spec opts in."""
+        property_mapping = {"k": PropertySpec("k", allow_explicit_none=True)}
+
+        assert (
+            FeatureChainParser.match_configuration_feature_chain_parser(
+                "any_feature", Options(context={"k": None}), property_mapping
+            )
+            is True
+        )
+
+    def test_flagless_explicit_none_reads_as_absent(self) -> None:
+        """C3 contrast (DoD 3): without the flag an explicit None reads as absent, so the required key is unmet."""
+        property_mapping = {"k": PropertySpec("k")}
+
+        assert (
+            FeatureChainParser.match_configuration_feature_chain_parser(
+                "any_feature", Options(context={"k": None}), property_mapping
+            )
+            is False
+        )
+
+
+class TestRequiredWhenHonorsExplicitNone:
+    """check_required_when reads an explicit None as present only when the spec opts in (#768)."""
+
+    def test_opted_in_explicit_none_satisfies_required_when(self) -> None:
+        """D1: an opted-in satisfied requirement is met by an explicit None, which now counts as present."""
+        property_mapping = {"k": PropertySpec("k", required_when=_always_required, allow_explicit_none=True)}
+
+        assert (
+            FeatureChainParser.check_required_when(
+                "Owner", "any_feature", [], property_mapping, Options(context={"k": None})
+            )
+            is True
+        )
+
+    def test_flagless_explicit_none_leaves_requirement_unmet(self) -> None:
+        """D2 contrast (DoD 3): without the flag the explicit None reads as absent, so the requirement is unmet."""
+        property_mapping = {"k": PropertySpec("k", required_when=_always_required)}
+
+        assert (
+            FeatureChainParser.check_required_when(
+                "Owner", "any_feature", [], property_mapping, Options(context={"k": None})
+            )
+            is False
+        )
+
+    def test_opted_in_absent_key_leaves_requirement_unmet(self) -> None:
+        """D3: absent stays absent; an opted-in required key that is truly absent is still unmet."""
+        property_mapping = {"k": PropertySpec("k", required_when=_always_required, allow_explicit_none=True)}
+
+        assert (
+            FeatureChainParser.check_required_when("Owner", "any_feature", [], property_mapping, Options(context={}))
+            is False
+        )
+
+
+class TestMatchGuardHonorsExplicitNone:
+    """_first_rejecting_guard runs a match_guard on an explicit None only when the spec opts in (#768)."""
+
+    def test_opted_in_explicit_none_runs_the_guard_and_records_rejection(self) -> None:
+        """E1: an opted-in guard that rejects None runs on the explicit None and records the rejection."""
+        property_mapping = {"k": PropertySpec("k", match_guard=_rejects_none, allow_explicit_none=True)}
+
+        rejection = FeatureChainParserMixin._first_rejecting_guard(Options(context={"k": None}), property_mapping)
+        assert rejection == ("k", None)
+
+    def test_flagless_explicit_none_skips_the_guard(self) -> None:
+        """E2 contrast (DoD 3): without the flag the guard is skipped for the None, so nothing is rejected."""
+        property_mapping = {"k": PropertySpec("k", match_guard=_rejects_none)}
+
+        rejection = FeatureChainParserMixin._first_rejecting_guard(Options(context={"k": None}), property_mapping)
+        assert rejection is None

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_spec_schema.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_spec_schema.py
@@ -45,7 +45,7 @@ class TestTheConstructorIsTheSchema:
     """The dataclass field set is the whole schema; an unknown field cannot exist."""
 
     def test_field_set_is_exactly_the_schema(self) -> None:
-        """The schema is these eight fields, nothing more: there is no key set to drift from."""
+        """The schema is these nine fields, nothing more: there is no key set to drift from."""
         assert {field.name for field in dataclasses.fields(PropertySpec)} == {
             "explanation",
             "allowed_values",
@@ -55,6 +55,7 @@ class TestTheConstructorIsTheSchema:
             "element_validator",
             "match_guard",
             "required_when",
+            "allow_explicit_none",
         }
 
     def test_typo_field_is_a_constructor_type_error_naming_the_offender(self) -> None:

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_spec_builder.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_spec_builder.py
@@ -677,3 +677,28 @@ class TestPropertySpecPassthroughRegressionGuards:
             match_guard=_is_list_of_strings,
         )
         assert built == hand_constructed
+
+
+class TestPropertySpecAllowExplicitNone:
+    """``allow_explicit_none`` passthrough (issue #768).
+
+    The opt-in flag defaults to ``False`` and rides through the builder onto the field; a built
+    spec equals the ``PropertySpec`` an author constructs by hand.
+    """
+
+    def test_allow_explicit_none_emitted_through_builder(self) -> None:
+        """``allow_explicit_none=True`` lands on the field; omitting it leaves the default ``False``."""
+        assert property_spec("d", allow_explicit_none=True).allow_explicit_none is True
+        assert property_spec("d").allow_explicit_none is False
+
+    def test_allow_explicit_none_spec_equals_direct_construction(self) -> None:
+        """An ``allow_explicit_none`` spec is exactly the ``PropertySpec`` an author would construct."""
+        built = property_spec("d", allow_explicit_none=True)
+
+        hand_constructed = PropertySpec(
+            "d",
+            context=True,
+            strict_validation=False,
+            allow_explicit_none=True,
+        )
+        assert built == hand_constructed

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_spec_type.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_spec_type.py
@@ -52,6 +52,7 @@ class TestConstructionAndFields:
         assert spec.element_validator is None
         assert spec.match_guard is None
         assert spec.required_when is None
+        assert spec.allow_explicit_none is False
 
     def test_explanation_is_required(self) -> None:
         """``PropertySpec()`` without an explanation raises TypeError."""
@@ -80,6 +81,16 @@ class TestConstructionAndFields:
         assert not hasattr(spec, "strict")
         with pytest.raises(TypeError):
             _spec("x", strict=True)
+
+    def test_allow_explicit_none_constructs_and_composes(self) -> None:
+        """``allow_explicit_none=True`` stores the flag and composes with strict and a declared None (#768)."""
+        assert PropertySpec("x", allow_explicit_none=True).allow_explicit_none is True
+
+        strict_spec = PropertySpec("x", allowed_values=("a",), strict_validation=True, allow_explicit_none=True)
+        assert strict_spec.allow_explicit_none is True
+
+        none_default_spec = PropertySpec("x", default=None, allow_explicit_none=True)
+        assert none_default_spec.allow_explicit_none is True
 
 
 class TestAllowedValuesNormalization:
@@ -138,6 +149,12 @@ class TestFlagAndCallableShapeRules:
         """A truthy non-bool under ``strict_validation`` raises, naming the expected type."""
         with pytest.raises(ValueError, match="(?i)bool"):
             _spec("x", allowed_values=("a",), strict_validation=bad_flag)
+
+    @pytest.mark.parametrize("bad_flag", ["false", 1])
+    def test_allow_explicit_none_must_be_a_real_bool(self, bad_flag: Any) -> None:
+        """A truthy non-bool under ``allow_explicit_none`` raises, mirroring ``strict_validation`` (#768)."""
+        with pytest.raises(ValueError, match="(?i)bool"):
+            _spec("x", allow_explicit_none=bad_flag)
 
     def test_non_callable_element_validator_raises(self) -> None:
         """``element_validator`` must be callable."""

--- a/tests/test_core/test_abstract_plugins/test_options_with_defaults.py
+++ b/tests/test_core/test_abstract_plugins/test_options_with_defaults.py
@@ -99,6 +99,27 @@ def _make_probe_fg() -> type[FeatureGroup]:
     return ProbeDefaultsFeatureGroup
 
 
+# A unique key for the explicit-None opt-in suite (#768), so it never collides with the probe above.
+EN_KEY = "owd_explicit_none_optin"  # context concrete default that opts into honoring an explicit None
+
+
+def _make_explicit_none_probe_fg() -> type[FeatureGroup]:
+    """A throwaway FeatureGroup whose one key opts into honoring an explicit None (#768)."""
+
+    class ExplicitNoneProbeFeatureGroup(FeatureGroup):
+        PROPERTY_MAPPING = {
+            EN_KEY: PropertySpec(
+                "Opted-in: an explicit None is honored.", context=True, default="ctx_val", allow_explicit_none=True
+            ),
+        }
+
+        @classmethod
+        def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+            return data
+
+    return ExplicitNoneProbeFeatureGroup
+
+
 class TestOptionsWithDefaultsMechanism:
     """FeatureGroup.options_with_defaults fills declared concrete defaults into runtime Options."""
 
@@ -306,3 +327,23 @@ class TestOptionsGetDefaultPrecedence:
         """An explicit None is unset to options_with_defaults, so the concrete spec default still applies."""
         view = _options_with_defaults(_make_probe_fg(), Options(context={CTX_KEY: None}))
         assert view.get(CTX_KEY, "callsite") == "ctx_val"
+
+
+class TestOptionsWithDefaultsHonorsExplicitNone:
+    """options_with_defaults honors an explicit None only when the spec opts in (#768).
+
+    Twin of ``test_explicit_none_is_overwritten_by_spec_default`` above: the flagless spec lets the
+    concrete default overwrite an explicit None, while the opted-in spec keeps the None. Each test
+    binds only the materialized ``Options`` to a local, so the throwaway probe FeatureGroup stays a
+    transient and the module's autouse no-leak guard still passes even when an assert fails.
+    """
+
+    def test_opted_in_explicit_none_survives_the_default(self) -> None:
+        """B1: an opted-in key present as an explicit None keeps the None; the concrete default does not overwrite it."""
+        view = _options_with_defaults(_make_explicit_none_probe_fg(), Options(context={EN_KEY: None}))
+        assert view.get(EN_KEY, "callsite") is None
+
+    def test_opted_in_absent_key_still_materializes_the_default(self) -> None:
+        """B3: absent stays absent; an opted-in key that is not present at all still gets its concrete default."""
+        view = _options_with_defaults(_make_explicit_none_probe_fg(), Options())
+        assert view.get(EN_KEY, "callsite") == "ctx_val"


### PR DESCRIPTION
Closes #768. Part of epic #761, phase 2 (options lifecycle), after #766 (framework-applied defaults) and #767 (`Options.get(key, default)`).

## Problem
An explicit `key=None` option was indistinguishable from omitting the key, so a user could neither override a non-None default with None nor have None validated. The fix had to be opt-in: shipped and downstream code presence-tests options with `is not None`, and that pattern must keep working unchanged.

## Design decision
Add a per-spec boolean `PropertySpec.allow_explicit_none` (default `False`). This is the only design that satisfies the opt-in constraint: a global sentinel, or a global switch to presence-based reads, would make every explicit None distinct from absent, changing behavior for all specs and breaking the pervasive "None means absent" contract. A per-spec flag defaulting to `False` changes nothing for the 12 shipped specs and all downstream, and #767 already gave consumers presence-based reads (`get(key, default)`, `key in options`). The flag lives on the spec that already owns default and validation semantics.

## Behavior
When `allow_explicit_none=True`, an explicit None for that key is a present, honored value across the match-time value mechanisms:
- `options_with_defaults` gates the default fill on presence (`key in options`), so an explicit None survives a concrete declared default.
- `_collect_option_value` lets a present-as-None value flow through membership / `element_validator` validation and satisfy required-presence.
- `check_required_when` counts it as present, so a satisfied `required_when` is met.
- `_first_rejecting_guard` runs `match_guard` on it instead of skipping.

When `False` (every existing spec) each site is byte-for-byte unchanged: `not (False and ...)` collapses to the original condition. The three DoD items are met, and the "None means absent" default is preserved.

## Scope boundaries (deliberate)
`build_effective_options` (string-name merge) and `resolve_subtype` keep `is not None`: they concern name-parsed value precedence and the "no subtype" case, not honoring an explicit config None, and behave identically for flagged and flagless specs. In-feature counting is likewise untouched (`in_features` is not a normal value spec).

## Review
Two independent deep reviews (Claude Opus and codex) ran on the initial commit. Both confirmed the core change is byte-for-byte safe for flagless specs, and both flagged the same two gaps: `required_when` and `match_guard` did not yet honor the flag, an inconsistency for specs that combine the flag with those mechanisms. Both were accepted and fixed (the two one-line symmetric changes above), which also makes the doc's "flows through validation" claim fully accurate. The name-merge and `resolve_subtype` boundaries were reviewed and judged defensible.

## Tests
New `test_explicit_none_opt_in.py`, plus additions to the PropertySpec type/builder/schema and `options_with_defaults` suites, cover: the flag field and its bool guard, an explicit None surviving a concrete default, None flowing through strict validation (both accepted and rejected), required-presence via an explicit None, and the `required_when` / `match_guard` interactions, each with a flagless contrast pinning the opt-in. Full `tox` is green (pytest + ruff + mypy --strict + bandit + license allowlist); the change adds no skips.
