### PR TITLE
docs: remove en and em dashes (#747)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 mloda is pre-1.0 and ships frequently. Security fixes are applied to the
 latest released version on [PyPI](https://pypi.org/project/mloda/) and the
-`main` branch. We do not backport fixes to older releases — please upgrade to
+`main` branch. We do not backport fixes to older releases. Please upgrade to
 the latest version before reporting.
 
 | Version        | Supported          |
@@ -20,11 +20,11 @@ prepared.
 
 Instead, use one of these private channels:
 
-1. **GitHub Private Vulnerability Reporting** (preferred) — open the
+1. **GitHub Private Vulnerability Reporting** (preferred): Open the
    [Security tab](https://github.com/mloda-ai/mloda/security/advisories/new)
    and click **Report a vulnerability**. This keeps the report, discussion, and
    coordinated disclosure in one place.
-2. **Email** — write to **security@mloda.ai**.
+2. **Email**: Write to **security@mloda.ai**.
 
 Please include as much of the following as you can:
 

--- a/docs/docs/chapter1/api-request.md
+++ b/docs/docs/chapter1/api-request.md
@@ -1,8 +1,8 @@
 ### API Request Example
 
-This example demonstrates a simple request to the mloda API. You describe WHAT data you need - mloda resolves HOW to get it.
+This example demonstrates a simple request to the mloda API. You describe WHAT data you need, mloda resolves HOW to get it.
 
-> **Tip:** For AI agents or quick prototyping, you can also use inline data with `api_data` - see the [30-second example](installation.md#4-quick-start).
+> **Tip:** For AI agents or quick prototyping, you can also use inline data with `api_data`, see the [30-second example](installation.md#4-quick-start).
 
 In this example, mloda automatically determines that a **CsvReader** feature group will fulfill the request and respond with the resulting DataFrame.
 
@@ -57,9 +57,9 @@ batch jobs, but in latency-sensitive scenarios the repeated planning overhead ma
 
 Typical examples where this applies:
 
-- **ML model serving** — a prediction endpoint computes the same derived features for every incoming request; only the raw input row changes.
-- **Streaming / event-driven pipelines** — each incoming event needs the same feature transformations applied in real time.
-- **Interactive applications** — a dashboard or API recalculates features on every user action with fresh parameters.
+- **ML model serving**: A prediction endpoint computes the same derived features for every incoming request; only the raw input row changes.
+- **Streaming / event-driven pipelines**: Each incoming event needs the same feature transformations applied in real time.
+- **Interactive applications**: A dashboard or API recalculates features on every user action with fresh parameters.
 
 The two-phase API lets you pay the planning cost once at startup and then execute
 cheaply per request:
@@ -72,7 +72,7 @@ session = mloda.prepare(feature_list, compute_frameworks=["PyArrowTable"], data_
 result = session.run(api_data={"MyKey": {"col": [1, 2]}})
 ```
 
-See [mloda API — Two-Phase Execution](../in_depth/mloda-api.md#two-phase-execution-prepare-run) for details.
+See [mloda API: Two-Phase Execution](../in_depth/mloda-api.md#two-phase-execution-prepare-run) for details.
 
 #### For AI Agents: JSON-Based Requests
 

--- a/docs/docs/chapter1/extender.md
+++ b/docs/docs/chapter1/extender.md
@@ -58,7 +58,7 @@ ERROR    test_getting_started:test_getting_started.py:29 Time taken: 0.001033782
 
 #### 3. Summary
 
-With this simple extender, you can easily log and monitor the execution time of any functionality within feature groups. By extending the Extender class, you can wrap additional behavior—such as performance monitoring, logging, or auditing—around critical functions to enhance observability and traceability in your data processing workflows.
+With this simple extender, you can easily log and monitor the execution time of any functionality within feature groups. By extending the Extender class, you can wrap additional behavior such as performance monitoring, logging, or auditing around critical functions to enhance observability and traceability in your data processing workflows.
 
 When multiple extenders are provided, they are automatically chained and executed in priority order (lower values first).
 

--- a/docs/docs/examples/mloda_basics/2_ml_advantage_process_focus.py
+++ b/docs/docs/examples/mloda_basics/2_ml_advantage_process_focus.py
@@ -48,7 +48,7 @@ def _(mo):
 
     In this scenario, embedding data specifics into the process prevents sharing or adapting it for other tasks, leading to repeated rewrites and wasted effort.
 
-    mloda addresses this issue by decoupling data and process definitions - the features. Instead of combining them in a single process, data and the features are treated as separate entities that come together only during calculation time. The following code snippet of mloda brings together data and features:
+    mloda addresses this issue by decoupling data and process definitions, the features. Instead of combining them in a single process, data and the features are treated as separate entities that come together only during calculation time. The following code snippet of mloda brings together data and features:
 
     ```python
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
@@ -82,7 +82,7 @@ def _(mo):
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""
-    In current systems, data processes are tightly coupled with the technologies used at specific lifecycle stages—ETL systems for batch pipelines, streaming platforms for real-time applications, and ML frameworks for training. This rigid coupling makes it challenging to adapt to changing technologies or switch between processing modes.
+    In current systems, data processes are tightly coupled with the technologies used at specific lifecycle stages i.e. ETL systems for batch pipelines, streaming platforms for real-time applications, and ML frameworks for training. This rigid coupling makes it challenging to adapt to changing technologies or switch between processing modes.
 
     Metadata management further complicates the situation, it is kept fragmented across separate tools:
 

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -8,11 +8,11 @@ mloda is designed for AI agents, ML pipelines, data scientists, and data practit
 
 #### What problems does mloda solve?
 
-mloda tackles redundant data work, complex feature dependencies, and inconsistent data management. It provides AI agents with safe, deterministic data access through a declarative API - agents describe WHAT they need, mloda resolves HOW to get it.
+mloda tackles redundant data work, complex feature dependencies, and inconsistent data management. It provides AI agents with safe, deterministic data access through a declarative API. Agents describe WHAT they need, mloda resolves HOW to get it.
 
 #### How does mloda differ from traditional data engineering frameworks?
 
-Unlike traditional tools, mloda focuses on defining transformations rather than managing static states. This approach allows you to share data transformations or pipeline steps without exposing sensitive data, as the true value lies in the state of the data—which remains protected.
+Unlike traditional tools, mloda focuses on defining transformations rather than managing static states. This approach allows you to share data transformations or pipeline steps without exposing sensitive data, as the true value lies in the state of the data which remains protected.
 
 ## AI and Agent Integration
 
@@ -38,7 +38,7 @@ Installation is straightforward via pip or by cloning the repository. [Installat
 
 #### What are the prerequisites for using mloda? 
 
-You'll need Python and a bit of time to understand the framework. mloda introduces a different way of thinking compared to standard approaches, but it builds on standard practices while bridging multiple disciplines—data engineering, software engineering, data science, machine learning, and business analysis. 
+You'll need Python and a bit of time to understand the framework. mloda introduces a different way of thinking compared to standard approaches, but it builds on standard practices while bridging multiple disciplines such as data engineering, software engineering, data science, machine learning, and business analysis. 
 
 You'll learn a lot along the way!
 
@@ -50,7 +50,7 @@ Feature Groups define dependencies and calculations. To create your first Featur
 
 #### What are Feature Groups in mloda and why are they important?
 
-Feature Groups are inspired by the concept of feature stores, where they represent logical groupings of reusable features. With mloda, Feature Groups define how features are calculated rather than stored, enabling hierarchical relationships between features that are resolved automatically—simplifying both creation and use.
+Feature Groups are inspired by the concept of feature stores, where they represent logical groupings of reusable features. With mloda, Feature Groups define how features are calculated rather than stored, enabling hierarchical relationships between features that are resolved automatically, simplifying both creation and use.
 
 #### How does mloda handle feature dependencies?
 

--- a/docs/docs/in_depth/data-type-enforcement.md
+++ b/docs/docs/in_depth/data-type-enforcement.md
@@ -10,27 +10,27 @@ Use typed constructors to declare the expected data type:
 from typing import Any, Optional
 from mloda.user import Feature
 
-# Typed features - will be validated at runtime
+# Typed features: Will be validated at runtime
 feature_int = Feature.int32_of("user_count")
 feature_double = Feature.double_of("price")
 feature_str = Feature.str_of("name")
 
-# Untyped feature - no validation
+# Untyped feature: No validation
 feature_any = Feature.not_typed("legacy_column")
 ```
 
 Available typed constructors:
-- `int32_of()`, `int64_of()` - Integer types
-- `float_of()`, `double_of()` - Floating point types
-- `str_of()` - String type
-- `boolean_of()` - Boolean type
-- `date_of()`, `timestamp_millis_of()`, `timestamp_micros_of()` - Date/time types
-- `decimal_of()`, `binary_of()` - Other types
+- `int32_of()`, `int64_of()`: Integer types
+- `float_of()`, `double_of()`: Floating point types
+- `str_of()`: String type
+- `boolean_of()`: Boolean type
+- `date_of()`, `timestamp_millis_of()`, `timestamp_micros_of()`: Date/time types
+- `decimal_of()`, `binary_of()`: Other types
 
 ## Declaring a Feature Group's Output Type
 
 The section above is the *data user* declaring a type on a `Feature`. A *feature group* can also
-declare the type it produces, via `return_data_type_rule` — the provider-side counterpart. mloda
+declare the type it produces, via `return_data_type_rule`, the provider-side counterpart. mloda
 reconciles the two at planning time.
 
 ```python
@@ -46,8 +46,8 @@ class UserCount(FeatureGroup):
 
 The rule returns either:
 
-- a concrete `DataType` — the group always emits this type;
-- `None` (the default) — no fixed type / polymorphic.
+- a concrete `DataType`: the group always emits this type;
+- `None` (the default): no fixed type / polymorphic.
 
 Reconciliation with the user's declared type, at planning:
 
@@ -62,7 +62,7 @@ a concrete declared type flows through to runtime checking against the actual co
 
 `return_data_type_rule` runs *after* the feature group has been selected for the feature, so a rule
 that raises is a failure of a committed component, not a non-applicable candidate. mloda does **not**
-catch it — the exception propagates and fails planning. If your rule does work that can legitimately
+catch it, the exception propagates and fails planning. If your rule does work that can legitimately
 fail to determine a type, return `None` for that case rather than letting it raise.
 
 ## Validation Behavior

--- a/docs/docs/in_depth/streaming.md
+++ b/docs/docs/in_depth/streaming.md
@@ -40,9 +40,9 @@ Streaming operates at **feature-group granularity**.  Each yielded value is a **
 
 ## What is not supported
 
-- **Row-by-row streaming** -- individual rows are not yielded as they are computed.
-- **Partial results** -- you cannot observe a feature group's output before it has fully completed.
-- **Chunked input** -- a single feature group's computation is not split into smaller streaming chunks.
+- **Row-by-row streaming**: individual rows are not yielded as they are computed.
+- **Partial results**: you cannot observe a feature group's output before it has fully completed.
+- **Chunked input**: a single feature group's computation is not split into smaller streaming chunks.
 
 ## When to use `stream_all`
 


### PR DESCRIPTION
Close #747 

Removed en and em dashes from the requested files.
docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md , did not have any so it remains unchanged.

### Files Changed
SECURITY.md
docs/docs/chapter1/api-request.md
docs/docs/chapter1/extender.md
docs/docs/examples/mloda_basics/2_ml_advantage_process_focus.py (markdown cells)
docs/docs/faq.md
docs/docs/in_depth/data-type-enforcement.md
docs/docs/in_depth/streaming.md

docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md (Requested but remains unchanged)

### Verification
tox passes for the docs changed.
The changes are only in texts , so might not break anything.