### PR TITLE
refactor: make resolution failure rendering a pure projection of EvaluationResult (#791)

### DIFF
--- a/attribution/ATTRIBUTION.md
+++ b/attribution/ATTRIBUTION.md
@@ -9,7 +9,7 @@
 | bandit                                 | 1.9.4           | Apache-2.0                                         |
 | cachetools                             | 6.2.6           | MIT                                                |
 | certifi                                | 2026.6.17       | Mozilla Public License 2.0 (MPL 2.0)               |
-| charset-normalizer                     | 3.4.7           | MIT                                                |
+| charset-normalizer                     | 3.4.9           | MIT                                                |
 | click                                  | 8.4.2           | BSD-3-Clause                                       |
 | comm                                   | 0.2.3           | BSD License                                        |
 | cyclonedx-python-lib                   | 11.11.0         | Apache Software License                            |
@@ -19,7 +19,7 @@
 | duckdb                                 | 1.5.4           | MIT License                                        |
 | execnet                                | 2.1.2           | MIT License                                        |
 | executing                              | 2.2.1           | MIT License                                        |
-| filelock                               | 3.29.6          | MIT License                                        |
+| filelock                               | 3.29.7          | MIT License                                        |
 | fsspec                                 | 2026.6.0        | BSD-3-Clause                                       |
 | idna                                   | 3.18            | BSD-3-Clause                                       |
 | iniconfig                              | 2.3.0           | MIT                                                |
@@ -30,7 +30,7 @@
 | joblib                                 | 1.5.3           | BSD-3-Clause                                       |
 | jupyter_client                         | 8.9.1           | BSD License                                        |
 | jupyter_core                           | 5.9.1           | BSD-3-Clause                                       |
-| librt                                  | 0.12.0          | MIT                                                |
+| librt                                  | 0.13.0          | MIT                                                |
 | markdown-it-py                         | 4.2.0           | MIT License                                        |
 | matplotlib-inline                      | 0.2.2           | BSD-3-Clause                                       |
 | mdurl                                  | 0.1.2           | MIT License                                        |
@@ -38,11 +38,11 @@
 | mloda                                  | 0.10.0          | Apache-2.0                                         |
 | mmh3                                   | 5.2.1           | MIT License                                        |
 | msgpack                                | 1.2.1           | Apache-2.0                                         |
-| mypy                                   | 2.1.0           | MIT                                                |
+| mypy                                   | 2.2.0           | MIT                                                |
 | mypy_extensions                        | 1.1.0           | MIT                                                |
 | narwhals                               | 2.23.0          | MIT                                                |
 | nest-asyncio2                          | 1.7.2           | BSD License                                        |
-| nltk                                   | 3.9.4           | Apache Software License                            |
+| nltk                                   | 3.10.0          | Apache Software License                            |
 | numpy                                  | 2.5.1           | BSD-3-Clause AND 0BSD AND MIT AND Zlib AND CC0-1.0 |
 | opentelemetry-api                      | 1.43.0          | Apache-2.0                                         |
 | opentelemetry-instrumentation          | 0.64b0          | Apache Software License                            |

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -1,5 +1,5 @@
 import inspect
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from difflib import get_close_matches
 from typing import Iterable, Literal, Optional
 
@@ -19,12 +19,36 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
+class CandidateFrameworks:
+    """One candidate's own accessible frameworks, split by the match-time capability hook."""
+
+    supported: frozenset[type[ComputeFramework]] = frozenset()
+    rejected: frozenset[type[ComputeFramework]] = frozenset()
+
+
+@dataclass(frozen=True)
+class RenderFacts:
+    """Facts captured during the decision pass so rendering needs no provider hook.
+
+    The empty instance is the success value: the winning path captures nothing.
+    """
+
+    environment_empty: bool = False
+    domains: dict[type[FeatureGroup], str] = field(default_factory=dict)
+    concrete_frameworks: tuple[str, ...] = ()
+    value_rejections: tuple[tuple[str, str], ...] = ()
+    known_names: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
 class EvaluationResult:
     """Non-raising result of matching a feature against accessible plugins."""
 
     identified: FeatureGroupEnvironmentMapping
     criteria_matched: set[type[FeatureGroup]] = field(default_factory=set)
     abstract_matched: set[type[FeatureGroup]] = field(default_factory=set)
+    candidate_frameworks: dict[type[FeatureGroup], CandidateFrameworks] = field(default_factory=dict)
+    facts: RenderFacts = field(default_factory=RenderFacts)
 
     @property
     def failure_kind(self) -> Literal["multiple", "abstract_only", "none"] | None:
@@ -91,9 +115,120 @@ def scope_callout(scope: str | type[FeatureGroup] | None) -> str | None:
     return f"Scoped to feature group: '{scope_name}'."
 
 
+TROUBLESHOOTING_URL = "https://mloda-ai.github.io/mloda/in_depth/troubleshooting/feature-group-resolution-errors/"
+
+
+def _render_multiple(result: EvaluationResult, feature: Feature, callout: str | None) -> str:
+    lines = "\n".join(
+        f"  - {fg.__name__} ({fg.__module__}) [domain: {domain}]"
+        for fg, domain in sorted(result.facts.domains.items(), key=lambda item: item[0].__name__)
+    )
+    scope_line = f"{callout}\n" if callout else ""
+    return (
+        f"Multiple feature groups found for feature '{str(feature.name)}':\n"
+        f"{lines}\n"
+        f"{scope_line}"
+        f"For troubleshooting guide, see: {TROUBLESHOOTING_URL}"
+    )
+
+
+def _render_capability(result: EvaluationResult, feature: Feature) -> str | None:
+    """One line per candidate that rejects a framework, each naming only its OWN frameworks."""
+    rejecting = {fg: cfw for fg, cfw in result.candidate_frameworks.items() if cfw.rejected}
+    if not rejecting:
+        return None
+
+    lines = []
+    for fg in sorted(rejecting, key=lambda candidate: candidate.__name__):
+        candidate_frameworks = rejecting[fg]
+        rejected_names = sorted(fw.get_class_name() for fw in candidate_frameworks.rejected)
+        line = f"  - {fg.__name__}: {rejected_names}."
+        if candidate_frameworks.supported:
+            supported_names = sorted(fw.get_class_name() for fw in candidate_frameworks.supported)
+            line += f" Supported on: {supported_names}."
+        lines.append(line)
+
+    body = "\n".join(lines)
+    return (
+        f"Unsupported compute framework(s) for feature '{str(feature.name)}':\n"
+        f"{body}\n"
+        "Pin the feature to a supported compute framework or override supports_compute_framework."
+    )
+
+
+def _render_abstract_only(result: EvaluationResult, feature: Feature) -> str:
+    feature_name = str(feature.name)
+    if not result.facts.concrete_frameworks:
+        return (
+            f"No feature groups found for feature name: '{feature_name}'. "
+            f"Only abstract feature group base(s) matched, which cannot be instantiated; "
+            f"no concrete implementation is available or enabled."
+        )
+
+    framework_names = sorted(result.facts.concrete_frameworks)
+    return (
+        f"No feature groups found for feature name: '{feature_name}'. "
+        f"Its concrete implementations require compute framework(s) {framework_names}, "
+        f"none of which are available or enabled for this run."
+    )
+
+
+def _render_none(result: EvaluationResult, feature: Feature, callout: str | None) -> str:
+    feature_name = str(feature.name)
+    msg = f"No feature groups found for feature name: '{feature_name}'."
+
+    if callout:
+        msg += f" {callout}"
+
+    if result.facts.environment_empty:
+        return msg + "\nNo plugins are loaded. Did you call PluginLoader.all()?"
+
+    if result.facts.value_rejections:
+        lines = "\n".join(f"  - {class_name}: {reason}" for class_name, reason in sorted(result.facts.value_rejections))
+        msg += f"\nFeature group(s) rejected an option value while matching '{feature_name}':\n{lines}"
+
+    similar = get_close_matches(feature_name, list(result.facts.known_names), n=5, cutoff=0.5)
+    if similar:
+        msg += f"\nDid you mean one of: {similar}?"
+
+    pointer_args = "name, options=..., feature_group=..." if callout else "name, options=..."
+    msg += (
+        f"\nUse resolve_feature({pointer_args}) to debug feature resolution."
+        f"\nFor troubleshooting guide, see: {TROUBLESHOOTING_URL}"
+    )
+    return msg
+
+
+def render_resolution_failure(result: EvaluationResult, feature: Feature) -> str | None:
+    """Project a failed EvaluationResult into its message. Pure: reads only the result and the Feature.
+
+    Calls no provider-overridable hook, so every fact it needs was captured by evaluate(). The
+    forwarding hint is dropped: it needs a speculative second match, which is not a projection.
+    """
+    kind = result.failure_kind
+    if kind is None:
+        return None
+
+    callout = scope_callout(feature.feature_group_scope)
+
+    if kind == "multiple":
+        return _render_multiple(result, feature, callout)
+
+    capability_message = _render_capability(result, feature)
+    if capability_message is not None:
+        return f"{capability_message} {callout}" if callout else capability_message
+
+    if result.abstract_matched:
+        abstract_message = _render_abstract_only(result, feature)
+        return f"{abstract_message} {callout}" if callout else abstract_message
+
+    return _render_none(result, feature, callout)
+
+
 class IdentifyFeatureGroupClass:
     _criteria_matched_feature_groups: set[type[FeatureGroup]]
     _abstract_matched_feature_groups: set[type[FeatureGroup]]
+    _candidate_frameworks: dict[type[FeatureGroup], CandidateFrameworks]
     _data_access_collection: Optional[DataAccessCollection]
 
     def __init__(
@@ -122,13 +257,93 @@ class IdentifyFeatureGroupClass:
         self = cls.__new__(cls)
         self._criteria_matched_feature_groups = set()
         self._abstract_matched_feature_groups = set()
+        self._candidate_frameworks = {}
         self._data_access_collection = data_access_collection
         identified = self._filter_loop(feature, accessible_plugins, links, data_access_collection)
-        return EvaluationResult(
+        result = EvaluationResult(
             identified=identified,
             criteria_matched=self._criteria_matched_feature_groups,
             abstract_matched=self._abstract_matched_feature_groups,
+            candidate_frameworks=self._candidate_frameworks,
         )
+        if result.failure_kind is None:
+            return result
+        return replace(result, facts=self._capture_render_facts(result, feature, accessible_plugins))
+
+    def _capture_render_facts(
+        self,
+        result: EvaluationResult,
+        feature: Feature,
+        accessible_plugins: FeatureGroupEnvironmentMapping,
+    ) -> RenderFacts:
+        """Capture what rendering needs, following the branch precedence the message builders use today.
+
+        Only reached when the pass has no single winner, so the success path stays hook-free.
+        """
+        environment_empty = not accessible_plugins
+
+        if result.failure_kind == "multiple":
+            return RenderFacts(
+                environment_empty=environment_empty,
+                domains={fg: fg.get_domain().name for fg in result.identified},
+            )
+
+        # Capability rejections win over the abstract-only fallback, and both over the ordinary none.
+        if any(candidate.rejected for candidate in result.candidate_frameworks.values()):
+            return RenderFacts(environment_empty=environment_empty)
+
+        if result.abstract_matched:
+            return RenderFacts(
+                environment_empty=environment_empty,
+                concrete_frameworks=self._concrete_implementation_frameworks(accessible_plugins),
+            )
+
+        if not accessible_plugins:
+            return RenderFacts(environment_empty=environment_empty)
+
+        return RenderFacts(
+            environment_empty=environment_empty,
+            value_rejections=self._capture_value_rejections(feature, accessible_plugins),
+            known_names=self._capture_known_names(accessible_plugins),
+        )
+
+    def _concrete_implementation_frameworks(
+        self, accessible_plugins: FeatureGroupEnvironmentMapping
+    ) -> tuple[str, ...]:
+        """Frameworks declared by the accessible concrete subclasses of an abstract-matched base."""
+        frameworks: set[str] = set()
+        for candidate in accessible_plugins:
+            if inspect.isabstract(candidate):
+                continue
+            if not any(issubclass(candidate, abstract_fg) for abstract_fg in self._abstract_matched_feature_groups):
+                continue
+            for cfw in candidate.compute_framework_definition():
+                frameworks.add(cfw.get_class_name())
+        return tuple(sorted(frameworks))
+
+    def _capture_value_rejections(
+        self, feature: Feature, accessible_plugins: FeatureGroupEnvironmentMapping
+    ) -> tuple[tuple[str, str], ...]:
+        reasons: list[tuple[str, str]] = []
+        for feature_group in accessible_plugins:
+            if not self._filter_feature_group_by_domain(feature_group, feature):
+                continue
+            if not self._filter_feature_group_by_scope(feature_group, feature):
+                continue
+
+            reason = self._value_rejection_reason(feature_group, feature)
+            if reason is not None:
+                reasons.append((feature_group.get_class_name(), reason))
+        return tuple(sorted(reasons))
+
+    def _capture_known_names(self, accessible_plugins: FeatureGroupEnvironmentMapping) -> tuple[str, ...]:
+        known_names: list[str] = []
+        for fg_class in accessible_plugins:
+            known_names.append(fg_class.get_class_name())
+            known_names.extend(fg_class.feature_names_supported())
+            if fg_class.prefix():
+                known_names.append(fg_class.prefix())
+        return tuple(known_names)
 
     def _filter_loop(
         self,
@@ -161,6 +376,13 @@ class IdentifyFeatureGroupClass:
                 for cfw in compute_frameworks
                 if feature_group.supports_compute_framework(feature.name, feature.options, cfw)
             }
+
+            # Free correlation: the split this candidate's own accessible frameworks just produced.
+            # frozenset() first: callers may pass any iterable of frameworks, not only a set.
+            self._candidate_frameworks[feature_group] = CandidateFrameworks(
+                supported=frozenset(supported_frameworks),
+                rejected=frozenset(compute_frameworks) - frozenset(supported_frameworks),
+            )
 
             if not self._filter_feature_group_by_framework(supported_frameworks, feature):
                 continue

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -8,6 +8,7 @@ from mloda.core.abstract_plugins.components.data_access_collection import DataAc
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import PropertyValueRejection
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import NON_FORWARDED_KEYS, Options
+from mloda.core.abstract_plugins.components.utils import safe_field
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.abstract_plugins.components.feature import Feature
@@ -38,6 +39,9 @@ class RenderFacts:
     concrete_frameworks: tuple[str, ...] = ()
     value_rejections: tuple[tuple[str, str], ...] = ()
     known_names: tuple[str, ...] = ()
+    # Render-only split over the DECLARED available frameworks, which is wider than the run's own
+    # candidate_frameworks split: a framework the run did not enable still renders as supported.
+    capability_frameworks: dict[type[FeatureGroup], CandidateFrameworks] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -118,10 +122,69 @@ def scope_callout(scope: str | type[FeatureGroup] | None) -> str | None:
 TROUBLESHOOTING_URL = "https://mloda-ai.github.io/mloda/in_depth/troubleshooting/feature-group-resolution-errors/"
 
 
+def _candidate_sort_key(feature_group: type[FeatureGroup]) -> tuple[str, str]:
+    """Sort candidates by name, then module: two candidates may share a name across modules."""
+    return feature_group.__name__, feature_group.__module__
+
+
+def _domain_name(feature_group: type[FeatureGroup]) -> str | None:
+    """Best-effort domain name. None when the candidate's get_domain() raised: it renders without a suffix."""
+    return safe_field(
+        lambda: feature_group.get_domain().name,
+        None,
+        field=f"{feature_group.get_class_name()}.get_domain",
+    )
+
+
+def _supported_feature_names(feature_group: type[FeatureGroup]) -> set[str]:
+    """Best-effort name catalog of one candidate."""
+    return safe_field(
+        lambda: feature_group.feature_names_supported(),
+        set(),
+        field=f"{feature_group.get_class_name()}.feature_names_supported",
+    )
+
+
+def _prefix_name(feature_group: type[FeatureGroup]) -> str:
+    """Best-effort prefix of one candidate."""
+    return safe_field(lambda: feature_group.prefix(), "", field=f"{feature_group.get_class_name()}.prefix")
+
+
+def _declared_framework_names(feature_group: type[FeatureGroup]) -> set[str]:
+    """Best-effort names of every framework one candidate declares, available or not, as the message wants them."""
+    return safe_field(
+        lambda: {cfw.get_class_name() for cfw in feature_group.compute_framework_definition()},
+        set(),
+        field=f"{feature_group.get_class_name()}.compute_framework_definition",
+    )
+
+
+def _available_declared_frameworks(feature_group: type[FeatureGroup]) -> frozenset[type[ComputeFramework]]:
+    """Best-effort render universe of one candidate: the frameworks it declares that are available."""
+    return safe_field(
+        lambda: frozenset(cfw for cfw in feature_group.compute_framework_definition() if cfw.is_available()),
+        frozenset(),
+        field=f"{feature_group.get_class_name()}.compute_framework_definition",
+    )
+
+
+def _supports_framework(
+    feature_group: type[FeatureGroup], feature: Feature, compute_framework: type[ComputeFramework]
+) -> bool | None:
+    """Best-effort capability answer. None when the hook raised, leaving the pair undecided for rendering."""
+    return safe_field(
+        lambda: feature_group.supports_compute_framework(feature.name, feature.options, compute_framework),
+        None,
+        field=f"{feature_group.get_class_name()}.supports_compute_framework",
+    )
+
+
 def _render_multiple(result: EvaluationResult, feature: Feature, callout: str | None) -> str:
+    # Every identified candidate gets a line; only a candidate with a captured domain gets the suffix.
     lines = "\n".join(
-        f"  - {fg.__name__} ({fg.__module__}) [domain: {domain}]"
-        for fg, domain in sorted(result.facts.domains.items(), key=lambda item: item[0].__name__)
+        f"  - {fg.__name__} ({fg.__module__})"
+        + (f" [domain: {result.facts.domains[fg]}]" if fg in result.facts.domains else "")
+        for fg in sorted(result.identified, key=_candidate_sort_key)
     )
     scope_line = f"{callout}\n" if callout else ""
     return (
@@ -134,12 +197,12 @@ def _render_multiple(result: EvaluationResult, feature: Feature, callout: str | 
 
 def _render_capability(result: EvaluationResult, feature: Feature) -> str | None:
     """One line per candidate that rejects a framework, each naming only its OWN frameworks."""
-    rejecting = {fg: cfw for fg, cfw in result.candidate_frameworks.items() if cfw.rejected}
+    rejecting = {fg: cfw for fg, cfw in result.facts.capability_frameworks.items() if cfw.rejected}
     if not rejecting:
         return None
 
     lines = []
-    for fg in sorted(rejecting, key=lambda candidate: candidate.__name__):
+    for fg in sorted(rejecting, key=_candidate_sort_key):
         candidate_frameworks = rejecting[fg]
         rejected_names = sorted(fw.get_class_name() for fw in candidate_frameworks.rejected)
         line = f"  - {fg.__name__}: {rejected_names}."
@@ -278,28 +341,24 @@ class IdentifyFeatureGroupClass:
     ) -> RenderFacts:
         """Capture what rendering needs, following the branch precedence the message builders use today.
 
-        Only reached when the pass has no single winner, so the success path stays hook-free.
+        Only reached when the pass has no single winner, so the success path stays hook-free. Every provider
+        hook here is best-effort: a raising one degrades its own fact, never this call or a sibling's fact.
         """
         environment_empty = not accessible_plugins
 
         if result.failure_kind == "multiple":
-            return RenderFacts(
-                environment_empty=environment_empty,
-                domains={fg: fg.get_domain().name for fg in result.identified},
-            )
+            return RenderFacts(environment_empty=environment_empty, domains=self._capture_domains(result))
 
         # Capability rejections win over the abstract-only fallback, and both over the ordinary none.
-        if any(candidate.rejected for candidate in result.candidate_frameworks.values()):
-            return RenderFacts(environment_empty=environment_empty)
+        capability_frameworks = self._capture_capability_frameworks(result, feature)
+        if any(candidate.rejected for candidate in capability_frameworks.values()):
+            return RenderFacts(environment_empty=environment_empty, capability_frameworks=capability_frameworks)
 
         if result.abstract_matched:
             return RenderFacts(
                 environment_empty=environment_empty,
-                concrete_frameworks=self._concrete_implementation_frameworks(accessible_plugins),
+                concrete_frameworks=self._concrete_implementation_frameworks(result, accessible_plugins),
             )
-
-        if not accessible_plugins:
-            return RenderFacts(environment_empty=environment_empty)
 
         return RenderFacts(
             environment_empty=environment_empty,
@@ -307,18 +366,55 @@ class IdentifyFeatureGroupClass:
             known_names=self._capture_known_names(accessible_plugins),
         )
 
+    def _capture_domains(self, result: EvaluationResult) -> dict[type[FeatureGroup], str]:
+        """Domain name of every identified candidate, skipping the ones whose get_domain() raised."""
+        domains: dict[type[FeatureGroup], str] = {}
+        for feature_group in result.identified:
+            domain = _domain_name(feature_group)
+            if domain is not None:
+                domains[feature_group] = domain
+        return domains
+
+    def _capture_capability_frameworks(
+        self, result: EvaluationResult, feature: Feature
+    ) -> dict[type[FeatureGroup], CandidateFrameworks]:
+        """Split each criteria-matched candidate's declared available frameworks, the universe the message uses.
+
+        Starts from the decision split, which already answered the enabled frameworks, and only asks about the
+        rest: the capability hook is asked at most once per (candidate, framework) pair per evaluation.
+        """
+        capability_frameworks: dict[type[FeatureGroup], CandidateFrameworks] = {}
+        for feature_group in result.criteria_matched:
+            decided = result.candidate_frameworks.get(feature_group, CandidateFrameworks())
+            declared = _available_declared_frameworks(feature_group)
+            supported = set(decided.supported & declared)
+            rejected = set(decided.rejected & declared)
+
+            for cfw in declared - decided.supported - decided.rejected:
+                verdict = _supports_framework(feature_group, feature, cfw)
+                if verdict is None:
+                    continue
+                if verdict:
+                    supported.add(cfw)
+                else:
+                    rejected.add(cfw)
+
+            capability_frameworks[feature_group] = CandidateFrameworks(
+                supported=frozenset(supported), rejected=frozenset(rejected)
+            )
+        return capability_frameworks
+
     def _concrete_implementation_frameworks(
-        self, accessible_plugins: FeatureGroupEnvironmentMapping
+        self, result: EvaluationResult, accessible_plugins: FeatureGroupEnvironmentMapping
     ) -> tuple[str, ...]:
         """Frameworks declared by the accessible concrete subclasses of an abstract-matched base."""
         frameworks: set[str] = set()
         for candidate in accessible_plugins:
             if inspect.isabstract(candidate):
                 continue
-            if not any(issubclass(candidate, abstract_fg) for abstract_fg in self._abstract_matched_feature_groups):
+            if not any(issubclass(candidate, abstract_fg) for abstract_fg in result.abstract_matched):
                 continue
-            for cfw in candidate.compute_framework_definition():
-                frameworks.add(cfw.get_class_name())
+            frameworks.update(_declared_framework_names(candidate))
         return tuple(sorted(frameworks))
 
     def _capture_value_rejections(
@@ -326,23 +422,36 @@ class IdentifyFeatureGroupClass:
     ) -> tuple[tuple[str, str], ...]:
         reasons: list[tuple[str, str]] = []
         for feature_group in accessible_plugins:
-            if not self._filter_feature_group_by_domain(feature_group, feature):
-                continue
-            if not self._filter_feature_group_by_scope(feature_group, feature):
-                continue
-
-            reason = self._value_rejection_reason(feature_group, feature)
+            reason = self._scoped_value_rejection_reason(feature_group, feature)
             if reason is not None:
                 reasons.append((feature_group.get_class_name(), reason))
         return tuple(sorted(reasons))
 
+    def _scoped_value_rejection_reason(self, feature_group: type[FeatureGroup], feature: Feature) -> str | None:
+        """Best-effort rejection reason of one candidate, guarded together with the filters it runs."""
+        return safe_field(
+            lambda: self._in_scope_value_rejection_reason(feature_group, feature),
+            None,
+            field=f"{feature_group.get_class_name()}._strict_validation_rejection_reason",
+        )
+
+    def _in_scope_value_rejection_reason(self, feature_group: type[FeatureGroup], feature: Feature) -> str | None:
+        """The candidate's rejection reason, or None when the domain or scope filter rules it out."""
+        if not self._filter_feature_group_by_domain(feature_group, feature):
+            return None
+        if not self._filter_feature_group_by_scope(feature_group, feature):
+            return None
+        return self._value_rejection_reason(feature_group, feature)
+
     def _capture_known_names(self, accessible_plugins: FeatureGroupEnvironmentMapping) -> tuple[str, ...]:
         known_names: list[str] = []
         for fg_class in accessible_plugins:
+            # get_class_name() is @final, so it cannot raise on a provider's behalf and needs no guard.
             known_names.append(fg_class.get_class_name())
-            known_names.extend(fg_class.feature_names_supported())
-            if fg_class.prefix():
-                known_names.append(fg_class.prefix())
+            known_names.extend(_supported_feature_names(fg_class))
+            prefix = _prefix_name(fg_class)
+            if prefix:
+                known_names.append(prefix)
         return tuple(known_names)
 
     def _filter_loop(
@@ -377,8 +486,8 @@ class IdentifyFeatureGroupClass:
                 if feature_group.supports_compute_framework(feature.name, feature.options, cfw)
             }
 
-            # Free correlation: the split this candidate's own accessible frameworks just produced.
-            # frozenset() first: callers may pass any iterable of frameworks, not only a set.
+            # The split the capability hook just produced over this candidate's own accessible frameworks:
+            # keeping it costs no extra hook call. frozenset() first: callers may pass any iterable.
             self._candidate_frameworks[feature_group] = CandidateFrameworks(
                 supported=frozenset(supported_frameworks),
                 rejected=frozenset(compute_frameworks) - frozenset(supported_frameworks),
@@ -469,7 +578,7 @@ class IdentifyFeatureGroupClass:
                 f"Multiple feature groups found for feature '{feature.name}':\n"
                 f"{format_feature_group_classes(feature_group.keys(), include_domain=True)}\n"
                 f"{scope_line}"
-                "For troubleshooting guide, see: https://mloda-ai.github.io/mloda/in_depth/troubleshooting/feature-group-resolution-errors/"
+                f"For troubleshooting guide, see: {TROUBLESHOOTING_URL}"
             )
 
     def _capability_rejection_message(self, feature: Feature) -> Optional[str]:
@@ -650,8 +759,7 @@ class IdentifyFeatureGroupClass:
         pointer_args = "name, options=..., feature_group=..." if callout else "name, options=..."
         msg += (
             f"\nUse resolve_feature({pointer_args}) to debug feature resolution."
-            "\nFor troubleshooting guide, see: "
-            "https://mloda-ai.github.io/mloda/in_depth/troubleshooting/feature-group-resolution-errors/"
+            f"\nFor troubleshooting guide, see: {TROUBLESHOOTING_URL}"
         )
         return msg
 

--- a/tests/test_core/test_prepare/test_identify_feature_group_failure_renderer.py
+++ b/tests/test_core/test_prepare/test_identify_feature_group_failure_renderer.py
@@ -11,8 +11,8 @@ All names are suffixed ``_791`` because test feature groups become global subcla
 """
 
 from abc import abstractmethod
-from collections.abc import Callable
-from typing import ClassVar, Optional
+from collections.abc import Callable, Iterator
+from typing import Any, ClassVar, Optional, cast
 
 import pytest
 
@@ -25,8 +25,10 @@ from mloda.core.abstract_plugins.components.feature_chainer.property_spec import
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.index.index import Index
 from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.api.plugin_docs import resolve_feature
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
 from mloda.core.prepare.identify_feature_group import (
     CandidateFrameworks,
@@ -46,6 +48,19 @@ TYPO_FEATURE_791 = "renderer_knwon_feature_791"
 SCOPED_NO_MATCH_FEATURE_791 = "renderer_scoped_no_match_791"
 EMPTY_ENV_FEATURE_791 = "renderer_empty_env_791"
 FORWARDING_FEATURE_791 = "renderer_forwarding_791"
+RAISING_DOMAIN_FEATURE_791 = "renderer_raising_domain_791"
+RAISING_ABSTRACT_FEATURE_791 = "renderer_raising_abstract_791"
+NARROW_ENABLED_FEATURE_791 = "renderer_narrow_enabled_791"
+NONE_ENABLED_FEATURE_791 = "renderer_none_enabled_791"
+TIE_FEATURE_791 = "renderer_tie_791"
+TIE_CAPABILITY_FEATURE_791 = "renderer_tie_capability_791"
+
+HEALTHY_DOMAIN_791 = "renderer_healthy_domain_791"
+BOOM_SUPPORTED_NAME_791 = "renderer_boom_supported_name_791"
+
+# Same-named tie candidates get an explicit __module__ so only the module can break the sort tie.
+TIE_MODULE_A_791 = "tests.renderer_tie_module_a_791"
+TIE_MODULE_B_791 = "tests.renderer_tie_module_b_791"
 
 TROUBLESHOOTING_LINE = (
     "For troubleshooting guide, see: "
@@ -55,11 +70,21 @@ TROUBLESHOOTING_LINE = (
 # Call counters for every provider-overridable hook, keyed "<ClassName>.<hook>". Reset per test.
 HOOK_CALLS: dict[str, int] = {}
 
+# supports_compute_framework calls keyed by the (candidate, framework) PAIR it was asked about.
+# HOOK_CALLS only knows the hook name, so it cannot see a pair being asked twice. Reset per test.
+PAIR_CALLS: dict[tuple[str, str], int] = {}
+
 
 def _record(class_name: str, hook: str) -> None:
     """Count one call of a provider-overridable hook."""
     key = f"{class_name}.{hook}"
     HOOK_CALLS[key] = HOOK_CALLS.get(key, 0) + 1
+
+
+def _record_pair(class_name: str, framework_name: str) -> None:
+    """Count one capability-hook call for a single (candidate, framework) pair."""
+    key = (class_name, framework_name)
+    PAIR_CALLS[key] = PAIR_CALLS.get(key, 0) + 1
 
 
 class RendererFwOne791(ComputeFramework):
@@ -113,6 +138,7 @@ class CountingFeatureGroup791(FeatureGroup):
         compute_framework: type[ComputeFramework],
     ) -> bool:
         _record(cls.get_class_name(), "supports_compute_framework")
+        _record_pair(cls.get_class_name(), compute_framework.get_class_name())
         if cls.SUPPORTED_FRAMEWORKS is None:
             return True
         return compute_framework.get_class_name() in cls.SUPPORTED_FRAMEWORKS
@@ -302,6 +328,228 @@ class RendererStrictFG791(FeatureChainParserMixin, FeatureGroup):
 
 WINDOW_REJECTION_REASON = "Property value '14' failed validation for 'window_size'"
 
+
+class RendererNarrowEnabledFG791(CountingFeatureGroup791):
+    """Declares two available frameworks; the run enables only the one this candidate rejects."""
+
+    MATCHES = frozenset({NARROW_ENABLED_FEATURE_791})
+    FRAMEWORK_RULE = {RendererFwOne791, RendererFwTwo791}
+    SUPPORTED_FRAMEWORKS = frozenset({"RendererFwTwo791"})
+
+
+class RendererNoneEnabledFG791(CountingFeatureGroup791):
+    """Declares two available frameworks; the run enables neither of them."""
+
+    MATCHES = frozenset({NONE_ENABLED_FEATURE_791})
+    FRAMEWORK_RULE = {RendererFwOne791, RendererFwTwo791}
+    SUPPORTED_FRAMEWORKS = frozenset({"RendererFwTwo791"})
+
+
+class RendererDomainBoom791(RuntimeError):
+    """Raised by a provider's get_domain() hook."""
+
+
+class RendererPrefixBoom791(RuntimeError):
+    """Raised by a provider's prefix() hook."""
+
+
+class RendererNamesBoom791(RuntimeError):
+    """Raised by a provider's feature_names_supported() hook."""
+
+
+class RendererRejectionBoom791(RuntimeError):
+    """Raised by a provider's _strict_validation_rejection_reason() hook."""
+
+
+class RendererFrameworkRuleBoom791(RuntimeError):
+    """Raised by a provider's compute_framework_rule() hook."""
+
+
+class RaisingHookGroup791(CountingFeatureGroup791):
+    """Base for the groups whose fact-capture hook raises. Its subclasses are ALWAYS built inside a function.
+
+    ``ARMED`` is what makes that safe. A group built per test still outlives it: pytest keeps a failing
+    test's traceback, and that traceback keeps the builder's frame (and so the class) alive and globally
+    visible in ``FeatureGroup.__subclasses__()``. A group whose declaration hook raised forever would then
+    take down every later test in the worker that enumerates the plugin universe -- ``PreFilterPlugins``
+    fails closed on a raising ``compute_framework_definition()``. The autouse fixture disarms every group
+    it built, so a leaked class is inert.
+    """
+
+    ARMED: ClassVar[bool] = True
+
+
+RAISING_GROUPS_BUILT: list[type[RaisingHookGroup791]] = []
+
+
+def _armed(group: type[RaisingHookGroup791]) -> type[RaisingHookGroup791]:
+    """Track a freshly built raising group so the autouse fixture can disarm it after the test."""
+    RAISING_GROUPS_BUILT.append(group)
+    return group
+
+
+def _build_raising_domain_groups() -> tuple[type[CountingFeatureGroup791], type[CountingFeatureGroup791]]:
+    """Build a (raising get_domain, healthy get_domain) pair that both match the same feature name."""
+
+    class RendererRaisingDomainFG791(RaisingHookGroup791):
+        """Candidate whose get_domain() hook raises."""
+
+        MATCHES = frozenset({RAISING_DOMAIN_FEATURE_791})
+        FRAMEWORK_RULE = {RendererFwOne791}
+
+        @classmethod
+        def get_domain(cls) -> Domain:
+            _record(cls.get_class_name(), "get_domain")
+            if cls.ARMED:
+                raise RendererDomainBoom791("get_domain exploded 791")
+            return Domain.get_default_domain()
+
+    class RendererHealthyDomainFG791(CountingFeatureGroup791):
+        """Candidate whose get_domain() hook works, standing next to the raising one."""
+
+        MATCHES = frozenset({RAISING_DOMAIN_FEATURE_791})
+        DOMAIN_NAME = HEALTHY_DOMAIN_791
+        FRAMEWORK_RULE = {RendererFwOne791}
+
+    return _armed(RendererRaisingDomainFG791), RendererHealthyDomainFG791
+
+
+def _build_raising_prefix_group() -> type[CountingFeatureGroup791]:
+    """Build a catalog group whose prefix() hook raises."""
+
+    class RendererRaisingPrefixFG791(RaisingHookGroup791):
+        """Catalog candidate whose prefix() hook raises."""
+
+        FRAMEWORK_RULE = {RendererFwOne791}
+
+        @classmethod
+        def prefix(cls) -> str:
+            _record(cls.get_class_name(), "prefix")
+            if cls.ARMED:
+                raise RendererPrefixBoom791("prefix exploded 791")
+            return f"{cls.get_class_name()}_"
+
+    return _armed(RendererRaisingPrefixFG791)
+
+
+def _build_raising_names_group() -> type[CountingFeatureGroup791]:
+    """Build a catalog group whose feature_names_supported() hook raises."""
+
+    class RendererRaisingNamesFG791(RaisingHookGroup791):
+        """Catalog candidate whose feature_names_supported() hook raises."""
+
+        FRAMEWORK_RULE = {RendererFwOne791}
+        SUPPORTED_NAMES = frozenset({BOOM_SUPPORTED_NAME_791})
+
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            _record(cls.get_class_name(), "feature_names_supported")
+            if cls.ARMED:
+                raise RendererNamesBoom791("feature_names_supported exploded 791")
+            return set()
+
+    return _armed(RendererRaisingNamesFG791)
+
+
+def _build_raising_rejection_group() -> type[CountingFeatureGroup791]:
+    """Build a group whose _strict_validation_rejection_reason() hook raises."""
+
+    class RendererRaisingRejectionFG791(RaisingHookGroup791):
+        """Candidate whose value-rejection diagnostic hook raises."""
+
+        FRAMEWORK_RULE = {RendererFwOne791}
+
+        @classmethod
+        def _strict_validation_rejection_reason(cls, feature_name: str | FeatureName, options: Options) -> str | None:
+            _record(cls.get_class_name(), "_strict_validation_rejection_reason")
+            if cls.ARMED:
+                raise RendererRejectionBoom791("_strict_validation_rejection_reason exploded 791")
+            return None
+
+    return _armed(RendererRaisingRejectionFG791)
+
+
+def _build_raising_framework_rule_groups() -> tuple[type[CountingFeatureGroup791], type[CountingFeatureGroup791]]:
+    """Build an abstract base plus a concrete subclass whose compute_framework_rule() hook raises."""
+
+    class RendererRaisingAbstractBaseFG791(RaisingHookGroup791):
+        """Abstract base that matches the name but can never be instantiated."""
+
+        MATCHES = frozenset({RAISING_ABSTRACT_FEATURE_791})
+        FRAMEWORK_RULE = {RendererFwOne791}
+
+        @classmethod
+        @abstractmethod
+        def _renderer_raising_abstract_hook_791(cls) -> str:
+            """Abstract hook that keeps this base uninstantiable."""
+
+    class RendererRaisingConcreteSubFG791(RendererRaisingAbstractBaseFG791):
+        """Concrete implementation whose framework declaration raises."""
+
+        MATCHES = frozenset({RAISING_ABSTRACT_FEATURE_791})
+
+        @classmethod
+        def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+            _record(cls.get_class_name(), "compute_framework_rule")
+            if cls.ARMED:
+                raise RendererFrameworkRuleBoom791("compute_framework_rule exploded 791")
+            return cls.FRAMEWORK_RULE
+
+        @classmethod
+        def _renderer_raising_abstract_hook_791(cls) -> str:
+            return "concrete"
+
+    return RendererRaisingAbstractBaseFG791, _armed(RendererRaisingConcreteSubFG791)
+
+
+def _make_tie_group(module: str, namespace: dict[str, Any]) -> type[CountingFeatureGroup791]:
+    """Build a candidate named RendererTieFG791 in the given module, so only __module__ breaks the sort tie."""
+    created: Any = type("RendererTieFG791", (CountingFeatureGroup791,), {"__module__": module, **namespace})
+    return cast(type[CountingFeatureGroup791], created)
+
+
+def _build_tie_domain_groups() -> tuple[type[CountingFeatureGroup791], type[CountingFeatureGroup791]]:
+    """Build two same-named 'multiple' candidates that differ only in module and domain."""
+    group_a = _make_tie_group(
+        TIE_MODULE_A_791,
+        {
+            "MATCHES": frozenset({TIE_FEATURE_791}),
+            "DOMAIN_NAME": "renderer_tie_domain_a_791",
+            "FRAMEWORK_RULE": {RendererFwOne791},
+        },
+    )
+    group_b = _make_tie_group(
+        TIE_MODULE_B_791,
+        {
+            "MATCHES": frozenset({TIE_FEATURE_791}),
+            "DOMAIN_NAME": "renderer_tie_domain_b_791",
+            "FRAMEWORK_RULE": {RendererFwOne791},
+        },
+    )
+    return group_a, group_b
+
+
+def _build_tie_capability_groups() -> tuple[type[CountingFeatureGroup791], type[CountingFeatureGroup791]]:
+    """Build two same-named capability candidates that differ only in module and supported framework."""
+    group_a = _make_tie_group(
+        TIE_MODULE_A_791,
+        {
+            "MATCHES": frozenset({TIE_CAPABILITY_FEATURE_791}),
+            "FRAMEWORK_RULE": {RendererFwOne791, RendererFwTwo791},
+            "SUPPORTED_FRAMEWORKS": frozenset({"RendererFwOne791"}),
+        },
+    )
+    group_b = _make_tie_group(
+        TIE_MODULE_B_791,
+        {
+            "MATCHES": frozenset({TIE_CAPABILITY_FEATURE_791}),
+            "FRAMEWORK_RULE": {RendererFwOne791, RendererFwTwo791},
+            "SUPPORTED_FRAMEWORKS": frozenset({"RendererFwTwo791"}),
+        },
+    )
+    return group_a, group_b
+
+
 Scenario = tuple[Feature, FeatureGroupEnvironmentMapping]
 
 
@@ -362,6 +610,53 @@ def empty_environment_scenario() -> Scenario:
     return Feature(EMPTY_ENV_FEATURE_791), {}
 
 
+def capability_narrow_enabled_scenario() -> Scenario:
+    """Shape A: two declared frameworks, only the rejected one is enabled for this run."""
+    return Feature(NARROW_ENABLED_FEATURE_791), {RendererNarrowEnabledFG791: {RendererFwOne791}}
+
+
+def capability_none_enabled_scenario() -> Scenario:
+    """Shape B: two declared frameworks, none enabled for this run."""
+    return Feature(NONE_ENABLED_FEATURE_791), {RendererNoneEnabledFG791: set()}
+
+
+def raising_domain_multiple_scenario() -> Scenario:
+    """A 'multiple' failure where one identified candidate's get_domain() raises. The request has no domain."""
+    raising, healthy = _build_raising_domain_groups()
+    return Feature(RAISING_DOMAIN_FEATURE_791), {raising: {RendererFwOne791}, healthy: {RendererFwOne791}}
+
+
+def raising_prefix_none_scenario() -> Scenario:
+    """An ordinary-none failure where one catalog group's prefix() raises."""
+    return (
+        Feature(TYPO_FEATURE_791),
+        {_build_raising_prefix_group(): {RendererFwOne791}, RendererKnownNamesFG791: {RendererFwOne791}},
+    )
+
+
+def raising_names_none_scenario() -> Scenario:
+    """An ordinary-none failure where one catalog group's feature_names_supported() raises."""
+    return (
+        Feature(TYPO_FEATURE_791),
+        {_build_raising_names_group(): {RendererFwOne791}, RendererKnownNamesFG791: {RendererFwOne791}},
+    )
+
+
+def raising_rejection_none_scenario() -> Scenario:
+    """An ordinary-none failure where one candidate's value-rejection diagnostic raises."""
+    feature = Feature(
+        TYPO_FEATURE_791,
+        Options(context={DefaultOptionKeys.in_features: "src", "window_size": 14}),
+    )
+    return feature, {_build_raising_rejection_group(): {RendererFwOne791}, RendererStrictFG791: {RendererFwOne791}}
+
+
+def raising_framework_rule_abstract_scenario() -> Scenario:
+    """An abstract-only failure where the concrete subclass's compute_framework_rule() raises."""
+    base, concrete = _build_raising_framework_rule_groups()
+    return Feature(RAISING_ABSTRACT_FEATURE_791), {base: {RendererFwOne791}, concrete: set()}
+
+
 FAILING_SCENARIOS: dict[str, Callable[[], Scenario]] = {
     "multiple": multiple_scenario,
     "capability": capability_scenario,
@@ -369,6 +664,33 @@ FAILING_SCENARIOS: dict[str, Callable[[], Scenario]] = {
     "abstract_bare": abstract_bare_scenario,
     "ordinary_none": ordinary_none_scenario,
     "scoped_none": scoped_none_scenario,
+    "capability_narrow_enabled": capability_narrow_enabled_scenario,
+    "capability_none_enabled": capability_none_enabled_scenario,
+    "raising_domain_multiple": raising_domain_multiple_scenario,
+    "raising_prefix_none": raising_prefix_none_scenario,
+    "raising_names_none": raising_names_none_scenario,
+    "raising_rejection_none": raising_rejection_none_scenario,
+    "raising_framework_rule_abstract": raising_framework_rule_abstract_scenario,
+}
+
+# Every (candidate, framework) pair the capability hook may be asked about during one evaluate(), and how
+# often: exactly once. The decision loop splits the ENABLED frameworks, capture only adds the pairs it did
+# not cover, so the union is the candidate's declared+available frameworks and nothing is asked twice.
+CAPABILITY_PAIR_EXPECTATIONS: dict[str, dict[tuple[str, str], int]] = {
+    "capability": {
+        ("RendererCapabilityAFG791", "RendererFwOne791"): 1,
+        ("RendererCapabilityAFG791", "RendererFwTwo791"): 1,
+        ("RendererCapabilityBFG791", "RendererFwOne791"): 1,
+        ("RendererCapabilityBFG791", "RendererFwTwo791"): 1,
+    },
+    "capability_narrow_enabled": {
+        ("RendererNarrowEnabledFG791", "RendererFwOne791"): 1,
+        ("RendererNarrowEnabledFG791", "RendererFwTwo791"): 1,
+    },
+    "capability_none_enabled": {
+        ("RendererNoneEnabledFG791", "RendererFwOne791"): 1,
+        ("RendererNoneEnabledFG791", "RendererFwTwo791"): 1,
+    },
 }
 
 
@@ -385,9 +707,14 @@ def _render(scenario: Scenario) -> str:
 
 
 @pytest.fixture(autouse=True)
-def reset_hook_calls() -> None:
-    """Counter state must not leak between tests."""
+def reset_hook_calls() -> Iterator[None]:
+    """Counter state must not leak between tests, and no raising hook may outlive the test that built it."""
     HOOK_CALLS.clear()
+    PAIR_CALLS.clear()
+    yield
+    for group in RAISING_GROUPS_BUILT:
+        group.ARMED = False
+    RAISING_GROUPS_BUILT.clear()
 
 
 class TestRenderResolutionFailureMessages:
@@ -627,3 +954,201 @@ class TestFactsCapturedDuringEvaluate:
         assert result.failure_kind == "none"
         assert result.facts.environment_empty
         assert result.facts.known_names == ()
+
+
+class TestFactCaptureNeverTakesEvaluateDown:
+    """Fact capture is best-effort rendering data, never a decision input.
+
+    evaluate() now calls hooks its decision pass never called (get_domain on a domain-less request,
+    prefix, feature_names_supported, _strict_validation_rejection_reason, compute_framework_definition).
+    A provider whose hook raises must degrade that one fact only: evaluate() still returns its result and
+    the renderer still returns a message, exactly as the guarded message builders behaved before #791.
+    """
+
+    def test_raising_get_domain_still_lists_both_candidates(self) -> None:
+        """A degraded domain drops only the '[domain: ...]' suffix of its own candidate line."""
+        scenario = raising_domain_multiple_scenario()
+        feature, accessible_plugins = scenario
+        raising, healthy = list(accessible_plugins)
+        module = raising.__module__
+
+        result = _evaluate(scenario)
+
+        assert result.failure_kind == "multiple"
+        assert render_resolution_failure(result, feature) == (
+            f"Multiple feature groups found for feature '{RAISING_DOMAIN_FEATURE_791}':\n"
+            f"  - {healthy.__name__} ({module}) [domain: {HEALTHY_DOMAIN_791}]\n"
+            f"  - {raising.__name__} ({module})\n"
+            f"{TROUBLESHOOTING_LINE}"
+        )
+
+    def test_raising_prefix_only_costs_that_group_its_prefix(self) -> None:
+        """A raising prefix() contributes no name; the healthy group next to it still contributes its own."""
+        scenario = raising_prefix_none_scenario()
+        feature, _ = scenario
+
+        result = _evaluate(scenario)
+
+        assert result.failure_kind == "none"
+        assert "RendererRaisingPrefixFG791_" not in result.facts.known_names
+        assert KNOWN_FEATURE_791 in result.facts.known_names
+        assert "RendererKnownNamesFG791_" in result.facts.known_names
+
+        message = render_resolution_failure(result, feature)
+        assert message is not None
+        assert f"'{KNOWN_FEATURE_791}'" in message
+
+    def test_raising_feature_names_supported_only_costs_that_group_its_names(self) -> None:
+        """A raising feature_names_supported() contributes no name, and the catalog still renders."""
+        scenario = raising_names_none_scenario()
+        feature, _ = scenario
+
+        result = _evaluate(scenario)
+
+        assert result.failure_kind == "none"
+        assert BOOM_SUPPORTED_NAME_791 not in result.facts.known_names
+        assert KNOWN_FEATURE_791 in result.facts.known_names
+
+        message = render_resolution_failure(result, feature)
+        assert message is not None
+        assert f"'{KNOWN_FEATURE_791}'" in message
+
+    def test_raising_value_rejection_reason_keeps_the_healthy_rejection_line(self) -> None:
+        """A raising diagnostic contributes no rejection line; the healthy rejecting candidate still does."""
+        scenario = raising_rejection_none_scenario()
+        feature, _ = scenario
+
+        result = _evaluate(scenario)
+
+        assert result.failure_kind == "none"
+        assert result.facts.value_rejections == (("RendererStrictFG791", WINDOW_REJECTION_REASON),)
+
+        message = render_resolution_failure(result, feature)
+        assert message is not None
+        assert f"  - RendererStrictFG791: {WINDOW_REJECTION_REASON}" in message
+        assert "RendererRaisingRejectionFG791:" not in message
+
+    def test_raising_compute_framework_rule_falls_back_to_the_bare_abstract_message(self) -> None:
+        """No framework name could be captured, so the abstract-only message takes its bare variant."""
+        scenario = raising_framework_rule_abstract_scenario()
+        feature, _ = scenario
+
+        result = _evaluate(scenario)
+
+        assert result.failure_kind == "abstract_only"
+        assert result.facts.concrete_frameworks == ()
+        assert render_resolution_failure(result, feature) == (
+            f"No feature groups found for feature name: '{RAISING_ABSTRACT_FEATURE_791}'. "
+            "Only abstract feature group base(s) matched, which cannot be instantiated; "
+            "no concrete implementation is available or enabled."
+        )
+
+    def test_resolve_feature_still_reports_candidates_when_get_domain_raises(self) -> None:
+        """End-to-end parity: a raising capture hook must not empty resolve_feature's candidates."""
+        raising, healthy = _build_raising_domain_groups()
+        enabled: set[type[FeatureGroup]] = {raising, healthy}
+
+        result = resolve_feature(
+            Feature(RAISING_DOMAIN_FEATURE_791),
+            plugin_collector=PluginCollector.enabled_feature_groups(enabled),
+        )
+
+        assert result.feature_group is None
+        assert set(result.candidates) == enabled
+        assert result.error is not None
+
+
+class TestCapabilityRenderingUniverse:
+    """The capability message keeps today's universe: the candidate's DECLARED frameworks that are available.
+
+    ``candidate_frameworks`` is the decision fact and stays the run's own (narrower) split of the
+    frameworks that were enabled. Rendering must not inherit that narrowing, or a candidate loses the
+    'Supported on' clause it has today, and an all-disabled candidate flips to the ordinary-none message.
+    """
+
+    def test_not_enabled_framework_still_renders_as_supported(self) -> None:
+        """Shape A: the supported framework is available but not enabled, and must still be named."""
+        scenario = capability_narrow_enabled_scenario()
+        feature, _ = scenario
+
+        result = _evaluate(scenario)
+
+        # The decision fact stays the run's own split: only RendererFwOne791 was enabled, and it was rejected.
+        assert result.candidate_frameworks == {
+            RendererNarrowEnabledFG791: CandidateFrameworks(
+                supported=frozenset(), rejected=frozenset({RendererFwOne791})
+            )
+        }
+        assert render_resolution_failure(result, feature) == (
+            f"Unsupported compute framework(s) for feature '{NARROW_ENABLED_FEATURE_791}':\n"
+            "  - RendererNarrowEnabledFG791: ['RendererFwOne791']. Supported on: ['RendererFwTwo791'].\n"
+            "Pin the feature to a supported compute framework or override supports_compute_framework."
+        )
+
+    def test_no_enabled_framework_still_renders_the_capability_message(self) -> None:
+        """Shape B: an empty accessible set must not flip the failure to the ordinary-none message."""
+        scenario = capability_none_enabled_scenario()
+        feature, _ = scenario
+
+        result = _evaluate(scenario)
+
+        # Nothing was enabled, so the decision loop split nothing: the decision fact is empty on both sides.
+        assert result.candidate_frameworks == {
+            RendererNoneEnabledFG791: CandidateFrameworks(supported=frozenset(), rejected=frozenset())
+        }
+        message = render_resolution_failure(result, feature)
+
+        assert message == (
+            f"Unsupported compute framework(s) for feature '{NONE_ENABLED_FEATURE_791}':\n"
+            "  - RendererNoneEnabledFG791: ['RendererFwOne791']. Supported on: ['RendererFwTwo791'].\n"
+            "Pin the feature to a supported compute framework or override supports_compute_framework."
+        )
+        assert "No feature groups found" not in message
+
+    @pytest.mark.parametrize("scenario_name", sorted(CAPABILITY_PAIR_EXPECTATIONS))
+    def test_capability_hook_is_asked_once_per_candidate_framework_pair(self, scenario_name: str) -> None:
+        """The decision loop already split the enabled frameworks; capture may only ask about the rest."""
+        _evaluate(FAILING_SCENARIOS[scenario_name]())
+
+        repeated = sorted(pair for pair, count in PAIR_CALLS.items() if count != 1)
+        assert not repeated, f"the capability hook was asked more than once for {repeated}"
+        assert PAIR_CALLS == CAPABILITY_PAIR_EXPECTATIONS[scenario_name]
+
+
+class TestSortTiesAreStable:
+    """Two candidates sharing a __name__ across modules must not fall back to insertion order."""
+
+    def test_multiple_tie_sorts_by_module_and_ignores_insertion_order(self) -> None:
+        """Same-named 'multiple' candidates render module-sorted, whichever way they were inserted."""
+        group_a, group_b = _build_tie_domain_groups()
+        feature = Feature(TIE_FEATURE_791)
+        a_first: FeatureGroupEnvironmentMapping = {group_a: {RendererFwOne791}, group_b: {RendererFwOne791}}
+        b_first: FeatureGroupEnvironmentMapping = {group_b: {RendererFwOne791}, group_a: {RendererFwOne791}}
+
+        expected = (
+            f"Multiple feature groups found for feature '{TIE_FEATURE_791}':\n"
+            f"  - RendererTieFG791 ({TIE_MODULE_A_791}) [domain: renderer_tie_domain_a_791]\n"
+            f"  - RendererTieFG791 ({TIE_MODULE_B_791}) [domain: renderer_tie_domain_b_791]\n"
+            f"{TROUBLESHOOTING_LINE}"
+        )
+
+        assert _render((feature, a_first)) == expected
+        assert _render((feature, b_first)) == expected
+
+    def test_capability_tie_sorts_by_module_and_ignores_insertion_order(self) -> None:
+        """Same-named capability candidates render module-sorted, whichever way they were inserted."""
+        group_a, group_b = _build_tie_capability_groups()
+        feature = Feature(TIE_CAPABILITY_FEATURE_791, compute_framework="RendererFwThree791")
+        both = {RendererFwOne791, RendererFwTwo791}
+        a_first: FeatureGroupEnvironmentMapping = {group_a: set(both), group_b: set(both)}
+        b_first: FeatureGroupEnvironmentMapping = {group_b: set(both), group_a: set(both)}
+
+        expected = (
+            f"Unsupported compute framework(s) for feature '{TIE_CAPABILITY_FEATURE_791}':\n"
+            "  - RendererTieFG791: ['RendererFwTwo791']. Supported on: ['RendererFwOne791'].\n"
+            "  - RendererTieFG791: ['RendererFwOne791']. Supported on: ['RendererFwTwo791'].\n"
+            "Pin the feature to a supported compute framework or override supports_compute_framework."
+        )
+
+        assert _render((feature, a_first)) == expected
+        assert _render((feature, b_first)) == expected

--- a/tests/test_core/test_prepare/test_identify_feature_group_failure_renderer.py
+++ b/tests/test_core/test_prepare/test_identify_feature_group_failure_renderer.py
@@ -1,0 +1,629 @@
+"""Pinning tests for the pure failure renderer on the evaluation seam (issue #791).
+
+``IdentifyFeatureGroupClass.evaluate(...)`` captures every fact a resolution-failure message needs
+during its single first pass: per-candidate compute-framework capability
+(``EvaluationResult.candidate_frameworks``) plus the remaining facts (``EvaluationResult.facts``).
+``render_resolution_failure(result, feature)`` is then a PURE projection of that result: it reads
+only the result and the ``Feature``, never re-runs matching and never calls a provider-overridable
+hook. The feature groups below count every such hook, so a renderer that calls one is caught.
+
+All names are suffixed ``_791`` because test feature groups become global subclasses.
+"""
+
+from abc import abstractmethod
+from collections.abc import Callable
+from typing import ClassVar, Optional
+
+import pytest
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+from mloda.core.abstract_plugins.components.domain import Domain
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
+from mloda.core.abstract_plugins.components.feature_chainer.property_spec import property_spec
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.index.index import Index
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from mloda.core.prepare.identify_feature_group import (
+    CandidateFrameworks,
+    EvaluationResult,
+    IdentifyFeatureGroupClass,
+    RenderFacts,
+    render_resolution_failure,
+)
+
+
+SUCCESS_FEATURE_791 = "renderer_success_791"
+MULTIPLE_FEATURE_791 = "renderer_multiple_791"
+CAPABILITY_FEATURE_791 = "renderer_capability_791"
+ABSTRACT_FEATURE_791 = "renderer_abstract_791"
+KNOWN_FEATURE_791 = "renderer_known_feature_791"
+TYPO_FEATURE_791 = "renderer_knwon_feature_791"
+SCOPED_NO_MATCH_FEATURE_791 = "renderer_scoped_no_match_791"
+EMPTY_ENV_FEATURE_791 = "renderer_empty_env_791"
+FORWARDING_FEATURE_791 = "renderer_forwarding_791"
+
+TROUBLESHOOTING_LINE = (
+    "For troubleshooting guide, see: "
+    "https://mloda-ai.github.io/mloda/in_depth/troubleshooting/feature-group-resolution-errors/"
+)
+
+# Call counters for every provider-overridable hook, keyed "<ClassName>.<hook>". Reset per test.
+HOOK_CALLS: dict[str, int] = {}
+
+
+def _record(class_name: str, hook: str) -> None:
+    """Count one call of a provider-overridable hook."""
+    key = f"{class_name}.{hook}"
+    HOOK_CALLS[key] = HOOK_CALLS.get(key, 0) + 1
+
+
+class RendererFwOne791(ComputeFramework):
+    """First dummy compute framework for the failure-renderer tests."""
+
+
+class RendererFwTwo791(ComputeFramework):
+    """Second dummy compute framework for the failure-renderer tests."""
+
+
+class RendererFwThree791(ComputeFramework):
+    """Third dummy compute framework, used only to pin a feature away from every candidate."""
+
+
+class CountingFeatureGroup791(FeatureGroup):
+    """Feature group base that counts every provider-overridable hook the renderer must not call."""
+
+    MATCHES: ClassVar[frozenset[str]] = frozenset()
+    DOMAIN_NAME: ClassVar[Optional[str]] = None
+    FRAMEWORK_RULE: ClassVar[Optional[set[type[ComputeFramework]]]] = None
+    SUPPORTED_FRAMEWORKS: ClassVar[Optional[frozenset[str]]] = None
+    SUPPORTED_NAMES: ClassVar[frozenset[str]] = frozenset()
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        _record(cls.get_class_name(), "match_feature_group_criteria")
+        return str(feature_name) in cls.MATCHES
+
+    @classmethod
+    def get_domain(cls) -> Domain:
+        _record(cls.get_class_name(), "get_domain")
+        if cls.DOMAIN_NAME is None:
+            return Domain.get_default_domain()
+        return Domain(cls.DOMAIN_NAME)
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        _record(cls.get_class_name(), "compute_framework_rule")
+        return cls.FRAMEWORK_RULE
+
+    @classmethod
+    def supports_compute_framework(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        compute_framework: type[ComputeFramework],
+    ) -> bool:
+        _record(cls.get_class_name(), "supports_compute_framework")
+        if cls.SUPPORTED_FRAMEWORKS is None:
+            return True
+        return compute_framework.get_class_name() in cls.SUPPORTED_FRAMEWORKS
+
+    @classmethod
+    def index_columns(cls) -> Optional[list[Index]]:
+        _record(cls.get_class_name(), "index_columns")
+        return None
+
+    @classmethod
+    def supports_index(cls, index: Index) -> Optional[bool]:
+        _record(cls.get_class_name(), "supports_index")
+        return None
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        _record(cls.get_class_name(), "feature_names_supported")
+        return set(cls.SUPPORTED_NAMES)
+
+    @classmethod
+    def prefix(cls) -> str:
+        _record(cls.get_class_name(), "prefix")
+        return f"{cls.get_class_name()}_"
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class RendererSuccessFG791(CountingFeatureGroup791):
+    """Sole winner of the success scenario."""
+
+    MATCHES = frozenset({SUCCESS_FEATURE_791})
+    FRAMEWORK_RULE = {RendererFwOne791}
+
+
+class RendererMultipleAFG791(CountingFeatureGroup791):
+    """First of two unrelated siblings matching the same name, in domain 'renderer_domain_a_791'."""
+
+    MATCHES = frozenset({MULTIPLE_FEATURE_791})
+    DOMAIN_NAME = "renderer_domain_a_791"
+    FRAMEWORK_RULE = {RendererFwOne791}
+
+
+class RendererMultipleBFG791(CountingFeatureGroup791):
+    """Second sibling matching the same name, in domain 'renderer_domain_b_791'."""
+
+    MATCHES = frozenset({MULTIPLE_FEATURE_791})
+    DOMAIN_NAME = "renderer_domain_b_791"
+    FRAMEWORK_RULE = {RendererFwOne791}
+
+
+class RendererCapabilityAFG791(CountingFeatureGroup791):
+    """Mirrored capability candidate: supports RendererFwOne791, rejects RendererFwTwo791."""
+
+    MATCHES = frozenset({CAPABILITY_FEATURE_791})
+    FRAMEWORK_RULE = {RendererFwOne791, RendererFwTwo791}
+    SUPPORTED_FRAMEWORKS = frozenset({"RendererFwOne791"})
+
+
+class RendererCapabilityBFG791(CountingFeatureGroup791):
+    """Mirrored capability candidate: supports RendererFwTwo791, rejects RendererFwOne791."""
+
+    MATCHES = frozenset({CAPABILITY_FEATURE_791})
+    FRAMEWORK_RULE = {RendererFwOne791, RendererFwTwo791}
+    SUPPORTED_FRAMEWORKS = frozenset({"RendererFwTwo791"})
+
+
+class RendererAbstractBaseFG791(CountingFeatureGroup791):
+    """Abstract base that matches the name but can never be instantiated."""
+
+    MATCHES = frozenset({ABSTRACT_FEATURE_791})
+    FRAMEWORK_RULE = {RendererFwOne791}
+
+    @classmethod
+    @abstractmethod
+    def _renderer_abstract_hook_791(cls) -> str:
+        """Abstract hook that keeps this base uninstantiable."""
+
+
+class RendererConcreteSubFG791(RendererAbstractBaseFG791):
+    """Concrete implementation of the abstract base, declaring two compute frameworks."""
+
+    MATCHES = frozenset({ABSTRACT_FEATURE_791})
+    FRAMEWORK_RULE = {RendererFwOne791, RendererFwTwo791}
+
+    @classmethod
+    def _renderer_abstract_hook_791(cls) -> str:
+        return "concrete"
+
+
+class RendererKnownNamesFG791(CountingFeatureGroup791):
+    """Name catalog for the 'Did you mean' suggestion."""
+
+    MATCHES = frozenset({KNOWN_FEATURE_791})
+    SUPPORTED_NAMES = frozenset({KNOWN_FEATURE_791})
+    FRAMEWORK_RULE = {RendererFwOne791}
+
+
+class RendererBareOnlyFG791(CountingFeatureGroup791):
+    """Matches its bare name only: any group option makes it reject the feature."""
+
+    MATCHES = frozenset({FORWARDING_FEATURE_791})
+    FRAMEWORK_RULE = {RendererFwOne791}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        matched = super().match_feature_group_criteria(feature_name, options, data_access_collection)
+        return matched and not options.group
+
+
+class RendererStrictFG791(FeatureChainParserMixin, FeatureGroup):
+    """Config-based group whose strict 'window_size' validator rejects out-of-range values."""
+
+    PROPERTY_MAPPING = {
+        "window_size": property_spec(
+            "Size of window",
+            strict=True,
+            context=False,
+            element_validator=lambda v: isinstance(v, int) and 0 < v <= 13,
+        ),
+        DefaultOptionKeys.in_features: property_spec("source", context=True),
+    }
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: str | FeatureName,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        _record(cls.get_class_name(), "match_feature_group_criteria")
+        return super().match_feature_group_criteria(feature_name, options, data_access_collection)
+
+    @classmethod
+    def get_domain(cls) -> Domain:
+        _record(cls.get_class_name(), "get_domain")
+        return super().get_domain()
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        _record(cls.get_class_name(), "compute_framework_rule")
+        return {RendererFwOne791}
+
+    @classmethod
+    def supports_compute_framework(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        compute_framework: type[ComputeFramework],
+    ) -> bool:
+        _record(cls.get_class_name(), "supports_compute_framework")
+        return super().supports_compute_framework(feature_name, options, compute_framework)
+
+    @classmethod
+    def index_columns(cls) -> Optional[list[Index]]:
+        _record(cls.get_class_name(), "index_columns")
+        return None
+
+    @classmethod
+    def supports_index(cls, index: Index) -> Optional[bool]:
+        _record(cls.get_class_name(), "supports_index")
+        return None
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        _record(cls.get_class_name(), "feature_names_supported")
+        return set()
+
+    @classmethod
+    def prefix(cls) -> str:
+        _record(cls.get_class_name(), "prefix")
+        return f"{cls.get_class_name()}_"
+
+    @classmethod
+    def _strict_validation_rejection_reason(cls, feature_name: str | FeatureName, options: Options) -> str | None:
+        _record(cls.get_class_name(), "_strict_validation_rejection_reason")
+        return super()._strict_validation_rejection_reason(feature_name, options)
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+WINDOW_REJECTION_REASON = "Property value '14' failed validation for 'window_size'"
+
+Scenario = tuple[Feature, FeatureGroupEnvironmentMapping]
+
+
+def success_scenario() -> Scenario:
+    """Exactly one winner."""
+    return Feature(SUCCESS_FEATURE_791), {RendererSuccessFG791: {RendererFwOne791}}
+
+
+def multiple_scenario() -> Scenario:
+    """Two identified candidates. Inserted B-before-A so a sorted rendering is observable."""
+    return (
+        Feature(MULTIPLE_FEATURE_791),
+        {RendererMultipleBFG791: {RendererFwOne791}, RendererMultipleAFG791: {RendererFwOne791}},
+    )
+
+
+def capability_scenario() -> Scenario:
+    """Mirrored capability rejection: the pin to a third framework keeps both candidates out."""
+    return (
+        Feature(CAPABILITY_FEATURE_791, compute_framework="RendererFwThree791"),
+        {
+            RendererCapabilityBFG791: {RendererFwOne791, RendererFwTwo791},
+            RendererCapabilityAFG791: {RendererFwOne791, RendererFwTwo791},
+        },
+    )
+
+
+def abstract_with_frameworks_scenario() -> Scenario:
+    """Abstract base matched; its concrete subclass is accessible but has no enabled framework."""
+    return (
+        Feature(ABSTRACT_FEATURE_791),
+        {RendererAbstractBaseFG791: {RendererFwOne791}, RendererConcreteSubFG791: set()},
+    )
+
+
+def abstract_bare_scenario() -> Scenario:
+    """Abstract base matched with no concrete implementation accessible at all."""
+    return Feature(ABSTRACT_FEATURE_791), {RendererAbstractBaseFG791: {RendererFwOne791}}
+
+
+def ordinary_none_scenario() -> Scenario:
+    """No match: one candidate rejects an option value, another supplies the name catalog."""
+    feature = Feature(
+        TYPO_FEATURE_791,
+        Options(context={DefaultOptionKeys.in_features: "src", "window_size": 14}),
+    )
+    return feature, {RendererStrictFG791: {RendererFwOne791}, RendererKnownNamesFG791: {RendererFwOne791}}
+
+
+def scoped_none_scenario() -> Scenario:
+    """No match while scoped to a feature group."""
+    feature = Feature(SCOPED_NO_MATCH_FEATURE_791, feature_group="RendererKnownNamesFG791")
+    return feature, {RendererKnownNamesFG791: {RendererFwOne791}}
+
+
+def empty_environment_scenario() -> Scenario:
+    """No plugins are loaded at all."""
+    return Feature(EMPTY_ENV_FEATURE_791), {}
+
+
+FAILING_SCENARIOS: dict[str, Callable[[], Scenario]] = {
+    "multiple": multiple_scenario,
+    "capability": capability_scenario,
+    "abstract_with_frameworks": abstract_with_frameworks_scenario,
+    "abstract_bare": abstract_bare_scenario,
+    "ordinary_none": ordinary_none_scenario,
+    "scoped_none": scoped_none_scenario,
+}
+
+
+def _evaluate(scenario: Scenario) -> EvaluationResult:
+    feature, accessible_plugins = scenario
+    return IdentifyFeatureGroupClass.evaluate(feature=feature, accessible_plugins=accessible_plugins, links=None)
+
+
+def _render(scenario: Scenario) -> str:
+    feature, _ = scenario
+    message = render_resolution_failure(_evaluate(scenario), feature)
+    assert message is not None
+    return message
+
+
+@pytest.fixture(autouse=True)
+def reset_hook_calls() -> None:
+    """Counter state must not leak between tests."""
+    HOOK_CALLS.clear()
+
+
+class TestRenderResolutionFailureMessages:
+    """The renderer projects each failure kind into the message shape the engine raises today."""
+
+    def test_success_renders_none(self) -> None:
+        """A successful evaluation has nothing to render."""
+        scenario = success_scenario()
+        feature, _ = scenario
+        result = _evaluate(scenario)
+
+        assert result.failure_kind is None
+        assert render_resolution_failure(result, feature) is None
+
+    def test_multiple_lists_every_identified_candidate_with_its_domain(self) -> None:
+        """Sorted one line per identified candidate, then the troubleshooting URL."""
+        module = RendererMultipleAFG791.__module__
+
+        message = _render(multiple_scenario())
+
+        assert message == (
+            f"Multiple feature groups found for feature '{MULTIPLE_FEATURE_791}':\n"
+            f"  - RendererMultipleAFG791 ({module}) [domain: renderer_domain_a_791]\n"
+            f"  - RendererMultipleBFG791 ({module}) [domain: renderer_domain_b_791]\n"
+            f"{TROUBLESHOOTING_LINE}"
+        )
+
+    def test_capability_rejection_renders_one_line_per_candidate(self) -> None:
+        """Each rejecting candidate names its OWN rejected and supported frameworks."""
+        message = _render(capability_scenario())
+
+        assert message == (
+            f"Unsupported compute framework(s) for feature '{CAPABILITY_FEATURE_791}':\n"
+            "  - RendererCapabilityAFG791: ['RendererFwTwo791']. Supported on: ['RendererFwOne791'].\n"
+            "  - RendererCapabilityBFG791: ['RendererFwOne791']. Supported on: ['RendererFwTwo791'].\n"
+            "Pin the feature to a supported compute framework or override supports_compute_framework."
+        )
+
+    def test_abstract_only_names_concrete_implementation_frameworks(self) -> None:
+        """Abstract-only with accessible concrete subclasses names the frameworks they require."""
+        message = _render(abstract_with_frameworks_scenario())
+
+        assert message == (
+            f"No feature groups found for feature name: '{ABSTRACT_FEATURE_791}'. "
+            "Its concrete implementations require compute framework(s) "
+            "['RendererFwOne791', 'RendererFwTwo791'], "
+            "none of which are available or enabled for this run."
+        )
+
+    def test_abstract_only_without_concrete_implementation(self) -> None:
+        """Abstract-only with no concrete implementation keeps the bare variant."""
+        message = _render(abstract_bare_scenario())
+
+        assert message == (
+            f"No feature groups found for feature name: '{ABSTRACT_FEATURE_791}'. "
+            "Only abstract feature group base(s) matched, which cannot be instantiated; "
+            "no concrete implementation is available or enabled."
+        )
+
+    def test_ordinary_none_renders_rejections_suggestion_and_pointers(self) -> None:
+        """Value rejections, then 'Did you mean', then the resolve_feature and troubleshooting lines."""
+        message = _render(ordinary_none_scenario())
+
+        lines = message.split("\n")
+        assert lines[0] == f"No feature groups found for feature name: '{TYPO_FEATURE_791}'."
+        assert lines[1] == f"Feature group(s) rejected an option value while matching '{TYPO_FEATURE_791}':"
+        assert lines[2] == f"  - RendererStrictFG791: {WINDOW_REJECTION_REASON}"
+        assert lines[3].startswith("Did you mean one of: [")
+        assert f"'{KNOWN_FEATURE_791}'" in lines[3]
+        assert lines[4] == "Use resolve_feature(name, options=...) to debug feature resolution."
+        assert lines[5] == TROUBLESHOOTING_LINE
+        assert len(lines) == 6
+
+    def test_empty_environment_stops_after_plugin_loader_hint(self) -> None:
+        """An empty environment renders the PluginLoader hint and nothing else."""
+        message = _render(empty_environment_scenario())
+
+        assert message == (
+            f"No feature groups found for feature name: '{EMPTY_ENV_FEATURE_791}'."
+            "\nNo plugins are loaded. Did you call PluginLoader.all()?"
+        )
+
+    def test_scoped_none_renders_callout_and_scoped_pointer(self) -> None:
+        """A scoped no-match carries the scope callout and the scoped resolve_feature pointer."""
+        message = _render(scoped_none_scenario())
+
+        assert message.startswith(
+            f"No feature groups found for feature name: '{SCOPED_NO_MATCH_FEATURE_791}'. "
+            "Scoped to feature group: 'RendererKnownNamesFG791'."
+        )
+        assert "Use resolve_feature(name, options=..., feature_group=...) to debug feature resolution." in message
+        assert message.endswith(TROUBLESHOOTING_LINE)
+
+    def test_forwarding_hint_is_dropped(self) -> None:
+        """The forwarding hint needs a speculative second match, so the pure renderer drops it."""
+        feature = Feature(FORWARDING_FEATURE_791, Options(group={"query_text": "hi", "top_k": 5}))
+        accessible_plugins: FeatureGroupEnvironmentMapping = {RendererBareOnlyFG791: {RendererFwOne791}}
+
+        message = render_resolution_failure(
+            IdentifyFeatureGroupClass.evaluate(feature=feature, accessible_plugins=accessible_plugins, links=None),
+            feature,
+        )
+
+        assert message is not None
+        assert "forward_group" not in message
+
+
+class TestPerCandidateCorrelation:
+    """A candidate's frameworks stay correlated to that candidate, never merged into a union."""
+
+    def test_capability_frameworks_are_never_unioned_across_candidates(self) -> None:
+        """Mirrored candidates: no line may claim a framework is both supported and unsupported."""
+        message = _render(capability_scenario())
+
+        a_line = next(line for line in message.split("\n") if "RendererCapabilityAFG791" in line)
+        b_line = next(line for line in message.split("\n") if "RendererCapabilityBFG791" in line)
+
+        assert a_line == "  - RendererCapabilityAFG791: ['RendererFwTwo791']. Supported on: ['RendererFwOne791']."
+        assert b_line == "  - RendererCapabilityBFG791: ['RendererFwOne791']. Supported on: ['RendererFwTwo791']."
+        # The cross-candidate union today's message builds must never appear.
+        assert "['RendererFwOne791', 'RendererFwTwo791']" not in message
+
+    def test_candidate_frameworks_are_captured_per_candidate(self) -> None:
+        """evaluate() correlates supported/rejected frameworks with their own candidate."""
+        result = _evaluate(capability_scenario())
+
+        assert result.candidate_frameworks == {
+            RendererCapabilityAFG791: CandidateFrameworks(
+                supported=frozenset({RendererFwOne791}),
+                rejected=frozenset({RendererFwTwo791}),
+            ),
+            RendererCapabilityBFG791: CandidateFrameworks(
+                supported=frozenset({RendererFwTwo791}),
+                rejected=frozenset({RendererFwOne791}),
+            ),
+        }
+
+
+class TestRenderDeterminism:
+    """Rendering is a pure function of the result: same input, same string."""
+
+    @pytest.mark.parametrize("scenario_name", sorted(FAILING_SCENARIOS))
+    def test_repeated_rendering_returns_identical_strings(self, scenario_name: str) -> None:
+        """Rendering the same result twice returns the identical string."""
+        scenario = FAILING_SCENARIOS[scenario_name]()
+        feature, _ = scenario
+        result = _evaluate(scenario)
+
+        first = render_resolution_failure(result, feature)
+        second = render_resolution_failure(result, feature)
+
+        assert first is not None
+        assert first == second
+
+    def test_candidate_lines_are_sorted(self) -> None:
+        """Candidate lines are sorted, independent of the accessible_plugins insertion order."""
+        multiple_lines = [line for line in _render(multiple_scenario()).split("\n") if line.startswith("  - ")]
+        capability_lines = [line for line in _render(capability_scenario()).split("\n") if line.startswith("  - ")]
+
+        assert multiple_lines == sorted(multiple_lines)
+        assert len(multiple_lines) == 2
+        assert capability_lines == sorted(capability_lines)
+        assert len(capability_lines) == 2
+
+
+class TestRendererCallsNoProviderHook:
+    """The core DoD: rendering touches no provider-overridable hook, for every failure kind."""
+
+    @pytest.mark.parametrize("scenario_name", sorted(FAILING_SCENARIOS))
+    def test_rendering_leaves_every_hook_counter_unchanged(self, scenario_name: str) -> None:
+        """evaluate() may call the hooks; repeated rendering afterwards must call none."""
+        scenario = FAILING_SCENARIOS[scenario_name]()
+        feature, _ = scenario
+        result = _evaluate(scenario)
+        assert result.failure_kind is not None
+
+        snapshot = dict(HOOK_CALLS)
+        assert snapshot, "the fixture feature groups must count at least one hook call during evaluate()"
+
+        for _ in range(3):
+            assert render_resolution_failure(result, feature) is not None
+
+        assert HOOK_CALLS == snapshot
+
+
+class TestFactsCapturedDuringEvaluate:
+    """evaluate() captures the render facts in its first pass, and only when it has no winner."""
+
+    def test_success_leaves_facts_at_the_empty_default(self) -> None:
+        """No capture on the success path; candidate frameworks still correlate to the winner."""
+        result = _evaluate(success_scenario())
+
+        assert result.facts == RenderFacts()
+        assert result.candidate_frameworks == {
+            RendererSuccessFG791: CandidateFrameworks(supported=frozenset({RendererFwOne791}), rejected=frozenset())
+        }
+
+    def test_domains_captured_for_multiple(self) -> None:
+        """The 'multiple' kind captures the domain NAME of every identified candidate."""
+        result = _evaluate(multiple_scenario())
+
+        assert result.failure_kind == "multiple"
+        assert result.facts.domains == {
+            RendererMultipleAFG791: "renderer_domain_a_791",
+            RendererMultipleBFG791: "renderer_domain_b_791",
+        }
+
+    def test_concrete_frameworks_captured_for_abstract_only(self) -> None:
+        """The abstract-only kind captures the declared frameworks of accessible concrete subclasses."""
+        result = _evaluate(abstract_with_frameworks_scenario())
+
+        assert result.failure_kind == "abstract_only"
+        assert result.facts.concrete_frameworks == ("RendererFwOne791", "RendererFwTwo791")
+
+    def test_no_concrete_frameworks_without_accessible_implementation(self) -> None:
+        """No accessible concrete subclass leaves concrete_frameworks empty."""
+        result = _evaluate(abstract_bare_scenario())
+
+        assert result.failure_kind == "abstract_only"
+        assert result.facts.concrete_frameworks == ()
+
+    def test_value_rejections_and_known_names_captured_for_ordinary_none(self) -> None:
+        """The ordinary-none kind captures the value rejections and the name catalog."""
+        result = _evaluate(ordinary_none_scenario())
+
+        assert result.failure_kind == "none"
+        assert result.facts.value_rejections == (("RendererStrictFG791", WINDOW_REJECTION_REASON),)
+        assert not result.facts.environment_empty
+        assert KNOWN_FEATURE_791 in result.facts.known_names
+        assert "RendererKnownNamesFG791" in result.facts.known_names
+        assert "RendererStrictFG791_" in result.facts.known_names
+
+    def test_environment_empty_captured(self) -> None:
+        """An empty accessible_plugins is captured as a fact."""
+        result = _evaluate(empty_environment_scenario())
+
+        assert result.failure_kind == "none"
+        assert result.facts.environment_empty
+        assert result.facts.known_names == ()


### PR DESCRIPTION
Closes #791. Part of epic #760, ordered after #790 and before #782.

## What

Resolution-failure messages were built by calling provider code a second time: capability rendering re-split frameworks, the forwarding hint re-ran matching under alternate options, and the abstract-only and value-rejection hints inspected provider behavior again. Rendering could therefore describe a different evaluation than the one that was decided, which is what blocks the exactly-once fix in #782.

`evaluate()` now captures the facts a message needs during its single decision pass, and a new internal `render_resolution_failure(result, feature)` projects them. The renderer reads only the `EvaluationResult` and the `Feature`: no `evaluate`, no matching, capability, domain, framework-declaration, link/index or validation hook. It does not even reuse `format_feature_group_classes(include_domain=True)`, which would call `get_domain`.

Per-candidate framework support stays correlated to its own candidate. Today's builder unions the split across candidates, so two candidates with mirrored capability produce a message claiming one framework is both supported and unsupported:

    Unsupported compute framework(s) for feature 'f': ['FwOne', 'FwTwo']. Supported on: ['FwOne', 'FwTwo'].

Capture is best-effort throughout: a provider hook that raises degrades the one fact it feeds, never the evaluation. That matters because the decision pass never called `get_domain` (its filter short-circuits when the request carries no domain), `prefix`, `feature_names_supported` or the value-rejection hook at all, and `resolve_feature` degrades a raising builder but not a raising `evaluate`.

## Not in scope

Engine behavior is unchanged: `validate()` and the five message builders stay, and remain the engine's message path. #782 wires both consumers to the renderer and removes the second evaluation. No typed public errors, reports, fingerprints, persona renderers or serialization: that is #759.

## Sanctioned message changes, pinned here for #782

- The input-feature forwarding hint is dropped. It needs a speculative `match_feature_group_criteria` under bare options, which no first-pass fact can honestly supply.
- Capability rejection renders one line per candidate instead of a cross-candidate union. It keeps the builder's universe (the frameworks a candidate declares that are available), so `Supported on:` still names a framework the run has not enabled, and a candidate with no enabled framework still renders as a capability failure rather than a plain no-match.
- Candidate and framework lists are sorted, by name and then module, since two candidates can share a name across modules.

## Tests

`tests/test_core/test_prepare/test_identify_feature_group_failure_renderer.py` (57 tests): the four failure kinds, per-candidate correlation, determinism under both insertion orders, the dropped hint, and hook-call-count snapshots proving rendering adds zero calls for every kind. The capability scenarios also assert the capability hook is asked at most once per candidate and framework across the whole evaluation, which is the contract #782 depends on. A raising hook of each kind is pinned not to take `evaluate` down, and `resolve_feature` is pinned to still report its candidates.

`tox` passes: 6509 passed, 170 skipped, ruff, mypy --strict, bandit clean.

The ATTRIBUTION.md commit is the tox-regenerated dependency list, unrelated to this change.