### PR TITLE
fix: materialize PropertySpec defaults at the central post-resolution boundary (#796)

### DIFF
--- a/attribution/ATTRIBUTION.md
+++ b/attribution/ATTRIBUTION.md
@@ -41,6 +41,7 @@
 | mypy                                   | 2.2.0           | MIT                                                |
 | mypy_extensions                        | 1.1.0           | MIT                                                |
 | narwhals                               | 2.23.0          | MIT                                                |
+| nest-asyncio                           | 1.6.0           | BSD License                                        |
 | nest-asyncio2                          | 1.7.2           | BSD License                                        |
 | nltk                                   | 3.10.0          | Apache Software License                            |
 | numpy                                  | 2.5.1           | BSD-3-Clause AND 0BSD AND MIT AND Zlib AND CC0-1.0 |
@@ -85,7 +86,7 @@
 | regex                                  | 2026.6.28       | Apache-2.0 AND CNRI-Python                         |
 | requests                               | 2.34.2          | Apache Software License                            |
 | rich                                   | 14.3.4          | MIT License                                        |
-| ruff                                   | 0.15.20         | MIT                                                |
+| ruff                                   | 0.15.21         | MIT                                                |
 | scikit-learn                           | 1.9.0           | BSD-3-Clause                                       |
 | scipy                                  | 1.18.0          | BSD License                                        |
 | six                                    | 1.17.0          | MIT License                                        |

--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -237,23 +237,28 @@ predicate that always returns `False` to make a key optional.
 
 A declared default is metadata until the resolved feature group materializes it.
 `FeatureGroup.options_with_defaults(options)` returns an `Options` view where every absent key
-with a concrete declared default is filled from its spec (into context or group per the spec),
-so compute reads see it. A present value is never overridden, even a falsy `0`/`False`/`""`.
-`NO_DEFAULT` and `default=None` fill nothing. A strict default is already validated at
-construction, so the materialized value is not re-checked. The view is applied *after*
-resolution, so it never changes matching or FeatureSet splitting.
+with a concrete declared default is filled from its spec (into context or group per the spec).
+A present value is never overridden, even a falsy `0`/`False`/`""`. `NO_DEFAULT` and
+`default=None` fill nothing. A strict default is already validated at construction, so the
+materialized value is not re-checked.
+
+The framework applies this centrally at the compute boundary: `run_calculate_feature`
+materializes the declared defaults into the `FeatureSet` before `calculate_feature` and any
+calculate-feature extender run, so a plugin reads `feature.options` directly.
+`options_with_defaults` remains for pre-materialization contexts (e.g. `resolve_subtype`
+internals). Materialization happens *after* resolution, so it never changes matching or
+FeatureSet splitting.
 
 ``` python
-opts = MyFeatureGroup.options_with_defaults(feature.options)
-graph_type = opts.get("graph_type")  # the declared default when the caller omitted it
+graph_type = feature.options.get("graph_type")  # the declared default when the caller omitted it
 ```
 
 `Options.get(key, default)` reads dict-style: a present key returns its stored value (even a falsy
 `0`/`False`/`""`), and the call-site `default` is returned only when the key is absent from both
-group and context. Because `options_with_defaults` has already materialized any declared default
-into the view, reading it back gives a three-level precedence, an explicit caller value first, then
-the declared spec default, then the call-site `default`. (Subtlety: `options_with_defaults` fills any
-key whose value `is None`, so an explicit `None` is replaced by a concrete spec default, while the
+group and context. Because the framework has already materialized any declared default before
+`calculate_feature` runs, reading it back gives a three-level precedence, an explicit caller value
+first, then the declared spec default, then the call-site `default`. (Subtlety: materialization fills
+any key whose value `is None`, so an explicit `None` is replaced by a concrete spec default, while the
 other falsy values `0`/`False`/`""` are kept. That "None means absent" rule is the default; a spec
 opts a single key out with `allow_explicit_none=True`, after which an explicit `None` overrides even a
 concrete default and is honored across the match-time value mechanisms: it counts as present for the
@@ -262,8 +267,7 @@ required-presence and `required_when` checks and is seen by membership, `element
 `is not None` presence tests keep working.)
 
 ``` python
-opts = MyFeatureGroup.options_with_defaults(feature.options)
-graph_type = opts.get("graph_type", "spring")  # explicit value; else the spec default; else "spring"
+graph_type = feature.options.get("graph_type", "spring")  # explicit value; else the spec default; else "spring"
 ```
 
 ## Parameter classification
@@ -388,6 +392,7 @@ if it really is a whole-value check.
 | Shape rules, relocated from class definition to construction | `tests/.../feature_chainer/test_property_mapping_spec_shape.py` |
 | Declared-default invariant | `tests/test_core/test_abstract_plugins/test_property_mapping_default_invariant.py` |
 | Declared defaults materialized into runtime options | `tests/test_core/test_abstract_plugins/test_options_with_defaults.py` |
+| Declared defaults materialized at the compute boundary | `tests/test_core/test_abstract_plugins/test_materialize_defaults_boundary.py` |
 | Container invariance, no stringification, str-as-scalar, dict-as-composite, empty containers | `tests/.../feature_chainer/test_property_mapping_sequence_unpacking.py` |
 | Present option values validated on the string-named path too; required presence stays config-only | `tests/.../feature_chainer/test_name_path_validates_option_values.py` |
 | `required_when` survives an overridden matcher, runs exactly once, and demands a classmethod | `tests/.../feature_chainer/test_required_when_enforced_on_override.py` |

--- a/mloda/core/abstract_plugins/components/feature_set.py
+++ b/mloda/core/abstract_plugins/components/feature_set.py
@@ -1,3 +1,4 @@
+from collections import Counter
 from typing import TYPE_CHECKING, Any, Iterable, Optional
 from uuid import UUID
 
@@ -75,7 +76,9 @@ class FeatureSet:
 
     def materialize_option_defaults(self, feature_group: "type[FeatureGroup]") -> None:
         """Rebind every feature's options (and self.options) through feature_group.options_with_defaults,
-        memoized by Options identity so aliases stay aliased; identity no-op without concrete defaults (#796)."""
+        memoized by Options identity so aliases stay aliased; identity no-op without concrete defaults (#796).
+        Precondition: same-named features distinguished only by an explicitly-set default value collapse
+        when the default fills their twin, and that raises."""
         # The memo holds a strong reference to each source Options so its id cannot be recycled mid-loop.
         memo: dict[int, tuple[Options, Options]] = {}
         rebound = False
@@ -89,11 +92,18 @@ class FeatureSet:
                 feature.options = entry[1]
                 rebound = True
         if rebound:
-            # Feature.__hash__ includes options: a fill changes hashes, so the set's buckets go stale.
-            # A comprehension rehashes each element; set(self.features) would copy the stale stored hashes.
+            # Only GROUP fills change Feature hashes (Options.__hash__ is group-only); a comprehension rehashes,
+            # set(self.features) would reuse stale stored hashes. The rebuild also surfaces twin collapses loudly.
             rebuilt = {feature for feature in self.features}
             if len(rebuilt) < len(self.features):
-                raise ValueError("materialize_option_defaults collapsed distinct features; upstream invariant broken")
+                names = sorted(
+                    name for name, count in Counter(str(feature.name) for feature in self.features).items() if count > 1
+                )
+                raise ValueError(
+                    "Materializing declared defaults collapsed duplicate features (same name, previously "
+                    "distinguished only by an explicitly-set default value now filled on its twin). "
+                    f"Deduplicate the request or set the key explicitly on all twins. Affected: {names}"
+                )
             self.features = rebuilt
         if self.options is not None:
             entry_for_options = memo.get(id(self.options))

--- a/mloda/core/abstract_plugins/components/feature_set.py
+++ b/mloda/core/abstract_plugins/components/feature_set.py
@@ -1,4 +1,4 @@
-from typing import Any, Iterable, Optional
+from typing import TYPE_CHECKING, Any, Iterable, Optional
 from uuid import UUID
 
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
@@ -8,6 +8,9 @@ from mloda.core.abstract_plugins.components.validators.feature_set_validator imp
 from mloda.core.filter.filter_engine import BaseFilterEngine
 from mloda.core.abstract_plugins.components.mask.base_mask_engine import BaseMaskEngine
 from mloda.core.filter.single_filter import SingleFilter
+
+if TYPE_CHECKING:
+    from mloda.core.abstract_plugins.feature_group import FeatureGroup
 
 
 class FeatureSet:
@@ -69,6 +72,35 @@ class FeatureSet:
 
     def remove(self, feature: Feature) -> None:
         self.features.discard(feature)
+
+    def materialize_option_defaults(self, feature_group: "type[FeatureGroup]") -> None:
+        """Rebind every feature's options (and self.options) through feature_group.options_with_defaults,
+        memoized by Options identity so aliases stay aliased; identity no-op without concrete defaults (#796)."""
+        # The memo holds a strong reference to each source Options so its id cannot be recycled mid-loop.
+        memo: dict[int, tuple[Options, Options]] = {}
+        rebound = False
+        for feature in self.features:
+            source = feature.options
+            entry = memo.get(id(source))
+            if entry is None:
+                entry = (source, feature_group.options_with_defaults(source))
+                memo[id(source)] = entry
+            if entry[1] is not source:
+                feature.options = entry[1]
+                rebound = True
+        if rebound:
+            # Feature.__hash__ includes options: a fill changes hashes, so the set's buckets go stale.
+            # A comprehension rehashes each element; set(self.features) would copy the stale stored hashes.
+            rebuilt = {feature for feature in self.features}
+            if len(rebuilt) < len(self.features):
+                raise ValueError("materialize_option_defaults collapsed distinct features; upstream invariant broken")
+            self.features = rebuilt
+        if self.options is not None:
+            entry_for_options = memo.get(id(self.options))
+            if entry_for_options is not None:
+                self.options = entry_for_options[1]
+            else:
+                self.options = feature_group.options_with_defaults(self.options)
 
     def get_all_feature_ids(self) -> set[UUID]:
         return {feature.uuid for feature in self.features}

--- a/mloda/core/abstract_plugins/compute_framework.py
+++ b/mloda/core/abstract_plugins/compute_framework.py
@@ -668,6 +668,12 @@ class ComputeFramework(ABC):
 
     @final
     def run_calculate_feature(self, feature_group: Any, features: Any) -> Any:
+        # Local import: feature_set -> feature -> compute_framework would cycle at module level.
+        from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+
+        # Tests pass non-FeatureSet stand-ins for features; only a real FeatureSet is materialized (#796).
+        if isinstance(features, FeatureSet):
+            features.materialize_option_defaults(feature_group)
         extender = self.get_function_extender(ExtenderHook.FEATURE_GROUP_CALCULATE_FEATURE)
 
         try:

--- a/mloda_plugins/feature_group/experimental/clustering/base.py
+++ b/mloda_plugins/feature_group/experimental/clustering/base.py
@@ -314,7 +314,7 @@ class ClusteringFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             cls._check_source_features_exist(data, resolved_features)
 
             # Check if we should output probabilities
-            output_probabilities = cls.options_with_defaults(feature.options).get(cls.OUTPUT_PROBABILITIES)
+            output_probabilities = feature.options.get(cls.OUTPUT_PROBABILITIES)
 
             # Perform clustering
             if output_probabilities:

--- a/mloda_plugins/feature_group/experimental/dimensionality_reduction/pandas.py
+++ b/mloda_plugins/feature_group/experimental/dimensionality_reduction/pandas.py
@@ -137,9 +137,6 @@ class PandasDimensionalityReductionFeatureGroup(DimensionalityReductionFeatureGr
                 f"Target dimension ({dimension}) must be less than the number of source features ({X_scaled.shape[1]})"
             )
 
-        # Materialize declared defaults so each branch reads the spec-backed value (#766)
-        options = DimensionalityReductionFeatureGroup.options_with_defaults(options)
-
         # Perform dimensionality reduction based on the algorithm
         if algorithm == "pca":
             svd_solver = options.get(DimensionalityReductionFeatureGroup.PCA_SVD_SOLVER)

--- a/mloda_plugins/feature_group/experimental/forecasting/base.py
+++ b/mloda_plugins/feature_group/experimental/forecasting/base.py
@@ -335,9 +335,7 @@ class ForecastingFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featu
                     raise ValueError("No artifact to load although it was requested.")
 
             # Check if we should output confidence intervals
-            output_confidence_intervals = cls.options_with_defaults(feature.options).get(
-                cls.OUTPUT_CONFIDENCE_INTERVALS
-            )
+            output_confidence_intervals = feature.options.get(cls.OUTPUT_CONFIDENCE_INTERVALS)
 
             # Perform forecasting using the original clean data
             if output_confidence_intervals:

--- a/mloda_plugins/feature_group/experimental/node_centrality/base.py
+++ b/mloda_plugins/feature_group/experimental/node_centrality/base.py
@@ -229,9 +229,8 @@ class NodeCentralityFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             centrality_type, source_feature_str = cls._extract_centrality_and_source_feature(feature)
 
             # Common parameter extraction (works for both approaches)
-            opts = cls.options_with_defaults(feature.options)
-            graph_type = opts.get(cls.GRAPH_TYPE)
-            weight_column = opts.get(cls.WEIGHT_COLUMN)
+            graph_type = feature.options.get(cls.GRAPH_TYPE)
+            weight_column = feature.options.get(cls.WEIGHT_COLUMN)
 
             # Validate graph type
             if graph_type not in cls.GRAPH_TYPES:

--- a/tests/test_core/test_abstract_plugins/test_materialize_defaults_boundary.py
+++ b/tests/test_core/test_abstract_plugins/test_materialize_defaults_boundary.py
@@ -1,0 +1,325 @@
+"""Pin runtime materialization of declared PropertySpec defaults at the calculate_feature boundary (#796).
+
+``FeatureGroup.options_with_defaults`` (#766) fills absent PROPERTY_MAPPING keys that declare a concrete
+default, but the framework still hands the ORIGINAL pre-default FeatureSet to ``calculate_feature``, so a
+plugin reading ``feature.options`` directly never sees declared defaults. The pinned contract:
+
+- ``FeatureSet.materialize_option_defaults(feature_group)`` rebinds every ``feature.options`` (and
+  ``self.options``) through ``feature_group.options_with_defaults``, memoized by Options object identity so
+  aliased Options stay aliased, rebuilding ``self.features`` when anything was rebound (Feature.__hash__
+  includes options). It is an identity no-op when the feature group declares no concrete defaults, and it
+  never mutates the input Options objects.
+- ``ComputeFramework.run_calculate_feature`` invokes it up front, so BOTH the direct ``calculate_feature``
+  call and the FEATURE_GROUP_CALCULATE_FEATURE extender path observe materialized options: absent keys carry
+  their declared defaults, present values (even falsy) win, and an ``allow_explicit_none=True`` explicit
+  None is retained.
+"""
+
+from __future__ import annotations
+
+import gc
+from typing import Any, Callable
+from uuid import uuid4
+
+import pytest
+
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.components.parallelization_modes import ParallelizationMode
+from mloda.core.abstract_plugins.components.utils import get_all_subclasses
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.abstract_plugins.function_extender import Extender, ExtenderHook
+from mloda.provider import DataCreator, PropertySpec
+from mloda.user import PluginCollector, mloda
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
+
+
+@pytest.fixture(autouse=True)
+def _no_feature_group_registry_pollution() -> Any:
+    """Guarantee this module never leaks throwaway FeatureGroup subclasses.
+
+    The tests below define FeatureGroup subclasses inside factory functions. Those class
+    objects sit in reference cycles, so they linger in ``FeatureGroup.__subclasses__()``
+    until a GC cycle runs. While they linger, other tests that enumerate feature groups via
+    ``get_all_subclasses(FeatureGroup)`` trip over them. After each test we force a
+    collection to reclaim the now-unreferenced classes and assert that none of this
+    module's classes remain registered, pinning the no-pollution contract.
+    """
+    yield
+    gc.collect()
+    gc.collect()
+    leaked = [c for c in get_all_subclasses(FeatureGroup) if c.__module__ == __name__]
+    assert not leaked, f"Leaked FeatureGroup subclasses from {__name__}: {[c.__name__ for c in leaked]}"
+
+
+# PROPERTY_MAPPING keys for the throwaway probes; the mdb_ prefix keeps them unique to this module.
+MDB_CTX_KEY = "mdb_ctx_default"  # context concrete default
+MDB_GRP_KEY = "mdb_grp_default"  # group concrete default (context=False)
+MDB_FALSY_KEY = "mdb_falsy_default"  # concrete default overridable by a falsy explicit value
+MDB_EN_KEY = "mdb_explicit_none_optin"  # allow_explicit_none=True with a concrete default
+MDB_SIBLING_KEY = "mdb_en_sibling_default"  # plain concrete default next to the opted-in key
+MDB_REQ_KEY = "mdb_required"  # NO_DEFAULT (no concrete default, never filled)
+
+CTX_DEFAULT = "mdb_ctx_val"
+GRP_DEFAULT = "mdb_grp_val"
+FALSY_DEFAULT = "mdb_nonfalsy"
+EN_DEFAULT = "mdb_en_val"
+SIBLING_DEFAULT = "mdb_sibling_val"
+
+
+def _make_boundary_probe_fg(feature_name: str) -> type[FeatureGroup]:
+    """A throwaway root FeatureGroup whose calculate_feature reads feature.options DIRECTLY.
+
+    It never calls options_with_defaults itself: the observed payload therefore proves (or
+    disproves) that the framework materialized the declared defaults before the call.
+    """
+
+    class MdbBoundaryProbeFeatureGroup(FeatureGroup):
+        PROPERTY_MAPPING = {
+            MDB_CTX_KEY: PropertySpec("A context concrete default.", context=True, default=CTX_DEFAULT),
+            MDB_GRP_KEY: PropertySpec("A group concrete default.", context=False, default=GRP_DEFAULT),
+            MDB_FALSY_KEY: PropertySpec("Overridable by a falsy explicit value.", context=True, default=FALSY_DEFAULT),
+        }
+
+        @classmethod
+        def input_data(cls) -> DataCreator:
+            return DataCreator({feature_name})
+
+        @classmethod
+        def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+            out: dict[str, list[Any]] = {}
+            for feature in features.features:
+                out[str(feature.name)] = [
+                    {
+                        "ctx": feature.options.get(MDB_CTX_KEY),
+                        "grp": feature.options.get(MDB_GRP_KEY),
+                        "falsy": feature.options.get(MDB_FALSY_KEY),
+                    }
+                ]
+            return out
+
+    return MdbBoundaryProbeFeatureGroup
+
+
+def _make_explicit_none_probe_fg(feature_name: str) -> type[FeatureGroup]:
+    """A throwaway root FeatureGroup pairing an opted-in explicit-None key with a plain default."""
+
+    class MdbExplicitNoneProbeFeatureGroup(FeatureGroup):
+        PROPERTY_MAPPING = {
+            MDB_EN_KEY: PropertySpec(
+                "Opted-in: an explicit None is honored.", context=True, default=EN_DEFAULT, allow_explicit_none=True
+            ),
+            MDB_SIBLING_KEY: PropertySpec("A plain context concrete default.", context=True, default=SIBLING_DEFAULT),
+        }
+
+        @classmethod
+        def input_data(cls) -> DataCreator:
+            return DataCreator({feature_name})
+
+        @classmethod
+        def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+            out: dict[str, list[Any]] = {}
+            for feature in features.features:
+                out[str(feature.name)] = [
+                    {
+                        "en": feature.options.get(MDB_EN_KEY),
+                        "sibling": feature.options.get(MDB_SIBLING_KEY),
+                    }
+                ]
+            return out
+
+    return MdbExplicitNoneProbeFeatureGroup
+
+
+def _make_unit_group_default_fg() -> type[FeatureGroup]:
+    """A throwaway FeatureGroup with a single group concrete default, for the FeatureSet unit tests."""
+
+    class MdbUnitGroupDefaultFeatureGroup(FeatureGroup):
+        PROPERTY_MAPPING = {
+            MDB_GRP_KEY: PropertySpec("A group concrete default.", context=False, default=GRP_DEFAULT),
+        }
+
+        @classmethod
+        def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+            return data
+
+    return MdbUnitGroupDefaultFeatureGroup
+
+
+def _make_unit_no_defaults_fg() -> type[FeatureGroup]:
+    """A throwaway FeatureGroup declaring no concrete defaults (NO_DEFAULT only)."""
+
+    class MdbUnitNoDefaultsFeatureGroup(FeatureGroup):
+        PROPERTY_MAPPING = {
+            MDB_REQ_KEY: PropertySpec("Required by omission (NO_DEFAULT).", context=True),
+        }
+
+        @classmethod
+        def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+            return data
+
+    return MdbUnitNoDefaultsFeatureGroup
+
+
+def _single_row(frame: Any, column: str) -> Any:
+    """Extract the single payload row, tolerant of columnar dict or list-of-row-dicts results."""
+    if isinstance(frame, dict):
+        values = list(frame[column])
+    else:
+        values = [row[column] for row in frame]
+    assert len(values) == 1, f"expected exactly one row for {column}, got {values!r}"
+    return values[0]
+
+
+def _run_probe(
+    make_fg: Callable[[str], type[FeatureGroup]], feature_name: str, options: Options | None = None
+) -> dict[str, Any]:
+    """Run one tiny end-to-end computation and return the observed payload of the single feature.
+
+    The probe class and collector stay locals of THIS frame, so a failing assert in the
+    caller never pins the throwaway class in a traceback and the no-leak guard stays green.
+    """
+    fg = make_fg(feature_name)
+    collector = PluginCollector.enabled_feature_groups({fg})
+    results = mloda.run_all(
+        [Feature(feature_name, options if options is not None else Options())],
+        compute_frameworks={PythonDictFramework},
+        plugin_collector=collector,
+    )
+    assert len(results) == 1, f"expected exactly one result frame, got: {results!r}"
+    payload = _single_row(results[0], feature_name)
+    assert isinstance(payload, dict)
+    return payload
+
+
+def _materialize(feature_set: FeatureSet, make_fg: Callable[[], type[FeatureGroup]]) -> None:
+    """Invoke ``FeatureSet.materialize_option_defaults`` directly; the method now lives on FeatureSet.
+
+    The direct typed call retires the dynamic ``getattr`` seam the RED phase needed while the
+    method was still absent.
+    """
+    feature_set.materialize_option_defaults(make_fg())
+
+
+class TestRuntimeDefaultMaterializationEndToEnd:
+    """calculate_feature observes declared defaults through the real engine (the #796 regression)."""
+
+    def test_declared_defaults_visible_in_calculate_feature(self) -> None:
+        """Absent context and group keys with concrete defaults are materialized before calculate_feature."""
+        observed = _run_probe(_make_boundary_probe_fg, "mdb_e2e_defaults_feature")
+        assert observed["ctx"] == CTX_DEFAULT, f"context default not materialized at runtime: {observed!r}"
+        assert observed["grp"] == GRP_DEFAULT, f"group default not materialized at runtime: {observed!r}"
+
+    def test_explicit_and_falsy_values_win_while_absent_key_materializes(self) -> None:
+        """Explicit (even falsy) values are never overridden, while the untouched key still gets its default."""
+        options = Options(context={MDB_CTX_KEY: "mdb_explicit", MDB_FALSY_KEY: ""})
+        observed = _run_probe(_make_boundary_probe_fg, "mdb_e2e_explicit_feature", options)
+        assert observed["ctx"] == "mdb_explicit", f"explicit value was overridden: {observed!r}"
+        assert observed["falsy"] == "", f"falsy explicit value was overridden: {observed!r}"
+        assert observed["grp"] == GRP_DEFAULT, f"absent group key not materialized in the same run: {observed!r}"
+
+    def test_opted_in_explicit_none_retained_while_sibling_default_materializes(self) -> None:
+        """An allow_explicit_none=True explicit None survives materialization; the sibling default is filled."""
+        options = Options(context={MDB_EN_KEY: None})
+        observed = _run_probe(_make_explicit_none_probe_fg, "mdb_e2e_explicit_none_feature", options)
+        assert observed["sibling"] == SIBLING_DEFAULT, f"sibling default not materialized: {observed!r}"
+        assert observed["en"] is None, f"opted-in explicit None was overwritten by the default: {observed!r}"
+
+
+class _CapturingExtender(Extender):
+    """Captures the ``features`` argument flowing through FEATURE_GROUP_CALCULATE_FEATURE."""
+
+    def __init__(self) -> None:
+        self.captured: list[Any] = []
+
+    def wraps(self) -> set[ExtenderHook]:
+        return {ExtenderHook.FEATURE_GROUP_CALCULATE_FEATURE}
+
+    def __call__(self, func: Any, *args: Any, **kwargs: Any) -> Any:
+        # _invoke_extender passes (data, features); capture the FeatureSet the plugin will see.
+        self.captured.append(args[1])
+        return func(*args, **kwargs)
+
+
+class TestExtenderPathObservesMaterializedOptions:
+    """run_calculate_feature materializes defaults BEFORE dispatching to a calculate-feature extender."""
+
+    def test_extender_receives_feature_set_with_materialized_defaults(self) -> None:
+        """The FeatureSet handed to the extender already carries the declared defaults."""
+        extender = _CapturingExtender()
+        cfw = PythonDictFramework(ParallelizationMode.SYNC, frozenset(), uuid4(), function_extender={extender})
+        feature = Feature("mdb_extender_feature")
+        feature_set = FeatureSet()
+        feature_set.add(feature)
+
+        # The probe class is created inline (no local binding), so a failing assert cannot pin it.
+        cfw.run_calculate_feature(_make_boundary_probe_fg("mdb_extender_feature"), feature_set)
+
+        assert len(extender.captured) == 1, "the extender must wrap exactly one calculate_feature call"
+        captured = extender.captured[0]
+        assert isinstance(captured, FeatureSet)
+        observed_ctx = [f.options.get(MDB_CTX_KEY) for f in captured.features]
+        observed_grp = [f.options.get(MDB_GRP_KEY) for f in captured.features]
+        assert observed_ctx == [CTX_DEFAULT], f"extender saw pre-default context options: {observed_ctx!r}"
+        assert observed_grp == [GRP_DEFAULT], f"extender saw pre-default group options: {observed_grp!r}"
+
+
+class TestFeatureSetMaterializeOptionDefaults:
+    """Unit contract of FeatureSet.materialize_option_defaults (RED: the method does not exist yet)."""
+
+    def test_group_default_fill_rebinds_feature_and_feature_set_options(self) -> None:
+        """The fill lands on the feature, the set stays coherent, and self.options reflects the fill."""
+        feature = Feature("mdb_unit_fill_feature")
+        original_uuid = feature.uuid
+        feature_set = FeatureSet()
+        feature_set.add(feature)
+
+        _materialize(feature_set, _make_unit_group_default_fg)
+
+        assert feature.options.get(MDB_GRP_KEY) == GRP_DEFAULT
+        assert len(feature_set.features) == 1
+        # Feature.__hash__ includes options: only a rebuilt set answers fresh membership correctly.
+        assert feature in feature_set.features, "features set was not rebuilt after rebinding options"
+        assert feature.uuid == original_uuid
+        assert feature_set.options is not None
+        assert feature_set.options.get(MDB_GRP_KEY) == GRP_DEFAULT, "self.options stayed the stale pre-default object"
+        assert feature_set.options is feature.options, "self.options lost its alias to the feature's options"
+
+    def test_shared_options_object_stays_shared_after_fill(self) -> None:
+        """Two features sharing ONE Options object still share one materialized object afterwards."""
+        shared = Options()
+        feature_a = Feature("mdb_unit_alias_a", shared)
+        feature_b = Feature("mdb_unit_alias_b", shared)
+        feature_set = FeatureSet([feature_a, feature_b])
+
+        _materialize(feature_set, _make_unit_group_default_fg)
+
+        assert len(feature_set.features) == 2
+        assert feature_a.options is feature_b.options, "aliased Options diverged during materialization"
+        assert feature_a.options.get(MDB_GRP_KEY) == GRP_DEFAULT
+        assert feature_a.options is not shared, "the fill must rebind to a new Options, not mutate in place"
+
+    def test_no_concrete_defaults_is_identity_noop(self) -> None:
+        """A feature group without concrete defaults leaves every Options object identical (is)."""
+        options = Options(context={"mdb_unrelated": "kept"})
+        feature = Feature("mdb_unit_noop_feature", options)
+        feature_set = FeatureSet([feature])
+
+        _materialize(feature_set, _make_unit_no_defaults_fg)
+
+        rebound = next(iter(feature_set.features))
+        assert rebound.options is options, "no-defaults materialization must be an identity no-op"
+        assert feature_set.options is options
+        assert rebound.options.get("mdb_unrelated") == "kept"
+
+    def test_original_options_object_not_mutated(self) -> None:
+        """Materialization rebinds; the original Options object never gains the filled key."""
+        original = Options()
+        feature = Feature("mdb_unit_nomutate_feature", original)
+        feature_set = FeatureSet([feature])
+
+        _materialize(feature_set, _make_unit_group_default_fg)
+
+        assert MDB_GRP_KEY not in original.group, "the input Options was mutated"
+        assert MDB_GRP_KEY not in original.context, "the input Options was mutated"

--- a/tests/test_core/test_abstract_plugins/test_materialize_defaults_boundary.py
+++ b/tests/test_core/test_abstract_plugins/test_materialize_defaults_boundary.py
@@ -147,6 +147,21 @@ def _make_unit_group_default_fg() -> type[FeatureGroup]:
     return MdbUnitGroupDefaultFeatureGroup
 
 
+def _make_unit_context_default_fg() -> type[FeatureGroup]:
+    """A throwaway FeatureGroup with a single context concrete default, for the collapse unit test."""
+
+    class MdbUnitContextDefaultFeatureGroup(FeatureGroup):
+        PROPERTY_MAPPING = {
+            MDB_CTX_KEY: PropertySpec("A context concrete default.", context=True, default=CTX_DEFAULT),
+        }
+
+        @classmethod
+        def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+            return data
+
+    return MdbUnitContextDefaultFeatureGroup
+
+
 def _make_unit_no_defaults_fg() -> type[FeatureGroup]:
     """A throwaway FeatureGroup declaring no concrete defaults (NO_DEFAULT only)."""
 
@@ -323,3 +338,23 @@ class TestFeatureSetMaterializeOptionDefaults:
 
         assert MDB_GRP_KEY not in original.group, "the input Options was mutated"
         assert MDB_GRP_KEY not in original.context, "the input Options was mutated"
+
+    def test_collapse_of_same_name_twins_raises_actionable_duplicate_message(self) -> None:
+        """Filling a context default on one twin of a same-name pair collapses the set: the ValueError
+        must name the duplicate-feature cause and list the affected names, not blame an upstream invariant."""
+        twin_name = "mdb_unit_twin_feature"
+        explicit = Feature(twin_name, Options(context={MDB_CTX_KEY: CTX_DEFAULT}))
+        absent = Feature(twin_name, Options())
+        feature_set = FeatureSet([explicit, absent])
+        # Precondition: group-only hash plus context-aware eq lets the twins coexist before the fill.
+        assert len(feature_set.features) == 2
+
+        with pytest.raises(ValueError) as excinfo:
+            _materialize(feature_set, _make_unit_context_default_fg)
+
+        message = str(excinfo.value)
+        # Drop the captured traceback before the message asserts: a failing assert would otherwise carry the
+        # probe class through teardown via excinfo and trip this module's no-leak guard.
+        del excinfo
+        assert "collapsed duplicate features" in message, f"message must name the duplicate-collapse cause: {message}"
+        assert twin_name in message, f"message must list the affected duplicate name: {message}"

--- a/tests/test_plugins/feature_group/experimental/test_dimensionality_reduction_feature_group/test_base_dimensionality_reduction_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/test_dimensionality_reduction_feature_group/test_base_dimensionality_reduction_feature_group.py
@@ -90,9 +90,11 @@ class TestDimensionalityReductionFeatureGroup:
         )
         source_features = ["f1", "f2", "f3"]
 
+        # _perform_reduction receives boundary-materialized options at runtime (#796); mirror that here.
+        options = PandasDimensionalityReductionFeatureGroup.options_with_defaults(Options())
         for algorithm in DimensionalityReductionFeatureGroup.REDUCTION_ALGORITHMS:
             result = PandasDimensionalityReductionFeatureGroup._perform_reduction(
-                data, algorithm, 2, source_features, Options()
+                data, algorithm, 2, source_features, options
             )
             assert result.shape == (12, 2), f"Unexpected result shape for algorithm {algorithm}"
 

--- a/tests/test_plugins/feature_group/experimental/test_dimensionality_reduction_feature_group/test_pandas_dimensionality_reduction_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/test_dimensionality_reduction_feature_group/test_pandas_dimensionality_reduction_feature_group.py
@@ -174,6 +174,9 @@ class TestPandasDimensionalityReductionFeatureGroup:
         feature_set = FeatureSet()
         feature_set.add(Feature("feature0,feature1,feature2__pca_2d"))
 
+        # Direct call bypasses run_calculate_feature, so mirror its default materialization (#796)
+        feature_set.materialize_option_defaults(PandasDimensionalityReductionFeatureGroup)
+
         # Calculate the feature
         result = PandasDimensionalityReductionFeatureGroup.calculate_feature(sample_data, feature_set)
 
@@ -202,6 +205,9 @@ class TestPandasDimensionalityReductionFeatureGroup:
         feature_set = FeatureSet()
         feature_set.add(Feature("feature0,feature1,feature2__pca_2d"))
         feature_set.add(Feature("feature0,feature1,feature2__ica_2d"))
+
+        # Direct call bypasses run_calculate_feature, so mirror its default materialization (#796)
+        feature_set.materialize_option_defaults(PandasDimensionalityReductionFeatureGroup)
 
         # Calculate the features
         result = PandasDimensionalityReductionFeatureGroup.calculate_feature(small_sample, feature_set)

--- a/tests/test_plugins/feature_group/experimental/test_node_centrality_feature_group/test_node_centrality_integration.py
+++ b/tests/test_plugins/feature_group/experimental/test_node_centrality_feature_group/test_node_centrality_integration.py
@@ -233,7 +233,7 @@ class TestNodeCentralityPandasIntegration:
         """Omitting graph_type computes the same centrality as graph_type='undirected'.
 
         End-to-end proof that the declared 'undirected' default is materialized at compute
-        (via options_with_defaults inside calculate_feature) rather than required from the user (#766).
+        (centrally at the run_calculate_feature boundary, #796) rather than required from the user (#766).
         """
         plugin_collector = PluginCollector.enabled_feature_groups(
             {NodeCentralityTestDataCreator, PandasNodeCentralityFeatureGroup}

--- a/tests/test_plugins/feature_group/experimental/test_node_centrality_feature_group/test_pandas_node_centrality_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/test_node_centrality_feature_group/test_pandas_node_centrality_feature_group.py
@@ -215,6 +215,9 @@ class TestPandasNodeCentralityFeatureGroup:
         feature_set = FeatureSet()
         feature_set.add(Feature("source__degree_centrality"))
 
+        # Direct call bypasses run_calculate_feature, so mirror its default materialization (#796)
+        feature_set.materialize_option_defaults(PandasNodeCentralityFeatureGroup)
+
         # Calculate the feature
         result = PandasNodeCentralityFeatureGroup.calculate_feature(sample_data, feature_set)
 
@@ -236,6 +239,9 @@ class TestPandasNodeCentralityFeatureGroup:
         ]
         for feature in features:
             feature_set.add(feature)
+
+        # Direct call bypasses run_calculate_feature, so mirror its default materialization (#796)
+        feature_set.materialize_option_defaults(PandasNodeCentralityFeatureGroup)
 
         # Calculate the features
         result = PandasNodeCentralityFeatureGroup.calculate_feature(sample_data, feature_set)

--- a/tests/test_plugins/integration_plugins/chainer/chainer_context_feature.py
+++ b/tests/test_plugins/integration_plugins/chainer/chainer_context_feature.py
@@ -202,8 +202,14 @@ def assert_propert2_is_set(feature: Feature) -> None:
 
 def assert_property3_is_set(feature: Feature) -> None:
     """
-    Assert that the 'property3' is set correctly for features that should have it,
-    and is absent for features that should not have it (demonstrating optional behavior).
+    Assert 'property3' follows the #796 contract: declared PropertySpec defaults materialize
+    at the compute boundary, so levels that omit the key observe the declared default
+    'opt_val1' at runtime, while explicit values win. Absence at runtime remains only for
+    keys without a concrete default; 'property3' declares one.
+
+    Cross-level isolation: placeholder2 omits 'property3' while its consumer placeholder3
+    explicitly sets 'opt_val2'. placeholder2 must observe its own default 'opt_val1',
+    never a value from another chain level.
 
     This is a utility function for testing chainer context features with optional properties.
 
@@ -212,26 +218,26 @@ def assert_property3_is_set(feature: Feature) -> None:
 
     val = feature.options.get("property3")
 
-    # Define which features should have property3 and their expected values
+    # Explicit values win; omitted levels observe the declared default (#796).
     expected_values = {
-        "placeholder1": "opt_val1",  # Should have property3
-        "placeholder2": None,  # Should NOT have property3 (optional)
-        "placeholder3": "opt_val2",  # Should have property3
-        "placeholder4": None,  # Should NOT have property3 (optional)
-        "placeholder4_5": None,  # Should NOT have property3 (optional)
-        "placeholder4_6": None,  # Should NOT have property3 (optional)
+        "placeholder1": "opt_val1",  # Explicit
+        "placeholder2": "opt_val1",  # Omitted -> declared default
+        "placeholder3": "opt_val2",  # Explicit
+        "placeholder4": "opt_val1",  # Omitted -> declared default
+        "placeholder4_5": "opt_val1",  # Omitted -> declared default
+        "placeholder4_6": "opt_val1",  # Omitted -> declared default
     }
 
     expected = expected_values.get(feature.name)
 
-    if expected is None and feature.name not in expected_values:
+    if expected is None:
         raise ValueError(f"Unknown feature name: {feature.name}. Cannot assert 'property3' value.")
 
-    # For features that should NOT have property3
-    if expected is None:
-        if val is not None:
-            raise ValueError(f"Property 'property3' for {feature.name} should be None (absent), but got '{val}'")
-    # For features that should have property3
-    else:
-        if val != expected:
-            raise ValueError(f"Property 'property3' for {feature.name} should be '{expected}', but got '{val}'")
+    if feature.name == "placeholder2" and val == "opt_val2":
+        raise ValueError(
+            "Cross-level isolation broken: placeholder2 observed 'opt_val2' leaked from another chain level "
+            "instead of its own declared default 'opt_val1'"
+        )
+
+    if val != expected:
+        raise ValueError(f"Property 'property3' for {feature.name} should be '{expected}', but got '{val}'")

--- a/tests/test_plugins/integration_plugins/chainer/context/test_chained_context_features.py
+++ b/tests/test_plugins/integration_plugins/chainer/context/test_chained_context_features.py
@@ -46,7 +46,7 @@ class TestChainedFeatures:
                 context={
                     DefaultOptionKeys.in_features: feature1,
                     "ident": "identifier1",  # Different context parameter (shouldn't affect resolution)
-                    # property3 omitted (optional context parameter)
+                    # property3 omitted: the declared default "opt_val1" materializes at the compute boundary (#796)
                 },
             ),
         )
@@ -76,7 +76,7 @@ class TestChainedFeatures:
                 context={
                     DefaultOptionKeys.in_features: frozenset([feature2]),
                     "ident": "identifier2",  # Context parameter
-                    # property3 omitted (optional)
+                    # property3 omitted: observes the declared default "opt_val1" at runtime (#796)
                 },
             ),
         )
@@ -121,7 +121,7 @@ class TestChainedFeatures:
                 context={
                     DefaultOptionKeys.in_features: frozenset([feature2]),
                     "ident": "identifier1",  # Context parameter
-                    # property3 omitted (optional)
+                    # property3 omitted: observes the declared default "opt_val1" at runtime (#796)
                 },
             ),
         )

--- a/tests/test_plugins/integration_plugins/chainer/context/test_chained_optional_features.py
+++ b/tests/test_plugins/integration_plugins/chainer/context/test_chained_optional_features.py
@@ -49,7 +49,7 @@ class TestChainedFeatures:
                 DefaultOptionKeys.in_features: feature1,
                 "ident": "identifier2",
                 "property2": "value2",
-                # property3 omitted - should still work since it's optional
+                # property3 omitted: the declared default "opt_val1" materializes at the compute boundary (#796)
             },
         )
 
@@ -69,7 +69,7 @@ class TestChainedFeatures:
                 DefaultOptionKeys.in_features: frozenset([feature2]),
                 "ident": "identifier2",
                 "property2": "value1",
-                # property3 omitted - should still work since it's optional
+                # property3 omitted: the declared default "opt_val1" materializes at the compute boundary (#796)
             },
         )
 


### PR DESCRIPTION
## Summary

Closes #796.

#766 added `FeatureGroup.options_with_defaults()`, but the framework still passed the pre-default `FeatureSet` into `calculate_feature`, so only plugins that called the helper themselves observed declared `PropertySpec` defaults. This PR materializes defaults once at the central post-resolution compute boundary, so every feature group and calculate-feature extender observes the same effective options.

## Changes

- `FeatureSet.materialize_option_defaults(feature_group)`: rebinds every feature's options through `options_with_defaults`, memoized by `Options` identity so aliases stay aliased and mutable-default isolation is preserved. Since `Feature.__hash__` includes options (group-only), the features set is rebuilt after group fills; a fill that collapses same-named twin features (one explicitly at the declared default, one omitting the key) raises an actionable `ValueError` instead of silently dropping a tracked feature uuid.
- `ComputeFramework.run_calculate_feature` calls it before the direct `calculate_feature` call and the extender path, behind an `isinstance(features, FeatureSet)` guard.
- Removed the four plugin-side `options_with_defaults` calls (clustering, forecasting, node_centrality, dimensionality_reduction pandas). `resolve_subtype`'s internal use stays: it runs pre-materialization.
- Chainer integration pins updated to the new contract: omitted keys with a declared default now observe the default at runtime; cross-level isolation is still asserted (a level omitting `property3` observes its own default, never a sibling level's explicit value).
- Docs: `property-mapping.md` now documents central materialization; plugins read `feature.options` directly.

## Testing

- New `tests/test_core/test_abstract_plugins/test_materialize_defaults_boundary.py` (9 tests): end-to-end default visibility without the helper, explicit and falsy values win, opted-in explicit None retained, extender path, aliasing, identity no-op, non-mutation of input Options, twin-collapse error contract.
- Full `tox` green: 6519 passed, 170 skipped, ruff, mypy --strict, licenses, bandit.

## Review

Two independent deep reviews (Claude Opus agent and codex) converged on one finding, the collapse-guard message misattributing the cause; fixed and pinned in the follow-up commit. Planning, matching, and feature splitting still operate on pre-materialization inputs; a planning-time canonicalization of default-equivalent twins was deliberately left out of scope.
