### PR TITLE
ci: install tox envs from uv.lock so the gate is reproducible per commit

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,10 @@ setenv =
     DEACTIVATE_NOTEBOOK_AND_DOC_TESTS =
 
 [testenv]
-package = uv-editable
+# Install from the committed uv.lock so the gate is reproducible per commit.
+# Fresh resolution under the rolling exclude-newer window let upstream releases
+# break CI with no code change (#806); dependency bumps are now lockfile diffs.
+runner = uv-venv-lock-runner
 extras = test,pandas,polars,duckdb,iceberg,otel,sklearn,text-cleaning
 allowlist_externals = sh, bandit
 setenv =
@@ -48,6 +51,9 @@ setenv =
 commands = pytest -n {env:PYTEST_WORKERS:8} --ignore=mloda_plugins/ --ignore=tests/test_documentation/ --ignore=tests/test_plugins/ --ignore=tests/test_examples/ --timeout=10
 
 [testenv: installed]
+# Exercises the built sdist as a user would install it, so it must resolve
+# fresh instead of syncing the workspace lock.
+runner = uv-venv-runner
 package = sdist
 extras = test,pandas,otel
 setenv =
@@ -81,6 +87,10 @@ commands =
     pytest -n {env:PYTEST_WORKERS:1} tests/test_plugins/compute_framework/base_implementations/spark/ -v
 
 [testenv: nopyarrow]
+# Needs `deps` (plain duckdb without the pyarrow-pulling extra), which the
+# lock runner does not support.
+runner = uv-venv-runner
+package = uv-editable
 extras = nopyarrow_test
 deps = duckdb
 setenv =
@@ -91,6 +101,7 @@ commands =
 
 [testenv:security]
 # CVE scanning environment - downloads specific version of published package
+runner = uv-venv-runner
 skip_install = False
 usedevelop = False
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ commands = sh -c "set -- pytest -n {env:PYTEST_WORKERS:8} --timeout=10 -m 'not n
            ruff check --line-length 120 .
            sh -c "if [ \"$WRITE_THIRD_PARTY_LICENSES\" = \"true\" ]; then pip-licenses --format=plain-vertical --with-urls --with-license-file | sed '/\/home\//d' > attribution/THIRD_PARTY_LICENSES.md; fi"
            sh -c "if [ -z \"${NO_WRITE_ATTRIBUTION_MD}\" ]; then pip-licenses --format=markdown > attribution/ATTRIBUTION.md; fi"
-           sh -c "pip-licenses --ignore-packages matplotlib-inline --allow-only='MPL-2.0 AND MIT; Apache-2.0 AND BSD-2-Clause; Apache-2.0 AND CNRI-Python; BSD-3-Clause AND 0BSD AND MIT AND Zlib AND CC0-1.0; 3-Clause BSD License;BSD-2-Clause;BSD-3-Clause;Apache-2.0;Apache Software License;MIT;The Unlicense (Unlicense);PSF-2.0;MIT License;Python Software Foundation License;BSD License;GNU Lesser General Public License v2 or later (LGPLv2+);ISC License (ISCL);Mozilla Public License 2.0 (MPL 2.0);Apache License, Version 2.0;Apache 2.0;Apache Software License 2.0;' > /dev/null"
+           sh -c "pip-licenses --ignore-packages matplotlib-inline --allow-only='MPL-2.0 AND MIT; Apache-2.0 AND BSD-2-Clause; Apache-2.0 OR BSD-2-Clause; Apache-2.0 AND CNRI-Python; BSD-3-Clause AND 0BSD AND MIT AND Zlib AND CC0-1.0; 3-Clause BSD License;BSD-2-Clause;BSD-3-Clause;Apache-2.0;Apache Software License;MIT;The Unlicense (Unlicense);PSF-2.0;MIT License;Python Software Foundation License;BSD License;GNU Lesser General Public License v2 or later (LGPLv2+);ISC License (ISCL);ISC;Mozilla Public License 2.0 (MPL 2.0);Apache License, Version 2.0;Apache 2.0;Apache Software License 2.0;' > /dev/null"
            mypy --strict --ignore-missing-imports .
            bandit -c pyproject.toml -r -q .
 


### PR DESCRIPTION
## Summary

Fixes #806 by taking the "lock the gate" option the issue recommends: the default `[testenv]` now uses tox-uv's `uv-venv-lock-runner`, so the gate installs exactly what the committed `uv.lock` pins (`uv sync --locked` with the same extras as before) instead of resolving fresh under the rolling `exclude-newer = "7 days"` window.

This addresses all three consequences observed in #804:

1. CI can no longer go red on a rolling clock with an empty diff — an upstream release only reaches the gate through a reviewable `uv.lock` diff.
2. `.venv` (locked) and `.tox` (previously fresh) can no longer hold different versions of the same package, so local `tox` and CI see the same tree.
3. The per-wheel-file `exclude-newer` cutoff can no longer split one release across Python versions inside a single run.

Envs that must keep resolving fresh are explicitly pinned to the non-lock `uv-venv-runner`:

- `installed` — exercises the built sdist as a user would install it (`package = sdist`)
- `nopyarrow` — needs `deps` (plain `duckdb` without the pyarrow-pulling extra), which the lock runner does not support
- `security` — installs the published package from PyPI for CVE scanning

`exclude-newer` still applies where it belongs now: deliberate lock refreshes.

## Verification

- `tox -e python310 --notest` provisions via `uv sync --locked --extra duckdb --extra iceberg ... ` and the env gets the lock's pinned `pyarrow==24.0.0` with mloda importable (editable).
- `tox -e installed --notest` still builds the sdist and resolves its deps fresh.
- `tox -e nopyarrow --notest` still installs `duckdb` with pyarrow absent (the env's own guard also passes).
- Full `core` suite under the locked env: **3570 passed, 6 skipped** (14 initial failures reproduced on my machine were the 10s per-test timeout under `-n 8` on Windows and pass with a relaxed timeout; unrelated to this change).