### PR TITLE
refactor: delete remaining resolution logic from the resolve_feature adapter (#792)

### DIFF
--- a/attribution/ATTRIBUTION.md
+++ b/attribution/ATTRIBUTION.md
@@ -41,7 +41,6 @@
 | mypy                                   | 2.2.0           | MIT                                                |
 | mypy_extensions                        | 1.1.0           | MIT                                                |
 | narwhals                               | 2.23.0          | MIT                                                |
-| nest-asyncio                           | 1.6.0           | BSD License                                        |
 | nest-asyncio2                          | 1.7.2           | BSD License                                        |
 | nltk                                   | 3.10.0          | Apache Software License                            |
 | numpy                                  | 2.5.1           | BSD-3-Clause AND 0BSD AND MIT AND Zlib AND CC0-1.0 |

--- a/docs/docs/in_depth/discover-plugins.md
+++ b/docs/docs/in_depth/discover-plugins.md
@@ -117,7 +117,10 @@ nothing resolves.
 
 ### Inspecting Candidates
 
-When resolution fails due to conflicts, check the candidates:
+When resolution reached matching but ended ambiguous (multiple FeatureGroups
+matched), `candidates` lists the classes that matched. When the environment
+build itself failed (for example a redefinition conflict), no matching runs,
+so `candidates` is empty and the error text carries the details:
 
 ``` python
 result = resolve_feature("my_feature")

--- a/docs/docs/in_depth/discover-plugins.md
+++ b/docs/docs/in_depth/discover-plugins.md
@@ -216,10 +216,11 @@ and resolution paths intentionally differ:
 - **`get_*_docs` degrade.** Documentation is a best-effort read-only view, so a
   conflict collapses to the most recently defined (live) class and listing
   continues. There is nothing to execute, so ambiguity is harmless.
-- **`resolve_feature` surfaces the conflict.** Resolution feeds execution, which
-  must be unambiguous to be safe, so it returns `feature_group=None` with the
-  conflict described in `error` and the conflicting classes that match the
-  requested feature name in `candidates` rather than silently picking one.
+- **`resolve_feature` fails closed.** Resolution feeds execution, so the
+  conflict fails closed like any other environment-build failure: it returns
+  `feature_group=None` with the conflict described in `error` and no
+  candidates. The failure is projected from the build error itself, which names
+  the conflicting classes in the message, and no matching runs.
 
 ### Broken framework declarations
 

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -26,7 +26,6 @@ from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.function_extender import Extender
 from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistry
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
-from mloda.core.abstract_plugins.components.domain import Domain
 from mloda.core.abstract_plugins.components.feature import Feature, normalize_feature_group_scope
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.link import Link
@@ -42,7 +41,6 @@ from mloda.core.prepare.accessible_plugins import (
 )
 from mloda.core.prepare.identify_feature_group import (
     IdentifyFeatureGroupClass,
-    matches_feature_group_scope,
     render_resolution_failure,
     scope_callout,
 )
@@ -96,31 +94,6 @@ def _dedup_degrading_on_conflict(
         return dedup_feature_group_subclasses(feature_groups, allow_redefinition=allow_redefinition)
     except RedefinitionConflictError:
         return dedup_feature_group_subclasses(feature_groups, allow_redefinition=True)
-
-
-def _matches_criteria_guarded(
-    fg_class: type[FeatureGroup],
-    feature_name: FeatureName,
-    options: Options,
-    data_access_collection: Optional[DataAccessCollection] = None,
-) -> bool:
-    """Match a feature group for the redefinition-conflict branch, treating any raise as 'not a match'.
-
-    resolve_feature is a non-throwing debug API: a conflicting candidate whose match hook raises must
-    not take the whole call down.
-    """
-    try:
-        return fg_class.match_feature_group_criteria(feature_name, options, data_access_collection)
-    except Exception:  # noqa: BLE001  (never-raising debug API)
-        return False
-
-
-def _matches_domain_guarded(fg_class: type[FeatureGroup], feature_domain: Optional[Domain]) -> bool:
-    """Domain gate for the conflict branch, mirroring the engine; a raising get_domain() is 'not a match'."""
-    try:
-        return feature_domain is None or fg_class.get_domain() == feature_domain
-    except Exception:  # noqa: BLE001  (never-raising debug API)
-        return False
 
 
 def get_feature_group_docs(
@@ -377,11 +350,12 @@ def resolve_feature(
     Never raises for matching errors: those are reported in the returned ResolvedFeature.error.
     Signature misuse (options/feature_group alongside a Feature) is a programmer error and raises TypeError.
 
-    Design note: resolve_feature DELEGATES matching to the #754 evaluation seam
-    IdentifyFeatureGroupClass.evaluate. It only builds the accessible-plugins environment locally
-    (applicability filter, dedup/redefinition-conflict handling), fail-closed exactly as the engine does:
-    a build failure is projected into ``error`` rather than raised, so no candidates are reported; the seam
-    owns name/domain/scope/abstract/subclass filtering, the winner, candidates, and the failure texts.
+    Design note: resolve_feature is a thin adapter. It only normalizes the standalone request, builds the
+    canonical accessible-plugins environment once, delegates one evaluation to
+    IdentifyFeatureGroupClass.evaluate, and projects the result. ANY environment-build failure (including
+    redefinition conflicts) is projected fail-closed from the failure itself into ``error`` with no
+    candidates and no re-matching; the seam owns name/domain/scope/abstract/subclass filtering, the
+    winner, candidates, and the failure texts.
 
     Engine inputs now covered: name, options, domain and compute-framework pin (carried on the Feature),
     scope (via the Feature's feature_group_scope or the feature_group argument for the string form), and
@@ -415,7 +389,6 @@ def resolve_feature(
         feature_name = str(feature.name)
         scope = feature.feature_group_scope
         resolved_options = feature.options
-        feature_domain: Optional[Domain] = feature.domain
     else:
         feature_obj = None
         feature_name = feature
@@ -429,8 +402,6 @@ def resolve_feature(
                 error=str(exc),
             )
         resolved_options = options if options is not None else Options()
-        raw_domain = resolved_options.get("domain")
-        feature_domain = Domain(raw_domain) if raw_domain else None
 
     callout = scope_callout(scope)
     scope_suffix = f" {callout}" if callout else ""
@@ -443,17 +414,8 @@ def resolve_feature(
         accessible_plugins: FeatureGroupEnvironmentMapping = PreFilterPlugins(
             restricted_frameworks, plugin_collector
         ).get_accessible_plugins()
-    except RedefinitionConflictError as exc:
-        matching_conflicts = [
-            fg
-            for fg in exc.conflicts
-            if (scope is None or matches_feature_group_scope(fg, scope))
-            and _matches_criteria_guarded(fg, feature_name_obj, resolved_options, data_access_collection)
-            and _matches_domain_guarded(fg, feature_domain)
-        ]
-        return ResolvedFeature(feature_name, None, matching_conflicts, error=f"{exc}{scope_suffix}")
-    except EnvironmentPreconditionError as exc:
-        # mloda's own precondition: already a complete sentence, and no plugin is to blame. Project it bare.
+    except (RedefinitionConflictError, EnvironmentPreconditionError) as exc:
+        # mloda's own environment failure: already a complete sentence. Project it bare, no candidates.
         return ResolvedFeature(feature_name, None, [], error=f"{exc}{scope_suffix}")
     except Exception as exc:  # noqa: BLE001  (never-raising debug API; projects a broken plugin's build failure)
         return ResolvedFeature(

--- a/mloda/core/prepare/accessible_plugins.py
+++ b/mloda/core/prepare/accessible_plugins.py
@@ -106,17 +106,11 @@ class EnvironmentPreconditionError(ValueError):
 
 
 class RedefinitionConflictError(ValueError):
-    """Raised by dedup when same-key FG classes differ in source.
+    """Raised by dedup when same-key FeatureGroup classes differ in source.
 
-    Carries the full list of conflicting classes via ``.conflicts`` so callers
-    (e.g. ``resolve_feature``) can populate ``ResolvedFeature.candidates``
-    instead of leaving it empty. Subclasses ``ValueError`` so existing
-    ``except ValueError:`` callers stay compatible.
+    The message is a complete user-facing text that callers project as-is. Subclasses ``ValueError``
+    so existing ``except ValueError:`` callers stay compatible.
     """
-
-    def __init__(self, message: str, conflicts: list[type[FeatureGroup]]) -> None:
-        super().__init__(message)
-        self.conflicts = conflicts
 
 
 def _running_in_zmq_shell() -> bool:
@@ -218,8 +212,7 @@ def dedup_feature_group_subclasses(
         conflicts.append((key, list(zip(members, hashes_str))))
 
     if conflicts:
-        all_conflicting_classes = [_cls for _, hashed in conflicts for _cls, _ in hashed]
-        raise RedefinitionConflictError(_build_conflict_error(conflicts), all_conflicting_classes)
+        raise RedefinitionConflictError(_build_conflict_error(conflicts))
 
     return survivors
 
@@ -232,7 +225,7 @@ def _pick_survivor(members: list[type[FeatureGroup]]) -> type[FeatureGroup]:
     ``_is_live_in_module``. And ``_is_live_in_module`` checks
     ``getattr(module, cls.__name__, None) is cls``, which is single-valued: at most
     one member can match because the module attribute resolves to exactly one
-    class object. The for-loop is therefore fully deterministic — set-iteration
+    class object. The for-loop is therefore fully deterministic: set-iteration
     order does not affect which class is returned.
 
     The ``return members[-1]`` fallback is only theoretically reachable in
@@ -263,7 +256,7 @@ def _cell_label(cls: type[FeatureGroup]) -> Optional[str]:
 
     Returns ``None`` for classes whose methods all live in real source files.
     Mirrors the synthetic-filename detection in ``_linecache_source_for_class``
-    but stops at the first match — sufficient for "where was this class defined"
+    but stops at the first match, sufficient for "where was this class defined"
     in the redef-conflict error message.
     """
     for value in cls.__dict__.values():

--- a/tests/test_core/test_api/test_resolve_feature.py
+++ b/tests/test_core/test_api/test_resolve_feature.py
@@ -1024,7 +1024,7 @@ def _exec_conflict_fg(class_name: str, body: str, cell_label: str) -> type[Featu
 
 
 def _raising_match_conflict_source(qualname: str, feature_name: str, extra_body: str = "") -> str:
-    """Source for a conflicting FeatureGroup whose match hook raises a NON-ValueError (RuntimeError)."""
+    """Source for a conflicting FeatureGroup whose match hook raises RuntimeError."""
     return f"""
 from mloda.core.abstract_plugins.feature_group import FeatureGroup as _FG_BASE_
 
@@ -1058,14 +1058,13 @@ def _cleanup_main_after() -> Any:
 
 
 class TestResolveFeatureRaisingMatchDuringConflict:
-    """A conflicting class whose match hook raises a non-ValueError must not escape resolve_feature."""
+    """A redefinition conflict is projected before matching, so a raising match hook cannot escape."""
 
     def test_raising_match_hook_during_redef_conflict_does_not_raise(self, _cleanup_main_after: Any) -> None:
-        """A RuntimeError from match_feature_group_criteria on a conflicting class must surface as an error.
+        """A conflicting class with a raising match hook must still yield a ResolvedFeature with an error.
 
-        The redefinition-conflict branch filters conflicts with a helper that today catches only
-        ValueError, so a conflicting class whose match hook raises RuntimeError propagates out of
-        resolve_feature. The never-raising debug contract requires it to surface in ResolvedFeature.error.
+        The redefinition conflict is projected fail-closed before any matching runs, so the raising
+        match_feature_group_criteria hook is never invoked and cannot take resolve_feature down.
         """
         qualname = "RaiseMatchConflictResolveFG755"
         feature_name = "raise_match_conflict_resolve_feature_755_xyz"

--- a/tests/test_core/test_api/test_resolve_feature.py
+++ b/tests/test_core/test_api/test_resolve_feature.py
@@ -6,6 +6,7 @@ to its matching FeatureGroup class, with support for subclass filtering
 and candidate tracking.
 """
 
+import ast
 import gc
 import inspect
 import linecache
@@ -26,8 +27,9 @@ from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
 from mloda.core.api.plugin_info import ResolvedFeature
+from mloda.core.api import plugin_docs
 from mloda.core.api.plugin_docs import resolve_feature
-from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping, RedefinitionConflictError
 from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
 from mloda.user import PluginLoader
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
@@ -1111,45 +1113,118 @@ class {qualname}(_FG_BASE_):
 """
 
 
-class TestResolveFeatureConflictBranchDomainParity:
-    """The redefinition-conflict branch must apply the feature's domain when building candidates (#756).
+class TestResolveFeatureConflictBranchProjectsFailure:
+    """The redefinition-conflict branch projects the canonical failure without re-matching (#792).
 
-    The engine adds a class to ``criteria_matched`` (which ``ResolvedFeature.candidates`` mirrors) only
-    AFTER it passes ``_filter_feature_group_by_domain``. The conflict branch of resolve_feature filters
-    conflicts by scope and match criteria only, omitting the domain, so a conflicting class whose domain
-    does not match the feature's domain is wrongly kept as a candidate.
+    A redefinition conflict is an environment-build failure: resolve_feature must project it exactly
+    like the EnvironmentPreconditionError branch, with NO candidates, instead of re-filtering the
+    conflicting classes through scope/match/domain hooks. Candidates are therefore always empty, for
+    matching and non-matching domains alike, and the exec'd conflict class never appears in them.
     """
 
-    def test_conflict_branch_excludes_nonmatching_domain_candidate(self, _cleanup_main_after: Any) -> None:
-        """A conflicting class whose domain differs from the feature's domain must not be a candidate."""
-        qualname = "DomainConflictResolveFG756"
-        feature_name = "domain_conflict_resolve_feature_756_xyz"
-        conflict_domain = "conflict_domain_756"
-        other_domain = "a_different_domain_than_the_conflict_class_756"
+    def test_conflict_branch_reports_no_candidates_for_any_domain(self, _cleanup_main_after: Any) -> None:
+        """Candidates are empty for a matching AND a non-matching domain; the error is the conflict text."""
+        qualname = "ConflictProjectionResolveFG792"
+        feature_name = "conflict_projection_resolve_feature_792_xyz"
+        conflict_domain = "conflict_domain_792"
+        other_domain = "a_different_domain_than_the_conflict_class_792"
 
         src_v1 = _domain_conflict_source(qualname, feature_name, conflict_domain)
         src_v2 = _domain_conflict_source(
             qualname,
             feature_name,
             conflict_domain,
-            extra_body="    def extra_method(self):\n        return 756\n",
+            extra_body="    def extra_method(self):\n        return 792\n",
         )
 
-        _exec_conflict_fg(qualname, src_v1, "cell-domain-conflict-756-v1")
-        conflict_cls = _exec_conflict_fg(qualname, src_v2, "cell-domain-conflict-756-v2")
+        _exec_conflict_fg(qualname, src_v1, "cell-conflict-projection-792-v1")
+        conflict_cls = _exec_conflict_fg(qualname, src_v2, "cell-conflict-projection-792-v2")
 
-        # Sanity: the exec'd conflict class declares the conflict domain.
+        # Sanity: the exec'd class declares the matching domain, so the OLD re-matching behavior
+        # would have kept it as a candidate. The pure projection must not.
         assert conflict_cls.get_domain() == Domain(conflict_domain)
 
-        # Domain mismatch: the feature carries a domain the conflict class does not declare. The engine
-        # would exclude it, so the conflict branch must too. Today it is wrongly kept in candidates.
+        match = resolve_feature(Feature(feature_name, domain=conflict_domain))
+
+        assert match.feature_group is None
+        assert match.error is not None
+        assert "FeatureGroup redefined with different source code" in match.error
+        assert conflict_cls not in match.candidates
+        assert match.candidates == []
+
         mismatch = resolve_feature(Feature(feature_name, domain=other_domain))
 
         assert mismatch.feature_group is None
         assert mismatch.error is not None
-        assert conflict_cls not in mismatch.candidates
+        assert mismatch.candidates == []
 
-        # Guard proving the exclusion is domain-driven, not always-empty: a matching domain keeps the class.
-        match = resolve_feature(Feature(feature_name, domain=conflict_domain))
+    def test_conflict_branch_scoped_string_form_keeps_callout_and_no_candidates(self, _cleanup_main_after: Any) -> None:
+        """The string form with a feature_group scope keeps the scope callout suffix, candidates stay empty."""
+        qualname = "ConflictProjectionScopedResolveFG792"
+        feature_name = "conflict_projection_scoped_resolve_feature_792_xyz"
+        conflict_domain = "conflict_domain_792"
 
-        assert conflict_cls in match.candidates
+        src_v1 = _domain_conflict_source(qualname, feature_name, conflict_domain)
+        src_v2 = _domain_conflict_source(
+            qualname,
+            feature_name,
+            conflict_domain,
+            extra_body="    def extra_method(self):\n        return 793\n",
+        )
+
+        _exec_conflict_fg(qualname, src_v1, "cell-conflict-projection-scoped-792-v1")
+        _exec_conflict_fg(qualname, src_v2, "cell-conflict-projection-scoped-792-v2")
+
+        result = resolve_feature(feature_name, feature_group=qualname)
+
+        assert result.feature_group is None
+        assert result.error is not None
+        assert result.error.endswith(f"Scoped to feature group: '{qualname}'.")
+        assert result.candidates == []
+
+
+class TestResolveFeatureAdapterIsThin:
+    """Structural (#792): resolve_feature is a thin adapter; no matching or provider-hook logic lives in it."""
+
+    @pytest.mark.parametrize(
+        "attribute",
+        [
+            "_matches_criteria_guarded",
+            "_matches_domain_guarded",
+        ],
+    )
+    def test_conflict_branch_helper_is_deleted(self, attribute: str) -> None:
+        """The conflict-branch re-matching helpers no longer exist in plugin_docs."""
+        assert not hasattr(plugin_docs, attribute)
+
+    def test_resolve_feature_source_calls_no_resolution_provider_hooks(self) -> None:
+        """resolve_feature's body invokes no FeatureGroup matching, domain, scope or capability hooks."""
+        source = textwrap.dedent(inspect.getsource(plugin_docs.resolve_feature))
+        tree = ast.parse(source)
+        called: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Attribute):
+                called.add(node.attr)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+                called.add(node.func.id)
+        forbidden = {
+            "match_feature_group_criteria",
+            "get_domain",
+            "matches_feature_group_scope",
+            "compute_framework_rule",
+            "compute_framework_definition",
+            "supports_compute_framework",
+            "validate_input_features",
+            "validate_output_features",
+            "index_columns",
+            "supports_index",
+            "input_features",
+            "_matches_criteria_guarded",
+            "_matches_domain_guarded",
+        }
+        overlap = sorted(called & forbidden)
+        assert overlap == [], f"resolve_feature invokes resolution provider hooks: {overlap}"
+
+    def test_redefinition_conflict_error_carries_no_conflicts_payload(self) -> None:
+        """RedefinitionConflictError has the plain ValueError __init__, no conflicts parameter."""
+        assert "conflicts" not in inspect.signature(RedefinitionConflictError.__init__).parameters

--- a/tests/test_core/test_prepare/test_feature_group_dedup.py
+++ b/tests/test_core/test_prepare/test_feature_group_dedup.py
@@ -482,9 +482,9 @@ def test_resolve_feature_after_jupyter_redefinition_succeeds() -> None:
 # Case 9: resolve_feature must not raise on redefinition conflict
 # ---------------------------------------------------------------------------
 def test_resolve_feature_returns_error_for_redef_conflict_does_not_raise() -> None:
-    """``resolve_feature`` is a non-throwing debug API: when ``dedup_feature_group_subclasses``
-    detects a different-content redefinition conflict, the error must surface in
-    ``ResolvedFeature.error`` rather than as an unhandled ``ValueError``.
+    """``resolve_feature`` is a non-throwing debug API: a different-content redefinition
+    conflict surfaces in ``ResolvedFeature.error`` and is projected fail-closed with no
+    candidates (#792), never as an unhandled exception.
     """
     qualname = "MyFG_Test9"
     feature_name = "case9_feature_unique_xyz"
@@ -510,9 +510,8 @@ def test_resolve_feature_returns_error_for_redef_conflict_does_not_raise() -> No
         f"error must mention the qualname, 'redefined', or 'set_allow_redefinition'; got: {result.error!r}"
     )
 
-    # candidates must surface the conflicting classes so callers can inspect them programmatically.
-    assert v1 in result.candidates, f"v1 must be in candidates on conflict, got: {result.candidates}"
-    assert v2 in result.candidates, f"v2 must be in candidates on conflict, got: {result.candidates}"
+    # Fail-closed projection (#792): conflicting classes are never re-matched into candidates.
+    assert result.candidates == [], f"candidates must be empty on conflict, got: {result.candidates}"
 
 
 # ---------------------------------------------------------------------------
@@ -1242,11 +1241,13 @@ case25 flush-left line at column zero
 
 # ---------------------------------------------------------------------------
 # Case 26 (issue 693): scoped resolve_feature during a redefinition conflict.
-# The dedup-conflict branch must filter the returned candidates by the
-# feature_group scope AND append the scope callout to the conflict error.
+# The conflict is projected fail-closed with no candidates (#792); the scope
+# callout must still be appended to the conflict error.
 # ---------------------------------------------------------------------------
 def test_resolve_feature_excluding_scope_empties_conflict_candidates_and_error_keeps_callout() -> None:
-    """A scope excluding the conflicting classes empties candidates while the error keeps conflict and callout."""
+    """A scope excluding the conflicting classes yields no candidates (fail-closed, #792);
+    the error keeps conflict and callout.
+    """
     qualname = "MyFG_Test26_Scope"
     feature_name = "case26_feature_unique_xyz"
     src_v1 = _make_fg_source(qualname, feature_name)
@@ -1265,7 +1266,7 @@ def test_resolve_feature_excluding_scope_empties_conflict_candidates_and_error_k
 
     assert result.feature_group is None
     assert result.candidates == [], (
-        f"conflicting classes outside the scope must be filtered from candidates, got: {result.candidates}"
+        f"conflict is projected fail-closed, so candidates must be empty, got: {result.candidates}"
     )
     assert result.error is not None
     assert any(token in result.error for token in (qualname, "redefined", "set_allow_redefinition")), (
@@ -1274,8 +1275,10 @@ def test_resolve_feature_excluding_scope_empties_conflict_candidates_and_error_k
     assert "Scoped to feature group: 'DocsCatalogAnchorFG'." in result.error
 
 
-def test_resolve_feature_matching_scope_keeps_conflict_candidates_and_error_keeps_callout() -> None:
-    """A scope naming the conflicting class keeps both versions in candidates and appends the callout."""
+def test_resolve_feature_matching_scope_projects_no_candidates_and_error_keeps_callout() -> None:
+    """Even a scope naming the conflicting class is projected fail-closed with no candidates (#792);
+    the error keeps the conflict and the scope callout.
+    """
     qualname = "MyFG_Test26_ScopeKeep"
     feature_name = "case26_keep_feature_unique_xyz"
     src_v1 = _make_fg_source(qualname, feature_name)
@@ -1292,10 +1295,8 @@ def test_resolve_feature_matching_scope_keeps_conflict_candidates_and_error_keep
     result = resolve_feature(feature_name, feature_group=qualname)
 
     assert result.feature_group is None
-    assert v1 in result.candidates, f"v1 matches scope and feature name, so it must stay; got: {result.candidates}"
-    assert v2 in result.candidates, f"v2 matches scope and feature name, so it must stay; got: {result.candidates}"
-    assert all(c.__name__ == qualname for c in result.candidates), (
-        f"only in-scope classes may appear in candidates, got: {result.candidates}"
+    assert result.candidates == [], (
+        f"conflict is projected fail-closed, so candidates must be empty even in scope, got: {result.candidates}"
     )
     assert result.error is not None
     assert "set_allow_redefinition" in result.error, f"error must report the conflict; got: {result.error!r}"


### PR DESCRIPTION
Closes #792. Part of epic #760, ordered after #782.

## Summary

Deletes the remaining resolution logic from the `resolve_feature` adapter in `plugin_docs.py`. The adapter now only normalizes the standalone request, builds the canonical accessible-plugins environment once, delegates one evaluation to `IdentifyFeatureGroupClass.evaluate`, and projects the result into `ResolvedFeature`.

## Changes

- `_matches_criteria_guarded` and `_matches_domain_guarded` are deleted. The redefinition-conflict branch no longer re-filters `exc.conflicts` through scope, match, and domain hooks: the conflict is projected fail-closed from the exception itself with no candidates, merged with the `EnvironmentPreconditionError` branch (both are mloda-authored complete-sentence failures projected identically, scope callout still appended).
- `RedefinitionConflictError` drops its `.conflicts` payload (its only consumer was the deleted branch); it is a plain `ValueError` subclass again and the raise site simplifies accordingly.
- Dead locals (`feature_domain`, `raw_domain`) and unused imports (`Domain`, `matches_feature_group_scope`) removed; `Feature.__init__` already derives the domain from options, so nothing changes for evaluation.
- Structural regression tests (`TestResolveFeatureAdapterIsThin`): the deleted helpers stay deleted, an ast walk keeps matching/domain/scope/framework/capability/validation hook calls out of `resolve_feature`'s body, and `RedefinitionConflictError.__init__` stays payload-free.
- Behavior tests rewritten to the new contract: conflict projection reports no candidates for matching and non-matching domains and for the scoped string form; the two stale dedup tests asserting the old enrichment were updated; the never-raising guard stays.
- Docs: `discover-plugins.md` redefinition-conflict and Inspecting Candidates sections now describe the fail-closed projection; `resolve_feature`'s design note describes the thin adapter.
- `attribution/ATTRIBUTION.md` regenerated by tox (one line of dependency drift, committed per repo practice).

## Validation

`tox` passes locally: 6622 tests passed, ruff format and check clean, license allowlist clean, `mypy --strict` clean, bandit clean. Reviewed by two independent deep reviews; both found no correctness blockers, and the two minor doc/docstring findings are fixed in the follow-up commit.
