### PR TITLE
fix: stop forecasting output being discarded as all-NaN

### DIFF
--- a/mloda_plugins/feature_group/experimental/forecasting/pandas.py
+++ b/mloda_plugins/feature_group/experimental/forecasting/pandas.py
@@ -96,18 +96,17 @@ class PandasForecastingFeatureGroup(ForecastingFeatureGroup):
 
     @classmethod
     def _add_result_to_data(cls, data: pd.DataFrame, feature_name: str, result: pd.Series) -> pd.DataFrame:
-        """
-        Add the forecast result to the DataFrame.
-
-        Args:
-            data: The pandas DataFrame
-            feature_name: The name of the feature to add
-            result: The forecast result to add
-
-        Returns:
-            The updated DataFrame
-        """
-        data[feature_name] = result
+        """Add the forecast result, growing the frame to the longest forecast horizon (never shrinking)."""
+        # result is indexed by the forecast datetime axis (history + horizon) and never aligns with
+        # data's positional index; align by position, grow the frame to hold the horizon, and never
+        # shrink it so a shorter forecast cannot truncate a longer one already in the frame.
+        values = result.reset_index(drop=True).to_numpy()
+        new_len = max(len(data), len(values))
+        if len(data) != new_len:
+            data = data.reset_index(drop=True).reindex(range(new_len))
+        if len(values) < new_len:
+            values = np.concatenate([values, np.full(new_len - len(values), np.nan)])
+        data[feature_name] = values
         return data
 
     @classmethod
@@ -218,18 +217,14 @@ class PandasForecastingFeatureGroup(ForecastingFeatureGroup):
         # Generate forecasts
         forecasts = model.predict(future_features_scaled)
 
-        # Create a Series with the forecasts
-        forecast_series = pd.Series(
-            index=future_timestamps,
-            data=forecasts,
+        # Historical actuals in the ORIGINAL row order, then the horizon forecasts; positionally
+        # aligned so _add_result_to_data extends the frame without relying on a datetime-index join.
+        historical = cast(pd.DataFrame, data)[source_feature_name].to_numpy()
+        result = pd.Series(
+            np.concatenate([historical, forecasts]),
+            dtype=float,
             name=f"{algorithm}_forecast_{horizon}{time_unit}__{source_feature_name}",
         )
-
-        # Combine with the original data's time index
-        combined_index = list(df[time_filter_feature]) + future_timestamps
-        result = pd.Series(index=combined_index, dtype=float)
-        result.loc[df[time_filter_feature]] = df[source_feature_name].values
-        result.loc[future_timestamps] = forecast_series.values
 
         return result, artifact
 
@@ -632,42 +627,11 @@ class PandasForecastingFeatureGroup(ForecastingFeatureGroup):
             lower_bound_values = forecasts - margin
             upper_bound_values = forecasts + margin
 
-        # Create Series for forecasts and confidence bounds
-        forecast_series = pd.Series(
-            index=future_timestamps,
-            data=forecasts,
-            name=f"{algorithm}_forecast_{horizon}{time_unit}__{source_feature_name}",
-        )
-
-        lower_bound_series = pd.Series(
-            index=future_timestamps,
-            data=lower_bound_values,
-            name=f"{algorithm}_forecast_{horizon}{time_unit}__{source_feature_name}~lower",
-        )
-
-        upper_bound_series = pd.Series(
-            index=future_timestamps,
-            data=upper_bound_values,
-            name=f"{algorithm}_forecast_{horizon}{time_unit}__{source_feature_name}~upper",
-        )
-
-        # Combine with the original data's time index
-        combined_index = list(df[time_filter_feature]) + future_timestamps
-
-        # Create result series for point forecast
-        result = pd.Series(index=combined_index, dtype=float)
-        result.loc[df[time_filter_feature]] = df[source_feature_name].values
-        result.loc[future_timestamps] = forecast_series.values
-
-        # Create result series for lower bound
-        lower_bound = pd.Series(index=combined_index, dtype=float)
-        lower_bound.loc[df[time_filter_feature]] = df[source_feature_name].values
-        lower_bound.loc[future_timestamps] = lower_bound_series.values
-
-        # Create result series for upper bound
-        upper_bound = pd.Series(index=combined_index, dtype=float)
-        upper_bound.loc[df[time_filter_feature]] = df[source_feature_name].values
-        upper_bound.loc[future_timestamps] = upper_bound_series.values
+        # Historical actuals (original row order) then the horizon values, positionally aligned.
+        historical = cast(pd.DataFrame, data)[source_feature_name].to_numpy()
+        result = pd.Series(np.concatenate([historical, forecasts]), dtype=float)
+        lower_bound = pd.Series(np.concatenate([historical, lower_bound_values]), dtype=float)
+        upper_bound = pd.Series(np.concatenate([historical, upper_bound_values]), dtype=float)
 
         return result, lower_bound, upper_bound, artifact
 

--- a/tests/test_plugins/feature_group/experimental/test_forecasting/test_forecasting_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/test_forecasting/test_forecasting_feature_group.py
@@ -177,6 +177,63 @@ class TestForecastingFeatureGroup:
         # Check that the result contains the forecast feature
         assert feature_name in result_df2.columns
 
+    def test_calculate_feature_populates_forecast_values(self) -> None:
+        """Forecast values must survive: N+horizon rows, no NaN, historical actuals preserved."""
+        feature_name = "sales__linear_forecast_7day"
+
+        feature_set = FeatureSet()
+        feature_set.add(Feature(feature_name, self.options))
+        feature_set.artifact_to_save = feature_name
+
+        result_df = PandasForecastingFeatureGroup.calculate_feature(self.df.copy(), feature_set)
+
+        assert feature_name in result_df.columns
+        assert len(result_df) == 37
+        assert result_df[feature_name].notna().all()
+
+        forecast_values = result_df[feature_name].to_numpy()
+        assert np.allclose(forecast_values[:30], self.df["sales"].to_numpy())
+        assert np.isfinite(forecast_values[30:]).all()
+
+    def test_calculate_feature_unsorted_input_preserves_row_alignment(self) -> None:
+        """Unsorted input must keep each row's historical forecast value aligned to its own source value."""
+        df_unsorted = self.df.iloc[::-1].reset_index(drop=True)  # reverse-chronological, default RangeIndex
+        feature_name = "sales__linear_forecast_7day"
+
+        feature_set = FeatureSet()
+        feature_set.add(Feature(feature_name, self.options))
+        feature_set.artifact_to_save = feature_name
+
+        result_df = PandasForecastingFeatureGroup.calculate_feature(df_unsorted.copy(), feature_set)
+
+        assert len(result_df) == 37
+        assert feature_name in result_df.columns
+
+        forecast_values = result_df[feature_name].to_numpy()
+        assert np.allclose(forecast_values[:30], df_unsorted["sales"].to_numpy())
+        assert np.isfinite(forecast_values[30:]).all()
+
+    def test_calculate_feature_multiple_horizons_not_truncated(self) -> None:
+        """Requesting two horizons together must not truncate the longer forecast; the shorter is NaN-padded."""
+        feature_set = FeatureSet()
+        feature_set.add(Feature("sales__linear_forecast_7day", self.options))
+        feature_set.add(Feature("sales__linear_forecast_14day", self.options))
+
+        result_df = PandasForecastingFeatureGroup.calculate_feature(self.df.copy(), feature_set)
+
+        assert len(result_df) == 44
+        assert "sales__linear_forecast_7day" in result_df.columns
+        assert "sales__linear_forecast_14day" in result_df.columns
+
+        assert result_df["sales__linear_forecast_14day"].notna().all()
+        assert len(result_df["sales__linear_forecast_14day"]) == 44
+
+        assert result_df["sales__linear_forecast_7day"].iloc[:37].notna().all()
+        assert result_df["sales__linear_forecast_7day"].iloc[37:].isna().all()
+
+        assert np.allclose(result_df["sales__linear_forecast_14day"].to_numpy()[:30], self.df["sales"].to_numpy())
+        assert np.allclose(result_df["sales__linear_forecast_7day"].to_numpy()[:30], self.df["sales"].to_numpy())
+
     def test_get_reference_time_column_default(self) -> None:
         """Test get_reference_time_column method returns default column name when no options provided."""
         # Test with no options - should return default column name


### PR DESCRIPTION
## Problem

`PandasForecastingFeatureGroup` produced a forecast column that was 100% NaN. `_add_result_to_data` did `data[feature_name] = result`, but `result` was a pandas Series indexed by a datetime axis (historical timestamps + horizon), while `data` has a default integer RangeIndex. Pandas aligns by index label, no labels overlapped, so every value became NaN and the horizon rows were dropped. The model trained and predicted correctly, then the entire output was discarded. The existing tests only asserted column presence and length, never a value, so this went unnoticed.

Reproduced before the fix: `calculate_feature` on a 30 row series returned 30 of 30 NaN.

## Fix

- `_perform_forecasting` and `_perform_forecasting_with_confidence` now build the result by concatenating the historical actuals (in the original data row order) with the horizon forecasts, as a plain positional Series. This drops the datetime-index detour that caused the all-NaN bug, and keeps historical values aligned to their own rows even when the input is not time sorted.
- `_add_result_to_data` aligns by position and grows the frame to `max(current, incoming)` rows, never shrinking. A shorter forecast is NaN padded to the frame length so it cannot truncate a longer forecast already present.

## Tests added

- `test_calculate_feature_populates_forecast_values`: single 7 day forecast on 30 rows yields 37 rows, no NaN, historical actuals preserved, forecast points finite.
- `test_calculate_feature_multiple_horizons_not_truncated`: 7 day and 14 day requested together yield 44 rows, the 14 day column fully populated, the 7 day column NaN padded (not truncating the frame).
- `test_calculate_feature_unsorted_input_preserves_row_alignment`: reverse chronological input keeps each row's historical forecast value aligned to its own source value.

## Validation

`tox` is fully green: 6620 passed, 170 skipped, plus ruff format/check, mypy --strict, bandit, and the license allowlist. The confidence interval path was also exercised end to end on unsorted input (`lower <= point <= upper` holds on the horizon).

## Review

Two independent deep reviews were run. The first caught a multi-horizon truncation regression in an earlier version of the fix (now fixed and covered by a test) and flagged unsorted-input misalignment; the second confirmed the loop invariants and re-flagged unsorted input, which is now fixed. The codex review arm could not be used in this environment (its host process targets a different repo clone), so it is not part of this gate.

## Known follow up (out of scope here)

The horizon rows added to the frame have no timestamp: the reference time column is `NaT` and other source columns are `NaN` for those rows. This is a usability gap, not a correctness bug (the forecast values themselves are correct). Populating the reference time column for forecast rows needs the time column plumbed into the row add path and is better done as a separate change.