### PR TITLE
fix: expand one-to-many joins in PythonDict merge engine

### DIFF
--- a/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_merge_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_merge_engine.py
@@ -45,6 +45,14 @@ class PythonDictMergeEngine(BaseMergeEngine):
                     ordered.append(col)
         return ordered
 
+    @staticmethod
+    def _group_by_key(rows: list[dict[str, Any]], cols: tuple[str, ...]) -> dict[tuple[Any, ...], list[dict[str, Any]]]:
+        # Maps each join key to every matching row so duplicate keys fan out instead of collapsing.
+        groups: dict[tuple[Any, ...], list[dict[str, Any]]] = {}
+        for row in rows:
+            groups.setdefault(tuple(row.get(col) for col in cols), []).append(row)
+        return groups
+
     def merge_inner(self, left_data: Any, right_data: Any, left_index: Index, right_index: Index) -> Any:
         return self.join_logic("inner", left_data, right_data, left_index, right_index, JoinType.INNER)
 
@@ -237,27 +245,27 @@ class PythonDictMergeEngine(BaseMergeEngine):
     def _inner_join(
         self, left_data: Any, right_data: Any, left_cols: tuple[str, ...], right_cols: tuple[str, ...]
     ) -> Any:
-        """Performs inner join."""
+        """Performs inner join, emitting one row per (left, matching-right) pair."""
         left_rows = self._to_rows(left_data)
         right_rows = self._to_rows(right_data)
-        right_index_map = {tuple(r.get(col) for col in right_cols): r for r in right_rows}
+        right_groups = self._group_by_key(right_rows, right_cols)
 
         out_columns = self._ordered_columns(left_data.keys(), right_data.keys())
         result = []
         for left in left_rows:
             key = tuple(left.get(col) for col in left_cols)
-            if key in right_index_map:
-                result.append({**left, **right_index_map[key]})
+            for right in right_groups.get(key, []):
+                result.append({**left, **right})
 
         return self._to_columnar(result, out_columns)
 
     def _left_join(
         self, left_data: Any, right_data: Any, left_cols: tuple[str, ...], right_cols: tuple[str, ...]
     ) -> Any:
-        """Performs left join."""
+        """Performs left join, fanning out matches and null-filling unmatched left rows."""
         left_rows = self._to_rows(left_data)
         right_rows = self._to_rows(right_data)
-        right_index_map = {tuple(r.get(col) for col in right_cols): r for r in right_rows}
+        right_groups = self._group_by_key(right_rows, right_cols)
 
         out_columns = self._ordered_columns(left_data.keys(), right_data.keys())
         right_columns = [col for col in right_data.keys() if col not in set(right_cols) and col not in left_data]
@@ -265,8 +273,10 @@ class PythonDictMergeEngine(BaseMergeEngine):
         result = []
         for left in left_rows:
             key = tuple(left.get(col) for col in left_cols)
-            if key in right_index_map:
-                result.append({**left, **right_index_map[key]})
+            matches = right_groups.get(key)
+            if matches:
+                for right in matches:
+                    result.append({**left, **right})
             else:
                 merged = {**left}
                 for col in right_columns:
@@ -278,21 +288,23 @@ class PythonDictMergeEngine(BaseMergeEngine):
     def _right_join(
         self, left_data: Any, right_data: Any, left_cols: tuple[str, ...], right_cols: tuple[str, ...]
     ) -> Any:
-        """Performs right join."""
+        """Performs right join, fanning out matches and null-filling unmatched right rows."""
         left_rows = self._to_rows(left_data)
         right_rows = self._to_rows(right_data)
-        left_index_map = {tuple(left.get(col) for col in left_cols): left for left in left_rows}
+        left_groups = self._group_by_key(left_rows, left_cols)
 
         out_columns = self._ordered_columns(right_data.keys(), left_data.keys())
         left_columns = [col for col in left_data.keys() if col not in set(left_cols) and col not in right_data]
 
         result = []
-        for r in right_rows:
-            key = tuple(r.get(col) for col in right_cols)
-            if key in left_index_map:
-                result.append({**left_index_map[key], **r})
+        for right in right_rows:
+            key = tuple(right.get(col) for col in right_cols)
+            matches = left_groups.get(key)
+            if matches:
+                for left in matches:
+                    result.append({**left, **right})
             else:
-                merged = {**r}
+                merged = {**right}
                 for col in left_columns:
                     merged[col] = None
                 result.append(merged)
@@ -302,26 +314,34 @@ class PythonDictMergeEngine(BaseMergeEngine):
     def _outer_join(
         self, left_data: Any, right_data: Any, left_cols: tuple[str, ...], right_cols: tuple[str, ...]
     ) -> Any:
-        """Performs outer join."""
+        """Performs outer join, fanning out matched keys into the full row product."""
         left_rows = self._to_rows(left_data)
         right_rows = self._to_rows(right_data)
-        left_index_map = {tuple(left.get(col) for col in left_cols): left for left in left_rows}
-        right_index_map = {tuple(r.get(col) for col in right_cols): r for r in right_rows}
-
-        all_keys = list(left_index_map.keys())
-        for key in right_index_map.keys():
-            if key not in left_index_map:
-                all_keys.append(key)
+        left_groups = self._group_by_key(left_rows, left_cols)
+        right_groups = self._group_by_key(right_rows, right_cols)
 
         left_columns = list(left_data.keys())
         right_columns = list(right_data.keys())
         out_columns = self._ordered_columns(left_columns, right_columns)
 
-        result = []
-        for key in all_keys:
-            left_row = left_index_map.get(key, {})
-            right_row = right_index_map.get(key, {})
+        # Each left row fans out over its right matches (or one null-filled row when unmatched);
+        # then every right row whose key has no left match emits one null-filled row.
+        no_row: dict[str, Any] = {}
+        pairs: list[tuple[tuple[Any, ...], dict[str, Any], dict[str, Any]]] = []
+        for left in left_rows:
+            key = tuple(left.get(col) for col in left_cols)
+            matches = right_groups.get(key)
+            if matches:
+                pairs.extend((key, left, right) for right in matches)
+            else:
+                pairs.append((key, left, no_row))
+        for right in right_rows:
+            key = tuple(right.get(col) for col in right_cols)
+            if key not in left_groups:
+                pairs.append((key, no_row, right))
 
+        result = []
+        for key, left_row, right_row in pairs:
             merged: dict[str, Any] = {}
 
             # Start with the key values
@@ -329,10 +349,10 @@ class PythonDictMergeEngine(BaseMergeEngine):
                 for i, col in enumerate(left_cols):
                     merged[col] = key[i]
             else:
-                if key in left_index_map:
+                if key in left_groups:
                     for i, col in enumerate(left_cols):
                         merged[col] = key[i]
-                if key in right_index_map:
+                if key in right_groups:
                     for i, col in enumerate(right_cols):
                         merged[col] = key[i]
 
@@ -351,24 +371,18 @@ class PythonDictMergeEngine(BaseMergeEngine):
     def _union_join(
         self, left_data: Any, right_data: Any, left_cols: tuple[str, ...], right_cols: tuple[str, ...]
     ) -> Any:
-        """Performs union (removes duplicates based on join columns)."""
+        """Performs union, dropping rows that fully duplicate an earlier row over the output columns."""
         left_rows = self._to_rows(left_data)
         right_rows = self._to_rows(right_data)
         out_columns = self._ordered_columns(left_data.keys(), right_data.keys())
 
-        seen_keys: set[Any] = set()
-        result = []
+        seen: set[tuple[Any, ...]] = set()
+        result: list[dict[str, Any]] = []
 
-        for row in left_rows:
-            key = tuple(row.get(col) for col in left_cols)
-            if key not in seen_keys:
-                seen_keys.add(key)
-                result.append(row)
-
-        for row in right_rows:
-            key = tuple(row.get(col) for col in right_cols)
-            if key not in seen_keys:
-                seen_keys.add(key)
+        for row in left_rows + right_rows:
+            signature = tuple(row.get(col) for col in out_columns)
+            if signature not in seen:
+                seen.add(signature)
                 result.append(row)
 
         return self._to_columnar(result, out_columns)

--- a/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_merge_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_merge_engine.py
@@ -72,11 +72,11 @@ class TestPythonDictMergeEngine:
         }
 
     def test_merge_union(self, left_data: Any, right_data: Any, index_obj: Any) -> None:
-        """Test union operation (removes duplicates)."""
+        """Test union operation (dedupes by full row, not by join key)."""
         engine = PythonDictMergeEngine()
         result = engine.merge_union(left_data, right_data, index_obj, index_obj)
 
-        assert result == {"idx": [1, 3, 2], "col1": ["a", "b", None], "col2": [None, None, "z"]}
+        assert result == {"idx": [1, 3, 1, 2], "col1": ["a", "b", None, None], "col2": [None, None, "x", "z"]}
 
     def test_merge_with_different_join_columns(self) -> None:
         """Test merge with different column names for join."""
@@ -206,6 +206,104 @@ class TestPythonDictEquiJoinTimezoneGuard:
 
         result = engine.merge(left_data, right_data, link)
         assert result == {"k": ["a"], "lv": [1], "rv": [2]}
+
+
+class TestPythonDictMergeEngineOneToMany:
+    """One-to-many / many-to-many join semantics pinned against pandas/polars.
+
+    Expected values were cross-checked by running the equivalent join through
+    PandasMergeEngine. Row order follows the natural nested-loop order: for each
+    left row in order, each matching right row in order.
+    """
+
+    def test_inner_one_to_many_expands_duplicate_right_keys(self) -> None:
+        """Inner join must emit one row per (left, matching-right) pair, not collapse to the last right row."""
+        engine = PythonDictMergeEngine()
+        idx = Index(("user_id",))
+        left = {"user_id": [1, 2], "name": ["ann", "bob"]}
+        right = {"user_id": [1, 1, 2, 2], "amount": [10, 20, 30, 40]}
+
+        result = engine.merge_inner(left, right, idx, idx)
+
+        assert result == {
+            "user_id": [1, 1, 2, 2],
+            "name": ["ann", "ann", "bob", "bob"],
+            "amount": [10, 20, 30, 40],
+        }
+
+    def test_left_one_to_many_expands_and_null_fills_unmatched(self) -> None:
+        """Left join must expand duplicate right matches and null-fill the unmatched left row."""
+        engine = PythonDictMergeEngine()
+        idx = Index(("user_id",))
+        left = {"user_id": [1, 2, 3], "name": ["ann", "bob", "cat"]}
+        right = {"user_id": [1, 1, 2, 2], "amount": [10, 20, 30, 40]}
+
+        result = engine.merge_left(left, right, idx, idx)
+
+        assert result == {
+            "user_id": [1, 1, 2, 2, 3],
+            "name": ["ann", "ann", "bob", "bob", "cat"],
+            "amount": [10, 20, 30, 40, None],
+        }
+
+    def test_right_one_to_many_expands_duplicate_left_keys(self) -> None:
+        """Right join must emit one row per (matching-left, right) pair, not collapse to the last left row."""
+        engine = PythonDictMergeEngine()
+        idx = Index(("user_id",))
+        left = {"user_id": [1, 1, 2, 2], "amount": [10, 20, 30, 40]}
+        right = {"user_id": [1, 2], "name": ["ann", "bob"]}
+
+        result = engine.merge_right(left, right, idx, idx)
+
+        assert result == {
+            "user_id": [1, 1, 2, 2],
+            "name": ["ann", "ann", "bob", "bob"],
+            "amount": [10, 20, 30, 40],
+        }
+
+    def test_outer_one_to_many_expands_duplicate_matching_keys(self) -> None:
+        """Outer join must expand matched duplicate keys into the full row product."""
+        engine = PythonDictMergeEngine()
+        idx = Index(("user_id",))
+        left = {"user_id": [1, 2], "name": ["ann", "bob"]}
+        right = {"user_id": [1, 1, 2, 2], "amount": [10, 20, 30, 40]}
+
+        result = engine.merge_full_outer(left, right, idx, idx)
+
+        assert result == {
+            "user_id": [1, 1, 2, 2],
+            "name": ["ann", "ann", "bob", "bob"],
+            "amount": [10, 20, 30, 40],
+        }
+
+    def test_inner_many_to_many_produces_cartesian_product(self) -> None:
+        """Many-to-many inner join must produce the full Cartesian product per shared key."""
+        engine = PythonDictMergeEngine()
+        idx = Index(("k",))
+        left = {"k": [1, 1], "l": ["l1", "l2"]}
+        right = {"k": [1, 1], "r": ["r1", "r2"]}
+
+        result = engine.merge_inner(left, right, idx, idx)
+
+        assert result == {
+            "k": [1, 1, 1, 1],
+            "l": ["l1", "l1", "l2", "l2"],
+            "r": ["r1", "r2", "r1", "r2"],
+        }
+
+    def test_union_dedupes_by_full_row_not_join_key(self) -> None:
+        """Union must keep distinct rows sharing a join key and collapse only fully identical rows."""
+        engine = PythonDictMergeEngine()
+        idx = Index(("user_id",))
+        left = {"user_id": [1, 1, 2], "name": ["ann", "amy", "bob"]}
+        right = {"user_id": [1, 2, 3], "name": ["ann", "bob", "cat"]}
+
+        result = engine.merge_union(left, right, idx, idx)
+
+        assert result == {
+            "user_id": [1, 1, 2, 3],
+            "name": ["ann", "amy", "bob", "cat"],
+        }
 
 
 class TestPythonDictMergeEngineMultiIndex(MultiIndexMergeEngineTestBase):

--- a/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_one_to_many_join_run_all.py
+++ b/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_one_to_many_join_run_all.py
@@ -1,0 +1,113 @@
+"""End-to-end one-to-many inner join through run_all on PythonDict.
+
+Proves the plumbing run_all -> JoinStep -> PythonDictMergeEngine.merge_inner
+preserves one-to-many fan-out: a unique-key left joined to a duplicate-key right
+must yield one row per matching right row, not collapse to the last one.
+"""
+
+from typing import Any, Optional
+
+import pytest
+
+from mloda.provider import BaseInputData
+from mloda.provider import DataCreator
+from mloda.provider import FeatureGroup
+from mloda.provider import FeatureSet
+from mloda.user import Feature
+from mloda.user import FeatureName
+from mloda.user import Index
+from mloda.user import JoinSpec
+from mloda.user import Link
+from mloda.user import Options
+from mloda.user import ParallelizationMode
+from mloda.user import PluginCollector
+from mloda.user import mloda
+
+# Import to register PythonDictFramework as a discoverable ComputeFramework subclass.
+import mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework  # noqa: F401
+
+
+def _one_to_many_link() -> Link:
+    """Inner join on user_id: unique-key left to duplicate-key right."""
+    return Link(
+        "inner",
+        JoinSpec(OneToManyLeftFeature, Index(("user_id",))),
+        JoinSpec(OneToManyRightFeature, Index(("user_id",))),
+    )
+
+
+class OneToManyLeftFeature(FeatureGroup):
+    """Left side: one row per user (unique join keys)."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={"user_id", "uname"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {"user_id": [1, 2], "uname": ["ann", "bob"]}
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return {"user_id", "uname"}
+
+
+class OneToManyRightFeature(FeatureGroup):
+    """Right side: many rows per user (duplicate join keys)."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={"user_id", "amount"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {"user_id": [1, 1, 2, 2], "amount": [10, 20, 30, 40]}
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return {"user_id", "amount"}
+
+
+class OneToManyJoinedFeature(FeatureGroup):
+    """Parent consuming the one-to-many join; encodes each joined row as 'uname|amount'."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        link = _one_to_many_link()
+        return {
+            Feature(name="uname", link=link, index=Index(("user_id",))),
+            Feature(name="amount", index=Index(("user_id",))),
+        }
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        length = len(next(iter(data.values())))
+        encoded = [f"{data['uname'][i]}|{data['amount'][i]}" for i in range(length)]
+        return {cls.get_class_name(): encoded}
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return {cls.get_class_name()}
+
+
+_ENABLED = PluginCollector.enabled_feature_groups({OneToManyLeftFeature, OneToManyRightFeature, OneToManyJoinedFeature})
+
+
+class TestPythonDictOneToManyJoinRunAll:
+    """A one-to-many inner join must fan out end-to-end through run_all."""
+
+    @pytest.mark.parametrize("modes", [{ParallelizationMode.SYNC}, {ParallelizationMode.THREADING}])
+    def test_one_to_many_inner_join(self, modes: set[ParallelizationMode], flight_server: Any) -> None:
+        """Unique-key left joined to a duplicate-key right yields four rows, not two."""
+        feature = Feature(name=OneToManyJoinedFeature.get_class_name())
+        result = mloda.run_all(
+            [feature],
+            links={_one_to_many_link()},
+            compute_frameworks=["PythonDictFramework"],
+            plugin_collector=_ENABLED,
+            flight_server=flight_server,
+            parallelization_modes=modes,
+        )
+
+        assert len(result) == 1
+        column = result[0][OneToManyJoinedFeature.get_class_name()]
+        assert sorted(column) == ["ann|10", "ann|20", "bob|30", "bob|40"]


### PR DESCRIPTION
## Problem

`PythonDictMergeEngine` silently dropped rows on any one-to-many join. Every equi-join built its lookup as a plain dict keyed on the join columns (`{tuple(...): row}`), so duplicate join keys collapsed to the last matching row, and surviving rows silently took that last row's values. A standard users-to-orders join returned one order per user instead of the full fan-out that pandas, pyarrow, polars, duckdb, sqlite, and spark all produce. Separately, `_union_join` deduped by join key instead of by full row, deleting distinct rows that happen to share a key.

The existing tests only used unique join keys, so nothing pinned the correct behavior.

## Reproduction (before)

Left `{user_id:[1,2]}` joined to right `{user_id:[1,1,2,2], amount:[10,20,30,40]}`:

| Join | PythonDict (before) | pandas |
|------|--------------------|--------|
| inner / left / outer | 2 rows, `amount=[20,40]` | 4 rows |
| right (dups on left) | 2 rows | 4 rows |
| many-to-many inner | 2 rows, `r=['r2','r2']` | 4 rows (Cartesian) |

## Fix

- Add a `_group_by_key` helper mapping each join key to the list of matching rows.
- `_inner_join`, `_left_join`, `_right_join`, `_outer_join` now emit one output row per `(left, right)` match pair (Cartesian expansion within a key). Left/right still null-fill an unmatched driving row exactly once; output column order is unchanged.
- `_union_join` now dedupes by the full row over the ordered output columns, matching SQL `UNION`, pandas `drop_duplicates`, and polars `unique`. Distinct rows sharing a join key both survive; only fully identical rows collapse.

## Tests

- 6 new unit tests covering inner/left/right/outer duplicate-key fan-out, many-to-many Cartesian product, and union full-row dedup.
- 1 new end-to-end test through `run_all` (parametrized SYNC + THREADING) proving the fan-out survives the real `run_all -> JoinStep -> merge_inner` plumbing.
- Corrected the pre-existing `test_merge_union`: it asserted 3 rows (join-key dedup) for disjoint-column input, which disagreed with pandas/polars/SQL (all 4 rows). It now pins the reference-engine result.

All expected values were cross-checked against `PandasMergeEngine`.

## Validation

- Full `tox` gate green: 6625 passed, 170 skipped; `ruff format`/`ruff check`/`mypy --strict`/`bandit` all clean.
- Deep independent review (Claude Opus) confirmed correctness against pandas across one-to-many, many-to-many, null-key, disjoint-column, and multi-index cases: no value bleed, no aliasing, correct null-fill.

Note: the second independent review gate (codex) was skipped for this change due to a local tooling conflict; it did not run against this diff.