### PR TITLE
feat: typed FeatureResolutionError carrying the captured EvaluationResult (#809)

### DIFF
--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -75,6 +75,10 @@ class FeatureResolutionError(ValueError):
         self.feature_name = feature_name
         self.result = result
 
+    def __reduce__(self) -> tuple[type["FeatureResolutionError"], tuple[str, str, EvaluationResult]]:
+        # The default reduction reconstructs from args=(message,) and drops the two extra constructor arguments.
+        return type(self), (str(self), self.feature_name, self.result)
+
 
 def matches_feature_group_scope(feature_group: type[FeatureGroup], scope: str | type[FeatureGroup]) -> bool:
     """Is the candidate inside the requested scope, for both the class-object and the string form.

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -67,6 +67,15 @@ class EvaluationResult:
         return "none"
 
 
+class FeatureResolutionError(ValueError):
+    """Typed resolution failure carrying the feature name and the EvaluationResult of its single pass."""
+
+    def __init__(self, message: str, feature_name: str, result: EvaluationResult) -> None:
+        super().__init__(message)
+        self.feature_name = feature_name
+        self.result = result
+
+
 def matches_feature_group_scope(feature_group: type[FeatureGroup], scope: str | type[FeatureGroup]) -> bool:
     """Is the candidate inside the requested scope, for both the class-object and the string form.
 
@@ -267,7 +276,7 @@ class IdentifyFeatureGroupClass:
         # The message is a projection of the pass that just ran: no second evaluation, no re-asked hook.
         message = render_resolution_failure(result, feature)
         if message is not None:
-            raise ValueError(message)
+            raise FeatureResolutionError(message, str(feature.name), result)
         self.feature_group_compute_framework_mapping = result.identified
 
     @classmethod

--- a/mloda/steward/__init__.py
+++ b/mloda/steward/__init__.py
@@ -32,6 +32,9 @@ from mloda.core.abstract_plugins.plugin_registry.plugin_policy import (
     PluginPolicyViolationError,
 )
 
+# Feature resolution
+from mloda.core.prepare.identify_feature_group import FeatureResolutionError
+
 __version__ = get_mloda_version()
 
 __all__ = [
@@ -59,4 +62,6 @@ __all__ = [
     "ApprovalStatus",
     "PluginPolicy",
     "PluginPolicyViolationError",
+    # Feature resolution
+    "FeatureResolutionError",
 ]

--- a/mloda/user/__init__.py
+++ b/mloda/user/__init__.py
@@ -51,6 +51,9 @@ from mloda.core.abstract_plugins.plugin_registry.plugin_registry import (
     register_plugin,
 )
 
+# Feature resolution
+from mloda.core.prepare.identify_feature_group import FeatureResolutionError
+
 # Config loading
 from mloda.core.api.feature_config.loader import load_features_from_config
 
@@ -105,6 +108,8 @@ __all__ = [
     # Plugin registry
     "PluginRegistryCollisionError",
     "register_plugin",
+    # Feature resolution
+    "FeatureResolutionError",
     # Streaming API
     "stream_all",
     # Config loading

--- a/tests/test_core/test_prepare/test_feature_resolution_error.py
+++ b/tests/test_core/test_prepare/test_feature_resolution_error.py
@@ -1,0 +1,200 @@
+"""Failing tests for the typed resolution exception ``FeatureResolutionError`` (issue #809).
+
+The raising seam in ``IdentifyFeatureGroupClass.__init__`` raises a bare ``ValueError`` when a feature
+cannot be resolved. This suite pins its replacement: ``FeatureResolutionError(ValueError)``, defined in
+``mloda.core.prepare.identify_feature_group`` beside the evaluation seam. It carries ``feature_name: str``
+and ``result: EvaluationResult``, keeps the rendered message text unchanged (the message still comes from
+``render_resolution_failure``), and is re-exported from ``mloda.user`` and ``mloda.steward``.
+
+All fixture names carry an ``_809`` suffix: test feature groups become global subclasses and the suite
+runs in parallel, so a shared name would leak into another module's candidate universe.
+"""
+
+from typing import Optional
+
+import pytest
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from mloda.core.prepare.identify_feature_group import (
+    FeatureResolutionError,
+    IdentifyFeatureGroupClass,
+    render_resolution_failure,
+)
+from mloda.user import mlodaAPI
+
+
+# Unique feature names so no other double in the parallel suite collides on them.
+KNOWN_FEATURE_809 = "resolution_error_known_809"
+NO_MATCH_FEATURE_809 = "resolution_error_no_match_809"
+MULTIPLE_FEATURE_809 = "resolution_error_multiple_809"
+
+
+class ResolutionErrorFw_809(ComputeFramework):
+    """Dummy compute framework for the typed-resolution-error tests."""
+
+
+class ResolutionErrorKnownFG_809(FeatureGroup):
+    """Concrete feature group matching exactly one unique feature name."""
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == KNOWN_FEATURE_809
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class ResolutionErrorSiblingAFG_809(FeatureGroup):
+    """First of two unrelated siblings matching the same name, forcing an ambiguous match."""
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == MULTIPLE_FEATURE_809
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class ResolutionErrorSiblingBFG_809(FeatureGroup):
+    """Second unrelated sibling matching the same name, forcing an ambiguous match."""
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == MULTIPLE_FEATURE_809
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+def _no_match_accessible_plugins() -> FeatureGroupEnvironmentMapping:
+    """One candidate that matches only its own known name: any other name yields failure_kind 'none'."""
+    return {ResolutionErrorKnownFG_809: {ResolutionErrorFw_809}}
+
+
+class TestFeatureResolutionErrorAtTheSeam:
+    """The raising seam raises the typed error, carrying the evaluation it just ran."""
+
+    def test_unresolvable_feature_raises_the_typed_error(self) -> None:
+        """An unresolvable feature raises FeatureResolutionError, which is a ValueError."""
+        feature = Feature(NO_MATCH_FEATURE_809)
+
+        with pytest.raises(FeatureResolutionError) as exc_info:
+            IdentifyFeatureGroupClass(
+                feature=feature,
+                accessible_plugins=_no_match_accessible_plugins(),
+                links=None,
+                data_access_collection=None,
+            )
+
+        assert isinstance(exc_info.value, ValueError)
+        assert exc_info.value.feature_name == NO_MATCH_FEATURE_809
+
+    def test_the_error_carries_the_evaluation_result(self) -> None:
+        """The raised error exposes the structured EvaluationResult of its single pass."""
+        feature = Feature(NO_MATCH_FEATURE_809)
+
+        with pytest.raises(FeatureResolutionError) as exc_info:
+            IdentifyFeatureGroupClass(
+                feature=feature,
+                accessible_plugins=_no_match_accessible_plugins(),
+                links=None,
+                data_access_collection=None,
+            )
+
+        result = exc_info.value.result
+        assert result.failure_kind == "none"
+        assert isinstance(result.criteria_matched, set)
+        assert isinstance(result.candidate_frameworks, dict)
+
+    def test_the_message_text_is_unchanged(self) -> None:
+        """str(error) is exactly render_resolution_failure over the same evaluation."""
+        feature = Feature(NO_MATCH_FEATURE_809)
+
+        with pytest.raises(FeatureResolutionError) as exc_info:
+            IdentifyFeatureGroupClass(
+                feature=feature,
+                accessible_plugins=_no_match_accessible_plugins(),
+                links=None,
+                data_access_collection=None,
+            )
+
+        result = IdentifyFeatureGroupClass.evaluate(
+            feature=feature,
+            accessible_plugins=_no_match_accessible_plugins(),
+            links=None,
+        )
+        expected = render_resolution_failure(result, feature)
+        assert expected is not None
+        assert str(exc_info.value) == expected
+
+    def test_ambiguous_match_reports_multiple_with_its_candidates(self) -> None:
+        """An ambiguous match carries failure_kind 'multiple' and a non-empty criteria_matched."""
+        feature = Feature(MULTIPLE_FEATURE_809)
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            ResolutionErrorSiblingAFG_809: {ResolutionErrorFw_809},
+            ResolutionErrorSiblingBFG_809: {ResolutionErrorFw_809},
+        }
+
+        with pytest.raises(FeatureResolutionError) as exc_info:
+            IdentifyFeatureGroupClass(
+                feature=feature,
+                accessible_plugins=accessible_plugins,
+                links=None,
+                data_access_collection=None,
+            )
+
+        assert exc_info.value.feature_name == MULTIPLE_FEATURE_809
+        result = exc_info.value.result
+        assert result.failure_kind == "multiple"
+        assert result.criteria_matched
+
+
+class TestFeatureResolutionErrorEndToEnd:
+    """The engine path surfaces the typed error unchanged."""
+
+    def test_run_all_raises_the_typed_error_for_an_unresolvable_name(self) -> None:
+        """mlodaAPI.run_all with an unresolvable feature name raises FeatureResolutionError."""
+        with pytest.raises(FeatureResolutionError):
+            mlodaAPI.run_all(
+                [NO_MATCH_FEATURE_809],
+                compute_frameworks={ResolutionErrorFw_809},
+                plugin_collector=PluginCollector.enabled_feature_groups({ResolutionErrorKnownFG_809}),
+            )
+
+
+class TestFeatureResolutionErrorImportSurfaces:
+    """The typed error is re-exported from the user and steward surfaces."""
+
+    def test_user_surface_reexports_the_same_class(self) -> None:
+        """mloda.user exposes the exact class the core module defines."""
+        from mloda.user import FeatureResolutionError as user_error
+
+        assert user_error is FeatureResolutionError
+
+    def test_steward_surface_reexports_the_same_class(self) -> None:
+        """mloda.steward exposes the exact class the core module defines."""
+        from mloda.steward import FeatureResolutionError as steward_error
+
+        assert steward_error is FeatureResolutionError

--- a/tests/test_core/test_prepare/test_feature_resolution_error.py
+++ b/tests/test_core/test_prepare/test_feature_resolution_error.py
@@ -10,6 +10,8 @@ All fixture names carry an ``_809`` suffix: test feature groups become global su
 runs in parallel, so a shared name would leak into another module's candidate universe.
 """
 
+import copy
+import pickle  # nosec B403
 from typing import Optional
 
 import pytest
@@ -91,6 +93,21 @@ class ResolutionErrorSiblingBFG_809(FeatureGroup):
 def _no_match_accessible_plugins() -> FeatureGroupEnvironmentMapping:
     """One candidate that matches only its own known name: any other name yields failure_kind 'none'."""
     return {ResolutionErrorKnownFG_809: {ResolutionErrorFw_809}}
+
+
+def _raised_resolution_error_809() -> FeatureResolutionError:
+    """Catch and return the typed error the raising seam produces for the no-match fixture."""
+    feature = Feature(NO_MATCH_FEATURE_809)
+
+    with pytest.raises(FeatureResolutionError) as exc_info:
+        IdentifyFeatureGroupClass(
+            feature=feature,
+            accessible_plugins=_no_match_accessible_plugins(),
+            links=None,
+            data_access_collection=None,
+        )
+
+    return exc_info.value
 
 
 class TestFeatureResolutionErrorAtTheSeam:
@@ -182,6 +199,37 @@ class TestFeatureResolutionErrorEndToEnd:
                 compute_frameworks={ResolutionErrorFw_809},
                 plugin_collector=PluginCollector.enabled_feature_groups({ResolutionErrorKnownFG_809}),
             )
+
+
+class TestFeatureResolutionErrorTransport:
+    """The typed error survives the transport boundaries the engine uses: pickle and deepcopy.
+
+    ``BaseException.__reduce__`` reconstructs an exception from ``self.args``, which here is only the
+    rendered message. Without a ``__reduce__`` override the round trips below raise ``TypeError`` for
+    the two missing constructor arguments instead of returning an equivalent error.
+    """
+
+    def test_pickle_round_trip_preserves_message_name_and_result(self) -> None:
+        """pickle.loads(pickle.dumps(error)) yields an equal FeatureResolutionError."""
+        original = _raised_resolution_error_809()
+
+        restored = pickle.loads(pickle.dumps(original))  # nosec B301
+
+        assert isinstance(restored, FeatureResolutionError)
+        assert str(restored) == str(original)
+        assert restored.feature_name == original.feature_name
+        assert restored.result.failure_kind == original.result.failure_kind
+
+    def test_deepcopy_round_trip_preserves_message_name_and_result(self) -> None:
+        """copy.deepcopy(error) yields an equal FeatureResolutionError."""
+        original = _raised_resolution_error_809()
+
+        duplicate = copy.deepcopy(original)
+
+        assert isinstance(duplicate, FeatureResolutionError)
+        assert str(duplicate) == str(original)
+        assert duplicate.feature_name == original.feature_name
+        assert duplicate.result.failure_kind == original.result.failure_kind
 
 
 class TestFeatureResolutionErrorImportSurfaces:


### PR DESCRIPTION
## Summary

First slice of the #759 diagnostics re-scope (decision record: https://github.com/mloda-ai/mloda/issues/759#issuecomment-5004923275). Resolution failures now raise `FeatureResolutionError`, a `ValueError` subclass carrying `feature_name` and the `EvaluationResult` of the single matching pass. The rendered message text is unchanged, so every existing `except ValueError` call site and message-pinning test stays valid.

Closes #809.

## Changes

- `FeatureResolutionError(ValueError)` defined beside the evaluation seam types in `identify_feature_group.py`; raised by `IdentifyFeatureGroupClass.__init__` with the untouched `render_resolution_failure` message
- `__reduce__` override so pickle and copy round-trips preserve all constructor state (the default reduction reconstructs from `args=(message,)` and fails with a masking `TypeError`, which matters when `run_all` runs inside a process pool)
- Re-exported from `mloda.user` and `mloda.steward`
- 9 new tests: structured payload at the seam, message identity with the renderer, ambiguous failure kind, end-to-end `run_all`, both import surfaces, pickle and deepcopy round-trips

## Review pass

Two independent deep reviews. Accepted and fixed: the exception was not picklable or copyable (both reviews flagged it, one with a live repro). Rejected: freezing the shallow-mutable collections on `EvaluationResult` (nothing shares that state today; the later report slices decide snapshot semantics) and extra failure-kind coverage (the raise site is kind-agnostic and those renderings are pinned by existing suites).

## Validation

`tox` green: 6631 passed, 170 skipped; ruff format, ruff check, license allowlist, `mypy --strict` (856 files), and bandit all pass.
