### PR TITLE
feat: structured parsed-name bindings for PROPERTY_MAPPING (#770)

### DIFF
--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -295,6 +295,17 @@ PROPERTY_MAPPING = {
 A caller who places the key explicitly in `Options(group=...)` or `Options(context=...)`
 overrides the spec's classification.
 
+## How a name-parsed value binds to a key
+
+A value captured from the feature name binds to a PROPERTY_MAPPING key by name: a named capture
+group `(?P<key>...)` binds to the key of the same name, so a secondary capture and an
+`element_validator`-only spec (one with no `allowed_values`) both receive their value. When a
+pattern declares any named group, binding is exclusively by name. A pattern with only positional
+groups falls back to the legacy rule of binding the first capture to the single key whose
+`allowed_values` already contain it. That fallback is transitional (retired by #772); a positional
+pattern whose keys share a reachable value is rejected at class-definition time, so migrate such a
+pattern to named capture groups.
+
 ## What the end user sees on a rejection
 
 A direct `FeatureChainParser` call raises `ValueError` immediately. Going through

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -15,6 +15,7 @@ from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+from mloda.core.abstract_plugins.components.feature_chainer.parsed_feature_name import ParsedFeatureName
 from mloda.core.abstract_plugins.components.feature_chainer.property_spec import PropertySpec, is_no_default
 from mloda.core.abstract_plugins.components.utils import safe_field
 
@@ -85,15 +86,17 @@ class FeatureChainParser:
         return CHAIN_SEPARATOR in feature_name
 
     @classmethod
-    def parse_feature_name(
+    def parse_name(
         cls,
         feature_name: FeatureName | str,
         prefix_patterns: list[Any],
         pattern: str = CHAIN_SEPARATOR,
-    ) -> tuple[str | None, str | None]:
-        """Internal method for parsing feature names - used by match_configuration_feature_chain_parser.
+    ) -> ParsedFeatureName:
+        """Parse a feature name into structured facts, keeping today's matching semantics.
 
         A prefix pattern is anything ``re.match`` accepts: a ``str`` or a compiled ``re.Pattern``.
+        A matched pattern with nothing before the separator raises the historical ValueError;
+        ``match_parser_criteria`` and ``_strict_validation_rejection_reason`` depend on that raise.
         """
         _feature_name: str = feature_name
 
@@ -102,21 +105,48 @@ class FeatureChainParser:
         operation_part = parts[1] if len(parts) > 1 else parts[0]
 
         for suffix_pattern in prefix_patterns:
-            if re.match(suffix_pattern, _feature_name) is None:
+            match = re.match(suffix_pattern, _feature_name)
+            if match is None:
                 continue
 
             if len(parts) == 1 or not source_feature:
                 raise ValueError(f"Matches the pattern {pattern}, but has no source feature: {_feature_name}")
 
-            match = re.match(suffix_pattern, _feature_name)
-            if match and match.groups():
-                operation_config = match.group(1)
-            else:
-                operation_config = operation_part.split("_")[0]
+            return ParsedFeatureName(
+                matched=True,
+                source_feature=source_feature,
+                operation_part=operation_part,
+                named_captures=match.groupdict(),
+                positional_captures=match.groups(),
+            )
 
-            return operation_config, source_feature
+        return ParsedFeatureName.no_match()
 
-        return None, None
+    @classmethod
+    def _legacy_operation_config(cls, parsed: ParsedFeatureName) -> str | None:
+        """The value the retired reverse-lookup binding consumes. #772 removes the fabrication."""
+        if parsed.positional_captures:
+            return parsed.positional_captures[0]
+        if parsed.operation_part is None:
+            return None
+        return parsed.operation_part.split("_")[0]  # fabrication, retired by #772
+
+    @classmethod
+    def parse_feature_name(
+        cls,
+        feature_name: FeatureName | str,
+        prefix_patterns: list[Any],
+        pattern: str = CHAIN_SEPARATOR,
+    ) -> tuple[str | None, str | None]:
+        """Legacy adapter over ``parse_name``: returns ``(operation_config, source_feature)``.
+
+        Public API (mloda_plugins call sites and documented examples), so the tuple stays
+        byte-for-byte identical to today, including the captureless fabrication and the ValueError.
+        """
+        parsed = cls.parse_name(feature_name, prefix_patterns, pattern)
+        if not parsed.matched:
+            return None, None
+        return cls._legacy_operation_config(parsed), parsed.source_feature
 
     @classmethod
     def _match_pattern_based_feature(
@@ -411,11 +441,17 @@ class FeatureChainParser:
             True if the feature matches either pattern-based or configuration-based parsing, False otherwise
         """
 
-        # string based matching
+        # string based matching. parse_name raises the no-source ValueError exactly as before, contained by
+        # match_parser_criteria. Effective options are built from the parse facts here, NOT via the
+        # monkeypatchable build_effective_options: a build raise stays owned by check_required_when, the one
+        # containment site that knows the owner (see build_effective_options / TestBuildEffectiveOptionsRaiseIsContained).
         if prefix_patterns is not None:
-            if cls._match_pattern_based_feature(feature_name, prefix_patterns, pattern):
+            parsed = cls.parse_name(feature_name, prefix_patterns, pattern)
+            if parsed.matched:
                 if property_mapping is not None:
-                    cls._validate_present_option_values(options, property_mapping)
+                    bindings = cls.bind_name_captures(parsed, property_mapping)
+                    effective_options = cls._merge_bindings(options, bindings, property_mapping)
+                    cls._validate_present_option_values(effective_options, property_mapping)
                 return True
 
         # configuration-based
@@ -449,6 +485,80 @@ class FeatureChainParser:
         return patterns
 
     @classmethod
+    def bind_name_captures(cls, parsed: ParsedFeatureName, property_mapping: dict[str, Any]) -> dict[str, str]:
+        """Turn parse facts into PROPERTY_MAPPING bindings by name; documented and deterministic.
+
+        Named captures bind EXCLUSIVELY by name: a capture whose name is a mapping key binds to that
+        key, an unmapped name binds nothing, a non-participating (None) capture binds nothing. Only
+        when the matched pattern declares no named capture at all does the legacy positional fallback
+        bind ``_legacy_operation_config`` to the single key whose ``allowed_values`` already contain
+        it (transitional compatibility for unmigrated positional patterns; retired by #772 /
+        mloda-registry#327). The fallback binds only a value already accepted, so it never fails strict
+        validation.
+        """
+        if not parsed.matched:
+            return {}
+
+        if parsed.named_captures:
+            bindings: dict[str, str] = {}
+            for name, value in parsed.named_captures.items():
+                if value is None or name not in property_mapping:
+                    continue
+                bindings[name] = value
+            return bindings
+
+        legacy_value = cls._legacy_operation_config(parsed)
+        if legacy_value is None:
+            return {}
+        for key, spec in property_mapping.items():
+            if not isinstance(spec, PropertySpec):
+                continue
+            if legacy_value in cls._extract_property_values(spec):
+                return {key: legacy_value}
+        return {}
+
+    @classmethod
+    def _merge_bindings(
+        cls, options: Options, bindings: dict[str, str], property_mapping: dict[str, Any] | None
+    ) -> Options:
+        """Merge name-derived bindings into options; a present option wins, nothing to merge is identity.
+
+        Provenance (inherited_group_keys / inherited_context_keys) and propagate_context_keys survive
+        the rebuild, so forwarded-mismatch protection still reads it off the effective options.
+        """
+        if property_mapping is None or not bindings:
+            return options
+
+        merged_group = dict(options.group)
+        merged_context = dict(options.context)
+        changed = False
+        for key, value in bindings.items():
+            spec = property_mapping.get(key)
+            if not isinstance(spec, PropertySpec):
+                continue
+            # An explicit option (including an opted-in explicit None, #768) is never overwritten.
+            if options.get(key) is not None or (spec.allow_explicit_none and key in options):
+                continue
+            if cls._determine_parameter_category(key, spec, options) == DefaultOptionKeys.context:
+                merged_context[key] = value
+            else:
+                merged_group[key] = value
+            changed = True
+
+        if not changed:
+            return options
+
+        effective = Options(
+            group=merged_group,
+            context=merged_context,
+            propagate_context_keys=options.propagate_context_keys,
+        )
+        effective.inherited_group_keys = options.inherited_group_keys
+        effective.inherited_context_keys = options.inherited_context_keys
+        effective.last_forwarded_group_keys = options.last_forwarded_group_keys
+        return effective
+
+    @classmethod
     def build_effective_options(
         cls,
         feature_name: str | FeatureName,
@@ -456,50 +566,84 @@ class FeatureChainParser:
         property_mapping: dict[str, Any],
         options: Options,
     ) -> Options:
-        """Build effective options by merging string-parsed values with explicit options.
+        """Merge every name-derived binding into options so predicates and validation see them.
 
-        When a feature is matched by string pattern, the operation_config value extracted
-        from the feature name is mapped to the corresponding PROPERTY_MAPPING key. This
-        ensures that required_when predicates see values from both sources.
-
-        If the feature is not string-based or no mapping key matches, returns the
-        original options unchanged.
+        Binding is by name (``bind_name_captures``): all captures merge at once, not just the first key.
+        A matcher may parse the name with its own separator, so CHAIN_SEPARATOR can leave it unparseable;
+        that is no name-parsed value to merge, never an exception out of a matcher. If nothing matches or
+        nothing binds, the original options come back by identity.
         """
-        # A matcher may parse the name with its own separator, so CHAIN_SEPARATOR can leave it
-        # unparseable. That is no name-parsed value to merge, never an exception out of a matcher.
-        nothing_parsed: tuple[str | None, str | None] = (None, None)
-        operation_config, _source_feature = safe_field(
-            lambda: cls.parse_feature_name(feature_name, prefix_patterns, CHAIN_SEPARATOR),
-            nothing_parsed,
+        parsed = safe_field(
+            lambda: cls.parse_name(feature_name, prefix_patterns, CHAIN_SEPARATOR),
+            ParsedFeatureName.no_match(),
             catching=(ValueError,),
         )
-        if operation_config is None:
+        if not parsed.matched:
             return options
+        bindings = cls.bind_name_captures(parsed, property_mapping)
+        return cls._merge_bindings(options, bindings, property_mapping)
 
-        # Find which property mapping key the operation_config value belongs to
-        for prop_key, prop_value in property_mapping.items():
-            if not isinstance(prop_value, PropertySpec):
-                continue
-            # Already present in options: no merge needed
-            if options.get(prop_key) is not None:
-                continue
-            # Check if operation_config is a valid value for this property
-            if operation_config not in cls._extract_property_values(prop_value):
-                continue
-            category = cls._determine_parameter_category(prop_key, prop_value, options)
-            merged_group = dict(options.group)
-            merged_context = dict(options.context)
-            if category == DefaultOptionKeys.context:
-                merged_context[prop_key] = operation_config
-            else:
-                merged_group[prop_key] = operation_config
-            return Options(
-                group=merged_group,
-                context=merged_context,
-                propagate_context_keys=options.propagate_context_keys,
-            )
+    @classmethod
+    def _pattern_named_and_total_groups(cls, pattern: Any) -> tuple[frozenset[str], int]:
+        """The named group names and total group count of a pattern; an uncompilable pattern reports neither."""
+        if isinstance(pattern, re.Pattern):
+            return frozenset(pattern.groupindex), pattern.groups
+        compiled: re.Pattern[str] | None = safe_field(lambda: re.compile(pattern), None, catching=(re.error, TypeError))
+        if compiled is None:
+            return frozenset(), 0
+        return frozenset(compiled.groupindex), compiled.groups
 
-        return options
+    @classmethod
+    def _str_reachable_values(cls, spec: PropertySpec) -> set[str]:
+        """The str members of a spec's value space; only a str can be reverse-looked-up from a capture."""
+        reachable: set[str] = set()
+        for value in cls._extract_property_values(spec):
+            if isinstance(value, str):
+                reachable.add(value)
+        return reachable
+
+    @classmethod
+    def validate_name_binding(cls, owner: type[Any]) -> None:
+        """Reject an order-dependent legacy positional binding at class-definition time.
+
+        Fires only when the class relies on the legacy fallback: it declares a capture group, no
+        pattern declares a named group, and two keys share a reachable (str) allowed value. Named
+        captures make binding explicit, so they are exempt; a captureless pattern has nothing to
+        misbind. Called from both FeatureGroup and FeatureChainParserMixin at class definition.
+        """
+        property_mapping = getattr(owner, "PROPERTY_MAPPING", None)
+        if not isinstance(property_mapping, dict):
+            return
+
+        patterns = cls.prefix_patterns_of(owner)
+        if not patterns:
+            return
+
+        has_capture_group = False
+        declares_named = False
+        for pattern in patterns:
+            named, total = cls._pattern_named_and_total_groups(pattern)
+            has_capture_group = has_capture_group or total >= 1
+            declares_named = declares_named or bool(named)
+
+        if not has_capture_group or declares_named:
+            return
+
+        reachable = {
+            key: cls._str_reachable_values(spec)
+            for key, spec in property_mapping.items()
+            if isinstance(spec, PropertySpec)
+        }
+        keys = list(reachable)
+        for i, left in enumerate(keys):
+            for right in keys[i + 1 :]:
+                overlap = reachable[left] & reachable[right]
+                if overlap:
+                    raise ValueError(
+                        f"{owner.__name__}: PROPERTY_MAPPING keys '{left}' and '{right}' share reachable "
+                        f"allowed value(s) {sorted(overlap)}, so a legacy positional capture cannot bind "
+                        f"unambiguously. Use named capture groups (?P<key>...) so binding is explicit."
+                    )
 
     @classmethod
     def check_required_when(

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -447,7 +447,7 @@ class FeatureChainParser:
         # containment site that knows the owner (see build_effective_options / TestBuildEffectiveOptionsRaiseIsContained).
         if prefix_patterns is not None:
             parsed = cls.parse_name(feature_name, prefix_patterns, pattern)
-            if parsed.matched:
+            if cls._name_identifies_group(parsed, property_mapping):
                 if property_mapping is not None:
                     bindings = cls.bind_name_captures(parsed, property_mapping)
                     effective_options = cls._merge_bindings(options, bindings, property_mapping)
@@ -516,6 +516,22 @@ class FeatureChainParser:
             if legacy_value in cls._extract_property_values(spec):
                 return {key: legacy_value}
         return {}
+
+    @classmethod
+    def _name_identifies_group(cls, parsed: ParsedFeatureName, property_mapping: dict[str, Any] | None) -> bool:
+        """True when a matched name string-identifies this group for matching.
+
+        A legacy positional pattern whose only capture is an absent optional first group does NOT
+        identify the group: reproduce the pre-#770 gate so required presence still guards it on the
+        config path (#769 owns changing that). A named capture that binds a mapping key identifies the
+        group even when the legacy operation value is absent, so a named-optional-first pattern gets
+        full binding, guard, and forwarded-mismatch visibility.
+        """
+        if not parsed.matched:
+            return False
+        if property_mapping and cls.bind_name_captures(parsed, property_mapping):
+            return True
+        return cls._legacy_operation_config(parsed) is not None
 
     @classmethod
     def _merge_bindings(
@@ -594,6 +610,21 @@ class FeatureChainParser:
         return frozenset(compiled.groupindex), compiled.groups
 
     @classmethod
+    def _flatten_patterns(cls, patterns: list[Any]) -> list[Any]:
+        """Flatten one level so a list/tuple pattern attribute contributes its elements as concrete patterns.
+
+        Mirrors how a ``SUFFIX_PATTERN = [regex]`` fixture passes the list straight to ``parse_name`` at
+        runtime. A compiled ``re.Pattern`` and a ``str`` stay as-is.
+        """
+        flattened: list[Any] = []
+        for pattern in patterns:
+            if isinstance(pattern, (list, tuple)):
+                flattened.extend(pattern)
+            else:
+                flattened.append(pattern)
+        return flattened
+
+    @classmethod
     def _str_reachable_values(cls, spec: PropertySpec) -> set[str]:
         """The str members of a spec's value space; only a str can be reverse-looked-up from a capture."""
         reachable: set[str] = set()
@@ -606,10 +637,13 @@ class FeatureChainParser:
     def validate_name_binding(cls, owner: type[Any]) -> None:
         """Reject an order-dependent legacy positional binding at class-definition time.
 
-        Fires only when the class relies on the legacy fallback: it declares a capture group, no
-        pattern declares a named group, and two keys share a reachable (str) allowed value. Named
-        captures make binding explicit, so they are exempt; a captureless pattern has nothing to
-        misbind. Called from both FeatureGroup and FeatureChainParserMixin at class definition.
+        The check is PER CONCRETE PATTERN: a list/tuple pattern attribute is flattened to its
+        elements first. A pattern needs the overlap check only when it declares a capture group
+        (``total >= 1``) AND no named group, so it relies on the legacy positional fallback. If any
+        such positional-only pattern exists and two keys share a reachable (str) allowed value, the
+        binding is order-dependent and rejected. A named-capture pattern is exempt (binding is
+        explicit for it); a captureless one has nothing to misbind. Called from both FeatureGroup and
+        FeatureChainParserMixin at class definition.
         """
         property_mapping = getattr(owner, "PROPERTY_MAPPING", None)
         if not isinstance(property_mapping, dict):
@@ -619,14 +653,13 @@ class FeatureChainParser:
         if not patterns:
             return
 
-        has_capture_group = False
-        declares_named = False
-        for pattern in patterns:
+        needs_overlap_check = False
+        for pattern in cls._flatten_patterns(patterns):
             named, total = cls._pattern_named_and_total_groups(pattern)
-            has_capture_group = has_capture_group or total >= 1
-            declares_named = declares_named or bool(named)
+            if total >= 1 and not named:
+                needs_overlap_check = True
 
-        if not has_capture_group or declares_named:
+        if not needs_overlap_check:
             return
 
         reachable = {

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -246,11 +246,16 @@ class FeatureChainParserMixin:
         effective_options = options
         if result:
             parsed = FeatureChainParser.parse_name(feature_name, prefix_patterns, CHAIN_SEPARATOR)
-            operation_config = FeatureChainParser._legacy_operation_config(parsed) if parsed.matched else None
-            if operation_config is not None and parsed.source_feature is not None:
-                if not cls._validate_string_match(feature_name, operation_config, parsed.source_feature):
-                    return False
+            if FeatureChainParser._name_identifies_group(parsed, property_mapping):
+                # Bound once and reused: the merge and the guards must see the name-derived value even
+                # when the legacy operation value is absent (a named-optional-first pattern).
                 bindings = FeatureChainParser.bind_name_captures(parsed, property_mapping or {})
+                operation_config = FeatureChainParser._legacy_operation_config(parsed)
+                # _validate_string_match needs a str operation, so it stays behind its own gate; the
+                # merge and forwarded-mismatch protection do not.
+                if operation_config is not None and parsed.source_feature is not None:
+                    if not cls._validate_string_match(feature_name, operation_config, parsed.source_feature):
+                        return False
                 effective_options = FeatureChainParser._merge_bindings(options, bindings, property_mapping)
                 cls._validate_forwarded_name_mismatch(feature_name, bindings, options)
 
@@ -310,7 +315,7 @@ class FeatureChainParserMixin:
                 parsed = FeatureChainParser.parse_name(feature_name, prefix_patterns, CHAIN_SEPARATOR)
             except ValueError:
                 return None
-            name_matched = parsed.matched
+            name_matched = FeatureChainParser._name_identifies_group(parsed, property_mapping)
             if name_matched:
                 bindings = FeatureChainParser.bind_name_captures(parsed, property_mapping)
                 effective_options = FeatureChainParser._merge_bindings(options, bindings, property_mapping)

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -116,6 +116,7 @@ class FeatureChainParserMixin:
         # The mixin sits first in the MRO of ``class X(FeatureChainParserMixin, FeatureGroup)``,
         # so super() is what lets FeatureGroup's own class-definition validation still run.
         super().__init_subclass__(**kwargs)
+        FeatureChainParser.validate_name_binding(cls)
         FeatureChainParser.install_required_when_guard(cls)
 
     @classmethod
@@ -239,17 +240,21 @@ class FeatureChainParserMixin:
 
         result = cls.match_parser_criteria(feature_name, options)
 
-        # If basic match succeeded and it's a string-based feature, call validation hook
+        # On a string match the guards see the EFFECTIVE options (name-derived bindings merged in), so a
+        # name-carried value is as visible to match_guard as an explicit one. A no-source ValueError cannot
+        # reach here: it would already have made match_parser_criteria a non-match.
+        effective_options = options
         if result:
-            operation_config, source_feature = FeatureChainParser.parse_feature_name(
-                feature_name, prefix_patterns, CHAIN_SEPARATOR
-            )
-            if operation_config is not None and source_feature is not None:
-                if not cls._validate_string_match(feature_name, operation_config, source_feature):
+            parsed = FeatureChainParser.parse_name(feature_name, prefix_patterns, CHAIN_SEPARATOR)
+            operation_config = FeatureChainParser._legacy_operation_config(parsed) if parsed.matched else None
+            if operation_config is not None and parsed.source_feature is not None:
+                if not cls._validate_string_match(feature_name, operation_config, parsed.source_feature):
                     return False
-                cls._validate_forwarded_name_mismatch(feature_name, operation_config, property_mapping, options)
+                bindings = FeatureChainParser.bind_name_captures(parsed, property_mapping or {})
+                effective_options = FeatureChainParser._merge_bindings(options, bindings, property_mapping)
+                cls._validate_forwarded_name_mismatch(feature_name, bindings, options)
 
-        if not cls._validate_match_guards(result, options, property_mapping):
+        if not cls._validate_match_guards(result, effective_options, property_mapping):
             return False
 
         if not cls._validate_in_features(result, options):
@@ -298,20 +303,24 @@ class FeatureChainParserMixin:
             return None
 
         name_matched = False
+        effective_options = options
         prefix_patterns = cls._get_prefix_patterns()
         if prefix_patterns:
             try:
-                name_matched = FeatureChainParser._match_pattern_based_feature(
-                    feature_name, prefix_patterns, CHAIN_SEPARATOR
-                )
+                parsed = FeatureChainParser.parse_name(feature_name, prefix_patterns, CHAIN_SEPARATOR)
             except ValueError:
                 return None
+            name_matched = parsed.matched
+            if name_matched:
+                bindings = FeatureChainParser.bind_name_captures(parsed, property_mapping)
+                effective_options = FeatureChainParser._merge_bindings(options, bindings, property_mapping)
 
         try:
             if name_matched:
-                # The name relates the feature group to the feature, so only the values of the
-                # present options are judged; required presence is the config path's business.
-                FeatureChainParser._validate_present_option_values(options, property_mapping)
+                # The name relates the feature group to the feature, so only the values of the present
+                # options (name-derived bindings included) are judged; required presence is the config
+                # path's business. Judging the effective options keeps the replay in step with the match.
+                FeatureChainParser._validate_present_option_values(effective_options, property_mapping)
             else:
                 matches_mapping = FeatureChainParser._validate_options_against_property_mapping(
                     options, property_mapping
@@ -323,7 +332,7 @@ class FeatureChainParserMixin:
         except ValueError as exc:
             return str(exc)
 
-        rejection = cls._first_rejecting_guard(options, property_mapping)
+        rejection = cls._first_rejecting_guard(effective_options, property_mapping)
         if rejection is None:
             return None
 
@@ -336,50 +345,40 @@ class FeatureChainParserMixin:
     def _validate_forwarded_name_mismatch(
         cls,
         feature_name: str | FeatureName,
-        operation_config: str,
-        property_mapping: dict[str, PropertySpec] | None,
+        bindings: dict[str, str],
         options: Options,
     ) -> None:
-        """Reject consumer-forwarded option values that contradict the name-parsed value.
+        """Reject consumer-forwarded option values that contradict a name-derived binding.
 
-        The name-parsed value takes precedence, so a differing forwarded value would be
-        silently ignored. Raises ValueError unless MLODA_ALLOW_FORWARDED_NAME_MISMATCH
-        downgrades the error to a warning.
+        Iterates every binding, so a secondary capture is protected exactly like the first one. The
+        name-parsed value takes precedence, so a differing forwarded value would be silently ignored.
+        Raises ValueError unless MLODA_ALLOW_FORWARDED_NAME_MISMATCH downgrades the error to a warning.
         """
-        if property_mapping is None or not options.inherited_group_keys:
+        if not options.inherited_group_keys or not bindings:
             return
-        prop_key = cls._find_property_key_for_value(property_mapping, operation_config)
-        if prop_key is None or prop_key not in options.inherited_group_keys:
-            return
-        inherited_value = options.get(prop_key)
-        if inherited_value is None:
-            return
-        # A singleton collection equals its sole element, exactly as _unpack_property_value treats it
-        # everywhere else; only a differing or multi-value forward is a real mismatch.
-        unpacked = FeatureChainParser._unpack_property_value(inherited_value)
-        if len(unpacked) == 1 and str(unpacked[0]) == operation_config:
-            return
-        message = (
-            f"Feature '{feature_name}': option '{prop_key}' was forwarded from a consumer with value "
-            f"'{inherited_value}', but the feature name parses to '{operation_config}'. The name-parsed value "
-            f"takes precedence, so the forwarded value would be silently ignored. Carve the key out with "
-            f"forward_group_exclude={{'{prop_key}'}} on the child in the consumer's input_features, or use an "
-            f"allowlist / forward_group=False. Set MLODA_ALLOW_FORWARDED_NAME_MISMATCH=1 to downgrade this "
-            f"error to a warning."
-        )
-        if os.environ.get("MLODA_ALLOW_FORWARDED_NAME_MISMATCH", "").lower() in ("1", "true"):
-            logger.warning(message)
-            return
-        raise ValueError(message)
-
-    @staticmethod
-    def _find_property_key_for_value(property_mapping: dict[str, PropertySpec], operation_config: str) -> str | None:
-        """Return the PROPERTY_MAPPING key whose values contain operation_config, if any."""
-        for prop_key, prop_value in property_mapping.items():
-            extracted = FeatureChainParser._extract_property_values(prop_value)
-            if operation_config in extracted:
-                return prop_key
-        return None
+        for prop_key, name_value in bindings.items():
+            if prop_key not in options.inherited_group_keys:
+                continue
+            inherited_value = options.get(prop_key)
+            if inherited_value is None:
+                continue
+            # A singleton collection equals its sole element, exactly as _unpack_property_value treats it
+            # everywhere else; only a differing or multi-value forward is a real mismatch.
+            unpacked = FeatureChainParser._unpack_property_value(inherited_value)
+            if len(unpacked) == 1 and str(unpacked[0]) == name_value:
+                continue
+            message = (
+                f"Feature '{feature_name}': option '{prop_key}' was forwarded from a consumer with value "
+                f"'{inherited_value}', but the feature name parses to '{name_value}'. The name-parsed value "
+                f"takes precedence, so the forwarded value would be silently ignored. Carve the key out with "
+                f"forward_group_exclude={{'{prop_key}'}} on the child in the consumer's input_features, or use an "
+                f"allowlist / forward_group=False. Set MLODA_ALLOW_FORWARDED_NAME_MISMATCH=1 to downgrade this "
+                f"error to a warning."
+            )
+            if os.environ.get("MLODA_ALLOW_FORWARDED_NAME_MISMATCH", "").lower() in ("1", "true"):
+                logger.warning(message)
+                continue
+            raise ValueError(message)
 
     @classmethod
     def _first_rejecting_guard(

--- a/mloda/core/abstract_plugins/components/feature_chainer/parsed_feature_name.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/parsed_feature_name.py
@@ -1,0 +1,28 @@
+"""The parse of a feature name as immutable facts (issue #770)."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class ParsedFeatureName:
+    """A frozen record of what parsing a feature name found, mirroring what ``re`` reports.
+
+    A named group appears in BOTH ``named_captures`` and ``positional_captures``, exactly as
+    ``re.Match.groupdict()`` and ``re.Match.groups()`` do; a non-participating optional group is
+    ``None`` in both views. ``operation_part`` is the raw suffix text after the last separator, never
+    a fabricated operation token.
+    """
+
+    matched: bool
+    source_feature: str | None = None
+    operation_part: str | None = None
+    named_captures: Mapping[str, str | None] = field(default_factory=dict)
+    positional_captures: tuple[str | None, ...] = ()
+
+    @classmethod
+    def no_match(cls) -> "ParsedFeatureName":
+        """The miss case: no pattern matched, so there are no facts."""
+        return cls(matched=False)

--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -90,6 +90,7 @@ class FeatureGroup(ABC):
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
         FeatureChainParser.validate_property_mapping_defaults(cls.__name__, cls.PROPERTY_MAPPING)
+        FeatureChainParser.validate_name_binding(cls)
         FeatureChainParser.install_required_when_guard(cls)
         cls._validate_subtype_declaration()
 

--- a/mloda/provider/__init__.py
+++ b/mloda/provider/__init__.py
@@ -72,6 +72,7 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
     INPUT_SEPARATOR,
 )
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
+from mloda.core.abstract_plugins.components.feature_chainer.parsed_feature_name import ParsedFeatureName
 from mloda.core.abstract_plugins.components.feature_chainer.property_spec import (
     NO_DEFAULT,
     PropertySpec,
@@ -141,6 +142,7 @@ __all__ = [
     "COLUMN_SEPARATOR",
     "INPUT_SEPARATOR",
     "FeatureChainParserMixin",
+    "ParsedFeatureName",
     "PropertySpec",
     "property_spec",
     "NO_DEFAULT",

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_parsed_name_bindings.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_parsed_name_bindings.py
@@ -1,0 +1,658 @@
+"""Structured parsed-name bindings for PROPERTY_MAPPING (issue #770).
+
+``parse_name`` returns the parse as FACTS (``ParsedFeatureName``), and ``bind_name_captures`` turns those
+facts into PROPERTY_MAPPING bindings by NAME instead of by a reverse allowed_values lookup. That makes a
+secondary capture and an element_validator-only spec reachable from the feature name.
+
+All fixture names carry a "pnb770" marker so they cannot collide with other tests in the global registry.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import re
+from typing import Any
+
+import pytest
+
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
+from mloda.core.abstract_plugins.components.feature_chainer.parsed_feature_name import ParsedFeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.provider import PropertySpec
+from mloda_plugins.feature_group.experimental.aggregated_feature_group.base import AggregatedFeatureGroup
+from mloda_plugins.feature_group.experimental.sklearn.scaling.base import ScalingFeatureGroup
+from mloda_plugins.feature_group.experimental.text_cleaning.base import TextCleaningFeatureGroup
+
+
+ALGORITHM_KEY = "algorithm_pnb770"
+SIZE_KEY = "size_pnb770"
+SOLVER_KEY = "solver_pnb770"
+NOTES_KEY = "notes_pnb770"
+
+ALGORITHMS = {"pca": "PCA", "tsne": "t-SNE"}
+
+
+def _is_digit_string(value: Any) -> bool:
+    """Accept a non-empty digit string, the shape a regex capture yields."""
+    return isinstance(value, str) and value.isdigit()
+
+
+def _rejects_tsne(value: Any) -> bool:
+    """match_guard: everything but tsne passes."""
+    return bool(value != "tsne")
+
+
+def _needs_notes(options: Options) -> bool:
+    """required_when: notes is required once the name carries size 3."""
+    return bool(options.get(SIZE_KEY) == "3")
+
+
+def _algorithm_spec(**overrides: Any) -> PropertySpec:
+    """A strict allowed_values spec for the algorithm key."""
+    kwargs: dict[str, Any] = {
+        "allowed_values": ALGORITHMS,
+        "context": True,
+        "strict_validation": True,
+    }
+    kwargs.update(overrides)
+    return PropertySpec("Algorithm of the pnb770 fixture", **kwargs)
+
+
+def _size_spec() -> PropertySpec:
+    """An element_validator-only spec: it declares NO allowed_values, so no reverse lookup can reach it."""
+    return PropertySpec(
+        "Size of the pnb770 fixture",
+        context=True,
+        strict_validation=True,
+        element_validator=_is_digit_string,
+    )
+
+
+class NamedCaptureGroup(FeatureChainParserMixin):
+    """Two named captures: algorithm has a value space, size has only an element_validator."""
+
+    PREFIX_PATTERN = rf".*__(?P<{ALGORITHM_KEY}>pca|tsne)_(?P<{SIZE_KEY}>\d+)d_pnb770$"
+
+    PROPERTY_MAPPING: dict[str, PropertySpec] = {
+        ALGORITHM_KEY: _algorithm_spec(),
+        SIZE_KEY: _size_spec(),
+    }
+
+
+class OptionalCaptureGroup(FeatureChainParserMixin):
+    """The size group is optional, so it may not participate in a match."""
+
+    PREFIX_PATTERN = rf".*__(?P<{ALGORITHM_KEY}>pca|tsne)(?:_(?P<{SIZE_KEY}>\d+)d)?_optional_pnb770$"
+
+    PROPERTY_MAPPING: dict[str, PropertySpec] = {
+        ALGORITHM_KEY: _algorithm_spec(),
+        SIZE_KEY: _size_spec(),
+    }
+
+
+class UnmappedNamedCaptureGroup(FeatureChainParserMixin):
+    """A named capture that is no mapping key, whose VALUE would satisfy the legacy reverse lookup."""
+
+    PREFIX_PATTERN = r".*__(?P<unmapped_pnb770>pca|tsne)_unmapped_pnb770$"
+
+    PROPERTY_MAPPING: dict[str, PropertySpec] = {ALGORITHM_KEY: _algorithm_spec()}
+
+
+class LegacyPositionalGroup(FeatureChainParserMixin):
+    """No named capture at all: the legacy allowed_values fallback still binds group 1."""
+
+    PREFIX_PATTERN = r".*__(pca|tsne)_legacy_pnb770$"
+
+    PROPERTY_MAPPING: dict[str, PropertySpec] = {
+        ALGORITHM_KEY: _algorithm_spec(),
+        NOTES_KEY: PropertySpec("Free text, no value space", context=True, strict_validation=False, default=""),
+    }
+
+
+class RequiredWhenNamedGroup(FeatureChainParserMixin):
+    """The SECONDARY capture drives a required_when predicate."""
+
+    PREFIX_PATTERN = rf".*__(?P<{ALGORITHM_KEY}>pca|tsne)_(?P<{SIZE_KEY}>\d+)d_reqwhen_pnb770$"
+
+    PROPERTY_MAPPING: dict[str, PropertySpec] = {
+        ALGORITHM_KEY: _algorithm_spec(),
+        SIZE_KEY: _size_spec(),
+        NOTES_KEY: PropertySpec("Notes", context=True, strict_validation=False, required_when=_needs_notes),
+    }
+
+
+class GuardedNamedGroup(FeatureChainParserMixin):
+    """A match_guard on a key the feature name carries."""
+
+    PREFIX_PATTERN = rf".*__(?P<{ALGORITHM_KEY}>pca|tsne)_guard_pnb770$"
+
+    PROPERTY_MAPPING: dict[str, PropertySpec] = {
+        ALGORITHM_KEY: _algorithm_spec(strict_validation=False, match_guard=_rejects_tsne)
+    }
+
+
+class StrictNamedGroup(FeatureChainParserMixin):
+    """The capture is wider than the value space, so the name can carry a rejected value."""
+
+    PREFIX_PATTERN = rf".*__(?P<{ALGORITHM_KEY}>\w+)_strict_pnb770$"
+
+    PROPERTY_MAPPING: dict[str, PropertySpec] = {ALGORITHM_KEY: _algorithm_spec()}
+
+
+class ForwardedSecondaryGroup(FeatureChainParserMixin):
+    """Both keys are group-categorized (context=False): only group options flow through forwarding."""
+
+    PREFIX_PATTERN = rf".*__(?P<{ALGORITHM_KEY}>pca|tsne)_(?P<{SOLVER_KEY}>auto|arpack)_fwd_pnb770$"
+
+    PROPERTY_MAPPING: dict[str, PropertySpec] = {
+        ALGORITHM_KEY: _algorithm_spec(context=False),
+        SOLVER_KEY: PropertySpec(
+            "Solver of the pnb770 fixture",
+            allowed_values={"auto": "Auto", "arpack": "ARPACK"},
+            context=False,
+            strict_validation=True,
+        ),
+    }
+
+
+FORWARDED_FEATURE_NAME = "sales__pca_auto_fwd_pnb770"
+
+
+def _inherited_child_options(consumer_group: dict[str, Any]) -> Options:
+    """Build child options exactly like the engine does: inherit_from the consumer."""
+    child_options = Options()
+    child_options.inherit_from(Options(group=consumer_group))
+    return child_options
+
+
+class TestParsedFeatureNameShape:
+    """The parse result is a frozen record of facts, mirroring what ``re`` reports."""
+
+    def test_fields_carry_the_parse(self) -> None:
+        """matched, source_feature, operation_part, named_captures and positional_captures are the shape."""
+        parsed = FeatureChainParser.parse_name("f0__pca_2d_pnb770", [NamedCaptureGroup.PREFIX_PATTERN])
+
+        assert parsed.matched is True
+        assert parsed.source_feature == "f0"
+        assert parsed.operation_part == "pca_2d_pnb770"
+        assert parsed.named_captures == {ALGORITHM_KEY: "pca", SIZE_KEY: "2"}
+        assert parsed.positional_captures == ("pca", "2")
+
+    def test_result_is_frozen(self) -> None:
+        """The parse is a fact, so it cannot be rewritten after the fact."""
+        parsed = ParsedFeatureName(matched=True, source_feature="f0", operation_part="pca_2d_pnb770")
+
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            setattr(parsed, "matched", False)
+
+    def test_defaults_describe_a_captureless_miss(self) -> None:
+        """Only ``matched`` has no default; everything else defaults to empty."""
+        parsed = ParsedFeatureName(matched=False)
+
+        assert parsed.source_feature is None
+        assert parsed.operation_part is None
+        assert parsed.named_captures == {}
+        assert parsed.positional_captures == ()
+
+    def test_named_capture_appears_in_both_capture_views(self) -> None:
+        """A named group is reported by name AND by position, exactly as ``re`` does."""
+        pattern = NamedCaptureGroup.PREFIX_PATTERN
+        parsed = FeatureChainParser.parse_name("f0__tsne_7d_pnb770", [pattern])
+        match = re.match(pattern, "f0__tsne_7d_pnb770")
+
+        assert match is not None
+        assert parsed.named_captures == match.groupdict()
+        assert parsed.positional_captures == match.groups()
+
+    def test_non_participating_optional_group_is_none_in_both_views(self) -> None:
+        """An optional group that did not participate is None by name and by position."""
+        parsed = FeatureChainParser.parse_name("f0__pca_optional_pnb770", [OptionalCaptureGroup.PREFIX_PATTERN])
+
+        assert parsed.matched is True
+        assert parsed.named_captures == {ALGORITHM_KEY: "pca", SIZE_KEY: None}
+        assert parsed.positional_captures == ("pca", None)
+
+
+class TestParseName:
+    """parse_name keeps today's matching semantics and fabricates nothing."""
+
+    def test_no_pattern_match_is_a_miss(self) -> None:
+        """A name no pattern matches yields matched=False and no facts."""
+        parsed = FeatureChainParser.parse_name("unrelated_pnb770", [NamedCaptureGroup.PREFIX_PATTERN])
+
+        assert parsed.matched is False
+        assert parsed.source_feature is None
+        assert parsed.named_captures == {}
+        assert parsed.positional_captures == ()
+
+    def test_pattern_match_without_source_feature_raises(self) -> None:
+        """A matched name with nothing before the separator still raises today's ValueError."""
+        with pytest.raises(ValueError, match="but has no source feature: orphan_pnb770_thing"):
+            FeatureChainParser.parse_name("orphan_pnb770_thing", [r"^orphan_pnb770_(\w+)$"])
+
+    def test_captureless_match_has_no_captures(self) -> None:
+        """A captureless pattern matches with zero captures of either kind."""
+        parsed = FeatureChainParser.parse_name("x__cleaned_text", [r".*__cleaned_text$"])
+
+        assert parsed.matched is True
+        assert parsed.source_feature == "x"
+        assert parsed.named_captures == {}
+        assert parsed.positional_captures == ()
+
+    def test_captureless_match_carries_the_raw_suffix_not_a_fabricated_token(self) -> None:
+        """operation_part is the raw text after the separator; the legacy 'cleaned' token is nowhere."""
+        parsed = FeatureChainParser.parse_name("x__cleaned_text", [r".*__cleaned_text$"])
+
+        assert parsed.operation_part == "cleaned_text"
+        assert "cleaned" not in dataclasses.asdict(parsed).values()
+
+
+class TestLegacyParseFeatureNameAdapter:
+    """parse_feature_name keeps returning exactly today's tuples: it is public API."""
+
+    def test_positional_capture_tuple_unchanged(self) -> None:
+        """Group 1 plus the source feature, as always."""
+        assert FeatureChainParser.parse_feature_name(
+            "f0__pca_legacy_pnb770", [LegacyPositionalGroup.PREFIX_PATTERN]
+        ) == (
+            "pca",
+            "f0",
+        )
+
+    def test_named_capture_tuple_uses_the_first_group(self) -> None:
+        """A named group is group 1 too, so the legacy tuple is unchanged."""
+        assert FeatureChainParser.parse_feature_name("f0__pca_2d_pnb770", [NamedCaptureGroup.PREFIX_PATTERN]) == (
+            "pca",
+            "f0",
+        )
+
+    def test_captureless_fabrication_unchanged(self) -> None:
+        """A captureless pattern still fabricates the first underscore-token of the suffix (#772 retires it)."""
+        assert FeatureChainParser.parse_feature_name("x__cleaned_text", [r".*__cleaned_text$"]) == ("cleaned", "x")
+
+    def test_miss_tuple_unchanged(self) -> None:
+        """No pattern match is still (None, None)."""
+        assert FeatureChainParser.parse_feature_name("unrelated_pnb770", [NamedCaptureGroup.PREFIX_PATTERN]) == (
+            None,
+            None,
+        )
+
+    def test_no_source_feature_valueerror_unchanged(self) -> None:
+        """match_parser_criteria depends on this raise, so the adapter must not swallow it."""
+        with pytest.raises(ValueError, match="but has no source feature: orphan_pnb770_thing"):
+            FeatureChainParser.parse_feature_name("orphan_pnb770_thing", [r"^orphan_pnb770_(\w+)$"])
+
+
+class TestBindNameCaptures:
+    """Binding is by name, deterministic, and documented: no first-matching-allowed_values search."""
+
+    def test_named_capture_binds_to_the_same_named_key(self) -> None:
+        """A named capture binds to the PROPERTY_MAPPING key of the same name."""
+        parsed = FeatureChainParser.parse_name("f0__pca_2d_pnb770", [NamedCaptureGroup.PREFIX_PATTERN])
+
+        bindings = FeatureChainParser.bind_name_captures(parsed, NamedCaptureGroup.PROPERTY_MAPPING)
+
+        assert bindings[ALGORITHM_KEY] == "pca"
+
+    def test_named_capture_binds_to_element_validator_only_spec(self) -> None:
+        """The core fix: a spec with NO allowed_values receives a name-derived value."""
+        parsed = FeatureChainParser.parse_name("f0__pca_2d_pnb770", [NamedCaptureGroup.PREFIX_PATTERN])
+
+        bindings = FeatureChainParser.bind_name_captures(parsed, NamedCaptureGroup.PROPERTY_MAPPING)
+
+        assert bindings[SIZE_KEY] == "2"
+
+    def test_multiple_named_captures_bind_to_separate_keys(self) -> None:
+        """Every capture reaches its own key, not just the first one."""
+        parsed = FeatureChainParser.parse_name("f0__tsne_7d_pnb770", [NamedCaptureGroup.PREFIX_PATTERN])
+
+        bindings = FeatureChainParser.bind_name_captures(parsed, NamedCaptureGroup.PROPERTY_MAPPING)
+
+        assert bindings == {ALGORITHM_KEY: "tsne", SIZE_KEY: "7"}
+
+    def test_named_capture_that_is_no_mapping_key_is_ignored(self) -> None:
+        """Patterns may use named groups for other purposes, so an unmapped name binds nothing."""
+        parsed = FeatureChainParser.parse_name("f0__pca_unmapped_pnb770", [UnmappedNamedCaptureGroup.PREFIX_PATTERN])
+
+        bindings = FeatureChainParser.bind_name_captures(parsed, UnmappedNamedCaptureGroup.PROPERTY_MAPPING)
+
+        assert bindings == {}
+
+    def test_named_pattern_never_falls_back_to_the_reverse_lookup(self) -> None:
+        """'pca' is in algorithm's allowed_values, but a named pattern binds by name ONLY."""
+        parsed = FeatureChainParser.parse_name("f0__pca_unmapped_pnb770", [UnmappedNamedCaptureGroup.PREFIX_PATTERN])
+
+        bindings = FeatureChainParser.bind_name_captures(parsed, UnmappedNamedCaptureGroup.PROPERTY_MAPPING)
+
+        assert ALGORITHM_KEY not in bindings
+
+    def test_non_participating_named_capture_binds_nothing(self) -> None:
+        """A None capture has no value to bind."""
+        parsed = FeatureChainParser.parse_name("f0__pca_optional_pnb770", [OptionalCaptureGroup.PREFIX_PATTERN])
+
+        bindings = FeatureChainParser.bind_name_captures(parsed, OptionalCaptureGroup.PROPERTY_MAPPING)
+
+        assert bindings == {ALGORITHM_KEY: "pca"}
+
+    def test_legacy_positional_fallback_binds_group_one(self) -> None:
+        """With no named capture anywhere, group 1 still binds via allowed_values membership."""
+        parsed = FeatureChainParser.parse_name("f0__pca_legacy_pnb770", [LegacyPositionalGroup.PREFIX_PATTERN])
+
+        bindings = FeatureChainParser.bind_name_captures(parsed, LegacyPositionalGroup.PROPERTY_MAPPING)
+
+        assert bindings == {ALGORITHM_KEY: "pca"}
+
+    def test_legacy_fallback_binds_nothing_when_no_value_space_contains_the_value(self) -> None:
+        """The fallback only ever binds a value that is already a member of an allowed_values."""
+        parsed = FeatureChainParser.parse_name("f0__bogus_strict_pnb770", [r".*__(\w+)_strict_pnb770$"])
+
+        bindings = FeatureChainParser.bind_name_captures(parsed, LegacyPositionalGroup.PROPERTY_MAPPING)
+
+        assert bindings == {}
+
+    def test_miss_binds_nothing(self) -> None:
+        """An unmatched name has no captures to bind."""
+        parsed = FeatureChainParser.parse_name("unrelated_pnb770", [NamedCaptureGroup.PREFIX_PATTERN])
+
+        assert FeatureChainParser.bind_name_captures(parsed, NamedCaptureGroup.PROPERTY_MAPPING) == {}
+
+
+class TestDefinitionTimeAmbiguity:
+    """Legacy positional binding over intersecting value spaces is order-dependent: reject it at definition."""
+
+    def test_positional_capture_with_overlapping_value_spaces_raises(self) -> None:
+        """Two keys reachable by the same captured string make the binding a guess."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class _OverlappingPositionalPnb770(FeatureChainParserMixin):
+                PREFIX_PATTERN = r".*__(\w+)_overlap_pnb770$"
+                PROPERTY_MAPPING = {
+                    ALGORITHM_KEY: PropertySpec("a", allowed_values=("pca", "shared_pnb770")),
+                    SOLVER_KEY: PropertySpec("b", allowed_values=("shared_pnb770", "auto")),
+                }
+
+        message = str(exc_info.value)
+        assert "_OverlappingPositionalPnb770" in message
+        assert ALGORITHM_KEY in message
+        assert SOLVER_KEY in message
+        assert "shared_pnb770" in message
+        assert "(?P<" in message
+
+    def test_feature_group_definition_is_validated_too(self) -> None:
+        """The check runs from FeatureGroup.__init_subclass__, not only from the mixin."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class _OverlappingFeatureGroupPnb770(FeatureGroup):
+                PREFIX_PATTERN = r".*__(\w+)_overlapfg_pnb770$"
+                PROPERTY_MAPPING = {
+                    ALGORITHM_KEY: PropertySpec("a", allowed_values=("pca", "shared_pnb770")),
+                    SOLVER_KEY: PropertySpec("b", allowed_values=("shared_pnb770", "auto")),
+                }
+
+        assert "shared_pnb770" in str(exc_info.value)
+
+    def test_named_captures_make_the_same_overlap_unambiguous(self) -> None:
+        """Named binding is explicit, so intersecting value spaces are no problem at all."""
+
+        class _OverlappingNamedPnb770(FeatureChainParserMixin):
+            PREFIX_PATTERN = rf".*__(?P<{ALGORITHM_KEY}>\w+)_(?P<{SOLVER_KEY}>\w+)_named_pnb770$"
+            PROPERTY_MAPPING = {
+                ALGORITHM_KEY: PropertySpec("a", allowed_values=("pca", "shared_pnb770")),
+                SOLVER_KEY: PropertySpec("b", allowed_values=("shared_pnb770", "auto")),
+            }
+
+        parsed = FeatureChainParser.parse_name(
+            "f0__shared_pnb770_auto_named_pnb770", [_OverlappingNamedPnb770.PREFIX_PATTERN]
+        )
+        bindings = FeatureChainParser.bind_name_captures(parsed, _OverlappingNamedPnb770.PROPERTY_MAPPING)
+
+        assert bindings == {ALGORITHM_KEY: "shared_pnb770", SOLVER_KEY: "auto"}
+
+    def test_non_str_overlap_does_not_raise(self) -> None:
+        """A capture is always a str, so a non-str member is unreachable and cannot be ambiguous."""
+
+        class _NonStrOverlapPnb770(FeatureChainParserMixin):
+            PREFIX_PATTERN = r".*__(\w+)_nonstr_pnb770$"
+            PROPERTY_MAPPING = {
+                ALGORITHM_KEY: PropertySpec("a", allowed_values=(1, 2)),
+                SOLVER_KEY: PropertySpec("b", allowed_values=(2, 3)),
+            }
+
+        assert _NonStrOverlapPnb770.PREFIX_PATTERN.endswith("_nonstr_pnb770$")
+
+    def test_captureless_pattern_with_overlap_does_not_raise(self) -> None:
+        """With no capture group there is no value to misbind."""
+
+        class _CapturelessOverlapPnb770(FeatureChainParserMixin):
+            PREFIX_PATTERN = r".*__captureless_pnb770$"
+            PROPERTY_MAPPING = {
+                ALGORITHM_KEY: PropertySpec("a", allowed_values=("shared_pnb770",)),
+                SOLVER_KEY: PropertySpec("b", allowed_values=("shared_pnb770",)),
+            }
+
+        assert _CapturelessOverlapPnb770.PREFIX_PATTERN.endswith("__captureless_pnb770$")
+
+    def test_uncompilable_pattern_does_not_break_class_definition(self) -> None:
+        """A pattern this check cannot compile is treated as declaring no named group, never a definition crash."""
+
+        class _BrokenPatternPnb770(FeatureChainParserMixin):
+            PREFIX_PATTERN = r".*__([unclosed_pnb770$"
+            PROPERTY_MAPPING = {ALGORITHM_KEY: _algorithm_spec()}
+
+        assert _BrokenPatternPnb770.PROPERTY_MAPPING[ALGORITHM_KEY].strict_validation is True
+
+
+class TestBuildEffectiveOptions:
+    """Every binding is merged at once, and nothing to merge means the very same object back."""
+
+    def test_all_bindings_are_merged(self) -> None:
+        """Merging no longer stops after the first key."""
+        effective = FeatureChainParser.build_effective_options(
+            "f0__pca_2d_pnb770",
+            [NamedCaptureGroup.PREFIX_PATTERN],
+            NamedCaptureGroup.PROPERTY_MAPPING,
+            Options(),
+        )
+
+        assert effective.get(ALGORITHM_KEY) == "pca"
+        assert effective.get(SIZE_KEY) == "2"
+
+    def test_present_option_wins_over_a_binding(self) -> None:
+        """An explicit option is never overwritten by a name-derived value."""
+        options = Options(context={ALGORITHM_KEY: "tsne"})
+
+        effective = FeatureChainParser.build_effective_options(
+            "f0__pca_2d_pnb770", [NamedCaptureGroup.PREFIX_PATTERN], NamedCaptureGroup.PROPERTY_MAPPING, options
+        )
+
+        assert effective.get(ALGORITHM_KEY) == "tsne"
+        assert effective.get(SIZE_KEY) == "2"
+
+    def test_nothing_to_merge_returns_the_same_object(self) -> None:
+        """Identity, not a copy: an unrelated name has nothing to contribute."""
+        options = Options(context={NOTES_KEY: "x"})
+
+        effective = FeatureChainParser.build_effective_options(
+            "unrelated_pnb770", [NamedCaptureGroup.PREFIX_PATTERN], NamedCaptureGroup.PROPERTY_MAPPING, options
+        )
+
+        assert effective is options
+
+    def test_unbindable_named_pattern_returns_the_same_object(self) -> None:
+        """A pattern whose named captures bind to nothing leaves the options untouched."""
+        options = Options()
+
+        effective = FeatureChainParser.build_effective_options(
+            "f0__pca_unmapped_pnb770",
+            [UnmappedNamedCaptureGroup.PREFIX_PATTERN],
+            UnmappedNamedCaptureGroup.PROPERTY_MAPPING,
+            options,
+        )
+
+        assert effective is options
+
+    def test_propagate_context_keys_survive_the_merge(self) -> None:
+        """Regression: the merged Options keeps the propagation contract of the original."""
+        options = Options(context={NOTES_KEY: "x"}, propagate_context_keys=frozenset({NOTES_KEY}))
+
+        effective = FeatureChainParser.build_effective_options(
+            "f0__pca_2d_pnb770", [NamedCaptureGroup.PREFIX_PATTERN], NamedCaptureGroup.PROPERTY_MAPPING, options
+        )
+
+        assert effective.propagate_context_keys == frozenset({NOTES_KEY})
+        assert effective.get(SIZE_KEY) == "2"
+
+
+class TestBoundValuesAreVisible:
+    """A name-bound value is a real value: required_when, match_guard and strict validation all see it."""
+
+    def test_required_when_sees_a_bound_secondary_capture(self) -> None:
+        """The predicate reads the size the name carries, so notes becomes required."""
+        result = RequiredWhenNamedGroup.match_feature_group_criteria("f0__pca_3d_reqwhen_pnb770", Options())
+
+        assert result is False
+
+    def test_required_when_satisfied_by_the_present_option(self) -> None:
+        """The same feature matches once the conditionally required option is there."""
+        result = RequiredWhenNamedGroup.match_feature_group_criteria(
+            "f0__pca_3d_reqwhen_pnb770", Options(context={NOTES_KEY: "n"})
+        )
+
+        assert result is True
+
+    def test_required_when_stays_off_when_the_bound_value_does_not_trigger_it(self) -> None:
+        """Guard against over-rejecting: a non-triggering bound value requires nothing."""
+        result = RequiredWhenNamedGroup.match_feature_group_criteria("f0__pca_2d_reqwhen_pnb770", Options())
+
+        assert result is True
+
+    def test_match_guard_sees_a_bound_value(self) -> None:
+        """A guard rejecting the name-carried value is a non-match."""
+        result = GuardedNamedGroup.match_feature_group_criteria("f0__tsne_guard_pnb770", Options())
+
+        assert result is False
+
+    def test_match_guard_accepts_a_bound_value_it_allows(self) -> None:
+        """The guard only rejects what it rejects."""
+        result = GuardedNamedGroup.match_feature_group_criteria("f0__pca_guard_pnb770", Options())
+
+        assert result is True
+
+    def test_strict_validation_sees_a_bound_value(self) -> None:
+        """A bound value outside the strict value space is a non-match."""
+        result = StrictNamedGroup.match_feature_group_criteria("f0__bogus_strict_pnb770", Options())
+
+        assert result is False
+
+    def test_strict_validation_accepts_a_bound_member(self) -> None:
+        """A bound member of the value space still matches."""
+        result = StrictNamedGroup.match_feature_group_criteria("f0__pca_strict_pnb770", Options())
+
+        assert result is True
+
+    def test_rejection_reason_reports_the_bound_value(self) -> None:
+        """The diagnostic replay must not disagree with the match decision."""
+        reason = StrictNamedGroup._strict_validation_rejection_reason("f0__bogus_strict_pnb770", Options())
+
+        assert reason is not None
+        assert ALGORITHM_KEY in reason
+        assert "bogus" in reason
+
+
+class TestForwardedMismatchOverBindings:
+    """Forwarded-mismatch protection covers every bound capture, not only group 1."""
+
+    def test_fixture_matches_without_options(self) -> None:
+        """Precondition: the fixture claims the chained name via string parsing."""
+        assert ForwardedSecondaryGroup.match_feature_group_criteria(FORWARDED_FEATURE_NAME, Options()) is True
+
+    def test_forwarded_secondary_capture_mismatch_raises(self) -> None:
+        """The solver key is bound by a SECONDARY capture, which today's single reverse lookup misses."""
+        child_options = _inherited_child_options({SOLVER_KEY: "arpack"})
+        assert child_options.inherited_group_keys == frozenset({SOLVER_KEY})  # precondition
+
+        with pytest.raises(ValueError) as exc_info:
+            ForwardedSecondaryGroup.match_feature_group_criteria(FORWARDED_FEATURE_NAME, child_options)
+
+        message = str(exc_info.value)
+        assert FORWARDED_FEATURE_NAME in message
+        assert SOLVER_KEY in message
+        assert "arpack" in message
+        assert "auto" in message
+        assert "forward_group_exclude" in message
+        assert "MLODA_ALLOW_FORWARDED_NAME_MISMATCH" in message
+
+    def test_forwarded_secondary_capture_equal_value_matches(self) -> None:
+        """An agreeing forwarded value is no mismatch."""
+        child_options = _inherited_child_options({SOLVER_KEY: "auto"})
+
+        assert ForwardedSecondaryGroup.match_feature_group_criteria(FORWARDED_FEATURE_NAME, child_options) is True
+
+    def test_forwarded_primary_capture_mismatch_still_raises(self) -> None:
+        """Group 1 keeps the protection it has today."""
+        child_options = _inherited_child_options({ALGORITHM_KEY: "tsne"})
+
+        with pytest.raises(ValueError, match="forward_group_exclude"):
+            ForwardedSecondaryGroup.match_feature_group_criteria(FORWARDED_FEATURE_NAME, child_options)
+
+    def test_forwarded_singleton_unwrap_still_applies_to_a_secondary_capture(self) -> None:
+        """#764 semantics: a forwarded singleton equals its sole element."""
+        child_options = _inherited_child_options({SOLVER_KEY: ["auto"]})
+
+        assert ForwardedSecondaryGroup.match_feature_group_criteria(FORWARDED_FEATURE_NAME, child_options) is True
+
+    def test_author_set_secondary_value_does_not_raise(self) -> None:
+        """Only FORWARDED values are protected; an author-set one keeps today's name precedence."""
+        child_options = Options(group={SOLVER_KEY: "arpack"})
+        assert child_options.inherited_group_keys == frozenset()  # precondition
+
+        assert ForwardedSecondaryGroup.match_feature_group_criteria(FORWARDED_FEATURE_NAME, child_options) is True
+
+    def test_env_var_downgrades_the_secondary_mismatch_to_a_warning(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The escape hatch covers the secondary capture too."""
+        monkeypatch.setenv("MLODA_ALLOW_FORWARDED_NAME_MISMATCH", "1")
+        child_options = _inherited_child_options({SOLVER_KEY: "arpack"})
+
+        with caplog.at_level(logging.WARNING):
+            result = ForwardedSecondaryGroup.match_feature_group_criteria(FORWARDED_FEATURE_NAME, child_options)
+
+        assert result is True
+        records = [record for record in caplog.records if SOLVER_KEY in record.getMessage()]
+        assert len(records) == 1
+
+
+class TestShippedPluginsUnchanged:
+    """Shipped PREFIX_PATTERNs stay positional and must parse byte-for-byte as before."""
+
+    def test_aggregated_feature_group_parses_unchanged(self) -> None:
+        """Group 1 is the aggregation type, everything before the separator is the source."""
+        parsed = FeatureChainParser.parse_feature_name("sales__sum_aggr", [AggregatedFeatureGroup.PREFIX_PATTERN])
+
+        assert parsed == ("sum", "sales")
+
+    def test_aggregated_feature_group_still_matches(self) -> None:
+        """The shipped matcher keeps claiming its chained name with no options at all."""
+        assert AggregatedFeatureGroup.match_feature_group_criteria("sales__sum_aggr", Options()) is True
+
+    def test_scaling_feature_group_parses_unchanged(self) -> None:
+        """The alternation capture is group 1, as before."""
+        parsed = FeatureChainParser.parse_feature_name("income__standard_scaled", [ScalingFeatureGroup.PREFIX_PATTERN])
+
+        assert parsed == ("standard", "income")
+
+    def test_scaling_feature_group_rejects_an_unknown_scaler(self) -> None:
+        """A value outside the alternation is still no match for the pattern."""
+        parsed = FeatureChainParser.parse_feature_name("income__bogus_scaled", [ScalingFeatureGroup.PREFIX_PATTERN])
+
+        assert parsed == (None, None)
+
+    def test_text_cleaning_feature_group_keeps_its_fabricated_token(self) -> None:
+        """The only captureless shipped pattern: the fabrication survives this PR (#772 retires it)."""
+        parsed = FeatureChainParser.parse_feature_name("text__cleaned_text", [TextCleaningFeatureGroup.PREFIX_PATTERN])
+
+        assert parsed == ("cleaned", "text")

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_parsed_name_bindings_review_fixes.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_parsed_name_bindings_review_fixes.py
@@ -1,0 +1,213 @@
+"""Regression tests for the #770 review fixes.
+
+FIX A unifies the "name string-identifies this group" predicate across the three match sites, so a
+named capture after an ABSENT optional first positional group is fully bound (guard, diagnostic,
+forwarded-mismatch), while a positional pattern that matches only via an absent optional first group
+keeps the pre-#770 required-presence rejection. FIX B makes the definition-time ambiguity guard
+per-pattern and flattens list-valued pattern attributes.
+
+Each corrected-behavior test fails against the committed code and passes once the fixes land. Fixture
+names carry an "rf770" marker so they cannot collide with the pnb770 fixtures or the registry.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
+from mloda.core.abstract_plugins.components.feature_chainer.property_spec import PropertySpec
+from mloda.core.abstract_plugins.components.options import Options
+
+
+SCALER_KEY = "scaler_rf770"
+OP_KEY = "op_rf770"
+KEY_A = "keya_rf770"
+KEY_B = "keyb_rf770"
+
+NAMED_GUARD_NAME = "standard__x_guard_rf770"
+NAMED_FWD_NAME = "standard__x_fwd_rf770"
+POSITIONAL_NAME = "x__op_rf770"
+
+
+def _rejects_standard(value: Any) -> bool:
+    """match_guard: every scaler but 'standard' passes."""
+    return bool(value != "standard")
+
+
+def _inherited_child_options(consumer_group: dict[str, Any]) -> Options:
+    """Build child options exactly like the engine does: inherit_from the consumer."""
+    child_options = Options()
+    child_options.inherit_from(Options(group=consumer_group))
+    return child_options
+
+
+class NamedOptionalFirstGuardedGroup(FeatureChainParserMixin):
+    """Named capture after an OPTIONAL first positional group, whose legacy positional value is None."""
+
+    PREFIX_PATTERN = rf"^(opt_)?(?P<{SCALER_KEY}>minmax|standard)__.+_guard_rf770$"
+
+    PROPERTY_MAPPING: dict[str, PropertySpec] = {
+        SCALER_KEY: PropertySpec(
+            "Scaler carried by a named capture; a guard rejects the 'standard' value",
+            allowed_values={"minmax", "standard"},
+            context=False,
+            strict_validation=True,
+            match_guard=_rejects_standard,
+        )
+    }
+
+
+class NamedOptionalFirstForwardedGroup(FeatureChainParserMixin):
+    """Same optional-first named shape, group-categorized so a forwarded value is protected."""
+
+    PREFIX_PATTERN = rf"^(opt_)?(?P<{SCALER_KEY}>minmax|standard)__.+_fwd_rf770$"
+
+    PROPERTY_MAPPING: dict[str, PropertySpec] = {
+        SCALER_KEY: PropertySpec(
+            "Scaler carried by a named capture, group-categorized for forwarding",
+            allowed_values={"minmax", "standard"},
+            context=False,
+            strict_validation=True,
+        )
+    }
+
+
+class PositionalOptionalFirstGroup(FeatureChainParserMixin):
+    """Positional pattern whose only capture is an absent optional first group; one required strict key."""
+
+    PREFIX_PATTERN = r".*__(foo_)?op_rf770$"
+
+    PROPERTY_MAPPING: dict[str, PropertySpec] = {
+        OP_KEY: PropertySpec(
+            "Required strict key that the name never carries",
+            allowed_values={"alpha", "beta"},
+            context=True,
+            strict_validation=True,
+        )
+    }
+
+
+class TestFixANamedOptionalFirst:
+    """A named capture identifies the group even when the legacy positional value is absent."""
+
+    def test_minmax_value_matches_without_options(self) -> None:
+        """Precondition: the fixture claims the chained name when the guard has nothing to reject."""
+        assert NamedOptionalFirstGuardedGroup.match_feature_group_criteria("minmax__x_guard_rf770", Options()) is True
+
+    def test_match_guard_sees_the_named_binding(self) -> None:
+        """The guard rejecting the name-carried scaler makes the match fail, though the legacy op is None."""
+        result = NamedOptionalFirstGuardedGroup.match_feature_group_criteria(NAMED_GUARD_NAME, Options())
+
+        assert result is False
+
+    def test_rejection_reason_agrees_with_the_match_decision(self) -> None:
+        """The diagnostic replay rejects exactly when the match does: both reject the guarded scaler."""
+        result = NamedOptionalFirstGuardedGroup.match_feature_group_criteria(NAMED_GUARD_NAME, Options())
+        reason = NamedOptionalFirstGuardedGroup._strict_validation_rejection_reason(NAMED_GUARD_NAME, Options())
+
+        assert result is False
+        assert reason is not None
+        assert SCALER_KEY in reason
+
+    def test_forwarded_scaler_mismatch_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A forwarded scaler that contradicts the name-parsed one is a hard error, not a silent override."""
+        monkeypatch.delenv("MLODA_ALLOW_FORWARDED_NAME_MISMATCH", raising=False)
+        child_options = _inherited_child_options({SCALER_KEY: "minmax"})
+        assert child_options.inherited_group_keys == frozenset({SCALER_KEY})  # precondition
+
+        with pytest.raises(ValueError) as exc_info:
+            NamedOptionalFirstForwardedGroup.match_feature_group_criteria(NAMED_FWD_NAME, child_options)
+
+        message = str(exc_info.value)
+        assert SCALER_KEY in message
+        assert "minmax" in message
+        assert "standard" in message
+        assert "forward_group_exclude" in message
+
+    def test_forwarded_fixture_matches_without_options(self) -> None:
+        """Precondition: the forwarded fixture claims the chained name on its own."""
+        assert NamedOptionalFirstForwardedGroup.match_feature_group_criteria(NAMED_FWD_NAME, Options()) is True
+
+    def test_agreeing_forwarded_scaler_matches(self) -> None:
+        """Guard against over-rejecting: an equal forwarded value is no mismatch."""
+        child_options = _inherited_child_options({SCALER_KEY: "standard"})
+
+        assert NamedOptionalFirstForwardedGroup.match_feature_group_criteria(NAMED_FWD_NAME, child_options) is True
+
+
+class TestFixAPositionalOptionalFirst:
+    """A positional pattern matching only via an absent optional first group keeps the pre-#770 rejection."""
+
+    def test_parser_empty_options_is_a_non_match(self) -> None:
+        """The string path no longer matches on the pattern alone: required presence still guards it."""
+        result = FeatureChainParser.match_configuration_feature_chain_parser(
+            POSITIONAL_NAME,
+            Options(),
+            PositionalOptionalFirstGroup.PROPERTY_MAPPING,
+            [PositionalOptionalFirstGroup.PREFIX_PATTERN],
+        )
+
+        assert result is False
+
+    def test_mixin_empty_options_is_a_non_match(self) -> None:
+        """The mixer agrees: no match-then-fail for the empty-options case."""
+        result = PositionalOptionalFirstGroup.match_feature_group_criteria(POSITIONAL_NAME, Options())
+
+        assert result is False
+
+    def test_required_key_present_matches(self) -> None:
+        """Guard against over-rejecting: the required key present and valid still matches."""
+        result = PositionalOptionalFirstGroup.match_feature_group_criteria(
+            POSITIONAL_NAME, Options(context={OP_KEY: "alpha"})
+        )
+
+        assert result is True
+
+
+class TestFixBPerPatternAmbiguity:
+    """The definition-time ambiguity guard is per-pattern and flattens list-valued pattern attributes."""
+
+    def test_positional_prefix_plus_named_suffix_raises(self) -> None:
+        """A named SUFFIX no longer excuses an ambiguous positional PREFIX: the positional pattern is checked."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class _PositionalPlusNamedRf770(FeatureChainParserMixin):
+                PREFIX_PATTERN = r".*__(\w+)_posrf770$"
+                SUFFIX_PATTERN = r".*__(?P<something_rf770>\w+)_sufrf770$"
+                PROPERTY_MAPPING = {
+                    KEY_A: PropertySpec("a", allowed_values=("pca", "sharedval_rf770")),
+                    KEY_B: PropertySpec("b", allowed_values=("sharedval_rf770", "auto")),
+                }
+
+        message = str(exc_info.value)
+        assert KEY_A in message
+        assert KEY_B in message
+        assert "sharedval_rf770" in message
+
+    def test_list_form_positional_pattern_raises(self) -> None:
+        """The list-form PREFIX_PATTERN is flattened to its element and checked, not skipped as zero-capture."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class _ListFormPositionalRf770(FeatureChainParserMixin):
+                PREFIX_PATTERN = [r".*__(shared_rf770)_listx_rf770$"]
+                PROPERTY_MAPPING = {
+                    KEY_A: PropertySpec("a", allowed_values=("shared_rf770", "pca")),
+                    KEY_B: PropertySpec("b", allowed_values=("shared_rf770", "auto")),
+                }
+
+        assert "shared_rf770" in str(exc_info.value)
+
+    def test_shipped_style_single_positional_no_overlap_does_not_raise(self) -> None:
+        """Guard against over-rejecting: a single positional pattern with disjoint keys still defines cleanly."""
+
+        class _ShippedStylePositionalRf770(FeatureChainParserMixin):
+            PREFIX_PATTERN = r".*__(\w+)_shipped_rf770$"
+            PROPERTY_MAPPING = {
+                KEY_A: PropertySpec("a", allowed_values=("pca", "tsne")),
+                KEY_B: PropertySpec("b", allowed_values=("auto", "arpack")),
+            }
+
+        assert _ShippedStylePositionalRf770.PREFIX_PATTERN.endswith("_shipped_rf770$")


### PR DESCRIPTION
Closes #770. Epic #761, phase 3.

## Problem

`build_effective_options()` took one `operation_config` string parsed from a feature name and assigned it to the first PROPERTY_MAPPING key whose `allowed_values` contained that value. As a result an `element_validator`-only spec could never receive a parsed value, secondary regex captures were discarded, overlapping value spaces made binding order-dependent, a captureless pattern fabricated a token, and a second copy of the reverse lookup lived in the mixin.

## Change

- **`ParsedFeatureName`** (new): a frozen record of what parsing found (matched, source feature, raw `operation_part`, named and positional captures), mirroring `re`. A captureless match is `matched=True` with zero captures and no fabricated token. `parse_feature_name()` is kept as a byte-identical legacy adapter over the new `parse_name()`.
- **Binding by name**: a named capture `(?P<key>...)` binds to the same-named key, so a secondary capture and an `element_validator`-only spec both receive their value. When a pattern declares any named group, binding is exclusively by name. A positional-only pattern keeps the legacy first-key-by-membership rule (transitional, retired by #772); it only ever binds an already-accepted value, so shipped plugins are unchanged.
- **Deterministic or definition-time error**: a positional pattern whose keys share a reachable value is rejected at class definition, naming both keys and the `(?P<key>...)` remedy. The check is per concrete pattern and flattens list-form pattern attributes.
- **Visibility**: bound captures merge once into the effective options, so strict validation, `match_guard`, `required_when`, and forwarded-mismatch protection all see every capture, including secondary ones. The second reverse lookup (`_find_property_key_for_value`) is removed.

Required-presence on the string path (#769) and captureless-fabrication removal (#772) are intentionally out of scope; shipped `PREFIX_PATTERN`s stay positional and behavior-identical.

## Definition of done

- [x] Typed parse result distinguishes matched / source / named / positional captures; captureless success is not a fabricated token
- [x] Documented binding rule maps captures to keys without searching `allowed_values`
- [x] Name-derived values reach `element_validator`-only specs and are visible to `required_when`, `match_guard`, and strict validation
- [x] Secondary captures bind to separate keys with forwarded-mismatch protection
- [x] Overlapping value spaces produce deterministic binding or a definition-time error
- [x] Public `parse_feature_name()` retained via an adapter
- [x] Tests cover named, positional, multiple, overlapping, and captureless patterns
- [x] `tox` passes

## Review

Two independent deep reviews (Claude Opus + codex) ran on the first commit. Both flagged the same defects in the new code (a match/replay disagreement for named-optional-first patterns, a match-then-fail regression for positional-optional-first patterns, and two holes in the definition-time ambiguity guard). The second commit fixes all of them by unifying the name-match gate into one predicate across the three match sites and making the ambiguity check per-pattern and list-form-aware, each pinned by regression tests. Full `tox` green (6683 passed, 170 skipped, ruff, licenses, mypy --strict, bandit).