### PR TITLE
fix: make time-window features respect time_unit

### DIFF
--- a/mloda_plugins/feature_group/experimental/time_window/base.py
+++ b/mloda_plugins/feature_group/experimental/time_window/base.py
@@ -4,6 +4,7 @@ Base implementation for time window feature groups.
 
 from __future__ import annotations
 
+import datetime
 from abc import abstractmethod
 from typing import Any, Optional
 
@@ -289,6 +290,31 @@ class TimeWindowFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featur
     def get_time_unit(cls, feature_name: str) -> str:
         """Extract the time unit from the feature name."""
         return cls.parse_time_window_prefix(feature_name)[2]
+
+    @classmethod
+    def _get_time_delta(cls, window_size: int, time_unit: str) -> datetime.timedelta:
+        """
+        Convert window size and time unit into the window span as a timedelta.
+
+        Shared by both backends so the time-based window is IDENTICAL across them.
+        week/month/year use fixed day approximations (7 / 30 / 365 days).
+        """
+        if time_unit == "second":
+            return datetime.timedelta(seconds=window_size)
+        elif time_unit == "minute":
+            return datetime.timedelta(minutes=window_size)
+        elif time_unit == "hour":
+            return datetime.timedelta(hours=window_size)
+        elif time_unit == "day":
+            return datetime.timedelta(days=window_size)
+        elif time_unit == "week":
+            return datetime.timedelta(weeks=window_size)
+        elif time_unit == "month":
+            return datetime.timedelta(days=30 * window_size)
+        elif time_unit == "year":
+            return datetime.timedelta(days=365 * window_size)
+        else:
+            raise ValueError(f"Unsupported time unit: {time_unit}")
 
     # match_feature_group_criteria() inherited from FeatureChainParserMixin
 

--- a/mloda_plugins/feature_group/experimental/time_window/base.py
+++ b/mloda_plugins/feature_group/experimental/time_window/base.py
@@ -316,6 +316,14 @@ class TimeWindowFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featur
         else:
             raise ValueError(f"Unsupported time unit: {time_unit}")
 
+    @classmethod
+    def _raise_null_reference_time(cls, reference_time_column: str) -> None:
+        """Raise a uniform ValueError when the reference time column contains null/NaT values."""
+        raise ValueError(
+            f"Reference time column '{reference_time_column}' contains null values. "
+            f"Time window operations require non-null reference times."
+        )
+
     # match_feature_group_criteria() inherited from FeatureChainParserMixin
 
     @classmethod

--- a/mloda_plugins/feature_group/experimental/time_window/pandas.py
+++ b/mloda_plugins/feature_group/experimental/time_window/pandas.py
@@ -112,7 +112,11 @@ class PandasTimeWindowFeatureGroup(TimeWindowFeatureGroup):
             # Multiple columns: keep as DataFrame
             selected_data = df_with_time_index[in_features]
 
-        rolling_window = selected_data.rolling(window=window_size, min_periods=1)
+        # Time-based (not row-count) window: include rows in (t - span, t].
+        # Pass a Timedelta, not an offset string: aliases like "3M"/"3Y" raise
+        # "passed window 3M is not compatible with a datetimelike index".
+        span = pd.Timedelta(cls._get_time_delta(window_size, time_unit))
+        rolling_window = selected_data.rolling(window=span, min_periods=1, closed="right")
 
         if window_function == "sum":
             result = rolling_window.sum()

--- a/mloda_plugins/feature_group/experimental/time_window/pandas.py
+++ b/mloda_plugins/feature_group/experimental/time_window/pandas.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 from typing import Any, Optional
 
+import numpy as np
+
 from mloda.provider import ComputeFramework
 from mloda_plugins.compute_framework.base_implementations.pandas import pandas_type_semantics
 from mloda.user.pandas import PandasDataFrame
@@ -100,17 +102,26 @@ class PandasTimeWindowFeatureGroup(TimeWindowFeatureGroup):
         if time_filter_feature is None:
             time_filter_feature = cls.get_reference_time_column()
 
-        # Create a copy of the DataFrame with the time filter feature as the index
-        # This is necessary for time-based rolling operations
-        df_with_time_index = data.set_index(time_filter_feature).sort_index()
+        # Coerce the reference column to a proper datetime index (handles arrow
+        # date32/date64 columns and keeps tz-awareness). A null/NaT reference time
+        # has no position on the timeline, so fail explicitly.
+        times = pd.to_datetime(data[time_filter_feature])
+        if times.isna().any():
+            cls._raise_null_reference_time(time_filter_feature)
 
-        # Select the columns to perform window operation on
+        # Sort STABLY by absolute time, remembering original positions, so the
+        # rolled result can be scattered back to the ORIGINAL (possibly unsorted)
+        # row order. to_numpy() on a tz-aware column yields absolute UTC instants.
+        order = np.argsort(times.to_numpy(), kind="stable")
+        sorted_index = pd.DatetimeIndex(times.to_numpy()[order])
+
+        # Select the columns to perform window operation on, in time-sorted order.
         if len(in_features) == 1:
             # Single column: extract as Series for simpler window operation
-            selected_data = df_with_time_index[in_features[0]]
+            selected_data = pd.Series(data[in_features[0]].to_numpy()[order], index=sorted_index)
         else:
             # Multiple columns: keep as DataFrame
-            selected_data = df_with_time_index[in_features]
+            selected_data = pd.DataFrame({c: data[c].to_numpy()[order] for c in in_features}, index=sorted_index)
 
         # Time-based (not row-count) window: include rows in (t - span, t].
         # Pass a Timedelta, not an offset string: aliases like "3M"/"3Y" raise
@@ -163,34 +174,8 @@ class PandasTimeWindowFeatureGroup(TimeWindowFeatureGroup):
                 # For first/last, already computed on each column, now aggregate across columns
                 result = result.mean(axis=1)  # Use mean as aggregation for first/last
 
-        # Convert to numpy array to avoid type issues
-        return result.values
-
-    @classmethod
-    def _get_pandas_freq(cls, window_size: int, time_unit: str) -> str:
-        """
-        Convert window size and time unit to a pandas-compatible frequency string.
-
-        Args:
-            window_size: The size of the window
-            time_unit: The time unit for the window
-
-        Returns:
-            A pandas-compatible frequency string
-        """
-        # Map time units to pandas frequency aliases
-        time_unit_map = {
-            "second": "S",
-            "minute": "T",
-            "hour": "H",
-            "day": "D",
-            "week": "W",
-            "month": "M",
-            "year": "Y",
-        }
-
-        if time_unit not in time_unit_map:
-            raise ValueError(f"Unsupported time unit: {time_unit}")
-
-        # Construct the frequency string
-        return f"{window_size}{time_unit_map[time_unit]}"
+        # Scatter the time-sorted results back to the ORIGINAL row order.
+        sorted_values = np.asarray(result)
+        out = np.empty(len(sorted_values), dtype=sorted_values.dtype)
+        out[order] = sorted_values
+        return out

--- a/mloda_plugins/feature_group/experimental/time_window/pyarrow.py
+++ b/mloda_plugins/feature_group/experimental/time_window/pyarrow.py
@@ -112,6 +112,10 @@ class PyArrowTimeWindowFeatureGroup(TimeWindowFeatureGroup):
         # Get the time column
         time_column = data.column(time_filter_feature)
 
+        # A null/NaT reference time has no position on the timeline; fail explicitly.
+        if time_column.null_count > 0:
+            cls._raise_null_reference_time(time_filter_feature)
+
         # Get the source columns
         source_columns = [data.column(name) for name in in_features]
 
@@ -123,9 +127,13 @@ class PyArrowTimeWindowFeatureGroup(TimeWindowFeatureGroup):
         sorted_sources = [pc.take(col, sorted_indices) for col in source_columns]
 
         # Time-based (not row-count) window: include rows in (t - span, t].
-        # Sorted times bound each window; span comes from the shared base helper.
-        sorted_times = pc.take(time_column, sorted_indices).to_pylist()
+        # Bound each window by ABSOLUTE integer nanoseconds (not Python datetimes):
+        # wall-clock datetime subtraction is wrong across a DST transition, whereas
+        # int64 ns since epoch is DST-safe, unit-uniform, and works for tz-aware
+        # timestamps and date32/date64 too.
+        sorted_times_ns = pc.take(time_column, sorted_indices).cast(pa.timestamp("ns")).cast(pa.int64()).to_pylist()
         span = cls._get_time_delta(window_size, time_unit)
+        span_ns = span.days * 86_400_000_000_000 + span.seconds * 1_000_000_000 + span.microseconds * 1_000
 
         # Create a list to store the results
         results = []
@@ -135,11 +143,11 @@ class PyArrowTimeWindowFeatureGroup(TimeWindowFeatureGroup):
             # Rows are time-sorted ascending, so the window is a contiguous slice
             # ending at i. bisect_right of (t_i - span) gives the first index strictly
             # greater than the lower bound, implementing the left-open boundary.
-            start_idx = bisect.bisect_right(sorted_times, sorted_times[i] - span)
-            window_indices = pa.array(range(start_idx, i + 1))
+            start_idx = bisect.bisect_right(sorted_times_ns, sorted_times_ns[i] - span_ns)
+            length = i - start_idx + 1
 
-            # Get window values for all columns
-            all_window_values = [pc.take(col, window_indices) for col in sorted_sources]
+            # Zero-copy slice of each sorted source column for the current window.
+            all_window_values = [col.slice(start_idx, length) for col in sorted_sources]
 
             # Apply the window function
             if len(all_window_values[0]) == 0:
@@ -202,9 +210,11 @@ class PyArrowTimeWindowFeatureGroup(TimeWindowFeatureGroup):
                     # Single column: use the result directly
                     results.append(column_results[0])
 
-        # We need to reorder the results to match the original order
-        # Create a mapping from sorted indices to original indices
-        reordered_results = [results[sorted_indices.to_pylist().index(i)] for i in range(len(results))]
+        # Scatter results back to original row order via the inverse permutation (O(n)).
+        sorted_idx_list = sorted_indices.to_pylist()
+        reordered_results: list[Any] = [None] * len(results)
+        for k, orig_pos in enumerate(sorted_idx_list):
+            reordered_results[orig_pos] = results[k]
 
         # Convert the results to a PyArrow array
         return pa.array(reordered_results)

--- a/mloda_plugins/feature_group/experimental/time_window/pyarrow.py
+++ b/mloda_plugins/feature_group/experimental/time_window/pyarrow.py
@@ -5,7 +5,7 @@ PyArrow implementation for time window feature groups.
 from __future__ import annotations
 
 from typing import Any, Optional
-import datetime
+import bisect
 
 import pyarrow as pa
 import pyarrow.compute as pc
@@ -122,14 +122,20 @@ class PyArrowTimeWindowFeatureGroup(TimeWindowFeatureGroup):
         # Get the sorted source values for each column
         sorted_sources = [pc.take(col, sorted_indices) for col in source_columns]
 
+        # Time-based (not row-count) window: include rows in (t - span, t].
+        # Sorted times bound each window; span comes from the shared base helper.
+        sorted_times = pc.take(time_column, sorted_indices).to_pylist()
+        span = cls._get_time_delta(window_size, time_unit)
+
         # Create a list to store the results
         results = []
 
-        # For each row, calculate the window operation using a fixed-size window
-        # This matches the pandas implementation which uses rolling(window=window_size, min_periods=1)
+        # For each row, calculate the window operation over the time-based window
         for i in range(len(sorted_sources[0])):
-            # Get the window values (current and previous values up to window_size)
-            start_idx = max(0, i - window_size + 1)
+            # Rows are time-sorted ascending, so the window is a contiguous slice
+            # ending at i. bisect_right of (t_i - span) gives the first index strictly
+            # greater than the lower bound, implementing the left-open boundary.
+            start_idx = bisect.bisect_right(sorted_times, sorted_times[i] - span)
             window_indices = pa.array(range(start_idx, i + 1))
 
             # Get window values for all columns
@@ -202,34 +208,3 @@ class PyArrowTimeWindowFeatureGroup(TimeWindowFeatureGroup):
 
         # Convert the results to a PyArrow array
         return pa.array(reordered_results)
-
-    @classmethod
-    def _get_time_delta(cls, window_size: int, time_unit: str) -> datetime.timedelta:
-        """
-        Convert window size and time unit to a timedelta.
-
-        Args:
-            window_size: The size of the window
-            time_unit: The time unit for the window
-
-        Returns:
-            A timedelta representing the window size
-        """
-        if time_unit == "second":
-            return datetime.timedelta(seconds=window_size)
-        elif time_unit == "minute":
-            return datetime.timedelta(minutes=window_size)
-        elif time_unit == "hour":
-            return datetime.timedelta(hours=window_size)
-        elif time_unit == "day":
-            return datetime.timedelta(days=window_size)
-        elif time_unit == "week":
-            return datetime.timedelta(weeks=window_size)
-        elif time_unit == "month":
-            # Approximate a month as 30 days
-            return datetime.timedelta(days=30 * window_size)
-        elif time_unit == "year":
-            # Approximate a year as 365 days
-            return datetime.timedelta(days=365 * window_size)
-        else:
-            raise ValueError(f"Unsupported time unit: {time_unit}")

--- a/tests/test_plugins/feature_group/experimental/test_time_window_feature_group/test_pandas_time_window_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/test_time_window_feature_group/test_pandas_time_window_feature_group.py
@@ -21,20 +21,6 @@ class TestPandasTimeWindowFeatureGroup:
         """Test compute_framework_rule method."""
         assert PandasTimeWindowFeatureGroup.compute_framework_rule() == {PandasDataFrame}
 
-    def test_get_pandas_freq(self) -> None:
-        """Test _get_pandas_freq method."""
-        assert PandasTimeWindowFeatureGroup._get_pandas_freq(3, "day") == "3D"
-        assert PandasTimeWindowFeatureGroup._get_pandas_freq(7, "hour") == "7H"
-        assert PandasTimeWindowFeatureGroup._get_pandas_freq(2, "minute") == "2T"
-        assert PandasTimeWindowFeatureGroup._get_pandas_freq(4, "second") == "4S"
-        assert PandasTimeWindowFeatureGroup._get_pandas_freq(1, "week") == "1W"
-        assert PandasTimeWindowFeatureGroup._get_pandas_freq(6, "month") == "6M"
-        assert PandasTimeWindowFeatureGroup._get_pandas_freq(2, "year") == "2Y"
-
-        # Test with invalid time unit
-        with pytest.raises(ValueError):
-            PandasTimeWindowFeatureGroup._get_pandas_freq(3, "invalid")
-
     @pytest.mark.parametrize(
         "window_function,expected_values",
         [

--- a/tests/test_plugins/feature_group/experimental/test_time_window_feature_group/test_time_window_respects_time_unit.py
+++ b/tests/test_plugins/feature_group/experimental/test_time_window_feature_group/test_time_window_respects_time_unit.py
@@ -1,0 +1,125 @@
+"""Regression tests: time-window feature groups must respect ``time_unit``.
+
+The window for a row at reference time ``t`` is the half-open interval
+``(t - span, t]`` (right-closed, left-open) where ``span = window_size * time_unit``.
+The buggy implementations ignore ``time_unit`` and compute a fixed ROW-COUNT
+window instead, so ``sum_3_hour_window`` and ``sum_3_second_window`` produce the
+same "last 3 rows" result on identical data. These tests assert the true
+time-based values and therefore fail on the current code.
+
+All input data is time-sorted ascending; sub-daily (minute) spacing makes the
+time unit observable.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+import pyarrow as pa
+import pytest
+
+from mloda.provider import DefaultOptionKeys
+from mloda_plugins.feature_group.experimental.time_window.pandas import PandasTimeWindowFeatureGroup
+from mloda_plugins.feature_group.experimental.time_window.pyarrow import PyArrowTimeWindowFeatureGroup
+
+
+REFERENCE_TIME = DefaultOptionKeys.reference_time
+
+# Minute-spaced data: 6 rows at 00:00..00:05, values 1..6.
+_MINUTE_TIMES = pd.date_range(start="2023-01-01 00:00:00", periods=6, freq="min")
+_MINUTE_VALUES = [1, 2, 3, 4, 5, 6]
+
+# Ground-truth time-based results (verified with pandas rolling, closed="right").
+# span=3h is wider than the 5-minute range -> cumulative over all prior rows.
+EXPECTED_SUM_3_HOUR = [1.0, 3.0, 6.0, 10.0, 15.0, 21.0]
+EXPECTED_AVG_3_HOUR = [1.0, 1.5, 2.0, 2.5, 3.0, 3.5]
+# span=3s is narrower than the 1-minute spacing -> each row's window is only itself.
+EXPECTED_SUM_3_SECOND = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+
+
+def _minute_dataframe() -> pd.DataFrame:
+    return pd.DataFrame({"value": list(_MINUTE_VALUES), REFERENCE_TIME: _MINUTE_TIMES})
+
+
+def _minute_table() -> pa.Table:
+    return pa.Table.from_pandas(_minute_dataframe())
+
+
+def _as_floats(result: Any) -> list[float]:
+    """Normalize pandas (numpy) / pyarrow window results to a plain float list."""
+    if hasattr(result, "to_pylist"):
+        return [float(v) for v in result.to_pylist()]
+    return [float(v) for v in list(result)]
+
+
+def test_pandas_sum_hour_window_is_time_based_not_row_count() -> None:
+    """sum_3_hour_window must sum all rows within 3h, not just the last 3 rows."""
+    result = PandasTimeWindowFeatureGroup._perform_window_operation(
+        _minute_dataframe(), "sum", 3, "hour", ["value"], REFERENCE_TIME
+    )
+    assert _as_floats(result) == pytest.approx(EXPECTED_SUM_3_HOUR)
+
+
+def test_pandas_time_unit_changes_result() -> None:
+    """3_second and 3_hour must differ on identical data (time_unit matters)."""
+    hour = PandasTimeWindowFeatureGroup._perform_window_operation(
+        _minute_dataframe(), "sum", 3, "hour", ["value"], REFERENCE_TIME
+    )
+    second = PandasTimeWindowFeatureGroup._perform_window_operation(
+        _minute_dataframe(), "sum", 3, "second", ["value"], REFERENCE_TIME
+    )
+    assert _as_floats(hour) == pytest.approx(EXPECTED_SUM_3_HOUR)
+    assert _as_floats(second) == pytest.approx(EXPECTED_SUM_3_SECOND)
+    assert _as_floats(hour) != _as_floats(second)
+
+
+def test_pyarrow_sum_hour_window_is_time_based_not_row_count() -> None:
+    """PyArrow must match the pandas time-based result for sum_3_hour_window."""
+    result = PyArrowTimeWindowFeatureGroup._perform_window_operation(
+        _minute_table(), "sum", 3, "hour", ["value"], REFERENCE_TIME
+    )
+    assert _as_floats(result) == pytest.approx(EXPECTED_SUM_3_HOUR)
+
+
+@pytest.mark.parametrize(
+    "window_function,expected",
+    [
+        ("sum", EXPECTED_SUM_3_HOUR),
+        ("avg", EXPECTED_AVG_3_HOUR),
+    ],
+)
+def test_pandas_and_pyarrow_agree_time_based(window_function: str, expected: list[float]) -> None:
+    """Both backends must produce the same time-based result on sub-daily data."""
+    pandas_result = _as_floats(
+        PandasTimeWindowFeatureGroup._perform_window_operation(
+            _minute_dataframe(), window_function, 3, "hour", ["value"], REFERENCE_TIME
+        )
+    )
+    pyarrow_result = _as_floats(
+        PyArrowTimeWindowFeatureGroup._perform_window_operation(
+            _minute_table(), window_function, 3, "hour", ["value"], REFERENCE_TIME
+        )
+    )
+    assert pandas_result == pytest.approx(expected)
+    assert pyarrow_result == pytest.approx(expected)
+    assert pandas_result == pytest.approx(pyarrow_result)
+
+
+@pytest.mark.parametrize("time_unit", ["month", "year"])
+def test_month_and_year_units_run_to_completion(time_unit: str) -> None:
+    """month/year must run without raising and return one value per row."""
+    dates = pd.date_range(start="2023-01-01", periods=5, freq="D")
+    values = [1, 2, 3, 4, 5]
+    df = pd.DataFrame({"value": values, REFERENCE_TIME: dates})
+    table = pa.Table.from_pandas(df)
+
+    pandas_result = PandasTimeWindowFeatureGroup._perform_window_operation(
+        df.copy(), "sum", 3, time_unit, ["value"], REFERENCE_TIME
+    )
+    pyarrow_result = PyArrowTimeWindowFeatureGroup._perform_window_operation(
+        table, "sum", 3, time_unit, ["value"], REFERENCE_TIME
+    )
+
+    assert len(_as_floats(pandas_result)) == len(values)
+    assert len(_as_floats(pyarrow_result)) == len(values)

--- a/tests/test_plugins/feature_group/experimental/test_time_window_feature_group/test_time_window_review_defects.py
+++ b/tests/test_plugins/feature_group/experimental/test_time_window_feature_group/test_time_window_review_defects.py
@@ -1,0 +1,258 @@
+"""Regression tests pinning defects found by two reviews of the time-window fix.
+
+The window for a row at reference time ``t`` is the half-open interval
+``(t - span, t]`` (right-closed, left-open) with ``span = window_size * time_unit``
+and week/month/year approximated as 7/30/365 days. All expected values are derived
+by an independent brute-force reference (``_reference``) so the tests are
+self-checking and never trust hand-computed numbers.
+
+Defects pinned:
+- Pandas mis-aligns time-sorted results back to original (unsorted) rows.
+- PyArrow computes windows with wall-clock (not absolute) datetime arithmetic,
+  so it is wrong across a DST transition.
+- A null/NaT reference time must be an explicit ``ValueError`` on BOTH backends;
+  PyArrow currently raises ``TypeError`` (``None - timedelta``).
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Any, Callable
+from zoneinfo import ZoneInfo
+
+import pandas as pd
+import pyarrow as pa
+import pytest
+
+from mloda.user import Feature
+from mloda.provider import FeatureSet
+from mloda.provider import DefaultOptionKeys
+from mloda_plugins.feature_group.experimental.time_window.base import TimeWindowFeatureGroup
+from mloda_plugins.feature_group.experimental.time_window.pandas import PandasTimeWindowFeatureGroup
+from mloda_plugins.feature_group.experimental.time_window.pyarrow import PyArrowTimeWindowFeatureGroup
+
+
+REFERENCE_TIME = DefaultOptionKeys.reference_time
+
+
+def _reference(times: list[datetime.datetime], values: list[int], span: datetime.timedelta, fn: str) -> list[float]:
+    """Brute-force window reference aligned to the INPUT row order.
+
+    For each row ``i`` the window is every value ``j`` with
+    ``times[i] - span < times[j] <= times[i]`` (right-closed, left-open).
+    ``times`` must be absolute instants (compare/subtract in absolute time).
+    """
+    out: list[float] = []
+    for i in range(len(times)):
+        lower = times[i] - span
+        window = [values[j] for j in range(len(times)) if lower < times[j] <= times[i]]
+        if fn == "sum":
+            out.append(float(sum(window)))
+        elif fn == "avg":
+            out.append(sum(window) / len(window))
+        elif fn == "min":
+            out.append(float(min(window)))
+        elif fn == "max":
+            out.append(float(max(window)))
+        else:  # pragma: no cover - guard against typos in tests
+            raise ValueError(f"Unsupported reference function: {fn}")
+    return out
+
+
+def _as_floats(result: Any) -> list[float]:
+    """Normalize pandas (numpy) / pyarrow window results to a plain float list."""
+    if hasattr(result, "to_pylist"):
+        return [float(v) for v in result.to_pylist()]
+    return [float(v) for v in list(result)]
+
+
+# --------------------------------------------------------------------------- #
+# 1. Unsorted-input alignment + cross-backend agreement (the headline bug).    #
+# --------------------------------------------------------------------------- #
+
+# Rows are deliberately NOT in ascending time order.
+_UNSORTED_VALUES = [300, 1, 20]
+_UNSORTED_TIMES = [
+    pd.Timestamp("2023-01-01 00:02:00"),
+    pd.Timestamp("2023-01-01 00:00:00"),
+    pd.Timestamp("2023-01-01 01:00:00"),
+]
+_UNSORTED_SPAN = datetime.timedelta(hours=3)
+
+
+def _unsorted_dataframe() -> pd.DataFrame:
+    return pd.DataFrame({"value": list(_UNSORTED_VALUES), REFERENCE_TIME: list(_UNSORTED_TIMES)})
+
+
+def _unsorted_table() -> pa.Table:
+    return pa.Table.from_pandas(_unsorted_dataframe())
+
+
+@pytest.mark.parametrize("window_function", ["sum", "avg"])
+def test_unsorted_input_end_to_end_alignment(window_function: str) -> None:
+    """End-to-end result must stay aligned to ORIGINAL row order on both backends.
+
+    Pins the pandas defect: it assigns time-sorted window results back to the
+    original (unsorted) rows, so the produced column is permuted. PyArrow is
+    correct here, so pandas != pyarrow as well.
+    """
+    feature_name = f"value__{window_function}_3_hour_window"
+    expected = _reference(
+        [t.to_pydatetime() for t in _UNSORTED_TIMES], _UNSORTED_VALUES, _UNSORTED_SPAN, window_function
+    )
+
+    pandas_fs = FeatureSet()
+    pandas_fs.add(Feature(feature_name))
+    pandas_out = PandasTimeWindowFeatureGroup.calculate_feature(_unsorted_dataframe(), pandas_fs)
+    pandas_result = _as_floats(pandas_out[feature_name].tolist())
+
+    pyarrow_fs = FeatureSet()
+    pyarrow_fs.add(Feature(feature_name))
+    pyarrow_out = PyArrowTimeWindowFeatureGroup.calculate_feature(_unsorted_table(), pyarrow_fs)
+    pyarrow_result = _as_floats(pyarrow_out.column(feature_name))
+
+    assert pandas_result == pytest.approx(expected)
+    assert pyarrow_result == pytest.approx(expected)
+    assert pandas_result == pytest.approx(pyarrow_result)
+
+
+# --------------------------------------------------------------------------- #
+# 2. DST / timezone: windows must use ABSOLUTE time, not wall clock.           #
+# --------------------------------------------------------------------------- #
+
+# 2023-03-12 is the US spring-forward: 02:00 -> 03:00 in America/New_York.
+# 01:45 EST and 03:15 EDT are only 30 minutes apart in ABSOLUTE time, so a
+# 1-hour window on the second row must include the first.
+_DST_TZ = ZoneInfo("America/New_York")
+_DST_TIMES = [
+    pd.Timestamp("2023-03-12 01:45:00", tz=_DST_TZ),
+    pd.Timestamp("2023-03-12 03:15:00", tz=_DST_TZ),
+]
+_DST_VALUES = [1, 10]
+_DST_SPAN = datetime.timedelta(hours=1)
+
+
+def _dst_dataframe() -> pd.DataFrame:
+    return pd.DataFrame({"value": list(_DST_VALUES), REFERENCE_TIME: list(_DST_TIMES)})
+
+
+def _dst_table() -> pa.Table:
+    return pa.Table.from_pandas(_dst_dataframe())
+
+
+def test_dst_transition_uses_absolute_time() -> None:
+    """Both backends must compute the window in absolute time across DST.
+
+    Reference is computed from UTC instants. Pins the pyarrow defect: it does
+    wall-clock arithmetic, drops the first row from the second window, and so
+    disagrees with both the reference and pandas.
+    """
+    utc_times = [t.tz_convert("UTC").to_pydatetime() for t in _DST_TIMES]
+    expected = _reference(utc_times, _DST_VALUES, _DST_SPAN, "sum")
+
+    pandas_result = _as_floats(
+        PandasTimeWindowFeatureGroup._perform_window_operation(
+            _dst_dataframe(), "sum", 1, "hour", ["value"], REFERENCE_TIME
+        )
+    )
+    pyarrow_result = _as_floats(
+        PyArrowTimeWindowFeatureGroup._perform_window_operation(
+            _dst_table(), "sum", 1, "hour", ["value"], REFERENCE_TIME
+        )
+    )
+
+    assert pandas_result == pytest.approx(expected)
+    assert pyarrow_result == pytest.approx(expected)
+    assert pandas_result == pytest.approx(pyarrow_result)
+
+
+# --------------------------------------------------------------------------- #
+# 3. month / year: assert exact values (span = 90 / 1095 days), not length.    #
+# --------------------------------------------------------------------------- #
+
+_MY_DATES = pd.date_range(start="2023-01-01", periods=6, freq="D")
+_MY_VALUES = [1, 2, 3, 4, 5, 6]
+_MY_SPAN_DAYS = {"month": 90, "year": 1095}
+
+
+@pytest.mark.parametrize("time_unit", ["month", "year"])
+def test_month_and_year_window_values(time_unit: str) -> None:
+    """month/year windows must return the exact brute-force values on both backends."""
+    span = datetime.timedelta(days=_MY_SPAN_DAYS[time_unit])
+    expected = _reference([d.to_pydatetime() for d in _MY_DATES], _MY_VALUES, span, "sum")
+
+    df = pd.DataFrame({"value": list(_MY_VALUES), REFERENCE_TIME: _MY_DATES})
+    table = pa.Table.from_pandas(df)
+
+    pandas_result = _as_floats(
+        PandasTimeWindowFeatureGroup._perform_window_operation(
+            df.copy(), "sum", 3, time_unit, ["value"], REFERENCE_TIME
+        )
+    )
+    pyarrow_result = _as_floats(
+        PyArrowTimeWindowFeatureGroup._perform_window_operation(table, "sum", 3, time_unit, ["value"], REFERENCE_TIME)
+    )
+
+    assert pandas_result == pytest.approx(expected)
+    assert pyarrow_result == pytest.approx(expected)
+    assert pandas_result == pytest.approx(pyarrow_result)
+
+
+# --------------------------------------------------------------------------- #
+# 4. PyArrow narrow window value (mirrors the pandas-only narrow test).        #
+# --------------------------------------------------------------------------- #
+
+_NARROW_DATES = pd.date_range(start="2023-01-01 00:00:00", periods=6, freq="min")
+_NARROW_VALUES = [1, 2, 3, 4, 5, 6]
+
+
+def test_pyarrow_narrow_window_value() -> None:
+    """A 3-second window over minute-spaced data leaves each row alone: [1..6]."""
+    expected = _reference(
+        [d.to_pydatetime() for d in _NARROW_DATES], _NARROW_VALUES, datetime.timedelta(seconds=3), "sum"
+    )
+    table = pa.Table.from_pandas(pd.DataFrame({"value": list(_NARROW_VALUES), REFERENCE_TIME: _NARROW_DATES}))
+
+    pyarrow_result = _as_floats(
+        PyArrowTimeWindowFeatureGroup._perform_window_operation(table, "sum", 3, "second", ["value"], REFERENCE_TIME)
+    )
+    assert pyarrow_result == pytest.approx(expected)
+
+
+# --------------------------------------------------------------------------- #
+# 5. Null / NaT reference time is invalid: BOTH backends must raise ValueError. #
+# --------------------------------------------------------------------------- #
+
+
+def _null_pandas() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "value": [1, 2, 3],
+            REFERENCE_TIME: [pd.Timestamp("2023-01-01 00:00:00"), pd.NaT, pd.Timestamp("2023-01-01 02:00:00")],
+        }
+    )
+
+
+def _null_pyarrow() -> pa.Table:
+    return pa.Table.from_pandas(_null_pandas())
+
+
+@pytest.mark.parametrize(
+    "cls,data_factory",
+    [
+        (PandasTimeWindowFeatureGroup, _null_pandas),
+        (PyArrowTimeWindowFeatureGroup, _null_pyarrow),
+    ],
+)
+def test_null_reference_time_raises_value_error(
+    cls: type[TimeWindowFeatureGroup], data_factory: Callable[[], Any]
+) -> None:
+    """A null/NaT reference time must raise a clear ValueError on both backends.
+
+    Pins the pyarrow defect: it raises TypeError (``None - timedelta``) instead
+    of a consistent ValueError.
+    """
+    feature_set = FeatureSet()
+    feature_set.add(Feature("value__sum_3_hour_window"))
+    with pytest.raises(ValueError):
+        cls.calculate_feature(data_factory(), feature_set)


### PR DESCRIPTION
## Problem

Time-window feature groups parsed `time_unit` from names like `sum_3_hour_window` but ignored it. Both backends computed a fixed row-count window (pandas `rolling(window=window_size)`, pyarrow `[i-window_size+1, i]` by row index), so `sum_3_hour_window`, `sum_3_second_window`, and `sum_3_day_window` all meant "last 3 rows". Existing tests used daily-spaced data where a 3-day span coincidentally equals 3 rows, masking the bug.

## Fix

Both backends now compute a true time-based window over the half-open interval `(t - span, t]` (right-closed, left-open), where `span = window_size * time_unit`, with week/month/year approximated as 7/30/365 days. A shared `_get_time_delta` on the base class keeps the two backends identical.

- Pandas uses a `pd.Timedelta` rolling window with `closed="right"` (offset strings like `"3M"` are rejected for datetimelike indexes).
- PyArrow bounds each window by absolute epoch nanoseconds via `bisect` over the sorted times.

## Review round

Two independent deep reviews (a fresh Claude Opus agent and codex) ran against the first commit. Accepted findings, fixed in the second commit:

- Pandas returned results in time-sorted order but they were assigned positionally to the original rows, so any non-time-sorted input got wrong values and diverged from pyarrow. Results are now scattered back to the original row order via a stable sort. The engine does not pre-sort input, so this was reachable.
- PyArrow compared window bounds with wall-clock datetime arithmetic, which is wrong across DST transitions. It now works in absolute epoch nanoseconds, so tz-aware data agrees across backends.
- Pandas crashed on Arrow-backed `date32`/`date64` reference columns that pass validation; the reference column is now coerced to `datetime64`.
- The pyarrow result reorder was O(n^2); replaced with an O(n) inverse permutation, and window values are now sliced zero-copy.
- Both backends raise a uniform `ValueError` on a null/NaT reference time (was an inconsistent `TypeError` on pyarrow).
- Removed the now-unused `_get_pandas_freq` helper.

## Tests

New tests use sub-daily spacing to make `time_unit` observable, plus a self-checking brute-force reference for the edge cases (unsorted input end-to-end through `calculate_feature`, a DST spring-forward crossing, month/year exact values, and null handling). Existing daily-spaced expected values are unchanged.

## Known limitation (follow-up)

The pyarrow per-row aggregation is still O(n * window) for the statistical reducers on very dense wide windows; the dominant O(n^2) reorder is fixed. A cross-backend int-vs-float result dtype difference is pre-existing and left as-is. Both are candidates for a separate change.

## Validation

`tox` is green: 6647 passed, 170 skipped, plus ruff format, ruff check, license allowlist, mypy --strict, and bandit.