### PR TITLE
fix: add context to core error messages

### DIFF
--- a/mloda/core/abstract_plugins/components/validators/feature_set_validator.py
+++ b/mloda/core/abstract_plugins/components/validators/feature_set_validator.py
@@ -30,7 +30,7 @@ class FeatureSetValidator:
     @staticmethod
     def validate_filters_not_set(filters: Any) -> None:
         if filters is not None:
-            raise ValueError("Filters already set")
+            raise ValueError(f"Filters already set to {filters}; they can only be assigned once per feature set")
 
     @staticmethod
     def validate_filters_is_set_type(filters: Any) -> None:

--- a/mloda/core/abstract_plugins/compute_framework.py
+++ b/mloda/core/abstract_plugins/compute_framework.py
@@ -806,7 +806,7 @@ Available join types:
     @final
     def get_uuid(self) -> UUID:
         if self.uuid is None:
-            raise ValueError("UUID is not set")
+            raise ValueError(f"UUID is not set on compute framework {self.__class__.__name__}")
         return self.uuid
 
     @final

--- a/mloda/core/runtime/data_lifecycle_manager.py
+++ b/mloda/core/runtime/data_lifecycle_manager.py
@@ -155,7 +155,10 @@ class DataLifecycleManager:
             ValueError: If no results have been collected.
         """
         if not self.result_data_collection:
-            raise ValueError("No results found")
+            raise ValueError(
+                f"No results found: {self.__class__.__name__} has an empty result collection, "
+                "so no step produced a result to return"
+            )
 
         return list(self.result_data_collection.values())
 

--- a/mloda/core/runtime/flight/flight_server.py
+++ b/mloda/core/runtime/flight/flight_server.py
@@ -114,7 +114,7 @@ class FlightServer:
             path = action.body.to_pybytes()
             self.drop_table(path)
         else:
-            raise ValueError("Unsupported action")
+            raise ValueError(f"Unsupported action {action.type!r}; this server only handles 'drop_table'")
 
     def drop_table(self, table_key: Any) -> None:
         if table_key in self.tables:

--- a/mloda/core/runtime/worker_manager.py
+++ b/mloda/core/runtime/worker_manager.py
@@ -86,7 +86,7 @@ class WorkerManager:
 
     def join_all(self) -> None:
         """Terminate processes (not threads), join all tasks, raise Exception if any fail."""
-        failed = False
+        failures: list[str] = []
         for task in self.tasks:
             try:
                 if isinstance(task, BaseProcess):
@@ -94,7 +94,9 @@ class WorkerManager:
                 task.join()
             except Exception as e:
                 logger.error(f"Error joining task: {e}")
-                failed = True
+                failures.append(f"{getattr(task, 'name', None) or task}: {e}")
 
-        if failed:
-            raise Exception("Error while joining tasks")
+        if failures:
+            raise Exception(
+                f"Error while joining tasks: {len(failures)} of {len(self.tasks)} failed ({'; '.join(failures)})"
+            )


### PR DESCRIPTION
## Summary

Fixes #749. Each of the five listed sites raised a bare string that named neither the object nor the value involved. Each message now carries the relevant identifier and stays to one sentence.

| Site | Before | After |
| --- | --- | --- |
| `feature_set_validator.py:33` | `Filters already set` | `Filters already set to {filters}; they can only be assigned once per feature set` |
| `compute_framework.py:809` | `UUID is not set` | `UUID is not set on compute framework {ClassName}` |
| `data_lifecycle_manager.py:158` | `No results found` | `No results found: {ClassName} has an empty result collection, so no step produced a result to return` |
| `flight_server.py:117` | `Unsupported action` | `Unsupported action {action.type!r}; this server only handles 'drop_table'` |
| `worker_manager.py:100` | `Error while joining tasks` | `Error while joining tasks: {n} of {total} failed ({task}: {err}; …)` |

`join_all` previously tracked only a `failed` boolean while logging each error separately, so the raised exception couldn't say which or how many tasks failed. It now collects the per-task failures and reports them in the message; the `logger.error` per task is unchanged.

## Compatibility

Two existing tests assert on these messages with `pytest.raises(..., match=...)`, which is a regex **search**:

- `test_data_lifecycle_manager.py:374` → `match="No results found"`
- `test_worker_manager.py:425,440` → `match="Error while joining tasks"`

Both messages keep those exact leading substrings, so the tests pass unchanged and no test edits were needed.

## Verification

- `pytest tests/test_core/test_runtime/test_worker_manager.py tests/test_core/test_runtime/test_data_lifecycle_manager.py` → 66 passed
- Core suite (`--ignore=mloda_plugins/ --ignore=tests/test_documentation/ --ignore=tests/test_plugins/ --ignore=tests/test_examples/`) → **3570 passed, 6 skipped**
- `ruff format --check --line-length 120` → 134 files already formatted; `ruff check` → all checks passed
- `mypy --strict --ignore-missing-imports` on all five changed files → success, no issues

Note: I ran the gates individually rather than via full `tox` because the suite's 10s per-test timeout under `-n 8` is flaky on my Windows machine (unrelated to this change); with `--timeout=60` everything passes.
