### PR TITLE
fix: align sklearn feature_engineering pipeline declaration with runtime dispatch

### DIFF
--- a/mloda_plugins/feature_group/experimental/sklearn/pipeline/base.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/pipeline/base.py
@@ -86,7 +86,7 @@ class SklearnPipelineFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         "preprocessing": "Standard preprocessing pipeline with imputation and scaling",
         "scaling": "Feature scaling pipeline",
         "imputation": "Missing value imputation pipeline",
-        "feature_engineering": "Feature engineering pipeline",
+        "feature_engineering": "Degree-2 polynomial and interaction feature generation, followed by scaling",
     }
 
     # Property mapping for new configuration-based approach
@@ -432,10 +432,11 @@ class SklearnPipelineFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         components = {}
 
         try:
-            from sklearn.preprocessing import StandardScaler
+            from sklearn.preprocessing import PolynomialFeatures, StandardScaler
             from sklearn.pipeline import Pipeline
 
             components["StandardScaler"] = StandardScaler
+            components["PolynomialFeatures"] = PolynomialFeatures
             components["Pipeline"] = Pipeline
 
             # Try to import SimpleImputer from different locations depending on sklearn version
@@ -468,21 +469,52 @@ class SklearnPipelineFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 
         Returns:
             Default pipeline configuration
+
+        Raises:
+            ValueError: If the pipeline type has no dispatch branch.
+            ImportError: If a component the pipeline type needs is unavailable.
         """
         sklearn_components = cls._import_sklearn_components()
         StandardScaler = sklearn_components["StandardScaler"]
         SimpleImputer = sklearn_components.get("SimpleImputer")
+        PolynomialFeatures = sklearn_components.get("PolynomialFeatures")
 
-        # Define common pipeline configurations
-        if pipeline_name == "preprocessing" and SimpleImputer:
-            return {"steps": [("imputer", SimpleImputer(strategy="mean")), ("scaler", StandardScaler())], "params": {}}
-        elif pipeline_name == "scaling":
+        def _require(component: Any, name: str) -> Any:
+            # A declared type must fail loudly when its component is missing rather
+            # than quietly degrading to a different pipeline than the one requested.
+            if component is None:
+                raise ImportError(
+                    f"The '{pipeline_name}' pipeline requires {name}, which is not available in the "
+                    "installed scikit-learn version."
+                )
+            return component
+
+        if pipeline_name == "scaling":
             return {"steps": [("scaler", StandardScaler())], "params": {}}
-        elif pipeline_name == "imputation" and SimpleImputer:
-            return {"steps": [("imputer", SimpleImputer(strategy="mean"))], "params": {}}
-        else:
-            # Default to simple scaling
-            return {"steps": [("scaler", StandardScaler())], "params": {}}
+
+        if pipeline_name == "preprocessing":
+            imputer = _require(SimpleImputer, "SimpleImputer")
+            return {"steps": [("imputer", imputer(strategy="mean")), ("scaler", StandardScaler())], "params": {}}
+
+        if pipeline_name == "imputation":
+            imputer = _require(SimpleImputer, "SimpleImputer")
+            return {"steps": [("imputer", imputer(strategy="mean"))], "params": {}}
+
+        if pipeline_name == "feature_engineering":
+            poly = _require(PolynomialFeatures, "PolynomialFeatures")
+            return {
+                "steps": [
+                    ("poly", poly(degree=2, include_bias=False)),
+                    ("scaler", StandardScaler()),
+                ],
+                "params": {},
+            }
+
+        # Every value in PIPELINE_TYPES is dispatched above. Anything else is a
+        # declaration/dispatch mismatch and must not silently become scaling.
+        raise ValueError(
+            f"Unsupported pipeline type {pipeline_name!r}; supported types are {sorted(cls.PIPELINE_TYPES)}."
+        )
 
     @classmethod
     def _pipeline_matches_config(cls, fitted_pipeline: Any, config: dict[str, Any]) -> bool:

--- a/tests/test_plugins/feature_group/experimental/sklearn/test_pipeline_feature_group/test_base_pipeline_feature_group.py
+++ b/tests/test_plugins/feature_group/experimental/sklearn/test_pipeline_feature_group/test_base_pipeline_feature_group.py
@@ -151,22 +151,19 @@ class TestSklearnPipelineFeatureGroup:
         assert "imputer" in step_names
 
     def test_create_default_pipeline_config_unknown(self) -> None:
-        """Test default pipeline configuration for unknown pipeline name."""
+        """An unknown pipeline name is rejected rather than silently scaled.
+
+        This previously asserted the opposite: any undispatched name fell through to the
+        scaling pipeline, which is what hid the missing feature_engineering branch (#797).
+        """
         # Skip test if sklearn not available
         try:
             SklearnPipelineFeatureGroup._import_sklearn_components()
         except ImportError:
             pytest.skip("scikit-learn not available")
 
-        config = SklearnPipelineFeatureGroup._create_default_pipeline_config("unknown_pipeline")
-
-        assert "steps" in config
-        assert "params" in config
-        assert len(config["steps"]) == 1
-
-        # Should default to scaling
-        step_names = [step[0] for step in config["steps"]]
-        assert "scaler" in step_names
+        with pytest.raises(ValueError, match="Unsupported pipeline type"):
+            SklearnPipelineFeatureGroup._create_default_pipeline_config("unknown_pipeline")
 
     def test_create_default_pipeline_config_missing_sklearn(self) -> None:
         """Test default pipeline configuration when sklearn is not available."""
@@ -308,3 +305,42 @@ class TestSklearnPipelineRequiredWhen:
             }
         )
         assert SklearnPipelineFeatureGroup.match_feature_group_criteria("x", options) is False
+
+
+class TestDefaultPipelineConfigDispatch:
+    """Every declared pipeline type must reach its own dispatch branch (see #797)."""
+
+    @staticmethod
+    def _step_names(pipeline_name: str) -> list[str]:
+        config = SklearnPipelineFeatureGroup._create_default_pipeline_config(pipeline_name)
+        return [name for name, _ in config["steps"]]
+
+    def test_every_declared_type_is_dispatched(self) -> None:
+        """No declared type may fall through to the scaling default."""
+        expected = {
+            "preprocessing": ["imputer", "scaler"],
+            "scaling": ["scaler"],
+            "imputation": ["imputer"],
+            "feature_engineering": ["poly", "scaler"],
+        }
+        assert set(expected) == set(SklearnPipelineFeatureGroup.PIPELINE_TYPES), (
+            "PIPELINE_TYPES changed; update this test so the declaration stays pinned to dispatch"
+        )
+        for pipeline_name, steps in expected.items():
+            assert self._step_names(pipeline_name) == steps, f"'{pipeline_name}' produced the wrong pipeline"
+
+    def test_feature_engineering_is_distinct_from_scaling(self) -> None:
+        """The defect in #797: feature_engineering silently produced the scaling pipeline."""
+        assert self._step_names("feature_engineering") != self._step_names("scaling")
+
+    def test_feature_engineering_generates_polynomial_features(self) -> None:
+        """feature_engineering must actually derive new features, not just rescale existing ones."""
+        config = SklearnPipelineFeatureGroup._create_default_pipeline_config("feature_engineering")
+        poly = dict(config["steps"])["poly"]
+        assert poly.degree == 2
+        assert poly.include_bias is False
+
+    def test_unknown_pipeline_type_raises(self) -> None:
+        """An undispatched type must fail loudly instead of becoming scaling."""
+        with pytest.raises(ValueError, match="Unsupported pipeline type"):
+            SklearnPipelineFeatureGroup._create_default_pipeline_config("not_a_real_type")


### PR DESCRIPTION
## Summary

Fixes #797. `PIPELINE_TYPES` advertised `feature_engineering` and the class docs gave `customer_data__sklearn_pipeline_feature_engineering` as a valid feature name, but `_create_default_pipeline_config()` only branched on `preprocessing`, `scaling` and `imputation`. Every other validated value hit the `else` and silently returned the **scaling** pipeline — so a user asking for feature engineering got plain rescaling with no signal.

## Change

**1. `feature_engineering` gets a real branch.** Degree-2 `PolynomialFeatures(include_bias=False)` followed by `StandardScaler`, i.e. it now actually derives new features (polynomial + interaction terms) instead of only rescaling existing ones, and the scaler keeps the generated terms on a comparable scale. `PIPELINE_TYPES` documents this rather than the previous placeholder text.

**2. No validated type can silently fall through.** The `else → scaling` default is replaced with an explicit `ValueError` naming the offending value and the supported set. This is the DoD item "a validated pipeline type never silently falls through to scaling solely because its dispatch branch is missing".

**3. Missing components fail loudly.** The old branches were guarded with `and SimpleImputer`, so if `SimpleImputer` were unavailable, `preprocessing`/`imputation` also degraded into scaling. Each type now raises an `ImportError` naming the component it needs instead of quietly running a different pipeline.

Resulting dispatch — every declared type distinct:

| type | steps |
| --- | --- |
| `preprocessing` | `imputer`, `scaler` |
| `scaling` | `scaler` |
| `imputation` | `imputer` |
| `feature_engineering` | `poly`, `scaler` |

## Tests

New `TestDefaultPipelineConfigDispatch` covers **every** supported default pipeline type, asserts `feature_engineering != scaling`, checks the polynomial step is really configured (`degree=2`, `include_bias=False`), and pins the unknown-type rejection. It also asserts its expectation set equals `PIPELINE_TYPES`, so adding a type without a dispatch branch fails the test — which is the drift contract #774 can build on.

`test_create_default_pipeline_config_unknown` previously asserted the old fall-through (unknown → scaling); since that behaviour is exactly what this issue removes, it now pins the rejection, with a docstring explaining the change.

## Verification

- `pytest tests/test_plugins/feature_group/experimental/sklearn/` → **119 passed**
- `pytest tests/test_plugins/` → **3042 passed, 170 skipped**
- `ruff format --check --line-length 120` → 714 files already formatted; `ruff check` → all checks passed
- `mypy --strict --ignore-missing-imports` on the changed module → success

One unrelated pre-existing failure, `test_sqlite.py::TestSQLITEReader::test_is_valid_credentials_nonexistent`, reproduces on a clean tree (stashed) on my Windows machine and is deselected above; it is untouched by this change.
