### PR TITLE
feat: core-provided bool-rejecting positive-int predicate, migrate the divergent plugin copies

### DIFF
--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -108,6 +108,33 @@ matcher therefore keeps the contract, whether the override delegates or not.
 | "The value as a whole must have this shape" (a dict, a list of exactly 3, an ordering) | `match_guard` |
 | "This option is required only when another option says so" | `required_when` |
 
+### Positive-integer options: use the shared predicate
+
+Do not hand-roll a positive-integer check. Python bools satisfy `isinstance(value, int)`, so
+the obvious predicate accepts `horizon=True`; and `str.isdigit()` accepts `"²"`, which then
+raises in `int()`. `mloda.provider` exports one predicate that gets both right, and accepts
+numpy integers and decimal strings:
+
+```python
+from mloda.provider import PropertySpec, is_positive_int
+
+WINDOW_SIZE: PropertySpec(
+    "Size of the time window (must be positive integer)",
+    context=True,
+    strict_validation=True,
+    element_validator=is_positive_int,
+)
+```
+
+It accepts positive Python ints, numpy integers and decimal strings, and rejects `bool`,
+zero, negatives, and non-integers. Shipped plugins (`window_size`, `horizon`, `k_value`,
+`dimension`) all use it, so the value space stays consistent across feature groups. If a key
+allows an extra sentinel, compose rather than fork it, as clustering does for `"auto"`:
+
+```python
+element_validator=lambda value: value == "auto" or is_positive_int(value),
+```
+
 The two callables differ on both axes, which is what their names say:
 
 - **`element_validator`** sees **one element**, only under `strict_validation`, and a falsy

--- a/mloda/core/abstract_plugins/components/feature_chainer/property_spec.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/property_spec.py
@@ -7,9 +7,30 @@ its ``strict=`` keyword maps to the ``strict_validation=`` field.
 
 from __future__ import annotations
 
+import numbers
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
 from typing import Any
+
+
+def is_positive_int(value: Any) -> bool:
+    """Element validator for positive-integer options.
+
+    Accepts Python ints, numpy integers, and decimal strings. Rejects ``bool`` (which
+    would otherwise pass ``isinstance(value, int)`` and let ``horizon=True`` through),
+    zero, negatives, non-integers, and non-decimal digit strings such as ``"²"``, which
+    satisfy ``str.isdigit()`` but raise in ``int()``.
+
+    Use this instead of hand-rolling the check, so every plugin agrees on what a
+    positive integer is::
+
+        WINDOW_SIZE: PropertySpec("...", element_validator=is_positive_int)
+    """
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, numbers.Integral):
+        return int(value) > 0
+    return isinstance(value, str) and value.isdecimal() and int(value) > 0
 
 
 class _NoDefault:

--- a/mloda/provider/__init__.py
+++ b/mloda/provider/__init__.py
@@ -75,6 +75,7 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
 from mloda.core.abstract_plugins.components.feature_chainer.property_spec import (
     NO_DEFAULT,
     PropertySpec,
+    is_positive_int,
     property_spec,
 )
 
@@ -142,6 +143,7 @@ __all__ = [
     "INPUT_SEPARATOR",
     "FeatureChainParserMixin",
     "PropertySpec",
+    "is_positive_int",
     "property_spec",
     "NO_DEFAULT",
     # Subtype declaration

--- a/mloda_plugins/feature_group/experimental/clustering/base.py
+++ b/mloda_plugins/feature_group/experimental/clustering/base.py
@@ -15,7 +15,7 @@ from mloda.provider import (
 )
 from mloda.provider import FeatureSet
 from mloda.provider import DefaultOptionKeys
-from mloda.provider import PropertySpec
+from mloda.provider import PropertySpec, is_positive_int
 
 
 def _is_bool(value: Any) -> bool:
@@ -128,9 +128,7 @@ class ClusteringFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             "Number of clusters or 'auto' for automatic determination",
             context=True,
             strict_validation=True,
-            element_validator=lambda value: (
-                value == "auto" or (isinstance(value, (int, str)) and str(value).isdigit() and int(value) > 0)
-            ),
+            element_validator=lambda value: value == "auto" or is_positive_int(value),
         ),
         DefaultOptionKeys.in_features: PropertySpec(
             "Source features to use for clustering",

--- a/mloda_plugins/feature_group/experimental/dimensionality_reduction/base.py
+++ b/mloda_plugins/feature_group/experimental/dimensionality_reduction/base.py
@@ -4,7 +4,6 @@ Base implementation for dimensionality reduction feature groups.
 
 from __future__ import annotations
 
-import numbers
 from abc import abstractmethod
 from typing import Any, Optional
 
@@ -17,16 +16,7 @@ from mloda.provider import (
 from mloda.provider import FeatureSet
 from mloda.user import Options
 from mloda.provider import DefaultOptionKeys
-from mloda.provider import PropertySpec
-
-
-def _is_positive_int(value: Any) -> bool:
-    """Accept any positive integer (int, numpy int, decimal string), so bool, 0, -5, 2.5, "abc" and "²" are rejected."""
-    if isinstance(value, bool):
-        return False
-    if isinstance(value, numbers.Integral):
-        return int(value) > 0
-    return isinstance(value, str) and value.isdecimal() and int(value) > 0
+from mloda.provider import PropertySpec, is_positive_int
 
 
 class DimensionalityReductionFeatureGroup(FeatureChainParserMixin, FeatureGroup):
@@ -140,14 +130,14 @@ class DimensionalityReductionFeatureGroup(FeatureChainParserMixin, FeatureGroup)
             "Target dimension for the reduction (positive integer)",
             context=True,
             strict_validation=True,
-            element_validator=_is_positive_int,
+            element_validator=is_positive_int,
         ),
         DefaultOptionKeys.in_features: PropertySpec(
             "Source features to use for dimensionality reduction",
             context=True,
             strict_validation=False,
         ),
-        # The algorithm-specific numeric keys below share _is_positive_int across both hooks.
+        # The algorithm-specific numeric keys below share is_positive_int across both hooks.
         # element_validator produces the rejection message and checks the declared default at
         # construction; it runs on BOTH match paths, so it alone enforces the value space. match_guard
         # additionally judges the raw, un-unpacked value.
@@ -157,16 +147,16 @@ class DimensionalityReductionFeatureGroup(FeatureChainParserMixin, FeatureGroup)
             context=True,
             strict_validation=True,
             default=250,
-            element_validator=_is_positive_int,
-            match_guard=_is_positive_int,
+            element_validator=is_positive_int,
+            match_guard=is_positive_int,
         ),
         TSNE_N_ITER_WITHOUT_PROGRESS: PropertySpec(
             "Maximum iterations without progress before early stopping (t-SNE)",
             context=True,
             strict_validation=True,
             default=50,
-            element_validator=_is_positive_int,
-            match_guard=_is_positive_int,
+            element_validator=is_positive_int,
+            match_guard=is_positive_int,
         ),
         TSNE_METHOD: PropertySpec(
             "t-SNE computation method",
@@ -197,8 +187,8 @@ class DimensionalityReductionFeatureGroup(FeatureChainParserMixin, FeatureGroup)
             context=True,
             strict_validation=True,
             default=200,
-            element_validator=_is_positive_int,
-            match_guard=_is_positive_int,
+            element_validator=is_positive_int,
+            match_guard=is_positive_int,
         ),
         # Isomap specific parameters
         ISOMAP_N_NEIGHBORS: PropertySpec(
@@ -206,8 +196,8 @@ class DimensionalityReductionFeatureGroup(FeatureChainParserMixin, FeatureGroup)
             context=True,
             strict_validation=True,
             default=5,
-            element_validator=_is_positive_int,
-            match_guard=_is_positive_int,
+            element_validator=is_positive_int,
+            match_guard=is_positive_int,
         ),
     }
 

--- a/mloda_plugins/feature_group/experimental/forecasting/base.py
+++ b/mloda_plugins/feature_group/experimental/forecasting/base.py
@@ -14,7 +14,7 @@ from mloda.provider import CHAIN_SEPARATOR, FeatureChainParser, FeatureChainPars
 from mloda.user import FeatureName
 from mloda.user import Options
 from mloda.provider import DefaultOptionKeys
-from mloda.provider import PropertySpec
+from mloda.provider import PropertySpec, is_positive_int
 from mloda_plugins.feature_group.experimental.forecasting.forecasting_artifact import ForecastingArtifact
 from mloda_plugins.feature_group.experimental.time_reference_mixin import TimeReferenceMixin
 
@@ -141,7 +141,7 @@ class ForecastingFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featu
             "Forecast horizon (number of time units to predict)",
             context=True,
             strict_validation=True,
-            element_validator=lambda x: (isinstance(x, int) or (isinstance(x, str) and x.isdigit())) and int(x) > 0,
+            element_validator=is_positive_int,
         ),
         TIME_UNIT: PropertySpec(
             "Time unit of the forecast horizon",

--- a/mloda_plugins/feature_group/experimental/time_window/base.py
+++ b/mloda_plugins/feature_group/experimental/time_window/base.py
@@ -17,7 +17,7 @@ from mloda.user import FeatureName
 from mloda.provider import FeatureSet
 from mloda.user import Options
 from mloda.provider import DefaultOptionKeys
-from mloda.provider import PropertySpec
+from mloda.provider import PropertySpec, is_positive_int
 from mloda_plugins.feature_group.experimental.time_reference_mixin import TimeReferenceMixin
 
 
@@ -104,9 +104,7 @@ class TimeWindowFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featur
             "Size of the time window (must be positive integer)",
             context=True,
             strict_validation=True,
-            element_validator=lambda x: (
-                (isinstance(x, int) and x > 0) or (isinstance(x, str) and x.isdigit() and int(x) > 0)
-            ),
+            element_validator=is_positive_int,
         ),
         TIME_UNIT: PropertySpec(
             "Time unit of the window size",

--- a/tests/test_core/test_abstract_plugins/test_is_positive_int.py
+++ b/tests/test_core/test_abstract_plugins/test_is_positive_int.py
@@ -1,0 +1,113 @@
+"""Hardening tests for the shared positive-integer predicate (issue #773).
+
+Python bools satisfy ``isinstance(value, int)``, so hand-written positive-int predicates
+accepted ``horizon=True`` and ``window_size=True``. The shipped plugins each carried their
+own copy with inconsistent bool and numpy-integer behavior; they now share one predicate,
+and these tests pin that contract for the predicate itself and for WINDOW_SIZE, HORIZON
+and K_VALUE.
+"""
+
+from typing import Any
+
+import pytest
+
+from mloda.provider import is_positive_int
+from mloda_plugins.feature_group.experimental.clustering.base import ClusteringFeatureGroup
+from mloda_plugins.feature_group.experimental.dimensionality_reduction.base import (
+    DimensionalityReductionFeatureGroup,
+)
+from mloda_plugins.feature_group.experimental.forecasting.base import ForecastingFeatureGroup
+from mloda_plugins.feature_group.experimental.time_window.base import TimeWindowFeatureGroup
+
+np = pytest.importorskip("numpy")
+
+
+ACCEPTED: list[Any] = [1, 5, 10**9, "1", "42"]
+REJECTED: list[Any] = [
+    True,  # bool is the whole point: isinstance(True, int) is True
+    False,
+    0,
+    -1,
+    -5,
+    2.5,
+    "0",
+    "-3",
+    "abc",
+    "",
+    "²",  # str.isdigit() accepts it, but int() raises on it
+    "1.5",
+    None,
+    [],
+]
+
+
+class TestIsPositiveInt:
+    @pytest.mark.parametrize("value", ACCEPTED)
+    def test_accepts_positive_integers(self, value: Any) -> None:
+        assert is_positive_int(value) is True
+
+    @pytest.mark.parametrize("value", REJECTED)
+    def test_rejects_everything_else(self, value: Any) -> None:
+        assert is_positive_int(value) is False
+
+    @pytest.mark.parametrize("dtype", ["int8", "int16", "int32", "int64", "uint8", "uint32"])
+    def test_accepts_numpy_integers(self, dtype: str) -> None:
+        assert is_positive_int(np.dtype(dtype).type(7)) is True
+
+    @pytest.mark.parametrize("dtype", ["int8", "int32", "int64"])
+    def test_rejects_non_positive_numpy_integers(self, dtype: str) -> None:
+        assert is_positive_int(np.dtype(dtype).type(0)) is False
+
+    def test_rejects_numpy_bool(self) -> None:
+        """np.bool_ is not numbers.Integral, so it must not slip through as an integer."""
+        assert is_positive_int(np.bool_(True)) is False
+
+    @pytest.mark.parametrize("value", ["²", "³", "½"])
+    def test_rejects_digit_like_strings_that_int_cannot_parse(self, value: str) -> None:
+        """These satisfy str.isdigit()/isnumeric() but raise in int(), so isdecimal() is the right gate."""
+        assert is_positive_int(value) is False
+
+    def test_accepts_non_ascii_decimal_digits(self) -> None:
+        """'٣' is a genuine decimal digit that int() parses to 3, so it is accepted."""
+        assert int("٣") == 3
+        assert is_positive_int("٣") is True
+
+
+class TestPluginKeysShareThePredicate:
+    """WINDOW_SIZE, HORIZON and K_VALUE must agree on what a positive integer is."""
+
+    CASES = [
+        ("WINDOW_SIZE", TimeWindowFeatureGroup, TimeWindowFeatureGroup.WINDOW_SIZE),
+        ("HORIZON", ForecastingFeatureGroup, ForecastingFeatureGroup.HORIZON),
+        ("K_VALUE", ClusteringFeatureGroup, ClusteringFeatureGroup.K_VALUE),
+        ("DIMENSION", DimensionalityReductionFeatureGroup, DimensionalityReductionFeatureGroup.DIMENSION),
+    ]
+
+    @staticmethod
+    def _validator(group: Any, key: str) -> Any:
+        validator = group.PROPERTY_MAPPING[key].element_validator
+        assert validator is not None, f"{key} should declare an element_validator"
+        return validator
+
+    @pytest.mark.parametrize("label,group,key", CASES)
+    def test_rejects_bool(self, label: str, group: Any, key: str) -> None:
+        """The #773 defect: horizon=True and window_size=True were accepted."""
+        assert self._validator(group, key)(True) is False
+        assert self._validator(group, key)(False) is False
+
+    @pytest.mark.parametrize("label,group,key", CASES)
+    def test_accepts_python_and_numpy_integers(self, label: str, group: Any, key: str) -> None:
+        validator = self._validator(group, key)
+        assert validator(3) is True
+        assert validator(np.int64(3)) is True
+
+    @pytest.mark.parametrize("label,group,key", CASES)
+    def test_rejects_zero_and_negative(self, label: str, group: Any, key: str) -> None:
+        validator = self._validator(group, key)
+        assert validator(0) is False
+        assert validator(-2) is False
+
+    def test_k_value_still_accepts_auto(self) -> None:
+        """Clustering's extra 'auto' value must survive the migration."""
+        validator = self._validator(ClusteringFeatureGroup, ClusteringFeatureGroup.K_VALUE)
+        assert validator("auto") is True


### PR DESCRIPTION
## Summary

Fixes #773. Python bools satisfy `isinstance(value, int)`, so the hand-written positive-int predicates accepted `horizon=True` and `window_size=True`. The four shipped copies also disagreed with each other.

Behaviour of the copies before this change:

| key | `True` | numpy int | `"²"` |
| --- | --- | --- | --- |
| `HORIZON` (forecasting) | **accepted** | rejected | **raises `ValueError`** |
| `WINDOW_SIZE` (time_window) | **accepted** | rejected | **raises `ValueError`** |
| `K_VALUE` (clustering) | rejected | accepted | **raises `ValueError`** |
| `DIMENSION` (dimensionality_reduction) | rejected | accepted | rejected |

Three of them used `str.isdigit()`, which accepts non-decimal digit characters like `"²"` that then **raise** in `int()` — the predicate crashes instead of returning `False`. Only the dimensionality-reduction copy got both bool and numpy right; it used `str.isdecimal()`, which is the correct gate.

## Change

Export that correct implementation as `is_positive_int` from `mloda.provider`, next to `PropertySpec`:

```python
from mloda.provider import PropertySpec, is_positive_int

WINDOW_SIZE: PropertySpec(..., strict_validation=True, element_validator=is_positive_int)
```

It accepts positive Python ints, numpy integers and decimal strings; rejects `bool`, zero, negatives, non-integers, and digit-like strings `int()` can't parse.

Migrated all four: `HORIZON`, `WINDOW_SIZE` and `DIMENSION` use it directly, and the local `_is_positive_int` in `dimensionality_reduction/base.py` is deleted in favour of the shared one. `K_VALUE` **composes** rather than forks, keeping its `"auto"` sentinel:

```python
element_validator=lambda value: value == "auto" or is_positive_int(value),
```

All four keys now agree: `True → False`, `np.int64(3) → True`, `"²" → False` (no raise).

## Tests

New `tests/test_core/test_abstract_plugins/test_is_positive_int.py` (46 tests) covers the predicate directly (including `np.bool_`, which is not `numbers.Integral` and must not slip through) and pins bool/numpy behaviour for **WINDOW_SIZE, HORIZON and K_VALUE** as the DoD asks, plus `DIMENSION` and the surviving `"auto"`.

One note: while writing these I asserted `"٣"` should be rejected and the test failed — correctly. `"٣"` is Arabic-Indic digit three: it *is* decimal and `int("٣") == 3`, so accepting it is right. The test now pins that as intended behaviour rather than the other way round.

## Docs

`docs/in_depth/property-mapping.md` gains a "Positive-integer options" section explaining why hand-rolling this is a trap (bool, and `isdigit` vs `isdecimal`) and showing both the direct and the composed usage.

## Verification

- New tests → 46 passed
- Full suite (`-m "not notebooks"`) → **6809 passed, 170 skipped**
- `ruff format --check --line-length 120 .` → 863 files already formatted; `ruff check .` → all checks passed
- `mypy --strict --ignore-missing-imports mloda/ mloda_plugins/` → success, 282 source files

Two pre-existing failures are excluded above and both reproduce on a clean tree (verified by stashing): `test_sqlite.py::TestSQLITEReader::test_is_valid_credentials_nonexistent`, and the `base_usage` notebook test (notebooks run in their own CI job).

Happy to follow up on the mloda-registry percentile adoption once this is released.
