### PR TITLE
refactor: drop no-op required_uuids.union() in add_tfs

### DIFF
--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -255,8 +255,7 @@ class ExecutionPlan:
                             match.add(found)
                             break
                     if match:
-                        # We add the uuid of the joinstep to the required_uuids of the feature group.
-                        ep.required_uuids.union(match)
+                        # parent is served by a join step; the consumer is already ordered after it via the link uuid
                         continue
 
                     # We only want to add TFS for direct parents and not for parent parents.


### PR DESCRIPTION
## Summary

Removes a dead line in `ExecutionPlan.add_tfs`. `ep.required_uuids.union(match)` called the non-mutating `set.union()` and discarded the result, so it never added anything to `required_uuids`. The comment above it claimed otherwise. It has been a no-op since the initial public commit.

The consumer feature group is already ordered after the join via the link uuid (`link.uuid` is in the consumer's `required_uuids`, `JoinStep.get_uuids()` emits both `js.uuid` and `link.uuid`, and the runtime scheduler gates on it), so no `required_uuids` entry was ever needed here. Removing the line rather than "fixing" it to `.update()` hides nothing. The comment is replaced with one that states why skipping is safe.

## Validation

- Full `tox` green (pytest, `ruff format`/`ruff check`, `mypy --strict`, bandit, license allowlist).
- Behavior-preserving: `required_uuids` is a plain `set`, `.union()` does not mutate, and the discarded return was the only effect. It is the only `.union(` call in the codebase whose result is discarded.