### PR TITLE
fix: replace deprecated feather.read_table with ipc.open_file

### DIFF
--- a/mloda_plugins/feature_group/input_data/read_files/feather.py
+++ b/mloda_plugins/feature_group/input_data/read_files/feather.py
@@ -1,9 +1,9 @@
 from typing import Any
 
 try:
-    from pyarrow import feather as pyarrow_feather
+    import pyarrow as pa
 except ImportError:
-    pyarrow_feather = None
+    pa = None
 
 from mloda.provider import FeatureSet
 from mloda_plugins.feature_group.input_data.read_file import ReadFile
@@ -109,9 +109,12 @@ class FeatherReader(ReadFile):
 
     @classmethod
     def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
-        if pyarrow_feather is None:
+        if pa is None:
             raise ImportError(
                 "pyarrow is required to read Feather files. Install it with: pip install 'mloda[pyarrow]'"
             )
         columns = list(features.get_all_names())
-        return pyarrow_feather.read_table(source=data_access, columns=columns).select(columns)
+        # Feather V2 is the Arrow IPC file format; use ipc.open_file instead of the
+        # deprecated pyarrow.feather.read_table (removed warning as of pyarrow 24).
+        with pa.ipc.open_file(data_access) as reader:
+            return reader.read_all().select(columns)

--- a/tests/test_plugins/feature_group/input_data/test_read_files/test_deterministic_column_order.py
+++ b/tests/test_plugins/feature_group/input_data/test_read_files/test_deterministic_column_order.py
@@ -4,7 +4,6 @@ import tempfile
 from typing import Any
 
 import pyarrow as pa
-import pyarrow.feather as pyarrow_feather
 import pyarrow.orc as pyarrow_orc
 import pyarrow.parquet as pyarrow_parquet
 
@@ -59,7 +58,9 @@ class TestDeterministicColumnOrder:
         table = pa.Table.from_pydict({"c1": [1, 2, 3], "a1": [4, 5, 6], "b1": [7, 8, 9]})
 
         cls.feather_file = f"{cls.base_path}/test.feather"
-        pyarrow_feather.write_feather(table, cls.feather_file)
+        with pa.OSFile(cls.feather_file, "wb") as sink:
+            with pa.ipc.new_file(sink, table.schema) as writer:
+                writer.write_table(table)
 
         cls.json_file = f"{cls.base_path}/test.json"
         with open(cls.json_file, "w") as f:

--- a/tests/test_plugins/feature_group/input_data/test_read_files/test_implementations.py
+++ b/tests/test_plugins/feature_group/input_data/test_read_files/test_implementations.py
@@ -5,12 +5,18 @@ import tempfile
 from typing import Any
 
 import pyarrow as pa
-import pyarrow.feather as pyarrow_feather
 import pyarrow.json as pyarrow_json
 import pyarrow.csv as pyarrow_csv
 import pyarrow.orc as pyarrow_orc
 import pyarrow.parquet as pyarrow_parquet
 import pytest
+
+
+def _read_feather_ipc(source: Any, columns: list[str] | None = None) -> Any:
+    """Non-deprecated Feather V2 reader used as the test comparison oracle."""
+    with pa.ipc.open_file(source) as reader:
+        table = reader.read_all()
+    return table.select(columns) if columns is not None else table
 
 from mloda_plugins.compute_framework.base_implementations.pyarrow.pyarrow_file_source_transformer import (
     FileSourcePyArrowTransformer,
@@ -50,7 +56,9 @@ class TestReadFilesImplementations:
 
         # Save datasets in different formats
         cls.feather_file = "test.feather"
-        pyarrow_feather.write_feather(cls.table, cls.feather_file)
+        with pa.OSFile(cls.feather_file, "wb") as sink:
+            with pa.ipc.new_file(sink, cls.table.schema) as writer:
+                writer.write_table(cls.table)
 
         cls.json_file = "test.json"
         with open(cls.json_file, "w") as f:
@@ -111,7 +119,7 @@ class TestReadFilesImplementations:
 
     def test_implementations_read(self) -> None:
         test_cases = [
-            (FeatherReader, self.feather_file, pyarrow_feather.read_table),
+            (FeatherReader, self.feather_file, _read_feather_ipc),
             (JsonReader, self.json_file, pyarrow_json.read_json),
             (CsvReader, self.csv_file, pyarrow_csv.read_csv),
             (OrcReader, self.orc_file, pyarrow_orc.read_table),


### PR DESCRIPTION
﻿## Summary
- Replace deprecated pyarrow.feather.read_table in FeatherReader.load_data with pa.ipc.open_file (Feather V2 is Arrow IPC)
- Update test comparison oracles and write fixtures to the non-deprecated IPC APIs so pyarrow 24 emits no FutureWarning

Closes #825

## Test plan
- [x] pytest feather read + deterministic column order tests with -W error::FutureWarning (4 passed)
