### PR TITLE
feat: capture per-feature EvaluationResult during planning and expose session.resolution_report() (#811)

### DIFF
--- a/attribution/ATTRIBUTION.md
+++ b/attribution/ATTRIBUTION.md
@@ -82,7 +82,7 @@
 | pytest-xdist                           | 3.8.0           | MIT                                                |
 | python-dateutil                        | 2.9.0.post0     | Apache Software License; BSD License               |
 | pyzmq                                  | 27.1.0          | BSD License                                        |
-| regex                                  | 2026.6.28       | Apache-2.0 AND CNRI-Python                         |
+| regex                                  | 2026.7.10       | Apache-2.0 AND CNRI-Python                         |
 | requests                               | 2.34.2          | Apache Software License                            |
 | rich                                   | 14.3.4          | MIT License                                        |
 | ruff                                   | 0.15.21         | MIT                                                |

--- a/mloda/core/api/request.py
+++ b/mloda/core/api/request.py
@@ -316,7 +316,7 @@ class mlodaAPI:
         """
         if self.engine is None:
             raise ValueError("Internal error: engine not initialized. This is likely a bug in mloda.")
-        return list(self.engine.resolution_records)
+        return deepcopy(self.engine.resolution_records)
 
     def run(
         self,

--- a/mloda/core/api/request.py
+++ b/mloda/core/api/request.py
@@ -9,6 +9,7 @@ from mloda.core.abstract_plugins.components.plugin_option.plugin_collector impor
 # Explicit alias re-exports Engine under no_implicit_reexport so tests can patch mloda.core.api.request.Engine.
 from mloda.core.core.engine import Engine as Engine
 from mloda.core.api.plan_info import PlanStep, build_plan_steps
+from mloda.core.prepare.identify_feature_group import ResolutionRecord
 from mloda.core.api.run_result import ResultStream, RunResult
 from mloda.core.api.prepare.setup_compute_framework import SetupComputeFramework
 from mloda.core.prepare.accessible_plugins import filter_extenders_by_strict_mode
@@ -307,6 +308,15 @@ class mlodaAPI:
         if self.engine is None:
             raise ValueError("Internal error: engine not initialized. This is likely a bug in mloda.")
         return build_plan_steps(self.engine.execution_planner)
+
+    def resolution_report(self) -> list[ResolutionRecord]:
+        """Return this session's per-feature resolution records, captured during planning.
+
+        Available after ``prepare()`` and unchanged by ``run()``. Mirrors ``resolved_plan()``.
+        """
+        if self.engine is None:
+            raise ValueError("Internal error: engine not initialized. This is likely a bug in mloda.")
+        return list(self.engine.resolution_records)
 
     def run(
         self,

--- a/mloda/core/core/engine.py
+++ b/mloda/core/core/engine.py
@@ -21,7 +21,11 @@ from mloda.core.prepare.execution_plan import ExecutionPlan
 from mloda.core.prepare.graph.build_graph import BuildGraph
 from mloda.core.prepare.resolve_graph import ResolveGraph
 from mloda.core.runtime.run import ExecutionOrchestrator
-from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+from mloda.core.prepare.identify_feature_group import (
+    EvaluationResult,
+    IdentifyFeatureGroupClass,
+    ResolutionRecord,
+)
 from mloda.core.runtime.flight.runner_flight_server import ParallelRunnerFlightServer
 from mloda.core.abstract_plugins.feature_group import FeatureGroup, format_feature_group_class
 from mloda.core.abstract_plugins.components.feature import Feature
@@ -73,6 +77,7 @@ class Engine:
         self.request_feature_order: list[str] = [str(f.name) for f in features]
         self._dual_consumption_warned: set[tuple[str, str, frozenset[str]]] = set()
         self._property_mapping_keys_cache: dict[type[FeatureGroup], frozenset[str]] = {}
+        self.resolution_records: list[ResolutionRecord] = []
         self.execution_planner = self.create_setup_execution_plan(features)
         self.tfs_connection_map = self._resolve_tfs_connection_map()
 
@@ -131,14 +136,15 @@ class Engine:
         execution_planner.create_execution_plan(planned_queue, graph, resolver.resolver_links.get_link_trekker())
         return execution_planner
 
-    def setup_features_recursion(self, features: Features) -> None:
+    def setup_features_recursion(self, features: Features, requested: bool = True) -> None:
         for feature in features:
-            self._process_feature(feature, features)
+            self._process_feature(feature, features, requested)
 
-    def _process_feature(self, feature: Feature, features: Features) -> None:
+    def _process_feature(self, feature: Feature, features: Features, requested: bool) -> None:
         """Processes a single feature by delegating tasks to helper methods."""
 
-        feature_group_class, compute_frameworks = self._identify_feature_group_and_frameworks(feature)
+        feature_group_class, compute_frameworks, result = self._identify_feature_group_and_frameworks(feature)
+        self.resolution_records.append(ResolutionRecord(str(feature.name), requested, result))
         self._warn_on_dual_option_consumption(feature, feature_group_class)
         feature_group = feature_group_class()
 
@@ -209,12 +215,13 @@ class Engine:
 
     def _identify_feature_group_and_frameworks(
         self, feature: Feature
-    ) -> tuple[type[FeatureGroup], set[type[ComputeFramework]]]:
-        """Identifies the feature group class and compute frameworks for a given feature."""
+    ) -> tuple[type[FeatureGroup], set[type[ComputeFramework]], EvaluationResult]:
+        """Identifies the feature group class, compute frameworks, and the EvaluationResult for a feature."""
         identifier = IdentifyFeatureGroupClass(
             feature, self.accessible_plugins, self.links, self.data_access_collection
         )
-        return identifier.get()
+        feature_group_class, compute_frameworks = identifier.get()
+        return feature_group_class, compute_frameworks, identifier.result
 
     def _add_index_feature(
         self,
@@ -399,7 +406,7 @@ class Engine:
             if features.child_uuid is None:
                 raise ValueError(f"Features {features} has no parent uuid although it should have one.")
             self.feature_link_parents[features.child_uuid] = features.parent_uuids
-            self.setup_features_recursion(features)
+            self.setup_features_recursion(features, requested=False)
 
     def set_compute_framework(self, feature: Feature, compute_frameworks: set[type[ComputeFramework]]) -> Feature:
         """

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -67,6 +67,15 @@ class EvaluationResult:
         return "none"
 
 
+@dataclass(frozen=True)
+class ResolutionRecord:
+    """One feature's identification during planning: its name, whether it was requested, and its EvaluationResult."""
+
+    feature_name: str
+    requested: bool
+    result: EvaluationResult
+
+
 class FeatureResolutionError(ValueError):
     """Typed resolution failure carrying the feature name and the EvaluationResult of its single pass."""
 
@@ -268,6 +277,7 @@ class IdentifyFeatureGroupClass:
     # they are scoped to one resolution attempt and never cache across runs.
     _domain_outcomes: dict[type[FeatureGroup], tuple[Optional[Domain], Optional[Exception]]]
     _declared_frameworks: dict[type[FeatureGroup], frozenset[type[ComputeFramework]]]
+    result: EvaluationResult
 
     def __init__(
         self,
@@ -282,6 +292,7 @@ class IdentifyFeatureGroupClass:
         if message is not None:
             raise FeatureResolutionError(message, str(feature.name), result)
         self.feature_group_compute_framework_mapping = result.identified
+        self.result = result
 
     @classmethod
     def evaluate(

--- a/mloda/steward/__init__.py
+++ b/mloda/steward/__init__.py
@@ -33,7 +33,7 @@ from mloda.core.abstract_plugins.plugin_registry.plugin_policy import (
 )
 
 # Feature resolution
-from mloda.core.prepare.identify_feature_group import FeatureResolutionError
+from mloda.core.prepare.identify_feature_group import FeatureResolutionError, ResolutionRecord
 
 __version__ = get_mloda_version()
 
@@ -64,4 +64,5 @@ __all__ = [
     "PluginPolicyViolationError",
     # Feature resolution
     "FeatureResolutionError",
+    "ResolutionRecord",
 ]

--- a/mloda/user/__init__.py
+++ b/mloda/user/__init__.py
@@ -52,7 +52,7 @@ from mloda.core.abstract_plugins.plugin_registry.plugin_registry import (
 )
 
 # Feature resolution
-from mloda.core.prepare.identify_feature_group import FeatureResolutionError
+from mloda.core.prepare.identify_feature_group import FeatureResolutionError, ResolutionRecord
 
 # Config loading
 from mloda.core.api.feature_config.loader import load_features_from_config
@@ -110,6 +110,7 @@ __all__ = [
     "register_plugin",
     # Feature resolution
     "FeatureResolutionError",
+    "ResolutionRecord",
     # Streaming API
     "stream_all",
     # Config loading

--- a/tests/test_core/test_api/test_resolution_report.py
+++ b/tests/test_core/test_api/test_resolution_report.py
@@ -1,0 +1,383 @@
+"""Failing tests for per-feature EvaluationResult capture and ``session.resolution_report()`` (issue #811).
+
+Contract under test:
+  * ``mloda.core.prepare.identify_feature_group.ResolutionRecord`` is a frozen dataclass beside
+    ``EvaluationResult``, with fields ``feature_name: str``, ``requested: bool``, ``result: EvaluationResult``
+    in that order. It is re-exported from both ``mloda.user`` and ``mloda.steward``.
+  * ``IdentifyFeatureGroupClass(...).result`` exposes the winning ``EvaluationResult`` on a successful
+    resolution (``failure_kind is None``, ``identified`` holding the winner).
+  * ``Engine`` gains ``resolution_records: list[ResolutionRecord]``, populated in traversal order as each
+    feature is identified: top-level requested features get ``requested=True``, features found via
+    ``input_features`` recursion get ``requested=False``. Records are not deduplicated.
+  * ``mlodaAPI.resolution_report() -> list[ResolutionRecord]`` returns those records (a fresh list each call)
+    without re-matching, available after ``prepare()`` and unchanged by ``run()`` (mirrors ``resolved_plan()``).
+  * On a mid-recursion ``FeatureResolutionError`` the records captured before the failing feature remain on
+    ``engine.resolution_records``; the failing feature's own record is not appended.
+
+All fixture feature-group names carry an ``_811`` suffix and all root feature names a ``res_report_`` prefix:
+test feature groups become global subclasses and a ``DataCreator`` claim is registry-wide, so a shared name
+would leak into another module's candidate universe in the parallel suite.
+"""
+
+import dataclasses
+from typing import Any, Optional
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+# Aliased: a bare ``import mloda.user`` would bind the name ``mloda`` to the package and collide with the
+# ``mloda`` mlodaAPI alias imported below.
+import mloda.steward as mloda_steward
+import mloda.user as mloda_user
+from mloda.core.core.engine import Engine
+from mloda.core.prepare.identify_feature_group import (
+    EvaluationResult,
+    FeatureResolutionError,
+    IdentifyFeatureGroupClass,
+    ResolutionRecord,
+)
+from mloda.provider import BaseInputData, ComputeFramework, DataCreator, FeatureGroup, FeatureSet
+from mloda.user import (
+    DataAccessCollection,
+    Feature,
+    FeatureName,
+    Features,
+    Options,
+    PluginCollector,
+    mloda,
+    mlodaAPI,
+)
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+
+
+# ---------------------------------------------------------------------------
+# Test feature groups
+# ---------------------------------------------------------------------------
+
+
+class ResReportSource_811(FeatureGroup):
+    """Pandas root source providing the feature the consumer chains off."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({"res_report_sales"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return pd.DataFrame({"res_report_sales": [10, 20, 30]})
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+
+class ResReportConsumer_811(FeatureGroup):
+    """Consumes the source feature, so the source becomes a derived input during recursion."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return {Feature("res_report_sales")}
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        data["ResReportConsumer_811"] = data["res_report_sales"] * 2
+        return data
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return {cls.get_class_name()}
+
+
+# Counts every match_feature_group_criteria call so a re-match after prepare would be visible.
+RES_REPORT_MATCH_CALLS_811: dict[str, int] = {}
+
+
+class ResReportCountingSource_811(FeatureGroup):
+    """Root source whose match hook counts calls, proving resolution_report() does not re-match."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({"res_report_counted_811"})
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        RES_REPORT_MATCH_CALLS_811[cls.get_class_name()] = RES_REPORT_MATCH_CALLS_811.get(cls.get_class_name(), 0) + 1
+        return super().match_feature_group_criteria(feature_name, options, data_access_collection)
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return pd.DataFrame({"res_report_counted_811": [1, 2, 3]})
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+
+# Feature names for the engine-level and identify-level tests.
+GOOD_FEATURE_811 = "res_report_good_811"
+BAD_FEATURE_811 = "res_report_bad_811"
+
+
+class ResReportFw_811(ComputeFramework):
+    """Dummy compute framework for the engine-level and identify-level tests."""
+
+
+class ResReportGoodFG_811(FeatureGroup):
+    """Resolves exactly GOOD_FEATURE_811; any other name finds no candidate and raises."""
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == GOOD_FEATURE_811
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+_RES_REPORT_PLUGINS = PluginCollector.enabled_feature_groups({ResReportSource_811, ResReportConsumer_811})
+_COUNTING_PLUGINS = PluginCollector.enabled_feature_groups({ResReportCountingSource_811})
+
+
+def _prepare_session() -> mlodaAPI:
+    """A prepared session whose requested consumer chains off one derived source feature."""
+    return mloda.prepare(
+        ["ResReportConsumer_811"],
+        compute_frameworks={PandasDataFrame},
+        plugin_collector=_RES_REPORT_PLUGINS,
+    )
+
+
+# ---------------------------------------------------------------------------
+# ResolutionRecord dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestResolutionRecordDataclass:
+    """ResolutionRecord is a frozen, value-comparable dataclass with the documented field order."""
+
+    def test_resolution_record_is_a_dataclass(self) -> None:
+        assert dataclasses.is_dataclass(ResolutionRecord)
+
+    def test_resolution_record_is_frozen(self) -> None:
+        record = ResolutionRecord(feature_name="x", requested=True, result=EvaluationResult(identified={}))
+
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            record.feature_name = "y"  # type: ignore[misc]
+
+    def test_resolution_record_field_order(self) -> None:
+        field_names = [field.name for field in dataclasses.fields(ResolutionRecord)]
+
+        assert field_names == ["feature_name", "requested", "result"]
+
+    def test_resolution_records_compare_by_value(self) -> None:
+        result = EvaluationResult(identified={})
+        first = ResolutionRecord(feature_name="x", requested=True, result=result)
+        second = ResolutionRecord(feature_name="x", requested=True, result=result)
+
+        assert first == second
+
+    def test_requested_flag_participates_in_equality(self) -> None:
+        """A requested record must not compare equal to an otherwise identical derived one."""
+        result = EvaluationResult(identified={})
+        requested = ResolutionRecord(feature_name="x", requested=True, result=result)
+        derived = ResolutionRecord(feature_name="x", requested=False, result=result)
+
+        assert requested != derived
+
+
+# ---------------------------------------------------------------------------
+# resolution_report() over a successful session
+# ---------------------------------------------------------------------------
+
+
+class TestResolutionReportSuccessfulSession:
+    """A prepared session reports how each feature resolved, in planning order."""
+
+    def test_resolution_report_returns_non_empty_list_of_records(self) -> None:
+        report = _prepare_session().resolution_report()
+
+        assert isinstance(report, list)
+        assert report, "a prepared session must report at least one resolution record"
+        assert all(isinstance(record, ResolutionRecord) for record in report)
+
+    def test_requested_feature_is_recorded_with_requested_true_and_no_failure(self) -> None:
+        report = _prepare_session().resolution_report()
+
+        consumer_records = [record for record in report if record.feature_name == "ResReportConsumer_811"]
+        assert len(consumer_records) == 1
+        assert consumer_records[0].requested is True
+        assert consumer_records[0].result.failure_kind is None
+
+    def test_derived_input_feature_is_recorded_with_requested_false(self) -> None:
+        report = _prepare_session().resolution_report()
+
+        source_records = [record for record in report if record.feature_name == "res_report_sales"]
+        assert len(source_records) == 1
+        assert source_records[0].requested is False
+        assert source_records[0].result.failure_kind is None
+
+    def test_requested_feature_is_recorded_before_its_derived_input(self) -> None:
+        report = _prepare_session().resolution_report()
+
+        names = [record.feature_name for record in report]
+        assert names.index("ResReportConsumer_811") < names.index("res_report_sales")
+
+    def test_each_record_result_is_an_evaluation_result(self) -> None:
+        report = _prepare_session().resolution_report()
+
+        assert all(isinstance(record.result, EvaluationResult) for record in report)
+
+    def test_record_result_identifies_the_resolving_feature_group(self) -> None:
+        """Each record's ``result.identified`` names the group that actually resolved the feature."""
+        report = _prepare_session().resolution_report()
+
+        consumer_record = next(record for record in report if record.feature_name == "ResReportConsumer_811")
+        source_record = next(record for record in report if record.feature_name == "res_report_sales")
+
+        assert ResReportConsumer_811 in consumer_record.result.identified
+        assert ResReportSource_811 in source_record.result.identified
+
+
+# ---------------------------------------------------------------------------
+# fresh list per call and run() invariance
+# ---------------------------------------------------------------------------
+
+
+class TestResolutionReportFreshListAndRunInvariance:
+    """resolution_report() hands back a fresh list and is unchanged by run() (mirrors resolved_plan())."""
+
+    def test_resolution_report_returns_a_distinct_list_object_each_call(self) -> None:
+        session = _prepare_session()
+
+        assert session.resolution_report() is not session.resolution_report()
+
+    def test_mutating_the_returned_list_does_not_affect_a_later_call(self) -> None:
+        session = _prepare_session()
+
+        first = session.resolution_report()
+        count = len(first)
+        first.clear()
+
+        assert len(session.resolution_report()) == count
+
+    def test_resolution_report_is_unchanged_by_run(self) -> None:
+        session = _prepare_session()
+
+        before_run = session.resolution_report()
+        results = session.run()
+        after_run = session.resolution_report()
+
+        assert after_run == before_run
+
+        # Sanity check that the session really did execute.
+        assert len(results) == 1
+        assert "ResReportConsumer_811" in results[0].columns
+
+
+# ---------------------------------------------------------------------------
+# resolution_report() does not re-match
+# ---------------------------------------------------------------------------
+
+
+class TestResolutionReportDoesNotRematch:
+    """resolution_report() reads captured records; it must not run matching again."""
+
+    def test_resolution_report_does_not_increase_the_match_call_count(self) -> None:
+        RES_REPORT_MATCH_CALLS_811.clear()
+
+        session = mloda.prepare(
+            ["res_report_counted_811"],
+            compute_frameworks={PandasDataFrame},
+            plugin_collector=_COUNTING_PLUGINS,
+        )
+        after_prepare = dict(RES_REPORT_MATCH_CALLS_811)
+        assert after_prepare, "the counting matcher must have run at least once during prepare()"
+
+        session.resolution_report()
+        session.resolution_report()
+
+        assert RES_REPORT_MATCH_CALLS_811 == after_prepare
+
+
+# ---------------------------------------------------------------------------
+# IdentifyFeatureGroupClass exposes the winning result on success
+# ---------------------------------------------------------------------------
+
+
+class TestIdentifyFeatureGroupResultOnSuccess:
+    """After a successful single-candidate resolution the identifier keeps its winning EvaluationResult."""
+
+    def test_result_is_an_evaluation_result_with_no_failure(self) -> None:
+        identifier = IdentifyFeatureGroupClass(
+            feature=Feature(GOOD_FEATURE_811),
+            accessible_plugins={ResReportGoodFG_811: {ResReportFw_811}},
+            links=None,
+            data_access_collection=None,
+        )
+
+        assert isinstance(identifier.result, EvaluationResult)
+        assert identifier.result.failure_kind is None
+        assert ResReportGoodFG_811 in identifier.result.identified
+
+
+# ---------------------------------------------------------------------------
+# Failure reachability at the engine level
+# ---------------------------------------------------------------------------
+
+
+class TestFailureReachabilityAtEngineLevel:
+    """Records captured before a mid-recursion FeatureResolutionError survive on the engine."""
+
+    def test_records_before_the_failing_feature_remain_on_the_engine(self) -> None:
+        with (
+            patch(
+                "mloda.core.prepare.accessible_plugins.PreFilterPlugins.resolve_feature_group_compute_framework_limitations"
+            ) as mocked_accessible_plugins,
+            patch("mloda.core.core.engine.Engine.create_setup_execution_plan"),
+        ):
+            mocked_accessible_plugins.return_value = {ResReportGoodFG_811: {ResReportFw_811}}
+
+            features = Features([GOOD_FEATURE_811, BAD_FEATURE_811])
+            engine = Engine(features, {ResReportFw_811}, None)
+
+            # The bare call must keep working: setup_features_recursion's new requested parameter defaults True.
+            with pytest.raises(FeatureResolutionError):
+                engine.setup_features_recursion(features)
+
+            recorded_names = [record.feature_name for record in engine.resolution_records]
+            assert GOOD_FEATURE_811 in recorded_names
+            assert BAD_FEATURE_811 not in recorded_names
+
+            good_records = [record for record in engine.resolution_records if record.feature_name == GOOD_FEATURE_811]
+            assert len(good_records) == 1
+            assert good_records[0].requested is True
+
+
+# ---------------------------------------------------------------------------
+# Public surface
+# ---------------------------------------------------------------------------
+
+
+class TestResolutionRecordIsPubliclyExported:
+    """ResolutionRecord is re-exported from mloda.user and mloda.steward, mirroring PlanStep."""
+
+    def test_resolution_record_exported_from_user_and_steward(self) -> None:
+        assert "ResolutionRecord" in mloda_user.__all__
+        assert "ResolutionRecord" in mloda_steward.__all__
+
+    def test_user_and_steward_reexport_the_same_object(self) -> None:
+        assert mloda_user.ResolutionRecord is ResolutionRecord
+        assert mloda_steward.ResolutionRecord is ResolutionRecord

--- a/tests/test_core/test_api/test_resolution_report.py
+++ b/tests/test_core/test_api/test_resolution_report.py
@@ -286,6 +286,19 @@ class TestResolutionReportFreshListAndRunInvariance:
         assert len(results) == 1
         assert "ResReportConsumer_811" in results[0].columns
 
+    def test_mutating_a_returned_records_nested_result_does_not_affect_a_later_call(self) -> None:
+        """Clearing a returned record's mutable EvaluationResult must not corrupt a fresh report."""
+        session = _prepare_session()
+
+        report = session.resolution_report()
+        target_name = report[0].feature_name
+        report[0].result.identified.clear()
+        report[0].result.criteria_matched.clear()
+
+        fresh_record = next(r for r in session.resolution_report() if r.feature_name == target_name)
+        assert fresh_record.result.identified, "a later report must not reflect the caller's mutation"
+        assert fresh_record.result.failure_kind is None
+
 
 # ---------------------------------------------------------------------------
 # resolution_report() does not re-match

--- a/tests/test_core/test_core/test_engine_domain_propagation.py
+++ b/tests/test_core/test_core/test_engine_domain_propagation.py
@@ -9,6 +9,7 @@ from uuid import uuid4
 
 
 from mloda.core.core.engine import Engine
+from mloda.core.prepare.identify_feature_group import EvaluationResult
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_collection import Features
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
@@ -112,9 +113,13 @@ class TestEngineDomainPropagation:
                 patch.object(engine, "add_feature_to_collection", return_value=True),
                 patch.object(engine, "_handle_input_features_recursion") as mock_recursion,
             ):
-                mock_identify.return_value = (BaseTestFeatureGroup1, {BaseTestComputeFramework1})
+                mock_identify.return_value = (
+                    BaseTestFeatureGroup1,
+                    {BaseTestComputeFramework1},
+                    EvaluationResult(identified={BaseTestFeatureGroup1: {BaseTestComputeFramework1}}),
+                )
 
-                engine._process_feature(test_feature, mock_features)
+                engine._process_feature(test_feature, mock_features, True)
 
                 mock_recursion.assert_called_once()
                 call_args = mock_recursion.call_args
@@ -163,9 +168,13 @@ class TestEngineDomainPropagation:
                 patch.object(engine, "add_feature_to_collection", return_value=True),
                 patch.object(engine, "_handle_input_features_recursion") as mock_recursion,
             ):
-                mock_identify.return_value = (BaseTestFeatureGroup1, {BaseTestComputeFramework1})
+                mock_identify.return_value = (
+                    BaseTestFeatureGroup1,
+                    {BaseTestComputeFramework1},
+                    EvaluationResult(identified={BaseTestFeatureGroup1: {BaseTestComputeFramework1}}),
+                )
 
-                engine._process_feature(test_feature, mock_features)
+                engine._process_feature(test_feature, mock_features, True)
 
                 mock_recursion.assert_called_once()
                 call_args = mock_recursion.call_args

--- a/tests/test_core/test_integration/test_core/test_resolution_report_integration.py
+++ b/tests/test_core/test_integration/test_core/test_resolution_report_integration.py
@@ -1,0 +1,111 @@
+"""End-to-end integration test for ``session.resolution_report()`` (issue #811).
+
+This exercises the shipped feature through the public API with real plugins and the real
+PandasDataFrame compute framework: shipped ``PandasAggregatedFeatureGroup`` aggregations chain
+off raw columns produced by a ``DataCreator`` source, so the report captures both the requested
+aggregations (``requested=True``) and their derived source columns (``requested=False``).
+
+Everything carries an ``_811`` suffix: the source becomes a global FeatureGroup subclass and its
+DataCreator claim is registry-wide, so shared names would leak into another module's candidate
+universe in the parallel suite.
+"""
+
+from typing import Any
+
+from mloda.core.prepare.identify_feature_group import EvaluationResult
+from mloda.provider import DefaultOptionKeys
+from mloda.user import Feature, Options, PluginCollector, ResolutionRecord, mloda, mlodaAPI
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.feature_group.experimental.aggregated_feature_group.base import AggregatedFeatureGroup
+from mloda_plugins.feature_group.experimental.aggregated_feature_group.pandas import PandasAggregatedFeatureGroup
+
+from tests.test_plugins.integration_plugins.test_data_creator import ATestDataCreator
+
+SALES_COL = "res_report_e2e_sales_811"
+REVENUE_COL = "res_report_e2e_revenue_811"
+SUM_FEATURE = "sum_res_report_e2e_sales_811"
+AVG_FEATURE = "avg_res_report_e2e_revenue_811"
+
+
+class ResReportE2ESource_811(ATestDataCreator):
+    """DataCreator source whose raw columns the shipped aggregations chain off."""
+
+    compute_framework = PandasDataFrame
+
+    @classmethod
+    def get_raw_data(cls) -> dict[str, Any]:
+        """Return the uniquely named raw columns as a dictionary."""
+        return {
+            SALES_COL: [100, 200, 300, 400, 500],
+            REVENUE_COL: [1000, 2000, 3000, 4000, 5000],
+        }
+
+
+def _prepared_session() -> mlodaAPI:
+    """Prepare a real plan for two aggregations chaining off the DataCreator source."""
+    f_sum = Feature(
+        SUM_FEATURE,
+        Options(context={AggregatedFeatureGroup.AGGREGATION_TYPE: "sum", DefaultOptionKeys.in_features: SALES_COL}),
+    )
+    f_avg = Feature(
+        AVG_FEATURE,
+        Options(context={AggregatedFeatureGroup.AGGREGATION_TYPE: "avg", DefaultOptionKeys.in_features: REVENUE_COL}),
+    )
+    plugins = PluginCollector.enabled_feature_groups({ResReportE2ESource_811, PandasAggregatedFeatureGroup})
+    return mloda.prepare([f_sum, f_avg], compute_frameworks={PandasDataFrame}, plugin_collector=plugins)
+
+
+class TestResolutionReportEndToEnd_811:
+    """resolution_report() reflects the real planning pass of an executed aggregation plan."""
+
+    def test_resolution_report_end_to_end(self) -> None:
+        """Prepare, run real data, then assert the report over the executed plan."""
+        session = _prepared_session()
+
+        report_before = session.resolution_report()
+        plan_before = session.resolved_plan()
+
+        results = session.run()
+
+        # Real end-to-end execution: the aggregations actually computed over the source columns.
+        agg_df = next((df for df in results if SUM_FEATURE in df.columns and AVG_FEATURE in df.columns), None)
+        assert agg_df is not None, "DataFrame with both aggregated features not found"
+        assert agg_df[SUM_FEATURE].iloc[0] == 1500  # sum of [100, 200, 300, 400, 500]
+        assert agg_df[AVG_FEATURE].iloc[0] == 3000  # avg of [1000, 2000, 3000, 4000, 5000]
+
+        report_after = session.resolution_report()
+
+        # A non-empty list of ResolutionRecord, mirroring resolved_plan()'s record shape.
+        assert isinstance(report_after, list)
+        assert report_after, "a prepared and executed session must report at least one resolution record"
+        assert all(isinstance(record, ResolutionRecord) for record in report_after)
+        assert all(isinstance(record.result, EvaluationResult) for record in report_after)
+
+        # Each requested aggregation resolves to the shipped PandasAggregatedFeatureGroup.
+        for requested_name in (SUM_FEATURE, AVG_FEATURE):
+            matches = [record for record in report_after if record.feature_name == requested_name]
+            assert len(matches) == 1, f"expected exactly one record for {requested_name}"
+            assert matches[0].requested is True
+            assert matches[0].result.failure_kind is None
+            assert PandasAggregatedFeatureGroup in matches[0].result.identified
+
+        # Each derived source column resolves (requested=False) to our DataCreator source.
+        for source_name in (SALES_COL, REVENUE_COL):
+            matches = [record for record in report_after if record.feature_name == source_name]
+            assert len(matches) == 1, f"expected exactly one record for {source_name}"
+            assert matches[0].requested is False
+            assert matches[0].result.failure_kind is None
+            assert ResReportE2ESource_811 in matches[0].result.identified
+
+        # Traversal order: a requested aggregation is recorded before its own derived source.
+        names = [record.feature_name for record in report_after]
+        assert names.index(SUM_FEATURE) < names.index(SALES_COL)
+        assert names.index(AVG_FEATURE) < names.index(REVENUE_COL)
+
+        # Sibling cross-check: every requested=True record names a user-requested feature.
+        requested_names = {record.feature_name for record in report_after if record.requested}
+        assert requested_names == {SUM_FEATURE, AVG_FEATURE}
+
+        # Unchanged by run(), mirroring resolved_plan()'s contract on the same session.
+        assert report_after == report_before
+        assert session.resolved_plan() == plan_before


### PR DESCRIPTION
## Summary

Closes #811 (second slice of #759). The engine now captures each feature's `EvaluationResult` during the actual planning pass and exposes it on the session via `resolution_report()`, without re-running matching.

Previously the per-feature evaluation was a throwaway local in `_identify_feature_group_and_frameworks`, so a successful session could not report how its features resolved. Capture happens at the existing single identify call site, yielding exact-run diagnostics for the pass that actually ran.

## What changed

- **`ResolutionRecord`** (frozen dataclass, in `identify_feature_group.py` beside `EvaluationResult`): `feature_name: str`, `requested: bool`, `result: EvaluationResult`. Re-exported from `mloda.user` and `mloda.steward`.
- **`IdentifyFeatureGroupClass`** now keeps its winning `EvaluationResult` on the success path (`self.result`); the failure path already carried it via `FeatureResolutionError`.
- **Engine** records one `ResolutionRecord` per identify, in planning/traversal order. A `requested` flag threads through `setup_features_recursion`: top-level requested features are `requested=True`, features found via `input_features` recursion are `requested=False`. Records are not deduplicated (a feature that is both requested and a derived input yields one of each). `resolution_records` is initialized before planning, so records captured before a mid-recursion `FeatureResolutionError` remain on the engine for the future preflight consumer; the failing feature's own record is not appended (its result rides on the raised error).
- **`mlodaAPI.resolution_report() -> list[ResolutionRecord]`** returns the captured records, mirroring `resolved_plan()`. It deep-copies so callers cannot mutate the session's captured planning state through the returned records.

## Definition of done

- [x] Engine records, in planning order, feature name + requested/derived context + `EvaluationResult`
- [x] `session.resolution_report()` returns those records without invoking matching again
- [x] On planning failure the records captured before the failing feature remain reachable on the engine
- [x] `tox` passes

## Testing

- New `tests/test_core/test_api/test_resolution_report.py` (20 tests): dataclass shape, success-path capture and ordering, requested/derived flags, no-rematch (call-count), fresh-list and run() invariance, nested-result immutability, engine-level failure reachability, and public re-export identity.
- Full `tox` green: 6742 passed, 170 skipped; `mypy --strict`, `ruff`, `bandit` all clean.

## Review

Two independent deep reviews (Claude Opus + codex). Both flagged that the accessor shared the engine's mutable `EvaluationResult`; fixed with a deep copy at the accessor boundary (second commit) and pinned with a regression test.