### PR TITLE
fix: make GlobalFilter return identical rows across compute frameworks

### DIFF
--- a/attribution/ATTRIBUTION.md
+++ b/attribution/ATTRIBUTION.md
@@ -41,6 +41,7 @@
 | mypy                                   | 2.2.0           | MIT                                                |
 | mypy_extensions                        | 1.1.0           | MIT                                                |
 | narwhals                               | 2.23.0          | MIT                                                |
+| nest-asyncio                           | 1.6.0           | BSD License                                        |
 | nest-asyncio2                          | 1.7.2           | BSD License                                        |
 | nltk                                   | 3.10.0          | Apache Software License                            |
 | numpy                                  | 2.5.1           | BSD-3-Clause AND 0BSD AND MIT AND Zlib AND CC0-1.0 |
@@ -82,7 +83,7 @@
 | pytest-xdist                           | 3.8.0           | MIT                                                |
 | python-dateutil                        | 2.9.0.post0     | Apache Software License; BSD License               |
 | pyzmq                                  | 27.1.0          | BSD License                                        |
-| regex                                  | 2026.6.28       | Apache-2.0 AND CNRI-Python                         |
+| regex                                  | 2026.7.10       | Apache-2.0 AND CNRI-Python                         |
 | requests                               | 2.34.2          | Apache Software License                            |
 | rich                                   | 14.3.4          | MIT License                                        |
 | ruff                                   | 0.15.21         | MIT                                                |

--- a/mloda_plugins/compute_framework/base_implementations/pandas/pandas_filter_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/pandas/pandas_filter_engine.py
@@ -56,7 +56,7 @@ class PandasFilterEngine(BaseFilterEngine):
         value = filter_feature.parameter.value
         if value is None:
             raise ValueError(f"Filter parameter 'value' not found in {filter_feature.parameter}")
-        return data[data[filter_feature.name].astype(str).str.match(value)]
+        return data[data[filter_feature.name].astype(str).str.contains(value, regex=True)]
 
     @classmethod
     def do_categorical_inclusion_filter(cls, data: Any, filter_feature: SingleFilter) -> Any:

--- a/mloda_plugins/compute_framework/base_implementations/polars/polars_filter_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/polars/polars_filter_engine.py
@@ -94,4 +94,8 @@ class PolarsFilterEngine(BaseFilterEngine):
         if values is None:
             raise ValueError(f"Filter parameter 'values' not found in {filter_feature.parameter}")
 
-        return data.filter(pl.col(column_name).is_in(values))
+        non_null = [v for v in values if v is not None]
+        mask = pl.col(column_name).is_in(non_null)
+        if len(non_null) != len(values):
+            mask = mask | pl.col(column_name).is_null()
+        return data.filter(mask)

--- a/mloda_plugins/compute_framework/base_implementations/pyarrow/pyarrow_filter_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/pyarrow/pyarrow_filter_engine.py
@@ -111,7 +111,7 @@ class PyArrowFilterEngine(BaseFilterEngine):
             raise ValueError(f"Filter parameter 'values' not found in {filter_feature.parameter}")
 
         # Create PyArrow array from the values
-        values_array = pa.array(values)
+        values_array = pa.array(values, type=data[column_name].type)
         # Apply is_in filter
         mask = pc.is_in(data[column_name], values_array)
         return data.filter(mask)

--- a/mloda_plugins/compute_framework/base_implementations/pyarrow/pyarrow_filter_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/pyarrow/pyarrow_filter_engine.py
@@ -110,8 +110,12 @@ class PyArrowFilterEngine(BaseFilterEngine):
         if values is None:
             raise ValueError(f"Filter parameter 'values' not found in {filter_feature.parameter}")
 
-        # Create PyArrow array from the values
-        values_array = pa.array(values, type=data[column_name].type)
-        # Apply is_in filter
+        non_null = [v for v in values if v is not None]
+        if non_null:
+            values_array = pa.array(values)
+        else:
+            column_type = data[column_name].type
+            target_type = column_type.value_type if pa.types.is_dictionary(column_type) else column_type
+            values_array = pa.array(values, type=target_type)
         mask = pc.is_in(data[column_name], values_array)
         return data.filter(mask)

--- a/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_filter_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/python_dict/python_dict_filter_engine.py
@@ -95,7 +95,7 @@ class PythonDictFilterEngine(BaseFilterEngine):
 
         compiled_pattern = re.compile(value)
 
-        return cls._apply_keep(data, column_name, lambda v: v is not None and bool(compiled_pattern.match(str(v))))
+        return cls._apply_keep(data, column_name, lambda v: v is not None and bool(compiled_pattern.search(str(v))))
 
     @classmethod
     def do_categorical_inclusion_filter(cls, data: Any, filter_feature: SingleFilter) -> Any:

--- a/mloda_plugins/compute_framework/base_implementations/spark/spark_filter_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/spark/spark_filter_engine.py
@@ -100,4 +100,8 @@ class SparkFilterEngine(BaseFilterEngine):
             raise ValueError(f"Filter parameter 'values' not found in {filter_feature.parameter}")
 
         # Use Spark's isin function for categorical inclusion
-        return data.filter(F.col(column_name).isin(values))
+        non_null = [v for v in values if v is not None]
+        condition = F.col(column_name).isin(non_null)
+        if len(non_null) != len(values):
+            condition = condition | F.col(column_name).isNull()
+        return data.filter(condition)

--- a/mloda_plugins/compute_framework/base_implementations/sql/sql_base_filter_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/sql/sql_base_filter_engine.py
@@ -97,9 +97,17 @@ class SqlBaseFilterEngine(BaseFilterEngine):
         if values is None:
             raise ValueError(f"Filter parameter 'values' not found in {filter_feature.parameter}")
 
-        if not values:
-            raise ValueError(f"Filter parameter 'values' must not be empty in {filter_feature.parameter}")
+        non_null = [v for v in values if v is not None]
+        has_null = len(non_null) != len(values)
 
-        placeholders = ", ".join("?" for _ in values)
-        condition = f"{quote_ident(column_name)} IN ({placeholders})"
-        return cls._apply_filter(data, condition, tuple(values))
+        conditions: list[str] = []
+        params: list[Any] = []
+        if non_null:
+            placeholders = ", ".join("?" for _ in non_null)
+            conditions.append(f"{quote_ident(column_name)} IN ({placeholders})")
+            params.extend(non_null)
+        if has_null:
+            conditions.append(f"{quote_ident(column_name)} IS NULL")
+
+        condition = " OR ".join(conditions) if conditions else "1 = 0"
+        return cls._apply_filter(data, condition, tuple(params))

--- a/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_filter_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/duckdb/test_duckdb_filter_engine.py
@@ -53,6 +53,12 @@ class TestDuckDBFilterEngine(FilterEngineTestMixin, TimeRangeFilterEngineTestMix
         )
         return DuckdbRelation.from_arrow(connection, arrow_table)
 
+    @pytest.fixture
+    def nullable_category_sample_data(self, connection: Any) -> Any:
+        """Create a sample DuckDB relation with null categories for testing."""
+        arrow_table = pa.Table.from_pydict({"id": [1, 2, 3, 4, 5], "category": ["A", None, "B", None, "C"]})
+        return DuckdbRelation.from_arrow(connection, arrow_table)
+
     def get_column_values(self, result: Any, column: str) -> list[Any]:
         """Extract column values from DuckDB relation via pandas DataFrame."""
         return result.df()[column].tolist()  # type: ignore[no-any-return]

--- a/tests/test_plugins/compute_framework/base_implementations/filter_engine_test_mixin.py
+++ b/tests/test_plugins/compute_framework/base_implementations/filter_engine_test_mixin.py
@@ -249,6 +249,20 @@ class FilterEngineTestMixin:
         assert self.result_row_count(result) == 1
         self._assert_values_equal(self.get_column_values(result, "id"), [1])
 
+    def test_do_categorical_inclusion_only_none_keeps_only_nulls(
+        self, filter_engine: Any, nullable_category_sample_data: Any
+    ) -> None:
+        """An allowed-values list of only [None] keeps exactly the null rows."""
+        feature = Feature("category")
+        filter_type = FilterType.CATEGORICAL_INCLUSION
+        parameter = {"values": [None]}
+        single_filter = SingleFilter(feature, filter_type, parameter)
+
+        result = filter_engine.do_categorical_inclusion_filter(nullable_category_sample_data, single_filter)
+
+        assert self.result_row_count(result) == 2
+        self._assert_values_equal(self.get_column_values(result, "id"), [2, 4])
+
     def test_apply_filters(self, filter_engine: Any, sample_data: Any) -> None:
         """Test applying multiple filters."""
         feature = Feature("age")

--- a/tests/test_plugins/compute_framework/base_implementations/filter_engine_test_mixin.py
+++ b/tests/test_plugins/compute_framework/base_implementations/filter_engine_test_mixin.py
@@ -45,6 +45,18 @@ class FilterEngineTestMixin:
         """
         raise NotImplementedError
 
+    @pytest.fixture
+    @abstractmethod
+    def nullable_category_sample_data(self) -> Any:
+        """Return framework-specific sample data with null categories.
+
+        Override in framework-specific test class.
+        Data should contain columns:
+            id: [1, 2, 3, 4, 5]
+            category: ["A", None, "B", None, "C"]
+        """
+        raise NotImplementedError
+
     @abstractmethod
     def get_column_values(self, result: Any, column: str) -> list[Any]:
         """Extract column values as a list from the result.
@@ -157,6 +169,25 @@ class FilterEngineTestMixin:
         assert self.get_column_values(result, "name")[0] == "Alice"
         assert self.get_column_values(result, "id")[0] == 1
 
+    def test_do_regex_filter_is_unanchored(self, filter_engine: Any, sample_data: Any) -> None:
+        """REGEX filter must use unanchored (substring / re.search) semantics.
+
+        The pattern ``"li"`` appears inside ``"Alice"`` and ``"Charlie"`` but neither
+        name STARTS with ``"li"``. With unanchored matching (the contract shared by all
+        compute frameworks) exactly those two rows survive. Anchored matching
+        (``Series.str.match`` / ``re.match``) would return 0 rows.
+        """
+        feature = Feature("name")
+        filter_type = FilterType.REGEX
+        parameter = {"value": "li"}
+        single_filter = SingleFilter(feature, filter_type, parameter)
+
+        result = filter_engine.do_regex_filter(sample_data, single_filter)
+
+        assert self.result_row_count(result) == 2
+        self._assert_values_equal(self.get_column_values(result, "name"), ["Alice", "Charlie"])
+        self._assert_values_equal(self.get_column_values(result, "id"), [1, 3])
+
     def test_do_categorical_inclusion_filter(self, filter_engine: Any, sample_data: Any) -> None:
         """Test categorical inclusion filter."""
         feature = Feature("category")
@@ -169,6 +200,54 @@ class FilterEngineTestMixin:
         assert self.result_row_count(result) == 4
         assert set(self.get_column_values(result, "category")) == {"A", "B"}
         assert set(self.get_column_values(result, "id")) == {1, 2, 3, 5}
+
+    def test_do_categorical_inclusion_empty_values(self, filter_engine: Any, sample_data: Any) -> None:
+        """An empty allowed-values list must yield an empty result across all frameworks."""
+        feature = Feature("category")
+        filter_type = FilterType.CATEGORICAL_INCLUSION
+        parameter: dict[str, Any] = {"values": []}
+        single_filter = SingleFilter(feature, filter_type, parameter)
+
+        result = filter_engine.do_categorical_inclusion_filter(sample_data, single_filter)
+
+        assert self.result_row_count(result) == 0
+
+    def test_do_categorical_inclusion_keeps_null_when_none_present(
+        self, filter_engine: Any, nullable_category_sample_data: Any
+    ) -> None:
+        """When None is in the allowed-values list, null rows must be KEPT.
+
+        Data: id=[1,2,3,4,5], category=["A", None, "B", None, "C"].
+        With values ["A", None], keep category == "A" OR category is null -> ids {1, 2, 4}.
+        Asserting on the id column avoids NaN/None comparison issues on the category column.
+        """
+        feature = Feature("category")
+        filter_type = FilterType.CATEGORICAL_INCLUSION
+        parameter = {"values": ["A", None]}
+        single_filter = SingleFilter(feature, filter_type, parameter)
+
+        result = filter_engine.do_categorical_inclusion_filter(nullable_category_sample_data, single_filter)
+
+        assert self.result_row_count(result) == 3
+        self._assert_values_equal(self.get_column_values(result, "id"), [1, 2, 4])
+
+    def test_do_categorical_inclusion_drops_null_when_none_absent(
+        self, filter_engine: Any, nullable_category_sample_data: Any
+    ) -> None:
+        """When None is absent from the allowed-values list, null rows must be DROPPED.
+
+        Data: id=[1,2,3,4,5], category=["A", None, "B", None, "C"].
+        With values ["A"], keep only category == "A"; nulls dropped -> id {1}.
+        """
+        feature = Feature("category")
+        filter_type = FilterType.CATEGORICAL_INCLUSION
+        parameter = {"values": ["A"]}
+        single_filter = SingleFilter(feature, filter_type, parameter)
+
+        result = filter_engine.do_categorical_inclusion_filter(nullable_category_sample_data, single_filter)
+
+        assert self.result_row_count(result) == 1
+        self._assert_values_equal(self.get_column_values(result, "id"), [1])
 
     def test_apply_filters(self, filter_engine: Any, sample_data: Any) -> None:
         """Test applying multiple filters."""

--- a/tests/test_plugins/compute_framework/base_implementations/pandas/test_pandas_filter_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/pandas/test_pandas_filter_engine.py
@@ -37,6 +37,11 @@ class TestPandasFilterEngine(FilterEngineTestMixin, TimeRangeFilterEngineTestMix
             }
         )
 
+    @pytest.fixture
+    def nullable_category_sample_data(self) -> Any:
+        """Create a sample pandas DataFrame with null categories for testing."""
+        return pd.DataFrame({"id": [1, 2, 3, 4, 5], "category": ["A", None, "B", None, "C"]})
+
     def get_column_values(self, result: Any, column: str) -> list[Any]:
         """Extract column values from pandas DataFrame."""
         return result[column].tolist()  # type: ignore[no-any-return]

--- a/tests/test_plugins/compute_framework/base_implementations/polars/test_polars_filter_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/polars/test_polars_filter_engine.py
@@ -49,6 +49,11 @@ class TestPolarsFilterEngine(FilterEngineTestMixin, TimeRangeFilterEngineTestMix
             }
         )
 
+    @pytest.fixture
+    def nullable_category_sample_data(self) -> Any:
+        """Create a sample Polars DataFrame with null categories for testing."""
+        return pl.DataFrame({"id": [1, 2, 3, 4, 5], "category": ["A", None, "B", None, "C"]})
+
     def get_column_values(self, result: Any, column: str) -> list[Any]:
         """Extract column values from Polars DataFrame."""
         return result[column].to_list()  # type: ignore[no-any-return]

--- a/tests/test_plugins/compute_framework/base_implementations/pyarrow/test_pyarrow_filter_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/pyarrow/test_pyarrow_filter_engine.py
@@ -5,6 +5,9 @@ from typing import Any
 import pytest
 import pyarrow as pa
 
+from mloda.user import Feature
+from mloda.user import SingleFilter
+from mloda.user import FilterType
 from mloda_plugins.compute_framework.base_implementations.pyarrow.pyarrow_filter_engine import PyArrowFilterEngine
 
 from tests.test_plugins.compute_framework.base_implementations.filter_engine_test_mixin import (
@@ -40,3 +43,38 @@ class TestPyArrowFilterEngine(FilterEngineTestMixin):
     def get_column_values(self, result: Any, column: str) -> list[Any]:
         """Extract column values from PyArrow table."""
         return result[column].to_pylist()  # type: ignore[no-any-return]
+
+    def test_categorical_inclusion_on_dictionary_encoded_column(self, filter_engine: Any) -> None:
+        """CATEGORICAL_INCLUSION must work on dictionary-encoded (categorical) columns.
+
+        ``pa.Table.from_pandas`` on a pandas ``category`` dtype column produces a
+        ``dictionary<large_string, int8>`` arrow column (same as dictionary-encoded
+        parquet). Categorical inclusion is exactly the filter meant for such columns,
+        so it must not crash. The engine builds its value-set with
+        ``pa.array(values, type=data[column_name].type)``; when the column type is a
+        dictionary type this raises ``ArrowNotImplementedError`` (DictionaryArray
+        converter ... not implemented).
+        """
+        import pandas as pd
+
+        pdf = pd.DataFrame(
+            {"id": [1, 2, 3, 4, 5], "category": pd.Series(["A", None, "B", None, "C"], dtype="category")}
+        )
+        table = pa.Table.from_pandas(pdf, preserve_index=False)
+
+        # Document intent: the category column is dictionary-encoded.
+        assert pa.types.is_dictionary(table["category"].type)
+
+        cases: list[tuple[dict[str, Any], list[int]]] = [
+            ({"values": ["A", None]}, [1, 2, 4]),  # "A" (id 1) plus nulls (ids 2, 4)
+            ({"values": ["A"]}, [1]),  # only "A"; nulls dropped
+            ({"values": []}, []),  # empty allowed-values -> empty result
+            ({"values": [None]}, [2, 4]),  # only nulls kept
+        ]
+
+        for parameter, expected_ids in cases:
+            single_filter = SingleFilter(Feature("category"), FilterType.CATEGORICAL_INCLUSION, parameter)
+
+            result = filter_engine.do_categorical_inclusion_filter(table, single_filter)
+
+            assert sorted(result["id"].to_pylist()) == expected_ids

--- a/tests/test_plugins/compute_framework/base_implementations/pyarrow/test_pyarrow_filter_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/pyarrow/test_pyarrow_filter_engine.py
@@ -32,6 +32,11 @@ class TestPyArrowFilterEngine(FilterEngineTestMixin):
             }
         )
 
+    @pytest.fixture
+    def nullable_category_sample_data(self) -> Any:
+        """Create a sample PyArrow table with null categories for testing."""
+        return pa.Table.from_pydict({"id": [1, 2, 3, 4, 5], "category": ["A", None, "B", None, "C"]})
+
     def get_column_values(self, result: Any, column: str) -> list[Any]:
         """Extract column values from PyArrow table."""
         return result[column].to_pylist()  # type: ignore[no-any-return]

--- a/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_filter_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/python_dict/test_python_dict_filter_engine.py
@@ -39,6 +39,11 @@ class TestPythonDictFilterEngine(FilterEngineTestMixin, TimeRangeFilterEngineTes
             "category": ["A", "B", "A", "C", "B"],
         }
 
+    @pytest.fixture
+    def nullable_category_sample_data(self) -> Any:
+        """Create a sample columnar dict with null categories for testing."""
+        return {"id": [1, 2, 3, 4, 5], "category": ["A", None, "B", None, "C"]}
+
     def result_row_count(self, result: Any) -> int:
         """A columnar dict's row count is the length of any of its columns."""
         for column in result.values():

--- a/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_filter_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/sqlite/test_sqlite_filter_engine.py
@@ -37,6 +37,11 @@ class TestSqliteFilterEngine(FilterEngineTestMixin, TimeRangeFilterEngineTestMix
         )
         return SqliteRelation.from_arrow(connection, arrow_table)
 
+    @pytest.fixture
+    def nullable_category_sample_data(self, connection: sqlite3.Connection) -> Any:
+        arrow_table = pa.Table.from_pydict({"id": [1, 2, 3, 4, 5], "category": ["A", None, "B", None, "C"]})
+        return SqliteRelation.from_arrow(connection, arrow_table)
+
     def get_column_values(self, result: Any, column: str) -> list[Any]:
         values: list[Any] = result.df()[column].tolist()
         return values


### PR DESCRIPTION
## Problem

The same `GlobalFilter` returned different rows depending on the compute framework. Three divergences in the filter engines, all proven by running the engines directly:

1. **REGEX anchoring.** `FilterType.REGEX` was anchored at the start of the string in pandas (`Series.str.match`) and python_dict (`re.match`), but an unanchored substring match in pyarrow, polars, spark, duckdb and sqlite. Filtering for `apple` kept `["apple"]` on pandas and `["apple", "pineapple"]` on pyarrow.
2. **Categorical inclusion with null.** `categorical_inclusion` with `None` among the allowed values kept null rows on some engines (pyarrow, python_dict) and dropped them on others (polars, the SQL engines).
3. **Empty allowed-values list.** An empty `values` list raised in the SQL engines (`ValueError`) and pyarrow (`ArrowTypeError`) while every other framework returned an empty result.

The shared contract test happened to use `^A`, which behaves identically under both regex semantics, so the suite never saw any of this.

## Contract (now enforced for every framework)

- **REGEX** uses unanchored (`re.search`) semantics everywhere. Callers add `^`/`$` to anchor.
- **CATEGORICAL_INCLUSION**: an empty allowed-values list yields an empty result; `None` in the allowed values keeps null rows; `None` absent drops them.

## Changes

- pandas: regex `str.match` -> `str.contains(..., regex=True)`.
- python_dict: regex `re.match` -> `re.search`.
- polars: keep null rows when `None` is in the allowed values.
- pyarrow: infer the value-set type from the values (fixes the empty-list raise, avoids a crash on dictionary-encoded / pandas `category` columns, and avoids lossy float-to-int coercion); pin the column type only for empty or all-None lists.
- sql base (duckdb, sqlite): build `IN (...) OR IS NULL` when `None` is present, and return an empty result (`1 = 0`) for an empty list instead of raising.
- spark: keep null rows when `None` is present (mirrors polars).

## Tests

Contract tests added to the shared `FilterEngineTestMixin` (unanchored regex, empty list, null-kept, null-dropped, all-None) so all six installed frameworks are checked, backed by a new nullable-category fixture per framework. A pyarrow-specific regression test covers dictionary-encoded columns.

`tox` green (pytest -n8, ruff format/check, licenses, mypy --strict, bandit).

## Notes

The spark engine change mirrors the verified polars fix but is validated by inspection only: spark tests require Java and are skipped in this environment, and the shared mixin does not cover spark.