### PR TITLE
Replace deprecated pyarrow.feather.read_table with ipc.open_file

### DIFF
--- a/mloda_plugins/feature_group/input_data/read_files/feather.py
+++ b/mloda_plugins/feature_group/input_data/read_files/feather.py
@@ -1,9 +1,9 @@
 from typing import Any
 
 try:
-    from pyarrow import feather as pyarrow_feather
+    import pyarrow as pa
 except ImportError:
-    pyarrow_feather = None
+    pa = None
 
 from mloda.provider import FeatureSet
 from mloda_plugins.feature_group.input_data.read_file import ReadFile
@@ -109,9 +109,12 @@ class FeatherReader(ReadFile):
 
     @classmethod
     def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
-        if pyarrow_feather is None:
+        if pa is None:
             raise ImportError(
                 "pyarrow is required to read Feather files. Install it with: pip install 'mloda[pyarrow]'"
             )
         columns = list(features.get_all_names())
-        return pyarrow_feather.read_table(source=data_access, columns=columns).select(columns)
+        # Feather V2 is the Arrow IPC file format; use ipc.open_file instead of
+        # the deprecated pyarrow.feather.read_table (removed warning as of 24.0.0).
+        with pa.ipc.open_file(data_access) as reader:
+            return reader.read_all().select(columns)

--- a/tests/test_plugins/feature_group/input_data/test_read_files/test_implementations.py
+++ b/tests/test_plugins/feature_group/input_data/test_read_files/test_implementations.py
@@ -22,6 +22,12 @@ from mloda_plugins.feature_group.input_data.read_files.orc import OrcReader
 from mloda_plugins.feature_group.input_data.read_files.parquet import ParquetReader
 
 
+def _read_feather_ipc(path: Any) -> Any:
+    """Read a Feather V2 / Arrow IPC file without the deprecated feather.read_table API."""
+    with pa.ipc.open_file(path) as reader:
+        return reader.read_all()
+
+
 class FeatureSet:
     def __init__(self, columns: list[str]) -> None:
         self.columns = columns
@@ -80,7 +86,7 @@ class TestReadFilesImplementations:
         if cls is CsvReader:
             result = FileSourcePyArrowTransformer.transform_fw_to_other_fw(result)
 
-        if cls in (CsvReader, JsonReader):
+        if cls in (CsvReader, JsonReader, FeatherReader):
             expected = reader(path).select(self.columns)
         else:
             expected = reader(source=path, columns=self.columns)
@@ -111,7 +117,7 @@ class TestReadFilesImplementations:
 
     def test_implementations_read(self) -> None:
         test_cases = [
-            (FeatherReader, self.feather_file, pyarrow_feather.read_table),
+            (FeatherReader, self.feather_file, _read_feather_ipc),
             (JsonReader, self.json_file, pyarrow_json.read_json),
             (CsvReader, self.csv_file, pyarrow_csv.read_csv),
             (OrcReader, self.orc_file, pyarrow_orc.read_table),


### PR DESCRIPTION
## Summary
- Switch `FeatherReader.load_data` to `pyarrow.ipc.open_file()` (Feather V2 = Arrow IPC) to avoid the `FutureWarning` from deprecated `pyarrow.feather.read_table` in pyarrow 24.0.0+.
- Update the test oracle to use the same non-deprecated reader.

## Test plan
- [ ] Run Feather reader tests / tox — no `FutureWarning` about `feather.read_table`
- [ ] Confirm column projection via `.select(columns)` still works

Fixes #825