### PR TITLE
feat: retire fabricated operation values from captureless PREFIX_PATTERNs (#772)

### DIFF
--- a/docs/docs/in_depth/feature-chain-parser.md
+++ b/docs/docs/in_depth/feature-chain-parser.md
@@ -144,6 +144,26 @@ class MyFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 | `MIN_IN_FEATURES` | `int` | `1` | Minimum required in_features |
 | `MAX_IN_FEATURES` | `int \| None` | `None` | Maximum allowed in_features (None = unlimited) |
 | `IN_FEATURE_SEPARATOR` | `str` | `"&"` | Separator for multiple in_features |
+| `RECOGNITION_ONLY_PATTERN` | `bool` | `False` | Declares a captureless pattern as recognition-only (binds no key from the name) |
+
+### Captureless Patterns and Name Binding
+
+A captureless `PREFIX_PATTERN` (one with no capture group, e.g. `r".*__cleaned_text$"`) binds no
+`PROPERTY_MAPPING` key from the feature name. The name identifies the feature group, but every value
+comes from options. The old behavior of fabricating an operation token from the suffix text has been
+retired.
+
+- To bind a key **from the name**, use a named capture: `r".*__(?P<operation>pca|tsne)_reduce$"`.
+- For a **recognition-only** pattern (the name identifies the group but all values come from
+  options), set `RECOGNITION_ONLY_PATTERN = True`:
+
+``` python
+RECOGNITION_ONLY_PATTERN = True
+```
+
+Deprecation note: a captureless pattern that also carries a non-empty `PROPERTY_MAPPING` keeps
+working, but logs a definition-time warning until it either adds a named capture or sets
+`RECOGNITION_ONLY_PATTERN = True`.
 
 ### Customization Hooks
 

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -124,12 +124,11 @@ class FeatureChainParser:
 
     @classmethod
     def _legacy_operation_config(cls, parsed: ParsedFeatureName) -> str | None:
-        """The value the retired reverse-lookup binding consumes. #772 removes the fabrication."""
+        """The value the legacy positional reverse-lookup binding consumes: the first positional
+        capture, or None. A captureless match fabricates nothing (#772)."""
         if parsed.positional_captures:
             return parsed.positional_captures[0]
-        if parsed.operation_part is None:
-            return None
-        return parsed.operation_part.split("_")[0]  # fabrication, retired by #772
+        return None
 
     @classmethod
     def parse_feature_name(
@@ -525,12 +524,19 @@ class FeatureChainParser:
         identify the group: reproduce the pre-#770 gate so required presence still guards it on the
         config path (#769 owns changing that). A named capture that binds a mapping key identifies the
         group even when the legacy operation value is absent, so a named-optional-first pattern gets
-        full binding, guard, and forwarded-mismatch visibility.
+        full binding, guard, and forwarded-mismatch visibility. A captureless match is a recognition
+        predicate (#772): it identifies the group and binds nothing.
         """
         if not parsed.matched:
             return False
         if property_mapping and cls.bind_name_captures(parsed, property_mapping):
             return True
+        if not parsed.positional_captures:
+            # Captureless pattern: zero declared groups. It identifies the group as a recognition
+            # predicate and binds nothing. #772 stopped fabricating a token here.
+            return True
+        # A positional group that did not participate (optional-first) still does not identify;
+        # #769 owns changing that.
         return cls._legacy_operation_config(parsed) is not None
 
     @classmethod
@@ -677,6 +683,35 @@ class FeatureChainParser:
                         f"allowed value(s) {sorted(overlap)}, so a legacy positional capture cannot bind "
                         f"unambiguously. Use named capture groups (?P<key>...) so binding is explicit."
                     )
+
+    @classmethod
+    def warn_captureless_without_binding(cls, owner: type[Any]) -> None:
+        """Nudge authors of a captureless pattern that carries a PROPERTY_MAPPING (#772).
+
+        A captureless pattern binds no key from the name. If a key must come from the name, add a
+        named capture (?P<key>...); if the pattern is only a recognition predicate, set
+        RECOGNITION_ONLY_PATTERN = True to declare that intent and silence this diagnostic.
+        """
+        if getattr(owner, "RECOGNITION_ONLY_PATTERN", False):
+            return
+        property_mapping = getattr(owner, "PROPERTY_MAPPING", None)
+        if not isinstance(property_mapping, dict) or not property_mapping:
+            return
+        patterns = cls.prefix_patterns_of(owner)
+        if not patterns:
+            return
+        for pattern in cls._flatten_patterns(patterns):
+            _named, total = cls._pattern_named_and_total_groups(pattern)
+            if total == 0:
+                logger.warning(
+                    "%s declares a captureless PREFIX_PATTERN/SUFFIX_PATTERN together with a PROPERTY_MAPPING. "
+                    "A captureless pattern binds no key from the feature name. Add a named capture "
+                    "(?P<key>...) if a mapping key must be populated from the name, or set "
+                    "RECOGNITION_ONLY_PATTERN = True to declare the pattern a recognition-only predicate "
+                    "and silence this warning.",
+                    owner.__name__,
+                )
+                return
 
     @classmethod
     def check_required_when(

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -29,6 +29,10 @@ INPUT_SEPARATOR = "&"  # Separates multiple input features
 # Marks a matcher that already carries the required_when guard, so it is never wrapped twice.
 REQUIRED_WHEN_GUARD_FLAG = "_mloda_required_when_guard"
 
+# Marks a class whose captureless diagnostic already ran, so the two __init_subclass__ hooks
+# emit it at most once. Checked on the class's OWN dict so a subclass still evaluates fresh.
+CAPTURELESS_DIAGNOSTIC_FLAG = "_mloda_captureless_diagnostic_emitted"
+
 # How many guards the current match call is nested in. A guarded matcher that delegates via super()
 # reaches the guard of its parent, and only the outermost one may evaluate the predicates.
 # A ContextVar (not a plain global) keeps the count per thread and per async task.
@@ -692,6 +696,8 @@ class FeatureChainParser:
         named capture (?P<key>...); if the pattern is only a recognition predicate, set
         RECOGNITION_ONLY_PATTERN = True to declare that intent and silence this diagnostic.
         """
+        if owner.__dict__.get(CAPTURELESS_DIAGNOSTIC_FLAG, False):
+            return
         if getattr(owner, "RECOGNITION_ONLY_PATTERN", False):
             return
         property_mapping = getattr(owner, "PROPERTY_MAPPING", None)
@@ -703,6 +709,7 @@ class FeatureChainParser:
         for pattern in cls._flatten_patterns(patterns):
             _named, total = cls._pattern_named_and_total_groups(pattern)
             if total == 0:
+                setattr(owner, CAPTURELESS_DIAGNOSTIC_FLAG, True)
                 logger.warning(
                     "%s declares a captureless PREFIX_PATTERN/SUFFIX_PATTERN together with a PROPERTY_MAPPING. "
                     "A captureless pattern binds no key from the feature name. Add a named capture "

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -161,14 +161,14 @@ class FeatureChainParserMixin:
             ValueError: If in_feature constraints are violated
         """
         prefix_patterns = self._get_prefix_patterns()
-        _operation_config, in_feature = FeatureChainParser.parse_feature_name(
-            feature_name, prefix_patterns, CHAIN_SEPARATOR
-        )
+        property_mapping = self._get_property_mapping()
+        parsed = FeatureChainParser.parse_name(feature_name, prefix_patterns, CHAIN_SEPARATOR)
 
-        # String-based parsing succeeded. A captureless match yields no operation but still a source
-        # feature, so the gate keys off the source alone (#772).
-        if in_feature is not None and in_feature:
-            in_features = in_feature.split(self.IN_FEATURE_SEPARATOR)
+        # The name is authoritative only when it identifies this group (a captureless recognition match
+        # or a participating capture). An optional-first positional group that did not participate does
+        # not identify the group, so its source comes from options, not the name (#772 / #769).
+        if FeatureChainParser._name_identifies_group(parsed, property_mapping) and parsed.source_feature:
+            in_features = parsed.source_feature.split(self.IN_FEATURE_SEPARATOR)
             self._validate_in_feature_count(in_features, feature_name)
             return {Feature(f) for f in in_features}
 
@@ -509,15 +509,14 @@ class FeatureChainParserMixin:
             List of source feature names
         """
         prefix_patterns = cls._get_prefix_patterns()
+        property_mapping = cls._get_property_mapping()
 
-        _operation_config, source_feature = FeatureChainParser.parse_feature_name(
-            feature.name, prefix_patterns, CHAIN_SEPARATOR
-        )
+        parsed = FeatureChainParser.parse_name(feature.name, prefix_patterns, CHAIN_SEPARATOR)
 
-        # String-based parsing succeeded. A captureless match yields no operation but still a source
-        # feature, so the gate keys off the source alone (#772).
-        if source_feature is not None and source_feature:
-            return source_feature.split(cls.IN_FEATURE_SEPARATOR)
+        # Same identification gate as input_features: the name owns the source only when it identifies
+        # the group (#772 / #769).
+        if FeatureChainParser._name_identifies_group(parsed, property_mapping) and parsed.source_feature:
+            return parsed.source_feature.split(cls.IN_FEATURE_SEPARATOR)
 
         # Configuration-based fallback using get_in_features()
         in_features_set = feature.options.get_in_features()

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -83,6 +83,8 @@ class FeatureChainParserMixin:
     - IN_FEATURE_SEPARATOR: Optional custom separator (default: "&")
     - MIN_IN_FEATURES: Optional minimum in_feature count (default: 1)
     - MAX_IN_FEATURES: Optional maximum in_feature count (default: None)
+    - RECOGNITION_ONLY_PATTERN: Optional marker for a recognition-only pattern that binds no key
+      from the name (all values come from options); default False (#772)
 
     PROPERTY_MAPPING supports conditional requirements via ``PropertySpec.required_when``.
     Attach a predicate ``(Options) -> bool`` to any spec. When the predicate returns
@@ -111,12 +113,15 @@ class FeatureChainParserMixin:
     IN_FEATURE_SEPARATOR: str = INPUT_SEPARATOR
     MIN_IN_FEATURES: int = 1
     MAX_IN_FEATURES: Optional[int] = None
+    # A recognition-only pattern binds no key from the name; all values come from options (#772).
+    RECOGNITION_ONLY_PATTERN: bool = False
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         # The mixin sits first in the MRO of ``class X(FeatureChainParserMixin, FeatureGroup)``,
         # so super() is what lets FeatureGroup's own class-definition validation still run.
         super().__init_subclass__(**kwargs)
         FeatureChainParser.validate_name_binding(cls)
+        FeatureChainParser.warn_captureless_without_binding(cls)
         FeatureChainParser.install_required_when_guard(cls)
 
     @classmethod
@@ -156,12 +161,13 @@ class FeatureChainParserMixin:
             ValueError: If in_feature constraints are violated
         """
         prefix_patterns = self._get_prefix_patterns()
-        operation_config, in_feature = FeatureChainParser.parse_feature_name(
+        _operation_config, in_feature = FeatureChainParser.parse_feature_name(
             feature_name, prefix_patterns, CHAIN_SEPARATOR
         )
 
-        # String-based parsing succeeded
-        if operation_config is not None and in_feature is not None and in_feature:
+        # String-based parsing succeeded. A captureless match yields no operation but still a source
+        # feature, so the gate keys off the source alone (#772).
+        if in_feature is not None and in_feature:
             in_features = in_feature.split(self.IN_FEATURE_SEPARATOR)
             self._validate_in_feature_count(in_features, feature_name)
             return {Feature(f) for f in in_features}
@@ -504,12 +510,13 @@ class FeatureChainParserMixin:
         """
         prefix_patterns = cls._get_prefix_patterns()
 
-        operation_config, source_feature = FeatureChainParser.parse_feature_name(
+        _operation_config, source_feature = FeatureChainParser.parse_feature_name(
             feature.name, prefix_patterns, CHAIN_SEPARATOR
         )
 
-        # String-based parsing succeeded
-        if operation_config is not None and source_feature is not None and source_feature:
+        # String-based parsing succeeded. A captureless match yields no operation but still a source
+        # feature, so the gate keys off the source alone (#772).
+        if source_feature is not None and source_feature:
             return source_feature.split(cls.IN_FEATURE_SEPARATOR)
 
         # Configuration-based fallback using get_in_features()

--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -91,6 +91,7 @@ class FeatureGroup(ABC):
         super().__init_subclass__(**kwargs)
         FeatureChainParser.validate_property_mapping_defaults(cls.__name__, cls.PROPERTY_MAPPING)
         FeatureChainParser.validate_name_binding(cls)
+        FeatureChainParser.warn_captureless_without_binding(cls)
         FeatureChainParser.install_required_when_guard(cls)
         cls._validate_subtype_declaration()
 

--- a/mloda_plugins/feature_group/experimental/text_cleaning/base.py
+++ b/mloda_plugins/feature_group/experimental/text_cleaning/base.py
@@ -87,6 +87,10 @@ class TextCleaningFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     # Define prefix pattern
     PREFIX_PATTERN = r".*__cleaned_text$"
 
+    # The cleaning operations come from options, so the pattern is recognition-only and binds
+    # nothing from the name (#772).
+    RECOGNITION_ONLY_PATTERN = True
+
     # In-feature configuration for FeatureChainParserMixin
     MIN_IN_FEATURES = 1
     MAX_IN_FEATURES = 1

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_captureless_no_binding.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_captureless_no_binding.py
@@ -19,10 +19,13 @@ from typing import Any
 
 import pytest
 
+from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
-from mloda.provider import PropertySpec
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.provider import DefaultOptionKeys, PropertySpec
 from mloda_plugins.feature_group.experimental.text_cleaning.base import TextCleaningFeatureGroup
 
 CLEANED_TEXT_NAME = "x__cleaned_text"
@@ -32,6 +35,27 @@ FEATURE_CHAIN_PARSER_LOGGER = "mloda.core.abstract_plugins.components.feature_ch
 # "cleaned" is exactly the token the retired code fabricated from ``__cleaned_text``.
 FABRICATED_TOKEN = "cleaned"  # nosec B105
 OPERATION_KEY_C772 = "operation_c772"
+
+# Defect A fixture: an OPTIONAL-FIRST positional group. When the optional group is absent the name has a
+# lone None positional capture, so it does NOT identify the group (#769 owns that case, unchanged by #772).
+# input_features / _extract_source_features must therefore fall back to options, not extract the name source.
+OPTFIRST_MARKER = "rf772a"
+OPTFIRST_PATTERN = rf".*__(?:(pca|tsne)_)?optfirst_{OPTFIRST_MARKER}$"
+OPTFIRST_ABSENT_NAME = f"x__optfirst_{OPTFIRST_MARKER}"
+OPTFIRST_PRESENT_NAME = f"x__pca_optfirst_{OPTFIRST_MARKER}"
+ALGORITHM_KEY_RF772A = f"algorithm_{OPTFIRST_MARKER}"
+OPTFIRST_MAPPING: dict[str, PropertySpec] = {
+    ALGORITHM_KEY_RF772A: PropertySpec(
+        "Algorithm of the rf772a fixture", allowed_values=("pca", "tsne"), context=True, strict_validation=True
+    ),
+}
+
+
+class _OptionalFirstAbsentMixinRf772a(FeatureChainParserMixin):
+    """A positional optional-first pattern: when the optional group is absent the name is non-identifying."""
+
+    PREFIX_PATTERN = OPTFIRST_PATTERN
+    PROPERTY_MAPPING = OPTFIRST_MAPPING
 
 
 def _inherited_child_options(consumer_group: dict[str, Any]) -> Options:
@@ -186,3 +210,118 @@ class TestTextCleaningMigration:
     def test_recognition_only_pattern_is_true(self) -> None:
         """TextCleaningFeatureGroup opts in to the recognition-only form."""
         assert TextCleaningFeatureGroup.RECOGNITION_ONLY_PATTERN is True
+
+
+class TestOptionalFirstAbsentUsesOptions:
+    """When an optional-first positional group is absent, the name does not identify the group (#769).
+
+    Both string-parse source paths (input_features / _extract_source_features) must then fall back to
+    options, not extract the source from the name. #772 wrongly regated these on "a source exists".
+    """
+
+    def test_absent_optional_first_does_not_identify_group(self) -> None:
+        """Boundary: an absent optional-first positional capture leaves the name NON-identifying (#769)."""
+        parsed = FeatureChainParser.parse_name(OPTFIRST_ABSENT_NAME, [OPTFIRST_PATTERN])
+
+        assert parsed.positional_captures == (None,)  # precondition: one positional group, absent
+        assert FeatureChainParser._name_identifies_group(parsed, OPTFIRST_MAPPING) is False
+
+    def test_present_optional_first_identifies_group(self) -> None:
+        """Boundary: with the optional-first capture present, the name identifies the group."""
+        parsed = FeatureChainParser.parse_name(OPTFIRST_PRESENT_NAME, [OPTFIRST_PATTERN])
+
+        assert parsed.positional_captures == ("pca",)  # precondition: the optional group participated
+        assert FeatureChainParser._name_identifies_group(parsed, OPTFIRST_MAPPING) is True
+
+    def test_input_features_absent_optional_first_falls_back_to_options(self) -> None:
+        """input_features must take the source from options when the name does not identify the group."""
+        instance = _OptionalFirstAbsentMixinRf772a()
+        options = Options(context={DefaultOptionKeys.in_features: "from_options"})
+
+        result = instance.input_features(options, FeatureName(OPTFIRST_ABSENT_NAME))
+
+        assert result is not None
+        assert {feature.name for feature in result} == {"from_options"}
+
+    def test_input_features_present_optional_first_uses_name_source(self) -> None:
+        """Guard: with the optional group present the name identifies the group, so the source is the name."""
+        instance = _OptionalFirstAbsentMixinRf772a()
+        options = Options(context={DefaultOptionKeys.in_features: "from_options"})
+
+        result = instance.input_features(options, FeatureName(OPTFIRST_PRESENT_NAME))
+
+        assert result is not None
+        assert {feature.name for feature in result} == {"x"}
+
+    def test_extract_source_features_absent_optional_first_falls_back_to_options(self) -> None:
+        """_extract_source_features must take the source from options when the name is non-identifying."""
+        feature = Feature(
+            name=OPTFIRST_ABSENT_NAME,
+            options=Options(context={DefaultOptionKeys.in_features: "from_options"}),
+        )
+
+        result = _OptionalFirstAbsentMixinRf772a._extract_source_features(feature)
+
+        assert result == ["from_options"]
+
+    def test_extract_source_features_present_optional_first_uses_name_source(self) -> None:
+        """Guard: with the optional group present, the name identifies the group and the source is the name."""
+        feature = Feature(
+            name=OPTFIRST_PRESENT_NAME,
+            options=Options(context={DefaultOptionKeys.in_features: "from_options"}),
+        )
+
+        result = _OptionalFirstAbsentMixinRf772a._extract_source_features(feature)
+
+        assert result == ["x"]
+
+
+class TestDiagnosticEmittedOnce:
+    """The captureless-without-binding diagnostic fires exactly once per class definition.
+
+    ``warn_captureless_without_binding`` is wired into BOTH FeatureGroup.__init_subclass__ and
+    FeatureChainParserMixin.__init_subclass__, so the standard ``class X(FeatureChainParserMixin,
+    FeatureGroup)`` shape currently logs the SAME warning twice. Exactly one is intended.
+    """
+
+    def test_standard_inheritance_shape_warns_exactly_once(self, caplog: pytest.LogCaptureFixture) -> None:
+        """class X(FeatureChainParserMixin, FeatureGroup) must emit ONE warning, not one per hook."""
+        with caplog.at_level(logging.WARNING):
+
+            class _X_rf772b(FeatureChainParserMixin, FeatureGroup):
+                PREFIX_PATTERN = r".*__recognize_rf772b$"
+                PROPERTY_MAPPING = {
+                    "op_rf772b": PropertySpec(
+                        "op", allowed_values=("normalize",), context=True, strict_validation=True
+                    ),
+                }
+
+            assert _X_rf772b.PREFIX_PATTERN.endswith("__recognize_rf772b$")
+
+        warnings = [
+            record
+            for record in caplog.records
+            if record.name == FEATURE_CHAIN_PARSER_LOGGER and "RECOGNITION_ONLY_PATTERN" in record.getMessage()
+        ]
+        assert len(warnings) == 1
+
+    def test_mixin_only_shape_still_warns_exactly_once(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Guard against over-suppression: the single-hook shape keeps its one legitimate warning."""
+        with caplog.at_level(logging.WARNING):
+
+            class _Y_rf772b(FeatureChainParserMixin):
+                PREFIX_PATTERN = r".*__recognize2_rf772b$"
+                PROPERTY_MAPPING = {
+                    "op_rf772b": PropertySpec(
+                        "op", allowed_values=("normalize",), context=True, strict_validation=True
+                    ),
+                }
+
+            assert _Y_rf772b.PREFIX_PATTERN.endswith("__recognize2_rf772b$")
+
+        warnings = [
+            record
+            for record in caplog.records
+            if record.name == FEATURE_CHAIN_PARSER_LOGGER and "RECOGNITION_ONLY_PATTERN" in record.getMessage()
+        ]
+        assert len(warnings) == 1

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_captureless_no_binding.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_captureless_no_binding.py
@@ -1,0 +1,188 @@
+"""Captureless PREFIX_PATTERNs bind nothing and no longer fabricate an operation token (issue #772).
+
+#770 fabricated a token for a captureless match via ``operation_part.split("_")[0]`` (e.g. "cleaned"
+from ``x__cleaned_text``) and fed it into reverse-lookup binding, the ``_name_identifies_group`` gate,
+the public ``parse_feature_name`` adapter, and the forwarded-mismatch check. #772 retires that
+fabrication: a captureless pattern is a pure RECOGNITION predicate. It still identifies its feature
+group, but it binds nothing, injects nothing into effective options, and cannot be steered by an
+unrelated allowed value. A class that declares a captureless pattern with a non-empty PROPERTY_MAPPING
+must opt in to the recognition-only form with ``RECOGNITION_ONLY_PATTERN = True`` or it is warned at
+class-definition time.
+
+All fixture markers carry a "c772" suffix so they cannot collide in the global plugin registry.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.provider import PropertySpec
+from mloda_plugins.feature_group.experimental.text_cleaning.base import TextCleaningFeatureGroup
+
+CLEANED_TEXT_NAME = "x__cleaned_text"
+CLEANED_TEXT_PATTERN = r".*__cleaned_text$"
+FEATURE_CHAIN_PARSER_LOGGER = "mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser"
+
+# "cleaned" is exactly the token the retired code fabricated from ``__cleaned_text``.
+FABRICATED_TOKEN = "cleaned"  # nosec B105
+OPERATION_KEY_C772 = "operation_c772"
+
+
+def _inherited_child_options(consumer_group: dict[str, Any]) -> Options:
+    """Build child options exactly like the engine does: inherit_from the consumer (records provenance)."""
+    child_options = Options()
+    child_options.inherit_from(Options(group=consumer_group))
+    return child_options
+
+
+class TestLegacyOperationConfigNoFabrication:
+    """``_legacy_operation_config`` is the first positional capture, or None; it fabricates nothing."""
+
+    def test_captureless_returns_none(self) -> None:
+        """A captureless match has zero positional captures, so there is no operation value to return."""
+        parsed = FeatureChainParser.parse_name(CLEANED_TEXT_NAME, [CLEANED_TEXT_PATTERN])
+
+        assert FeatureChainParser._legacy_operation_config(parsed) is None
+
+    def test_positional_still_returns_group_one(self) -> None:
+        """A positional pattern is unchanged: group 1 is the operation value."""
+        parsed = FeatureChainParser.parse_name("f0__pca_legacy_c772", [r".*__(pca|tsne)_legacy_c772$"])
+
+        assert FeatureChainParser._legacy_operation_config(parsed) == "pca"
+
+
+class TestCapturelessStillIdentifiesGroup:
+    """A captureless match is a recognition predicate: it identifies the group with no fabricated token."""
+
+    def test_captureless_match_identifies_group_without_mapping(self) -> None:
+        """Zero positional captures plus a match still identifies the group, even without a mapping."""
+        parsed = FeatureChainParser.parse_name(CLEANED_TEXT_NAME, [CLEANED_TEXT_PATTERN])
+
+        assert FeatureChainParser._name_identifies_group(parsed, None) is True
+
+    def test_captureless_match_identifies_group_with_mapping(self) -> None:
+        """The shipped captureless mapping binds nothing, so recognition alone must identify the group."""
+        parsed = FeatureChainParser.parse_name(CLEANED_TEXT_NAME, [CLEANED_TEXT_PATTERN])
+
+        assert FeatureChainParser._name_identifies_group(parsed, TextCleaningFeatureGroup.PROPERTY_MAPPING) is True
+
+    def test_text_cleaning_match_criteria_still_true(self) -> None:
+        """The recognition predicate keeps claiming its chained name with no options at all."""
+        assert TextCleaningFeatureGroup.match_feature_group_criteria("review__cleaned_text", Options()) is True
+
+    def test_optional_first_positional_group_does_not_identify(self) -> None:
+        """A POSITIONAL optional-first group that did not participate still does NOT identify (unchanged)."""
+        parsed = FeatureChainParser.parse_name("x__optfirst_c772", [r".*__(?:(pca|tsne)_)?optfirst_c772$"])
+
+        assert parsed.positional_captures == (None,)  # precondition: one positional group, absent
+        assert FeatureChainParser._name_identifies_group(parsed, None) is False
+
+
+class TestCapturelessBindsNothing:
+    """An unrelated allowed value cannot change a captureless pattern's behavior (DoD item 6)."""
+
+    def test_bind_name_captures_ignores_unrelated_allowed_value(self) -> None:
+        """Even when a key's allowed_values contains the old fabricated token, a captureless match binds nothing."""
+        parsed = FeatureChainParser.parse_name(CLEANED_TEXT_NAME, [CLEANED_TEXT_PATTERN])
+        property_mapping = {
+            OPERATION_KEY_C772: PropertySpec(
+                "op", allowed_values=(FABRICATED_TOKEN, "other"), context=True, strict_validation=True
+            ),
+        }
+
+        assert FeatureChainParser.bind_name_captures(parsed, property_mapping) == {}
+
+    def test_build_effective_options_injects_nothing(self) -> None:
+        """Nothing to bind means nothing to merge: the original options come back by identity, untouched."""
+        options = Options()
+        property_mapping = {
+            OPERATION_KEY_C772: PropertySpec(
+                "op", allowed_values=(FABRICATED_TOKEN,), context=True, strict_validation=True
+            ),
+        }
+
+        effective = FeatureChainParser.build_effective_options(
+            CLEANED_TEXT_NAME, [CLEANED_TEXT_PATTERN], property_mapping, options
+        )
+
+        assert effective is options
+        assert effective.get(OPERATION_KEY_C772) is None
+
+
+class TestCapturelessDefinitionDiagnostic:
+    """A captureless pattern with a non-empty mapping must opt in to the recognition-only form."""
+
+    def test_captureless_mapping_without_marker_warns(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Defining such a class without the marker emits a definition-time WARNING mentioning the marker."""
+        with caplog.at_level(logging.WARNING):
+
+            class _CapturelessNoMarkerC772(FeatureChainParserMixin):
+                PREFIX_PATTERN = r".*__recognize_c772$"
+                PROPERTY_MAPPING = {
+                    OPERATION_KEY_C772: PropertySpec(
+                        "op", allowed_values=("normalize",), context=True, strict_validation=True
+                    ),
+                }
+
+            assert _CapturelessNoMarkerC772.PREFIX_PATTERN.endswith("__recognize_c772$")
+
+        warnings = [
+            record
+            for record in caplog.records
+            if record.levelno == logging.WARNING
+            and record.name == FEATURE_CHAIN_PARSER_LOGGER
+            and "RECOGNITION_ONLY_PATTERN" in record.getMessage()
+        ]
+        assert warnings
+
+    def test_recognition_only_marker_suppresses_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """The explicit no-binding form (RECOGNITION_ONLY_PATTERN=True) emits no such definition-time warning."""
+        with caplog.at_level(logging.WARNING):
+
+            class _CapturelessWithMarkerC772(FeatureChainParserMixin):
+                RECOGNITION_ONLY_PATTERN = True
+                PREFIX_PATTERN = r".*__recognize2_c772$"
+                PROPERTY_MAPPING = {
+                    OPERATION_KEY_C772: PropertySpec(
+                        "op", allowed_values=("normalize",), context=True, strict_validation=True
+                    ),
+                }
+
+            assert _CapturelessWithMarkerC772.RECOGNITION_ONLY_PATTERN is True
+
+        warnings = [
+            record
+            for record in caplog.records
+            if record.levelno == logging.WARNING
+            and record.name == FEATURE_CHAIN_PARSER_LOGGER
+            and "RECOGNITION_ONLY_PATTERN" in record.getMessage()
+        ]
+        assert not warnings
+
+
+class TestCapturelessForwardedMismatchAbsent:
+    """A captureless pattern binds nothing, so forwarded-mismatch protection never fires for it."""
+
+    def test_forwarded_option_does_not_raise_for_captureless(self) -> None:
+        """A consumer-forwarded PROPERTY_MAPPING key present on the child is no mismatch: the match stays True."""
+        child_options = _inherited_child_options({TextCleaningFeatureGroup.CLEANING_OPERATIONS: "normalize"})
+        # precondition: the key really arrived via forwarding (provenance recorded)
+        assert TextCleaningFeatureGroup.CLEANING_OPERATIONS in child_options.inherited_group_keys
+
+        result = TextCleaningFeatureGroup.match_feature_group_criteria("review__cleaned_text", child_options)
+
+        assert result is True
+
+
+class TestTextCleaningMigration:
+    """The only shipped captureless plugin declares itself recognition-only."""
+
+    def test_recognition_only_pattern_is_true(self) -> None:
+        """TextCleaningFeatureGroup opts in to the recognition-only form."""
+        assert TextCleaningFeatureGroup.RECOGNITION_ONLY_PATTERN is True

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_parsed_name_bindings.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_parsed_name_bindings.py
@@ -269,9 +269,9 @@ class TestLegacyParseFeatureNameAdapter:
             "f0",
         )
 
-    def test_captureless_fabrication_unchanged(self) -> None:
-        """A captureless pattern still fabricates the first underscore-token of the suffix (#772 retires it)."""
-        assert FeatureChainParser.parse_feature_name("x__cleaned_text", [r".*__cleaned_text$"]) == ("cleaned", "x")
+    def test_captureless_no_longer_fabricates(self) -> None:
+        """#772: a captureless match no longer fabricates a token; operation_config is None, the source stays."""
+        assert FeatureChainParser.parse_feature_name("x__cleaned_text", [r".*__cleaned_text$"]) == (None, "x")
 
     def test_miss_tuple_unchanged(self) -> None:
         """No pattern match is still (None, None)."""
@@ -651,8 +651,8 @@ class TestShippedPluginsUnchanged:
 
         assert parsed == (None, None)
 
-    def test_text_cleaning_feature_group_keeps_its_fabricated_token(self) -> None:
-        """The only captureless shipped pattern: the fabrication survives this PR (#772 retires it)."""
+    def test_text_cleaning_captureless_no_longer_fabricates(self) -> None:
+        """The only captureless shipped pattern: #772 retires the fabrication, so operation_config is None."""
         parsed = FeatureChainParser.parse_feature_name("text__cleaned_text", [TextCleaningFeatureGroup.PREFIX_PATTERN])
 
-        assert parsed == ("cleaned", "text")
+        assert parsed == (None, "text")


### PR DESCRIPTION
Closes #772.

## Problem

A captureless `PREFIX_PATTERN` fabricated an operation token from the suffix text (`operation_part.split("_")[0]`, e.g. `cleaned` from `x__cleaned_text`). That invented token fed reverse-lookup binding, the name-match gate, and the forwarded-mismatch check, so adding an unrelated value to some key's `allowed_values` could silently change matching. This applies the structured parse model from #770 (part of epic #761, phase 3).

## Change

- `_legacy_operation_config` returns the first positional capture or `None`; the `.split("_")[0]` fabrication is gone.
- `_name_identifies_group` treats a captureless match (zero declared groups) as a recognition predicate: it identifies the group and binds nothing. An optional-first positional group that did not participate still does not identify (that boundary stays with #769).
- `input_features` and `_extract_source_features` gate the name-derived source on `_name_identifies_group` rather than on "a source exists", so an optional-first-absent positional pattern draws its in_features from options, not the name.
- New `warn_captureless_without_binding` diagnostic: a captureless pattern carrying a non-empty `PROPERTY_MAPPING` logs a definition-time warning unless the class sets the new `RECOGNITION_ONLY_PATTERN = True` marker. The diagnostic is idempotent per class, so the standard `(Mixin, FeatureGroup)` shape warns exactly once.
- `TextCleaningFeatureGroup` (the only shipped captureless pattern) declares `RECOGNITION_ONLY_PATTERN = True`; its operations come from options.
- Docs (`feature-chain-parser.md`) describe the named-capture path, the recognition-only marker, and the deprecation path for external captureless patterns.

## Definition of done

- [x] Captureless success is matched with no bound value; no token fabricated from the operation text
- [x] Definition-time diagnostic tells authors to add explicit captures when a mapping key must be populated from the name
- [x] Explicit no-binding form (`RECOGNITION_ONLY_PATTERN`) available for recognition-only patterns
- [x] Core-shipped captureless pattern (text_cleaning) migrated
- [x] Compatibility/deprecation path documented
- [x] Tests prove an unrelated allowed value cannot change a captureless pattern's behavior
- [x] `tox` passes (pytest, ruff format/check, pip-licenses, mypy --strict, bandit)

Registry patterns (ema, ffill, sessionization, resample) are tracked separately in mloda-registry#327.

## Validation

`tox` fully green. Two independent deep reviews (a fresh Claude Opus agent and codex) converged on two minor findings, both fixed in this PR: gating the name-derived source on group identification, and de-duplicating the definition-time diagnostic.
