### PR TITLE
fix: preserve both keys in polars joins with differing key names

### DIFF
--- a/mloda_plugins/compute_framework/base_implementations/polars/polars_merge_engine.py
+++ b/mloda_plugins/compute_framework/base_implementations/polars/polars_merge_engine.py
@@ -1,3 +1,4 @@
+import inspect
 from typing import Any
 
 from mloda.core.abstract_plugins.components.contract.comparison_contract import ColumnSemantics
@@ -11,6 +12,8 @@ try:
     import polars as pl
 except ImportError:
     pl = None  # type: ignore[assignment]
+
+_JOIN_SUPPORTS_COALESCE = pl is not None and "coalesce" in inspect.signature(pl.DataFrame.join).parameters
 
 
 class PolarsMergeEngine(BaseMergeEngine):
@@ -157,22 +160,22 @@ class PolarsMergeEngine(BaseMergeEngine):
         if empty_result is not None:
             return empty_result
 
+        # For differing single-key names, keep both keys via coalesce=False (correct null semantics).
+        # Only pass coalesce when the installed polars supports it; older versions degrade to legacy behavior.
+        different_single_key = isinstance(left_idx, str) and isinstance(right_idx, str) and left_idx != right_idx
+        join_kwargs: dict[str, Any] = {"left_on": left_idx, "right_on": right_idx, "how": join_type}
+        if different_single_key and _JOIN_SUPPORTS_COALESCE:
+            join_kwargs["coalesce"] = False
+
         # Perform the join with nulls_equal=True to match null values (updated parameter name)
         try:
-            result = left_data.join(right_data, left_on=left_idx, right_on=right_idx, how=join_type, nulls_equal=True)
+            result = left_data.join(right_data, nulls_equal=True, **join_kwargs)
         except TypeError:
             # Fallback for older polars versions
-            result = left_data.join(right_data, left_on=left_idx, right_on=right_idx, how=join_type, join_nulls=True)
+            result = left_data.join(right_data, join_nulls=True, **join_kwargs)
 
         # Single-index specific post-processing
         if isinstance(left_idx, str) and isinstance(right_idx, str):
-            # For different join column names, add the right join column manually
-            # because Polars drops it when column names are different
-            if left_idx != right_idx:
-                # Add the right join column by copying the left join column values
-                # This works because the join ensures they have matching values
-                result = result.with_columns(pl.col(left_idx).alias(right_idx))
-
             # Handle duplicate join columns only for full outer joins when column names are the same
             right_col_name = f"{right_idx}_right"
             if self.column_exists_in_result(result, right_col_name) and join_type == "full" and left_idx == right_idx:

--- a/tests/test_plugins/compute_framework/base_implementations/polars/test_polars_merge_engine.py
+++ b/tests/test_plugins/compute_framework/base_implementations/polars/test_polars_merge_engine.py
@@ -4,6 +4,7 @@ import pytest
 from mloda.user import JoinType
 from mloda.user import Index
 from mloda_plugins.compute_framework.base_implementations.polars.polars_merge_engine import PolarsMergeEngine
+from mloda_plugins.compute_framework.base_implementations.polars.polars_lazy_merge_engine import PolarsLazyMergeEngine
 from tests.test_plugins.compute_framework.test_tooling.merge_link import make_merge_link
 
 import logging
@@ -102,6 +103,118 @@ class TestPolarsMergeEngine:
 
         expected = pl.DataFrame({"left_id": [1], "col1": ["a"], "right_id": [1], "col2": ["x"]})
         assert result.equals(expected)
+
+    def test_merge_left_with_different_join_columns(self) -> None:
+        """Left join with different key names must keep both keys with correct null semantics.
+
+        The unmatched left row (left_id=3) has no right match, so right_id must be None.
+        The current implementation fabricates right_id by aliasing the left key, wrongly
+        producing right_id=3 for that row.
+        """
+        left_data = pl.DataFrame({"left_id": [1, 3], "col1": ["a", "b"]})
+        right_data = pl.DataFrame({"right_id": [1, 2], "col2": ["x", "z"]})
+
+        left_index = Index(("left_id",))
+        right_index = Index(("right_id",))
+
+        engine = PolarsMergeEngine()
+        result = engine.merge_left(left_data, right_data, left_index, right_index)
+
+        result_sorted = result.sort(["left_id", "right_id"], nulls_last=True)
+        expected = pl.DataFrame(
+            {
+                "left_id": [1, 3],
+                "col1": ["a", "b"],
+                "right_id": [1, None],
+                "col2": ["x", None],
+            }
+        )
+        assert result_sorted.equals(expected)
+
+    def test_merge_right_with_different_join_columns(self) -> None:
+        """Right join with different key names must preserve right-only keys.
+
+        The right-only key (right_id=2) has no left match, so left_id/col1 must be None
+        while right_id=2 is retained. The current implementation crashes on this join.
+        """
+        left_data = pl.DataFrame({"left_id": [1, 3], "col1": ["a", "b"]})
+        right_data = pl.DataFrame({"right_id": [1, 2], "col2": ["x", "z"]})
+
+        left_index = Index(("left_id",))
+        right_index = Index(("right_id",))
+
+        engine = PolarsMergeEngine()
+        result = engine.merge_right(left_data, right_data, left_index, right_index)
+
+        result_sorted = result.sort(["left_id", "right_id"], nulls_last=True)
+        expected = pl.DataFrame(
+            {
+                "left_id": [1, None],
+                "col1": ["a", None],
+                "right_id": [1, 2],
+                "col2": ["x", "z"],
+            }
+        )
+        assert result_sorted.equals(expected)
+
+    def test_merge_full_outer_with_different_join_columns(self) -> None:
+        """Full outer join with different key names must keep both keys with correct null semantics.
+
+        Result contains an unmatched-left row (right_id=None) and a right-only row
+        (left_id=None, right_id=2). The current implementation produces wrong key values.
+        """
+        left_data = pl.DataFrame({"left_id": [1, 3], "col1": ["a", "b"]})
+        right_data = pl.DataFrame({"right_id": [1, 2], "col2": ["x", "z"]})
+
+        left_index = Index(("left_id",))
+        right_index = Index(("right_id",))
+
+        engine = PolarsMergeEngine()
+        result = engine.merge_full_outer(left_data, right_data, left_index, right_index)
+
+        result_sorted = result.sort(["left_id", "right_id"], nulls_last=True)
+        expected = pl.DataFrame(
+            {
+                "left_id": [1, 3, None],
+                "col1": ["a", "b", None],
+                "right_id": [1, None, 2],
+                "col2": ["x", None, "z"],
+            }
+        )
+        assert result_sorted.equals(expected)
+
+    def test_merge_left_different_columns_lazy_equivalence(self) -> None:
+        """Lazy and eager engines must produce identical left joins for differing key names."""
+        left_data = pl.DataFrame({"left_id": [1, 3], "col1": ["a", "b"]})
+        right_data = pl.DataFrame({"right_id": [1, 2], "col2": ["x", "z"]})
+
+        left_index = Index(("left_id",))
+        right_index = Index(("right_id",))
+
+        eager_result = (
+            PolarsMergeEngine()
+            .merge_left(left_data, right_data, left_index, right_index)
+            .sort(["left_id", "right_id"], nulls_last=True)
+        )
+
+        lazy_engine = PolarsLazyMergeEngine()
+        lazy_result = (
+            lazy_engine.merge_left(left_data.lazy(), right_data.lazy(), left_index, right_index)
+            .collect()
+            .sort(["left_id", "right_id"], nulls_last=True)
+        )
+
+        assert lazy_result.equals(eager_result)
+
+        expected = pl.DataFrame(
+            {
+                "left_id": [1, 3],
+                "col1": ["a", "b"],
+                "right_id": [1, None],
+                "col2": ["x", None],
+            }
+        )
+        assert lazy_result.equals(expected)
 
     def test_merge_with_empty_datasets(self, index_obj: Any) -> None:
         """Test merge operations with empty datasets."""


### PR DESCRIPTION
## Problem

`PolarsMergeEngine.join_logic` mishandled single-key joins where the left and right key names differ (`polars_merge_engine.py:171`). It re-added the dropped right key with `result.with_columns(pl.col(left_idx).alias(right_idx))`, which assumes the right key equals the left key on every row. That only holds for inner-join matched rows, so:

- **left join**: unmatched left rows got a fabricated right key (copied from the left key) instead of null;
- **right / full-outer join**: Polars drops the left key column, so `pl.col(left_idx)` raised `ColumnNotFoundError` (crash), and real right-only key values were lost.

Pandas and PyArrow both keep both key columns with correct null semantics, so this was a cross-framework consistency bug.

## Fix

For the differing single-key case, pass `coalesce=False` to the Polars join so it natively keeps both key columns with correct join semantics, and remove the manual fabrication. Verified against the pandas reference for inner, left, right, and full-outer joins. Same-name joins are untouched (they keep default coalesce, including the existing `_right` coalesce for same-name full outer). The `coalesce` kwarg is gated on installed-polars support so releases predating the keyword degrade to legacy behavior rather than raising in both join fallbacks. `PolarsLazyMergeEngine` inherits the fix.

## Tests

Added left / right / full-outer differing-key tests plus a lazy-vs-eager equivalence test that also pins the concrete expected frame. All assert pandas-equivalent null semantics. Full `tox` gate is green (pytest, ruff, mypy --strict, bandit, licenses).

## Out of scope (pre-existing, not regressions)

Multi-index differing-name joins remain lossy, and value-column / key-name collision edge cases predate this change; both are candidates for a follow-up.