### PR TITLE
feat: definition-time guard against all-optional universal-matcher PROPERTY_MAPPINGs (#771)

### DIFF
--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -78,6 +78,7 @@ does not understand can be absorbed silently.
 | Match time (mixin) | `match_guard` | The whole value has an acceptable shape | The raw value | Non-match (`False`) |
 | Match time (mixin) | `MIN/MAX_IN_FEATURES` | In-feature count is within bounds | The in-features | Non-match (`False`) |
 | Match time (guard installed at class definition) | `required_when` | A conditionally required option is present | `Options` | Non-match (`False`) |
+| Class definition (mixin) | Universal-matcher diagnostic | An all-optional `PROPERTY_MAPPING` inherits the configuration matcher, so it matches any name with empty options | The class | `logger.warning`, unless `ALLOW_UNIVERSAL_MATCHER = True` |
 
 A spec is constructed inside the class body, so its own rules fire before the class exists.
 Class definition is left with exactly one rule: the type itself. Within `__post_init__` the
@@ -414,6 +415,24 @@ The matcher must be a `classmethod`; a `staticmethod` matcher on a class that de
 The guard is installed at class definition, so mutating `PROPERTY_MAPPING` or replacing
 `match_feature_group_criteria` after the class body escapes it.
 
+## Guarding against a universal configuration matcher
+
+A key is unconditionally required only when it declares no `default` and no `required_when`. A
+`PROPERTY_MAPPING` whose every key is optional or conditional has no such key, so on the
+configuration path it matches any feature name with empty options. A feature group that inherits
+the mixin's `match_feature_group_criteria` and declares such a mapping is a universal matcher: it
+claims features it was never meant to.
+
+At class definition the mixin warns about this, naming the class and the escape hatch. It fires
+only when the mapping has zero unconditionally required keys AND the resolved matcher still accepts
+an unrelated name with empty options. So a genuinely discriminating `match_feature_group_criteria`,
+or a `required_when` predicate that fires for empty options, is not warned, while a pass-through
+override that only delegates to the base still is.
+
+Set `ALLOW_UNIVERSAL_MATCHER = True` on the class to declare the universal match intentional and
+silence the warning. Otherwise give one key no `default` (making it unconditionally required), or a
+`required_when` predicate that fires when the option is absent.
+
 ## Migrating from the dict form
 
 Spec dicts are gone. Every value in a `PROPERTY_MAPPING` must be a `PropertySpec`; an
@@ -455,6 +474,7 @@ if it really is a whole-value check.
 | Plugin specs behave identically across containers | `tests/test_plugins/feature_group/experimental/test_property_mapping_container_invariance.py` |
 | `property_spec` builder surface | `tests/.../feature_chainer/test_property_spec_builder.py` |
 | Rejection reasons surfaced to the end user | `tests/test_core/test_prepare/test_identify_feature_group_error_message.py` |
+| The all-optional universal-matcher diagnostic and its `ALLOW_UNIVERSAL_MATCHER` escape hatch | `tests/.../feature_chainer/test_universal_optional_matcher.py` |
 
 ## Context propagation
 

--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -418,16 +418,17 @@ The guard is installed at class definition, so mutating `PROPERTY_MAPPING` or re
 ## Guarding against a universal configuration matcher
 
 A key is unconditionally required only when it declares no `default` and no `required_when`. A
-`PROPERTY_MAPPING` whose every key is optional or conditional has no such key, so on the
-configuration path it matches any feature name with empty options. A feature group that inherits
-the mixin's `match_feature_group_criteria` and declares such a mapping is a universal matcher: it
-claims features it was never meant to.
+`PROPERTY_MAPPING` with only declared-default keys (and, as the degenerate case, an empty mapping)
+has no such key, so on the configuration path it matches any feature name with empty options. A
+feature group that inherits the mixin's `match_feature_group_criteria` and declares such a mapping
+is a universal matcher: it claims features it was never meant to.
 
-At class definition the mixin warns about this, naming the class and the escape hatch. It fires
-only when the mapping has zero unconditionally required keys AND the resolved matcher still accepts
-an unrelated name with empty options. So a genuinely discriminating `match_feature_group_criteria`,
-or a `required_when` predicate that fires for empty options, is not warned, while a pass-through
-override that only delegates to the base still is.
+At class definition the mixin warns about this, naming the class and the escape hatch. A key that is
+unconditionally required, or conditionally required via `required_when`, gates the match, so the
+mapping is not warned. For the remaining all-default mappings, universality is confirmed by calling
+the resolved matcher with an unrelated, separator-free name and empty options: a genuinely
+discriminating `match_feature_group_criteria` is not warned, while a pass-through override that only
+delegates to the base still is.
 
 Set `ALLOW_UNIVERSAL_MATCHER = True` on the class to declare the universal match intentional and
 silence the warning. Otherwise give one key no `default` (making it unconditionally required), or a

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -34,9 +34,10 @@ REQUIRED_WHEN_GUARD_FLAG = "_mloda_required_when_guard"
 CAPTURELESS_DIAGNOSTIC_FLAG = "_mloda_captureless_diagnostic_emitted"
 
 # An unrelated feature name used to probe whether a matcher is universal: does it accept a name it
-# has no business matching, with empty options? Contains a chain separator so it reaches the
-# configuration path cleanly.
-_UNIVERSAL_MATCHER_PROBE_NAME = "mloda_universal_matcher_probe_source__mloda_universal_matcher_probe"
+# has no business matching, with empty options? It carries NO chain separator, so no
+# PREFIX_PATTERN/SUFFIX_PATTERN can capture it and the resolved matcher falls through to the
+# configuration path, where the universal-matcher problem actually lives.
+_UNIVERSAL_MATCHER_PROBE_NAME = "mloda_universal_matcher_probe"
 
 # How many guards the current match call is nested in. A guarded matcher that delegates via super()
 # reaches the guard of its parent, and only the outermost one may evaluate the predicates.
@@ -730,21 +731,31 @@ class FeatureChainParser:
         """Nudge authors whose all-optional PROPERTY_MAPPING inherits the universal configuration matcher (#771).
 
         With zero unconditionally required keys, the configuration path matches any feature name given
-        empty options. Warn unless the class opts in with ALLOW_UNIVERSAL_MATCHER = True. A single
-        unconditionally required key already discriminates, so it is not warned. Universality is
-        confirmed behaviorally: the resolved matcher is called with an unrelated name and empty options,
-        which exempts a genuine custom matcher and a required_when that fires for empty options, while
-        still catching a pass-through override that delegates to the universal base.
+        empty options. Warn unless the class opts in with ALLOW_UNIVERSAL_MATCHER = True. A key that is
+        unconditionally required, or conditionally required via required_when, gates the match, so the
+        mapping is not warned. Universality is confirmed behaviorally: the resolved matcher is called
+        with an unrelated, separator-free name and empty options, which exempts a genuine custom matcher
+        while still catching a pass-through override that delegates to the universal base.
         """
         if getattr(owner, "ALLOW_UNIVERSAL_MATCHER", False):
             return
         property_mapping = getattr(owner, "PROPERTY_MAPPING", None)
-        if not isinstance(property_mapping, dict) or not property_mapping:
+        # A None mapping is not a configuration matcher; an EMPTY dict is the strongest universal
+        # matcher (it validates vacuously), so it stays in scope.
+        if not isinstance(property_mapping, dict):
             return
-        # A key that declares no default and no required_when is unconditionally required and already
-        # discriminates on the configuration path, so the mapping is not universal.
         for spec in property_mapping.values():
-            if isinstance(spec, PropertySpec) and not cls._can_skip_required_check(spec):
+            if not isinstance(spec, PropertySpec):
+                continue
+            # A required_when key gates the match with a runtime predicate, so the mapping is not a
+            # blanket universal matcher. It is also left unprobed: the predicate may reference the
+            # class being defined, which is not yet bound to its name during __init_subclass__, so
+            # probing it would raise (#771).
+            if spec.required_when is not None:
+                return
+            # A key that declares no default (and, per the check above, no required_when) is
+            # unconditionally required and already discriminates on the configuration path.
+            if not cls._can_skip_required_check(spec):
                 return
         matcher = getattr(owner, "match_feature_group_criteria", None)
         if matcher is None:
@@ -752,7 +763,8 @@ class FeatureChainParser:
         # A matcher that raises on the probe is doing custom work, so it is not treated as universal.
         try:
             universal = bool(matcher(_UNIVERSAL_MATCHER_PROBE_NAME, Options()))
-        except Exception:
+        except Exception as exc:
+            logger.debug("universal-matcher probe for %s raised %s; treating it as non-universal.", owner.__name__, exc)
             return
         if not universal:
             return

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -33,6 +33,11 @@ REQUIRED_WHEN_GUARD_FLAG = "_mloda_required_when_guard"
 # emit it at most once. Checked on the class's OWN dict so a subclass still evaluates fresh.
 CAPTURELESS_DIAGNOSTIC_FLAG = "_mloda_captureless_diagnostic_emitted"
 
+# An unrelated feature name used to probe whether a matcher is universal: does it accept a name it
+# has no business matching, with empty options? Contains a chain separator so it reaches the
+# configuration path cleanly.
+_UNIVERSAL_MATCHER_PROBE_NAME = "mloda_universal_matcher_probe_source__mloda_universal_matcher_probe"
+
 # How many guards the current match call is nested in. A guarded matcher that delegates via super()
 # reaches the guard of its parent, and only the outermost one may evaluate the predicates.
 # A ContextVar (not a plain global) keeps the count per thread and per async task.
@@ -719,6 +724,45 @@ class FeatureChainParser:
                     owner.__name__,
                 )
                 return
+
+    @classmethod
+    def warn_universal_optional_matcher(cls, owner: type[Any]) -> None:
+        """Nudge authors whose all-optional PROPERTY_MAPPING inherits the universal configuration matcher (#771).
+
+        With zero unconditionally required keys, the configuration path matches any feature name given
+        empty options. Warn unless the class opts in with ALLOW_UNIVERSAL_MATCHER = True. A single
+        unconditionally required key already discriminates, so it is not warned. Universality is
+        confirmed behaviorally: the resolved matcher is called with an unrelated name and empty options,
+        which exempts a genuine custom matcher and a required_when that fires for empty options, while
+        still catching a pass-through override that delegates to the universal base.
+        """
+        if getattr(owner, "ALLOW_UNIVERSAL_MATCHER", False):
+            return
+        property_mapping = getattr(owner, "PROPERTY_MAPPING", None)
+        if not isinstance(property_mapping, dict) or not property_mapping:
+            return
+        # A key that declares no default and no required_when is unconditionally required and already
+        # discriminates on the configuration path, so the mapping is not universal.
+        for spec in property_mapping.values():
+            if isinstance(spec, PropertySpec) and not cls._can_skip_required_check(spec):
+                return
+        matcher = getattr(owner, "match_feature_group_criteria", None)
+        if matcher is None:
+            return
+        # A matcher that raises on the probe is doing custom work, so it is not treated as universal.
+        try:
+            universal = bool(matcher(_UNIVERSAL_MATCHER_PROBE_NAME, Options()))
+        except Exception:
+            return
+        if not universal:
+            return
+        logger.warning(
+            "%s declares a PROPERTY_MAPPING with no unconditionally required key and inherits the "
+            "universal configuration matcher: with empty options it matches any feature name. Add a "
+            "required key (a PropertySpec with no default, or a required_when predicate that fires), or "
+            "set ALLOW_UNIVERSAL_MATCHER = True to declare the universal match intentional.",
+            owner.__name__,
+        )
 
     @classmethod
     def check_required_when(

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -85,6 +85,8 @@ class FeatureChainParserMixin:
     - MAX_IN_FEATURES: Optional maximum in_feature count (default: None)
     - RECOGNITION_ONLY_PATTERN: Optional marker for a recognition-only pattern that binds no key
       from the name (all values come from options); default False (#772)
+    - ALLOW_UNIVERSAL_MATCHER: Optional opt-in marking an all-optional PROPERTY_MAPPING as an
+      intentional universal configuration matcher; default False (#771)
 
     PROPERTY_MAPPING supports conditional requirements via ``PropertySpec.required_when``.
     Attach a predicate ``(Options) -> bool`` to any spec. When the predicate returns
@@ -115,6 +117,9 @@ class FeatureChainParserMixin:
     MAX_IN_FEATURES: Optional[int] = None
     # A recognition-only pattern binds no key from the name; all values come from options (#772).
     RECOGNITION_ONLY_PATTERN: bool = False
+    # An all-optional PROPERTY_MAPPING that inherits the config matcher matches any feature name with
+    # empty options; set True to declare that universal match intentional and silence the #771 warning.
+    ALLOW_UNIVERSAL_MATCHER: bool = False
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         # The mixin sits first in the MRO of ``class X(FeatureChainParserMixin, FeatureGroup)``,
@@ -123,6 +128,7 @@ class FeatureChainParserMixin:
         FeatureChainParser.validate_name_binding(cls)
         FeatureChainParser.warn_captureless_without_binding(cls)
         FeatureChainParser.install_required_when_guard(cls)
+        FeatureChainParser.warn_universal_optional_matcher(cls)
 
     @classmethod
     def _validate_string_match(cls, _feature_name: str, _operation_config: str, _in_feature: str) -> bool:

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_universal_optional_matcher.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_universal_optional_matcher.py
@@ -132,6 +132,66 @@ class TestUniversalMatcherWarns:
         warnings = _universal_matcher_warnings(caplog, "_PassThroughU771d")
         assert warnings, "a pass-through override is still a universal matcher and must warn"
 
+    def test_named_capture_optional_pattern_warns(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Case 10: a named-capture pattern plus an all-optional mapping is universal via config -> WARNS.
+
+        An unrelated name WITHOUT a chain separator reaches the configuration path, where the sole key is
+        optional, so the class matches it with empty options: it is a universal matcher. The definition-time
+        probe must confirm universality on a name the pattern does NOT capture. Today's ``__``-bearing probe
+        IS captured by the pattern, the captured value fails strict validation, the match returns False, and
+        no warning fires. Fixed once the probe stops using a name that contains the chain separator.
+        """
+        with caplog.at_level(logging.WARNING):
+
+            class _NamedOptionalPatternU771j(FeatureChainParserMixin, FeatureGroup):
+                PREFIX_PATTERN = r".*__(?P<mode_u771j>\w+)$"
+                PROPERTY_MAPPING = {
+                    "mode_u771j": PropertySpec(
+                        "mode", allowed_values=("special_u771j",), default=None, strict_validation=True
+                    ),
+                }
+
+            # Precondition (holds now and after the fix): a name with NO chain separator reaches the config
+            # path, where the optional key lets the class match with empty options -> universal.
+            assert _NamedOptionalPatternU771j.match_feature_group_criteria("plainunrelatedu771j", Options()) is True
+
+        warnings = _universal_matcher_warnings(caplog, "_NamedOptionalPatternU771j")
+        assert warnings, "a named-capture pattern with an all-optional mapping is still a universal matcher"
+
+    def test_empty_mapping_warns(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Case 11: an explicit empty PROPERTY_MAPPING validates vacuously -> universal matcher -> WARNS.
+
+        An empty mapping enforces nothing, so with empty options it matches any feature name: it is the most
+        universal shape there is. Today the guard early-returns on the empty dict and stays silent; it must
+        warn once that early return is removed.
+        """
+        with caplog.at_level(logging.WARNING):
+
+            class _EmptyMappingU771k(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {}
+
+            # Precondition: an empty mapping validates vacuously, so an unrelated name matches -> universal.
+            assert _EmptyMappingU771k.match_feature_group_criteria("unrelatedu771k", Options()) is True
+
+        warnings = _universal_matcher_warnings(caplog, "_EmptyMappingU771k")
+        assert warnings, "an empty PROPERTY_MAPPING is vacuously universal and must warn"
+
+    def test_warns_exactly_once(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Case 15 (pin, once-count): the definition-time warning fires exactly once per class.
+
+        Only ``FeatureChainParserMixin.__init_subclass__`` runs this diagnostic. Mirrors the captureless
+        suite's once-count and guards against a future regression that also wires the guard into
+        ``FeatureGroup.__init_subclass__``, which would double the warning through the super() chain.
+        """
+        with caplog.at_level(logging.WARNING):
+
+            class _OnceCountU771o(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {"opt_u771o": PropertySpec("optional", default=None)}
+
+            assert "opt_u771o" in _OnceCountU771o.PROPERTY_MAPPING
+
+        assert len(_universal_matcher_warnings(caplog, "_OnceCountU771o")) == 1
+
 
 class TestUniversalMatcherDoesNotWarn:
     """The guard stays quiet whenever the class is NOT a universal matcher, or opts out explicitly."""
@@ -211,6 +271,109 @@ class TestUniversalMatcherDoesNotWarn:
             assert _EscapeHatchU771g.ALLOW_UNIVERSAL_MATCHER is True
 
         assert not _universal_matcher_warnings(caplog), "the escape hatch must silence the diagnostic"
+
+    def test_self_referential_required_when_no_spurious_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Case 12: a self-referential required_when must NOT trigger a spurious class-definition warning.
+
+        An all-conditional mapping whose ``required_when`` references the class's own not-yet-bound name is a
+        common authoring style (sklearn's pipeline uses
+        ``lambda o: o.get(SklearnPipelineFeatureGroup.KEY) is None``). During ``__init_subclass__`` the class
+        name is unbound, so calling the predicate raises NameError. Today the universal-matcher probe runs the
+        installed guard, which triggers the predicate; ``check_required_when`` catches the NameError and logs a
+        misleading "required_when predicate ... raised ..." warning. A conditional mapping is not a universal
+        matcher and must not be probed at class-definition time.
+        """
+        with caplog.at_level(logging.WARNING):
+
+            class _SelfRefConditionalU771l(FeatureChainParserMixin, FeatureGroup):
+                COND_KEY_U771L = "cond_u771l"
+                OTHER_KEY_U771L = "other_u771l"
+                PROPERTY_MAPPING = {
+                    "cond_u771l": PropertySpec(
+                        "cond",
+                        default=None,
+                        required_when=(lambda o: o.get(_SelfRefConditionalU771l.OTHER_KEY_U771L) is None),
+                    ),
+                    "other_u771l": PropertySpec(
+                        "other",
+                        default=None,
+                        required_when=(lambda o: o.get(_SelfRefConditionalU771l.COND_KEY_U771L) is None),
+                    ),
+                }
+
+            assert "cond_u771l" in _SelfRefConditionalU771l.PROPERTY_MAPPING
+
+        # 1) A conditional mapping is not warned as a universal matcher (holds now and after the fix).
+        assert not _universal_matcher_warnings(caplog, "_SelfRefConditionalU771l")
+        # 2) The probe must not run the required_when predicate at class-definition time. Doing so today
+        # raises NameError (the class name is unbound during __init_subclass__) and logs this spurious record.
+        spurious = [
+            record
+            for record in caplog.records
+            if record.name == FEATURE_CHAIN_PARSER_LOGGER
+            and "required_when" in record.getMessage()
+            and "raised" in record.getMessage()
+        ]
+        assert not spurious, "the guard's probe must not run required_when predicates at class definition"
+
+    def test_required_key_with_always_true_matcher_no_warn(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Case 13 (pin): an unconditionally-required key keeps the class out of scope even when a custom
+        matcher returns True for everything.
+
+        The diagnostic is scoped to the MAPPING SHAPE (all-optional), not "is this matcher universal in
+        general". A required key means the class is out of #771 scope, whatever the matcher answers, so the
+        probe is never even reached.
+        """
+        with caplog.at_level(logging.WARNING):
+
+            class _RequiredKeyCustomTrueU771m(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {
+                    "req_u771m": PropertySpec("required", allowed_values=("v_u771m",), strict_validation=True),
+                }
+
+                @classmethod
+                def match_feature_group_criteria(
+                    cls,
+                    feature_name: str | FeatureName,
+                    options: Options,
+                    data_access_collection: Any = None,
+                ) -> bool:
+                    return True
+
+            # Precondition: the key is unconditionally required, so the mapping shape is not universal.
+            required_spec = _RequiredKeyCustomTrueU771m.PROPERTY_MAPPING["req_u771m"]
+            assert FeatureChainParser._can_skip_required_check(required_spec) is False
+
+        assert not _universal_matcher_warnings(caplog, "_RequiredKeyCustomTrueU771m"), (
+            "a required key keeps the class out of scope even if the matcher returns True for everything"
+        )
+
+    def test_probe_exception_contained_no_warn(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Case 14 (pin): a matcher that raises on the probe is contained -> no warning, no crash.
+
+        The class-definition probe must never let a matcher exception escape and abort the class body, and a
+        raising matcher is not treated as universal.
+        """
+        with caplog.at_level(logging.WARNING):
+
+            class _RaisingMatcherU771n(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {"opt_u771n": PropertySpec("optional", default=None)}
+
+                @classmethod
+                def match_feature_group_criteria(
+                    cls,
+                    feature_name: str | FeatureName,
+                    options: Options,
+                    data_access_collection: Any = None,
+                ) -> bool:
+                    raise RuntimeError("boom_u771n")
+
+            # The class body completes: the probe exception did not escape class definition.
+            assert "opt_u771n" in _RaisingMatcherU771n.PROPERTY_MAPPING
+
+        assert not _universal_matcher_warnings(caplog, "_RaisingMatcherU771n"), (
+            "a probe exception is contained, so the class is not warned as universal"
+        )
 
 
 class TestUniversalMatcherMotivation:

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_universal_optional_matcher.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_universal_optional_matcher.py
@@ -1,0 +1,239 @@
+"""Definition-time diagnostic for a "universal configuration matcher" PROPERTY_MAPPING (issue #771).
+
+A FeatureGroup whose PROPERTY_MAPPING has ZERO unconditionally-required keys, declares no capturing
+pattern, and inherits the mixin's configuration matcher will match ANY feature name with EMPTY
+options (Finding 10 of #750). That silent over-matching is what this diagnostic warns about at
+class-definition time. The warning names the escape hatch ``ALLOW_UNIVERSAL_MATCHER`` and the class.
+
+Authors silence it legitimately by: declaring an unconditionally-required key, supplying a genuinely
+discriminating ``match_feature_group_criteria``, gating with ``required_when`` predicates that fire
+for empty options, or opting in with ``ALLOW_UNIVERSAL_MATCHER = True``.
+
+Requiredness (final PropertySpec semantics, already in the repo):
+- ``default=NO_DEFAULT`` AND ``required_when is None``  -> unconditionally required.
+- any declared ``default`` (including ``default=None``)  -> optional.
+- ``required_when=<predicate>``                          -> conditionally required (not unconditional).
+``FeatureChainParser._can_skip_required_check(spec)`` is True for the optional-or-conditional cases.
+
+Every fixture carries a "u771" marker in its class name, keys, and values so it cannot collide in the
+global plugin registry; the captureless test (test_captureless_no_binding.py) uses "c772" the same way.
+The universal fixtures declare NO PREFIX_PATTERN/SUFFIX_PATTERN (a pure-config matcher), so the ONLY
+diagnostic in scope is the universal-matcher warning, never the captureless one.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.provider import PropertySpec
+from mloda_plugins.feature_group.experimental.aggregated_feature_group.base import AggregatedFeatureGroup
+
+FEATURE_CHAIN_PARSER_LOGGER = "mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser"
+
+# A name that no fixture pattern would ever recognize, used as the "unrelated probe".
+UNRELATED_NAME_U771 = "some_unrelated_feature_u771"
+
+# Case 5's two mutually-exclusive conditional keys (modeled on the sklearn PIPELINE_NAME/PIPELINE_STEPS
+# pattern): each is required only when the other is absent, so EMPTY options leaves both required.
+COND_KEY_A_U771 = "pipe_a_u771e"
+COND_KEY_B_U771 = "pipe_b_u771e"
+
+
+def _universal_matcher_warnings(
+    caplog: pytest.LogCaptureFixture, class_name: str | None = None
+) -> list[logging.LogRecord]:
+    """The ALLOW_UNIVERSAL_MATCHER definition-time warnings, optionally scoped to one class name.
+
+    Filters exactly like the captureless test filters RECOGNITION_ONLY_PATTERN records: by logger
+    name, WARNING level, and the marker substring in the rendered message.
+    """
+    records = [
+        record
+        for record in caplog.records
+        if record.levelno == logging.WARNING
+        and record.name == FEATURE_CHAIN_PARSER_LOGGER
+        and "ALLOW_UNIVERSAL_MATCHER" in record.getMessage()
+    ]
+    if class_name is not None:
+        records = [record for record in records if class_name in record.getMessage()]
+    return records
+
+
+class TestUniversalMatcherWarns:
+    """The guard warns when an inherited config matcher matches any feature name with empty options."""
+
+    def test_inherited_all_declared_default_warns(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Case 1: every key declares ``default=None``, no pattern -> universal matcher -> WARNS."""
+        with caplog.at_level(logging.WARNING):
+
+            class _InheritedAllDefaultU771a(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {
+                    "opt_a_u771a": PropertySpec("optional a", default=None),
+                    "opt_b_u771a": PropertySpec("optional b", default=None),
+                }
+
+            assert "opt_a_u771a" in _InheritedAllDefaultU771a.PROPERTY_MAPPING
+
+        warnings = _universal_matcher_warnings(caplog, "_InheritedAllDefaultU771a")
+        assert warnings, "expected an ALLOW_UNIVERSAL_MATCHER warning naming the class"
+
+    def test_declared_default_value_is_optional_warns(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Case 6: a concrete declared default (not just None) still counts as optional -> WARNS."""
+        with caplog.at_level(logging.WARNING):
+
+            class _DeclaredDefaultU771f(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {
+                    "defaulted_u771f": PropertySpec(
+                        "declared concrete default",
+                        default="x_u771",
+                        strict_validation=True,
+                        allowed_values=("x_u771",),
+                    ),
+                }
+
+            # Precondition: a concrete declared default makes the key optional, not required.
+            spec = _DeclaredDefaultU771f.PROPERTY_MAPPING["defaulted_u771f"]
+            assert FeatureChainParser._can_skip_required_check(spec) is True
+
+        warnings = _universal_matcher_warnings(caplog, "_DeclaredDefaultU771f")
+        assert warnings, "a declared default is optional, so the class is still a universal matcher"
+
+    def test_passthrough_override_warns(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Case 4: an override that only delegates via super() stays universal -> WARNS.
+
+        This is the DoD "distinguish genuine custom from pass-through" case: a pass-through matcher is
+        as universal as the inherited one, so the guard must still fire.
+        """
+        with caplog.at_level(logging.WARNING):
+
+            class _PassThroughU771d(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {"opt_u771d": PropertySpec("optional", default=None)}
+
+                @classmethod
+                def match_feature_group_criteria(
+                    cls,
+                    feature_name: str | FeatureName,
+                    options: Options,
+                    data_access_collection: Any = None,
+                ) -> bool:
+                    return super().match_feature_group_criteria(feature_name, options, data_access_collection)
+
+            # Precondition: the pass-through override still matches an unrelated name with empty options.
+            assert _PassThroughU771d.match_feature_group_criteria("anything_u771d", Options()) is True
+
+        warnings = _universal_matcher_warnings(caplog, "_PassThroughU771d")
+        assert warnings, "a pass-through override is still a universal matcher and must warn"
+
+
+class TestUniversalMatcherDoesNotWarn:
+    """The guard stays quiet whenever the class is NOT a universal matcher, or opts out explicitly."""
+
+    def test_unconditionally_required_key_no_warn(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Case 2: one unconditionally-required key (NO_DEFAULT, no required_when) -> NO WARN."""
+        with caplog.at_level(logging.WARNING):
+
+            class _RequiredKeyU771b(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {
+                    "required_u771b": PropertySpec(
+                        "required op", allowed_values=("agg_u771b",), strict_validation=True
+                    ),
+                    "opt_u771b": PropertySpec("optional", default=None),
+                }
+
+            # Precondition: the first key is unconditionally required (cannot be skipped).
+            required_spec = _RequiredKeyU771b.PROPERTY_MAPPING["required_u771b"]
+            assert FeatureChainParser._can_skip_required_check(required_spec) is False
+
+        assert not _universal_matcher_warnings(caplog), "a required key means the matcher is not universal"
+
+    def test_genuine_custom_matcher_no_warn(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Case 3: a real, discriminating override rejects the unrelated probe -> NO WARN."""
+        with caplog.at_level(logging.WARNING):
+
+            class _GenuineCustomU771c(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {"opt_u771c": PropertySpec("optional", default=None)}
+
+                @classmethod
+                def match_feature_group_criteria(
+                    cls,
+                    feature_name: str | FeatureName,
+                    options: Options,
+                    data_access_collection: Any = None,
+                ) -> bool:
+                    return str(feature_name) == "specific_u771c"
+
+            # Precondition: the custom matcher really discriminates (True only for its own name).
+            assert _GenuineCustomU771c.match_feature_group_criteria("specific_u771c", Options()) is True
+            assert _GenuineCustomU771c.match_feature_group_criteria(UNRELATED_NAME_U771, Options()) is False
+
+        assert not _universal_matcher_warnings(caplog), "a genuinely custom matcher is not universal"
+
+    def test_conditional_requirement_fires_no_warn(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Case 5: mutually-exclusive required_when keys make empty options a non-match -> NO WARN."""
+        with caplog.at_level(logging.WARNING):
+
+            class _ConditionalU771e(FeatureChainParserMixin, FeatureGroup):
+                PROPERTY_MAPPING = {
+                    COND_KEY_A_U771: PropertySpec(
+                        "a, required when b is absent",
+                        default=None,
+                        required_when=(lambda options: options.get(COND_KEY_B_U771) is None),
+                    ),
+                    COND_KEY_B_U771: PropertySpec(
+                        "b, required when a is absent",
+                        default=None,
+                        required_when=(lambda options: options.get(COND_KEY_A_U771) is None),
+                    ),
+                }
+
+            # Precondition: with EMPTY options at least one conditional key is required, so the
+            # config match fails and the class is therefore NOT a universal matcher.
+            assert _ConditionalU771e.match_feature_group_criteria(UNRELATED_NAME_U771, Options()) is False
+
+        assert not _universal_matcher_warnings(caplog), "a conditional requirement that fires is not universal"
+
+    def test_escape_hatch_no_warn(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Case 7: ALLOW_UNIVERSAL_MATCHER = True opts out of the diagnostic -> NO WARN."""
+        with caplog.at_level(logging.WARNING):
+
+            class _EscapeHatchU771g(FeatureChainParserMixin, FeatureGroup):
+                ALLOW_UNIVERSAL_MATCHER = True
+                PROPERTY_MAPPING = {"opt_u771g": PropertySpec("optional", default=None)}
+
+            assert _EscapeHatchU771g.ALLOW_UNIVERSAL_MATCHER is True
+
+        assert not _universal_matcher_warnings(caplog), "the escape hatch must silence the diagnostic"
+
+
+class TestUniversalMatcherMotivation:
+    """Behavioral pins that document WHY the guard exists and keep shipped plugins out of scope."""
+
+    def test_inherited_all_optional_matches_unrelated_name(self) -> None:
+        """Case 8: without the escape hatch, an all-optional inherited matcher claims an unrelated name.
+
+        This is the motivation for the diagnostic and holds both before and after implementation: the
+        guard only warns, it does not change matching behavior.
+        """
+
+        class _UniversalMotivationU771h(FeatureChainParserMixin, FeatureGroup):
+            PROPERTY_MAPPING = {"opt_u771h": PropertySpec("optional", default=None)}
+
+        assert _UniversalMotivationU771h.match_feature_group_criteria(UNRELATED_NAME_U771, Options()) is True
+
+    def test_shipped_aggregated_feature_group_is_not_universal(self) -> None:
+        """Case 9: a representative shipped plugin has an unconditionally-required key -> out of scope.
+
+        Pins that shipped plugins do not trip the diagnostic; passes before and after implementation.
+        """
+        assert any(
+            not FeatureChainParser._can_skip_required_check(spec)
+            for spec in AggregatedFeatureGroup.PROPERTY_MAPPING.values()
+        ), "AggregatedFeatureGroup must keep an unconditionally-required key so it is not a universal matcher"


### PR DESCRIPTION
Closes #771. Part of epic #761, phase 3 (Finding 10 of #750).

## Problem

On the configuration path, a `PROPERTY_MAPPING` with zero unconditionally required keys matches any feature name with empty options: `_validate_options_against_property_mapping` returns `True` when every key is skippable. Such a feature group silently claims features it was never meant to, and nothing flagged it at class definition.

## Change

A definition-time diagnostic, `FeatureChainParser.warn_universal_optional_matcher`, wired into `FeatureChainParserMixin.__init_subclass__` (the universal configuration matcher is a mixin phenomenon; a plain `FeatureGroup` uses the name-based matcher and is out of scope). It mirrors the existing `warn_captureless_without_binding` guard and the `RECOGNITION_ONLY_PATTERN` escape-hatch precedent.

It warns when a mapping has zero unconditionally required keys and the class still matches an unrelated name with empty options. It stays silent when:
- a key is unconditionally required (no default, no `required_when`),
- a key is conditionally required via `required_when` (a runtime gate; also left unprobed so a self-referential predicate cannot raise at definition time),
- the resolved `match_feature_group_criteria` genuinely discriminates (a custom matcher that rejects the unrelated probe), or
- the class opts in with the documented escape hatch `ALLOW_UNIVERSAL_MATCHER = True`.

Universality is confirmed behaviorally by calling the resolved matcher with an unrelated, separator-free name and empty options. This is what distinguishes a genuine custom matcher (probe rejects it) from a pass-through override that still delegates to the universal base (probe accepts it).

No shipped plugin trips the warning: each declares `in_features` (or an operation key) with no default, so it has an unconditionally required key and stays out of scope. The change is purely additive.

## Definition of done

- [x] Definition-time analysis identifies mappings with zero unconditionally required keys under the final `PropertySpec` semantics
- [x] Such a mapping is warned when it inherits the universal base matcher
- [x] An explicit, documented escape hatch (`ALLOW_UNIVERSAL_MATCHER`) exists
- [x] The rule distinguishes a genuine custom matcher from a pass-through override that remains universal
- [x] Tests cover inherited matching, custom matching, conditional requirements, declared defaults, and the escape hatch (plus empty mapping, named-capture pattern, probe-raises, and once-count pins)
- [x] `tox` passes (6901 passed, 170 skipped; ruff, mypy --strict, bandit clean)

## Review

Two independent deep reviews (a fresh Claude Opus reviewer and codex) gated this. They surfaced three probe gaps, all fixed in the second commit: a `__`-bearing probe that a named-capture pattern captured and hid a universal matcher, an exempted empty mapping, and a self-referential `required_when` predicate raising `NameError` when probed at class definition. Docs: a new section and lifecycle/pinned-invariant rows in `docs/docs/in_depth/property-mapping.md`.