### PR TITLE
feat: mlodaAPI.diagnose, a non-raising whole-request resolution preflight (#812)

### DIFF
--- a/attribution/ATTRIBUTION.md
+++ b/attribution/ATTRIBUTION.md
@@ -41,7 +41,6 @@
 | mypy                                   | 2.2.0           | MIT                                                |
 | mypy_extensions                        | 1.1.0           | MIT                                                |
 | narwhals                               | 2.23.0          | MIT                                                |
-| nest-asyncio                           | 1.6.0           | BSD License                                        |
 | nest-asyncio2                          | 1.7.2           | BSD License                                        |
 | nltk                                   | 3.10.0          | Apache Software License                            |
 | numpy                                  | 2.5.1           | BSD-3-Clause AND 0BSD AND MIT AND Zlib AND CC0-1.0 |

--- a/mloda/core/api/request.py
+++ b/mloda/core/api/request.py
@@ -29,6 +29,10 @@ from mloda.core.abstract_plugins.components.link import Link
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
 
 
+class SetupConfigurationError(ValueError):
+    """Invalid mlodaAPI setup argument, raised before any feature resolution runs."""
+
+
 class mlodaAPI:
     """Main API for executing mloda feature requests.
 
@@ -53,10 +57,9 @@ class mlodaAPI:
         strict_type_enforcement: bool = False,
         column_ordering: Optional[str] = None,
         parallelization_modes: Optional[set[ParallelizationMode]] = None,
-        _defer_planning: bool = False,
     ) -> None:
         if column_ordering is not None and column_ordering not in ("alphabetical", "request_order"):
-            raise ValueError(
+            raise SetupConfigurationError(
                 f"column_ordering must be None, 'alphabetical', or 'request_order', got '{column_ordering}'"
             )
         self.column_ordering = column_ordering
@@ -86,7 +89,6 @@ class mlodaAPI:
         self.runner: None | ExecutionOrchestrator = None
         self.engine: None | Engine = None
 
-        self._defer_planning = _defer_planning
         self.engine = self._create_engine()
 
     def _process_features(
@@ -326,10 +328,10 @@ class mlodaAPI:
 
         Runs the same eager planning as prepare() but projects the outcome instead of raising: on success
         records equals resolution_report() with complete True; on a resolution failure records holds the
-        features resolved before the failing one plus that feature's EvaluationResult and rendered message.
-        A configuration error raised while building the session (for example an invalid column_ordering)
-        yields only the message; any other error raised during the planning pass propagates. Every parameter
-        after features is keyword-only.
+        features resolved before the failing one (from the error payload, capped at PARTIAL_RECORDS_CAP on
+        huge requests) plus that feature's EvaluationResult and rendered message. A SetupConfigurationError
+        (for example an invalid column_ordering) yields only the message; any other error propagates. Every
+        parameter after features is keyword-only.
         """
         try:
             session = cls(
@@ -344,27 +346,17 @@ class mlodaAPI:
                 strict_type_enforcement=strict_type_enforcement,
                 column_ordering=column_ordering,
                 parallelization_modes=parallelization_modes,
-                _defer_planning=True,
             )
-        except ValueError as error:
-            # Setup-phase configuration error (e.g. bad column_ordering); no feature was resolved yet.
-            return ResolutionDiagnosis(records=[], complete=False, message=str(error))
-
-        engine = session.engine
-        if engine is None:
-            raise ValueError("Internal error: engine not initialized. This is likely a bug in mloda.")
-
-        try:
-            engine.plan()
         except FeatureResolutionError as error:
             return ResolutionDiagnosis(
-                records=deepcopy(engine.resolution_records),
+                records=list(error.partial_records),
                 complete=False,
                 feature_name=error.feature_name,
                 failed_result=deepcopy(error.result),
                 message=str(error),
             )
-
+        except SetupConfigurationError as error:
+            return ResolutionDiagnosis(records=[], complete=False, message=str(error))
         return ResolutionDiagnosis(records=session.resolution_report(), complete=True)
 
     def resolved_plan(self) -> list[PlanStep]:
@@ -490,7 +482,6 @@ class mlodaAPI:
             self.api_input_data_collection,
             self.plugin_collector,
             column_ordering=self.column_ordering,
-            auto_plan=not self._defer_planning,
         )
         if not isinstance(engine, Engine):
             raise ValueError("Engine initialization failed.")

--- a/mloda/core/api/request.py
+++ b/mloda/core/api/request.py
@@ -58,33 +58,39 @@ class mlodaAPI:
         column_ordering: Optional[str] = None,
         parallelization_modes: Optional[set[ParallelizationMode]] = None,
     ) -> None:
-        if column_ordering is not None and column_ordering not in ("alphabetical", "request_order"):
-            raise SetupConfigurationError(
-                f"column_ordering must be None, 'alphabetical', or 'request_order', got '{column_ordering}'"
-            )
-        self.column_ordering = column_ordering
-        # The features object is potentially changed during the run, so we need to deepcopy it by default, so that follow up runs with the same object are not affected.
-        # Set copy_features=False to disable deep copying for use cases where features contain non-copyable objects.
-        _requested_features = deepcopy(requested_features) if copy_features else requested_features
+        # Setup boundary: any invalid request argument surfaces as the typed error before planning.
+        try:
+            if column_ordering is not None and column_ordering not in ("alphabetical", "request_order"):
+                raise SetupConfigurationError(
+                    f"column_ordering must be None, 'alphabetical', or 'request_order', got '{column_ordering}'"
+                )
+            self.column_ordering = column_ordering
+            # The features object is potentially changed during the run, so we need to deepcopy it by default, so that follow up runs with the same object are not affected.
+            # Set copy_features=False to disable deep copying for use cases where features contain non-copyable objects.
+            _requested_features = deepcopy(requested_features) if copy_features else requested_features
 
-        # Handle api_data: create ApiInputDataCollection if api_data provided
-        api_input_data_collection: Optional[ApiInputDataCollection] = None
-        if api_data is not None and len(api_data) > 0:
-            api_input_data_collection = ApiInputDataCollection()
-            for key_name, key_data in api_data.items():
-                api_input_data_collection.setup_key_class(key_name, list(key_data.keys()))
+            # Handle api_data: create ApiInputDataCollection if api_data provided
+            api_input_data_collection: Optional[ApiInputDataCollection] = None
+            if api_data is not None and len(api_data) > 0:
+                api_input_data_collection = ApiInputDataCollection()
+                for key_name, key_data in api_data.items():
+                    api_input_data_collection.setup_key_class(key_name, list(key_data.keys()))
 
-        self.strict_type_enforcement = strict_type_enforcement
-        self.features = self._process_features(_requested_features, api_input_data_collection)
-        self.compute_framework = SetupComputeFramework(
-            compute_frameworks, self.features, parallelization_modes=parallelization_modes
-        ).compute_frameworks
-        self.links = links
-        self.data_access_collection = data_access_collection
-        self.global_filter = global_filter
-        self.api_input_data_collection = api_input_data_collection
-        self.api_data = api_data
-        self.plugin_collector = plugin_collector
+            self.strict_type_enforcement = strict_type_enforcement
+            self.features = self._process_features(_requested_features, api_input_data_collection)
+            self.compute_framework = SetupComputeFramework(
+                compute_frameworks, self.features, parallelization_modes=parallelization_modes
+            ).compute_frameworks
+            self.links = links
+            self.data_access_collection = data_access_collection
+            self.global_filter = global_filter
+            self.api_input_data_collection = api_input_data_collection
+            self.api_data = api_data
+            self.plugin_collector = plugin_collector
+        except SetupConfigurationError:
+            raise
+        except ValueError as error:
+            raise SetupConfigurationError(str(error)) from error
 
         self.runner: None | ExecutionOrchestrator = None
         self.engine: None | Engine = None
@@ -330,8 +336,9 @@ class mlodaAPI:
         records equals resolution_report() with complete True; on a resolution failure records holds the
         features resolved before the failing one (from the error payload, capped at PARTIAL_RECORDS_CAP on
         huge requests) plus that feature's EvaluationResult and rendered message. A SetupConfigurationError
-        (for example an invalid column_ordering) yields only the message; any other error propagates. Every
-        parameter after features is keyword-only.
+        (any invalid request argument caught during session setup, before planning, for example an invalid
+        column_ordering or an unknown compute framework name) yields only the message; any other error
+        propagates. Every parameter after features is keyword-only.
         """
         try:
             session = cls(

--- a/mloda/core/api/request.py
+++ b/mloda/core/api/request.py
@@ -9,7 +9,11 @@ from mloda.core.abstract_plugins.components.plugin_option.plugin_collector impor
 # Explicit alias re-exports Engine under no_implicit_reexport so tests can patch mloda.core.api.request.Engine.
 from mloda.core.core.engine import Engine as Engine
 from mloda.core.api.plan_info import PlanStep, build_plan_steps
-from mloda.core.prepare.identify_feature_group import ResolutionRecord
+from mloda.core.prepare.identify_feature_group import (
+    FeatureResolutionError,
+    ResolutionDiagnosis,
+    ResolutionRecord,
+)
 from mloda.core.api.run_result import ResultStream, RunResult
 from mloda.core.api.prepare.setup_compute_framework import SetupComputeFramework
 from mloda.core.prepare.accessible_plugins import filter_extenders_by_strict_mode
@@ -49,6 +53,7 @@ class mlodaAPI:
         strict_type_enforcement: bool = False,
         column_ordering: Optional[str] = None,
         parallelization_modes: Optional[set[ParallelizationMode]] = None,
+        _defer_planning: bool = False,
     ) -> None:
         if column_ordering is not None and column_ordering not in ("alphabetical", "request_order"):
             raise ValueError(
@@ -81,6 +86,7 @@ class mlodaAPI:
         self.runner: None | ExecutionOrchestrator = None
         self.engine: None | Engine = None
 
+        self._defer_planning = _defer_planning
         self.engine = self._create_engine()
 
     def _process_features(
@@ -300,6 +306,67 @@ class mlodaAPI:
         )
         return session.resolved_plan()
 
+    @classmethod
+    def diagnose(
+        cls,
+        features: Features | list[Feature | str],
+        *,
+        compute_frameworks: set[type[ComputeFramework]] | Optional[list[str]] = None,
+        links: Optional[set[Link]] = None,
+        data_access_collection: Optional[DataAccessCollection] = None,
+        global_filter: Optional[GlobalFilter] = None,
+        api_data: Optional[dict[str, dict[str, Any]]] = None,
+        plugin_collector: Optional[PluginCollector] = None,
+        copy_features: bool = True,
+        strict_type_enforcement: bool = False,
+        column_ordering: Optional[str] = None,
+        parallelization_modes: Optional[set[ParallelizationMode]] = None,
+    ) -> ResolutionDiagnosis:
+        """Non-raising whole-request resolution preflight.
+
+        Runs the same eager planning as prepare() but projects the outcome instead of raising: on success
+        records equals resolution_report() with complete True; on a resolution failure records holds the
+        features resolved before the failing one plus that feature's EvaluationResult and rendered message.
+        A configuration error raised while building the session (for example an invalid column_ordering)
+        yields only the message; any other error raised during the planning pass propagates. Every parameter
+        after features is keyword-only.
+        """
+        try:
+            session = cls(
+                features,
+                compute_frameworks,
+                links,
+                data_access_collection,
+                global_filter,
+                api_data=api_data,
+                plugin_collector=plugin_collector,
+                copy_features=copy_features,
+                strict_type_enforcement=strict_type_enforcement,
+                column_ordering=column_ordering,
+                parallelization_modes=parallelization_modes,
+                _defer_planning=True,
+            )
+        except ValueError as error:
+            # Setup-phase configuration error (e.g. bad column_ordering); no feature was resolved yet.
+            return ResolutionDiagnosis(records=[], complete=False, message=str(error))
+
+        engine = session.engine
+        if engine is None:
+            raise ValueError("Internal error: engine not initialized. This is likely a bug in mloda.")
+
+        try:
+            engine.plan()
+        except FeatureResolutionError as error:
+            return ResolutionDiagnosis(
+                records=deepcopy(engine.resolution_records),
+                complete=False,
+                feature_name=error.feature_name,
+                failed_result=deepcopy(error.result),
+                message=str(error),
+            )
+
+        return ResolutionDiagnosis(records=session.resolution_report(), complete=True)
+
     def resolved_plan(self) -> list[PlanStep]:
         """Return the resolved execution plan of this session as ``PlanStep`` records.
 
@@ -423,6 +490,7 @@ class mlodaAPI:
             self.api_input_data_collection,
             self.plugin_collector,
             column_ordering=self.column_ordering,
+            auto_plan=not self._defer_planning,
         )
         if not isinstance(engine, Engine):
             raise ValueError("Engine initialization failed.")

--- a/mloda/core/core/engine.py
+++ b/mloda/core/core/engine.py
@@ -49,6 +49,7 @@ class Engine:
         api_input_data_collection: Optional[ApiInputDataCollection] = None,
         plugin_collector: Optional[PluginCollector] = None,
         column_ordering: Optional[str] = None,
+        auto_plan: bool = True,
     ) -> None:
         # setup variables which track the primary sources and the compute platforms
         self.feature_group_collection: dict[type[FeatureGroup], set[Feature]] = defaultdict(set)
@@ -78,7 +79,18 @@ class Engine:
         self._dual_consumption_warned: set[tuple[str, str, frozenset[str]]] = set()
         self._property_mapping_keys_cache: dict[type[FeatureGroup], frozenset[str]] = {}
         self.resolution_records: list[ResolutionRecord] = []
-        self.execution_planner = self.create_setup_execution_plan(features)
+        self.features = features
+        if auto_plan:
+            self.plan()
+
+    def plan(self) -> None:
+        """Run the eager planning pass: build the execution plan and resolve the TFS connection map.
+
+        Split from __init__ so mlodaAPI.diagnose can retain the engine, and the records captured before a
+        FeatureResolutionError, when planning fails. Meant to run once per engine: it appends to
+        resolution_records and mutates the feature collections, so a second call would double-count.
+        """
+        self.execution_planner = self.create_setup_execution_plan(self.features)
         self.tfs_connection_map = self._resolve_tfs_connection_map()
 
     def _resolve_tfs_connection_map(self) -> dict[type[ComputeFramework], Any]:

--- a/mloda/core/core/engine.py
+++ b/mloda/core/core/engine.py
@@ -22,9 +22,12 @@ from mloda.core.prepare.graph.build_graph import BuildGraph
 from mloda.core.prepare.resolve_graph import ResolveGraph
 from mloda.core.runtime.run import ExecutionOrchestrator
 from mloda.core.prepare.identify_feature_group import (
+    PARTIAL_RECORDS_CAP,
     EvaluationResult,
+    FeatureResolutionError,
     IdentifyFeatureGroupClass,
     ResolutionRecord,
+    render_resolution_failure,
 )
 from mloda.core.runtime.flight.runner_flight_server import ParallelRunnerFlightServer
 from mloda.core.abstract_plugins.feature_group import FeatureGroup, format_feature_group_class
@@ -49,7 +52,6 @@ class Engine:
         api_input_data_collection: Optional[ApiInputDataCollection] = None,
         plugin_collector: Optional[PluginCollector] = None,
         column_ordering: Optional[str] = None,
-        auto_plan: bool = True,
     ) -> None:
         # setup variables which track the primary sources and the compute platforms
         self.feature_group_collection: dict[type[FeatureGroup], set[Feature]] = defaultdict(set)
@@ -79,18 +81,7 @@ class Engine:
         self._dual_consumption_warned: set[tuple[str, str, frozenset[str]]] = set()
         self._property_mapping_keys_cache: dict[type[FeatureGroup], frozenset[str]] = {}
         self.resolution_records: list[ResolutionRecord] = []
-        self.features = features
-        if auto_plan:
-            self.plan()
-
-    def plan(self) -> None:
-        """Run the eager planning pass: build the execution plan and resolve the TFS connection map.
-
-        Split from __init__ so mlodaAPI.diagnose can retain the engine, and the records captured before a
-        FeatureResolutionError, when planning fails. Meant to run once per engine: it appends to
-        resolution_records and mutates the feature collections, so a second call would double-count.
-        """
-        self.execution_planner = self.create_setup_execution_plan(self.features)
+        self.execution_planner = self.create_setup_execution_plan(features)
         self.tfs_connection_map = self._resolve_tfs_connection_map()
 
     def _resolve_tfs_connection_map(self) -> dict[type[ComputeFramework], Any]:
@@ -228,12 +219,21 @@ class Engine:
     def _identify_feature_group_and_frameworks(
         self, feature: Feature
     ) -> tuple[type[FeatureGroup], set[type[ComputeFramework]], EvaluationResult]:
-        """Identifies the feature group class, compute frameworks, and the EvaluationResult for a feature."""
-        identifier = IdentifyFeatureGroupClass(
+        """Identify the winning feature group via the non-raising seam; on failure raise the enriched error."""
+        result = IdentifyFeatureGroupClass.evaluate(
             feature, self.accessible_plugins, self.links, self.data_access_collection
         )
-        feature_group_class, compute_frameworks = identifier.get()
-        return feature_group_class, compute_frameworks, identifier.result
+        message = render_resolution_failure(result, feature)
+        if message is not None:
+            # Slice before deepcopy so the attached payload stays bounded.
+            raise FeatureResolutionError(
+                message,
+                str(feature.name),
+                result,
+                partial_records=deepcopy(self.resolution_records[-PARTIAL_RECORDS_CAP:]),
+            )
+        feature_group_class, compute_frameworks = next(iter(result.identified.items()))
+        return feature_group_class, compute_frameworks, result
 
     def _add_index_feature(
         self,

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -1,4 +1,5 @@
 import inspect
+from collections.abc import Sequence
 from dataclasses import dataclass, field, replace
 from difflib import get_close_matches
 from typing import Any, Literal, Optional
@@ -76,14 +77,19 @@ class ResolutionRecord:
     result: EvaluationResult
 
 
+# Cap on records attached to a FeatureResolutionError so the copy stays bounded on huge requests.
+PARTIAL_RECORDS_CAP = 1000
+
+
 @dataclass(frozen=True)
 class ResolutionDiagnosis:
     """Non-raising outcome of mlodaAPI.diagnose, a whole-request resolution preflight.
 
     complete is True iff the whole request resolved; then records equals session.resolution_report() and
     feature_name/failed_result/message are None. On a resolution failure records holds the features resolved
-    before the failing one, feature_name/failed_result carry that feature's failed evaluation, and message is
-    its rendered text. On a configuration error records is empty and only message is set.
+    before the failing one (capped at PARTIAL_RECORDS_CAP on huge requests), feature_name/failed_result carry
+    that feature's failed evaluation, and message is its rendered text. On a configuration error records is
+    empty and only message is set.
     """
 
     records: list[ResolutionRecord]
@@ -94,16 +100,26 @@ class ResolutionDiagnosis:
 
 
 class FeatureResolutionError(ValueError):
-    """Typed resolution failure carrying the feature name and the EvaluationResult of its single pass."""
+    """Typed resolution failure carrying the feature name, the EvaluationResult of its single pass,
+    and the records resolved before the failure, capped at PARTIAL_RECORDS_CAP."""
 
-    def __init__(self, message: str, feature_name: str, result: EvaluationResult) -> None:
+    def __init__(
+        self,
+        message: str,
+        feature_name: str,
+        result: EvaluationResult,
+        partial_records: Sequence[ResolutionRecord] = (),
+    ) -> None:
         super().__init__(message)
         self.feature_name = feature_name
         self.result = result
+        self.partial_records: tuple[ResolutionRecord, ...] = tuple(partial_records[-PARTIAL_RECORDS_CAP:])
 
-    def __reduce__(self) -> tuple[type["FeatureResolutionError"], tuple[str, str, EvaluationResult]]:
-        # The default reduction reconstructs from args=(message,) and drops the two extra constructor arguments.
-        return type(self), (str(self), self.feature_name, self.result)
+    def __reduce__(
+        self,
+    ) -> tuple[type["FeatureResolutionError"], tuple[str, str, EvaluationResult, tuple[ResolutionRecord, ...]]]:
+        # The default reduction reconstructs from args=(message,) and drops the extra constructor arguments.
+        return type(self), (str(self), self.feature_name, self.result, self.partial_records)
 
 
 def matches_feature_group_scope(feature_group: type[FeatureGroup], scope: str | type[FeatureGroup]) -> bool:

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -76,6 +76,23 @@ class ResolutionRecord:
     result: EvaluationResult
 
 
+@dataclass(frozen=True)
+class ResolutionDiagnosis:
+    """Non-raising outcome of mlodaAPI.diagnose, a whole-request resolution preflight.
+
+    complete is True iff the whole request resolved; then records equals session.resolution_report() and
+    feature_name/failed_result/message are None. On a resolution failure records holds the features resolved
+    before the failing one, feature_name/failed_result carry that feature's failed evaluation, and message is
+    its rendered text. On a configuration error records is empty and only message is set.
+    """
+
+    records: list[ResolutionRecord]
+    complete: bool
+    feature_name: str | None = None
+    failed_result: EvaluationResult | None = None
+    message: str | None = None
+
+
 class FeatureResolutionError(ValueError):
     """Typed resolution failure carrying the feature name and the EvaluationResult of its single pass."""
 

--- a/mloda/steward/__init__.py
+++ b/mloda/steward/__init__.py
@@ -33,7 +33,11 @@ from mloda.core.abstract_plugins.plugin_registry.plugin_policy import (
 )
 
 # Feature resolution
-from mloda.core.prepare.identify_feature_group import FeatureResolutionError, ResolutionRecord
+from mloda.core.prepare.identify_feature_group import (
+    FeatureResolutionError,
+    ResolutionDiagnosis,
+    ResolutionRecord,
+)
 
 __version__ = get_mloda_version()
 
@@ -65,4 +69,5 @@ __all__ = [
     # Feature resolution
     "FeatureResolutionError",
     "ResolutionRecord",
+    "ResolutionDiagnosis",
 ]

--- a/mloda/user/__init__.py
+++ b/mloda/user/__init__.py
@@ -52,7 +52,11 @@ from mloda.core.abstract_plugins.plugin_registry.plugin_registry import (
 )
 
 # Feature resolution
-from mloda.core.prepare.identify_feature_group import FeatureResolutionError, ResolutionRecord
+from mloda.core.prepare.identify_feature_group import (
+    FeatureResolutionError,
+    ResolutionDiagnosis,
+    ResolutionRecord,
+)
 
 # Config loading
 from mloda.core.api.feature_config.loader import load_features_from_config
@@ -111,6 +115,7 @@ __all__ = [
     # Feature resolution
     "FeatureResolutionError",
     "ResolutionRecord",
+    "ResolutionDiagnosis",
     # Streaming API
     "stream_all",
     # Config loading

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_universal_optional_matcher.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_universal_optional_matcher.py
@@ -28,7 +28,10 @@ from typing import Any
 
 import pytest
 
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import (
+    FeatureChainParser,
+    _UNIVERSAL_MATCHER_PROBE_NAME,
+)
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
@@ -366,7 +369,10 @@ class TestUniversalMatcherDoesNotWarn:
                     options: Options,
                     data_access_collection: Any = None,
                 ) -> bool:
-                    raise RuntimeError("boom_u771n")
+                    # Leaked into the global subclass registry: stay inert for all but the definition-time probe.
+                    if str(feature_name) == _UNIVERSAL_MATCHER_PROBE_NAME:
+                        raise RuntimeError("boom_u771n")
+                    return False
 
             # The class body completes: the probe exception did not escape class definition.
             assert "opt_u771n" in _RaisingMatcherU771n.PROPERTY_MAPPING

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_universal_optional_matcher.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_universal_optional_matcher.py
@@ -23,7 +23,9 @@ diagnostic in scope is the universal-matcher warning, never the captureless one.
 
 from __future__ import annotations
 
+import gc
 import logging
+from collections.abc import Iterator
 from typing import Any
 
 import pytest
@@ -48,6 +50,13 @@ UNRELATED_NAME_U771 = "some_unrelated_feature_u771"
 # pattern): each is required only when the other is absent, so EMPTY options leaves both required.
 COND_KEY_A_U771 = "pipe_a_u771e"
 COND_KEY_B_U771 = "pipe_b_u771e"
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _collect_leaked_local_feature_groups() -> Iterator[None]:
+    """Function-local FeatureGroup subclasses are cyclic garbage; collect them before the next module runs."""
+    yield
+    gc.collect()
 
 
 def _universal_matcher_warnings(

--- a/tests/test_core/test_api/test_diagnose.py
+++ b/tests/test_core/test_api/test_diagnose.py
@@ -1,0 +1,385 @@
+"""Failing tests for the non-raising resolution preflight ``mlodaAPI.diagnose()`` (issue #812).
+
+Contract under test:
+  * ``mloda.core.prepare.identify_feature_group.ResolutionDiagnosis`` is a frozen dataclass beside
+    ``ResolutionRecord`` and ``EvaluationResult``, with fields ``records``, ``complete``, ``feature_name``,
+    ``failed_result``, ``message`` in that order. It is re-exported from ``mloda.user`` and ``mloda.steward``.
+  * ``mlodaAPI.diagnose(...)`` runs the SAME eager planning as ``prepare(...)`` but NEVER raises for a
+    resolution or configuration failure; it projects the outcome into a ``ResolutionDiagnosis``.
+      - success: ``complete is True``, ``records == prepare(...).resolution_report()``, the three failure fields None.
+      - resolution failure: ``complete is False``, ``records`` holds the records captured before the failing
+        feature, and ``feature_name``/``failed_result``/``message`` describe it and equal the raising path's error.
+      - configuration error: ``complete is False``, ``records == []``, ``message`` equals the raised ValueError text.
+
+All fixture feature-group names carry an ``_812`` suffix and root feature names a ``diagnose_`` prefix: test
+feature groups become global subclasses and a ``DataCreator`` claim is registry-wide, so a shared name would
+leak into another module's candidate universe in the parallel suite.
+"""
+
+import dataclasses
+from typing import Any, Optional
+
+import pandas as pd
+import pytest
+
+# Aliased: a bare ``import mloda.user`` would bind the name ``mloda`` to the package and collide with the
+# ``mloda`` mlodaAPI alias imported below.
+import mloda.steward as mloda_steward
+import mloda.user as mloda_user
+from mloda.core.prepare.identify_feature_group import (
+    EvaluationResult,
+    FeatureResolutionError,
+    ResolutionDiagnosis,
+    ResolutionRecord,
+)
+from mloda.provider import BaseInputData, ComputeFramework, DataCreator, FeatureGroup, FeatureSet
+from mloda.user import Feature, FeatureName, Options, PluginCollector, mloda, mlodaAPI
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+
+
+# ---------------------------------------------------------------------------
+# Test feature groups and fixtures
+# ---------------------------------------------------------------------------
+
+SOURCE_FEATURE_812 = "diagnose_sales_812"
+UNKNOWN_FEATURE_812 = "diagnose_unknown_812"
+BOGUS_ORDERING = "bogus"
+
+
+class DiagnoseSource_812(FeatureGroup):
+    """Pandas root source providing the feature the consumer chains off."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({SOURCE_FEATURE_812})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return pd.DataFrame({SOURCE_FEATURE_812: [10, 20, 30]})
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+
+class DiagnoseConsumer_812(FeatureGroup):
+    """Consumes the source feature, so the source becomes a derived input during recursion."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return {Feature(SOURCE_FEATURE_812)}
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        data["DiagnoseConsumer_812"] = data[SOURCE_FEATURE_812] * 2
+        return data
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return {cls.get_class_name()}
+
+
+class DiagnoseRaisingInputs_812(FeatureGroup):
+    """Resolves, but raises a plain ValueError during the planning recursion (not a resolution failure)."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        raise ValueError("diagnose planning boom 812")
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return {cls.get_class_name()}
+
+
+_DIAGNOSE_PLUGINS = PluginCollector.enabled_feature_groups({DiagnoseSource_812, DiagnoseConsumer_812})
+
+
+def _success_features() -> list[Feature | str]:
+    """A single requested consumer chaining off one derived source feature."""
+    return ["DiagnoseConsumer_812"]
+
+
+def _failure_features() -> list[Feature | str]:
+    """A resolvable consumer FIRST, then an unknown name that no group can resolve."""
+    return ["DiagnoseConsumer_812", UNKNOWN_FEATURE_812]
+
+
+def _diagnose_success() -> ResolutionDiagnosis:
+    return mloda.diagnose(_success_features(), compute_frameworks={PandasDataFrame}, plugin_collector=_DIAGNOSE_PLUGINS)
+
+
+def _prepare_success() -> mlodaAPI:
+    return mloda.prepare(_success_features(), compute_frameworks={PandasDataFrame}, plugin_collector=_DIAGNOSE_PLUGINS)
+
+
+def _diagnose_failure() -> ResolutionDiagnosis:
+    return mloda.diagnose(_failure_features(), compute_frameworks={PandasDataFrame}, plugin_collector=_DIAGNOSE_PLUGINS)
+
+
+def _raised_failure_error() -> FeatureResolutionError:
+    """Catch the typed error the raising path produces for the same failing request."""
+    with pytest.raises(FeatureResolutionError) as exc_info:
+        mloda.prepare(_failure_features(), compute_frameworks={PandasDataFrame}, plugin_collector=_DIAGNOSE_PLUGINS)
+    return exc_info.value
+
+
+def _diagnose_config_error() -> ResolutionDiagnosis:
+    return mloda.diagnose(
+        _success_features(),
+        compute_frameworks={PandasDataFrame},
+        plugin_collector=_DIAGNOSE_PLUGINS,
+        column_ordering=BOGUS_ORDERING,
+    )
+
+
+def _raised_config_error() -> ValueError:
+    """Catch the plain configuration ValueError the raising path produces for a bogus column_ordering."""
+    with pytest.raises(ValueError) as exc_info:
+        mloda.prepare(
+            _success_features(),
+            compute_frameworks={PandasDataFrame},
+            plugin_collector=_DIAGNOSE_PLUGINS,
+            column_ordering=BOGUS_ORDERING,
+        )
+    # The column_ordering guard runs first in __init__, before resolution, so this is not a resolution error.
+    assert not isinstance(exc_info.value, FeatureResolutionError)
+    return exc_info.value
+
+
+# ---------------------------------------------------------------------------
+# ResolutionDiagnosis dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestResolutionDiagnosisDataclass:
+    """ResolutionDiagnosis is a frozen dataclass with the documented field order and defaults."""
+
+    def test_resolution_diagnosis_is_a_dataclass(self) -> None:
+        assert dataclasses.is_dataclass(ResolutionDiagnosis)
+
+    def test_resolution_diagnosis_is_frozen(self) -> None:
+        diagnosis = ResolutionDiagnosis(records=[], complete=True)
+
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            diagnosis.complete = False  # type: ignore[misc]
+
+    def test_resolution_diagnosis_field_order(self) -> None:
+        field_names = [field.name for field in dataclasses.fields(ResolutionDiagnosis)]
+
+        assert field_names == ["records", "complete", "feature_name", "failed_result", "message"]
+
+    def test_optional_fields_default_to_none(self) -> None:
+        diagnosis = ResolutionDiagnosis(records=[], complete=True)
+
+        assert diagnosis.feature_name is None
+        assert diagnosis.failed_result is None
+        assert diagnosis.message is None
+
+
+# ---------------------------------------------------------------------------
+# diagnose() success outcome
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnoseSuccess:
+    """A fully resolvable request yields a complete diagnosis whose records mirror prepare()."""
+
+    def test_diagnose_is_available_on_both_aliases(self) -> None:
+        # mloda is an alias of the mlodaAPI class, so diagnose resolves to the same method under both names.
+        assert mloda is mlodaAPI
+        assert callable(mlodaAPI.diagnose)
+
+    def test_success_returns_a_resolution_diagnosis(self) -> None:
+        assert isinstance(_diagnose_success(), ResolutionDiagnosis)
+
+    def test_success_is_complete_with_no_failure_fields(self) -> None:
+        diagnosis = _diagnose_success()
+
+        assert diagnosis.complete is True
+        assert diagnosis.feature_name is None
+        assert diagnosis.failed_result is None
+        assert diagnosis.message is None
+
+    def test_success_records_are_non_empty_resolution_records(self) -> None:
+        diagnosis = _diagnose_success()
+
+        assert isinstance(diagnosis.records, list)
+        assert diagnosis.records, "a resolvable request must report at least one resolution record"
+        assert all(isinstance(record, ResolutionRecord) for record in diagnosis.records)
+
+    def test_success_records_equal_prepare_resolution_report(self) -> None:
+        """diagnose() runs the same eager planning as prepare(): the records match exactly."""
+        diagnosis = _diagnose_success()
+        report = _prepare_success().resolution_report()
+
+        assert diagnosis.records == report
+
+
+# ---------------------------------------------------------------------------
+# diagnose() success records are detached
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnoseSuccessRecordsAreDetached:
+    """The returned records are a detached copy; mutating them does not corrupt a fresh diagnosis."""
+
+    def test_clearing_records_does_not_corrupt_a_fresh_diagnosis(self) -> None:
+        first = _diagnose_success()
+        count = len(first.records)
+        assert count
+
+        first.records.clear()
+
+        assert len(_diagnose_success().records) == count
+
+    def test_mutating_a_records_nested_result_does_not_corrupt_a_fresh_diagnosis(self) -> None:
+        """Clearing a returned record's mutable EvaluationResult must not corrupt a fresh diagnosis."""
+        first = _diagnose_success()
+        first.records[0].result.identified.clear()
+        first.records[0].result.criteria_matched.clear()
+
+        fresh = _diagnose_success()
+
+        assert fresh.records[0].result.identified, "a later diagnosis must not reflect the caller's mutation"
+        assert fresh.records[0].result.failure_kind is None
+
+    def test_records_still_equal_a_fresh_prepare_report_after_mutation(self) -> None:
+        first = _diagnose_success()
+        first.records.clear()
+
+        assert _diagnose_success().records == _prepare_success().resolution_report()
+
+
+# ---------------------------------------------------------------------------
+# diagnose() resolution-failure outcome
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnoseResolutionFailure:
+    """An unresolvable feature name projects the raising path's error instead of raising."""
+
+    def test_resolution_failure_is_incomplete(self) -> None:
+        assert _diagnose_failure().complete is False
+
+    def test_records_hold_the_feature_resolved_before_the_failure(self) -> None:
+        names = [record.feature_name for record in _diagnose_failure().records]
+
+        assert "DiagnoseConsumer_812" in names
+
+    def test_failing_feature_record_is_not_in_records(self) -> None:
+        names = [record.feature_name for record in _diagnose_failure().records]
+
+        assert UNKNOWN_FEATURE_812 not in names
+
+    def test_feature_name_is_the_failing_feature(self) -> None:
+        assert _diagnose_failure().feature_name == UNKNOWN_FEATURE_812
+
+    def test_failed_result_is_an_evaluation_result_with_a_failure_kind(self) -> None:
+        failed = _diagnose_failure().failed_result
+
+        assert isinstance(failed, EvaluationResult)
+        assert failed.failure_kind is not None
+
+    def test_message_equals_the_raising_paths_error_text(self) -> None:
+        diagnosis = _diagnose_failure()
+        caught = _raised_failure_error()
+
+        assert isinstance(diagnosis.message, str)
+        assert diagnosis.message
+        assert diagnosis.message == str(caught)
+
+    def test_feature_name_and_failure_kind_match_the_raising_path(self) -> None:
+        diagnosis = _diagnose_failure()
+        caught = _raised_failure_error()
+
+        assert diagnosis.feature_name == caught.feature_name
+        assert diagnosis.failed_result is not None
+        assert diagnosis.failed_result.failure_kind == caught.result.failure_kind
+
+
+# ---------------------------------------------------------------------------
+# diagnose() configuration-error outcome
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnoseConfigurationError:
+    """A non-resolution ValueError (bogus column_ordering) is projected, not raised."""
+
+    def test_configuration_error_is_incomplete(self) -> None:
+        assert _diagnose_config_error().complete is False
+
+    def test_configuration_error_has_empty_records(self) -> None:
+        assert _diagnose_config_error().records == []
+
+    def test_configuration_error_has_no_failing_feature_fields(self) -> None:
+        diagnosis = _diagnose_config_error()
+
+        assert diagnosis.feature_name is None
+        assert diagnosis.failed_result is None
+
+    def test_message_equals_the_raised_value_error_text(self) -> None:
+        diagnosis = _diagnose_config_error()
+        caught = _raised_config_error()
+
+        assert isinstance(diagnosis.message, str)
+        assert diagnosis.message
+        assert diagnosis.message == str(caught)
+
+
+# ---------------------------------------------------------------------------
+# Public surface
+# ---------------------------------------------------------------------------
+
+
+class TestResolutionDiagnosisIsPubliclyExported:
+    """ResolutionDiagnosis is re-exported from mloda.user and mloda.steward, mirroring ResolutionRecord."""
+
+    def test_resolution_diagnosis_exported_from_user_and_steward(self) -> None:
+        assert "ResolutionDiagnosis" in mloda_user.__all__
+        assert "ResolutionDiagnosis" in mloda_steward.__all__
+
+    def test_user_and_steward_reexport_the_same_object(self) -> None:
+        assert mloda_user.ResolutionDiagnosis is ResolutionDiagnosis
+        assert mloda_steward.ResolutionDiagnosis is ResolutionDiagnosis
+
+
+# ---------------------------------------------------------------------------
+# diagnose() only swallows resolution and setup-configuration errors
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnoseDoesNotSwallowPlanningErrors:
+    """A non-resolution ValueError raised during the planning pass must propagate, not be projected."""
+
+    def test_non_resolution_planning_error_propagates(self) -> None:
+        plugins = PluginCollector.enabled_feature_groups({DiagnoseRaisingInputs_812})
+        with pytest.raises(ValueError) as exc_info:
+            mloda.diagnose(
+                ["DiagnoseRaisingInputs_812"], compute_frameworks={PandasDataFrame}, plugin_collector=plugins
+            )
+        # It is the planning-time error, not a resolution failure projected into a diagnosis.
+        assert not isinstance(exc_info.value, FeatureResolutionError)
+        assert "diagnose planning boom 812" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# diagnose() empty request
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnoseEmptyRequest:
+    """An empty request resolves to a trivially complete diagnosis with no records."""
+
+    def test_empty_request_is_trivially_complete(self) -> None:
+        diagnosis = mloda.diagnose([], compute_frameworks={PandasDataFrame}, plugin_collector=_DIAGNOSE_PLUGINS)
+        assert diagnosis.complete is True
+        assert diagnosis.records == []
+        assert diagnosis.feature_name is None
+        assert diagnosis.failed_result is None
+        assert diagnosis.message is None

--- a/tests/test_core/test_integration/test_core/test_diagnose_integration.py
+++ b/tests/test_core/test_integration/test_core/test_diagnose_integration.py
@@ -1,0 +1,143 @@
+"""End-to-end integration test for ``mlodaAPI.diagnose()`` (issue #812).
+
+Exercises the non-raising preflight through the public API with real plugins and the real
+PandasDataFrame compute framework: shipped ``PandasAggregatedFeatureGroup`` aggregations chain off raw
+columns produced by a ``DataCreator`` source. A fully resolvable request yields a complete diagnosis;
+adding an unknown feature name projects a resolution-failure diagnosis instead of raising, and that
+projection equals the raising path's ``FeatureResolutionError``.
+
+Everything carries an ``_812`` suffix: the source becomes a global FeatureGroup subclass and its
+DataCreator claim is registry-wide, so shared names would leak into another module's candidate universe
+in the parallel suite.
+"""
+
+from typing import Any
+
+import pytest
+
+from mloda.core.prepare.identify_feature_group import (
+    EvaluationResult,
+    FeatureResolutionError,
+    ResolutionDiagnosis,
+    ResolutionRecord,
+)
+from mloda.provider import DefaultOptionKeys
+from mloda.user import Feature, Options, PluginCollector, mloda
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.feature_group.experimental.aggregated_feature_group.base import AggregatedFeatureGroup
+from mloda_plugins.feature_group.experimental.aggregated_feature_group.pandas import PandasAggregatedFeatureGroup
+
+from tests.test_plugins.integration_plugins.test_data_creator import ATestDataCreator
+
+SALES_COL = "diag_e2e_sales_812"
+REVENUE_COL = "diag_e2e_revenue_812"
+SUM_FEATURE = "sum_diag_e2e_sales_812"
+AVG_FEATURE = "avg_diag_e2e_revenue_812"
+UNKNOWN_FEATURE = "diag_e2e_unknown_812"
+
+
+class DiagE2ESource_812(ATestDataCreator):
+    """DataCreator source whose raw columns the shipped aggregations chain off."""
+
+    compute_framework = PandasDataFrame
+
+    @classmethod
+    def get_raw_data(cls) -> dict[str, Any]:
+        """Return the uniquely named raw columns as a dictionary."""
+        return {
+            SALES_COL: [100, 200, 300, 400, 500],
+            REVENUE_COL: [1000, 2000, 3000, 4000, 5000],
+        }
+
+
+_PLUGINS = PluginCollector.enabled_feature_groups({DiagE2ESource_812, PandasAggregatedFeatureGroup})
+
+
+def _sum_feature() -> Feature:
+    return Feature(
+        SUM_FEATURE,
+        Options(context={AggregatedFeatureGroup.AGGREGATION_TYPE: "sum", DefaultOptionKeys.in_features: SALES_COL}),
+    )
+
+
+def _avg_feature() -> Feature:
+    return Feature(
+        AVG_FEATURE,
+        Options(context={AggregatedFeatureGroup.AGGREGATION_TYPE: "avg", DefaultOptionKeys.in_features: REVENUE_COL}),
+    )
+
+
+def _success_features() -> list[Feature | str]:
+    return [_sum_feature(), _avg_feature()]
+
+
+def _failure_features() -> list[Feature | str]:
+    """The two resolvable aggregations first, then an unknown name that no group can resolve."""
+    return [_sum_feature(), _avg_feature(), UNKNOWN_FEATURE]
+
+
+class TestDiagnoseEndToEnd_812:
+    """diagnose() projects the real planning pass over a shipped aggregation plan."""
+
+    def test_full_request_yields_a_complete_diagnosis(self) -> None:
+        """A fully resolvable request diagnoses complete and mirrors prepare().resolution_report()."""
+        diagnosis = mloda.diagnose(_success_features(), compute_frameworks={PandasDataFrame}, plugin_collector=_PLUGINS)
+
+        assert isinstance(diagnosis, ResolutionDiagnosis)
+        assert diagnosis.complete is True
+        assert diagnosis.feature_name is None
+        assert diagnosis.failed_result is None
+        assert diagnosis.message is None
+
+        assert isinstance(diagnosis.records, list)
+        assert diagnosis.records, "a resolvable request must report at least one resolution record"
+        assert all(isinstance(record, ResolutionRecord) for record in diagnosis.records)
+        assert all(isinstance(record.result, EvaluationResult) for record in diagnosis.records)
+
+        # Each requested aggregation resolves to the shipped PandasAggregatedFeatureGroup.
+        for requested_name in (SUM_FEATURE, AVG_FEATURE):
+            matches = [record for record in diagnosis.records if record.feature_name == requested_name]
+            assert len(matches) == 1, f"expected exactly one record for {requested_name}"
+            assert matches[0].requested is True
+            assert matches[0].result.failure_kind is None
+            assert PandasAggregatedFeatureGroup in matches[0].result.identified
+
+        # Each derived source column resolves (requested=False) to our DataCreator source.
+        for source_name in (SALES_COL, REVENUE_COL):
+            matches = [record for record in diagnosis.records if record.feature_name == source_name]
+            assert len(matches) == 1, f"expected exactly one record for {source_name}"
+            assert matches[0].requested is False
+            assert matches[0].result.failure_kind is None
+            assert DiagE2ESource_812 in matches[0].result.identified
+
+        # Same eager planning as prepare(): the records equal what prepare(...).resolution_report() reports.
+        report = mloda.prepare(
+            _success_features(), compute_frameworks={PandasDataFrame}, plugin_collector=_PLUGINS
+        ).resolution_report()
+        assert diagnosis.records == report
+
+    def test_unknown_feature_yields_a_resolution_failure_diagnosis(self) -> None:
+        """Adding an unknown name projects the raising path's FeatureResolutionError, records held so far."""
+        diagnosis = mloda.diagnose(_failure_features(), compute_frameworks={PandasDataFrame}, plugin_collector=_PLUGINS)
+
+        assert diagnosis.complete is False
+        assert diagnosis.feature_name == UNKNOWN_FEATURE
+
+        names = [record.feature_name for record in diagnosis.records]
+        assert SUM_FEATURE in names, "the aggregation resolved before the failure must be recorded"
+        assert UNKNOWN_FEATURE not in names
+
+        assert isinstance(diagnosis.failed_result, EvaluationResult)
+        assert diagnosis.failed_result.failure_kind is not None
+
+        assert isinstance(diagnosis.message, str)
+        assert diagnosis.message
+
+        # The projection equals the raising path's typed error for the same failing request.
+        with pytest.raises(FeatureResolutionError) as exc_info:
+            mloda.prepare(_failure_features(), compute_frameworks={PandasDataFrame}, plugin_collector=_PLUGINS)
+        caught = exc_info.value
+
+        assert diagnosis.message == str(caught)
+        assert diagnosis.feature_name == caught.feature_name
+        assert diagnosis.failed_result.failure_kind == caught.result.failure_kind

--- a/tests/test_core/test_prepare/test_feature_resolution_error_partial_records.py
+++ b/tests/test_core/test_prepare/test_feature_resolution_error_partial_records.py
@@ -21,6 +21,7 @@ from typing import Any, Optional
 import pandas as pd
 import pytest
 
+from mloda.core.api.request import SetupConfigurationError
 from mloda.core.core.engine import Engine
 from mloda.core.prepare.identify_feature_group import (
     EvaluationResult,
@@ -263,3 +264,47 @@ class TestDiagnoseRecordsComeFromTheErrorPayload:
         error = _raised_failure_error()
 
         assert diagnosis.records == list(error.partial_records)
+
+
+# ---------------------------------------------------------------------------
+# Pre-planning setup errors surface as SetupConfigurationError
+# ---------------------------------------------------------------------------
+
+DUPLICATE_FEATURE_836PR = "diag_dup_836pr"
+UNKNOWN_FRAMEWORK_836PR = "NotAFramework_836pr"
+
+
+class TestPrePlanningSetupErrorsAreConfigurationErrors:
+    """Every ValueError raised during setup BEFORE engine planning surfaces as SetupConfigurationError."""
+
+    def test_duplicate_string_feature_raises_setup_configuration_error(self) -> None:
+        with pytest.raises(SetupConfigurationError) as exc_info:
+            mloda.prepare([DUPLICATE_FEATURE_836PR, DUPLICATE_FEATURE_836PR], compute_frameworks={PandasDataFrame})
+
+        assert str(exc_info.value) == f"You are adding same feature as string twice: {DUPLICATE_FEATURE_836PR}"
+
+    def test_unknown_framework_name_raises_setup_configuration_error(self) -> None:
+        with pytest.raises(SetupConfigurationError):
+            mloda.prepare([DUPLICATE_FEATURE_836PR], compute_frameworks=[UNKNOWN_FRAMEWORK_836PR])
+
+    def test_diagnose_projects_the_unknown_framework_error_as_message_only(self) -> None:
+        diagnosis = mloda.diagnose([DUPLICATE_FEATURE_836PR], compute_frameworks=[UNKNOWN_FRAMEWORK_836PR])
+
+        with pytest.raises(ValueError) as exc_info:
+            mloda.prepare([DUPLICATE_FEATURE_836PR], compute_frameworks=[UNKNOWN_FRAMEWORK_836PR])
+
+        assert diagnosis.complete is False
+        assert diagnosis.records == []
+        assert diagnosis.feature_name is None
+        assert diagnosis.failed_result is None
+        assert diagnosis.message == str(exc_info.value)
+
+    def test_pickle_preserves_class_bearing_identified_mappings(self) -> None:
+        """Pins current behavior: a partial record whose EvaluationResult maps a FeatureGroup class survives pickle."""
+        result = EvaluationResult(identified={PartialRecordsSource_836pr: {PandasDataFrame}})
+        record = ResolutionRecord(feature_name="pinned_836pr", requested=True, result=result)
+        error = FeatureResolutionError("pin boom 836pr", UNKNOWN_FEATURE_836PR, result, partial_records=[record])
+
+        restored = pickle.loads(pickle.dumps(error))  # nosec B301
+
+        assert PartialRecordsSource_836pr in restored.partial_records[0].result.identified

--- a/tests/test_core/test_prepare/test_feature_resolution_error_partial_records.py
+++ b/tests/test_core/test_prepare/test_feature_resolution_error_partial_records.py
@@ -1,0 +1,265 @@
+"""Failing tests for the diagnose refactor: FeatureResolutionError carries the partial resolution records.
+
+Contract under test (PR #836):
+  * ``PARTIAL_RECORDS_CAP`` is a module-level int constant (1000) in ``identify_feature_group``.
+  * ``FeatureResolutionError.__init__`` accepts ``partial_records: Sequence[ResolutionRecord] = ()`` and stores
+    it as a tuple truncated to the LAST ``PARTIAL_RECORDS_CAP`` entries; ``__reduce__`` round-trips it via pickle.
+  * The raising ``mloda.prepare`` path attaches the records resolved before the failure to the error, and
+    ``mloda.diagnose`` sources its failure projection records from that payload instead of a retained engine.
+  * ``SetupConfigurationError`` (a ValueError, not a FeatureResolutionError) replaces the plain ValueError for
+    setup-phase configuration errors, and the ``_defer_planning`` / ``auto_plan`` / ``Engine.plan`` hack is gone.
+
+All fixture feature-group names carry an ``_836pr`` suffix and root feature names a ``partial_records_`` prefix:
+test feature groups become global subclasses and a ``DataCreator`` claim is registry-wide, so a shared name would
+leak into another module's candidate universe in the parallel suite.
+"""
+
+import inspect
+import pickle
+from typing import Any, Optional
+
+import pandas as pd
+import pytest
+
+from mloda.core.core.engine import Engine
+from mloda.core.prepare.identify_feature_group import (
+    EvaluationResult,
+    FeatureResolutionError,
+    ResolutionRecord,
+)
+from mloda.provider import BaseInputData, ComputeFramework, DataCreator, FeatureGroup, FeatureSet
+from mloda.user import Feature, FeatureName, Options, PluginCollector, mloda, mlodaAPI
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+
+
+# ---------------------------------------------------------------------------
+# Test feature groups and fixtures
+# ---------------------------------------------------------------------------
+
+SOURCE_FEATURE_836PR = "partial_records_sales_836pr"
+UNKNOWN_FEATURE_836PR = "partial_records_unknown_836pr"
+CONSUMER_FEATURE_836PR = "PartialRecordsConsumer_836pr"
+
+
+class PartialRecordsSource_836pr(FeatureGroup):
+    """Pandas root source providing the feature the consumer chains off."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator({SOURCE_FEATURE_836PR})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return pd.DataFrame({SOURCE_FEATURE_836PR: [10, 20, 30]})
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+
+class PartialRecordsConsumer_836pr(FeatureGroup):
+    """Consumes the source feature, so the source resolves as a derived input before the failing request."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return {Feature(SOURCE_FEATURE_836PR)}
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        data[CONSUMER_FEATURE_836PR] = data[SOURCE_FEATURE_836PR] * 2
+        return data
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return {cls.get_class_name()}
+
+
+_PLUGINS_836PR = PluginCollector.enabled_feature_groups({PartialRecordsSource_836pr, PartialRecordsConsumer_836pr})
+
+
+def _empty_result() -> EvaluationResult:
+    """A minimal EvaluationResult for cheap ResolutionRecord construction."""
+    return EvaluationResult(identified={})
+
+
+def _record(name: str, result: EvaluationResult) -> ResolutionRecord:
+    """A cheap ResolutionRecord with the given feature name."""
+    return ResolutionRecord(feature_name=name, requested=True, result=result)
+
+
+def _failing_request_features() -> list[Feature | str]:
+    """A resolvable consumer FIRST, then an unknown name that no group can resolve."""
+    return [CONSUMER_FEATURE_836PR, UNKNOWN_FEATURE_836PR]
+
+
+def _raised_failure_error() -> FeatureResolutionError:
+    """Catch the typed error the raising prepare path produces for the failing request."""
+    with pytest.raises(FeatureResolutionError) as exc_info:
+        mloda.prepare(
+            _failing_request_features(), compute_frameworks={PandasDataFrame}, plugin_collector=_PLUGINS_836PR
+        )
+    return exc_info.value
+
+
+# ---------------------------------------------------------------------------
+# PARTIAL_RECORDS_CAP constant
+# ---------------------------------------------------------------------------
+
+
+class TestPartialRecordsCapConstant:
+    """PARTIAL_RECORDS_CAP is a module-level int constant with value 1000."""
+
+    def test_partial_records_cap_is_1000(self) -> None:
+        from mloda.core.prepare.identify_feature_group import PARTIAL_RECORDS_CAP
+
+        assert isinstance(PARTIAL_RECORDS_CAP, int)
+        assert PARTIAL_RECORDS_CAP == 1000
+
+
+# ---------------------------------------------------------------------------
+# FeatureResolutionError.partial_records constructor behavior
+# ---------------------------------------------------------------------------
+
+
+class TestFeatureResolutionErrorPartialRecords:
+    """The error stores partial_records as a tuple, defaulting to empty and capped to the tail."""
+
+    def test_partial_records_defaults_to_the_empty_tuple(self) -> None:
+        error = FeatureResolutionError("boom 836pr", UNKNOWN_FEATURE_836PR, _empty_result())
+
+        assert error.partial_records == ()
+
+    def test_partial_records_is_stored_as_a_tuple(self) -> None:
+        result = _empty_result()
+        records = [_record("kept_836pr_a", result), _record("kept_836pr_b", result)]
+
+        error = FeatureResolutionError("boom 836pr", UNKNOWN_FEATURE_836PR, result, partial_records=records)
+
+        assert isinstance(error.partial_records, tuple)
+        assert error.partial_records == tuple(records)
+
+    def test_partial_records_is_truncated_to_the_last_cap_entries(self) -> None:
+        from mloda.core.prepare.identify_feature_group import PARTIAL_RECORDS_CAP
+
+        result = _empty_result()
+        records = [_record(f"capped_836pr_{index}", result) for index in range(PARTIAL_RECORDS_CAP + 5)]
+
+        error = FeatureResolutionError("boom 836pr", UNKNOWN_FEATURE_836PR, result, partial_records=records)
+
+        assert len(error.partial_records) == PARTIAL_RECORDS_CAP
+        # Tail kept, head dropped: the first 5 records are gone and the last one survives.
+        assert error.partial_records[0].feature_name == "capped_836pr_5"
+        assert error.partial_records[-1].feature_name == f"capped_836pr_{PARTIAL_RECORDS_CAP + 4}"
+
+
+# ---------------------------------------------------------------------------
+# FeatureResolutionError pickle round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestFeatureResolutionErrorPickleRoundTrip:
+    """__reduce__ carries partial_records through pickle alongside message, feature_name and result."""
+
+    def test_pickle_round_trips_partial_records(self) -> None:
+        result = _empty_result()
+        records = [_record("pickled_836pr_a", result), _record("pickled_836pr_b", result)]
+        error = FeatureResolutionError("pickle boom 836pr", UNKNOWN_FEATURE_836PR, result, partial_records=records)
+
+        restored = pickle.loads(pickle.dumps(error))
+
+        assert str(restored) == "pickle boom 836pr"
+        assert restored.feature_name == UNKNOWN_FEATURE_836PR
+        assert len(restored.partial_records) == 2
+
+
+# ---------------------------------------------------------------------------
+# Raising path carries the payload
+# ---------------------------------------------------------------------------
+
+
+class TestRaisingPathCarriesPartialRecords:
+    """mloda.prepare attaches the records resolved before the failure to the raised error."""
+
+    def test_error_partial_records_is_a_tuple(self) -> None:
+        error = _raised_failure_error()
+
+        assert isinstance(error.partial_records, tuple)
+
+    def test_partial_records_hold_the_features_resolved_before_the_failure(self) -> None:
+        error = _raised_failure_error()
+
+        names = [record.feature_name for record in error.partial_records]
+
+        assert CONSUMER_FEATURE_836PR in names
+        assert SOURCE_FEATURE_836PR in names
+
+    def test_partial_records_hold_no_record_for_the_failing_feature(self) -> None:
+        error = _raised_failure_error()
+
+        names = [record.feature_name for record in error.partial_records]
+
+        assert UNKNOWN_FEATURE_836PR not in names
+
+
+# ---------------------------------------------------------------------------
+# SetupConfigurationError
+# ---------------------------------------------------------------------------
+
+
+class TestSetupConfigurationError:
+    """Setup-phase configuration errors raise a dedicated ValueError subclass."""
+
+    def test_is_a_value_error_but_not_a_resolution_error(self) -> None:
+        from mloda.core.api.request import SetupConfigurationError
+
+        assert issubclass(SetupConfigurationError, ValueError)
+        assert not issubclass(SetupConfigurationError, FeatureResolutionError)
+
+    def test_bogus_column_ordering_raises_setup_configuration_error(self) -> None:
+        from mloda.core.api.request import SetupConfigurationError
+
+        with pytest.raises(SetupConfigurationError):
+            mloda.prepare(
+                [CONSUMER_FEATURE_836PR],
+                compute_frameworks={PandasDataFrame},
+                plugin_collector=_PLUGINS_836PR,
+                column_ordering="bogus",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Deferred-planning hack removal
+# ---------------------------------------------------------------------------
+
+
+class TestDeferredPlanningHackIsRemoved:
+    """The _defer_planning / auto_plan / Engine.plan plumbing is gone from the public constructors."""
+
+    def test_mloda_api_init_has_no_defer_planning_parameter(self) -> None:
+        assert "_defer_planning" not in inspect.signature(mlodaAPI.__init__).parameters
+
+    def test_engine_init_has_no_auto_plan_parameter(self) -> None:
+        assert "auto_plan" not in inspect.signature(Engine.__init__).parameters
+
+    def test_engine_has_no_plan_method(self) -> None:
+        assert not hasattr(Engine, "plan")
+
+
+# ---------------------------------------------------------------------------
+# diagnose() sources its failure records from the error payload
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnoseRecordsComeFromTheErrorPayload:
+    """The failure projection's records equal the raising path's partial_records for the same request."""
+
+    def test_diagnose_records_equal_the_errors_partial_records(self) -> None:
+        diagnosis = mloda.diagnose(
+            _failing_request_features(), compute_frameworks={PandasDataFrame}, plugin_collector=_PLUGINS_836PR
+        )
+        error = _raised_failure_error()
+
+        assert diagnosis.records == list(error.partial_records)

--- a/tests/test_core/test_prepare/test_feature_resolution_error_partial_records.py
+++ b/tests/test_core/test_prepare/test_feature_resolution_error_partial_records.py
@@ -15,7 +15,7 @@ leak into another module's candidate universe in the parallel suite.
 """
 
 import inspect
-import pickle
+import pickle  # nosec B403
 from typing import Any, Optional
 
 import pandas as pd
@@ -168,7 +168,7 @@ class TestFeatureResolutionErrorPickleRoundTrip:
         records = [_record("pickled_836pr_a", result), _record("pickled_836pr_b", result)]
         error = FeatureResolutionError("pickle boom 836pr", UNKNOWN_FEATURE_836PR, result, partial_records=records)
 
-        restored = pickle.loads(pickle.dumps(error))
+        restored = pickle.loads(pickle.dumps(error))  # nosec B301
 
         assert str(restored) == "pickle boom 836pr"
         assert restored.feature_name == UNKNOWN_FEATURE_836PR


### PR DESCRIPTION
## Summary

Adds `mlodaAPI.diagnose(...)`, a non-raising whole-request resolution preflight. It runs the same eager planning as `prepare(...)` and projects the outcome into a `ResolutionDiagnosis` instead of raising:

- success: `complete=True`, `records` equals `session.resolution_report()`, the failure fields `None`;
- resolution failure: `complete=False`, `records` holds the features resolved before the failing one, plus the failing feature's `feature_name`, its `EvaluationResult` (`failed_result`), and the unchanged rendered `message`;
- setup configuration error (invalid `column_ordering`, duplicate feature strings, unknown compute framework name): `complete=False`, no records, only `message`.

Closes #812. Third slice of #759, after #809 (typed `FeatureResolutionError`) and #811 (`session.resolution_report()`).

## Design

The exception carries the diagnosis payload; there is no deferred-planning state:

- `FeatureResolutionError` gains `partial_records`, the records resolved before the failure, capped at `PARTIAL_RECORDS_CAP` (1000, tail kept, sliced before the deepcopy so the attached payload stays bounded on huge requests). It is raised at the engine layer through the existing non-raising `IdentifyFeatureGroupClass.evaluate` seam, so evaluation still runs exactly once per feature and `Engine` stays single-phase (no `auto_plan`/`_defer_planning` flags, no `Engine.plan()` split).
- `mlodaAPI.__init__` wraps its setup phase in a typed boundary: any invalid request argument raises `SetupConfigurationError` (a `ValueError` subclass) before planning begins.
- `diagnose` is one constructor call with two typed except arms: `FeatureResolutionError` projects its payload, `SetupConfigurationError` projects message-only, and any other error (including plugin errors raised during planning) propagates rather than being masked as a diagnosis.

`ResolutionDiagnosis` is a frozen dataclass beside `ResolutionRecord`/`EvaluationResult`, re-exported from `mloda.user` and `mloda.steward`.

## Tests

Unit suites `tests/test_core/test_api/test_diagnose.py` (dataclass shape, success equals `prepare().resolution_report()`, record detachment, resolution-failure projection matching the raising path, setup config error, empty request, non-resolution planning errors propagate, public exports) and `tests/test_core/test_prepare/test_feature_resolution_error_partial_records.py` (partial_records content and cap, pickle round trips including a class-bearing payload, typed setup boundary for duplicate features and unknown frameworks, removal of the deferred-planning flags pinned by signature), plus an end-to-end integration test over shipped `PandasAggregatedFeatureGroup` aggregations.

## Validation

`tox` passes: 6954 passed, 170 skipped, ruff format/check, pip-licenses, `mypy --strict`, bandit all green. Two independent deep reviews gated the change (a fresh Claude Opus reviewer and codex). Accepted and fixed: diagnose must project every pre-planning setup error, not only `column_ordering` (both reviewers). Rejected: attaching a truncation flag to `ResolutionDiagnosis` (cap only bites past 1000 features, field order is a pinned contract) and degrading `partial_records` for unpicklable local classes (pre-existing semantics of `result`; planning runs in the main process; a round-trip pin covers the supported case).
