### PR TITLE
fix: make graph traversals iterative and memoized

### DIFF
--- a/mloda/core/prepare/graph/graph.py
+++ b/mloda/core/prepare/graph/graph.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from collections.abc import Iterator
 from copy import copy
 from uuid import UUID
 
@@ -39,13 +40,18 @@ class Graph:
         if node in self.visited:
             return
         self.visited.add(node)
-
-        # Iterate through dependent edges
-        for child in self.adjacency_list[node]:
-            if child not in self.visited:
+        stack: list[tuple[UUID, Iterator[UUID]]] = [(node, iter(self.adjacency_list[node]))]
+        while stack:
+            _, children = stack[-1]
+            for child in children:
+                if child in self.visited:
+                    continue
                 self.queue.append(child)
-
-            self.dfs(child)
+                self.visited.add(child)
+                stack.append((child, iter(self.adjacency_list[child])))
+                break
+            else:
+                stack.pop()
 
     def iterate_nodes_and_edges(self) -> None:
         self.visited: set[UUID] = set()
@@ -66,31 +72,42 @@ class Graph:
                 in_degree[child] += 1
         return in_degree
 
-    def get_direct_parents_for_each_child(self, parent: UUID, children: list[UUID]) -> None:
-        for child in children:
-            self.parents_by_direct_[child].add(parent)
-            self.get_direct_parents_for_each_child(child, self.adjacency_list[child])
-
     def set_direct_parents_for_each_child(self) -> None:
         for parent, children in self.adjacency_list.items():
-            self.get_direct_parents_for_each_child(parent, children)
-
-    def get_all_parents_for_each_child(self, child: UUID, parents: set[UUID]) -> set[UUID]:
-        if not parents:
-            return parents
-
-        result_set: set[UUID] = set()
-
-        for parent in parents:
-            parents_of_parent = self.parents_by_direct_[parent]
-            result_set = result_set.union(self.get_all_parents_for_each_child(child, parents_of_parent))
-
-        return parents.union(result_set)
+            for child in children:
+                self.parents_by_direct_[child].add(parent)
 
     def set_all_parents_for_each_child(self) -> None:
-        for child, parents in self.parents_by_direct_.copy().items():
-            result_set = self.get_all_parents_for_each_child(child, parents)
-            self.parent_to_children_mapping[child] = result_set.union(parents)
+        memo: dict[UUID, set[UUID]] = {}
+        direct = self.parents_by_direct_
+        for start in list(direct):
+            if start in memo:
+                continue
+            stack: list[UUID] = [start]
+            on_path: set[UUID] = set()
+            while stack:
+                cur = stack[-1]
+                if cur in memo:
+                    stack.pop()
+                    continue
+                # .get, not direct[cur]: indexing the defaultdict would insert spurious root keys
+                parents = direct.get(cur, set())
+                unresolved = [p for p in parents if p not in memo]
+                if unresolved:
+                    if cur in on_path:
+                        raise ValueError(f"cycle detected in feature graph at {cur}")
+                    on_path.add(cur)
+                    stack.extend(unresolved)
+                    continue
+                ancestors: set[UUID] = set()
+                for p in parents:
+                    ancestors.add(p)
+                    ancestors |= memo[p]
+                memo[cur] = ancestors
+                on_path.discard(cur)
+                stack.pop()
+        for child in direct:
+            self.parent_to_children_mapping[child] = memo[child]
 
     def set_root_parents_by_direct_(self) -> None:
         for child, parents in self.parent_to_children_mapping.items():

--- a/tests/test_core/test_setup/test_graph_traversal.py
+++ b/tests/test_core/test_setup/test_graph_traversal.py
@@ -1,16 +1,14 @@
 """Traversal-behavior tests for mloda.core.prepare.graph.graph.Graph.
 
-These tests pin the observable outputs of the Graph traversal helpers and
-define three requirements the current recursive implementation does not meet:
+These pin the observable outputs of the Graph traversal helpers and guard three
+requirements:
 
-1. dfs / iterate_nodes_and_edges must survive deep (long) feature chains
-   without RecursionError.
-2. set_direct_parents_for_each_child + set_all_parents_for_each_child must
-   survive deep chains without RecursionError and must not be exponential on
-   diamond-shaped DAGs.
-3. The existing outputs (roots, queue order, parents_by_direct_,
-   parent_to_children_mapping, child_with_root) must stay byte-for-byte the
-   same as they are today (regression guard).
+1. dfs / iterate_nodes_and_edges handles deep (long) feature chains without
+   RecursionError.
+2. set_direct_parents_for_each_child + set_all_parents_for_each_child handle deep
+   chains without RecursionError and stay polynomial on diamond-shaped DAGs.
+3. The observable outputs (roots, queue order, parents_by_direct_,
+   parent_to_children_mapping, child_with_root) are stable (regression guard).
 
 Graphs are built manually so node-insertion order and edge order are fully
 controlled. BuildGraph is intentionally avoided because it stores nodes/edges
@@ -43,11 +41,11 @@ def build_graph(node_ids: list[int], edges: list[tuple[int, int]]) -> Graph:
 
 class TestGraphTraversal:
     def test_regression_seven_node_golden_values(self) -> None:
-        """Characterization / regression guard.
+        """Characterization / regression guard for the exact traversal outputs.
 
-        Passes on the current implementation and must keep passing after any
-        refactor. Every asserted value was captured from today's recursive
-        implementation, including the load-bearing dfs pre-order in `queue`.
+        Pins roots, the load-bearing dfs pre-order in `queue`, parents_by_direct_,
+        parent_to_children_mapping, and child_with_root so any future refactor
+        keeps them identical.
         """
         node_ids = [0, 1, 2, 3, 4, 5, 6]
         edges = [(0, 1), (0, 2), (1, 3), (2, 3), (3, 4), (0, 5), (5, 6)]
@@ -84,10 +82,11 @@ class TestGraphTraversal:
             assert g.child_with_root[_u(i)] == {_u(0)}
 
     def test_deep_chain_dfs_no_recursion_error(self) -> None:
-        """Deep linear chain must not blow the Python recursion limit in dfs.
+        """dfs handles a chain deeper than the CPython recursion limit.
 
-        RED: today `dfs` recurses once per chain link, so a 2000-node chain
-        raises RecursionError inside iterate_nodes_and_edges.
+        A 2000-node linear chain exceeds the default recursion limit;
+        iterate_nodes_and_edges completes without RecursionError. A naive
+        recursive dfs would raise here.
         """
         node_ids = list(range(2000))
         edges = [(i, i + 1) for i in range(1999)]
@@ -99,11 +98,11 @@ class TestGraphTraversal:
         assert g.queue[:3] == [_u(0), _u(1), _u(2)]
 
     def test_deep_chain_ancestors_no_recursion_error(self) -> None:
-        """Ancestor computation must not blow the recursion limit on deep chains.
+        """Ancestor computation handles a chain deeper than the recursion limit.
 
-        RED: today `set_direct_parents_for_each_child` recurses once per chain
-        link, so a 2000-node chain raises RecursionError before we ever reach
-        set_all_parents_for_each_child.
+        set_direct_parents_for_each_child + set_all_parents_for_each_child resolve
+        a 2000-node chain without RecursionError. A naive recursive walk would
+        raise here.
         """
         node_ids = list(range(2000))
         edges = [(i, i + 1) for i in range(1999)]
@@ -116,17 +115,13 @@ class TestGraphTraversal:
         assert len(g.parent_to_children_mapping[_u(1999)]) == 1999
 
     def test_diamond_dag_not_exponential(self) -> None:
-        """Chained diamonds must be traversed in polynomial (not exponential) time.
+        """Chained diamonds are traversed in polynomial (not exponential) time.
 
         The graph is `entry -> {a, b} -> exit`, chained DIAMONDS times, so the
-        number of distinct root-to-leaf paths is 2**DIAMONDS.
-
-        RED: today `set_direct_parents_for_each_child` (and
-        set_all_parents_for_each_child) re-walk every path with no memoization,
-        making this O(2**DIAMONDS). With DIAMONDS=30 that is ~1e9 calls and the
-        method never finishes; the global pytest `--timeout=10` (or the outer
-        wall-clock cap used to validate the RED state) trips instead. After a
-        memoized/iterative fix this completes in milliseconds.
+        number of distinct root-to-leaf paths is 2**DIAMONDS. A per-path walk
+        without memoization would be O(2**DIAMONDS): at DIAMONDS=30 (~1e9 paths)
+        it would exceed the global pytest `--timeout=10`. The memoized traversal
+        completes in milliseconds.
         """
         diamonds = 30
 
@@ -150,7 +145,7 @@ class TestGraphTraversal:
         # Shallow dfs (depth ~60) mirrors the production call order and is fine.
         g.iterate_nodes_and_edges()
 
-        # Current recursive, unmemoized implementation is exponential here.
+        # Memoized ancestor closure: polynomial regardless of path count.
         g.set_direct_parents_for_each_child()
         g.set_all_parents_for_each_child()
 

--- a/tests/test_core/test_setup/test_graph_traversal.py
+++ b/tests/test_core/test_setup/test_graph_traversal.py
@@ -1,0 +1,159 @@
+"""Traversal-behavior tests for mloda.core.prepare.graph.graph.Graph.
+
+These tests pin the observable outputs of the Graph traversal helpers and
+define three requirements the current recursive implementation does not meet:
+
+1. dfs / iterate_nodes_and_edges must survive deep (long) feature chains
+   without RecursionError.
+2. set_direct_parents_for_each_child + set_all_parents_for_each_child must
+   survive deep chains without RecursionError and must not be exponential on
+   diamond-shaped DAGs.
+3. The existing outputs (roots, queue order, parents_by_direct_,
+   parent_to_children_mapping, child_with_root) must stay byte-for-byte the
+   same as they are today (regression guard).
+
+Graphs are built manually so node-insertion order and edge order are fully
+controlled. BuildGraph is intentionally avoided because it stores nodes/edges
+in sets and therefore yields nondeterministic traversal order.
+"""
+
+from uuid import UUID
+
+from mloda.core.prepare.graph.graph import Graph
+from mloda.core.prepare.graph.properties import EdgeProperties, NodeProperties
+from mloda.provider import FeatureGroup
+from mloda.user import Feature
+
+
+def _u(i: int) -> UUID:
+    return UUID(int=i)
+
+
+def build_graph(node_ids: list[int], edges: list[tuple[int, int]]) -> Graph:
+    """Build a Graph with deterministic node-insertion and edge order."""
+    g = Graph()
+    for i in node_ids:
+        f = Feature(f"f{i}")
+        f.uuid = _u(i)
+        g.add_node(_u(i), NodeProperties(f, FeatureGroup))
+    for p, c in edges:
+        g.add_edge(_u(p), _u(c), EdgeProperties(FeatureGroup, FeatureGroup))
+    return g
+
+
+class TestGraphTraversal:
+    def test_regression_seven_node_golden_values(self) -> None:
+        """Characterization / regression guard.
+
+        Passes on the current implementation and must keep passing after any
+        refactor. Every asserted value was captured from today's recursive
+        implementation, including the load-bearing dfs pre-order in `queue`.
+        """
+        node_ids = [0, 1, 2, 3, 4, 5, 6]
+        edges = [(0, 1), (0, 2), (1, 3), (2, 3), (3, 4), (0, 5), (5, 6)]
+        g = build_graph(node_ids, edges)
+
+        g.iterate_nodes_and_edges()
+        assert g.roots == [_u(0)]
+        # dfs pre-order, load-bearing downstream:
+        assert g.queue == [_u(0), _u(1), _u(3), _u(4), _u(2), _u(5), _u(6)]
+
+        g.set_direct_parents_for_each_child()
+        # parents_by_direct_ (transpose of edges):
+        #   1:{0}  2:{0}  3:{1,2}  4:{3}  5:{0}  6:{5}
+        assert g.parents_by_direct_[_u(1)] == {_u(0)}
+        assert g.parents_by_direct_[_u(2)] == {_u(0)}
+        assert g.parents_by_direct_[_u(3)] == {_u(1), _u(2)}
+        assert g.parents_by_direct_[_u(4)] == {_u(3)}
+        assert g.parents_by_direct_[_u(5)] == {_u(0)}
+        assert g.parents_by_direct_[_u(6)] == {_u(5)}
+
+        g.set_all_parents_for_each_child()
+        # parent_to_children_mapping (all transitive ancestors):
+        #   1:{0} 2:{0} 3:{0,1,2} 4:{0,1,2,3} 5:{0} 6:{0,5}
+        assert g.parent_to_children_mapping[_u(1)] == {_u(0)}
+        assert g.parent_to_children_mapping[_u(2)] == {_u(0)}
+        assert g.parent_to_children_mapping[_u(3)] == {_u(0), _u(1), _u(2)}
+        assert g.parent_to_children_mapping[_u(4)] == {_u(0), _u(1), _u(2), _u(3)}
+        assert g.parent_to_children_mapping[_u(5)] == {_u(0)}
+        assert g.parent_to_children_mapping[_u(6)] == {_u(0), _u(5)}
+
+        g.set_root_parents_by_direct_()
+        # every child's only root ancestor is 0
+        for i in (1, 2, 3, 4, 5, 6):
+            assert g.child_with_root[_u(i)] == {_u(0)}
+
+    def test_deep_chain_dfs_no_recursion_error(self) -> None:
+        """Deep linear chain must not blow the Python recursion limit in dfs.
+
+        RED: today `dfs` recurses once per chain link, so a 2000-node chain
+        raises RecursionError inside iterate_nodes_and_edges.
+        """
+        node_ids = list(range(2000))
+        edges = [(i, i + 1) for i in range(1999)]
+        g = build_graph(node_ids, edges)
+
+        g.iterate_nodes_and_edges()
+        assert g.roots == [_u(0)]
+        assert len(g.queue) == 2000
+        assert g.queue[:3] == [_u(0), _u(1), _u(2)]
+
+    def test_deep_chain_ancestors_no_recursion_error(self) -> None:
+        """Ancestor computation must not blow the recursion limit on deep chains.
+
+        RED: today `set_direct_parents_for_each_child` recurses once per chain
+        link, so a 2000-node chain raises RecursionError before we ever reach
+        set_all_parents_for_each_child.
+        """
+        node_ids = list(range(2000))
+        edges = [(i, i + 1) for i in range(1999)]
+        g = build_graph(node_ids, edges)
+
+        g.set_direct_parents_for_each_child()
+        g.set_all_parents_for_each_child()
+        assert g.parent_to_children_mapping[_u(1)] == {_u(0)}
+        assert g.parent_to_children_mapping[_u(500)] == {_u(i) for i in range(500)}
+        assert len(g.parent_to_children_mapping[_u(1999)]) == 1999
+
+    def test_diamond_dag_not_exponential(self) -> None:
+        """Chained diamonds must be traversed in polynomial (not exponential) time.
+
+        The graph is `entry -> {a, b} -> exit`, chained DIAMONDS times, so the
+        number of distinct root-to-leaf paths is 2**DIAMONDS.
+
+        RED: today `set_direct_parents_for_each_child` (and
+        set_all_parents_for_each_child) re-walk every path with no memoization,
+        making this O(2**DIAMONDS). With DIAMONDS=30 that is ~1e9 calls and the
+        method never finishes; the global pytest `--timeout=10` (or the outer
+        wall-clock cap used to validate the RED state) trips instead. After a
+        memoized/iterative fix this completes in milliseconds.
+        """
+        diamonds = 30
+
+        node_ids = list(range(3 * diamonds + 1))
+        edges: list[tuple[int, int]] = []
+        entry = 0
+        n = 0
+        for _ in range(diamonds):
+            a = n + 1
+            b = n + 2
+            exit_node = n + 3
+            edges.append((entry, a))
+            edges.append((entry, b))
+            edges.append((a, exit_node))
+            edges.append((b, exit_node))
+            entry = exit_node
+            n += 3
+
+        g = build_graph(node_ids, edges)
+
+        # Shallow dfs (depth ~60) mirrors the production call order and is fine.
+        g.iterate_nodes_and_edges()
+
+        # Current recursive, unmemoized implementation is exponential here.
+        g.set_direct_parents_for_each_child()
+        g.set_all_parents_for_each_child()
+
+        final_exit = _u(3 * diamonds)
+        # every earlier node is a transitive ancestor of the final exit node
+        assert len(g.parent_to_children_mapping[final_exit]) == 3 * diamonds


### PR DESCRIPTION
## Problem

Graph traversal helpers in `mloda/core/prepare/graph/graph.py` recursed without memoization:

- `dfs`, `set_direct_parents_for_each_child`, and `set_all_parents_for_each_child` all recursed once per graph edge/level, so a chain of ~1500+ features raised `RecursionError` at the Python recursion limit.
- The two ancestor helpers re-walked every root-to-leaf path with no memoization, giving exponential time on diamond-shaped DAGs (measured ~10s on a 61-node graph with 2^20 paths).

Both are reachable from ordinary planning: `ResolveGraph.create_initial_queue` (dfs) and `ResolveLinks.resolve_links` (the ancestor helpers). Diamonds occur whenever a feature depends on two features sharing an upstream ancestor.

## Change

- `dfs`: explicit-stack iteration, preserving the exact `queue` pre-order (load-bearing for downstream planning) and the `visited` semantics.
- `set_direct_parents_for_each_child`: single O(E) transpose over `adjacency_list`, dropping the recursive helper. This also removes a latent `dictionary changed size during iteration` crash (the old code auto-inserted leaf keys into `adjacency_list` mid-iteration and only survived because `dfs` happened to run first).
- `set_all_parents_for_each_child`: iterative memoized ancestor closure with a cycle guard, dropping the recursive helper.

Consumed outputs (`queue`, `parent_to_children_mapping`, `child_with_root`) are unchanged.

## Tests

`tests/test_core/test_setup/test_graph_traversal.py`:
- Regression guard pinning the exact `roots`, `queue` order, `parents_by_direct_`, `parent_to_children_mapping`, and `child_with_root` on a 7-node graph.
- 2000-node linear chain: no `RecursionError` in dfs or ancestor computation.
- 30-diamond DAG (2^30 paths): completes in polynomial time.

## Validation

- Full `tox` green: 6896 passed, 170 skipped, `mypy --strict` clean, ruff, bandit.
- Two independent reviews (Claude Opus and codex) confirmed the rewrite preserves DFS order and ancestor sets; each ran differential comparisons of old-vs-new across thousands of random DAGs plus cycles, self-loops, duplicate edges, disconnected and multi-root graphs. Only benign nits, no blockers.