### PR TITLE
minor: enforce required-presence on the string-named match path (#769)

### DIFF
--- a/attribution/ATTRIBUTION.md
+++ b/attribution/ATTRIBUTION.md
@@ -1,112 +1,108 @@
 | Name                                   | Version         | License                                            |
 |----------------------------------------|-----------------|----------------------------------------------------|
-| CacheControl                           | 0.14.4          | Apache-2.0                                         |
 | PyYAML                                 | 6.0.3           | MIT License                                        |
 | Pygments                               | 2.20.0          | BSD-2-Clause                                       |
 | annotated-types                        | 0.7.0           | MIT License                                        |
-| ast_serialize                          | 0.6.0           | MIT                                                |
-| asttokens                              | 3.0.2           | Apache 2.0                                         |
+| ast_serialize                          | 0.4.0           | MIT                                                |
+| asttokens                              | 3.0.1           | Apache 2.0                                         |
 | bandit                                 | 1.9.4           | Apache-2.0                                         |
 | cachetools                             | 6.2.6           | MIT                                                |
-| certifi                                | 2026.6.17       | Mozilla Public License 2.0 (MPL 2.0)               |
-| charset-normalizer                     | 3.4.9           | MIT                                                |
-| click                                  | 8.4.2           | BSD-3-Clause                                       |
+| certifi                                | 2026.4.22       | Mozilla Public License 2.0 (MPL 2.0)               |
+| charset-normalizer                     | 3.4.7           | MIT                                                |
+| click                                  | 8.4.0           | BSD-3-Clause                                       |
 | comm                                   | 0.2.3           | BSD License                                        |
-| cyclonedx-python-lib                   | 11.11.0         | Apache Software License                            |
-| debugpy                                | 1.8.21          | MIT License                                        |
+| dataclasses                            | 0.8             | Apache Software License                            |
+| debugpy                                | 1.8.20          | MIT License                                        |
 | decorator                              | 5.3.1           | BSD-2-Clause                                       |
-| defusedxml                             | 0.7.1           | Python Software Foundation License                 |
-| duckdb                                 | 1.5.4           | MIT License                                        |
+| duckdb                                 | 1.5.2           | MIT License                                        |
+| entrypoints                            | 0.4             | MIT License                                        |
 | execnet                                | 2.1.2           | MIT License                                        |
 | executing                              | 2.2.1           | MIT License                                        |
-| filelock                               | 3.29.7          | MIT License                                        |
-| fsspec                                 | 2026.6.0        | BSD-3-Clause                                       |
-| idna                                   | 3.18            | BSD-3-Clause                                       |
+| fsspec                                 | 2026.4.0        | BSD-3-Clause                                       |
+| html5lib                               | 1.1             | MIT License                                        |
+| idna                                   | 3.15            | BSD-3-Clause                                       |
+| importlib_metadata                     | 8.7.1           | Apache-2.0                                         |
 | iniconfig                              | 2.3.0           | MIT                                                |
-| ipykernel                              | 7.3.0           | BSD-3-Clause                                       |
-| ipython                                | 9.15.0          | BSD-3-Clause                                       |
+| ipykernel                              | 6.29.5          | BSD License                                        |
+| ipython                                | 9.13.0          | BSD-3-Clause                                       |
 | ipython_pygments_lexers                | 1.1.1           | BSD License                                        |
-| jedi                                   | 0.20.0          | MIT License                                        |
+| jedi                                   | 0.19.2          | MIT License                                        |
 | joblib                                 | 1.5.3           | BSD-3-Clause                                       |
-| jupyter_client                         | 8.9.1           | BSD License                                        |
+| jupyter_client                         | 7.4.9           | BSD License                                        |
 | jupyter_core                           | 5.9.1           | BSD-3-Clause                                       |
-| librt                                  | 0.13.0          | MIT                                                |
+| librt                                  | 0.11.0          | MIT                                                |
 | markdown-it-py                         | 4.2.0           | MIT License                                        |
 | matplotlib-inline                      | 0.2.2           | BSD-3-Clause                                       |
 | mdurl                                  | 0.1.2           | MIT License                                        |
 | mktestdocs                             | 0.2.5           | MIT                                                |
 | mloda                                  | 0.10.0          | Apache-2.0                                         |
 | mmh3                                   | 5.2.1           | MIT License                                        |
-| msgpack                                | 1.2.1           | Apache-2.0                                         |
-| mypy                                   | 2.2.0           | MIT                                                |
+| mypy                                   | 2.1.0           | MIT                                                |
 | mypy_extensions                        | 1.1.0           | MIT                                                |
-| narwhals                               | 2.23.0          | MIT                                                |
-| nest-asyncio2                          | 1.7.2           | BSD License                                        |
-| nltk                                   | 3.10.0          | Apache Software License                            |
-| numpy                                  | 2.5.1           | BSD-3-Clause AND 0BSD AND MIT AND Zlib AND CC0-1.0 |
-| opentelemetry-api                      | 1.43.0          | Apache-2.0                                         |
-| opentelemetry-instrumentation          | 0.64b0          | Apache Software License                            |
-| opentelemetry-instrumentation-logging  | 0.64b0          | Apache Software License                            |
-| opentelemetry-instrumentation-requests | 0.64b0          | Apache Software License                            |
-| opentelemetry-sdk                      | 1.43.0          | Apache-2.0                                         |
-| opentelemetry-semantic-conventions     | 0.64b0          | Apache-2.0                                         |
-| opentelemetry-util-http                | 0.64b0          | Apache Software License                            |
-| packageurl-python                      | 0.17.6          | MIT License                                        |
+| nest-asyncio                           | 1.6.0           | BSD License                                        |
+| nltk                                   | 3.9.4           | Apache Software License                            |
+| numpy                                  | 2.4.5           | BSD-3-Clause AND 0BSD AND MIT AND Zlib AND CC0-1.0 |
+| opentelemetry-api                      | 1.41.1          | Apache-2.0                                         |
+| opentelemetry-instrumentation          | 0.62b1          | Apache Software License                            |
+| opentelemetry-instrumentation-logging  | 0.62b1          | Apache Software License                            |
+| opentelemetry-instrumentation-requests | 0.62b1          | Apache Software License                            |
+| opentelemetry-sdk                      | 1.41.1          | Apache-2.0                                         |
+| opentelemetry-semantic-conventions     | 0.62b1          | Apache-2.0                                         |
+| opentelemetry-util-http                | 0.62b1          | Apache Software License                            |
 | packaging                              | 26.2            | Apache-2.0 OR BSD-2-Clause                         |
 | pandas                                 | 3.0.3           | BSD License                                        |
-| pandera                                | 0.32.1          | MIT License                                        |
+| pandera                                | 0.31.1          | MIT License                                        |
 | parso                                  | 0.8.7           | MIT License                                        |
 | pathspec                               | 1.1.1           | Mozilla Public License 2.0 (MPL 2.0)               |
 | pexpect                                | 4.9.0           | ISC License (ISCL)                                 |
 | pip-api                                | 0.0.34          | Apache Software License                            |
-| pip-requirements-parser                | 32.0.1          | MIT                                                |
-| pip_audit                              | 2.10.1          | Apache Software License                            |
-| platformdirs                           | 4.10.0          | MIT License                                        |
+| pip-audit                              | 0.0.1           | Apache Software License                            |
+| platformdirs                           | 4.9.6           | MIT License                                        |
 | pluggy                                 | 1.6.0           | MIT License                                        |
-| polars                                 | 1.42.1          | MIT License                                        |
-| polars-runtime-32                      | 1.42.1          | MIT License                                        |
+| polars                                 | 1.40.1          | MIT License                                        |
+| polars-runtime-32                      | 1.40.1          | MIT License                                        |
+| progress                               | 1.6.1           | ISC                                                |
 | prompt_toolkit                         | 3.0.52          | BSD License                                        |
 | psutil                                 | 7.2.2           | BSD-3-Clause                                       |
 | ptyprocess                             | 0.7.0           | ISC License (ISCL)                                 |
 | pure_eval                              | 0.2.3           | MIT License                                        |
-| py-serializable                        | 2.1.0           | Apache Software License                            |
-| pyarrow                                | 25.0.0          | Apache-2.0                                         |
+| pyarrow                                | 24.0.0          | Apache-2.0                                         |
 | pydantic                               | 2.13.4          | MIT                                                |
 | pydantic_core                          | 2.46.4          | MIT                                                |
 | pyiceberg                              | 0.11.1          | Apache-2.0                                         |
 | pyparsing                              | 3.3.2           | MIT                                                |
 | pyroaring                              | 1.1.0           | MIT License                                        |
-| pytest                                 | 9.1.1           | MIT                                                |
-| pytest-order                           | 1.5.0           | MIT                                                |
+| pytest                                 | 9.0.3           | MIT                                                |
+| pytest-order                           | 1.4.0           | MIT                                                |
 | pytest-timeout                         | 2.4.0           | DFSG approved; MIT License                         |
 | pytest-xdist                           | 3.8.0           | MIT                                                |
 | python-dateutil                        | 2.9.0.post0     | Apache Software License; BSD License               |
 | pyzmq                                  | 27.1.0          | BSD License                                        |
-| regex                                  | 2026.7.10       | Apache-2.0 AND CNRI-Python                         |
+| regex                                  | 2026.5.9        | Apache-2.0 AND CNRI-Python                         |
 | requests                               | 2.34.2          | Apache Software License                            |
+| resolvelib                             | 1.2.1           | ISC License (ISCL)                                 |
 | rich                                   | 14.3.4          | MIT License                                        |
-| ruff                                   | 0.15.21         | MIT                                                |
-| scikit-learn                           | 1.9.0           | BSD-3-Clause                                       |
-| scipy                                  | 1.18.0          | BSD License                                        |
+| ruff                                   | 0.15.13         | MIT                                                |
+| scikit-learn                           | 1.8.0           | BSD-3-Clause                                       |
+| scipy                                  | 1.17.1          | BSD License                                        |
 | six                                    | 1.17.0          | MIT License                                        |
-| sortedcontainers                       | 2.4.0           | Apache Software License                            |
 | stack-data                             | 0.6.3           | MIT License                                        |
-| stevedore                              | 5.9.0           | Apache-2.0                                         |
+| stevedore                              | 5.7.0           | Apache Software License                            |
 | strictyaml                             | 1.7.3           | MIT License                                        |
 | tenacity                               | 9.1.4           | Apache Software License                            |
 | threadpoolctl                          | 3.6.0           | BSD License                                        |
-| tomli                                  | 2.4.1           | MIT                                                |
-| tomli_w                                | 1.2.0           | MIT License                                        |
 | tornado                                | 6.5.7           | Apache Software License                            |
-| tqdm                                   | 4.68.4          | MPL-2.0 AND MIT                                    |
-| traitlets                              | 5.15.1          | BSD License                                        |
+| tqdm                                   | 4.67.3          | MPL-2.0 AND MIT                                    |
+| traitlets                              | 5.15.0          | BSD License                                        |
 | typeguard                              | 4.5.2           | MIT                                                |
-| types-PyYAML                           | 6.0.12.20260518 | Apache-2.0                                         |
-| types-requests                         | 2.33.0.20260712 | Apache-2.0                                         |
-| types-toml                             | 0.10.8.20260518 | Apache-2.0                                         |
+| types-PyYAML                           | 6.0.12.20260510 | Apache-2.0                                         |
+| types-requests                         | 2.33.0.20260513 | Apache-2.0                                         |
+| types-toml                             | 0.10.8.20260508 | Apache-2.0                                         |
 | typing-inspect                         | 0.9.0           | MIT License                                        |
 | typing-inspection                      | 0.4.2           | MIT                                                |
-| typing_extensions                      | 4.16.0          | PSF-2.0                                            |
+| typing_extensions                      | 4.15.0          | PSF-2.0                                            |
 | urllib3                                | 2.7.0           | MIT                                                |
-| wrapt                                  | 2.2.2           | BSD-2-Clause                                       |
+| webencodings                           | 0.5.1           | BSD License                                        |
+| wrapt                                  | 2.1.2           | BSD-2-Clause                                       |
+| zipp                                   | 3.23.1          | MIT                                                |
 | zstandard                              | 0.25.0          | BSD-3-Clause                                       |

--- a/attribution/ATTRIBUTION.md
+++ b/attribution/ATTRIBUTION.md
@@ -5,7 +5,7 @@
 | Pygments                               | 2.20.0          | BSD-2-Clause                                       |
 | annotated-types                        | 0.7.0           | MIT License                                        |
 | ast_serialize                          | 0.6.0           | MIT                                                |
-| asttokens                              | 3.0.1           | Apache 2.0                                         |
+| asttokens                              | 3.0.2           | Apache 2.0                                         |
 | bandit                                 | 1.9.4           | Apache-2.0                                         |
 | cachetools                             | 6.2.6           | MIT                                                |
 | certifi                                | 2026.6.17       | Mozilla Public License 2.0 (MPL 2.0)               |
@@ -102,7 +102,7 @@
 | traitlets                              | 5.15.1          | BSD License                                        |
 | typeguard                              | 4.5.2           | MIT                                                |
 | types-PyYAML                           | 6.0.12.20260518 | Apache-2.0                                         |
-| types-requests                         | 2.33.0.20260518 | Apache-2.0                                         |
+| types-requests                         | 2.33.0.20260712 | Apache-2.0                                         |
 | types-toml                             | 0.10.8.20260518 | Apache-2.0                                         |
 | typing-inspect                         | 0.9.0           | MIT License                                        |
 | typing-inspection                      | 0.4.2           | MIT                                                |

--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -76,7 +76,7 @@ does not understand can be absorbed silently.
 | Match time (parser) | `allowed_values` membership | Each element of a **present** option is in the accepted set | One element | `ValueError`, surfaced to the end user |
 | Match time (parser) | `element_validator` | Each element of a **present** option satisfies a predicate | One element | `ValueError`, surfaced to the end user |
 | Match time (parser) | Required presence (config path) | A key that declares no `default` and no `required_when` was provided | The options | Non-match (`False`) |
-| Match time (parser) | Required presence (string-named path) | Same, after declared defaults and name bindings resolve; `deferred_binding=True` and the source (`in_features`) key are exempt | The effective options | Warn or non-match per `MLODA_NAME_PATH_REQUIRED_PRESENCE` (`warn` default / `enforce` / `off`) |
+| Match time (parser) | Required presence (string-named path) | Same, after declared defaults and name bindings resolve; `deferred_binding=True` and the source (`in_features`) key are exempt | The effective options | Non-match (`False`), with a warning naming the missing key(s) |
 | Match time (mixin) | `match_guard` | The whole value has an acceptable shape | The raw value | Non-match (`False`) |
 | Match time (mixin) | `MIN/MAX_IN_FEATURES` | In-feature count is within bounds | The in-features | Non-match (`False`) |
 | Match time (guard installed at class definition) | `required_when` | A conditionally required option is present | `Options` | Non-match (`False`) |
@@ -95,9 +95,8 @@ short-circuits, and `match_guard` is never reached.
 
 Value validation does not depend on how the feature was created: membership and
 `element_validator` run on **both** match paths, the configuration-based one and the
-string-named one. Required **presence** now runs on both too, differing only in strength: the
-configuration path rejects a missing required key outright, while the string-named path is
-warn-by-default and becomes a non-match only under `MLODA_NAME_PATH_REQUIRED_PRESENCE=enforce`
+string-named one. Required **presence** runs on both too: the string-named path rejects a
+missing required key exactly like the configuration path does
 (see [Required presence on the string-named path](#required-presence-on-the-string-named-path)).
 A key the name encodes, a `deferred_binding=True` key, a declared-default key, and the source
 (`in_features`) key are never falsely reported missing. So `"income__pca_2d"` with no options at
@@ -371,16 +370,8 @@ resolved. Exempt from the check: a declared default, a `required_when` key, a
 `deferred_binding=True` key, and the source key (`in_features`), whose presence the name prefix
 supplies and whose count `MIN/MAX_IN_FEATURES` enforces.
 
-`MLODA_NAME_PATH_REQUIRED_PRESENCE` selects the mode (case-insensitive; unset or invalid means
-`warn`):
-
-| Value | Effect |
-| --- | --- |
-| `warn` (default) | Logs a warning naming the group and the missing key(s), still **matches**. The migration default. |
-| `enforce` | The missing key makes it a **non-match**. |
-| `off` (or `0`, `false`, `no`) | The check is skipped. |
-
-Under `enforce`, the resolution-failure report also names the missing key(s), not only the log.
+A flagged missing key makes the match a **non-match**: a warning names the group, the feature,
+and the missing key(s), and the resolution-failure report names the missing key(s) too.
 
 Two migrations remove the warning for a flagged key. Give the pattern a named capture
 `(?P<key>...)` so the framework binds the key from the name; or, for a key bound outside

--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -378,7 +378,9 @@ supplies and whose count `MIN/MAX_IN_FEATURES` enforces.
 | --- | --- |
 | `warn` (default) | Logs a warning naming the group and the missing key(s), still **matches**. The migration default. |
 | `enforce` | The missing key makes it a **non-match**. |
-| `off` | The check is skipped. |
+| `off` (or `0`, `false`, `no`) | The check is skipped. |
+
+Under `enforce`, the resolution-failure report also names the missing key(s), not only the log.
 
 Two migrations remove the warning for a flagged key. Give the pattern a named capture
 `(?P<key>...)` so the framework binds the key from the name; or, for a key bound outside

--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -377,15 +377,14 @@ Two migrations remove the warning for a flagged key. Give the pattern a named ca
 `(?P<key>...)` so the framework binds the key from the name; or, for a key bound outside
 match-time name capture (parsed by the plugin from the name, or supplied downstream), set
 `deferred_binding=True`, which exempts it from this check only and leaves it required on the
-config path. `TimeWindowFeatureGroup` marks its name-parsed `window_size` and `time_unit` keys
-this way:
+config path. `ClusteringFeatureGroup` marks its name-parsed `k_value` key this way:
 
 ``` python
 from mloda.provider import PropertySpec
 
 PROPERTY_MAPPING = {
-    "window_size": PropertySpec(
-        "Window size parsed from the feature name by the plugin",
+    "k_value": PropertySpec(
+        "Cluster count parsed from the feature name by the plugin",
         deferred_binding=True,  # exempt from the string-named presence check only
     ),
 }
@@ -404,7 +403,7 @@ If every candidate rejects the feature, the final "No feature groups found" erro
 discarded reasons and appends them:
 
 ```
-Feature group(s) rejected an option value while matching 'window_size_windowed':
+Feature group(s) rejected the supplied options while matching 'window_size_windowed':
   - WindowedFeatureGroup: Property value '14' failed validation for 'window_size'
 ```
 

--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -39,6 +39,7 @@ PROPERTY_MAPPING = {
 | `match_guard` | `Callable \| None` | `None` | Whole-value predicate. A falsy return is a non-match. |
 | `required_when` | `Callable \| None` | `None` | `(Options) -> bool`: the key is required only when it returns truthy. |
 | `allow_explicit_none` | `bool` | `False` | Opt-in so an explicit `None` is honored (not treated as absent) and flows through validation. |
+| `deferred_binding` | `bool` | `False` | Exempts a required key from the string-named path presence check only; its value is bound outside match-time name capture. Not optionality: the key stays required on the config path. See [Required presence on the string-named path](#required-presence-on-the-string-named-path). |
 
 **`property_spec(...)` is the authoring path to reach for.** It is a thin builder over the
 same fields, its keyword is `strict=` (which sets `strict_validation`), and it keeps the
@@ -74,7 +75,8 @@ does not understand can be absorbed silently.
 | Class definition (`FeatureGroup.__init_subclass__`) | Spec type | Every spec IS a `PropertySpec` | Every value in the mapping | `ValueError` naming the class and the key |
 | Match time (parser) | `allowed_values` membership | Each element of a **present** option is in the accepted set | One element | `ValueError`, surfaced to the end user |
 | Match time (parser) | `element_validator` | Each element of a **present** option satisfies a predicate | One element | `ValueError`, surfaced to the end user |
-| Match time (parser) | Required presence | A key that declares no `default` and no `required_when` was provided | The options | Non-match (`False`), configuration-based path only |
+| Match time (parser) | Required presence (config path) | A key that declares no `default` and no `required_when` was provided | The options | Non-match (`False`) |
+| Match time (parser) | Required presence (string-named path) | Same, after declared defaults and name bindings resolve; `deferred_binding=True` and the source (`in_features`) key are exempt | The effective options | Warn or non-match per `MLODA_NAME_PATH_REQUIRED_PRESENCE` (`warn` default / `enforce` / `off`) |
 | Match time (mixin) | `match_guard` | The whole value has an acceptable shape | The raw value | Non-match (`False`) |
 | Match time (mixin) | `MIN/MAX_IN_FEATURES` | In-feature count is within bounds | The in-features | Non-match (`False`) |
 | Match time (guard installed at class definition) | `required_when` | A conditionally required option is present | `Options` | Non-match (`False`) |
@@ -93,10 +95,14 @@ short-circuits, and `match_guard` is never reached.
 
 Value validation does not depend on how the feature was created: membership and
 `element_validator` run on **both** match paths, the configuration-based one and the
-string-named one. Only required **presence** differs, enforced on the configuration-based
-path alone, because a key the feature name encodes is satisfied by the name. So
-`"income__pca_2d"` with no options at all still matches, while the same feature group with
-`pca_svd_solver="bogus"` in its options is rejected either way.
+string-named one. Required **presence** now runs on both too, differing only in strength: the
+configuration path rejects a missing required key outright, while the string-named path is
+warn-by-default and becomes a non-match only under `MLODA_NAME_PATH_REQUIRED_PRESENCE=enforce`
+(see [Required presence on the string-named path](#required-presence-on-the-string-named-path)).
+A key the name encodes, a `deferred_binding=True` key, a declared-default key, and the source
+(`in_features`) key are never falsely reported missing. So `"income__pca_2d"` with no options at
+all still matches, while the same feature group with `pca_svd_solver="bogus"` in its options is
+rejected either way.
 
 `required_when` is the one mechanism that does not live inside a matcher. A class that
 declares it gets its resolved `match_feature_group_criteria` wrapped at class definition,
@@ -279,6 +285,10 @@ check would read that copy's sentinel as a *declared* default.
 `required_when` is for a *conditional* requirement, not for optionality: never write a
 predicate that always returns `False` to make a key optional.
 
+`deferred_binding` is not optionality either: the key stays required on the configuration path,
+and the flag only defers its string-named path presence check (see
+[Required presence on the string-named path](#required-presence-on-the-string-named-path)).
+
 ## Applying declared defaults
 
 A declared default is metadata until the resolved feature group materializes it.
@@ -351,6 +361,42 @@ groups falls back to the legacy rule of binding the first capture to the single 
 `allowed_values` already contain it. That fallback is transitional (retired by #772); a positional
 pattern whose keys share a reachable value is rejected at class-definition time, so migrate such a
 pattern to named capture groups.
+
+## Required presence on the string-named path
+
+Required presence is checked when a feature matches by its name, not on the configuration path
+alone. A key is flagged when it declares no `default`, no `required_when`, and
+`deferred_binding=False`, and is still absent after declared defaults and name captures are
+resolved. Exempt from the check: a declared default, a `required_when` key, a
+`deferred_binding=True` key, and the source key (`in_features`), whose presence the name prefix
+supplies and whose count `MIN/MAX_IN_FEATURES` enforces.
+
+`MLODA_NAME_PATH_REQUIRED_PRESENCE` selects the mode (case-insensitive; unset or invalid means
+`warn`):
+
+| Value | Effect |
+| --- | --- |
+| `warn` (default) | Logs a warning naming the group and the missing key(s), still **matches**. The migration default. |
+| `enforce` | The missing key makes it a **non-match**. |
+| `off` | The check is skipped. |
+
+Two migrations remove the warning for a flagged key. Give the pattern a named capture
+`(?P<key>...)` so the framework binds the key from the name; or, for a key bound outside
+match-time name capture (parsed by the plugin from the name, or supplied downstream), set
+`deferred_binding=True`, which exempts it from this check only and leaves it required on the
+config path. `TimeWindowFeatureGroup` marks its name-parsed `window_size` and `time_unit` keys
+this way:
+
+``` python
+from mloda.provider import PropertySpec
+
+PROPERTY_MAPPING = {
+    "window_size": PropertySpec(
+        "Window size parsed from the feature name by the plugin",
+        deferred_binding=True,  # exempt from the string-named presence check only
+    ),
+}
+```
 
 ## What the end user sees on a rejection
 
@@ -470,7 +516,8 @@ if it really is a whole-value check.
 | Declared defaults materialized into runtime options | `tests/test_core/test_abstract_plugins/test_options_with_defaults.py` |
 | Declared defaults materialized at the compute boundary | `tests/test_core/test_abstract_plugins/test_materialize_defaults_boundary.py` |
 | Container invariance, no stringification, str-as-scalar, dict-as-composite, empty containers | `tests/.../feature_chainer/test_property_mapping_sequence_unpacking.py` |
-| Present option values validated on the string-named path too; required presence stays config-only | `tests/.../feature_chainer/test_name_path_validates_option_values.py` |
+| Present option values validated on the string-named path too | `tests/.../feature_chainer/test_name_path_validates_option_values.py` |
+| Required presence on the string-named path: warn/enforce/off modes, and the `deferred_binding` / `in_features` exemptions | `tests/.../feature_chainer/test_name_path_required_presence.py` |
 | `required_when` survives an overridden matcher, runs exactly once, and demands a classmethod | `tests/.../feature_chainer/test_required_when_enforced_on_override.py` |
 | Plugin specs behave identically across containers | `tests/test_plugins/feature_group/experimental/test_property_mapping_container_invariance.py` |
 | `property_spec` builder surface | `tests/.../feature_chainer/test_property_spec_builder.py` |

--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -510,7 +510,7 @@ if it really is a whole-value check.
 | Declared defaults materialized at the compute boundary | `tests/test_core/test_abstract_plugins/test_materialize_defaults_boundary.py` |
 | Container invariance, no stringification, str-as-scalar, dict-as-composite, empty containers | `tests/.../feature_chainer/test_property_mapping_sequence_unpacking.py` |
 | Present option values validated on the string-named path too | `tests/.../feature_chainer/test_name_path_validates_option_values.py` |
-| Required presence on the string-named path: warn/enforce/off modes, and the `deferred_binding` / `in_features` exemptions | `tests/.../feature_chainer/test_name_path_required_presence.py` |
+| Required presence on the string-named path: the mandatory non-match, the retired env var stays ignored, and the `deferred_binding` / `in_features` exemptions | `tests/.../feature_chainer/test_name_path_required_presence.py` |
 | `required_when` survives an overridden matcher, runs exactly once, and demands a classmethod | `tests/.../feature_chainer/test_required_when_enforced_on_override.py` |
 | Plugin specs behave identically across containers | `tests/test_plugins/feature_group/experimental/test_property_mapping_container_invariance.py` |
 | `property_spec` builder surface | `tests/.../feature_chainer/test_property_spec_builder.py` |

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -29,6 +29,9 @@ INPUT_SEPARATOR = "&"  # Separates multiple input features
 # Marks a matcher that already carries the required_when guard, so it is never wrapped twice.
 REQUIRED_WHEN_GUARD_FLAG = "_mloda_required_when_guard"
 
+# Marks a matcher that already carries the name-path presence guard, so it is never wrapped twice.
+NAME_PATH_PRESENCE_GUARD_FLAG = "_mloda_name_path_presence_guard"
+
 # Marks a class whose captureless diagnostic already ran, so the two __init_subclass__ hooks
 # emit it at most once. Checked on the class's OWN dict so a subclass still evaluates fresh.
 CAPTURELESS_DIAGNOSTIC_FLAG = "_mloda_captureless_diagnostic_emitted"
@@ -44,6 +47,11 @@ _UNIVERSAL_MATCHER_PROBE_NAME = "mloda_universal_matcher_probe"
 # A ContextVar (not a plain global) keeps the count per thread and per async task.
 REQUIRED_WHEN_GUARD_DEPTH: contextvars.ContextVar[int] = contextvars.ContextVar(
     "mloda_required_when_guard_depth", default=0
+)
+
+# Same nesting rule for the name-path presence guard, tracked independently so the two guards compose.
+NAME_PATH_PRESENCE_GUARD_DEPTH: contextvars.ContextVar[int] = contextvars.ContextVar(
+    "mloda_name_path_presence_guard_depth", default=0
 )
 
 # Exception classes a user callable raises when it merely cannot judge a value.
@@ -927,6 +935,15 @@ class FeatureChainParser:
         return feature_name, options
 
     @classmethod
+    def _matcher_is_staticmethod(cls, owner: type[Any]) -> bool:
+        """True when the class's resolved matcher is a staticmethod descriptor."""
+        for klass in owner.__mro__:
+            descriptor = klass.__dict__.get("match_feature_group_criteria")
+            if descriptor is not None:
+                return isinstance(descriptor, staticmethod)
+        return False
+
+    @classmethod
     def _reject_staticmethod_matcher(cls, owner: type[Any]) -> None:
         """Reject a staticmethod matcher on a class that declares required_when.
 
@@ -1007,6 +1024,79 @@ class FeatureChainParser:
                 REQUIRED_WHEN_GUARD_DEPTH.reset(token)
 
         setattr(guarded, REQUIRED_WHEN_GUARD_FLAG, True)
+        setattr(owner, "match_feature_group_criteria", classmethod(guarded))
+
+    @classmethod
+    def install_name_path_presence_guard(cls, owner: type[Any]) -> None:
+        """Wrap a class's RESOLVED matcher so the name-path required-presence rule (#769) survives an override.
+
+        Mirrors ``install_required_when_guard``: installed at class definition from both
+        ``__init_subclass__`` hooks, never wrapped twice, and guards nest so only the outermost one
+        evaluates. An inner False stands untouched, so the inner path's own presence warning is never
+        duplicated. Installed before the required_when guard, which therefore stays outermost.
+        """
+        property_mapping = getattr(owner, "PROPERTY_MAPPING", None)
+        if not isinstance(property_mapping, dict):
+            return
+        if not cls.prefix_patterns_of(owner):
+            return
+        # Same exemptions as the inner rule: with empty options, the missing keys ARE the flaggable ones.
+        if not cls._name_path_missing_required_keys(Options(), property_mapping):
+            return
+
+        # The install condition is broad (any pattern class with an unconditionally required key), so a
+        # staticmethod matcher is skipped rather than rejected: a hard raise could break existing classes.
+        if cls._matcher_is_staticmethod(owner):
+            return
+
+        matcher = getattr(owner, "match_feature_group_criteria", None)
+        if matcher is None:
+            return
+
+        inner: Any = getattr(matcher, "__func__", matcher)
+        if getattr(inner, NAME_PATH_PRESENCE_GUARD_FLAG, False):
+            return
+
+        @functools.wraps(inner)
+        def guarded(guarded_cls: type[Any], *args: Any, **kwargs: Any) -> bool:
+            outermost = NAME_PATH_PRESENCE_GUARD_DEPTH.get() == 0
+            token = NAME_PATH_PRESENCE_GUARD_DEPTH.set(NAME_PATH_PRESENCE_GUARD_DEPTH.get() + 1)
+            try:
+                # An inner False stands: the inner default path already warned on its own presence
+                # non-match, so passing it through keeps one warning per match call.
+                if not inner(guarded_cls, *args, **kwargs):
+                    return False
+
+                if not outermost:
+                    return True
+
+                feature_name, options = FeatureChainParser._resolve_match_arguments(args, kwargs)
+                if options is None:
+                    return True
+
+                mapping = getattr(guarded_cls, "PROPERTY_MAPPING", None)
+                if not isinstance(mapping, dict):
+                    return True
+                # Flattened, because a matcher passes a list-valued pattern attribute straight to
+                # parse_name, so its ELEMENTS are the concrete patterns. A matcher must never leak
+                # an exception, so the parse is contained exactly as in build_effective_options.
+                patterns = FeatureChainParser._flatten_patterns(FeatureChainParser.prefix_patterns_of(guarded_cls))
+                parsed = safe_field(
+                    lambda: FeatureChainParser.parse_name(feature_name, patterns, CHAIN_SEPARATOR),
+                    ParsedFeatureName.no_match(),
+                    catching=(ValueError,),
+                )
+                if not FeatureChainParser._name_identifies_group(parsed, mapping):
+                    return True
+                bindings = FeatureChainParser.bind_name_captures(parsed, mapping)
+                effective_options = FeatureChainParser._merge_bindings(options, bindings, mapping)
+                return FeatureChainParser._check_name_path_required_presence(
+                    guarded_cls.__name__, feature_name, effective_options, mapping
+                )
+            finally:
+                NAME_PATH_PRESENCE_GUARD_DEPTH.reset(token)
+
+        setattr(guarded, NAME_PATH_PRESENCE_GUARD_FLAG, True)
         setattr(owner, "match_feature_group_criteria", classmethod(guarded))
 
     @classmethod

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import contextvars
 import functools
 import logging
+import os
 import re
 from collections.abc import Callable
 from typing import Any, Optional
@@ -48,6 +49,15 @@ REQUIRED_WHEN_GUARD_DEPTH: contextvars.ContextVar[int] = contextvars.ContextVar(
 
 # Exception classes a user callable raises when it merely cannot judge a value.
 _EXPECTED_JUDGMENT_ERRORS: tuple[type[Exception], ...] = (TypeError, ValueError, AttributeError)
+
+# Name-path required-presence migration (#769): warn (default) / enforce / off.
+_NAME_PATH_PRESENCE_ENV = "MLODA_NAME_PATH_REQUIRED_PRESENCE"
+
+
+def _name_path_presence_mode() -> str:
+    """Read the #769 migration mode from the env var, defaulting to ``"warn"`` on any invalid value."""
+    mode = os.environ.get(_NAME_PATH_PRESENCE_ENV, "warn").strip().lower()
+    return mode if mode in ("off", "warn", "enforce") else "warn"
 
 
 def _contained_raise_log_level(exc: BaseException) -> int:
@@ -424,6 +434,75 @@ class FeatureChainParser:
         return cls._validate_final_properties(property_tracker, property_mapping)
 
     @classmethod
+    def _name_path_missing_required_keys(
+        cls, effective_options: Options, property_mapping: dict[str, PropertySpec]
+    ) -> list[str]:
+        """Missing required keys on the name path, in mapping order (#769).
+
+        The source key is name-provided (its count is enforced by MIN/MAX_IN_FEATURES), so
+        ``in_features`` is excluded. A declared-default or ``required_when`` key is skippable
+        (``_can_skip_required_check``); ``deferred_binding`` is the #769 opt-out. A key is absent
+        exactly as ``_collect_option_value`` / ``check_required_when`` read absence.
+        """
+        missing: list[str] = []
+        for key, spec in property_mapping.items():
+            if not isinstance(spec, PropertySpec):
+                continue
+            if key == DefaultOptionKeys.in_features:
+                continue
+            if cls._can_skip_required_check(spec) is not False:
+                continue
+            if spec.deferred_binding is not False:
+                continue
+            absent = effective_options.get(key) is None and not (spec.allow_explicit_none and key in effective_options)
+            if absent:
+                missing.append(key)
+        return missing
+
+    @classmethod
+    def _check_name_path_required_presence(
+        cls,
+        owner_name: str | None,
+        feature_name: str | FeatureName,
+        effective_options: Options,
+        property_mapping: dict[str, PropertySpec],
+    ) -> bool:
+        """Warn-then-enforce the name-path required-presence rule (#769). False means non-match."""
+        mode = _name_path_presence_mode()
+        if mode == "off":
+            return True
+
+        missing = cls._name_path_missing_required_keys(effective_options, property_mapping)
+        if not missing:
+            return True
+
+        owner = owner_name or "A feature group"
+        keys = ", ".join(sorted(missing))
+        if mode == "enforce":
+            logger.warning(
+                "%s did not match feature '%s': required option(s) %s are absent after declared defaults and "
+                "name bindings (%s=enforce). Provide the option(s), add a named capture (?P<key>...), or set "
+                "deferred_binding=True on each key bound outside the name.",
+                owner,
+                feature_name,
+                keys,
+                _NAME_PATH_PRESENCE_ENV,
+            )
+            return False
+
+        logger.warning(
+            "%s matched feature '%s' on its name, but required option(s) %s are absent after declared defaults "
+            "and name bindings; they will become a non-match once %s=enforce. Add a named capture (?P<key>...) "
+            "so the name binds them, provide the option(s), or set deferred_binding=True on each key intentionally "
+            "bound outside the name.",
+            owner,
+            feature_name,
+            keys,
+            _NAME_PATH_PRESENCE_ENV,
+        )
+        return True
+
+    @classmethod
     def match_configuration_feature_chain_parser(
         cls,
         feature_name: str | FeatureName,
@@ -431,6 +510,7 @@ class FeatureChainParser:
         property_mapping: Optional[dict[str, PropertySpec]] = None,
         prefix_patterns: Optional[list[Any]] = None,
         pattern: str = CHAIN_SEPARATOR,
+        owner_name: str | None = None,
     ) -> bool:
         """
         Unified method for matching features using either configuration-based or pattern-based parsing.
@@ -461,6 +541,10 @@ class FeatureChainParser:
                     bindings = cls.bind_name_captures(parsed, property_mapping)
                     effective_options = cls._merge_bindings(options, bindings, property_mapping)
                     cls._validate_present_option_values(effective_options, property_mapping)
+                    if not cls._check_name_path_required_presence(
+                        owner_name, feature_name, effective_options, property_mapping
+                    ):
+                        return False
                 return True
 
         # configuration-based

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import contextvars
 import functools
 import logging
-import os
 import re
 from collections.abc import Callable
 from typing import Any, Optional
@@ -49,19 +48,6 @@ REQUIRED_WHEN_GUARD_DEPTH: contextvars.ContextVar[int] = contextvars.ContextVar(
 
 # Exception classes a user callable raises when it merely cannot judge a value.
 _EXPECTED_JUDGMENT_ERRORS: tuple[type[Exception], ...] = (TypeError, ValueError, AttributeError)
-
-# Name-path required-presence migration (#769): warn (default) / enforce / off.
-_NAME_PATH_PRESENCE_ENV = "MLODA_NAME_PATH_REQUIRED_PRESENCE"
-
-
-def _name_path_presence_mode() -> str:
-    """Read the #769 migration mode from the env var; off/0/false/no disable it, else warn (default) or enforce."""
-    mode = os.environ.get(_NAME_PATH_PRESENCE_ENV, "warn").strip().lower()
-    if mode in ("off", "0", "false", "no"):
-        return "off"
-    if mode == "enforce":
-        return "enforce"
-    return "warn"
 
 
 def _contained_raise_log_level(exc: BaseException) -> int:
@@ -471,59 +457,36 @@ class FeatureChainParser:
         effective_options: Options,
         property_mapping: dict[str, PropertySpec],
     ) -> bool:
-        """Warn-then-enforce the name-path required-presence rule (#769). False means non-match."""
-        mode = _name_path_presence_mode()
-        if mode == "off":
-            return True
-
+        """Enforce the name-path required-presence rule (#769). False means non-match."""
         missing = cls._name_path_missing_required_keys(effective_options, property_mapping)
         if not missing:
             return True
 
         owner = owner_name or "A feature group"
         keys = ", ".join(sorted(missing))
-        if mode == "enforce":
-            logger.warning(
-                "%s did not match feature '%s': required option(s) %s are absent after declared defaults and "
-                "name bindings (%s=enforce). Provide the option(s), add a named capture (?P<key>...), or set "
-                "deferred_binding=True on each key bound outside the name.",
-                owner,
-                feature_name,
-                keys,
-                _NAME_PATH_PRESENCE_ENV,
-            )
-            return False
-
         logger.warning(
-            "%s matched feature '%s' on its name, but required option(s) %s are absent after declared defaults "
-            "and name bindings; they will become a non-match once %s=enforce. Add a named capture (?P<key>...) "
-            "so the name binds them, provide the option(s), or set deferred_binding=True on each key intentionally "
-            "bound outside the name.",
+            "%s did not match feature '%s': required option(s) %s are absent after declared defaults and "
+            "name bindings. Provide the option(s), add a named capture (?P<key>...), or set "
+            "deferred_binding=True on each key bound outside the name.",
             owner,
             feature_name,
             keys,
-            _NAME_PATH_PRESENCE_ENV,
         )
-        return True
+        return False
 
     @classmethod
     def name_path_presence_rejection_reason(
         cls, effective_options: Options, property_mapping: dict[str, PropertySpec]
     ) -> str | None:
-        """Enforce-mode reason a name-path candidate was rejected for missing presence (#769); else None.
+        """The reason a name-path candidate was rejected for missing presence (#769); None when nothing is missing.
 
-        Diagnostic-only: mirrors the enforce branch of _check_name_path_required_presence so the
-        resolution-failure report explains the same non-match the matcher produced.
+        Diagnostic-only: mirrors _check_name_path_required_presence so the resolution-failure
+        report explains the same non-match the matcher produced.
         """
-        if _name_path_presence_mode() != "enforce":
-            return None
         missing = cls._name_path_missing_required_keys(effective_options, property_mapping)
         if not missing:
             return None
-        return (
-            f"required option(s) {', '.join(sorted(missing))} are absent after declared defaults and name "
-            f"bindings ({_NAME_PATH_PRESENCE_ENV}=enforce)"
-        )
+        return f"required option(s) {', '.join(sorted(missing))} are absent after declared defaults and name bindings"
 
     @classmethod
     def match_configuration_feature_chain_parser(
@@ -538,9 +501,10 @@ class FeatureChainParser:
         """
         Unified method for matching features using either configuration-based or pattern-based parsing.
 
-        Both paths validate the values of the present options; only required presence is enforced on the
-        configuration-based path alone. This raises on a rejected value, so an overridden
-        ``match_feature_group_criteria`` must reach it through ``FeatureChainParserMixin.match_parser_criteria``.
+        Both paths validate the values of the present options and enforce required presence; the
+        string-named path resolves declared defaults and name bindings first (#769). This raises on a
+        rejected value, so an overridden ``match_feature_group_criteria`` must reach it through
+        ``FeatureChainParserMixin.match_parser_criteria``.
 
         Args:
             feature_name: The feature name to match

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -55,9 +55,13 @@ _NAME_PATH_PRESENCE_ENV = "MLODA_NAME_PATH_REQUIRED_PRESENCE"
 
 
 def _name_path_presence_mode() -> str:
-    """Read the #769 migration mode from the env var, defaulting to ``"warn"`` on any invalid value."""
+    """Read the #769 migration mode from the env var; off/0/false/no disable it, else warn (default) or enforce."""
     mode = os.environ.get(_NAME_PATH_PRESENCE_ENV, "warn").strip().lower()
-    return mode if mode in ("off", "warn", "enforce") else "warn"
+    if mode in ("off", "0", "false", "no"):
+        return "off"
+    if mode == "enforce":
+        return "enforce"
+    return "warn"
 
 
 def _contained_raise_log_level(exc: BaseException) -> int:
@@ -437,7 +441,7 @@ class FeatureChainParser:
     def _name_path_missing_required_keys(
         cls, effective_options: Options, property_mapping: dict[str, PropertySpec]
     ) -> list[str]:
-        """Missing required keys on the name path, in mapping order (#769).
+        """The missing required keys on the name path (#769).
 
         The source key is name-provided (its count is enforced by MIN/MAX_IN_FEATURES), so
         ``in_features`` is excluded. A declared-default or ``required_when`` key is skippable
@@ -450,9 +454,9 @@ class FeatureChainParser:
                 continue
             if key == DefaultOptionKeys.in_features:
                 continue
-            if cls._can_skip_required_check(spec) is not False:
+            if cls._can_skip_required_check(spec):
                 continue
-            if spec.deferred_binding is not False:
+            if spec.deferred_binding:
                 continue
             absent = effective_options.get(key) is None and not (spec.allow_explicit_none and key in effective_options)
             if absent:
@@ -501,6 +505,25 @@ class FeatureChainParser:
             _NAME_PATH_PRESENCE_ENV,
         )
         return True
+
+    @classmethod
+    def name_path_presence_rejection_reason(
+        cls, effective_options: Options, property_mapping: dict[str, PropertySpec]
+    ) -> str | None:
+        """Enforce-mode reason a name-path candidate was rejected for missing presence (#769); else None.
+
+        Diagnostic-only: mirrors the enforce branch of _check_name_path_required_presence so the
+        resolution-failure report explains the same non-match the matcher produced.
+        """
+        if _name_path_presence_mode() != "enforce":
+            return None
+        missing = cls._name_path_missing_required_keys(effective_options, property_mapping)
+        if not missing:
+            return None
+        return (
+            f"required option(s) {', '.join(sorted(missing))} are absent after declared defaults and name "
+            f"bindings ({_NAME_PATH_PRESENCE_ENV}=enforce)"
+        )
 
     @classmethod
     def match_configuration_feature_chain_parser(

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -1033,7 +1033,8 @@ class FeatureChainParser:
         Mirrors ``install_required_when_guard``: installed at class definition from both
         ``__init_subclass__`` hooks, never wrapped twice, and guards nest so only the outermost one
         evaluates. An inner False stands untouched, so the inner path's own presence warning is never
-        duplicated. Installed before the required_when guard, which therefore stays outermost.
+        duplicated. Nesting order relative to the required_when guard is behaviorally irrelevant:
+        each guard ANDs its own predicate onto the inner verdict and passes False through unchanged.
         """
         property_mapping = getattr(owner, "PROPERTY_MAPPING", None)
         if not isinstance(property_mapping, dict):
@@ -1044,11 +1045,14 @@ class FeatureChainParser:
         if not cls._name_path_missing_required_keys(Options(), property_mapping):
             return
 
-        # The install condition is broad (any pattern class with an unconditionally required key), so a
-        # staticmethod matcher is skipped rather than rejected: a hard raise could break existing classes.
-        if cls._matcher_is_staticmethod(owner):
+        # Wrapping a staticmethod matcher would hide it from _reject_staticmethod_matcher, so the
+        # required_when installer's existing definition-time ValueError keeps precedence.
+        is_static = cls._matcher_is_staticmethod(owner)
+        if is_static and cls.has_required_when_predicates(property_mapping):
             return
 
+        # getattr on a staticmethod returns the plain function, so the __func__ fetch below is a no-op
+        # for it and the flag check covers both shapes.
         matcher = getattr(owner, "match_feature_group_criteria", None)
         if matcher is None:
             return
@@ -1062,9 +1066,11 @@ class FeatureChainParser:
             outermost = NAME_PATH_PRESENCE_GUARD_DEPTH.get() == 0
             token = NAME_PATH_PRESENCE_GUARD_DEPTH.set(NAME_PATH_PRESENCE_GUARD_DEPTH.get() + 1)
             try:
-                # An inner False stands: the inner default path already warned on its own presence
-                # non-match, so passing it through keeps one warning per match call.
-                if not inner(guarded_cls, *args, **kwargs):
+                # A staticmethod inner keeps its calling convention: no cls injected. An inner False
+                # stands: the inner default path already warned on its own presence non-match, so
+                # passing it through keeps one warning per match call.
+                inner_verdict = inner(*args, **kwargs) if is_static else inner(guarded_cls, *args, **kwargs)
+                if not inner_verdict:
                     return False
 
                 if not outermost:

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -127,6 +127,7 @@ class FeatureChainParserMixin:
         super().__init_subclass__(**kwargs)
         FeatureChainParser.validate_name_binding(cls)
         FeatureChainParser.warn_captureless_without_binding(cls)
+        FeatureChainParser.install_name_path_presence_guard(cls)
         FeatureChainParser.install_required_when_guard(cls)
         FeatureChainParser.warn_universal_optional_matcher(cls)
 

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -350,6 +350,11 @@ class FeatureChainParserMixin:
         except ValueError as exc:
             return str(exc)
 
+        if name_matched:
+            reason = FeatureChainParser.name_path_presence_rejection_reason(effective_options, property_mapping)
+            if reason is not None:
+                return reason
+
         rejection = cls._first_rejecting_guard(effective_options, property_mapping)
         if rejection is None:
             return None

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -10,8 +10,8 @@ They serve different purposes and run at different points in the pipeline.
 ``element_validator`` (``PropertySpec.element_validator``)
   - Requires ``strict_validation=True`` on the same spec.
   - Runs inside ``FeatureChainParser._validate_property_value`` on **both** match paths,
-    the configuration-based one and the string-named one. Only required *presence* is
-    config-based only, because a key encoded in the feature name is satisfied by the name.
+    the configuration-based one and the string-named one. Required *presence* holds on both
+    too; a key encoded in the feature name is satisfied by the name binding.
   - Receives **individual parsed elements** after list unpacking
     (``_process_found_property_value`` unpacks a sequence value into a list and
     iterates over each element).
@@ -335,9 +335,9 @@ class FeatureChainParserMixin:
 
         try:
             if name_matched:
-                # The name relates the feature group to the feature, so only the values of the present
-                # options (name-derived bindings included) are judged; required presence is the config
-                # path's business. Judging the effective options keeps the replay in step with the match.
+                # The name relates the feature group to the feature, so the values of the present
+                # options (name-derived bindings included) are judged here; the name-path presence
+                # reason follows below. Judging the effective options keeps the replay in step with the match.
                 FeatureChainParser._validate_present_option_values(effective_options, property_mapping)
             else:
                 matches_mapping = FeatureChainParser._validate_options_against_property_mapping(

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -292,6 +292,7 @@ class FeatureChainParserMixin:
                 options,
                 property_mapping=cls._get_property_mapping(),
                 prefix_patterns=cls._get_prefix_patterns(),
+                owner_name=cls.__name__,
             )
         except ValueError:
             return False

--- a/mloda/core/abstract_plugins/components/feature_chainer/property_spec.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/property_spec.py
@@ -84,6 +84,10 @@ class PropertySpec:
     match_guard: Callable[[Any], Any] | None = None
     required_when: Callable[[Any], Any] | None = None
     allow_explicit_none: bool = False
+    # Exempts a NO_DEFAULT key from the name-path required-presence check (#769): its value is bound
+    # outside match-time name capture (parsed from the name by the plugin, or supplied downstream).
+    # It does NOT change config-path requiredness.
+    deferred_binding: bool = False
 
     def __post_init__(self) -> None:
         prefix = f"PropertySpec({self.explanation!r})"
@@ -114,6 +118,9 @@ class PropertySpec:
             raise ValueError(
                 f"{prefix}: allow_explicit_none must be a bool, got {type(self.allow_explicit_none).__name__}."
             )
+
+        if not isinstance(self.deferred_binding, bool):
+            raise ValueError(f"{prefix}: deferred_binding must be a bool, got {type(self.deferred_binding).__name__}.")
 
         if self.element_validator is not None and not callable(self.element_validator):
             raise ValueError(f"{prefix}: element_validator must be callable.")
@@ -191,6 +198,7 @@ def property_spec(
     required_when: Callable[[Any], Any] | None = None,
     match_guard: Callable[[Any], Any] | None = None,
     allow_explicit_none: bool = False,
+    deferred_binding: bool = False,
 ) -> PropertySpec:
     """Build a ``PropertySpec``; the ``strict=`` keyword sets the ``strict_validation`` field."""
     return PropertySpec(
@@ -203,4 +211,5 @@ def property_spec(
         match_guard=match_guard,
         required_when=required_when,
         allow_explicit_none=allow_explicit_none,
+        deferred_binding=deferred_binding,
     )

--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -92,6 +92,7 @@ class FeatureGroup(ABC):
         FeatureChainParser.validate_property_mapping_defaults(cls.__name__, cls.PROPERTY_MAPPING)
         FeatureChainParser.validate_name_binding(cls)
         FeatureChainParser.warn_captureless_without_binding(cls)
+        FeatureChainParser.install_name_path_presence_guard(cls)
         FeatureChainParser.install_required_when_guard(cls)
         cls._validate_subtype_declaration()
 

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -261,7 +261,7 @@ def _render_none(result: EvaluationResult, feature: Feature, callout: str | None
 
     if result.facts.value_rejections:
         lines = "\n".join(f"  - {class_name}: {reason}" for class_name, reason in sorted(result.facts.value_rejections))
-        msg += f"\nFeature group(s) rejected an option value while matching '{feature_name}':\n{lines}"
+        msg += f"\nFeature group(s) rejected the supplied options while matching '{feature_name}':\n{lines}"
 
     similar = get_close_matches(feature_name, list(result.facts.known_names), n=5, cutoff=0.5)
     if similar:

--- a/mloda_plugins/feature_group/experimental/clustering/base.py
+++ b/mloda_plugins/feature_group/experimental/clustering/base.py
@@ -129,6 +129,7 @@ class ClusteringFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             context=True,
             strict_validation=True,
             element_validator=lambda value: value == "auto" or is_positive_int(value),
+            deferred_binding=True,  # parsed from the name by this group, not a framework-bound capture (#769)
         ),
         DefaultOptionKeys.in_features: PropertySpec(
             "Source features to use for clustering",

--- a/mloda_plugins/feature_group/experimental/dimensionality_reduction/base.py
+++ b/mloda_plugins/feature_group/experimental/dimensionality_reduction/base.py
@@ -131,6 +131,7 @@ class DimensionalityReductionFeatureGroup(FeatureChainParserMixin, FeatureGroup)
             context=True,
             strict_validation=True,
             element_validator=is_positive_int,
+            deferred_binding=True,  # parsed from the name by this group, not a framework-bound capture (#769)
         ),
         DefaultOptionKeys.in_features: PropertySpec(
             "Source features to use for dimensionality reduction",

--- a/mloda_plugins/feature_group/experimental/forecasting/base.py
+++ b/mloda_plugins/feature_group/experimental/forecasting/base.py
@@ -142,12 +142,14 @@ class ForecastingFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featu
             context=True,
             strict_validation=True,
             element_validator=is_positive_int,
+            deferred_binding=True,  # parsed from the name by this group, not a framework-bound capture (#769)
         ),
         TIME_UNIT: PropertySpec(
             "Time unit of the forecast horizon",
             allowed_values=TimeReferenceMixin.TIME_UNITS,
             context=True,
             strict_validation=True,
+            deferred_binding=True,
         ),
         DefaultOptionKeys.in_features: PropertySpec(
             "Source feature to generate forecasts for",

--- a/mloda_plugins/feature_group/experimental/text_cleaning/base.py
+++ b/mloda_plugins/feature_group/experimental/text_cleaning/base.py
@@ -104,6 +104,7 @@ class TextCleaningFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             strict_validation=True,
             # The option is a sequence of operations; core unpacks it, so this judges ONE operation.
             element_validator=lambda op: op in TextCleaningFeatureGroup.SUPPORTED_OPERATIONS,
+            deferred_binding=True,  # parsed from the name by this group, not a framework-bound capture (#769)
         ),
         DefaultOptionKeys.in_features: PropertySpec(
             "Source feature to apply text cleaning operations to",

--- a/mloda_plugins/feature_group/experimental/text_cleaning/base.py
+++ b/mloda_plugins/feature_group/experimental/text_cleaning/base.py
@@ -9,7 +9,6 @@ from typing import Any, Optional
 
 from mloda.provider import FeatureGroup
 from mloda.user import Feature
-from mloda.provider import FeatureChainParser
 from mloda.provider import (
     FeatureChainParserMixin,
 )
@@ -104,7 +103,6 @@ class TextCleaningFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             strict_validation=True,
             # The option is a sequence of operations; core unpacks it, so this judges ONE operation.
             element_validator=lambda op: op in TextCleaningFeatureGroup.SUPPORTED_OPERATIONS,
-            deferred_binding=True,  # parsed from the name by this group, not a framework-bound capture (#769)
         ),
         DefaultOptionKeys.in_features: PropertySpec(
             "Source feature to apply text cleaning operations to",
@@ -133,26 +131,7 @@ class TextCleaningFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 
     @classmethod
     def _extract_cleaning_operations(cls, feature: Feature) -> Optional[tuple[Any, Any]]:
-        """
-        Extract cleaning operations from a feature.
-
-        Tries string-based parsing first, falls back to configuration-based approach.
-
-        Args:
-            feature: The feature to extract operations from
-
-        Returns:
-            Tuple of cleaning operations, or None if not found
-        """
-        # Try string-based parsing first
-        feature_name_str = feature.name
-
-        if FeatureChainParser.is_chained_feature(feature_name_str):
-            # For string-based features, get operations from options
-            operations = feature.options.get(cls.CLEANING_OPERATIONS) or ()
-            return operations  # type: ignore
-
-        # Fall back to configuration-based approach
+        """Cleaning operations from feature options (both paths), or None when absent."""
         operations = feature.options.get(cls.CLEANING_OPERATIONS)
         return operations if operations is not None else None
 

--- a/mloda_plugins/feature_group/experimental/time_window/base.py
+++ b/mloda_plugins/feature_group/experimental/time_window/base.py
@@ -106,14 +106,12 @@ class TimeWindowFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featur
             context=True,
             strict_validation=True,
             element_validator=is_positive_int,
-            deferred_binding=True,  # parsed from the name by this group, not a framework-bound capture (#769)
         ),
         TIME_UNIT: PropertySpec(
             "Time unit of the window size",
             allowed_values=TimeReferenceMixin.TIME_UNITS,
             context=True,
             strict_validation=True,
-            deferred_binding=True,
         ),
         DefaultOptionKeys.in_features: PropertySpec(
             "Source feature to apply time window operation to",
@@ -122,8 +120,8 @@ class TimeWindowFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featur
         ),
     }
 
-    # Define the regex pattern for this feature group
-    PREFIX_PATTERN = r".*__([\w]+)_(\d+)_([\w]+)_window$"
+    # Named captures bind window_function/window_size/time_unit; core validates them at match time.
+    PREFIX_PATTERN = r".*__(?P<window_function>[\w]+)_(?P<window_size>\d+)_(?P<time_unit>[\w]+)_window$"
 
     # In-feature configuration for FeatureChainParserMixin
     MIN_IN_FEATURES = 1

--- a/mloda_plugins/feature_group/experimental/time_window/base.py
+++ b/mloda_plugins/feature_group/experimental/time_window/base.py
@@ -106,12 +106,14 @@ class TimeWindowFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featur
             context=True,
             strict_validation=True,
             element_validator=is_positive_int,
+            deferred_binding=True,  # parsed from the name by this group, not a framework-bound capture (#769)
         ),
         TIME_UNIT: PropertySpec(
             "Time unit of the window size",
             allowed_values=TimeReferenceMixin.TIME_UNITS,
             context=True,
             strict_validation=True,
+            deferred_binding=True,
         ),
         DefaultOptionKeys.in_features: PropertySpec(
             "Source feature to apply time window operation to",

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_captureless_no_binding.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_captureless_no_binding.py
@@ -97,8 +97,10 @@ class TestCapturelessStillIdentifiesGroup:
         assert FeatureChainParser._name_identifies_group(parsed, TextCleaningFeatureGroup.PROPERTY_MAPPING) is True
 
     def test_text_cleaning_match_criteria_still_true(self) -> None:
-        """The recognition predicate keeps claiming its chained name with no options at all."""
-        assert TextCleaningFeatureGroup.match_feature_group_criteria("review__cleaned_text", Options()) is True
+        """The recognition predicate keeps claiming its chained name once the option-required key is supplied."""
+        options = Options(context={TextCleaningFeatureGroup.CLEANING_OPERATIONS: ("normalize",)})
+
+        assert TextCleaningFeatureGroup.match_feature_group_criteria("review__cleaned_text", options) is True
 
     def test_optional_first_positional_group_does_not_identify(self) -> None:
         """A POSITIONAL optional-first group that did not participate still does NOT identify (unchanged)."""

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_name_path_presence_guard.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_name_path_presence_guard.py
@@ -103,6 +103,90 @@ class TestOverrideBypass:
         assert len(warnings) == 1, "one enforcement site per match call: exactly one presence warning"
 
 
+class TestStaticmethodOverrideBypass:
+    """A staticmethod matcher must be guarded too: wrapped without injecting cls, never skipped."""
+
+    def test_staticmethod_true_override_is_still_a_non_match(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Skipping staticmethod matchers reopens the bypass; the guard must reject and warn here too."""
+
+        class _StaticBypassR769pg6(FeatureChainParserMixin):
+            PREFIX_PATTERN = r".*__(?P<carried_r769pg6>\w+)$"
+            PROPERTY_MAPPING = {
+                "carried_r769pg6": PropertySpec("required, carried by the name", context=True),
+                "missing_r769pg6": PropertySpec("required, options-only, absent", context=True),
+            }
+
+            @staticmethod
+            def match_feature_group_criteria(
+                feature_name: str | FeatureName,
+                options: Options,
+                data_access_collection: Any = None,
+            ) -> bool:
+                return True
+
+        with caplog.at_level(logging.WARNING):
+            result = _StaticBypassR769pg6.match_feature_group_criteria("src__op_r769pg6", Options())
+
+        assert result is False, "a staticmethod True override must not bypass the presence rule"
+        warnings = _presence_warnings(caplog, "_StaticBypassR769pg6")
+        assert warnings, "the guarded non-match must warn, naming the class"
+        assert "missing_r769pg6" in warnings[0].getMessage(), "the warning must name the missing key"
+
+    def test_staticmethod_override_with_supplied_key_keeps_the_match(self, caplog: pytest.LogCaptureFixture) -> None:
+        """The wrapper must preserve the staticmethod's verdict and calling convention: match, no warning."""
+
+        class _StaticSatisfiedR769pg7(FeatureChainParserMixin):
+            PREFIX_PATTERN = r".*__(?P<carried_r769pg7>\w+)$"
+            PROPERTY_MAPPING = {
+                "carried_r769pg7": PropertySpec("required, carried by the name", context=True),
+                "present_r769pg7": PropertySpec("required, present in options", context=True),
+            }
+
+            @staticmethod
+            def match_feature_group_criteria(
+                feature_name: str | FeatureName,
+                options: Options,
+                data_access_collection: Any = None,
+            ) -> bool:
+                return True
+
+        with caplog.at_level(logging.WARNING):
+            result = _StaticSatisfiedR769pg7.match_feature_group_criteria(
+                "src__op_r769pg7", Options(context={"present_r769pg7": "v_r769pg7"})
+            )
+
+        assert result is True, "a satisfied required key must keep the staticmethod's match"
+        assert not _presence_warnings(caplog, "_StaticSatisfiedR769pg7")
+
+    def test_staticmethod_override_with_deferred_binding_keeps_the_match(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """``deferred_binding=True`` exempts the key for a staticmethod matcher exactly as for a classmethod."""
+
+        class _StaticDeferredR769pg8(FeatureChainParserMixin):
+            PREFIX_PATTERN = r".*__(?P<carried_r769pg8>\w+)$"
+            PROPERTY_MAPPING = {
+                "carried_r769pg8": PropertySpec("required, carried by the name", context=True),
+                "deferred_r769pg8": PropertySpec(
+                    "required but bound outside the name", context=True, deferred_binding=True
+                ),
+            }
+
+            @staticmethod
+            def match_feature_group_criteria(
+                feature_name: str | FeatureName,
+                options: Options,
+                data_access_collection: Any = None,
+            ) -> bool:
+                return True
+
+        with caplog.at_level(logging.WARNING):
+            result = _StaticDeferredR769pg8.match_feature_group_criteria("src__op_r769pg8", Options())
+
+        assert result is True, "deferred_binding=True must keep the staticmethod's match"
+        assert not _presence_warnings(caplog, "_StaticDeferredR769pg8")
+
+
 class TestGuardHonorsTheInnerRule:
     """The guard mirrors the inner rule: same exemptions, name-path only, no false rejections."""
 

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_name_path_presence_guard.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_name_path_presence_guard.py
@@ -1,0 +1,186 @@
+"""Name-path required-presence must survive a matcher override (issue #769 review).
+
+The rule is enforced inside ``FeatureChainParserMixin.match_parser_criteria``, so a provider that
+overrides ``match_feature_group_criteria`` and returns True WITHOUT delegating bypasses it entirely.
+Like ``required_when`` (``FeatureChainParser.install_required_when_guard``), the enforcement must be
+a definition-time wrapper around the matcher: it turns the bypass into a warned non-match, honors
+the same exemptions as the inner rule, applies only when the name identifies the group, and never
+duplicates the inner path's warning.
+
+Every fixture carries an "r769pg" marker in its class name and keys so it cannot collide with other
+feature groups in the global registry.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.provider import PropertySpec
+
+FEATURE_CHAIN_PARSER_LOGGER = "mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser"
+
+# The marker substring the presence warning is contractually required to contain.
+MARKER = "required option(s)"
+
+
+def _presence_warnings(caplog: pytest.LogCaptureFixture, class_name: str) -> list[logging.LogRecord]:
+    """One class's required-presence WARNINGs: logger name + WARNING level + marker + class name."""
+    return [
+        record
+        for record in caplog.records
+        if record.levelno == logging.WARNING
+        and record.name == FEATURE_CHAIN_PARSER_LOGGER
+        and MARKER in record.getMessage()
+        and class_name in record.getMessage()
+    ]
+
+
+class TestOverrideBypass:
+    """A non-delegating True override must not bypass the presence rule."""
+
+    def test_non_delegating_true_override_is_still_a_non_match(self, caplog: pytest.LogCaptureFixture) -> None:
+        """The override never reaches the inner rule, so the guard must reject and warn itself."""
+
+        class _BypassR769pg1(FeatureChainParserMixin):
+            PREFIX_PATTERN = r".*__(?P<carried_r769pg1>\w+)$"
+            PROPERTY_MAPPING = {
+                "carried_r769pg1": PropertySpec("required, carried by the name", context=True),
+                "missing_r769pg1": PropertySpec("required, options-only, absent", context=True),
+            }
+
+            @classmethod
+            def match_feature_group_criteria(
+                cls,
+                feature_name: str | FeatureName,
+                options: Options,
+                data_access_collection: Any = None,
+            ) -> bool:
+                return True
+
+        # Precondition: the missing key is unconditionally required and name-path relevant.
+        missing_spec = _BypassR769pg1.PROPERTY_MAPPING["missing_r769pg1"]
+        assert FeatureChainParser._can_skip_required_check(missing_spec) is False
+
+        with caplog.at_level(logging.WARNING):
+            result = _BypassR769pg1.match_feature_group_criteria("src__op_r769pg1", Options())
+
+        assert result is False, "a non-delegating True override must not bypass the presence rule"
+        warnings = _presence_warnings(caplog, "_BypassR769pg1")
+        assert warnings, "the guarded non-match must warn, naming the class"
+        assert "missing_r769pg1" in warnings[0].getMessage(), "the warning must name the missing key"
+
+    def test_delegating_override_warns_exactly_once(self, caplog: pytest.LogCaptureFixture) -> None:
+        """The inner path already warns on the delegated call; the guard must not add a second warning."""
+
+        class _DelegatingR769pg2(FeatureChainParserMixin):
+            PREFIX_PATTERN = r".*__(?P<carried_r769pg2>\w+)$"
+            PROPERTY_MAPPING = {
+                "carried_r769pg2": PropertySpec("required, carried by the name", context=True),
+                "missing_r769pg2": PropertySpec("required, options-only, absent", context=True),
+            }
+
+            @classmethod
+            def match_feature_group_criteria(
+                cls,
+                feature_name: str | FeatureName,
+                options: Options,
+                data_access_collection: Any = None,
+            ) -> bool:
+                return super().match_feature_group_criteria(feature_name, options, data_access_collection)
+
+        with caplog.at_level(logging.WARNING):
+            result = _DelegatingR769pg2.match_feature_group_criteria("src__op_r769pg2", Options())
+
+        assert result is False, "the delegated inner path rejects the missing required key"
+        warnings = _presence_warnings(caplog, "_DelegatingR769pg2")
+        assert len(warnings) == 1, "one enforcement site per match call: exactly one presence warning"
+
+
+class TestGuardHonorsTheInnerRule:
+    """The guard mirrors the inner rule: same exemptions, name-path only, no false rejections."""
+
+    def test_deferred_binding_keeps_the_override_verdict(self, caplog: pytest.LogCaptureFixture) -> None:
+        """``deferred_binding=True`` exempts the key inside the guard exactly as inside the inner rule."""
+
+        class _DeferredBypassR769pg3(FeatureChainParserMixin):
+            PREFIX_PATTERN = r".*__(?P<carried_r769pg3>\w+)$"
+            PROPERTY_MAPPING = {
+                "carried_r769pg3": PropertySpec("required, carried by the name", context=True),
+                "deferred_r769pg3": PropertySpec(
+                    "required but bound outside the name", context=True, deferred_binding=True
+                ),
+            }
+
+            @classmethod
+            def match_feature_group_criteria(
+                cls,
+                feature_name: str | FeatureName,
+                options: Options,
+                data_access_collection: Any = None,
+            ) -> bool:
+                return True
+
+        with caplog.at_level(logging.WARNING):
+            result = _DeferredBypassR769pg3.match_feature_group_criteria("src__op_r769pg3", Options())
+
+        assert result is True, "deferred_binding=True must keep the override's match"
+        assert not _presence_warnings(caplog, "_DeferredBypassR769pg3")
+
+    def test_guard_applies_only_when_the_name_identifies_the_group(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A name no pattern matches is not on the name path: the override's True stands."""
+
+        class _NamePathOnlyR769pg4(FeatureChainParserMixin):
+            PREFIX_PATTERN = r".*__(?P<carried_r769pg4>\w+)$"
+            PROPERTY_MAPPING = {
+                "carried_r769pg4": PropertySpec("required, carried by the name", context=True),
+                "missing_r769pg4": PropertySpec("required, options-only, absent", context=True),
+            }
+
+            @classmethod
+            def match_feature_group_criteria(
+                cls,
+                feature_name: str | FeatureName,
+                options: Options,
+                data_access_collection: Any = None,
+            ) -> bool:
+                return True
+
+        with caplog.at_level(logging.WARNING):
+            result = _NamePathOnlyR769pg4.match_feature_group_criteria("plain_feature_r769pg4", Options())
+
+        assert result is True, "the presence rule is name-path only; the guard must not flip the verdict"
+        assert not _presence_warnings(caplog, "_NamePathOnlyR769pg4")
+
+    def test_supplied_required_key_keeps_the_match(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A required key present in options satisfies the guard: match, no warning."""
+
+        class _SatisfiedBypassR769pg5(FeatureChainParserMixin):
+            PREFIX_PATTERN = r".*__(?P<carried_r769pg5>\w+)$"
+            PROPERTY_MAPPING = {
+                "carried_r769pg5": PropertySpec("required, carried by the name", context=True),
+                "present_r769pg5": PropertySpec("required, present in options", context=True),
+            }
+
+            @classmethod
+            def match_feature_group_criteria(
+                cls,
+                feature_name: str | FeatureName,
+                options: Options,
+                data_access_collection: Any = None,
+            ) -> bool:
+                return True
+
+        with caplog.at_level(logging.WARNING):
+            result = _SatisfiedBypassR769pg5.match_feature_group_criteria(
+                "src__op_r769pg5", Options(context={"present_r769pg5": "v_r769pg5"})
+            )
+
+        assert result is True, "a satisfied required key must keep the override's match"
+        assert not _presence_warnings(caplog, "_SatisfiedBypassR769pg5")

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_name_path_required_presence.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_name_path_required_presence.py
@@ -1,0 +1,657 @@
+"""Name-path required-presence, warn-then-enforce migration (issue #769).
+
+Historically the STRING-NAMED match path never enforced required presence: a key with no declared
+default and no ``required_when`` could be absent and the feature still matched, as long as the name
+identified the group. The config-based path always enforced it. #769 closes that gap on the name path
+behind a warn-then-enforce migration mechanism, with a per-key opt-out (``PropertySpec.deferred_binding``).
+
+Mode is read from the env var ``MLODA_NAME_PATH_REQUIRED_PRESENCE`` (case-insensitive):
+
+- unset OR ``"warn"`` (DEFAULT) -> WARN: a missing required key still MATCHES but logs a WARNING.
+- ``"enforce"``                 -> ENFORCE: a missing required key becomes a NON-MATCH (and warns).
+- ``"off"``                     -> the check is disabled: no warning, no enforcement (kill-switch).
+- any other/invalid value       -> treated as WARN.
+
+A "required, name-path-relevant" key is one where ``FeatureChainParser._can_skip_required_check(spec)``
+is False (no declared default AND no ``required_when``) AND ``spec.deferred_binding`` is False. A key is
+"missing" when, after name bindings are merged into effective options, its option value is absent (None,
+honoring ``allow_explicit_none``). Declared-default keys and ``required_when`` keys are NOT flagged by this
+check (``required_when`` has its own guard).
+
+Contract details pinned here:
+- The warning names the feature group class and each missing key, and mentions both the
+  ``deferred_binding`` opt-out and the ``MLODA_NAME_PATH_REQUIRED_PRESENCE`` env var.
+- ``deferred_binding=True`` silences the warning (warn) and keeps the match (enforce) for that key.
+- The config-based path is UNCHANGED: a required key absent there is still a non-match in every mode,
+  and ``deferred_binding=True`` does NOT exempt it on the config path.
+- ``required_when`` gating is owned by its own guard, not by this check.
+
+Every fixture carries an "r769" marker in its class name, keys, and values so it cannot collide with
+other feature groups in the global registry. Warnings are filtered by the feature_chain_parser logger
+name + WARNING level + the ``MLODA_NAME_PATH_REQUIRED_PRESENCE`` marker substring, exactly like the
+sibling universal-matcher and forwarded-mismatch suites filter theirs.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.provider import PropertySpec
+from mloda.user import Options
+from mloda_plugins.feature_group.experimental.aggregated_feature_group.base import AggregatedFeatureGroup
+from mloda_plugins.feature_group.experimental.time_window.base import TimeWindowFeatureGroup
+
+FEATURE_CHAIN_PARSER_LOGGER = "mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser"
+
+ENV_VAR = "MLODA_NAME_PATH_REQUIRED_PRESENCE"
+
+# A name the fixture patterns recognize: "<source>__<capture>". The capture binds the "carried" key.
+NAME_PATH_FEATURE = "src__val_r769"
+# A separator-free name no fixture pattern captures, so it falls through to the configuration path.
+CONFIG_PATH_FEATURE = "config_only_r769"
+
+
+def _required_presence_warnings(
+    caplog: pytest.LogCaptureFixture, class_name: str | None = None
+) -> list[logging.LogRecord]:
+    """The #769 name-path required-presence WARNINGs, optionally scoped to one class name.
+
+    Filters by logger name, WARNING level, and the env-var marker substring the warning is contractually
+    required to mention, mirroring how the sibling suites scope their diagnostics.
+    """
+    records = [
+        record
+        for record in caplog.records
+        if record.levelno == logging.WARNING
+        and record.name == FEATURE_CHAIN_PARSER_LOGGER
+        and ENV_VAR in record.getMessage()
+    ]
+    if class_name is not None:
+        records = [record for record in records if class_name in record.getMessage()]
+    return records
+
+
+class TestWarnMode:
+    """WARN mode (default): a missing required key still matches, but the gap is announced."""
+
+    def test_missing_required_key_matches_but_warns(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Case 1: default (unset) mode -> the name-path match returns True and logs a naming WARNING."""
+        monkeypatch.delenv(ENV_VAR, raising=False)  # unset == warn
+
+        class _WarnMissingR769a(FeatureChainParserMixin):
+            PREFIX_PATTERN = r".*__(?P<carried_r769a>\w+)$"
+            PROPERTY_MAPPING = {
+                "carried_r769a": PropertySpec("required, carried by the name", context=True),
+                "missing_r769a": PropertySpec("required, options-only, absent", context=True),
+            }
+
+        # Preconditions: the missing key is unconditionally required and name-path relevant.
+        missing_spec = _WarnMissingR769a.PROPERTY_MAPPING["missing_r769a"]
+        assert FeatureChainParser._can_skip_required_check(missing_spec) is False
+
+        with caplog.at_level(logging.WARNING):
+            result = _WarnMissingR769a.match_feature_group_criteria(NAME_PATH_FEATURE, Options())
+
+        assert result is True, "warn mode must not change the verdict: the name match still succeeds"
+        warnings = _required_presence_warnings(caplog, "_WarnMissingR769a")
+        assert warnings, "warn mode must log a required-presence warning naming the class"
+        message = warnings[0].getMessage()
+        assert "missing_r769a" in message, "the warning must name the missing key"
+        assert "deferred_binding" in message, "the warning must mention the deferred_binding opt-out"
+        assert ENV_VAR in message, "the warning must mention the migration env var"
+
+    def test_all_satisfied_no_warning(self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+        """Case 2: no warning when every required key is satisfied by name/default/required_when/options."""
+        monkeypatch.delenv(ENV_VAR, raising=False)
+
+        class _WarnSatisfiedR769b(FeatureChainParserMixin):
+            PREFIX_PATTERN = r".*__(?P<carried_r769b>\w+)$"
+            PROPERTY_MAPPING = {
+                # required, satisfied by the name binding
+                "carried_r769b": PropertySpec("carried by the name", context=True),
+                # declared default -> optional, never flagged
+                "defaulted_r769b": PropertySpec("has a declared default", context=True, default="d_r769"),
+                # required_when -> owned by its own guard, not this check
+                "cond_r769b": PropertySpec(
+                    "conditionally required", context=True, default=None, required_when=lambda o: False
+                ),
+                # required, explicitly present in options
+                "present_r769b": PropertySpec("required, present in options", context=True),
+            }
+
+        with caplog.at_level(logging.WARNING):
+            result = _WarnSatisfiedR769b.match_feature_group_criteria(
+                NAME_PATH_FEATURE, Options(context={"present_r769b": "x_r769"})
+            )
+
+        assert result is True
+        assert not _required_presence_warnings(caplog, "_WarnSatisfiedR769b"), (
+            "no key is missing, so nothing must be warned"
+        )
+
+    def test_deferred_binding_silences_warning(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Case 3: ``deferred_binding=True`` on the otherwise-missing required key silences the warning.
+
+        Pre-implementation this fixture raises ``TypeError`` at construction (``deferred_binding`` is not
+        yet a PropertySpec field): the expected Part-A-surfacing failure.
+        """
+        monkeypatch.delenv(ENV_VAR, raising=False)
+
+        class _WarnDeferredR769c(FeatureChainParserMixin):
+            PREFIX_PATTERN = r".*__(?P<carried_r769c>\w+)$"
+            PROPERTY_MAPPING = {
+                "carried_r769c": PropertySpec("carried by the name", context=True),
+                "deferred_r769c": PropertySpec(
+                    "required but opted out of the name-path check", context=True, deferred_binding=True
+                ),
+            }
+
+        with caplog.at_level(logging.WARNING):
+            result = _WarnDeferredR769c.match_feature_group_criteria(NAME_PATH_FEATURE, Options())
+
+        assert result is True
+        assert not _required_presence_warnings(caplog, "_WarnDeferredR769c"), (
+            "deferred_binding=True must silence the required-presence warning"
+        )
+
+    def test_multiple_missing_keys_all_named_in_warning(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Case 6 (warn): the warning identifies ALL missing required keys, not just the first."""
+        monkeypatch.delenv(ENV_VAR, raising=False)
+
+        class _WarnMultiR769f(FeatureChainParserMixin):
+            PREFIX_PATTERN = r".*__(?P<carried_r769f>\w+)$"
+            PROPERTY_MAPPING = {
+                "carried_r769f": PropertySpec("carried by the name", context=True),
+                "missing_one_r769f": PropertySpec("required, absent", context=True),
+                "missing_two_r769f": PropertySpec("required, absent", context=True),
+            }
+
+        with caplog.at_level(logging.WARNING):
+            result = _WarnMultiR769f.match_feature_group_criteria(NAME_PATH_FEATURE, Options())
+
+        assert result is True
+        warnings = _required_presence_warnings(caplog, "_WarnMultiR769f")
+        assert warnings, "a multi-missing name-path match must warn"
+        rendered = " ".join(record.getMessage() for record in warnings)
+        assert "missing_one_r769f" in rendered
+        assert "missing_two_r769f" in rendered
+
+    def test_explicit_warn_value_warns(self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+        """The explicit value ``"warn"`` behaves exactly like the unset default."""
+        monkeypatch.setenv(ENV_VAR, "warn")
+
+        class _ExplicitWarnR769w(FeatureChainParserMixin):
+            PREFIX_PATTERN = r".*__(?P<carried_r769w>\w+)$"
+            PROPERTY_MAPPING = {
+                "carried_r769w": PropertySpec("carried by the name", context=True),
+                "missing_r769w": PropertySpec("required, absent", context=True),
+            }
+
+        with caplog.at_level(logging.WARNING):
+            result = _ExplicitWarnR769w.match_feature_group_criteria(NAME_PATH_FEATURE, Options())
+
+        assert result is True
+        assert _required_presence_warnings(caplog, "_ExplicitWarnR769w"), "explicit 'warn' must warn"
+
+    def test_invalid_env_value_behaves_like_warn(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Case 9: an unrecognized value (e.g. ``"banana"``) falls back to warn behavior."""
+        monkeypatch.setenv(ENV_VAR, "banana")
+
+        class _InvalidEnvR769(FeatureChainParserMixin):
+            PREFIX_PATTERN = r".*__(?P<carried_r769inv>\w+)$"
+            PROPERTY_MAPPING = {
+                "carried_r769inv": PropertySpec("carried by the name", context=True),
+                "missing_r769inv": PropertySpec("required, absent", context=True),
+            }
+
+        with caplog.at_level(logging.WARNING):
+            result = _InvalidEnvR769.match_feature_group_criteria(NAME_PATH_FEATURE, Options())
+
+        assert result is True, "an invalid value must not enforce"
+        assert _required_presence_warnings(caplog, "_InvalidEnvR769"), "an invalid value must warn"
+
+
+class TestEnforceMode:
+    """ENFORCE mode: a missing required key on the name path becomes a non-match (and still warns)."""
+
+    def test_missing_required_key_is_non_match(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Case 4: env=enforce turns the same missing-required-key name-path match into False + a WARNING."""
+        monkeypatch.setenv(ENV_VAR, "enforce")
+
+        class _EnforceMissingR769d(FeatureChainParserMixin):
+            PREFIX_PATTERN = r".*__(?P<carried_r769d>\w+)$"
+            PROPERTY_MAPPING = {
+                "carried_r769d": PropertySpec("required, carried by the name", context=True),
+                "missing_r769d": PropertySpec("required, options-only, absent", context=True),
+            }
+
+        with caplog.at_level(logging.WARNING):
+            result = _EnforceMissingR769d.match_feature_group_criteria(NAME_PATH_FEATURE, Options())
+
+        assert result is False, "enforce mode must reject a name-path match with a missing required key"
+        warnings = _required_presence_warnings(caplog, "_EnforceMissingR769d")
+        assert warnings, "enforce mode must still name the class and missing key"
+        assert "missing_r769d" in warnings[0].getMessage()
+
+    def test_deferred_binding_still_matches(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Case 4 (deferred): ``deferred_binding=True`` matches even under enforce.
+
+        Pre-implementation this raises ``TypeError`` at construction (unknown ``deferred_binding``).
+        """
+        monkeypatch.setenv(ENV_VAR, "enforce")
+
+        class _EnforceDeferredR769de(FeatureChainParserMixin):
+            PREFIX_PATTERN = r".*__(?P<carried_r769de>\w+)$"
+            PROPERTY_MAPPING = {
+                "carried_r769de": PropertySpec("carried by the name", context=True),
+                "deferred_r769de": PropertySpec("required but opted out", context=True, deferred_binding=True),
+            }
+
+        with caplog.at_level(logging.WARNING):
+            result = _EnforceDeferredR769de.match_feature_group_criteria(NAME_PATH_FEATURE, Options())
+
+        assert result is True, "deferred_binding=True must keep the match even under enforce"
+        assert not _required_presence_warnings(caplog, "_EnforceDeferredR769de")
+
+    def test_present_key_matches(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Case 4 (present): a required key present in options matches under enforce."""
+        monkeypatch.setenv(ENV_VAR, "enforce")
+
+        class _EnforcePresentR769e(FeatureChainParserMixin):
+            PREFIX_PATTERN = r".*__(?P<carried_r769e>\w+)$"
+            PROPERTY_MAPPING = {
+                "carried_r769e": PropertySpec("carried by the name", context=True),
+                "present_r769e": PropertySpec("required, present in options", context=True),
+            }
+
+        result = _EnforcePresentR769e.match_feature_group_criteria(
+            NAME_PATH_FEATURE, Options(context={"present_r769e": "y_r769"})
+        )
+
+        assert result is True
+
+    def test_name_bound_key_matches(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Case 4 (name-bound): a required key satisfied purely by the name binding matches under enforce."""
+        monkeypatch.setenv(ENV_VAR, "enforce")
+
+        class _EnforceNameBoundR769j(FeatureChainParserMixin):
+            PREFIX_PATTERN = r".*__(?P<carried_r769j>\w+)$"
+            PROPERTY_MAPPING = {
+                "carried_r769j": PropertySpec("required, carried by the name", context=True),
+            }
+
+        result = _EnforceNameBoundR769j.match_feature_group_criteria(NAME_PATH_FEATURE, Options())
+
+        assert result is True, "a name-bound required key is satisfied by the name, so enforce still matches"
+
+    def test_multiple_missing_keys_all_named_in_rejection(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Case 6 (enforce): the rejection warning identifies ALL missing required keys."""
+        monkeypatch.setenv(ENV_VAR, "enforce")
+
+        class _EnforceMultiR769em(FeatureChainParserMixin):
+            PREFIX_PATTERN = r".*__(?P<carried_r769em>\w+)$"
+            PROPERTY_MAPPING = {
+                "carried_r769em": PropertySpec("carried by the name", context=True),
+                "missing_one_r769em": PropertySpec("required, absent", context=True),
+                "missing_two_r769em": PropertySpec("required, absent", context=True),
+            }
+
+        with caplog.at_level(logging.WARNING):
+            result = _EnforceMultiR769em.match_feature_group_criteria(NAME_PATH_FEATURE, Options())
+
+        assert result is False
+        warnings = _required_presence_warnings(caplog, "_EnforceMultiR769em")
+        assert warnings, "an enforced multi-missing rejection must warn"
+        rendered = " ".join(record.getMessage() for record in warnings)
+        assert "missing_one_r769em" in rendered
+        assert "missing_two_r769em" in rendered
+
+    def test_enforce_is_case_insensitive(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The mode read is case-insensitive: ``"ENFORCE"`` enforces exactly like ``"enforce"``."""
+        monkeypatch.setenv(ENV_VAR, "ENFORCE")
+
+        class _EnforceCaseR769ci(FeatureChainParserMixin):
+            PREFIX_PATTERN = r".*__(?P<carried_r769ci>\w+)$"
+            PROPERTY_MAPPING = {
+                "carried_r769ci": PropertySpec("carried by the name", context=True),
+                "missing_r769ci": PropertySpec("required, absent", context=True),
+            }
+
+        with caplog.at_level(logging.WARNING):
+            result = _EnforceCaseR769ci.match_feature_group_criteria(NAME_PATH_FEATURE, Options())
+
+        assert result is False, "the mode value must be matched case-insensitively"
+        assert _required_presence_warnings(caplog, "_EnforceCaseR769ci")
+
+
+class TestOffMode:
+    """OFF mode: the check is a real kill-switch: no warning, no enforcement."""
+
+    def test_missing_required_key_matches_no_warning(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Case 5: env=off -> the missing-required-key name-path match returns True and logs no warning."""
+        monkeypatch.setenv(ENV_VAR, "off")
+
+        class _OffMissingR769o(FeatureChainParserMixin):
+            PREFIX_PATTERN = r".*__(?P<carried_r769o>\w+)$"
+            PROPERTY_MAPPING = {
+                "carried_r769o": PropertySpec("carried by the name", context=True),
+                "missing_r769o": PropertySpec("required, absent", context=True),
+            }
+
+        with caplog.at_level(logging.WARNING):
+            result = _OffMissingR769o.match_feature_group_criteria(NAME_PATH_FEATURE, Options())
+
+        assert result is True, "off mode must not enforce"
+        assert not _required_presence_warnings(caplog, "_OffMissingR769o"), "off mode must not warn"
+
+    def test_off_is_case_insensitive(self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+        """``"OFF"`` disables the check exactly like ``"off"``."""
+        monkeypatch.setenv(ENV_VAR, "OFF")
+
+        class _OffCaseR769oc(FeatureChainParserMixin):
+            PREFIX_PATTERN = r".*__(?P<carried_r769oc>\w+)$"
+            PROPERTY_MAPPING = {
+                "carried_r769oc": PropertySpec("carried by the name", context=True),
+                "missing_r769oc": PropertySpec("required, absent", context=True),
+            }
+
+        with caplog.at_level(logging.WARNING):
+            result = _OffCaseR769oc.match_feature_group_criteria(NAME_PATH_FEATURE, Options())
+
+        assert result is True
+        assert not _required_presence_warnings(caplog, "_OffCaseR769oc")
+
+
+class TestConfigPathUnchanged:
+    """Turning the name path on must not touch the config path's long-standing required-presence rule."""
+
+    def test_config_path_rejects_missing_required_all_modes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Case 7: a NO_DEFAULT key absent on the config path is a non-match in every mode."""
+
+        class _ConfigReqR769g(FeatureChainParserMixin):
+            PREFIX_PATTERN = r".*__(?P<carried_r769g>\w+)$"
+            PROPERTY_MAPPING = {
+                "carried_r769g": PropertySpec("bound by the name on the name path", context=True),
+                "req_r769g": PropertySpec("required, options-only", context=True),
+            }
+
+        for mode in (None, "warn", "enforce", "off"):
+            if mode is None:
+                monkeypatch.delenv(ENV_VAR, raising=False)
+            else:
+                monkeypatch.setenv(ENV_VAR, mode)
+            # CONFIG_PATH_FEATURE carries no separator, so the name never identifies the group: the
+            # config path decides, and req_r769g (NO_DEFAULT) is absent -> non-match, whatever the mode.
+            result = _ConfigReqR769g.match_feature_group_criteria(
+                CONFIG_PATH_FEATURE, Options(context={"carried_r769g": "x_r769"})
+            )
+            assert result is False, f"config-path required presence must hold in mode {mode!r}"
+
+    def test_deferred_binding_does_not_exempt_config_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Case 7 (deferred): ``deferred_binding=True`` exempts only the name path, never the config path.
+
+        Pre-implementation this raises ``TypeError`` at construction (unknown ``deferred_binding``).
+        """
+        monkeypatch.setenv(ENV_VAR, "warn")
+
+        class _ConfigDeferredR769gd(FeatureChainParserMixin):
+            PREFIX_PATTERN = r".*__(?P<carried_r769gd>\w+)$"
+            PROPERTY_MAPPING = {
+                "carried_r769gd": PropertySpec("bound by the name on the name path", context=True),
+                "req_deferred_r769gd": PropertySpec(
+                    "required, deferred on the name path only", context=True, deferred_binding=True
+                ),
+            }
+
+        result = _ConfigDeferredR769gd.match_feature_group_criteria(
+            CONFIG_PATH_FEATURE, Options(context={"carried_r769gd": "x_r769"})
+        )
+
+        assert result is False, "deferred_binding must not exempt the required key on the config path"
+
+    def test_name_path_warns_where_config_path_rejects(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Case 7 (contrast): same fixture, same missing key -> name path warns-and-matches, config path rejects."""
+        monkeypatch.delenv(ENV_VAR, raising=False)  # warn
+
+        class _ContrastR769h(FeatureChainParserMixin):
+            PREFIX_PATTERN = r".*__(?P<carried_r769h>\w+)$"
+            PROPERTY_MAPPING = {
+                "carried_r769h": PropertySpec("bound by the name / provided on the config path", context=True),
+                "req_only_r769h": PropertySpec("required, options-only, absent", context=True),
+            }
+
+        with caplog.at_level(logging.WARNING):
+            name_result = _ContrastR769h.match_feature_group_criteria(NAME_PATH_FEATURE, Options())
+            config_result = _ContrastR769h.match_feature_group_criteria(
+                CONFIG_PATH_FEATURE, Options(context={"carried_r769h": "x_r769"})
+            )
+
+        assert name_result is True, "the name path (warn mode) still matches despite the missing key"
+        assert config_result is False, "the config path rejects the same missing required key"
+        warnings = _required_presence_warnings(caplog, "_ContrastR769h")
+        assert warnings, "the name-path match must have warned about the missing key"
+        assert "req_only_r769h" in warnings[0].getMessage()
+
+
+class TestRequiredWhenInterplay:
+    """A required_when-only gating is owned by its own guard, never by the #769 name-path check."""
+
+    def test_required_when_only_not_warned_in_warn_mode(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Case 8 (warn): a group whose only requirement is a required_when predicate is not warned."""
+        monkeypatch.delenv(ENV_VAR, raising=False)
+
+        class _ReqWhenWarnR769i(FeatureChainParserMixin):
+            PREFIX_PATTERN = r".*__(?P<carried_r769i>\w+)$"
+            PROPERTY_MAPPING = {
+                "carried_r769i": PropertySpec("optional, carried by the name", context=True, default=None),
+                "cond_r769i": PropertySpec(
+                    "required only when trigger is present",
+                    context=True,
+                    default=None,
+                    required_when=lambda o: o.get("trigger_r769i") is not None,
+                ),
+            }
+
+        with caplog.at_level(logging.WARNING):
+            result = _ReqWhenWarnR769i.match_feature_group_criteria(NAME_PATH_FEATURE, Options())
+
+        assert result is True
+        assert not _required_presence_warnings(caplog, "_ReqWhenWarnR769i"), (
+            "required_when is owned by its own guard, not by the name-path required-presence check"
+        )
+
+    def test_required_when_only_not_enforced_in_enforce_mode(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Case 8 (enforce): the same required_when-only group matches under enforce and is not warned."""
+        monkeypatch.setenv(ENV_VAR, "enforce")
+
+        class _ReqWhenEnforceR769ie(FeatureChainParserMixin):
+            PREFIX_PATTERN = r".*__(?P<carried_r769ie>\w+)$"
+            PROPERTY_MAPPING = {
+                "carried_r769ie": PropertySpec("optional, carried by the name", context=True, default=None),
+                "cond_r769ie": PropertySpec(
+                    "required only when trigger is present",
+                    context=True,
+                    default=None,
+                    required_when=lambda o: o.get("trigger_r769ie") is not None,
+                ),
+            }
+
+        with caplog.at_level(logging.WARNING):
+            result = _ReqWhenEnforceR769ie.match_feature_group_criteria(NAME_PATH_FEATURE, Options())
+
+        assert result is True, "a required_when that does not fire must not be enforced by the #769 check"
+        assert not _required_presence_warnings(caplog, "_ReqWhenEnforceR769ie")
+
+
+class TestInFeaturesExcluded:
+    """The name-path check must EXCLUDE ``DefaultOptionKeys.in_features``.
+
+    On the name path the source features come from the name prefix (the ``src`` in ``src__op``), so
+    the ``in_features`` key is name-satisfied, never missing. All 12 shipped plugins declare
+    ``in_features`` as a NO_DEFAULT spec, so without this exclusion every shipped plugin would falsely
+    warn on every name-path match. These guards pin the behavior the Green phase must produce: the
+    in_features key stays silent while a genuine missing key is still reported.
+    """
+
+    def test_warn_mode_in_features_not_reported_missing(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """WARN mode: op captured + in_features excluded -> match True and NO presence warning."""
+        monkeypatch.delenv(ENV_VAR, raising=False)  # warn
+
+        class _InFeaturesExcludedR769inf(FeatureChainParserMixin, FeatureGroup):
+            PREFIX_PATTERN = r".*__(\w+)_r769inf$"
+            PROPERTY_MAPPING = {
+                "op_r769inf": PropertySpec(
+                    "operation carried by the positional capture",
+                    allowed_values=("op",),
+                    context=True,
+                    strict_validation=True,
+                ),
+                DefaultOptionKeys.in_features: PropertySpec("source", context=True, strict_validation=False),
+            }
+
+        # Precondition: in_features is unconditionally required as a spec, so the exclusion is what keeps
+        # it quiet, not a declared default.
+        in_features_spec = _InFeaturesExcludedR769inf.PROPERTY_MAPPING[DefaultOptionKeys.in_features]
+        assert FeatureChainParser._can_skip_required_check(in_features_spec) is False
+
+        with caplog.at_level(logging.WARNING):
+            result = _InFeaturesExcludedR769inf.match_feature_group_criteria("src__op_r769inf", Options())
+
+        assert result is True
+        warnings = _required_presence_warnings(caplog, "_InFeaturesExcludedR769inf")
+        assert not warnings, "in_features is name-satisfied by the source prefix and must never be flagged"
+
+    def test_enforce_mode_in_features_not_enforced(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """ENFORCE mode: op captured + in_features excluded -> still a match (no missing key)."""
+        monkeypatch.setenv(ENV_VAR, "enforce")
+
+        class _InFeaturesEnforcedR769inf(FeatureChainParserMixin, FeatureGroup):
+            PREFIX_PATTERN = r".*__(\w+)_r769inf$"
+            PROPERTY_MAPPING = {
+                "op_r769inf": PropertySpec(
+                    "operation carried by the positional capture",
+                    allowed_values=("op",),
+                    context=True,
+                    strict_validation=True,
+                ),
+                DefaultOptionKeys.in_features: PropertySpec("source", context=True, strict_validation=False),
+            }
+
+        result = _InFeaturesEnforcedR769inf.match_feature_group_criteria("src__op_r769inf", Options())
+
+        assert result is True, "in_features is excluded, so enforce mode still matches a name-path feature"
+
+    def test_in_features_silent_while_genuine_missing_key_warns(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Contrast: a genuine missing key (not in_features, not deferred) still warns; in_features stays silent."""
+        monkeypatch.delenv(ENV_VAR, raising=False)  # warn
+
+        class _InFeaturesContrastR769inf2(FeatureChainParserMixin, FeatureGroup):
+            PREFIX_PATTERN = r".*__(\w+)_r769inf2$"
+            PROPERTY_MAPPING = {
+                "op_r769inf2": PropertySpec(
+                    "operation carried by the positional capture",
+                    allowed_values=("op",),
+                    context=True,
+                    strict_validation=True,
+                ),
+                DefaultOptionKeys.in_features: PropertySpec("source", context=True, strict_validation=False),
+                "genuine_missing_r769inf2": PropertySpec("required, not captured, absent", context=True),
+            }
+
+        with caplog.at_level(logging.WARNING):
+            result = _InFeaturesContrastR769inf2.match_feature_group_criteria("src__op_r769inf2", Options())
+
+        assert result is True
+        warnings = _required_presence_warnings(caplog, "_InFeaturesContrastR769inf2")
+        assert warnings, "a genuine missing required key must still warn"
+        rendered = " ".join(record.getMessage() for record in warnings)
+        assert "genuine_missing_r769inf2" in rendered, "the genuine missing key must be named"
+        assert "in_features" not in rendered, "in_features is name-satisfied and must never be reported missing"
+
+
+class TestShippedPluginsClean:
+    """Shipped plugins stay clean on the name path once the #769 migration lands.
+
+    These guards pin the end state: the ``in_features`` exclusion plus the per-plugin
+    ``deferred_binding`` marks keep representative shipped plugins from falsely warning on a plain
+    name-path match. The white-box asserts pin the core migration (deferred marks) directly; they error
+    with AttributeError until ``PropertySpec.deferred_binding`` exists.
+    """
+
+    def test_aggregated_feature_group_name_match_is_clean(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """WARN mode: AggregatedFeatureGroup matches a string name with no presence warning.
+
+        Its only otherwise-flaggable key is in_features, which the exclusion keeps quiet.
+        """
+        monkeypatch.delenv(ENV_VAR, raising=False)  # warn
+
+        with caplog.at_level(logging.WARNING):
+            result = AggregatedFeatureGroup.match_feature_group_criteria("sales__sum_aggr", Options())
+
+        assert result is True
+        assert not _required_presence_warnings(caplog, "AggregatedFeatureGroup"), (
+            "in_features exclusion must keep AggregatedFeatureGroup clean on the name path"
+        )
+
+    def test_time_window_feature_group_name_match_is_clean(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """WARN mode: TimeWindowFeatureGroup matches a string name with no presence warning.
+
+        window_size/time_unit are marked deferred_binding by Green and in_features is excluded, so the
+        name-only match reports nothing.
+        """
+        monkeypatch.delenv(ENV_VAR, raising=False)  # warn
+
+        with caplog.at_level(logging.WARNING):
+            result = TimeWindowFeatureGroup.match_feature_group_criteria("temperature__avg_7_days_window", Options())
+
+        assert result is True
+        assert not _required_presence_warnings(caplog, "TimeWindowFeatureGroup"), (
+            "deferred_binding + in_features exclusion must keep TimeWindowFeatureGroup clean on the name path"
+        )
+
+    def test_time_window_deferred_binding_marks_are_present(self) -> None:
+        """White-box: the core migration marks window_size and time_unit as deferred_binding.
+
+        Pre-implementation this errors (``PropertySpec`` has no ``deferred_binding`` attribute yet): the
+        expected pre-implementation state.
+        """
+        assert TimeWindowFeatureGroup.PROPERTY_MAPPING["window_size"].deferred_binding is True
+        assert TimeWindowFeatureGroup.PROPERTY_MAPPING["time_unit"].deferred_binding is True

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_name_path_required_presence.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_name_path_required_presence.py
@@ -400,20 +400,20 @@ class TestShippedPluginsClean:
         )
 
     def test_time_window_feature_group_name_match_is_clean(self, caplog: pytest.LogCaptureFixture) -> None:
-        """TimeWindowFeatureGroup matches a string name with no presence warning.
+        """TimeWindowFeatureGroup matches a valid string name with no presence warning.
 
-        window_size/time_unit are deferred_binding and in_features is excluded, so the name-only
-        match reports nothing.
+        window_function/window_size/time_unit are name-bound via named captures and in_features is
+        excluded, so the name-only match reports nothing.
         """
         with caplog.at_level(logging.WARNING):
-            result = TimeWindowFeatureGroup.match_feature_group_criteria("temperature__avg_7_days_window", Options())
+            result = TimeWindowFeatureGroup.match_feature_group_criteria("temperature__avg_7_day_window", Options())
 
         assert result is True
         assert not _required_presence_warnings(caplog, "TimeWindowFeatureGroup"), (
-            "deferred_binding + in_features exclusion must keep TimeWindowFeatureGroup clean on the name path"
+            "name-bound captures + in_features exclusion must keep TimeWindowFeatureGroup clean on the name path"
         )
 
-    def test_time_window_deferred_binding_marks_are_present(self) -> None:
-        """White-box: window_size and time_unit carry the deferred_binding mark."""
-        assert TimeWindowFeatureGroup.PROPERTY_MAPPING["window_size"].deferred_binding is True
-        assert TimeWindowFeatureGroup.PROPERTY_MAPPING["time_unit"].deferred_binding is True
+    def test_time_window_binds_name_values_instead_of_deferring(self) -> None:
+        """White-box: window_size and time_unit are name-bound, not deferred_binding."""
+        assert TimeWindowFeatureGroup.PROPERTY_MAPPING["window_size"].deferred_binding is False
+        assert TimeWindowFeatureGroup.PROPERTY_MAPPING["time_unit"].deferred_binding is False

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_name_path_required_presence.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_name_path_required_presence.py
@@ -1,35 +1,20 @@
-"""Name-path required-presence, warn-then-enforce migration (issue #769).
+"""Name-path required-presence is mandatory (issue #769).
 
-Historically the STRING-NAMED match path never enforced required presence: a key with no declared
-default and no ``required_when`` could be absent and the feature still matched, as long as the name
-identified the group. The config-based path always enforced it. #769 closes that gap on the name path
-behind a warn-then-enforce migration mechanism, with a per-key opt-out (``PropertySpec.deferred_binding``).
+A feature that matches on its NAME while a required option key is absent (after declared defaults
+and name-capture bindings resolve) is a NON-MATCH. The check is unconditional: there is no warn
+mode, no off mode, and the env var ``MLODA_NAME_PATH_REQUIRED_PRESENCE`` is ignored entirely.
 
-Mode is read from the env var ``MLODA_NAME_PATH_REQUIRED_PRESENCE`` (case-insensitive):
+On the non-match a WARNING names the owning feature group, the feature name, and every missing key;
+it references no env var and no mode. Warnings are filtered by the feature_chain_parser logger name
++ WARNING level + the contractual ``required option(s)`` marker substring.
 
-- unset OR ``"warn"`` (DEFAULT) -> WARN: a missing required key still MATCHES but logs a WARNING.
-- ``"enforce"``                 -> ENFORCE: a missing required key becomes a NON-MATCH (and warns).
-- ``"off"``                     -> the check is disabled: no warning, no enforcement (kill-switch).
-- any other/invalid value       -> treated as WARN.
-
-A "required, name-path-relevant" key is one where ``FeatureChainParser._can_skip_required_check(spec)``
-is False (no declared default AND no ``required_when``) AND ``spec.deferred_binding`` is False. A key is
-"missing" when, after name bindings are merged into effective options, its option value is absent (None,
-honoring ``allow_explicit_none``). Declared-default keys and ``required_when`` keys are NOT flagged by this
-check (``required_when`` has its own guard).
-
-Contract details pinned here:
-- The warning names the feature group class and each missing key, and mentions both the
-  ``deferred_binding`` opt-out and the ``MLODA_NAME_PATH_REQUIRED_PRESENCE`` env var.
-- ``deferred_binding=True`` silences the warning (warn) and keeps the match (enforce) for that key.
-- The config-based path is UNCHANGED: a required key absent there is still a non-match in every mode,
-  and ``deferred_binding=True`` does NOT exempt it on the config path.
-- ``required_when`` gating is owned by its own guard, not by this check.
+Exemptions (unchanged): a declared default, ``required_when`` (owned by its own guard), the source
+key ``in_features`` (name-satisfied), ``deferred_binding=True``, a key bound by a named capture
+``(?P<key>...)``, and an ``allow_explicit_none`` key present as None. The config path is unchanged:
+a missing required key is a plain non-match there and ``deferred_binding`` does NOT exempt it.
 
 Every fixture carries an "r769" marker in its class name, keys, and values so it cannot collide with
-other feature groups in the global registry. Warnings are filtered by the feature_chain_parser logger
-name + WARNING level + the ``MLODA_NAME_PATH_REQUIRED_PRESENCE`` marker substring, exactly like the
-sibling universal-matcher and forwarded-mismatch suites filter theirs.
+other feature groups in the global registry.
 """
 
 from __future__ import annotations
@@ -49,7 +34,11 @@ from mloda_plugins.feature_group.experimental.time_window.base import TimeWindow
 
 FEATURE_CHAIN_PARSER_LOGGER = "mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser"
 
+# Retired: tests only set it to prove it is ignored, and assert it never appears in messages.
 ENV_VAR = "MLODA_NAME_PATH_REQUIRED_PRESENCE"
+
+# The marker substring the non-match warning is contractually required to contain.
+MARKER = "required option(s)"
 
 # A name the fixture patterns recognize: "<source>__<capture>". The capture binds the "carried" key.
 NAME_PATH_FEATURE = "src__val_r769"
@@ -60,117 +49,70 @@ CONFIG_PATH_FEATURE = "config_only_r769"
 def _required_presence_warnings(
     caplog: pytest.LogCaptureFixture, class_name: str | None = None
 ) -> list[logging.LogRecord]:
-    """The #769 name-path required-presence WARNINGs, optionally scoped to one class name.
+    """The name-path required-presence WARNINGs, optionally scoped to one class name.
 
-    Filters by logger name, WARNING level, and the env-var marker substring the warning is contractually
-    required to mention, mirroring how the sibling suites scope their diagnostics.
+    Filters by logger name, WARNING level, and the ``required option(s)`` marker substring the
+    warning is contractually required to contain.
     """
     records = [
         record
         for record in caplog.records
         if record.levelno == logging.WARNING
         and record.name == FEATURE_CHAIN_PARSER_LOGGER
-        and ENV_VAR in record.getMessage()
+        and MARKER in record.getMessage()
     ]
     if class_name is not None:
         records = [record for record in records if class_name in record.getMessage()]
     return records
 
 
-class TestWarnMode:
-    """WARN mode (default): a missing required key still matches, but the gap is announced."""
+class TestMandatoryEnforcement:
+    """A missing required key on the name path is a non-match, unconditionally."""
 
-    def test_missing_required_key_matches_but_warns(
-        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """Case 1: default (unset) mode -> the name-path match returns True and logs a naming WARNING."""
-        monkeypatch.delenv(ENV_VAR, raising=False)  # unset == warn
+    def test_missing_required_key_is_non_match(self) -> None:
+        """The name identifies the group, one required key is absent -> match returns False."""
 
-        class _WarnMissingR769a(FeatureChainParserMixin):
+        class _MissingR769a(FeatureChainParserMixin):
             PREFIX_PATTERN = r".*__(?P<carried_r769a>\w+)$"
             PROPERTY_MAPPING = {
                 "carried_r769a": PropertySpec("required, carried by the name", context=True),
                 "missing_r769a": PropertySpec("required, options-only, absent", context=True),
             }
 
-        # Preconditions: the missing key is unconditionally required and name-path relevant.
-        missing_spec = _WarnMissingR769a.PROPERTY_MAPPING["missing_r769a"]
+        # Precondition: the missing key is unconditionally required and name-path relevant.
+        missing_spec = _MissingR769a.PROPERTY_MAPPING["missing_r769a"]
         assert FeatureChainParser._can_skip_required_check(missing_spec) is False
 
-        with caplog.at_level(logging.WARNING):
-            result = _WarnMissingR769a.match_feature_group_criteria(NAME_PATH_FEATURE, Options())
+        result = _MissingR769a.match_feature_group_criteria(NAME_PATH_FEATURE, Options())
 
-        assert result is True, "warn mode must not change the verdict: the name match still succeeds"
-        warnings = _required_presence_warnings(caplog, "_WarnMissingR769a")
-        assert warnings, "warn mode must log a required-presence warning naming the class"
-        message = warnings[0].getMessage()
-        assert "missing_r769a" in message, "the warning must name the missing key"
-        assert "deferred_binding" in message, "the warning must mention the deferred_binding opt-out"
-        assert ENV_VAR in message, "the warning must mention the migration env var"
+        assert result is False, "a missing required key on the name path must be a non-match"
 
-    def test_all_satisfied_no_warning(self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
-        """Case 2: no warning when every required key is satisfied by name/default/required_when/options."""
-        monkeypatch.delenv(ENV_VAR, raising=False)
+    def test_non_match_warning_names_group_feature_and_keys(self, caplog: pytest.LogCaptureFixture) -> None:
+        """The non-match WARNING names the class, the feature name, and the missing key; no env var, no mode."""
 
-        class _WarnSatisfiedR769b(FeatureChainParserMixin):
+        class _WarnedR769b(FeatureChainParserMixin):
             PREFIX_PATTERN = r".*__(?P<carried_r769b>\w+)$"
             PROPERTY_MAPPING = {
-                # required, satisfied by the name binding
-                "carried_r769b": PropertySpec("carried by the name", context=True),
-                # declared default -> optional, never flagged
-                "defaulted_r769b": PropertySpec("has a declared default", context=True, default="d_r769"),
-                # required_when -> owned by its own guard, not this check
-                "cond_r769b": PropertySpec(
-                    "conditionally required", context=True, default=None, required_when=lambda o: False
-                ),
-                # required, explicitly present in options
-                "present_r769b": PropertySpec("required, present in options", context=True),
+                "carried_r769b": PropertySpec("required, carried by the name", context=True),
+                "missing_r769b": PropertySpec("required, options-only, absent", context=True),
             }
 
         with caplog.at_level(logging.WARNING):
-            result = _WarnSatisfiedR769b.match_feature_group_criteria(
-                NAME_PATH_FEATURE, Options(context={"present_r769b": "x_r769"})
-            )
+            result = _WarnedR769b.match_feature_group_criteria(NAME_PATH_FEATURE, Options())
 
-        assert result is True
-        assert not _required_presence_warnings(caplog, "_WarnSatisfiedR769b"), (
-            "no key is missing, so nothing must be warned"
-        )
+        warnings = _required_presence_warnings(caplog, "_WarnedR769b")
+        assert warnings, "the non-match must be announced with a WARNING naming the class"
+        message = warnings[0].getMessage()
+        assert NAME_PATH_FEATURE in message, "the warning must name the feature"
+        assert "missing_r769b" in message, "the warning must name the missing key"
+        assert ENV_VAR not in message, "the warning must not reference the retired env var"
+        assert "mode" not in message, "the warning must not reference any mode"
+        assert result is False, "the warning accompanies the non-match, it does not replace it"
 
-    def test_deferred_binding_silences_warning(
-        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """Case 3: ``deferred_binding=True`` on the otherwise-missing required key silences the warning.
+    def test_multiple_missing_keys_all_named(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Every missing required key is a non-match reason and every one is named in the warning."""
 
-        Pre-implementation this fixture raises ``TypeError`` at construction (``deferred_binding`` is not
-        yet a PropertySpec field): the expected Part-A-surfacing failure.
-        """
-        monkeypatch.delenv(ENV_VAR, raising=False)
-
-        class _WarnDeferredR769c(FeatureChainParserMixin):
-            PREFIX_PATTERN = r".*__(?P<carried_r769c>\w+)$"
-            PROPERTY_MAPPING = {
-                "carried_r769c": PropertySpec("carried by the name", context=True),
-                "deferred_r769c": PropertySpec(
-                    "required but opted out of the name-path check", context=True, deferred_binding=True
-                ),
-            }
-
-        with caplog.at_level(logging.WARNING):
-            result = _WarnDeferredR769c.match_feature_group_criteria(NAME_PATH_FEATURE, Options())
-
-        assert result is True
-        assert not _required_presence_warnings(caplog, "_WarnDeferredR769c"), (
-            "deferred_binding=True must silence the required-presence warning"
-        )
-
-    def test_multiple_missing_keys_all_named_in_warning(
-        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """Case 6 (warn): the warning identifies ALL missing required keys, not just the first."""
-        monkeypatch.delenv(ENV_VAR, raising=False)
-
-        class _WarnMultiR769f(FeatureChainParserMixin):
+        class _MultiR769f(FeatureChainParserMixin):
             PREFIX_PATTERN = r".*__(?P<carried_r769f>\w+)$"
             PROPERTY_MAPPING = {
                 "carried_r769f": PropertySpec("carried by the name", context=True),
@@ -179,296 +121,122 @@ class TestWarnMode:
             }
 
         with caplog.at_level(logging.WARNING):
-            result = _WarnMultiR769f.match_feature_group_criteria(NAME_PATH_FEATURE, Options())
+            result = _MultiR769f.match_feature_group_criteria(NAME_PATH_FEATURE, Options())
 
-        assert result is True
-        warnings = _required_presence_warnings(caplog, "_WarnMultiR769f")
-        assert warnings, "a multi-missing name-path match must warn"
+        assert result is False, "multiple missing required keys must be a non-match"
+        warnings = _required_presence_warnings(caplog, "_MultiR769f")
+        assert warnings, "the multi-missing non-match must warn"
         rendered = " ".join(record.getMessage() for record in warnings)
         assert "missing_one_r769f" in rendered
         assert "missing_two_r769f" in rendered
 
-    def test_explicit_warn_value_warns(self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
-        """The explicit value ``"warn"`` behaves exactly like the unset default."""
-        monkeypatch.setenv(ENV_VAR, "warn")
+    def test_all_required_keys_satisfied_matches_without_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """No warning and a match when every required key is satisfied by name/default/required_when/options."""
 
-        class _ExplicitWarnR769w(FeatureChainParserMixin):
-            PREFIX_PATTERN = r".*__(?P<carried_r769w>\w+)$"
+        class _SatisfiedR769c(FeatureChainParserMixin):
+            PREFIX_PATTERN = r".*__(?P<carried_r769c>\w+)$"
             PROPERTY_MAPPING = {
-                "carried_r769w": PropertySpec("carried by the name", context=True),
-                "missing_r769w": PropertySpec("required, absent", context=True),
+                # required, satisfied by the name binding
+                "carried_r769c": PropertySpec("carried by the name", context=True),
+                # declared default -> optional, never flagged
+                "defaulted_r769c": PropertySpec("has a declared default", context=True, default="d_r769"),
+                # required_when -> owned by its own guard, not this check
+                "cond_r769c": PropertySpec(
+                    "conditionally required", context=True, default=None, required_when=lambda o: False
+                ),
+                # required, explicitly present in options
+                "present_r769c": PropertySpec("required, present in options", context=True),
             }
 
         with caplog.at_level(logging.WARNING):
-            result = _ExplicitWarnR769w.match_feature_group_criteria(NAME_PATH_FEATURE, Options())
+            result = _SatisfiedR769c.match_feature_group_criteria(
+                NAME_PATH_FEATURE, Options(context={"present_r769c": "x_r769"})
+            )
 
         assert result is True
-        assert _required_presence_warnings(caplog, "_ExplicitWarnR769w"), "explicit 'warn' must warn"
+        assert not _required_presence_warnings(caplog, "_SatisfiedR769c"), "no key is missing, so nothing is warned"
 
-    def test_invalid_env_value_behaves_like_warn(
-        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """Case 9: an unrecognized value (e.g. ``"banana"``) falls back to warn behavior."""
-        monkeypatch.setenv(ENV_VAR, "banana")
+    def test_present_key_matches(self) -> None:
+        """A required key present in options satisfies the check."""
 
-        class _InvalidEnvR769(FeatureChainParserMixin):
-            PREFIX_PATTERN = r".*__(?P<carried_r769inv>\w+)$"
-            PROPERTY_MAPPING = {
-                "carried_r769inv": PropertySpec("carried by the name", context=True),
-                "missing_r769inv": PropertySpec("required, absent", context=True),
-            }
-
-        with caplog.at_level(logging.WARNING):
-            result = _InvalidEnvR769.match_feature_group_criteria(NAME_PATH_FEATURE, Options())
-
-        assert result is True, "an invalid value must not enforce"
-        assert _required_presence_warnings(caplog, "_InvalidEnvR769"), "an invalid value must warn"
-
-
-class TestEnforceMode:
-    """ENFORCE mode: a missing required key on the name path becomes a non-match (and still warns)."""
-
-    def test_missing_required_key_is_non_match(
-        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """Case 4: env=enforce turns the same missing-required-key name-path match into False + a WARNING."""
-        monkeypatch.setenv(ENV_VAR, "enforce")
-
-        class _EnforceMissingR769d(FeatureChainParserMixin):
-            PREFIX_PATTERN = r".*__(?P<carried_r769d>\w+)$"
-            PROPERTY_MAPPING = {
-                "carried_r769d": PropertySpec("required, carried by the name", context=True),
-                "missing_r769d": PropertySpec("required, options-only, absent", context=True),
-            }
-
-        with caplog.at_level(logging.WARNING):
-            result = _EnforceMissingR769d.match_feature_group_criteria(NAME_PATH_FEATURE, Options())
-
-        assert result is False, "enforce mode must reject a name-path match with a missing required key"
-        warnings = _required_presence_warnings(caplog, "_EnforceMissingR769d")
-        assert warnings, "enforce mode must still name the class and missing key"
-        assert "missing_r769d" in warnings[0].getMessage()
-
-    def test_deferred_binding_still_matches(
-        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """Case 4 (deferred): ``deferred_binding=True`` matches even under enforce.
-
-        Pre-implementation this raises ``TypeError`` at construction (unknown ``deferred_binding``).
-        """
-        monkeypatch.setenv(ENV_VAR, "enforce")
-
-        class _EnforceDeferredR769de(FeatureChainParserMixin):
-            PREFIX_PATTERN = r".*__(?P<carried_r769de>\w+)$"
-            PROPERTY_MAPPING = {
-                "carried_r769de": PropertySpec("carried by the name", context=True),
-                "deferred_r769de": PropertySpec("required but opted out", context=True, deferred_binding=True),
-            }
-
-        with caplog.at_level(logging.WARNING):
-            result = _EnforceDeferredR769de.match_feature_group_criteria(NAME_PATH_FEATURE, Options())
-
-        assert result is True, "deferred_binding=True must keep the match even under enforce"
-        assert not _required_presence_warnings(caplog, "_EnforceDeferredR769de")
-
-    def test_present_key_matches(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Case 4 (present): a required key present in options matches under enforce."""
-        monkeypatch.setenv(ENV_VAR, "enforce")
-
-        class _EnforcePresentR769e(FeatureChainParserMixin):
+        class _PresentR769e(FeatureChainParserMixin):
             PREFIX_PATTERN = r".*__(?P<carried_r769e>\w+)$"
             PROPERTY_MAPPING = {
                 "carried_r769e": PropertySpec("carried by the name", context=True),
                 "present_r769e": PropertySpec("required, present in options", context=True),
             }
 
-        result = _EnforcePresentR769e.match_feature_group_criteria(
+        result = _PresentR769e.match_feature_group_criteria(
             NAME_PATH_FEATURE, Options(context={"present_r769e": "y_r769"})
         )
 
         assert result is True
 
-    def test_name_bound_key_matches(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Case 4 (name-bound): a required key satisfied purely by the name binding matches under enforce."""
-        monkeypatch.setenv(ENV_VAR, "enforce")
+    def test_name_bound_key_matches(self) -> None:
+        """A required key satisfied purely by a named capture from the feature name matches."""
 
-        class _EnforceNameBoundR769j(FeatureChainParserMixin):
+        class _NameBoundR769j(FeatureChainParserMixin):
             PREFIX_PATTERN = r".*__(?P<carried_r769j>\w+)$"
             PROPERTY_MAPPING = {
                 "carried_r769j": PropertySpec("required, carried by the name", context=True),
             }
 
-        result = _EnforceNameBoundR769j.match_feature_group_criteria(NAME_PATH_FEATURE, Options())
+        result = _NameBoundR769j.match_feature_group_criteria(NAME_PATH_FEATURE, Options())
 
-        assert result is True, "a name-bound required key is satisfied by the name, so enforce still matches"
+        assert result is True, "a name-bound required key is satisfied by the name"
 
-    def test_multiple_missing_keys_all_named_in_rejection(
-        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+
+class TestEnvVarIgnored:
+    """MLODA_NAME_PATH_REQUIRED_PRESENCE is retired: no value changes the mandatory non-match."""
+
+    @pytest.mark.parametrize("env_value", ["off", "OFF", "0", "false", "no", "warn", "enforce", "banana"])
+    def test_env_value_does_not_change_the_verdict(
+        self, env_value: str, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """Case 6 (enforce): the rejection warning identifies ALL missing required keys."""
-        monkeypatch.setenv(ENV_VAR, "enforce")
+        """Former modes, off aliases, and garbage values all change nothing: still a warned non-match."""
+        monkeypatch.setenv(ENV_VAR, env_value)
 
-        class _EnforceMultiR769em(FeatureChainParserMixin):
-            PREFIX_PATTERN = r".*__(?P<carried_r769em>\w+)$"
+        class _EnvIgnoredR769env(FeatureChainParserMixin):
+            PREFIX_PATTERN = r".*__(?P<carried_r769env>\w+)$"
             PROPERTY_MAPPING = {
-                "carried_r769em": PropertySpec("carried by the name", context=True),
-                "missing_one_r769em": PropertySpec("required, absent", context=True),
-                "missing_two_r769em": PropertySpec("required, absent", context=True),
+                "carried_r769env": PropertySpec("required, carried by the name", context=True),
+                "missing_r769env": PropertySpec("required, options-only, absent", context=True),
             }
 
         with caplog.at_level(logging.WARNING):
-            result = _EnforceMultiR769em.match_feature_group_criteria(NAME_PATH_FEATURE, Options())
+            result = _EnvIgnoredR769env.match_feature_group_criteria(NAME_PATH_FEATURE, Options())
 
-        assert result is False
-        warnings = _required_presence_warnings(caplog, "_EnforceMultiR769em")
-        assert warnings, "an enforced multi-missing rejection must warn"
-        rendered = " ".join(record.getMessage() for record in warnings)
-        assert "missing_one_r769em" in rendered
-        assert "missing_two_r769em" in rendered
+        assert result is False, f"env value {env_value!r} must be ignored: the non-match is mandatory"
+        warnings = _required_presence_warnings(caplog, "_EnvIgnoredR769env")
+        assert warnings, f"env value {env_value!r} must not silence the non-match warning"
+        assert "missing_r769env" in warnings[0].getMessage()
 
-    def test_enforce_is_case_insensitive(
-        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """The mode read is case-insensitive: ``"ENFORCE"`` enforces exactly like ``"enforce"``."""
-        monkeypatch.setenv(ENV_VAR, "ENFORCE")
 
-        class _EnforceCaseR769ci(FeatureChainParserMixin):
-            PREFIX_PATTERN = r".*__(?P<carried_r769ci>\w+)$"
+class TestExemptionsUnchanged:
+    """The documented exemptions keep the match and stay silent."""
+
+    def test_deferred_binding_key_matches_without_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """``deferred_binding=True`` exempts the key on the name path: match, no warning."""
+
+        class _DeferredR769d(FeatureChainParserMixin):
+            PREFIX_PATTERN = r".*__(?P<carried_r769d>\w+)$"
             PROPERTY_MAPPING = {
-                "carried_r769ci": PropertySpec("carried by the name", context=True),
-                "missing_r769ci": PropertySpec("required, absent", context=True),
-            }
-
-        with caplog.at_level(logging.WARNING):
-            result = _EnforceCaseR769ci.match_feature_group_criteria(NAME_PATH_FEATURE, Options())
-
-        assert result is False, "the mode value must be matched case-insensitively"
-        assert _required_presence_warnings(caplog, "_EnforceCaseR769ci")
-
-
-class TestOffMode:
-    """OFF mode: the check is a real kill-switch: no warning, no enforcement."""
-
-    def test_missing_required_key_matches_no_warning(
-        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """Case 5: env=off -> the missing-required-key name-path match returns True and logs no warning."""
-        monkeypatch.setenv(ENV_VAR, "off")
-
-        class _OffMissingR769o(FeatureChainParserMixin):
-            PREFIX_PATTERN = r".*__(?P<carried_r769o>\w+)$"
-            PROPERTY_MAPPING = {
-                "carried_r769o": PropertySpec("carried by the name", context=True),
-                "missing_r769o": PropertySpec("required, absent", context=True),
-            }
-
-        with caplog.at_level(logging.WARNING):
-            result = _OffMissingR769o.match_feature_group_criteria(NAME_PATH_FEATURE, Options())
-
-        assert result is True, "off mode must not enforce"
-        assert not _required_presence_warnings(caplog, "_OffMissingR769o"), "off mode must not warn"
-
-    def test_off_is_case_insensitive(self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
-        """``"OFF"`` disables the check exactly like ``"off"``."""
-        monkeypatch.setenv(ENV_VAR, "OFF")
-
-        class _OffCaseR769oc(FeatureChainParserMixin):
-            PREFIX_PATTERN = r".*__(?P<carried_r769oc>\w+)$"
-            PROPERTY_MAPPING = {
-                "carried_r769oc": PropertySpec("carried by the name", context=True),
-                "missing_r769oc": PropertySpec("required, absent", context=True),
-            }
-
-        with caplog.at_level(logging.WARNING):
-            result = _OffCaseR769oc.match_feature_group_criteria(NAME_PATH_FEATURE, Options())
-
-        assert result is True
-        assert not _required_presence_warnings(caplog, "_OffCaseR769oc")
-
-
-class TestConfigPathUnchanged:
-    """Turning the name path on must not touch the config path's long-standing required-presence rule."""
-
-    def test_config_path_rejects_missing_required_all_modes(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Case 7: a NO_DEFAULT key absent on the config path is a non-match in every mode."""
-
-        class _ConfigReqR769g(FeatureChainParserMixin):
-            PREFIX_PATTERN = r".*__(?P<carried_r769g>\w+)$"
-            PROPERTY_MAPPING = {
-                "carried_r769g": PropertySpec("bound by the name on the name path", context=True),
-                "req_r769g": PropertySpec("required, options-only", context=True),
-            }
-
-        for mode in (None, "warn", "enforce", "off"):
-            if mode is None:
-                monkeypatch.delenv(ENV_VAR, raising=False)
-            else:
-                monkeypatch.setenv(ENV_VAR, mode)
-            # CONFIG_PATH_FEATURE carries no separator, so the name never identifies the group: the
-            # config path decides, and req_r769g (NO_DEFAULT) is absent -> non-match, whatever the mode.
-            result = _ConfigReqR769g.match_feature_group_criteria(
-                CONFIG_PATH_FEATURE, Options(context={"carried_r769g": "x_r769"})
-            )
-            assert result is False, f"config-path required presence must hold in mode {mode!r}"
-
-    def test_deferred_binding_does_not_exempt_config_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Case 7 (deferred): ``deferred_binding=True`` exempts only the name path, never the config path.
-
-        Pre-implementation this raises ``TypeError`` at construction (unknown ``deferred_binding``).
-        """
-        monkeypatch.setenv(ENV_VAR, "warn")
-
-        class _ConfigDeferredR769gd(FeatureChainParserMixin):
-            PREFIX_PATTERN = r".*__(?P<carried_r769gd>\w+)$"
-            PROPERTY_MAPPING = {
-                "carried_r769gd": PropertySpec("bound by the name on the name path", context=True),
-                "req_deferred_r769gd": PropertySpec(
-                    "required, deferred on the name path only", context=True, deferred_binding=True
+                "carried_r769d": PropertySpec("carried by the name", context=True),
+                "deferred_r769d": PropertySpec(
+                    "required but bound outside the name", context=True, deferred_binding=True
                 ),
             }
 
-        result = _ConfigDeferredR769gd.match_feature_group_criteria(
-            CONFIG_PATH_FEATURE, Options(context={"carried_r769gd": "x_r769"})
-        )
-
-        assert result is False, "deferred_binding must not exempt the required key on the config path"
-
-    def test_name_path_warns_where_config_path_rejects(
-        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """Case 7 (contrast): same fixture, same missing key -> name path warns-and-matches, config path rejects."""
-        monkeypatch.delenv(ENV_VAR, raising=False)  # warn
-
-        class _ContrastR769h(FeatureChainParserMixin):
-            PREFIX_PATTERN = r".*__(?P<carried_r769h>\w+)$"
-            PROPERTY_MAPPING = {
-                "carried_r769h": PropertySpec("bound by the name / provided on the config path", context=True),
-                "req_only_r769h": PropertySpec("required, options-only, absent", context=True),
-            }
-
         with caplog.at_level(logging.WARNING):
-            name_result = _ContrastR769h.match_feature_group_criteria(NAME_PATH_FEATURE, Options())
-            config_result = _ContrastR769h.match_feature_group_criteria(
-                CONFIG_PATH_FEATURE, Options(context={"carried_r769h": "x_r769"})
-            )
+            result = _DeferredR769d.match_feature_group_criteria(NAME_PATH_FEATURE, Options())
 
-        assert name_result is True, "the name path (warn mode) still matches despite the missing key"
-        assert config_result is False, "the config path rejects the same missing required key"
-        warnings = _required_presence_warnings(caplog, "_ContrastR769h")
-        assert warnings, "the name-path match must have warned about the missing key"
-        assert "req_only_r769h" in warnings[0].getMessage()
+        assert result is True, "deferred_binding=True must keep the match"
+        assert not _required_presence_warnings(caplog, "_DeferredR769d")
 
+    def test_required_when_key_owned_by_its_own_guard(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A required_when key is gated by its own guard, never by the presence check."""
 
-class TestRequiredWhenInterplay:
-    """A required_when-only gating is owned by its own guard, never by the #769 name-path check."""
-
-    def test_required_when_only_not_warned_in_warn_mode(
-        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """Case 8 (warn): a group whose only requirement is a required_when predicate is not warned."""
-        monkeypatch.delenv(ENV_VAR, raising=False)
-
-        class _ReqWhenWarnR769i(FeatureChainParserMixin):
+        class _ReqWhenR769i(FeatureChainParserMixin):
             PREFIX_PATTERN = r".*__(?P<carried_r769i>\w+)$"
             PROPERTY_MAPPING = {
                 "carried_r769i": PropertySpec("optional, carried by the name", context=True, default=None),
@@ -481,55 +249,27 @@ class TestRequiredWhenInterplay:
             }
 
         with caplog.at_level(logging.WARNING):
-            result = _ReqWhenWarnR769i.match_feature_group_criteria(NAME_PATH_FEATURE, Options())
+            result = _ReqWhenR769i.match_feature_group_criteria(NAME_PATH_FEATURE, Options())
 
         assert result is True
-        assert not _required_presence_warnings(caplog, "_ReqWhenWarnR769i"), (
-            "required_when is owned by its own guard, not by the name-path required-presence check"
+        assert not _required_presence_warnings(caplog, "_ReqWhenR769i"), (
+            "required_when is owned by its own guard, not by the presence check"
         )
-
-    def test_required_when_only_not_enforced_in_enforce_mode(
-        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """Case 8 (enforce): the same required_when-only group matches under enforce and is not warned."""
-        monkeypatch.setenv(ENV_VAR, "enforce")
-
-        class _ReqWhenEnforceR769ie(FeatureChainParserMixin):
-            PREFIX_PATTERN = r".*__(?P<carried_r769ie>\w+)$"
-            PROPERTY_MAPPING = {
-                "carried_r769ie": PropertySpec("optional, carried by the name", context=True, default=None),
-                "cond_r769ie": PropertySpec(
-                    "required only when trigger is present",
-                    context=True,
-                    default=None,
-                    required_when=lambda o: o.get("trigger_r769ie") is not None,
-                ),
-            }
-
-        with caplog.at_level(logging.WARNING):
-            result = _ReqWhenEnforceR769ie.match_feature_group_criteria(NAME_PATH_FEATURE, Options())
-
-        assert result is True, "a required_when that does not fire must not be enforced by the #769 check"
-        assert not _required_presence_warnings(caplog, "_ReqWhenEnforceR769ie")
 
 
 class TestInFeaturesExcluded:
-    """The name-path check must EXCLUDE ``DefaultOptionKeys.in_features``.
+    """The check must EXCLUDE ``DefaultOptionKeys.in_features``.
 
     On the name path the source features come from the name prefix (the ``src`` in ``src__op``), so
     the ``in_features`` key is name-satisfied, never missing. All 12 shipped plugins declare
-    ``in_features`` as a NO_DEFAULT spec, so without this exclusion every shipped plugin would falsely
-    warn on every name-path match. These guards pin the behavior the Green phase must produce: the
-    in_features key stays silent while a genuine missing key is still reported.
+    ``in_features`` as a NO_DEFAULT spec, so without this exclusion every shipped plugin would be a
+    false non-match on every name-path feature.
     """
 
-    def test_warn_mode_in_features_not_reported_missing(
-        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """WARN mode: op captured + in_features excluded -> match True and NO presence warning."""
-        monkeypatch.delenv(ENV_VAR, raising=False)  # warn
+    def test_in_features_not_flagged(self, caplog: pytest.LogCaptureFixture) -> None:
+        """op captured + in_features excluded -> match True and NO presence warning."""
 
-        class _InFeaturesExcludedR769inf(FeatureChainParserMixin, FeatureGroup):
+        class _InFeaturesR769inf(FeatureChainParserMixin, FeatureGroup):
             PREFIX_PATTERN = r".*__(\w+)_r769inf$"
             PROPERTY_MAPPING = {
                 "op_r769inf": PropertySpec(
@@ -541,43 +281,21 @@ class TestInFeaturesExcluded:
                 DefaultOptionKeys.in_features: PropertySpec("source", context=True, strict_validation=False),
             }
 
-        # Precondition: in_features is unconditionally required as a spec, so the exclusion is what keeps
-        # it quiet, not a declared default.
-        in_features_spec = _InFeaturesExcludedR769inf.PROPERTY_MAPPING[DefaultOptionKeys.in_features]
+        # Precondition: in_features is unconditionally required as a spec, so the exclusion is what
+        # keeps it quiet, not a declared default.
+        in_features_spec = _InFeaturesR769inf.PROPERTY_MAPPING[DefaultOptionKeys.in_features]
         assert FeatureChainParser._can_skip_required_check(in_features_spec) is False
 
         with caplog.at_level(logging.WARNING):
-            result = _InFeaturesExcludedR769inf.match_feature_group_criteria("src__op_r769inf", Options())
+            result = _InFeaturesR769inf.match_feature_group_criteria("src__op_r769inf", Options())
 
         assert result is True
-        warnings = _required_presence_warnings(caplog, "_InFeaturesExcludedR769inf")
-        assert not warnings, "in_features is name-satisfied by the source prefix and must never be flagged"
+        assert not _required_presence_warnings(caplog, "_InFeaturesR769inf"), (
+            "in_features is name-satisfied by the source prefix and must never be flagged"
+        )
 
-    def test_enforce_mode_in_features_not_enforced(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """ENFORCE mode: op captured + in_features excluded -> still a match (no missing key)."""
-        monkeypatch.setenv(ENV_VAR, "enforce")
-
-        class _InFeaturesEnforcedR769inf(FeatureChainParserMixin, FeatureGroup):
-            PREFIX_PATTERN = r".*__(\w+)_r769inf$"
-            PROPERTY_MAPPING = {
-                "op_r769inf": PropertySpec(
-                    "operation carried by the positional capture",
-                    allowed_values=("op",),
-                    context=True,
-                    strict_validation=True,
-                ),
-                DefaultOptionKeys.in_features: PropertySpec("source", context=True, strict_validation=False),
-            }
-
-        result = _InFeaturesEnforcedR769inf.match_feature_group_criteria("src__op_r769inf", Options())
-
-        assert result is True, "in_features is excluded, so enforce mode still matches a name-path feature"
-
-    def test_in_features_silent_while_genuine_missing_key_warns(
-        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """Contrast: a genuine missing key (not in_features, not deferred) still warns; in_features stays silent."""
-        monkeypatch.delenv(ENV_VAR, raising=False)  # warn
+    def test_genuine_missing_key_is_non_match_in_features_silent(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Contrast: a genuine missing key (not in_features, not deferred) rejects; in_features stays silent."""
 
         class _InFeaturesContrastR769inf2(FeatureChainParserMixin, FeatureGroup):
             PREFIX_PATTERN = r".*__(\w+)_r769inf2$"
@@ -595,32 +313,84 @@ class TestInFeaturesExcluded:
         with caplog.at_level(logging.WARNING):
             result = _InFeaturesContrastR769inf2.match_feature_group_criteria("src__op_r769inf2", Options())
 
-        assert result is True
+        assert result is False, "a genuine missing required key must be a non-match"
         warnings = _required_presence_warnings(caplog, "_InFeaturesContrastR769inf2")
-        assert warnings, "a genuine missing required key must still warn"
+        assert warnings, "the genuine missing key must be warned about"
         rendered = " ".join(record.getMessage() for record in warnings)
         assert "genuine_missing_r769inf2" in rendered, "the genuine missing key must be named"
         assert "in_features" not in rendered, "in_features is name-satisfied and must never be reported missing"
 
 
-class TestShippedPluginsClean:
-    """Shipped plugins stay clean on the name path once the #769 migration lands.
+class TestConfigPathUnchanged:
+    """The config path keeps its long-standing required-presence rule, with no name-path special cases."""
 
-    These guards pin the end state: the ``in_features`` exclusion plus the per-plugin
-    ``deferred_binding`` marks keep representative shipped plugins from falsely warning on a plain
-    name-path match. The white-box asserts pin the core migration (deferred marks) directly; they error
-    with AttributeError until ``PropertySpec.deferred_binding`` exists.
+    def test_config_path_rejects_missing_required(self) -> None:
+        """A NO_DEFAULT key absent on the config path is a plain non-match."""
+
+        class _ConfigReqR769g(FeatureChainParserMixin):
+            PREFIX_PATTERN = r".*__(?P<carried_r769g>\w+)$"
+            PROPERTY_MAPPING = {
+                "carried_r769g": PropertySpec("bound by the name on the name path", context=True),
+                "req_r769g": PropertySpec("required, options-only", context=True),
+            }
+
+        # CONFIG_PATH_FEATURE carries no separator, so the name never identifies the group: the
+        # config path decides, and req_r769g (NO_DEFAULT) is absent -> non-match.
+        result = _ConfigReqR769g.match_feature_group_criteria(
+            CONFIG_PATH_FEATURE, Options(context={"carried_r769g": "x_r769"})
+        )
+
+        assert result is False, "config-path required presence must hold"
+
+    def test_deferred_binding_does_not_exempt_config_path(self) -> None:
+        """``deferred_binding=True`` exempts only the name path, never the config path."""
+
+        class _ConfigDeferredR769gd(FeatureChainParserMixin):
+            PREFIX_PATTERN = r".*__(?P<carried_r769gd>\w+)$"
+            PROPERTY_MAPPING = {
+                "carried_r769gd": PropertySpec("bound by the name on the name path", context=True),
+                "req_deferred_r769gd": PropertySpec(
+                    "required, deferred on the name path only", context=True, deferred_binding=True
+                ),
+            }
+
+        result = _ConfigDeferredR769gd.match_feature_group_criteria(
+            CONFIG_PATH_FEATURE, Options(context={"carried_r769gd": "x_r769"})
+        )
+
+        assert result is False, "deferred_binding must not exempt the required key on the config path"
+
+    def test_name_and_config_paths_agree_on_missing_required(self) -> None:
+        """Same fixture, same missing key: BOTH paths are a non-match now."""
+
+        class _UnifiedR769h(FeatureChainParserMixin):
+            PREFIX_PATTERN = r".*__(?P<carried_r769h>\w+)$"
+            PROPERTY_MAPPING = {
+                "carried_r769h": PropertySpec("bound by the name / provided on the config path", context=True),
+                "req_only_r769h": PropertySpec("required, options-only, absent", context=True),
+            }
+
+        name_result = _UnifiedR769h.match_feature_group_criteria(NAME_PATH_FEATURE, Options())
+        config_result = _UnifiedR769h.match_feature_group_criteria(
+            CONFIG_PATH_FEATURE, Options(context={"carried_r769h": "x_r769"})
+        )
+
+        assert name_result is False, "the name path rejects the missing required key"
+        assert config_result is False, "the config path rejects the same missing required key"
+
+
+class TestShippedPluginsClean:
+    """Shipped plugins stay clean on the name path.
+
+    The ``in_features`` exclusion plus the per-plugin ``deferred_binding`` marks keep representative
+    shipped plugins matching plain name-path features without a presence warning.
     """
 
-    def test_aggregated_feature_group_name_match_is_clean(
-        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """WARN mode: AggregatedFeatureGroup matches a string name with no presence warning.
+    def test_aggregated_feature_group_name_match_is_clean(self, caplog: pytest.LogCaptureFixture) -> None:
+        """AggregatedFeatureGroup matches a string name with no presence warning.
 
         Its only otherwise-flaggable key is in_features, which the exclusion keeps quiet.
         """
-        monkeypatch.delenv(ENV_VAR, raising=False)  # warn
-
         with caplog.at_level(logging.WARNING):
             result = AggregatedFeatureGroup.match_feature_group_criteria("sales__sum_aggr", Options())
 
@@ -629,16 +399,12 @@ class TestShippedPluginsClean:
             "in_features exclusion must keep AggregatedFeatureGroup clean on the name path"
         )
 
-    def test_time_window_feature_group_name_match_is_clean(
-        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """WARN mode: TimeWindowFeatureGroup matches a string name with no presence warning.
+    def test_time_window_feature_group_name_match_is_clean(self, caplog: pytest.LogCaptureFixture) -> None:
+        """TimeWindowFeatureGroup matches a string name with no presence warning.
 
-        window_size/time_unit are marked deferred_binding by Green and in_features is excluded, so the
-        name-only match reports nothing.
+        window_size/time_unit are deferred_binding and in_features is excluded, so the name-only
+        match reports nothing.
         """
-        monkeypatch.delenv(ENV_VAR, raising=False)  # warn
-
         with caplog.at_level(logging.WARNING):
             result = TimeWindowFeatureGroup.match_feature_group_criteria("temperature__avg_7_days_window", Options())
 
@@ -648,10 +414,6 @@ class TestShippedPluginsClean:
         )
 
     def test_time_window_deferred_binding_marks_are_present(self) -> None:
-        """White-box: the core migration marks window_size and time_unit as deferred_binding.
-
-        Pre-implementation this errors (``PropertySpec`` has no ``deferred_binding`` attribute yet): the
-        expected pre-implementation state.
-        """
+        """White-box: window_size and time_unit carry the deferred_binding mark."""
         assert TimeWindowFeatureGroup.PROPERTY_MAPPING["window_size"].deferred_binding is True
         assert TimeWindowFeatureGroup.PROPERTY_MAPPING["time_unit"].deferred_binding is True

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_name_path_required_presence_review_fixes.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_name_path_required_presence_review_fixes.py
@@ -10,8 +10,11 @@ Pinned here:
 - ``allow_explicit_none``: an explicit None counts as present on the name path; the same key
   entirely absent is a non-match.
 - Every shipped FeatureGroup that declares a PROPERTY_MAPPING stays clean on the name path: its
-  required keys are name-carried (legacy first-capture fallback) or marked ``deferred_binding=True``.
-  This guard fails loudly if that fallback is ever retired without marking the affected keys deferred.
+  required keys are name-carried, supplied via the case's options, or marked ``deferred_binding=True``.
+  This guard fails loudly if a group starts warning or rejecting on its representative case.
+- Second review round (#769): TimeWindow name-carried window values are match-time strict (an
+  invalid size or unit is a non-match with a reason) and TextCleaning's ``cleaning_operations``
+  is option-required on the name path (its pattern is recognition-only and binds nothing).
 
 Warnings are filtered by the feature_chain_parser logger name + WARNING level + the contractual
 ``required option(s)`` marker substring, exactly like the sibling suite. Every fixture carries an
@@ -269,47 +272,134 @@ class TestAllowExplicitNoneOnNamePath:
         assert "nullable_r769rfna" in warnings[0].getMessage(), "the warning must name the absent key"
 
 
-# Representative valid name per shipped FeatureGroup that declares a PROPERTY_MAPPING. Each name
+# Representative valid case per shipped FeatureGroup that declares a PROPERTY_MAPPING. Each name
 # matches its PREFIX_PATTERN and every captured token is within the bound key's allowed_values, so
-# the group is clean on the name path (required keys are name-carried or deferred_binding=True).
-SHIPPED_NAME_PATH_CASES: list[tuple[type[Any], str]] = [
-    (AggregatedFeatureGroup, "sales__sum_aggr"),
-    (TimeWindowFeatureGroup, "temperature__avg_7_days_window"),
-    (GeoDistanceFeatureGroup, "point1&point2__haversine_distance"),
-    (TextCleaningFeatureGroup, "review__cleaned_text"),
-    (DimensionalityReductionFeatureGroup, "features__pca_2d"),
-    (EncodingFeatureGroup, "category__onehot_encoded"),
-    (MissingValueFeatureGroup, "amount__mean_imputed"),
-    (ScalingFeatureGroup, "amount__standard_scaled"),
-    (ClusteringFeatureGroup, "features__cluster_kmeans_3"),
-    (NodeCentralityFeatureGroup, "graph__degree_centrality"),
-    (SklearnPipelineFeatureGroup, "data__sklearn_pipeline_preprocessing"),
-    (ForecastingFeatureGroup, "sales__linear_forecast_7day"),
+# the group is clean on the name path (required keys are name-carried, supplied via the case's
+# options, or deferred_binding=True). Most cases need no options; TextCleaning must supply its
+# option-only cleaning_operations key.
+SHIPPED_NAME_PATH_CASES: list[tuple[type[Any], str, Options]] = [
+    (AggregatedFeatureGroup, "sales__sum_aggr", Options()),
+    (TimeWindowFeatureGroup, "temperature__avg_7_day_window", Options()),
+    (GeoDistanceFeatureGroup, "point1&point2__haversine_distance", Options()),
+    (
+        TextCleaningFeatureGroup,
+        "review__cleaned_text",
+        Options(context={TextCleaningFeatureGroup.CLEANING_OPERATIONS: ("normalize",)}),
+    ),
+    (DimensionalityReductionFeatureGroup, "features__pca_2d", Options()),
+    (EncodingFeatureGroup, "category__onehot_encoded", Options()),
+    (MissingValueFeatureGroup, "amount__mean_imputed", Options()),
+    (ScalingFeatureGroup, "amount__standard_scaled", Options()),
+    (ClusteringFeatureGroup, "features__cluster_kmeans_3", Options()),
+    (NodeCentralityFeatureGroup, "graph__degree_centrality", Options()),
+    (SklearnPipelineFeatureGroup, "data__sklearn_pipeline_preprocessing", Options()),
+    (ForecastingFeatureGroup, "sales__linear_forecast_7day", Options()),
 ]
 
-SHIPPED_IDS = [group.__name__ for group, _ in SHIPPED_NAME_PATH_CASES]
+SHIPPED_IDS = [case[0].__name__ for case in SHIPPED_NAME_PATH_CASES]
 
 
 class TestShippedPluginsCleanAcrossAllGroups:
     """GUARD: every shipped PROPERTY_MAPPING group is clean on the name path.
 
-    Fails loudly if the legacy positional-binding fallback (or a per-key ``deferred_binding`` mark)
-    is ever retired without keeping these groups quiet on the name path.
+    Fails loudly if a shipped group starts warning or rejecting on its representative case
+    (name-carried binding retired, an option-only key left unsupplied, or a ``deferred_binding``
+    mark dropped without a replacement binding).
     """
 
-    @pytest.mark.parametrize("group, valid_name", SHIPPED_NAME_PATH_CASES, ids=SHIPPED_IDS)
+    @pytest.mark.parametrize("group, valid_name, options", SHIPPED_NAME_PATH_CASES, ids=SHIPPED_IDS)
     def test_shipped_group_name_path_is_clean(
         self,
         group: type[Any],
         valid_name: str,
+        options: Options,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """A representative valid name matches with NO presence warning."""
+        """A representative valid case matches with NO presence warning."""
         with caplog.at_level(logging.WARNING):
-            result = group.match_feature_group_criteria(valid_name, Options())
+            result = group.match_feature_group_criteria(valid_name, options)
 
         assert result is True, f"{group.__name__} must match its representative name {valid_name!r}"
         assert not _required_presence_warnings(caplog, group.__name__), (
             f"{group.__name__} must stay clean on the name path "
-            f"(required keys are name-carried or deferred_binding=True)"
+            "(required keys are name-carried, option-supplied, or deferred_binding)"
         )
+
+
+# Second review round: names whose window values are invalid (zero size, unknown unit, plural unit).
+INVALID_TIME_WINDOW_NAMES: list[str] = [
+    "temperature__avg_0_day_window",
+    "temperature__avg_3_banana_window",
+    "temperature__avg_7_days_window",
+]
+
+
+class TestTimeWindowNameValuesMatchTimeStrict:
+    """Second review round: TimeWindow name-carried window values are match-time strict.
+
+    window_function/window_size/time_unit are bound from the name, so an invalid value is a
+    non-match with a rejection reason instead of a compute-time failure.
+    """
+
+    @pytest.mark.parametrize("invalid_name", INVALID_TIME_WINDOW_NAMES)
+    def test_invalid_name_value_is_a_non_match(self, invalid_name: str) -> None:
+        """An invalid name-carried window value must be rejected at match time."""
+        assert TimeWindowFeatureGroup.match_feature_group_criteria(invalid_name, Options()) is False
+
+    @pytest.mark.parametrize("invalid_name", INVALID_TIME_WINDOW_NAMES)
+    def test_invalid_name_value_has_a_rejection_reason(self, invalid_name: str) -> None:
+        """The strict-validation replay explains the rejection."""
+        reason = TimeWindowFeatureGroup._strict_validation_rejection_reason(invalid_name, Options())
+
+        assert reason is not None, f"{invalid_name!r} must produce a rejection reason"
+
+    def test_rejection_reason_surfaces_the_invalid_time_unit(self) -> None:
+        """The reason names the offending value."""
+        reason = TimeWindowFeatureGroup._strict_validation_rejection_reason(
+            "temperature__avg_3_banana_window", Options()
+        )
+
+        assert reason is not None
+        assert "banana" in reason, "the reason must surface the invalid time unit"
+
+    def test_valid_name_still_matches_clean(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Companion regression: the valid singular-unit name matches with no presence warning."""
+        with caplog.at_level(logging.WARNING):
+            result = TimeWindowFeatureGroup.match_feature_group_criteria("temperature__avg_7_day_window", Options())
+
+        assert result is True
+        assert not _required_presence_warnings(caplog, "TimeWindowFeatureGroup")
+
+
+class TestTextCleaningNamePathRequiresOperations:
+    """Second review round: cleaning_operations is option-required on the name path.
+
+    The recognition-only pattern binds nothing from the name, so the key is not deferred and its
+    absence is a warned non-match.
+    """
+
+    def test_empty_options_is_a_non_match_with_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Absent cleaning_operations on the name path is a non-match naming the key."""
+        with caplog.at_level(logging.WARNING):
+            result = TextCleaningFeatureGroup.match_feature_group_criteria("review__cleaned_text", Options())
+
+        assert result is False, "absent cleaning_operations must be a name-path non-match"
+        warnings = _required_presence_warnings(caplog, "TextCleaningFeatureGroup")
+        assert warnings, "the absent required key must be warned about"
+        assert "cleaning_operations" in warnings[0].getMessage(), "the warning must name the absent key"
+
+    def test_supplied_operations_match_clean(self, caplog: pytest.LogCaptureFixture) -> None:
+        """With the option supplied the same name matches with no presence warning."""
+        options = Options(context={TextCleaningFeatureGroup.CLEANING_OPERATIONS: ("normalize",)})
+
+        with caplog.at_level(logging.WARNING):
+            result = TextCleaningFeatureGroup.match_feature_group_criteria("review__cleaned_text", options)
+
+        assert result is True
+        assert not _required_presence_warnings(caplog, "TextCleaningFeatureGroup")
+
+    def test_cleaning_operations_deferred_mark_is_removed(self) -> None:
+        """White-box: the key is not parsed from the name, so it must not be marked deferred."""
+        spec = TextCleaningFeatureGroup.PROPERTY_MAPPING[TextCleaningFeatureGroup.CLEANING_OPERATIONS]
+
+        assert spec.deferred_binding is False

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_name_path_required_presence_review_fixes.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_name_path_required_presence_review_fixes.py
@@ -1,33 +1,21 @@
-"""Regression tests for the #769 name-path required-presence review fixes.
+"""Regression pins for the mandatory name-path required-presence rule (issue #769).
 
-Issue #769 (warn-then-enforce name-path required presence) is implemented and green; a deep review
-found four minor gaps. This file pins the ACCEPTED fixes. Two groups are RED (they fail against the
-committed code and pass once the Green phase lands the fix); two are GUARDs (they pass today and fail
-loudly if the pinned behavior ever regresses).
+Pinned here:
 
-Findings pinned here:
+- ``FeatureChainParser.name_path_presence_rejection_reason`` returns a reason naming the missing
+  key(s) UNCONDITIONALLY when keys are missing, None when nothing is missing, and never mentions
+  the retired env var. ``FeatureChainParserMixin._strict_validation_rejection_reason`` surfaces it,
+  so the resolution-failure report explains the non-match.
+- ``MLODA_NAME_PATH_REQUIRED_PRESENCE`` is retired: no value changes the reason or the verdict.
+- ``allow_explicit_none``: an explicit None counts as present on the name path; the same key
+  entirely absent is a non-match.
+- Every shipped FeatureGroup that declares a PROPERTY_MAPPING stays clean on the name path: its
+  required keys are name-carried (legacy first-capture fallback) or marked ``deferred_binding=True``.
+  This guard fails loudly if that fallback is ever retired without marking the affected keys deferred.
 
-- Finding #2 (RED): an ENFORCE-mode name-path non-match currently vanishes with no explanation. The
-  Green phase adds ``FeatureChainParser.name_path_presence_rejection_reason(effective_options,
-  property_mapping) -> str | None`` (a reason ONLY in enforce mode when required keys are missing) and
-  wires it into ``FeatureChainParserMixin._strict_validation_rejection_reason``, so the diagnostic replay
-  that feeds "no feature group matched" explains the missing key. Today the replay returns None.
-
-- Finding #3 (RED): the env var only recognizes ``off`` as the kill-switch. The Green phase also treats
-  ``0``, ``false``, ``no`` (case-insensitive) as disabled. Today those aliases fall through to warn.
-
-- Finding #5a (GUARD): a NO_DEFAULT key with ``allow_explicit_none=True`` counts an EXPLICIT None as
-  present on the name path (no warning, matches under enforce), while an ABSENT one is still missing.
-
-- Finding #1 (GUARD): every shipped FeatureGroup that declares a PROPERTY_MAPPING stays clean on the
-  name path in BOTH warn and enforce mode, because its required keys are name-carried (legacy first-
-  capture fallback) or marked ``deferred_binding=True``. This guard fails loudly if that legacy
-  positional-binding fallback is ever retired without also marking the affected keys deferred.
-
-Warnings are filtered by the feature_chain_parser logger name + WARNING level + the
-``MLODA_NAME_PATH_REQUIRED_PRESENCE`` marker substring, exactly like the sibling
-``test_name_path_required_presence.py`` suite. Every fixture carries an "r769rf" marker so it cannot
-collide with the r769 fixtures, the rf770 fixtures, or the global registry.
+Warnings are filtered by the feature_chain_parser logger name + WARNING level + the contractual
+``required option(s)`` marker substring, exactly like the sibling suite. Every fixture carries an
+"r769rf" marker so it cannot collide with the r769 fixtures or the global registry.
 """
 
 from __future__ import annotations
@@ -37,6 +25,7 @@ from typing import Any
 
 import pytest
 
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.provider import PropertySpec
@@ -56,46 +45,44 @@ from mloda_plugins.feature_group.experimental.time_window.base import TimeWindow
 
 FEATURE_CHAIN_PARSER_LOGGER = "mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser"
 
+# Retired: tests only set it to prove it is ignored, and assert it never appears in reasons.
 ENV_VAR = "MLODA_NAME_PATH_REQUIRED_PRESENCE"
+
+# The marker substring the non-match warning is contractually required to contain.
+MARKER = "required option(s)"
 
 
 def _required_presence_warnings(
     caplog: pytest.LogCaptureFixture, class_name: str | None = None
 ) -> list[logging.LogRecord]:
-    """The #769 name-path required-presence WARNINGs, optionally scoped to one class name.
+    """The name-path required-presence WARNINGs, optionally scoped to one class name.
 
-    Filters by logger name, WARNING level, and the env-var marker substring the warning is
-    contractually required to mention, exactly like the sibling suite.
+    Filters by logger name, WARNING level, and the ``required option(s)`` marker substring the
+    warning is contractually required to contain, exactly like the sibling suite.
     """
     records = [
         record
         for record in caplog.records
         if record.levelno == logging.WARNING
         and record.name == FEATURE_CHAIN_PARSER_LOGGER
-        and ENV_VAR in record.getMessage()
+        and MARKER in record.getMessage()
     ]
     if class_name is not None:
         records = [record for record in records if class_name in record.getMessage()]
     return records
 
 
-class TestEnforceRejectionReasonSurfaced:
-    """Finding #2: an enforce-mode name-path non-match must explain the missing key (RED today).
+class TestRejectionReasonSurfaced:
+    """A name-path presence non-match must explain the missing key in the resolution-failure replay.
 
     The diagnostic replay ``_strict_validation_rejection_reason`` feeds the engine's
-    "no feature group matched" message. Today it never runs the presence check, so an enforced
-    non-match is silent. The Green phase surfaces the reason ONLY in enforce mode.
+    "no feature group matched" message; the presence reason is reported unconditionally.
     """
 
-    def test_enforce_mode_surfaces_missing_key_reason(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """RED: enforce mode must return a reason naming the missing key and the migration env var.
+    def test_missing_key_reason_surfaced(self) -> None:
+        """The replay returns a reason naming the missing key, with no env manipulation."""
 
-        Pre-implementation this fails: ``_strict_validation_rejection_reason`` returns None because the
-        diagnostic replay does not run the name-path presence check.
-        """
-        monkeypatch.setenv(ENV_VAR, "enforce")
-
-        class _EnforceReasonR769rfen(FeatureChainParserMixin, FeatureGroup):
+        class _ReasonR769rfen(FeatureChainParserMixin, FeatureGroup):
             PREFIX_PATTERN = r".*__(\w+)_r769rfen$"
             PROPERTY_MAPPING = {
                 "op_r769rfen": PropertySpec(
@@ -107,55 +94,37 @@ class TestEnforceRejectionReasonSurfaced:
                 "missing_r769rfen": PropertySpec("required, options-only, absent on the name path", context=True),
             }
 
-        reason = _EnforceReasonR769rfen._strict_validation_rejection_reason("src__op_r769rfen", Options())
+        reason = _ReasonR769rfen._strict_validation_rejection_reason("src__op_r769rfen", Options())
 
-        assert reason is not None, "enforce mode must explain why the name-path candidate did not match"
+        assert reason is not None, "a name-path presence non-match must explain itself"
         assert "missing_r769rfen" in reason, "the reason must name the missing required key"
-        assert ENV_VAR in reason, "the reason must mention the migration env var so the user can act"
+        assert ENV_VAR not in reason, "the reason must not reference the retired env var"
 
-    def test_warn_mode_reports_no_rejection_reason(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """GUARD: warn mode still matches, so there is no rejection reason to report."""
-        monkeypatch.setenv(ENV_VAR, "warn")
+    @pytest.mark.parametrize("env_value", ["off", "warn", "0", "enforce"])
+    def test_env_value_does_not_change_the_reason(self, env_value: str, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The env var is retired: any value still yields the same env-var-free reason."""
+        monkeypatch.setenv(ENV_VAR, env_value)
 
-        class _WarnReasonR769rfwn(FeatureChainParserMixin, FeatureGroup):
-            PREFIX_PATTERN = r".*__(\w+)_r769rfwn$"
+        class _ReasonEnvR769rfev(FeatureChainParserMixin, FeatureGroup):
+            PREFIX_PATTERN = r".*__(\w+)_r769rfev$"
             PROPERTY_MAPPING = {
-                "op_r769rfwn": PropertySpec(
+                "op_r769rfev": PropertySpec(
                     "operation carried by the positional capture",
                     allowed_values=("op",),
                     context=True,
                     strict_validation=True,
                 ),
-                "missing_r769rfwn": PropertySpec("required, options-only, absent on the name path", context=True),
+                "missing_r769rfev": PropertySpec("required, options-only, absent on the name path", context=True),
             }
 
-        reason = _WarnReasonR769rfwn._strict_validation_rejection_reason("src__op_r769rfwn", Options())
+        reason = _ReasonEnvR769rfev._strict_validation_rejection_reason("src__op_r769rfev", Options())
 
-        assert reason is None, "warn mode matches, so the presence reason is scoped out"
+        assert reason is not None, f"env value {env_value!r} must be ignored: the reason is unconditional"
+        assert "missing_r769rfev" in reason
+        assert ENV_VAR not in reason, "the reason must not reference the retired env var"
 
-    def test_off_mode_reports_no_rejection_reason(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """GUARD: off mode disables the check, so there is no rejection reason to report."""
-        monkeypatch.setenv(ENV_VAR, "off")
-
-        class _OffReasonR769rfof(FeatureChainParserMixin, FeatureGroup):
-            PREFIX_PATTERN = r".*__(\w+)_r769rfof$"
-            PROPERTY_MAPPING = {
-                "op_r769rfof": PropertySpec(
-                    "operation carried by the positional capture",
-                    allowed_values=("op",),
-                    context=True,
-                    strict_validation=True,
-                ),
-                "missing_r769rfof": PropertySpec("required, options-only, absent on the name path", context=True),
-            }
-
-        reason = _OffReasonR769rfof._strict_validation_rejection_reason("src__op_r769rfof", Options())
-
-        assert reason is None, "off mode disables the check, so nothing is reported"
-
-    def test_enforce_present_key_no_reason(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """GUARD: enforce mode with the required key present in options has nothing missing to report."""
-        monkeypatch.setenv(ENV_VAR, "enforce")
+    def test_present_key_no_reason(self) -> None:
+        """GUARD: the required key present in options leaves nothing missing to report."""
 
         class _PresentReasonR769rfpr(FeatureChainParserMixin, FeatureGroup):
             PREFIX_PATTERN = r".*__(\w+)_r769rfpr$"
@@ -175,9 +144,8 @@ class TestEnforceRejectionReasonSurfaced:
 
         assert reason is None, "a present required key leaves nothing missing to explain"
 
-    def test_enforce_deferred_key_no_reason(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """GUARD: enforce mode with a deferred_binding key has nothing missing to report."""
-        monkeypatch.setenv(ENV_VAR, "enforce")
+    def test_deferred_key_no_reason(self) -> None:
+        """GUARD: a deferred_binding key has nothing missing to report."""
 
         class _DeferredReasonR769rfdf(FeatureChainParserMixin, FeatureGroup):
             PREFIX_PATTERN = r".*__(\w+)_r769rfdf$"
@@ -197,9 +165,8 @@ class TestEnforceRejectionReasonSurfaced:
 
         assert reason is None, "deferred_binding exempts the key, so nothing is missing"
 
-    def test_enforce_defaulted_key_no_reason(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """GUARD: enforce mode with a declared-default key has nothing missing to report."""
-        monkeypatch.setenv(ENV_VAR, "enforce")
+    def test_defaulted_key_no_reason(self) -> None:
+        """GUARD: a declared-default key has nothing missing to report."""
 
         class _DefaultedReasonR769rfdd(FeatureChainParserMixin, FeatureGroup):
             PREFIX_PATTERN = r".*__(\w+)_r769rfdd$"
@@ -218,68 +185,41 @@ class TestEnforceRejectionReasonSurfaced:
         assert reason is None, "a declared default makes the key optional, so nothing is missing"
 
 
-class TestOffAliases:
-    """Finding #3: 0/false/no (case-insensitive) also disable the check, like off (RED for the aliases)."""
+class TestNamePathPresenceRejectionReasonUnit:
+    """Direct contract of ``FeatureChainParser.name_path_presence_rejection_reason``."""
 
-    @pytest.mark.parametrize("env_value", ["0", "false", "FALSE", "no", "off", "OFF"])
-    def test_off_aliases_disable_the_check(
-        self, env_value: str, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """A missing-required-key match that WOULD warn matches True and logs NO warning when disabled.
+    def test_reason_when_key_missing(self) -> None:
+        """Missing keys produce a reason unconditionally; the reason names them and no env var."""
+        mapping = {"missing_r769rfu": PropertySpec("required, absent", context=True)}
 
-        Pre-implementation the ``0``/``false``/``FALSE``/``no`` cases fail: those values fall through to
-        warn, so the name-path match still logs a presence warning. ``off``/``OFF`` already pass (guard).
-        """
-        monkeypatch.setenv(ENV_VAR, env_value)
+        reason = FeatureChainParser.name_path_presence_rejection_reason(Options(), mapping)
 
-        class _OffAliasR769rfal(FeatureChainParserMixin):
-            PREFIX_PATTERN = r".*__(?P<carried_r769rfal>\w+)$"
-            PROPERTY_MAPPING = {
-                "carried_r769rfal": PropertySpec("required, carried by the name", context=True),
-                "missing_r769rfal": PropertySpec("required, options-only, absent", context=True),
-            }
+        assert reason is not None, "missing keys must produce a reason unconditionally"
+        assert "missing_r769rfu" in reason, "the reason must name the missing key"
+        assert ENV_VAR not in reason, "the reason must not reference the retired env var"
 
-        with caplog.at_level(logging.WARNING):
-            result = _OffAliasR769rfal.match_feature_group_criteria("src__val_r769rf", Options())
+    def test_none_when_nothing_missing(self) -> None:
+        """Nothing missing means no reason."""
+        mapping = {"present_r769rfu2": PropertySpec("required, present", context=True)}
 
-        assert result is True, f"a disabled mode ({env_value!r}) must not enforce"
-        assert not _required_presence_warnings(caplog, "_OffAliasR769rfal"), (
-            f"a disabled mode ({env_value!r}) must not warn"
+        reason = FeatureChainParser.name_path_presence_rejection_reason(
+            Options(context={"present_r769rfu2": "v_r769rf"}), mapping
         )
 
-    def test_invalid_value_still_behaves_like_warn(
-        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """GUARD: a genuinely invalid value (``banana``) still matches AND warns, never disables the check."""
-        monkeypatch.setenv(ENV_VAR, "banana")
-
-        class _BananaR769rfbn(FeatureChainParserMixin):
-            PREFIX_PATTERN = r".*__(?P<carried_r769rfbn>\w+)$"
-            PROPERTY_MAPPING = {
-                "carried_r769rfbn": PropertySpec("required, carried by the name", context=True),
-                "missing_r769rfbn": PropertySpec("required, options-only, absent", context=True),
-            }
-
-        with caplog.at_level(logging.WARNING):
-            result = _BananaR769rfbn.match_feature_group_criteria("src__val_r769rf", Options())
-
-        assert result is True, "an invalid value must not enforce"
-        assert _required_presence_warnings(caplog, "_BananaR769rfbn"), "an invalid value must fall back to warn"
+        assert reason is None
 
 
 class TestAllowExplicitNoneOnNamePath:
-    """Finding #5a (GUARD): allow_explicit_none makes an explicit None count as present on the name path.
+    """allow_explicit_none makes an explicit None count as present on the name path.
 
-    The key is NO_DEFAULT, non-deferred, ``allow_explicit_none=True``; the operation key is name-carried.
+    The key is NO_DEFAULT, non-deferred, ``allow_explicit_none=True``; the operation key is
+    name-carried.
     """
 
-    def test_warn_explicit_none_matches_no_warning(
-        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """WARN: an explicit None for the allow_explicit_none key counts as present -> no presence warning."""
-        monkeypatch.setenv(ENV_VAR, "warn")
+    def test_explicit_none_counts_as_present(self, caplog: pytest.LogCaptureFixture) -> None:
+        """An explicit None for the allow_explicit_none key counts as present: match, no warning."""
 
-        class _AllowNoneWarnR769rfnw(FeatureChainParserMixin, FeatureGroup):
+        class _AllowNonePresentR769rfnw(FeatureChainParserMixin, FeatureGroup):
             PREFIX_PATTERN = r".*__(\w+)_r769rfnw$"
             PROPERTY_MAPPING = {
                 "op_r769rfnw": PropertySpec(
@@ -294,18 +234,17 @@ class TestAllowExplicitNoneOnNamePath:
             }
 
         with caplog.at_level(logging.WARNING):
-            result = _AllowNoneWarnR769rfnw.match_feature_group_criteria(
+            result = _AllowNonePresentR769rfnw.match_feature_group_criteria(
                 "src__op_r769rfnw", Options(context={"nullable_r769rfnw": None})
             )
 
-        assert result is True
-        assert not _required_presence_warnings(caplog, "_AllowNoneWarnR769rfnw"), (
+        assert result is True, "an explicit None is present, so the match succeeds"
+        assert not _required_presence_warnings(caplog, "_AllowNonePresentR769rfnw"), (
             "an explicit None must count as present, so the key is not flagged missing"
         )
 
-    def test_warn_absent_warns(self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
-        """WARN (contrast): the same key entirely ABSENT is missing and warns, naming the key."""
-        monkeypatch.setenv(ENV_VAR, "warn")
+    def test_absent_key_is_non_match(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Contrast: the same key entirely ABSENT is missing, so the match is rejected and warned."""
 
         class _AllowNoneAbsentR769rfna(FeatureChainParserMixin, FeatureGroup):
             PREFIX_PATTERN = r".*__(\w+)_r769rfna$"
@@ -324,61 +263,15 @@ class TestAllowExplicitNoneOnNamePath:
         with caplog.at_level(logging.WARNING):
             result = _AllowNoneAbsentR769rfna.match_feature_group_criteria("src__op_r769rfna", Options())
 
-        assert result is True, "warn mode still matches despite the absent key"
+        assert result is False, "an absent required key is a non-match, allow_explicit_none or not"
         warnings = _required_presence_warnings(caplog, "_AllowNoneAbsentR769rfna")
-        assert warnings, "an absent required key must warn, even when allow_explicit_none is set"
+        assert warnings, "the absent required key must be warned about"
         assert "nullable_r769rfna" in warnings[0].getMessage(), "the warning must name the absent key"
 
-    def test_enforce_explicit_none_matches(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """ENFORCE: an explicit None counts as present, so the name-path match still succeeds."""
-        monkeypatch.setenv(ENV_VAR, "enforce")
 
-        class _AllowNoneEnforceR769rfne(FeatureChainParserMixin, FeatureGroup):
-            PREFIX_PATTERN = r".*__(\w+)_r769rfne$"
-            PROPERTY_MAPPING = {
-                "op_r769rfne": PropertySpec(
-                    "operation carried by the positional capture",
-                    allowed_values=("op",),
-                    context=True,
-                    strict_validation=True,
-                ),
-                "nullable_r769rfne": PropertySpec(
-                    "required, but an explicit None counts as present", context=True, allow_explicit_none=True
-                ),
-            }
-
-        result = _AllowNoneEnforceR769rfne.match_feature_group_criteria(
-            "src__op_r769rfne", Options(context={"nullable_r769rfne": None})
-        )
-
-        assert result is True, "an explicit None is present, so enforce mode still matches"
-
-    def test_enforce_absent_is_non_match(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """ENFORCE (contrast): the same key entirely ABSENT is missing, so the match is rejected."""
-        monkeypatch.setenv(ENV_VAR, "enforce")
-
-        class _AllowNoneEnforceAbsentR769rfnx(FeatureChainParserMixin, FeatureGroup):
-            PREFIX_PATTERN = r".*__(\w+)_r769rfnx$"
-            PROPERTY_MAPPING = {
-                "op_r769rfnx": PropertySpec(
-                    "operation carried by the positional capture",
-                    allowed_values=("op",),
-                    context=True,
-                    strict_validation=True,
-                ),
-                "nullable_r769rfnx": PropertySpec(
-                    "required, but an explicit None counts as present", context=True, allow_explicit_none=True
-                ),
-            }
-
-        result = _AllowNoneEnforceAbsentR769rfnx.match_feature_group_criteria("src__op_r769rfnx", Options())
-
-        assert result is False, "an absent required key is a non-match under enforce, allow_explicit_none or not"
-
-
-# Finding #1 (GUARD): representative valid name per shipped FeatureGroup that declares a PROPERTY_MAPPING.
-# Each name matches its PREFIX_PATTERN and every captured token is within the bound key's allowed_values,
-# so the group is clean on the name path today (required keys are name-carried or deferred_binding=True).
+# Representative valid name per shipped FeatureGroup that declares a PROPERTY_MAPPING. Each name
+# matches its PREFIX_PATTERN and every captured token is within the bound key's allowed_values, so
+# the group is clean on the name path (required keys are name-carried or deferred_binding=True).
 SHIPPED_NAME_PATH_CASES: list[tuple[type[Any], str]] = [
     (AggregatedFeatureGroup, "sales__sum_aggr"),
     (TimeWindowFeatureGroup, "temperature__avg_7_days_window"),
@@ -398,30 +291,25 @@ SHIPPED_IDS = [group.__name__ for group, _ in SHIPPED_NAME_PATH_CASES]
 
 
 class TestShippedPluginsCleanAcrossAllGroups:
-    """Finding #1 (GUARD): every shipped PROPERTY_MAPPING group is clean on the name path in every mode.
+    """GUARD: every shipped PROPERTY_MAPPING group is clean on the name path.
 
-    Fails loudly if the legacy positional-binding fallback (or a per-key ``deferred_binding`` mark) is
-    ever retired without keeping these groups quiet on the name path.
+    Fails loudly if the legacy positional-binding fallback (or a per-key ``deferred_binding`` mark)
+    is ever retired without keeping these groups quiet on the name path.
     """
 
-    @pytest.mark.parametrize("mode", ["warn", "enforce"])
     @pytest.mark.parametrize("group, valid_name", SHIPPED_NAME_PATH_CASES, ids=SHIPPED_IDS)
     def test_shipped_group_name_path_is_clean(
         self,
         group: type[Any],
         valid_name: str,
-        mode: str,
-        monkeypatch: pytest.MonkeyPatch,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """A representative valid name matches with NO presence warning, in both warn and enforce mode."""
-        monkeypatch.setenv(ENV_VAR, mode)
-
+        """A representative valid name matches with NO presence warning."""
         with caplog.at_level(logging.WARNING):
             result = group.match_feature_group_criteria(valid_name, Options())
 
-        assert result is True, f"{group.__name__} must match its representative name {valid_name!r} in {mode} mode"
+        assert result is True, f"{group.__name__} must match its representative name {valid_name!r}"
         assert not _required_presence_warnings(caplog, group.__name__), (
-            f"{group.__name__} must stay clean on the name path in {mode} mode "
+            f"{group.__name__} must stay clean on the name path "
             f"(required keys are name-carried or deferred_binding=True)"
         )

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_name_path_required_presence_review_fixes.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_name_path_required_presence_review_fixes.py
@@ -1,0 +1,427 @@
+"""Regression tests for the #769 name-path required-presence review fixes.
+
+Issue #769 (warn-then-enforce name-path required presence) is implemented and green; a deep review
+found four minor gaps. This file pins the ACCEPTED fixes. Two groups are RED (they fail against the
+committed code and pass once the Green phase lands the fix); two are GUARDs (they pass today and fail
+loudly if the pinned behavior ever regresses).
+
+Findings pinned here:
+
+- Finding #2 (RED): an ENFORCE-mode name-path non-match currently vanishes with no explanation. The
+  Green phase adds ``FeatureChainParser.name_path_presence_rejection_reason(effective_options,
+  property_mapping) -> str | None`` (a reason ONLY in enforce mode when required keys are missing) and
+  wires it into ``FeatureChainParserMixin._strict_validation_rejection_reason``, so the diagnostic replay
+  that feeds "no feature group matched" explains the missing key. Today the replay returns None.
+
+- Finding #3 (RED): the env var only recognizes ``off`` as the kill-switch. The Green phase also treats
+  ``0``, ``false``, ``no`` (case-insensitive) as disabled. Today those aliases fall through to warn.
+
+- Finding #5a (GUARD): a NO_DEFAULT key with ``allow_explicit_none=True`` counts an EXPLICIT None as
+  present on the name path (no warning, matches under enforce), while an ABSENT one is still missing.
+
+- Finding #1 (GUARD): every shipped FeatureGroup that declares a PROPERTY_MAPPING stays clean on the
+  name path in BOTH warn and enforce mode, because its required keys are name-carried (legacy first-
+  capture fallback) or marked ``deferred_binding=True``. This guard fails loudly if that legacy
+  positional-binding fallback is ever retired without also marking the affected keys deferred.
+
+Warnings are filtered by the feature_chain_parser logger name + WARNING level + the
+``MLODA_NAME_PATH_REQUIRED_PRESENCE`` marker substring, exactly like the sibling
+``test_name_path_required_presence.py`` suite. Every fixture carries an "r769rf" marker so it cannot
+collide with the r769 fixtures, the rf770 fixtures, or the global registry.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.provider import PropertySpec
+from mloda.user import Options
+from mloda_plugins.feature_group.experimental.aggregated_feature_group.base import AggregatedFeatureGroup
+from mloda_plugins.feature_group.experimental.clustering.base import ClusteringFeatureGroup
+from mloda_plugins.feature_group.experimental.data_quality.missing_value.base import MissingValueFeatureGroup
+from mloda_plugins.feature_group.experimental.dimensionality_reduction.base import DimensionalityReductionFeatureGroup
+from mloda_plugins.feature_group.experimental.forecasting.base import ForecastingFeatureGroup
+from mloda_plugins.feature_group.experimental.geo_distance.base import GeoDistanceFeatureGroup
+from mloda_plugins.feature_group.experimental.node_centrality.base import NodeCentralityFeatureGroup
+from mloda_plugins.feature_group.experimental.sklearn.encoding.base import EncodingFeatureGroup
+from mloda_plugins.feature_group.experimental.sklearn.pipeline.base import SklearnPipelineFeatureGroup
+from mloda_plugins.feature_group.experimental.sklearn.scaling.base import ScalingFeatureGroup
+from mloda_plugins.feature_group.experimental.text_cleaning.base import TextCleaningFeatureGroup
+from mloda_plugins.feature_group.experimental.time_window.base import TimeWindowFeatureGroup
+
+FEATURE_CHAIN_PARSER_LOGGER = "mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser"
+
+ENV_VAR = "MLODA_NAME_PATH_REQUIRED_PRESENCE"
+
+
+def _required_presence_warnings(
+    caplog: pytest.LogCaptureFixture, class_name: str | None = None
+) -> list[logging.LogRecord]:
+    """The #769 name-path required-presence WARNINGs, optionally scoped to one class name.
+
+    Filters by logger name, WARNING level, and the env-var marker substring the warning is
+    contractually required to mention, exactly like the sibling suite.
+    """
+    records = [
+        record
+        for record in caplog.records
+        if record.levelno == logging.WARNING
+        and record.name == FEATURE_CHAIN_PARSER_LOGGER
+        and ENV_VAR in record.getMessage()
+    ]
+    if class_name is not None:
+        records = [record for record in records if class_name in record.getMessage()]
+    return records
+
+
+class TestEnforceRejectionReasonSurfaced:
+    """Finding #2: an enforce-mode name-path non-match must explain the missing key (RED today).
+
+    The diagnostic replay ``_strict_validation_rejection_reason`` feeds the engine's
+    "no feature group matched" message. Today it never runs the presence check, so an enforced
+    non-match is silent. The Green phase surfaces the reason ONLY in enforce mode.
+    """
+
+    def test_enforce_mode_surfaces_missing_key_reason(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """RED: enforce mode must return a reason naming the missing key and the migration env var.
+
+        Pre-implementation this fails: ``_strict_validation_rejection_reason`` returns None because the
+        diagnostic replay does not run the name-path presence check.
+        """
+        monkeypatch.setenv(ENV_VAR, "enforce")
+
+        class _EnforceReasonR769rfen(FeatureChainParserMixin, FeatureGroup):
+            PREFIX_PATTERN = r".*__(\w+)_r769rfen$"
+            PROPERTY_MAPPING = {
+                "op_r769rfen": PropertySpec(
+                    "operation carried by the positional capture",
+                    allowed_values=("op",),
+                    context=True,
+                    strict_validation=True,
+                ),
+                "missing_r769rfen": PropertySpec("required, options-only, absent on the name path", context=True),
+            }
+
+        reason = _EnforceReasonR769rfen._strict_validation_rejection_reason("src__op_r769rfen", Options())
+
+        assert reason is not None, "enforce mode must explain why the name-path candidate did not match"
+        assert "missing_r769rfen" in reason, "the reason must name the missing required key"
+        assert ENV_VAR in reason, "the reason must mention the migration env var so the user can act"
+
+    def test_warn_mode_reports_no_rejection_reason(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """GUARD: warn mode still matches, so there is no rejection reason to report."""
+        monkeypatch.setenv(ENV_VAR, "warn")
+
+        class _WarnReasonR769rfwn(FeatureChainParserMixin, FeatureGroup):
+            PREFIX_PATTERN = r".*__(\w+)_r769rfwn$"
+            PROPERTY_MAPPING = {
+                "op_r769rfwn": PropertySpec(
+                    "operation carried by the positional capture",
+                    allowed_values=("op",),
+                    context=True,
+                    strict_validation=True,
+                ),
+                "missing_r769rfwn": PropertySpec("required, options-only, absent on the name path", context=True),
+            }
+
+        reason = _WarnReasonR769rfwn._strict_validation_rejection_reason("src__op_r769rfwn", Options())
+
+        assert reason is None, "warn mode matches, so the presence reason is scoped out"
+
+    def test_off_mode_reports_no_rejection_reason(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """GUARD: off mode disables the check, so there is no rejection reason to report."""
+        monkeypatch.setenv(ENV_VAR, "off")
+
+        class _OffReasonR769rfof(FeatureChainParserMixin, FeatureGroup):
+            PREFIX_PATTERN = r".*__(\w+)_r769rfof$"
+            PROPERTY_MAPPING = {
+                "op_r769rfof": PropertySpec(
+                    "operation carried by the positional capture",
+                    allowed_values=("op",),
+                    context=True,
+                    strict_validation=True,
+                ),
+                "missing_r769rfof": PropertySpec("required, options-only, absent on the name path", context=True),
+            }
+
+        reason = _OffReasonR769rfof._strict_validation_rejection_reason("src__op_r769rfof", Options())
+
+        assert reason is None, "off mode disables the check, so nothing is reported"
+
+    def test_enforce_present_key_no_reason(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """GUARD: enforce mode with the required key present in options has nothing missing to report."""
+        monkeypatch.setenv(ENV_VAR, "enforce")
+
+        class _PresentReasonR769rfpr(FeatureChainParserMixin, FeatureGroup):
+            PREFIX_PATTERN = r".*__(\w+)_r769rfpr$"
+            PROPERTY_MAPPING = {
+                "op_r769rfpr": PropertySpec(
+                    "operation carried by the positional capture",
+                    allowed_values=("op",),
+                    context=True,
+                    strict_validation=True,
+                ),
+                "present_r769rfpr": PropertySpec("required, supplied in options", context=True),
+            }
+
+        reason = _PresentReasonR769rfpr._strict_validation_rejection_reason(
+            "src__op_r769rfpr", Options(context={"present_r769rfpr": "v_r769"})
+        )
+
+        assert reason is None, "a present required key leaves nothing missing to explain"
+
+    def test_enforce_deferred_key_no_reason(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """GUARD: enforce mode with a deferred_binding key has nothing missing to report."""
+        monkeypatch.setenv(ENV_VAR, "enforce")
+
+        class _DeferredReasonR769rfdf(FeatureChainParserMixin, FeatureGroup):
+            PREFIX_PATTERN = r".*__(\w+)_r769rfdf$"
+            PROPERTY_MAPPING = {
+                "op_r769rfdf": PropertySpec(
+                    "operation carried by the positional capture",
+                    allowed_values=("op",),
+                    context=True,
+                    strict_validation=True,
+                ),
+                "deferred_r769rfdf": PropertySpec(
+                    "required, bound outside the name", context=True, deferred_binding=True
+                ),
+            }
+
+        reason = _DeferredReasonR769rfdf._strict_validation_rejection_reason("src__op_r769rfdf", Options())
+
+        assert reason is None, "deferred_binding exempts the key, so nothing is missing"
+
+    def test_enforce_defaulted_key_no_reason(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """GUARD: enforce mode with a declared-default key has nothing missing to report."""
+        monkeypatch.setenv(ENV_VAR, "enforce")
+
+        class _DefaultedReasonR769rfdd(FeatureChainParserMixin, FeatureGroup):
+            PREFIX_PATTERN = r".*__(\w+)_r769rfdd$"
+            PROPERTY_MAPPING = {
+                "op_r769rfdd": PropertySpec(
+                    "operation carried by the positional capture",
+                    allowed_values=("op",),
+                    context=True,
+                    strict_validation=True,
+                ),
+                "defaulted_r769rfdd": PropertySpec("optional via a declared default", context=True, default="d_r769"),
+            }
+
+        reason = _DefaultedReasonR769rfdd._strict_validation_rejection_reason("src__op_r769rfdd", Options())
+
+        assert reason is None, "a declared default makes the key optional, so nothing is missing"
+
+
+class TestOffAliases:
+    """Finding #3: 0/false/no (case-insensitive) also disable the check, like off (RED for the aliases)."""
+
+    @pytest.mark.parametrize("env_value", ["0", "false", "FALSE", "no", "off", "OFF"])
+    def test_off_aliases_disable_the_check(
+        self, env_value: str, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A missing-required-key match that WOULD warn matches True and logs NO warning when disabled.
+
+        Pre-implementation the ``0``/``false``/``FALSE``/``no`` cases fail: those values fall through to
+        warn, so the name-path match still logs a presence warning. ``off``/``OFF`` already pass (guard).
+        """
+        monkeypatch.setenv(ENV_VAR, env_value)
+
+        class _OffAliasR769rfal(FeatureChainParserMixin):
+            PREFIX_PATTERN = r".*__(?P<carried_r769rfal>\w+)$"
+            PROPERTY_MAPPING = {
+                "carried_r769rfal": PropertySpec("required, carried by the name", context=True),
+                "missing_r769rfal": PropertySpec("required, options-only, absent", context=True),
+            }
+
+        with caplog.at_level(logging.WARNING):
+            result = _OffAliasR769rfal.match_feature_group_criteria("src__val_r769rf", Options())
+
+        assert result is True, f"a disabled mode ({env_value!r}) must not enforce"
+        assert not _required_presence_warnings(caplog, "_OffAliasR769rfal"), (
+            f"a disabled mode ({env_value!r}) must not warn"
+        )
+
+    def test_invalid_value_still_behaves_like_warn(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """GUARD: a genuinely invalid value (``banana``) still matches AND warns, never disables the check."""
+        monkeypatch.setenv(ENV_VAR, "banana")
+
+        class _BananaR769rfbn(FeatureChainParserMixin):
+            PREFIX_PATTERN = r".*__(?P<carried_r769rfbn>\w+)$"
+            PROPERTY_MAPPING = {
+                "carried_r769rfbn": PropertySpec("required, carried by the name", context=True),
+                "missing_r769rfbn": PropertySpec("required, options-only, absent", context=True),
+            }
+
+        with caplog.at_level(logging.WARNING):
+            result = _BananaR769rfbn.match_feature_group_criteria("src__val_r769rf", Options())
+
+        assert result is True, "an invalid value must not enforce"
+        assert _required_presence_warnings(caplog, "_BananaR769rfbn"), "an invalid value must fall back to warn"
+
+
+class TestAllowExplicitNoneOnNamePath:
+    """Finding #5a (GUARD): allow_explicit_none makes an explicit None count as present on the name path.
+
+    The key is NO_DEFAULT, non-deferred, ``allow_explicit_none=True``; the operation key is name-carried.
+    """
+
+    def test_warn_explicit_none_matches_no_warning(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """WARN: an explicit None for the allow_explicit_none key counts as present -> no presence warning."""
+        monkeypatch.setenv(ENV_VAR, "warn")
+
+        class _AllowNoneWarnR769rfnw(FeatureChainParserMixin, FeatureGroup):
+            PREFIX_PATTERN = r".*__(\w+)_r769rfnw$"
+            PROPERTY_MAPPING = {
+                "op_r769rfnw": PropertySpec(
+                    "operation carried by the positional capture",
+                    allowed_values=("op",),
+                    context=True,
+                    strict_validation=True,
+                ),
+                "nullable_r769rfnw": PropertySpec(
+                    "required, but an explicit None counts as present", context=True, allow_explicit_none=True
+                ),
+            }
+
+        with caplog.at_level(logging.WARNING):
+            result = _AllowNoneWarnR769rfnw.match_feature_group_criteria(
+                "src__op_r769rfnw", Options(context={"nullable_r769rfnw": None})
+            )
+
+        assert result is True
+        assert not _required_presence_warnings(caplog, "_AllowNoneWarnR769rfnw"), (
+            "an explicit None must count as present, so the key is not flagged missing"
+        )
+
+    def test_warn_absent_warns(self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+        """WARN (contrast): the same key entirely ABSENT is missing and warns, naming the key."""
+        monkeypatch.setenv(ENV_VAR, "warn")
+
+        class _AllowNoneAbsentR769rfna(FeatureChainParserMixin, FeatureGroup):
+            PREFIX_PATTERN = r".*__(\w+)_r769rfna$"
+            PROPERTY_MAPPING = {
+                "op_r769rfna": PropertySpec(
+                    "operation carried by the positional capture",
+                    allowed_values=("op",),
+                    context=True,
+                    strict_validation=True,
+                ),
+                "nullable_r769rfna": PropertySpec(
+                    "required, but an explicit None counts as present", context=True, allow_explicit_none=True
+                ),
+            }
+
+        with caplog.at_level(logging.WARNING):
+            result = _AllowNoneAbsentR769rfna.match_feature_group_criteria("src__op_r769rfna", Options())
+
+        assert result is True, "warn mode still matches despite the absent key"
+        warnings = _required_presence_warnings(caplog, "_AllowNoneAbsentR769rfna")
+        assert warnings, "an absent required key must warn, even when allow_explicit_none is set"
+        assert "nullable_r769rfna" in warnings[0].getMessage(), "the warning must name the absent key"
+
+    def test_enforce_explicit_none_matches(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """ENFORCE: an explicit None counts as present, so the name-path match still succeeds."""
+        monkeypatch.setenv(ENV_VAR, "enforce")
+
+        class _AllowNoneEnforceR769rfne(FeatureChainParserMixin, FeatureGroup):
+            PREFIX_PATTERN = r".*__(\w+)_r769rfne$"
+            PROPERTY_MAPPING = {
+                "op_r769rfne": PropertySpec(
+                    "operation carried by the positional capture",
+                    allowed_values=("op",),
+                    context=True,
+                    strict_validation=True,
+                ),
+                "nullable_r769rfne": PropertySpec(
+                    "required, but an explicit None counts as present", context=True, allow_explicit_none=True
+                ),
+            }
+
+        result = _AllowNoneEnforceR769rfne.match_feature_group_criteria(
+            "src__op_r769rfne", Options(context={"nullable_r769rfne": None})
+        )
+
+        assert result is True, "an explicit None is present, so enforce mode still matches"
+
+    def test_enforce_absent_is_non_match(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """ENFORCE (contrast): the same key entirely ABSENT is missing, so the match is rejected."""
+        monkeypatch.setenv(ENV_VAR, "enforce")
+
+        class _AllowNoneEnforceAbsentR769rfnx(FeatureChainParserMixin, FeatureGroup):
+            PREFIX_PATTERN = r".*__(\w+)_r769rfnx$"
+            PROPERTY_MAPPING = {
+                "op_r769rfnx": PropertySpec(
+                    "operation carried by the positional capture",
+                    allowed_values=("op",),
+                    context=True,
+                    strict_validation=True,
+                ),
+                "nullable_r769rfnx": PropertySpec(
+                    "required, but an explicit None counts as present", context=True, allow_explicit_none=True
+                ),
+            }
+
+        result = _AllowNoneEnforceAbsentR769rfnx.match_feature_group_criteria("src__op_r769rfnx", Options())
+
+        assert result is False, "an absent required key is a non-match under enforce, allow_explicit_none or not"
+
+
+# Finding #1 (GUARD): representative valid name per shipped FeatureGroup that declares a PROPERTY_MAPPING.
+# Each name matches its PREFIX_PATTERN and every captured token is within the bound key's allowed_values,
+# so the group is clean on the name path today (required keys are name-carried or deferred_binding=True).
+SHIPPED_NAME_PATH_CASES: list[tuple[type[Any], str]] = [
+    (AggregatedFeatureGroup, "sales__sum_aggr"),
+    (TimeWindowFeatureGroup, "temperature__avg_7_days_window"),
+    (GeoDistanceFeatureGroup, "point1&point2__haversine_distance"),
+    (TextCleaningFeatureGroup, "review__cleaned_text"),
+    (DimensionalityReductionFeatureGroup, "features__pca_2d"),
+    (EncodingFeatureGroup, "category__onehot_encoded"),
+    (MissingValueFeatureGroup, "amount__mean_imputed"),
+    (ScalingFeatureGroup, "amount__standard_scaled"),
+    (ClusteringFeatureGroup, "features__cluster_kmeans_3"),
+    (NodeCentralityFeatureGroup, "graph__degree_centrality"),
+    (SklearnPipelineFeatureGroup, "data__sklearn_pipeline_preprocessing"),
+    (ForecastingFeatureGroup, "sales__linear_forecast_7day"),
+]
+
+SHIPPED_IDS = [group.__name__ for group, _ in SHIPPED_NAME_PATH_CASES]
+
+
+class TestShippedPluginsCleanAcrossAllGroups:
+    """Finding #1 (GUARD): every shipped PROPERTY_MAPPING group is clean on the name path in every mode.
+
+    Fails loudly if the legacy positional-binding fallback (or a per-key ``deferred_binding`` mark) is
+    ever retired without keeping these groups quiet on the name path.
+    """
+
+    @pytest.mark.parametrize("mode", ["warn", "enforce"])
+    @pytest.mark.parametrize("group, valid_name", SHIPPED_NAME_PATH_CASES, ids=SHIPPED_IDS)
+    def test_shipped_group_name_path_is_clean(
+        self,
+        group: type[Any],
+        valid_name: str,
+        mode: str,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A representative valid name matches with NO presence warning, in both warn and enforce mode."""
+        monkeypatch.setenv(ENV_VAR, mode)
+
+        with caplog.at_level(logging.WARNING):
+            result = group.match_feature_group_criteria(valid_name, Options())
+
+        assert result is True, f"{group.__name__} must match its representative name {valid_name!r} in {mode} mode"
+        assert not _required_presence_warnings(caplog, group.__name__), (
+            f"{group.__name__} must stay clean on the name path in {mode} mode "
+            f"(required keys are name-carried or deferred_binding=True)"
+        )

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_name_path_validates_option_values.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_name_path_validates_option_values.py
@@ -1,7 +1,8 @@
 """The string-named match path validates the option values that are present.
 
-Only required presence differs from the config-based path: a key the name carries is satisfied by the
-name. A rejected value is a non-match, and the parser's message is still available as the reason.
+Required presence is enforced on both paths: a key the name carries is satisfied by the name, and
+deferred_binding exempts a key on the name path only. A rejected value is a non-match, and the
+parser's message is still available as the reason.
 """
 
 from __future__ import annotations
@@ -50,12 +51,14 @@ class NamePathFeatureGroup(FeatureChainParserMixin):
             strict_validation=True,
             default="auto",
         ),
-        # No declared default: the key is REQUIRED on the config path.
+        # No declared default: the key is REQUIRED on the config path; deferred_binding
+        # exempts it on the name path only (it models a key bound after matching).
         "size": PropertySpec(
             "strict, element_validator, never encoded in the name",
             context=True,
             strict_validation=True,
             element_validator=_is_positive_int,
+            deferred_binding=True,
         ),
         "notes": PropertySpec(
             "non-strict, so no value space is enforced",
@@ -158,7 +161,7 @@ class TestNamePathStillAcceptsValidOptions:
         assert result is True
 
     def test_plain_name_match_without_options_still_matches(self) -> None:
-        """Required-PRESENCE stays off on the name path: no options at all still matches."""
+        """No options still matches: the name carries algorithm, defaults and deferred_binding cover the rest."""
         result = NamePathFeatureGroup.match_feature_group_criteria("f0__pca_2d", Options())
 
         assert result is True

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_option_value_rejection_never_escapes.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_option_value_rejection_never_escapes.py
@@ -190,6 +190,7 @@ class RaisingTypeErrorValidatorFeatureGroup(FeatureChainParserMixin, FeatureGrou
             context=True,
             strict_validation=True,
             element_validator=lambda op: op in SUPPORTED_OPERATIONS_ESC732,
+            deferred_binding=True,  # mirrors TextCleaningFeatureGroup: parsed from the name by the group (#769)
         ),
         DefaultOptionKeys.in_features: PropertySpec(
             "Source feature (esc732 fixture)",

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_spec_schema.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_spec_schema.py
@@ -45,7 +45,7 @@ class TestTheConstructorIsTheSchema:
     """The dataclass field set is the whole schema; an unknown field cannot exist."""
 
     def test_field_set_is_exactly_the_schema(self) -> None:
-        """The schema is these nine fields, nothing more: there is no key set to drift from."""
+        """The schema is these ten fields, nothing more: there is no key set to drift from."""
         assert {field.name for field in dataclasses.fields(PropertySpec)} == {
             "explanation",
             "allowed_values",
@@ -56,6 +56,7 @@ class TestTheConstructorIsTheSchema:
             "match_guard",
             "required_when",
             "allow_explicit_none",
+            "deferred_binding",
         }
 
     def test_typo_field_is_a_constructor_type_error_naming_the_offender(self) -> None:

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_spec_builder.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_spec_builder.py
@@ -702,3 +702,36 @@ class TestPropertySpecAllowExplicitNone:
             allow_explicit_none=True,
         )
         assert built == hand_constructed
+
+
+class TestPropertySpecDeferredBinding:
+    """``deferred_binding`` passthrough (issue #769).
+
+    The per-key opt-out defaults to ``False`` and rides through the builder onto the field; a built
+    spec equals the ``PropertySpec`` an author constructs by hand, and a non-bool value is rejected at
+    construction (mirroring ``allow_explicit_none``). ``deferred_binding=True`` exempts the key from the
+    name-path required-presence check only; it does not change config-path requiredness.
+    """
+
+    def test_deferred_binding_emitted_through_builder(self) -> None:
+        """``deferred_binding=True`` lands on the field; omitting it leaves the default ``False``."""
+        assert property_spec("d", deferred_binding=True).deferred_binding is True
+        assert property_spec("d").deferred_binding is False
+
+    def test_deferred_binding_spec_equals_direct_construction(self) -> None:
+        """A ``deferred_binding`` spec is exactly the ``PropertySpec`` an author would construct."""
+        built = property_spec("d", deferred_binding=True)
+
+        hand_constructed = PropertySpec(
+            "d",
+            context=True,
+            strict_validation=False,
+            deferred_binding=True,
+        )
+        assert built == hand_constructed
+
+    def test_non_bool_deferred_binding_raises(self) -> None:
+        """A non-bool ``deferred_binding`` is rejected up front, like ``allow_explicit_none``."""
+        not_a_bool: Any = "yes"
+        with pytest.raises(ValueError, match=r"PropertySpec\('d'\)"):
+            property_spec("d", deferred_binding=not_a_bool)

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_required_when_enforced_on_override.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_required_when_enforced_on_override.py
@@ -14,7 +14,10 @@ from typing import Any
 
 import pytest
 
+from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import (
+    NAME_PATH_PRESENCE_GUARD_FLAG,
+    REQUIRED_WHEN_GUARD_FLAG,
     FeatureChainParser,
 )
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import (
@@ -258,8 +261,12 @@ class TestGuardInstallation:
         assert InheritsMixinMatcher.match_feature_group_criteria("x__first_guarded", REQUIRES_ORDER_BY) is False
         assert predicate.calls == 1
 
-    def test_no_required_when_leaves_the_matcher_untouched(self) -> None:
-        """No conditional requirement declared means nothing to enforce: no wrapper is installed."""
+    def test_no_required_when_means_no_required_when_guard(self) -> None:
+        """No conditional requirement declared means no required_when guard on the resolved matcher.
+
+        The unconditionally required op_type key still earns the name-path presence guard (#769),
+        so a wrapper IS installed; only the required_when flag must stay absent.
+        """
 
         class NoRequiredWhen(FeatureChainParserMixin, FeatureGroup):
             PREFIX_PATTERN = GUARDED_PATTERN
@@ -272,9 +279,28 @@ class TestGuardInstallation:
                 ),
             }
 
-        assert "match_feature_group_criteria" not in NoRequiredWhen.__dict__
         resolved = NoRequiredWhen.match_feature_group_criteria.__func__  # type: ignore[attr-defined]
-        assert resolved is FeatureChainParserMixin.match_feature_group_criteria.__func__  # type: ignore[attr-defined]
+        assert getattr(resolved, REQUIRED_WHEN_GUARD_FLAG, False) is False
+        # The wrapper that is present is the presence guard, not a mislabeled required_when guard.
+        assert getattr(resolved, NAME_PATH_PRESENCE_GUARD_FLAG, False) is True
+
+    def test_no_flaggable_required_key_installs_no_guard_at_all(self) -> None:
+        """A defaulted-only mapping (in_features is name-satisfied) gives neither guard a job."""
+
+        class AllDefaultedNoGuard(FeatureChainParserMixin, FeatureGroup):
+            PREFIX_PATTERN = GUARDED_PATTERN
+            PROPERTY_MAPPING = {
+                OP_TYPE: PropertySpec(
+                    "Operation to apply",
+                    allowed_values={"sum": "Sum of values"},
+                    context=True,
+                    strict_validation=True,
+                    default="sum",
+                ),
+                DefaultOptionKeys.in_features: PropertySpec("source", context=True, strict_validation=False),
+            }
+
+        assert "match_feature_group_criteria" not in AllDefaultedNoGuard.__dict__
 
 
 class TestGuardAnswersInsteadOfRaising:

--- a/tests/test_core/test_api/test_subtype_docs.py
+++ b/tests/test_core/test_api/test_subtype_docs.py
@@ -82,6 +82,7 @@ class SubDeclDocRankFG(FeatureChainParserMixin, FeatureGroup):
             "Rank subtype.",
             strict=True,
             allowed_values={"dense": "Dense ranking", "ordinal": "Ordinal ranking"},
+            deferred_binding=True,  # parametric subtypes (ntile_2) are resolved by SUBTYPES, not name capture
         ),
     }
 
@@ -201,6 +202,7 @@ class SubDeclDocR4RejectingFG(FeatureChainParserMixin, FeatureGroup):
             "Operation kind rejected almost everywhere.",
             strict=True,
             allowed_values={"median": "Median", "sum": "Sum"},
+            deferred_binding=True,  # parametric subtypes (ntile_3) are resolved by SUBTYPES, not name capture
         ),
     }
 

--- a/tests/test_core/test_prepare/test_identify_feature_group_failure_renderer.py
+++ b/tests/test_core/test_prepare/test_identify_feature_group_failure_renderer.py
@@ -54,6 +54,7 @@ NARROW_ENABLED_FEATURE_791 = "renderer_narrow_enabled_791"
 NONE_ENABLED_FEATURE_791 = "renderer_none_enabled_791"
 TIE_FEATURE_791 = "renderer_tie_791"
 TIE_CAPABILITY_FEATURE_791 = "renderer_tie_capability_791"
+MISSING_OPTION_FEATURE_791 = "renderer_missing_option_791__sum_renderer791m"
 
 HEALTHY_DOMAIN_791 = "renderer_healthy_domain_791"
 BOOM_SUPPORTED_NAME_791 = "renderer_boom_supported_name_791"
@@ -329,6 +330,23 @@ class RendererStrictFG791(FeatureChainParserMixin, FeatureGroup):
 WINDOW_REJECTION_REASON = "Property value '14' failed validation for 'window_size'"
 
 
+class RendererMissingOptionFG791(FeatureChainParserMixin, FeatureGroup):
+    """Name-path group whose required options-only key is absent: a MISSING-option rejection, not a wrong value."""
+
+    PREFIX_PATTERN = r".*__(?P<op_791m>\w+)_renderer791m$"
+    PROPERTY_MAPPING = {
+        "op_791m": property_spec("operation carried by the name", context=True),
+        "some_key_791m": property_spec("required, options-only", context=True),
+        DefaultOptionKeys.in_features: property_spec("source", context=True),
+    }
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+MISSING_OPTION_REASON_791 = "required option(s) some_key_791m are absent after declared defaults and name bindings"
+
+
 class RendererNarrowEnabledFG791(CountingFeatureGroup791):
     """Declares two available frameworks; the run enables only the one this candidate rejects."""
 
@@ -599,6 +617,11 @@ def ordinary_none_scenario() -> Scenario:
     return feature, {RendererStrictFG791: {RendererFwOne791}, RendererKnownNamesFG791: {RendererFwOne791}}
 
 
+def missing_option_scenario() -> Scenario:
+    """No match: the sole candidate rejects for a MISSING required option."""
+    return Feature(MISSING_OPTION_FEATURE_791), {RendererMissingOptionFG791: {RendererFwOne791}}
+
+
 def scoped_none_scenario() -> Scenario:
     """No match while scoped to a feature group."""
     feature = Feature(SCOPED_NO_MATCH_FEATURE_791, feature_group="RendererKnownNamesFG791")
@@ -780,13 +803,29 @@ class TestRenderResolutionFailureMessages:
 
         lines = message.split("\n")
         assert lines[0] == f"No feature groups found for feature name: '{TYPO_FEATURE_791}'."
-        assert lines[1] == f"Feature group(s) rejected an option value while matching '{TYPO_FEATURE_791}':"
+        assert lines[1] == f"Feature group(s) rejected the supplied options while matching '{TYPO_FEATURE_791}':"
         assert lines[2] == f"  - RendererStrictFG791: {WINDOW_REJECTION_REASON}"
         assert lines[3].startswith("Did you mean one of: [")
         assert f"'{KNOWN_FEATURE_791}'" in lines[3]
         assert lines[4] == "Use resolve_feature(name, options=...) to debug feature resolution."
         assert lines[5] == TROUBLESHOOTING_LINE
         assert len(lines) == 6
+
+    def test_missing_option_rejection_renders_under_the_options_heading(self) -> None:
+        """A MISSING required option is not a wrong value, so the heading must cover both rejection kinds."""
+        scenario = missing_option_scenario()
+        feature, _ = scenario
+        result = _evaluate(scenario)
+
+        assert result.failure_kind == "none"
+        assert result.facts.value_rejections == (("RendererMissingOptionFG791", MISSING_OPTION_REASON_791),)
+
+        message = render_resolution_failure(result, feature)
+        assert message is not None
+        assert f"Feature group(s) rejected the supplied options while matching '{MISSING_OPTION_FEATURE_791}':" in (
+            message
+        )
+        assert f"  - RendererMissingOptionFG791: {MISSING_OPTION_REASON_791}" in message
 
     def test_empty_environment_stops_after_plugin_loader_hint(self) -> None:
         """An empty environment renders the PluginLoader hint and nothing else."""

--- a/tests/test_core/test_prepare/test_subtype_matching.py
+++ b/tests/test_core/test_prepare/test_subtype_matching.py
@@ -50,6 +50,7 @@ class SubDeclMatchWindowFG(FeatureChainParserMixin, FeatureGroup):
             "Window function subtype.",
             strict=True,
             allowed_values={"median": "Median", "sum": "Sum", "lag": "Lag"},
+            deferred_binding=True,  # parametric subtypes (ntile_2) are resolved by SUBTYPES, not name capture
         ),
     }
 
@@ -136,6 +137,7 @@ class SubDeclMatchRankLikeFG(FeatureChainParserMixin, FeatureGroup):
             "Ranking method.",
             strict=True,
             allowed_values={"dense": "Dense rank", "ordinal": "Ordinal rank"},
+            deferred_binding=True,  # parametric subtypes (ntile_2) are resolved by SUBTYPES, not name capture
         ),
     }
 

--- a/tests/test_plugins/feature_group/experimental/test_text_cleaning/test_cleaning_operations_option_validation.py
+++ b/tests/test_plugins/feature_group/experimental/test_text_cleaning/test_cleaning_operations_option_validation.py
@@ -91,8 +91,9 @@ class TestOrdinaryOperationVerdictsUnchanged:
 
         assert result is True
 
-    def test_name_path_without_options_matches(self) -> None:
-        assert TextCleaningFeatureGroup.match_feature_group_criteria(CLEANED_FEATURE, Options()) is True
+    def test_name_path_without_options_is_a_non_match(self) -> None:
+        """cleaning_operations is option-required on the name path, so its absence is a non-match."""
+        assert TextCleaningFeatureGroup.match_feature_group_criteria(CLEANED_FEATURE, Options()) is False
 
     def test_hashable_unsupported_operation_is_a_non_match(self) -> None:
         """A value the validator can judge (and rejects) keeps its verdict."""

--- a/tests/test_plugins/feature_group/experimental/test_text_cleaning/test_text_cleaning_base.py
+++ b/tests/test_plugins/feature_group/experimental/test_text_cleaning/test_text_cleaning_base.py
@@ -2,6 +2,9 @@
 Tests for the TextCleaningFeatureGroup base class.
 """
 
+import pytest
+
+from mloda.user import Feature
 from mloda.user import FeatureName
 from mloda.user import Options
 from mloda.provider import DefaultOptionKeys
@@ -13,10 +16,10 @@ class TestTextCleaningFeatureGroupBase:
     """Tests for the TextCleaningFeatureGroup base class."""
 
     def test_match_feature_group_criteria_valid(self) -> None:
-        """Test that valid feature names are accepted."""
-        # Valid feature name
+        """Test that valid feature names with cleaning operations supplied are accepted."""
+        # Valid feature name; cleaning_operations is option-required on the name path.
         feature_name = "review__cleaned_text"
-        options = Options()
+        options = Options(context={TextCleaningFeatureGroup.CLEANING_OPERATIONS: ("normalize",)})
 
         # Test with string
         assert TextCleaningFeatureGroup.match_feature_group_criteria(feature_name, options)
@@ -24,6 +27,13 @@ class TestTextCleaningFeatureGroupBase:
         # Test with FeatureName
         feature_name_obj = FeatureName(feature_name)
         assert TextCleaningFeatureGroup.match_feature_group_criteria(feature_name_obj, options)
+
+    def test_extract_operations_without_options_raises(self) -> None:
+        """Absent cleaning operations must raise instead of silently copying the source column."""
+        feature = Feature(FeatureName("text__cleaned_text"), Options())
+
+        with pytest.raises(ValueError):
+            TextCleaningFeatureGroup._extract_operations_and_source_feature(feature)
 
     def test_match_feature_group_criteria_invalid(self) -> None:
         """Test that invalid feature names are rejected."""


### PR DESCRIPTION
Closes #769. Part of epic #761, phase 3.

## Problem

Finding 8 of #750: the string-named (feature-name-based) match path skipped required-presence validation for every option key, so a feature group with multiple `NO_DEFAULT` keys could match on its name with those keys absent and only fail later at compute time.

## Change

Required presence is now enforced on the string-named path, unconditionally. A required key still absent after declared defaults and parsed-name bindings resolve makes the match a non-match, with a warning naming the feature group and the missing key(s); the resolution-failure report names them too. This is deliberately not backwards compatible: the interim migration mechanism (the `MLODA_NAME_PATH_REQUIRED_PRESENCE` env var with warn/enforce/off modes) is removed, and regression tests pin that the env var is ignored.

### Never falsely flagged

Declared-default keys, `required_when` keys (owned by their own guard), the source key (`in_features`, provided by the name prefix and counted by MIN/MAX_IN_FEATURES), and `deferred_binding` keys.

### `PropertySpec.deferred_binding`

Per-key declaration (default `False`) that a required key is bound outside match-time name capture (parsed from the name by the plugin, or supplied downstream). It exempts the string-named path only and leaves config-path requiredness unchanged.

### Shipped-plugin migration

Groups whose keys are parsed from the name after matching are marked `deferred_binding=True`: time_window (`window_size`, `time_unit`), text_cleaning (`cleaning_operations`), dimensionality_reduction (`dimension`), clustering (`k_value`), forecasting (`horizon`, `time_unit`). The config path for these is unchanged. The registry-plugin migration is tracked in mloda-registry#327.

## Tests

Suites cover multiple required keys, declared defaults, conditional (`required_when`) requirements, name-bound captures, `allow_explicit_none`, the source-key exemption, intentionally-deferred values on both creation paths, the surfaced failure diagnostic, regression pins that the retired env var is ignored, and a guard that all 12 shipped groups stay clean on the name path. Docs in `property-mapping.md` describe the final behavior. `tox` passes (pytest, ruff, pip-licenses, mypy --strict, bandit).

## Review

Two independent deep review rounds (Claude Opus and codex): one on the interim migration version, one on the mandatory version. The mandatory round found no correctness defect; the one accepted finding (stale migration wording in the docs test index) is applied. Deferred follow-ups: migrating shipped `PREFIX_PATTERN`s to named captures (#772 / mloda-registry#327) and optional dedup of the match-time warning.
