### PR TITLE
fix: harden multiprocessing runtime against stale drop signals and dead workers

### DIFF
--- a/mloda/core/runtime/run.py
+++ b/mloda/core/runtime/run.py
@@ -144,6 +144,9 @@ class ExecutionOrchestrator:
                 if isinstance(original, BaseException):
                     raise original
                 raise MlodaRunError(self.cfw_register.get_error_msg())
+            dead = self.worker_manager.find_dead_workers()
+            if dead:
+                raise MlodaRunError(f"Worker process(es) died unexpectedly: {dead}")
             return False
         return True
 

--- a/mloda/core/runtime/worker_manager.py
+++ b/mloda/core/runtime/worker_manager.py
@@ -59,13 +59,27 @@ class WorkerManager:
         command_queue.put(command)
 
     def poll_result_queues(self) -> None:
-        """Non-blocking poll all result queues, add UUIDs to result_uuids_collection."""
+        """Non-blocking poll all result queues, collect step-UUID strings.
+
+        The result queue also carries ("DROP_COMPLETE", cfw_uuid) control tuples;
+        skip non-str messages rather than pass them to UUID().
+        """
         for r_queue in self.result_queues_collection:
             try:
-                result_uuid = r_queue.get(block=False)
-                self.result_uuids_collection.add(UUID(result_uuid))
+                msg = r_queue.get(block=False)
             except queue.Empty:
                 continue
+            if isinstance(msg, str):
+                self.result_uuids_collection.add(UUID(msg))
+
+    def find_dead_workers(self) -> list[tuple[UUID, int]]:
+        """Return (cfw_uuid, exitcode) for workers that died abnormally (exitcode not in {None, 0})."""
+        dead: list[tuple[UUID, int]] = []
+        for cfw_uuid, (process, _, _) in self.process_register.items():
+            exitcode = process.exitcode
+            if exitcode is not None and exitcode != 0:
+                dead.append((cfw_uuid, exitcode))
+        return dead
 
     def is_step_done(self, step_uuid: UUID) -> bool:
         """Return step_uuid in result_uuids_collection."""

--- a/tests/test_core/test_runtime/test_worker_liveness.py
+++ b/tests/test_core/test_runtime/test_worker_liveness.py
@@ -1,0 +1,50 @@
+"""Failing tests: the orchestrator must abort when a worker dies without reporting an error.
+
+``ExecutionOrchestrator.compute`` loops until every step UUID is finished. A
+worker SIGKILL'd by the OOM killer never emits its step UUID (so it is never
+marked finished) AND never runs its except block (so ``cfw_register.set_error``
+is never called). ``_check_for_error`` therefore returns ``False`` and the loop
+spins forever.
+
+The fix adds ``WorkerManager.find_dead_workers`` (see test_worker_manager.py)
+and has ``_check_for_error`` raise ``MlodaRunError`` when it returns a non-empty
+list. This test pins that liveness check.
+
+It FAILS today because ``_check_for_error`` does not inspect worker liveness: it
+returns ``False`` and never raises, so ``pytest.raises(MlodaRunError)`` reports
+DID NOT RAISE.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, Mock
+from uuid import uuid4
+
+import pytest
+
+from mloda.core.abstract_plugins.components.error_utils import MlodaRunError
+from mloda.core.prepare.execution_plan import ExecutionPlan
+from mloda.core.runtime.run import ExecutionOrchestrator
+
+
+def test_check_for_error_raises_when_worker_dead_without_reported_error() -> None:
+    """_check_for_error must raise MlodaRunError for a dead worker even with no reported error.
+
+    This is the SIGKILL/OOM case: ``get_error`` returns ``None`` (the worker
+    never reached its except block), yet a registered process has a non-zero
+    exitcode. Without a liveness check the run loop would never terminate.
+    """
+    orchestrator = ExecutionOrchestrator(Mock(spec=ExecutionPlan))
+
+    cfw_register = MagicMock()
+    cfw_register.get_error.return_value = None
+    cfw_register.get_parallelization_modes.return_value = set()
+    orchestrator.cfw_register = cfw_register
+
+    dead_process = MagicMock()
+    dead_process.exitcode = -9
+    dead_process.is_alive.return_value = False
+    orchestrator.worker_manager.process_register[uuid4()] = (dead_process, MagicMock(), MagicMock())
+
+    with pytest.raises(MlodaRunError):
+        orchestrator._check_for_error()

--- a/tests/test_core/test_runtime/test_worker_manager.py
+++ b/tests/test_core/test_runtime/test_worker_manager.py
@@ -285,6 +285,59 @@ class TestWorkerManagerResultPolling:
         assert UUID(uuid2) in manager.result_uuids_collection
         assert len(manager.result_uuids_collection) == 2
 
+    def test_poll_result_queues_ignores_stale_drop_complete_tuple(self) -> None:
+        """A stale ("DROP_COMPLETE", cfw_uuid) control tuple must not be parsed as a UUID.
+
+        The worker's single result_queue carries BOTH step-completion UUID
+        strings and ("DROP_COMPLETE", cfw_uuid) control tuples. When a drop
+        wait times out, the tuple lingers in the queue and a later poll picks
+        it up. poll_result_queues must skip it instead of calling
+        ``UUID(("DROP_COMPLETE", cfw_uuid))`` (which raises
+        ``AttributeError: 'tuple' object has no attribute 'replace'``).
+        """
+        manager = WorkerManager()
+        cfw_uuid = uuid4()
+
+        mock_queue = MagicMock()
+        mock_queue.get.side_effect = [("DROP_COMPLETE", cfw_uuid), queue.Empty()]
+        manager.result_queues_collection.add(mock_queue)
+
+        # Must not raise; the control tuple is ignored, not interpreted as a UUID.
+        manager.poll_result_queues()
+
+        assert cfw_uuid not in manager.result_uuids_collection
+        assert manager.result_uuids_collection == set()
+
+    def test_poll_result_queues_keeps_valid_uuid_when_interleaved_with_stale_tuple(self) -> None:
+        """A valid UUID string must still be collected even when a stale tuple follows it.
+
+        Mirrors production: one poll consumes the step-completion UUID string,
+        a later poll consumes the lingering ("DROP_COMPLETE", cfw_uuid) tuple.
+        Extra ``queue.Empty()`` sentinels keep the test robust whether the fix
+        keeps single-get-per-poll semantics or drains each queue to empty.
+        """
+        manager = WorkerManager()
+        valid_uuid = str(uuid4())
+        other_uuid = uuid4()
+
+        mock_queue = MagicMock()
+        mock_queue.get.side_effect = [
+            valid_uuid,
+            ("DROP_COMPLETE", other_uuid),
+            queue.Empty(),
+            queue.Empty(),
+            queue.Empty(),
+        ]
+        manager.result_queues_collection.add(mock_queue)
+
+        # First poll picks up the valid UUID; the second reaches the stale tuple,
+        # which must be ignored rather than raise AttributeError.
+        manager.poll_result_queues()
+        manager.poll_result_queues()
+
+        assert UUID(valid_uuid) in manager.result_uuids_collection
+        assert other_uuid not in manager.result_uuids_collection
+
 
 class TestWorkerManagerStepCompletion:
     """Test checking if steps are completed."""
@@ -303,6 +356,56 @@ class TestWorkerManagerStepCompletion:
         step_uuid = uuid4()
 
         assert manager.is_step_done(step_uuid) is False
+
+
+class TestWorkerManagerDeadWorkerDetection:
+    """Test detection of abnormally-terminated worker processes (e.g. OOM SIGKILL)."""
+
+    @pytest.mark.timeout(30)
+    def test_find_dead_workers_detects_sigkilled_worker(self) -> None:
+        """find_dead_workers must report a worker that died abnormally.
+
+        A worker SIGKILL'd by the OOM killer never emits its step UUID and
+        never runs its except block (so no error is set on cfw_register). The
+        only observable signal is the process exitcode, which is non-zero
+        (``-9`` for SIGKILL). find_dead_workers must surface it as a
+        (cfw_uuid, exitcode) entry so the run loop can abort instead of
+        spinning forever.
+        """
+        manager = WorkerManager()
+        cfw_uuid = uuid4()
+
+        process, _, _ = manager.create_worker_process(cfw_uuid=cfw_uuid, target=_loop_forever_target, args=())
+        process.kill()
+        process.join(timeout=5)
+
+        # Sanity: the real process died abnormally (non-zero, non-None exit).
+        assert process.exitcode is not None
+        assert process.exitcode != 0
+
+        dead = manager.find_dead_workers()
+
+        assert any(entry[0] == cfw_uuid for entry in dead)
+
+    def test_find_dead_workers_ignores_alive_and_clean_workers(self) -> None:
+        """find_dead_workers must return [] when every worker is healthy.
+
+        A healthy worker is either still alive (exitcode is None) or exited
+        cleanly via STOP (exitcode 0). Neither counts as a dead worker.
+        """
+        manager = WorkerManager()
+
+        alive_process = MagicMock()
+        alive_process.exitcode = None
+        alive_process.is_alive.return_value = True
+        manager.process_register[uuid4()] = (alive_process, MagicMock(), MagicMock())
+
+        clean_process = MagicMock()
+        clean_process.exitcode = 0
+        clean_process.is_alive.return_value = False
+        manager.process_register[uuid4()] = (clean_process, MagicMock(), MagicMock())
+
+        assert manager.find_dead_workers() == []
 
 
 class TestWorkerManagerDropCompletion:


### PR DESCRIPTION
## Problem

Two robustness bugs in the multiprocessing runtime, both confirmed by tracing the result-queue protocol.

1. **Stale `DROP_COMPLETE` tuple crashes the poll.** A worker's single `result_queue` carries both step-completion UUID strings (`str(command.uuid)`) and `("DROP_COMPLETE", cfw_uuid)` control tuples. `WorkerManager.poll_result_queues` called `UUID()` on every message. When `wait_for_drop_completion` hits its 5s timeout, the tuple lingers in the queue; the next poll runs `UUID(("DROP_COMPLETE", ...))` and raises `AttributeError: 'tuple' object has no attribute 'replace'`, aborting the whole run. The 5s timeout was meant to degrade gracefully (a logged warning), but the leftover tuple turned that soft failure into a hard crash.

2. **No worker-liveness check wedges `compute()` forever.** The run loop spins until `finished_ids == to_finish_ids`. A worker SIGKILL'd by the OOM killer never emits its step UUID and never runs its except block (so it never records an error via `cfw_register`), so `_check_for_error` returns `False` and the loop spins forever at 10ms per iteration.

Both bugs affect only the `MULTIPROCESSING` path; `compute_stream()` inherits both through the shared `_run_planner_pass` / `_check_for_error`.

## Fix

- `poll_result_queues` now only parses `str` messages into UUIDs; non-str control tuples are ignored (they are pure synchronization signals, and drop bookkeeping is tracked independently in `_drop_data_if_possible`).
- New `WorkerManager.find_dead_workers()` returns `(cfw_uuid, exitcode)` for any registered worker whose `exitcode` is not in `{None, 0}`. The `worker()` function catches all exceptions and returns 0, so any non-zero/non-None exit is a genuine abnormal death (SIGKILL is -9).
- `_check_for_error` raises `MlodaRunError` when `find_dead_workers()` is non-empty, so an OOM-killed worker aborts the run promptly instead of hanging.

## Tests

Five new tests (TDD): poll ignores a stale `DROP_COMPLETE` tuple and still collects a valid interleaved UUID; `find_dead_workers` detects a real SIGKILL'd spawn process and ignores alive/clean workers; `_check_for_error` raises `MlodaRunError` on a dead worker with no reported error.

## Validation

`tox` green: 6916 passed, 170 skipped, ruff format/check clean, `mypy --strict` clean (871 files), bandit clean. Independently reviewed by a fresh Claude Opus agent and codex; both found no material issues.