### PR TITLE
fix: name the plugin whose framework declaration aborted the environment build

### DIFF
--- a/docs/docs/in_depth/discover-plugins.md
+++ b/docs/docs/in_depth/discover-plugins.md
@@ -248,11 +248,13 @@ consulted, so the build succeeds and the feature is an ordinary no-match:
 ``` python
 # One broken third-party plugin, and every call reports its failure:
 resolve_feature("timestamp_unix").error
-# "Failed to build the plugin environment: RuntimeError: ..."
+# "Failed to build the plugin environment: RuntimeError: ... (raised by pkg.module:BrokenFG while declaring its compute frameworks)"
 
 # Scope it out, and resolution works again:
 resolve_feature("timestamp_unix", plugin_collector=PluginCollector().disabled_feature_groups({BrokenFG}))
 ```
+
+`resolve_feature` names the culprit class as `module:qualname` in the error, so you know exactly which plugin to scope out.
 
 Strict mode is the other filter: an unregistered broken plugin is dropped before
 its declaration is read. Both apply identically to a run, so a scope that rescues

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -34,6 +34,7 @@ from mloda.core.api.plugin_info import ComputeFrameworkInfo, ExtenderInfo, Featu
 from mloda.core.prepare.accessible_plugins import (
     EnvironmentPreconditionError,
     FeatureGroupEnvironmentMapping,
+    FrameworkDeclarationError,
     PreFilterPlugins,
     RedefinitionConflictError,
     dedup_feature_group_subclasses,
@@ -412,9 +413,9 @@ def resolve_feature(
     )
     try:
         accessible_plugins: FeatureGroupEnvironmentMapping = PreFilterPlugins(
-            restricted_frameworks, plugin_collector
+            restricted_frameworks, plugin_collector, attribute_declaration_failures=True
         ).get_accessible_plugins()
-    except (RedefinitionConflictError, EnvironmentPreconditionError) as exc:
+    except (RedefinitionConflictError, EnvironmentPreconditionError, FrameworkDeclarationError) as exc:
         # mloda's own environment failure: already a complete sentence. Project it bare, no candidates.
         return ResolvedFeature(feature_name, None, [], error=f"{exc}{scope_suffix}")
     except Exception as exc:  # noqa: BLE001  (never-raising debug API; projects a broken plugin's build failure)

--- a/mloda/core/prepare/accessible_plugins.py
+++ b/mloda/core/prepare/accessible_plugins.py
@@ -113,6 +113,22 @@ class RedefinitionConflictError(ValueError):
     """
 
 
+class FrameworkDeclarationError(ValueError):
+    """A FeatureGroup raised while declaring its compute frameworks; carries the culprit's identity.
+
+    resolve_feature builds the environment with attribution on so it can name the broken plugin; the engine
+    builds with it off and keeps propagating the provider exception raw (#790). The message is a complete
+    user-facing sentence that callers project as-is. Subclasses ``ValueError`` like the sibling build errors.
+    """
+
+    def __init__(self, feature_group_identity: str, original: BaseException) -> None:
+        self.feature_group_identity = feature_group_identity
+        super().__init__(
+            f"Failed to build the plugin environment: {type(original).__name__}: {original} "
+            f"(raised by {feature_group_identity} while declaring its compute frameworks)"
+        )
+
+
 def _running_in_zmq_shell() -> bool:
     """Detect IPython kernel (Jupyter) environment for the kernel-restart hint."""
     try:
@@ -293,7 +309,9 @@ class PreFilterPlugins:
         self,
         compute_frameworks: set[type[ComputeFramework]],
         plugin_collector: Optional[PluginCollector] = None,
+        attribute_declaration_failures: bool = False,
     ) -> None:
+        self.attribute_declaration_failures = attribute_declaration_failures
         feature_groups = self._set_feature_groups(plugin_collector)
         compute_frameworks = self._set_compute_frameworks(compute_frameworks, plugin_collector)
 
@@ -414,7 +432,14 @@ class PreFilterPlugins:
         # Fail closed: a provider that raises while declaring its frameworks aborts the build, raw and unwrapped.
         accessible_plugins: FeatureGroupEnvironmentMapping = {}
         for feature_group in feature_groups:
-            definition = feature_group.compute_framework_definition()
+            if self.attribute_declaration_failures:
+                try:
+                    definition = feature_group.compute_framework_definition()
+                except Exception as exc:  # noqa: BLE001  attribute the culprit, then re-raise typed
+                    identity = f"{feature_group.__module__}:{feature_group.__qualname__}"
+                    raise FrameworkDeclarationError(identity, exc) from exc
+            else:
+                definition = feature_group.compute_framework_definition()
             new_set_of_compute_frameworks = {cp_fg for cp_fg in definition if cp_fg in compute_frameworks}
             accessible_plugins[feature_group] = new_set_of_compute_frameworks
 

--- a/mloda/core/prepare/accessible_plugins.py
+++ b/mloda/core/prepare/accessible_plugins.py
@@ -429,7 +429,9 @@ class PreFilterPlugins:
         feature_groups: set[type[FeatureGroup]],
         compute_frameworks: set[type[ComputeFramework]],
     ) -> FeatureGroupEnvironmentMapping:
-        # Fail closed: a provider that raises while declaring its frameworks aborts the build, raw and unwrapped.
+        # Fail closed: a provider that raises while declaring its frameworks aborts the build. The engine
+        # build (flag off) propagates it raw and unwrapped (#790); resolve_feature (flag on) attributes it
+        # to the culprit FeatureGroup as FrameworkDeclarationError.
         accessible_plugins: FeatureGroupEnvironmentMapping = {}
         for feature_group in feature_groups:
             if self.attribute_declaration_failures:

--- a/tests/test_core/test_resolution_parity/test_environment_build_failure_parity.py
+++ b/tests/test_core/test_resolution_parity/test_environment_build_failure_parity.py
@@ -158,6 +158,29 @@ def test_resolve_feature_projects_the_environment_build_failure() -> None:
     assert environment == "standalone-default"
 
 
+def test_resolve_feature_names_the_broken_plugin_for_an_unrelated_feature() -> None:
+    """An unrelated feature still surfaces the broken plugin, named as module:qualname (#794)."""
+    broken_fg = _make_broken_rule_fg()
+    identity = f"{broken_fg.__module__}:{broken_fg.__qualname__}"
+    try:
+        result = resolve_feature("unrelated_probe794_feature")
+        winner_name = result.feature_group.get_class_name() if result.feature_group is not None else None
+        error = result.error
+        candidate_names = [candidate.get_class_name() for candidate in result.candidates]
+        del result
+    finally:
+        del broken_fg
+        gc.collect()
+
+    # The broken plugin declares EVERY group's frameworks, so it aborts the build of an unrelated feature too.
+    assert winner_name is None
+    assert error is not None
+    assert "Failed to build the plugin environment" in error
+    # #794: the fail-closed error must name the culprit class, not just the raised exception.
+    assert identity in error
+    assert candidate_names == []
+
+
 def test_engine_and_resolve_feature_report_the_same_provider_failure() -> None:
     """Parity: both paths surface the SAME provider failure, not two independently drifting strings."""
     broken_fg = _make_broken_rule_fg()

--- a/tests/test_core/test_resolution_parity/test_environment_build_failure_parity.py
+++ b/tests/test_core/test_resolution_parity/test_environment_build_failure_parity.py
@@ -7,8 +7,9 @@ keeps its never-raising contract by projecting the same failure into ResolvedFea
 aborts before matching, a broken group is not a listed candidate.
 
 That projection has two shapes, split by who is at fault rather than by which exception type a plugin
-happens to raise: a PLUGIN's failure is attributed ("Failed to build the plugin environment: <type>: <msg>"),
-while mloda's own environment preconditions are already complete user-facing sentences and stay bare.
+happens to raise: a PLUGIN's failure is attributed ("Failed to build the plugin environment: <type>: <msg>
+(raised by <module:qualname> while declaring its compute frameworks)"), while mloda's own environment
+preconditions are already complete user-facing sentences and stay bare.
 
 The broken class is built per test by a factory and dropped in a finally (del + gc.collect(), same pattern as
 test_sbdg_resolve_feature_broken_rule.py). This matters more than usual here: under fail-closed semantics a
@@ -176,6 +177,8 @@ def test_resolve_feature_names_the_broken_plugin_for_an_unrelated_feature() -> N
     assert winner_name is None
     assert error is not None
     assert "Failed to build the plugin environment" in error
+    assert "RuntimeError" in error
+    assert ENV_BUILD_FAILURE_MESSAGE in error
     # #794: the fail-closed error must name the culprit class, not just the raised exception.
     assert identity in error
     assert candidate_names == []


### PR DESCRIPTION
Closes #794.

## Problem
When one installed plugin's `compute_framework_definition()` raises, the environment build fails closed process-wide (the build declares every FeatureGroup's frameworks, so one broken plugin aborts resolution of even unrelated features). `resolve_feature(...)` projected that failure as `"Failed to build the plugin environment: <type>: <msg>"` without naming which plugin broke, so a user with one broken plugin had no pointer to which one to scope out. The debug tool whose job is to explain resolution could not name the thing that broke it.

## Design decision (option 3: attribute at the projection site)
- **Rejected option 1 (log a warning):** leaves `ResolvedFeature.error` itself unattributed, so it fails "identify from `resolve_feature` alone", and a log on the shared build loop would fire on the engine path too (an engine-behavior change, exactly what #790 removed).
- **Rejected option 2 (carry attribution on the exception the engine raises):** changes the engine's error text, violating the #790 byte-identical constraint.
- **Chosen option 3:** `PreFilterPlugins` gains an opt-in `attribute_declaration_failures` flag that **only `resolve_feature` sets**. The engine (`engine.py`) constructs the build with the flag off, so its loop is code-identical to before and keeps propagating the provider exception raw and unwrapped. On the debug path the flag is on: a raising declaration is re-raised as a typed `FrameworkDeclarationError` whose message embeds the original type, original text, and the culprit's `module:qualname`. `resolve_feature` projects that message as-is.

Attribution carries a **string identity only**, never the class object, so nothing pins the broken FeatureGroup (fail-closed semantics mean a leaked broken class would abort unrelated tests in the same xdist worker).

## Definition of done
- [x] Decide and record the approach (option 3, above)
- [x] A user with one broken plugin can identify it from `resolve_feature` alone (error now names `module:qualname`)
- [x] Engine behavior and error texts stay byte-identical (flag defaults off; engine path unchanged, parity tests green)
- [x] Test pinning attribution for a broken plugin with an unrelated feature requested
- [x] `tox` passes (6959 passed, ruff, licenses, mypy --strict, bandit)

## Changes
- `mloda/core/prepare/accessible_plugins.py`: new `FrameworkDeclarationError`; opt-in `attribute_declaration_failures` on `PreFilterPlugins`; the declaration loop wraps and attributes only when the flag is on.
- `mloda/core/api/plugin_docs.py`: `resolve_feature` builds with the flag on and projects `FrameworkDeclarationError` bare.
- `tests/.../test_environment_build_failure_parity.py`: new leak-safe test with an unrelated feature requested, asserting the error names the broken plugin.
- `docs/docs/in_depth/discover-plugins.md`: the "Broken framework declarations" example shows the attributed message.

## Review
Two independent deep reviews ran on the diff: codex (no findings) and a fresh Claude Opus pass (no blockers, no majors). Accepted nits (comment/docstring accuracy, a self-contained test assertion) are applied; the one rejected finding (non-`Exception` `BaseException` slipping the never-raising contract) is pre-existing and out of scope, and catching `BaseException` would wrongly swallow `KeyboardInterrupt`.
