### PR TITLE
chore: remove dead debug comments from core planner

### DIFF
--- a/mloda/core/core/engine.py
+++ b/mloda/core/core/engine.py
@@ -71,7 +71,6 @@ class Engine:
         # set api input collection if relevant
         self.api_input_data_collection = api_input_data_collection
 
-        # TODO
         self.plugin_collector = plugin_collector
         self.copy_compute_frameworks = deepcopy(compute_frameworks)
 

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -292,30 +292,6 @@ class ExecutionPlan:
                     if _ep.features.any_uuid in need_to_upload_collector:
                         _ep.need_to_upload = True
 
-        # 1.7.2024
-        # print()
-        # for ep in new_execution_plan:
-        #    print("--------")
-        #    if isinstance(ep, FeatureGroupStep):
-        #        print("FGS", ep.feature_group.get_class_name(), ep.features.get_all_feature_ids())
-        #        print(ep.features.get_all_names())
-        #        print(ep.children_if_root)
-        #        # print(next(iter(ep.features.features)).compute_frameworks)
-        #        print(ep.required_uuids)
-        #    elif isinstance(ep, TransformFrameworkStep):
-        #        print("TFS")
-        #        print(ep.from_feature_group.get_class_name(), " -> ", ep.to_feature_group.get_class_name())
-        #        print(ep.from_framework.get_class_name(), " -> ", ep.to_framework.get_class_name())
-        #        print(ep.required_uuids)
-        #    elif isinstance(ep, JoinStep):
-        #        print("JOIN")
-        #        print(ep.link.uuid)
-        #        print(ep.destination_framework_uuids)
-        #        print(ep.source_framework_uuids)
-        #       print(ep.source_framework.get_class_name(), " -> ", ep.destination_framework.get_class_name())
-        #        print(ep.required_uuids)
-        # print("###############################")
-
         return new_execution_plan
 
     def set_store_value_to_left_most_index_and_update_feature_group(


### PR DESCRIPTION
Closes #746

Removes two dead-code comments identified in #746:

1. **`mloda/core/prepare/execution_plan.py`**: a large commented-out debug `print` block dated `1.7.2024`, covering execution plan step inspection. It was never re-enabled after development and adds noise to the planner logic.

2. **`mloda/core/core/engine.py`**: a bare `# TODO` with no content above the `plugin_collector` assignment — not actionable.

### Changes
- 2 files changed, 0 insertions, 25 deletions
- No behavior change

### Verification
- `ruff format --check --line-length 120` → ✅ 2 files already formatted
- `ruff check --line-length 120` → ✅ All checks passed
- `pytest` (599 passed, 299 skipped) → ✅