### PR TITLE
refactor: unify environment-build failure handling across engine and diagnostic surfaces

### DIFF
--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -413,7 +413,7 @@ def resolve_feature(
     )
     try:
         accessible_plugins: FeatureGroupEnvironmentMapping = PreFilterPlugins(
-            restricted_frameworks, plugin_collector, attribute_declaration_failures=True
+            restricted_frameworks, plugin_collector
         ).get_accessible_plugins()
     except (RedefinitionConflictError, EnvironmentPreconditionError, FrameworkDeclarationError) as exc:
         # mloda's own environment failure: already a complete sentence. Project it bare, no candidates.

--- a/mloda/core/api/request.py
+++ b/mloda/core/api/request.py
@@ -16,7 +16,12 @@ from mloda.core.prepare.identify_feature_group import (
 )
 from mloda.core.api.run_result import ResultStream, RunResult
 from mloda.core.api.prepare.setup_compute_framework import SetupComputeFramework
-from mloda.core.prepare.accessible_plugins import filter_extenders_by_strict_mode
+from mloda.core.prepare.accessible_plugins import (
+    EnvironmentPreconditionError,
+    FrameworkDeclarationError,
+    RedefinitionConflictError,
+    filter_extenders_by_strict_mode,
+)
 from mloda.core.filter.global_filter import GlobalFilter
 from mloda.core.runtime.run import ExecutionOrchestrator
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
@@ -337,8 +342,10 @@ class mlodaAPI:
         features resolved before the failing one (from the error payload, capped at PARTIAL_RECORDS_CAP on
         huge requests) plus that feature's EvaluationResult and rendered message. A SetupConfigurationError
         (any invalid request argument caught during session setup, before planning, for example an invalid
-        column_ordering or an unknown compute framework name) yields only the message; any other error
-        propagates. Every parameter after features is keyword-only.
+        column_ordering or an unknown compute framework name) yields only the message. Environment-build
+        failures (EnvironmentPreconditionError, RedefinitionConflictError, FrameworkDeclarationError) are
+        likewise projected into the diagnosis instead of raising; any other error propagates. Every parameter
+        after features is keyword-only.
         """
         try:
             session = cls(
@@ -362,6 +369,8 @@ class mlodaAPI:
                 failed_result=deepcopy(error.result),
                 message=str(error),
             )
+        except (EnvironmentPreconditionError, RedefinitionConflictError, FrameworkDeclarationError) as error:
+            return ResolutionDiagnosis(records=[], complete=False, message=str(error))
         except SetupConfigurationError as error:
             return ResolutionDiagnosis(records=[], complete=False, message=str(error))
         return ResolutionDiagnosis(records=session.resolution_report(), complete=True)

--- a/mloda/core/prepare/accessible_plugins.py
+++ b/mloda/core/prepare/accessible_plugins.py
@@ -116,8 +116,8 @@ class RedefinitionConflictError(ValueError):
 class FrameworkDeclarationError(ValueError):
     """A FeatureGroup raised while declaring its compute frameworks; carries the culprit's identity.
 
-    resolve_feature builds the environment with attribution on so it can name the broken plugin; the engine
-    builds with it off and keeps propagating the provider exception raw (#790). The message is a complete
+    The environment build always attributes the culprit on every path (engine and resolve_feature), so the
+    broken plugin is named rather than its raw exception propagated (#850). The message is a complete
     user-facing sentence that callers project as-is. Subclasses ``ValueError`` like the sibling build errors.
     """
 
@@ -309,9 +309,7 @@ class PreFilterPlugins:
         self,
         compute_frameworks: set[type[ComputeFramework]],
         plugin_collector: Optional[PluginCollector] = None,
-        attribute_declaration_failures: bool = False,
     ) -> None:
-        self.attribute_declaration_failures = attribute_declaration_failures
         feature_groups = self._set_feature_groups(plugin_collector)
         compute_frameworks = self._set_compute_frameworks(compute_frameworks, plugin_collector)
 
@@ -325,10 +323,14 @@ class PreFilterPlugins:
     def _set_feature_groups(self, plugin_collector: Optional[PluginCollector] = None) -> set[type[FeatureGroup]]:
         accessible_feature_groups = self.get_featuregroup_subclasses()
 
+        loaded_universe_was_non_empty = bool(accessible_feature_groups)
         if plugin_collector:
             for accessible_fg in deepcopy(accessible_feature_groups):
                 if not plugin_collector.applicable_feature_group_class(accessible_fg):
                     accessible_feature_groups.remove(accessible_fg)
+        collector_filtered_everything = (
+            plugin_collector is not None and loaded_universe_was_non_empty and len(accessible_feature_groups) == 0
+        )
 
         allow_redefinition = plugin_collector.allow_redefinition if plugin_collector is not None else False
         strict_mode = plugin_collector.strict_mode if plugin_collector is not None else strict_mode_from_env()
@@ -383,6 +385,12 @@ class PreFilterPlugins:
                 )
 
         if len(accessible_feature_groups) == 0:
+            if collector_filtered_everything:
+                raise EnvironmentPreconditionError(
+                    "The PluginCollector filtered out every FeatureGroup: none of the loaded FeatureGroups "
+                    "satisfied its enabled/disabled configuration. Adjust the classes passed to "
+                    "enabled_feature_groups()/disabled_feature_groups() (or the collector's applicability filter)."
+                )
             raise EnvironmentPreconditionError("No feature groups are loaded. Did you call PluginLoader.all()?")
         return accessible_feature_groups
 
@@ -429,19 +437,16 @@ class PreFilterPlugins:
         feature_groups: set[type[FeatureGroup]],
         compute_frameworks: set[type[ComputeFramework]],
     ) -> FeatureGroupEnvironmentMapping:
-        # Fail closed: a provider that raises while declaring its frameworks aborts the build. The engine
-        # build (flag off) propagates it raw and unwrapped (#790); resolve_feature (flag on) attributes it
-        # to the culprit FeatureGroup as FrameworkDeclarationError.
+        # Fail closed: a provider that raises while declaring its frameworks aborts the build. The build
+        # always attributes a raising provider as FrameworkDeclarationError, on both the engine and
+        # resolve_feature paths (#850).
         accessible_plugins: FeatureGroupEnvironmentMapping = {}
         for feature_group in feature_groups:
-            if self.attribute_declaration_failures:
-                try:
-                    definition = feature_group.compute_framework_definition()
-                except Exception as exc:  # noqa: BLE001  attribute the culprit, then re-raise typed
-                    identity = f"{feature_group.__module__}:{feature_group.__qualname__}"
-                    raise FrameworkDeclarationError(identity, exc) from exc
-            else:
+            try:
                 definition = feature_group.compute_framework_definition()
+            except Exception as exc:  # noqa: BLE001  attribute the culprit, then re-raise typed
+                identity = f"{feature_group.__module__}:{feature_group.__qualname__}"
+                raise FrameworkDeclarationError(identity, exc) from exc
             new_set_of_compute_frameworks = {cp_fg for cp_fg in definition if cp_fg in compute_frameworks}
             accessible_plugins[feature_group] = new_set_of_compute_frameworks
 

--- a/tests/test_core/test_prepare/test_feature_group_dedup.py
+++ b/tests/test_core/test_prepare/test_feature_group_dedup.py
@@ -28,12 +28,16 @@ from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.api.plugin_docs import get_feature_group_docs, resolve_feature
 from mloda.core.api.plugin_info import FeatureGroupInfo, ResolvedFeature
+from mloda.core.api.request import mlodaAPI
 from mloda.core.abstract_plugins.components.base_feature_group_version import BaseFeatureGroupVersion
 from mloda.core.prepare.accessible_plugins import (
     PreFilterPlugins,
+    RedefinitionConflictError,
     dedup_feature_group_subclasses,
     _safe_class_source_hash,
 )
+from mloda.core.prepare.identify_feature_group import ResolutionDiagnosis
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 
 
 # Module-level reference store. This simulates IPython's ``_oh``/``Out[N]`` history,
@@ -512,6 +516,51 @@ def test_resolve_feature_returns_error_for_redef_conflict_does_not_raise() -> No
 
     # Fail-closed projection (#792): conflicting classes are never re-matched into candidates.
     assert result.candidates == [], f"candidates must be empty on conflict, got: {result.candidates}"
+
+
+# ---------------------------------------------------------------------------
+# Case 9b (#850): mlodaAPI.diagnose projects a RedefinitionConflictError instead
+# of raising, and the projected message equals what prepare() throws.
+# ---------------------------------------------------------------------------
+def test_diagnose_projects_redefinition_conflict_and_matches_prepare() -> None:
+    """diagnose() catches the dedup RedefinitionConflictError and projects it fail-closed (#850).
+
+    A different-source Jupyter-style redefinition raises RedefinitionConflictError during the
+    environment build (dedup, allow_redefinition defaults False). diagnose() must not raise: it
+    returns a ResolutionDiagnosis with no records and no failed feature (the build aborts before any
+    feature is resolved), carrying the SAME text the raising prepare() path throws for the same request.
+    The generated FG declares no compute_framework_rule, so PandasDataFrame is a valid framework to pass;
+    the conflict fires in dedup before any framework matching, so the choice does not affect the outcome.
+    """
+    qualname = "MyFG_Diagnose850"
+    feature_name = "case_diagnose850_feature_unique_xyz"
+    src_v1 = _make_fg_source(qualname, feature_name)
+    src_v2 = _make_fg_source(
+        qualname,
+        feature_name,
+        extra_body="    def extra_method(self):\n        return 850\n",
+    )
+
+    v1 = _exec_fg_in_main(qualname, src_v1, "cell-diagnose850-v1")
+    v2 = _exec_fg_in_main(qualname, src_v2, "cell-diagnose850-v2")
+    _REF_STORE.extend([v1, v2])
+
+    diagnosis = mlodaAPI.diagnose([feature_name], compute_frameworks={PandasDataFrame})
+
+    assert isinstance(diagnosis, ResolutionDiagnosis)
+    assert diagnosis.complete is False
+    assert diagnosis.records == []
+    assert diagnosis.feature_name is None
+    assert diagnosis.failed_result is None
+    assert diagnosis.message is not None
+    assert any(token in diagnosis.message for token in (qualname, "redefined", "set_allow_redefinition")), (
+        f"message must report the redefinition conflict; got: {diagnosis.message!r}"
+    )
+
+    # Parity with the raising path: prepare() throws the exact text diagnose() projected.
+    with pytest.raises(RedefinitionConflictError) as exc_info:
+        mlodaAPI.prepare([feature_name], compute_frameworks={PandasDataFrame})
+    assert diagnosis.message == str(exc_info.value)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_core/test_resolution_parity/test_environment_build_failure_parity.py
+++ b/tests/test_core/test_resolution_parity/test_environment_build_failure_parity.py
@@ -1,22 +1,28 @@
-"""Paired engine/debug tests for environment-build failure semantics (#790).
+"""Paired engine/debug tests for environment-build failure semantics (#790, unified in #850).
 
 A FeatureGroup whose compute_framework_rule() raises is an ENVIRONMENT-BUILD failure: it breaks
 PreFilterPlugins while it maps feature groups to their frameworks, before any matching happens. That build is
-fail-closed for both callers: the engine lets the provider's exception propagate raw, and resolve_feature
-keeps its never-raising contract by projecting the same failure into ResolvedFeature.error. Since the build
+fail-closed for every caller and now attributes the culprit uniformly (#850): the engine RAISES the typed
+FrameworkDeclarationError instead of letting the provider's raw exception propagate, and resolve_feature keeps
+its never-raising contract by projecting the SAME attributed text into ResolvedFeature.error. For an unscoped
+feature the two strings are identical (resolve_feature only appends a scope suffix, empty here).
+mlodaAPI.diagnose projects the same failure into a ResolutionDiagnosis instead of raising. Since the build
 aborts before matching, a broken group is not a listed candidate.
 
-That projection has two shapes, split by who is at fault rather than by which exception type a plugin
-happens to raise: a PLUGIN's failure is attributed ("Failed to build the plugin environment: <type>: <msg>
-(raised by <module:qualname> while declaring its compute frameworks)"), while mloda's own environment
-preconditions are already complete user-facing sentences and stay bare.
+Attribution is split by who is at fault rather than by which exception type a plugin happens to raise: a
+PLUGIN's failure is attributed ("Failed to build the plugin environment: <type>: <msg> (raised by
+<module:qualname> while declaring its compute frameworks)"), while mloda's own environment preconditions are
+already complete user-facing sentences and stay bare. A PluginCollector that filters out every FeatureGroup is
+one such precondition, and its message names the collector rather than the loader (#850).
 
 The broken class is built per test by a factory and dropped in a finally (del + gc.collect(), same pattern as
 test_sbdg_resolve_feature_broken_rule.py). This matters more than usual here: under fail-closed semantics a
 leaked broken class aborts the environment build of every unrelated resolve_feature/engine test in the same
-xdist worker. So nothing that could pin it may outlive the scoped block: no exception traceback, and no
-ResolvedFeature holding it in candidates. The assertions therefore run on plain strings read out of the
-result before the scope closes.
+xdist worker. So nothing that could pin it may outlive the scoped block: no exception traceback (the engine and
+prepare failures are caught unbound and read via sys.exc_info(), never pytest.raises/as exc), and no
+ResolvedFeature holding it in candidates. The assertions therefore run on plain strings read out of the result
+before the scope closes. The collector-filtered probe below is exempt: it declares its frameworks cleanly and
+is merely filtered, so plain pytest.raises is safe for it.
 """
 
 import gc
@@ -35,12 +41,16 @@ from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistry
 from mloda.core.api.plugin_docs import resolve_feature
+from mloda.core.api.request import mlodaAPI
 from mloda.core.core.engine import Engine
 from mloda.core.prepare.accessible_plugins import (
     EnvironmentPreconditionError,
+    FrameworkDeclarationError,
     PreFilterPlugins,
     RedefinitionConflictError,
 )
+from mloda.core.prepare.identify_feature_group import ResolutionDiagnosis
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 
 
 ENV_BUILD_FAILURE_FEATURE = "probe790_env_build_failure"
@@ -155,20 +165,22 @@ def _capture_engine_build_failure() -> Optional[str]:
     is the exact drift these paired tests exist to catch. Engine.__init__ reaches its environment build
     before any planning work, so this raises in well under a millisecond and constructs nothing else.
 
-    An unbound 'except' plus a transient sys.exc_info() read: a bound 'except ... as exc' (or pytest.raises)
-    keeps a traceback that pins the broken class through the Engine frame. Only the message string escapes
-    here, so no traceback outlives the block.
+    The engine attributes the provider failure as FrameworkDeclarationError (#850), so that is the type
+    caught here. An unbound 'except' plus a transient sys.exc_info() read: a bound 'except ... as exc' (or
+    pytest.raises) keeps a traceback that pins the broken class through the Engine frame. Only the message
+    string escapes here, so no traceback outlives the block.
     """
     try:
         Engine(Features([Feature(ENV_BUILD_FAILURE_FEATURE)]), PreFilterPlugins.get_cfw_subclasses(), None)
-    except RuntimeError:
+    except FrameworkDeclarationError:
         return str(sys.exc_info()[1])
     return None
 
 
 def test_engine_environment_build_fails_fast_on_broken_rule() -> None:
-    """The engine aborts the run: the provider's failure propagates raw out of Engine construction."""
+    """The engine aborts the run and ATTRIBUTES the culprit as FrameworkDeclarationError, not a raw exception (#850)."""
     broken_fg = _make_broken_rule_fg()
+    identity = f"{broken_fg.__module__}:{broken_fg.__qualname__}"
     try:
         message = _capture_engine_build_failure()
     finally:
@@ -176,7 +188,10 @@ def test_engine_environment_build_fails_fast_on_broken_rule() -> None:
         gc.collect()
 
     assert message is not None, "the engine must not swallow a raising compute_framework_rule"
+    assert "Failed to build the plugin environment" in message
+    assert "RuntimeError" in message
     assert ENV_BUILD_FAILURE_MESSAGE in message
+    assert identity in message
 
 
 def test_resolve_feature_projects_the_environment_build_failure() -> None:
@@ -230,7 +245,7 @@ def test_resolve_feature_names_the_broken_plugin_for_an_unrelated_feature() -> N
 
 
 def test_engine_and_resolve_feature_report_the_same_provider_failure() -> None:
-    """Parity: both paths surface the SAME provider failure, not two independently drifting strings."""
+    """Parity: for an unscoped feature both paths surface the SAME attributed string, not two drifting ones (#850)."""
     broken_fg = _make_broken_rule_fg()
     try:
         engine_message = _capture_engine_build_failure()
@@ -243,7 +258,46 @@ def test_engine_and_resolve_feature_report_the_same_provider_failure() -> None:
 
     assert engine_message is not None
     assert resolve_error is not None
-    assert engine_message in resolve_error
+    # resolve_feature appends only a scope suffix, empty for this unscoped feature, so the strings are equal.
+    assert engine_message == resolve_error
+
+
+def test_diagnose_projects_the_environment_build_failure() -> None:
+    """mlodaAPI.diagnose projects the attributed build failure into a ResolutionDiagnosis instead of raising (#850).
+
+    The diagnosis carries the same text the raising prepare() path throws, with no records and no failed
+    feature: the build aborts before any feature is resolved. prepare()'s failure is caught unbound and read
+    via sys.exc_info() so its traceback never pins the broken class, matching the engine helper's discipline.
+    """
+    broken_fg = _make_broken_rule_fg()
+    identity = f"{broken_fg.__module__}:{broken_fg.__qualname__}"
+    try:
+        diagnosis = mlodaAPI.diagnose([ENV_BUILD_FAILURE_FEATURE], compute_frameworks={PandasDataFrame})
+        complete = diagnosis.complete
+        message = diagnosis.message
+        records = diagnosis.records
+        feature_name = diagnosis.feature_name
+        failed_result = diagnosis.failed_result
+        del diagnosis
+        prepare_error: Optional[str] = None
+        try:
+            mlodaAPI.prepare([ENV_BUILD_FAILURE_FEATURE], compute_frameworks={PandasDataFrame})
+        except FrameworkDeclarationError:
+            prepare_error = str(sys.exc_info()[1])
+    finally:
+        del broken_fg
+        gc.collect()
+
+    assert complete is False
+    assert records == []
+    assert feature_name is None
+    assert failed_result is None
+    assert message is not None
+    assert "Failed to build the plugin environment" in message
+    assert identity in message
+    # The projected message is exactly what the raising path throws for the same request.
+    assert prepare_error is not None
+    assert message == prepare_error
 
 
 def test_resolve_feature_attributes_a_plugin_raised_value_error() -> None:
@@ -351,3 +405,82 @@ def test_own_environment_precondition_is_projected_bare() -> None:
     assert "Failed to build the plugin environment" not in error
     assert ENV_BUILD_FAILURE_MESSAGE not in error
     assert candidate_names == []
+
+
+COLLECTOR_FILTERED_FEATURE_850 = "probe850_collector_filtered_feature"
+
+
+class CollectorFilteredProbe850(FeatureGroup):
+    """Declares its frameworks cleanly; exists only to be enabled AND disabled by one collector (#850).
+
+    A module-scope, harmless global subclass: its rule never raises and it matches nothing, so it does not
+    pollute any other test's candidate universe. It is not subject to the leaked-broken-class hazard, so the
+    tests below may use plain pytest.raises.
+    """
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PandasDataFrame}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return False
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+def _collector_that_filters_everything() -> PluginCollector:
+    """A collector that both enables and disables the probe, emptying the (non-empty) loaded universe.
+
+    applicable_feature_group_class checks disabled first, so the probe is dropped; and because the enabled set
+    is non-empty and holds only that probe, every OTHER FeatureGroup is dropped too. The universe was
+    non-empty, so this is a collector configuration mistake, not a nothing-loaded state.
+    """
+    collector = PluginCollector()
+    collector.add_enabled_feature_group_classes({CollectorFilteredProbe850})
+    collector.add_disabled_feature_group_classes({CollectorFilteredProbe850})
+    return collector
+
+
+def test_collector_that_filters_everything_names_the_collector_not_the_loader() -> None:
+    """The env build blames the PluginCollector, with a message distinct from the nothing-loaded hint (#850)."""
+    collector = _collector_that_filters_everything()
+
+    with pytest.raises(EnvironmentPreconditionError) as exc_info:
+        PreFilterPlugins(PreFilterPlugins.get_cfw_subclasses(), collector)
+
+    message = str(exc_info.value)
+    assert "PluginCollector" in message
+    # The loaded universe was non-empty, so the nothing-loaded hint would misdirect the fix.
+    assert "Did you call PluginLoader.all()?" not in message
+
+
+def test_diagnose_projects_the_collector_precondition_failure() -> None:
+    """mlodaAPI.diagnose projects the collector's env-build precondition failure instead of raising (#850)."""
+    collector = _collector_that_filters_everything()
+
+    diagnosis = mlodaAPI.diagnose(
+        [COLLECTOR_FILTERED_FEATURE_850], compute_frameworks={PandasDataFrame}, plugin_collector=collector
+    )
+
+    assert isinstance(diagnosis, ResolutionDiagnosis)
+    assert diagnosis.complete is False
+    assert diagnosis.records == []
+    assert diagnosis.feature_name is None
+    assert diagnosis.failed_result is None
+
+    with pytest.raises(EnvironmentPreconditionError) as exc_info:
+        mlodaAPI.prepare(
+            [COLLECTOR_FILTERED_FEATURE_850], compute_frameworks={PandasDataFrame}, plugin_collector=collector
+        )
+
+    message = diagnosis.message
+    assert message is not None
+    assert message == str(exc_info.value)
+    assert "PluginCollector" in message

--- a/tests/test_core/test_resolution_parity/test_environment_build_failure_parity.py
+++ b/tests/test_core/test_resolution_parity/test_environment_build_failure_parity.py
@@ -457,6 +457,8 @@ def test_collector_that_filters_everything_names_the_collector_not_the_loader() 
 
     message = str(exc_info.value)
     assert "PluginCollector" in message
+    # A distinctive fragment: it cannot match an unrelated collector error, unlike the bare substring.
+    assert "filtered out every FeatureGroup" in message
     # The loaded universe was non-empty, so the nothing-loaded hint would misdirect the fix.
     assert "Did you call PluginLoader.all()?" not in message
 
@@ -484,3 +486,5 @@ def test_diagnose_projects_the_collector_precondition_failure() -> None:
     assert message is not None
     assert message == str(exc_info.value)
     assert "PluginCollector" in message
+    # A distinctive fragment: it cannot match an unrelated collector error, unlike the bare substring.
+    assert "filtered out every FeatureGroup" in message


### PR DESCRIPTION
Closes #850. Part of #760, follow-up of #795 (PR #849).

## Problem

The environment-build boundary ran two inconsistent presentation policies:

- `Engine.__init__` built the plugin environment with attribution OFF, so `run_all`/`prepare`/`diagnose` users saw a provider's raw, unattributed exception, while `resolve_feature` (attribution ON) named the culprit `module:qualname`. A plugin raising from its `compute_framework_rule` was indistinguishable from mloda's own policy error.
- `mlodaAPI.diagnose`, documented as a non-raising preflight, caught only `FeatureResolutionError` and `SetupConfigurationError`; environment-build failures propagated out of it, while `resolve_feature` projected the same failures into its error field.
- When a `PluginCollector` filtered out every FeatureGroup, the precondition message still said "No feature groups are loaded. Did you call PluginLoader.all()?", naming the wrong fix.

## Change

- Remove the `attribute_declaration_failures` flag. `PreFilterPlugins` now always attributes a raising compute-framework declaration as `FrameworkDeclarationError`, on the engine path as well as `resolve_feature`.
- `mlodaAPI.diagnose` projects `EnvironmentPreconditionError`, `RedefinitionConflictError`, and `FrameworkDeclarationError` into `ResolutionDiagnosis` instead of raising; every other error keeps propagating.
- A `PluginCollector` that filters out every FeatureGroup now raises a distinct precondition message naming the collector's enabled/disabled configuration, not the nothing-loaded hint.

Backwards compatibility was explicitly not required.

## Tests

Paired engine / `resolve_feature` / `diagnose` tests pin the unified behavior, including all three environment-build failure types projected by `diagnose` and the distinct collector-filtered message. The parity file's leaked-broken-class isolation discipline is preserved. `tox` is green (7039 passed, 170 skipped; ruff format + check, pip-licenses, mypy --strict, bandit all clean).