### PR TITLE
fix: validate the single-compute-framework pin before matching runs (#851)

### DIFF
--- a/mloda/core/api/request.py
+++ b/mloda/core/api/request.py
@@ -10,6 +10,7 @@ from mloda.core.abstract_plugins.components.plugin_option.plugin_collector impor
 from mloda.core.core.engine import Engine as Engine
 from mloda.core.api.plan_info import PlanStep, build_plan_steps
 from mloda.core.prepare.identify_feature_group import (
+    ComputeFrameworkPinError,
     FeatureResolutionError,
     ResolutionDiagnosis,
     ResolutionRecord,
@@ -343,9 +344,9 @@ class mlodaAPI:
         huge requests) plus that feature's EvaluationResult and rendered message. A SetupConfigurationError
         (any invalid request argument caught during session setup, before planning, for example an invalid
         column_ordering or an unknown compute framework name) yields only the message. Environment-build
-        failures (EnvironmentPreconditionError, RedefinitionConflictError, FrameworkDeclarationError) are
-        likewise projected into the diagnosis instead of raising; any other error propagates. Every parameter
-        after features is keyword-only.
+        failures (EnvironmentPreconditionError, RedefinitionConflictError, FrameworkDeclarationError) and
+        compute-framework pin misuse (ComputeFrameworkPinError) are likewise projected into the diagnosis
+        instead of raising; any other error propagates. Every parameter after features is keyword-only.
         """
         try:
             session = cls(
@@ -369,7 +370,12 @@ class mlodaAPI:
                 failed_result=deepcopy(error.result),
                 message=str(error),
             )
-        except (EnvironmentPreconditionError, RedefinitionConflictError, FrameworkDeclarationError) as error:
+        except (
+            ComputeFrameworkPinError,
+            EnvironmentPreconditionError,
+            RedefinitionConflictError,
+            FrameworkDeclarationError,
+        ) as error:
             return ResolutionDiagnosis(records=[], complete=False, message=str(error))
         except SetupConfigurationError as error:
             return ResolutionDiagnosis(records=[], complete=False, message=str(error))

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -122,6 +122,10 @@ class FeatureResolutionError(ValueError):
         return type(self), (str(self), self.feature_name, self.result, self.partial_records)
 
 
+class ComputeFrameworkPinError(ValueError):
+    """User pinned more than one compute framework; validated before matching (#851)."""
+
+
 def matches_feature_group_scope(feature_group: type[FeatureGroup], scope: str | type[FeatureGroup]) -> bool:
     """Is the candidate inside the requested scope, for both the class-object and the string form.
 
@@ -327,6 +331,17 @@ class IdentifyFeatureGroupClass:
         self.feature_group_compute_framework_mapping = result.identified
         self.result = result
 
+    @staticmethod
+    def _validate_single_framework_pin(feature: Feature) -> None:
+        """Raise if the user pinned more than one compute framework; this misuse is only a programmer error."""
+        pinned = feature.compute_frameworks
+        if pinned is not None and len(pinned) > 1:
+            names = ", ".join(sorted(cfw.get_class_name() for cfw in pinned))
+            raise ComputeFrameworkPinError(
+                f"Feature '{feature.name}' is pinned to more than one compute framework ({names}); "
+                f"pin at most one compute framework."
+            )
+
     @classmethod
     def evaluate(
         cls,
@@ -336,6 +351,9 @@ class IdentifyFeatureGroupClass:
         data_access_collection: Optional[DataAccessCollection] = None,
     ) -> EvaluationResult:
         """Run the matching/filter logic without raising, returning a structured result."""
+        # Pre-matching guard: a >1 pin fires regardless of whether any candidate matches (the old check
+        # sat inside the filter loop, so it never ran when the name matched nothing).
+        cls._validate_single_framework_pin(feature)
         self = cls.__new__(cls)
         self._criteria_matched_feature_groups = set()
         self._abstract_matched_feature_groups = set()
@@ -651,11 +669,9 @@ class IdentifyFeatureGroupClass:
         compute_frameworks: set[type[ComputeFramework]],
         feature: Feature,
     ) -> bool:
+        # Cardinality (<=1) is validated up front in evaluate(), so no >1 pin reaches here.
         if feature.compute_frameworks is None:
             return True
-
-        if len(feature.compute_frameworks) > 1:
-            raise ValueError(f"Feature should only have one compute framework when set by user {feature.name}.")
 
         return feature.get_compute_framework() in compute_frameworks
 

--- a/tests/test_core/test_prepare/test_identify_feature_group_evaluation_seam.py
+++ b/tests/test_core/test_prepare/test_identify_feature_group_evaluation_seam.py
@@ -20,8 +20,15 @@ from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.api.plugin_docs import resolve_feature
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
-from mloda.core.prepare.identify_feature_group import EvaluationResult, IdentifyFeatureGroupClass
+from mloda.core.prepare.identify_feature_group import (
+    ComputeFrameworkPinError,
+    EvaluationResult,
+    IdentifyFeatureGroupClass,
+)
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
 
 
 # Unique feature names so no other double in the parallel suite collides on them.
@@ -29,6 +36,9 @@ SEAM_SINGLE_FEATURE = "seam_single_match_test_754"
 SEAM_MULTIPLE_FEATURE = "seam_multiple_match_test_754"
 SEAM_ABSTRACT_FEATURE = "seam_abstract_only_test_754"
 SEAM_NO_MATCH_FEATURE = "seam_no_match_at_all_test_754"
+
+# A name no group matches, used to prove the pin-cardinality check fires BEFORE matching (issue #851).
+PIN_NO_MATCH_FEATURE = "pin_no_match_test_851"
 
 
 class SeamFwAlpha(ComputeFramework):
@@ -225,3 +235,71 @@ class TestEvaluationSeamParityWithEngineWrapper:
 
         assert result.identified == {}
         assert result.failure_kind == "none"
+
+
+class TestSingleFrameworkPinValidatedBeforeMatching:
+    """A >1 compute-framework pin is a misuse that must be reported even when the name matches nothing (issue #851)."""
+
+    def test_evaluate_raises_pin_error_when_no_candidate_matches(self) -> None:
+        """evaluate() validates pin cardinality at entry, so a >1 pin raises even with zero name matches (#851)."""
+        feature = Feature(SEAM_NO_MATCH_FEATURE)
+        feature.compute_frameworks = {SeamFwAlpha, SeamFwBeta}
+        accessible_plugins: FeatureGroupEnvironmentMapping = {SeamSingleFG: {SeamFwAlpha}}
+
+        with pytest.raises(ComputeFrameworkPinError):
+            IdentifyFeatureGroupClass.evaluate(
+                feature=feature,
+                accessible_plugins=accessible_plugins,
+                links=None,
+            )
+
+    def test_engine_wrapper_raises_pin_error_when_no_candidate_matches(self) -> None:
+        """The raising engine wrapper surfaces the same pin error, still an isinstance of ValueError (#851)."""
+        feature = Feature(SEAM_NO_MATCH_FEATURE)
+        feature.compute_frameworks = {SeamFwAlpha, SeamFwBeta}
+        accessible_plugins: FeatureGroupEnvironmentMapping = {SeamSingleFG: {SeamFwAlpha}}
+
+        with pytest.raises(ComputeFrameworkPinError) as exc_info:
+            IdentifyFeatureGroupClass(
+                feature=feature,
+                accessible_plugins=accessible_plugins,
+                links=None,
+                data_access_collection=None,
+            )
+
+        assert isinstance(exc_info.value, ValueError)
+
+    def test_resolve_feature_projects_the_pin_error(self) -> None:
+        """resolve_feature never raises: it projects the pin error into ResolvedFeature.error with no candidates (#851)."""
+        feature = Feature(PIN_NO_MATCH_FEATURE)
+        feature.compute_frameworks = {PandasDataFrame, PythonDictFramework}
+
+        result = resolve_feature(feature)
+
+        assert result.feature_group is None
+        assert result.candidates == []
+        assert result.error is not None
+        assert str(feature.name) in result.error
+        assert PandasDataFrame.get_class_name() in result.error
+        assert PythonDictFramework.get_class_name() in result.error
+
+    def test_engine_and_resolve_feature_report_the_same_pin_error(self) -> None:
+        """Engine and resolve_feature report identical text, mirroring the #850 parity model (unscoped: empty scope suffix)."""
+        feature = Feature(PIN_NO_MATCH_FEATURE)
+        feature.compute_frameworks = {PandasDataFrame, PythonDictFramework}
+        accessible_plugins: FeatureGroupEnvironmentMapping = {SeamSingleFG: {SeamFwAlpha}}
+
+        with pytest.raises(ComputeFrameworkPinError) as exc_info:
+            IdentifyFeatureGroupClass(
+                feature=feature,
+                accessible_plugins=accessible_plugins,
+                links=None,
+                data_access_collection=None,
+            )
+        engine_message = str(exc_info.value)
+
+        result = resolve_feature(feature)
+
+        assert result.error == engine_message
+        assert result.feature_group is None
+        assert result.candidates == []

--- a/tests/test_core/test_prepare/test_identify_feature_group_evaluation_seam.py
+++ b/tests/test_core/test_prepare/test_identify_feature_group_evaluation_seam.py
@@ -21,6 +21,7 @@ from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.api.plugin_docs import resolve_feature
+from mloda.core.api.request import mlodaAPI
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
 from mloda.core.prepare.identify_feature_group import (
     ComputeFrameworkPinError,
@@ -303,3 +304,23 @@ class TestSingleFrameworkPinValidatedBeforeMatching:
         assert result.error == engine_message
         assert result.feature_group is None
         assert result.candidates == []
+
+    def test_diagnose_projects_the_pin_error(self) -> None:
+        """diagnose never raises: it projects the pin error into a ResolutionDiagnosis, matching prepare()'s throw (#851)."""
+        feature = Feature(PIN_NO_MATCH_FEATURE)
+        feature.compute_frameworks = {PandasDataFrame, PythonDictFramework}
+
+        diagnosis = mlodaAPI.diagnose([feature], compute_frameworks={PandasDataFrame})
+
+        assert diagnosis.complete is False
+        assert diagnosis.records == []
+        assert diagnosis.feature_name is None
+        assert diagnosis.failed_result is None
+        assert diagnosis.message is not None
+        assert str(feature.name) in diagnosis.message
+        assert PandasDataFrame.get_class_name() in diagnosis.message
+        assert PythonDictFramework.get_class_name() in diagnosis.message
+
+        with pytest.raises(ComputeFrameworkPinError) as exc_info:
+            mlodaAPI.prepare([feature], compute_frameworks={PandasDataFrame})
+        assert diagnosis.message == str(exc_info.value)


### PR DESCRIPTION
## Summary

Fixes #851 (part of #760).

A feature pinned to more than one compute framework was only rejected once some candidate first passed the criteria/domain/scope filters, because `_filter_feature_group_by_framework` raised the ">1 compute framework" error from inside the filter loop. When the feature name matched no group, the loop never reached that check, so the misuse was silently swallowed and rendered as "No feature groups found". Whether the error fired depended on unrelated environment state.

## Changes

- Add the typed `ComputeFrameworkPinError(ValueError)` and hoist the pin-cardinality validation to `IdentifyFeatureGroupClass.evaluate()` entry, before matching. Both surfaces route through `evaluate()`, so the engine raises it and `resolve_feature` projects the same text into `ResolvedFeature.error` (unscoped: identical strings). The message is deterministic (sorted framework names).
- Drop the now-unreachable `len > 1` raise from `_filter_feature_group_by_framework` (cardinality is guaranteed by the up-front guard).
- `mlodaAPI.diagnose` (a documented non-raising preflight) projects `ComputeFrameworkPinError` into a `ResolutionDiagnosis` instead of raising, matching how the environment-build failures are handled and keeping the two non-raising debug surfaces (`resolve_feature`, `diagnose`) consistent. This was surfaced by review: the new error otherwise escaped `_create_engine()` uncaught.

## Tests

New `TestSingleFrameworkPinValidatedBeforeMatching` in `test_identify_feature_group_evaluation_seam.py`:
- `evaluate()` raises when no candidate matches the criteria (the core regression).
- The raising engine wrapper raises it, still an `isinstance(ValueError)`.
- `resolve_feature` projects the same message with no candidates and no raise.
- Engine and `resolve_feature` report identical text (unscoped parity, mirroring #850).
- `diagnose` projects the error into a `ResolutionDiagnosis`, matching what `prepare()` raises.

## Validation

Full `tox` gate green: 7044 passed, 170 skipped; ruff format + check, `mypy --strict`, bandit all clean. Reviewed by an independent Claude Opus agent and codex; the one accepted finding (diagnose non-raising regression) is fixed above.