### PR TITLE
fix: preserve exception types in resolution errors

### DIFF
--- a/mloda/core/abstract_plugins/components/utils.py
+++ b/mloda/core/abstract_plugins/components/utils.py
@@ -34,11 +34,12 @@ def safe_field_with_error(
     fallback: T,
     catching: tuple[type[Exception], ...] = (Exception,),
 ) -> tuple[T, str | None]:
-    """Like safe_field, but returns (value, None) on success and (fallback, str(exc)) on a raise."""
+    """Returns (value, None) on success; on a raise, (fallback, str(exc)), or the exception type name if that is empty."""
     try:
         return read(), None
     except catching as exc:
-        return fallback, str(exc)
+        message = str(exc)
+        return fallback, message if message else type(exc).__name__
 
 
 def get_all_subclasses(cls: Any, log_n_subclasses: int = 0) -> set[type[Any]]:

--- a/tests/test_core/test_abstract_plugins/test_components/test_safe_field_with_error.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_safe_field_with_error.py
@@ -10,8 +10,12 @@ def _sbfix_boom() -> int:
     raise ValueError("sbfix boom")
 
 
+def _sbfix_empty_boom() -> int:
+    raise RuntimeError
+
+
 class TestSbfixSafeFieldWithError:
-    """safe_field_with_error(read, fallback) returns (value, None) or (fallback, str(exc))."""
+    """safe_field_with_error(read, fallback) returns a value or a diagnosed fallback."""
 
     def test_success_returns_value_and_none(self) -> None:
         assert safe_field_with_error(lambda: 5, 0) == (5, None)
@@ -21,3 +25,8 @@ class TestSbfixSafeFieldWithError:
         assert value == 0
         assert error is not None
         assert "sbfix boom" in error
+
+    def test_empty_exception_message_returns_exception_type(self) -> None:
+        value, error = safe_field_with_error(_sbfix_empty_boom, 0)
+        assert value == 0
+        assert error == "RuntimeError"

--- a/tests/test_core/test_api/test_subtype_docs_degradation.py
+++ b/tests/test_core/test_api/test_subtype_docs_degradation.py
@@ -105,6 +105,15 @@ class TestSbfixRaisingHookFailsClosed:
         assert result.error is not None
         assert "sbfix hook exploded" in result.error
 
+    def test_empty_exception_message_surfaces_exception_type(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def raise_empty(*args: object, **kwargs: object) -> None:
+            raise RuntimeError
+
+        monkeypatch.setattr("mloda.core.api.plugin_docs.IdentifyFeatureGroupClass.evaluate", raise_empty)
+        result = resolve_feature(SBFIX_HOOK_FEATURE)
+        assert result.feature_group is None
+        assert result.error == "RuntimeError"
+
 
 class TestSbfixBogusSupportedSurfacedInDocs:
     """Docs surface the undeclared 'supported' framework as subtype_error."""


### PR DESCRIPTION
## Summary

Ensure captured resolution failures always include their exception type, so an exception with no message cannot produce a falsy error result.

## Related issue

Closes #852

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Documentation (`docs:`)
- [ ] Refactor / maintenance (`refactor:` / `chore:`)
- [ ] Other (explain below)

## Checklist

- [ ] `tox` passes locally (tests, `ruff format --check`, `ruff check`, `mypy --strict`, `bandit`, license check)
- [x] Tests added or updated for the change (and the skip count adjusted if needed)
- [x] Documentation updated where relevant
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
