### PR TITLE
fix: resolve_feature can return a falsy empty error string (#852)

### DIFF
--- a/mloda/core/abstract_plugins/components/utils.py
+++ b/mloda/core/abstract_plugins/components/utils.py
@@ -34,11 +34,12 @@ def safe_field_with_error(
     fallback: T,
     catching: tuple[type[Exception], ...] = (Exception,),
 ) -> tuple[T, str | None]:
-    """Like safe_field, but returns (value, None) on success and (fallback, non-empty error, the exception type name if the message is empty) on a raise."""
+    """Like safe_field but returns (value, None), else (fallback, str(exc) or the exception type name when blank)."""
     try:
         return read(), None
     except catching as exc:
-        return fallback, str(exc) or type(exc).__name__
+        message = str(exc)
+        return fallback, message if message.strip() else type(exc).__name__
 
 
 def get_all_subclasses(cls: Any, log_n_subclasses: int = 0) -> set[type[Any]]:

--- a/mloda/core/abstract_plugins/components/utils.py
+++ b/mloda/core/abstract_plugins/components/utils.py
@@ -34,11 +34,11 @@ def safe_field_with_error(
     fallback: T,
     catching: tuple[type[Exception], ...] = (Exception,),
 ) -> tuple[T, str | None]:
-    """Like safe_field, but returns (value, None) on success and (fallback, str(exc)) on a raise."""
+    """Like safe_field, but returns (value, None) on success and (fallback, non-empty error, the exception type name if the message is empty) on a raise."""
     try:
         return read(), None
     except catching as exc:
-        return fallback, str(exc)
+        return fallback, str(exc) or type(exc).__name__
 
 
 def get_all_subclasses(cls: Any, log_n_subclasses: int = 0) -> set[type[Any]]:

--- a/tests/test_core/test_abstract_plugins/test_components/test_safe_field_with_error.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_safe_field_with_error.py
@@ -10,6 +10,10 @@ def _sbfix_boom() -> int:
     raise ValueError("sbfix boom")
 
 
+def _sbfix852_empty_boom() -> int:
+    raise RuntimeError()
+
+
 class TestSbfixSafeFieldWithError:
     """safe_field_with_error(read, fallback) returns (value, None) or (fallback, str(exc))."""
 
@@ -21,3 +25,10 @@ class TestSbfixSafeFieldWithError:
         assert value == 0
         assert error is not None
         assert "sbfix boom" in error
+
+    def test_empty_message_exception_yields_non_empty_typed_error(self) -> None:
+        # An empty-message exception must not collapse to a falsy error (issue #852).
+        value, error = safe_field_with_error(_sbfix852_empty_boom, 0)
+        assert value == 0
+        assert error
+        assert "RuntimeError" in error

--- a/tests/test_core/test_abstract_plugins/test_components/test_safe_field_with_error.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_safe_field_with_error.py
@@ -14,6 +14,10 @@ def _sbfix852_empty_boom() -> int:
     raise RuntimeError()
 
 
+def _sbfix852_blank_boom() -> int:
+    raise RuntimeError("   ")
+
+
 class TestSbfixSafeFieldWithError:
     """safe_field_with_error(read, fallback) returns (value, None) or (fallback, str(exc))."""
 
@@ -29,6 +33,13 @@ class TestSbfixSafeFieldWithError:
     def test_empty_message_exception_yields_non_empty_typed_error(self) -> None:
         # An empty-message exception must not collapse to a falsy error (issue #852).
         value, error = safe_field_with_error(_sbfix852_empty_boom, 0)
+        assert value == 0
+        assert error
+        assert "RuntimeError" in error
+
+    def test_blank_message_exception_yields_typed_error(self) -> None:
+        # A whitespace-only message must also name the type, not return the blank string (issue #852).
+        value, error = safe_field_with_error(_sbfix852_blank_boom, 0)
         assert value == 0
         assert error
         assert "RuntimeError" in error

--- a/tests/test_core/test_api/test_subtype_docs_degradation.py
+++ b/tests/test_core/test_api/test_subtype_docs_degradation.py
@@ -27,6 +27,7 @@ from mloda_plugins.compute_framework.base_implementations.python_dict.python_dic
 SBFIX_HOOK_FEATURE = "sbfix_raising_hook_feature"
 SBFIX_DOC_KEY = "sbfixdoc_kind"
 SBFIX_BOGUS_FRAMEWORK = "SbfixNoSuchDocFramework"
+SBFIX852_EMPTY_HOOK_FEATURE = "sbfix852_empty_message_hook_feature"
 
 
 class SbfixRaisingHookFG(FeatureGroup):
@@ -53,6 +54,35 @@ class SbfixRaisingHookFG(FeatureGroup):
         compute_framework: type[ComputeFramework],
     ) -> bool:
         raise RuntimeError("sbfix hook exploded")
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class Sbfix852EmptyHookFG(FeatureGroup):
+    """supports_compute_framework hook that raises with an EMPTY message (issue #852)."""
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {PythonDictFramework}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) == SBFIX852_EMPTY_HOOK_FEATURE
+
+    @classmethod
+    def supports_compute_framework(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        compute_framework: type[ComputeFramework],
+    ) -> bool:
+        raise RuntimeError()
 
     def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
         return None
@@ -104,6 +134,18 @@ class TestSbfixRaisingHookFailsClosed:
         assert result.feature_group is None
         assert result.error is not None
         assert "sbfix hook exploded" in result.error
+
+
+class TestSbfix852EmptyMessageHookErrorIsNonEmpty:
+    """A raising hook with an empty message must still carry a non-empty, typed error (issue #852)."""
+
+    def test_empty_message_hook_error_is_truthy_and_typed(self) -> None:
+        # str(RuntimeError()) is "", so a naive error must not collapse to a falsy value that reads as success.
+        result = resolve_feature(SBFIX852_EMPTY_HOOK_FEATURE)
+        assert result.feature_group is None
+        assert bool(result.error) is True
+        assert result.error is not None
+        assert "RuntimeError" in result.error
 
 
 class TestSbfixBogusSupportedSurfacedInDocs:


### PR DESCRIPTION
## Summary

`safe_field_with_error` returned `str(exc)`, which is empty for an exception with no message (e.g. `RuntimeError()`). Both failing paths in `resolve_feature` (feature construction and the evaluation projection) then built a falsy empty `error`, so callers doing `if result.error:` read the failure as success.

The fix falls back to the exception type name when the message is blank (empty or whitespace-only), while passing non-blank messages through unchanged so engine/`resolve_feature` parity strings stay identical. Every failing `resolve_feature` result now carries a non-empty `error` that names at least the exception type.

## Changes

- `mloda/core/abstract_plugins/components/utils.py`: `safe_field_with_error` returns `type(exc).__name__` when `str(exc)` is blank; docstring corrected (was over-length and implied a 3-tuple).
- Tests: pin the empty-message and whitespace-only-message cases at both the helper level and through `resolve_feature` (a raising `supports_compute_framework` hook with an empty message).

## Validation

- Full `tox` gate green: 7120 passed, 170 skipped; `ruff format`/`ruff check`/license allowlist/`mypy --strict`/`bandit` all pass.
- Two independent reviews (a fresh Claude Opus pass and codex) gated the change: both confirmed correctness and that engine-parity / exact-string contracts and the subtype-docs caller are preserved. The whitespace-guard and docstring nits they surfaced are folded in. One reviewer-flagged latent path (the bare env-build projection in `plugin_docs.py`) is non-empty by construction today and is left as a possible follow-up under #760.

Fixes #852. Part of #760.