### PR TITLE
refactor: remove dead code and duplication left by the resolution consolidation (#853)

### DIFF
--- a/docs/docs/in_depth/discover-plugins.md
+++ b/docs/docs/in_depth/discover-plugins.md
@@ -38,9 +38,8 @@ raises that failure; `resolve_feature` reports the same failure in `result.error
 with no candidates, because the build never reaches matching. The difference stays
 presentation-only.
 
-Its environment is a **standalone default**, not a replay of a specific run:
-`ResolvedFeature.environment` reads `"standalone-default"`. The candidate
-universe defaults to every installed compute framework unless you narrow it (see
+Its candidate universe is a **standalone default**, not a replay of a specific
+run: it defaults to every installed compute framework unless you narrow it (see
 [Expressing the full request](#expressing-the-full-request)).
 
 ### Expressing the full request

--- a/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
+++ b/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
@@ -21,11 +21,10 @@ its frameworks fails the environment build, which `resolve_feature` prefixes wit
 `Failed to build the plugin environment:` where a run raises it bare. See
 [Broken framework declarations](../discover-plugins.md#broken-framework-declarations).
 
-Its environment is a standalone default (`result.environment` is
-`"standalone-default"`), not a replay of a specific run. Pass a `Feature`,
-`options`, `plugin_collector`, `links`, `data_access_collection`, or
-`compute_frameworks` (a run that restricts its frameworks needs this to mirror)
-to reproduce the run you are debugging. See
+Its candidate universe is a standalone default, not a replay of a specific run.
+Pass a `Feature`, `options`, `plugin_collector`, `links`,
+`data_access_collection`, or `compute_frameworks` (a run that restricts its
+frameworks needs this to mirror) to reproduce the run you are debugging. See
 [Discover Plugins](../discover-plugins.md) for the full signature.
 
 ## Multiple Feature Groups Error

--- a/mloda/core/abstract_plugins/components/utils.py
+++ b/mloda/core/abstract_plugins/components/utils.py
@@ -42,6 +42,13 @@ def safe_field_with_error(
         return fallback, message if message.strip() else type(exc).__name__
 
 
+def as_str(value: Any) -> str:
+    """Return `value` unchanged, raising TypeError on a non-str so the guarded read that wraps it degrades."""
+    if not isinstance(value, str):
+        raise TypeError(f"expected str, got {type(value).__name__}")
+    return value
+
+
 def get_all_subclasses(cls: Any, log_n_subclasses: int = 0) -> set[type[Any]]:
     all_subclasses = set()
 

--- a/mloda/core/api/plugin_docs.py
+++ b/mloda/core/api/plugin_docs.py
@@ -21,7 +21,7 @@ from mloda.core.abstract_plugins.components.base_feature_group_version import SO
 from mloda.core.abstract_plugins.components.subtype_declaration import SubtypeDeclaration
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.abstract_plugins.components.plugin_option.plugin_collector import PluginCollector
-from mloda.core.abstract_plugins.components.utils import get_all_subclasses, safe_field, safe_field_with_error
+from mloda.core.abstract_plugins.components.utils import as_str, get_all_subclasses, safe_field, safe_field_with_error
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.function_extender import Extender
 from mloda.core.abstract_plugins.plugin_registry.plugin_registry import PluginRegistry
@@ -41,6 +41,7 @@ from mloda.core.prepare.accessible_plugins import (
     registry_for,
 )
 from mloda.core.prepare.identify_feature_group import (
+    CandidateFrameworks,
     IdentifyFeatureGroupClass,
     render_resolution_failure,
     scope_callout,
@@ -52,16 +53,9 @@ def list_registered(plugin_type: type[Any]) -> list[type[Any]]:
     return PluginRegistry.default().list_registered(plugin_type)
 
 
-def _as_str(value: Any) -> str:
-    """Return `value` unchanged, raising TypeError if a plugin returned a non-str, so the guarded read degrades."""
-    if not isinstance(value, str):
-        raise TypeError(f"expected str, got {type(value).__name__}")
-    return value
-
-
 def _safe_version(fg_class: type[FeatureGroup]) -> str:
     """Return the feature group version or "unavailable" if source introspection fails or version() is not a str."""
-    return safe_field(lambda: _as_str(fg_class.version()), "unavailable", catching=SOURCE_INTROSPECTION_ERRORS)
+    return safe_field(lambda: as_str(fg_class.version()), "unavailable", catching=SOURCE_INTROSPECTION_ERRORS)
 
 
 def _subtype_support_or_error(fg_class: type[FeatureGroup]) -> tuple[dict[str, list[str]], Optional[str]]:
@@ -144,9 +138,9 @@ def get_feature_group_docs(
             continue
 
         cls_name = fg_class.__name__
-        fg_name = safe_field(lambda: _as_str(fg_class.get_class_name()), cls_name, field=f"{cls_name}.get_class_name")
+        fg_name = safe_field(lambda: as_str(fg_class.get_class_name()), cls_name, field=f"{cls_name}.get_class_name")
         doc_fallback = (fg_class.__doc__ or "").strip() or cls_name
-        description = safe_field(lambda: _as_str(fg_class.description()), doc_fallback, field=f"{cls_name}.description")
+        description = safe_field(lambda: as_str(fg_class.description()), doc_fallback, field=f"{cls_name}.description")
         version = _safe_version(fg_class)
         module = fg_class.__module__
         compute_frameworks: list[str] = safe_field(
@@ -449,10 +443,10 @@ def resolve_feature(
     candidates = sorted(result.criteria_matched, key=lambda c: c.get_class_name())
 
     if result.failure_kind is None:
-        winner, supported_frameworks = next(iter(result.identified.items()))
-        available = accessible_plugins.get(winner, set())
-        supported_names = sorted(c.get_class_name() for c in supported_frameworks)
-        unsupported_names = sorted(c.get_class_name() for c in (available - supported_frameworks))
+        winner = next(iter(result.identified))
+        split = result.candidate_frameworks.get(winner, CandidateFrameworks())
+        supported_names = sorted(c.get_class_name() for c in split.supported)
+        unsupported_names = sorted(c.get_class_name() for c in split.rejected)
         subtype, subtype_family = _resolved_subtype_fields(winner, feature_name_obj, resolved_options)
         return ResolvedFeature(
             feature_name,

--- a/mloda/core/api/plugin_info.py
+++ b/mloda/core/api/plugin_info.py
@@ -59,6 +59,3 @@ class ResolvedFeature:
     subtype: Optional[str] = None
     # Family name only when the subtype is a parametric instance (e.g. "ntile" for "ntile_2"), else None.
     subtype_family: Optional[str] = None
-    # Candidate universe built from a standalone default environment (PreFilterPlugins over installed
-    # plugins), not a captured live run.
-    environment: str = "standalone-default"

--- a/mloda/core/core/engine.py
+++ b/mloda/core/core/engine.py
@@ -22,7 +22,6 @@ from mloda.core.prepare.graph.build_graph import BuildGraph
 from mloda.core.prepare.resolve_graph import ResolveGraph
 from mloda.core.runtime.run import ExecutionOrchestrator
 from mloda.core.prepare.identify_feature_group import (
-    PARTIAL_RECORDS_CAP,
     EvaluationResult,
     FeatureResolutionError,
     IdentifyFeatureGroupClass,
@@ -72,7 +71,6 @@ class Engine:
         self.api_input_data_collection = api_input_data_collection
 
         self.plugin_collector = plugin_collector
-        self.copy_compute_frameworks = deepcopy(compute_frameworks)
 
         self.data_access_collection = data_access_collection
         self.column_ordering = column_ordering
@@ -224,12 +222,11 @@ class Engine:
         )
         message = render_resolution_failure(result, feature)
         if message is not None:
-            # Slice before deepcopy so the attached payload stays bounded.
             raise FeatureResolutionError(
                 message,
                 str(feature.name),
                 result,
-                partial_records=deepcopy(self.resolution_records[-PARTIAL_RECORDS_CAP:]),
+                partial_records=self.resolution_records,
             )
         feature_group_class, compute_frameworks = next(iter(result.identified.items()))
         return feature_group_class, compute_frameworks, result

--- a/mloda/core/prepare/accessible_plugins.py
+++ b/mloda/core/prepare/accessible_plugins.py
@@ -27,6 +27,14 @@ logger = logging.getLogger(__name__)
 _warned_unregistered: set[str] = set()
 
 
+def _warn_once_unregistered(unregistered_names: list[str], plugin_kind: str) -> None:
+    """Warn about registry-missing plugins, remembering names so each is warned at most once across runs."""
+    new_names = [name for name in unregistered_names if name not in _warned_unregistered]
+    if new_names:
+        _warned_unregistered.update(new_names)
+        logger.warning("%s not registered in the plugin registry: %s.", plugin_kind, ", ".join(new_names))
+
+
 FeatureGroupEnvironmentMapping = dict[type[FeatureGroup], set[type[ComputeFramework]]]
 
 
@@ -81,10 +89,7 @@ def filter_extenders_by_strict_mode(
     unregistered_names = sorted({f"{type(e).__module__}:{type(e).__qualname__}" for e in unregistered})
 
     if strict_mode == "warn":
-        new_names = [name for name in unregistered_names if name not in _warned_unregistered]
-        if new_names:
-            _warned_unregistered.update(new_names)
-            logger.warning("Extenders not registered in the plugin registry: %s.", ", ".join(new_names))
+        _warn_once_unregistered(unregistered_names, "Extenders")
         return extenders
 
     if unregistered:
@@ -373,16 +378,9 @@ class PreFilterPlugins:
             unregistered = sorted(
                 f"{fg.__module__}:{fg.__qualname__}"
                 for fg in accessible_feature_groups
-                if fg not in registered
-                and not inspect.isabstract(fg)
-                and f"{fg.__module__}:{fg.__qualname__}" not in _warned_unregistered
+                if fg not in registered and not inspect.isabstract(fg)
             )
-            if unregistered:
-                _warned_unregistered.update(unregistered)
-                logger.warning(
-                    "FeatureGroups not registered in the plugin registry: %s.",
-                    ", ".join(unregistered),
-                )
+            _warn_once_unregistered(unregistered, "FeatureGroups")
 
         if len(accessible_feature_groups) == 0:
             if collector_filtered_everything:
@@ -415,10 +413,7 @@ class PreFilterPlugins:
         unregistered_names = sorted(f"{cfw.__module__}:{cfw.__qualname__}" for cfw in unregistered)
 
         if strict_mode == "warn":
-            new_names = [name for name in unregistered_names if name not in _warned_unregistered]
-            if new_names:
-                _warned_unregistered.update(new_names)
-                logger.warning("ComputeFrameworks not registered in the plugin registry: %s.", ", ".join(new_names))
+            _warn_once_unregistered(unregistered_names, "ComputeFrameworks")
             return compute_frameworks
 
         surviving = compute_frameworks - unregistered

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -303,22 +303,14 @@ class IdentifyFeatureGroupClass:
     # they are scoped to one resolution attempt and never cache across runs.
     _domain_outcomes: dict[type[FeatureGroup], tuple[Optional[Domain], Optional[Exception]]]
     _declared_frameworks: dict[type[FeatureGroup], frozenset[type[ComputeFramework]]]
-    result: EvaluationResult
 
-    def __init__(
-        self,
-        feature: Feature,
-        accessible_plugins: FeatureGroupEnvironmentMapping,
-        links: Optional[set[Link]],
-        data_access_collection: Optional[DataAccessCollection] = None,
-    ):
-        result = self.evaluate(feature, accessible_plugins, links, data_access_collection)
-        # The message is a projection of the pass that just ran: no second evaluation, no re-asked hook.
-        message = render_resolution_failure(result, feature)
-        if message is not None:
-            raise FeatureResolutionError(message, str(feature.name), result)
-        self.feature_group_compute_framework_mapping = result.identified
-        self.result = result
+    def __init__(self, data_access_collection: Optional[DataAccessCollection] = None) -> None:
+        self._criteria_matched_feature_groups = set()
+        self._abstract_matched_feature_groups = set()
+        self._candidate_frameworks = {}
+        self._domain_outcomes = {}
+        self._declared_frameworks = {}
+        self._data_access_collection = data_access_collection
 
     @staticmethod
     def _validate_single_framework_pin(feature: Feature) -> None:
@@ -343,13 +335,7 @@ class IdentifyFeatureGroupClass:
         # Pre-matching guard: a >1 pin fires regardless of whether any candidate matches (the old check
         # sat inside the filter loop, so it never ran when the name matched nothing).
         cls._validate_single_framework_pin(feature)
-        self = cls.__new__(cls)
-        self._criteria_matched_feature_groups = set()
-        self._abstract_matched_feature_groups = set()
-        self._candidate_frameworks = {}
-        self._domain_outcomes = {}
-        self._declared_frameworks = {}
-        self._data_access_collection = data_access_collection
+        self = cls(data_access_collection)
         identified = self._filter_loop(feature, accessible_plugins, links, data_access_collection)
         result = EvaluationResult(
             identified=identified,
@@ -667,9 +653,6 @@ class IdentifyFeatureGroupClass:
             return None
         reason: Optional[str] = rejection_check(feature.name, feature.options)
         return reason
-
-    def get(self) -> tuple[type[FeatureGroup], set[type[ComputeFramework]]]:
-        return next(iter(self.feature_group_compute_framework_mapping.items()))
 
     def filter_subclasses(
         self, _identified_feature_groups: FeatureGroupEnvironmentMapping

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -1,14 +1,15 @@
 import inspect
 from collections.abc import Sequence
+from copy import deepcopy
 from dataclasses import dataclass, field, replace
 from difflib import get_close_matches
-from typing import Any, Literal, Optional
+from typing import Literal, Optional
 
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.domain import Domain
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import PropertyValueRejection
-from mloda.core.abstract_plugins.components.utils import safe_field
+from mloda.core.abstract_plugins.components.utils import safe_field, as_str
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.abstract_plugins.components.feature import Feature
@@ -113,7 +114,10 @@ class FeatureResolutionError(ValueError):
         super().__init__(message)
         self.feature_name = feature_name
         self.result = result
-        self.partial_records: tuple[ResolutionRecord, ...] = tuple(partial_records[-PARTIAL_RECORDS_CAP:])
+        # Cap then snapshot: slicing before deepcopy keeps the copied payload bounded on huge requests.
+        self.partial_records: tuple[ResolutionRecord, ...] = tuple(
+            deepcopy(record) for record in partial_records[-PARTIAL_RECORDS_CAP:]
+        )
 
     def __reduce__(
         self,
@@ -160,21 +164,10 @@ def _candidate_sort_key(feature_group: type[FeatureGroup]) -> tuple[str, str]:
     return feature_group.__name__, feature_group.__module__
 
 
-def _as_str(value: Any) -> str:
-    """Return `value` unchanged, raising TypeError on a non-str, so the guarded read that wraps this degrades.
-
-    A hook's annotation is a promise, not a guarantee. A non-str name reaching difflib raises there instead,
-    far from the plugin to blame, so every captured name is validated where it is read.
-    """
-    if not isinstance(value, str):
-        raise TypeError(f"expected str, got {type(value).__name__}")
-    return value
-
-
 def _supported_feature_names(feature_group: type[FeatureGroup]) -> set[str]:
     """Best-effort name catalog of one candidate. A malformed entry costs that candidate its whole catalog."""
     return safe_field(
-        lambda: {_as_str(name) for name in feature_group.feature_names_supported()},
+        lambda: {as_str(name) for name in feature_group.feature_names_supported()},
         set(),
         field=f"{feature_group.get_class_name()}.feature_names_supported",
     )
@@ -182,7 +175,7 @@ def _supported_feature_names(feature_group: type[FeatureGroup]) -> set[str]:
 
 def _prefix_name(feature_group: type[FeatureGroup]) -> str:
     """Best-effort prefix of one candidate."""
-    return safe_field(lambda: _as_str(feature_group.prefix()), "", field=f"{feature_group.get_class_name()}.prefix")
+    return safe_field(lambda: as_str(feature_group.prefix()), "", field=f"{feature_group.get_class_name()}.prefix")
 
 
 def _supports_framework(
@@ -459,7 +452,7 @@ class IdentifyFeatureGroupClass:
         ComputeFramework costs the whole candidate its names, well-formed entries included, as before the memo.
         """
         return safe_field(
-            lambda: {_as_str(cfw.get_class_name()) for cfw in self._declared_frameworks_of(feature_group)},
+            lambda: {as_str(cfw.get_class_name()) for cfw in self._declared_frameworks_of(feature_group)},
             set(),
             field=f"{feature_group.get_class_name()}.compute_framework_definition",
         )
@@ -552,7 +545,7 @@ class IdentifyFeatureGroupClass:
         if not self._filter_feature_group_by_scope(feature_group, feature):
             return None
         reason = self._value_rejection_reason(feature_group, feature)
-        return None if reason is None else _as_str(reason)
+        return None if reason is None else as_str(reason)
 
     def _capture_known_names(self, accessible_plugins: FeatureGroupEnvironmentMapping) -> tuple[str, ...]:
         known_names: list[str] = []

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -35,7 +35,6 @@ class RenderFacts:
     The empty instance is the success value: the winning path captures nothing.
     """
 
-    environment_empty: bool = False
     domains: dict[type[FeatureGroup], str] = field(default_factory=dict)
     concrete_frameworks: tuple[str, ...] = ()
     value_rejections: tuple[tuple[str, str], ...] = ()
@@ -253,9 +252,6 @@ def _render_none(result: EvaluationResult, feature: Feature, callout: str | None
     if callout:
         msg += f" {callout}"
 
-    if result.facts.environment_empty:
-        return msg + "\nNo plugins are loaded. Did you call PluginLoader.all()?"
-
     if result.facts.value_rejections:
         lines = "\n".join(f"  - {class_name}: {reason}" for class_name, reason in sorted(result.facts.value_rejections))
         msg += f"\nFeature group(s) rejected the supplied options while matching '{feature_name}':\n{lines}"
@@ -379,24 +375,20 @@ class IdentifyFeatureGroupClass:
         Only reached when the pass has no single winner, so the success path stays hook-free. Every provider
         hook here is best-effort: a raising one degrades its own fact, never this call or a sibling's fact.
         """
-        environment_empty = not accessible_plugins
-
         if result.failure_kind == "multiple":
-            return RenderFacts(environment_empty=environment_empty, domains=self._capture_domains(result))
+            return RenderFacts(domains=self._capture_domains(result))
 
         # Capability rejections win over the abstract-only fallback, and both over the ordinary none.
         capability_frameworks = self._capture_capability_frameworks(result, feature)
         if any(candidate.rejected for candidate in capability_frameworks.values()):
-            return RenderFacts(environment_empty=environment_empty, capability_frameworks=capability_frameworks)
+            return RenderFacts(capability_frameworks=capability_frameworks)
 
         if result.abstract_matched:
             return RenderFacts(
-                environment_empty=environment_empty,
                 concrete_frameworks=self._concrete_implementation_frameworks(result, accessible_plugins),
             )
 
         return RenderFacts(
-            environment_empty=environment_empty,
             value_rejections=self._capture_value_rejections(feature, accessible_plugins),
             known_names=self._capture_known_names(accessible_plugins),
         )

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_option_value_rejection_never_escapes.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_option_value_rejection_never_escapes.py
@@ -29,7 +29,7 @@ from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
-from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+from tests.test_core.test_prepare.identify_seam import identify_winner
 
 
 PIPELINE_KEY = "pipeline_name_esc732"
@@ -313,13 +313,10 @@ class RequiredWhenNeighborFeatureGroupEsc763(FeatureGroup):
         return None
 
 
-def _identify(feature: Feature, accessible_plugins: FeatureGroupEnvironmentMapping) -> IdentifyFeatureGroupClass:
-    return IdentifyFeatureGroupClass(
-        feature=feature,
-        accessible_plugins=accessible_plugins,
-        links=None,
-        data_access_collection=None,
-    )
+def _identify(
+    feature: Feature, accessible_plugins: FeatureGroupEnvironmentMapping
+) -> tuple[type[FeatureGroup], set[type[ComputeFramework]]]:
+    return identify_winner(feature, accessible_plugins)
 
 
 def _records_at_or_above(caplog: pytest.LogCaptureFixture, logger_name: str, levelno: int) -> list[logging.LogRecord]:
@@ -482,7 +479,7 @@ class TestRejectionNeverEscapesTheEngine:
 
         identified = _identify(feature, accessible_plugins)
 
-        feature_group, _frameworks = identified.get()
+        feature_group, _frameworks = identified
         assert feature_group is NeighborFeatureGroup
 
     def test_raising_element_validator_yields_the_standard_no_match_error(self) -> None:
@@ -514,7 +511,7 @@ class TestRejectionNeverEscapesTheEngine:
 
         identified = _identify(feature, accessible_plugins)
 
-        feature_group, _frameworks = identified.get()
+        feature_group, _frameworks = identified
         assert feature_group is DirectParserOverrideFeatureGroup
 
 
@@ -630,7 +627,7 @@ class TestKeyErrorRejectionNeverEscapesTheEngine:
 
         identified = _identify(feature, accessible_plugins)
 
-        feature_group, _frameworks = identified.get()
+        feature_group, _frameworks = identified
         assert feature_group is RequiredWhenNeighborFeatureGroupEsc763
 
 

--- a/tests/test_core/test_api/test_resolution_report.py
+++ b/tests/test_core/test_api/test_resolution_report.py
@@ -4,7 +4,7 @@ Contract under test:
   * ``mloda.core.prepare.identify_feature_group.ResolutionRecord`` is a frozen dataclass beside
     ``EvaluationResult``, with fields ``feature_name: str``, ``requested: bool``, ``result: EvaluationResult``
     in that order. It is re-exported from both ``mloda.user`` and ``mloda.steward``.
-  * ``IdentifyFeatureGroupClass(...).result`` exposes the winning ``EvaluationResult`` on a successful
+  * ``IdentifyFeatureGroupClass.evaluate(...)`` returns the winning ``EvaluationResult`` on a successful
     resolution (``failure_kind is None``, ``identified`` holding the winner).
   * ``Engine`` gains ``resolution_records: list[ResolutionRecord]``, populated in traversal order as each
     feature is identified: top-level requested features get ``requested=True``, features found via
@@ -34,9 +34,9 @@ from mloda.core.core.engine import Engine
 from mloda.core.prepare.identify_feature_group import (
     EvaluationResult,
     FeatureResolutionError,
-    IdentifyFeatureGroupClass,
     ResolutionRecord,
 )
+from tests.test_core.test_prepare.identify_seam import evaluate_or_raise
 from mloda.provider import BaseInputData, ComputeFramework, DataCreator, FeatureGroup, FeatureSet
 from mloda.user import (
     DataAccessCollection,
@@ -334,16 +334,16 @@ class TestIdentifyFeatureGroupResultOnSuccess:
     """After a successful single-candidate resolution the identifier keeps its winning EvaluationResult."""
 
     def test_result_is_an_evaluation_result_with_no_failure(self) -> None:
-        identifier = IdentifyFeatureGroupClass(
+        result = evaluate_or_raise(
             feature=Feature(GOOD_FEATURE_811),
             accessible_plugins={ResReportGoodFG_811: {ResReportFw_811}},
             links=None,
             data_access_collection=None,
         )
 
-        assert isinstance(identifier.result, EvaluationResult)
-        assert identifier.result.failure_kind is None
-        assert ResReportGoodFG_811 in identifier.result.identified
+        assert isinstance(result, EvaluationResult)
+        assert result.failure_kind is None
+        assert ResReportGoodFG_811 in result.identified
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_core/test_api/test_resolve_feature.py
+++ b/tests/test_core/test_api/test_resolve_feature.py
@@ -30,7 +30,7 @@ from mloda.core.api.plugin_info import ResolvedFeature
 from mloda.core.api import plugin_docs
 from mloda.core.api.plugin_docs import resolve_feature
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping, RedefinitionConflictError
-from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+from tests.test_core.test_prepare.identify_seam import evaluate_or_raise
 from mloda.user import PluginLoader
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
@@ -991,7 +991,7 @@ class TestResolveFeatureScopedEngineParity:
         feature = Feature(SIBLING_SCOPED_FEATURE, feature_group="UnrelatedScopedResolve693FeatureGroup")
 
         with pytest.raises(ValueError) as exc_info:
-            IdentifyFeatureGroupClass(
+            evaluate_or_raise(
                 feature=feature,
                 accessible_plugins=accessible_plugins,
                 links=None,

--- a/tests/test_core/test_api/test_resolve_feature_full_request.py
+++ b/tests/test_core/test_api/test_resolve_feature_full_request.py
@@ -46,7 +46,7 @@ from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.api.plugin_docs import resolve_feature
 from mloda.core.api.plugin_info import ResolvedFeature
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
-from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+from tests.test_core.test_prepare.identify_seam import evaluate_or_raise
 from mloda.user import PluginCollector, PluginLoader
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
@@ -365,13 +365,13 @@ class TestResolveFeatureFrameworkPinViaFeature:
 
         # Declared pin: the engine identifies the group, and resolve_feature resolves it.
         pinned_declared = Feature(FRAMEWORK_FEATURE, compute_framework="PandasDataFrame")
-        engine_declared = IdentifyFeatureGroupClass(
+        engine_declared = evaluate_or_raise(
             feature=pinned_declared,
             accessible_plugins=accessible_plugins,
             links=None,
             data_access_collection=None,
         )
-        assert engine_declared.get()[0] is FrameworkPinResolve756FeatureGroup
+        assert next(iter(engine_declared.identified)) is FrameworkPinResolve756FeatureGroup
 
         collector = PluginCollector.enabled_feature_groups({FrameworkPinResolve756FeatureGroup})
         debug_declared = resolve_feature(
@@ -382,7 +382,7 @@ class TestResolveFeatureFrameworkPinViaFeature:
         # Undeclared pin: the engine refuses (ValueError), and resolve_feature fails closed.
         pinned_undeclared = Feature(FRAMEWORK_FEATURE, compute_framework="SqliteFramework")
         with pytest.raises(ValueError):
-            IdentifyFeatureGroupClass(
+            evaluate_or_raise(
                 feature=pinned_undeclared,
                 accessible_plugins=accessible_plugins,
                 links=None,
@@ -431,20 +431,20 @@ class TestResolveFeatureLinksThreaded:
         collector = PluginCollector.enabled_feature_groups({LinkResolve756FeatureGroup})
 
         supported = {_supported_link()}
-        engine_supported = IdentifyFeatureGroupClass(
+        engine_supported = evaluate_or_raise(
             feature=Feature(LINK_FEATURE),
             accessible_plugins=accessible_plugins,
             links=supported,
             data_access_collection=None,
         )
-        assert engine_supported.get()[0] is LinkResolve756FeatureGroup
+        assert next(iter(engine_supported.identified)) is LinkResolve756FeatureGroup
         assert resolve_feature(LINK_FEATURE, plugin_collector=collector, links=supported).feature_group is (
             LinkResolve756FeatureGroup
         )
 
         unsupported = {_unsupported_link()}
         with pytest.raises(ValueError):
-            IdentifyFeatureGroupClass(
+            evaluate_or_raise(
                 feature=Feature(LINK_FEATURE),
                 accessible_plugins=accessible_plugins,
                 links=unsupported,
@@ -481,20 +481,20 @@ class TestResolveFeatureDataAccessCollectionThreaded:
         collector = PluginCollector.enabled_feature_groups({DataAccessResolve756FeatureGroup})
         dac = DataAccessCollection(files={EXPECTED_FILE_HANDLE})
 
-        engine_with = IdentifyFeatureGroupClass(
+        engine_with = evaluate_or_raise(
             feature=Feature(DATA_ACCESS_FEATURE),
             accessible_plugins=accessible_plugins,
             links=None,
             data_access_collection=dac,
         )
-        assert engine_with.get()[0] is DataAccessResolve756FeatureGroup
+        assert next(iter(engine_with.identified)) is DataAccessResolve756FeatureGroup
         assert (
             resolve_feature(DATA_ACCESS_FEATURE, plugin_collector=collector, data_access_collection=dac).feature_group
             is DataAccessResolve756FeatureGroup
         )
 
         with pytest.raises(ValueError):
-            IdentifyFeatureGroupClass(
+            evaluate_or_raise(
                 feature=Feature(DATA_ACCESS_FEATURE),
                 accessible_plugins=accessible_plugins,
                 links=None,

--- a/tests/test_core/test_api/test_resolve_feature_prefilter_universe.py
+++ b/tests/test_core/test_api/test_resolve_feature_prefilter_universe.py
@@ -7,8 +7,7 @@ uses, so the debug API resolves against the universe a real run sees. What that 
      a framework a matching group does not declare empties its available set, so the group fails to resolve,
      mirroring how ``PreFilterPlugins`` intersects the caller's framework set.
   2. A ``plugin_collector`` yields the same universe the engine builds, registry strict mode included.
-  3. ``ResolvedFeature.environment`` ("standalone-default") is carried on every result, success and error.
-  4. Scoping the universe (strict mode, and equally a collector's enabled/disabled filter) drops a broken
+  3. Scoping the universe (strict mode, and equally a collector's enabled/disabled filter) drops a broken
      plugin before its declaration is consulted, so it cannot abort the build for everyone (#790).
 """
 
@@ -24,7 +23,6 @@ from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.api.plugin_docs import resolve_feature
-from mloda.core.api.plugin_info import ResolvedFeature
 from mloda.core.prepare.accessible_plugins import PreFilterPlugins
 from mloda.user import PluginCollector, PluginLoader
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
@@ -33,7 +31,6 @@ from mloda_plugins.compute_framework.base_implementations.python_dict.python_dic
 )
 
 
-PLAIN_FEATURE_757 = "PlainResolve757Feature"
 PYTHON_DICT_ONLY_FEATURE = "PythonDictOnlyResolve757Feature"
 STRICT_EXCLUDED_FEATURE = "StrictExcludedResolve757Feature"
 BROKEN_RULE_FEATURE_757 = "broken_rule_resolve_757_feature"
@@ -43,26 +40,6 @@ BROKEN_RULE_FEATURE_757 = "broken_rule_resolve_757_feature"
 def load_plugins() -> None:
     """Load all plugins before running tests in this module."""
     PluginLoader.all()
-
-
-class PlainResolve757FeatureGroup(FeatureGroup):
-    """A plain, unambiguously resolvable fixture matching its own feature name."""
-
-    @classmethod
-    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
-        return {PandasDataFrame, PythonDictFramework}
-
-    @classmethod
-    def match_feature_group_criteria(
-        cls,
-        feature_name: FeatureName | str,
-        options: Options,
-        data_access_collection: Optional[DataAccessCollection] = None,
-    ) -> bool:
-        return str(feature_name) == PLAIN_FEATURE_757
-
-    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
-        return None
 
 
 class PythonDictOnlyResolve757FeatureGroup(FeatureGroup):
@@ -201,32 +178,6 @@ class TestResolveFeatureCollectorUniverseParity:
         assert scoped.error is not None
 
 
-class TestResolvedFeatureEnvironmentLabel:
-    """DoD-3: ResolvedFeature gains environment: str = "standalone-default", carried on every result (#757)."""
-
-    def test_dataclass_default_is_standalone_default(self) -> None:
-        """The 4-positional-arg constructor still works and defaults environment to the literal label."""
-        result = ResolvedFeature("n", None, [], None)
-        assert result.environment == "standalone-default"
-
-    def test_resolving_result_carries_environment(self) -> None:
-        """A successful resolution reports the standalone-default environment."""
-        collector = PluginCollector.enabled_feature_groups({PlainResolve757FeatureGroup})
-
-        result = resolve_feature(PLAIN_FEATURE_757, plugin_collector=collector)
-
-        assert result.feature_group is PlainResolve757FeatureGroup
-        assert result.environment == "standalone-default"
-
-    def test_no_match_error_result_carries_environment(self) -> None:
-        """A no-match / error result also reports the standalone-default environment."""
-        result = resolve_feature("CompletelyMissing757FeatureXYZ")
-
-        assert result.feature_group is None
-        assert result.error is not None
-        assert result.environment == "standalone-default"
-
-
 class TestScopingABrokenPluginOutOfTheUniverse:
     """DoD-4: scoping the universe keeps a broken plugin from ever being consulted (#757, #790)."""
 
@@ -249,7 +200,6 @@ class TestScopingABrokenPluginOutOfTheUniverse:
             result = resolve_feature(BROKEN_RULE_FEATURE_757, plugin_collector=collector)
             winner_name = result.feature_group.get_class_name() if result.feature_group is not None else None
             error = result.error
-            environment = result.environment
             del result
         finally:
             del broken_fg
@@ -259,4 +209,3 @@ class TestScopingABrokenPluginOutOfTheUniverse:
         assert error is not None
         assert f"No feature groups found for feature name: '{BROKEN_RULE_FEATURE_757}'" in error
         assert "Failed to build the plugin environment" not in error
-        assert environment == "standalone-default"

--- a/tests/test_core/test_prepare/identify_seam.py
+++ b/tests/test_core/test_prepare/identify_seam.py
@@ -1,0 +1,46 @@
+"""Test seam mirroring how production raises a resolution failure over IdentifyFeatureGroupClass.
+
+The raising IdentifyFeatureGroupClass(...) constructor was removed: the engine and resolve_feature call
+evaluate() and render the failure themselves. These helpers reproduce that engine seam so unit tests can
+drive it without the deleted wrapper. Everything here is built on evaluate() + render_resolution_failure.
+"""
+
+from typing import Optional
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.link import Link
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from mloda.core.prepare.identify_feature_group import (
+    EvaluationResult,
+    FeatureResolutionError,
+    IdentifyFeatureGroupClass,
+    render_resolution_failure,
+)
+
+
+def evaluate_or_raise(
+    feature: Feature,
+    accessible_plugins: FeatureGroupEnvironmentMapping,
+    links: Optional[set[Link]] = None,
+    data_access_collection: Optional[DataAccessCollection] = None,
+) -> EvaluationResult:
+    """Evaluate one feature and raise the typed error on failure, exactly as the engine seam does."""
+    result = IdentifyFeatureGroupClass.evaluate(feature, accessible_plugins, links, data_access_collection)
+    message = render_resolution_failure(result, feature)
+    if message is not None:
+        raise FeatureResolutionError(message, str(feature.name), result)
+    return result
+
+
+def identify_winner(
+    feature: Feature,
+    accessible_plugins: FeatureGroupEnvironmentMapping,
+    links: Optional[set[Link]] = None,
+    data_access_collection: Optional[DataAccessCollection] = None,
+) -> tuple[type[FeatureGroup], set[type[ComputeFramework]]]:
+    """The winning (feature_group, frameworks) pair, mirroring the removed IdentifyFeatureGroupClass.get()."""
+    result = evaluate_or_raise(feature, accessible_plugins, links, data_access_collection)
+    return next(iter(result.identified.items()))

--- a/tests/test_core/test_prepare/test_abstract_feature_group_not_instantiated.py
+++ b/tests/test_core/test_prepare/test_abstract_feature_group_not_instantiated.py
@@ -23,7 +23,7 @@ from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.abstract_plugins.plugin_loader.plugin_loader import PluginLoader
 from mloda.core.api.request import mlodaAPI
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
-from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+from tests.test_core.test_prepare.identify_seam import evaluate_or_raise
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 
 
@@ -249,7 +249,7 @@ class TestAbstractOnlyMessageCorrectness:
         }
 
         with pytest.raises(ValueError) as exc_info:
-            IdentifyFeatureGroupClass(
+            evaluate_or_raise(
                 feature=feature,
                 accessible_plugins=accessible_plugins,
                 links=None,
@@ -277,7 +277,7 @@ class TestAbstractOnlyMessageCorrectness:
         }
 
         with pytest.raises(ValueError) as exc_info:
-            IdentifyFeatureGroupClass(
+            evaluate_or_raise(
                 feature=feature,
                 accessible_plugins=accessible_plugins,
                 links=None,
@@ -316,7 +316,7 @@ class TestAbstractFeatureGroupNotSelectedByResolution:
         }
 
         with pytest.raises(ValueError) as exc_info:
-            IdentifyFeatureGroupClass(
+            evaluate_or_raise(
                 feature=feature,
                 accessible_plugins=accessible_plugins,
                 links=None,

--- a/tests/test_core/test_prepare/test_compute_framework_capability.py
+++ b/tests/test_core/test_prepare/test_compute_framework_capability.py
@@ -29,7 +29,7 @@ from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
-from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+from tests.test_core.test_prepare.identify_seam import evaluate_or_raise, identify_winner
 
 
 CAPABILITY_FEATURE = "capability_test_feature"
@@ -173,14 +173,12 @@ class TestComputeFrameworkCapabilityHook:
             PlainCapabilityFeatureGroup: {CapabilityFwA, CapabilityFwB},
         }
 
-        identified = IdentifyFeatureGroupClass(
+        feature_group_class, compute_frameworks = identify_winner(
             feature=feature,
             accessible_plugins=accessible_plugins,
             links=None,
             data_access_collection=None,
         )
-
-        feature_group_class, compute_frameworks = identified.get()
         assert feature_group_class is PlainCapabilityFeatureGroup
         assert compute_frameworks == {CapabilityFwA, CapabilityFwB}, (
             f"Default behaviour must keep all declared frameworks; got {compute_frameworks}"
@@ -198,14 +196,12 @@ class TestComputeFrameworkCapabilityHook:
             RejectBCapabilityFeatureGroup: {CapabilityFwA, CapabilityFwB},
         }
 
-        identified = IdentifyFeatureGroupClass(
+        feature_group_class, compute_frameworks = identify_winner(
             feature=feature,
             accessible_plugins=accessible_plugins,
             links=None,
             data_access_collection=None,
         )
-
-        feature_group_class, compute_frameworks = identified.get()
         assert feature_group_class is RejectBCapabilityFeatureGroup
         assert compute_frameworks == {CapabilityFwA}, (
             f"Unsupported CapabilityFwB must be narrowed out, leaving only CapabilityFwA; got {compute_frameworks}"
@@ -221,7 +217,7 @@ class TestComputeFrameworkCapabilityHook:
         }
 
         with pytest.raises(ValueError) as exc_info:
-            IdentifyFeatureGroupClass(
+            evaluate_or_raise(
                 feature=feature,
                 accessible_plugins=accessible_plugins,
                 links=None,
@@ -253,7 +249,7 @@ class TestComputeFrameworkCapabilityHook:
         }
 
         with pytest.raises(ValueError) as exc_info:
-            IdentifyFeatureGroupClass(
+            evaluate_or_raise(
                 feature=feature,
                 accessible_plugins=accessible_plugins,
                 links=None,
@@ -283,7 +279,7 @@ class TestComputeFrameworkCapabilityHook:
         }
 
         with pytest.raises(ValueError) as unknown_exc:
-            IdentifyFeatureGroupClass(
+            evaluate_or_raise(
                 feature=unknown_feature,
                 accessible_plugins=unknown_accessible,
                 links=None,
@@ -302,7 +298,7 @@ class TestComputeFrameworkCapabilityHook:
         }
 
         with pytest.raises(ValueError) as capability_exc:
-            IdentifyFeatureGroupClass(
+            evaluate_or_raise(
                 feature=pinned_feature,
                 accessible_plugins=capability_accessible,
                 links=None,
@@ -336,7 +332,7 @@ class TestComputeFrameworkCapabilityHook:
         }
 
         with pytest.raises(ValueError) as exc_info:
-            IdentifyFeatureGroupClass(
+            evaluate_or_raise(
                 feature=feature,
                 accessible_plugins=accessible_plugins,
                 links=None,

--- a/tests/test_core/test_prepare/test_feature_group_scope_resolution.py
+++ b/tests/test_core/test_prepare/test_feature_group_scope_resolution.py
@@ -26,7 +26,8 @@ from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
-from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass, matches_feature_group_scope
+from mloda.core.prepare.identify_feature_group import matches_feature_group_scope
+from tests.test_core.test_prepare.identify_seam import evaluate_or_raise
 from mloda.provider import BaseInputData, DataCreator, FeatureSet
 from mloda.user import PluginCollector, mloda
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
@@ -136,7 +137,7 @@ def test_unscoped_shared_name_is_ambiguous() -> None:
     feature = Feature("subject_token")
 
     with pytest.raises(ValueError, match="Multiple feature groups found"):
-        IdentifyFeatureGroupClass(
+        evaluate_or_raise(
             feature=feature,
             accessible_plugins=_both_sources(),
             links=None,
@@ -148,13 +149,13 @@ def test_scope_class_resolves_uniquely_by_identity() -> None:
     """A class-object scope resolves uniquely to that class (matched by identity)."""
     feature = Feature("subject_token", feature_group=ScopeSourceA)
 
-    identifier = IdentifyFeatureGroupClass(
+    identifier = evaluate_or_raise(
         feature=feature,
         accessible_plugins=_both_sources(),
         links=None,
         data_access_collection=None,
     )
-    resolved_feature_group, _compute_frameworks = identifier.get()
+    resolved_feature_group, _compute_frameworks = next(iter(identifier.identified.items()))
     assert resolved_feature_group is ScopeSourceA
 
 
@@ -162,13 +163,13 @@ def test_scope_string_resolves_uniquely_by_class_name() -> None:
     """A class-name string scope resolves uniquely to the matching class."""
     feature = Feature("subject_token", feature_group=ScopeSourceA.get_class_name())
 
-    identifier = IdentifyFeatureGroupClass(
+    identifier = evaluate_or_raise(
         feature=feature,
         accessible_plugins=_both_sources(),
         links=None,
         data_access_collection=None,
     )
-    resolved_feature_group, _compute_frameworks = identifier.get()
+    resolved_feature_group, _compute_frameworks = next(iter(identifier.identified.items()))
     assert resolved_feature_group is ScopeSourceA
 
 
@@ -177,7 +178,7 @@ def test_unknown_scope_raises_no_feature_groups_found() -> None:
     feature = Feature("subject_token", feature_group="CompletelyUnknownScope")
 
     with pytest.raises(ValueError, match="No feature groups found") as exc_info:
-        IdentifyFeatureGroupClass(
+        evaluate_or_raise(
             feature=feature,
             accessible_plugins=_both_sources(),
             links=None,
@@ -196,7 +197,7 @@ def test_class_scope_pointing_at_inaccessible_group_raises_no_feature_groups_fou
     feature = Feature("subject_token", feature_group=InaccessibleScopeSource)
 
     with pytest.raises(ValueError, match="No feature groups found") as exc_info:
-        IdentifyFeatureGroupClass(
+        evaluate_or_raise(
             feature=feature,
             accessible_plugins=_both_sources(),
             links=None,
@@ -225,7 +226,7 @@ def test_string_scope_name_collision_reports_scope_in_multiple_found() -> None:
     feature = Feature("subject_token", feature_group="DupNameSource")
 
     with pytest.raises(ValueError, match="Multiple feature groups found") as exc_info:
-        IdentifyFeatureGroupClass(
+        evaluate_or_raise(
             feature=feature,
             accessible_plugins=accessible_plugins,
             links=None,
@@ -258,13 +259,13 @@ def test_base_class_scope_resolves_to_accessible_subclass() -> None:
         ScopeSourceB: {MockComputeFramework},
     }
 
-    identifier = IdentifyFeatureGroupClass(
+    identifier = evaluate_or_raise(
         feature=feature,
         accessible_plugins=accessible_plugins,
         links=None,
         data_access_collection=None,
     )
-    resolved_feature_group, _compute_frameworks = identifier.get()
+    resolved_feature_group, _compute_frameworks = next(iter(identifier.identified.items()))
     assert resolved_feature_group is ScopeSourceASub
 
 
@@ -281,13 +282,13 @@ def test_base_class_scope_prefers_subclass_when_both_accessible() -> None:
         ScopeSourceASub: {MockComputeFramework},
     }
 
-    identifier = IdentifyFeatureGroupClass(
+    identifier = evaluate_or_raise(
         feature=feature,
         accessible_plugins=accessible_plugins,
         links=None,
         data_access_collection=None,
     )
-    resolved_feature_group, _compute_frameworks = identifier.get()
+    resolved_feature_group, _compute_frameworks = next(iter(identifier.identified.items()))
     assert resolved_feature_group is ScopeSourceASub
 
 
@@ -343,7 +344,7 @@ def test_capability_rejection_error_names_the_scope() -> None:
     }
 
     with pytest.raises(ValueError) as exc_info:
-        IdentifyFeatureGroupClass(
+        evaluate_or_raise(
             feature=feature,
             accessible_plugins=accessible_plugins,
             links=None,
@@ -377,7 +378,7 @@ def test_scoped_ambiguity_callout_precedes_troubleshooting_url() -> None:
     feature = Feature("subject_token", feature_group="DupNameSource")
 
     with pytest.raises(ValueError, match="Multiple feature groups found") as exc_info:
-        IdentifyFeatureGroupClass(
+        evaluate_or_raise(
             feature=feature,
             accessible_plugins=accessible_plugins,
             links=None,
@@ -417,13 +418,13 @@ def test_base_class_name_string_scope_resolves_to_accessible_subclass() -> None:
         ScopeSourceASub: {MockComputeFramework},
     }
 
-    identifier = IdentifyFeatureGroupClass(
+    identifier = evaluate_or_raise(
         feature=feature,
         accessible_plugins=accessible_plugins,
         links=None,
         data_access_collection=None,
     )
-    resolved_feature_group, _compute_frameworks = identifier.get()
+    resolved_feature_group, _compute_frameworks = next(iter(identifier.identified.items()))
     assert resolved_feature_group is ScopeSourceASub
 
 
@@ -440,13 +441,13 @@ def test_base_class_name_string_scope_prefers_subclass_when_both_accessible() ->
         ScopeSourceASub: {MockComputeFramework},
     }
 
-    identifier = IdentifyFeatureGroupClass(
+    identifier = evaluate_or_raise(
         feature=feature,
         accessible_plugins=accessible_plugins,
         links=None,
         data_access_collection=None,
     )
-    resolved_feature_group, _compute_frameworks = identifier.get()
+    resolved_feature_group, _compute_frameworks = next(iter(identifier.identified.items()))
     assert resolved_feature_group is ScopeSourceASub
 
 
@@ -463,13 +464,13 @@ def test_string_scope_does_not_widen_to_unrelated_groups() -> None:
         ScopeSourceB: {MockComputeFramework},
     }
 
-    identifier = IdentifyFeatureGroupClass(
+    identifier = evaluate_or_raise(
         feature=feature,
         accessible_plugins=accessible_plugins,
         links=None,
         data_access_collection=None,
     )
-    resolved_feature_group, _compute_frameworks = identifier.get()
+    resolved_feature_group, _compute_frameworks = next(iter(identifier.identified.items()))
     assert resolved_feature_group is ScopeSourceASub
 
 
@@ -523,13 +524,13 @@ def test_abstract_base_name_string_scope_resolves_to_concrete_subclass() -> None
         ScopeSourceB: {MockComputeFramework},
     }
 
-    identifier = IdentifyFeatureGroupClass(
+    identifier = evaluate_or_raise(
         feature=feature,
         accessible_plugins=accessible_plugins,
         links=None,
         data_access_collection=None,
     )
-    resolved_feature_group, _compute_frameworks = identifier.get()
+    resolved_feature_group, _compute_frameworks = next(iter(identifier.identified.items()))
     assert resolved_feature_group is ScopeConcreteFamilyMember
 
 
@@ -553,7 +554,7 @@ def test_string_scope_matching_two_same_named_bases_stays_ambiguous() -> None:
     feature = Feature("subject_token", feature_group="DupNameAncestorBase")
 
     with pytest.raises(ValueError, match="Multiple feature groups found") as exc_info:
-        IdentifyFeatureGroupClass(
+        evaluate_or_raise(
             feature=feature,
             accessible_plugins=accessible_plugins,
             links=None,
@@ -579,7 +580,7 @@ def test_base_name_string_scope_with_two_sibling_subclasses_stays_ambiguous() ->
     feature = Feature("subject_token", feature_group=_DupNameBase.get_class_name())
 
     with pytest.raises(ValueError, match="Multiple feature groups found") as exc_info:
-        IdentifyFeatureGroupClass(
+        evaluate_or_raise(
             feature=feature,
             accessible_plugins=accessible_plugins,
             links=None,
@@ -607,7 +608,7 @@ def test_base_name_string_scope_with_differing_framework_siblings_stays_ambiguou
     feature = Feature("subject_token", feature_group=_DupNameBase.get_class_name())
 
     with pytest.raises(ValueError, match="Multiple feature groups found") as exc_info:
-        IdentifyFeatureGroupClass(
+        evaluate_or_raise(
             feature=feature,
             accessible_plugins=accessible_plugins,
             links=None,
@@ -657,13 +658,13 @@ def test_abstract_base_name_string_scope_resolves_when_base_is_not_accessible() 
     }
     assert ScopeAbstractFamilyBase not in accessible_plugins, "the scoped base must be absent from the mapping"
 
-    identifier = IdentifyFeatureGroupClass(
+    identifier = evaluate_or_raise(
         feature=feature,
         accessible_plugins=accessible_plugins,
         links=None,
         data_access_collection=None,
     )
-    resolved_feature_group, _compute_frameworks = identifier.get()
+    resolved_feature_group, _compute_frameworks = next(iter(identifier.identified.items()))
     assert resolved_feature_group is ScopeConcreteFamilyMember
 
 
@@ -716,7 +717,7 @@ def test_framework_pin_narrows_base_name_scope_to_primary_member() -> None:
     """
     unpinned = Feature("subject_token", feature_group=ScopeAbstractFamilyBase.get_class_name())
     with pytest.raises(ValueError, match="Multiple feature groups found"):
-        IdentifyFeatureGroupClass(
+        evaluate_or_raise(
             feature=unpinned,
             accessible_plugins=_framework_split_family(),
             links=None,
@@ -729,13 +730,13 @@ def test_framework_pin_narrows_base_name_scope_to_primary_member() -> None:
         compute_framework=ScopePinnedPrimaryFramework.get_class_name(),
     )
 
-    identifier = IdentifyFeatureGroupClass(
+    identifier = evaluate_or_raise(
         feature=feature,
         accessible_plugins=_framework_split_family(),
         links=None,
         data_access_collection=None,
     )
-    resolved_feature_group, compute_frameworks = identifier.get()
+    resolved_feature_group, compute_frameworks = next(iter(identifier.identified.items()))
     assert resolved_feature_group is ScopeConcreteFamilyMember
     assert compute_frameworks == {ScopePinnedPrimaryFramework}
 
@@ -752,13 +753,13 @@ def test_framework_pin_narrows_base_name_scope_to_secondary_member() -> None:
         compute_framework=ScopePinnedSecondaryFramework.get_class_name(),
     )
 
-    identifier = IdentifyFeatureGroupClass(
+    identifier = evaluate_or_raise(
         feature=feature,
         accessible_plugins=_framework_split_family(),
         links=None,
         data_access_collection=None,
     )
-    resolved_feature_group, compute_frameworks = identifier.get()
+    resolved_feature_group, compute_frameworks = next(iter(identifier.identified.items()))
     assert resolved_feature_group is ScopeConcreteFamilyMemberSecondary
     assert compute_frameworks == {ScopePinnedSecondaryFramework}
 

--- a/tests/test_core/test_prepare/test_feature_resolution_error.py
+++ b/tests/test_core/test_prepare/test_feature_resolution_error.py
@@ -30,6 +30,7 @@ from mloda.core.prepare.identify_feature_group import (
     render_resolution_failure,
 )
 from mloda.user import mlodaAPI
+from tests.test_core.test_prepare.identify_seam import evaluate_or_raise
 
 
 # Unique feature names so no other double in the parallel suite collides on them.
@@ -100,7 +101,7 @@ def _raised_resolution_error_809() -> FeatureResolutionError:
     feature = Feature(NO_MATCH_FEATURE_809)
 
     with pytest.raises(FeatureResolutionError) as exc_info:
-        IdentifyFeatureGroupClass(
+        evaluate_or_raise(
             feature=feature,
             accessible_plugins=_no_match_accessible_plugins(),
             links=None,
@@ -118,7 +119,7 @@ class TestFeatureResolutionErrorAtTheSeam:
         feature = Feature(NO_MATCH_FEATURE_809)
 
         with pytest.raises(FeatureResolutionError) as exc_info:
-            IdentifyFeatureGroupClass(
+            evaluate_or_raise(
                 feature=feature,
                 accessible_plugins=_no_match_accessible_plugins(),
                 links=None,
@@ -133,7 +134,7 @@ class TestFeatureResolutionErrorAtTheSeam:
         feature = Feature(NO_MATCH_FEATURE_809)
 
         with pytest.raises(FeatureResolutionError) as exc_info:
-            IdentifyFeatureGroupClass(
+            evaluate_or_raise(
                 feature=feature,
                 accessible_plugins=_no_match_accessible_plugins(),
                 links=None,
@@ -150,7 +151,7 @@ class TestFeatureResolutionErrorAtTheSeam:
         feature = Feature(NO_MATCH_FEATURE_809)
 
         with pytest.raises(FeatureResolutionError) as exc_info:
-            IdentifyFeatureGroupClass(
+            evaluate_or_raise(
                 feature=feature,
                 accessible_plugins=_no_match_accessible_plugins(),
                 links=None,
@@ -175,7 +176,7 @@ class TestFeatureResolutionErrorAtTheSeam:
         }
 
         with pytest.raises(FeatureResolutionError) as exc_info:
-            IdentifyFeatureGroupClass(
+            evaluate_or_raise(
                 feature=feature,
                 accessible_plugins=accessible_plugins,
                 links=None,

--- a/tests/test_core/test_prepare/test_identify_feature_group_error_message.py
+++ b/tests/test_core/test_prepare/test_identify_feature_group_error_message.py
@@ -249,17 +249,6 @@ class KnownFeatureGroup(FeatureGroup):
 class TestNoFeatureGroupFoundErrorMessage:
     """Tests for the improved 'no feature groups found' error message."""
 
-    def test_no_plugins_loaded_suggests_plugin_loader(self) -> None:
-        feature = Feature("some_feature")
-        accessible_plugins: FeatureGroupEnvironmentMapping = {}
-
-        with pytest.raises(ValueError, match="PluginLoader.all"):
-            IdentifyFeatureGroupClass(
-                feature=feature,
-                accessible_plugins=accessible_plugins,
-                links=None,
-            )
-
     def test_suggests_similar_feature_names(self) -> None:
         feature = Feature("knwon_feature")  # typo of "known_feature"
         accessible_plugins: FeatureGroupEnvironmentMapping = {

--- a/tests/test_core/test_prepare/test_identify_feature_group_error_message.py
+++ b/tests/test_core/test_prepare/test_identify_feature_group_error_message.py
@@ -21,7 +21,7 @@ from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
-from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+from tests.test_core.test_prepare.identify_seam import evaluate_or_raise
 
 
 class MockComputeFramework(ComputeFramework):
@@ -100,7 +100,7 @@ class TestIdentifyFeatureGroupErrorMessageFormat:
         }
 
         with pytest.raises(ValueError) as exc_info:
-            IdentifyFeatureGroupClass(
+            evaluate_or_raise(
                 feature=feature,
                 accessible_plugins=accessible_plugins,
                 links=None,
@@ -128,7 +128,7 @@ class TestIdentifyFeatureGroupErrorMessageFormat:
         }
 
         with pytest.raises(ValueError) as exc_info:
-            IdentifyFeatureGroupClass(
+            evaluate_or_raise(
                 feature=feature,
                 accessible_plugins=accessible_plugins,
                 links=None,
@@ -155,7 +155,7 @@ class TestIdentifyFeatureGroupErrorMessageFormat:
         }
 
         with pytest.raises(ValueError) as exc_info:
-            IdentifyFeatureGroupClass(
+            evaluate_or_raise(
                 feature=feature,
                 accessible_plugins=accessible_plugins,
                 links=None,
@@ -187,7 +187,7 @@ class TestIdentifyFeatureGroupErrorMessageFormat:
         }
 
         with pytest.raises(ValueError) as exc_info:
-            IdentifyFeatureGroupClass(
+            evaluate_or_raise(
                 feature=feature,
                 accessible_plugins=accessible_plugins,
                 links=None,
@@ -210,7 +210,7 @@ class TestIdentifyFeatureGroupErrorMessageFormat:
         }
 
         with pytest.raises(ValueError) as exc_info:
-            IdentifyFeatureGroupClass(
+            evaluate_or_raise(
                 feature=feature,
                 accessible_plugins=accessible_plugins,
                 links=None,
@@ -256,7 +256,7 @@ class TestNoFeatureGroupFoundErrorMessage:
         }
 
         with pytest.raises(ValueError, match="Did you mean") as exc_info:
-            IdentifyFeatureGroupClass(
+            evaluate_or_raise(
                 feature=feature,
                 accessible_plugins=accessible_plugins,
                 links=None,
@@ -272,7 +272,7 @@ class TestNoFeatureGroupFoundErrorMessage:
         }
 
         with pytest.raises(ValueError, match="troubleshooting"):
-            IdentifyFeatureGroupClass(
+            evaluate_or_raise(
                 feature=feature,
                 accessible_plugins=accessible_plugins,
                 links=None,
@@ -285,7 +285,7 @@ class TestNoFeatureGroupFoundErrorMessage:
         }
 
         with pytest.raises(ValueError, match="resolve_feature"):
-            IdentifyFeatureGroupClass(
+            evaluate_or_raise(
                 feature=feature,
                 accessible_plugins=accessible_plugins,
                 links=None,
@@ -298,7 +298,7 @@ class TestNoFeatureGroupFoundErrorMessage:
         }
 
         with pytest.raises(ValueError) as exc_info:
-            IdentifyFeatureGroupClass(
+            evaluate_or_raise(
                 feature=feature,
                 accessible_plugins=accessible_plugins,
                 links=None,
@@ -320,7 +320,7 @@ class TestScopedResolveFeaturePointerWording:
         }
 
         with pytest.raises(ValueError) as exc_info:
-            IdentifyFeatureGroupClass(
+            evaluate_or_raise(
                 feature=feature,
                 accessible_plugins=accessible_plugins,
                 links=None,
@@ -341,7 +341,7 @@ class TestScopedResolveFeaturePointerWording:
         }
 
         with pytest.raises(ValueError) as exc_info:
-            IdentifyFeatureGroupClass(
+            evaluate_or_raise(
                 feature=feature,
                 accessible_plugins=accessible_plugins,
                 links=None,
@@ -416,7 +416,7 @@ class TestStrictValidationRejectionHint:
         }
 
         with pytest.raises(ValueError) as exc_info:
-            IdentifyFeatureGroupClass(
+            evaluate_or_raise(
                 feature=feature,
                 accessible_plugins=accessible_plugins,
                 links=None,
@@ -444,7 +444,7 @@ class TestStrictValidationRejectionHint:
         }
 
         with pytest.raises(ValueError) as exc_info:
-            IdentifyFeatureGroupClass(
+            evaluate_or_raise(
                 feature=feature,
                 accessible_plugins=accessible_plugins,
                 links=None,
@@ -480,7 +480,7 @@ class TestStrictValidationRejectionHint:
         }
 
         with pytest.raises(ValueError) as exc_info:
-            IdentifyFeatureGroupClass(
+            evaluate_or_raise(
                 feature=feature,
                 accessible_plugins=accessible_plugins,
                 links=None,

--- a/tests/test_core/test_prepare/test_identify_feature_group_evaluation_seam.py
+++ b/tests/test_core/test_prepare/test_identify_feature_group_evaluation_seam.py
@@ -1,11 +1,9 @@
 """Pinning tests for the non-raising evaluation seam on IdentifyFeatureGroupClass (issue #754).
 
-The engine wrapper ``IdentifyFeatureGroupClass(...)`` validates and RAISES ``ValueError`` on
-any unresolved / ambiguous match. This suite pins a parallel, non-raising classmethod
 ``IdentifyFeatureGroupClass.evaluate(feature, accessible_plugins, links, data_access_collection=None)``
-that runs the same matching/filter logic but returns a structured ``EvaluationResult`` instead of
-raising. Both symbols are imported from ``mloda.core.prepare.identify_feature_group``; the seam is
-implemented, and these tests pin its non-raising contract.
+runs the matching/filter logic and returns a structured ``EvaluationResult`` instead of raising. The
+raising path now lives in the engine seam, mirrored here by the ``evaluate_or_raise`` test helper. This
+suite pins evaluate()'s non-raising contract against that raising counterpart.
 """
 
 from abc import abstractmethod
@@ -30,6 +28,7 @@ from mloda.core.prepare.identify_feature_group import (
 )
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
+from tests.test_core.test_prepare.identify_seam import evaluate_or_raise
 
 
 # Unique feature names so no other double in the parallel suite collides on them.
@@ -220,7 +219,7 @@ class TestEvaluationSeamParityWithEngineWrapper:
         }
 
         with pytest.raises(ValueError):
-            IdentifyFeatureGroupClass(
+            evaluate_or_raise(
                 feature=feature,
                 accessible_plugins=accessible_plugins,
                 links=None,
@@ -261,7 +260,7 @@ class TestSingleFrameworkPinValidatedBeforeMatching:
         accessible_plugins: FeatureGroupEnvironmentMapping = {SeamSingleFG: {SeamFwAlpha}}
 
         with pytest.raises(ComputeFrameworkPinError) as exc_info:
-            IdentifyFeatureGroupClass(
+            evaluate_or_raise(
                 feature=feature,
                 accessible_plugins=accessible_plugins,
                 links=None,
@@ -291,7 +290,7 @@ class TestSingleFrameworkPinValidatedBeforeMatching:
         accessible_plugins: FeatureGroupEnvironmentMapping = {SeamSingleFG: {SeamFwAlpha}}
 
         with pytest.raises(ComputeFrameworkPinError) as exc_info:
-            IdentifyFeatureGroupClass(
+            evaluate_or_raise(
                 feature=feature,
                 accessible_plugins=accessible_plugins,
                 links=None,

--- a/tests/test_core/test_prepare/test_identify_feature_group_failure_renderer.py
+++ b/tests/test_core/test_prepare/test_identify_feature_group_failure_renderer.py
@@ -46,7 +46,6 @@ ABSTRACT_FEATURE_791 = "renderer_abstract_791"
 KNOWN_FEATURE_791 = "renderer_known_feature_791"
 TYPO_FEATURE_791 = "renderer_knwon_feature_791"
 SCOPED_NO_MATCH_FEATURE_791 = "renderer_scoped_no_match_791"
-EMPTY_ENV_FEATURE_791 = "renderer_empty_env_791"
 FORWARDING_FEATURE_791 = "renderer_forwarding_791"
 RAISING_DOMAIN_FEATURE_791 = "renderer_raising_domain_791"
 RAISING_ABSTRACT_FEATURE_791 = "renderer_raising_abstract_791"
@@ -628,11 +627,6 @@ def scoped_none_scenario() -> Scenario:
     return feature, {RendererKnownNamesFG791: {RendererFwOne791}}
 
 
-def empty_environment_scenario() -> Scenario:
-    """No plugins are loaded at all."""
-    return Feature(EMPTY_ENV_FEATURE_791), {}
-
-
 def capability_narrow_enabled_scenario() -> Scenario:
     """Shape A: two declared frameworks, only the rejected one is enabled for this run."""
     return Feature(NARROW_ENABLED_FEATURE_791), {RendererNarrowEnabledFG791: {RendererFwOne791}}
@@ -827,15 +821,6 @@ class TestRenderResolutionFailureMessages:
         )
         assert f"  - RendererMissingOptionFG791: {MISSING_OPTION_REASON_791}" in message
 
-    def test_empty_environment_stops_after_plugin_loader_hint(self) -> None:
-        """An empty environment renders the PluginLoader hint and nothing else."""
-        message = _render(empty_environment_scenario())
-
-        assert message == (
-            f"No feature groups found for feature name: '{EMPTY_ENV_FEATURE_791}'."
-            "\nNo plugins are loaded. Did you call PluginLoader.all()?"
-        )
-
     def test_scoped_none_renders_callout_and_scoped_pointer(self) -> None:
         """A scoped no-match carries the scope callout and the scoped resolve_feature pointer."""
         message = _render(scoped_none_scenario())
@@ -981,18 +966,9 @@ class TestFactsCapturedDuringEvaluate:
 
         assert result.failure_kind == "none"
         assert result.facts.value_rejections == (("RendererStrictFG791", WINDOW_REJECTION_REASON),)
-        assert not result.facts.environment_empty
         assert KNOWN_FEATURE_791 in result.facts.known_names
         assert "RendererKnownNamesFG791" in result.facts.known_names
         assert "RendererStrictFG791_" in result.facts.known_names
-
-    def test_environment_empty_captured(self) -> None:
-        """An empty accessible_plugins is captured as a fact."""
-        result = _evaluate(empty_environment_scenario())
-
-        assert result.failure_kind == "none"
-        assert result.facts.environment_empty
-        assert result.facts.known_names == ()
 
 
 class TestFactCaptureNeverTakesEvaluateDown:

--- a/tests/test_core/test_prepare/test_single_pass_exactly_once.py
+++ b/tests/test_core/test_prepare/test_single_pass_exactly_once.py
@@ -45,6 +45,7 @@ from mloda.core.api.plugin_docs import resolve_feature
 from mloda.core.prepare import identify_feature_group
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping, PreFilterPlugins
 from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass, render_resolution_failure
+from tests.test_core.test_prepare.identify_seam import evaluate_or_raise
 
 
 MULTIPLE_FEATURE_782 = "single_pass_multiple_782"
@@ -654,7 +655,7 @@ def _engine_error(scenario: Scenario782) -> str:
     _reset_counters()
 
     with pytest.raises(ValueError) as exc_info:
-        IdentifyFeatureGroupClass(
+        evaluate_or_raise(
             feature=scenario.feature,
             accessible_plugins=accessible_plugins,
             links=scenario.links,
@@ -1264,10 +1265,11 @@ class TestTheSecondEvaluationIsGone:
             "_abstract_only_message",
             "_strict_validation_rejection_hint",
             "_input_feature_forwarding_hint",
+            "get",
         ],
     )
     def test_legacy_raising_path_attribute_is_deleted(self, attribute: str) -> None:
-        """The raising wrapper renders from the EvaluationResult; the legacy builders are gone."""
+        """The raising wrapper and its winner accessors are gone; failures render from the EvaluationResult."""
         assert not hasattr(IdentifyFeatureGroupClass, attribute)
 
     def test_split_frameworks_by_capability_is_deleted(self) -> None:

--- a/tests/test_core/test_prepare/test_subtype_matching.py
+++ b/tests/test_core/test_prepare/test_subtype_matching.py
@@ -13,6 +13,7 @@ from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
 from mloda.core.prepare.identify_feature_group import CandidateFrameworks, IdentifyFeatureGroupClass
 from mloda.provider import FeatureChainParserMixin, FeatureGroup, SubtypeDeclaration, property_spec
+from tests.test_core.test_prepare.identify_seam import identify_winner
 
 
 MATCH_KEY = "subdeclm_window_function"
@@ -180,13 +181,10 @@ class SubDeclMatchFrameSpecFG(FeatureGroup):
         return None
 
 
-def _identify(feature: Feature, accessible_plugins: FeatureGroupEnvironmentMapping) -> IdentifyFeatureGroupClass:
-    return IdentifyFeatureGroupClass(
-        feature=feature,
-        accessible_plugins=accessible_plugins,
-        links=None,
-        data_access_collection=None,
-    )
+def _identify(
+    feature: Feature, accessible_plugins: FeatureGroupEnvironmentMapping
+) -> tuple[type[FeatureGroup], set[type[ComputeFramework]]]:
+    return identify_winner(feature, accessible_plugins)
 
 
 class TestMatchTimeIntegration:
@@ -198,7 +196,7 @@ class TestMatchTimeIntegration:
             SubDeclMatchWindowFG: {SubDeclMatchFwAlpha, SubDeclMatchFwBeta},
         }
 
-        feature_group_class, compute_frameworks = _identify(feature, accessible_plugins).get()
+        feature_group_class, compute_frameworks = _identify(feature, accessible_plugins)
         assert feature_group_class is SubDeclMatchWindowFG
         assert compute_frameworks == {SubDeclMatchFwAlpha}, (
             f"'median' is unsupported on SubDeclMatchFwBeta and must be routed around; got {compute_frameworks}"
@@ -229,7 +227,7 @@ class TestMatchTimeIntegration:
             SubDeclMatchWindowFG: {SubDeclMatchFwAlpha, SubDeclMatchFwBeta},
         }
 
-        feature_group_class, compute_frameworks = _identify(feature, accessible_plugins).get()
+        feature_group_class, compute_frameworks = _identify(feature, accessible_plugins)
         assert feature_group_class is SubDeclMatchWindowFG
         assert compute_frameworks == {SubDeclMatchFwAlpha}, (
             f"Family 'ntile' is unsupported on SubDeclMatchFwBeta, so 'ntile_2' must be routed around; "
@@ -244,7 +242,7 @@ class TestMatchTimeIntegration:
             SubDeclMatchWindowFG: {SubDeclMatchFwAlpha, SubDeclMatchFwBeta},
         }
 
-        _, compute_frameworks = _identify(feature, accessible_plugins).get()
+        _, compute_frameworks = _identify(feature, accessible_plugins)
         assert compute_frameworks == {SubDeclMatchFwAlpha, SubDeclMatchFwBeta}, (
             f"An undeclared subtype must stay open on every framework; got {compute_frameworks}"
         )
@@ -258,7 +256,7 @@ class TestMatchTimeIntegration:
             SubDeclMatchPlainFG: {SubDeclMatchFwAlpha, SubDeclMatchFwBeta},
         }
 
-        _, compute_frameworks = _identify(feature, accessible_plugins).get()
+        _, compute_frameworks = _identify(feature, accessible_plugins)
         assert compute_frameworks == {SubDeclMatchFwAlpha, SubDeclMatchFwBeta}
 
     def test_matching_stays_orthogonal_to_subtype_support(self) -> None:
@@ -282,7 +280,7 @@ class TestRankLikeFamily:
             SubDeclMatchRankLikeFG: {SubDeclMatchFwAlpha, SubDeclMatchFwBeta},
         }
 
-        feature_group_class, compute_frameworks = _identify(feature, accessible_plugins).get()
+        feature_group_class, compute_frameworks = _identify(feature, accessible_plugins)
         assert feature_group_class is SubDeclMatchRankLikeFG
         assert compute_frameworks == {SubDeclMatchFwAlpha}, (
             f"'ntile' is only supported on SubDeclMatchFwAlpha; got {compute_frameworks}"
@@ -294,7 +292,7 @@ class TestRankLikeFamily:
             SubDeclMatchRankLikeFG: {SubDeclMatchFwAlpha, SubDeclMatchFwBeta},
         }
 
-        _, compute_frameworks = _identify(feature, accessible_plugins).get()
+        _, compute_frameworks = _identify(feature, accessible_plugins)
         assert compute_frameworks == {SubDeclMatchFwAlpha, SubDeclMatchFwBeta}
 
 
@@ -318,7 +316,7 @@ class TestFrameSpecLikeFamily:
             SubDeclMatchFrameSpecFG: {SubDeclMatchFwAlpha, SubDeclMatchFwBeta},
         }
 
-        feature_group_class, compute_frameworks = _identify(feature, accessible_plugins).get()
+        feature_group_class, compute_frameworks = _identify(feature, accessible_plugins)
         assert feature_group_class is SubDeclMatchFrameSpecFG
         assert compute_frameworks == {SubDeclMatchFwAlpha}, (
             f"'rows_7' is unsupported on SubDeclMatchFwBeta; got {compute_frameworks}"
@@ -330,7 +328,7 @@ class TestFrameSpecLikeFamily:
             SubDeclMatchFrameSpecFG: {SubDeclMatchFwAlpha, SubDeclMatchFwBeta},
         }
 
-        _, compute_frameworks = _identify(feature, accessible_plugins).get()
+        _, compute_frameworks = _identify(feature, accessible_plugins)
         assert compute_frameworks == {SubDeclMatchFwAlpha, SubDeclMatchFwBeta}
 
 
@@ -393,7 +391,7 @@ class TestCompiledPrefixPatternParity:
             SubDeclMatchCompiledWindowFG: {SubDeclMatchFwAlpha, SubDeclMatchFwBeta},
         }
 
-        feature_group_class, compute_frameworks = _identify(feature, accessible_plugins).get()
+        feature_group_class, compute_frameworks = _identify(feature, accessible_plugins)
         assert feature_group_class is SubDeclMatchCompiledWindowFG
         assert compute_frameworks == {SubDeclMatchFwAlpha}, (
             f"'median' is unsupported on SubDeclMatchFwBeta and must be routed around even when PREFIX_PATTERN "
@@ -406,7 +404,7 @@ class TestCompiledPrefixPatternParity:
             SubDeclMatchCompiledWindowFG: {SubDeclMatchFwAlpha, SubDeclMatchFwBeta},
         }
 
-        _, compute_frameworks = _identify(feature, accessible_plugins).get()
+        _, compute_frameworks = _identify(feature, accessible_plugins)
         # Pin resolution directly: pre-fix the dropped compiled pattern returns None, so routing merely fails open.
         assert SubDeclMatchCompiledWindowFG.resolve_subtype("value__sum_subdeclmcompiled", Options()) == "sum"
         assert compute_frameworks == {SubDeclMatchFwAlpha, SubDeclMatchFwBeta}, (
@@ -422,7 +420,7 @@ class TestCompiledPrefixPatternParity:
             SubDeclMatchCompiledSuffixFG: {SubDeclMatchFwAlpha, SubDeclMatchFwBeta},
         }
 
-        feature_group_class, compute_frameworks = _identify(feature, accessible_plugins).get()
+        feature_group_class, compute_frameworks = _identify(feature, accessible_plugins)
         assert feature_group_class is SubDeclMatchCompiledSuffixFG
         assert compute_frameworks == {SubDeclMatchFwAlpha}, (
             f"'median' is unsupported on SubDeclMatchFwBeta and must be routed around even when the compiled "

--- a/tests/test_core/test_resolution_parity/test_environment_build_failure_parity.py
+++ b/tests/test_core/test_resolution_parity/test_environment_build_failure_parity.py
@@ -461,6 +461,16 @@ def test_collector_that_filters_everything_names_the_collector_not_the_loader() 
     assert "Did you call PluginLoader.all()?" not in message
 
 
+def test_nothing_loaded_raises_the_plugin_loader_hint(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An empty FeatureGroup universe raises the nothing-loaded loader hint, not the collector message (#853)."""
+    monkeypatch.setattr(PreFilterPlugins, "get_featuregroup_subclasses", lambda self: set())
+
+    with pytest.raises(EnvironmentPreconditionError) as exc_info:
+        PreFilterPlugins(PreFilterPlugins.get_cfw_subclasses())
+
+    assert str(exc_info.value) == "No feature groups are loaded. Did you call PluginLoader.all()?"
+
+
 def test_diagnose_projects_the_collector_precondition_failure() -> None:
     """mlodaAPI.diagnose projects the collector's env-build precondition failure instead of raising (#850)."""
     collector = _collector_that_filters_everything()

--- a/tests/test_core/test_resolution_parity/test_environment_build_failure_parity.py
+++ b/tests/test_core/test_resolution_parity/test_environment_build_failure_parity.py
@@ -202,7 +202,6 @@ def test_resolve_feature_projects_the_environment_build_failure() -> None:
         winner_name = result.feature_group.get_class_name() if result.feature_group is not None else None
         error = result.error
         candidate_names = [candidate.get_class_name() for candidate in result.candidates]
-        environment = result.environment
         del result
     finally:
         del broken_fg
@@ -216,7 +215,6 @@ def test_resolve_feature_projects_the_environment_build_failure() -> None:
     assert ENV_BUILD_FAILURE_MESSAGE in error
     # The build aborts before matching, so a broken group is not a listed candidate.
     assert candidate_names == []
-    assert environment == "standalone-default"
 
 
 def test_resolve_feature_names_the_broken_plugin_for_an_unrelated_feature() -> None:

--- a/tests/test_core/test_resolution_parity/test_verified_false_positives.py
+++ b/tests/test_core/test_resolution_parity/test_verified_false_positives.py
@@ -25,8 +25,8 @@ from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.api.plugin_docs import resolve_feature
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping, PreFilterPlugins
-from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
 from mloda.user import PluginCollector
+from tests.test_core.test_prepare.identify_seam import evaluate_or_raise
 
 
 ABSTRACT_ONLY_FEATURE = "probe753_abstract_only"
@@ -140,7 +140,7 @@ def test_engine_rejects_lone_abstract_match() -> None:
     accessible_plugins: FeatureGroupEnvironmentMapping = {AbstractOnlyProbe753: {CfwAbstract753}}
 
     with pytest.raises(ValueError, match="Only abstract feature group base") as exc_info:
-        IdentifyFeatureGroupClass(
+        evaluate_or_raise(
             feature=feature,
             accessible_plugins=accessible_plugins,
             links=None,
@@ -185,7 +185,7 @@ def test_engine_unavailable_only_framework_raises_no_feature_groups() -> None:
     assert accessible == {UnavailableOnlyProbe753: set()}
 
     with pytest.raises(ValueError, match="No feature groups found for feature name: 'probe753_unavailable'"):
-        IdentifyFeatureGroupClass(
+        evaluate_or_raise(
             feature=Feature(UNAVAILABLE_FEATURE),
             accessible_plugins=accessible,
             links=None,
@@ -221,7 +221,7 @@ def test_engine_parent_child_differing_framework_sets_stays_ambiguous() -> None:
     }
 
     with pytest.raises(ValueError, match="Multiple feature groups found") as exc_info:
-        IdentifyFeatureGroupClass(
+        evaluate_or_raise(
             feature=feature,
             accessible_plugins=accessible_plugins,
             links=None,

--- a/tests/test_plugins/feature_group/experimental/sklearn/test_pipeline_feature_group/test_pipeline_name_option_validation.py
+++ b/tests/test_plugins/feature_group/experimental/sklearn/test_pipeline_feature_group/test_pipeline_name_option_validation.py
@@ -10,7 +10,7 @@ import pytest
 
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
-from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+from tests.test_core.test_prepare.identify_seam import evaluate_or_raise
 from mloda.provider import DefaultOptionKeys
 from mloda.user import Options
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
@@ -94,7 +94,7 @@ class TestBogusPipelineNameAtEngineLevel:
         }
 
         with pytest.raises(ValueError) as exc_info:
-            IdentifyFeatureGroupClass(
+            evaluate_or_raise(
                 feature=feature,
                 accessible_plugins=accessible_plugins,
                 links=None,

--- a/tests/test_plugins/feature_group/experimental/test_dimensionality_reduction_feature_group/test_name_path_option_validation.py
+++ b/tests/test_plugins/feature_group/experimental/test_dimensionality_reduction_feature_group/test_name_path_option_validation.py
@@ -10,7 +10,7 @@ import pytest
 
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
-from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+from tests.test_core.test_prepare.identify_seam import evaluate_or_raise
 from mloda.provider import DefaultOptionKeys
 from mloda.user import Options
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
@@ -164,7 +164,7 @@ class TestForwardedAlgorithmOutsideTheChildValueSpace:
         }
 
         with pytest.raises(ValueError) as exc_info:
-            IdentifyFeatureGroupClass(
+            evaluate_or_raise(
                 feature=feature,
                 accessible_plugins=accessible_plugins,
                 links=None,
@@ -201,7 +201,7 @@ class TestForwardedAlgorithmInsideTheChildValueSpace:
         }
 
         with pytest.raises(ValueError) as exc_info:
-            IdentifyFeatureGroupClass(
+            evaluate_or_raise(
                 feature=feature,
                 accessible_plugins=accessible_plugins,
                 links=None,

--- a/tests/test_plugins/feature_group/experimental/test_property_mapping_enforced_validators.py
+++ b/tests/test_plugins/feature_group/experimental/test_property_mapping_enforced_validators.py
@@ -20,7 +20,7 @@ from typing import Any, cast
 import pytest
 
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
-from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+from tests.test_core.test_prepare.identify_seam import evaluate_or_raise
 from mloda.provider import DefaultOptionKeys
 from mloda.provider import FeatureChainParserMixin
 from mloda.provider import FeatureGroup
@@ -187,7 +187,7 @@ def _resolution_error(feature: Feature, feature_group: type[FeatureGroup]) -> st
     """Resolve the feature against a single accessible feature group and return the raised error."""
     accessible_plugins: FeatureGroupEnvironmentMapping = {feature_group: {PandasDataFrame}}
     with pytest.raises(ValueError) as exc_info:
-        IdentifyFeatureGroupClass(feature=feature, accessible_plugins=accessible_plugins, links=None)
+        evaluate_or_raise(feature=feature, accessible_plugins=accessible_plugins, links=None)
     return str(exc_info.value)
 
 

--- a/tests/test_plugins/feature_group/experimental/test_text_cleaning/test_cleaning_operations_option_validation.py
+++ b/tests/test_plugins/feature_group/experimental/test_text_cleaning/test_cleaning_operations_option_validation.py
@@ -10,7 +10,7 @@ import pytest
 
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
-from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+from tests.test_core.test_prepare.identify_seam import evaluate_or_raise
 from mloda.provider import DefaultOptionKeys
 from mloda.user import Options
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
@@ -112,7 +112,7 @@ class TestUnhashableOperationAtEngineLevel:
         }
 
         with pytest.raises(ValueError) as exc_info:
-            IdentifyFeatureGroupClass(
+            evaluate_or_raise(
                 feature=feature,
                 accessible_plugins=accessible_plugins,
                 links=None,


### PR DESCRIPTION
Closes the #853 cleanup: removes dead surface and collapses duplicated logic left by the FeatureGroup-resolution consolidation. No production behavior change is intended.

## Dead surface removed
- `Engine.copy_compute_frameworks` (assigned, never read).
- The raising-constructor surface of `IdentifyFeatureGroupClass` (`__init__` that raised, `get()`, `.result`, `feature_group_compute_framework_mapping`). The engine and `resolve_feature` already resolve through `evaluate()`; removing the wrapper also drops the `cls.__new__(cls)` contortion inside `evaluate()` (now a plain `__init__` builds the per-attempt instance).
- The unreachable empty-environment render branch and its now-dead `environment_empty` fact. `PreFilterPlugins` raises `EnvironmentPreconditionError("No feature groups are loaded. Did you call PluginLoader.all()?")` before an empty mapping can reach the renderer, so the render-layer duplicate was unreachable in production.
- The constant `ResolvedFeature.environment` (always `"standalone-default"`).

## Duplications collapsed to a single owner
- `_as_str` moved next to `safe_field` as `components/utils.as_str` (was defined twice).
- `PARTIAL_RECORDS_CAP` is now applied in one place: `FeatureResolutionError.__init__` caps and snapshots (deep-copies) the records; the engine passes them raw.
- `resolve_feature` reads the winner's supported/unsupported framework split from the seam's captured `result.candidate_frameworks` instead of recomputing it.
- The three near-identical strict-mode "warn about unregistered plugins" blocks (FeatureGroups, ComputeFrameworks, Extenders) now call one `_warn_once_unregistered` helper.

## Tests
Migrated ~15 test files off the removed raising constructor to `IdentifyFeatureGroupClass.evaluate(...)`, via a shared engine-seam helper `tests/test_core/test_prepare/identify_seam.py` (`evaluate_or_raise` / `identify_winner`) that mirrors how the engine renders and raises a resolution failure. Added a positive assertion for the nothing-loaded `PluginLoader.all()` precondition (now owned by `PreFilterPlugins`).

## Breaking change
`ResolvedFeature.environment` (a public dataclass field added in #757) is removed. It was a constant, the four-positional-argument constructor is unchanged, and #853 states backwards compatibility is not required, but external consumers reading `result.environment` are affected.

## Validation
`tox` green: 7115 passed, 170 skipped, `ruff format`/`ruff check` clean, license allowlist OK, `mypy --strict` no issues in 880 files, bandit OK. Two independent deep reviews (a fresh Claude Opus agent and codex) found no correctness regressions; the one actionable finding (the missing positive assertion above) is addressed in this PR.