### PR TITLE
feat: declare input_data reader option keys and widen the undeclared-read sweep

### DIFF
--- a/attribution/ATTRIBUTION.md
+++ b/attribution/ATTRIBUTION.md
@@ -14,6 +14,7 @@
 | dataclasses                            | 0.8             | Apache Software License                            |
 | debugpy                                | 1.8.20          | MIT License                                        |
 | decorator                              | 5.3.1           | BSD-2-Clause                                       |
+| defusedxml                             | 0.7.1           | Python Software Foundation License                 |
 | duckdb                                 | 1.5.2           | MIT License                                        |
 | entrypoints                            | 0.4             | MIT License                                        |
 | execnet                                | 2.1.2           | MIT License                                        |
@@ -40,7 +41,7 @@
 | mypy                                   | 2.1.0           | MIT                                                |
 | mypy_extensions                        | 1.1.0           | MIT                                                |
 | nest-asyncio                           | 1.6.0           | BSD License                                        |
-| nltk                                   | 3.9.4           | Apache Software License                            |
+| nltk                                   | 3.10.0          | Apache Software License                            |
 | numpy                                  | 2.4.5           | BSD-3-Clause AND 0BSD AND MIT AND Zlib AND CC0-1.0 |
 | opentelemetry-api                      | 1.41.1          | Apache-2.0                                         |
 | opentelemetry-instrumentation          | 0.62b1          | Apache Software License                            |

--- a/mloda_plugins/feature_group/input_data/read_context_files.py
+++ b/mloda_plugins/feature_group/input_data/read_context_files.py
@@ -9,7 +9,7 @@ from mloda.user import FeatureName
 from mloda.provider import FeatureSet
 from mloda.user import JoinType
 from mloda.user import Options
-from mloda.provider import DefaultOptionKeys
+from mloda.provider import DefaultOptionKeys, property_spec
 from mloda_plugins.feature_group.experimental.dynamic_feature_group_factory.dynamic_feature_group_factory import (
     DynamicFeatureGroupCreator,
 )
@@ -36,6 +36,34 @@ class ConcatenatedFileContent(FeatureGroup):
 
     It uses dynamic feature group creation to create the single reader feature groups (a feature group per file).
     """
+
+    PROPERTY_MAPPING = {
+        "disallowed_files": property_spec(
+            "File basenames excluded from reading; the runtime default is ['__init__.py'].",
+            default=None,
+            context=False,
+        ),
+        "file_paths": property_spec(
+            "Explicit files to concatenate; when unset, target_folder is scanned (one of the two is required at runtime).",
+            default=None,
+            context=False,
+        ),
+        "target_folder": property_spec(
+            "Folder(s) scanned for files when file_paths is unset (one of the two is required at runtime).",
+            default=None,
+            context=False,
+        ),
+        "file_type": property_spec(
+            "File suffix to scan for in target_folder; the runtime default is 'py'.",
+            default=None,
+            context=False,
+        ),
+        "document_reader_class": property_spec(
+            "Name of the ReadDocument subclass that reads each file; required at runtime.",
+            default=None,
+            context=False,
+        ),
+    }
 
     # This feature should just be created once mlodaAPI run.
     join_feature_name = "FGConcatenatedFileContent_JoinLLMFiles"

--- a/mloda_plugins/feature_group/input_data/read_db_feature.py
+++ b/mloda_plugins/feature_group/input_data/read_db_feature.py
@@ -4,6 +4,10 @@ from mloda.provider import FeatureGroup
 from mloda.provider import FeatureSet
 from mloda.provider import BaseInputData
 from mloda_plugins.feature_group.input_data.read_db import ReadDB
+from mloda_plugins.feature_group.input_data.reader_option_specs import (
+    DATA_ACCESS_HANDLE,
+    DATA_ACCESS_HANDLE_SPEC,
+)
 
 
 class ReadDBFeature(FeatureGroup):
@@ -12,6 +16,10 @@ class ReadDBFeature(FeatureGroup):
     Delegates to ``ReadDB``, which executes queries against a configured
     database connection and returns the result as a compute-framework object.
     """
+
+    PROPERTY_MAPPING = {
+        DATA_ACCESS_HANDLE: DATA_ACCESS_HANDLE_SPEC,
+    }
 
     @classmethod
     def input_data(cls) -> Optional[BaseInputData]:

--- a/mloda_plugins/feature_group/input_data/read_document_feature.py
+++ b/mloda_plugins/feature_group/input_data/read_document_feature.py
@@ -4,6 +4,12 @@ from mloda.provider import FeatureGroup
 from mloda.provider import FeatureSet
 from mloda.provider import BaseInputData
 from mloda_plugins.feature_group.input_data.read_document import ReadDocument
+from mloda_plugins.feature_group.input_data.reader_option_specs import (
+    DATA_ACCESS_HANDLE,
+    DATA_ACCESS_HANDLE_SPEC,
+    DOCUMENT_SUFFIXES,
+    DOCUMENT_SUFFIXES_SPEC,
+)
 
 
 class ReadDocumentFeature(FeatureGroup):
@@ -12,6 +18,11 @@ class ReadDocumentFeature(FeatureGroup):
     Delegates to ``ReadDocument``, which extracts structured data from
     document formats and returns the result as a compute-framework object.
     """
+
+    PROPERTY_MAPPING = {
+        DOCUMENT_SUFFIXES: DOCUMENT_SUFFIXES_SPEC,
+        DATA_ACCESS_HANDLE: DATA_ACCESS_HANDLE_SPEC,
+    }
 
     @classmethod
     def input_data(cls) -> Optional[BaseInputData]:

--- a/mloda_plugins/feature_group/input_data/read_file_feature.py
+++ b/mloda_plugins/feature_group/input_data/read_file_feature.py
@@ -4,6 +4,12 @@ from mloda.provider import FeatureGroup
 from mloda.provider import FeatureSet
 from mloda.provider import BaseInputData
 from mloda_plugins.feature_group.input_data.read_file import ReadFile
+from mloda_plugins.feature_group.input_data.reader_option_specs import (
+    DATA_ACCESS_HANDLE,
+    DATA_ACCESS_HANDLE_SPEC,
+    DOCUMENT_SUFFIXES,
+    DOCUMENT_SUFFIXES_SPEC,
+)
 
 
 class ReadFileFeature(FeatureGroup):
@@ -13,6 +19,11 @@ class ReadFileFeature(FeatureGroup):
     ``ReadFile``, which selects a reader based on the file extension provided
     in the feature options.
     """
+
+    PROPERTY_MAPPING = {
+        DOCUMENT_SUFFIXES: DOCUMENT_SUFFIXES_SPEC,
+        DATA_ACCESS_HANDLE: DATA_ACCESS_HANDLE_SPEC,
+    }
 
     @classmethod
     def input_data(cls) -> Optional[BaseInputData]:

--- a/mloda_plugins/feature_group/input_data/reader_option_specs.py
+++ b/mloda_plugins/feature_group/input_data/reader_option_specs.py
@@ -1,0 +1,16 @@
+"""Shared option-key declarations for the readers, which are BaseInputData classes without PROPERTY_MAPPING; the wrapper feature groups declare their user keys here."""
+
+from mloda.provider import property_spec
+
+DOCUMENT_SUFFIXES = "document_suffixes"
+DATA_ACCESS_HANDLE = "data_access_handle"
+
+DOCUMENT_SUFFIXES_SPEC = property_spec(
+    "Structured file suffixes (e.g. '.json') ReadDocument may claim as documents; ReadFile auto-excludes them for that feature. Owned by the ReadFile and ReadDocument matchers.",
+    default=None,
+    context=False,
+)
+DATA_ACCESS_HANDLE_SPEC = property_spec(
+    "Name of a DataAccessCollection handle pinning which registered file or credentials entry the reader uses; see docs/in_depth/named-data-access-handles.md.",
+    default=None,
+)

--- a/mloda_plugins/feature_group/input_data/reader_option_specs.py
+++ b/mloda_plugins/feature_group/input_data/reader_option_specs.py
@@ -1,4 +1,6 @@
-"""Shared option-key declarations for the readers, which are BaseInputData classes without PROPERTY_MAPPING; the wrapper feature groups declare their user keys here."""
+"""Shared option-key specs for the input_data readers.
+
+The readers are BaseInputData classes without PROPERTY_MAPPING; the wrapper feature groups declare these user keys."""
 
 from mloda.provider import property_spec
 
@@ -11,6 +13,6 @@ DOCUMENT_SUFFIXES_SPEC = property_spec(
     context=False,
 )
 DATA_ACCESS_HANDLE_SPEC = property_spec(
-    "Name of a DataAccessCollection handle pinning which registered file or credentials entry the reader uses; see docs/in_depth/named-data-access-handles.md.",
+    "Name of a DataAccessCollection handle pinning which registered file or credentials entry the reader uses; see docs/docs/in_depth/named-data-access-handles.md.",
     default=None,
 )

--- a/tests/test_plugins/test_undeclared_option_reads.py
+++ b/tests/test_plugins/test_undeclared_option_reads.py
@@ -1,4 +1,4 @@
-"""Static sweep: every Options key an experimental plugin reads must be a declared PROPERTY_MAPPING key.
+"""Static sweep: every Options key a feature_group plugin reads must be a declared PROPERTY_MAPPING key.
 
 A feature group that reads ``options.get("foo")`` (directly, through a class constant, through a
 ``DefaultOptionKeys`` member, or through a local alias of one) is promising its users a ``foo`` option.
@@ -10,12 +10,10 @@ The check is deliberately GLOBAL: a key passes when SOME shipped feature group d
 that reads it. That is the intended model for shared keys like ``reference_time``; per-group owning-surface
 attribution is out of scope for this sweep.
 
-Scope notes (both are load-bearing and deliberately narrower than a naive reading of the ticket):
+Scope notes:
 
-* ``SCAN_ROOT`` is ``mloda_plugins/feature_group/experimental`` rather than the whole ``feature_group``
-  tree. The ticket inventory covers exactly the experimental subtree, and the dynamic allowlist path
-  below is written relative to it. The ``input_data`` readers under ``feature_group`` carry their own,
-  out-of-ticket set of undeclared literal reads that this sweep intentionally does not touch.
+* ``SCAN_ROOT`` is the whole ``mloda_plugins/feature_group`` tree (issue os-013 widened it from the
+  experimental subtree), so the ``input_data`` readers are swept too; allowlist paths are relative to it.
 * ``reference_time`` is a ``DefaultOptionKeys`` member yet is NOT treated as framework-reserved here.
   The time-based groups expose it as a user-overridable column option, so os-004 reclassifies it as a
   key those groups must DECLARE. The remaining ``DefaultOptionKeys`` values stay framework-reserved.
@@ -38,11 +36,15 @@ from mloda_plugins.feature_group.experimental.sklearn.encoding.base import Encod
 from mloda_plugins.feature_group.experimental.sklearn.pipeline.base import SklearnPipelineFeatureGroup
 from mloda_plugins.feature_group.experimental.sklearn.scaling.base import ScalingFeatureGroup
 from mloda_plugins.feature_group.experimental.time_window.base import TimeWindowFeatureGroup
+from mloda_plugins.feature_group.input_data.read_context_files import ConcatenatedFileContent
+from mloda_plugins.feature_group.input_data.read_db_feature import ReadDBFeature
+from mloda_plugins.feature_group.input_data.read_document_feature import ReadDocumentFeature
+from mloda_plugins.feature_group.input_data.read_file_feature import ReadFileFeature
 
 # Anchor the scan root to the repo layout via __file__, not the cwd: a cwd-relative root makes the
 # rglob loops empty and the sweep pass vacuously. This file sits two parents below the repo root.
 _REPO_ROOT = Path(__file__).resolve().parents[2]
-SCAN_ROOT = _REPO_ROOT / "mloda_plugins" / "feature_group" / "experimental"
+SCAN_ROOT = _REPO_ROOT / "mloda_plugins" / "feature_group"
 assert SCAN_ROOT.exists(), f"scan root not found; check the parents index for the repo root: {SCAN_ROOT}"
 
 # Accessor calls whose result is an Options-like object: cls.get_singular_option_from_options(...).get(...)
@@ -67,17 +69,27 @@ FRAMEWORK_KEYS: frozenset[str] = frozenset(_DEFAULT_OPTION_KEY_MEMBERS.values())
 # source file (relative to SCAN_ROOT): a read of the same literal from any other file is still flagged.
 ALLOWED_LITERAL_KEYS: dict[str, tuple[str, str, str]] = {
     "initial_requested_data": (
-        "source_input_feature.py",
+        "experimental/source_input_feature.py",
         "SourceInputFeatureComposite",
         "engine-internal request-scoping signal set as a Feature attribute; not a user-facing option",
+    ),
+    "BaseInputData": (
+        "input_data/read_dbs/sqlite.py",
+        "SQLITEReader",
+        "engine-internal (ReaderClass, data_access) tuple recorded by BaseInputData matching and "
+        "consumed by init_reader; not a user-facing option",
     ),
 }
 
 # Reads whose key is computed at runtime, keyed by (path relative to SCAN_ROOT, enclosing function).
 ALLOWED_DYNAMIC_READS: dict[tuple[str, str], tuple[str, str]] = {
-    ("forecasting/forecasting_artifact.py", "custom_loader"): (
+    ("experimental/forecasting/forecasting_artifact.py", "custom_loader"): (
         "ForecastingArtifact",
         "artifact is keyed by the runtime feature name, not a fixed option key",
+    ),
+    ("input_data/read_document.py", "load_data"): (
+        "ReadDocument",
+        "reader-selection contract: the options key is the reader's class name, computed at runtime",
     ),
 }
 
@@ -305,9 +317,9 @@ def declared_union() -> frozenset[str]:
 
 
 def test_no_undeclared_static_option_reads() -> None:
-    """No experimental plugin reads an Options key that no FeatureGroup declares (outside the narrow allowlist)."""
+    """No feature_group plugin reads an Options key that no FeatureGroup declares (outside the narrow allowlist)."""
     assert SCAN_ROOT.exists(), SCAN_ROOT
-    assert _count_reads(SCAN_ROOT) >= 25, "scan found too few reads; SCAN_ROOT is likely misconfigured"
+    assert _count_reads(SCAN_ROOT) >= 40, "scan found too few reads; SCAN_ROOT is likely misconfigured"
     violations = find_violations(
         SCAN_ROOT,
         declared_union(),
@@ -331,6 +343,26 @@ def test_artifact_storage_path_declared_by_sklearn_groups() -> None:
     assert "artifact_storage_path" in EncodingFeatureGroup.declared_option_keys()
     assert "artifact_storage_path" in ScalingFeatureGroup.declared_option_keys()
     assert "artifact_storage_path" in SklearnPipelineFeatureGroup.declared_option_keys()
+
+
+def test_reader_groups_declare_document_suffixes() -> None:
+    """The file and document readers declare the document_suffixes option they read."""
+    assert "document_suffixes" in ReadFileFeature.declared_option_keys()
+    assert "document_suffixes" in ReadDocumentFeature.declared_option_keys()
+
+
+def test_reader_groups_declare_data_access_handle() -> None:
+    """The reader groups declare the data_access_handle option their readers consume."""
+    assert "data_access_handle" in ReadFileFeature.declared_option_keys()
+    assert "data_access_handle" in ReadDocumentFeature.declared_option_keys()
+    assert "data_access_handle" in ReadDBFeature.declared_option_keys()
+
+
+def test_concatenated_file_content_declares_its_keys() -> None:
+    """ConcatenatedFileContent declares every option key it reads."""
+    declared = ConcatenatedFileContent.declared_option_keys()
+    for key in ("disallowed_files", "file_paths", "target_folder", "file_type", "document_reader_class"):
+        assert key in declared, key
 
 
 def test_scanner_flags_new_undeclared_literal_read(tmp_path: Path) -> None:

--- a/tests/test_plugins/test_undeclared_option_reads.py
+++ b/tests/test_plugins/test_undeclared_option_reads.py
@@ -372,6 +372,16 @@ def test_scanner_flags_new_undeclared_literal_read(tmp_path: Path) -> None:
     assert any("totally_new_key" in v for v in violations), violations
 
 
+def test_scanner_reports_plugin_key_and_location(tmp_path: Path) -> None:
+    """A violation names the reading class, the key, and the file:line of the read."""
+    source = "class Foo:\n    @classmethod\n    def f(cls, options):\n        return options.get('totally_new_key')\n"
+    (tmp_path / "mod.py").write_text(source)
+    violations = find_violations(tmp_path, frozenset(), frozenset(), {}, {})
+    assert any("plugin Foo" in v and "totally_new_key" in v and v.startswith("mod.py:4") for v in violations), (
+        violations
+    )
+
+
 def test_scanner_resolves_declared_class_constant(tmp_path: Path) -> None:
     """``options.get(cls.CONST)`` resolves through the class constant: declared passes, undeclared flags."""
     source = (


### PR DESCRIPTION
Closes os-013 (property-mapping-hardening epic, phase 5). Follow-up to os-004 / mloda#862, finding 12 of #750.

## Problem

The `input_data` reader feature groups read several user option keys that no `PROPERTY_MAPPING` declares, so those keys had no validation and appeared on no owning surface. os-004 scoped its undeclared-read sweep to `mloda_plugins/feature_group/experimental` precisely because the readers declare no `PROPERTY_MAPPING` at all and could not be cleared then.

## Change

- Declare the statically read user option keys on the owning wrapper feature groups. Since the readers are `BaseInputData` classes without `PROPERTY_MAPPING`, the wrapper groups own the declarations:
  - `document_suffixes` and `data_access_handle` as shared specs (new `reader_option_specs.py`) on `ReadFileFeature` and `ReadDocumentFeature`; `data_access_handle` also on `ReadDBFeature`. A shared module avoids a `read_db` to `read_file` import cycle.
  - `disallowed_files`, `file_paths`, `target_folder`, `file_type`, `document_reader_class` inline on `ConcatenatedFileContent` (its keys alone).
  - Declarations only: every spec is `default=None`, so all keys stay optional and matching, hashing, and option forwarding are unchanged.
- Classify the two non-user reads with the sweep's narrow allowlist recording owner and reason: the reserved `options.get("BaseInputData")` tuple read in `read_dbs/sqlite.py`, and the runtime `features.get_options_key(cls.__name__)` reader-selection read in `ReadDocument.load_data`.
- Widen the os-004 sweep (`tests/test_plugins/test_undeclared_option_reads.py`) from the experimental subtree to the whole `mloda_plugins/feature_group` tree, re-anchor the existing allowlist paths, remove the documented `input_data` exclusion, and keep it green.

## Tests

New declaration tests pin which group owns each key; a new scanner unit test pins that a violation names plugin, key, and file:line. `tox` passes (7138 passed, 170 skipped; ruff, licenses, mypy `--strict`, bandit all green).

## Review

Two independent deep reviews (Claude Opus and codex) ran on the diff. Both found no blockers or majors. Applied nits: corrected the `data_access_handle` doc path to the real `docs/docs/in_depth/...`, tightened the shared-spec module docstring, and added the plugin-name assertion above.
