### PR TITLE
refactor: retire transitional PROPERTY_MAPPING parser seams (#798)

### DIFF
--- a/attribution/ATTRIBUTION.md
+++ b/attribution/ATTRIBUTION.md
@@ -14,6 +14,7 @@
 | dataclasses                            | 0.8             | Apache Software License                            |
 | debugpy                                | 1.8.20          | MIT License                                        |
 | decorator                              | 5.3.1           | BSD-2-Clause                                       |
+| defusedxml                             | 0.7.1           | Python Software Foundation License                 |
 | duckdb                                 | 1.5.2           | MIT License                                        |
 | entrypoints                            | 0.4             | MIT License                                        |
 | execnet                                | 2.1.2           | MIT License                                        |
@@ -40,7 +41,7 @@
 | mypy                                   | 2.1.0           | MIT                                                |
 | mypy_extensions                        | 1.1.0           | MIT                                                |
 | nest-asyncio                           | 1.6.0           | BSD License                                        |
-| nltk                                   | 3.9.4           | Apache Software License                            |
+| nltk                                   | 3.10.0          | Apache Software License                            |
 | numpy                                  | 2.4.5           | BSD-3-Clause AND 0BSD AND MIT AND Zlib AND CC0-1.0 |
 | opentelemetry-api                      | 1.41.1          | Apache-2.0                                         |
 | opentelemetry-instrumentation          | 0.62b1          | Apache Software License                            |

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -53,8 +53,9 @@ NAME_PATH_PRESENCE_GUARD_DEPTH: contextvars.ContextVar[int] = contextvars.Contex
     "mloda_name_path_presence_guard_depth", default=0
 )
 
-# Active only while the engine evaluates candidates for one feature; maps owner class name to the first
-# structured rejection reason the real match pass produced (os-005 replaces the diagnostic replay).
+# Active for one candidate's match call: the engine opens a window per candidate. Maps the recording
+# site's owner name to the first structured rejection reason the real match pass produced, and the
+# engine attributes the harvest to the candidate class object it called (os-005 replaces the replay).
 MATCH_REJECTION_REASONS: contextvars.ContextVar[dict[str, str] | None] = contextvars.ContextVar(
     "mloda_match_rejection_reasons", default=None
 )

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -53,6 +53,12 @@ NAME_PATH_PRESENCE_GUARD_DEPTH: contextvars.ContextVar[int] = contextvars.Contex
     "mloda_name_path_presence_guard_depth", default=0
 )
 
+# Active only while the engine evaluates candidates for one feature; maps owner class name to the first
+# structured rejection reason the real match pass produced (os-005 replaces the diagnostic replay).
+MATCH_REJECTION_REASONS: contextvars.ContextVar[dict[str, str] | None] = contextvars.ContextVar(
+    "mloda_match_rejection_reasons", default=None
+)
+
 # Exception classes a user callable raises when it merely cannot judge a value.
 _EXPECTED_JUDGMENT_ERRORS: tuple[type[Exception], ...] = (TypeError, ValueError, AttributeError)
 
@@ -60,6 +66,14 @@ _EXPECTED_JUDGMENT_ERRORS: tuple[type[Exception], ...] = (TypeError, ValueError,
 def _contained_raise_log_level(exc: BaseException) -> int:
     """DEBUG for expected judgment failures, WARNING for classes that suggest a broken callable."""
     return logging.DEBUG if isinstance(exc, _EXPECTED_JUDGMENT_ERRORS) else logging.WARNING
+
+
+def record_match_rejection(owner_name: str, reason: str) -> None:
+    """Record a match rejection; the first reason per owner wins, and outside an active evaluation it is a no-op."""
+    reasons = MATCH_REJECTION_REASONS.get()
+    if reasons is None:
+        return
+    reasons.setdefault(owner_name, reason)
 
 
 def option_key_is_present(spec: PropertySpec, key: str, options: Options) -> bool:
@@ -121,7 +135,7 @@ class FeatureChainParser:
 
         A prefix pattern is anything ``re.match`` accepts: a ``str`` or a compiled ``re.Pattern``.
         A matched pattern with nothing before the separator raises the historical ValueError;
-        ``match_parser_criteria`` and ``_strict_validation_rejection_reason`` depend on that raise.
+        ``match_parser_criteria`` and the mixin's standalone rejection diagnostic depend on that raise.
         """
         _feature_name: str = feature_name
 
@@ -444,6 +458,11 @@ class FeatureChainParser:
                 missing.append(key)
         return missing
 
+    @staticmethod
+    def _presence_rejection_reason(missing: list[str]) -> str:
+        """The one formatting of the missing-required-keys reason, shared by the matcher and the diagnostic."""
+        return f"required option(s) {', '.join(sorted(missing))} are absent after declared defaults and name bindings"
+
     @classmethod
     def _check_name_path_required_presence(
         cls,
@@ -456,6 +475,9 @@ class FeatureChainParser:
         missing = cls._name_path_missing_required_keys(effective_options, property_mapping)
         if not missing:
             return True
+
+        if owner_name is not None:
+            record_match_rejection(owner_name, cls._presence_rejection_reason(missing))
 
         owner = owner_name or "A feature group"
         keys = ", ".join(sorted(missing))
@@ -481,7 +503,7 @@ class FeatureChainParser:
         missing = cls._name_path_missing_required_keys(effective_options, property_mapping)
         if not missing:
             return None
-        return f"required option(s) {', '.join(sorted(missing))} are absent after declared defaults and name bindings"
+        return cls._presence_rejection_reason(missing)
 
     @classmethod
     def match_configuration_feature_chain_parser(

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -513,9 +513,9 @@ class FeatureChainParser:
         """
 
         # string based matching. parse_name raises the no-source ValueError exactly as before, contained by
-        # match_parser_criteria. Effective options are built from the parse facts here, NOT via the
-        # monkeypatchable build_effective_options: a build raise stays owned by check_required_when, the one
-        # containment site that knows the owner (see build_effective_options / TestBuildEffectiveOptionsRaiseIsContained).
+        # match_parser_criteria. Effective options are built from the parse facts here, keeping the matcher's
+        # own parse containment; a raise out of build_effective_options in check_required_when now surfaces
+        # as a framework defect (os-005, see TestBuildEffectiveOptionsRaiseSurfaces).
         if prefix_patterns is not None:
             parsed = cls.parse_name(feature_name, prefix_patterns, pattern)
             if cls._name_identifies_group(parsed, property_mapping):
@@ -860,17 +860,9 @@ class FeatureChainParser:
         if property_mapping is None or not cls.has_required_when_predicates(property_mapping):
             return True
 
-        # Building effective options may itself raise, so a raise here is contained as a non-match too.
-        try:
-            effective_options = cls.build_effective_options(feature_name, prefix_patterns, property_mapping, options)
-        except Exception as exc:
-            logger.log(
-                _contained_raise_log_level(exc),
-                "building effective options for required_when on %s raised %s; treating feature group as a non-match.",
-                owner_name,
-                exc,
-            )
-            return False
+        # build_effective_options runs no user callback, so a raise from it is a framework defect (or a user
+        # configuration error carrying actionable guidance) and must surface, not read as a non-match (os-005, #763).
+        effective_options = cls.build_effective_options(feature_name, prefix_patterns, property_mapping, options)
         for key, spec in property_mapping.items():
             if not isinstance(spec, PropertySpec):
                 continue

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -8,7 +8,6 @@ import contextvars
 import functools
 import logging
 import re
-from collections.abc import Callable
 from typing import Any, Optional
 
 from mloda.core.abstract_plugins.components.feature import Feature
@@ -61,6 +60,14 @@ _EXPECTED_JUDGMENT_ERRORS: tuple[type[Exception], ...] = (TypeError, ValueError,
 def _contained_raise_log_level(exc: BaseException) -> int:
     """DEBUG for expected judgment failures, WARNING for classes that suggest a broken callable."""
     return logging.DEBUG if isinstance(exc, _EXPECTED_JUDGMENT_ERRORS) else logging.WARNING
+
+
+def option_key_is_present(spec: PropertySpec, key: str, options: Options) -> bool:
+    """The single presence decision (#768 matrix): an opted-in explicit None counts as present, a flagless
+    present-as-None does not."""
+    if spec.allow_explicit_none:
+        return key in options
+    return options.get(key) is not None
 
 
 class PropertyValueRejection(ValueError):
@@ -193,21 +200,6 @@ class FeatureChainParser:
         return not is_no_default(spec.default) or spec.required_when is not None
 
     @classmethod
-    def _is_context_parameter(cls, spec: PropertySpec) -> bool:
-        """Check if the spec marks the property as a context parameter."""
-        return spec.context
-
-    @classmethod
-    def _is_strict_validation(cls, spec: PropertySpec) -> bool:
-        """Check if the spec requires strict validation (values must be in the value space)."""
-        return spec.strict_validation
-
-    @classmethod
-    def _get_element_validator(cls, spec: PropertySpec) -> Callable[[Any], Any] | None:
-        """Get the spec's per-element validator if present."""
-        return spec.element_validator
-
-    @classmethod
     def _validate_property_value(
         cls, found_property_val: Any, property_value: Any, property_name: str, original_property_config: PropertySpec
     ) -> None:
@@ -216,10 +208,10 @@ class FeatureChainParser:
 
         Raises PropertyValueRejection if validation fails, otherwise returns None.
         """
-        if not cls._is_strict_validation(original_property_config):
+        if not original_property_config.strict_validation:
             return  # No validation needed
 
-        element_validator = cls._get_element_validator(original_property_config)
+        element_validator = original_property_config.element_validator
 
         if element_validator is not None:
             # A validator that raises cannot judge the value, so the value is rejected, not the run.
@@ -290,7 +282,7 @@ class FeatureChainParser:
             return DefaultOptionKeys.group
         elif property_name in options.context:
             return DefaultOptionKeys.context
-        elif cls._is_context_parameter(property_value):
+        elif property_value.context:
             return DefaultOptionKeys.context
         else:
             return DefaultOptionKeys.group
@@ -301,11 +293,6 @@ class FeatureChainParser:
         if spec.allowed_values is None:
             return {}
         return spec.allowed_values
-
-    @classmethod
-    def _extract_property_values(cls, spec: PropertySpec) -> Any:
-        """Alias kept for existing callers."""
-        return cls.extract_property_values(spec)
 
     @classmethod
     def _require_spec(cls, owner_name: str, key: str, spec: Any) -> PropertySpec:
@@ -393,10 +380,10 @@ class FeatureChainParser:
         property_config = property_mapping[property_name]
         found_property_value = options.get(property_name)
         # An opted-in spec treats a present-as-None value as PRESENT, so it flows through validation (#768).
-        if found_property_value is None and not (property_config.allow_explicit_none and property_name in options):
+        if not option_key_is_present(property_config, property_name, options):
             return None
         return cls._process_found_property_value(
-            found_property_value, cls._extract_property_values(property_config), property_name, property_config
+            found_property_value, cls.extract_property_values(property_config), property_name, property_config
         )
 
     @classmethod
@@ -452,7 +439,7 @@ class FeatureChainParser:
                 continue
             if spec.deferred_binding:
                 continue
-            absent = effective_options.get(key) is None and not (spec.allow_explicit_none and key in effective_options)
+            absent = not option_key_is_present(spec, key, effective_options)
             if absent:
                 missing.append(key)
         return missing
@@ -601,7 +588,7 @@ class FeatureChainParser:
         for key, spec in property_mapping.items():
             if not isinstance(spec, PropertySpec):
                 continue
-            if legacy_value in cls._extract_property_values(spec):
+            if legacy_value in cls.extract_property_values(spec):
                 return {key: legacy_value}
         return {}
 
@@ -648,7 +635,7 @@ class FeatureChainParser:
             if not isinstance(spec, PropertySpec):
                 continue
             # An explicit option (including an opted-in explicit None, #768) is never overwritten.
-            if options.get(key) is not None or (spec.allow_explicit_none and key in options):
+            if option_key_is_present(spec, key, options):
                 continue
             if cls._determine_parameter_category(key, spec, options) == DefaultOptionKeys.context:
                 merged_context[key] = value
@@ -723,7 +710,7 @@ class FeatureChainParser:
     def _str_reachable_values(cls, spec: PropertySpec) -> set[str]:
         """The str members of a spec's value space; only a str can be reverse-looked-up from a capture."""
         reachable: set[str] = set()
-        for value in cls._extract_property_values(spec):
+        for value in cls.extract_property_values(spec):
             if isinstance(value, str):
                 reachable.add(value)
         return reachable
@@ -905,11 +892,7 @@ class FeatureChainParser:
                 )
                 return False
             # An opted-in key present as an explicit None counts as present, so the requirement is met (#768).
-            if (
-                is_required
-                and effective_options.get(key) is None
-                and not (spec.allow_explicit_none and key in effective_options)
-            ):
+            if is_required and not option_key_is_present(spec, key, effective_options):
                 logger.debug(
                     "Feature group %s requires option '%s' (predicate %s is satisfied) but it was not provided.",
                     owner_name,

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -65,6 +65,7 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
     CHAIN_SEPARATOR,
     INPUT_SEPARATOR,
     _contained_raise_log_level,
+    option_key_is_present,
 )
 from mloda.core.abstract_plugins.components.feature_chainer.property_spec import PropertySpec
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
@@ -423,7 +424,7 @@ class FeatureChainParserMixin:
                 continue
             value = options.get(key)
             # An opted-in explicit None reaches the guard; every flagless spec still skips a None (#768).
-            if value is None and not (mapping_entry.allow_explicit_none and key in options):
+            if not option_key_is_present(mapping_entry, key, options):
                 continue
             try:
                 rejected = not guard(value)
@@ -495,17 +496,6 @@ class FeatureChainParserMixin:
         if hasattr(cls, "PROPERTY_MAPPING"):
             return cast(Optional[dict[str, PropertySpec]], cls.PROPERTY_MAPPING)
         return None
-
-    @classmethod
-    def _build_effective_options(
-        cls,
-        feature_name: str,
-        prefix_patterns: list[Any],
-        property_mapping: dict[str, PropertySpec],
-        options: Options,
-    ) -> Options:
-        """Merge the value parsed from the feature name into the options the predicates see."""
-        return FeatureChainParser.build_effective_options(feature_name, prefix_patterns, property_mapping, options)
 
     @classmethod
     def _extract_source_features(cls, feature: Feature) -> list[str]:

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -302,6 +302,9 @@ class FeatureChainParserMixin:
         except PropertyValueRejection as exc:
             record_match_rejection(cls.__name__, str(exc))
             return False
+        # Known asymmetry deliberately kept in scope: a config error raised while merging name bindings on the
+        # string path (e.g. a key in both group and context) is still contained as a non-match here, while the
+        # required_when path surfaces it via build_effective_options (os-005 review note).
         except ValueError:
             return False
 

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -40,9 +40,10 @@ element, the match fails with a ``ValueError`` before ``match_guard`` is
 reached.
 
 A guard rejection on a spec that also sets ``strict_validation=True`` is
-reportable: ``_strict_validation_rejection_reason`` turns it into a message so
-the feature group does not vanish silently. A guard on a non-strict spec keeps
-its "not mine" meaning and reports nothing.
+reportable: the match pass records it as it happens, and the recorded reason
+feeds the resolution-failure report. ``_strict_validation_rejection_reason``
+remains a standalone diagnostic facade producing the same message. A guard on
+a non-strict spec keeps its "not mine" meaning and reports nothing.
 
 Validators must be pure functions with no side effects. They may be called
 multiple times during feature group resolution (once per candidate feature
@@ -64,8 +65,10 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
     FeatureChainParser,
     CHAIN_SEPARATOR,
     INPUT_SEPARATOR,
+    PropertyValueRejection,
     _contained_raise_log_level,
     option_key_is_present,
+    record_match_rejection,
 )
 from mloda.core.abstract_plugins.components.feature_chainer.property_spec import PropertySpec
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
@@ -296,12 +299,19 @@ class FeatureChainParserMixin:
                 prefix_patterns=cls._get_prefix_patterns(),
                 owner_name=cls.__name__,
             )
+        except PropertyValueRejection as exc:
+            record_match_rejection(cls.__name__, str(exc))
+            return False
         except ValueError:
             return False
 
     @classmethod
     def _strict_validation_rejection_reason(cls, feature_name: str | FeatureName, options: Options) -> str | None:
         """Return the rejection message that match_feature_group_criteria discards, if any.
+
+        The engine no longer calls this: it renders the reasons the first match pass recorded via
+        ``record_match_rejection``. This stays a compatibility facade for direct diagnostic calls
+        and must keep producing the same messages the match pass records.
 
         Reports two kinds of value rejection, both gated on the feature group OTHERWISE matching
         the feature:
@@ -339,7 +349,7 @@ class FeatureChainParserMixin:
             if name_matched:
                 # The name relates the feature group to the feature, so the values of the present
                 # options (name-derived bindings included) are judged here; the name-path presence
-                # reason follows below. Judging the effective options keeps the replay in step with the match.
+                # reason follows below. Judging the effective options keeps the diagnostic in step with the match.
                 FeatureChainParser._validate_present_option_values(effective_options, property_mapping)
             else:
                 matches_mapping = FeatureChainParser._validate_options_against_property_mapping(
@@ -454,6 +464,8 @@ class FeatureChainParserMixin:
 
         key, value = rejection
         logger.debug("match_guard for '%s' rejected value %r", key, value)
+        if property_mapping is not None and property_mapping[key].strict_validation:
+            record_match_rejection(cls.__name__, f"Property value '{value}' rejected by match_guard for '{key}'")
         return False
 
     @classmethod

--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -15,6 +15,7 @@ from mloda.core.abstract_plugins.components.base_feature_group_version import Ba
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import (
     CHAIN_SEPARATOR,
     FeatureChainParser,
+    option_key_is_present,
 )
 from mloda.core.abstract_plugins.components.feature_chainer.property_spec import PropertySpec, is_no_default
 from mloda.core.abstract_plugins.components.subtype_declaration import SubtypeDeclaration
@@ -243,7 +244,7 @@ class FeatureGroup(ABC):
         fills_context: dict[str, Any] = {}
         for key, spec in mapping.items():
             # An opted-in spec honors an explicit None: presence, not non-None-ness, gates the fill (#768).
-            present = key in options if spec.allow_explicit_none else options.get(key) is not None
+            present = option_key_is_present(spec, key, options)
             if present:
                 continue
             if is_no_default(spec.default) or spec.default is None:

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -302,7 +302,7 @@ class IdentifyFeatureGroupClass:
     _criteria_matched_feature_groups: set[type[FeatureGroup]]
     _abstract_matched_feature_groups: set[type[FeatureGroup]]
     _candidate_frameworks: dict[type[FeatureGroup], CandidateFrameworks]
-    _match_rejections: dict[str, str]
+    _match_rejections: dict[type[FeatureGroup], str]
     _data_access_collection: Optional[DataAccessCollection]
     # Per-evaluation memos of the hooks more than one reader wants. evaluate() builds a fresh instance, so
     # they are scoped to one resolution attempt and never cache across runs.
@@ -313,7 +313,7 @@ class IdentifyFeatureGroupClass:
         self._criteria_matched_feature_groups = set()
         self._abstract_matched_feature_groups = set()
         self._candidate_frameworks = {}
-        # Reasons the first pass recorded, keyed by class name.
+        # Reasons the first pass recorded, keyed by candidate class.
         self._match_rejections = {}
         self._domain_outcomes = {}
         self._declared_frameworks = {}
@@ -343,13 +343,7 @@ class IdentifyFeatureGroupClass:
         # sat inside the filter loop, so it never ran when the name matched nothing).
         cls._validate_single_framework_pin(feature)
         self = cls(data_access_collection)
-        # try/finally so a raising hook cannot leak an active recorder out of this evaluation.
-        token = MATCH_REJECTION_REASONS.set({})
-        try:
-            identified = self._filter_loop(feature, accessible_plugins, links, data_access_collection)
-        finally:
-            self._match_rejections = MATCH_REJECTION_REASONS.get() or {}
-            MATCH_REJECTION_REASONS.reset(token)
+        identified = self._filter_loop(feature, accessible_plugins, links, data_access_collection)
         result = EvaluationResult(
             identified=identified,
             criteria_matched=self._criteria_matched_feature_groups,
@@ -536,7 +530,7 @@ class IdentifyFeatureGroupClass:
             return None
         if not self._filter_feature_group_by_scope(feature_group, feature):
             return None
-        reason = self._value_rejection_reason(feature_group, feature)
+        reason = self._value_rejection_reason(feature_group)
         return None if reason is None else as_str(reason)
 
     def _capture_known_names(self, accessible_plugins: FeatureGroupEnvironmentMapping) -> tuple[str, ...]:
@@ -629,13 +623,26 @@ class IdentifyFeatureGroupClass:
         """A rejected option value is a non-match, whoever calls the parser: a candidate that overrides the match
         hook and calls FeatureChainParser directly must not take the whole filter loop down. Only the rejection is
         caught, so a plain ValueError (the forwarded-name-mismatch guidance) still reaches the user.
+
+        The per-candidate recording window is what keys reasons by candidate class, so same-named classes cannot
+        collide (review fix). The try/finally guarantees the reset even when an unexpected exception propagates;
+        in that case nothing is attributed.
         """
+        token = MATCH_REJECTION_REASONS.set({})
         try:
-            return feature_group.match_feature_group_criteria(feature.name, feature.options, data_access_collection)
+            matched = feature_group.match_feature_group_criteria(feature.name, feature.options, data_access_collection)
         except PropertyValueRejection as exc:
             logger.debug("%s rejected an option value while matching '%s': %s", feature_group, feature.name, exc)
             record_match_rejection(feature_group.get_class_name(), str(exc))
-            return False
+            matched = False
+        finally:
+            recorded = MATCH_REJECTION_REASONS.get() or {}
+            MATCH_REJECTION_REASONS.reset(token)
+        if not matched and recorded:
+            # Everything recorded during this candidate's window belongs to this candidate, whatever
+            # owner name an inner delegation stamped; first recorded reason wins (insertion order).
+            self._match_rejections[feature_group] = next(iter(recorded.values()))
+        return matched
 
     def _filter_feature_group_by_domain(self, feature_group: type[FeatureGroup], feature: Feature) -> bool:
         """Decision-side domain gate: unguarded, so a raising get_domain() still fails the engine loudly."""
@@ -661,9 +668,9 @@ class IdentifyFeatureGroupClass:
 
         return feature.get_compute_framework() in compute_frameworks
 
-    def _value_rejection_reason(self, feature_group: type[FeatureGroup], feature: Feature) -> Optional[str]:
-        """The reason the first pass recorded for this candidate, if any."""
-        return self._match_rejections.get(feature_group.get_class_name())
+    def _value_rejection_reason(self, feature_group: type[FeatureGroup]) -> Optional[str]:
+        """The reason the first pass recorded for this candidate class, if any."""
+        return self._match_rejections.get(feature_group)
 
     def filter_subclasses(
         self, _identified_feature_groups: FeatureGroupEnvironmentMapping

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -8,7 +8,11 @@ from typing import Literal, Optional
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.domain import Domain
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import PropertyValueRejection
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import (
+    MATCH_REJECTION_REASONS,
+    PropertyValueRejection,
+    record_match_rejection,
+)
 from mloda.core.abstract_plugins.components.utils import safe_field, as_str
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
@@ -298,6 +302,7 @@ class IdentifyFeatureGroupClass:
     _criteria_matched_feature_groups: set[type[FeatureGroup]]
     _abstract_matched_feature_groups: set[type[FeatureGroup]]
     _candidate_frameworks: dict[type[FeatureGroup], CandidateFrameworks]
+    _match_rejections: dict[str, str]
     _data_access_collection: Optional[DataAccessCollection]
     # Per-evaluation memos of the hooks more than one reader wants. evaluate() builds a fresh instance, so
     # they are scoped to one resolution attempt and never cache across runs.
@@ -308,6 +313,8 @@ class IdentifyFeatureGroupClass:
         self._criteria_matched_feature_groups = set()
         self._abstract_matched_feature_groups = set()
         self._candidate_frameworks = {}
+        # Reasons the first pass recorded, keyed by class name.
+        self._match_rejections = {}
         self._domain_outcomes = {}
         self._declared_frameworks = {}
         self._data_access_collection = data_access_collection
@@ -336,7 +343,13 @@ class IdentifyFeatureGroupClass:
         # sat inside the filter loop, so it never ran when the name matched nothing).
         cls._validate_single_framework_pin(feature)
         self = cls(data_access_collection)
-        identified = self._filter_loop(feature, accessible_plugins, links, data_access_collection)
+        # try/finally so a raising hook cannot leak an active recorder out of this evaluation.
+        token = MATCH_REJECTION_REASONS.set({})
+        try:
+            identified = self._filter_loop(feature, accessible_plugins, links, data_access_collection)
+        finally:
+            self._match_rejections = MATCH_REJECTION_REASONS.get() or {}
+            MATCH_REJECTION_REASONS.reset(token)
         result = EvaluationResult(
             identified=identified,
             criteria_matched=self._criteria_matched_feature_groups,
@@ -497,6 +510,7 @@ class IdentifyFeatureGroupClass:
     def _capture_value_rejections(
         self, feature: Feature, accessible_plugins: FeatureGroupEnvironmentMapping
     ) -> tuple[tuple[str, str], ...]:
+        """Project the reasons the first pass recorded onto the domain/scope-filtered candidates, no replay."""
         reasons: list[tuple[str, str]] = []
         for feature_group in accessible_plugins:
             reason = self._scoped_value_rejection_reason(feature_group, feature)
@@ -505,18 +519,18 @@ class IdentifyFeatureGroupClass:
         return tuple(sorted(reasons))
 
     def _scoped_value_rejection_reason(self, feature_group: type[FeatureGroup], feature: Feature) -> str | None:
-        """Best-effort rejection reason of one candidate, guarded together with the filters it runs."""
+        """Best-effort recorded rejection reason of one candidate, guarded together with the filters it runs."""
         return safe_field(
             lambda: self._in_scope_value_rejection_reason(feature_group, feature),
             None,
-            field=f"{feature_group.get_class_name()}._strict_validation_rejection_reason",
+            field=f"{feature_group.get_class_name()} value rejection capture",
         )
 
     def _in_scope_value_rejection_reason(self, feature_group: type[FeatureGroup], feature: Feature) -> str | None:
-        """The candidate's rejection reason, or None when the domain or scope filter rules it out.
+        """The candidate's recorded rejection reason, or None when the domain or scope filter rules it out.
 
-        The reason is validated here, inside the caller's guard: a non-str one only detonates later, in the
-        sorted() over reasons, where two same-named candidates make it a str/int comparison.
+        Recorded reasons are always str, so the as_str below is a cheap invariant check, not a guard
+        against a hostile hook.
         """
         if not self._filter_feature_group_by_domain(feature_group, feature):
             return None
@@ -620,6 +634,7 @@ class IdentifyFeatureGroupClass:
             return feature_group.match_feature_group_criteria(feature.name, feature.options, data_access_collection)
         except PropertyValueRejection as exc:
             logger.debug("%s rejected an option value while matching '%s': %s", feature_group, feature.name, exc)
+            record_match_rejection(feature_group.get_class_name(), str(exc))
             return False
 
     def _filter_feature_group_by_domain(self, feature_group: type[FeatureGroup], feature: Feature) -> bool:
@@ -647,12 +662,8 @@ class IdentifyFeatureGroupClass:
         return feature.get_compute_framework() in compute_frameworks
 
     def _value_rejection_reason(self, feature_group: type[FeatureGroup], feature: Feature) -> Optional[str]:
-        """The candidate's own message for rejecting an option VALUE, if it has one."""
-        rejection_check = getattr(feature_group, "_strict_validation_rejection_reason", None)
-        if rejection_check is None:
-            return None
-        reason: Optional[str] = rejection_check(feature.name, feature.options)
-        return reason
+        """The reason the first pass recorded for this candidate, if any."""
+        return self._match_rejections.get(feature_group.get_class_name())
 
     def filter_subclasses(
         self, _identified_feature_groups: FeatureGroupEnvironmentMapping

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_option_value_rejection_never_escapes.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_option_value_rejection_never_escapes.py
@@ -69,9 +69,10 @@ GOOD_VALUE_ESC763 = "good_esc763"
 NEEDS_MODE_ESC763 = "needs_esc763"
 OPTIONAL_MODE_ESC763 = "optional_esc763"
 
-# The tier763 markers pin the two-tier logging contract on the same containment sites: an expected judgment
-# failure (TypeError, ValueError, AttributeError) stays at DEBUG, while any other exception class means the
-# callable itself looks broken and must surface at WARNING. Containment (reject / non-match) is unchanged.
+# The tier763 markers pin the two-tier logging contract on the user-callable containment sites: an expected
+# judgment failure (TypeError, ValueError, AttributeError) stays at DEBUG, while any other exception class means
+# the callable itself looks broken and must surface at WARNING. Containment (reject / non-match) is unchanged
+# for user callables; a raise from framework-owned build_effective_options surfaces instead (os-005).
 TYPE_POISON_VALUE_TIER763 = "type_poison_tier763"
 CAUSE_KEY_TIER763 = "cause_key_tier763"
 
@@ -109,12 +110,12 @@ def _keyerror_required_when_esc763(options: Options) -> bool:
 
 
 def _raise_build_effective_options_esc763(cls: Any, *args: Any, **kwargs: Any) -> Options:
-    """Force build_effective_options to raise a plain ValueError: the escape #763 must contain."""
+    """Force build_effective_options to raise a plain ValueError: a raise the narrowed containment must surface."""
     raise ValueError("esc763 build_effective_options boom")
 
 
 def _raise_keyerror_build_effective_options_tier763(cls: Any, *args: Any, **kwargs: Any) -> Options:
-    """Force build_effective_options to raise KeyError: a broken-looking class that must surface at WARNING."""
+    """Force build_effective_options to raise KeyError: a raise the narrowed containment must surface, not contain."""
     raise KeyError("tier763 build_effective_options boom")
 
 
@@ -674,15 +675,18 @@ class TestKeyErrorPathsDoNotOverReject:
         )
 
 
-class TestBuildEffectiveOptionsRaiseIsContained:
-    """issue #763: a raise from build_effective_options inside the required_when guard is a non-match, not an escape.
+class TestBuildEffectiveOptionsRaiseSurfaces:
+    """os-005 narrows the #763 containment to user-supplied callables (element_validator, match_guard,
+    required_when predicates). No user callback runs inside the framework-owned build_effective_options,
+    so a raise out of it is a framework defect (or a user configuration error carrying actionable
+    guidance) and must propagate out of matching instead of being contained as a non-match.
 
     The driver is OPTIONAL_MODE_ESC763, so the predicate itself returns False (would match True): the monkeypatched
-    build_effective_options, called before the predicate loop and outside its try/except, is the sole raise source.
+    build_effective_options, called before the predicate loop, is the sole raise source.
     """
 
-    def test_build_effective_options_raise_is_a_non_match(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """A ValueError from build_effective_options is contained as a non-match, not an escape out of the matcher."""
+    def test_build_effective_options_raise_propagates_from_the_matcher(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A ValueError from build_effective_options propagates out of the matcher instead of being contained."""
         monkeypatch.setattr(
             FeatureChainParser,
             "build_effective_options",
@@ -690,16 +694,13 @@ class TestBuildEffectiveOptionsRaiseIsContained:
         )
         options = Options(context={DRIVER_KEY_ESC763: OPTIONAL_MODE_ESC763})
 
-        result = RaisingKeyErrorRequiredWhenFeatureGroupEsc763.match_feature_group_criteria(
-            REQUIRED_WHEN_FEATURE_ESC763, options
-        )
+        with pytest.raises(ValueError, match="esc763 build_effective_options boom"):
+            RaisingKeyErrorRequiredWhenFeatureGroupEsc763.match_feature_group_criteria(
+                REQUIRED_WHEN_FEATURE_ESC763, options
+            )
 
-        assert result is False
-
-    def test_build_effective_options_raise_yields_the_standard_no_match_error(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """The engine turns that contained raise into the standard no-match error, not a bare escape."""
+    def test_build_effective_options_raise_propagates_out_of_the_engine(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The engine no longer converts the raise into the standard no-match error: the boom itself surfaces."""
         monkeypatch.setattr(
             FeatureChainParser,
             "build_effective_options",
@@ -710,19 +711,65 @@ class TestBuildEffectiveOptionsRaiseIsContained:
             RaisingKeyErrorRequiredWhenFeatureGroupEsc763: {MockComputeFrameworkEsc732},
         }
 
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match="esc763 build_effective_options boom") as exc_info:
             _identify(feature, accessible_plugins)
 
-        message = str(exc_info.value)
-        assert "No feature groups found" in message, (
-            f"A build_effective_options raise must be a non-match, not an exception out of the engine, but got: {message}"
+        assert "No feature groups found" not in str(exc_info.value), (
+            "a framework-defect raise must not be converted into the standard no-match error"
+        )
+
+    def test_keyerror_build_effective_options_raise_propagates_without_warning(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A KeyError from build_effective_options propagates unchanged; the parser logs no WARNING containment."""
+        caplog.set_level(logging.DEBUG, logger=PARSER_LOGGER_NAME)
+        monkeypatch.setattr(
+            FeatureChainParser,
+            "build_effective_options",
+            classmethod(_raise_keyerror_build_effective_options_tier763),
+        )
+        options = Options(context={DRIVER_KEY_ESC763: OPTIONAL_MODE_ESC763})
+
+        with pytest.raises(KeyError, match="tier763 build_effective_options boom"):
+            RaisingKeyErrorRequiredWhenFeatureGroupEsc763.match_feature_group_criteria(
+                REQUIRED_WHEN_FEATURE_ESC763, options
+            )
+
+        assert _records_at_or_above(caplog, PARSER_LOGGER_NAME, logging.WARNING) == [], (
+            "a propagating build_effective_options raise must not leave a WARNING-tier containment record"
+        )
+
+    def test_valueerror_build_effective_options_raise_leaves_no_containment_record(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A ValueError from build_effective_options propagates unchanged and leaves no containment record at all."""
+        caplog.set_level(logging.DEBUG, logger=PARSER_LOGGER_NAME)
+        monkeypatch.setattr(
+            FeatureChainParser,
+            "build_effective_options",
+            classmethod(_raise_build_effective_options_esc763),
+        )
+        options = Options(context={DRIVER_KEY_ESC763: OPTIONAL_MODE_ESC763})
+
+        with pytest.raises(ValueError, match="esc763 build_effective_options boom"):
+            RaisingKeyErrorRequiredWhenFeatureGroupEsc763.match_feature_group_criteria(
+                REQUIRED_WHEN_FEATURE_ESC763, options
+            )
+
+        assert _records_at_or_above(caplog, PARSER_LOGGER_NAME, logging.WARNING) == []
+        debug_records = _records_at_exactly(caplog, PARSER_LOGGER_NAME, logging.DEBUG)
+        assert all("non-match" not in record.getMessage() for record in debug_records), (
+            "a propagating build_effective_options raise must not leave a DEBUG non-match containment record"
         )
 
 
 class TestContainedRaiseLogTiers:
-    """Two-tier logging for contained raises: an expected judgment failure (TypeError, ValueError,
+    """Two-tier logging for raises contained from user-supplied callables only (element_validator,
+    match_guard, required_when predicates): an expected judgment failure (TypeError, ValueError,
     AttributeError) stays at DEBUG, any other exception class looks like a broken callable and must
-    surface at WARNING. Containment itself (reject / non-match, never escape) is unchanged either way.
+    surface at WARNING. Containment itself (reject / non-match, never escape) is unchanged for these
+    user callables; framework-owned build_effective_options raises propagate instead (os-005, see
+    TestBuildEffectiveOptionsRaiseSurfaces).
     """
 
     def test_keyerror_validator_raise_logs_at_warning(self, caplog: pytest.LogCaptureFixture) -> None:
@@ -835,53 +882,6 @@ class TestContainedRaiseLogTiers:
         assert any(
             REQUIRED_WHEN_KEY_ESC763 in record.getMessage() or owner in record.getMessage() for record in debug_records
         ), "the DEBUG containment record must name the guarded key or the owning feature group"
-
-    def test_keyerror_build_effective_options_raise_logs_at_warning(
-        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """build_effective_options raising KeyError is still a non-match, but the containment surfaces at WARNING."""
-        caplog.set_level(logging.DEBUG, logger=PARSER_LOGGER_NAME)
-        monkeypatch.setattr(
-            FeatureChainParser,
-            "build_effective_options",
-            classmethod(_raise_keyerror_build_effective_options_tier763),
-        )
-        options = Options(context={DRIVER_KEY_ESC763: OPTIONAL_MODE_ESC763})
-
-        result = RaisingKeyErrorRequiredWhenFeatureGroupEsc763.match_feature_group_criteria(
-            REQUIRED_WHEN_FEATURE_ESC763, options
-        )
-
-        assert result is False
-        warnings = _records_at_or_above(caplog, PARSER_LOGGER_NAME, logging.WARNING)
-        assert warnings, "a KeyError out of build_effective_options looks broken and must log at WARNING"
-        owner = RaisingKeyErrorRequiredWhenFeatureGroupEsc763.__name__
-        assert any(owner in record.getMessage() for record in warnings)
-
-    def test_valueerror_build_effective_options_raise_logs_at_debug_only(
-        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """build_effective_options raising ValueError is an expected failure: contained at DEBUG, never WARNING."""
-        caplog.set_level(logging.DEBUG, logger=PARSER_LOGGER_NAME)
-        monkeypatch.setattr(
-            FeatureChainParser,
-            "build_effective_options",
-            classmethod(_raise_build_effective_options_esc763),
-        )
-        options = Options(context={DRIVER_KEY_ESC763: OPTIONAL_MODE_ESC763})
-
-        result = RaisingKeyErrorRequiredWhenFeatureGroupEsc763.match_feature_group_criteria(
-            REQUIRED_WHEN_FEATURE_ESC763, options
-        )
-
-        assert result is False
-        assert _records_at_or_above(caplog, PARSER_LOGGER_NAME, logging.WARNING) == []
-        debug_records = _records_at_exactly(caplog, PARSER_LOGGER_NAME, logging.DEBUG)
-        assert debug_records, "the contained ValueError must still log its rejection at DEBUG"
-        owner = RaisingKeyErrorRequiredWhenFeatureGroupEsc763.__name__
-        assert any(owner in record.getMessage() for record in debug_records), (
-            "the DEBUG containment record must name the feature group whose match was denied"
-        )
 
 
 class TestValidatorCauseChaining:

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_allowed_values.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_allowed_values.py
@@ -2,12 +2,12 @@
 
 PROPERTY_MAPPING specs historically conflated allowed-value->docstring entries,
 flag keys, and a magic plain-string ``"explanation"`` doc key in one namespace.
-``FeatureChainParser._extract_property_values`` recovered the allowed-value set by
+``FeatureChainParser.extract_property_values`` recovered the allowed-value set by
 subtracting a hardcoded blocklist. This module pins the ``PropertySpec.allowed_values``
 field that replaced that:
 
 * authors DECLARE the accepted values under ``allowed_values``,
-* ``_extract_property_values`` returns exactly that mapping, so both membership
+* ``extract_property_values`` returns exactly that mapping, so both membership
   validation and the class-definition default invariant follow automatically,
 * nothing else in the spec can widen the value space.
 
@@ -162,7 +162,7 @@ class TestNoSilentWidening:
             strict_validation=True,
         )
 
-        extracted = FeatureChainParser._extract_property_values(spec)
+        extracted = FeatureChainParser.extract_property_values(spec)
         assert extracted == {"add": "Addition"}
 
     def test_doc_key_name_rejected_by_strict_validation(self) -> None:

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_required_when.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_required_when.py
@@ -94,7 +94,7 @@ class TestRequiredWhenUnit:
             strict_validation=False,
             required_when=_needs_order_by,
         )
-        extracted = FeatureChainParser._extract_property_values(mapping_entry)
+        extracted = FeatureChainParser.extract_property_values(mapping_entry)
         assert extracted == {}
 
     def test_extract_property_values_strips_explanation(self) -> None:
@@ -104,7 +104,7 @@ class TestRequiredWhenUnit:
             context=True,
             strict_validation=False,
         )
-        extracted = FeatureChainParser._extract_property_values(mapping_entry)
+        extracted = FeatureChainParser.extract_property_values(mapping_entry)
         assert extracted == {}
 
     def test_can_skip_required_check_with_required_when(self) -> None:
@@ -225,7 +225,7 @@ class TestRequiredWhenIntegration:
             context={"order_by": "ts"},
             propagate_context_keys=frozenset({"order_by"}),
         )
-        effective = MockWithConditionalRequired._build_effective_options(
+        effective = FeatureChainParser.build_effective_options(
             "source__first_windowed",
             [MockWithConditionalRequired.PREFIX_PATTERN],
             MockWithConditionalRequired.PROPERTY_MAPPING,

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_unified_model.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_unified_model.py
@@ -132,13 +132,13 @@ class TestValidatorFieldNames:
 class TestRenamedInternalHelpers:
     """The internal helpers follow the field names, so the vocabulary is consistent end to end."""
 
-    def test_parser_exposes_get_element_validator(self) -> None:
-        """``FeatureChainParser._get_element_validator`` reads the field; the old name is gone."""
+    def test_element_validator_is_read_from_the_field(self) -> None:
+        """``PropertySpec.element_validator`` is the field callers read; the old getter name is gone."""
         assert not hasattr(FeatureChainParser, f"_get_{STALE_ELEMENT_VALIDATOR_NAME}")
 
         spec = PropertySpec("Size of the time window", strict_validation=True, element_validator=_positive_int)
-        assert FeatureChainParser._get_element_validator(spec) is _positive_int
-        assert FeatureChainParser._get_element_validator(PropertySpec("x")) is None
+        assert spec.element_validator is _positive_int
+        assert PropertySpec("x").element_validator is None
 
     def test_mixin_exposes_validate_match_guards(self) -> None:
         """``FeatureChainParserMixin._validate_match_guards`` replaces ``_validate_type_validators``."""

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_spec_hard_break.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_spec_hard_break.py
@@ -152,7 +152,7 @@ class TestPropertySpecMappingBehavesAsBefore:
             PREFIX_PATTERN = r".*__([\w]+)_hardbreak694$"
             PROPERTY_MAPPING = {"hardbreak694_agg": spec}
 
-        effective = HardBreak694ContextCategorization._build_effective_options(
+        effective = FeatureChainParser.build_effective_options(
             "source__first_hardbreak694",
             [HardBreak694ContextCategorization.PREFIX_PATTERN],
             HardBreak694ContextCategorization.PROPERTY_MAPPING,

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_retire_transitional_seams.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_retire_transitional_seams.py
@@ -1,0 +1,135 @@
+"""Cycle A of retiring the transitional PROPERTY_MAPPING parser seams (os-005, was mloda#798).
+
+Two production changes are pinned here:
+
+1. ``option_key_is_present`` is the ONE module-level presence helper implementing the #768
+   behavior matrix, centralizing the existing inline copies:
+
+   * ``allow_explicit_none=True``: present iff the key is in the options, so an explicit
+     None value counts as PRESENT.
+   * flagless (default): present iff ``options.get(key)`` is not None, so a present-as-None
+     value counts as ABSENT.
+
+2. The trivial private wrappers and aliases are DELETED:
+
+   * ``FeatureChainParser._is_context_parameter`` (read ``spec.context``)
+   * ``FeatureChainParser._is_strict_validation`` (read ``spec.strict_validation``)
+   * ``FeatureChainParser._get_element_validator`` (read ``spec.element_validator``)
+   * ``FeatureChainParser._extract_property_values`` (call ``extract_property_values``)
+   * ``FeatureChainParserMixin._build_effective_options`` (call
+     ``FeatureChainParser.build_effective_options``)
+
+   The public canonical names survive: ``FeatureChainParser.extract_property_values`` and
+   ``FeatureChainParser.build_effective_options``.
+"""
+
+from __future__ import annotations
+
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import (
+    FeatureChainParser,
+    option_key_is_present,
+)
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
+from mloda.core.abstract_plugins.components.feature_chainer.property_spec import PropertySpec
+from mloda.core.abstract_plugins.components.options import Options
+
+_FLAGLESS_SPEC = PropertySpec("a key with the default presence rule")
+_EXPLICIT_NONE_SPEC = PropertySpec("a key opted into explicit-None presence", allow_explicit_none=True)
+
+
+class TestOptionKeyIsPresentFlagless:
+    """Flagless spec: presence means a non-None value; a present-as-None value counts as absent."""
+
+    def test_absent_key_is_absent(self) -> None:
+        """A key in neither group nor context is absent."""
+        assert option_key_is_present(_FLAGLESS_SPEC, "os005_key", Options()) is False
+
+    def test_present_as_none_in_group_is_absent(self) -> None:
+        """An explicit None value counts as absent without the opt-in flag."""
+        options = Options(group={"os005_key": None})
+        assert option_key_is_present(_FLAGLESS_SPEC, "os005_key", options) is False
+
+    def test_real_value_is_present(self) -> None:
+        """A real value is present."""
+        options = Options(group={"os005_key": "value"})
+        assert option_key_is_present(_FLAGLESS_SPEC, "os005_key", options) is True
+
+
+class TestOptionKeyIsPresentAllowExplicitNone:
+    """``allow_explicit_none=True``: presence means the key is in the options, None value or not (#768)."""
+
+    def test_present_as_none_is_present(self) -> None:
+        """An explicit None value counts as present with the opt-in flag."""
+        options = Options(group={"os005_key": None})
+        assert option_key_is_present(_EXPLICIT_NONE_SPEC, "os005_key", options) is True
+
+    def test_absent_key_is_absent(self) -> None:
+        """The flag never fabricates presence for a key that is not in the options at all."""
+        assert option_key_is_present(_EXPLICIT_NONE_SPEC, "os005_key", Options()) is False
+
+    def test_real_value_is_present(self) -> None:
+        """A real value is present, exactly as without the flag."""
+        options = Options(group={"os005_key": "value"})
+        assert option_key_is_present(_EXPLICIT_NONE_SPEC, "os005_key", options) is True
+
+
+class TestOptionKeyIsPresentContextStorage:
+    """Presence reads through ``Options`` as a whole, so a context-stored key behaves like a group-stored one."""
+
+    def test_real_value_in_context_is_present_for_flagless_spec(self) -> None:
+        """A real value stored in context is present."""
+        options = Options(context={"os005_key": "value"})
+        assert option_key_is_present(_FLAGLESS_SPEC, "os005_key", options) is True
+
+    def test_none_in_context_is_absent_for_flagless_spec(self) -> None:
+        """A present-as-None context value counts as absent without the opt-in flag."""
+        options = Options(context={"os005_key": None})
+        assert option_key_is_present(_FLAGLESS_SPEC, "os005_key", options) is False
+
+    def test_none_in_context_is_present_for_explicit_none_spec(self) -> None:
+        """A present-as-None context value counts as present with the opt-in flag."""
+        options = Options(context={"os005_key": None})
+        assert option_key_is_present(_EXPLICIT_NONE_SPEC, "os005_key", options) is True
+
+
+class TestTransitionalSeamsAreGone:
+    """The trivial private wrappers and aliases are deleted; callers use the spec fields or the public API."""
+
+    def test_is_context_parameter_is_gone(self) -> None:
+        """``_is_context_parameter`` is gone: read ``spec.context``."""
+        assert not hasattr(FeatureChainParser, "_is_context_parameter")
+
+    def test_is_strict_validation_is_gone(self) -> None:
+        """``_is_strict_validation`` is gone: read ``spec.strict_validation``."""
+        assert not hasattr(FeatureChainParser, "_is_strict_validation")
+
+    def test_get_element_validator_is_gone(self) -> None:
+        """``_get_element_validator`` is gone: read ``spec.element_validator``."""
+        assert not hasattr(FeatureChainParser, "_get_element_validator")
+
+    def test_private_extract_property_values_alias_is_gone(self) -> None:
+        """``_extract_property_values`` is gone: call the public ``extract_property_values``."""
+        assert not hasattr(FeatureChainParser, "_extract_property_values")
+
+    def test_mixin_build_effective_options_passthrough_is_gone(self) -> None:
+        """The mixin pass-through is gone: call ``FeatureChainParser.build_effective_options``."""
+        assert not hasattr(FeatureChainParserMixin, "_build_effective_options")
+
+
+class TestPublicSurvivorsStay:
+    """The public canonical names the wrappers delegated to keep existing."""
+
+    def test_extract_property_values_survives(self) -> None:
+        """``FeatureChainParser.extract_property_values`` stays and keeps its semantics."""
+        assert hasattr(FeatureChainParser, "extract_property_values")
+        assert FeatureChainParser.extract_property_values(PropertySpec("no declared value space")) == {}
+
+        spec = PropertySpec("declared value space", allowed_values={"add": "Addition"})
+        assert FeatureChainParser.extract_property_values(spec) == {"add": "Addition"}
+
+    def test_build_effective_options_survives(self) -> None:
+        """``FeatureChainParser.build_effective_options`` stays; nothing to bind returns options by identity."""
+        assert hasattr(FeatureChainParser, "build_effective_options")
+
+        options = Options(group={"os005_key": "value"})
+        assert FeatureChainParser.build_effective_options("plain_name", [], {}, options) is options

--- a/tests/test_core/test_prepare/test_first_pass_rejection_recording.py
+++ b/tests/test_core/test_prepare/test_first_pass_rejection_recording.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import contextvars
 from collections.abc import Iterator
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 import pytest
 
@@ -46,6 +46,15 @@ STRICT_REJECTION_REASON_OS005R = "Property value '14' failed validation for 'win
 MISSING_OPTION_REASON_OS005R = "required option(s) some_key_os005r are absent after declared defaults and name bindings"
 GUARD_REJECTION_REASON_OS005R = "Property value 'ok_os005r' rejected by match_guard for 'guarded_key_os005r'"
 FACADE_SENTINEL_REASON_OS005R = "facade sentinel reason os005r"
+
+# The name-collision groups carry an os005c suffix of their own so their names and option keys stay
+# unique to this test; the shared class NAME is the point of the collision scenario.
+COLLIDING_FEATURE_OS005C = "colliding_recording_feature_os005c"
+COLLIDING_NAME_OS005C = "CollidingRejectFGOs005c"
+COLLIDING_MODULE_A_OS005C = "tests.colliding_reject_module_a_os005c"
+COLLIDING_MODULE_B_OS005C = "tests.colliding_reject_module_b_os005c"
+COLLIDE_A_REASON_OS005C = "Property value 'bogus_os005c' not found in mapping for 'collide_a_os005c'"
+COLLIDE_B_REASON_OS005C = "Property value 'bogus_os005c' not found in mapping for 'collide_b_os005c'"
 
 # Every value the strict element_validator judged, across the WHOLE failed resolution. Reset per test.
 VALIDATOR_CALLS_OS005R: list[Any] = []
@@ -138,6 +147,42 @@ class FacadeProbeFGOs005r(FeatureGroup):
         return None
 
 
+def _build_colliding_rejection_groups_os005c() -> tuple[type[FeatureGroup], type[FeatureGroup]]:
+    """Build two same-named candidates across modules, each strictly rejecting its OWN option key.
+
+    Sharing a ``__name__`` is a supported scenario, so a recording keyed by class name would collapse
+    the two into one slot. Each group's strict key is unique (``collide_a_os005c`` / ``collide_b_os005c``),
+    so the same failed feature yields a DIFFERENT rejection reason per class. Leaked into another test's
+    universe the groups are inert: each matches only when its own required collide key is present.
+    """
+
+    def make(module: str, key: str) -> type[FeatureGroup]:
+        def input_features(self: Any, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+            return None
+
+        namespace: dict[str, Any] = {
+            "__module__": module,
+            "__doc__": "Same-named candidate whose strict key rejects the provided value.",
+            "PROPERTY_MAPPING": {
+                key: property_spec(
+                    "strict key accepting only its ok sentinel",
+                    strict=True,
+                    allowed_values=("ok_os005c",),
+                    context=False,
+                ),
+                DefaultOptionKeys.in_features: property_spec("source", context=True),
+            },
+            "input_features": input_features,
+        }
+        created: Any = type(COLLIDING_NAME_OS005C, (FeatureChainParserMixin, FeatureGroup), namespace)
+        return cast(type[FeatureGroup], created)
+
+    return (
+        make(COLLIDING_MODULE_A_OS005C, "collide_a_os005c"),
+        make(COLLIDING_MODULE_B_OS005C, "collide_b_os005c"),
+    )
+
+
 @pytest.fixture(autouse=True)
 def _reset_recording_state() -> Iterator[None]:
     """Recorder and counter state must not leak between tests, in either direction."""
@@ -190,6 +235,36 @@ class TestFirstPassRejectionRecording:
         facts = _failed_facts(feature, accessible_plugins)
 
         assert facts.value_rejections == (("GuardRecordingFGOs005r", GUARD_REJECTION_REASON_OS005R),)
+
+    def test_same_named_candidates_each_keep_their_own_recorded_reason(self) -> None:
+        """Two candidates sharing a __name__ each report the reason their OWN match produced.
+
+        A recording keyed by class name collapses both classes into one first-wins slot: the second
+        class's distinct reason is dropped and the shared reason is attributed to both candidates.
+        Scoped per candidate, the facts carry two entries with the same name and two different reasons.
+        """
+        group_a, group_b = _build_colliding_rejection_groups_os005c()
+        feature = Feature(
+            COLLIDING_FEATURE_OS005C,
+            Options(
+                context={
+                    DefaultOptionKeys.in_features: "src",
+                    "collide_a_os005c": "bogus_os005c",
+                    "collide_b_os005c": "bogus_os005c",
+                }
+            ),
+        )
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            group_a: {RecorderFwOneOs005r},
+            group_b: {RecorderFwOneOs005r},
+        }
+
+        facts = _failed_facts(feature, accessible_plugins)
+
+        assert facts.value_rejections == (
+            (COLLIDING_NAME_OS005C, COLLIDE_A_REASON_OS005C),
+            (COLLIDING_NAME_OS005C, COLLIDE_B_REASON_OS005C),
+        )
 
 
 class TestEngineNeverCallsTheFacade:

--- a/tests/test_core/test_prepare/test_first_pass_rejection_recording.py
+++ b/tests/test_core/test_prepare/test_first_pass_rejection_recording.py
@@ -1,0 +1,244 @@
+"""First-pass rejection recording for feature resolution failures (board issue os-005, mloda#798).
+
+Matching RECORDS each rejection as it happens: ``record_match_rejection`` writes into the
+``MATCH_REJECTION_REASONS`` recorder the engine activates around its filter loop, the first reason
+per owner wins, and the failure facts render from that recording. The engine never replays diagnosis
+through ``_strict_validation_rejection_reason``; that method stays a standalone diagnostic facade.
+
+All names carry an ``os005r`` suffix: test feature groups become global subclasses and the suite runs
+in parallel, so a shared name would leak into another module's candidate universe. Every group here is
+inert for unrelated features (it matches only its own unique name or option keys), so no disarm
+fixture is needed.
+"""
+
+from __future__ import annotations
+
+import contextvars
+from collections.abc import Iterator
+from typing import Any, Optional
+
+import pytest
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import (
+    MATCH_REJECTION_REASONS,
+    record_match_rejection,
+)
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
+from mloda.core.abstract_plugins.components.feature_chainer.property_spec import property_spec
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from mloda.core.prepare.identify_feature_group import FeatureResolutionError, RenderFacts
+from tests.test_core.test_prepare.identify_seam import evaluate_or_raise
+
+
+STRICT_FEATURE_OS005R = "strict_recording_feature_os005r"
+MISSING_OPTION_FEATURE_OS005R = "missing_option_source_os005r__sum_os005rmiss"
+GUARD_FEATURE_OS005R = "guard_recording_feature_os005r"
+FACADE_FEATURE_OS005R = "facade_probe_feature_os005r"
+
+STRICT_REJECTION_REASON_OS005R = "Property value '14' failed validation for 'window_size_os005r'"
+MISSING_OPTION_REASON_OS005R = "required option(s) some_key_os005r are absent after declared defaults and name bindings"
+GUARD_REJECTION_REASON_OS005R = "Property value 'ok_os005r' rejected by match_guard for 'guarded_key_os005r'"
+FACADE_SENTINEL_REASON_OS005R = "facade sentinel reason os005r"
+
+# Every value the strict element_validator judged, across the WHOLE failed resolution. Reset per test.
+VALIDATOR_CALLS_OS005R: list[Any] = []
+
+# Every feature name the facade override was asked about. Reset per test.
+FACADE_CALLS_OS005R: list[str] = []
+
+
+def _counting_window_validator_os005r(value: Any) -> bool:
+    """Count one judgment, then accept ints in (0, 13]."""
+    VALIDATOR_CALLS_OS005R.append(value)
+    return isinstance(value, int) and 0 < value <= 13
+
+
+class RecorderFwOneOs005r(ComputeFramework):
+    """Dummy compute framework for the recording tests."""
+
+
+class StrictRecordingFGOs005r(FeatureChainParserMixin, FeatureGroup):
+    """Config-path group whose strict validator counts every call it receives."""
+
+    PROPERTY_MAPPING = {
+        "window_size_os005r": property_spec(
+            "Size of window",
+            strict=True,
+            context=False,
+            element_validator=_counting_window_validator_os005r,
+        ),
+        DefaultOptionKeys.in_features: property_spec("source", context=True),
+    }
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class MissingOptionRecordingFGOs005r(FeatureChainParserMixin, FeatureGroup):
+    """Name-path group whose required options-only key is absent: a MISSING-option rejection."""
+
+    PREFIX_PATTERN = r".*__(?P<op_os005r>\w+)_os005rmiss$"
+    PROPERTY_MAPPING = {
+        "op_os005r": property_spec("operation carried by the name", context=True),
+        "some_key_os005r": property_spec("required, options-only", context=True),
+        DefaultOptionKeys.in_features: property_spec("source", context=True),
+    }
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class GuardRecordingFGOs005r(FeatureChainParserMixin, FeatureGroup):
+    """Group whose strict spec carries a match_guard that rejects every value."""
+
+    PROPERTY_MAPPING = {
+        "guarded_key_os005r": property_spec(
+            "strict key whose guard rejects every value",
+            strict=True,
+            allowed_values=("ok_os005r",),
+            match_guard=lambda _value: False,
+        ),
+    }
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class FacadeProbeFGOs005r(FeatureGroup):
+    """Never-matching candidate whose rejection facade records every call and returns a sentinel.
+
+    The sentinel is gated on this group's own feature name, so a class leaked into another test's
+    universe injects nothing there.
+    """
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return False
+
+    @classmethod
+    def _strict_validation_rejection_reason(cls, feature_name: str | FeatureName, options: Options) -> str | None:
+        FACADE_CALLS_OS005R.append(str(feature_name))
+        if str(feature_name) == FACADE_FEATURE_OS005R:
+            return FACADE_SENTINEL_REASON_OS005R
+        return None
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _reset_recording_state() -> Iterator[None]:
+    """Recorder and counter state must not leak between tests, in either direction."""
+    token = MATCH_REJECTION_REASONS.set(None)
+    VALIDATOR_CALLS_OS005R.clear()
+    FACADE_CALLS_OS005R.clear()
+    yield
+    MATCH_REJECTION_REASONS.reset(token)
+    VALIDATOR_CALLS_OS005R.clear()
+    FACADE_CALLS_OS005R.clear()
+
+
+def _failed_facts(feature: Feature, accessible_plugins: FeatureGroupEnvironmentMapping) -> RenderFacts:
+    """Run one engine attempt that must fail and return the facts its single pass captured."""
+    with pytest.raises(FeatureResolutionError) as exc_info:
+        evaluate_or_raise(feature=feature, accessible_plugins=accessible_plugins, links=None)
+    return exc_info.value.result.facts
+
+
+class TestFirstPassRejectionRecording:
+    """The failure facts carry the rejections the real match pass produced, without a replay."""
+
+    def test_strict_value_rejection_is_reported_and_the_validator_runs_once(self) -> None:
+        """One failed resolution judges the bad value exactly once: match only, no diagnosis replay."""
+        feature = Feature(
+            STRICT_FEATURE_OS005R,
+            Options(context={DefaultOptionKeys.in_features: "src", "window_size_os005r": 14}),
+        )
+        accessible_plugins: FeatureGroupEnvironmentMapping = {StrictRecordingFGOs005r: {RecorderFwOneOs005r}}
+
+        facts = _failed_facts(feature, accessible_plugins)
+
+        assert facts.value_rejections == (("StrictRecordingFGOs005r", STRICT_REJECTION_REASON_OS005R),)
+        assert VALIDATOR_CALLS_OS005R == [14]
+
+    def test_missing_required_option_reason_is_reported_from_the_first_pass(self) -> None:
+        """The name-path presence non-match records its reason as it happens."""
+        feature = Feature(MISSING_OPTION_FEATURE_OS005R)
+        accessible_plugins: FeatureGroupEnvironmentMapping = {MissingOptionRecordingFGOs005r: {RecorderFwOneOs005r}}
+
+        facts = _failed_facts(feature, accessible_plugins)
+
+        assert facts.value_rejections == (("MissingOptionRecordingFGOs005r", MISSING_OPTION_REASON_OS005R),)
+
+    def test_strict_match_guard_rejection_is_reported_from_the_first_pass(self) -> None:
+        """A guard rejection on a strict spec records the same message the facade produces."""
+        feature = Feature(GUARD_FEATURE_OS005R, Options(context={"guarded_key_os005r": "ok_os005r"}))
+        accessible_plugins: FeatureGroupEnvironmentMapping = {GuardRecordingFGOs005r: {RecorderFwOneOs005r}}
+
+        facts = _failed_facts(feature, accessible_plugins)
+
+        assert facts.value_rejections == (("GuardRecordingFGOs005r", GUARD_REJECTION_REASON_OS005R),)
+
+
+class TestEngineNeverCallsTheFacade:
+    """``_strict_validation_rejection_reason`` stays a standalone diagnostic; the engine never calls it."""
+
+    def test_the_engine_never_calls_the_rejection_facade(self) -> None:
+        """A failed resolution neither calls the facade nor lets its sentinel reach the facts."""
+        feature = Feature(FACADE_FEATURE_OS005R)
+        accessible_plugins: FeatureGroupEnvironmentMapping = {FacadeProbeFGOs005r: {RecorderFwOneOs005r}}
+
+        facts = _failed_facts(feature, accessible_plugins)
+
+        assert FACADE_CALLS_OS005R == []
+        assert facts.value_rejections == ()
+
+    def test_the_facade_still_answers_standalone_calls(self) -> None:
+        """Called directly, the facade keeps working: many tests use it as a diagnostic."""
+        reason = FacadeProbeFGOs005r._strict_validation_rejection_reason(FACADE_FEATURE_OS005R, Options())
+
+        assert reason == FACADE_SENTINEL_REASON_OS005R
+        assert FACADE_CALLS_OS005R == [FACADE_FEATURE_OS005R]
+
+
+class TestRecorderActivation:
+    """The recorder is inactive by default; only the engine's activation makes recording effective."""
+
+    def test_recorder_defaults_to_inactive(self) -> None:
+        """In a fresh context the recorder holds None: recording is off."""
+        assert contextvars.Context().run(MATCH_REJECTION_REASONS.get) is None
+
+    def test_record_match_rejection_is_a_no_op_while_inactive(self) -> None:
+        """Recording outside an active evaluation changes nothing."""
+        record_match_rejection("InertOwnerOs005r", "inert reason os005r")
+
+        assert MATCH_REJECTION_REASONS.get() is None
+
+    def test_direct_matcher_call_outside_the_engine_records_nothing(self) -> None:
+        """A rejecting match outside the engine stays side-effect free."""
+        options = Options(context={DefaultOptionKeys.in_features: "src", "window_size_os005r": 14})
+
+        assert StrictRecordingFGOs005r.match_feature_group_criteria(STRICT_FEATURE_OS005R, options) is False
+        assert MATCH_REJECTION_REASONS.get() is None
+
+    def test_the_first_recorded_reason_per_owner_wins(self) -> None:
+        """With the recorder active, a second reason for the same owner never overwrites the first."""
+        token = MATCH_REJECTION_REASONS.set({})
+        record_match_rejection("FirstWinsOwnerOs005r", "first reason os005r")
+        record_match_rejection("FirstWinsOwnerOs005r", "second reason os005r")
+        recorded = MATCH_REJECTION_REASONS.get()
+        MATCH_REJECTION_REASONS.reset(token)
+
+        assert recorded == {"FirstWinsOwnerOs005r": "first reason os005r"}

--- a/tests/test_core/test_prepare/test_identify_feature_group_error_message.py
+++ b/tests/test_core/test_prepare/test_identify_feature_group_error_message.py
@@ -358,8 +358,9 @@ class StrictWindowFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     Deliberately does NOT override match_feature_group_criteria, so it exercises the
     mixin's default swallow-to-False path: an element_validator rejection inside
     FeatureChainParser._validate_property_value raises ValueError, which
-    match_feature_group_criteria catches and turns into a plain False, discarding the
-    actionable message. _strict_validation_rejection_reason recovers that message.
+    match_feature_group_criteria catches and turns into a plain False. The match pass
+    records that rejection as it happens, and the failure message renders the recorded
+    reason.
     """
 
     PROPERTY_MAPPING = {
@@ -399,10 +400,10 @@ class StrictMaxWindowFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 class TestStrictValidationRejectionHint:
     """Tests for the strict-validation rejection hint in the no-feature-group error.
 
-    The no-feature-group-found error consults
-    FeatureChainParserMixin._strict_validation_rejection_reason for each accessible
-    candidate and surfaces the discarded ValueError (e.g. "Property value '14' failed
-    validation for 'window_size'") together with the culprit class name(s).
+    The match pass records each candidate's strict-validation rejection as it happens,
+    and the no-feature-group-found error surfaces the recorded reason (e.g. "Property
+    value '14' failed validation for 'window_size'") together with the culprit class
+    name(s).
     """
 
     def test_hint_names_rejected_option_value_and_class(self) -> None:
@@ -436,7 +437,7 @@ class TestStrictValidationRejectionHint:
     def test_no_hint_when_feature_is_unrelated(self) -> None:
         """A feature with none of the mapped keys present is a non-match, not a
         rejection: match_feature_group_criteria returns False without raising, so
-        _strict_validation_rejection_reason must find nothing to surface."""
+        no rejection is recorded and there is nothing to surface."""
         feature = Feature("totally_unrelated_feature")
 
         accessible_plugins: FeatureGroupEnvironmentMapping = {

--- a/tests/test_core/test_prepare/test_identify_feature_group_failure_renderer.py
+++ b/tests/test_core/test_prepare/test_identify_feature_group_failure_renderer.py
@@ -660,7 +660,7 @@ def raising_names_none_scenario() -> Scenario:
 
 
 def raising_rejection_none_scenario() -> Scenario:
-    """An ordinary-none failure where one candidate's value-rejection diagnostic raises."""
+    """An ordinary-none failure next to a candidate whose value-rejection diagnostic would raise if consulted."""
     feature = Feature(
         TYPO_FEATURE_791,
         Options(context={DefaultOptionKeys.in_features: "src", "window_size": 14}),
@@ -975,7 +975,7 @@ class TestFactCaptureNeverTakesEvaluateDown:
     """Fact capture is best-effort rendering data, never a decision input.
 
     evaluate() now calls hooks its decision pass never called (get_domain on a domain-less request,
-    prefix, feature_names_supported, _strict_validation_rejection_reason, compute_framework_definition).
+    prefix, feature_names_supported, compute_framework_definition).
     A provider whose hook raises must degrade that one fact only: evaluate() still returns its result and
     the renderer still returns a message, exactly as the guarded message builders behaved before #791.
     """
@@ -1028,14 +1028,19 @@ class TestFactCaptureNeverTakesEvaluateDown:
         assert message is not None
         assert f"'{KNOWN_FEATURE_791}'" in message
 
-    def test_raising_value_rejection_reason_keeps_the_healthy_rejection_line(self) -> None:
-        """A raising diagnostic contributes no rejection line; the healthy rejecting candidate still does."""
+    def test_the_raising_rejection_hook_is_never_consulted(self) -> None:
+        """The engine renders rejections recorded in the first pass, so a raising hook simply never fires.
+
+        The healthy strict candidate's rejection was recorded while matching and still renders; the
+        hostile diagnostic is never called, so there is nothing to degrade.
+        """
         scenario = raising_rejection_none_scenario()
         feature, _ = scenario
 
         result = _evaluate(scenario)
 
         assert result.failure_kind == "none"
+        assert "RendererRaisingRejectionFG791._strict_validation_rejection_reason" not in HOOK_CALLS
         assert result.facts.value_rejections == (("RendererStrictFG791", WINDOW_REJECTION_REASON),)
 
         message = render_resolution_failure(result, feature)

--- a/tests/test_core/test_prepare/test_single_pass_exactly_once.py
+++ b/tests/test_core/test_prepare/test_single_pass_exactly_once.py
@@ -71,6 +71,7 @@ BAD_NAME_VALUE_782 = 123
 BAD_PREFIX_VALUE_782 = 456
 BAD_REASON_VALUE_782 = 999
 HEALTHY_REJECTION_REASON_782 = "single pass healthy rejection reason 782"
+STRICT_REJECTION_REASON_782 = "Property value '14' failed validation for 'window_size_782'"
 
 # Same-named tie candidates get an explicit __module__ so only the module can break the sort tie.
 TIE_MODULE_A_782 = "tests.single_pass_tie_module_a_782"
@@ -516,15 +517,17 @@ def _build_bad_declaration_groups_782() -> tuple[
 
 
 def _build_tie_rejection_groups_782() -> tuple[type[FeatureGroup], type[FeatureGroup]]:
-    """Build two same-named candidates across modules, one returning a non-str rejection reason.
+    """Build two same-named candidates across modules, both overriding the rejection hook, one with a non-str reason.
 
-    Sharing a __name__ is what forces ``sorted()`` past the first tuple element and onto the reason,
-    so a malformed reason is compared against a well-formed one.
+    Sharing a __name__ once forced ``sorted()`` past the first tuple element and onto the hook-provided
+    reason. Reasons now come only from first-pass recording, so the pin is that these hooks are never
+    consulted at all; the hook counts its calls to prove it.
     """
 
     def rejection_hook(cls: Any, feature_name: Any, options: Any) -> Any:
         # Disarmed, the group reports no rejection at all, which is what makes a leaked one inert: these two
         # SHARE a __name__, so an armed leak would poison any later sorted() over the whole universe.
+        _record(cls.get_class_name(), "_strict_validation_rejection_reason")
         return _malformed(cls.REASON) if cls.ARMED else None
 
     def make(module: str, reason: Any) -> type[FeatureGroup]:
@@ -972,21 +975,23 @@ class TestDecisionHooksRunAtMostOncePerCandidate:
             ("SinglePassLinkFG_782", str(RIGHT_INDEX_782)): 1,
         }
 
-    def test_engine_asks_the_typed_value_rejection_hook_once_per_candidate(self) -> None:
-        """The rejection reason is captured once and rendered from the capture."""
+    def test_engine_renders_the_value_rejection_from_the_first_pass_without_the_hook(self) -> None:
+        """The rejection reason is rendered from the first pass; the hook is not consulted."""
         scenario = strict_none_scenario()
 
-        _engine_error(scenario)
+        message = _engine_error(scenario)
 
-        assert _counts_for("_strict_validation_rejection_reason") == _once_each(scenario.candidates)
+        assert _counts_for("_strict_validation_rejection_reason") == {}
+        assert f"  - SinglePassStrictFG_782: {STRICT_REJECTION_REASON_782}" in message
 
-    def test_resolve_feature_asks_the_typed_value_rejection_hook_once_per_candidate(self) -> None:
-        """Same budget across the diagnostic API."""
+    def test_resolve_feature_renders_the_value_rejection_from_the_first_pass_without_the_hook(self) -> None:
+        """Same contract across the diagnostic API: rendered from the first pass, hook not consulted."""
         scenario = strict_none_scenario()
 
-        _resolve_error(scenario)
+        message = _resolve_error(scenario)
 
-        assert _counts_for("_strict_validation_rejection_reason") == _once_each(scenario.candidates)
+        assert _counts_for("_strict_validation_rejection_reason") == {}
+        assert f"  - SinglePassStrictFG_782: {STRICT_REJECTION_REASON_782}" in message
 
     def test_engine_asks_a_reader_style_matcher_once_per_candidate(self) -> None:
         """A matcher that consults a DataAccessCollection is asked once, like any other."""
@@ -1172,8 +1177,14 @@ class TestMalformedHookValuesDegradeLikeARaise:
         assert message.startswith(f"No feature groups found for feature name: '{BAD_CATALOG_FEATURE_782}'.")
         assert TROUBLESHOOTING_LINE_782 in message
 
-    def test_evaluate_does_not_raise_when_a_rejection_reason_is_non_str(self) -> None:
-        """Two candidates sharing a __name__ force sorted() onto the reason, where a non-str one detonates."""
+    def test_a_hostile_rejection_hook_cannot_inject_a_reason_into_the_facts(self) -> None:
+        """Two same-named groups override the hook, one with a non-str reason: neither is consulted.
+
+        The old hazard was a sorted() over hook-provided reasons, where two same-named candidates forced
+        the comparison onto a malformed (non-str) reason. Rejection reasons are now recorded during the
+        first pass only, and these matchers record nothing, so a hook cannot inject a reason at all and
+        the sorted() poisoning hazard is structurally gone.
+        """
         healthy, malformed = _build_tie_rejection_groups_782()
         feature = Feature(TIE_REJECT_FEATURE_782)
         accessible_plugins: FeatureGroupEnvironmentMapping = {
@@ -1184,9 +1195,10 @@ class TestMalformedHookValuesDegradeLikeARaise:
         result = IdentifyFeatureGroupClass.evaluate(feature=feature, accessible_plugins=accessible_plugins, links=None)
         message = render_resolution_failure(result, feature)
 
-        assert result.facts.value_rejections == (("SinglePassTieRejectFG_782", HEALTHY_REJECTION_REASON_782),)
+        assert _counts_for("_strict_validation_rejection_reason") == {}
+        assert result.facts.value_rejections == ()
         assert message is not None
-        assert HEALTHY_REJECTION_REASON_782 in message
+        assert HEALTHY_REJECTION_REASON_782 not in message
         assert str(BAD_REASON_VALUE_782) not in message
 
     def test_malformed_get_domain_degrades_only_its_own_domain_suffix(self) -> None:

--- a/tests/test_plugins/integration_plugins/chainer/context/test_parameter_resolution_unit.py
+++ b/tests/test_plugins/integration_plugins/chainer/context/test_parameter_resolution_unit.py
@@ -222,21 +222,21 @@ class TestParameterResolutionUnit:
         assert cannot_skip is False, "ident should not be identified as optional"
 
     def test_context_parameter_identification(self) -> None:
-        """Test the _is_context_parameter logic."""
+        """Test the spec.context flag."""
         property_mapping = ChainedContextFeatureGroupTest.PROPERTY_MAPPING
 
         # Test: Parameters marked as context
-        is_context_ident = FeatureChainParser._is_context_parameter(property_mapping["ident"])
+        is_context_ident = property_mapping["ident"].context
         assert is_context_ident is True, "ident should be identified as context parameter"
 
-        is_context_property3 = FeatureChainParser._is_context_parameter(property_mapping["property3"])
+        is_context_property3 = property_mapping["property3"].context
         assert is_context_property3 is True, "property3 should be identified as context parameter"
 
-        is_context_source = FeatureChainParser._is_context_parameter(property_mapping[DefaultOptionKeys.in_features])
+        is_context_source = property_mapping[DefaultOptionKeys.in_features].context
         assert is_context_source is True, "in_features should be identified as context parameter"
 
         # Test: Parameters not marked as context (group parameters)
-        is_context_property2 = FeatureChainParser._is_context_parameter(property_mapping["property2"])
+        is_context_property2 = property_mapping["property2"].context
         assert is_context_property2 is False, "property2 should not be identified as context parameter"
 
     def test_edge_case_parameter_values(self) -> None:
@@ -269,7 +269,7 @@ class TestParameterResolutionUnit:
         assert result is True, "Should handle special test value for property2"
 
     def test_parameter_extraction_logic(self) -> None:
-        """Test the _extract_property_values logic."""
+        """Test the extract_property_values logic."""
         # Test: the declared value space is returned, the fields around it are not
         spec_with_default = PropertySpec(
             "Optional property with a default",
@@ -278,7 +278,7 @@ class TestParameterResolutionUnit:
             context=True,
         )
 
-        extracted = FeatureChainParser._extract_property_values(spec_with_default)
+        extracted = FeatureChainParser.extract_property_values(spec_with_default)
         expected = {"opt_val1": "explanation", "opt_val2": "explanation"}
         assert extracted == expected, "Should return exactly the declared allowed_values"
 
@@ -287,7 +287,7 @@ class TestParameterResolutionUnit:
         # PropertySpec has no such fallback.)
         spec_without_allowed_values = PropertySpec("Spec without a declared value space")
 
-        extracted = FeatureChainParser._extract_property_values(spec_without_allowed_values)
+        extracted = FeatureChainParser.extract_property_values(spec_without_allowed_values)
         assert extracted == {}, "Should declare an empty value space when allowed_values is absent"
 
     def test_validation_final_properties(self) -> None:
@@ -423,8 +423,8 @@ class TestParameterResolutionUnit:
         )
         assert result is True, "Should pass validation when in_features has default flexible validation"
 
-    def test_strict_validation_helper_methods(self) -> None:
-        """Test the _is_strict_validation helper method with default non-strict behavior."""
+    def test_strict_validation_flag(self) -> None:
+        """Test the spec.strict_validation flag with default non-strict behavior."""
 
         # Test: Spec with explicit strict validation = True
         strict_spec = PropertySpec(
@@ -432,7 +432,7 @@ class TestParameterResolutionUnit:
             allowed_values={"value1": "explanation"},
             strict_validation=True,
         )
-        assert FeatureChainParser._is_strict_validation(strict_spec) is True, "Should identify strict validation = True"
+        assert strict_spec.strict_validation is True, "Should identify strict validation = True"
 
         # Test: Spec with explicit strict validation = False
         flexible_spec = PropertySpec(
@@ -440,9 +440,7 @@ class TestParameterResolutionUnit:
             allowed_values={"value1": "explanation"},
             strict_validation=False,
         )
-        assert FeatureChainParser._is_strict_validation(flexible_spec) is False, (
-            "Should identify strict validation = False"
-        )
+        assert flexible_spec.strict_validation is False, "Should identify strict validation = False"
 
         # Test: Spec without an explicit strict validation flag (defaults to False)
         default_spec = PropertySpec(
@@ -450,17 +448,13 @@ class TestParameterResolutionUnit:
             allowed_values={"value1": "explanation"},
             context=True,
         )
-        assert FeatureChainParser._is_strict_validation(default_spec) is False, (
-            "Should default to strict validation = False"
-        )
+        assert default_spec.strict_validation is False, "Should default to strict validation = False"
 
         # Test: Minimal spec (explanation only) defaults to False. The non-spec inputs
         # the old helper tolerated (bare strings, empty dicts) are rejected at class
         # definition now, so PropertySpec instances are the only shapes left to test.
         minimal_spec = PropertySpec("Minimal spec")
-        assert FeatureChainParser._is_strict_validation(minimal_spec) is False, (
-            "Should default to strict validation = False for a minimal spec"
-        )
+        assert minimal_spec.strict_validation is False, "Should default to strict validation = False for a minimal spec"
 
     def test_mixed_validation_scenarios(self) -> None:
         """Test complex scenarios with mixed strict and flexible validation."""


### PR DESCRIPTION
Retires the transitional PROPERTY_MAPPING parser seams left by the hardening epic (board issue os-005, migrated from #798, phase 7 of the epic tracked in #761).

## What changed

1. **Trivial private wrappers removed.** `FeatureChainParser._is_context_parameter`, `_is_strict_validation`, `_get_element_validator`, and the `_extract_property_values` alias are gone; production code and tests read the canonical `PropertySpec` fields and call the public `extract_property_values()`. The mixin's test-only `_build_effective_options` pass-through is gone too (no public compatibility contract required it).

2. **Presence semantics centralized.** The `allow_explicit_none` presence decision existed as six inline copies (four in the parser, one in the mixin, one in `feature_group.py`). They are replaced by one shared helper, `option_key_is_present`, keeping the behavior matrix from #768: an opted-in explicit `None` counts as present, a flagless present-as-`None` does not. Equivalence at every site follows from `Options.get`/`__contains__` semantics and is pinned by tests.

3. **Framework-owned exception containment narrowed.** `check_required_when` no longer swallows a raise out of framework-owned `build_effective_options` as a non-match. No user callback runs inside the build, so such a raise is a framework defect (or a user configuration error carrying actionable guidance) and now surfaces. Containment of user-supplied validators, guards, and `required_when` predicates is unchanged.

4. **Diagnostic replay removed from the engine.** The resolution-failure report used to re-run `_strict_validation_rejection_reason` per candidate, re-executing user validators and parser logic a second time. The engine now opens a recording window around each candidate's real match call and captures the structured rejection reason as it happens (strict value rejections, strict `match_guard` rejections, name-path missing-required-option reasons), keyed by the candidate class object so same-named classes from different modules keep their own reasons. `_strict_validation_rejection_reason` remains as a standalone diagnostic facade producing identical messages, but the engine never calls it: user callbacks run exactly once per candidate per resolution.

No public API is removed; all deleted names were underscore-private transitional seams. `attribution/ATTRIBUTION.md` picked up the current dependency resolution (defusedxml, nltk 3.10.0) per the tox regeneration rule.

## Review

Two independent reviews (Claude Opus and codex) ran on the diff. Both flagged the same defect in the first recorder implementation: name-keyed, first-wins recording collapsed same-named candidate classes. Fixed by the per-candidate recording window with class-object attribution, with a regression test. Remaining accepted nits: dropped an unused parameter and documented the deliberately kept string-path containment asymmetry (a config error raised while merging name bindings stays contained on the string path, while the `required_when` path surfaces it).

## Testing

Full `tox` green twice (after the main change and after the review fixes): 7160 passed, 170 skipped, ruff format/check, license allowlist, `mypy --strict` (883 files), bandit.
