### PR TITLE
feat: per-candidate elimination reasons in resolution failure facts (#854)

### DIFF
--- a/docs/docs/in_depth/compute-framework-integration.md
+++ b/docs/docs/in_depth/compute-framework-integration.md
@@ -40,21 +40,22 @@ feature only**:
 - If another framework can still run the operation, the matcher routes around
   the rejected one silently (no error).
 - If the only remaining candidate is the rejected framework (for example, the
-  user pinned the feature to it), resolution fails with a dedicated,
-  actionable error listing one line per rejecting feature group, each naming
-  only that group's own unsupported and supported frameworks, e.g.
+  user pinned the feature to it), resolution fails with the standard
+  "No feature groups found" error, which names the near-miss feature group and
+  why it dropped, one line per eliminated candidate under a
+  "Feature group(s) eliminated while matching '...'" block, e.g.
 
 ```
-Unsupported compute framework(s) for feature 'X':
-  - MedianFeatureGroup: ['SQLiteFramework']. Supported on: ['DuckDBFramework', 'PandasDataFrame'].
-Pin the feature to a supported compute framework or override supports_compute_framework.
+No feature groups found for feature name: 'X'.
+Feature group(s) eliminated while matching 'X':
+  - MedianFeatureGroup (compute framework pin): pinned compute framework 'SQLiteFramework' is not among its supported ['DuckDBFramework', 'PandasDataFrame']
+Use resolve_feature(name, options=...) to debug feature resolution.
 ```
 
-This is distinct from the "no feature group found" error, so an unsupported
-operation is no longer indistinguishable from an unknown feature. Prefer this
-hook over raising a generic error from inside `calculate_feature`: the
-rejection happens during planning rather than at compute time, and the message
-is built for you.
+The rejected framework is named as a near-miss with its reason rather than
+vanishing into a generic "unknown feature" message. Prefer this hook over
+raising a generic error from inside `calculate_feature`: the rejection happens
+during planning rather than at compute time, and the message is built for you.
 
 The debug inspector `resolve_feature(name)` reflects the hook too, because it
 runs the **same matcher over the same candidate universe as the engine** (it

--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -399,12 +399,12 @@ candidate's "no match" must not abort the search for another candidate that migh
 the feature. This holds on both paths: a bad option value on a string-named feature is the same
 non-match as on a configuration-based one.
 
-If every candidate rejects the feature, the final "No feature groups found" error collects the
-discarded reasons and appends them:
+If every candidate rejects the feature, the final "No feature groups found" error names each
+discarded candidate and why it dropped:
 
 ```
-Feature group(s) rejected the supplied options while matching 'window_size_windowed':
-  - WindowedFeatureGroup: Property value '14' failed validation for 'window_size'
+Feature group(s) eliminated while matching 'window_size_windowed':
+  - WindowedFeatureGroup (option value): Property value '14' failed validation for 'window_size'
 ```
 
 This is diagnostic only. It does not change the `True`/`False` contract, so a value rejected by

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -32,6 +32,25 @@ class CandidateFrameworks:
     rejected: frozenset[type[ComputeFramework]] = frozenset()
 
 
+EliminationStage = Literal[
+    "value_rejection",
+    "domain",
+    "scope",
+    "capability",
+    "frameworks_not_enabled",
+    "framework_pin",
+    "links",
+]
+
+
+@dataclass(frozen=True)
+class Elimination:
+    """Why one near-miss candidate lost: the first gate it failed and that gate's reason."""
+
+    stage: EliminationStage
+    reason: str
+
+
 @dataclass(frozen=True)
 class RenderFacts:
     """Facts captured during the decision pass so rendering needs no provider hook.
@@ -41,11 +60,7 @@ class RenderFacts:
 
     domains: dict[type[FeatureGroup], str] = field(default_factory=dict)
     concrete_frameworks: tuple[str, ...] = ()
-    value_rejections: tuple[tuple[str, str], ...] = ()
     known_names: tuple[str, ...] = ()
-    # Render-only split over the DECLARED available frameworks, which is wider than the run's own
-    # candidate_frameworks split: a framework the run did not enable still renders as supported.
-    capability_frameworks: dict[type[FeatureGroup], CandidateFrameworks] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -56,6 +71,7 @@ class EvaluationResult:
     criteria_matched: set[type[FeatureGroup]] = field(default_factory=set)
     abstract_matched: set[type[FeatureGroup]] = field(default_factory=set)
     candidate_frameworks: dict[type[FeatureGroup], CandidateFrameworks] = field(default_factory=dict)
+    eliminations: dict[type[FeatureGroup], Elimination] = field(default_factory=dict)
     facts: RenderFacts = field(default_factory=RenderFacts)
 
     @property
@@ -181,15 +197,26 @@ def _prefix_name(feature_group: type[FeatureGroup]) -> str:
     return safe_field(lambda: as_str(feature_group.prefix()), "", field=f"{feature_group.get_class_name()}.prefix")
 
 
-def _supports_framework(
-    feature_group: type[FeatureGroup], feature: Feature, compute_framework: type[ComputeFramework]
-) -> bool | None:
-    """Best-effort capability answer. None when the hook raised, leaving the pair undecided for rendering."""
-    return safe_field(
-        lambda: feature_group.supports_compute_framework(feature.name, feature.options, compute_framework),
-        None,
-        field=f"{feature_group.get_class_name()}.supports_compute_framework",
+_STAGE_LABELS: dict[EliminationStage, str] = {
+    "value_rejection": "option value",
+    "domain": "domain",
+    "scope": "scope",
+    "capability": "compute framework",
+    "frameworks_not_enabled": "compute framework",
+    "framework_pin": "compute framework pin",
+    "links": "links",
+}
+
+
+def _render_near_miss_block(result: EvaluationResult, feature: Feature) -> str | None:
+    """Shared section naming each eliminated near-miss candidate, its gate label, and its reason."""
+    if not result.eliminations:
+        return None
+    lines = "\n".join(
+        f"  - {fg.__name__} ({_STAGE_LABELS[result.eliminations[fg].stage]}): {result.eliminations[fg].reason}"
+        for fg in sorted(result.eliminations, key=_candidate_sort_key)
     )
+    return f"Feature group(s) eliminated while matching '{str(feature.name)}':\n{lines}"
 
 
 def _render_multiple(result: EvaluationResult, feature: Feature, callout: str | None) -> str:
@@ -208,45 +235,26 @@ def _render_multiple(result: EvaluationResult, feature: Feature, callout: str | 
     )
 
 
-def _render_capability(result: EvaluationResult, feature: Feature) -> str | None:
-    """One line per candidate that rejects a framework, each naming only its OWN frameworks."""
-    rejecting = {fg: cfw for fg, cfw in result.facts.capability_frameworks.items() if cfw.rejected}
-    if not rejecting:
-        return None
-
-    lines = []
-    for fg in sorted(rejecting, key=_candidate_sort_key):
-        candidate_frameworks = rejecting[fg]
-        rejected_names = sorted(fw.get_class_name() for fw in candidate_frameworks.rejected)
-        line = f"  - {fg.__name__}: {rejected_names}."
-        if candidate_frameworks.supported:
-            supported_names = sorted(fw.get_class_name() for fw in candidate_frameworks.supported)
-            line += f" Supported on: {supported_names}."
-        lines.append(line)
-
-    body = "\n".join(lines)
-    return (
-        f"Unsupported compute framework(s) for feature '{str(feature.name)}':\n"
-        f"{body}\n"
-        "Pin the feature to a supported compute framework or override supports_compute_framework."
-    )
-
-
 def _render_abstract_only(result: EvaluationResult, feature: Feature) -> str:
     feature_name = str(feature.name)
     if not result.facts.concrete_frameworks:
-        return (
+        msg = (
             f"No feature groups found for feature name: '{feature_name}'. "
             f"Only abstract feature group base(s) matched, which cannot be instantiated; "
             f"no concrete implementation is available or enabled."
         )
+    else:
+        framework_names = sorted(result.facts.concrete_frameworks)
+        msg = (
+            f"No feature groups found for feature name: '{feature_name}'. "
+            f"Its concrete implementations require compute framework(s) {framework_names}, "
+            f"none of which are available or enabled for this run."
+        )
 
-    framework_names = sorted(result.facts.concrete_frameworks)
-    return (
-        f"No feature groups found for feature name: '{feature_name}'. "
-        f"Its concrete implementations require compute framework(s) {framework_names}, "
-        f"none of which are available or enabled for this run."
-    )
+    near_miss = _render_near_miss_block(result, feature)
+    if near_miss is not None:
+        msg += f"\n{near_miss}"
+    return msg
 
 
 def _render_none(result: EvaluationResult, feature: Feature, callout: str | None) -> str:
@@ -256,9 +264,9 @@ def _render_none(result: EvaluationResult, feature: Feature, callout: str | None
     if callout:
         msg += f" {callout}"
 
-    if result.facts.value_rejections:
-        lines = "\n".join(f"  - {class_name}: {reason}" for class_name, reason in sorted(result.facts.value_rejections))
-        msg += f"\nFeature group(s) rejected the supplied options while matching '{feature_name}':\n{lines}"
+    near_miss = _render_near_miss_block(result, feature)
+    if near_miss is not None:
+        msg += f"\n{near_miss}"
 
     similar = get_close_matches(feature_name, list(result.facts.known_names), n=5, cutoff=0.5)
     if similar:
@@ -287,10 +295,6 @@ def render_resolution_failure(result: EvaluationResult, feature: Feature) -> str
     if kind == "multiple":
         return _render_multiple(result, feature, callout)
 
-    capability_message = _render_capability(result, feature)
-    if capability_message is not None:
-        return f"{capability_message} {callout}" if callout else capability_message
-
     if result.abstract_matched:
         abstract_message = _render_abstract_only(result, feature)
         return f"{abstract_message} {callout}" if callout else abstract_message
@@ -303,6 +307,7 @@ class IdentifyFeatureGroupClass:
     _abstract_matched_feature_groups: set[type[FeatureGroup]]
     _candidate_frameworks: dict[type[FeatureGroup], CandidateFrameworks]
     _match_rejections: dict[type[FeatureGroup], str]
+    _eliminations: dict[type[FeatureGroup], Elimination]
     _data_access_collection: Optional[DataAccessCollection]
     # Per-evaluation memos of the hooks more than one reader wants. evaluate() builds a fresh instance, so
     # they are scoped to one resolution attempt and never cache across runs.
@@ -313,8 +318,9 @@ class IdentifyFeatureGroupClass:
         self._criteria_matched_feature_groups = set()
         self._abstract_matched_feature_groups = set()
         self._candidate_frameworks = {}
-        # Reasons the first pass recorded, keyed by candidate class.
+        # Reasons the first match pass recorded, keyed by candidate class.
         self._match_rejections = {}
+        self._eliminations = {}
         self._domain_outcomes = {}
         self._declared_frameworks = {}
         self._data_access_collection = data_access_collection
@@ -349,9 +355,13 @@ class IdentifyFeatureGroupClass:
             criteria_matched=self._criteria_matched_feature_groups,
             abstract_matched=self._abstract_matched_feature_groups,
             candidate_frameworks=self._candidate_frameworks,
+            eliminations=self._eliminations,
         )
         if result.failure_kind is not None:
-            result = replace(result, facts=self._capture_render_facts(result, feature, accessible_plugins))
+            # eliminations is the same dict object result carries, so this precedence-free pass fills in the
+            # value_rejection near-misses (setdefault keeps any earlier gate a candidate already failed).
+            self._capture_value_rejections(feature, accessible_plugins)
+            result = replace(result, facts=self._capture_render_facts(result, accessible_plugins))
         # A captured exception pins its traceback, whose frames pin this instance: a refcount cycle that would
         # keep both alive until a gc pass. Dropping the outcomes here makes the memo's lifetime what it claims.
         self._domain_outcomes.clear()
@@ -360,29 +370,19 @@ class IdentifyFeatureGroupClass:
     def _capture_render_facts(
         self,
         result: EvaluationResult,
-        feature: Feature,
         accessible_plugins: FeatureGroupEnvironmentMapping,
     ) -> RenderFacts:
-        """Capture what rendering needs, following the branch precedence the message builders use today.
+        """Capture the non-elimination facts the messages still need, precedence-free.
 
-        Only reached when the pass has no single winner, so the success path stays hook-free. Every provider
-        hook here is best-effort: a raising one degrades its own fact, never this call or a sibling's fact.
+        The renderer alone owns which message wins, so this does not mirror its branch order: it captures
+        all three facts unconditionally (the failure path is rare). domains feeds the multiple message,
+        concrete_frameworks the abstract_only message, known_names the none message. Only reached when the
+        pass has no single winner. Every provider hook here is best-effort: a raising one degrades its own
+        fact, never this call or a sibling's fact.
         """
-        if result.failure_kind == "multiple":
-            return RenderFacts(domains=self._capture_domains(result))
-
-        # Capability rejections win over the abstract-only fallback, and both over the ordinary none.
-        capability_frameworks = self._capture_capability_frameworks(result, feature)
-        if any(candidate.rejected for candidate in capability_frameworks.values()):
-            return RenderFacts(capability_frameworks=capability_frameworks)
-
-        if result.abstract_matched:
-            return RenderFacts(
-                concrete_frameworks=self._concrete_implementation_frameworks(result, accessible_plugins),
-            )
-
         return RenderFacts(
-            value_rejections=self._capture_value_rejections(feature, accessible_plugins),
+            domains=self._capture_domains(result),
+            concrete_frameworks=self._concrete_implementation_frameworks(result, accessible_plugins),
             known_names=self._capture_known_names(accessible_plugins),
         )
 
@@ -442,14 +442,6 @@ class IdentifyFeatureGroupClass:
             field=f"{feature_group.get_class_name()}.compute_framework_definition",
         )
 
-    def _available_declared_frameworks(self, feature_group: type[FeatureGroup]) -> frozenset[type[ComputeFramework]]:
-        """Best-effort render universe of one candidate: the frameworks it declares that are available."""
-        return safe_field(
-            lambda: frozenset(cfw for cfw in self._declared_frameworks_of(feature_group) if cfw.is_available()),
-            frozenset(),
-            field=f"{feature_group.get_class_name()}.is_available",
-        )
-
     def _capture_domains(self, result: EvaluationResult) -> dict[type[FeatureGroup], str]:
         """Domain name of every identified candidate, skipping the ones whose get_domain() raised."""
         domains: dict[type[FeatureGroup], str] = {}
@@ -458,35 +450,6 @@ class IdentifyFeatureGroupClass:
             if domain is not None:
                 domains[feature_group] = domain
         return domains
-
-    def _capture_capability_frameworks(
-        self, result: EvaluationResult, feature: Feature
-    ) -> dict[type[FeatureGroup], CandidateFrameworks]:
-        """Split each criteria-matched candidate's declared available frameworks, the universe the message uses.
-
-        Starts from the decision split, which already answered the enabled frameworks, and only asks about the
-        rest: the capability hook is asked at most once per (candidate, framework) pair per evaluation.
-        """
-        capability_frameworks: dict[type[FeatureGroup], CandidateFrameworks] = {}
-        for feature_group in result.criteria_matched:
-            decided = result.candidate_frameworks.get(feature_group, CandidateFrameworks())
-            declared = self._available_declared_frameworks(feature_group)
-            supported = set(decided.supported & declared)
-            rejected = set(decided.rejected & declared)
-
-            for cfw in declared - decided.supported - decided.rejected:
-                verdict = _supports_framework(feature_group, feature, cfw)
-                if verdict is None:
-                    continue
-                if verdict:
-                    supported.add(cfw)
-                else:
-                    rejected.add(cfw)
-
-            capability_frameworks[feature_group] = CandidateFrameworks(
-                supported=frozenset(supported), rejected=frozenset(rejected)
-            )
-        return capability_frameworks
 
     def _concrete_implementation_frameworks(
         self, result: EvaluationResult, accessible_plugins: FeatureGroupEnvironmentMapping
@@ -500,38 +463,6 @@ class IdentifyFeatureGroupClass:
                 continue
             frameworks.update(self._declared_framework_names(candidate))
         return tuple(sorted(frameworks))
-
-    def _capture_value_rejections(
-        self, feature: Feature, accessible_plugins: FeatureGroupEnvironmentMapping
-    ) -> tuple[tuple[str, str], ...]:
-        """Project the reasons the first pass recorded onto the domain/scope-filtered candidates, no replay."""
-        reasons: list[tuple[str, str]] = []
-        for feature_group in accessible_plugins:
-            reason = self._scoped_value_rejection_reason(feature_group, feature)
-            if reason is not None:
-                reasons.append((feature_group.get_class_name(), reason))
-        return tuple(sorted(reasons))
-
-    def _scoped_value_rejection_reason(self, feature_group: type[FeatureGroup], feature: Feature) -> str | None:
-        """Best-effort recorded rejection reason of one candidate, guarded together with the filters it runs."""
-        return safe_field(
-            lambda: self._in_scope_value_rejection_reason(feature_group, feature),
-            None,
-            field=f"{feature_group.get_class_name()} value rejection capture",
-        )
-
-    def _in_scope_value_rejection_reason(self, feature_group: type[FeatureGroup], feature: Feature) -> str | None:
-        """The candidate's recorded rejection reason, or None when the domain or scope filter rules it out.
-
-        Recorded reasons are always str, so the as_str below is a cheap invariant check, not a guard
-        against a hostile hook.
-        """
-        if not self._filter_feature_group_by_domain(feature_group, feature):
-            return None
-        if not self._filter_feature_group_by_scope(feature_group, feature):
-            return None
-        reason = self._value_rejection_reason(feature_group)
-        return None if reason is None else as_str(reason)
 
     def _capture_known_names(self, accessible_plugins: FeatureGroupEnvironmentMapping) -> tuple[str, ...]:
         known_names: list[str] = []
@@ -554,16 +485,21 @@ class IdentifyFeatureGroupClass:
         _identified_feature_groups: FeatureGroupEnvironmentMapping = {}
 
         for feature_group, compute_frameworks in accessible_plugins.items():
+            # A criteria non-match records nothing here: a plain name mismatch is not a near-miss, and a value
+            # rejection is captured on the failure path by _capture_value_rejections over the rejection hook.
             if not self._filter_feature_group_by_criteria(feature_group, feature, data_access_collection):
                 continue
 
             if not self._filter_feature_group_by_domain(feature_group, feature):
+                self._record_elimination(feature_group, "domain", self._domain_reason(feature_group, feature))
                 continue
 
             if not self._filter_feature_group_by_scope(feature_group, feature):
+                self._record_elimination(feature_group, "scope", "outside the requested feature group scope")
                 continue
 
-            # Abstract bases can match name+domain+scope but cannot be instantiated; never let one win.
+            # Abstract bases can match name+domain+scope but cannot be instantiated; never let one win, and
+            # never record one as a near-miss: the abstract_only message owns them.
             if inspect.isabstract(feature_group):
                 self._abstract_matched_feature_groups.add(feature_group)
                 continue
@@ -583,17 +519,90 @@ class IdentifyFeatureGroupClass:
                 rejected=frozenset(compute_frameworks) - frozenset(supported_frameworks),
             )
 
+            # Decide the empty-supported case FIRST so a pin over an empty supported set reports the deeper
+            # capability / not-enabled reason rather than framework_pin. The identification decision (all three
+            # gates must hold) is order-independent, so this reordering only changes which reason is recorded.
+            if not supported_frameworks:
+                if compute_frameworks:
+                    rejected_names = sorted(cfw.get_class_name() for cfw in compute_frameworks)
+                    self._record_elimination(
+                        feature_group, "capability", f"supports_compute_framework rejected {rejected_names}"
+                    )
+                else:
+                    self._record_elimination(
+                        feature_group,
+                        "frameworks_not_enabled",
+                        "none of its compute frameworks are enabled for this run",
+                    )
+                continue
+
             if not self._filter_feature_group_by_framework(supported_frameworks, feature):
+                pin_name = feature.get_compute_framework().get_class_name()
+                supported_names = sorted(cfw.get_class_name() for cfw in supported_frameworks)
+                self._record_elimination(
+                    feature_group,
+                    "framework_pin",
+                    f"pinned compute framework '{pin_name}' is not among its supported {supported_names}",
+                )
                 continue
 
             if not self._filter_feature_group_by_links(feature_group, links):
+                self._record_elimination(feature_group, "links", "no index column matches the run's links")
                 continue
 
-            if supported_frameworks:
-                _identified_feature_groups[feature_group] = supported_frameworks
+            _identified_feature_groups[feature_group] = supported_frameworks
 
         _identified_feature_groups = self.filter_subclasses(_identified_feature_groups)
         return _identified_feature_groups
+
+    def _record_elimination(self, feature_group: type[FeatureGroup], stage: EliminationStage, reason: str) -> None:
+        """Record the first gate a non-winning name-matching candidate failed; one entry per candidate."""
+        self._eliminations.setdefault(feature_group, Elimination(stage=stage, reason=reason))
+
+    def _capture_value_rejections(self, feature: Feature, accessible_plugins: FeatureGroupEnvironmentMapping) -> None:
+        """Record a value_rejection for each accessible candidate that rejects an option VALUE.
+
+        Precedence-free: it asks every candidate that passes the domain and scope gates, and setdefault keeps
+        any earlier gate a candidate already failed in the decision loop. Its own domain/scope/rejection reads
+        are guarded, so a raising provider degrades only its own candidate, never this pass.
+        """
+        for feature_group in accessible_plugins:
+            reason = self._scoped_value_rejection_reason(feature_group, feature)
+            if reason is not None:
+                self._record_elimination(feature_group, "value_rejection", reason)
+
+    def _scoped_value_rejection_reason(self, feature_group: type[FeatureGroup], feature: Feature) -> str | None:
+        """Best-effort recorded rejection reason of one candidate, guarded together with the filters it runs."""
+        return safe_field(
+            lambda: self._in_scope_value_rejection_reason(feature_group, feature),
+            None,
+            field=f"{feature_group.get_class_name()} value rejection capture",
+        )
+
+    def _in_scope_value_rejection_reason(self, feature_group: type[FeatureGroup], feature: Feature) -> str | None:
+        """The candidate's recorded rejection reason, or None when the domain or scope filter rules it out.
+
+        Recorded reasons are always str, so the as_str below is a cheap invariant check, not a guard
+        against a hostile hook.
+        """
+        if not self._filter_feature_group_by_domain(feature_group, feature):
+            return None
+        if not self._filter_feature_group_by_scope(feature_group, feature):
+            return None
+        reason = self._value_rejection_reason(feature_group)
+        return None if reason is None else as_str(reason)
+
+    def _value_rejection_reason(self, feature_group: type[FeatureGroup]) -> Optional[str]:
+        """The reason the first match pass recorded for this candidate class, if any."""
+        return self._match_rejections.get(feature_group)
+
+    def _domain_reason(self, feature_group: type[FeatureGroup], feature: Feature) -> str:
+        """Reason wording for a candidate dropped at the domain gate."""
+        requested = feature.domain.name if feature.domain is not None else ""
+        candidate_domain = self._domain_name(feature_group)
+        if candidate_domain is None:
+            return f"does not declare the requested domain '{requested}'"
+        return f"declares domain '{candidate_domain}', but the run requested '{requested}'"
 
     def _filter_feature_group_by_links(self, feature_group: type[FeatureGroup], links: Optional[set[Link]]) -> bool:
         # Case index columns not given, so no validation possible
@@ -667,10 +676,6 @@ class IdentifyFeatureGroupClass:
             return True
 
         return feature.get_compute_framework() in compute_frameworks
-
-    def _value_rejection_reason(self, feature_group: type[FeatureGroup]) -> Optional[str]:
-        """The reason the first pass recorded for this candidate class, if any."""
-        return self._match_rejections.get(feature_group)
 
     def filter_subclasses(
         self, _identified_feature_groups: FeatureGroupEnvironmentMapping

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -61,6 +61,9 @@ class RenderFacts:
     domains: dict[type[FeatureGroup], str] = field(default_factory=dict)
     concrete_frameworks: tuple[str, ...] = ()
     known_names: tuple[str, ...] = ()
+    # Class name and prefix of each eliminated near-miss, so a "Did you mean" suggestion that merely echoes
+    # a candidate the near-miss block already named can be suppressed.
+    eliminated_hints: frozenset[str] = frozenset()
 
 
 @dataclass(frozen=True)
@@ -235,7 +238,7 @@ def _render_multiple(result: EvaluationResult, feature: Feature, callout: str | 
     )
 
 
-def _render_abstract_only(result: EvaluationResult, feature: Feature) -> str:
+def _render_abstract_only(result: EvaluationResult, feature: Feature, callout: str | None) -> str:
     feature_name = str(feature.name)
     if not result.facts.concrete_frameworks:
         msg = (
@@ -250,6 +253,11 @@ def _render_abstract_only(result: EvaluationResult, feature: Feature) -> str:
             f"Its concrete implementations require compute framework(s) {framework_names}, "
             f"none of which are available or enabled for this run."
         )
+
+    # Place the callout on the sentence line, before the near-miss block, exactly as _render_none does, so it
+    # is never space-glued to the last near-miss bullet.
+    if callout:
+        msg += f" {callout}"
 
     near_miss = _render_near_miss_block(result, feature)
     if near_miss is not None:
@@ -269,6 +277,9 @@ def _render_none(result: EvaluationResult, feature: Feature, callout: str | None
         msg += f"\n{near_miss}"
 
     similar = get_close_matches(feature_name, list(result.facts.known_names), n=5, cutoff=0.5)
+    # Drop suggestions that merely echo a candidate the near-miss block already named; if that empties the
+    # list, omit the line rather than repeat what was just eliminated.
+    similar = [name for name in similar if name not in result.facts.eliminated_hints]
     if similar:
         msg += f"\nDid you mean one of: {similar}?"
 
@@ -296,8 +307,7 @@ def render_resolution_failure(result: EvaluationResult, feature: Feature) -> str
         return _render_multiple(result, feature, callout)
 
     if result.abstract_matched:
-        abstract_message = _render_abstract_only(result, feature)
-        return f"{abstract_message} {callout}" if callout else abstract_message
+        return _render_abstract_only(result, feature, callout)
 
     return _render_none(result, feature, callout)
 
@@ -358,9 +368,8 @@ class IdentifyFeatureGroupClass:
             eliminations=self._eliminations,
         )
         if result.failure_kind is not None:
-            # eliminations is the same dict object result carries, so this precedence-free pass fills in the
-            # value_rejection near-misses (setdefault keeps any earlier gate a candidate already failed).
-            self._capture_value_rejections(feature, accessible_plugins)
+            # Every elimination (value_rejection included) was already recorded during the single filter pass;
+            # this only captures the non-elimination facts the messages still need.
             result = replace(result, facts=self._capture_render_facts(result, accessible_plugins))
         # A captured exception pins its traceback, whose frames pin this instance: a refcount cycle that would
         # keep both alive until a gc pass. Dropping the outcomes here makes the memo's lifetime what it claims.
@@ -384,7 +393,19 @@ class IdentifyFeatureGroupClass:
             domains=self._capture_domains(result),
             concrete_frameworks=self._concrete_implementation_frameworks(result, accessible_plugins),
             known_names=self._capture_known_names(accessible_plugins),
+            eliminated_hints=self._capture_eliminated_hints(result),
         )
+
+    def _capture_eliminated_hints(self, result: EvaluationResult) -> frozenset[str]:
+        """Class name and prefix of every eliminated near-miss, so the none message can suppress a
+        'Did you mean' suggestion that merely echoes a candidate its near-miss block already names."""
+        hints: set[str] = set()
+        for feature_group in result.eliminations:
+            hints.add(feature_group.get_class_name())
+            prefix = _prefix_name(feature_group)
+            if prefix:
+                hints.add(prefix)
+        return frozenset(hints)
 
     def _domain_outcome(self, feature_group: type[FeatureGroup]) -> tuple[Optional[Domain], Optional[Exception]]:
         """Memoized get_domain() OUTCOME, value or raise, so one candidate's hook runs once per evaluation.
@@ -485,9 +506,15 @@ class IdentifyFeatureGroupClass:
         _identified_feature_groups: FeatureGroupEnvironmentMapping = {}
 
         for feature_group, compute_frameworks in accessible_plugins.items():
-            # A criteria non-match records nothing here: a plain name mismatch is not a near-miss, and a value
-            # rejection is captured on the failure path by _capture_value_rejections over the rejection hook.
+            # A criteria non-match records a value_rejection only when the first pass recorded a reason for it:
+            # a plain name mismatch is not a near-miss, but a value the candidate declined (with a reportable
+            # reason) is. The criteria call above just recorded any rejection under this candidate's window, so
+            # this reads it back for a criteria-FAILING candidate only; a matched/winning/abstract candidate is
+            # never probed. Recorded regardless of domain/scope or of the overall outcome (a sibling may win).
             if not self._filter_feature_group_by_criteria(feature_group, feature, data_access_collection):
+                reason = self._value_rejection_reason(feature_group)
+                if reason is not None:
+                    self._record_elimination(feature_group, "value_rejection", reason)
                 continue
 
             if not self._filter_feature_group_by_domain(feature_group, feature):
@@ -559,46 +586,18 @@ class IdentifyFeatureGroupClass:
         """Record the first gate a non-winning name-matching candidate failed; one entry per candidate."""
         self._eliminations.setdefault(feature_group, Elimination(stage=stage, reason=reason))
 
-    def _capture_value_rejections(self, feature: Feature, accessible_plugins: FeatureGroupEnvironmentMapping) -> None:
-        """Record a value_rejection for each accessible candidate that rejects an option VALUE.
-
-        Precedence-free: it asks every candidate that passes the domain and scope gates, and setdefault keeps
-        any earlier gate a candidate already failed in the decision loop. Its own domain/scope/rejection reads
-        are guarded, so a raising provider degrades only its own candidate, never this pass.
-        """
-        for feature_group in accessible_plugins:
-            reason = self._scoped_value_rejection_reason(feature_group, feature)
-            if reason is not None:
-                self._record_elimination(feature_group, "value_rejection", reason)
-
-    def _scoped_value_rejection_reason(self, feature_group: type[FeatureGroup], feature: Feature) -> str | None:
-        """Best-effort recorded rejection reason of one candidate, guarded together with the filters it runs."""
-        return safe_field(
-            lambda: self._in_scope_value_rejection_reason(feature_group, feature),
-            None,
-            field=f"{feature_group.get_class_name()} value rejection capture",
-        )
-
-    def _in_scope_value_rejection_reason(self, feature_group: type[FeatureGroup], feature: Feature) -> str | None:
-        """The candidate's recorded rejection reason, or None when the domain or scope filter rules it out.
-
-        Recorded reasons are always str, so the as_str below is a cheap invariant check, not a guard
-        against a hostile hook.
-        """
-        if not self._filter_feature_group_by_domain(feature_group, feature):
-            return None
-        if not self._filter_feature_group_by_scope(feature_group, feature):
-            return None
-        reason = self._value_rejection_reason(feature_group)
-        return None if reason is None else as_str(reason)
-
     def _value_rejection_reason(self, feature_group: type[FeatureGroup]) -> Optional[str]:
-        """The reason the first match pass recorded for this candidate class, if any."""
+        """The reason the first match pass recorded for this candidate class, if any.
+
+        The candidate's criteria match records its own value rejection under a per-candidate window; this
+        only reads that record back, so no rejection hook is ever reran on the failure path.
+        """
         return self._match_rejections.get(feature_group)
 
     def _domain_reason(self, feature_group: type[FeatureGroup], feature: Feature) -> str:
-        """Reason wording for a candidate dropped at the domain gate."""
-        requested = feature.domain.name if feature.domain is not None else ""
+        """Reason wording for a candidate dropped at the domain gate, which only fires for a domain-carrying request."""
+        assert feature.domain is not None  # the domain gate only drops a candidate when the request carries a domain
+        requested = feature.domain.name
         candidate_domain = self._domain_name(feature_group)
         if candidate_domain is None:
             return f"does not declare the requested domain '{requested}'"
@@ -635,7 +634,8 @@ class IdentifyFeatureGroupClass:
 
         The per-candidate recording window is what keys reasons by candidate class, so same-named classes cannot
         collide (review fix). The try/finally guarantees the reset even when an unexpected exception propagates;
-        in that case nothing is attributed.
+        in that case nothing is attributed. The filter loop reads the recorded reason back at this candidate's
+        non-match point, so the value_rejection near-miss is captured without ever re-probing a rejection hook.
         """
         token = MATCH_REJECTION_REASONS.set({})
         try:

--- a/tests/test_core/test_api/test_capability_run_all.py
+++ b/tests/test_core/test_api/test_capability_run_all.py
@@ -69,6 +69,11 @@ class TestCapabilityRunAllEndToEnd:
         assert "E2ECapRunAllFeatureGroup (compute framework):" in message, (
             f"Capability error must name the eliminated candidate under the near-miss line, got: {message}"
         )
+        # The near-miss block already names the eliminated candidate; the fuzzy suggestion must not echo it.
+        suggestion_line = next((line for line in message.split("\n") if line.startswith("Did you mean")), "")
+        assert "E2ECapRunAllFeatureGroup" not in suggestion_line, (
+            f"the 'Did you mean' suggestion must not echo the already-named eliminated candidate, got: {message}"
+        )
 
     def test_route_around_to_pandas_returns_dataframe(self) -> None:
         """With both frameworks enabled, the run routes around to Pandas and computes."""

--- a/tests/test_core/test_api/test_capability_run_all.py
+++ b/tests/test_core/test_api/test_capability_run_all.py
@@ -62,10 +62,13 @@ class TestCapabilityRunAllEndToEnd:
         else:
             raise AssertionError("Expected a ValueError when pinned to the unsupported framework")
 
-        lowered = message.lower()
-        assert "unsupported" in lowered, f"Capability error must signal 'unsupported', got: {message}"
+        assert "supports_compute_framework rejected" in message, (
+            f"Capability error must signal the capability hook rejection, got: {message}"
+        )
         assert "PythonDictFramework" in message, f"Error must name the rejected framework, got: {message}"
-        assert "Did you mean" not in message, f"Capability error must skip the fuzzy suggestion path, got: {message}"
+        assert "E2ECapRunAllFeatureGroup (compute framework):" in message, (
+            f"Capability error must name the eliminated candidate under the near-miss line, got: {message}"
+        )
 
     def test_route_around_to_pandas_returns_dataframe(self) -> None:
         """With both frameworks enabled, the run routes around to Pandas and computes."""

--- a/tests/test_core/test_api/test_resolve_feature.py
+++ b/tests/test_core/test_api/test_resolve_feature.py
@@ -580,14 +580,15 @@ class TestResolveFeatureCapabilityAware:
         assert result.feature_group is None
         assert result.error is not None
 
-        lowered = result.error.lower()
-        assert "unsupported" in lowered, f"Error must signal 'unsupported', got: {result.error}"
+        # Engine wording: the near-miss line names the eliminated candidate and the capability hook.
+        assert "AllRejectedCapResolveFeatureGroup (compute framework):" in result.error, (
+            f"Error must name the eliminated candidate, got: {result.error}"
+        )
+        assert "supports_compute_framework rejected" in result.error, (
+            f"Error must signal the capability hook rejection, got: {result.error}"
+        )
         assert "PandasDataFrame" in result.error, f"Error must name PandasDataFrame, got: {result.error}"
         assert "PythonDictFramework" in result.error, f"Error must name PythonDictFramework, got: {result.error}"
-        # Engine wording: names the capability hook and drops the debug-only phrasings.
-        assert "Pin the feature to a supported compute framework" in result.error, (
-            f"Error must carry the engine's capability-rejection guidance, got: {result.error}"
-        )
         assert "default options" not in result.error, (
             f"Engine error has no 'default options' caveat, got: {result.error}"
         )
@@ -908,7 +909,8 @@ class TestResolveFeatureScopedCapabilityRejection:
         assert result.feature_group is None
         assert result.error is not None
         # After #755 the engine builds the capability-rejection message; the scope callout is retained.
-        assert "Pin the feature to a supported compute framework" in result.error
+        assert "AllRejectedCapResolveFeatureGroup (compute framework):" in result.error
+        assert "supports_compute_framework rejected" in result.error
         assert "PandasDataFrame" in result.error
         assert "PythonDictFramework" in result.error
         assert "Scoped to feature group: 'AllRejectedCapResolveFeatureGroup'." in result.error

--- a/tests/test_core/test_api/test_subtype_docs.py
+++ b/tests/test_core/test_api/test_subtype_docs.py
@@ -393,10 +393,10 @@ class TestSubDeclDocContractDUnsupportedEverywhere:
         assert result.feature_group is None
         assert result.candidates == [SubDeclDocR4RejectingFG]
         assert result.error is not None
-        # Engine wording names the frameworks and the capability hook.
-        assert "Unsupported compute framework(s)" in result.error
+        # Engine wording names the frameworks and the capability hook via the near-miss line.
+        assert "Feature group(s) eliminated while matching 'value__median_sbddr4':" in result.error
+        assert "SubDeclDocR4RejectingFG (compute framework): supports_compute_framework rejected" in result.error
         assert "PythonDictFramework" in result.error
-        assert "Pin the feature to a supported compute framework" in result.error
         # The delegated failure path returns the ResolvedFeature defaults: no structured split, no subtype.
         assert result.supported_compute_frameworks == []
         assert result.unsupported_compute_frameworks == []
@@ -407,7 +407,7 @@ class TestSubDeclDocContractDUnsupportedEverywhere:
         result = resolve_feature("value__ntile_3_sbddr4")
         assert result.feature_group is None
         assert result.error is not None
-        assert "Unsupported compute framework(s)" in result.error
+        assert "SubDeclDocR4RejectingFG (compute framework): supports_compute_framework rejected" in result.error
         assert "PythonDictFramework" in result.error
         # No structured subtype on the delegated failure path.
         assert result.subtype is None

--- a/tests/test_core/test_prepare/test_abstract_feature_group_not_instantiated.py
+++ b/tests/test_core/test_prepare/test_abstract_feature_group_not_instantiated.py
@@ -266,8 +266,8 @@ class TestAbstractOnlyMessageCorrectness:
     def test_capability_rejection_not_shadowed_by_abstract_only(self) -> None:
         """Finding B: a concrete subclass matched criteria/domain/scope but its available
         framework was rejected by ``supports_compute_framework`` (a capability rejection).
-        The user must get the capability-rejection message, NOT the abstract-only message
-        that wrongly claims the framework is 'none of which are available or enabled'.
+        os-011 keeps the abstract-only sentence AND appends the near-miss block, so the concrete
+        subclass's capability rejection is surfaced alongside the abstract note rather than shadowed.
         """
         feature = Feature(CAPABILITY_SHADOW_FEATURE)
 
@@ -285,15 +285,15 @@ class TestAbstractOnlyMessageCorrectness:
             )
 
         error_message = str(exc_info.value)
-        lowered = error_message.lower()
 
-        assert "none of which are available or enabled" not in error_message, (
-            f"A capability rejection must not be shadowed by the abstract-only message; the "
-            f"framework IS available and was rejected by supports_compute_framework, but got: {error_message}"
+        assert "Feature group(s) eliminated while matching" in error_message, (
+            f"The concrete subclass's capability rejection must surface as a near-miss line, but got: {error_message}"
         )
-        assert "supports_compute_framework" in error_message or "unsupported compute framework" in lowered, (
-            f"Error should be the capability-rejection message (mentioning 'supports_compute_framework' "
-            f"or 'Unsupported compute framework'), but got: {error_message}"
+        assert "supports_compute_framework rejected" in error_message, (
+            f"The near-miss line must name the supports_compute_framework rejection, but got: {error_message}"
+        )
+        assert CapabilityShadowConcrete.get_class_name() in error_message, (
+            f"The near-miss line must name the rejected concrete subclass, but got: {error_message}"
         )
 
 

--- a/tests/test_core/test_prepare/test_candidate_elimination_reasons.py
+++ b/tests/test_core/test_prepare/test_candidate_elimination_reasons.py
@@ -1,0 +1,489 @@
+"""Red-phase pins for os-011: per-candidate elimination reasons on ``EvaluationResult``.
+
+The design contract (``scratchpad/os-011-design.md``) adds a public elimination surface to the
+resolution result:
+
+- ``Elimination`` is a frozen dataclass with ``.stage`` and ``.reason``.
+- ``EvaluationResult.eliminations`` maps every non-winning candidate that reached at least the name
+  filter to the ``Elimination`` recorded at the first gate it failed.
+- ``render_resolution_failure`` projects those eliminations into a shared near-miss block on the
+  ``none`` and ``abstract_only`` messages.
+
+These symbols do NOT exist yet, so importing ``Elimination`` fails collection: that is the expected
+Red failure. Every feature group and compute framework double is suffixed ``011`` because test feature
+groups become global ``FeatureGroup`` subclasses and must not collide with other suites.
+"""
+
+from abc import abstractmethod
+from typing import ClassVar, Optional
+
+import pytest
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.domain import Domain
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import PropertyValueRejection
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.index.index import Index
+from mloda.core.abstract_plugins.components.link import JoinSpec, Link
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from mloda.core.prepare.identify_feature_group import (
+    Elimination,
+    FeatureResolutionError,
+    IdentifyFeatureGroupClass,
+    render_resolution_failure,
+)
+from tests.test_core.test_prepare.identify_seam import evaluate_or_raise, identify_winner
+
+
+# --- feature names, one per scenario ------------------------------------------------------------
+
+VALUE_FEATURE = "elim_value_reject_feat_011"
+DOMAIN_FEATURE = "elim_domain_feat_011"
+SCOPE_FEATURE = "elim_scope_feat_011"
+CAPABILITY_FEATURE = "elim_capability_feat_011"
+NOT_ENABLED_FEATURE = "elim_not_enabled_feat_011"
+PIN_FEATURE = "elim_pin_feat_011"
+LINKS_FEATURE = "elim_links_feat_011"
+ABSTRACT_FEATURE = "elim_abstract_feat_011"
+SORT_FEATURE = "elim_sort_feat_011"
+PRECEDENCE_CAP_FEATURE = "elim_precedence_cap_feat_011"
+PRECEDENCE_NE_FEATURE = "elim_precedence_ne_feat_011"
+SUCCESS_FEATURE = "elim_success_feat_011"
+NONMATCH_ONLY_NAME = "elim_only_this_other_name_011"
+
+REQUESTED_DOMAIN = "elim_requested_domain_011"
+CANDIDATE_DOMAIN = "elim_candidate_domain_011"
+UNRELATED_SCOPE = "ElimUnrelatedScope011"
+
+# Value-rejection wording matches today's ``_strict_validation_rejection_reason`` output.
+VALUE_REJECT_REASON = "Property value '14' failed validation for 'window_size'"
+
+
+# --- compute framework doubles ------------------------------------------------------------------
+
+
+class ElimFwOne011(ComputeFramework):
+    """First dummy compute framework for the elimination-reason tests."""
+
+
+class ElimFwTwo011(ComputeFramework):
+    """Second dummy compute framework for the elimination-reason tests."""
+
+
+class ElimFwThree011(ComputeFramework):
+    """Third dummy compute framework, used only to pin a feature away from every candidate."""
+
+
+# --- feature group doubles ----------------------------------------------------------------------
+
+
+class _ElimBaseFG(FeatureGroup):
+    """Minimal, fully declarative feature group double driven by class variables.
+
+    Every hook is deterministic and non-raising (except the value-rejection subclass, which raises
+    only for its own matching name), so a leaked global subclass stays inert for other suites.
+    """
+
+    MATCHES: ClassVar[frozenset[str]] = frozenset()
+    DOMAIN_NAME: ClassVar[Optional[str]] = None
+    FRAMEWORK_RULE: ClassVar[Optional[set[type[ComputeFramework]]]] = None
+    SUPPORTED_FRAMEWORKS: ClassVar[Optional[frozenset[str]]] = None
+    INDEX_COLUMNS: ClassVar[Optional[list[Index]]] = None
+    SUPPORTS_INDEX_RESULT: ClassVar[Optional[bool]] = None
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        return str(feature_name) in cls.MATCHES
+
+    @classmethod
+    def get_domain(cls) -> Domain:
+        if cls.DOMAIN_NAME is None:
+            return Domain.get_default_domain()
+        return Domain(cls.DOMAIN_NAME)
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return cls.FRAMEWORK_RULE
+
+    @classmethod
+    def supports_compute_framework(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        compute_framework: type[ComputeFramework],
+    ) -> bool:
+        if cls.SUPPORTED_FRAMEWORKS is None:
+            return True
+        return compute_framework.get_class_name() in cls.SUPPORTED_FRAMEWORKS
+
+    @classmethod
+    def index_columns(cls) -> Optional[list[Index]]:
+        return cls.INDEX_COLUMNS
+
+    @classmethod
+    def supports_index(cls, index: Index) -> Optional[bool]:
+        return cls.SUPPORTS_INDEX_RESULT
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+class ElimValueRejectFG011(_ElimBaseFG):
+    """Name matches, but the criteria hook raises ``PropertyValueRejection`` on the value.
+
+    ``_strict_validation_rejection_reason`` returns the reportable wording. The contract prefers that
+    hook over ``str(exc)``, so the recorded reason is the hook's return, not the raw exception text.
+    """
+
+    MATCHES = frozenset({VALUE_FEATURE})
+    FRAMEWORK_RULE = {ElimFwOne011}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        if str(feature_name) in cls.MATCHES:
+            raise PropertyValueRejection("raw exception text 011 that must not surface as the reason")
+        return False
+
+    @classmethod
+    def _strict_validation_rejection_reason(cls, feature_name: str | FeatureName, options: Options) -> str | None:
+        return VALUE_REJECT_REASON
+
+
+class ElimDomainFG011(_ElimBaseFG):
+    """Name matches, but the candidate declares a domain the run did not request."""
+
+    MATCHES = frozenset({DOMAIN_FEATURE})
+    DOMAIN_NAME = CANDIDATE_DOMAIN
+    FRAMEWORK_RULE = {ElimFwOne011}
+
+
+class ElimScopeFG011(_ElimBaseFG):
+    """Name matches, but the candidate is outside the requested feature-group scope."""
+
+    MATCHES = frozenset({SCOPE_FEATURE})
+    FRAMEWORK_RULE = {ElimFwOne011}
+
+
+class ElimCapabilityFG011(_ElimBaseFG):
+    """Reaches the framework split with an empty supported set while a framework WAS enabled."""
+
+    MATCHES = frozenset({CAPABILITY_FEATURE})
+    FRAMEWORK_RULE = {ElimFwOne011, ElimFwTwo011}
+    SUPPORTED_FRAMEWORKS = frozenset({"ElimFwTwo011"})
+
+
+class ElimNotEnabledFG011(_ElimBaseFG):
+    """Reaches the framework split with an empty supported set and NO framework enabled for the run."""
+
+    MATCHES = frozenset({NOT_ENABLED_FEATURE})
+    FRAMEWORK_RULE = {ElimFwOne011}
+
+
+class ElimPinFG011(_ElimBaseFG):
+    """Supports its enabled framework, but the run pins a framework it does not support."""
+
+    MATCHES = frozenset({PIN_FEATURE})
+    FRAMEWORK_RULE = {ElimFwOne011}
+
+
+class ElimLinksFG011(_ElimBaseFG):
+    """Supports its enabled framework and no pin, but no index column matches the run's links."""
+
+    MATCHES = frozenset({LINKS_FEATURE})
+    FRAMEWORK_RULE = {ElimFwOne011}
+    INDEX_COLUMNS = [Index(("elim_index_col_011",))]
+    SUPPORTS_INDEX_RESULT = False
+
+
+class ElimAbstractBaseFG011(_ElimBaseFG):
+    """Abstract base that matches the name but can never be instantiated (never an elimination)."""
+
+    MATCHES = frozenset({ABSTRACT_FEATURE})
+    FRAMEWORK_RULE = {ElimFwOne011}
+
+    @classmethod
+    @abstractmethod
+    def _elim_abstract_hook_011(cls) -> str:
+        """Abstract hook that keeps this base uninstantiable."""
+
+
+class ElimAbstractNearMissFG011(_ElimBaseFG):
+    """Concrete near-miss sharing the abstract base's name, eliminated at the capability gate."""
+
+    MATCHES = frozenset({ABSTRACT_FEATURE})
+    FRAMEWORK_RULE = {ElimFwOne011, ElimFwTwo011}
+    SUPPORTED_FRAMEWORKS = frozenset({"ElimFwTwo011"})
+
+
+class ElimSortAFG011(_ElimBaseFG):
+    """First of two capability near-misses; its name sorts before ElimSortBFG011."""
+
+    MATCHES = frozenset({SORT_FEATURE})
+    FRAMEWORK_RULE = {ElimFwOne011, ElimFwTwo011}
+    SUPPORTED_FRAMEWORKS = frozenset({"ElimFwTwo011"})
+
+
+class ElimSortBFG011(_ElimBaseFG):
+    """Second capability near-miss; its name sorts after ElimSortAFG011."""
+
+    MATCHES = frozenset({SORT_FEATURE})
+    FRAMEWORK_RULE = {ElimFwOne011, ElimFwTwo011}
+    SUPPORTED_FRAMEWORKS = frozenset({"ElimFwTwo011"})
+
+
+class ElimPrecedenceCapFG011(_ElimBaseFG):
+    """Empty supported set with a framework enabled AND a pin set: capability must win over the pin."""
+
+    MATCHES = frozenset({PRECEDENCE_CAP_FEATURE})
+    FRAMEWORK_RULE = {ElimFwOne011, ElimFwTwo011}
+    SUPPORTED_FRAMEWORKS = frozenset({"ElimFwTwo011"})
+
+
+class ElimPrecedenceNotEnabledFG011(_ElimBaseFG):
+    """Empty supported set, no framework enabled, AND a pin set: not-enabled must win over the pin."""
+
+    MATCHES = frozenset({PRECEDENCE_NE_FEATURE})
+    FRAMEWORK_RULE = {ElimFwOne011}
+
+
+class ElimSuccessFG011(_ElimBaseFG):
+    """Sole winner: matches the name and supports its enabled framework."""
+
+    MATCHES = frozenset({SUCCESS_FEATURE})
+    FRAMEWORK_RULE = {ElimFwOne011}
+
+
+class ElimNonMatchingFG011(_ElimBaseFG):
+    """Matches a different name; never a near-miss for the scenarios below."""
+
+    MATCHES = frozenset({NONMATCH_ONLY_NAME})
+    FRAMEWORK_RULE = {ElimFwOne011}
+
+
+# A link whose indexes ElimLinksFG011 does not support, driving the links gate to reject.
+ELIM_LINK = Link.inner(
+    JoinSpec(ElimLinksFG011, "elim_left_index_011"),
+    JoinSpec(ElimLinksFG011, "elim_right_index_011"),
+)
+
+
+# --- helpers ------------------------------------------------------------------------------------
+
+
+def _fail(
+    feature: Feature,
+    accessible_plugins: FeatureGroupEnvironmentMapping,
+    links: Optional[set[Link]] = None,
+) -> FeatureResolutionError:
+    """Drive the engine seam and return the raised typed error (carrying ``.result`` and message)."""
+    with pytest.raises(FeatureResolutionError) as excinfo:
+        evaluate_or_raise(feature, accessible_plugins, links=links)
+    return excinfo.value
+
+
+class TestEliminationStages:
+    """One test per stage: the eliminated candidate maps to the expected (stage, reason), and the
+    near-miss message line carries the contract's stage label."""
+
+    def test_value_rejection_stage(self) -> None:
+        feature = Feature(VALUE_FEATURE)
+        plugins: FeatureGroupEnvironmentMapping = {ElimValueRejectFG011: {ElimFwOne011}}
+
+        err = _fail(feature, plugins)
+
+        assert err.result.eliminations[ElimValueRejectFG011] == Elimination(
+            stage="value_rejection", reason=VALUE_REJECT_REASON
+        )
+        assert f"  - ElimValueRejectFG011 (option value): {VALUE_REJECT_REASON}" in str(err)
+
+    def test_domain_stage(self) -> None:
+        feature = Feature(DOMAIN_FEATURE, domain=REQUESTED_DOMAIN)
+        plugins: FeatureGroupEnvironmentMapping = {ElimDomainFG011: {ElimFwOne011}}
+
+        err = _fail(feature, plugins)
+
+        reason = f"declares domain '{CANDIDATE_DOMAIN}', but the run requested '{REQUESTED_DOMAIN}'"
+        assert err.result.eliminations[ElimDomainFG011] == Elimination(stage="domain", reason=reason)
+        assert f"  - ElimDomainFG011 (domain): {reason}" in str(err)
+
+    def test_scope_stage(self) -> None:
+        feature = Feature(SCOPE_FEATURE, feature_group=UNRELATED_SCOPE)
+        plugins: FeatureGroupEnvironmentMapping = {ElimScopeFG011: {ElimFwOne011}}
+
+        err = _fail(feature, plugins)
+
+        reason = "outside the requested feature group scope"
+        assert err.result.eliminations[ElimScopeFG011] == Elimination(stage="scope", reason=reason)
+        assert f"  - ElimScopeFG011 (scope): {reason}" in str(err)
+
+    def test_capability_stage(self) -> None:
+        feature = Feature(CAPABILITY_FEATURE)
+        plugins: FeatureGroupEnvironmentMapping = {ElimCapabilityFG011: {ElimFwOne011}}
+
+        err = _fail(feature, plugins)
+
+        reason = "supports_compute_framework rejected ['ElimFwOne011']"
+        assert err.result.eliminations[ElimCapabilityFG011] == Elimination(stage="capability", reason=reason)
+        assert f"  - ElimCapabilityFG011 (compute framework): {reason}" in str(err)
+
+    def test_frameworks_not_enabled_stage(self) -> None:
+        feature = Feature(NOT_ENABLED_FEATURE)
+        plugins: FeatureGroupEnvironmentMapping = {ElimNotEnabledFG011: set()}
+
+        err = _fail(feature, plugins)
+
+        reason = "none of its compute frameworks are enabled for this run"
+        assert err.result.eliminations[ElimNotEnabledFG011] == Elimination(
+            stage="frameworks_not_enabled", reason=reason
+        )
+        assert f"  - ElimNotEnabledFG011 (compute framework): {reason}" in str(err)
+
+    def test_framework_pin_stage(self) -> None:
+        feature = Feature(PIN_FEATURE, compute_framework="ElimFwThree011")
+        plugins: FeatureGroupEnvironmentMapping = {ElimPinFG011: {ElimFwOne011}}
+
+        err = _fail(feature, plugins)
+
+        reason = "pinned compute framework 'ElimFwThree011' is not among its supported ['ElimFwOne011']"
+        assert err.result.eliminations[ElimPinFG011] == Elimination(stage="framework_pin", reason=reason)
+        assert f"  - ElimPinFG011 (compute framework pin): {reason}" in str(err)
+
+    def test_links_stage(self) -> None:
+        feature = Feature(LINKS_FEATURE)
+        plugins: FeatureGroupEnvironmentMapping = {ElimLinksFG011: {ElimFwOne011}}
+
+        err = _fail(feature, plugins, links={ELIM_LINK})
+
+        reason = "no index column matches the run's links"
+        assert err.result.eliminations[ElimLinksFG011] == Elimination(stage="links", reason=reason)
+        assert f"  - ElimLinksFG011 (links): {reason}" in str(err)
+
+
+class TestNearMissMessageBlock:
+    """The shared near-miss block projects the eliminations onto the none / abstract_only messages."""
+
+    def test_none_message_renders_sorted_near_miss_block(self) -> None:
+        feature = Feature(SORT_FEATURE)
+        # B inserted before A so a sorted rendering (by class name, then module) is observable.
+        plugins: FeatureGroupEnvironmentMapping = {
+            ElimSortBFG011: {ElimFwOne011},
+            ElimSortAFG011: {ElimFwOne011},
+        }
+
+        err = _fail(feature, plugins)
+
+        assert err.result.failure_kind == "none"
+        message = str(err)
+        assert message.startswith(f"No feature groups found for feature name: '{SORT_FEATURE}'.")
+        assert (
+            f"Feature group(s) eliminated while matching '{SORT_FEATURE}':\n"
+            "  - ElimSortAFG011 (compute framework): supports_compute_framework rejected ['ElimFwOne011']\n"
+            "  - ElimSortBFG011 (compute framework): supports_compute_framework rejected ['ElimFwOne011']"
+        ) in message
+
+    def test_abstract_only_message_appends_near_miss_block(self) -> None:
+        feature = Feature(ABSTRACT_FEATURE)
+        plugins: FeatureGroupEnvironmentMapping = {
+            ElimAbstractBaseFG011: {ElimFwOne011},
+            ElimAbstractNearMissFG011: {ElimFwOne011},
+        }
+
+        err = _fail(feature, plugins)
+
+        assert err.result.failure_kind == "abstract_only"
+        # The abstract base is handled by abstract_matched, never recorded as an elimination.
+        assert ElimAbstractBaseFG011 not in err.result.eliminations
+        assert err.result.eliminations[ElimAbstractNearMissFG011] == Elimination(
+            stage="capability", reason="supports_compute_framework rejected ['ElimFwOne011']"
+        )
+
+        message = str(err)
+        # The existing abstract sentence is retained ...
+        assert f"No feature groups found for feature name: '{ABSTRACT_FEATURE}'." in message
+        # ... and the shared near-miss block is appended.
+        assert (
+            f"Feature group(s) eliminated while matching '{ABSTRACT_FEATURE}':\n"
+            "  - ElimAbstractNearMissFG011 (compute framework): supports_compute_framework rejected ['ElimFwOne011']"
+        ) in message
+
+
+class TestEmptySupportedPrecedence:
+    """An empty supported set is decided before the pin filter: capability / not-enabled win over pin."""
+
+    def test_pin_over_empty_supported_reports_capability_not_pin(self) -> None:
+        feature = Feature(PRECEDENCE_CAP_FEATURE, compute_framework="ElimFwThree011")
+        plugins: FeatureGroupEnvironmentMapping = {ElimPrecedenceCapFG011: {ElimFwOne011}}
+
+        err = _fail(feature, plugins)
+
+        elimination = err.result.eliminations[ElimPrecedenceCapFG011]
+        assert elimination.stage == "capability"
+        assert elimination.reason == "supports_compute_framework rejected ['ElimFwOne011']"
+
+    def test_pin_over_empty_supported_none_enabled_reports_frameworks_not_enabled(self) -> None:
+        feature = Feature(PRECEDENCE_NE_FEATURE, compute_framework="ElimFwThree011")
+        plugins: FeatureGroupEnvironmentMapping = {ElimPrecedenceNotEnabledFG011: set()}
+
+        err = _fail(feature, plugins)
+
+        elimination = err.result.eliminations[ElimPrecedenceNotEnabledFG011]
+        assert elimination.stage == "frameworks_not_enabled"
+        assert elimination.reason == "none of its compute frameworks are enabled for this run"
+
+
+class TestNoEliminationRecorded:
+    """Winners, abstract bases, and name-mismatched candidates are never near-misses."""
+
+    def test_winner_has_no_elimination_entry(self) -> None:
+        feature = Feature(SUCCESS_FEATURE)
+        plugins: FeatureGroupEnvironmentMapping = {ElimSuccessFG011: {ElimFwOne011}}
+
+        winner_fg, _ = identify_winner(feature, plugins)
+        assert winner_fg is ElimSuccessFG011
+
+        result = IdentifyFeatureGroupClass.evaluate(feature, plugins, None)
+        assert result.failure_kind is None
+        assert result.eliminations == {}
+
+    def test_abstract_base_has_no_elimination_entry(self) -> None:
+        feature = Feature(ABSTRACT_FEATURE)
+        plugins: FeatureGroupEnvironmentMapping = {ElimAbstractBaseFG011: {ElimFwOne011}}
+
+        err = _fail(feature, plugins)
+
+        assert err.result.failure_kind == "abstract_only"
+        assert ElimAbstractBaseFG011 not in err.result.eliminations
+        assert err.result.eliminations == {}
+
+    def test_name_mismatch_has_no_elimination_entry(self) -> None:
+        feature = Feature(VALUE_FEATURE)
+        plugins: FeatureGroupEnvironmentMapping = {
+            ElimValueRejectFG011: {ElimFwOne011},
+            ElimNonMatchingFG011: {ElimFwOne011},
+        }
+
+        err = _fail(feature, plugins)
+
+        # The value-rejecting candidate matched the name and is recorded ...
+        assert ElimValueRejectFG011 in err.result.eliminations
+        # ... but the candidate whose name never matched is not a near-miss.
+        assert ElimNonMatchingFG011 not in err.result.eliminations
+
+
+def test_render_resolution_failure_is_importable() -> None:
+    """Guard that the renderer entry point the near-miss block lives in stays importable."""
+    assert callable(render_resolution_failure)

--- a/tests/test_core/test_prepare/test_candidate_elimination_reasons.py
+++ b/tests/test_core/test_prepare/test_candidate_elimination_reasons.py
@@ -54,6 +54,10 @@ PRECEDENCE_CAP_FEATURE = "elim_precedence_cap_feat_011"
 PRECEDENCE_NE_FEATURE = "elim_precedence_ne_feat_011"
 SUCCESS_FEATURE = "elim_success_feat_011"
 NONMATCH_ONLY_NAME = "elim_only_this_other_name_011"
+WIN_WITH_REJECTOR_FEATURE = "elim_win_with_rejector_feat_011"
+DOMAIN_AND_VALUE_REJECT_FEATURE = "elim_domain_and_value_reject_feat_011"
+REPROBE_FEATURE = "elim_reprobe_feat_011"
+SCOPED_ABSTRACT_SCOPE = "_ElimBaseFG"
 
 REQUESTED_DOMAIN = "elim_requested_domain_011"
 CANDIDATE_DOMAIN = "elim_candidate_domain_011"
@@ -61,6 +65,13 @@ UNRELATED_SCOPE = "ElimUnrelatedScope011"
 
 # Value-rejection wording matches today's ``_strict_validation_rejection_reason`` output.
 VALUE_REJECT_REASON = "Property value '14' failed validation for 'window_size'"
+WIN_REJECT_REASON = "Property value 'bad' rejected by match_guard for 'mode'"
+DOMAIN_VALUE_REASON = "Property value '7' failed validation for 'k'"
+REPROBE_REASON = "a criteria-matched candidate must never be re-probed as a value rejection"
+
+# A criteria-matched candidate's value must be inspected once (at match time). A failure-path capture that
+# re-probed such a candidate via ``_strict_validation_rejection_reason`` would inspect it a second time.
+REPROBE_INSPECT_CALLS: dict[str, int] = {}
 
 
 # --- compute framework doubles ------------------------------------------------------------------
@@ -140,8 +151,8 @@ class _ElimBaseFG(FeatureGroup):
 class ElimValueRejectFG011(_ElimBaseFG):
     """Name matches, but the criteria hook raises ``PropertyValueRejection`` on the value.
 
-    ``_strict_validation_rejection_reason`` returns the reportable wording. The contract prefers that
-    hook over ``str(exc)``, so the recorded reason is the hook's return, not the raw exception text.
+    The first match pass records the raised message as the value_rejection reason, so the rejection's own
+    wording is what surfaces; no diagnostic hook is re-probed on the failure path.
     """
 
     MATCHES = frozenset({VALUE_FEATURE})
@@ -155,12 +166,8 @@ class ElimValueRejectFG011(_ElimBaseFG):
         data_access_collection: Optional[DataAccessCollection] = None,
     ) -> bool:
         if str(feature_name) in cls.MATCHES:
-            raise PropertyValueRejection("raw exception text 011 that must not surface as the reason")
+            raise PropertyValueRejection(VALUE_REJECT_REASON)
         return False
-
-    @classmethod
-    def _strict_validation_rejection_reason(cls, feature_name: str | FeatureName, options: Options) -> str | None:
-        return VALUE_REJECT_REASON
 
 
 class ElimDomainFG011(_ElimBaseFG):
@@ -272,6 +279,99 @@ class ElimNonMatchingFG011(_ElimBaseFG):
 
     MATCHES = frozenset({NONMATCH_ONLY_NAME})
     FRAMEWORK_RULE = {ElimFwOne011}
+
+
+class ElimWinnerFG011(_ElimBaseFG):
+    """Sole winner of the win-with-losing-rejector scenario; matches the shared name and supports its framework."""
+
+    MATCHES = frozenset({WIN_WITH_REJECTOR_FEATURE})
+    FRAMEWORK_RULE = {ElimFwOne011}
+
+
+class ElimLosingRejectorFG011(_ElimBaseFG):
+    """Matches the shared name but rejects the option VALUE, recording a reportable reason: a losing near-miss.
+
+    The rejection is name-guarded so a leaked global subclass records nothing for any other suite's feature.
+    """
+
+    MATCHES = frozenset({WIN_WITH_REJECTOR_FEATURE})
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        # Name matches, but the value is rejected: the first pass records the reason as the match fails.
+        if str(feature_name) == WIN_WITH_REJECTOR_FEATURE:
+            raise PropertyValueRejection(WIN_REJECT_REASON)
+        return False
+
+
+class ElimDomainAndValueRejectFG011(_ElimBaseFG):
+    """Rejects the option VALUE (criteria fails first) AND declares an unrequested domain.
+
+    The value_rejection is recorded at the criteria gate, before the domain gate is ever consulted, so the
+    stage is value_rejection rather than domain. The reason is name-guarded to stay inert when leaked.
+    """
+
+    MATCHES = frozenset({DOMAIN_AND_VALUE_REJECT_FEATURE})
+    DOMAIN_NAME = CANDIDATE_DOMAIN
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        # The value is rejected at the criteria gate, recording the reason before the domain gate is reached.
+        if str(feature_name) == DOMAIN_AND_VALUE_REJECT_FEATURE:
+            raise PropertyValueRejection(DOMAIN_VALUE_REASON)
+        return False
+
+
+class _ElimReprobeFG011(_ElimBaseFG):
+    """Criteria-matched candidate whose value is inspected once, at match time.
+
+    Both match and the rejection hook increment the SAME per-class counter, so a re-probe of this matched
+    candidate via ``_strict_validation_rejection_reason`` would push its count to two. The hook is name-guarded
+    to stay inert when leaked into another suite's candidate universe.
+    """
+
+    FRAMEWORK_RULE = {ElimFwOne011}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        matched = str(feature_name) in cls.MATCHES
+        if matched:
+            REPROBE_INSPECT_CALLS[cls.get_class_name()] = REPROBE_INSPECT_CALLS.get(cls.get_class_name(), 0) + 1
+        return matched
+
+    @classmethod
+    def _strict_validation_rejection_reason(cls, feature_name: str | FeatureName, options: Options) -> str | None:
+        if str(feature_name) != REPROBE_FEATURE:
+            return None
+        REPROBE_INSPECT_CALLS[cls.get_class_name()] = REPROBE_INSPECT_CALLS.get(cls.get_class_name(), 0) + 1
+        return REPROBE_REASON
+
+
+class ElimReprobeAFG011(_ElimReprobeFG011):
+    """First of two matched winners sharing the re-probe name; the pair triggers a 'multiple' failure."""
+
+    MATCHES = frozenset({REPROBE_FEATURE})
+
+
+class ElimReprobeBFG011(_ElimReprobeFG011):
+    """Second matched winner sharing the re-probe name."""
+
+    MATCHES = frozenset({REPROBE_FEATURE})
 
 
 # A link whose indexes ElimLinksFG011 does not support, driving the links gate to reject.
@@ -482,6 +582,86 @@ class TestNoEliminationRecorded:
         assert ElimValueRejectFG011 in err.result.eliminations
         # ... but the candidate whose name never matched is not a near-miss.
         assert ElimNonMatchingFG011 not in err.result.eliminations
+
+
+class TestValueRejectionCaptureCorrectness:
+    """value_rejection is recorded for a criteria-FAILING candidate at that first gate, regardless of domain
+    or scope and regardless of the overall outcome; a criteria-matched candidate is never re-probed."""
+
+    def test_losing_value_rejector_recorded_even_when_a_sibling_wins(self) -> None:
+        """A losing value-rejecter is a near-miss even when a sibling WINS and the resolution succeeds."""
+        feature = Feature(WIN_WITH_REJECTOR_FEATURE)
+        plugins: FeatureGroupEnvironmentMapping = {
+            ElimWinnerFG011: {ElimFwOne011},
+            ElimLosingRejectorFG011: {ElimFwOne011},
+        }
+
+        result = IdentifyFeatureGroupClass.evaluate(feature, plugins, None)
+
+        # A sibling won, so the resolution as a whole is a success ...
+        assert result.failure_kind is None
+        winner_fg, _ = next(iter(result.identified.items()))
+        assert winner_fg is ElimWinnerFG011
+        # ... yet the losing value-rejecter is still recorded, which the old failure-only capture never did.
+        assert result.eliminations[ElimLosingRejectorFG011] == Elimination(
+            stage="value_rejection", reason=WIN_REJECT_REASON
+        )
+        assert ElimWinnerFG011 not in result.eliminations
+
+    def test_value_rejection_recorded_even_with_a_domain_mismatch(self) -> None:
+        """A candidate that value-rejects AND declares an unrequested domain is staged value_rejection.
+
+        The criteria gate is first, so the reason is captured there; the old domain/scope-gated capture
+        dropped such a candidate entirely.
+        """
+        feature = Feature(DOMAIN_AND_VALUE_REJECT_FEATURE, domain=REQUESTED_DOMAIN)
+        plugins: FeatureGroupEnvironmentMapping = {ElimDomainAndValueRejectFG011: {ElimFwOne011}}
+
+        err = _fail(feature, plugins)
+
+        assert err.result.eliminations[ElimDomainAndValueRejectFG011] == Elimination(
+            stage="value_rejection", reason=DOMAIN_VALUE_REASON
+        )
+
+    def test_criteria_matched_candidates_are_not_reprobed_as_value_rejections(self) -> None:
+        """Two matched winners (a 'multiple' failure) are each inspected once, never re-probed as rejections."""
+        REPROBE_INSPECT_CALLS.clear()
+        feature = Feature(REPROBE_FEATURE)
+        plugins: FeatureGroupEnvironmentMapping = {
+            ElimReprobeAFG011: {ElimFwOne011},
+            ElimReprobeBFG011: {ElimFwOne011},
+        }
+
+        err = _fail(feature, plugins)
+
+        assert err.result.failure_kind == "multiple"
+        # Each matched candidate's value was inspected exactly once, at match time: the rejection hook, which
+        # would inspect it a second time, is never asked of a criteria-matched candidate.
+        assert REPROBE_INSPECT_CALLS == {"ElimReprobeAFG011": 1, "ElimReprobeBFG011": 1}
+        # And no matched winner is recorded as a value_rejection near-miss.
+        assert err.result.eliminations == {}
+
+
+class TestScopedAbstractOnlyCallout:
+    """FIX C: the scope callout in the abstract_only branch sits on the sentence line, never glued to a bullet."""
+
+    def test_scoped_abstract_only_callout_is_not_glued_to_a_near_miss_bullet(self) -> None:
+        feature = Feature(ABSTRACT_FEATURE, feature_group=SCOPED_ABSTRACT_SCOPE)
+        plugins: FeatureGroupEnvironmentMapping = {
+            ElimAbstractBaseFG011: {ElimFwOne011},
+            ElimAbstractNearMissFG011: {ElimFwOne011},
+        }
+
+        err = _fail(feature, plugins)
+        message = str(err)
+
+        assert err.result.failure_kind == "abstract_only"
+        # A near-miss block is present, so a glued callout would land on the last bullet line.
+        assert f"Feature group(s) eliminated while matching '{ABSTRACT_FEATURE}':" in message
+        assert message.count("Scoped to feature group:") == 1
+        callout_line = next(line for line in message.split("\n") if "Scoped to feature group:" in line)
+        assert not callout_line.startswith("  - ")
+        assert callout_line.startswith(f"No feature groups found for feature name: '{ABSTRACT_FEATURE}'.")
 
 
 def test_render_resolution_failure_is_importable() -> None:

--- a/tests/test_core/test_prepare/test_compute_framework_capability.py
+++ b/tests/test_core/test_prepare/test_compute_framework_capability.py
@@ -208,7 +208,7 @@ class TestComputeFrameworkCapabilityHook:
         )
 
     def test_distinguishable_error_when_pinned_to_unsupported_framework(self) -> None:
-        """Pinning to the unsupported framework yields a dedicated, distinguishable error."""
+        """Pinning to the unsupported framework names the pin as a compute-framework-pin near-miss."""
         feature = Feature(CAPABILITY_FEATURE)
         feature.compute_frameworks = {CapabilityFwB}
 
@@ -225,19 +225,19 @@ class TestComputeFrameworkCapabilityHook:
             )
 
         error_message = str(exc_info.value)
-        lowered = error_message.lower()
 
-        assert "unsupported" in lowered or "not supported" in lowered, (
-            f"Capability error must signal an unsupported framework, but got: {error_message}"
+        assert "Feature group(s) eliminated while matching" in error_message, (
+            f"Capability pin rejection must render as a near-miss line, but got: {error_message}"
+        )
+        assert "compute framework pin" in error_message, (
+            f"A pin rejection must be labelled a compute framework pin, but got: {error_message}"
         )
         assert CapabilityFwB.get_class_name() in error_message, (
-            f"Error must name the unsupported framework '{CapabilityFwB.get_class_name()}', but got: {error_message}"
+            f"Error must name the pinned unsupported framework '{CapabilityFwB.get_class_name()}', "
+            f"but got: {error_message}"
         )
         assert CapabilityFwA.get_class_name() in error_message, (
             f"Error must name the supported framework '{CapabilityFwA.get_class_name()}', but got: {error_message}"
-        )
-        assert "Did you mean" not in error_message, (
-            f"Capability error must skip the fuzzy suggestion path, but got: {error_message}"
         )
 
     def test_all_frameworks_reject_operation(self) -> None:
@@ -257,11 +257,13 @@ class TestComputeFrameworkCapabilityHook:
             )
 
         error_message = str(exc_info.value)
-        lowered = error_message.lower()
 
         assert CAPABILITY_FEATURE in error_message, f"Error must mention the feature name, but got: {error_message}"
-        assert "unsupported" in lowered or "not supported" in lowered, (
-            f"Error must signal that the framework(s) are unsupported, but got: {error_message}"
+        assert "Feature group(s) eliminated while matching" in error_message, (
+            f"An all-rejected candidate must render as a capability near-miss, but got: {error_message}"
+        )
+        assert "supports_compute_framework rejected" in error_message, (
+            f"Error must signal that supports_compute_framework rejected the frameworks, but got: {error_message}"
         )
         assert CapabilityFwA.get_class_name() in error_message, (
             f"Error must name rejected framework '{CapabilityFwA.get_class_name()}', but got: {error_message}"
@@ -305,23 +307,23 @@ class TestComputeFrameworkCapabilityHook:
                 data_access_collection=None,
             )
         capability_message = str(capability_exc.value)
-        lowered = capability_message.lower()
 
-        assert "unsupported" in lowered or "not supported" in lowered, (
-            f"Capability error must signal an unsupported framework, but got: {capability_message}"
+        # Both share the base "No feature groups found" line now; the capability rejection is
+        # distinguished by its near-miss block, which the unknown-feature error never carries.
+        assert "Feature group(s) eliminated while matching" in capability_message, (
+            f"Capability error must name the eliminated near-miss candidate, but got: {capability_message}"
         )
-        assert "No feature groups found for feature name" not in capability_message, (
-            f"Capability error must be distinguishable from the unknown-feature error, but got: {capability_message}"
+        assert "Feature group(s) eliminated while matching" not in unknown_message, (
+            f"Unknown-feature error must carry no near-miss block, but got: {unknown_message}"
         )
 
-    def test_supported_list_includes_declared_but_not_enabled_framework(self) -> None:
-        """A declared+available+supporting framework appears in 'Supported on' even if not enabled this run.
+    def test_capability_reason_names_only_run_enabled_rejected_framework(self) -> None:
+        """Run-only capability reason: only the run-enabled framework the candidate rejected is named.
 
-        The 'Supported on' list is derived from the candidate's OWN
-        ``compute_framework_definition()`` intersected with availability and
-        ``supports_compute_framework``, NOT from the run-enabled set. Here CapabilityFwA is declared by
-        ``DualDeclaringFG_782`` and available, but only CapabilityFwB is enabled for this run. FwA must
-        still show up as supported on that candidate's line.
+        os-011 (Q2 = run-only) dropped the wider declared-available universe. ``DualDeclaringFG_782``
+        declares {CapabilityFwA, CapabilityFwB} and supports the op on CapabilityFwA, but only CapabilityFwB
+        is enabled for this run and CapabilityFwB is exactly what it rejects. The capability reason names only
+        the run-enabled, rejected CapabilityFwB; the declared-but-not-enabled CapabilityFwA no longer appears.
         """
         feature = Feature(CAPABILITY_FEATURE)
         feature.compute_frameworks = {CapabilityFwB}
@@ -340,18 +342,15 @@ class TestComputeFrameworkCapabilityHook:
             )
 
         error_message = str(exc_info.value)
-        lowered = error_message.lower()
 
-        assert "unsupported" in lowered or "not supported" in lowered, (
-            f"Capability error must signal an unsupported framework, but got: {error_message}"
+        assert "Feature group(s) eliminated while matching" in error_message, (
+            f"Capability rejection must render as a near-miss line, but got: {error_message}"
         )
-        assert CapabilityFwB.get_class_name() in error_message, (
-            f"Error must name the unsupported framework '{CapabilityFwB.get_class_name()}', but got: {error_message}"
+        assert f"supports_compute_framework rejected ['{CapabilityFwB.get_class_name()}']" in error_message, (
+            f"Reason must name the run-enabled rejected framework '{CapabilityFwB.get_class_name()}', "
+            f"but got: {error_message}"
         )
-        assert CapabilityFwA.get_class_name() in error_message, (
-            "Error 'Supported on' list must include the declared+available+supporting framework "
-            f"'{CapabilityFwA.get_class_name()}' even though it was not enabled this run, but got: {error_message}"
-        )
-        assert "Did you mean" not in error_message, (
-            f"Capability error must skip the fuzzy suggestion path, but got: {error_message}"
+        assert CapabilityFwA.get_class_name() not in error_message, (
+            "run-only capability reason must not name the declared-but-not-enabled framework "
+            f"'{CapabilityFwA.get_class_name()}', but got: {error_message}"
         )

--- a/tests/test_core/test_prepare/test_compute_framework_capability.py
+++ b/tests/test_core/test_prepare/test_compute_framework_capability.py
@@ -239,6 +239,11 @@ class TestComputeFrameworkCapabilityHook:
         assert CapabilityFwA.get_class_name() in error_message, (
             f"Error must name the supported framework '{CapabilityFwA.get_class_name()}', but got: {error_message}"
         )
+        # The near-miss block already names the eliminated candidate; a fuzzy suggestion must not echo it.
+        suggestion_line = next((line for line in error_message.split("\n") if line.startswith("Did you mean")), "")
+        assert RejectBCapabilityFeatureGroup.get_class_name() not in suggestion_line, (
+            f"the 'Did you mean' suggestion must not echo the already-named eliminated candidate, got: {error_message}"
+        )
 
     def test_all_frameworks_reject_operation(self) -> None:
         """When every framework rejects the op, a graceful error names the feature."""
@@ -353,4 +358,9 @@ class TestComputeFrameworkCapabilityHook:
         assert CapabilityFwA.get_class_name() not in error_message, (
             "run-only capability reason must not name the declared-but-not-enabled framework "
             f"'{CapabilityFwA.get_class_name()}', but got: {error_message}"
+        )
+        # The eliminated candidate is named in the near-miss block; a fuzzy suggestion must not echo it.
+        suggestion_line = next((line for line in error_message.split("\n") if line.startswith("Did you mean")), "")
+        assert DualDeclaringFG_782.get_class_name() not in suggestion_line, (
+            f"the 'Did you mean' suggestion must not echo the already-named eliminated candidate, got: {error_message}"
         )

--- a/tests/test_core/test_prepare/test_feature_group_scope_resolution.py
+++ b/tests/test_core/test_prepare/test_feature_group_scope_resolution.py
@@ -334,9 +334,9 @@ def test_capability_rejection_error_names_the_scope() -> None:
     """When every framework of the scoped group is capability-rejected, the error names the scope.
 
     The scoped group matches the feature name, but supports_compute_framework
-    rejects all of its frameworks, so the no-match error takes the capability
-    branch. That message must still call out the requested scope, otherwise the
-    scoped request looks like a plain capability failure.
+    rejects all of its frameworks, so the no-match error carries a capability
+    near-miss line. That message must still call out the requested scope, otherwise
+    the scoped request looks like a plain capability failure.
     """
     feature = Feature("subject_token", feature_group=RejectAllScopedSource)
     accessible_plugins: FeatureGroupEnvironmentMapping = {
@@ -351,8 +351,9 @@ def test_capability_rejection_error_names_the_scope() -> None:
             data_access_collection=None,
         )
     message = str(exc_info.value)
-    # Prove the capability branch was taken (guards against a fixture bug).
-    assert "Unsupported compute framework" in message
+    # Prove the capability near-miss was recorded (guards against a fixture bug).
+    assert "Feature group(s) eliminated while matching 'subject_token':" in message
+    assert "supports_compute_framework rejected ['ScopedCapabilityFw']" in message
     assert "Scoped to feature group: 'RejectAllScopedSource'" in message
 
 

--- a/tests/test_core/test_prepare/test_first_pass_rejection_recording.py
+++ b/tests/test_core/test_prepare/test_first_pass_rejection_recording.py
@@ -33,7 +33,7 @@ from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
-from mloda.core.prepare.identify_feature_group import FeatureResolutionError, RenderFacts
+from mloda.core.prepare.identify_feature_group import Elimination, EvaluationResult, FeatureResolutionError
 from tests.test_core.test_prepare.identify_seam import evaluate_or_raise
 
 
@@ -195,15 +195,15 @@ def _reset_recording_state() -> Iterator[None]:
     FACADE_CALLS_OS005R.clear()
 
 
-def _failed_facts(feature: Feature, accessible_plugins: FeatureGroupEnvironmentMapping) -> RenderFacts:
-    """Run one engine attempt that must fail and return the facts its single pass captured."""
+def _failed_result(feature: Feature, accessible_plugins: FeatureGroupEnvironmentMapping) -> EvaluationResult:
+    """Run one engine attempt that must fail and return the structured result its single pass produced."""
     with pytest.raises(FeatureResolutionError) as exc_info:
         evaluate_or_raise(feature=feature, accessible_plugins=accessible_plugins, links=None)
-    return exc_info.value.result.facts
+    return exc_info.value.result
 
 
 class TestFirstPassRejectionRecording:
-    """The failure facts carry the rejections the real match pass produced, without a replay."""
+    """The failure eliminations carry the rejections the real match pass produced, without a replay."""
 
     def test_strict_value_rejection_is_reported_and_the_validator_runs_once(self) -> None:
         """One failed resolution judges the bad value exactly once: match only, no diagnosis replay."""
@@ -213,9 +213,11 @@ class TestFirstPassRejectionRecording:
         )
         accessible_plugins: FeatureGroupEnvironmentMapping = {StrictRecordingFGOs005r: {RecorderFwOneOs005r}}
 
-        facts = _failed_facts(feature, accessible_plugins)
+        result = _failed_result(feature, accessible_plugins)
 
-        assert facts.value_rejections == (("StrictRecordingFGOs005r", STRICT_REJECTION_REASON_OS005R),)
+        assert result.eliminations == {
+            StrictRecordingFGOs005r: Elimination(stage="value_rejection", reason=STRICT_REJECTION_REASON_OS005R)
+        }
         assert VALIDATOR_CALLS_OS005R == [14]
 
     def test_missing_required_option_reason_is_reported_from_the_first_pass(self) -> None:
@@ -223,25 +225,29 @@ class TestFirstPassRejectionRecording:
         feature = Feature(MISSING_OPTION_FEATURE_OS005R)
         accessible_plugins: FeatureGroupEnvironmentMapping = {MissingOptionRecordingFGOs005r: {RecorderFwOneOs005r}}
 
-        facts = _failed_facts(feature, accessible_plugins)
+        result = _failed_result(feature, accessible_plugins)
 
-        assert facts.value_rejections == (("MissingOptionRecordingFGOs005r", MISSING_OPTION_REASON_OS005R),)
+        assert result.eliminations == {
+            MissingOptionRecordingFGOs005r: Elimination(stage="value_rejection", reason=MISSING_OPTION_REASON_OS005R)
+        }
 
     def test_strict_match_guard_rejection_is_reported_from_the_first_pass(self) -> None:
         """A guard rejection on a strict spec records the same message the facade produces."""
         feature = Feature(GUARD_FEATURE_OS005R, Options(context={"guarded_key_os005r": "ok_os005r"}))
         accessible_plugins: FeatureGroupEnvironmentMapping = {GuardRecordingFGOs005r: {RecorderFwOneOs005r}}
 
-        facts = _failed_facts(feature, accessible_plugins)
+        result = _failed_result(feature, accessible_plugins)
 
-        assert facts.value_rejections == (("GuardRecordingFGOs005r", GUARD_REJECTION_REASON_OS005R),)
+        assert result.eliminations == {
+            GuardRecordingFGOs005r: Elimination(stage="value_rejection", reason=GUARD_REJECTION_REASON_OS005R)
+        }
 
     def test_same_named_candidates_each_keep_their_own_recorded_reason(self) -> None:
         """Two candidates sharing a __name__ each report the reason their OWN match produced.
 
         A recording keyed by class name collapses both classes into one first-wins slot: the second
         class's distinct reason is dropped and the shared reason is attributed to both candidates.
-        Scoped per candidate, the facts carry two entries with the same name and two different reasons.
+        Keyed by the class OBJECT, the eliminations carry two entries with the same name and two reasons.
         """
         group_a, group_b = _build_colliding_rejection_groups_os005c()
         feature = Feature(
@@ -259,12 +265,12 @@ class TestFirstPassRejectionRecording:
             group_b: {RecorderFwOneOs005r},
         }
 
-        facts = _failed_facts(feature, accessible_plugins)
+        result = _failed_result(feature, accessible_plugins)
 
-        assert facts.value_rejections == (
-            (COLLIDING_NAME_OS005C, COLLIDE_A_REASON_OS005C),
-            (COLLIDING_NAME_OS005C, COLLIDE_B_REASON_OS005C),
-        )
+        assert result.eliminations == {
+            group_a: Elimination(stage="value_rejection", reason=COLLIDE_A_REASON_OS005C),
+            group_b: Elimination(stage="value_rejection", reason=COLLIDE_B_REASON_OS005C),
+        }
 
 
 class TestEngineNeverCallsTheFacade:
@@ -275,10 +281,10 @@ class TestEngineNeverCallsTheFacade:
         feature = Feature(FACADE_FEATURE_OS005R)
         accessible_plugins: FeatureGroupEnvironmentMapping = {FacadeProbeFGOs005r: {RecorderFwOneOs005r}}
 
-        facts = _failed_facts(feature, accessible_plugins)
+        result = _failed_result(feature, accessible_plugins)
 
         assert FACADE_CALLS_OS005R == []
-        assert facts.value_rejections == ()
+        assert result.eliminations == {}
 
     def test_the_facade_still_answers_standalone_calls(self) -> None:
         """Called directly, the facade keeps working: many tests use it as a diagnostic."""

--- a/tests/test_core/test_prepare/test_identify_feature_group_failure_renderer.py
+++ b/tests/test_core/test_prepare/test_identify_feature_group_failure_renderer.py
@@ -850,7 +850,7 @@ class TestRenderResolutionFailureMessages:
 class TestPerCandidateCorrelation:
     """A candidate's frameworks stay correlated to that candidate, never merged into a union."""
 
-    def test_capability_frameworks_are_never_unioned_across_candidates(self) -> None:
+    def test_near_miss_lines_name_only_each_candidates_own_frameworks(self) -> None:
         """Mirrored candidates: each near-miss line names only its OWN supported framework, never the union."""
         message = _render(capability_scenario())
 
@@ -967,7 +967,7 @@ class TestFactsCapturedDuringEvaluate:
         assert result.failure_kind == "abstract_only"
         assert result.facts.concrete_frameworks == ()
 
-    def test_value_rejections_and_known_names_captured_for_ordinary_none(self) -> None:
+    def test_ordinary_none_records_value_rejection_elimination_and_captures_known_names(self) -> None:
         """The ordinary-none kind records the value rejection as an elimination and captures the name catalog."""
         result = _evaluate(ordinary_none_scenario())
 
@@ -1174,7 +1174,11 @@ class TestSortTiesAreStable:
         assert _render((feature, b_first)) == expected
 
     def test_capability_tie_sorts_by_module_and_ignores_insertion_order(self) -> None:
-        """Same-named capability candidates render module-sorted, whichever way they were inserted."""
+        """Same-named capability candidates render module-sorted, whichever way they were inserted.
+
+        Every close match here is a candidate the near-miss block already named (its class name or prefix), so
+        the 'Did you mean' line is suppressed entirely rather than echoing the eliminated candidates back.
+        """
         group_a, group_b = _build_tie_capability_groups()
         feature = Feature(TIE_CAPABILITY_FEATURE_791, compute_framework="RendererFwThree791")
         both = {RendererFwOne791, RendererFwTwo791}
@@ -1188,10 +1192,11 @@ class TestSortTiesAreStable:
             " is not among its supported ['RendererFwOne791']\n"
             "  - RendererTieFG791 (compute framework pin): pinned compute framework 'RendererFwThree791'"
             " is not among its supported ['RendererFwTwo791']\n"
-            "Did you mean one of: ['RendererTieFG791', 'RendererTieFG791', 'RendererTieFG791_', 'RendererTieFG791_']?\n"
             "Use resolve_feature(name, options=...) to debug feature resolution.\n"
             f"{TROUBLESHOOTING_LINE}"
         )
 
         assert _render((feature, a_first)) == expected
         assert _render((feature, b_first)) == expected
+        # The suppressed suggestion must not echo the already-named eliminated candidate or its prefix.
+        assert "Did you mean" not in _render((feature, a_first))

--- a/tests/test_core/test_prepare/test_identify_feature_group_failure_renderer.py
+++ b/tests/test_core/test_prepare/test_identify_feature_group_failure_renderer.py
@@ -32,6 +32,7 @@ from mloda.core.api.plugin_docs import resolve_feature
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
 from mloda.core.prepare.identify_feature_group import (
     CandidateFrameworks,
+    Elimination,
     EvaluationResult,
     IdentifyFeatureGroupClass,
     RenderFacts,
@@ -691,8 +692,8 @@ FAILING_SCENARIOS: dict[str, Callable[[], Scenario]] = {
 }
 
 # Every (candidate, framework) pair the capability hook may be asked about during one evaluate(), and how
-# often: exactly once. The decision loop splits the ENABLED frameworks, capture only adds the pairs it did
-# not cover, so the union is the candidate's declared+available frameworks and nothing is asked twice.
+# often: exactly once. Run-only: the hook is asked solely over the frameworks the run enabled for the
+# candidate, so a declared-but-disabled framework is never asked about at all.
 CAPABILITY_PAIR_EXPECTATIONS: dict[str, dict[tuple[str, str], int]] = {
     "capability": {
         ("RendererCapabilityAFG791", "RendererFwOne791"): 1,
@@ -702,12 +703,8 @@ CAPABILITY_PAIR_EXPECTATIONS: dict[str, dict[tuple[str, str], int]] = {
     },
     "capability_narrow_enabled": {
         ("RendererNarrowEnabledFG791", "RendererFwOne791"): 1,
-        ("RendererNarrowEnabledFG791", "RendererFwTwo791"): 1,
     },
-    "capability_none_enabled": {
-        ("RendererNoneEnabledFG791", "RendererFwOne791"): 1,
-        ("RendererNoneEnabledFG791", "RendererFwTwo791"): 1,
-    },
+    "capability_none_enabled": {},
 }
 
 
@@ -760,25 +757,29 @@ class TestRenderResolutionFailureMessages:
         )
 
     def test_capability_rejection_renders_one_line_per_candidate(self) -> None:
-        """Each rejecting candidate names its OWN rejected and supported frameworks."""
+        """Each pinned-out candidate names its OWN supported frameworks in one sorted near-miss line."""
         message = _render(capability_scenario())
 
-        assert message == (
-            f"Unsupported compute framework(s) for feature '{CAPABILITY_FEATURE_791}':\n"
-            "  - RendererCapabilityAFG791: ['RendererFwTwo791']. Supported on: ['RendererFwOne791'].\n"
-            "  - RendererCapabilityBFG791: ['RendererFwOne791']. Supported on: ['RendererFwTwo791'].\n"
-            "Pin the feature to a supported compute framework or override supports_compute_framework."
-        )
+        assert message.startswith(f"No feature groups found for feature name: '{CAPABILITY_FEATURE_791}'.")
+        assert (
+            f"Feature group(s) eliminated while matching '{CAPABILITY_FEATURE_791}':\n"
+            "  - RendererCapabilityAFG791 (compute framework pin): pinned compute framework 'RendererFwThree791'"
+            " is not among its supported ['RendererFwOne791']\n"
+            "  - RendererCapabilityBFG791 (compute framework pin): pinned compute framework 'RendererFwThree791'"
+            " is not among its supported ['RendererFwTwo791']"
+        ) in message
 
     def test_abstract_only_names_concrete_implementation_frameworks(self) -> None:
-        """Abstract-only with accessible concrete subclasses names the frameworks they require."""
+        """Abstract-only names the concrete frameworks, then appends the near-miss line for the concrete subclass."""
         message = _render(abstract_with_frameworks_scenario())
 
         assert message == (
             f"No feature groups found for feature name: '{ABSTRACT_FEATURE_791}'. "
             "Its concrete implementations require compute framework(s) "
             "['RendererFwOne791', 'RendererFwTwo791'], "
-            "none of which are available or enabled for this run."
+            "none of which are available or enabled for this run.\n"
+            f"Feature group(s) eliminated while matching '{ABSTRACT_FEATURE_791}':\n"
+            "  - RendererConcreteSubFG791 (compute framework): none of its compute frameworks are enabled for this run"
         )
 
     def test_abstract_only_without_concrete_implementation(self) -> None:
@@ -792,13 +793,13 @@ class TestRenderResolutionFailureMessages:
         )
 
     def test_ordinary_none_renders_rejections_suggestion_and_pointers(self) -> None:
-        """Value rejections, then 'Did you mean', then the resolve_feature and troubleshooting lines."""
+        """The near-miss block, then 'Did you mean', then the resolve_feature and troubleshooting lines."""
         message = _render(ordinary_none_scenario())
 
         lines = message.split("\n")
         assert lines[0] == f"No feature groups found for feature name: '{TYPO_FEATURE_791}'."
-        assert lines[1] == f"Feature group(s) rejected the supplied options while matching '{TYPO_FEATURE_791}':"
-        assert lines[2] == f"  - RendererStrictFG791: {WINDOW_REJECTION_REASON}"
+        assert lines[1] == f"Feature group(s) eliminated while matching '{TYPO_FEATURE_791}':"
+        assert lines[2] == f"  - RendererStrictFG791 (option value): {WINDOW_REJECTION_REASON}"
         assert lines[3].startswith("Did you mean one of: [")
         assert f"'{KNOWN_FEATURE_791}'" in lines[3]
         assert lines[4] == "Use resolve_feature(name, options=...) to debug feature resolution."
@@ -806,20 +807,20 @@ class TestRenderResolutionFailureMessages:
         assert len(lines) == 6
 
     def test_missing_option_rejection_renders_under_the_options_heading(self) -> None:
-        """A MISSING required option is not a wrong value, so the heading must cover both rejection kinds."""
+        """A MISSING required option is a value_rejection too, so it lands in the near-miss block as an option value."""
         scenario = missing_option_scenario()
         feature, _ = scenario
         result = _evaluate(scenario)
 
         assert result.failure_kind == "none"
-        assert result.facts.value_rejections == (("RendererMissingOptionFG791", MISSING_OPTION_REASON_791),)
+        assert result.eliminations == {
+            RendererMissingOptionFG791: Elimination(stage="value_rejection", reason=MISSING_OPTION_REASON_791)
+        }
 
         message = render_resolution_failure(result, feature)
         assert message is not None
-        assert f"Feature group(s) rejected the supplied options while matching '{MISSING_OPTION_FEATURE_791}':" in (
-            message
-        )
-        assert f"  - RendererMissingOptionFG791: {MISSING_OPTION_REASON_791}" in message
+        assert f"Feature group(s) eliminated while matching '{MISSING_OPTION_FEATURE_791}':" in message
+        assert f"  - RendererMissingOptionFG791 (option value): {MISSING_OPTION_REASON_791}" in message
 
     def test_scoped_none_renders_callout_and_scoped_pointer(self) -> None:
         """A scoped no-match carries the scope callout and the scoped resolve_feature pointer."""
@@ -850,14 +851,20 @@ class TestPerCandidateCorrelation:
     """A candidate's frameworks stay correlated to that candidate, never merged into a union."""
 
     def test_capability_frameworks_are_never_unioned_across_candidates(self) -> None:
-        """Mirrored candidates: no line may claim a framework is both supported and unsupported."""
+        """Mirrored candidates: each near-miss line names only its OWN supported framework, never the union."""
         message = _render(capability_scenario())
 
         a_line = next(line for line in message.split("\n") if "RendererCapabilityAFG791" in line)
         b_line = next(line for line in message.split("\n") if "RendererCapabilityBFG791" in line)
 
-        assert a_line == "  - RendererCapabilityAFG791: ['RendererFwTwo791']. Supported on: ['RendererFwOne791']."
-        assert b_line == "  - RendererCapabilityBFG791: ['RendererFwOne791']. Supported on: ['RendererFwTwo791']."
+        assert a_line == (
+            "  - RendererCapabilityAFG791 (compute framework pin): pinned compute framework 'RendererFwThree791'"
+            " is not among its supported ['RendererFwOne791']"
+        )
+        assert b_line == (
+            "  - RendererCapabilityBFG791 (compute framework pin): pinned compute framework 'RendererFwThree791'"
+            " is not among its supported ['RendererFwTwo791']"
+        )
         # The cross-candidate union today's message builds must never appear.
         assert "['RendererFwOne791', 'RendererFwTwo791']" not in message
 
@@ -961,11 +968,13 @@ class TestFactsCapturedDuringEvaluate:
         assert result.facts.concrete_frameworks == ()
 
     def test_value_rejections_and_known_names_captured_for_ordinary_none(self) -> None:
-        """The ordinary-none kind captures the value rejections and the name catalog."""
+        """The ordinary-none kind records the value rejection as an elimination and captures the name catalog."""
         result = _evaluate(ordinary_none_scenario())
 
         assert result.failure_kind == "none"
-        assert result.facts.value_rejections == (("RendererStrictFG791", WINDOW_REJECTION_REASON),)
+        assert result.eliminations == {
+            RendererStrictFG791: Elimination(stage="value_rejection", reason=WINDOW_REJECTION_REASON)
+        }
         assert KNOWN_FEATURE_791 in result.facts.known_names
         assert "RendererKnownNamesFG791" in result.facts.known_names
         assert "RendererStrictFG791_" in result.facts.known_names
@@ -1041,12 +1050,14 @@ class TestFactCaptureNeverTakesEvaluateDown:
 
         assert result.failure_kind == "none"
         assert "RendererRaisingRejectionFG791._strict_validation_rejection_reason" not in HOOK_CALLS
-        assert result.facts.value_rejections == (("RendererStrictFG791", WINDOW_REJECTION_REASON),)
+        assert result.eliminations == {
+            RendererStrictFG791: Elimination(stage="value_rejection", reason=WINDOW_REJECTION_REASON)
+        }
 
         message = render_resolution_failure(result, feature)
         assert message is not None
-        assert f"  - RendererStrictFG791: {WINDOW_REJECTION_REASON}" in message
-        assert "RendererRaisingRejectionFG791:" not in message
+        assert f"  - RendererStrictFG791 (option value): {WINDOW_REJECTION_REASON}" in message
+        assert "RendererRaisingRejectionFG791 (option value)" not in message
 
     def test_raising_compute_framework_rule_falls_back_to_the_bare_abstract_message(self) -> None:
         """No framework name could be captured, so the abstract-only message takes its bare variant."""
@@ -1060,7 +1071,10 @@ class TestFactCaptureNeverTakesEvaluateDown:
         assert render_resolution_failure(result, feature) == (
             f"No feature groups found for feature name: '{RAISING_ABSTRACT_FEATURE_791}'. "
             "Only abstract feature group base(s) matched, which cannot be instantiated; "
-            "no concrete implementation is available or enabled."
+            "no concrete implementation is available or enabled.\n"
+            f"Feature group(s) eliminated while matching '{RAISING_ABSTRACT_FEATURE_791}':\n"
+            "  - RendererRaisingConcreteSubFG791 (compute framework): "
+            "none of its compute frameworks are enabled for this run"
         )
 
     def test_resolve_feature_still_reports_candidates_when_get_domain_raises(self) -> None:
@@ -1079,15 +1093,15 @@ class TestFactCaptureNeverTakesEvaluateDown:
 
 
 class TestCapabilityRenderingUniverse:
-    """The capability message keeps today's universe: the candidate's DECLARED frameworks that are available.
+    """Run-only: the capability near-miss names ONLY the run-enabled frameworks the candidate rejected.
 
     ``candidate_frameworks`` is the decision fact and stays the run's own (narrower) split of the
-    frameworks that were enabled. Rendering must not inherit that narrowing, or a candidate loses the
-    'Supported on' clause it has today, and an all-disabled candidate flips to the ordinary-none message.
+    frameworks that were enabled. Rendering inherits that narrowing: a declared-but-not-enabled framework
+    is never named, and an all-disabled candidate renders under the ordinary-none message.
     """
 
     def test_not_enabled_framework_still_renders_as_supported(self) -> None:
-        """Shape A: the supported framework is available but not enabled, and must still be named."""
+        """Shape A: only the enabled framework is named; the supported-but-not-enabled one is dropped."""
         scenario = capability_narrow_enabled_scenario()
         feature, _ = scenario
 
@@ -1099,14 +1113,18 @@ class TestCapabilityRenderingUniverse:
                 supported=frozenset(), rejected=frozenset({RendererFwOne791})
             )
         }
-        assert render_resolution_failure(result, feature) == (
-            f"Unsupported compute framework(s) for feature '{NARROW_ENABLED_FEATURE_791}':\n"
-            "  - RendererNarrowEnabledFG791: ['RendererFwOne791']. Supported on: ['RendererFwTwo791'].\n"
-            "Pin the feature to a supported compute framework or override supports_compute_framework."
-        )
+        message = render_resolution_failure(result, feature)
+        assert message is not None
+        assert message.startswith(f"No feature groups found for feature name: '{NARROW_ENABLED_FEATURE_791}'.")
+        assert (
+            "  - RendererNarrowEnabledFG791 (compute framework): "
+            "supports_compute_framework rejected ['RendererFwOne791']"
+        ) in message
+        # The declared-but-not-enabled framework is no longer part of the run-only universe.
+        assert "RendererFwTwo791" not in message
 
     def test_no_enabled_framework_still_renders_the_capability_message(self) -> None:
-        """Shape B: an empty accessible set must not flip the failure to the ordinary-none message."""
+        """Shape B: nothing enabled renders the frameworks_not_enabled near-miss under the ordinary-none message."""
         scenario = capability_none_enabled_scenario()
         feature, _ = scenario
 
@@ -1118,12 +1136,12 @@ class TestCapabilityRenderingUniverse:
         }
         message = render_resolution_failure(result, feature)
 
-        assert message == (
-            f"Unsupported compute framework(s) for feature '{NONE_ENABLED_FEATURE_791}':\n"
-            "  - RendererNoneEnabledFG791: ['RendererFwOne791']. Supported on: ['RendererFwTwo791'].\n"
-            "Pin the feature to a supported compute framework or override supports_compute_framework."
-        )
-        assert "No feature groups found" not in message
+        assert message is not None
+        assert message.startswith(f"No feature groups found for feature name: '{NONE_ENABLED_FEATURE_791}'.")
+        assert (
+            "  - RendererNoneEnabledFG791 (compute framework): none of its compute frameworks are enabled for this run"
+        ) in message
+        assert "RendererFwTwo791" not in message
 
     @pytest.mark.parametrize("scenario_name", sorted(CAPABILITY_PAIR_EXPECTATIONS))
     def test_capability_hook_is_asked_once_per_candidate_framework_pair(self, scenario_name: str) -> None:
@@ -1164,10 +1182,15 @@ class TestSortTiesAreStable:
         b_first: FeatureGroupEnvironmentMapping = {group_b: set(both), group_a: set(both)}
 
         expected = (
-            f"Unsupported compute framework(s) for feature '{TIE_CAPABILITY_FEATURE_791}':\n"
-            "  - RendererTieFG791: ['RendererFwTwo791']. Supported on: ['RendererFwOne791'].\n"
-            "  - RendererTieFG791: ['RendererFwOne791']. Supported on: ['RendererFwTwo791'].\n"
-            "Pin the feature to a supported compute framework or override supports_compute_framework."
+            f"No feature groups found for feature name: '{TIE_CAPABILITY_FEATURE_791}'.\n"
+            f"Feature group(s) eliminated while matching '{TIE_CAPABILITY_FEATURE_791}':\n"
+            "  - RendererTieFG791 (compute framework pin): pinned compute framework 'RendererFwThree791'"
+            " is not among its supported ['RendererFwOne791']\n"
+            "  - RendererTieFG791 (compute framework pin): pinned compute framework 'RendererFwThree791'"
+            " is not among its supported ['RendererFwTwo791']\n"
+            "Did you mean one of: ['RendererTieFG791', 'RendererTieFG791', 'RendererTieFG791_', 'RendererTieFG791_']?\n"
+            "Use resolve_feature(name, options=...) to debug feature resolution.\n"
+            f"{TROUBLESHOOTING_LINE}"
         )
 
         assert _render((feature, a_first)) == expected

--- a/tests/test_core/test_prepare/test_single_pass_exactly_once.py
+++ b/tests/test_core/test_prepare/test_single_pass_exactly_once.py
@@ -985,7 +985,7 @@ class TestDecisionHooksRunAtMostOncePerCandidate:
         message = _engine_error(scenario)
 
         assert _counts_for("_strict_validation_rejection_reason") == {}
-        assert f"  - SinglePassStrictFG_782: {STRICT_REJECTION_REASON_782}" in message
+        assert f"  - SinglePassStrictFG_782 (option value): {STRICT_REJECTION_REASON_782}" in message
 
     def test_resolve_feature_renders_the_value_rejection_from_the_first_pass_without_the_hook(self) -> None:
         """Same contract across the diagnostic API: rendered from the first pass, hook not consulted."""
@@ -994,7 +994,7 @@ class TestDecisionHooksRunAtMostOncePerCandidate:
         message = _resolve_error(scenario)
 
         assert _counts_for("_strict_validation_rejection_reason") == {}
-        assert f"  - SinglePassStrictFG_782: {STRICT_REJECTION_REASON_782}" in message
+        assert f"  - SinglePassStrictFG_782 (option value): {STRICT_REJECTION_REASON_782}" in message
 
     def test_engine_asks_a_reader_style_matcher_once_per_candidate(self) -> None:
         """A matcher that consults a DataAccessCollection is asked once, like any other."""

--- a/tests/test_core/test_prepare/test_single_pass_exactly_once.py
+++ b/tests/test_core/test_prepare/test_single_pass_exactly_once.py
@@ -44,7 +44,10 @@ from mloda.core.api import plugin_docs
 from mloda.core.api.plugin_docs import resolve_feature
 from mloda.core.prepare import identify_feature_group
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping, PreFilterPlugins
-from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass, render_resolution_failure
+from mloda.core.prepare.identify_feature_group import (
+    IdentifyFeatureGroupClass,
+    render_resolution_failure,
+)
 from tests.test_core.test_prepare.identify_seam import evaluate_or_raise
 
 
@@ -853,7 +856,9 @@ class TestEngineAndResolveFeatureAgree:
         if "multiple" in scenario_name:
             assert message.startswith("Multiple feature groups found for feature")
         elif "capability" in scenario_name:
-            assert message.startswith("Unsupported compute framework(s) for feature")
+            # Capability rejection is now a near-miss line under the ordinary none message, not its own message.
+            assert message.startswith("No feature groups found for feature name:")
+            assert "(compute framework): supports_compute_framework rejected" in message
         else:
             assert message.startswith("No feature groups found for feature name:")
 
@@ -928,12 +933,11 @@ class TestDecisionHooksRunAtMostOncePerCandidate:
         }
 
     def test_engine_asks_the_capability_hook_once_per_candidate_framework_pair(self) -> None:
-        """The decision loop split the enabled framework; capture may only ask about the declared rest."""
+        """Run-only: the hook is asked solely over the run-enabled frameworks, so the disabled FwTwo is dropped."""
         _engine_error(capability_scenario())
 
         assert PAIR_CALLS == {
             ("SinglePassCapabilityRejectFG_782", "SinglePassFwOne_782"): 1,
-            ("SinglePassCapabilityRejectFG_782", "SinglePassFwTwo_782"): 1,
         }
 
     def test_resolve_feature_asks_the_capability_hook_once_per_candidate_framework_pair(self) -> None:
@@ -942,14 +946,13 @@ class TestDecisionHooksRunAtMostOncePerCandidate:
 
         assert PAIR_CALLS == {
             ("SinglePassCapabilityRejectFG_782", "SinglePassFwOne_782"): 1,
-            ("SinglePassCapabilityRejectFG_782", "SinglePassFwTwo_782"): 1,
         }
 
     def test_engine_asks_the_capability_hook_once_for_the_abstract_only_concrete_subclass(self) -> None:
-        """The subclass declares one framework the run disabled: capture asks about it once, and only it."""
+        """Run-only: the subclass declares only a run-disabled framework, so the hook is not asked at all."""
         _engine_error(abstract_only_scenario())
 
-        assert PAIR_CALLS == {("SinglePassConcreteSubFG_782", "SinglePassFwTwo_782"): 1}
+        assert PAIR_CALLS == {}
 
     def test_engine_asks_the_link_hooks_once_per_candidate_and_index(self) -> None:
         """index_columns is per candidate; supports_index is per (candidate, index)."""
@@ -1016,7 +1019,7 @@ class TestStatefulHookCannotChangeTheResultOrItsMessage:
         resolve_message = _resolve_error(stateful_match_scenario())
 
         assert engine_message == resolve_message
-        assert engine_message.startswith("Unsupported compute framework(s) for feature")
+        assert engine_message.startswith("No feature groups found for feature name:")
         assert "SinglePassFwOne_782" in engine_message
 
     def test_stateful_matcher_keeps_its_candidate_in_resolve_feature(self) -> None:
@@ -1031,7 +1034,7 @@ class TestStatefulHookCannotChangeTheResultOrItsMessage:
 
         assert resolved.error is not None
         assert [candidate.get_class_name() for candidate in resolved.candidates] == ["SinglePassStatefulMatchFG_782"]
-        assert resolved.error.startswith("Unsupported compute framework(s) for feature")
+        assert resolved.error.startswith("No feature groups found for feature name:")
 
     def test_stateful_capability_hook_message_describes_the_first_answer(self) -> None:
         """First answer: the framework is rejected. A later 'supported' answer must not rewrite the message."""
@@ -1040,7 +1043,7 @@ class TestStatefulHookCannotChangeTheResultOrItsMessage:
         resolve_message = _resolve_error(stateful_support_scenario())
 
         assert engine_message == resolve_message
-        assert engine_message.startswith("Unsupported compute framework(s) for feature")
+        assert engine_message.startswith("No feature groups found for feature name:")
         assert "SinglePassFwOne_782" in engine_message
 
     def test_stateful_capability_hook_is_asked_once_per_pair(self) -> None:
@@ -1177,7 +1180,7 @@ class TestMalformedHookValuesDegradeLikeARaise:
         assert message.startswith(f"No feature groups found for feature name: '{BAD_CATALOG_FEATURE_782}'.")
         assert TROUBLESHOOTING_LINE_782 in message
 
-    def test_a_hostile_rejection_hook_cannot_inject_a_reason_into_the_facts(self) -> None:
+    def test_a_hostile_rejection_hook_cannot_inject_a_reason_into_the_eliminations(self) -> None:
         """Two same-named groups override the hook, one with a non-str reason: neither is consulted.
 
         The old hazard was a sorted() over hook-provided reasons, where two same-named candidates forced
@@ -1195,8 +1198,9 @@ class TestMalformedHookValuesDegradeLikeARaise:
         result = IdentifyFeatureGroupClass.evaluate(feature=feature, accessible_plugins=accessible_plugins, links=None)
         message = render_resolution_failure(result, feature)
 
+        # These matchers name-mismatch and record nothing, so no reason (malformed or not) is ever attributed.
         assert _counts_for("_strict_validation_rejection_reason") == {}
-        assert result.facts.value_rejections == ()
+        assert result.eliminations == {}
         assert message is not None
         assert HEALTHY_REJECTION_REASON_782 not in message
         assert str(BAD_REASON_VALUE_782) not in message

--- a/tests/test_core/test_prepare/test_subtype_matching.py
+++ b/tests/test_core/test_prepare/test_subtype_matching.py
@@ -213,8 +213,10 @@ class TestMatchTimeIntegration:
             _identify(feature, accessible_plugins)
 
         message = str(exc_info.value)
-        lowered = message.lower()
-        assert "unsupported" in lowered or "not supported" in lowered, (
+        assert "compute framework pin" in message, (
+            f"Error must signal a rejected compute-framework pin, but got: {message}"
+        )
+        assert "is not among its supported" in message, (
             f"Error must signal an unsupported framework, but got: {message}"
         )
         assert SubDeclMatchFwBeta.get_class_name() in message


### PR DESCRIPTION
## What

Per-candidate elimination reasons in resolution failure facts (os-011, was #854; part of #760).

Candidates eliminated by a compute-framework pin, the link filter, frameworks the run did not enable, capability rejection, an option-value rejection, or a domain/scope mismatch previously vanished from failure messages, leaving a generic "No feature groups found". They are now recorded during the single resolution pass and named in the message.

## Changes

- `EvaluationResult.eliminations`: a per-candidate `Elimination(stage, reason)` recorded at the first gate each non-winning, name-matching candidate fails, within the single decision pass.
- Failure messages gain a shared near-miss block naming each eliminated candidate and its reason (option value, domain, scope, compute framework, compute framework pin, links).
- The capture/render precedence duplication is gone: the renderer alone owns precedence and projects the recorded eliminations; rendering calls no provider-overridable hook.
- Capability reasons name only the run-enabled frameworks (no wider declared-but-disabled universe); the standalone "Unsupported compute framework(s)" message folds into the near-miss block.

## Review

Two independent deep reviews (Claude Opus and codex) ran on the first commit. Accepted findings fixed in the second commit: `value_rejection` is recorded only for criteria-failing candidates (matched or winning candidates are never re-probed, and a losing rejector is captured even when a sibling wins), "Did you mean" suggestions that only echo a named near-miss are suppressed, the scope callout is no longer glued to a near-miss bullet, and the resolution-error docs are refreshed.

## Testing

`tox` green: 7153 passed, 170 skipped; ruff format/check clean; pip-licenses clean; mypy --strict clean (882 files); bandit OK.
