### PR TITLE
fix: contain malformed prefix patterns

### DIFF
--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -1089,9 +1089,11 @@ class FeatureChainParser:
                 patterns = FeatureChainParser._flatten_patterns(FeatureChainParser.prefix_patterns_of(guarded_cls))
                 parsed = safe_field(
                     lambda: FeatureChainParser.parse_name(feature_name, patterns, CHAIN_SEPARATOR),
-                    ParsedFeatureName.no_match(),
-                    catching=(ValueError,),
+                    None,
+                    catching=(ValueError, re.error),
                 )
+                if parsed is None:
+                    return False
                 if not FeatureChainParser._name_identifies_group(parsed, mapping):
                     return True
                 bindings = FeatureChainParser.bind_name_captures(parsed, mapping)

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -1085,15 +1085,15 @@ class FeatureChainParser:
                     return True
                 # Flattened, because a matcher passes a list-valued pattern attribute straight to
                 # parse_name, so its ELEMENTS are the concrete patterns. A matcher must never leak
-                # an exception, so the parse is contained exactly as in build_effective_options.
+                # an exception, so the parse is contained as in build_effective_options; re.error is
+                # additionally caught here because a malformed pattern must degrade to a non-match
+                # of the name path, never veto the inner verdict (#868).
                 patterns = FeatureChainParser._flatten_patterns(FeatureChainParser.prefix_patterns_of(guarded_cls))
                 parsed = safe_field(
                     lambda: FeatureChainParser.parse_name(feature_name, patterns, CHAIN_SEPARATOR),
-                    None,
+                    ParsedFeatureName.no_match(),
                     catching=(ValueError, re.error),
                 )
-                if parsed is None:
-                    return False
                 if not FeatureChainParser._name_identifies_group(parsed, mapping):
                     return True
                 bindings = FeatureChainParser.bind_name_captures(parsed, mapping)

--- a/tests/test_core/test_prepare/test_subtype_option_parity.py
+++ b/tests/test_core/test_prepare/test_subtype_option_parity.py
@@ -161,6 +161,12 @@ class TestSbparPropertyMappingDefaultParity:
 class TestSbparMalformedPrefixPatternNeverRaises:
     """resolve_subtype degrades to None on a malformed PREFIX_PATTERN instead of raising re.error."""
 
+    def test_matcher_degrades_malformed_pattern_to_non_match(self) -> None:
+        assert (
+            SbparBadPrefixFG.match_feature_group_criteria(FeatureName(SbparBadPrefixFG.get_class_name()), Options())
+            is False
+        )
+
     def test_resolve_subtype_returns_none_for_chained_name(self) -> None:
         assert SbparBadPrefixFG.resolve_subtype("value__sum_x", Options()) is None
 

--- a/tests/test_core/test_prepare/test_subtype_option_parity.py
+++ b/tests/test_core/test_prepare/test_subtype_option_parity.py
@@ -161,10 +161,10 @@ class TestSbparPropertyMappingDefaultParity:
 class TestSbparMalformedPrefixPatternNeverRaises:
     """resolve_subtype degrades to None on a malformed PREFIX_PATTERN instead of raising re.error."""
 
-    def test_matcher_degrades_malformed_pattern_to_non_match(self) -> None:
+    def test_matcher_contains_malformed_pattern_and_keeps_class_name_match(self) -> None:
         assert (
             SbparBadPrefixFG.match_feature_group_criteria(FeatureName(SbparBadPrefixFG.get_class_name()), Options())
-            is False
+            is True
         )
 
     def test_resolve_subtype_returns_none_for_chained_name(self) -> None:


### PR DESCRIPTION
## Summary

Malformed `PREFIX_PATTERN` regular expressions now degrade to a non-match instead of leaking `re.PatternError` from the name-path presence guard. A focused regression covers the reported matcher path.

## Related issue

Closes #868

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Documentation (`docs:`)
- [ ] Refactor / maintenance (`refactor:` / `chore:`)
- [ ] Other (explain below)

## Checklist

- [ ] `tox` passes locally (tests, `ruff format --check`, `ruff check`, `mypy --strict`, `bandit`, license check)
- [x] Tests added or updated for the change (and the skip count adjusted if needed)
- [x] Documentation updated where relevant
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
