### PR TITLE
test: consolidate PROPERTY_MAPPING suites around a public behavior matrix (#799)

### DIFF
--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/PROPERTY_MAPPING_TEST_MATRIX.md
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/PROPERTY_MAPPING_TEST_MATRIX.md
@@ -1,0 +1,57 @@
+# PROPERTY_MAPPING test behavior matrix
+
+The map for the PROPERTY_MAPPING / PropertySpec hardening suite (mloda#750 epic, phase 7).
+Each behavior is owned by a public-boundary test; private-helper tests survive only where the
+helper is itself an intentional contract (listed at the end). Keep this file in step when tests move.
+
+Public boundaries: `FeatureGroup.match_feature_group_criteria`, `FeatureChainParser.parse_feature_name`
+/ `extract_property_values` / `build_effective_options`, `FeatureGroup.options_with_defaults`,
+`option_key_is_present`, the identify engine (`identify_winner` / `evaluate_or_raise`), and
+`mloda.run_all` / compute.
+
+## Axes
+
+| Axis | Values | Owning tests |
+|---|---|---|
+| Match path | config (options only), name (string-named), bare name | `test_name_path_validates_option_values.py` (config / name / bare name), `test_property_mapping_enforced_validators.py` (config + name per key) |
+| Option source | group, context | `test_options_with_defaults.py` (group vs context fill), `test_retire_transitional_seams.py::TestOptionKeyIsPresentContextStorage` |
+| Presence | absent, present-as-None (flagless -> absent), explicit None opt-in -> present, present | `test_explicit_none_opt_in.py`, `test_retire_transitional_seams.py::TestOptionKeyIsPresent*`, `test_property_mapping_enforced_validators.py::TestStrictValidationDoesNotMakeKeysRequired` |
+| Required / conditional | required, `required_when` predicate, `default`, optional | `test_property_mapping_required_when.py`, `test_property_spec_builder.py` (default-based `_can_skip_required_check` verdicts), `test_universal_optional_matcher.py` (`required_when` / conditional verdicts) |
+| Value shape | scalar, list/tuple/set/frozenset, empty container, string (scalar), dict (composite) | `test_property_mapping_sequence_unpacking.py` (core), `test_property_mapping_container_invariance.py` (shipped plugins) |
+| Value space | `allowed_values` membership, `element_validator` (per element), `match_guard` (raw value) | `test_property_mapping_allowed_values.py`, `test_property_mapping_type_constraints.py`, `test_property_mapping_unified_model.py` |
+| Callback outcome | returns True/False, raises (expected TypeError, broken-looking KeyError, AttributeError) | `test_option_value_rejection_never_escapes.py` (containment + DEBUG/WARNING tiers + cause chaining) |
+| Diagnostics | rejection reason surfaced, recorded on first pass, no phantom reason for unrelated groups | `test_option_value_rejection_never_escapes.py` (identify carries reason), `test_property_mapping_enforced_validators.py::TestRejectedValueNamedInResolutionError`, render layer under `test_prepare/` |
+| Defaults lifecycle | pure `options_with_defaults` view; central materialization at compute | `test_options_with_defaults.py` (view), `test_materialize_defaults_boundary.py` (`calculate_feature` boundary) |
+| Construction time | constructor is the schema, shape rules fire in the class body, one default check | `test_property_mapping_spec_schema.py`, `test_property_mapping_spec_shape.py`, `test_property_mapping_unified_model.py::TestOneDefaultCheckImplementation` |
+| Definition-time diagnostics | universal all-optional matcher warning, probe containment | `test_universal_optional_matcher.py` |
+
+## Intentional private-helper contracts (kept on purpose)
+
+- `_strict_validation_rejection_reason` (diagnostic facade): asserted directly where the public
+  identify path cannot reach the value range, because some invalid values collide with feature-name
+  tokens (see the `reported_invalid_value` note in `test_property_mapping_enforced_validators.py`).
+  Kept for the collision-free reason content and for the "no phantom reason for an unrelated group"
+  scoping contract.
+- `option_key_is_present`: module-level, public; the one #768 presence helper
+  (`test_retire_transitional_seams.py`).
+- `_can_skip_required_check` truth table: owned by `test_property_spec_builder.py`.
+- `_UNIVERSAL_MATCHER_PROBE_NAME` and the probe DEBUG record: #771 definition-time machinery
+  (`test_universal_optional_matcher.py`).
+
+## Retired seams (absence pinned, in one place)
+
+`test_retire_transitional_seams.py::TestTransitionalSeamsAreGone` pins that the deleted private
+wrappers stay gone: `_is_context_parameter`, `_is_strict_validation`, `_get_element_validator`,
+`_get_validation_function`, the `_extract_property_values` alias, the `_validate_type_validators`
+rename, and the mixin `_build_effective_options` pass-through.
+
+## Deferred (documented, not silently dropped)
+
+- FeatureGroup-shape parametrization: single-key `element_validator` / `match_guard` / membership /
+  `required_when` shapes recur across `test_property_mapping_sequence_unpacking.py`,
+  `test_property_mapping_unified_model.py`, and `test_property_mapping_type_constraints.py`. Not
+  collapsed here: several sibling files run autouse registry-leak guards and the local-subclass GC
+  race is a known flake source (mloda#868), so moving these classes into shared modules needs its
+  own change. The behavior is already owned above; the remaining duplication is organizational.
+- Cross-layer `_strict_validation_rejection_reason` coverage in the `test_prepare/` render layer is
+  the public reason surface and stays where it is.

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_unified_model.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_mapping_unified_model.py
@@ -36,9 +36,6 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import PropertySpec, property_spec
 
-STALE_ELEMENT_VALIDATOR_NAME = "validation_function"
-STALE_MATCH_GUARD_NAME = "type_validator"
-
 
 def _construct(*args: Any, **kwargs: Any) -> PropertySpec:
     """Call ``PropertySpec`` through an untyped seam, keeping the stale-keyword tests mypy-clean."""
@@ -113,6 +110,8 @@ class TestValidatorFieldNames:
 
         assert spec.element_validator is _positive_int
         assert spec.match_guard is _positive_int
+        assert PropertySpec("x").element_validator is None
+        assert PropertySpec("x").match_guard is None
 
     def test_stale_validation_function_name_is_a_type_error(self) -> None:
         """``validation_function`` is an unknown keyword on the constructor and the builder."""
@@ -127,23 +126,6 @@ class TestValidatorFieldNames:
             _construct("cols", type_validator=_positive_int)
         with pytest.raises(TypeError):
             _build("cols", type_validator=_positive_int)
-
-
-class TestRenamedInternalHelpers:
-    """The internal helpers follow the field names, so the vocabulary is consistent end to end."""
-
-    def test_element_validator_is_read_from_the_field(self) -> None:
-        """``PropertySpec.element_validator`` is the field callers read; the old getter name is gone."""
-        assert not hasattr(FeatureChainParser, f"_get_{STALE_ELEMENT_VALIDATOR_NAME}")
-
-        spec = PropertySpec("Size of the time window", strict_validation=True, element_validator=_positive_int)
-        assert spec.element_validator is _positive_int
-        assert PropertySpec("x").element_validator is None
-
-    def test_mixin_exposes_validate_match_guards(self) -> None:
-        """``FeatureChainParserMixin._validate_match_guards`` replaces ``_validate_type_validators``."""
-        assert not hasattr(FeatureChainParserMixin, "_validate_type_validators")
-        assert hasattr(FeatureChainParserMixin, "_validate_match_guards")
 
 
 class TestElementValidatorSemantics:

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_retire_transitional_seams.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_retire_transitional_seams.py
@@ -115,6 +115,15 @@ class TestTransitionalSeamsAreGone:
         """The mixin pass-through is gone: call ``FeatureChainParser.build_effective_options``."""
         assert not hasattr(FeatureChainParserMixin, "_build_effective_options")
 
+    def test_get_validation_function_is_gone(self) -> None:
+        """The pre-rename ``_get_validation_function`` getter is gone: read ``spec.element_validator``."""
+        assert not hasattr(FeatureChainParser, "_get_validation_function")
+
+    def test_validate_type_validators_rename_is_gone(self) -> None:
+        """``_validate_type_validators`` was renamed to ``_validate_match_guards`` on the mixin."""
+        assert not hasattr(FeatureChainParserMixin, "_validate_type_validators")
+        assert hasattr(FeatureChainParserMixin, "_validate_match_guards")
+
 
 class TestPublicSurvivorsStay:
     """The public canonical names the wrappers delegated to keep existing."""

--- a/tests/test_plugins/feature_group/experimental/test_property_mapping_container_invariance.py
+++ b/tests/test_plugins/feature_group/experimental/test_property_mapping_container_invariance.py
@@ -44,12 +44,8 @@ def _text_cleaning_options(operations: Any) -> Options:
 
 
 class TestTextCleaningOperationsAreValidatedPerElement:
-    """Each cleaning operation is validated individually against ``SUPPORTED_OPERATIONS``.
-
-    The plugin's ``element_validator`` currently string-parses a stringified tuple back
-    apart (``op.strip("'\\" ,")``) because core used to stringify tuples. That workaround
-    only ever worked for tuples: a list of the very same operations does not match today.
-    """
+    """Each cleaning operation is validated individually against ``SUPPORTED_OPERATIONS``: the same
+    operations match whether the caller writes a list, a tuple or a frozenset (issue #600)."""
 
     @pytest.mark.parametrize(("label", "operations"), VALID_OPERATIONS, ids=[label for label, _ in VALID_OPERATIONS])
     def test_supported_operations_match_in_any_container(self, label: str, operations: Any) -> None:
@@ -71,19 +67,6 @@ class TestTextCleaningOperationsAreValidatedPerElement:
             assert TextCleaningFeatureGroup.match_feature_group_criteria(
                 "placeholder", _text_cleaning_options([operation])
             ), f"{operation} must be accepted"
-
-    def test_operations_validator_is_a_plain_per_element_membership_check(self) -> None:
-        """The declared ``element_validator`` judges ONE operation, not a container of them.
-
-        Calling it with a whole container must not be how it works: it receives an
-        element. This is what lets the plugin's lambda collapse to a membership check.
-        """
-        spec = TextCleaningFeatureGroup.PROPERTY_MAPPING[TextCleaningFeatureGroup.CLEANING_OPERATIONS]
-        validator = spec.element_validator
-
-        assert validator is not None
-        assert validator("normalize") is True
-        assert validator("bogus_operation") is False
 
 
 class TestGeoDistanceInFeaturesContainerInvariance:

--- a/tests/test_plugins/feature_group/experimental/test_property_mapping_enforced_validators.py
+++ b/tests/test_plugins/feature_group/experimental/test_property_mapping_enforced_validators.py
@@ -263,19 +263,6 @@ class TestMatchGuardRejectionIsReportable:
         assert str(invalid_value) in reason
 
     @pytest.mark.parametrize("case", _case_params())
-    def test_string_named_path_reports_nothing_for_valid_value(self, case: KeyCase) -> None:
-        """No false positives: a value the guard accepts has nothing to report."""
-        reason = case.feature_group._strict_validation_rejection_reason(
-            case.string_feature_name, case.options(case.valid_value)
-        )
-        assert reason is None
-
-    @pytest.mark.parametrize("case", _case_params())
-    def test_string_named_path_reports_nothing_when_key_is_absent(self, case: KeyCase) -> None:
-        """No false positives: an absent key is not a rejection."""
-        assert case.feature_group._strict_validation_rejection_reason(case.string_feature_name, Options()) is None
-
-    @pytest.mark.parametrize("case", _case_params())
     def test_no_guard_rejection_reported_for_unrelated_feature_name(self, case: KeyCase) -> None:
         """A feature group that does not match the name at all must not report its guards.
 


### PR DESCRIPTION
## Summary

Phase 7 cleanup for the PROPERTY_MAPPING hardening epic (os-006, was #799). Consolidates the PROPERTY_MAPPING test suite around an explicit public-behavior matrix and retires duplicate private-helper coverage, with no production change and no loss of unique regression protection.

## Changes

- **Behavior matrix doc** (`PROPERTY_MAPPING_TEST_MATRIX.md`): maps each behavior axis (match path, option source, presence, required/conditional, value shape, value space, callback outcome, diagnostics, defaults lifecycle, construction) to its owning public-boundary test. Records the private-helper tests deliberately kept as intentional contracts, the retired seams, and the deferred fixture-parametrization work with its rationale.
- **Centralize transitional seam-absence pins**: move the `_get_validation_function` gone and `_validate_type_validators` -> `_validate_match_guards` rename pins out of `test_property_mapping_unified_model.py` into `test_retire_transitional_seams.py`, next to the os-005 seam-absence pins they belong with. The public field-default assertion is preserved on the fields test.
- **Drop a private-lambda pin**: `test_property_mapping_container_invariance.py` no longer pins the plugin `element_validator` lambda directly; its three public sibling tests and core `test_property_mapping_sequence_unpacking.py` own that per-element contract.
- **Drop two shipped-plugin facade duplicates**: the "reason is None for a valid or absent value" pair in `test_property_mapping_enforced_validators.py`; that contract is core-owned in `test_name_path_validates_option_values.py`.
- Remove the stale-name constants left unreferenced by the above.

## Coverage preservation

Net change over the 15 PROPERTY_MAPPING test files: 529 -> 514 collected node ids. Every removed or moved test traces to a surviving public or core boundary that asserts the same behavior; the two seam-absence pins are relocated, not deleted. No new module-level FeatureGroup subclasses, so no added registry-leak surface.

## Validation

- `tox` green: 7147 passed, 170 skipped (skip count unchanged), ruff format + check, pip-licenses, `mypy --strict`, and bandit all pass.
- Two independent deep reviews (a fresh Claude Opus reviewer and codex): both confirm no coverage silently dropped and no production behavior change. Matrix wording nits raised by the Opus review were fixed; the dropped element-validator-shape pin was accepted as intended per the ticket (not an intentional contract).

Test refactor only.
