### PR TITLE
docs: refresh memory bank for PropertySpec hardening (os-007)

### DIFF
--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,49 +1,25 @@
 # Active Context
 
-## Current Status
-
-```mermaid
-timeline
-    title Recent Completions
-    
-    2025-06 : Spark Framework
-            : Iceberg Framework
-            : DuckDB Framework
-            
-    2025-07 : Options Refactoring
-            : Group/Context Separation
-            
-    2025-08 : Sklearn Pipeline
-            : Feature Groups
-            : Artifact Storage
-```
-
 ## Current Work Focus
 
-✅ **Phase 1 Completed: Options Object Refactoring**
-- Implemented group/context parameter separation
-- Feature Groups now correctly split only on isolation-requiring parameters
-- Full backward compatibility maintained
+The active initiative is the **PROPERTY_MAPPING / PropertySpec consumption hardening** epic (from the mloda#750 audit): make the typed option contract safe from authoring through compute, migrate downstream plugins, and retire transitional code.
 
-✅ **Sklearn Pipeline Feature Group**
-- File-based artifact storage with joblib
-- Comprehensive pipeline management
-- 43 test cases, all passing
+Core hardening is complete and the full `tox` gate is green (170 skipped, plus format, lint, licenses, strict mypy, and bandit).
+
+## Status
+
+- ✅ Typed `PropertySpec` is the sole `PROPERTY_MAPPING` contract; raw-dict specs are a hard break.
+- ✅ Defaults are materialized once at the central compute boundary (framework-enforced), with opt-in explicit-`None` semantics.
+- ✅ Structured name parsing and explicit capture-to-spec binding replace reverse lookup and fabricated captureless tokens.
+- ✅ Required-presence enforcement on the string-named match path; all-optional universal-matcher guard.
+- ✅ Resolution failures carry per-candidate elimination facts (`EvaluationResult`).
+- ✅ Post-hardening cleanup: retired transitional parser seams (os-005) and consolidated the `PROPERTY_MAPPING` test suite around a public behavior matrix (os-006).
 
 ## Next Steps
 
-- Add integration tests for filtering with compute frameworks
-- Phase 2: Individual sklearn transformation feature groups
-- Continue feature group parameter migration
+- **os-008**: decide effective-options materialization placement and default-equivalent twin canonicalization (follow-up from the #796 / #803 reviews).
+- **Phase 6 downstream** (owning repos): migrate mloda-registry raw mappings and captureless patterns, align declared value spaces with runtime behavior, scaffold the plugin-template example, and refresh mloda.ai samples before raising the registry `>=0.10,<0.11` cap.
 
-## Active Architecture
+## Architecture Snapshot
 
-```mermaid
-flowchart TD
-    Options --> |group| Isolation[Feature Group Splitting]
-    Options --> |context| Metadata[Algorithm Parameters]
-    
-    Isolation --> |Different Sources| Split[Separate Resolution]
-    Metadata --> |Same Group| Together[Resolve Together]
-    
-    style Options fill:#bbf,stroke:#333,stroke-width:2px
+The typed option lifecycle (author -> parse -> bind -> match -> resolve -> materialize defaults -> compute) is documented in `systemPatterns.md`.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1,63 +1,34 @@
 # Progress
 
-## Status Overview
-
-```mermaid
-pie title Implementation Status
-    "Completed" : 85
-    "In Progress" : 10
-    "Planned" : 5
-```
-
 ## Working Features
 
-```mermaid
-mindmap
-  root((mloda))
-    Feature Groups
-      Core
-        AggregatedFeatureGroup
-        TimeWindowFeatureGroup
-        MissingValueFeatureGroup
-      Analytics
-        ClusteringFeatureGroup
-        DimensionalityReduction
-        ForecastingFeatureGroup
-        NodeCentralityFeatureGroup
-      Processing
-        TextCleaningFeatureGroup
-        GeoDistanceFeatureGroup
-        SklearnPipelineFeatureGroup
-    Compute Frameworks
-      PandasDataFrame
-      PyArrowTable
-      PythonDict
-      PolarsDataFrame
-      DuckDBFramework
-      IcebergFramework
-      SparkFramework
-    Core Systems
-      Options Refactoring
-      PROPERTY_MAPPING
-      Feature Chaining
-      Artifact Storage
-```
+### Compute Frameworks (9)
+
+PythonDict (dependency-free) needs no extra and SQLite needs only PyArrow; the rest are optional extras: Pandas, PyArrow, Polars (eager and lazy), DuckDB, Iceberg, Spark. DuckDB and SQLite share a common SQL base.
+
+### Feature Groups
+
+- **Core transforms**: Aggregated, TimeWindow, MissingValue (under data quality).
+- **Analytics**: Clustering, DimensionalityReduction, Forecasting (scikit-learn); NodeCentrality (numpy graph centrality).
+- **Sklearn family**: Pipeline, Encoding, Scaling (shared artifact storage).
+- **Processing**: TextCleaning (nltk), GeoDistance.
+- **LLM**: API-backed LLM feature groups, CLI features, and tool integrations.
+- **Infrastructure**: environment introspection (InstalledPackages, ListDirectory), dynamic feature-group factory, source-input composition, and the input-data reader suite (CSV / Parquet / Feather / ORC / JSON file readers, document readers, SQLite DB reader).
+
+### Extenders
+
+- OtelExtender (OpenTelemetry).
 
 ## Recent Achievements
-- ✅ Options object refactoring with group/context separation
-- ✅ All Feature Groups modernized to PROPERTY_MAPPING
-- ✅ Sklearn Pipeline with artifact storage
-- ✅ Complete compute framework implementations
-- ✅ **Options.data property deprecated and removed** (October 2025)
 
-## Known Issues
+- ✅ `PROPERTY_MAPPING` hardening: typed `PropertySpec` contract, raw-dict hard break, `property_spec()` authoring path.
+- ✅ Framework-enforced default materialization at the compute boundary; opt-in explicit-`None`.
+- ✅ Structured parsed-name bindings; required-presence enforcement; all-optional universal-matcher guard.
+- ✅ Typed resolution failures with per-candidate elimination facts and a `session.resolution_report()`.
+- ✅ Post-hardening cleanup: retired transitional parser seams; `PROPERTY_MAPPING` test suite consolidated around a public behavior matrix.
 
-```mermaid
-flowchart TD
-    Issue1[FeatureSet Creation] --> |Unintuitive| Fix1[feature_set.add syntax]
+## Remaining / Known Issues
 
-    style Issue1 fill:#fbb,stroke:#333
-```
-
-- **FeatureSet creation**: Requires `FeatureSet()` then `.add(feature)`
-
+- **os-008**: effective-options materialization placement and default-equivalent twin canonicalization.
+- **Phase 6 downstream**: raw-mapping migration and doc/sample refresh in mloda-registry, plugin-template, and mloda.ai.
+- **Local FeatureGroup subclass GC race** (mloda#868): shared-fixture test parametrization is deferred until this flake is resolved.

--- a/memory-bank/systemPatterns.md
+++ b/memory-bank/systemPatterns.md
@@ -7,27 +7,49 @@ graph TB
     subgraph Core
         CE[Core Engine]
     end
-    
+
     subgraph Plugins
         FG[Feature Groups]
         CF[Compute Frameworks]
         EX[Extenders]
     end
-    
+
     FG --> |Dependencies| CE
     CF --> |Execution| CE
     EX --> |Metadata| CE
     CE --> |Orchestrates| Output[Transformed Features]
-    
+
     style CE fill:#f9f,stroke:#333,stroke-width:3px
     style Output fill:#dfd,stroke:#333,stroke-width:2px
 ```
 
 ## Key Design Decisions
 
-- **Transformations over static states**: Define how data changes
-- **Plugin-based architecture**: Automatic plugin selection
-- **Decoupled execution**: Features independent of compute technology
+- **Transformations over static states**: define how data changes, not fixed outputs.
+- **Plugin-based architecture**: Feature Groups, Compute Frameworks, Extenders; the engine selects plugins automatically.
+- **Decoupled execution**: features are independent of the compute technology.
+- **Dependency-free core**: the `mloda` core declares no runtime dependencies; the PythonDict backend also needs none, while every other backend is an optional extra.
+
+## PropertySpec lifecycle
+
+A FeatureGroup declares its configuration surface as `PROPERTY_MAPPING: dict[str, PropertySpec]`. The typed, frozen `PropertySpec` is the single contract; raw-dict specs are a hard error. Each option key flows through the stages below, from authoring to compute. Types live in `mloda/core/abstract_plugins/components/feature_chainer/`.
+
+```mermaid
+flowchart LR
+    A[Author PropertySpec] --> P[Parse name]
+    P --> B[Bind captures]
+    B --> M[Match]
+    M --> R[Resolve]
+    R --> D[Materialize defaults]
+    D --> C[Compute]
+```
+
+1. **Author** (`property_spec.py`): `property_spec()` (or `PropertySpec(...)`) builds a frozen spec whose `__post_init__` enforces every invariant. `NO_DEFAULT` marks a key required; `is_no_default()` tests for it by type, not identity, so a reimported module copy still reads correctly. `PropertySpec`, `property_spec`, `NO_DEFAULT`, `is_no_default`, `is_positive_int` are all exported from `mloda.provider`.
+2. **Parse**: `FeatureChainParser.parse_name` (`feature_chain_parser.py`) returns a frozen `ParsedFeatureName` (`parsed_feature_name.py`) recording exactly what `re` found. `operation_part` is the raw suffix, never a fabricated token.
+3. **Bind** (`feature_chain_parser.py`): `bind_name_captures` binds named captures exclusively by name into an effective `Options`; a captureless pattern is a recognition predicate that identifies the group and binds nothing. A present option value always wins over a name-derived one. A transitional positional fallback (`_legacy_operation_config`) still reverse-looks-up single-capture legacy patterns, pending downstream migration (mloda-registry#327).
+4. **Match**: `match_configuration_feature_chain_parser` validates present values (a bad value raises `PropertyValueRejection`, a `ValueError` verdict rather than a crash) and enforces required presence on the string-named path.
+5. **Resolve** (`prepare/identify_feature_group.py`): `IdentifyFeatureGroupClass.evaluate` runs one non-raising resolution pass, recording per-candidate elimination facts (`EvaluationResult`, `Elimination`) so a failure explains which gate each near-miss failed. Class-definition-time checks reject order-dependent bindings and install guards enforcing `required_when` and name-path required presence; an all-optional matcher that would match any name emits a definition-time warning unless the class sets `ALLOW_UNIVERSAL_MATCHER`.
+6. **Materialize defaults, then compute**: `ComputeFramework.run_calculate_feature` (`@final`) calls `FeatureSet.materialize_option_defaults` once, immediately before `calculate_feature`. Defaults are framework-enforced at this single boundary, not opt-in per plugin. `options_with_defaults()` fills only absent keys that declare a concrete default; `NO_DEFAULT` and a declared `None` fill nothing. Presence honors the explicit-`None` policy: a present `None` counts as set only when the spec sets `allow_explicit_none=True`.
 
 ## Component Roles
 
@@ -37,3 +59,4 @@ flowchart LR
     CF[Compute Frameworks] -->|Execute| Trans
     EX[Extenders] -->|Extract| Meta[Metadata]
     CE[Core Engine] -->|Orchestrate| All[All Components]
+```

--- a/memory-bank/techContext.md
+++ b/memory-bank/techContext.md
@@ -1,27 +1,33 @@
 # Technical Context
 
-## Technologies Used
+## Language and Runtime
 
-*   Python
-*   PyArrow
-*   Pandas
-*   mkdocs
-*   mkdocs-jupyter
-*   marimo (example notebooks, authored as .py)
-*   pytest
-*   tox
-*   ruff
+- Python `>=3.10,<3.15`; CI matrixes 3.10, 3.11, 3.12, 3.13, 3.14.
+- Modern type hints only (`list[str]`, `X | None`), enforced by ruff `UP006` / `UP007`.
+- The core declares no runtime dependencies; the PythonDict backend also needs none, while every other backend is an optional extra.
+
+## Optional Extras (backends)
+
+`pandas`, `pyarrow`, `polars`, `duckdb`, `sqlite`, `iceberg`, `spark`, `sklearn` (scikit-learn + joblib), `text_cleaning` (nltk), `otel` (OpenTelemetry), `docs` (mkdocs, mkdocs-jupyter, marimo, mermaid-py).
+
+## Tooling
+
+- **uv**: dependency management; the committed `uv.lock` is installed by the gate so each commit resolves reproducibly.
+- **tox**: the single gate. It runs, in order: `pytest -n 8 --timeout=10`, `ruff format --check` (line length 120), `ruff check`, a `pip-licenses` allowlist check, `mypy --strict --ignore-missing-imports`, and `bandit`. All must pass.
+- Tests assert `EXPECTED_SKIP_COUNT=170`; a newly skipped test must update the count or be unskipped.
+- `pip-audit` runs in a dedicated CVE-scan env.
 
 ## Development Setup
 
-*   Clone the repository: `git clone https://github.com/mloda-ai/mloda.git`
-*   Use a dev container (optional, requires Docker)
-*   Install test dependencies: `pip install -r tests/requirements-test.txt && pip install tox`
+```bash
+uv sync --all-extras
+source .venv/bin/activate
+tox
+```
 
-## Technical Constraints
+## Constraints
 
-*   None specified
-
-## Dependencies
-
-*   See `pyproject.toml` and `docs/requirements.txt` for a complete list of dependencies.
+- Tests must be parallel-safe (pytest-xdist) and finish under the 10-second timeout.
+- Supply chain: `[tool.uv] exclude-newer = "7 days"` defers new releases; dependency licenses must satisfy the `tox.ini` allowlist.
+- `attribution/ATTRIBUTION.md` is regenerated on every `tox` run and committed alongside dependency changes.
+- The package ships `py.typed` (typed distribution).


### PR DESCRIPTION
Refreshes the four memory-bank files that had drifted to a 2025 options/sklearn snapshot so they describe the current PropertySpec model, resolution architecture, supported Python range, and completed PROPERTY_MAPPING hardening work.

## Changes
- `systemPatterns.md`: documents the typed PropertySpec lifecycle (author, parse, bind, match, resolve, materialize defaults, compute), including the raw-dict hard break, framework-enforced default materialization at the compute boundary, and the explicit-None policy.
- `activeContext.md`: replaces the stale sklearn/options next-steps with the property-mapping-hardening epic status: core hardening complete, os-008 and phase-6 downstream remaining.
- `progress.md`: updates the working-feature catalog (9 compute frameworks, current feature-group families including the sklearn split and the LLM family, OtelExtender) and the hardening achievements.
- `techContext.md`: corrects the supported Python range (>=3.10,<3.15), the dependency-free core, and the current tox gate.

## Verification
Docs-only change. The tox gate does not exercise `memory-bank/*.md` (no test reads them; ruff/mypy/bandit are Python-only; mktestdocs targets `docs/`), so CI is unaffected. Content was verified against the current code and config, and factual-accuracy fixes were applied for the NodeCentrality dependency (numpy, not scikit-learn), the all-optional universal-matcher (a definition-time warning, not a runtime guard), the transitional positional-binding fallback, the PythonDict backend needing no extra, and the `parse_name` file pointer.

Addresses eng-board os-007 (migrated from mloda#800). Part of the PROPERTY_MAPPING hardening epic.
