### PR TITLE
feat: export resolution debug tooling from mloda.provider (#855)

### DIFF
--- a/docs/docs/in_depth/discover-plugins.md
+++ b/docs/docs/in_depth/discover-plugins.md
@@ -17,6 +17,8 @@ else:
     print(f"Resolution failed: {result.error}")
 ```
 
+Plugin authors can also import `resolve_feature` from `mloda.provider`; it is the same function.
+
 This is useful for:
 - Debugging feature resolution issues
 - Understanding which plugin handles a feature

--- a/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
+++ b/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
@@ -1,14 +1,14 @@
 # Feature Group Resolution Errors
 
 Resolution runs inside a full `mloda` request, but you do not need to build one
-to reproduce a resolution error. `resolve_feature` (from `mloda.steward`) runs
+to reproduce a resolution error. `resolve_feature` (from `mloda.provider`) runs
 the **same matcher over the same candidate universe** as a run and reports what a
 run would, without raising: the failure lands in `result.error` instead of an
 exception, so for the matching failures on this page the message below is the
 message you get back.
 
 ``` python
-from mloda.steward import resolve_feature
+from mloda.provider import resolve_feature
 
 result = resolve_feature("my_feature")  # or resolve_feature(Feature(...)) for a full request
 if result.error:

--- a/mloda/provider/__init__.py
+++ b/mloda/provider/__init__.py
@@ -99,6 +99,14 @@ from mloda.core.filter.filter_engine import BaseFilterEngine
 from mloda.core.abstract_plugins.components.mask.base_mask_engine import BaseMaskEngine
 from mloda.core.abstract_plugins.components.merge.base_merge_engine import BaseMergeEngine
 
+# Feature resolution debugging
+from mloda.core.api.plugin_docs import resolve_feature
+from mloda.core.prepare.identify_feature_group import (
+    FeatureResolutionError,
+    ResolutionDiagnosis,
+    ResolutionRecord,
+)
+
 __version__ = get_mloda_version()
 
 __all__ = [
@@ -162,4 +170,9 @@ __all__ = [
     "BaseFilterEngine",
     "BaseMaskEngine",
     "BaseMergeEngine",
+    # Feature resolution debugging
+    "resolve_feature",
+    "FeatureResolutionError",
+    "ResolutionRecord",
+    "ResolutionDiagnosis",
 ]

--- a/tests/test_core/test_abstract_plugins/test_provider_resolution_surface.py
+++ b/tests/test_core/test_abstract_plugins/test_provider_resolution_surface.py
@@ -1,0 +1,34 @@
+"""mloda.provider must re-export the resolution-debug surface, identical to mloda.user (issue #855)."""
+
+import pytest
+
+import mloda.provider as provider
+import mloda.steward as steward
+import mloda.user as user
+
+RESOLUTION_SURFACE = ["resolve_feature", "FeatureResolutionError", "ResolutionRecord", "ResolutionDiagnosis"]
+
+
+class TestResolutionSurfaceIsExported:
+    @pytest.mark.parametrize("name", RESOLUTION_SURFACE)
+    def test_name_is_public(self, name: str) -> None:
+        assert hasattr(provider, name)
+        assert name in provider.__all__, f"{name} should be listed in mloda.provider.__all__"
+
+
+class TestResolutionSurfaceMatchesUser:
+    @pytest.mark.parametrize("name", RESOLUTION_SURFACE)
+    def test_reexport_is_the_same_object(self, name: str) -> None:
+        """A divergent duplicate import would break debugging tools that compare identity."""
+        assert getattr(provider, name, None) is getattr(user, name), (
+            f"mloda.provider.{name} must be the same object as mloda.user.{name}"
+        )
+
+
+class TestResolutionSurfaceMatchesSteward:
+    @pytest.mark.parametrize("name", RESOLUTION_SURFACE)
+    def test_reexport_is_the_same_object(self, name: str) -> None:
+        """Issue #855 pins the surface against mloda.steward too, not just mloda.user."""
+        assert getattr(provider, name, None) is getattr(steward, name), (
+            f"mloda.provider.{name} must be the same object as mloda.steward.{name}"
+        )


### PR DESCRIPTION
## What

Re-export the resolution-debug surface from `mloda.provider`:

- `resolve_feature`
- `FeatureResolutionError`
- `ResolutionRecord`
- `ResolutionDiagnosis`

These were importable only from `mloda.user` and `mloda.steward`. A plugin author (provider) debugging "why does my feature group not match" now imports them from the same namespace as the base classes they already use, instead of reaching into another persona's namespace.

## Why

Closes os-012 (migrated from #855). "Why does my feature group not match" is the plugin author's question, but the debugging entry points lived only in the user and steward namespaces.

## Details

- Imports come from the same source modules `mloda.user`/`mloda.steward` use (`mloda.core.api.plugin_docs`, `mloda.core.prepare.identify_feature_group`), so the re-exports are the exact same objects, not divergent copies. The surface test pins object identity against both namespaces.
- Docs: the resolution-errors troubleshooting page now imports `resolve_feature` from `mloda.provider` (it already imports `FeatureGroup`/`EmptyResultError` from there); `discover-plugins.md` gains a one-line note that plugin authors can use the provider import.
- Out of scope, deferred per the #759 decision record: serialization and persona renderers. The broader steward framing of `discover-plugins.md`/`mloda-api.md` is left intact.

## Testing

New surface test `tests/test_core/test_abstract_plugins/test_provider_resolution_surface.py` (public attr + `__all__` membership + object identity vs both `mloda.user` and `mloda.steward`). Full `tox` green (pytest, ruff, licenses, mypy --strict, bandit).