### PR TITLE
feat: materialize option defaults at feature intake, canonicalizing default-equivalent twins

### DIFF
--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -9,7 +9,7 @@ Core hardening is complete and the full `tox` gate is green (170 skipped, plus f
 ## Status
 
 - ✅ Typed `PropertySpec` is the sole `PROPERTY_MAPPING` contract; raw-dict specs are a hard break.
-- ✅ Defaults are materialized once at the central compute boundary (framework-enforced), with opt-in explicit-`None` semantics.
+- ✅ Defaults are materialized at feature intake (framework-enforced), with opt-in explicit-`None` semantics; default-equivalent twin requests canonicalize during planning, and the compute boundary remains an idempotent safety net (os-008).
 - ✅ Structured name parsing and explicit capture-to-spec binding replace reverse lookup and fabricated captureless tokens.
 - ✅ Required-presence enforcement on the string-named match path; all-optional universal-matcher guard.
 - ✅ Resolution failures carry per-candidate elimination facts (`EvaluationResult`).
@@ -17,7 +17,6 @@ Core hardening is complete and the full `tox` gate is green (170 skipped, plus f
 
 ## Next Steps
 
-- **os-008**: decide effective-options materialization placement and default-equivalent twin canonicalization (follow-up from the #796 / #803 reviews).
 - **Phase 6 downstream** (owning repos): migrate mloda-registry raw mappings and captureless patterns, align declared value spaces with runtime behavior, scaffold the plugin-template example, and refresh mloda.ai samples before raising the registry `>=0.10,<0.11` cap.
 
 ## Architecture Snapshot

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -22,13 +22,12 @@ PythonDict (dependency-free) needs no extra and SQLite needs only PyArrow; the r
 ## Recent Achievements
 
 - ✅ `PROPERTY_MAPPING` hardening: typed `PropertySpec` contract, raw-dict hard break, `property_spec()` authoring path.
-- ✅ Framework-enforced default materialization at the compute boundary; opt-in explicit-`None`.
+- ✅ Framework-enforced default materialization at feature intake; default-equivalent twin canonicalization at planning (os-008); opt-in explicit-`None`.
 - ✅ Structured parsed-name bindings; required-presence enforcement; all-optional universal-matcher guard.
 - ✅ Typed resolution failures with per-candidate elimination facts and a `session.resolution_report()`.
 - ✅ Post-hardening cleanup: retired transitional parser seams; `PROPERTY_MAPPING` test suite consolidated around a public behavior matrix.
 
 ## Remaining / Known Issues
 
-- **os-008**: effective-options materialization placement and default-equivalent twin canonicalization.
 - **Phase 6 downstream**: raw-mapping migration and doc/sample refresh in mloda-registry, plugin-template, and mloda.ai.
 - **Local FeatureGroup subclass GC race** (mloda#868): shared-fixture test parametrization is deferred until this flake is resolved.

--- a/memory-bank/systemPatterns.md
+++ b/memory-bank/systemPatterns.md
@@ -55,7 +55,7 @@ Which lifecycle stages observe which options view:
 
 | Stage | Options view |
 |-------|--------------|
-| Parse, bind, match, resolve (candidate selection) | declared (pre-default) |
+| Parse, bind, match, resolve (candidate selection; subtype resolution applies defaults internally) | declared (pre-default) |
 | `input_features()` and child option inheritance | declared (pre-default) |
 | Splitting, planning, validators, filters, compute | effective (post-default) |
 

--- a/memory-bank/systemPatterns.md
+++ b/memory-bank/systemPatterns.md
@@ -49,7 +49,15 @@ flowchart LR
 3. **Bind** (`feature_chain_parser.py`): `bind_name_captures` binds named captures exclusively by name into an effective `Options`; a captureless pattern is a recognition predicate that identifies the group and binds nothing. A present option value always wins over a name-derived one. A transitional positional fallback (`_legacy_operation_config`) still reverse-looks-up single-capture legacy patterns, pending downstream migration (mloda-registry#327).
 4. **Match**: `match_configuration_feature_chain_parser` validates present values (a bad value raises `PropertyValueRejection`, a `ValueError` verdict rather than a crash) and enforces required presence on the string-named path.
 5. **Resolve** (`prepare/identify_feature_group.py`): `IdentifyFeatureGroupClass.evaluate` runs one non-raising resolution pass, recording per-candidate elimination facts (`EvaluationResult`, `Elimination`) so a failure explains which gate each near-miss failed. Class-definition-time checks reject order-dependent bindings and install guards enforcing `required_when` and name-path required presence; an all-optional matcher that would match any name emits a definition-time warning unless the class sets `ALLOW_UNIVERSAL_MATCHER`.
-6. **Materialize defaults, then compute**: `ComputeFramework.run_calculate_feature` (`@final`) calls `FeatureSet.materialize_option_defaults` once, immediately before `calculate_feature`. Defaults are framework-enforced at this single boundary, not opt-in per plugin. `options_with_defaults()` fills only absent keys that declare a concrete default; `NO_DEFAULT` and a declared `None` fill nothing. Presence honors the explicit-`None` policy: a present `None` counts as set only when the spec sets `allow_explicit_none=True`.
+6. **Materialize defaults at intake, then compute** (os-008): `Engine.add_feature_to_collection` rebinds each resolved feature's options through `options_with_defaults()` as it enters the plan, so default-equivalent twins (same name, one key explicitly set to its declared default) merge through the standard duplicate path with uuid remapping. `ComputeFramework.run_calculate_feature` (`@final`) still calls `FeatureSet.materialize_option_defaults` as an idempotent safety net for direct API use; its twin-collapse ValueError is unreachable from engine-driven requests. `options_with_defaults()` fills only absent keys that declare a concrete default; `NO_DEFAULT` and a declared `None` fill nothing. Presence honors the explicit-`None` policy: a present `None` counts as set only when the spec sets `allow_explicit_none=True`.
+
+Which lifecycle stages observe which options view:
+
+| Stage | Options view |
+|-------|--------------|
+| Parse, bind, match, resolve (candidate selection) | declared (pre-default) |
+| `input_features()` and child option inheritance | declared (pre-default) |
+| Splitting, planning, validators, filters, compute | effective (post-default) |
 
 ## Component Roles
 

--- a/mloda/core/abstract_plugins/components/feature_set.py
+++ b/mloda/core/abstract_plugins/components/feature_set.py
@@ -78,8 +78,8 @@ class FeatureSet:
         """Rebind every feature's options (and self.options) through feature_group.options_with_defaults,
         memoized by Options identity so aliases stay aliased; identity no-op without concrete defaults (#796).
         Precondition: same-named features distinguished only by an explicitly-set default value collapse
-        when the default fills their twin, and that raises. Since os-008 the engine canonicalizes
-        default-equivalent twins at intake, so the raise is a defensive invariant for direct API use."""
+        when the default fills their twin, and that raises. The engine canonicalizes default-equivalent
+        twins at intake, so the raise is a defensive invariant for direct API use."""
         # The memo holds a strong reference to each source Options so its id cannot be recycled mid-loop.
         memo: dict[int, tuple[Options, Options]] = {}
         rebound = False

--- a/mloda/core/abstract_plugins/components/feature_set.py
+++ b/mloda/core/abstract_plugins/components/feature_set.py
@@ -78,7 +78,8 @@ class FeatureSet:
         """Rebind every feature's options (and self.options) through feature_group.options_with_defaults,
         memoized by Options identity so aliases stay aliased; identity no-op without concrete defaults (#796).
         Precondition: same-named features distinguished only by an explicitly-set default value collapse
-        when the default fills their twin, and that raises."""
+        when the default fills their twin, and that raises. Since os-008 the engine canonicalizes
+        default-equivalent twins at intake, so the raise is a defensive invariant for direct API use."""
         # The memo holds a strong reference to each source Options so its id cannot be recycled mid-loop.
         memo: dict[int, tuple[Options, Options]] = {}
         rebound = False

--- a/mloda/core/core/engine.py
+++ b/mloda/core/core/engine.py
@@ -77,8 +77,8 @@ class Engine:
         self.request_feature_order: list[str] = [str(f.name) for f in features]
         self._dual_consumption_warned: set[tuple[str, str, frozenset[str]]] = set()
         self._property_mapping_keys_cache: dict[type[FeatureGroup], frozenset[str]] = {}
-        # Intake materialization memo (os-008): the strong source reference keeps its id from being
-        # recycled, so features sharing one pre-default Options share one effective Options.
+        # Intake materialization memo: the strong source reference keeps its id stable, so features
+        # sharing one pre-default Options share one effective Options.
         self._intake_options_memo: dict[tuple[type[FeatureGroup], int], tuple[Options, Options]] = {}
         # Declared (pre-default) options per surviving feature uuid, for default-equivalent merge warnings.
         self._declared_options_by_uuid: dict[UUID, Options] = {}
@@ -156,8 +156,8 @@ class Engine:
         self._set_feature_name(feature, feature_group)
         self._set_compute_framework_and_data_type(feature, compute_frameworks, feature_group_class)
 
-        # Stash the declared pre-default options: dependency declaration and child inheritance
-        # observe them, while intake materialization canonicalizes default-equivalent twins (os-008).
+        # Stash the declared pre-default options: dependency declaration and child inheritance observe
+        # them; intake materialization canonicalizes default-equivalent twins.
         declared_options = feature.options
         added = self.add_feature_to_collection(feature_group_class, feature, features.child_uuid)
 
@@ -362,9 +362,8 @@ class Engine:
         child_uuid: Optional[UUID],
         if_index_feature: bool = False,
     ) -> bool:
-        # Materialize declared defaults at intake (os-008): default-equivalent twins become equal and
-        # merge through the standard duplicate path below. Identity no-op without concrete defaults.
-        # Memoized per (feature group, source Options identity) so a shared Options stays aliased.
+        # Materialize declared defaults at intake: default-equivalent twins become equal and merge
+        # via the duplicate path below; identity no-op without concrete defaults.
         declared_options = feature.options
         memo_key = (feature_group_class, id(declared_options))
         entry = self._intake_options_memo.get(memo_key)

--- a/mloda/core/core/engine.py
+++ b/mloda/core/core/engine.py
@@ -77,6 +77,11 @@ class Engine:
         self.request_feature_order: list[str] = [str(f.name) for f in features]
         self._dual_consumption_warned: set[tuple[str, str, frozenset[str]]] = set()
         self._property_mapping_keys_cache: dict[type[FeatureGroup], frozenset[str]] = {}
+        # Intake materialization memo (os-008): the strong source reference keeps its id from being
+        # recycled, so features sharing one pre-default Options share one effective Options.
+        self._intake_options_memo: dict[tuple[type[FeatureGroup], int], tuple[Options, Options]] = {}
+        # Declared (pre-default) options per surviving feature uuid, for default-equivalent merge warnings.
+        self._declared_options_by_uuid: dict[UUID, Options] = {}
         self.resolution_records: list[ResolutionRecord] = []
         self.execution_planner = self.create_setup_execution_plan(features)
         self.tfs_connection_map = self._resolve_tfs_connection_map()
@@ -335,6 +340,8 @@ class Engine:
                 # it is treated as a separate instance from the original filter feature
                 match.filter_feature.uuid = uuid.uuid4()
                 self.global_filter.add_filter_to_collection(feature_group_class, feature.name, match)
+                # The filter feature's options are already post-default via unify_options, so this intake
+                # call must remain an identity no-op (no rebind) to keep the SingleFilter set hash stable.
                 self.add_feature_to_collection(feature_group_class, match.filter_feature, features.child_uuid)
 
     def add_feature_link_to_links(self, feature: Feature) -> None:
@@ -357,7 +364,14 @@ class Engine:
     ) -> bool:
         # Materialize declared defaults at intake (os-008): default-equivalent twins become equal and
         # merge through the standard duplicate path below. Identity no-op without concrete defaults.
-        feature.options = feature_group_class.options_with_defaults(feature.options)
+        # Memoized per (feature group, source Options identity) so a shared Options stays aliased.
+        declared_options = feature.options
+        memo_key = (feature_group_class, id(declared_options))
+        entry = self._intake_options_memo.get(memo_key)
+        if entry is None:
+            entry = (declared_options, feature_group_class.options_with_defaults(declared_options))
+            self._intake_options_memo[memo_key] = entry
+        feature.options = entry[1]
         feature_collection = self.feature_group_collection[feature_group_class]
 
         if feature not in feature_collection:
@@ -365,11 +379,13 @@ class Engine:
 
             self.feature_link_parents[feature.uuid] = set()
             feature_collection.add(feature)
+            self._declared_options_by_uuid[feature.uuid] = declared_options
             return True
 
         existing_feature = next((f for f in feature_collection if feature == f), None)
 
         if existing_feature is not None:
+            self._warn_on_default_equivalent_merge(feature, declared_options, existing_feature)
             # Propagate the requested flag: filter twins must not displace requested output columns (issue #712).
             if feature.initial_requested_data and not existing_feature.initial_requested_data:
                 existing_feature.initial_requested_data = True
@@ -378,6 +394,19 @@ class Engine:
                 self._update_feature_link_parents(child_uuid, feature.uuid, existing_feature.uuid, if_index_feature)
 
         return False
+
+    def _warn_on_default_equivalent_merge(
+        self, feature: Feature, declared_options: Options, existing_feature: Feature
+    ) -> None:
+        """Warn when a merge holds only post-materialization: the declared (pre-default) options differ."""
+        survivor_declared = self._declared_options_by_uuid.get(existing_feature.uuid, existing_feature.options)
+        if declared_options.group == survivor_declared.group and declared_options.context == survivor_declared.context:
+            return
+        logger.warning(
+            f"Feature '{feature.name}' was requested twice with default-equivalent options: the requests "
+            f"differ only in explicitly-set declared defaults and merged into one feature at intake. "
+            f"Deduplicate the request; dependency declaration follows the first-listed request."
+        )
 
     def _update_feature_link_parents(
         self, child_uuid: UUID, original_uuid: UUID, wanted_uuid: UUID, if_index_feature: bool

--- a/mloda/core/core/engine.py
+++ b/mloda/core/core/engine.py
@@ -151,12 +151,15 @@ class Engine:
         self._set_feature_name(feature, feature_group)
         self._set_compute_framework_and_data_type(feature, compute_frameworks, feature_group_class)
 
+        # Stash the declared pre-default options: dependency declaration and child inheritance
+        # observe them, while intake materialization canonicalizes default-equivalent twins (os-008).
+        declared_options = feature.options
         added = self.add_feature_to_collection(feature_group_class, feature, features.child_uuid)
 
         if added:
             parent_domain = feature.domain.name if feature.domain else None
             self._handle_input_features_recursion(
-                feature_group_class, feature.uuid, feature.options, feature.name, parent_domain=parent_domain
+                feature_group_class, feature.uuid, declared_options, feature.name, parent_domain=parent_domain
             )
 
         if self.global_filter:
@@ -352,6 +355,9 @@ class Engine:
         child_uuid: Optional[UUID],
         if_index_feature: bool = False,
     ) -> bool:
+        # Materialize declared defaults at intake (os-008): default-equivalent twins become equal and
+        # merge through the standard duplicate path below. Identity no-op without concrete defaults.
+        feature.options = feature_group_class.options_with_defaults(feature.options)
         feature_collection = self.feature_group_collection[feature_group_class]
 
         if feature not in feature_collection:

--- a/tests/test_core/test_abstract_plugins/test_intake_default_canonicalization.py
+++ b/tests/test_core/test_abstract_plugins/test_intake_default_canonicalization.py
@@ -9,6 +9,7 @@ inheritance observe the pre-default options. The compute boundary remains an ide
 from __future__ import annotations
 
 import gc
+import logging
 from typing import Any, Callable
 
 import pytest
@@ -55,6 +56,21 @@ IDC_INHERIT_DEFAULT = "idc_inherit_val"
 IDC_CHILD_DECLARED = "idc_child_declared"  # resolved when IDC_DEP_KEY is absent (pre-default view)
 IDC_CHILD_EFFECTIVE = "idc_child_effective"  # resolved when IDC_DEP_KEY is present
 IDC_INHERIT_CHILD = "idc_inherit_child"  # root child under the group-default consumer parent
+
+IDC_ALIAS_KEY = "idc_alias_ctx_default"  # context concrete default on the shared-Options alias probe
+IDC_ALIAS_DEFAULT = "idc_alias_val"
+IDC_ALIAS_NAME_A = "idc_alias_feature_a"  # two different names served by ONE root FG, sharing ONE Options
+IDC_ALIAS_NAME_B = "idc_alias_feature_b"
+IDC_GRP_NON_DEFAULT = "idc_grp_other_val"  # explicit non-default group value; NOT default-equivalent
+
+IDC_DUP_KEY = "idc_dup_ctx_default"  # context concrete default on the plain-duplicate child probe
+IDC_DUP_DEFAULT = "idc_dup_val"
+IDC_DUP_CHILD = "idc_dup_child"  # child declared IDENTICALLY by both parents (plain duplicate)
+IDC_DUP_PARENT_A = "idc_dup_parent_a"
+IDC_DUP_PARENT_B = "idc_dup_parent_b"
+
+# Verified against the module logger definition in mloda/core/core/engine.py (logging.getLogger(__name__)).
+IDC_ENGINE_LOGGER = "mloda.core.core.engine"
 
 
 def _make_ctx_default_root_fg(feature_name: str) -> type[FeatureGroup]:
@@ -179,6 +195,72 @@ def _make_option_echo_child_fg() -> type[FeatureGroup]:
     return IdcOptionEchoChildFeatureGroup
 
 
+def _make_alias_probe_root_fg() -> type[FeatureGroup]:
+    """A throwaway root FG serving both alias names, echoing options-object sharing and the observed default."""
+
+    class IdcAliasProbeRootFeatureGroup(FeatureGroup):
+        PROPERTY_MAPPING = {
+            IDC_ALIAS_KEY: PropertySpec("A context concrete default.", context=True, default=IDC_ALIAS_DEFAULT),
+        }
+
+        @classmethod
+        def input_data(cls) -> DataCreator:
+            return DataCreator({IDC_ALIAS_NAME_A, IDC_ALIAS_NAME_B})
+
+        @classmethod
+        def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+            options_identities = len({id(feature.options) for feature in features.features})
+            return {
+                str(feature.name): [
+                    {
+                        "features_in_set": len(list(features.features)),
+                        "options_identities": options_identities,
+                        "observed_default": feature.options.get(IDC_ALIAS_KEY),
+                    }
+                ]
+                for feature in features.features
+            }
+
+    return IdcAliasProbeRootFeatureGroup
+
+
+def _make_dup_child_root_fg() -> type[FeatureGroup]:
+    """A throwaway root child with a context concrete default, echoing the observed value."""
+
+    class IdcDupChildRootFeatureGroup(FeatureGroup):
+        PROPERTY_MAPPING = {
+            IDC_DUP_KEY: PropertySpec("A context concrete default.", context=True, default=IDC_DUP_DEFAULT),
+        }
+
+        @classmethod
+        def input_data(cls) -> DataCreator:
+            return DataCreator({IDC_DUP_CHILD})
+
+        @classmethod
+        def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+            return {str(feature.name): [feature.options.get(IDC_DUP_KEY)] for feature in features.features}
+
+    return IdcDupChildRootFeatureGroup
+
+
+def _make_dup_parents_fg() -> type[FeatureGroup]:
+    """A throwaway consumer serving two names, each declaring the SAME fully-explicit child feature."""
+
+    class IdcDupParentsFeatureGroup(FeatureGroup):
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {IDC_DUP_PARENT_A, IDC_DUP_PARENT_B}
+
+        def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+            return {Feature(IDC_DUP_CHILD, Options(context={IDC_DUP_KEY: IDC_DUP_DEFAULT}))}
+
+        @classmethod
+        def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+            return {str(feature.name): [data[IDC_DUP_CHILD][0]] for feature in features.features}
+
+    return IdcDupParentsFeatureGroup
+
+
 def _single_row(frame: Any, column: str) -> Any:
     """Extract the single payload row, tolerant of columnar dict or list-of-row-dicts results."""
     if isinstance(frame, dict):
@@ -230,6 +312,51 @@ def _run_parent_child(
     payload = _single_row(results[0], parent_name)
     assert isinstance(payload, dict)
     return payload
+
+
+def _run_alias_probe() -> list[Any]:
+    """Run two different-name features sharing ONE Options instance; return the raw result frames.
+
+    The probe class and collector stay locals of THIS frame (see _run_twins) so caller asserts
+    never pin the throwaway class.
+    """
+    fg = _make_alias_probe_root_fg()
+    collector = PluginCollector.enabled_feature_groups({fg})
+    shared_options = Options()
+    results = mloda.run_all(
+        [Feature(IDC_ALIAS_NAME_A, shared_options), Feature(IDC_ALIAS_NAME_B, shared_options)],
+        compute_frameworks={PythonDictFramework},
+        plugin_collector=collector,
+    )
+    return list(results)
+
+
+def _run_dup_parents() -> list[Any]:
+    """Run two parents that both declare the SAME fully-explicit child; return the raw result frames.
+
+    Both throwaway classes stay locals of THIS frame (see _run_twins) so caller asserts never
+    pin them.
+    """
+    parent_fg = _make_dup_parents_fg()
+    child_fg = _make_dup_child_root_fg()
+    collector = PluginCollector.enabled_feature_groups({parent_fg, child_fg})
+    results = mloda.run_all(
+        [Feature(IDC_DUP_PARENT_A), Feature(IDC_DUP_PARENT_B)],
+        compute_frameworks={PythonDictFramework},
+        plugin_collector=collector,
+    )
+    return list(results)
+
+
+def _default_equivalent_warnings(caplog: pytest.LogCaptureFixture) -> list[str]:
+    """Collect the engine logger's default-equivalent merge warning messages captured by caplog."""
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == IDC_ENGINE_LOGGER
+        and record.levelno >= logging.WARNING
+        and "default-equivalent" in record.getMessage()
+    ]
 
 
 def test_context_default_twins_merge_instead_of_raising() -> None:
@@ -291,3 +418,86 @@ def test_child_does_not_inherit_parent_default_group_key() -> None:
     assert payload["observed_parent_grp_key"] is None, (
         f"the child must not inherit the parent's declared group default: {payload!r}"
     )
+
+
+@pytest.mark.parametrize("explicit_first", [True, False], ids=["explicit_then_absent", "absent_then_explicit"])
+def test_default_equivalent_twin_merge_warns_in_both_orders(
+    explicit_first: bool, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A materialization-driven twin merge warns on the engine logger in either request order.
+
+    The twins are unequal pre-materialization and become equal only through intake default
+    canonicalization, so the engine must name the feature in a "default-equivalent" warning
+    advising deduplication; plain duplicates stay silent (pinned separately).
+    """
+    caplog.set_level(logging.WARNING, logger=IDC_ENGINE_LOGGER)
+    name = f"idc_ctx_warn_twin_{'ea' if explicit_first else 'ae'}"
+    explicit = Options(context={IDC_CTX_KEY: IDC_CTX_DEFAULT})
+    absent = Options()
+    twin_options = [explicit, absent] if explicit_first else [absent, explicit]
+    frames = _run_twins(_make_ctx_default_root_fg, name, twin_options)
+    assert len(frames) == 1, f"default-equivalent twins must still merge into one frame, got: {len(frames)}"
+    observed = _single_row(frames[0], name)
+    assert observed == IDC_CTX_DEFAULT, f"the merged feature must observe the declared default: {observed!r}"
+    warnings = _default_equivalent_warnings(caplog)
+    matching = [message for message in warnings if name in message]
+    assert matching, (
+        f"expected a default-equivalent merge warning naming {name!r} on logger {IDC_ENGINE_LOGGER!r}, "
+        f"captured engine warnings: {warnings!r}"
+    )
+
+
+def test_plain_duplicate_requests_do_not_warn(caplog: pytest.LogCaptureFixture) -> None:
+    """Fully identical duplicate features merge silently through the duplicate path: no warning (guard).
+
+    Identical user-level requests are rejected at API setup ("Duplicate feature setup"), so the
+    engine's plain-duplicate path is exercised via two parents declaring the SAME fully-explicit
+    child. The twins are equal before AND after materialization: no default-equivalent warning.
+    """
+    caplog.set_level(logging.WARNING, logger=IDC_ENGINE_LOGGER)
+    frames = _run_dup_parents()
+    assert len(frames) == 1, f"both parents must compute in one frame, got: {len(frames)}"
+    for name in (IDC_DUP_PARENT_A, IDC_DUP_PARENT_B):
+        observed = _single_row(frames[0], name)
+        assert observed == IDC_DUP_DEFAULT, f"each parent must observe the shared child's value: {observed!r}"
+    warnings = _default_equivalent_warnings(caplog)
+    assert not warnings, f"plain duplicates must not trigger a default-equivalent warning, got: {warnings!r}"
+
+
+def test_shared_options_stay_aliased_through_intake() -> None:
+    """One Options instance shared by two features keeps ONE effective Options identity after intake.
+
+    Intake materialization must be memoized per (feature group class, source Options identity):
+    two features sharing a pre-default Options instance must share the effective instance too,
+    not receive two separate equal-but-distinct objects.
+    """
+    frames = _run_alias_probe()
+    assert len(frames) == 1, f"both alias features must compute in one frame, got: {len(frames)}"
+    for name in (IDC_ALIAS_NAME_A, IDC_ALIAS_NAME_B):
+        payload = _single_row(frames[0], name)
+        assert isinstance(payload, dict)
+        assert payload["features_in_set"] == 2, f"both alias features must share one FeatureSet: {payload!r}"
+        assert payload["observed_default"] == IDC_ALIAS_DEFAULT, (
+            f"the declared default must be materialized on the shared options: {payload!r}"
+        )
+        assert payload["options_identities"] == 1, (
+            f"intake must keep the shared Options instance aliased across both features: {payload!r}"
+        )
+
+
+def test_non_default_equivalent_twins_do_not_merge(caplog: pytest.LogCaptureFixture) -> None:
+    """An explicit NON-default group value against an absent twin stays split with no warning (guard)."""
+    caplog.set_level(logging.WARNING, logger=IDC_ENGINE_LOGGER)
+    name = "idc_grp_split_feature"
+    frames = _run_twins(
+        _make_grp_default_root_fg,
+        name,
+        [Options(group={IDC_GRP_KEY: IDC_GRP_NON_DEFAULT}), Options()],
+    )
+    assert len(frames) == 2, f"non-default-equivalent twins must stay split into two frames, got: {len(frames)}"
+    observed = {_single_row(frame, name) for frame in frames}
+    assert observed == {IDC_GRP_NON_DEFAULT, IDC_GRP_DEFAULT}, (
+        f"the split twins must observe the explicit non-default and the materialized default: {observed!r}"
+    )
+    warnings = _default_equivalent_warnings(caplog)
+    assert not warnings, f"non-default-equivalent twins must not trigger a warning, got: {warnings!r}"

--- a/tests/test_core/test_abstract_plugins/test_intake_default_canonicalization.py
+++ b/tests/test_core/test_abstract_plugins/test_intake_default_canonicalization.py
@@ -1,4 +1,4 @@
-"""Pin the os-008 intake-default-canonicalization contract.
+"""Pin the intake default-canonicalization contract.
 
 Declared PropertySpec defaults are materialized at feature intake on the resolved feature's own
 options, so default-equivalent same-name twins canonicalize through the standard duplicate path.
@@ -362,7 +362,7 @@ def _default_equivalent_warnings(caplog: pytest.LogCaptureFixture) -> list[str]:
 def test_context_default_twins_merge_instead_of_raising() -> None:
     """Same-name twins split only by an explicitly-set declared context default merge at intake.
 
-    Pre-os-008 the absent twin is filled at the compute boundary, collapsing the FeatureSet
+    Without intake canonicalization the absent twin is filled at the compute boundary, collapsing the FeatureSet
     with the "collapsed duplicate features" ValueError; intake canonicalization must instead
     merge the twins through the standard duplicate path and compute once.
     """
@@ -380,7 +380,7 @@ def test_context_default_twins_merge_instead_of_raising() -> None:
 def test_group_default_twins_merge_into_single_computation() -> None:
     """Same-name twins split only by an explicitly-set declared group default merge at intake.
 
-    Pre-os-008 the pre-default group options differ, so the twins split into two FeatureSets
+    Without intake canonicalization the pre-default group options differ, so the twins split into two FeatureSets
     and yield two result frames; intake canonicalization must merge them into ONE computation.
     """
     name = "idc_grp_twin_feature"

--- a/tests/test_core/test_abstract_plugins/test_intake_default_canonicalization.py
+++ b/tests/test_core/test_abstract_plugins/test_intake_default_canonicalization.py
@@ -1,0 +1,293 @@
+"""Pin the os-008 intake-default-canonicalization contract.
+
+Declared PropertySpec defaults are materialized at feature intake on the resolved feature's own
+options, so default-equivalent same-name twins canonicalize through the standard duplicate path.
+Dependency declaration keeps declared pre-default semantics: input_features and child option
+inheritance observe the pre-default options. The compute boundary remains an idempotent safety net.
+"""
+
+from __future__ import annotations
+
+import gc
+from typing import Any, Callable
+
+import pytest
+
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.components.utils import get_all_subclasses
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.provider import DataCreator, PropertySpec
+from mloda.user import FeatureName, PluginCollector, mloda
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
+
+
+@pytest.fixture(autouse=True)
+def _no_feature_group_registry_pollution() -> Any:
+    """Guarantee this module never leaks throwaway FeatureGroup subclasses.
+
+    The tests below define FeatureGroup subclasses inside factory functions. Those class
+    objects sit in reference cycles, so they linger in ``FeatureGroup.__subclasses__()``
+    until a GC cycle runs. While they linger, other tests that enumerate feature groups via
+    ``get_all_subclasses(FeatureGroup)`` trip over them. After each test we force a
+    collection to reclaim the now-unreferenced classes and assert that none of this
+    module's classes remain registered, pinning the no-pollution contract.
+    """
+    yield
+    gc.collect()
+    gc.collect()
+    leaked = [c for c in get_all_subclasses(FeatureGroup) if c.__module__ == __name__]
+    assert not leaked, f"Leaked FeatureGroup subclasses from {__name__}: {[c.__name__ for c in leaked]}"
+
+
+# PROPERTY_MAPPING keys for the throwaway probes; the idc_ prefix keeps them unique to this module.
+IDC_CTX_KEY = "idc_ctx_default"  # context concrete default (twin merge, test 1)
+IDC_GRP_KEY = "idc_grp_default"  # group concrete default (twin merge, test 2)
+IDC_DEP_KEY = "idc_dep_ctx_default"  # context concrete default steering input_features (test 3)
+IDC_INHERIT_KEY = "idc_inherit_grp_default"  # group concrete default on a consumer parent (test 4)
+
+IDC_CTX_DEFAULT = "idc_ctx_val"
+IDC_GRP_DEFAULT = "idc_grp_val"
+IDC_DEP_DEFAULT = "idc_dep_val"
+IDC_INHERIT_DEFAULT = "idc_inherit_val"
+
+IDC_CHILD_DECLARED = "idc_child_declared"  # resolved when IDC_DEP_KEY is absent (pre-default view)
+IDC_CHILD_EFFECTIVE = "idc_child_effective"  # resolved when IDC_DEP_KEY is present
+IDC_INHERIT_CHILD = "idc_inherit_child"  # root child under the group-default consumer parent
+
+
+def _make_ctx_default_root_fg(feature_name: str) -> type[FeatureGroup]:
+    """A throwaway root FeatureGroup with one context concrete default, echoing the observed value."""
+
+    class IdcCtxDefaultRootFeatureGroup(FeatureGroup):
+        PROPERTY_MAPPING = {
+            IDC_CTX_KEY: PropertySpec("A context concrete default.", context=True, default=IDC_CTX_DEFAULT),
+        }
+
+        @classmethod
+        def input_data(cls) -> DataCreator:
+            return DataCreator({feature_name})
+
+        @classmethod
+        def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+            return {str(feature.name): [feature.options.get(IDC_CTX_KEY)] for feature in features.features}
+
+    return IdcCtxDefaultRootFeatureGroup
+
+
+def _make_grp_default_root_fg(feature_name: str) -> type[FeatureGroup]:
+    """A throwaway root FeatureGroup with one group concrete default, echoing the observed value."""
+
+    class IdcGrpDefaultRootFeatureGroup(FeatureGroup):
+        PROPERTY_MAPPING = {
+            IDC_GRP_KEY: PropertySpec("A group concrete default.", context=False, default=IDC_GRP_DEFAULT),
+        }
+
+        @classmethod
+        def input_data(cls) -> DataCreator:
+            return DataCreator({feature_name})
+
+        @classmethod
+        def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+            return {str(feature.name): [feature.options.get(IDC_GRP_KEY)] for feature in features.features}
+
+    return IdcGrpDefaultRootFeatureGroup
+
+
+def _make_dep_probe_parent_fg(feature_name: str) -> type[FeatureGroup]:
+    """A throwaway parent whose input_features branches on the presence of its own defaulted key.
+
+    With pre-default (declared) semantics the key is absent for a plain request, so the parent
+    must resolve IDC_CHILD_DECLARED; a premature default fill would flip it to IDC_CHILD_EFFECTIVE.
+    """
+
+    class IdcDepProbeParentFeatureGroup(FeatureGroup):
+        PROPERTY_MAPPING = {
+            IDC_DEP_KEY: PropertySpec("Steers the declared dependency.", context=True, default=IDC_DEP_DEFAULT),
+        }
+
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {feature_name}
+
+        def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+            if options.get(IDC_DEP_KEY) is None:
+                return {Feature(IDC_CHILD_DECLARED)}
+            return {Feature(IDC_CHILD_EFFECTIVE)}
+
+        @classmethod
+        def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+            resolved = [name for name in (IDC_CHILD_DECLARED, IDC_CHILD_EFFECTIVE) if name in data]
+            return {feature_name: [{"resolved_children": resolved}]}
+
+    return IdcDepProbeParentFeatureGroup
+
+
+def _make_marker_child_fg() -> type[FeatureGroup]:
+    """A throwaway root child serving both dependency names with a marker payload per requested name."""
+
+    class IdcMarkerChildFeatureGroup(FeatureGroup):
+        @classmethod
+        def input_data(cls) -> DataCreator:
+            return DataCreator({IDC_CHILD_DECLARED, IDC_CHILD_EFFECTIVE})
+
+        @classmethod
+        def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+            return {str(feature.name): [f"idc_payload_{feature.name}"] for feature in features.features}
+
+    return IdcMarkerChildFeatureGroup
+
+
+def _make_inherit_parent_fg(feature_name: str) -> type[FeatureGroup]:
+    """A throwaway parent with a group concrete default that declares one root child dependency."""
+
+    class IdcInheritParentFeatureGroup(FeatureGroup):
+        PROPERTY_MAPPING = {
+            IDC_INHERIT_KEY: PropertySpec("A group concrete default.", context=False, default=IDC_INHERIT_DEFAULT),
+        }
+
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {feature_name}
+
+        def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+            return {Feature(IDC_INHERIT_CHILD)}
+
+        @classmethod
+        def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+            return {feature_name: [data[IDC_INHERIT_CHILD][0]]}
+
+    return IdcInheritParentFeatureGroup
+
+
+def _make_option_echo_child_fg() -> type[FeatureGroup]:
+    """A throwaway root child echoing whether the parent's group-default key reached its options."""
+
+    class IdcOptionEchoChildFeatureGroup(FeatureGroup):
+        @classmethod
+        def input_data(cls) -> DataCreator:
+            return DataCreator({IDC_INHERIT_CHILD})
+
+        @classmethod
+        def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+            return {
+                str(feature.name): [{"observed_parent_grp_key": feature.options.get(IDC_INHERIT_KEY)}]
+                for feature in features.features
+            }
+
+    return IdcOptionEchoChildFeatureGroup
+
+
+def _single_row(frame: Any, column: str) -> Any:
+    """Extract the single payload row, tolerant of columnar dict or list-of-row-dicts results."""
+    if isinstance(frame, dict):
+        values = list(frame[column])
+    else:
+        values = [row[column] for row in frame]
+    assert len(values) == 1, f"expected exactly one row for {column}, got {values!r}"
+    return values[0]
+
+
+def _run_twins(
+    make_fg: Callable[[str], type[FeatureGroup]], feature_name: str, twin_options: list[Options]
+) -> list[Any]:
+    """Run same-name twin requests end-to-end and return the raw result frames.
+
+    The probe class and collector stay locals of THIS frame, so a failing assert in the
+    caller never pins the throwaway class in a traceback and the no-leak guard stays green.
+    """
+    fg = make_fg(feature_name)
+    collector = PluginCollector.enabled_feature_groups({fg})
+    results = mloda.run_all(
+        [Feature(feature_name, options) for options in twin_options],
+        compute_frameworks={PythonDictFramework},
+        plugin_collector=collector,
+    )
+    return list(results)
+
+
+def _run_parent_child(
+    make_parent: Callable[[str], type[FeatureGroup]],
+    make_child: Callable[[], type[FeatureGroup]],
+    parent_name: str,
+    options: Options,
+) -> dict[str, Any]:
+    """Run one parent-child computation and return the parent's single payload row.
+
+    Both throwaway classes stay locals of THIS frame (see _run_twins) so caller asserts
+    never pin them.
+    """
+    parent_fg = make_parent(parent_name)
+    child_fg = make_child()
+    collector = PluginCollector.enabled_feature_groups({parent_fg, child_fg})
+    results = mloda.run_all(
+        [Feature(parent_name, options)],
+        compute_frameworks={PythonDictFramework},
+        plugin_collector=collector,
+    )
+    assert len(results) == 1, f"expected exactly one result frame, got: {results!r}"
+    payload = _single_row(results[0], parent_name)
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_context_default_twins_merge_instead_of_raising() -> None:
+    """Same-name twins split only by an explicitly-set declared context default merge at intake.
+
+    Pre-os-008 the absent twin is filled at the compute boundary, collapsing the FeatureSet
+    with the "collapsed duplicate features" ValueError; intake canonicalization must instead
+    merge the twins through the standard duplicate path and compute once.
+    """
+    name = "idc_ctx_twin_feature"
+    frames = _run_twins(
+        _make_ctx_default_root_fg,
+        name,
+        [Options(context={IDC_CTX_KEY: IDC_CTX_DEFAULT}), Options()],
+    )
+    assert len(frames) == 1, f"merged twins must produce exactly one result frame, got: {frames!r}"
+    observed = _single_row(frames[0], name)
+    assert observed == IDC_CTX_DEFAULT, f"the merged feature must observe the declared default: {observed!r}"
+
+
+def test_group_default_twins_merge_into_single_computation() -> None:
+    """Same-name twins split only by an explicitly-set declared group default merge at intake.
+
+    Pre-os-008 the pre-default group options differ, so the twins split into two FeatureSets
+    and yield two result frames; intake canonicalization must merge them into ONE computation.
+    """
+    name = "idc_grp_twin_feature"
+    frames = _run_twins(
+        _make_grp_default_root_fg,
+        name,
+        [Options(group={IDC_GRP_KEY: IDC_GRP_DEFAULT}), Options()],
+    )
+    assert len(frames) == 1, f"default-equivalent group twins must merge into one frame, got {len(frames)} frames"
+    observed = _single_row(frames[0], name)
+    assert observed == IDC_GRP_DEFAULT, f"the merged feature must observe the declared default: {observed!r}"
+
+
+def test_input_features_observes_pre_default_options() -> None:
+    """input_features sees the declared pre-default options: the defaulted key stays absent (guard).
+
+    A naive implementation materializing defaults BEFORE the dependency recursion would make the
+    parent resolve IDC_CHILD_EFFECTIVE instead of IDC_CHILD_DECLARED.
+    """
+    payload = _run_parent_child(_make_dep_probe_parent_fg, _make_marker_child_fg, "idc_dep_parent_feature", Options())
+    assert payload["resolved_children"] == [IDC_CHILD_DECLARED], (
+        f"input_features must observe pre-default options and resolve the declared child: {payload!r}"
+    )
+
+
+def test_child_does_not_inherit_parent_default_group_key() -> None:
+    """Child inheritance flows from the declared pre-default options: no default group key leaks (guard).
+
+    Children inherit ALL consumer group options at planning; materializing the parent's group
+    default before the recursion would leak it into the child's options.
+    """
+    payload = _run_parent_child(
+        _make_inherit_parent_fg, _make_option_echo_child_fg, "idc_inherit_parent_feature", Options()
+    )
+    assert payload["observed_parent_grp_key"] is None, (
+        f"the child must not inherit the parent's declared group default: {payload!r}"
+    )

--- a/tests/test_core/test_abstract_plugins/test_materialize_defaults_boundary.py
+++ b/tests/test_core/test_abstract_plugins/test_materialize_defaults_boundary.py
@@ -13,6 +13,9 @@ plugin reading ``feature.options`` directly never sees declared defaults. The pi
   call and the FEATURE_GROUP_CALCULATE_FEATURE extender path observe materialized options: absent keys carry
   their declared defaults, present values (even falsy) win, and an ``allow_explicit_none=True`` explicit
   None is retained.
+
+Since os-008 the engine canonicalizes default-equivalent twins at intake, so the compute-boundary call is
+an idempotent safety net and its collapse ValueError is unreachable from engine-driven requests.
 """
 
 from __future__ import annotations
@@ -341,7 +344,9 @@ class TestFeatureSetMaterializeOptionDefaults:
 
     def test_collapse_of_same_name_twins_raises_actionable_duplicate_message(self) -> None:
         """Filling a context default on one twin of a same-name pair collapses the set: the ValueError
-        must name the duplicate-feature cause and list the affected names, not blame an upstream invariant."""
+        must name the duplicate-feature cause and list the affected names, not blame an upstream invariant.
+        Since os-008 the engine merges such twins at intake, so this raise is a defensive invariant for
+        direct FeatureSet/API use, unreachable from engine-driven requests."""
         twin_name = "mdb_unit_twin_feature"
         explicit = Feature(twin_name, Options(context={MDB_CTX_KEY: CTX_DEFAULT}))
         absent = Feature(twin_name, Options())

--- a/tests/test_core/test_abstract_plugins/test_materialize_defaults_boundary.py
+++ b/tests/test_core/test_abstract_plugins/test_materialize_defaults_boundary.py
@@ -14,7 +14,7 @@ plugin reading ``feature.options`` directly never sees declared defaults. The pi
   their declared defaults, present values (even falsy) win, and an ``allow_explicit_none=True`` explicit
   None is retained.
 
-Since os-008 the engine canonicalizes default-equivalent twins at intake, so the compute-boundary call is
+The engine canonicalizes default-equivalent twins at intake, so the compute-boundary call is
 an idempotent safety net and its collapse ValueError is unreachable from engine-driven requests.
 """
 
@@ -345,7 +345,7 @@ class TestFeatureSetMaterializeOptionDefaults:
     def test_collapse_of_same_name_twins_raises_actionable_duplicate_message(self) -> None:
         """Filling a context default on one twin of a same-name pair collapses the set: the ValueError
         must name the duplicate-feature cause and list the affected names, not blame an upstream invariant.
-        Since os-008 the engine merges such twins at intake, so this raise is a defensive invariant for
+        The engine merges such twins at intake, so this raise is a defensive invariant for
         direct FeatureSet/API use, unreachable from engine-driven requests."""
         twin_name = "mdb_unit_twin_feature"
         explicit = Feature(twin_name, Options(context={MDB_CTX_KEY: CTX_DEFAULT}))


### PR DESCRIPTION
## Summary

Declared PropertySpec defaults are now materialized at feature intake (Engine.add_feature_to_collection). Two requests for the same feature that differ only by explicitly setting a key to its declared default merge into one feature during planning instead of raising at compute time; a warning advises deduplicating the request. Dependency declaration (input_features, child option inheritance) still observes declared pre-default options. The compute-boundary materialization remains as an idempotent safety net, and its twin-collapse ValueError is unreachable from engine-driven runs. The lifecycle stage table lives in memory-bank/systemPatterns.md.

## Review and tests

Two independent deep reviews. Accepted fixes: merge warning with first-listed dependency precedence, an intake memo keeping shared Options instances aliased, and a filter-path invariant comment. 9 new test pins; full tox gate green (7195 passed, 170 skipped).