### PR TITLE
docs: remove stale memory-bank references and clarify the transient todo.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,11 @@
 
 ## Phase Completion Protocol
 
-When working with `memory-bank/todo.md` that contains phases:
+Phased work uses a `memory-bank/todo.md` checklist. This file is **transient**: it is
+created for the duration of a phased task and removed when the work lands, so it is not
+part of the Memory Bank core files below and is normally absent from the repository.
+
+When such a `todo.md` exists and contains phases:
 
 1. **After completing each phase**: Run `tox` to validate all tests pass
 2. **If tox passes**:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,11 @@
 
 ## Phase Completion Protocol
 
-When working with `memory-bank/todo.md` that contains phases:
+Phased work uses a `memory-bank/todo.md` checklist. This file is **transient**: it is
+created for the duration of a phased task and removed when the work lands, so it is not
+part of the Memory Bank core files below and is normally absent from the repository.
+
+When such a `todo.md` exists and contains phases:
 
 1. **After completing each phase**: Run `tox` to validate all tests pass
 2. **If tox passes**:

--- a/tests/README.md
+++ b/tests/README.md
@@ -27,7 +27,6 @@ tests/
 ├── test_documentation/         # Tests for documentation examples
 ├── test_examples/              # Tests for example code
 │   └── mloda_basics/           # Tests for basic mloda examples
-├── test_memory_bank/           # Tests for memory bank functionality
 └── test_plugins/               # Tests for plugin implementations
     ├── compute_framework/      # Tests for compute framework plugins
     ├── extender/               # Tests for extender plugins

--- a/tests/test_core/test_setup/test_link_on_methods.py
+++ b/tests/test_core/test_setup/test_link_on_methods.py
@@ -22,7 +22,6 @@ Usage:
 
 See Also:
     - GitHub Issue #133: JoinSpec Convenience Function
-    - Design Decision: /memory-bank/design-decisions/joinspec-convenience-function.md
 """
 
 from typing import Any, Optional


### PR DESCRIPTION
All three references from the issue, each verified against `main` before touching it.

## 1. `tests/README.md` — `test_memory_bank/`
The layout tree listed a `test_memory_bank/` directory. There is no such directory under `tests/`. Removed the line.

## 2. `test_link_on_methods.py` — dead design-decision path
The module docstring's **See Also** pointed at `/memory-bank/design-decisions/joinspec-convenience-function.md`. Neither that file nor the `memory-bank/design-decisions/` directory exists on `main`.

Dropped that line and kept `GitHub Issue #133: JoinSpec Convenience Function`, which still resolves — so the docstring keeps a working pointer to the rationale rather than losing the context entirely.

## 3. `todo.md` in the Phase Completion Protocol
The protocol read as though `memory-bank/todo.md` were a standing file, which sits oddly next to the slimmed Memory Bank section.

I **clarified rather than dropped** it: the protocol itself is still used, it's only the file's status that was unstated. Both files now say up front that `todo.md` is transient — created for the duration of a phased task, removed when the work lands, and therefore not one of the Memory Bank core files — before listing the steps.

`CLAUDE.md` and `AGENTS.md` are kept in sync (I diffed the two sections to confirm they're identical).

## Note on overlap
This deliberately avoids the Memory Bank / core-files section that #877 is rewriting — the only shared files are `CLAUDE.md`/`AGENTS.md`, and this change is confined to the **Phase Completion Protocol** section, which #877 doesn't touch. So the two should merge cleanly in either order.

I did not touch #873's two catalog files, since #877 already removes them.

## Checks
`ruff format --check --line-length 120` (597 files already formatted) and `ruff check` both clean; `tests/test_core/test_setup/test_link_on_methods.py` — 18 passed. Docs/comments only, no behaviour change.

Closes #878