### PR TITLE
chore(deps): bump pymdown-extensions to 11.0.1 via uv override

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,3 +187,9 @@ constraint-dependencies = [
     "soupsieve>=2.8.4",
     "nbconvert>=7.17.1",
 ]
+# Overrides, not constraints: marimo pins `pymdown-extensions<11`, and the fix for the
+# b64 path-traversal advisory only ships in 11.0. A constraint cannot beat that upper
+# pin, so the pin is overridden here. Drop this once marimo allows 11.x.
+override-dependencies = [
+    "pymdown-extensions>=11.0.1",
+]

--- a/uv.lock
+++ b/uv.lock
@@ -29,6 +29,7 @@ constraints = [
     { name = "soupsieve", specifier = ">=2.8.4" },
     { name = "urllib3", specifier = ">=2.7.0" },
 ]
+overrides = [{ name = "pymdown-extensions", specifier = ">=11.0.1" }]
 
 [[package]]
 name = "annotated-types"
@@ -2885,15 +2886,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21.3"
+version = "11.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/a9/5f0c535ba3b08fe09270c16808e053a968868242ecbd5676d4e3a488bf28/pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0", size = 857113, upload-time = "2026-07-02T17:59:22.955Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2", size = 269455, upload-time = "2026-07-02T17:59:21.271Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Clears the one open Dependabot alert on this repo.

## What was blocking it

`pymdown-extensions` is transitive here (marimo, mkdocs-material). The b64 path-traversal advisory is fixed only in `11.0`, and there is no patched `10.x`. marimo declares `pymdown-extensions>=10.21.2,<11`, so `uv lock --upgrade-package pymdown-extensions` is a no-op: a constraint cannot beat an upper pin.

## What this does

Adds `override-dependencies = ["pymdown-extensions>=11.0.1"]` to `[tool.uv]`, next to the existing security-remediation constraints, and relocks. Resolves 10.21.3 -> 11.0.1.

The 11.0 break is `b64` restricting relative links to `base_path` by default (that is the fix) plus dropping Python 3.9, which is below this project's floor. marimo imports and runs fine against 11.0.1.

Remove the override once marimo allows 11.x.

## Verification

`tox -e python314`: 7308 passed, 170 skipped; ruff format, ruff check, license allowlist, mypy --strict and bandit all clean.