### PR TITLE
refactor: declare the columnwise framework hooks once on FeatureChainParserMixin

### DIFF
--- a/mloda_plugins/feature_group/experimental/aggregated_feature_group/base.py
+++ b/mloda_plugins/feature_group/experimental/aggregated_feature_group/base.py
@@ -17,9 +17,10 @@ from mloda.provider import (
 from mloda.provider import DefaultOptionKeys
 from mloda.provider import PropertySpec
 from mloda.provider import SubtypeDeclaration
+from mloda_plugins.feature_group.experimental.columnwise_framework_hooks import ColumnDiscoveryFrameworkHooks
 
 
-class AggregatedFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+class AggregatedFeatureGroup(FeatureChainParserMixin, ColumnDiscoveryFrameworkHooks, FeatureGroup):
     """
     Base class for all aggregated feature groups.
 
@@ -191,51 +192,6 @@ class AggregatedFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             data = cls._add_result_to_data(data, feature.name, result)
 
         return data
-
-    @classmethod
-    @abstractmethod
-    def _get_available_columns(cls, data: Any) -> set[str]:
-        """
-        Get the set of available column names from the data.
-
-        Args:
-            data: The input data
-
-        Returns:
-            Set of column names available in the data
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
-    def _check_source_features_exist(cls, data: Any, feature_names: list[str]) -> None:
-        """
-        Check if the resolved source features exist in the data.
-
-        Args:
-            data: The input data
-            feature_names: List of resolved feature names (may contain ~N suffixes)
-
-        Raises:
-            ValueError: If none of the features exist in the data (partial presence is accepted).
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
-    def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:
-        """
-        Add the result to the data.
-
-        Args:
-            data: The input data
-            feature_name: The name of the feature to add
-            result: The result to add
-
-        Returns:
-            The updated data
-        """
-        ...
 
     @classmethod
     @abstractmethod

--- a/mloda_plugins/feature_group/experimental/clustering/base.py
+++ b/mloda_plugins/feature_group/experimental/clustering/base.py
@@ -16,6 +16,7 @@ from mloda.provider import (
 from mloda.provider import FeatureSet
 from mloda.provider import DefaultOptionKeys
 from mloda.provider import PropertySpec, is_positive_int
+from mloda_plugins.feature_group.experimental.columnwise_framework_hooks import ColumnDiscoveryFrameworkHooks
 
 
 def _is_bool(value: Any) -> bool:
@@ -23,7 +24,7 @@ def _is_bool(value: Any) -> bool:
     return isinstance(value, bool)
 
 
-class ClusteringFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+class ClusteringFeatureGroup(FeatureChainParserMixin, ColumnDiscoveryFrameworkHooks, FeatureGroup):
     """
     Base class for all clustering feature groups.
 
@@ -335,51 +336,6 @@ class ClusteringFeatureGroup(FeatureChainParserMixin, FeatureGroup):
                 data = cls._add_result_to_data(data, feature.name, result)
 
         return data
-
-    @classmethod
-    @abstractmethod
-    def _get_available_columns(cls, data: Any) -> set[str]:
-        """
-        Get the set of available column names from the data.
-
-        Args:
-            data: The input data
-
-        Returns:
-            Set of column names available in the data
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
-    def _check_source_features_exist(cls, data: Any, feature_names: list[str]) -> None:
-        """
-        Check if the resolved source features exist in the data.
-
-        Args:
-            data: The input data
-            feature_names: List of resolved feature names (may contain ~N suffixes)
-
-        Raises:
-            ValueError: If none of the features exist in the data (partial presence is accepted).
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
-    def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:
-        """
-        Add the result to the data.
-
-        Args:
-            data: The input data
-            feature_name: The name of the feature to add
-            result: The result to add
-
-        Returns:
-            The updated data
-        """
-        ...
 
     @classmethod
     @abstractmethod

--- a/mloda_plugins/feature_group/experimental/columnwise_framework_hooks.py
+++ b/mloda_plugins/feature_group/experimental/columnwise_framework_hooks.py
@@ -20,9 +20,10 @@ class ColumnwiseFrameworkHooks(ABC):
             feature_names: Resolved source feature names (may contain ~N suffixes)
 
         Raises:
-            ValueError: When the source features this feature group needs are absent. Tolerant
-                groups raise only when none of the names exist, strict groups raise when any name
-                is missing; see test_check_source_features_signature.py.
+            ValueError: When the source features this feature group needs are absent.
+                Aggregated, clustering, time window, and forecasting groups are tolerant
+                and raise only when none of the names exist; every other column-wise
+                group is strict and raises when any name is missing.
         """
         ...
 

--- a/mloda_plugins/feature_group/experimental/columnwise_framework_hooks.py
+++ b/mloda_plugins/feature_group/experimental/columnwise_framework_hooks.py
@@ -1,0 +1,61 @@
+"""Shared abstract framework hooks for column-wise experimental feature groups."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class ColumnwiseFrameworkHooks(ABC):
+    """Declares the check/add hooks every column-wise feature group delegates to its compute framework."""
+
+    @classmethod
+    @abstractmethod
+    def _check_source_features_exist(cls, data: Any, feature_names: list[str]) -> None:
+        """
+        Check that the resolved source features exist in the data.
+
+        Args:
+            data: The input data
+            feature_names: Resolved source feature names (may contain ~N suffixes)
+
+        Raises:
+            ValueError: When the source features this feature group needs are absent. Tolerant
+                groups raise only when none of the names exist, strict groups raise when any name
+                is missing; see test_check_source_features_signature.py.
+        """
+        ...
+
+    @classmethod
+    @abstractmethod
+    def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:
+        """
+        Add the result to the data.
+
+        Args:
+            data: The input data
+            feature_name: The name of the feature to add
+            result: The result to add
+
+        Returns:
+            The updated data
+        """
+        ...
+
+
+class ColumnDiscoveryFrameworkHooks(ColumnwiseFrameworkHooks):
+    """Adds the column discovery hook for feature groups that resolve column names against the data."""
+
+    @classmethod
+    @abstractmethod
+    def _get_available_columns(cls, data: Any) -> set[str]:
+        """
+        Get the set of available column names from the data.
+
+        Args:
+            data: The input data
+
+        Returns:
+            Set of column names available in the data
+        """
+        ...

--- a/mloda_plugins/feature_group/experimental/data_quality/missing_value/base.py
+++ b/mloda_plugins/feature_group/experimental/data_quality/missing_value/base.py
@@ -16,9 +16,10 @@ from mloda.provider import (
 from mloda.provider import FeatureSet
 from mloda.provider import DefaultOptionKeys
 from mloda.provider import PropertySpec
+from mloda_plugins.feature_group.experimental.columnwise_framework_hooks import ColumnDiscoveryFrameworkHooks
 
 
-class MissingValueFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+class MissingValueFeatureGroup(FeatureChainParserMixin, ColumnDiscoveryFrameworkHooks, FeatureGroup):
     """
     Base class for all missing value imputation feature groups.
 
@@ -306,51 +307,6 @@ class MissingValueFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             # Add the result to the data
             data = cls._add_result_to_data(data, feature.name, result)
         return data
-
-    @classmethod
-    @abstractmethod
-    def _get_available_columns(cls, data: Any) -> set[str]:
-        """
-        Get the set of available column names from the data.
-
-        Args:
-            data: The input data
-
-        Returns:
-            Set of column names available in the data
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
-    def _check_source_features_exist(cls, data: Any, feature_names: list[str]) -> None:
-        """
-        Check if the resolved source features exist in the data.
-
-        Args:
-            data: The input data
-            feature_names: List of resolved feature names (may contain ~N suffixes)
-
-        Raises:
-            ValueError: If any of the features do not exist in the data.
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
-    def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:
-        """
-        Add the result to the data.
-
-        Args:
-            data: The input data
-            feature_name: The name of the feature to add
-            result: The result to add
-
-        Returns:
-            The updated data
-        """
-        ...
 
     @classmethod
     @abstractmethod

--- a/mloda_plugins/feature_group/experimental/dimensionality_reduction/base.py
+++ b/mloda_plugins/feature_group/experimental/dimensionality_reduction/base.py
@@ -17,9 +17,10 @@ from mloda.provider import FeatureSet
 from mloda.user import Options
 from mloda.provider import DefaultOptionKeys
 from mloda.provider import PropertySpec, is_positive_int
+from mloda_plugins.feature_group.experimental.columnwise_framework_hooks import ColumnwiseFrameworkHooks
 
 
-class DimensionalityReductionFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+class DimensionalityReductionFeatureGroup(FeatureChainParserMixin, ColumnwiseFrameworkHooks, FeatureGroup):
     """
     Base class for all dimensionality reduction feature groups.
 
@@ -365,37 +366,6 @@ class DimensionalityReductionFeatureGroup(FeatureChainParserMixin, FeatureGroup)
             # Add the result to the data
             data = cls._add_result_to_data(data, feature.name, result)
         return data
-
-    @classmethod
-    @abstractmethod
-    def _check_source_features_exist(cls, data: Any, feature_names: list[str]) -> None:
-        """
-        Check if the source features exist in the data.
-
-        Args:
-            data: The input data
-            feature_names: List of feature names to check
-
-        Raises:
-            ValueError: If any of the features do not exist in the data.
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
-    def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:
-        """
-        Add the result to the data.
-
-        Args:
-            data: The input data
-            feature_name: The name of the feature to add
-            result: The result to add
-
-        Returns:
-            The updated data
-        """
-        ...
 
     @classmethod
     @abstractmethod

--- a/mloda_plugins/feature_group/experimental/forecasting/base.py
+++ b/mloda_plugins/feature_group/experimental/forecasting/base.py
@@ -15,6 +15,7 @@ from mloda.user import FeatureName
 from mloda.user import Options
 from mloda.provider import DefaultOptionKeys
 from mloda.provider import PropertySpec, is_positive_int
+from mloda_plugins.feature_group.experimental.columnwise_framework_hooks import ColumnDiscoveryFrameworkHooks
 from mloda_plugins.feature_group.experimental.forecasting.forecasting_artifact import ForecastingArtifact
 from mloda_plugins.feature_group.experimental.time_reference_mixin import TimeReferenceMixin
 
@@ -24,7 +25,7 @@ def _is_bool(value: Any) -> bool:
     return isinstance(value, bool)
 
 
-class ForecastingFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, FeatureGroup):
+class ForecastingFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, ColumnDiscoveryFrameworkHooks, FeatureGroup):
     """
     Base class for all forecasting feature groups.
 
@@ -492,51 +493,6 @@ class ForecastingFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featu
 
         Raises:
             ValueError: If the reference time column is not a datetime column
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
-    def _get_available_columns(cls, data: Any) -> set[str]:
-        """
-        Get the set of available column names from the data.
-
-        Args:
-            data: The input data
-
-        Returns:
-            Set of column names available in the data
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
-    def _check_source_features_exist(cls, data: Any, feature_names: list[str]) -> None:
-        """
-        Check if the resolved source features exist in the data.
-
-        Args:
-            data: The input data
-            feature_names: List of resolved feature names (may contain ~N suffixes)
-
-        Raises:
-            ValueError: If none of the features exist in the data (partial presence is accepted).
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
-    def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:
-        """
-        Add the result to the data.
-
-        Args:
-            data: The input data
-            feature_name: The name of the feature to add
-            result: The result to add
-
-        Returns:
-            The updated data
         """
         ...
 

--- a/mloda_plugins/feature_group/experimental/geo_distance/base.py
+++ b/mloda_plugins/feature_group/experimental/geo_distance/base.py
@@ -18,9 +18,10 @@ from mloda.provider import (
 )
 from mloda.provider import DefaultOptionKeys
 from mloda.provider import PropertySpec
+from mloda_plugins.feature_group.experimental.columnwise_framework_hooks import ColumnwiseFrameworkHooks
 
 
-class GeoDistanceFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+class GeoDistanceFeatureGroup(FeatureChainParserMixin, ColumnwiseFrameworkHooks, FeatureGroup):
     """
     Base class for all geo distance feature groups.
 
@@ -265,37 +266,6 @@ class GeoDistanceFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             )
 
         return str(distance_type)
-
-    @classmethod
-    @abstractmethod
-    def _check_source_features_exist(cls, data: Any, feature_names: list[str]) -> None:
-        """
-        Check if the source features exist in the data.
-
-        Args:
-            data: The input data
-            feature_names: List of feature names to check
-
-        Raises:
-            ValueError: If any of the features do not exist in the data.
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
-    def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:
-        """
-        Add the result to the data.
-
-        Args:
-            data: The input data
-            feature_name: The name of the feature to add
-            result: The result to add
-
-        Returns:
-            The updated data
-        """
-        ...
 
     @classmethod
     @abstractmethod

--- a/mloda_plugins/feature_group/experimental/node_centrality/base.py
+++ b/mloda_plugins/feature_group/experimental/node_centrality/base.py
@@ -16,9 +16,10 @@ from mloda.provider import (
 from mloda.provider import FeatureSet
 from mloda.provider import DefaultOptionKeys
 from mloda.provider import PropertySpec
+from mloda_plugins.feature_group.experimental.columnwise_framework_hooks import ColumnwiseFrameworkHooks
 
 
-class NodeCentralityFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+class NodeCentralityFeatureGroup(FeatureChainParserMixin, ColumnwiseFrameworkHooks, FeatureGroup):
     # Option keys for centrality configuration
     CENTRALITY_TYPE = "centrality_type"
     GRAPH_TYPE = "graph_type"
@@ -293,37 +294,6 @@ class NodeCentralityFeatureGroup(FeatureChainParserMixin, FeatureGroup):
         # Fall back to configuration-based approach
         centrality_type = feature.options.get(cls.CENTRALITY_TYPE)
         return str(centrality_type) if centrality_type is not None else None
-
-    @classmethod
-    @abstractmethod
-    def _check_source_features_exist(cls, data: Any, feature_names: list[str]) -> None:
-        """
-        Check if the source features exist in the data.
-
-        Args:
-            data: The input data
-            feature_names: List of feature names to check
-
-        Raises:
-            ValueError: If any of the features do not exist in the data.
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
-    def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:
-        """
-        Add the result to the data.
-
-        Args:
-            data: The input data
-            feature_name: The name of the feature to add
-            result: The result to add
-
-        Returns:
-            The updated data
-        """
-        ...
 
     @classmethod
     @abstractmethod

--- a/mloda_plugins/feature_group/experimental/sklearn/encoding/base.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/encoding/base.py
@@ -20,10 +20,11 @@ from mloda.provider import (
 from mloda.provider import BaseArtifact
 from mloda.provider import DefaultOptionKeys
 from mloda.provider import PropertySpec
+from mloda_plugins.feature_group.experimental.columnwise_framework_hooks import ColumnwiseFrameworkHooks
 from mloda_plugins.feature_group.experimental.sklearn.sklearn_artifact import SklearnArtifact
 
 
-class EncodingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+class EncodingFeatureGroup(FeatureChainParserMixin, ColumnwiseFrameworkHooks, FeatureGroup):
     """
     Base class for scikit-learn encoding feature groups.
 
@@ -490,36 +491,5 @@ class EncodingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 
         Returns:
             Encoded data
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
-    def _check_source_features_exist(cls, data: Any, feature_names: list[str]) -> None:
-        """
-        Check if the source features exist in the data.
-
-        Args:
-            data: The input data
-            feature_names: List of feature names to check
-
-        Raises:
-            ValueError: If any of the features do not exist in the data.
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
-    def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:
-        """
-        Add the result to the data.
-
-        Args:
-            data: The input data
-            feature_name: The name of the feature to add
-            result: The result to add
-
-        Returns:
-            The updated data
         """
         ...

--- a/mloda_plugins/feature_group/experimental/sklearn/pipeline/base.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/pipeline/base.py
@@ -20,10 +20,11 @@ from mloda.provider import (
 from mloda.provider import BaseArtifact
 from mloda.provider import DefaultOptionKeys
 from mloda.provider import PropertySpec
+from mloda_plugins.feature_group.experimental.columnwise_framework_hooks import ColumnwiseFrameworkHooks
 from mloda_plugins.feature_group.experimental.sklearn.sklearn_artifact import SklearnArtifact
 
 
-class SklearnPipelineFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+class SklearnPipelineFeatureGroup(FeatureChainParserMixin, ColumnwiseFrameworkHooks, FeatureGroup):
     """
     Base class for scikit-learn pipeline feature groups.
 
@@ -598,36 +599,5 @@ class SklearnPipelineFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 
         Returns:
             Transformed data
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
-    def _check_source_features_exist(cls, data: Any, feature_names: list[str]) -> None:
-        """
-        Check if the source features exist in the data.
-
-        Args:
-            data: The input data
-            feature_names: List of feature names to check
-
-        Raises:
-            ValueError: If any of the features do not exist in the data.
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
-    def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:
-        """
-        Add the result to the data.
-
-        Args:
-            data: The input data
-            feature_name: The name of the feature to add
-            result: The result to add
-
-        Returns:
-            The updated data
         """
         ...

--- a/mloda_plugins/feature_group/experimental/sklearn/scaling/base.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/scaling/base.py
@@ -18,10 +18,11 @@ from mloda.provider import (
 from mloda.provider import BaseArtifact
 from mloda.provider import DefaultOptionKeys
 from mloda.provider import PropertySpec
+from mloda_plugins.feature_group.experimental.columnwise_framework_hooks import ColumnwiseFrameworkHooks
 from mloda_plugins.feature_group.experimental.sklearn.sklearn_artifact import SklearnArtifact
 
 
-class ScalingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+class ScalingFeatureGroup(FeatureChainParserMixin, ColumnwiseFrameworkHooks, FeatureGroup):
     """
     Base class for scikit-learn scaling feature groups.
 
@@ -352,36 +353,5 @@ class ScalingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 
         Returns:
             Scaled data
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
-    def _check_source_features_exist(cls, data: Any, feature_names: list[str]) -> None:
-        """
-        Check if the source features exist in the data.
-
-        Args:
-            data: The input data
-            feature_names: List of feature names to check
-
-        Raises:
-            ValueError: If any of the features do not exist in the data.
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
-    def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:
-        """
-        Add the result to the data.
-
-        Args:
-            data: The input data
-            feature_name: The name of the feature to add
-            result: The result to add
-
-        Returns:
-            The updated data
         """
         ...

--- a/mloda_plugins/feature_group/experimental/text_cleaning/base.py
+++ b/mloda_plugins/feature_group/experimental/text_cleaning/base.py
@@ -15,9 +15,10 @@ from mloda.provider import (
 from mloda.provider import FeatureSet
 from mloda.provider import DefaultOptionKeys
 from mloda.provider import PropertySpec
+from mloda_plugins.feature_group.experimental.columnwise_framework_hooks import ColumnwiseFrameworkHooks
 
 
-class TextCleaningFeatureGroup(FeatureChainParserMixin, FeatureGroup):
+class TextCleaningFeatureGroup(FeatureChainParserMixin, ColumnwiseFrameworkHooks, FeatureGroup):
     """
     Base class for all text cleaning feature groups.
 
@@ -179,21 +180,6 @@ class TextCleaningFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 
     @classmethod
     @abstractmethod
-    def _check_source_features_exist(cls, data: Any, feature_names: list[str]) -> None:
-        """
-        Check if the source features exist in the data.
-
-        Args:
-            data: The input data
-            feature_names: List of feature names to check
-
-        Raises:
-            ValueError: If any of the features do not exist in the data.
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
     def _get_source_text(cls, data: Any, feature_name: str) -> Any:
         """
         Get the source text from the data.
@@ -204,22 +190,6 @@ class TextCleaningFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 
         Returns:
             The source text
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
-    def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:
-        """
-        Add the result to the data.
-
-        Args:
-            data: The input data
-            feature_name: The name of the feature to add
-            result: The result to add
-
-        Returns:
-            The updated data
         """
         ...
 

--- a/mloda_plugins/feature_group/experimental/time_window/base.py
+++ b/mloda_plugins/feature_group/experimental/time_window/base.py
@@ -19,10 +19,11 @@ from mloda.provider import FeatureSet
 from mloda.user import Options
 from mloda.provider import DefaultOptionKeys
 from mloda.provider import PropertySpec, is_positive_int
+from mloda_plugins.feature_group.experimental.columnwise_framework_hooks import ColumnDiscoveryFrameworkHooks
 from mloda_plugins.feature_group.experimental.time_reference_mixin import TimeReferenceMixin
 
 
-class TimeWindowFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, FeatureGroup):
+class TimeWindowFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, ColumnDiscoveryFrameworkHooks, FeatureGroup):
     """
     Base class for all time window feature groups.
 
@@ -402,51 +403,6 @@ class TimeWindowFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featur
 
         Raises:
             ValueError: If the reference time column is not a datetime column
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
-    def _get_available_columns(cls, data: Any) -> set[str]:
-        """
-        Get the set of available column names from the data.
-
-        Args:
-            data: The input data
-
-        Returns:
-            Set of column names available in the data
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
-    def _check_source_features_exist(cls, data: Any, feature_names: list[str]) -> None:
-        """
-        Check if the resolved source features exist in the data.
-
-        Args:
-            data: The input data
-            feature_names: List of resolved feature names (may contain ~N suffixes)
-
-        Raises:
-            ValueError: If none of the features exist in the data (partial presence is accepted).
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
-    def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:
-        """
-        Add the result to the data.
-
-        Args:
-            data: The input data
-            feature_name: The name of the feature to add
-            result: The result to add
-
-        Returns:
-            The updated data
         """
         ...
 

--- a/tests/test_plugins/feature_group/experimental/test_check_source_features_signature.py
+++ b/tests/test_plugins/feature_group/experimental/test_check_source_features_signature.py
@@ -112,6 +112,12 @@ class TestUnifiedCheckSourceFeaturesSignature:
         )
 
 
+@pytest.mark.parametrize("cls", ALL_PANDAS_CLASSES, ids=lambda c: c.__name__)
+def test_pandas_plugin_is_concrete(cls: Any) -> None:
+    """An unimplemented abstract method keeps a plugin abstract, and registration then skips it silently."""
+    assert inspect.isabstract(cls) is False, f"{cls.__name__} is abstract: {sorted(cls.__abstractmethods__)}"
+
+
 TOLERANT_PANDAS_CLASSES = [
     PandasAggregatedFeatureGroup,
     PandasClusteringFeatureGroup,

--- a/tests/test_plugins/feature_group/experimental/test_columnwise_framework_hooks.py
+++ b/tests/test_plugins/feature_group/experimental/test_columnwise_framework_hooks.py
@@ -1,0 +1,107 @@
+"""Pins that the twelve experimental bases inherit their framework hooks from the shared mixins (os-017)."""
+
+from typing import Any
+
+import pytest
+
+from mloda.provider import FeatureGroup
+from mloda_plugins.feature_group.experimental.aggregated_feature_group.base import AggregatedFeatureGroup
+from mloda_plugins.feature_group.experimental.clustering.base import ClusteringFeatureGroup
+from mloda_plugins.feature_group.experimental.columnwise_framework_hooks import (
+    ColumnDiscoveryFrameworkHooks,
+    ColumnwiseFrameworkHooks,
+)
+from mloda_plugins.feature_group.experimental.data_quality.missing_value.base import MissingValueFeatureGroup
+from mloda_plugins.feature_group.experimental.dimensionality_reduction.base import DimensionalityReductionFeatureGroup
+from mloda_plugins.feature_group.experimental.forecasting.base import ForecastingFeatureGroup
+from mloda_plugins.feature_group.experimental.geo_distance.base import GeoDistanceFeatureGroup
+from mloda_plugins.feature_group.experimental.node_centrality.base import NodeCentralityFeatureGroup
+from mloda_plugins.feature_group.experimental.sklearn.encoding.base import EncodingFeatureGroup
+from mloda_plugins.feature_group.experimental.sklearn.pipeline.base import SklearnPipelineFeatureGroup
+from mloda_plugins.feature_group.experimental.sklearn.scaling.base import ScalingFeatureGroup
+from mloda_plugins.feature_group.experimental.text_cleaning.base import TextCleaningFeatureGroup
+from mloda_plugins.feature_group.experimental.time_window.base import TimeWindowFeatureGroup
+
+PAIR_HOOKS: frozenset[str] = frozenset({"_check_source_features_exist", "_add_result_to_data"})
+DISCOVERY_HOOK = "_get_available_columns"
+ALL_HOOKS: frozenset[str] = PAIR_HOOKS | {DISCOVERY_HOOK}
+
+# Bases that resolve column names against the data before computing, so they need the discovery hook.
+DISCOVERY_BASES: list[type[Any]] = [
+    AggregatedFeatureGroup,
+    ClusteringFeatureGroup,
+    MissingValueFeatureGroup,
+    ForecastingFeatureGroup,
+    TimeWindowFeatureGroup,
+]
+
+# Bases that only check and write columns, so the discovery hook must stay out of their abstract surface.
+PAIR_ONLY_BASES: list[type[Any]] = [
+    DimensionalityReductionFeatureGroup,
+    GeoDistanceFeatureGroup,
+    NodeCentralityFeatureGroup,
+    EncodingFeatureGroup,
+    SklearnPipelineFeatureGroup,
+    ScalingFeatureGroup,
+    TextCleaningFeatureGroup,
+]
+
+ALL_BASES: list[type[Any]] = DISCOVERY_BASES + PAIR_ONLY_BASES
+
+EXPECTED_ABSTRACT_HOOKS = [pytest.param(base, ALL_HOOKS, id=base.__name__) for base in DISCOVERY_BASES] + [
+    pytest.param(base, PAIR_HOOKS, id=base.__name__) for base in PAIR_ONLY_BASES
+]
+
+
+@pytest.mark.parametrize("base", ALL_BASES, ids=lambda base: base.__name__)
+def test_every_base_inherits_columnwise_hooks(base: type[Any]) -> None:
+    """All twelve bases take the check/add pair from ColumnwiseFrameworkHooks."""
+    assert issubclass(base, ColumnwiseFrameworkHooks), f"{base.__name__} does not inherit ColumnwiseFrameworkHooks"
+
+
+@pytest.mark.parametrize("base", DISCOVERY_BASES, ids=lambda base: base.__name__)
+def test_discovery_bases_inherit_discovery_hooks(base: type[Any]) -> None:
+    """The five column-resolving bases take all three hooks from ColumnDiscoveryFrameworkHooks."""
+    assert issubclass(base, ColumnDiscoveryFrameworkHooks), (
+        f"{base.__name__} does not inherit ColumnDiscoveryFrameworkHooks"
+    )
+
+
+@pytest.mark.parametrize("base", PAIR_ONLY_BASES, ids=lambda base: base.__name__)
+def test_pair_only_bases_are_not_discovery_hooks(base: type[Any]) -> None:
+    """The seven pair-only bases must not be widened to ColumnDiscoveryFrameworkHooks."""
+    assert not issubclass(base, ColumnDiscoveryFrameworkHooks), (
+        f"{base.__name__} must not inherit ColumnDiscoveryFrameworkHooks"
+    )
+
+
+@pytest.mark.parametrize("base", ALL_BASES, ids=lambda base: base.__name__)
+def test_base_does_not_redeclare_hooks(base: type[Any]) -> None:
+    """No base redeclares a hook in its own body, the declaration lives only in the mixin."""
+    redeclared = sorted(name for name in ALL_HOOKS if name in vars(base))
+    assert redeclared == [], f"{base.__name__} still declares {redeclared} itself instead of inheriting them"
+
+
+@pytest.mark.parametrize(("base", "expected"), EXPECTED_ABSTRACT_HOOKS)
+def test_abstract_hook_surface_is_unchanged(base: type[Any], expected: frozenset[str]) -> None:
+    """Each base keeps exactly the hooks it had as abstract, so no family silently gains one."""
+    actual = ALL_HOOKS & set(base.__abstractmethods__)
+    assert actual == set(expected), f"{base.__name__} abstract hooks are {sorted(actual)}, expected {sorted(expected)}"
+
+
+def test_columnwise_hooks_is_not_a_feature_group() -> None:
+    """ColumnwiseFrameworkHooks must stay out of the FeatureGroup tree so plugin collection is unaffected."""
+    assert not issubclass(ColumnwiseFrameworkHooks, FeatureGroup)
+
+
+def test_column_discovery_hooks_is_not_a_feature_group() -> None:
+    """ColumnDiscoveryFrameworkHooks must stay out of the FeatureGroup tree so plugin collection is unaffected."""
+    assert not issubclass(ColumnDiscoveryFrameworkHooks, FeatureGroup)
+
+
+def test_mixins_declare_the_hooks_abstractly() -> None:
+    """The mixins own the declarations: the pair on the base mixin, the discovery hook on the subclass."""
+    assert PAIR_HOOKS <= set(ColumnwiseFrameworkHooks.__abstractmethods__)
+    assert DISCOVERY_HOOK not in ColumnwiseFrameworkHooks.__abstractmethods__
+    assert ALL_HOOKS <= set(ColumnDiscoveryFrameworkHooks.__abstractmethods__)
+    assert issubclass(ColumnDiscoveryFrameworkHooks, ColumnwiseFrameworkHooks)

--- a/tests/test_plugins/feature_group/experimental/test_columnwise_framework_hooks.py
+++ b/tests/test_plugins/feature_group/experimental/test_columnwise_framework_hooks.py
@@ -1,6 +1,7 @@
 """Pins that the twelve experimental bases inherit their framework hooks from the shared mixins (os-017)."""
 
-from typing import Any
+import ast
+from pathlib import Path
 
 import pytest
 
@@ -26,17 +27,26 @@ PAIR_HOOKS: frozenset[str] = frozenset({"_check_source_features_exist", "_add_re
 DISCOVERY_HOOK = "_get_available_columns"
 ALL_HOOKS: frozenset[str] = PAIR_HOOKS | {DISCOVERY_HOOK}
 
+# Anchor the scan root to the repo layout via __file__, not the cwd: a cwd-relative root makes the
+# rglob loop empty and the sweep pass vacuously. This file sits four parents below the repo root.
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+SCAN_ROOT = _REPO_ROOT / "mloda_plugins" / "feature_group" / "experimental"
+assert SCAN_ROOT.exists(), f"scan root not found; check the parents index for the repo root: {SCAN_ROOT}"
+
+EXPECTED_BASE_MODULES = 12
+
 # Bases that resolve column names against the data before computing, so they need the discovery hook.
-DISCOVERY_BASES: list[type[Any]] = [
+DISCOVERY_BASES: list[type[FeatureGroup]] = [
     AggregatedFeatureGroup,
     ClusteringFeatureGroup,
     MissingValueFeatureGroup,
     ForecastingFeatureGroup,
     TimeWindowFeatureGroup,
 ]
+assert len(DISCOVERY_BASES) == 5, f"DISCOVERY_BASES lists {len(DISCOVERY_BASES)} bases, expected 5"
 
 # Bases that only check and write columns, so the discovery hook must stay out of their abstract surface.
-PAIR_ONLY_BASES: list[type[Any]] = [
+PAIR_ONLY_BASES: list[type[FeatureGroup]] = [
     DimensionalityReductionFeatureGroup,
     GeoDistanceFeatureGroup,
     NodeCentralityFeatureGroup,
@@ -45,8 +55,10 @@ PAIR_ONLY_BASES: list[type[Any]] = [
     ScalingFeatureGroup,
     TextCleaningFeatureGroup,
 ]
+assert len(PAIR_ONLY_BASES) == 7, f"PAIR_ONLY_BASES lists {len(PAIR_ONLY_BASES)} bases, expected 7"
 
-ALL_BASES: list[type[Any]] = DISCOVERY_BASES + PAIR_ONLY_BASES
+ALL_BASES: list[type[FeatureGroup]] = DISCOVERY_BASES + PAIR_ONLY_BASES
+assert len(ALL_BASES) == EXPECTED_BASE_MODULES, f"ALL_BASES lists {len(ALL_BASES)} bases, expected 12"
 
 EXPECTED_ABSTRACT_HOOKS = [pytest.param(base, ALL_HOOKS, id=base.__name__) for base in DISCOVERY_BASES] + [
     pytest.param(base, PAIR_HOOKS, id=base.__name__) for base in PAIR_ONLY_BASES
@@ -54,13 +66,13 @@ EXPECTED_ABSTRACT_HOOKS = [pytest.param(base, ALL_HOOKS, id=base.__name__) for b
 
 
 @pytest.mark.parametrize("base", ALL_BASES, ids=lambda base: base.__name__)
-def test_every_base_inherits_columnwise_hooks(base: type[Any]) -> None:
+def test_every_base_inherits_columnwise_hooks(base: type[FeatureGroup]) -> None:
     """All twelve bases take the check/add pair from ColumnwiseFrameworkHooks."""
     assert issubclass(base, ColumnwiseFrameworkHooks), f"{base.__name__} does not inherit ColumnwiseFrameworkHooks"
 
 
 @pytest.mark.parametrize("base", DISCOVERY_BASES, ids=lambda base: base.__name__)
-def test_discovery_bases_inherit_discovery_hooks(base: type[Any]) -> None:
+def test_discovery_bases_inherit_discovery_hooks(base: type[FeatureGroup]) -> None:
     """The five column-resolving bases take all three hooks from ColumnDiscoveryFrameworkHooks."""
     assert issubclass(base, ColumnDiscoveryFrameworkHooks), (
         f"{base.__name__} does not inherit ColumnDiscoveryFrameworkHooks"
@@ -68,7 +80,7 @@ def test_discovery_bases_inherit_discovery_hooks(base: type[Any]) -> None:
 
 
 @pytest.mark.parametrize("base", PAIR_ONLY_BASES, ids=lambda base: base.__name__)
-def test_pair_only_bases_are_not_discovery_hooks(base: type[Any]) -> None:
+def test_pair_only_bases_are_not_discovery_hooks(base: type[FeatureGroup]) -> None:
     """The seven pair-only bases must not be widened to ColumnDiscoveryFrameworkHooks."""
     assert not issubclass(base, ColumnDiscoveryFrameworkHooks), (
         f"{base.__name__} must not inherit ColumnDiscoveryFrameworkHooks"
@@ -76,14 +88,14 @@ def test_pair_only_bases_are_not_discovery_hooks(base: type[Any]) -> None:
 
 
 @pytest.mark.parametrize("base", ALL_BASES, ids=lambda base: base.__name__)
-def test_base_does_not_redeclare_hooks(base: type[Any]) -> None:
+def test_base_does_not_redeclare_hooks(base: type[FeatureGroup]) -> None:
     """No base redeclares a hook in its own body, the declaration lives only in the mixin."""
     redeclared = sorted(name for name in ALL_HOOKS if name in vars(base))
     assert redeclared == [], f"{base.__name__} still declares {redeclared} itself instead of inheriting them"
 
 
 @pytest.mark.parametrize(("base", "expected"), EXPECTED_ABSTRACT_HOOKS)
-def test_abstract_hook_surface_is_unchanged(base: type[Any], expected: frozenset[str]) -> None:
+def test_abstract_hook_surface_is_unchanged(base: type[FeatureGroup], expected: frozenset[str]) -> None:
     """Each base keeps exactly the hooks it had as abstract, so no family silently gains one."""
     actual = ALL_HOOKS & set(base.__abstractmethods__)
     assert actual == set(expected), f"{base.__name__} abstract hooks are {sorted(actual)}, expected {sorted(expected)}"
@@ -97,6 +109,28 @@ def test_columnwise_hooks_is_not_a_feature_group() -> None:
 def test_column_discovery_hooks_is_not_a_feature_group() -> None:
     """ColumnDiscoveryFrameworkHooks must stay out of the FeatureGroup tree so plugin collection is unaffected."""
     assert not issubclass(ColumnDiscoveryFrameworkHooks, FeatureGroup)
+
+
+def test_no_base_module_declares_a_hook_in_source() -> None:
+    """Static sweep: no base.py under the experimental tree re-adds a hook declaration to a class body."""
+    offenders: list[str] = []
+    visited = 0
+    for path in sorted(SCAN_ROOT.rglob("base.py")):
+        visited += 1
+        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+            if not isinstance(node, ast.ClassDef):
+                continue
+            declared = sorted(
+                child.name
+                for child in node.body
+                if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)) and child.name in ALL_HOOKS
+            )
+            if declared:
+                offenders.append(f"{path.relative_to(_REPO_ROOT)}::{node.name} declares {declared}")
+    assert offenders == [], f"base modules must inherit the hooks from the mixins, found: {offenders}"
+    assert visited == EXPECTED_BASE_MODULES, (
+        f"sweep visited {visited} base.py files under {SCAN_ROOT}, expected {EXPECTED_BASE_MODULES}"
+    )
 
 
 def test_mixins_declare_the_hooks_abstractly() -> None:


### PR DESCRIPTION
Superseded: the work continued on a renamed branch and was reopened as a new pull request.