### PR TITLE
refactor: declare the columnwise framework hooks once on FeatureChainParserMixin

### DIFF
--- a/docs/docs/in_depth/feature-chain-parser.md
+++ b/docs/docs/in_depth/feature-chain-parser.md
@@ -146,6 +146,18 @@ class MyFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 | `IN_FEATURE_SEPARATOR` | `str` | `"&"` | Separator for multiple in_features |
 | `RECOGNITION_ONLY_PATTERN` | `bool` | `False` | Declares a captureless pattern as recognition-only (binds no key from the name) |
 
+### Column-Wise Data Hooks
+
+Beyond parsing, the mixin declares three column-wise data hooks: `_get_available_columns`,
+`_check_source_features_exist` and `_add_result_to_data`. The concrete compute-framework subclass
+(pandas, PyArrow, Polars, python dict, ...) implements them; the inherited defaults raise
+`NotImplementedError` naming the class and the hook, so a missing implementation fails loudly
+instead of silently. A group that resolves column names against the data implements the discovery
+hook too; the others only need the check/add pair.
+
+Whether `_check_source_features_exist` tolerates partial presence (some source names missing) or
+rejects it is a per-feature-group policy, not a framework rule.
+
 ### Captureless Patterns and Name Binding
 
 A captureless `PREFIX_PATTERN` (one with no capture group, e.g. `r".*__cleaned_text$"`) binds no

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -81,6 +81,9 @@ class FeatureChainParserMixin:
     """
     Mixin providing default implementations for feature chain parsing.
 
+    Beyond the chain-parsing helpers, it also carries the column-wise data hooks
+    (see the section at the end of the class).
+
     Subclasses should define:
     - PREFIX_PATTERN or SUFFIX_PATTERN: Regex patterns for matching
     - PROPERTY_MAPPING: Property validation mapping (see docs/in_depth/property-mapping.md)
@@ -619,3 +622,50 @@ class FeatureChainParserMixin:
         if value is not None:
             return str(value)
         return None
+
+    # Column-wise data hooks: the concrete compute-framework subclass (pandas, pyarrow, ...) implements
+    # these. They are deliberately not @abstractmethod, since this is a plain class where that would be
+    # unenforced; the defaults below raise instead, naming the class that skipped the implementation.
+
+    @classmethod
+    def _get_available_columns(cls, data: Any) -> set[str]:
+        """
+        Get the set of available column names from the data.
+
+        Args:
+            data: The input data
+
+        Returns:
+            Set of column names available in the data
+        """
+        raise NotImplementedError(f"{cls.__name__} must implement _get_available_columns")
+
+    @classmethod
+    def _check_source_features_exist(cls, data: Any, feature_names: list[str]) -> None:
+        """
+        Check that the resolved source features exist in the data.
+
+        Args:
+            data: The input data
+            feature_names: Resolved source feature names (may contain ~N suffixes)
+
+        Raises:
+            ValueError: When the source features this feature group needs are absent. Whether
+                partial presence is accepted is defined by the implementing feature group.
+        """
+        raise NotImplementedError(f"{cls.__name__} must implement _check_source_features_exist")
+
+    @classmethod
+    def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:
+        """
+        Add the result to the data.
+
+        Args:
+            data: The input data
+            feature_name: The name of the feature to add
+            result: The result to add
+
+        Returns:
+            The updated data
+        """
+        raise NotImplementedError(f"{cls.__name__} must implement _add_result_to_data")

--- a/mloda_plugins/feature_group/experimental/aggregated_feature_group/base.py
+++ b/mloda_plugins/feature_group/experimental/aggregated_feature_group/base.py
@@ -194,51 +194,6 @@ class AggregatedFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 
     @classmethod
     @abstractmethod
-    def _get_available_columns(cls, data: Any) -> set[str]:
-        """
-        Get the set of available column names from the data.
-
-        Args:
-            data: The input data
-
-        Returns:
-            Set of column names available in the data
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
-    def _check_source_features_exist(cls, data: Any, feature_names: list[str]) -> None:
-        """
-        Check if the resolved source features exist in the data.
-
-        Args:
-            data: The input data
-            feature_names: List of resolved feature names (may contain ~N suffixes)
-
-        Raises:
-            ValueError: If none of the features exist in the data (partial presence is accepted).
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
-    def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:
-        """
-        Add the result to the data.
-
-        Args:
-            data: The input data
-            feature_name: The name of the feature to add
-            result: The result to add
-
-        Returns:
-            The updated data
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
     def _perform_aggregation(cls, data: Any, aggregation_type: str, in_features: list[str]) -> Any:
         """
         Method to perform the aggregation. Should be implemented by subclasses.

--- a/mloda_plugins/feature_group/experimental/clustering/base.py
+++ b/mloda_plugins/feature_group/experimental/clustering/base.py
@@ -338,51 +338,6 @@ class ClusteringFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 
     @classmethod
     @abstractmethod
-    def _get_available_columns(cls, data: Any) -> set[str]:
-        """
-        Get the set of available column names from the data.
-
-        Args:
-            data: The input data
-
-        Returns:
-            Set of column names available in the data
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
-    def _check_source_features_exist(cls, data: Any, feature_names: list[str]) -> None:
-        """
-        Check if the resolved source features exist in the data.
-
-        Args:
-            data: The input data
-            feature_names: List of resolved feature names (may contain ~N suffixes)
-
-        Raises:
-            ValueError: If none of the features exist in the data (partial presence is accepted).
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
-    def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:
-        """
-        Add the result to the data.
-
-        Args:
-            data: The input data
-            feature_name: The name of the feature to add
-            result: The result to add
-
-        Returns:
-            The updated data
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
     def _perform_clustering(
         cls,
         data: Any,

--- a/mloda_plugins/feature_group/experimental/data_quality/missing_value/base.py
+++ b/mloda_plugins/feature_group/experimental/data_quality/missing_value/base.py
@@ -309,51 +309,6 @@ class MissingValueFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 
     @classmethod
     @abstractmethod
-    def _get_available_columns(cls, data: Any) -> set[str]:
-        """
-        Get the set of available column names from the data.
-
-        Args:
-            data: The input data
-
-        Returns:
-            Set of column names available in the data
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
-    def _check_source_features_exist(cls, data: Any, feature_names: list[str]) -> None:
-        """
-        Check if the resolved source features exist in the data.
-
-        Args:
-            data: The input data
-            feature_names: List of resolved feature names (may contain ~N suffixes)
-
-        Raises:
-            ValueError: If any of the features do not exist in the data.
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
-    def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:
-        """
-        Add the result to the data.
-
-        Args:
-            data: The input data
-            feature_name: The name of the feature to add
-            result: The result to add
-
-        Returns:
-            The updated data
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
     def _perform_imputation(
         cls,
         data: Any,

--- a/mloda_plugins/feature_group/experimental/dimensionality_reduction/base.py
+++ b/mloda_plugins/feature_group/experimental/dimensionality_reduction/base.py
@@ -368,37 +368,6 @@ class DimensionalityReductionFeatureGroup(FeatureChainParserMixin, FeatureGroup)
 
     @classmethod
     @abstractmethod
-    def _check_source_features_exist(cls, data: Any, feature_names: list[str]) -> None:
-        """
-        Check if the source features exist in the data.
-
-        Args:
-            data: The input data
-            feature_names: List of feature names to check
-
-        Raises:
-            ValueError: If any of the features do not exist in the data.
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
-    def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:
-        """
-        Add the result to the data.
-
-        Args:
-            data: The input data
-            feature_name: The name of the feature to add
-            result: The result to add
-
-        Returns:
-            The updated data
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
     def _perform_reduction(
         cls,
         data: Any,

--- a/mloda_plugins/feature_group/experimental/forecasting/base.py
+++ b/mloda_plugins/feature_group/experimental/forecasting/base.py
@@ -497,51 +497,6 @@ class ForecastingFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featu
 
     @classmethod
     @abstractmethod
-    def _get_available_columns(cls, data: Any) -> set[str]:
-        """
-        Get the set of available column names from the data.
-
-        Args:
-            data: The input data
-
-        Returns:
-            Set of column names available in the data
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
-    def _check_source_features_exist(cls, data: Any, feature_names: list[str]) -> None:
-        """
-        Check if the resolved source features exist in the data.
-
-        Args:
-            data: The input data
-            feature_names: List of resolved feature names (may contain ~N suffixes)
-
-        Raises:
-            ValueError: If none of the features exist in the data (partial presence is accepted).
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
-    def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:
-        """
-        Add the result to the data.
-
-        Args:
-            data: The input data
-            feature_name: The name of the feature to add
-            result: The result to add
-
-        Returns:
-            The updated data
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
     def _perform_forecasting(
         cls,
         data: Any,

--- a/mloda_plugins/feature_group/experimental/geo_distance/base.py
+++ b/mloda_plugins/feature_group/experimental/geo_distance/base.py
@@ -268,37 +268,6 @@ class GeoDistanceFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 
     @classmethod
     @abstractmethod
-    def _check_source_features_exist(cls, data: Any, feature_names: list[str]) -> None:
-        """
-        Check if the source features exist in the data.
-
-        Args:
-            data: The input data
-            feature_names: List of feature names to check
-
-        Raises:
-            ValueError: If any of the features do not exist in the data.
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
-    def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:
-        """
-        Add the result to the data.
-
-        Args:
-            data: The input data
-            feature_name: The name of the feature to add
-            result: The result to add
-
-        Returns:
-            The updated data
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
     def _calculate_distance(cls, data: Any, distance_type: str, point1_feature: str, point2_feature: str) -> Any:
         """
         Method to calculate the distance. Should be implemented by subclasses.

--- a/mloda_plugins/feature_group/experimental/node_centrality/base.py
+++ b/mloda_plugins/feature_group/experimental/node_centrality/base.py
@@ -296,37 +296,6 @@ class NodeCentralityFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 
     @classmethod
     @abstractmethod
-    def _check_source_features_exist(cls, data: Any, feature_names: list[str]) -> None:
-        """
-        Check if the source features exist in the data.
-
-        Args:
-            data: The input data
-            feature_names: List of feature names to check
-
-        Raises:
-            ValueError: If any of the features do not exist in the data.
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
-    def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:
-        """
-        Add the result to the data.
-
-        Args:
-            data: The input data
-            feature_name: The name of the feature to add
-            result: The result to add
-
-        Returns:
-            The updated data
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
     def _calculate_centrality(
         cls,
         data: Any,

--- a/mloda_plugins/feature_group/experimental/sklearn/encoding/base.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/encoding/base.py
@@ -492,34 +492,3 @@ class EncodingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             Encoded data
         """
         ...
-
-    @classmethod
-    @abstractmethod
-    def _check_source_features_exist(cls, data: Any, feature_names: list[str]) -> None:
-        """
-        Check if the source features exist in the data.
-
-        Args:
-            data: The input data
-            feature_names: List of feature names to check
-
-        Raises:
-            ValueError: If any of the features do not exist in the data.
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
-    def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:
-        """
-        Add the result to the data.
-
-        Args:
-            data: The input data
-            feature_name: The name of the feature to add
-            result: The result to add
-
-        Returns:
-            The updated data
-        """
-        ...

--- a/mloda_plugins/feature_group/experimental/sklearn/pipeline/base.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/pipeline/base.py
@@ -600,34 +600,3 @@ class SklearnPipelineFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             Transformed data
         """
         ...
-
-    @classmethod
-    @abstractmethod
-    def _check_source_features_exist(cls, data: Any, feature_names: list[str]) -> None:
-        """
-        Check if the source features exist in the data.
-
-        Args:
-            data: The input data
-            feature_names: List of feature names to check
-
-        Raises:
-            ValueError: If any of the features do not exist in the data.
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
-    def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:
-        """
-        Add the result to the data.
-
-        Args:
-            data: The input data
-            feature_name: The name of the feature to add
-            result: The result to add
-
-        Returns:
-            The updated data
-        """
-        ...

--- a/mloda_plugins/feature_group/experimental/sklearn/scaling/base.py
+++ b/mloda_plugins/feature_group/experimental/sklearn/scaling/base.py
@@ -354,34 +354,3 @@ class ScalingFeatureGroup(FeatureChainParserMixin, FeatureGroup):
             Scaled data
         """
         ...
-
-    @classmethod
-    @abstractmethod
-    def _check_source_features_exist(cls, data: Any, feature_names: list[str]) -> None:
-        """
-        Check if the source features exist in the data.
-
-        Args:
-            data: The input data
-            feature_names: List of feature names to check
-
-        Raises:
-            ValueError: If any of the features do not exist in the data.
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
-    def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:
-        """
-        Add the result to the data.
-
-        Args:
-            data: The input data
-            feature_name: The name of the feature to add
-            result: The result to add
-
-        Returns:
-            The updated data
-        """
-        ...

--- a/mloda_plugins/feature_group/experimental/text_cleaning/base.py
+++ b/mloda_plugins/feature_group/experimental/text_cleaning/base.py
@@ -179,21 +179,6 @@ class TextCleaningFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 
     @classmethod
     @abstractmethod
-    def _check_source_features_exist(cls, data: Any, feature_names: list[str]) -> None:
-        """
-        Check if the source features exist in the data.
-
-        Args:
-            data: The input data
-            feature_names: List of feature names to check
-
-        Raises:
-            ValueError: If any of the features do not exist in the data.
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
     def _get_source_text(cls, data: Any, feature_name: str) -> Any:
         """
         Get the source text from the data.
@@ -204,22 +189,6 @@ class TextCleaningFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 
         Returns:
             The source text
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
-    def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:
-        """
-        Add the result to the data.
-
-        Args:
-            data: The input data
-            feature_name: The name of the feature to add
-            result: The result to add
-
-        Returns:
-            The updated data
         """
         ...
 

--- a/mloda_plugins/feature_group/experimental/time_window/base.py
+++ b/mloda_plugins/feature_group/experimental/time_window/base.py
@@ -407,51 +407,6 @@ class TimeWindowFeatureGroup(TimeReferenceMixin, FeatureChainParserMixin, Featur
 
     @classmethod
     @abstractmethod
-    def _get_available_columns(cls, data: Any) -> set[str]:
-        """
-        Get the set of available column names from the data.
-
-        Args:
-            data: The input data
-
-        Returns:
-            Set of column names available in the data
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
-    def _check_source_features_exist(cls, data: Any, feature_names: list[str]) -> None:
-        """
-        Check if the resolved source features exist in the data.
-
-        Args:
-            data: The input data
-            feature_names: List of resolved feature names (may contain ~N suffixes)
-
-        Raises:
-            ValueError: If none of the features exist in the data (partial presence is accepted).
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
-    def _add_result_to_data(cls, data: Any, feature_name: str, result: Any) -> Any:
-        """
-        Add the result to the data.
-
-        Args:
-            data: The input data
-            feature_name: The name of the feature to add
-            result: The result to add
-
-        Returns:
-            The updated data
-        """
-        ...
-
-    @classmethod
-    @abstractmethod
     def _perform_window_operation(
         cls,
         data: Any,

--- a/tests/test_plugins/feature_group/experimental/columnwise_hooks_test_mixin.py
+++ b/tests/test_plugins/feature_group/experimental/columnwise_hooks_test_mixin.py
@@ -1,0 +1,144 @@
+"""
+Shared test mixins for the three column-wise framework hooks.
+
+The hooks (_get_available_columns, _check_source_features_exist, _add_result_to_data) are
+declared on FeatureChainParserMixin as raising defaults, not as abstract methods, so nothing
+in the type system forces a concrete plugin to implement them. These mixins are that guarantee.
+
+Each family-specific test class inherits ColumnwiseHooksTestMixin and provides:
+- plugin_class fixture: the concrete feature group class under test
+- sample_data fixture: a two-column container of the family's compute framework
+- strict fixture: True when the family raises if ANY source name is missing, False when it
+  raises only if NONE of the names exist
+
+Families that resolve column names against the data inherit ColumnDiscoveryHooksTestMixin
+instead, which extends ColumnwiseHooksTestMixin with the discovery-hook tests.
+
+A non-pandas family overrides column_names so the shared tests can read its container.
+A family whose _add_result_to_data renames or expands the result column overrides
+result_feature_name, make_result, and expected_result_columns.
+"""
+
+import inspect
+from abc import abstractmethod
+from typing import Any
+
+import pandas as pd
+import pytest
+
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
+
+CHECK_HOOK = "_check_source_features_exist"
+ADD_HOOK = "_add_result_to_data"
+DISCOVERY_HOOK = "_get_available_columns"
+
+
+def resolved_hook(owner: type[Any], hook_name: str) -> Any:
+    """Return the plain function behind a hook attribute, or None when the owner has no such hook."""
+    attribute = inspect.getattr_static(owner, hook_name, None)
+    return getattr(attribute, "__func__", attribute)
+
+
+def assert_hook_is_implemented(plugin_class: type[Any], hook_name: str) -> None:
+    """Assert the plugin resolves the hook to its own function instead of the raising default."""
+    plugin_hook = resolved_hook(plugin_class, hook_name)
+    assert plugin_hook is not None, f"{plugin_class.__name__} provides no {hook_name}"
+    default_hook = resolved_hook(FeatureChainParserMixin, hook_name)
+    assert plugin_hook is not default_hook, (
+        f"{plugin_class.__name__} inherits the raising {hook_name} default instead of implementing it"
+    )
+
+
+class ColumnwiseHooksTestMixin:
+    """Shared tests for the check/add hook pair every column-wise feature group must implement."""
+
+    # Overridable knobs for families whose _add_result_to_data renames or expands the result column.
+    result_feature_name: str = "hook_result"
+
+    @pytest.fixture
+    @abstractmethod
+    def plugin_class(self) -> Any:
+        """Return the concrete feature group class under test.
+
+        Override in the family-specific test class.
+        """
+        raise NotImplementedError
+
+    @pytest.fixture
+    @abstractmethod
+    def sample_data(self) -> Any:
+        """Return a two-column container of the family's compute framework.
+
+        Override in the family-specific test class.
+        """
+        raise NotImplementedError
+
+    @pytest.fixture
+    @abstractmethod
+    def strict(self) -> bool:
+        """Return True when the family raises on ANY missing name, False when only on all missing.
+
+        Override in the family-specific test class, or supply it from a shared strictness mapping.
+        """
+        raise NotImplementedError
+
+    def column_names(self, data: Any) -> list[str]:
+        """Return the column names of the data as strings (pandas-shaped by default)."""
+        return [str(column) for column in data.columns]
+
+    def make_result(self, sample_data: Any) -> Any:
+        """Return a result value _add_result_to_data accepts (a row-aligned Series by default)."""
+        return pd.Series(range(len(sample_data)))
+
+    def expected_result_columns(self) -> set[str]:
+        """Return the columns _add_result_to_data must add (the feature name by default)."""
+        return {self.result_feature_name}
+
+    def test_plugin_implements_check_source_features_exist(self, plugin_class: Any) -> None:
+        """The family must own the source-feature check, not inherit the raising default."""
+        assert_hook_is_implemented(plugin_class, CHECK_HOOK)
+
+    def test_plugin_implements_add_result_to_data(self, plugin_class: Any) -> None:
+        """The family must own the result writer, not inherit the raising default."""
+        assert_hook_is_implemented(plugin_class, ADD_HOOK)
+
+    def test_check_accepts_existing_feature_names(self, plugin_class: Any, sample_data: Any) -> None:
+        """Names that all exist in the data pass the check in every family."""
+        plugin_class._check_source_features_exist(sample_data, self.column_names(sample_data))
+
+    def test_partial_presence_follows_family_strictness(
+        self, plugin_class: Any, sample_data: Any, strict: bool
+    ) -> None:
+        """A strict family rejects a partially present name set, a tolerant family accepts it."""
+        names = [self.column_names(sample_data)[0], "nonexistent"]
+        if strict:
+            with pytest.raises(ValueError):
+                plugin_class._check_source_features_exist(sample_data, names)
+            return
+        plugin_class._check_source_features_exist(sample_data, names)
+
+    def test_check_raises_when_no_feature_exists(self, plugin_class: Any, sample_data: Any) -> None:
+        """Every family raises when no name exists, and names the available columns for debuggability."""
+        with pytest.raises(ValueError) as exc_info:
+            plugin_class._check_source_features_exist(sample_data, ["nonexistent"])
+        message = str(exc_info.value)
+        for column in self.column_names(sample_data):
+            assert column in message, f"{plugin_class.__name__} error omits available column '{column}': {message}"
+
+    def test_add_result_to_data_returns_data_with_new_column(self, plugin_class: Any, sample_data: Any) -> None:
+        """The add hook returns data carrying the new column(s)."""
+        updated = plugin_class._add_result_to_data(sample_data, self.result_feature_name, self.make_result(sample_data))
+        missing = sorted(self.expected_result_columns() - set(self.column_names(updated)))
+        assert missing == [], f"{plugin_class.__name__}._add_result_to_data did not add {missing}"
+
+
+class ColumnDiscoveryHooksTestMixin(ColumnwiseHooksTestMixin):
+    """Adds the discovery-hook tests for the families that resolve column names against the data."""
+
+    def test_plugin_implements_get_available_columns(self, plugin_class: Any) -> None:
+        """The family must own the discovery hook, not inherit the raising default."""
+        assert_hook_is_implemented(plugin_class, DISCOVERY_HOOK)
+
+    def test_get_available_columns_returns_column_names(self, plugin_class: Any, sample_data: Any) -> None:
+        """The discovery hook reports exactly the column names of the data."""
+        assert plugin_class._get_available_columns(sample_data) == set(self.column_names(sample_data))

--- a/tests/test_plugins/feature_group/experimental/test_check_source_features_signature.py
+++ b/tests/test_plugins/feature_group/experimental/test_check_source_features_signature.py
@@ -112,6 +112,12 @@ class TestUnifiedCheckSourceFeaturesSignature:
         )
 
 
+@pytest.mark.parametrize("cls", ALL_PANDAS_CLASSES, ids=lambda c: c.__name__)
+def test_pandas_plugin_is_concrete(cls: Any) -> None:
+    """No abstract method (_perform_aggregation and friends) is left unimplemented, which would hide the plugin."""
+    assert inspect.isabstract(cls) is False, f"{cls.__name__} is abstract: {sorted(cls.__abstractmethods__)}"
+
+
 TOLERANT_PANDAS_CLASSES = [
     PandasAggregatedFeatureGroup,
     PandasClusteringFeatureGroup,

--- a/tests/test_plugins/feature_group/experimental/test_columnwise_hooks_contract.py
+++ b/tests/test_plugins/feature_group/experimental/test_columnwise_hooks_contract.py
@@ -1,0 +1,471 @@
+"""Pins the three column-wise framework hooks to FeatureChainParserMixin and to every concrete family.
+
+FeatureChainParserMixin declares the hooks as non-abstract classmethods whose body raises
+NotImplementedError. That is deliberate: an @abstractmethod on a non-ABC class is silently
+unenforced, so it would guarantee nothing. These tests are the enforcement instead. They check
+both ends of the contract: the raising default exists on the mixin, and no shipped family
+(pandas, PyArrow, Polars, python dict) falls through to it.
+"""
+
+from __future__ import annotations
+
+import ast
+from abc import ABC, ABCMeta
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+import pytest
+
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
+from mloda.user.python_dict import row_count
+from mloda_plugins.feature_group.experimental.aggregated_feature_group.pandas import PandasAggregatedFeatureGroup
+from mloda_plugins.feature_group.experimental.aggregated_feature_group.polars_lazy import (
+    PolarsLazyAggregatedFeatureGroup,
+)
+from mloda_plugins.feature_group.experimental.aggregated_feature_group.pyarrow import PyArrowAggregatedFeatureGroup
+from mloda_plugins.feature_group.experimental.clustering.pandas import PandasClusteringFeatureGroup
+from mloda_plugins.feature_group.experimental.data_quality.missing_value.pandas import PandasMissingValueFeatureGroup
+from mloda_plugins.feature_group.experimental.data_quality.missing_value.pyarrow import PyArrowMissingValueFeatureGroup
+from mloda_plugins.feature_group.experimental.data_quality.missing_value.python_dict import (
+    PythonDictMissingValueFeatureGroup,
+)
+from mloda_plugins.feature_group.experimental.dimensionality_reduction.pandas import (
+    PandasDimensionalityReductionFeatureGroup,
+)
+from mloda_plugins.feature_group.experimental.forecasting.pandas import PandasForecastingFeatureGroup
+from mloda_plugins.feature_group.experimental.geo_distance.pandas import PandasGeoDistanceFeatureGroup
+from mloda_plugins.feature_group.experimental.node_centrality.pandas import PandasNodeCentralityFeatureGroup
+from mloda_plugins.feature_group.experimental.sklearn.encoding.pandas import PandasEncodingFeatureGroup
+from mloda_plugins.feature_group.experimental.sklearn.pipeline.pandas import PandasSklearnPipelineFeatureGroup
+from mloda_plugins.feature_group.experimental.sklearn.scaling.pandas import PandasScalingFeatureGroup
+from mloda_plugins.feature_group.experimental.text_cleaning.pandas import PandasTextCleaningFeatureGroup
+from mloda_plugins.feature_group.experimental.text_cleaning.python_dict import PythonDictTextCleaningFeatureGroup
+from mloda_plugins.feature_group.experimental.time_window.pandas import PandasTimeWindowFeatureGroup
+from mloda_plugins.feature_group.experimental.time_window.pyarrow import PyArrowTimeWindowFeatureGroup
+from tests.test_plugins.feature_group.experimental.columnwise_hooks_test_mixin import (
+    ADD_HOOK,
+    CHECK_HOOK,
+    DISCOVERY_HOOK,
+    ColumnDiscoveryHooksTestMixin,
+    ColumnwiseHooksTestMixin,
+)
+from tests.test_plugins.feature_group.experimental.test_check_source_features_signature import (
+    STRICT_PANDAS_CLASSES,
+    TOLERANT_PANDAS_CLASSES,
+)
+
+try:
+    import polars as pl
+
+    POLARS_AVAILABLE = True
+except ImportError:
+    POLARS_AVAILABLE = False
+    pl = None  # type: ignore
+
+HOOK_NAMES: tuple[str, ...] = (DISCOVERY_HOOK, CHECK_HOOK, ADD_HOOK)
+
+# Anchor the scan root to the repo layout via __file__, not the cwd: a cwd-relative root makes the
+# rglob loop empty and the sweep pass vacuously. This file sits four parents below the repo root.
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+SCAN_ROOT = _REPO_ROOT / "mloda_plugins" / "feature_group" / "experimental"
+assert SCAN_ROOT.exists(), f"scan root not found; check the parents index for the repo root: {SCAN_ROOT}"
+
+# Lower bound only: a new experimental family adds a base.py and must not fail this sweep.
+MIN_BASE_MODULES = 12
+PANDAS_CONSUMER_COUNT = 12
+
+# Single source of truth for the tolerant/strict split: a strict group raises when ANY source name is
+# missing, a tolerant one only when NONE of them exists. Every strict fixture below reads this map,
+# and test_strictness_map_agrees_with_signature_lists pins it against the signature suite's lists.
+STRICTNESS: dict[type[Any], bool] = {
+    PandasAggregatedFeatureGroup: False,
+    PandasClusteringFeatureGroup: False,
+    PandasForecastingFeatureGroup: False,
+    PandasTimeWindowFeatureGroup: False,
+    PandasMissingValueFeatureGroup: True,
+    PandasDimensionalityReductionFeatureGroup: True,
+    PandasGeoDistanceFeatureGroup: True,
+    PandasNodeCentralityFeatureGroup: True,
+    PandasEncodingFeatureGroup: True,
+    PandasSklearnPipelineFeatureGroup: True,
+    PandasScalingFeatureGroup: True,
+    PandasTextCleaningFeatureGroup: True,
+    PolarsLazyAggregatedFeatureGroup: False,
+    PyArrowAggregatedFeatureGroup: False,
+    PyArrowTimeWindowFeatureGroup: False,
+    PyArrowMissingValueFeatureGroup: True,
+    PythonDictMissingValueFeatureGroup: True,
+    PythonDictTextCleaningFeatureGroup: True,
+}
+
+
+def sample_frame() -> pd.DataFrame:
+    """Return the two-column frame every pandas hook consumer works on."""
+    return pd.DataFrame({"col_a": [1, 2], "col_b": [3, 4]})
+
+
+def sample_table() -> pa.Table:
+    """Return the two-column table every PyArrow hook consumer works on."""
+    return pa.table({"col_a": [1, 2], "col_b": [3, 4]})
+
+
+def sample_columnar_dict() -> dict[str, list[Any]]:
+    """Return the two-column columnar dict every python-dict hook consumer works on."""
+    return {"col_a": ["one", "two"], "col_b": ["three", "four"]}
+
+
+class HooklessConsumer(FeatureChainParserMixin):
+    """Inherits FeatureChainParserMixin and overrides no hook, so every hook call must raise."""
+
+
+HOOK_INVOCATIONS: list[tuple[str, Callable[[Any, Any], Any]]] = [
+    (DISCOVERY_HOOK, lambda hook, data: hook(data)),
+    (CHECK_HOOK, lambda hook, data: hook(data, ["col_a"])),
+    (ADD_HOOK, lambda hook, data: hook(data, "hook_result", [1, 2])),
+]
+
+
+class StrictnessFromMap:
+    """Supplies the strict fixture from STRICTNESS, so no consumer restates the split."""
+
+    @pytest.fixture
+    def strict(self, plugin_class: Any) -> bool:
+        return STRICTNESS[plugin_class]
+
+
+class PyArrowColumns:
+    """Reads column names off a PyArrow Table."""
+
+    def column_names(self, data: Any) -> list[str]:
+        return [str(name) for name in data.schema.names]
+
+
+class PythonDictColumns:
+    """Reads column names off a columnar ``dict[str, list]``, and writes row-aligned lists."""
+
+    def column_names(self, data: Any) -> list[str]:
+        return [str(name) for name in data]
+
+    def make_result(self, sample_data: Any) -> Any:
+        """Return a row-aligned list, the only shape the columnar dict writer accepts."""
+        return [str(index) for index in range(row_count(sample_data))]
+
+
+@pytest.mark.parametrize("hook_name", HOOK_NAMES)
+def test_feature_chain_parser_mixin_declares_hook(hook_name: str) -> None:
+    """The mixin owns all three hook declarations, and each one is callable."""
+    hook = getattr(FeatureChainParserMixin, hook_name, None)
+    assert hook is not None, f"FeatureChainParserMixin does not declare {hook_name}"
+    assert callable(hook), f"FeatureChainParserMixin.{hook_name} is not callable"
+
+
+@pytest.mark.parametrize("hook_name", HOOK_NAMES)
+def test_hook_is_not_abstract(hook_name: str) -> None:
+    """The hooks must not be decorated @abstractmethod: on a non-ABC class that enforces nothing."""
+    hook = getattr(FeatureChainParserMixin, hook_name, None)
+    assert hook is not None, f"FeatureChainParserMixin does not declare {hook_name}"
+    assert getattr(hook, "__isabstractmethod__", False) is False, f"{hook_name} is marked abstract"
+
+
+def test_feature_chain_parser_mixin_is_not_an_abc() -> None:
+    """The mixin stays a plain class, which is why the hooks raise instead of being abstract."""
+    assert not issubclass(FeatureChainParserMixin, ABC)
+    assert not isinstance(FeatureChainParserMixin, ABCMeta)
+
+
+@pytest.mark.parametrize(("hook_name", "invoke"), HOOK_INVOCATIONS, ids=[name for name, _ in HOOK_INVOCATIONS])
+def test_unimplemented_hook_raises_not_implemented(hook_name: str, invoke: Callable[[Any, Any], Any]) -> None:
+    """A subclass that does not implement a hook fails loudly, naming the class and the hook."""
+    hook = getattr(HooklessConsumer, hook_name, None)
+    assert hook is not None, f"FeatureChainParserMixin does not declare {hook_name}"
+
+    with pytest.raises(NotImplementedError) as exc_info:
+        invoke(hook, sample_frame())
+
+    message = str(exc_info.value)
+    assert HooklessConsumer.__name__ in message, f"{hook_name} error omits the class name: {message}"
+    assert hook_name in message, f"{hook_name} error omits the hook name: {message}"
+
+
+def test_strictness_map_agrees_with_signature_lists() -> None:
+    """The strict/tolerant split here must not drift from the lists the signature suite drives."""
+    from_lists: dict[type[Any], bool] = {cls: True for cls in STRICT_PANDAS_CLASSES}
+    from_lists.update({cls: False for cls in TOLERANT_PANDAS_CLASSES})
+    assert len(from_lists) == PANDAS_CONSUMER_COUNT, (
+        f"signature lists cover {len(from_lists)} pandas classes, expected {PANDAS_CONSUMER_COUNT}"
+    )
+    mismatches = sorted(cls.__name__ for cls, strict in from_lists.items() if STRICTNESS.get(cls) is not strict)
+    assert mismatches == [], f"STRICTNESS disagrees with test_check_source_features_signature for: {mismatches}"
+
+
+def test_no_base_module_declares_a_hook_in_source() -> None:
+    """Static sweep: no base.py under the experimental tree re-adds a hook declaration to a class body."""
+    offenders: list[str] = []
+    visited = 0
+    for path in sorted(SCAN_ROOT.rglob("base.py")):
+        visited += 1
+        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+            if not isinstance(node, ast.ClassDef):
+                continue
+            declared = sorted(
+                child.name
+                for child in node.body
+                if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)) and child.name in HOOK_NAMES
+            )
+            if declared:
+                offenders.append(f"{path.relative_to(_REPO_ROOT)}::{node.name} declares {declared}")
+    assert offenders == [], f"base modules must inherit the hook declarations, found: {offenders}"
+    assert visited >= MIN_BASE_MODULES, (
+        f"sweep visited only {visited} base.py files under {SCAN_ROOT}: the sweep root is wrong or the glob broke"
+    )
+
+
+class TestPandasAggregatedHooks(StrictnessFromMap, ColumnDiscoveryHooksTestMixin):
+    """Aggregated pandas group: tolerant check, plus column discovery."""
+
+    @pytest.fixture
+    def plugin_class(self) -> Any:
+        return PandasAggregatedFeatureGroup
+
+    @pytest.fixture
+    def sample_data(self) -> Any:
+        return sample_frame()
+
+
+class TestPandasClusteringHooks(StrictnessFromMap, ColumnDiscoveryHooksTestMixin):
+    """Clustering pandas group: tolerant check, plus column discovery."""
+
+    @pytest.fixture
+    def plugin_class(self) -> Any:
+        return PandasClusteringFeatureGroup
+
+    @pytest.fixture
+    def sample_data(self) -> Any:
+        return sample_frame()
+
+
+class TestPandasMissingValueHooks(StrictnessFromMap, ColumnDiscoveryHooksTestMixin):
+    """Missing value pandas group: strict check, plus column discovery."""
+
+    @pytest.fixture
+    def plugin_class(self) -> Any:
+        return PandasMissingValueFeatureGroup
+
+    @pytest.fixture
+    def sample_data(self) -> Any:
+        return sample_frame()
+
+
+class TestPandasForecastingHooks(StrictnessFromMap, ColumnDiscoveryHooksTestMixin):
+    """Forecasting pandas group: tolerant check, plus column discovery."""
+
+    @pytest.fixture
+    def plugin_class(self) -> Any:
+        return PandasForecastingFeatureGroup
+
+    @pytest.fixture
+    def sample_data(self) -> Any:
+        return sample_frame()
+
+
+class TestPandasTimeWindowHooks(StrictnessFromMap, ColumnDiscoveryHooksTestMixin):
+    """Time window pandas group: tolerant check, plus column discovery."""
+
+    @pytest.fixture
+    def plugin_class(self) -> Any:
+        return PandasTimeWindowFeatureGroup
+
+    @pytest.fixture
+    def sample_data(self) -> Any:
+        return sample_frame()
+
+
+class TestPandasDimensionalityReductionHooks(StrictnessFromMap, ColumnwiseHooksTestMixin):
+    """Dimensionality reduction pandas group: strict check, and one result expands to per-dimension columns."""
+
+    result_feature_name = "col_a__pca_2d"
+
+    def make_result(self, sample_data: Any) -> Any:
+        """Return a two-dimensional reduction result with one row per data row."""
+        rows = len(sample_data)
+        return np.arange(rows * 2, dtype=float).reshape(rows, 2)
+
+    def expected_result_columns(self) -> set[str]:
+        return {f"{self.result_feature_name}~dim1", f"{self.result_feature_name}~dim2"}
+
+    @pytest.fixture
+    def plugin_class(self) -> Any:
+        return PandasDimensionalityReductionFeatureGroup
+
+    @pytest.fixture
+    def sample_data(self) -> Any:
+        return sample_frame()
+
+
+class TestPandasGeoDistanceHooks(StrictnessFromMap, ColumnwiseHooksTestMixin):
+    """Geo distance pandas group: strict check."""
+
+    @pytest.fixture
+    def plugin_class(self) -> Any:
+        return PandasGeoDistanceFeatureGroup
+
+    @pytest.fixture
+    def sample_data(self) -> Any:
+        return sample_frame()
+
+
+class TestPandasNodeCentralityHooks(StrictnessFromMap, ColumnwiseHooksTestMixin):
+    """Node centrality pandas group: strict check."""
+
+    @pytest.fixture
+    def plugin_class(self) -> Any:
+        return PandasNodeCentralityFeatureGroup
+
+    @pytest.fixture
+    def sample_data(self) -> Any:
+        return sample_frame()
+
+
+class TestPandasEncodingHooks(StrictnessFromMap, ColumnwiseHooksTestMixin):
+    """Encoding pandas group: strict check."""
+
+    @pytest.fixture
+    def plugin_class(self) -> Any:
+        return PandasEncodingFeatureGroup
+
+    @pytest.fixture
+    def sample_data(self) -> Any:
+        return sample_frame()
+
+
+class TestPandasSklearnPipelineHooks(StrictnessFromMap, ColumnwiseHooksTestMixin):
+    """Sklearn pipeline pandas group: strict check."""
+
+    @pytest.fixture
+    def plugin_class(self) -> Any:
+        return PandasSklearnPipelineFeatureGroup
+
+    @pytest.fixture
+    def sample_data(self) -> Any:
+        return sample_frame()
+
+
+class TestPandasScalingHooks(StrictnessFromMap, ColumnwiseHooksTestMixin):
+    """Scaling pandas group: strict check."""
+
+    @pytest.fixture
+    def plugin_class(self) -> Any:
+        return PandasScalingFeatureGroup
+
+    @pytest.fixture
+    def sample_data(self) -> Any:
+        return sample_frame()
+
+
+class TestPandasTextCleaningHooks(StrictnessFromMap, ColumnwiseHooksTestMixin):
+    """Text cleaning pandas group: strict check."""
+
+    @pytest.fixture
+    def plugin_class(self) -> Any:
+        return PandasTextCleaningFeatureGroup
+
+    @pytest.fixture
+    def sample_data(self) -> Any:
+        return sample_frame()
+
+
+class TestPolarsLazyAggregatedHooks(StrictnessFromMap, ColumnDiscoveryHooksTestMixin):
+    """Aggregated Polars lazy group: tolerant check, plus column discovery on the lazy schema."""
+
+    def column_names(self, data: Any) -> list[str]:
+        return [str(name) for name in data.collect_schema().names()]
+
+    def make_result(self, sample_data: Any) -> Any:
+        """Return a Polars expression, the only shape the lazy writer accepts."""
+        return pl.col("col_a")
+
+    @pytest.fixture
+    def plugin_class(self) -> Any:
+        return PolarsLazyAggregatedFeatureGroup
+
+    @pytest.fixture
+    def sample_data(self) -> Any:
+        if not POLARS_AVAILABLE:
+            pytest.skip("Polars not available")
+        return pl.LazyFrame({"col_a": [1, 2], "col_b": [3, 4]})
+
+
+class TestPyArrowAggregatedHooks(StrictnessFromMap, PyArrowColumns, ColumnDiscoveryHooksTestMixin):
+    """Aggregated PyArrow group: tolerant check, plus column discovery."""
+
+    def make_result(self, sample_data: Any) -> Any:
+        """Return a scalar, which the aggregated writer broadcasts over the rows."""
+        return 1
+
+    @pytest.fixture
+    def plugin_class(self) -> Any:
+        return PyArrowAggregatedFeatureGroup
+
+    @pytest.fixture
+    def sample_data(self) -> Any:
+        return sample_table()
+
+
+class TestPyArrowMissingValueHooks(StrictnessFromMap, PyArrowColumns, ColumnDiscoveryHooksTestMixin):
+    """Missing value PyArrow group: strict check, plus column discovery."""
+
+    def make_result(self, sample_data: Any) -> Any:
+        """Return a row-aligned PyArrow array, the shape append_column takes."""
+        return pa.array(range(sample_data.num_rows))
+
+    @pytest.fixture
+    def plugin_class(self) -> Any:
+        return PyArrowMissingValueFeatureGroup
+
+    @pytest.fixture
+    def sample_data(self) -> Any:
+        return sample_table()
+
+
+class TestPyArrowTimeWindowHooks(StrictnessFromMap, PyArrowColumns, ColumnDiscoveryHooksTestMixin):
+    """Time window PyArrow group: tolerant check, plus column discovery."""
+
+    def make_result(self, sample_data: Any) -> Any:
+        """Return a row-aligned PyArrow array, the shape append_column takes."""
+        return pa.array(range(sample_data.num_rows))
+
+    @pytest.fixture
+    def plugin_class(self) -> Any:
+        return PyArrowTimeWindowFeatureGroup
+
+    @pytest.fixture
+    def sample_data(self) -> Any:
+        return sample_table()
+
+
+class TestPythonDictMissingValueHooks(StrictnessFromMap, PythonDictColumns, ColumnDiscoveryHooksTestMixin):
+    """Missing value python-dict group: strict check, plus column discovery."""
+
+    @pytest.fixture
+    def plugin_class(self) -> Any:
+        return PythonDictMissingValueFeatureGroup
+
+    @pytest.fixture
+    def sample_data(self) -> Any:
+        return sample_columnar_dict()
+
+
+class TestPythonDictTextCleaningHooks(StrictnessFromMap, PythonDictColumns, ColumnwiseHooksTestMixin):
+    """Text cleaning python-dict group: strict check, no column discovery."""
+
+    @pytest.fixture
+    def plugin_class(self) -> Any:
+        return PythonDictTextCleaningFeatureGroup
+
+    @pytest.fixture
+    def sample_data(self) -> Any:
+        return sample_columnar_dict()


### PR DESCRIPTION
## Problem

Twelve experimental feature group `base.py` files each redeclared the same three framework hooks (`_get_available_columns`, `_check_source_features_exist`, `_add_result_to_data`) as abstract classmethods with identical 15-line docstrings, roughly 50 lines of copy-paste per file.

## What changed

All twelve already inherit `FeatureChainParserMixin`, so the declarations move there. Every `base.py` in this diff is **pure deletion**, no base list changes at all: `-442` lines across the twelve, `+50` on the mixin.

The hooks are plain classmethods raising `NotImplementedError` naming the class and the hook, not `abstractmethod`s.

## Why not an abstract mixin

That was the first attempt and it was rejected: it adds a class for something an already-inherited class covers.

Putting `@abstractmethod` on `FeatureChainParserMixin` instead is not an option either. It is a plain class, where the decorator is silently inert (ABCMeta only collects from a base's `__abstractmethods__`, which a non-ABC base does not have), and converting it to an ABC would make the 200-plus unrelated chain-parser subclasses abstract.

The enforcement being given up is also weaker than it looks. `register_module_plugins` skips abstract classes without warning, so a plugin that forgot a hook previously vanished from the registry silently and matching reported only that an abstract base matched. A `NotImplementedError` naming the missing method is the louder signal, at the cost of failing during execution rather than at class creation.

## Docstrings

`_add_result_to_data` and `_get_available_columns` were byte-identical everywhere, so their text carried over unchanged. `_check_source_features_exist` had three divergent variants covering two real contracts: tolerant groups raise only when none of the names exist, strict groups raise when any name is missing. The shared docstring states the contract without naming families, since the mixin lives in `mloda/core` and must not encode `mloda_plugins` specifics.

## Tests

Nothing in the type system forces a concrete plugin to implement these hooks now, so a shared test mixin takes over, following the existing `*_test_mixin.py` convention. All **eighteen** shipped concrete implementations (pandas, pyarrow, polars lazy, python_dict) assert they own each hook rather than inheriting the raising default, plus their partial-presence policy, which lives in one map checked for agreement against the pre-existing per-family lists. An AST sweep over every `base.py` in the experimental tree keeps the declarations from coming back.

## Verification

No runtime change: an introspection diff over every shipped `FeatureGroup` subclass shows an identical subclass universe and identical `isabstract`, with the only delta being the three hook names leaving `__abstractmethods__` on the twelve bases. Every base keeps other abstract methods, so none flipped abstract to concrete, and plugin collection, registration, strict mode and matching all see the same sets as before.

`tox` green: 7374 passed, 170 skipped, ruff format and check clean, `mypy --strict` clean on 891 files, bandit clean.
