### PR TITLE
feat: give BaseInputData its own reader option declaration surface

### DIFF
--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -81,6 +81,8 @@ does not understand can be absorbed silently.
 | Match time (mixin) | `MIN/MAX_IN_FEATURES` | In-feature count is within bounds | The in-features | Non-match (`False`) |
 | Match time (guard installed at class definition) | `required_when` | A conditionally required option is present | `Options` | Non-match (`False`) |
 | Class definition (mixin) | Universal-matcher diagnostic | An all-optional `PROPERTY_MAPPING` inherits the configuration matcher, so it matches any name with empty options | The class | `logger.warning`, unless `ALLOW_UNIVERSAL_MATCHER = True` |
+| Author time (reader surface) | `mypy --strict` | `READER_OPTIONS` holds `ReaderOptionSpec` values and each field exists: `runtime_defualt=...` (typo) | The constructor call | mypy error at the declaration. Without mypy: an unknown field is a `TypeError` |
+| Match time (reader selection) | `ReaderOptionSpec.runtime_default` | Nothing is validated. The reader's OWN code applies its declared fallback for an absent key, reading it back with `reader_option_default(key)` | The key name | `ValueError` naming the key and the reader class, for a key no `READER_OPTIONS` declares |
 
 A spec is constructed inside the class body, so its own rules fire before the class exists.
 Class definition is left with exactly one rule: the type itself. Within `__post_init__` the
@@ -107,6 +109,66 @@ rejected either way.
 declares it gets its resolved `match_feature_group_criteria` wrapped at class definition,
 and the wrapper runs the predicates after that matcher returns `True`. Overriding the
 matcher therefore keeps the contract, whether the override delegates or not.
+
+The last two rows are the whole reader surface, and they sit outside the ordered match-time sequence
+above: a `READER_OPTIONS` key is consumed during reader selection, and no other moment fires for it.
+See [Two declaration surfaces](#two-declaration-surfaces).
+
+## Two declaration surfaces
+
+Option keys are declared in two places, and only one of the two is enforced.
+
+| Surface | Declared on | What the framework does with it |
+| --- | --- | --- |
+| `PROPERTY_MAPPING` (values are `PropertySpec`) | a `FeatureGroup` | Enforces it: value validation (`allowed_values`, `element_validator`), presence and `required_when`, and materialization of declared defaults. |
+| `READER_OPTIONS` (values are `ReaderOptionSpec`) | a `BaseInputData` reader | Nothing. It is an inventory: which keys the reader reads, and what the reader itself does with them. |
+
+A reader consumes its option keys during reader **selection** (`match_subclass_data_access`, reached
+through `BaseInputData.matches` from the matcher), which runs at match time, before the framework
+materializes anything. Nothing can be applied on a reader's behalf at that point, so
+`ReaderOptionSpec` declares only what is true there:
+
+| Field | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `explanation` | `str` | required, positional | What the key means. |
+| `runtime_default` | `Any` | `None` | The fallback the reader's OWN code applies when the key is absent. The reader reads it back with `reader_option_default(key)`, so the declaration is load-bearing rather than decorative: `ReadFile` and `ReadDocument` resolve `document_suffixes` that way, and a reader declaring a different default matches differently with no option set. |
+| `framework_set` | `bool` | `False` | The framework writes this key, the user does not. The reserved `"BaseInputData"` key holds the matched `(ReaderClass, data_access)` pair, written by `add_base_input_data_to_options` and read back by `init_reader`. |
+
+`READER_OPTIONS` merges across the MRO (`reader_option_specs()`, most-derived declaration winning),
+so a concrete reader inherits its family's keys and redeclares nothing, and
+`declared_reader_option_keys()` is the merged key set. `reader_option_default()` raises for a key no
+declaration carries, so a typo in *reader* code is loud instead of a silent `None`.
+
+What a plugin author may rely on:
+
+| Guarantee | `PropertySpec` | `ReaderOptionSpec` |
+| --- | --- | --- |
+| The declared value space is enforced against user values | yes, under `strict_validation` | no |
+| The declared default is applied by the framework | yes (see [Applying declared defaults](#applying-declared-defaults)) | no, only the reader's own code applies it |
+| Presence and `required_when` are checked | yes | no |
+| A user's mistyped key surfaces | for a required key, yes: absence is a non-match, with a warning on the string-named path | no: the reader falls back to its `runtime_default`, so the typo is silently ignored |
+
+That silence is a property of match-time consumption, not an oversight, and it is why these keys are
+not declared as `PropertySpec`s: a spec would promise enforcement that could never fire, because
+selection is over before the framework touches the options.
+
+### A pattern-less feature group sits in between
+
+A `FeatureGroup` that declares no `PREFIX_PATTERN` or `SUFFIX_PATTERN` (`ConcatenatedFileContent` is
+the in-repo example) carries a real `PROPERTY_MAPPING`, but only part of the enforced surface reaches
+it:
+
+- `required_when` **is** enforced. Its guard is installed from `FeatureGroup.__init_subclass__` and
+  wraps the class's resolved `match_feature_group_criteria` instead of living inside the chain-parser
+  matcher, so a missing required key is a non-match at match time, not a late `ValueError` inside
+  `input_features`.
+- `strict_validation` is never reached: value validation lives inside the chain-parser matcher, and a
+  pattern-less group keeps the default class-name matcher, which does not call the parser. The
+  name-path presence rule is unavailable too, because it needs a parsed name and its guard installs
+  only for a class that declares a pattern.
+- Declared defaults stay metadata until the group materializes them itself by calling
+  `options_with_defaults` at its own read site. That call is what makes a declared default real at an
+  `input_features` read site (see [Applying declared defaults](#applying-declared-defaults)).
 
 ## Choosing a mechanism
 
@@ -297,12 +359,24 @@ A present value is never overridden, even a falsy `0`/`False`/`""`. `NO_DEFAULT`
 `default=None` fill nothing. A strict default is already validated at construction, so the
 materialized value is not re-checked.
 
-The framework applies this centrally at the compute boundary: `run_calculate_feature`
-materializes the declared defaults into the `FeatureSet` before `calculate_feature` and any
-calculate-feature extender run, so a plugin reads `feature.options` directly.
-`options_with_defaults` remains for pre-materialization contexts (e.g. `resolve_subtype`
-internals). Materialization happens *after* resolution, so it never changes matching or
-FeatureSet splitting.
+The framework applies this at two sites. At feature **intake**
+(`Engine.add_feature_to_collection`) a feature's options are rebound through
+`options_with_defaults` as it enters the collection. At the **compute boundary**
+`run_calculate_feature` materializes the declared defaults into the `FeatureSet` before
+`calculate_feature` and any calculate-feature extender run, so a plugin reads `feature.options`
+directly. `options_with_defaults` remains for pre-materialization contexts (e.g. `resolve_subtype`
+internals) and for read sites the framework hands pre-default options, `input_features` above all.
+
+Both sites run *after* resolution, so materialization never changes **matching**. It does change
+how features **group**: intake materialization deliberately canonicalizes default-equivalent twins,
+so a feature that passes a declared default explicitly and one that omits it become equal and merge
+into a single feature (with a warning naming the duplicated request) instead of computing twice.
+
+One consequence for authors: `input_features` is called with the DECLARED, pre-default options (the
+engine stashes them before intake rebinds, and a child inherits the same pre-default options), so a
+declared default does NOT reach an `input_features` read site. A group that wants it there calls
+`options_with_defaults` itself, as `ConcatenatedFileContent` does (see
+[A pattern-less feature group sits in between](#a-pattern-less-feature-group-sits-in-between)).
 
 ``` python
 graph_type = feature.options.get("graph_type")  # the declared default when the caller omitted it
@@ -507,6 +581,10 @@ if it really is a whole-value check.
 | Declared-default invariant | `tests/test_core/test_abstract_plugins/test_property_mapping_default_invariant.py` |
 | Declared defaults materialized into runtime options | `tests/test_core/test_abstract_plugins/test_options_with_defaults.py` |
 | Declared defaults materialized at the compute boundary | `tests/test_core/test_abstract_plugins/test_materialize_defaults_boundary.py` |
+| Declared defaults materialized at intake, canonicalizing default-equivalent twins | `tests/test_core/test_abstract_plugins/test_intake_default_canonicalization.py` |
+| The reader surface: the spec type, the reserved framework key, the MRO merge, the loud undeclared key | `tests/.../test_components/test_reader_option_declarations.py` |
+| Per-reader declarations, and the `runtime_default` that is load-bearing at selection | `tests/.../input_data/test_reader_option_declarations.py` |
+| A pattern-less group: enforced `required_when`, and defaults it applies itself | `tests/.../input_data/test_read_context_files_option_declarations.py` |
 | Container invariance, no stringification, str-as-scalar, dict-as-composite, empty containers | `tests/.../feature_chainer/test_property_mapping_sequence_unpacking.py` |
 | Present option values validated on the string-named path too | `tests/.../feature_chainer/test_name_path_validates_option_values.py` |
 | Required presence on the string-named path: the mandatory non-match, the retired env var stays ignored, and the `deferred_binding` / `in_features` exemptions | `tests/.../feature_chainer/test_name_path_required_presence.py` |

--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -82,7 +82,8 @@ does not understand can be absorbed silently.
 | Match time (guard installed at class definition) | `required_when` | A conditionally required option is present | `Options` | Non-match (`False`) |
 | Class definition (mixin) | Universal-matcher diagnostic | An all-optional `PROPERTY_MAPPING` inherits the configuration matcher, so it matches any name with empty options | The class | `logger.warning`, unless `ALLOW_UNIVERSAL_MATCHER = True` |
 | Author time (reader surface) | `mypy --strict` | `READER_OPTIONS` holds `ReaderOptionSpec` values and each field exists: `runtime_defualt=...` (typo) | The constructor call | mypy error at the declaration. Without mypy: an unknown field is a `TypeError` |
-| Match time (reader selection) | `ReaderOptionSpec.runtime_default` | Nothing is validated. The reader's OWN code applies its declared fallback for an absent key, reading it back with `reader_option_default(key)` | The key name | `ValueError` naming the key and the reader class, for a key no `READER_OPTIONS` declares |
+| Class definition (`BaseInputData.__init_subclass__`) | Spec type | Every value in the class's OWN `READER_OPTIONS` IS a `ReaderOptionSpec`, mirroring the `PropertySpec` rule above | Every value in that class's declaration | `ValueError` naming the class and the key |
+| Match time (reader selection) | `ReaderOptionSpec.runtime_default` | No user value is validated. The reader's OWN code applies its declared fallback for an absent key, reading it with `reader_option(key, options)` | The key name and the options | `ValueError` naming the key and the reader class, for a key no `READER_OPTIONS` declares |
 
 A spec is constructed inside the class body, so its own rules fire before the class exists.
 Class definition is left with exactly one rule: the type itself. Within `__post_init__` the
@@ -110,18 +111,20 @@ declares it gets its resolved `match_feature_group_criteria` wrapped at class de
 and the wrapper runs the predicates after that matcher returns `True`. Overriding the
 matcher therefore keeps the contract, whether the override delegates or not.
 
-The last two rows are the whole reader surface, and they sit outside the ordered match-time sequence
-above: a `READER_OPTIONS` key is consumed during reader selection, and no other moment fires for it.
+The last three rows are the whole reader surface, and the match-time one sits outside the ordered
+sequence above: a user-facing `READER_OPTIONS` key is consumed during reader selection, and no other
+moment fires for it. The reserved `"BaseInputData"` key is the exception, written at selection and read
+back at load time by `BaseInputData.init_reader` and by `SQLITEReader.get_table`.
 See [Two declaration surfaces](#two-declaration-surfaces).
 
 ## Two declaration surfaces
 
-Option keys are declared in two places, and only one of the two is enforced.
+Option keys are declared in two places, and only one of the two is enforced against user values.
 
 | Surface | Declared on | What the framework does with it |
 | --- | --- | --- |
 | `PROPERTY_MAPPING` (values are `PropertySpec`) | a `FeatureGroup` | Enforces it: value validation (`allowed_values`, `element_validator`), presence and `required_when`, and materialization of declared defaults. |
-| `READER_OPTIONS` (values are `ReaderOptionSpec`) | a `BaseInputData` reader | Nothing. It is an inventory: which keys the reader reads, and what the reader itself does with them. |
+| `READER_OPTIONS` (values are `ReaderOptionSpec`) | a `BaseInputData` reader | Nothing with a user's value; only the declaration's own type, at class definition. It is an inventory: which keys the reader reads, and what the reader itself does with them. |
 
 A reader consumes its option keys during reader **selection** (`match_subclass_data_access`, reached
 through `BaseInputData.matches` from the matcher), which runs at match time, before the framework
@@ -131,13 +134,14 @@ materializes anything. Nothing can be applied on a reader's behalf at that point
 | Field | Type | Default | Meaning |
 | --- | --- | --- | --- |
 | `explanation` | `str` | required, positional | What the key means. |
-| `runtime_default` | `Any` | `None` | The fallback the reader's OWN code applies when the key is absent. The reader reads it back with `reader_option_default(key)`, so the declaration is load-bearing rather than decorative: `ReadFile` and `ReadDocument` resolve `document_suffixes` that way, and a reader declaring a different default matches differently with no option set. |
+| `runtime_default` | `Any` | `None` | The fallback the reader's OWN code applies when the key is absent. The reader reads it with `reader_option(key, options)`, which returns a supplied value and falls back to this declaration only for an absent key; presence is `options.get(key) is not None`, so an explicit `None` reads as absent while an explicit empty or otherwise falsy value is honored, the same three-state rule as [Applying declared defaults](#applying-declared-defaults). The declaration is load-bearing rather than decorative: `ReadFile` and `ReadDocument` resolve `document_suffixes` that way, and a reader declaring a different default matches differently with no option set (for `ReadDocument` only in its `DataAccessCollection` branch: its bare str/Path branch passes no `document_suffixes`, so the declaration is inert there). |
 | `framework_set` | `bool` | `False` | The framework writes this key, the user does not. The reserved `"BaseInputData"` key holds the matched `(ReaderClass, data_access)` pair, written by `add_base_input_data_to_options` and read back by `init_reader`. |
 
 `READER_OPTIONS` merges across the MRO (`reader_option_specs()`, most-derived declaration winning),
 so a concrete reader inherits its family's keys and redeclares nothing, and
-`declared_reader_option_keys()` is the merged key set. `reader_option_default()` raises for a key no
-declaration carries, so a typo in *reader* code is loud instead of a silent `None`.
+`declared_reader_option_keys()` is the merged key set. Both `reader_option()` and
+`reader_option_default()` raise for a key no declaration carries, so a typo in *reader* code is loud
+instead of a silent `None`.
 
 What a plugin author may rely on:
 
@@ -158,10 +162,13 @@ A `FeatureGroup` that declares no `PREFIX_PATTERN` or `SUFFIX_PATTERN` (`Concate
 the in-repo example) carries a real `PROPERTY_MAPPING`, but only part of the enforced surface reaches
 it:
 
-- `required_when` **is** enforced. Its guard is installed from `FeatureGroup.__init_subclass__` and
-  wraps the class's resolved `match_feature_group_criteria` instead of living inside the chain-parser
-  matcher, so a missing required key is a non-match at match time, not a late `ValueError` inside
-  `input_features`.
+- `required_when` **is** enforced, for absence. Its guard is installed from
+  `FeatureGroup.__init_subclass__` and wraps the class's resolved `match_feature_group_criteria`
+  instead of living inside the chain-parser matcher, so an **absent** required key is a non-match at
+  match time, not a late `ValueError` inside `input_features`. Requiredness reads presence
+  (`options.get(key) is not None`), so a present-but-falsy value (`target_folder=[]`,
+  `document_reader_class=""`) satisfies the requirement and matches; the hand-rolled `ValueError`
+  backstops inside `input_features` are what catch that, which is why they stay.
 - `strict_validation` is never reached: value validation lives inside the chain-parser matcher, and a
   pattern-less group keeps the default class-name matcher, which does not call the parser. The
   name-path presence rule is unavailable too, because it needs a parsed name and its guard installs
@@ -513,9 +520,11 @@ PROPERTY_MAPPING = {
 }
 ```
 
-When the predicate returns `True` and the option is absent, the match fails; entries with
-`required_when` are otherwise optional. The predicate must be pure and must not raise. It is
-callable by construction, and a non-bool truthy return counts as `True`.
+When the predicate returns `True` and the option is absent, the match fails and the non-match records
+a rejection reason naming the owning class and the missing key, so the resolution-failure report
+carries a near-miss line for it; entries with `required_when` are otherwise optional. The predicate
+must be pure and must not raise. It is callable by construction, and a non-bool truthy return counts
+as `True`.
 
 The enforcement is installed on the class, not on one matcher, so overriding
 `match_feature_group_criteria` does not lose it: the predicates still run after the override
@@ -582,13 +591,14 @@ if it really is a whole-value check.
 | Declared defaults materialized into runtime options | `tests/test_core/test_abstract_plugins/test_options_with_defaults.py` |
 | Declared defaults materialized at the compute boundary | `tests/test_core/test_abstract_plugins/test_materialize_defaults_boundary.py` |
 | Declared defaults materialized at intake, canonicalizing default-equivalent twins | `tests/test_core/test_abstract_plugins/test_intake_default_canonicalization.py` |
-| The reader surface: the spec type, the reserved framework key, the MRO merge, the loud undeclared key | `tests/.../test_components/test_reader_option_declarations.py` |
-| Per-reader declarations, and the `runtime_default` that is load-bearing at selection | `tests/.../input_data/test_reader_option_declarations.py` |
+| The reader surface: the spec type and its class-definition guard, the reserved framework key, the MRO merge, the loud undeclared key, the presence rule of `reader_option()` | `tests/.../test_components/test_reader_option_declarations.py` |
+| Per-reader declarations, the `runtime_default` that is load-bearing at selection, and the bare-path branch it does not reach | `tests/.../input_data/test_reader_option_declarations.py` |
 | A pattern-less group: enforced `required_when`, and defaults it applies itself | `tests/.../input_data/test_read_context_files_option_declarations.py` |
 | Container invariance, no stringification, str-as-scalar, dict-as-composite, empty containers | `tests/.../feature_chainer/test_property_mapping_sequence_unpacking.py` |
 | Present option values validated on the string-named path too | `tests/.../feature_chainer/test_name_path_validates_option_values.py` |
 | Required presence on the string-named path: the mandatory non-match, the retired env var stays ignored, and the `deferred_binding` / `in_features` exemptions | `tests/.../feature_chainer/test_name_path_required_presence.py` |
 | `required_when` survives an overridden matcher, runs exactly once, and demands a classmethod | `tests/.../feature_chainer/test_required_when_enforced_on_override.py` |
+| A `required_when` non-match records its reason, so the failure report names the key and its owner | `tests/test_core/test_prepare/test_required_when_rejection_recording.py` |
 | Plugin specs behave identically across containers | `tests/test_plugins/feature_group/experimental/test_property_mapping_container_invariance.py` |
 | `property_spec` builder surface | `tests/.../feature_chainer/test_property_spec_builder.py` |
 | Rejection reasons surfaced to the end user | `tests/test_core/test_prepare/test_identify_feature_group_error_message.py` |

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -894,11 +894,20 @@ class FeatureChainParser:
                 return False
             # An opted-in key present as an explicit None counts as present, so the requirement is met (#768).
             if is_required and not option_key_is_present(spec, key, effective_options):
+                predicate_name = getattr(predicate, "__name__", repr(predicate))
                 logger.debug(
                     "Feature group %s requires option '%s' (predicate %s is satisfied) but it was not provided.",
                     owner_name,
                     key,
-                    getattr(predicate, "__name__", repr(predicate)),
+                    predicate_name,
+                )
+                # Same diagnostic seam as the sibling presence rules, so the resolution-failure report can
+                # explain this non-match. The engine re-keys the harvest by candidate, so the reason itself
+                # names the class that declared the requirement.
+                record_match_rejection(
+                    owner_name,
+                    f"required option '{key}' is absent, but {owner_name} declares it required "
+                    f"(required_when predicate {predicate_name} is satisfied)",
                 )
                 return False
         return True

--- a/mloda/core/abstract_plugins/components/input_data/base_input_data.py
+++ b/mloda/core/abstract_plugins/components/input_data/base_input_data.py
@@ -1,8 +1,9 @@
 from abc import ABC
-from typing import Any, Optional
+from typing import Any, ClassVar, Optional
 
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+from mloda.core.abstract_plugins.components.input_data.reader_option_spec import ReaderOptionSpec
 from mloda.core.abstract_plugins.components.options import Options
 
 
@@ -10,8 +11,41 @@ from mloda.core.abstract_plugins.components.utils import get_all_subclasses
 
 
 class BaseInputData(ABC):
+    READER_OPTIONS: ClassVar[dict[str, ReaderOptionSpec]] = {
+        "BaseInputData": ReaderOptionSpec(
+            "The matched (ReaderClass, data_access) pair, written by add_base_input_data_to_options "
+            "and read back by init_reader.",
+            framework_set=True,
+        ),
+    }
+
     def __init__(self) -> None:
         pass
+
+    @classmethod
+    def reader_option_specs(cls) -> dict[str, ReaderOptionSpec]:
+        """Merge READER_OPTIONS across cls.__mro__, most-derived winning; a fresh dict per call.
+
+        Reads each class's own __dict__ so an inherited attribute is not merged twice, and walks the
+        MRO in reverse so a derived declaration overwrites the base one on a key collision.
+        """
+        merged: dict[str, ReaderOptionSpec] = {}
+        for klass in reversed(cls.__mro__):
+            merged.update(klass.__dict__.get("READER_OPTIONS", {}))
+        return merged
+
+    @classmethod
+    def declared_reader_option_keys(cls) -> frozenset[str]:
+        """Every option key this reader family declares."""
+        return frozenset(cls.reader_option_specs())
+
+    @classmethod
+    def reader_option_default(cls, key: str) -> Any:
+        """The declared runtime_default of key; an undeclared key is a typo, not a silent None."""
+        specs = cls.reader_option_specs()
+        if key not in specs:
+            raise ValueError(f"Reader option '{key}' is not declared in READER_OPTIONS of {cls.__name__}.")
+        return specs[key].runtime_default
 
     @classmethod
     def data_access_name(cls) -> str:

--- a/mloda/core/abstract_plugins/components/input_data/base_input_data.py
+++ b/mloda/core/abstract_plugins/components/input_data/base_input_data.py
@@ -19,33 +19,87 @@ class BaseInputData(ABC):
         ),
     }
 
+    _reader_option_specs_cache: ClassVar[Optional[dict[str, ReaderOptionSpec]]] = None
+    """Merged declarations of ONE class, written into that class's own __dict__ by _merged_reader_option_specs."""
+
     def __init__(self) -> None:
         pass
 
-    @classmethod
-    def reader_option_specs(cls) -> dict[str, ReaderOptionSpec]:
-        """Merge READER_OPTIONS across cls.__mro__, most-derived winning; a fresh dict per call.
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        cls._validate_reader_options()
 
-        Reads each class's own __dict__ so an inherited attribute is not merged twice, and walks the
-        MRO in reverse so a derived declaration overwrites the base one on a key collision.
+    @classmethod
+    def _validate_reader_options(cls) -> None:
+        """Reject a non-ReaderOptionSpec value where it is written, not later on .runtime_default.
+
+        Mirrors FeatureChainParser._require_spec for PROPERTY_MAPPING, and checks only this class's
+        own declaration so a bad child under a valid parent still raises.
         """
+        for key, spec in cls.__dict__.get("READER_OPTIONS", {}).items():
+            if not isinstance(spec, ReaderOptionSpec):
+                raise ValueError(
+                    f"{cls.__name__}.READER_OPTIONS['{key}'] is a {type(spec).__name__}, not a ReaderOptionSpec. "
+                    f"Construct ReaderOptionSpec(...) instead."
+                )
+
+    @classmethod
+    def _merged_reader_option_specs(cls) -> dict[str, ReaderOptionSpec]:
+        """The merged declarations of cls, cached in cls's OWN __dict__; internal, never handed out.
+
+        Reader selection is a hot path, so the MRO walk runs once per class. The cache is read back
+        with cls.__dict__.get so a subclass never answers from a warm parent cache, and it lives on
+        the class itself rather than in a class-keyed registry so it holds no reference to any class.
+        """
+        cached: Optional[dict[str, ReaderOptionSpec]] = cls.__dict__.get("_reader_option_specs_cache")
+        if cached is not None:
+            return cached
+
         merged: dict[str, ReaderOptionSpec] = {}
         for klass in reversed(cls.__mro__):
             merged.update(klass.__dict__.get("READER_OPTIONS", {}))
+        cls._reader_option_specs_cache = merged
         return merged
+
+    @classmethod
+    def reader_option_specs(cls) -> dict[str, ReaderOptionSpec]:
+        """The declarations of this reader family, most-derived winning; a fresh dict per call.
+
+        Merged across cls.__mro__ from each class's own __dict__ so an inherited attribute is not
+        merged twice, walking the MRO in reverse so a derived declaration wins on a key collision.
+        """
+        return dict(cls._merged_reader_option_specs())
 
     @classmethod
     def declared_reader_option_keys(cls) -> frozenset[str]:
         """Every option key this reader family declares."""
-        return frozenset(cls.reader_option_specs())
+        return frozenset(cls._merged_reader_option_specs())
+
+    @classmethod
+    def _declared_reader_option_spec(cls, key: str) -> ReaderOptionSpec:
+        """The declaration of key; an undeclared key is a typo, not a silent None."""
+        specs = cls._merged_reader_option_specs()
+        if key not in specs:
+            raise ValueError(f"Reader option '{key}' is not declared in READER_OPTIONS of {cls.__name__}.")
+        return specs[key]
 
     @classmethod
     def reader_option_default(cls, key: str) -> Any:
-        """The declared runtime_default of key; an undeclared key is a typo, not a silent None."""
-        specs = cls.reader_option_specs()
-        if key not in specs:
-            raise ValueError(f"Reader option '{key}' is not declared in READER_OPTIONS of {cls.__name__}.")
-        return specs[key].runtime_default
+        """The declared runtime_default of key, without consulting any Options."""
+        return cls._declared_reader_option_spec(key).runtime_default
+
+    @classmethod
+    def reader_option(cls, key: str, options: Options) -> Any:
+        """The supplied value of key when present, else the declared runtime_default.
+
+        Presence, not truthiness: an explicit empty value ("hand nothing over") survives, while None
+        reads as absent per the framework's dominant absence rule.
+        """
+        spec = cls._declared_reader_option_spec(key)
+        value = options.get(key)
+        if value is None:
+            return spec.runtime_default
+        return value
 
     @classmethod
     def data_access_name(cls) -> str:

--- a/mloda/core/abstract_plugins/components/input_data/reader_option_spec.py
+++ b/mloda/core/abstract_plugins/components/input_data/reader_option_spec.py
@@ -1,0 +1,21 @@
+"""The ``READER_OPTIONS`` spec type: a deliberately weaker sibling of ``PropertySpec``.
+
+Reader option keys are consumed at MATCH time, inside reader selection, which runs before the
+framework materializes any ``PROPERTY_MAPPING`` default, so nothing declared here is ever applied
+by the framework. ``runtime_default`` only RECORDS the fallback the reader's own code applies when
+the key is absent, and ``framework_set`` marks a key the framework writes rather than the user.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ReaderOptionSpec:
+    """Frozen declaration of one reader option key."""
+
+    explanation: str
+    runtime_default: Any = None
+    framework_set: bool = False

--- a/mloda/provider/__init__.py
+++ b/mloda/provider/__init__.py
@@ -38,6 +38,7 @@ from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.input_data.base_input_data import BaseInputData
 from mloda.core.abstract_plugins.components.input_data.file_source import FileSource
 from mloda.core.abstract_plugins.components.input_data.input_data_descriptor import InputDataDescriptor
+from mloda.core.abstract_plugins.components.input_data.reader_option_spec import ReaderOptionSpec
 from mloda.core.abstract_plugins.components.input_data.api.api_input_data import ApiInputData
 from mloda.core.abstract_plugins.components.input_data.api.api_input_data_feature import ApiInputDataFeature
 from mloda.core.abstract_plugins.components.input_data.api.base_api_data import BaseApiData
@@ -127,6 +128,7 @@ __all__ = [
     "BaseInputData",
     "FileSource",
     "InputDataDescriptor",
+    "ReaderOptionSpec",
     "ApiInputData",
     "ApiInputDataFeature",
     "BaseApiData",

--- a/mloda_plugins/feature_group/input_data/read_context_files.py
+++ b/mloda_plugins/feature_group/input_data/read_context_files.py
@@ -9,7 +9,7 @@ from mloda.user import FeatureName
 from mloda.provider import FeatureSet
 from mloda.user import JoinType
 from mloda.user import Options
-from mloda.provider import DefaultOptionKeys
+from mloda.provider import DefaultOptionKeys, PropertySpec
 from mloda_plugins.feature_group.experimental.dynamic_feature_group_factory.dynamic_feature_group_factory import (
     DynamicFeatureGroupCreator,
 )
@@ -26,6 +26,16 @@ except ImportError:
     pd = None
 
 
+def target_folder_required(options: Options) -> bool:
+    """``target_folder`` is the source only when no explicit ``file_paths`` were given."""
+    return not options.get("file_paths")
+
+
+def document_reader_class_required(options: Options) -> bool:
+    """A reader is needed for every read, whatever the source is."""
+    return True
+
+
 class ConcatenatedFileContent(FeatureGroup):
     """
     A feature group that reads and combines content from files within a directory (default: python files).
@@ -40,28 +50,47 @@ class ConcatenatedFileContent(FeatureGroup):
     # This feature should just be created once mlodaAPI run.
     join_feature_name = "FGConcatenatedFileContent_JoinLLMFiles"
 
+    # All five keys change WHAT gets read, so each is a group parameter (context=False).
+    PROPERTY_MAPPING = {
+        # The default is a tuple: a materialized context=False default lands in group options, which are hashed.
+        "disallowed_files": PropertySpec("File names to skip.", default=("__init__.py",), context=False),
+        "file_type": PropertySpec("Suffix collected from target_folder.", default="py", context=False),
+        "file_paths": PropertySpec(
+            "Explicit files to read, instead of scanning target_folder.", default=None, context=False
+        ),
+        "target_folder": PropertySpec(
+            "Folders scanned for file_type; required when no file_paths are given.",
+            default=None,
+            context=False,
+            required_when=target_folder_required,
+        ),
+        # NO_DEFAULT is the truthful declaration, but the name-path presence rule that enforces it installs only
+        # for a PREFIX/SUFFIX-declaring class; this group declares none, so required_when enforces it at match time.
+        "document_reader_class": PropertySpec(
+            "Reader class name used per file; declares no default, so it is required.",
+            context=False,
+            required_when=document_reader_class_required,
+        ),
+    }
+
     def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
-        disallowed_files = list(options.get("disallowed_files")) if options.get("disallowed_files") else ["__init__.py"]
+        # The engine passes DECLARED options, so the declared defaults only reach this read site here.
+        effective = self.options_with_defaults(options)
+        disallowed_files = list(effective.get("disallowed_files"))
 
         if options.get("file_paths"):
-            file_paths = list(options.get("file_paths"))
-
-            if options.get("file_paths"):
-                file_paths = list(options.get("file_paths"))
-
-                new_file_paths = []
-                for file in file_paths:
-                    file_name = os.path.basename(file)  # Extracts only the file name
-                    if file_name not in disallowed_files:
-                        _file = file.replace("\n", "")
-                        new_file_paths.append(_file)
+            file_paths: list[str] = []
+            for file in options.get("file_paths"):
+                clean_file = file.replace("\n", "")  # Line-oriented file lists carry newlines into the path.
+                if os.path.basename(clean_file) not in disallowed_files:  # Compares only the file name.
+                    file_paths.append(clean_file)
 
         else:
             target_folder = options.get("target_folder")
             if not target_folder:
                 raise ValueError(f"The option 'target_folder' is required for {self.get_class_name()}.")
 
-            file_type = options.get("file_type") or "py"
+            file_type = effective.get("file_type")
             file_paths = find_file_paths(list(target_folder), file_type, not_allowed_files_names=disallowed_files)
 
         document_reader_class = options.get("document_reader_class")

--- a/mloda_plugins/feature_group/input_data/read_context_files.py
+++ b/mloda_plugins/feature_group/input_data/read_context_files.py
@@ -50,9 +50,14 @@ class ConcatenatedFileContent(FeatureGroup):
     # This feature should just be created once mlodaAPI run.
     join_feature_name = "FGConcatenatedFileContent_JoinLLMFiles"
 
-    # All five keys change WHAT gets read, so each is a group parameter (context=False).
+    # All five keys change WHAT gets read, so context=False classifies each truthfully as a group
+    # parameter. The flag is only consulted where the framework PLACES a value, i.e. when it fills a
+    # declared default or binds a name capture; with no pattern there are no captures, so it is
+    # load-bearing for the two keys below that declare a default and descriptive for the other three.
     PROPERTY_MAPPING = {
-        # The default is a tuple: a materialized context=False default lands in group options, which are hashed.
+        # The default is a tuple for EQUALITY, not hashing: Options normalizes a list for hashing, so a
+        # list and a tuple hash equal yet compare unequal, and a caller passing ["__init__.py"] would
+        # get a feature that never merges with the materialized default.
         "disallowed_files": PropertySpec("File names to skip.", default=("__init__.py",), context=False),
         "file_type": PropertySpec("Suffix collected from target_folder.", default="py", context=False),
         "file_paths": PropertySpec(
@@ -78,13 +83,21 @@ class ConcatenatedFileContent(FeatureGroup):
         effective = self.options_with_defaults(options)
         disallowed_files = list(effective.get("disallowed_files"))
 
-        if options.get("file_paths"):
+        given_file_paths = options.get("file_paths")
+        if given_file_paths:
             file_paths: list[str] = []
-            for file in options.get("file_paths"):
+            for file in given_file_paths:
                 clean_file = file.replace("\n", "")  # Line-oriented file lists carry newlines into the path.
                 if os.path.basename(clean_file) not in disallowed_files:  # Compares only the file name.
                     file_paths.append(clean_file)
 
+            # Mirrors find_file_paths on the other branch: an empty selection cannot be read, so it
+            # fails here instead of producing a join child with an empty in_features frozenset.
+            if not file_paths:
+                raise ValueError(
+                    f"No files left for {self.get_class_name()}: 'disallowed_files' {tuple(disallowed_files)} "
+                    f"excluded every path given in 'file_paths' {tuple(given_file_paths)}."
+                )
         else:
             target_folder = options.get("target_folder")
             if not target_folder:

--- a/mloda_plugins/feature_group/input_data/read_db.py
+++ b/mloda_plugins/feature_group/input_data/read_db.py
@@ -1,6 +1,6 @@
-from typing import Any
+from typing import Any, ClassVar
 from mloda.user import DataAccessCollection
-from mloda.provider import FeatureSet, BaseInputData
+from mloda.provider import FeatureSet, BaseInputData, ReaderOptionSpec
 from mloda.user import Options
 
 
@@ -22,6 +22,13 @@ class ReadDB(BaseInputData):
     """
 
     _auto_load_group: str = "feature_group/input_data/read_dbs"
+
+    READER_OPTIONS: ClassVar[dict[str, ReaderOptionSpec]] = {
+        "data_access_handle": ReaderOptionSpec(
+            "Hint naming which DataAccessCollection credentials handle to prefer while matching.",
+            runtime_default=None,
+        ),
+    }
 
     @classmethod
     def prepare_credentials(cls, data_access: Any, features: FeatureSet) -> Any:

--- a/mloda_plugins/feature_group/input_data/read_document.py
+++ b/mloda_plugins/feature_group/input_data/read_document.py
@@ -100,7 +100,7 @@ class ReadDocument(BaseInputData):
                 pinned = cls._resolve_pinned_file(data_access, feature_names)
                 if pinned is not None:
                     return pinned
-            document_suffixes = options.get("document_suffixes") or cls.reader_option_default("document_suffixes")
+            document_suffixes = cls.reader_option("document_suffixes", options)
             hint = options.get("data_access_handle")
             if hint is not None:
                 handle_kind = data_access.handles().get(hint)

--- a/mloda_plugins/feature_group/input_data/read_document.py
+++ b/mloda_plugins/feature_group/input_data/read_document.py
@@ -1,8 +1,8 @@
 import os
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, ClassVar, Optional
 
-from mloda.provider import BaseInputData, FeatureSet
+from mloda.provider import BaseInputData, FeatureSet, ReaderOptionSpec
 from mloda.user import DataAccessCollection, Options
 from mloda_plugins.feature_group.input_data.read_file import ReadFile
 
@@ -34,6 +34,17 @@ class ReadDocument(BaseInputData):
     """
 
     _auto_load_group: str = "feature_group/input_data/read_files"
+
+    READER_OPTIONS: ClassVar[dict[str, ReaderOptionSpec]] = {
+        "document_suffixes": ReaderOptionSpec(
+            "Structured suffixes this document reader claims instead of leaving them to ReadFile.",
+            runtime_default=frozenset(),
+        ),
+        "data_access_handle": ReaderOptionSpec(
+            "Hint naming which DataAccessCollection file handle to prefer while matching.",
+            runtime_default=None,
+        ),
+    }
 
     @classmethod
     def produce_document(cls, file_path: str) -> Any:
@@ -89,7 +100,7 @@ class ReadDocument(BaseInputData):
                 pinned = cls._resolve_pinned_file(data_access, feature_names)
                 if pinned is not None:
                     return pinned
-            document_suffixes = options.get("document_suffixes") or frozenset()
+            document_suffixes = options.get("document_suffixes") or cls.reader_option_default("document_suffixes")
             hint = options.get("data_access_handle")
             if hint is not None:
                 handle_kind = data_access.handles().get(hint)

--- a/mloda_plugins/feature_group/input_data/read_file.py
+++ b/mloda_plugins/feature_group/input_data/read_file.py
@@ -1,9 +1,9 @@
 import os
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 from mloda.user import DataAccessCollection
 from mloda.provider import FeatureSet
-from mloda.provider import BaseInputData
+from mloda.provider import BaseInputData, ReaderOptionSpec
 from mloda.user import Options
 
 
@@ -38,6 +38,17 @@ class ReadFile(BaseInputData):
     """
 
     _auto_load_group: str = "feature_group/input_data/read_files"
+
+    READER_OPTIONS: ClassVar[dict[str, ReaderOptionSpec]] = {
+        "document_suffixes": ReaderOptionSpec(
+            "Suffixes handed over to document readers; ReadFile auto-excludes them from its own matching.",
+            runtime_default=frozenset(),
+        ),
+        "data_access_handle": ReaderOptionSpec(
+            "Hint naming which DataAccessCollection file handle to prefer while matching.",
+            runtime_default=None,
+        ),
+    }
 
     _structured_suffixes: "frozenset[str]" = frozenset(
         {
@@ -78,7 +89,9 @@ class ReadFile(BaseInputData):
 
     @classmethod
     def match_subclass_data_access(cls, data_access: Any, feature_names: list[str], options: Options) -> Any:
-        document_suffixes: "frozenset[str]" = options.get("document_suffixes") or frozenset()
+        document_suffixes: "frozenset[str]" = options.get("document_suffixes") or cls.reader_option_default(
+            "document_suffixes"
+        )
 
         if isinstance(data_access, DataAccessCollection):
             if data_access.column_to_file is not None:

--- a/mloda_plugins/feature_group/input_data/read_file.py
+++ b/mloda_plugins/feature_group/input_data/read_file.py
@@ -89,9 +89,7 @@ class ReadFile(BaseInputData):
 
     @classmethod
     def match_subclass_data_access(cls, data_access: Any, feature_names: list[str], options: Options) -> Any:
-        document_suffixes: "frozenset[str]" = options.get("document_suffixes") or cls.reader_option_default(
-            "document_suffixes"
-        )
+        document_suffixes: "frozenset[str]" = cls.reader_option("document_suffixes", options)
 
         if isinstance(data_access, DataAccessCollection):
             if data_access.column_to_file is not None:

--- a/tests/test_core/test_abstract_plugins/test_components/test_reader_option_declarations.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_reader_option_declarations.py
@@ -1,0 +1,234 @@
+"""Pins the ``READER_OPTIONS`` declaration surface on ``BaseInputData``.
+
+Reader option keys are consumed at MATCH time, inside reader selection, which runs before the
+framework materializes any ``PROPERTY_MAPPING`` default. A ``PropertySpec`` on a wrapper
+FeatureGroup could therefore never be enforced for them, so readers get their own, deliberately
+smaller spec type: ``ReaderOptionSpec`` declares an explanation, the ``runtime_default`` the
+reader's OWN code applies when the key is absent, and a ``framework_set`` flag for keys the
+framework writes and users do not.
+
+What is pinned here:
+
+* ``ReaderOptionSpec`` lives in ``mloda/core/abstract_plugins/components/input_data/
+  reader_option_spec.py``, is a frozen dataclass with value equality, and is exported from
+  ``mloda.provider``.
+* ``BaseInputData.READER_OPTIONS`` declares the reserved ``"BaseInputData"`` key (the matched
+  ``(ReaderClass, data_access)`` tuple written by ``add_base_input_data_to_options`` and read by
+  ``init_reader``) with ``framework_set=True``.
+* ``reader_option_specs()`` merges declarations across ``cls.__mro__`` with the most-derived class
+  winning, ``declared_reader_option_keys()`` exposes the merged keys, and
+  ``reader_option_default()`` raises a loud ``ValueError`` for an undeclared key so a typo in
+  reader code cannot silently read as ``None``.
+
+The synthetic classes below are built directly on ``BaseInputData``, never override ``load_data``
+(so ``is_final_reader()`` is False and reader discovery never collects them), and their matcher
+returns None; they cannot pollute reader selection in sibling tests.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any, ClassVar
+
+import pytest
+
+import mloda.provider as mloda_provider
+from mloda.core.abstract_plugins.components.input_data.base_input_data import BaseInputData
+from mloda.core.abstract_plugins.components.input_data.reader_option_spec import ReaderOptionSpec
+from mloda.core.abstract_plugins.components.options import Options
+
+
+def _spec(*args: Any, **kwargs: Any) -> ReaderOptionSpec:
+    """Build a ``ReaderOptionSpec`` through an untyped seam so type-invalid calls stay runtime tests."""
+    return ReaderOptionSpec(*args, **kwargs)
+
+
+class _ReaderOptDeclParent(BaseInputData):
+    """Parent declaring key A only; inherits the reserved framework key."""
+
+    READER_OPTIONS: ClassVar[dict[str, ReaderOptionSpec]] = {
+        "rod_key_a": ReaderOptionSpec("Key A, declared on the parent.", runtime_default="parent_a"),
+    }
+
+    @classmethod
+    def match_subclass_data_access(cls, data_access: Any, feature_names: list[str], options: Any = None) -> Any:
+        return None
+
+
+class _ReaderOptDeclChild(_ReaderOptDeclParent):
+    """Child declaring key B only; A and the reserved key must still be visible."""
+
+    READER_OPTIONS: ClassVar[dict[str, ReaderOptionSpec]] = {
+        "rod_key_b": ReaderOptionSpec("Key B, declared on the child.", runtime_default="child_b"),
+    }
+
+
+class _ReaderOptDeclOverride(_ReaderOptDeclParent):
+    """Child redeclaring key A with a different runtime_default; the most-derived declaration wins."""
+
+    READER_OPTIONS: ClassVar[dict[str, ReaderOptionSpec]] = {
+        "rod_key_a": ReaderOptionSpec("Key A, redeclared on the child.", runtime_default="child_a"),
+    }
+
+
+class TestReaderOptionSpecType:
+    """Construction, immutability, and value equality of the spec type itself."""
+
+    def test_minimal_construction_uses_documented_defaults(self) -> None:
+        """``ReaderOptionSpec("why")`` constructs with runtime_default None and framework_set False."""
+        spec = ReaderOptionSpec("Why this key exists.")
+
+        assert spec.explanation == "Why this key exists."
+        assert spec.runtime_default is None
+        assert spec.framework_set is False
+
+    def test_explanation_is_positional_and_required(self) -> None:
+        """The explanation is the one positional field; omitting it is Python's own TypeError."""
+        with pytest.raises(TypeError):
+            _spec()
+        assert _spec("positional explanation").explanation == "positional explanation"
+
+    def test_declared_fields_are_named_runtime_default_and_framework_set(self) -> None:
+        """A typo'd keyword raises TypeError instead of being silently absorbed."""
+        with pytest.raises(TypeError):
+            _spec("x", runtime_defualt=1)
+        with pytest.raises(TypeError):
+            _spec("x", framework_setting=True)
+
+    def test_instances_are_frozen(self) -> None:
+        """Assigning any field raises ``dataclasses.FrozenInstanceError``."""
+        spec = ReaderOptionSpec("x", runtime_default=frozenset(), framework_set=False)
+
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            setattr(spec, "explanation", "changed")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            setattr(spec, "runtime_default", "changed")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            setattr(spec, "framework_set", True)
+
+    def test_equality_is_by_value(self) -> None:
+        """Two specs with equal fields are equal; a differing field makes them unequal."""
+        assert ReaderOptionSpec("x", runtime_default=frozenset()) == ReaderOptionSpec("x", runtime_default=frozenset())
+        assert ReaderOptionSpec("x") != ReaderOptionSpec("y")
+        assert ReaderOptionSpec("x", runtime_default=1) != ReaderOptionSpec("x", runtime_default=2)
+        assert ReaderOptionSpec("x", framework_set=True) != ReaderOptionSpec("x", framework_set=False)
+
+    def test_exported_from_mloda_provider(self) -> None:
+        """``from mloda.provider import ReaderOptionSpec`` resolves to this exact class."""
+        from mloda.provider import ReaderOptionSpec as ProviderReaderOptionSpec
+
+        assert ProviderReaderOptionSpec is ReaderOptionSpec
+        assert "ReaderOptionSpec" in mloda_provider.__all__
+
+
+class TestReservedFrameworkKey:
+    """``BaseInputData`` itself declares the reserved ``"BaseInputData"`` options key."""
+
+    def test_base_declares_reader_options_locally(self) -> None:
+        """The declaration lives on ``BaseInputData``, not only on some subclass."""
+        assert "READER_OPTIONS" in BaseInputData.__dict__
+        assert isinstance(BaseInputData.READER_OPTIONS, dict)
+        assert "BaseInputData" in BaseInputData.READER_OPTIONS
+
+    def test_declared_keys_contain_the_reserved_key(self) -> None:
+        """``declared_reader_option_keys()`` on the base contains the reserved key."""
+        keys = BaseInputData.declared_reader_option_keys()
+
+        assert isinstance(keys, frozenset)
+        assert "BaseInputData" in keys
+
+    def test_reserved_key_is_framework_set(self) -> None:
+        """The reserved key is written by the framework, so users never set it."""
+        spec = BaseInputData.reader_option_specs()["BaseInputData"]
+
+        assert isinstance(spec, ReaderOptionSpec)
+        assert spec.framework_set is True
+
+    def test_reserved_key_has_no_runtime_default(self) -> None:
+        """No reader code falls back for the reserved key; init_reader raises when it is absent."""
+        assert BaseInputData.reader_option_default("BaseInputData") is None
+
+    def test_reserved_key_is_the_key_the_framework_actually_writes(self) -> None:
+        """``add_base_input_data_to_options`` writes exactly the declared reserved key."""
+        options = Options()
+        BaseInputData.add_base_input_data_to_options(_ReaderOptDeclParent, "rod_reserved_access", options)
+
+        written = set(options.keys())
+        assert written == {"BaseInputData"}
+        assert written <= BaseInputData.declared_reader_option_keys()
+
+
+class TestMroMerge:
+    """Declarations merge across ``cls.__mro__``, most-derived class winning on a collision."""
+
+    def test_parent_keys_include_own_and_inherited(self) -> None:
+        """The parent sees its own key A plus the reserved key from the base."""
+        assert _ReaderOptDeclParent.declared_reader_option_keys() == {"rod_key_a", "BaseInputData"}
+
+    def test_child_merges_parent_and_own_keys(self) -> None:
+        """A child declaring only B still sees A and the reserved key."""
+        assert _ReaderOptDeclChild.declared_reader_option_keys() == {"rod_key_a", "rod_key_b", "BaseInputData"}
+
+    def test_child_declaration_does_not_leak_into_the_parent(self) -> None:
+        """The merge walks up the MRO only; the parent never gains the child's key."""
+        assert "rod_key_b" not in _ReaderOptDeclParent.declared_reader_option_keys()
+
+    def test_specs_are_returned_keyed_by_option_name(self) -> None:
+        """``reader_option_specs()`` maps every merged key to its ``ReaderOptionSpec``."""
+        specs = _ReaderOptDeclChild.reader_option_specs()
+
+        assert set(specs) == _ReaderOptDeclChild.declared_reader_option_keys()
+        assert all(isinstance(spec, ReaderOptionSpec) for spec in specs.values())
+        assert specs["rod_key_a"].runtime_default == "parent_a"
+        assert specs["rod_key_b"].runtime_default == "child_b"
+
+    def test_most_derived_declaration_wins_on_a_key_collision(self) -> None:
+        """Redeclaring key A with another runtime_default overrides the parent's declaration."""
+        assert _ReaderOptDeclOverride.reader_option_default("rod_key_a") == "child_a"
+        assert _ReaderOptDeclOverride.reader_option_specs()["rod_key_a"].runtime_default == "child_a"
+        assert _ReaderOptDeclParent.reader_option_default("rod_key_a") == "parent_a"
+
+    def test_returned_mapping_is_a_fresh_copy(self) -> None:
+        """A caller mutating the merged mapping cannot corrupt the class declarations."""
+        specs = _ReaderOptDeclChild.reader_option_specs()
+        specs["rod_key_injected"] = ReaderOptionSpec("Injected by a caller.")
+
+        assert "rod_key_injected" not in _ReaderOptDeclChild.declared_reader_option_keys()
+        assert "rod_key_injected" not in _ReaderOptDeclChild.reader_option_specs()
+
+
+class TestReaderOptionDefault:
+    """``reader_option_default`` returns the declared fallback and is loud about typos."""
+
+    def test_declared_default_is_returned(self) -> None:
+        """The declared ``runtime_default`` is what reader code gets for an absent key."""
+        assert _ReaderOptDeclParent.reader_option_default("rod_key_a") == "parent_a"
+        assert _ReaderOptDeclChild.reader_option_default("rod_key_b") == "child_b"
+
+    def test_inherited_default_is_returned(self) -> None:
+        """A child needs no re-declaration to reach the parent's default."""
+        assert _ReaderOptDeclChild.reader_option_default("rod_key_a") == "parent_a"
+
+    def test_undeclared_key_raises_value_error_naming_key_and_class(self) -> None:
+        """A typo in reader code is loud, not a silent None."""
+        with pytest.raises(ValueError) as exc_info:
+            _ReaderOptDeclChild.reader_option_default("not_a_key")
+
+        message = str(exc_info.value)
+        assert "not_a_key" in message
+        assert "_ReaderOptDeclChild" in message
+
+    def test_undeclared_key_on_base_raises_value_error(self) -> None:
+        """The same guard holds on ``BaseInputData`` itself."""
+        with pytest.raises(ValueError, match="not_a_key"):
+            BaseInputData.reader_option_default("not_a_key")
+
+
+class TestDeclarationsDoNotAffectDiscovery:
+    """The synthetic declaring classes stay invisible to reader selection."""
+
+    def test_synthetic_declaring_classes_are_not_final_readers(self) -> None:
+        """No ``load_data`` override means ``get_all_filtered_subclasses`` never collects them."""
+        assert _ReaderOptDeclParent.is_final_reader() is False
+        assert _ReaderOptDeclChild.is_final_reader() is False
+        assert _ReaderOptDeclOverride.is_final_reader() is False

--- a/tests/test_core/test_abstract_plugins/test_components/test_reader_option_declarations.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_reader_option_declarations.py
@@ -19,23 +19,32 @@ What is pinned here:
   winning, ``declared_reader_option_keys()`` exposes the merged keys, and
   ``reader_option_default()`` raises a loud ``ValueError`` for an undeclared key so a typo in
   reader code cannot silently read as ``None``.
+* ``reader_option(key, options)`` is the accessor reader code calls: it returns the SUPPLIED value
+  whenever the key is present and the declared ``runtime_default`` otherwise, so an explicit
+  falsy value ("hand nothing over") is never silently replaced by a non-empty declared default.
+* ``READER_OPTIONS`` values must BE ``ReaderOptionSpec`` instances, enforced at class definition
+  the way ``FeatureGroup.__init_subclass__`` enforces ``PROPERTY_MAPPING``.
 
-The synthetic classes below are built directly on ``BaseInputData``, never override ``load_data``
-(so ``is_final_reader()`` is False and reader discovery never collects them), and their matcher
-returns None; they cannot pollute reader selection in sibling tests.
+Subclass-leak policy: this module DELIBERATELY leaks its throwaway ``BaseInputData`` subclasses
+(module-level ones permanently, function-local ones until a gc cycle). That is benign and pinned:
+none of them overrides ``load_data`` or declares ``_final_reader_requires``, so ``is_final_reader()``
+is False and ``get_all_filtered_subclasses`` never collects them into reader selection.
 """
 
 from __future__ import annotations
 
 import dataclasses
+import inspect
 from typing import Any, ClassVar
 
 import pytest
 
 import mloda.provider as mloda_provider
+from mloda.core.abstract_plugins.components.feature_chainer.property_spec import PropertySpec
 from mloda.core.abstract_plugins.components.input_data.base_input_data import BaseInputData
 from mloda.core.abstract_plugins.components.input_data.reader_option_spec import ReaderOptionSpec
 from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.components.utils import get_all_subclasses
 
 
 def _spec(*args: Any, **kwargs: Any) -> ReaderOptionSpec:
@@ -149,13 +158,33 @@ class TestReservedFrameworkKey:
         assert BaseInputData.reader_option_default("BaseInputData") is None
 
     def test_reserved_key_is_the_key_the_framework_actually_writes(self) -> None:
-        """``add_base_input_data_to_options`` writes exactly the declared reserved key."""
+        """``add_base_input_data_to_options`` writes exactly the keys declared ``framework_set``.
+
+        This is what makes ``framework_set`` load-bearing: nothing in the framework reads the flag
+        (deliberately, reader selection is a hot path), so the flag's meaning is pinned here instead.
+        Flipping it to False, or marking a second key ``framework_set`` that nothing writes, fails.
+        """
         options = Options()
         BaseInputData.add_base_input_data_to_options(_ReaderOptDeclParent, "rod_reserved_access", options)
 
         written = set(options.keys())
+        specs = BaseInputData.reader_option_specs()
         assert written == {"BaseInputData"}
         assert written <= BaseInputData.declared_reader_option_keys()
+        assert written == {key for key, spec in specs.items() if spec.framework_set}
+        assert specs["BaseInputData"].framework_set is True
+
+    def test_the_declaring_reader_family_marks_no_further_framework_keys(self) -> None:
+        """A reader family inherits the one framework-written key and adds no second one.
+
+        The flag marks keys USERS never set, so a reader declaring its own user-facing keys must
+        leave them ``framework_set=False``; otherwise the invariant above stops describing writes.
+        """
+        specs = _ReaderOptDeclChild.reader_option_specs()
+
+        assert {key for key, spec in specs.items() if spec.framework_set} == {"BaseInputData"}
+        assert specs["rod_key_a"].framework_set is False
+        assert specs["rod_key_b"].framework_set is False
 
 
 class TestMroMerge:
@@ -224,6 +253,286 @@ class TestReaderOptionDefault:
             BaseInputData.reader_option_default("not_a_key")
 
 
+class TestReaderOptionHonoursPresence:
+    """``reader_option(key, options)`` reads presence, not truthiness."""
+
+    def test_signature_is_key_first_options_second(self) -> None:
+        """The KEY comes first, mirroring ``reader_option_default(key)``; the Options is second."""
+        parameters = list(inspect.signature(BaseInputData.reader_option).parameters)
+
+        assert parameters == ["key", "options"]
+
+    def test_absent_key_falls_back_to_the_declared_default(self) -> None:
+        """Nothing supplied means the reader's own declared fallback applies."""
+        assert _ReaderOptDeclParent.reader_option("rod_key_a", Options()) == "parent_a"
+
+    def test_supplied_value_wins_over_the_declared_default(self) -> None:
+        """A user-set value is returned unchanged."""
+        options = Options({"rod_key_a": "supplied"})
+
+        assert _ReaderOptDeclParent.reader_option("rod_key_a", options) == "supplied"
+
+    @pytest.mark.parametrize("falsy_value", [frozenset(), (), [], "", 0, False, {}])
+    def test_present_but_falsy_value_is_honoured_not_replaced(self, falsy_value: Any) -> None:
+        """An explicit empty value means "hand nothing over" and must survive the read.
+
+        This is the whole defect: ``options.get(key) or cls.reader_option_default(key)`` cannot tell
+        an absent key from an explicit empty one, so a non-empty declared default silently wins and
+        the option can never be turned off.
+        """
+        options = Options({"rod_key_a": falsy_value})
+
+        result = _ReaderOptDeclParent.reader_option("rod_key_a", options)
+
+        assert result == falsy_value
+        assert result != "parent_a"
+
+    def test_explicit_none_reads_as_absent(self) -> None:
+        """``None`` is the framework's dominant absence marker, so the declared default applies."""
+        options = Options({"rod_key_a": None})
+
+        assert "rod_key_a" in options
+        assert _ReaderOptDeclParent.reader_option("rod_key_a", options) == "parent_a"
+
+    def test_a_context_option_is_read_like_a_group_option(self) -> None:
+        """The accessor reads through ``Options.get``, so the category never changes the answer."""
+        options = Options(context={"rod_key_a": frozenset()})
+
+        assert _ReaderOptDeclParent.reader_option("rod_key_a", options) == frozenset()
+
+    def test_inherited_declaration_supplies_the_default(self) -> None:
+        """A child needs no re-declaration to reach the parent's fallback."""
+        assert _ReaderOptDeclChild.reader_option("rod_key_a", Options()) == "parent_a"
+
+    def test_most_derived_declaration_supplies_the_default(self) -> None:
+        """A redeclared key resolves to the most-derived ``runtime_default``, like the sibling accessor."""
+        assert _ReaderOptDeclOverride.reader_option("rod_key_a", Options()) == "child_a"
+        assert _ReaderOptDeclParent.reader_option("rod_key_a", Options()) == "parent_a"
+
+    def test_undeclared_key_raises_value_error_naming_key_and_class(self) -> None:
+        """A typo is loud here exactly as in ``reader_option_default``, not a silent None."""
+        with pytest.raises(ValueError) as exc_info:
+            _ReaderOptDeclChild.reader_option("not_a_key", Options())
+
+        message = str(exc_info.value)
+        assert "not_a_key" in message
+        assert "_ReaderOptDeclChild" in message
+
+    def test_undeclared_key_raises_even_when_a_value_is_supplied(self) -> None:
+        """The declaration gates the read: a supplied value cannot legitimize an undeclared key."""
+        options = Options({"not_a_key": "supplied"})
+
+        with pytest.raises(ValueError, match="not_a_key"):
+            _ReaderOptDeclChild.reader_option("not_a_key", options)
+
+    def test_undeclared_key_on_the_base_raises(self) -> None:
+        """The same guard holds on ``BaseInputData`` itself."""
+        with pytest.raises(ValueError, match="not_a_key"):
+            BaseInputData.reader_option("not_a_key", Options())
+
+
+class TestReaderOptionSpecCacheStaysFresh:
+    """The merged-spec cache is per class, so it can never answer for the wrong class.
+
+    Every family below is built INSIDE its test so the cache starts cold: module-level classes are
+    warmed by whichever test the xdist worker happened to run first, which would make these vacuous.
+    """
+
+    def test_a_subclass_defined_after_a_warm_parent_cache_sees_its_own_declaration(self) -> None:
+        """Warming the parent must not answer for a child that redeclares the key."""
+
+        class RodColdParentReader(BaseInputData):
+            READER_OPTIONS: ClassVar[dict[str, ReaderOptionSpec]] = {
+                "rod_cache_key": ReaderOptionSpec("Declared on the parent.", runtime_default="parent"),
+            }
+
+        assert RodColdParentReader.reader_option("rod_cache_key", Options()) == "parent"
+
+        class RodLateChildReader(RodColdParentReader):
+            READER_OPTIONS: ClassVar[dict[str, ReaderOptionSpec]] = {
+                "rod_cache_key": ReaderOptionSpec("Redeclared on the child.", runtime_default="child"),
+            }
+
+        assert RodLateChildReader.reader_option("rod_cache_key", Options()) == "child"
+        assert RodColdParentReader.reader_option("rod_cache_key", Options()) == "parent"
+
+    def test_a_warm_child_cache_does_not_change_the_parent(self) -> None:
+        """The reverse order: reading the child first leaves the parent's answer alone."""
+
+        class RodParentReadSecond(BaseInputData):
+            READER_OPTIONS: ClassVar[dict[str, ReaderOptionSpec]] = {
+                "rod_cache_key": ReaderOptionSpec("Declared on the parent.", runtime_default="parent"),
+            }
+
+        class RodChildReadFirst(RodParentReadSecond):
+            READER_OPTIONS: ClassVar[dict[str, ReaderOptionSpec]] = {
+                "rod_cache_key": ReaderOptionSpec("Redeclared on the child.", runtime_default="child"),
+            }
+
+        assert RodChildReadFirst.reader_option("rod_cache_key", Options()) == "child"
+        assert RodParentReadSecond.reader_option("rod_cache_key", Options()) == "parent"
+
+    def test_a_key_added_by_a_late_subclass_is_visible_after_a_warm_parent_cache(self) -> None:
+        """``declared_reader_option_keys`` shares the cache, so it must not go stale either."""
+
+        class RodKeysParentReader(BaseInputData):
+            READER_OPTIONS: ClassVar[dict[str, ReaderOptionSpec]] = {
+                "rod_cache_parent_key": ReaderOptionSpec("Parent only."),
+            }
+
+        assert RodKeysParentReader.declared_reader_option_keys() == {"rod_cache_parent_key", "BaseInputData"}
+
+        class RodKeysChildReader(RodKeysParentReader):
+            READER_OPTIONS: ClassVar[dict[str, ReaderOptionSpec]] = {
+                "rod_cache_child_key": ReaderOptionSpec("Child only."),
+            }
+
+        assert RodKeysChildReader.declared_reader_option_keys() == {
+            "rod_cache_parent_key",
+            "rod_cache_child_key",
+            "BaseInputData",
+        }
+        assert "rod_cache_child_key" not in RodKeysParentReader.declared_reader_option_keys()
+
+    def test_an_undeclared_key_still_raises_on_a_warm_cache(self) -> None:
+        """The guard reads the cached mapping, so warming it cannot make a typo silent."""
+
+        class RodWarmGuardReader(BaseInputData):
+            READER_OPTIONS: ClassVar[dict[str, ReaderOptionSpec]] = {
+                "rod_cache_key": ReaderOptionSpec("Declared.", runtime_default="declared"),
+            }
+
+        assert RodWarmGuardReader.reader_option("rod_cache_key", Options()) == "declared"
+
+        with pytest.raises(ValueError, match="not_a_key"):
+            RodWarmGuardReader.reader_option("not_a_key", Options())
+
+    def test_mutating_the_returned_specs_cannot_poison_the_cache(self) -> None:
+        """The caller-facing mapping stays a fresh copy: a cache must not be handed out by reference."""
+
+        class RodCopyProbeReader(BaseInputData):
+            READER_OPTIONS: ClassVar[dict[str, ReaderOptionSpec]] = {
+                "rod_cache_key": ReaderOptionSpec("Declared.", runtime_default="declared"),
+            }
+
+        specs = RodCopyProbeReader.reader_option_specs()
+        specs["rod_cache_key"] = ReaderOptionSpec("Injected.", runtime_default="injected")
+        specs["rod_cache_injected_key"] = ReaderOptionSpec("Injected.")
+
+        assert RodCopyProbeReader.reader_option("rod_cache_key", Options()) == "declared"
+        assert "rod_cache_injected_key" not in RodCopyProbeReader.declared_reader_option_keys()
+
+    def test_repeated_reads_stay_equal(self) -> None:
+        """Caching is invisible: two reads of the same key on the same class agree."""
+
+        class RodRepeatReader(BaseInputData):
+            READER_OPTIONS: ClassVar[dict[str, ReaderOptionSpec]] = {
+                "rod_cache_key": ReaderOptionSpec("Declared.", runtime_default=frozenset({".json"})),
+            }
+
+        first = RodRepeatReader.reader_option("rod_cache_key", Options())
+        second = RodRepeatReader.reader_option("rod_cache_key", Options())
+
+        assert first == second == frozenset({".json"})
+        assert RodRepeatReader.reader_option_specs() == RodRepeatReader.reader_option_specs()
+
+
+class TestReaderOptionsAreValidatedAtClassDefinition:
+    """``READER_OPTIONS`` accepts ``ReaderOptionSpec`` instances and NOTHING else.
+
+    Mirrors ``FeatureGroup.__init_subclass__``'s ``PROPERTY_MAPPING`` type rule (see
+    ``tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_property_spec_hard_break.py``):
+    the mistake must surface where it is written, not later as an ``AttributeError`` on
+    ``runtime_default`` deep inside reader matching.
+    """
+
+    def test_string_value_rejected_at_class_definition(self) -> None:
+        """The reviewer's exact case: ``{"k": "just a string"}`` names the class, the key and the type."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class RodBadStringSpecReader(BaseInputData):
+                READER_OPTIONS: ClassVar[dict[str, ReaderOptionSpec]] = {"rod_bad_key": "just a string"}  # type: ignore[dict-item]  # wrong type is the point
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "RodBadStringSpecReader" in message
+        assert "rod_bad_key" in message
+        assert "ReaderOptionSpec" in message
+
+    def test_dict_value_rejected_at_class_definition(self) -> None:
+        """A hand-rolled spec dict (the plausible authoring mistake) is rejected the same way."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class RodBadDictSpecReader(BaseInputData):
+                READER_OPTIONS: ClassVar[dict[str, ReaderOptionSpec]] = {
+                    "rod_bad_key": {"explanation": "x", "runtime_default": None}  # type: ignore[dict-item]  # wrong type is the point
+                }
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "RodBadDictSpecReader" in message
+        assert "rod_bad_key" in message
+        assert "ReaderOptionSpec" in message
+
+    def test_a_property_spec_is_not_a_reader_option_spec(self) -> None:
+        """The two declaration surfaces are separate types; crossing them is the same error."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class RodPropertySpecReader(BaseInputData):
+                READER_OPTIONS: ClassVar[dict[str, ReaderOptionSpec]] = {
+                    "rod_bad_key": PropertySpec("wrong surface")  # type: ignore[dict-item]  # wrong type is the point
+                }
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "rod_bad_key" in message
+        assert "ReaderOptionSpec" in message
+
+    def test_a_valid_declaration_defines_fine(self) -> None:
+        """Control: the check rejects only the wrong type, never a real declaration."""
+
+        class RodValidSpecReader(BaseInputData):
+            READER_OPTIONS: ClassVar[dict[str, ReaderOptionSpec]] = {
+                "rod_valid_key": ReaderOptionSpec("Valid.", runtime_default=frozenset()),
+            }
+
+        assert RodValidSpecReader.reader_option_default("rod_valid_key") == frozenset()
+
+    def test_an_absent_declaration_defines_fine(self) -> None:
+        """A reader declaring nothing is the common case and must stay definable."""
+
+        class RodNoDeclarationReader(BaseInputData):
+            pass
+
+        assert RodNoDeclarationReader.declared_reader_option_keys() == {"BaseInputData"}
+
+    def test_an_empty_declaration_defines_fine(self) -> None:
+        """An explicitly empty mapping declares nothing new and is not an error."""
+
+        class RodEmptyDeclarationReader(BaseInputData):
+            READER_OPTIONS: ClassVar[dict[str, ReaderOptionSpec]] = {}
+
+        assert RodEmptyDeclarationReader.declared_reader_option_keys() == {"BaseInputData"}
+
+    def test_a_bad_declaration_on_a_subclass_of_a_good_one_still_raises(self) -> None:
+        """The check runs per class, so inheriting a valid declaration does not buy a free pass."""
+
+        class RodGoodBaseReader(BaseInputData):
+            READER_OPTIONS: ClassVar[dict[str, ReaderOptionSpec]] = {
+                "rod_good_key": ReaderOptionSpec("Valid."),
+            }
+
+        with pytest.raises(ValueError) as exc_info:
+
+            class RodBadChildReader(RodGoodBaseReader):
+                READER_OPTIONS: ClassVar[dict[str, ReaderOptionSpec]] = {"rod_bad_key": 42}  # type: ignore[dict-item]  # wrong type is the point
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "RodBadChildReader" in message
+        assert "rod_bad_key" in message
+
+
 class TestDeclarationsDoNotAffectDiscovery:
     """The synthetic declaring classes stay invisible to reader selection."""
 
@@ -232,3 +541,10 @@ class TestDeclarationsDoNotAffectDiscovery:
         assert _ReaderOptDeclParent.is_final_reader() is False
         assert _ReaderOptDeclChild.is_final_reader() is False
         assert _ReaderOptDeclOverride.is_final_reader() is False
+
+    def test_no_reader_this_module_leaks_is_a_final_reader(self) -> None:
+        """The module's leak policy, machine-checked over every reader of this module still reachable."""
+        local = [cls for cls in get_all_subclasses(BaseInputData) if cls.__module__ == __name__]
+
+        assert local, "expected this module's throwaway readers to be reachable through __subclasses__()"
+        assert [cls.__name__ for cls in local if cls.is_final_reader()] == []

--- a/tests/test_core/test_prepare/test_required_when_rejection_recording.py
+++ b/tests/test_core/test_prepare/test_required_when_rejection_recording.py
@@ -1,0 +1,125 @@
+"""A ``required_when`` non-match must be DIAGNOSABLE: it records its reason like the sibling presence rules.
+
+``record_match_rejection`` is the seam the engine activates per candidate around its filter loop
+(``IdentifyFeatureGroupClass._filter_feature_group_by_criteria``): a reason recorded while a candidate
+matches becomes that candidate's ``value_rejection`` ``Elimination`` and reaches the resolution-failure
+report. Two presence rules already record there, the name-path required-presence rule
+(``FeatureChainParser._check_name_path_required_presence``) and the strict ``match_guard``
+(``FeatureChainParserMixin``). ``FeatureChainParser.check_required_when`` only logs at debug and records
+nothing, so a feature group that a declared ``required_when`` turned into a non-match is invisible in
+the failure report. See ``test_first_pass_rejection_recording.py`` for the seam's full contract.
+
+Names carry an ``rwrec`` suffix: a test feature group becomes a global subclass and the suite runs in
+parallel, so a shared name would leak into another module's candidate universe. The group here is inert
+for unrelated features: it matches only its own unique class name, and even then its ``required_when``
+guard turns the match into a non-match unless its own unique option keys are present.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Optional
+
+import pytest
+
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import MATCH_REJECTION_REASONS
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from mloda.core.prepare.identify_feature_group import EvaluationResult, FeatureResolutionError
+from mloda.provider import PropertySpec
+from tests.test_core.test_prepare.identify_seam import evaluate_or_raise
+
+
+RWREC_REQUIRED_KEY = "rwrec_required_key"
+RWREC_COMPANION_KEY = "rwrec_companion_key"
+
+
+class RwrecFwOne(ComputeFramework):
+    """Dummy compute framework for the required_when recording tests."""
+
+
+class RwrecRequiredWhenFG(FeatureGroup):
+    """Pattern-less group whose declared key is required exactly when its companion key is absent."""
+
+    PROPERTY_MAPPING = {
+        RWREC_REQUIRED_KEY: PropertySpec(
+            "Required whenever the companion key is absent.",
+            context=False,
+            default=None,
+            required_when=(lambda options: options.get(RWREC_COMPANION_KEY) is None),
+        ),
+        RWREC_COMPANION_KEY: PropertySpec("The alternative to the required key.", context=False, default=None),
+    }
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+RWREC_FEATURE = RwrecRequiredWhenFG.get_class_name()
+
+
+@pytest.fixture(autouse=True)
+def _reset_recording_state() -> Iterator[None]:
+    """Recorder state must not leak between tests, in either direction."""
+    token = MATCH_REJECTION_REASONS.set(None)
+    yield
+    MATCH_REJECTION_REASONS.reset(token)
+
+
+def _failed_result(feature: Feature, accessible_plugins: FeatureGroupEnvironmentMapping) -> EvaluationResult:
+    """Run one engine attempt that must fail and return the structured result its single pass produced."""
+    with pytest.raises(FeatureResolutionError) as exc_info:
+        evaluate_or_raise(feature=feature, accessible_plugins=accessible_plugins, links=None)
+    return exc_info.value.result
+
+
+class TestRequiredWhenRejectionRecording:
+    """A declared requirement that fires is reported as a near-miss, naming the key and its owner."""
+
+    def test_required_when_non_match_is_reported_as_a_near_miss(self) -> None:
+        """The failed resolution carries a value_rejection naming the missing key and the owning class."""
+        feature = Feature(RWREC_FEATURE)
+        accessible_plugins: FeatureGroupEnvironmentMapping = {RwrecRequiredWhenFG: {RwrecFwOne}}
+
+        result = _failed_result(feature, accessible_plugins)
+
+        elimination = result.eliminations.get(RwrecRequiredWhenFG)
+        assert elimination is not None, (
+            "the required_when non-match recorded no reason, so the failure report cannot explain it; "
+            f"eliminations={result.eliminations}"
+        )
+        assert elimination.stage == "value_rejection"
+        assert RWREC_REQUIRED_KEY in elimination.reason, elimination.reason
+        assert RwrecRequiredWhenFG.__name__ in elimination.reason, elimination.reason
+
+    def test_the_reason_is_recorded_under_the_owning_class_name(self) -> None:
+        """With the recorder active, the non-match records exactly one reason keyed by the owning class."""
+        token = MATCH_REJECTION_REASONS.set({})
+        matched = RwrecRequiredWhenFG.match_feature_group_criteria(RWREC_FEATURE, Options())
+        recorded = MATCH_REJECTION_REASONS.get()
+        MATCH_REJECTION_REASONS.reset(token)
+
+        assert matched is False
+        assert recorded is not None
+        assert list(recorded) == [RwrecRequiredWhenFG.__name__], recorded
+
+    def test_a_satisfied_requirement_records_nothing(self) -> None:
+        """Control: with the companion key present the predicate is unsatisfied, so nothing is recorded."""
+        token = MATCH_REJECTION_REASONS.set({})
+        matched = RwrecRequiredWhenFG.match_feature_group_criteria(
+            RWREC_FEATURE, Options({RWREC_COMPANION_KEY: "rwrec_value"})
+        )
+        recorded = MATCH_REJECTION_REASONS.get()
+        MATCH_REJECTION_REASONS.reset(token)
+
+        assert matched is True
+        assert recorded == {}
+
+    def test_a_direct_match_outside_an_evaluation_records_nothing(self) -> None:
+        """Activation contract: recording is inert outside the engine's per-candidate window."""
+        assert RwrecRequiredWhenFG.match_feature_group_criteria(RWREC_FEATURE, Options()) is False
+        assert MATCH_REJECTION_REASONS.get() is None

--- a/tests/test_plugins/feature_group/input_data/test_read_context_files_file_paths_filtering.py
+++ b/tests/test_plugins/feature_group/input_data/test_read_context_files_file_paths_filtering.py
@@ -1,0 +1,156 @@
+"""Pins that the explicit-``file_paths`` branch of ``ConcatenatedFileContent`` honours its declarations.
+
+``input_features`` has two source branches, and today they disagree:
+
+* the ``target_folder`` branch filters through ``find_file_paths(..., not_allowed_files_names=...)``, so
+  the declared ``disallowed_files`` option really removes files;
+* the ``file_paths`` branch contains a duplicated ``if options.get("file_paths"):`` check whose body
+  builds a ``new_file_paths`` list, applies the ``disallowed_files`` filter and strips newlines out of
+  each entry, and then never assigns it back. Every file survives and every newline stays.
+
+``disallowed_files`` is a declared option with a declared default of ``("__init__.py",)``. A declaration
+that one code path silently ignores is exactly the untruthful-metadata problem this work is fixing, so
+the intended behavior is pinned here: the two branches must agree, and the newline stripping the dead
+body performs must actually happen. ruff cannot see the defect because ``new_file_paths.append(...)``
+counts as a use of the list.
+
+The reads are observed the same way as in the sibling declaration tests: call ``_create_join_class``
+first, then read ``DefaultOptionKeys.in_features`` off the produced feature and inspect each
+``SourceTuple``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mloda.provider import DefaultOptionKeys
+from mloda.user import FeatureName, Options
+from mloda_plugins.feature_group.experimental.source_input_feature import SourceTuple
+from mloda_plugins.feature_group.input_data.read_context_files import ConcatenatedFileContent
+from mloda_plugins.feature_group.input_data.read_files.text_file_reader import PyFileReader
+
+
+PROBE_FEATURE = FeatureName("rcff_file_paths_probe")
+
+
+def _source_tuples(instance: ConcatenatedFileContent, options: Options) -> set[SourceTuple]:
+    """Every SourceTuple ``input_features`` produced for ``options``."""
+    instance._create_join_class(instance.join_feature_name)
+    features = instance.input_features(options, PROBE_FEATURE)
+    assert features is not None
+    feature = next(iter(features))
+    source_tuples = feature.options.get(DefaultOptionKeys.in_features)
+    assert source_tuples is not None
+    return set(source_tuples)
+
+
+def _names(instance: ConcatenatedFileContent, options: Options) -> set[str]:
+    """The SourceTuple feature names, which are the short file names."""
+    return {source_tuple.feature_name for source_tuple in _source_tuples(instance, options)}
+
+
+def _values(instance: ConcatenatedFileContent, options: Options) -> set[str | None]:
+    """The SourceTuple source values, which are the file paths handed to the reader."""
+    return {source_tuple.source_value for source_tuple in _source_tuples(instance, options)}
+
+
+def _write(tmp_path: Path, *names: str) -> None:
+    """Create the named python files so the fixtures mirror a real directory."""
+    for name in names:
+        (tmp_path / name).write_text(f"# {name}\n", encoding="utf-8")
+
+
+def _options(tmp_path: Path, file_names: list[str], **extra: object) -> Options:
+    """Options selecting the given files explicitly, i.e. driving the ``file_paths`` branch."""
+    return Options(
+        {
+            "file_paths": [str(tmp_path / name) for name in file_names],
+            "document_reader_class": PyFileReader.get_class_name(),
+            **extra,
+        }
+    )
+
+
+class TestDisallowedFilesAppliesToExplicitFilePaths:
+    """``disallowed_files`` must remove files on the ``file_paths`` branch, not only under ``target_folder``."""
+
+    def test_declared_default_excludes_dunder_init(self, tmp_path: Path) -> None:
+        """With no ``disallowed_files`` option, the declared ``("__init__.py",)`` default still applies."""
+        _write(tmp_path, "a.py", "__init__.py")
+        options = _options(tmp_path, ["a.py", "__init__.py"])
+
+        instance = ConcatenatedFileContent()
+
+        assert _names(instance, options) == {"a.py"}
+        assert _values(instance, options) == {str(tmp_path / "a.py")}
+
+    def test_explicit_disallowed_files_excludes_the_named_file(self, tmp_path: Path) -> None:
+        """An explicitly passed ``disallowed_files`` removes exactly the files it names."""
+        _write(tmp_path, "keep.py", "skip.py")
+        options = _options(tmp_path, ["keep.py", "skip.py"], disallowed_files=("skip.py",))
+
+        instance = ConcatenatedFileContent()
+
+        assert _names(instance, options) == {"keep.py"}
+        assert _values(instance, options) == {str(tmp_path / "keep.py")}
+
+    def test_both_source_branches_exclude_the_same_files(self, tmp_path: Path) -> None:
+        """Naming the files explicitly must select the same set as scanning the folder that holds them."""
+        _write(tmp_path, "a.py", "b.py", "__init__.py")
+        explicit = _options(tmp_path, ["a.py", "b.py", "__init__.py"])
+        scanned = Options(
+            {
+                "target_folder": [str(tmp_path)],
+                "document_reader_class": PyFileReader.get_class_name(),
+            }
+        )
+
+        instance = ConcatenatedFileContent()
+
+        assert _names(instance, explicit) == _names(instance, scanned)
+
+    def test_control_nothing_is_dropped_when_nothing_is_disallowed(self, tmp_path: Path) -> None:
+        """Control: an empty ``disallowed_files`` keeps every named file, so the filter cannot over-reach."""
+        _write(tmp_path, "a.py", "__init__.py")
+        options = _options(tmp_path, ["a.py", "__init__.py"], disallowed_files=())
+
+        instance = ConcatenatedFileContent()
+
+        assert _names(instance, options) == {"a.py", "__init__.py"}
+
+
+class TestEmbeddedNewlinesAreStrippedFromExplicitFilePaths:
+    """A ``file_paths`` entry read from a line-oriented list must not carry its newline into the reader."""
+
+    @pytest.mark.parametrize("newline_position", ["trailing", "interior"])
+    def test_newline_is_stripped_from_the_source_value(self, tmp_path: Path, newline_position: str) -> None:
+        """The source value is the clean path, so the reader receives an openable file name."""
+        _write(tmp_path, "a.py")
+        clean = str(tmp_path / "a.py")
+        raw = f"{clean}\n" if newline_position == "trailing" else f"{tmp_path}\n/a.py"
+        options = Options(
+            {
+                "file_paths": [raw],
+                "document_reader_class": PyFileReader.get_class_name(),
+            }
+        )
+
+        instance = ConcatenatedFileContent()
+
+        assert _values(instance, options) == {clean}
+
+    def test_newline_does_not_leak_into_the_feature_name(self, tmp_path: Path) -> None:
+        """The short name drives merge indexes and links, so it must not end in a newline either."""
+        _write(tmp_path, "a.py")
+        options = Options(
+            {
+                "file_paths": [f"{tmp_path / 'a.py'}\n"],
+                "document_reader_class": PyFileReader.get_class_name(),
+            }
+        )
+
+        instance = ConcatenatedFileContent()
+
+        assert _names(instance, options) == {"a.py"}

--- a/tests/test_plugins/feature_group/input_data/test_read_context_files_file_paths_filtering.py
+++ b/tests/test_plugins/feature_group/input_data/test_read_context_files_file_paths_filtering.py
@@ -17,6 +17,12 @@ counts as a use of the list.
 The reads are observed the same way as in the sibling declaration tests: call ``_create_join_class``
 first, then read ``DefaultOptionKeys.in_features`` off the produced feature and inspect each
 ``SourceTuple``.
+
+Filtering that removes EVERY named file is the sharp edge of the fix and is pinned here too: an
+empty result must be a loud error, not a join child whose ``in_features`` is an empty frozenset.
+
+Subclass-leak policy: this module defines no ``FeatureGroup`` or ``BaseInputData`` subclass at all,
+so it has nothing to leak; it drives the shipped ``ConcatenatedFileContent`` directly.
 """
 
 from __future__ import annotations
@@ -119,6 +125,91 @@ class TestDisallowedFilesAppliesToExplicitFilePaths:
         instance = ConcatenatedFileContent()
 
         assert _names(instance, options) == {"a.py", "__init__.py"}
+
+
+class TestFilteringEveryFileOutIsALoudError:
+    """An emptied ``file_paths`` list must raise where the option is read, not produce an empty join.
+
+    RED: the filter currently leaves ``file_paths`` empty, still creates the join child, and stores an
+    empty ``in_features`` frozenset. The uncomputable join then fails far away from the cause
+    (``AttributeError: 'NoneType' object has no attribute 'columns'`` in ``calculate_feature``, plus a
+    ``FeatureResolutionError`` for the join feature name). On ``origin/main`` this same input returned
+    the file, so this is a regression the filtering fix introduced. The ``target_folder`` branch already
+    behaves correctly here: ``find_file_paths`` raises ``No files found in the root directory``.
+    """
+
+    def test_the_declared_default_filtering_out_the_only_file_raises(self, tmp_path: Path) -> None:
+        """The reviewer's reproduction: one explicit path, removed by the declared default."""
+        _write(tmp_path, "__init__.py")
+        options = _options(tmp_path, ["__init__.py"])
+
+        instance = ConcatenatedFileContent()
+        instance._create_join_class(instance.join_feature_name)
+
+        with pytest.raises(ValueError) as exc_info:
+            instance.input_features(options, PROBE_FEATURE)
+
+        message = str(exc_info.value)
+        assert "file_paths" in message
+        assert "disallowed_files" in message
+        assert ConcatenatedFileContent.get_class_name() in message
+
+    def test_an_explicit_disallowed_files_emptying_the_list_raises(self, tmp_path: Path) -> None:
+        """The same error for an explicitly named exclusion: the emptied result is what matters."""
+        _write(tmp_path, "skip.py")
+        options = _options(tmp_path, ["skip.py"], disallowed_files=("skip.py",))
+
+        instance = ConcatenatedFileContent()
+        instance._create_join_class(instance.join_feature_name)
+
+        with pytest.raises(ValueError, match="file_paths"):
+            instance.input_features(options, PROBE_FEATURE)
+
+    def test_both_source_branches_raise_when_nothing_survives_the_filter(self, tmp_path: Path) -> None:
+        """The two branches must agree on the empty case as they now do on the non-empty one.
+
+        Scanning the folder already raises through ``find_file_paths``; naming the same file
+        explicitly must not instead hand back a join child with an empty ``in_features`` frozenset.
+        """
+        _write(tmp_path, "__init__.py")
+        explicit = _options(tmp_path, ["__init__.py"])
+        scanned = Options(
+            {
+                "target_folder": [str(tmp_path)],
+                "document_reader_class": PyFileReader.get_class_name(),
+            }
+        )
+
+        instance = ConcatenatedFileContent()
+        instance._create_join_class(instance.join_feature_name)
+
+        with pytest.raises(ValueError):
+            instance.input_features(scanned, PROBE_FEATURE)
+        with pytest.raises(ValueError):
+            instance.input_features(explicit, PROBE_FEATURE)
+
+    def test_one_survivor_is_enough_to_keep_going(self, tmp_path: Path) -> None:
+        """Control: partial filtering is normal and must not raise."""
+        _write(tmp_path, "a.py", "__init__.py")
+        options = _options(tmp_path, ["a.py", "__init__.py"])
+
+        instance = ConcatenatedFileContent()
+
+        assert _names(instance, options) == {"a.py"}
+
+    def test_an_empty_file_paths_option_still_falls_through_to_target_folder(self) -> None:
+        """An empty ``file_paths`` is not an emptied one: it selects the other source branch."""
+        options = Options(
+            {
+                "file_paths": [],
+                "document_reader_class": PyFileReader.get_class_name(),
+            }
+        )
+
+        instance = ConcatenatedFileContent()
+
+        with pytest.raises(ValueError, match="target_folder"):
+            instance.input_features(options, PROBE_FEATURE)
 
 
 class TestEmbeddedNewlinesAreStrippedFromExplicitFilePaths:

--- a/tests/test_plugins/feature_group/input_data/test_read_context_files_option_declarations.py
+++ b/tests/test_plugins/feature_group/input_data/test_read_context_files_option_declarations.py
@@ -1,0 +1,299 @@
+"""Pins ``ConcatenatedFileContent``'s five option keys on a real, ENFORCED ``PROPERTY_MAPPING``.
+
+``input_features`` reads ``disallowed_files``, ``file_paths``, ``target_folder``, ``file_type`` and
+``document_reader_class``, and hand-rolls both their defaults (``["__init__.py"]``, ``"py"``) and their
+requiredness (two ``ValueError`` raises). Those are promises to users that no declaration carries.
+
+What is pinned here:
+
+* **Inventory**: the five keys are declared, and every declared value is a ``PropertySpec``.
+* **Truthful defaults**: ``disallowed_files`` declares ``("__init__.py",)`` (a TUPLE, because with
+  ``context=False`` the materialized default lands in GROUP options, which are hashed) and
+  ``file_type`` declares ``"py"``. ``file_paths`` / ``target_folder`` declare ``default=None``
+  (optional, applies no value), not ``NO_DEFAULT``. All five are group parameters: they change what
+  gets read, so they must split feature groups.
+* **Truthful requiredness, enforced**: ``target_folder`` is required exactly when ``file_paths`` is
+  absent, ``document_reader_class`` always. ``FeatureGroup.__init_subclass__`` installs the
+  ``required_when`` guard on the class's resolved matcher, so the declaration is enforced at
+  match time even for this pattern-less feature group; the four matcher cases pin that.
+* **Load-bearing defaults**: ``input_features`` must read through ``self.options_with_defaults(options)``.
+  The engine calls ``input_features`` with the feature's DECLARED (pre-default) options
+  (``mloda/core/core/engine.py``: ``declared_options = feature.options``), so a declared default only
+  reaches the read site when the group opts in itself. ``TestDeclaredDefaultsAreLoadBearing`` proves
+  the opt-in behaviorally: a subclass that declares ``file_type`` default ``"md"`` must read ``.md``
+  files with no ``file_type`` option set.
+
+The hand-rolled ``ValueError`` backstops in ``input_features`` are KEPT, so
+``test_read_context_files.py::TestConcatenatedFileContentFormatAgnostic::test_missing_document_reader_class_raises_error``
+stays green.
+
+Isolation: the one throwaway subclass is built inside a helper (never at module import time, so a
+missing ``PROPERTY_MAPPING`` fails one test instead of the whole module) and carries a distinctive
+``Rcfd`` name, so its inherited class-name matcher cannot hijack a real feature. The autouse fixture
+forces the GC pass that reclaims it.
+"""
+
+from __future__ import annotations
+
+import gc
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from mloda.core.abstract_plugins.components.utils import get_all_subclasses
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.provider import DefaultOptionKeys, PropertySpec, is_no_default
+from mloda.user import FeatureName, Options
+from mloda_plugins.feature_group.input_data.read_context_files import ConcatenatedFileContent
+from mloda_plugins.feature_group.input_data.read_files.markdown_document_reader import MarkdownDocumentReader
+from mloda_plugins.feature_group.input_data.read_files.text_file_reader import PyFileReader
+
+
+# Every option key ``ConcatenatedFileContent.input_features`` reads.
+DECLARED_KEYS = frozenset({"disallowed_files", "file_paths", "target_folder", "file_type", "document_reader_class"})
+
+PROBE_FEATURE = FeatureName("rcfd_declaration_probe")
+
+
+@pytest.fixture(autouse=True)
+def _no_feature_group_registry_pollution() -> Any:
+    """Guarantee this module never leaks its throwaway ConcatenatedFileContent subclass.
+
+    A test-local FeatureGroup subclass sits in reference cycles, so it lingers in
+    ``FeatureGroup.__subclasses__()`` until a GC cycle runs, where other tests enumerating feature
+    groups trip over it. Forcing the collection here reclaims it and pins the no-pollution contract.
+    """
+    yield
+    gc.collect()
+    gc.collect()
+    leaked = [c for c in get_all_subclasses(FeatureGroup) if c.__module__ == __name__]
+    assert not leaked, f"Leaked FeatureGroup subclasses from {__name__}: {[c.__name__ for c in leaked]}"
+
+
+def _declared_mapping() -> dict[str, PropertySpec]:
+    """The declared ``PROPERTY_MAPPING``, asserted present so callers read a non-optional mapping."""
+    mapping = ConcatenatedFileContent.PROPERTY_MAPPING
+    assert mapping is not None, "ConcatenatedFileContent declares no PROPERTY_MAPPING"
+    return mapping
+
+
+def _spec(key: str) -> PropertySpec:
+    """The ``PropertySpec`` ``ConcatenatedFileContent`` declares for ``key``."""
+    mapping = _declared_mapping()
+    assert key in mapping, f"ConcatenatedFileContent does not declare '{key}'; declared: {sorted(mapping)}"
+    return mapping[key]
+
+
+def _source_tuple_names(instance: ConcatenatedFileContent, options: Options) -> set[str]:
+    """The SourceTuple feature names ``input_features`` produced, following the sibling test's pattern."""
+    instance._create_join_class(instance.join_feature_name)
+    features = instance.input_features(options, PROBE_FEATURE)
+    assert features is not None
+    feature = next(iter(features))
+    source_tuples = feature.options.get(DefaultOptionKeys.in_features)
+    return {source_tuple.feature_name for source_tuple in source_tuples}
+
+
+def _source_tuple_values(instance: ConcatenatedFileContent, options: Options) -> set[str]:
+    """The SourceTuple source values (file paths) ``input_features`` produced."""
+    instance._create_join_class(instance.join_feature_name)
+    features = instance.input_features(options, PROBE_FEATURE)
+    assert features is not None
+    feature = next(iter(features))
+    source_tuples = feature.options.get(DefaultOptionKeys.in_features)
+    return {source_tuple.source_value for source_tuple in source_tuples}
+
+
+def _make_markdown_default_subclass() -> type[ConcatenatedFileContent]:
+    """A throwaway subclass whose only change is a declared ``file_type`` default of ``"md"``.
+
+    Built here rather than in the class body of this module, so a missing base ``PROPERTY_MAPPING``
+    fails only the test that needs it instead of breaking module import.
+    """
+    inherited = _declared_mapping()
+
+    class RcfdMarkdownDefaultProbeFeatureGroup(ConcatenatedFileContent):
+        """Declares markdown as its file type; everything else is inherited."""
+
+        PROPERTY_MAPPING = {
+            **inherited,
+            "file_type": PropertySpec("Markdown files by declaration.", default="md", context=False),
+        }
+
+    return RcfdMarkdownDefaultProbeFeatureGroup
+
+
+class TestDeclarationInventory:
+    """The five keys ``input_features`` reads are declared, and nothing else is."""
+
+    def test_declares_exactly_the_five_keys_it_reads(self) -> None:
+        """``declared_option_keys`` is the inventory of what ``input_features`` reads."""
+        assert ConcatenatedFileContent.declared_option_keys() == DECLARED_KEYS
+
+    def test_every_declared_value_is_a_property_spec(self) -> None:
+        """A declaration is only enforceable when each value IS a ``PropertySpec``."""
+        mapping = ConcatenatedFileContent.PROPERTY_MAPPING
+        assert mapping is not None, "ConcatenatedFileContent declares no PROPERTY_MAPPING"
+        non_specs = {key: type(value).__name__ for key, value in mapping.items() if not isinstance(value, PropertySpec)}
+        assert non_specs == {}
+
+
+class TestDeclaredDefaults:
+    """The declared defaults are the real runtime fallbacks, not documentation."""
+
+    def test_disallowed_files_declares_a_hashable_tuple_default(self) -> None:
+        """``context=False`` puts the materialized default in hashed GROUP options, so it must be hashable."""
+        default = _spec("disallowed_files").default
+
+        assert default == ("__init__.py",)
+        assert isinstance(default, tuple), f"a list default would break group hashing; got {type(default).__name__}"
+        assert hash(default) is not None
+
+    def test_file_type_declares_the_py_default(self) -> None:
+        """``file_type`` falls back to ``"py"`` at the read site, so the spec declares it."""
+        assert _spec("file_type").default == "py"
+
+    @pytest.mark.parametrize("key", ["file_paths", "target_folder"])
+    def test_optional_source_keys_declare_none_rather_than_no_default(self, key: str) -> None:
+        """Either source key may be omitted, so each declares ``default=None`` (applies no value)."""
+        default = _spec(key).default
+
+        assert not is_no_default(default), f"'{key}' declares NO_DEFAULT, which makes it unconditionally required"
+        assert default is None
+
+    @pytest.mark.parametrize("key", sorted(DECLARED_KEYS))
+    def test_every_key_is_a_group_parameter(self, key: str) -> None:
+        """All five keys change WHAT gets read, so each must split feature groups (``context=False``)."""
+        assert _spec(key).context is False
+
+
+class TestDeclaredRequiredness:
+    """Requiredness is declared as ``required_when`` predicates, and the installed guard enforces them."""
+
+    def test_target_folder_is_required_exactly_when_file_paths_is_absent(self) -> None:
+        """The predicate mirrors the read site's ``if options.get("file_paths")`` branch."""
+        predicate = _spec("target_folder").required_when
+        assert predicate is not None, "target_folder declares no required_when predicate"
+
+        assert bool(predicate(Options({"file_paths": ["/rcfd/a.py"]}))) is False
+        assert bool(predicate(Options({}))) is True
+
+    def test_document_reader_class_is_always_required(self) -> None:
+        """The read site raises whenever it is absent, so its predicate is always satisfied."""
+        predicate = _spec("document_reader_class").required_when
+        assert predicate is not None, "document_reader_class declares no required_when predicate"
+
+        assert bool(predicate(Options({}))) is True
+        assert bool(predicate(Options({"file_paths": ["/rcfd/a.py"], "target_folder": ["/rcfd"]}))) is True
+
+    def test_matcher_accepts_file_paths_with_a_reader(self) -> None:
+        """``file_paths`` satisfies the source requirement, so the group matches."""
+        options = Options({"file_paths": ["/rcfd/a.py"], "document_reader_class": PyFileReader.get_class_name()})
+
+        matched = ConcatenatedFileContent.match_feature_group_criteria(
+            FeatureName(ConcatenatedFileContent.get_class_name()), options
+        )
+
+        assert matched is True
+
+    def test_matcher_accepts_target_folder_with_a_reader(self) -> None:
+        """``target_folder`` is the other way to satisfy the source requirement."""
+        options = Options({"target_folder": ["/rcfd"], "document_reader_class": PyFileReader.get_class_name()})
+
+        matched = ConcatenatedFileContent.match_feature_group_criteria(
+            FeatureName(ConcatenatedFileContent.get_class_name()), options
+        )
+
+        assert matched is True
+
+    def test_matcher_rejects_a_missing_document_reader_class(self) -> None:
+        """Without the always-required reader the group is a non-match, not a late ValueError."""
+        options = Options({"file_paths": ["/rcfd/a.py"]})
+
+        matched = ConcatenatedFileContent.match_feature_group_criteria(
+            FeatureName(ConcatenatedFileContent.get_class_name()), options
+        )
+
+        assert matched is False
+
+    def test_matcher_rejects_neither_file_paths_nor_target_folder(self) -> None:
+        """With no source at all the group is a non-match, not a late ValueError."""
+        options = Options({"document_reader_class": PyFileReader.get_class_name()})
+
+        matched = ConcatenatedFileContent.match_feature_group_criteria(
+            FeatureName(ConcatenatedFileContent.get_class_name()), options
+        )
+
+        assert matched is False
+
+
+class TestDeclaredDefaultsAreLoadBearing:
+    """The declaration IS the mechanism at the read site, not a second copy of the constants."""
+
+    def test_absent_defaults_materialize_into_the_group_namespace(self) -> None:
+        """``options_with_defaults`` fills the two concrete defaults, and ``context=False`` puts them in group."""
+        options = Options({"target_folder": ["/rcfd"], "document_reader_class": PyFileReader.get_class_name()})
+
+        materialized = ConcatenatedFileContent.options_with_defaults(options)
+
+        assert materialized.group.get("file_type") == "py"
+        assert materialized.group.get("disallowed_files") == ("__init__.py",)
+        assert "file_type" not in materialized.context
+        assert "disallowed_files" not in materialized.context
+
+    def test_present_values_are_never_overridden(self) -> None:
+        """A user-set value wins over the declared default."""
+        options = Options(
+            {
+                "target_folder": ["/rcfd"],
+                "document_reader_class": PyFileReader.get_class_name(),
+                "file_type": "md",
+                "disallowed_files": ("a.py",),
+            }
+        )
+
+        materialized = ConcatenatedFileContent.options_with_defaults(options)
+
+        assert materialized.get("file_type") == "md"
+        assert materialized.get("disallowed_files") == ("a.py",)
+
+    def test_declared_file_type_default_drives_the_read(self, tmp_path: Path) -> None:
+        """A subclass declaring ``file_type="md"`` reads the ``.md`` files with no ``file_type`` option set.
+
+        This is the whole point of the refactor: ``input_features`` must resolve ``file_type`` through
+        ``self.options_with_defaults(options)``, so a subclass's declaration changes what is read. A
+        hard-coded ``or "py"`` fallback ignores the declaration and picks up ``a.py`` instead.
+        """
+        (tmp_path / "a.py").write_text("# python\n", encoding="utf-8")
+        (tmp_path / "b.md").write_text("# markdown\n", encoding="utf-8")
+        options = Options(
+            {
+                "target_folder": [str(tmp_path)],
+                "document_reader_class": MarkdownDocumentReader.get_class_name(),
+            }
+        )
+
+        instance = _make_markdown_default_subclass()()
+
+        assert _source_tuple_names(instance, options) == {"b.md"}
+
+    def test_declared_disallowed_files_default_excludes_dunder_init(self, tmp_path: Path) -> None:
+        """With no ``disallowed_files`` option the declared ``("__init__.py",)`` default excludes it.
+
+        Behavior-preservation guard: the declaration must reproduce today's hand-rolled fallback exactly,
+        so this stays green across the refactor.
+        """
+        (tmp_path / "a.py").write_text("# kept\n", encoding="utf-8")
+        (tmp_path / "__init__.py").write_text("# skipped\n", encoding="utf-8")
+        options = Options(
+            {
+                "target_folder": [str(tmp_path)],
+                "document_reader_class": PyFileReader.get_class_name(),
+            }
+        )
+
+        instance = ConcatenatedFileContent()
+
+        assert _source_tuple_names(instance, options) == {"a.py"}
+        assert _source_tuple_values(instance, options) == {str((tmp_path / "a.py").resolve())}

--- a/tests/test_plugins/feature_group/input_data/test_read_context_files_option_declarations.py
+++ b/tests/test_plugins/feature_group/input_data/test_read_context_files_option_declarations.py
@@ -27,17 +27,22 @@ The hand-rolled ``ValueError`` backstops in ``input_features`` are KEPT, so
 ``test_read_context_files.py::TestConcatenatedFileContentFormatAgnostic::test_missing_document_reader_class_raises_error``
 stays green.
 
-Isolation: the one throwaway subclass is built inside a helper (never at module import time, so a
-missing ``PROPERTY_MAPPING`` fails one test instead of the whole module) and carries a distinctive
-``Rcfd`` name, so its inherited class-name matcher cannot hijack a real feature. The autouse fixture
-forces the GC pass that reclaims it.
+Subclass-leak policy: this module tolerates NO leak, unlike its reader-side siblings. Its throwaway
+class is a ``FeatureGroup``, and a leaked feature group is reachable by resolution: it inherits a
+class-name matcher and would compete for features in any test that enumerates feature groups. It is
+therefore built inside a helper (never at module import time, so a missing ``PROPERTY_MAPPING`` fails
+one test instead of the whole module), carries a distinctive ``Rcfd`` name, and the ONE test that
+builds it requests the ``no_feature_group_registry_pollution`` fixture that forces the reclaiming GC
+pass and asserts the class is gone. The fixture is deliberately not autouse: a failure anywhere else
+in the module would otherwise pin the frame, keep the class alive, and fire a second, misleading
+failure in teardown.
 """
 
 from __future__ import annotations
 
 import gc
+from collections.abc import Iterator
 from pathlib import Path
-from typing import Any
 
 import pytest
 
@@ -56,13 +61,17 @@ DECLARED_KEYS = frozenset({"disallowed_files", "file_paths", "target_folder", "f
 PROBE_FEATURE = FeatureName("rcfd_declaration_probe")
 
 
-@pytest.fixture(autouse=True)
-def _no_feature_group_registry_pollution() -> Any:
-    """Guarantee this module never leaks its throwaway ConcatenatedFileContent subclass.
+@pytest.fixture
+def no_feature_group_registry_pollution() -> Iterator[None]:
+    """Guarantee the one test that builds a throwaway ConcatenatedFileContent subclass leaks nothing.
 
     A test-local FeatureGroup subclass sits in reference cycles, so it lingers in
     ``FeatureGroup.__subclasses__()`` until a GC cycle runs, where other tests enumerating feature
     groups trip over it. Forcing the collection here reclaims it and pins the no-pollution contract.
+
+    Requested explicitly rather than autouse: only one test in this module builds a class, and an
+    autouse teardown assertion turns any unrelated failure in the module into two failures, because
+    pytest holds the failing frame alive and with it every class that frame references.
     """
     yield
     gc.collect()
@@ -142,13 +151,31 @@ class TestDeclarationInventory:
 class TestDeclaredDefaults:
     """The declared defaults are the real runtime fallbacks, not documentation."""
 
-    def test_disallowed_files_declares_a_hashable_tuple_default(self) -> None:
-        """``context=False`` puts the materialized default in hashed GROUP options, so it must be hashable."""
+    def test_disallowed_files_declares_a_tuple_default(self) -> None:
+        """``context=False`` puts the materialized default in GROUP options, which decide feature identity."""
         default = _spec("disallowed_files").default
 
         assert default == ("__init__.py",)
-        assert isinstance(default, tuple), f"a list default would break group hashing; got {type(default).__name__}"
+        assert isinstance(default, tuple), (
+            "a list default would compare unequal to the tuple form while hashing the same, so a caller "
+            f"passing the default explicitly would never merge with the materialized one; got {type(default).__name__}"
+        )
         assert hash(default) is not None
+
+    def test_a_list_default_would_hash_equal_yet_compare_unequal(self) -> None:
+        """The real reason the declared default is a tuple, pinned on ``Options`` itself.
+
+        Group hashing is NOT the problem: ``Options.__hash__`` runs ``_make_hashable``, which normalizes
+        a list to a tuple, so a list default hashes fine. The problem is that hashing and equality then
+        disagree: the two forms land in the same hash bucket but compare unequal, so a caller who passes
+        ``["__init__.py"]`` gets a feature that never merges with the materialized ``("__init__.py",)``.
+        """
+        as_declared = Options({"disallowed_files": ("__init__.py",)})
+        as_list = Options({"disallowed_files": ["__init__.py"]})
+
+        assert hash(as_declared) == hash(as_list), "group hashing normalizes lists, so hashing is not the issue"
+        assert as_declared != as_list
+        assert as_declared.group["disallowed_files"] != as_list.group["disallowed_files"]
 
     def test_file_type_declares_the_py_default(self) -> None:
         """``file_type`` falls back to ``"py"`` at the read site, so the spec declares it."""
@@ -258,7 +285,9 @@ class TestDeclaredDefaultsAreLoadBearing:
         assert materialized.get("file_type") == "md"
         assert materialized.get("disallowed_files") == ("a.py",)
 
-    def test_declared_file_type_default_drives_the_read(self, tmp_path: Path) -> None:
+    def test_declared_file_type_default_drives_the_read(
+        self, tmp_path: Path, no_feature_group_registry_pollution: None
+    ) -> None:
         """A subclass declaring ``file_type="md"`` reads the ``.md`` files with no ``file_type`` option set.
 
         This is the whole point of the refactor: ``input_features`` must resolve ``file_type`` through
@@ -277,6 +306,53 @@ class TestDeclaredDefaultsAreLoadBearing:
         instance = _make_markdown_default_subclass()()
 
         assert _source_tuple_names(instance, options) == {"b.md"}
+
+    def test_an_explicit_empty_file_type_is_not_replaced_by_the_declared_default(self) -> None:
+        """Presence, not truthiness: ``options_with_defaults`` keeps an explicit ``""``.
+
+        The declared ``"py"`` default fills only an ABSENT key, so a caller who explicitly asks for an
+        empty suffix gets exactly that. Pinned as the contrast case to the reader surface, where the
+        ``or``-based fallback cannot tell an absent key from an explicit empty one.
+        """
+        options = Options(
+            {
+                "target_folder": ["/rcfd"],
+                "document_reader_class": PyFileReader.get_class_name(),
+                "file_type": "",
+            }
+        )
+
+        materialized = ConcatenatedFileContent.options_with_defaults(options)
+
+        assert materialized.get("file_type") == ""
+
+    def test_an_explicit_empty_file_type_raises_the_no_files_found_error(self, tmp_path: Path) -> None:
+        """An empty suffix matches nothing, and a zero-match scan is the existing loud ValueError.
+
+        Chosen behavior: no new validation layer for ``file_type=""``. The honoured empty value reaches
+        ``find_file_paths``, whose ``rglob("*.")`` matches nothing, and the existing
+        "No files found in the root directory" raise names the folder that was scanned. That is already
+        the clear, actionable failure this branch gives for any suffix with no matches, so an extra
+        empty-string check would add surface without adding information.
+        """
+        (tmp_path / "a.py").write_text("# python\n", encoding="utf-8")
+        options = Options(
+            {
+                "target_folder": [str(tmp_path)],
+                "document_reader_class": PyFileReader.get_class_name(),
+                "file_type": "",
+            }
+        )
+
+        instance = ConcatenatedFileContent()
+        instance._create_join_class(instance.join_feature_name)
+
+        with pytest.raises(ValueError) as exc_info:
+            instance.input_features(options, PROBE_FEATURE)
+
+        message = str(exc_info.value)
+        assert "No files found" in message
+        assert str(tmp_path) in message
 
     def test_declared_disallowed_files_default_excludes_dunder_init(self, tmp_path: Path) -> None:
         """With no ``disallowed_files`` option the declared ``("__init__.py",)`` default excludes it.

--- a/tests/test_plugins/feature_group/input_data/test_reader_option_declarations.py
+++ b/tests/test_plugins/feature_group/input_data/test_reader_option_declarations.py
@@ -19,10 +19,14 @@ What is pinned here:
   ``runtime_default=frozenset({".json"})`` therefore matches ``.json`` differently from a stock
   reader even when the option is not set: ReadFile DECLINES the file (``document_suffixes``
   auto-excludes those suffixes for structured readers) while ReadDocument CLAIMS it.
+* The declared default applies only when the option is ABSENT. An explicit ``frozenset()`` means
+  "hand nothing over" and must beat a non-empty declared default, otherwise the option cannot be
+  turned off for a reader that declares one. That is what ``reader_option(key, options)`` fixes.
 
-Isolation: every reader defined here deliberately does NOT override ``load_data``, so
-``is_final_reader()`` is False and ``get_all_filtered_subclasses`` never collects it. Matching is
-exercised by calling ``match_subclass_data_access`` directly, never through ``mlodaAPI``.
+Subclass-leak policy: this module DELIBERATELY leaks its module-level ``BaseInputData`` subclasses.
+That is benign and pinned by ``TestLocalReadersStayOutOfDiscovery``: none of them overrides
+``load_data``, so ``is_final_reader()`` is False and ``get_all_filtered_subclasses`` never collects
+them. Matching is exercised by calling ``match_subclass_data_access`` directly, never via ``mlodaAPI``.
 """
 
 from __future__ import annotations
@@ -244,6 +248,77 @@ class TestDeclaredDefaultIsLoadBearing:
 
         matched = _RodStockJsonReadDocument.match_subclass_data_access(data_access, ["content"], options)
         assert matched == json_path
+
+
+class TestAnExplicitEmptyOptionBeatsTheDeclaredDefault:
+    """Presence, not truthiness: an explicit ``frozenset()`` turns the option OFF.
+
+    RED until ``reader_option(key, options)`` replaces
+    ``options.get("document_suffixes") or cls.reader_option_default("document_suffixes")``: today a
+    reader declaring a non-empty ``runtime_default`` silently overrides an explicit empty value, so
+    the option it declares can never be switched off by the caller.
+    """
+
+    def test_explicit_empty_makes_read_file_claim_json_again(self, json_path: str) -> None:
+        """The declaring reader excludes ``.json`` by default, and an explicit empty set undoes that."""
+        options = Options({"document_suffixes": frozenset()})
+
+        matched = _RodJsonExcludingReadFile.match_subclass_data_access(json_path, ["value"], options)
+
+        assert matched == json_path
+
+    def test_read_file_still_declines_without_the_option(self, json_path: str) -> None:
+        """Control for the pair above: absent means the declared default applies."""
+        assert _RodJsonExcludingReadFile.match_subclass_data_access(json_path, ["value"], Options()) is None
+
+    def test_explicit_none_reads_as_absent_for_read_file(self, json_path: str) -> None:
+        """An explicit ``None`` is absence, so the declared default still applies."""
+        options = Options({"document_suffixes": None})
+
+        assert _RodJsonExcludingReadFile.match_subclass_data_access(json_path, ["value"], options) is None
+
+    def test_explicit_empty_makes_read_document_skip_json_again(self, json_path: str) -> None:
+        """The declaring document reader claims ``.json`` by default; an explicit empty set undoes that."""
+        data_access = DataAccessCollection(files={"rod_payload": json_path})
+        options = Options({"document_suffixes": frozenset()})
+
+        matched = _RodJsonClaimingReadDocument.match_subclass_data_access(data_access, ["content"], options)
+
+        assert matched is None
+
+    def test_read_document_still_claims_without_the_option(self, json_path: str) -> None:
+        """Control for the pair above: absent means the declared default applies."""
+        data_access = DataAccessCollection(files={"rod_payload": json_path})
+
+        matched = _RodJsonClaimingReadDocument.match_subclass_data_access(data_access, ["content"], Options())
+
+        assert matched == json_path
+
+    def test_explicit_none_reads_as_absent_for_read_document(self, json_path: str) -> None:
+        """An explicit ``None`` is absence here too."""
+        data_access = DataAccessCollection(files={"rod_payload": json_path})
+        options = Options({"document_suffixes": None})
+
+        matched = _RodJsonClaimingReadDocument.match_subclass_data_access(data_access, ["content"], options)
+
+        assert matched == json_path
+
+    def test_read_document_reads_the_option_only_for_a_data_access_collection(self, json_path: str) -> None:
+        """Documented asymmetry: the bare-path branch never consults ``document_suffixes`` at all.
+
+        ``ReadDocument.match_subclass_data_access`` reads the key inside its ``DataAccessCollection``
+        branch only, so a resolved path claims the file whatever the option says. Pinned so the
+        presence fix is not mistaken for a behaviour change on this branch.
+        """
+        claimed_with_option = _RodJsonClaimingReadDocument.match_subclass_data_access(
+            json_path, ["content"], Options({"document_suffixes": frozenset()})
+        )
+        claimed_without_option = _RodJsonClaimingReadDocument.match_subclass_data_access(
+            json_path, ["content"], Options()
+        )
+
+        assert claimed_with_option == json_path
+        assert claimed_without_option == json_path
 
 
 class TestLocalReadersStayOutOfDiscovery:

--- a/tests/test_plugins/feature_group/input_data/test_reader_option_declarations.py
+++ b/tests/test_plugins/feature_group/input_data/test_reader_option_declarations.py
@@ -1,0 +1,260 @@
+"""Pins the per-reader ``READER_OPTIONS`` declarations and makes the declared default load-bearing.
+
+Reader option keys are read at MATCH time (inside ``match_subclass_data_access``), before the
+framework materializes any ``PROPERTY_MAPPING`` default, so the readers declare them themselves
+through ``ReaderOptionSpec``. See the core-side contract in
+``tests/test_core/test_abstract_plugins/test_components/test_reader_option_declarations.py``.
+
+What is pinned here:
+
+* ``ReadFile`` and ``ReadDocument`` declare ``document_suffixes`` (``runtime_default=frozenset()``)
+  and ``data_access_handle`` (``runtime_default=None``); ``ReadDB`` declares
+  ``data_access_handle``. Shipped concrete readers (``CsvReader``, ``MarkdownDocumentReader``,
+  ``SQLITEReader``) inherit the declarations and re-declare nothing.
+* Every options key these three readers actually read is a declared key. The reads are observed
+  behaviorally through a recording ``Options`` subclass, so the inventory cannot drift.
+* The declared ``runtime_default`` is load-bearing, not documentation: the ``document_suffixes``
+  fallback in ``ReadFile.match_subclass_data_access`` / ``ReadDocument.match_subclass_data_access``
+  comes from the declaration instead of a hard-coded ``frozenset()``. A reader that declares
+  ``runtime_default=frozenset({".json"})`` therefore matches ``.json`` differently from a stock
+  reader even when the option is not set: ReadFile DECLINES the file (``document_suffixes``
+  auto-excludes those suffixes for structured readers) while ReadDocument CLAIMS it.
+
+Isolation: every reader defined here deliberately does NOT override ``load_data``, so
+``is_final_reader()`` is False and ``get_all_filtered_subclasses`` never collects it. Matching is
+exercised by calling ``match_subclass_data_access`` directly, never through ``mlodaAPI``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, ClassVar
+
+import pytest
+
+from mloda.core.abstract_plugins.components.input_data.reader_option_spec import ReaderOptionSpec
+from mloda.user import DataAccessCollection, Options
+from mloda_plugins.feature_group.input_data.read_db import ReadDB
+from mloda_plugins.feature_group.input_data.read_dbs.sqlite import SQLITEReader
+from mloda_plugins.feature_group.input_data.read_document import ReadDocument
+from mloda_plugins.feature_group.input_data.read_file import ReadFile
+from mloda_plugins.feature_group.input_data.read_files.csv import CsvReader
+from mloda_plugins.feature_group.input_data.read_files.markdown_document_reader import MarkdownDocumentReader
+
+
+_RESERVED_KEY = "BaseInputData"
+
+
+class _RodRecordingOptions(Options):
+    """Empty Options that records every key read through ``get``."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.read_keys: list[str] = []
+
+    def get(self, key: str, default: Any = None) -> Any:
+        self.read_keys.append(key)
+        return super().get(key, default)
+
+
+class _RodFileProbe(ReadFile):
+    """ReadFile probe with an inert suffix; only exists because ``ReadFile.suffix()`` raises."""
+
+    @classmethod
+    def suffix(cls) -> tuple[str, ...]:
+        return (".rod_unused",)
+
+
+class _RodStockJsonReadFile(ReadFile):
+    """Stock ReadFile reader for ``.json``: inherits the ``frozenset()`` document_suffixes default."""
+
+    @classmethod
+    def suffix(cls) -> tuple[str, ...]:
+        return (".json",)
+
+
+class _RodJsonExcludingReadFile(ReadFile):
+    """ReadFile reader declaring ``.json`` as a document suffix, so it must decline ``.json`` files."""
+
+    READER_OPTIONS: ClassVar[dict[str, ReaderOptionSpec]] = {
+        "document_suffixes": ReaderOptionSpec(
+            "Suffixes handed to document readers; declared non-empty so ReadFile auto-excludes them.",
+            runtime_default=frozenset({".json"}),
+        ),
+    }
+
+    @classmethod
+    def suffix(cls) -> tuple[str, ...]:
+        return (".json",)
+
+
+class _RodStockJsonReadDocument(ReadDocument):
+    """Stock ReadDocument reader for ``.json``: skips the structured suffix by default."""
+
+    @classmethod
+    def suffix(cls) -> tuple[str, ...]:
+        return (".json",)
+
+
+class _RodJsonClaimingReadDocument(ReadDocument):
+    """ReadDocument reader declaring ``.json`` as a document suffix, so it must claim ``.json`` files."""
+
+    READER_OPTIONS: ClassVar[dict[str, ReaderOptionSpec]] = {
+        "document_suffixes": ReaderOptionSpec(
+            "Structured suffixes this document reader owns; declared non-empty to claim .json.",
+            runtime_default=frozenset({".json"}),
+        ),
+    }
+
+    @classmethod
+    def suffix(cls) -> tuple[str, ...]:
+        return (".json",)
+
+
+@pytest.fixture
+def json_path(tmp_path: Path) -> str:
+    """A real ``.json`` file path in an isolated tmp dir."""
+    path = tmp_path / "rod_payload.json"
+    path.write_text('{"value": 1}', encoding="utf-8")
+    return str(path)
+
+
+@pytest.fixture
+def csv_path(tmp_path: Path) -> str:
+    """A real ``.csv`` file path in an isolated tmp dir."""
+    path = tmp_path / "rod_rows.csv"
+    path.write_text("id,amount\n1,10\n", encoding="utf-8")
+    return str(path)
+
+
+class TestReadFileDeclarations:
+    """ReadFile declares the two keys its matcher reads, and its concrete readers inherit them."""
+
+    def test_declares_exactly_its_match_time_keys(self) -> None:
+        assert ReadFile.declared_reader_option_keys() == {"document_suffixes", "data_access_handle", _RESERVED_KEY}
+
+    def test_declared_runtime_defaults(self) -> None:
+        assert ReadFile.reader_option_default("document_suffixes") == frozenset()
+        assert ReadFile.reader_option_default("data_access_handle") is None
+
+    def test_csv_reader_inherits_without_redeclaring(self) -> None:
+        assert "READER_OPTIONS" not in CsvReader.__dict__
+        assert CsvReader.declared_reader_option_keys() == ReadFile.declared_reader_option_keys()
+        assert CsvReader.reader_option_default("document_suffixes") == frozenset()
+        assert CsvReader.reader_option_default("data_access_handle") is None
+
+
+class TestReadDocumentDeclarations:
+    """ReadDocument declares the same two keys, and its concrete readers inherit them."""
+
+    def test_declares_exactly_its_match_time_keys(self) -> None:
+        assert ReadDocument.declared_reader_option_keys() == {"document_suffixes", "data_access_handle", _RESERVED_KEY}
+
+    def test_declared_runtime_defaults(self) -> None:
+        assert ReadDocument.reader_option_default("document_suffixes") == frozenset()
+        assert ReadDocument.reader_option_default("data_access_handle") is None
+
+    def test_markdown_reader_inherits_without_redeclaring(self) -> None:
+        assert "READER_OPTIONS" not in MarkdownDocumentReader.__dict__
+        assert MarkdownDocumentReader.declared_reader_option_keys() == ReadDocument.declared_reader_option_keys()
+        assert MarkdownDocumentReader.reader_option_default("document_suffixes") == frozenset()
+
+
+class TestReadDBDeclarations:
+    """ReadDB reads only the handle hint, so it declares only that key."""
+
+    def test_declares_exactly_its_match_time_keys(self) -> None:
+        assert ReadDB.declared_reader_option_keys() == {"data_access_handle", _RESERVED_KEY}
+
+    def test_declared_runtime_default(self) -> None:
+        assert ReadDB.reader_option_default("data_access_handle") is None
+
+    def test_document_suffixes_is_not_a_read_db_key(self) -> None:
+        with pytest.raises(ValueError, match="document_suffixes"):
+            ReadDB.reader_option_default("document_suffixes")
+
+    def test_sqlite_reader_inherits_without_redeclaring(self) -> None:
+        assert "READER_OPTIONS" not in SQLITEReader.__dict__
+        assert SQLITEReader.declared_reader_option_keys() == ReadDB.declared_reader_option_keys()
+        assert SQLITEReader.reader_option_default("data_access_handle") is None
+
+
+class TestEveryOptionKeyReadIsDeclared:
+    """Observed match-time reads are a subset of the declared keys, per reader family."""
+
+    def test_read_file_reads_only_declared_keys(self, csv_path: str) -> None:
+        options = _RodRecordingOptions()
+        data_access = DataAccessCollection(files={"rod_rows": csv_path})
+
+        assert _RodFileProbe.match_subclass_data_access(data_access, ["id"], options) is None
+        assert set(options.read_keys) == {"document_suffixes", "data_access_handle"}
+        assert set(options.read_keys) <= ReadFile.declared_reader_option_keys()
+
+    def test_read_document_reads_only_declared_keys(self, csv_path: str) -> None:
+        options = _RodRecordingOptions()
+        data_access = DataAccessCollection(files={"rod_rows": csv_path})
+
+        assert ReadDocument.match_subclass_data_access(data_access, ["content"], options) is None
+        assert set(options.read_keys) == {"document_suffixes", "data_access_handle"}
+        assert set(options.read_keys) <= ReadDocument.declared_reader_option_keys()
+
+    def test_read_db_reads_only_declared_keys(self, tmp_path: Path) -> None:
+        options = _RodRecordingOptions()
+        data_access = DataAccessCollection(credentials=[{"db_path": str(tmp_path / "rod.sqlite")}])
+
+        assert ReadDB.match_subclass_data_access(data_access, ["any"], options) is None
+        assert set(options.read_keys) == {"data_access_handle"}
+        assert set(options.read_keys) <= ReadDB.declared_reader_option_keys()
+
+
+class TestDeclaredDefaultIsLoadBearing:
+    """The document_suffixes fallback comes from the declaration, not a hard-coded frozenset()."""
+
+    def test_stock_read_file_claims_a_json_path(self, json_path: str) -> None:
+        """Control: the stock ``frozenset()`` default excludes nothing, so ReadFile claims the file."""
+        assert _RodStockJsonReadFile.match_subclass_data_access(json_path, ["value"], Options()) == json_path
+
+    def test_declared_default_makes_read_file_decline_json(self, json_path: str) -> None:
+        """The declared ``frozenset({".json"})`` default auto-excludes ``.json`` with no option set."""
+        assert _RodJsonExcludingReadFile.match_subclass_data_access(json_path, ["value"], Options()) is None
+
+    def test_explicit_option_still_overrides_the_read_file_default(self, json_path: str) -> None:
+        """A user-set ``document_suffixes`` wins over the declared default."""
+        options = Options({"document_suffixes": frozenset({".json"})})
+
+        assert _RodStockJsonReadFile.match_subclass_data_access(json_path, ["value"], options) is None
+
+    def test_stock_read_document_declines_a_json_file(self, json_path: str) -> None:
+        """Control: with the stock default, ``.json`` stays a structured suffix ReadDocument skips."""
+        data_access = DataAccessCollection(files={"rod_payload": json_path})
+
+        assert _RodStockJsonReadDocument.match_subclass_data_access(data_access, ["content"], Options()) is None
+
+    def test_declared_default_makes_read_document_claim_json(self, json_path: str) -> None:
+        """The declared ``frozenset({".json"})`` default claims ``.json`` with no option set."""
+        data_access = DataAccessCollection(files={"rod_payload": json_path})
+
+        matched = _RodJsonClaimingReadDocument.match_subclass_data_access(data_access, ["content"], Options())
+        assert matched == json_path
+
+    def test_explicit_option_still_overrides_the_read_document_default(self, json_path: str) -> None:
+        """A user-set ``document_suffixes`` wins over the declared default."""
+        data_access = DataAccessCollection(files={"rod_payload": json_path})
+        options = Options({"document_suffixes": frozenset({".json"})})
+
+        matched = _RodStockJsonReadDocument.match_subclass_data_access(data_access, ["content"], options)
+        assert matched == json_path
+
+
+class TestLocalReadersStayOutOfDiscovery:
+    """None of the readers defined here can hijack reader selection elsewhere."""
+
+    def test_no_local_reader_is_a_final_reader(self) -> None:
+        for reader in (
+            _RodFileProbe,
+            _RodStockJsonReadFile,
+            _RodJsonExcludingReadFile,
+            _RodStockJsonReadDocument,
+            _RodJsonClaimingReadDocument,
+        ):
+            assert reader.is_final_reader() is False

--- a/tests/test_plugins/test_undeclared_option_reads.py
+++ b/tests/test_plugins/test_undeclared_option_reads.py
@@ -19,6 +19,11 @@ Scope notes:
 * ``reference_time`` is a ``DefaultOptionKeys`` member yet is NOT treated as framework-reserved here.
   The time-based groups expose it as a user-overridable column option, so os-004 reclassifies it as a
   key those groups must DECLARE. The remaining ``DefaultOptionKeys`` values stay framework-reserved.
+
+Subclass-leak policy: this module NEEDS a leaked test-tree ``BaseInputData`` subclass to stay reachable
+through ``__subclasses__()`` mid-test, because that is what proves the module-prefix filter in
+``reader_declared_union`` really excludes it; the probe is built inside a helper and reclaimed by the
+module teardown gc pass, and it is never a final reader, so it cannot reach reader selection.
 """
 
 from __future__ import annotations
@@ -42,6 +47,7 @@ from mloda_plugins.feature_group.experimental.sklearn.encoding.base import Encod
 from mloda_plugins.feature_group.experimental.sklearn.pipeline.base import SklearnPipelineFeatureGroup
 from mloda_plugins.feature_group.experimental.sklearn.scaling.base import ScalingFeatureGroup
 from mloda_plugins.feature_group.experimental.time_window.base import TimeWindowFeatureGroup
+from mloda_plugins.feature_group.input_data.read_context_files import ConcatenatedFileContent
 from mloda_plugins.feature_group.input_data.read_document import ReadDocument
 from mloda_plugins.feature_group.input_data.read_files.markdown_document_reader import MarkdownDocumentReader
 
@@ -51,14 +57,19 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 SCAN_ROOT = _REPO_ROOT / "mloda_plugins" / "feature_group"
 assert SCAN_ROOT.exists(), f"scan root not found; check the parents index for the repo root: {SCAN_ROOT}"
 
-# Accessor calls whose result is an Options-like object: cls.get_singular_option_from_options(...).get(...)
-# and get_options(...).get(...). Anything else (arbitrary methods containing "option") is not an Options read.
-_OPTIONS_ACCESSORS = frozenset({"get_singular_option_from_options", "get_options"})
+# Accessor calls whose result is an Options-like object: cls.get_singular_option_from_options(...).get(...),
+# get_options(...).get(...) and cls.options_with_defaults(...).get(...). Anything else (arbitrary methods
+# containing "option") is not an Options read. options_with_defaults is load-bearing here: a group that
+# resolves its declared defaults reads every key through it, so leaving it out blinds the scan to those
+# reads entirely (that is how ConcatenatedFileContent's disallowed_files/file_type reads went missing).
+_OPTIONS_ACCESSORS = frozenset({"get_singular_option_from_options", "get_options", "options_with_defaults"})
 _OPTIONS_RECEIVER_NAMES = frozenset({"options", "option"})
-_READ_METHODS = frozenset({"get", "get_options_key"})
-# get_options_key is a FeatureSet method: its receiver (features/self) is never options-like, so it is
-# recognized by method name alone. The name is distinctive enough to carry the match on its own.
-_METHOD_NAME_ONLY_READS = frozenset({"get_options_key"})
+_READ_METHODS = frozenset({"get", "get_options_key", "reader_option"})
+# Reads whose receiver is never options-like, so they are recognized by method name alone: get_options_key
+# is a FeatureSet method (receiver features/self) and reader_option is a BaseInputData classmethod
+# (receiver cls) taking the key FIRST and the Options second. Both names are distinctive enough to carry
+# the match on their own, and both take the key as their first positional argument.
+_METHOD_NAME_ONLY_READS = frozenset({"get_options_key", "reader_option"})
 
 # DefaultOptionKeys.<member> resolves to the member's string value. Built from the enum so it cannot drift.
 _DEFAULT_OPTION_KEY_MEMBERS: dict[str, str] = {member.name: member.value for member in DefaultOptionKeys}
@@ -97,6 +108,12 @@ ALLOWED_DYNAMIC_READS: dict[tuple[str, str], tuple[str, str]] = {
 # the probe for whether the union really reaches READER_OPTIONS. "BaseInputData" is the reserved key the
 # framework itself writes; the other two are read inside reader matching.
 READER_ONLY_KEYS: frozenset[str] = frozenset({"BaseInputData", "data_access_handle", "document_suffixes"})
+
+# Individual source files whose reads are asserted key-by-key below, so a scanner blind spot cannot
+# silently drop them again. Relative to SCAN_ROOT.
+READ_CONTEXT_FILES_REL = "input_data/read_context_files.py"
+READ_FILE_REL = "input_data/read_file.py"
+READ_DOCUMENT_REL = "input_data/read_document.py"
 
 # Declared by the throwaway reader below, never by shipped code.
 _PROBE_READER_KEY = "uor_leaked_test_tree_probe_key"
@@ -297,6 +314,34 @@ def _count_reads(root: Path) -> int:
     return total
 
 
+def _resolved_keys_in(rel: str) -> set[str]:
+    """Every statically resolved option key the scanner sees in one file under SCAN_ROOT."""
+    path = SCAN_ROOT / rel
+    by_class, by_name = _collect_class_constants(SCAN_ROOT)
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    return {read.key for read in _reads_in_tree(tree, by_class, by_name) if read.key is not None}
+
+
+def _reader_option_call_keys(rel: str) -> set[str]:
+    """Literal keys read through ``cls.reader_option(key, options)`` in one file under SCAN_ROOT.
+
+    Independent of the scanner on purpose: it pins the ACCESSOR the reader uses, while
+    ``_resolved_keys_in`` pins that the scanner still resolves the key behind it.
+    """
+    path = SCAN_ROOT / rel
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    keys: set[str] = set()
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)):
+            continue
+        if node.func.attr != "reader_option" or not node.args:
+            continue
+        first = node.args[0]
+        if isinstance(first, ast.Constant) and isinstance(first.value, str):
+            keys.add(first.value)
+    return keys
+
+
 def _dynamic_allowed(rel: str, func_name: str | None, dynamic_allow: dict[tuple[str, str], tuple[str, str]]) -> bool:
     """A dynamic read is documented when its (path, function) exactly matches an allowlist entry."""
     for (path_rel, allowed_func), _ in dynamic_allow.items():
@@ -370,7 +415,10 @@ def declared_union() -> frozenset[str]:
 def test_no_undeclared_static_option_reads() -> None:
     """No shipped feature_group plugin reads an Options key that nothing declares (outside the narrow allowlist)."""
     assert SCAN_ROOT.exists(), SCAN_ROOT
-    assert _count_reads(SCAN_ROOT) >= 40, "scan found too few reads; SCAN_ROOT is likely misconfigured"
+    # Vacuity floor, NOT a target: its only job is to prove the rglob loops really walked the tree
+    # instead of finding nothing. Keep it around half the measured total (55 today) so that removing a
+    # read site stays a legitimate change; pinning it to the exact count made deleting reads fail here.
+    assert _count_reads(SCAN_ROOT) >= 28, "scan found too few reads; SCAN_ROOT is likely misconfigured"
     violations = find_violations(
         SCAN_ROOT,
         declared_union(),
@@ -470,6 +518,120 @@ def test_read_document_selection_key_is_the_reader_class_name() -> None:
     assert ALLOWED_DYNAMIC_READS[READ_DOCUMENT_DYNAMIC_READ][0] == ReadDocument.__name__
     assert MarkdownDocumentReader.data_access_name() == MarkdownDocumentReader.__name__
     assert MarkdownDocumentReader.__name__ not in declared_union()
+
+
+class TestEveryKnownReadSiteStaysVisible:
+    """Per-key pins on the three reader/group files whose reads a scanner blind spot could drop."""
+
+    @pytest.mark.parametrize("key", ["disallowed_files", "file_type"])
+    def test_read_context_files_default_backed_reads_are_resolved(self, key: str) -> None:
+        """The two keys read through ``self.options_with_defaults(options)`` are seen by the scanner.
+
+        These are exactly the reads that vanished when the read site moved behind the accessor: the
+        receiver stopped being a name the scanner recognized as options-like.
+        """
+        assert key in _resolved_keys_in(READ_CONTEXT_FILES_REL)
+
+    @pytest.mark.parametrize("key", ["file_paths", "target_folder", "document_reader_class"])
+    def test_read_context_files_direct_reads_are_resolved(self, key: str) -> None:
+        """Control: the three keys still read straight off ``options`` are seen too."""
+        assert key in _resolved_keys_in(READ_CONTEXT_FILES_REL)
+
+    def test_read_context_files_resolves_all_five_declared_keys(self) -> None:
+        """The scanner's view of the file covers the whole declared inventory, with nothing extra."""
+        assert _resolved_keys_in(READ_CONTEXT_FILES_REL) == ConcatenatedFileContent.declared_option_keys()
+
+    @pytest.mark.parametrize("rel", [READ_FILE_REL, READ_DOCUMENT_REL])
+    def test_reader_match_time_reads_are_resolved(self, rel: str) -> None:
+        """Both readers' match-time keys stay visible whichever accessor resolves them."""
+        resolved = _resolved_keys_in(rel)
+
+        assert "document_suffixes" in resolved
+        assert "data_access_handle" in resolved
+
+    @pytest.mark.parametrize("rel", [READ_FILE_REL, READ_DOCUMENT_REL])
+    def test_document_suffixes_is_read_through_the_reader_option_accessor(self, rel: str) -> None:
+        """``document_suffixes`` resolves its declared default through the presence-honouring accessor.
+
+        RED until the ``reader_option(key, options)`` accessor lands and both readers call it: today
+        they use ``options.get(...) or cls.reader_option_default(...)``, which silently replaces an
+        explicit empty value with the declared default.
+        """
+        assert "document_suffixes" in _reader_option_call_keys(rel)
+
+
+def test_scanner_resolves_a_read_behind_options_with_defaults(tmp_path: Path) -> None:
+    """A read behind ``x = obj.options_with_defaults(options)`` is resolved, not silently ignored."""
+    source = (
+        "class Foo:\n"
+        "    def f(self, options):\n"
+        "        effective = self.options_with_defaults(options)\n"
+        "        return effective.get('undeclared_x')\n"
+    )
+    (tmp_path / "mod.py").write_text(source)
+
+    violations = find_violations(tmp_path, frozenset(), frozenset(), {}, {})
+
+    assert any("undeclared_x" in v for v in violations), violations
+    assert find_violations(tmp_path, frozenset({"undeclared_x"}), frozenset(), {}, {}) == []
+
+
+def test_scanner_resolves_a_direct_read_off_options_with_defaults(tmp_path: Path) -> None:
+    """The un-aliased ``self.options_with_defaults(options).get(key)`` chain resolves too."""
+    source = (
+        "class Foo:\n"
+        "    def f(self, options):\n"
+        "        return self.options_with_defaults(options).get('undeclared_x')\n"
+    )
+    (tmp_path / "mod.py").write_text(source)
+
+    violations = find_violations(tmp_path, frozenset(), frozenset(), {}, {})
+
+    assert any("undeclared_x" in v for v in violations), violations
+
+
+def test_scanner_flags_reader_option(tmp_path: Path) -> None:
+    """``cls.reader_option('k', options)`` is recognized by method name, with the KEY as first argument."""
+    source = (
+        "class Foo:\n"
+        "    @classmethod\n"
+        "    def f(cls, options):\n"
+        "        return cls.reader_option('undeclared_x', options)\n"
+    )
+    (tmp_path / "mod.py").write_text(source)
+
+    violations = find_violations(tmp_path, frozenset(), frozenset(), {}, {})
+
+    assert any("undeclared_x" in v for v in violations), violations
+    assert find_violations(tmp_path, frozenset({"undeclared_x"}), frozenset(), {}, {}) == []
+
+
+def test_scanner_reads_the_first_positional_argument_of_reader_option(tmp_path: Path) -> None:
+    """The key is the FIRST argument: the Options in second position is never mistaken for the key."""
+    source = (
+        "class Foo:\n"
+        "    @classmethod\n"
+        "    def f(cls, options):\n"
+        "        return cls.reader_option('undeclared_x', options)\n"
+    )
+    (tmp_path / "mod.py").write_text(source)
+
+    violations = find_violations(tmp_path, frozenset(), frozenset(), {}, {})
+
+    assert len(violations) == 1, violations
+    assert "'undeclared_x'" in violations[0], violations[0]
+    assert "dynamic" not in violations[0], violations[0]
+
+
+def test_scanner_ignores_reader_option_default(tmp_path: Path) -> None:
+    """``reader_option_default(key)`` consults no Options, so it is not an Options read.
+
+    The recognition is an exact method-name match, so the longer sibling name does not match.
+    """
+    source = "class Foo:\n    @classmethod\n    def f(cls):\n        return cls.reader_option_default('undeclared_x')\n"
+    (tmp_path / "mod.py").write_text(source)
+
+    assert find_violations(tmp_path, frozenset(), frozenset(), {}, {}) == []
 
 
 def test_scanner_flags_new_undeclared_literal_read(tmp_path: Path) -> None:

--- a/tests/test_plugins/test_undeclared_option_reads.py
+++ b/tests/test_plugins/test_undeclared_option_reads.py
@@ -1,21 +1,21 @@
-"""Static sweep: every Options key an experimental plugin reads must be a declared PROPERTY_MAPPING key.
+"""Static sweep: every Options key a shipped ``feature_group`` plugin reads must be a DECLARED key.
 
-A feature group that reads ``options.get("foo")`` (directly, through a class constant, through a
+A plugin that reads ``options.get("foo")`` (directly, through a class constant, through a
 ``DefaultOptionKeys`` member, or through a local alias of one) is promising its users a ``foo`` option.
-If ``foo`` is in no ``PROPERTY_MAPPING`` (issue os-004 / mloda#775), that promise is undocumented and
-unvalidated. This sweep resolves each read to its key and flags any key that no shipped FeatureGroup
+If ``foo`` is in no declaration (issue os-004 / mloda#775), that promise is undocumented and
+unvalidated. This sweep resolves each read to its key and flags any key that no shipped plugin
 declares, accepting only a narrow allowlist of genuinely engine-internal and genuinely dynamic reads.
 
-The check is deliberately GLOBAL: a key passes when SOME shipped feature group declares it, not the one
-that reads it. That is the intended model for shared keys like ``reference_time``; per-group owning-surface
+The check spans TWO declaration surfaces and is deliberately GLOBAL across both: a key passes when
+SOME shipped FeatureGroup declares it in ``PROPERTY_MAPPING`` or SOME shipped reader declares it in
+``READER_OPTIONS``. Readers need their own surface because their keys are consumed at reader-selection
+time, before the framework materializes any ``PROPERTY_MAPPING`` default. Per-group owning-surface
 attribution is out of scope for this sweep.
 
-Scope notes (both are load-bearing and deliberately narrower than a naive reading of the ticket):
+Scope notes:
 
-* ``SCAN_ROOT`` is ``mloda_plugins/feature_group/experimental`` rather than the whole ``feature_group``
-  tree. The ticket inventory covers exactly the experimental subtree, and the dynamic allowlist path
-  below is written relative to it. The ``input_data`` readers under ``feature_group`` carry their own,
-  out-of-ticket set of undeclared literal reads that this sweep intentionally does not touch.
+* ``SCAN_ROOT`` is the whole ``mloda_plugins/feature_group`` tree, ``input_data`` readers included;
+  the allowlist paths below are written relative to it.
 * ``reference_time`` is a ``DefaultOptionKeys`` member yet is NOT treated as framework-reserved here.
   The time-based groups expose it as a user-overridable column option, so os-004 reclassifies it as a
   key those groups must DECLARE. The remaining ``DefaultOptionKeys`` values stay framework-reserved.
@@ -24,11 +24,15 @@ Scope notes (both are load-bearing and deliberately narrower than a naive readin
 from __future__ import annotations
 
 import ast
+import gc
+from collections.abc import Iterator
 from pathlib import Path
-from typing import NamedTuple
+from typing import ClassVar, NamedTuple
 
 import pytest
 
+from mloda.core.abstract_plugins.components.input_data.base_input_data import BaseInputData
+from mloda.core.abstract_plugins.components.input_data.reader_option_spec import ReaderOptionSpec
 from mloda.core.abstract_plugins.components.utils import get_all_subclasses
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.abstract_plugins.plugin_loader.plugin_loader import PluginLoader
@@ -38,11 +42,13 @@ from mloda_plugins.feature_group.experimental.sklearn.encoding.base import Encod
 from mloda_plugins.feature_group.experimental.sklearn.pipeline.base import SklearnPipelineFeatureGroup
 from mloda_plugins.feature_group.experimental.sklearn.scaling.base import ScalingFeatureGroup
 from mloda_plugins.feature_group.experimental.time_window.base import TimeWindowFeatureGroup
+from mloda_plugins.feature_group.input_data.read_document import ReadDocument
+from mloda_plugins.feature_group.input_data.read_files.markdown_document_reader import MarkdownDocumentReader
 
 # Anchor the scan root to the repo layout via __file__, not the cwd: a cwd-relative root makes the
 # rglob loops empty and the sweep pass vacuously. This file sits two parents below the repo root.
 _REPO_ROOT = Path(__file__).resolve().parents[2]
-SCAN_ROOT = _REPO_ROOT / "mloda_plugins" / "feature_group" / "experimental"
+SCAN_ROOT = _REPO_ROOT / "mloda_plugins" / "feature_group"
 assert SCAN_ROOT.exists(), f"scan root not found; check the parents index for the repo root: {SCAN_ROOT}"
 
 # Accessor calls whose result is an Options-like object: cls.get_singular_option_from_options(...).get(...)
@@ -67,25 +73,62 @@ FRAMEWORK_KEYS: frozenset[str] = frozenset(_DEFAULT_OPTION_KEY_MEMBERS.values())
 # source file (relative to SCAN_ROOT): a read of the same literal from any other file is still flagged.
 ALLOWED_LITERAL_KEYS: dict[str, tuple[str, str, str]] = {
     "initial_requested_data": (
-        "source_input_feature.py",
+        "experimental/source_input_feature.py",
         "SourceInputFeatureComposite",
         "engine-internal request-scoping signal set as a Feature attribute; not a user-facing option",
     ),
 }
 
 # Reads whose key is computed at runtime, keyed by (path relative to SCAN_ROOT, enclosing function).
+READ_DOCUMENT_DYNAMIC_READ = ("input_data/read_document.py", "load_data")
 ALLOWED_DYNAMIC_READS: dict[tuple[str, str], tuple[str, str]] = {
-    ("forecasting/forecasting_artifact.py", "custom_loader"): (
+    ("experimental/forecasting/forecasting_artifact.py", "custom_loader"): (
         "ForecastingArtifact",
         "artifact is keyed by the runtime feature name, not a fixed option key",
     ),
+    READ_DOCUMENT_DYNAMIC_READ: (
+        "ReadDocument",
+        "reader selection keys the option by the reader's own class name (data_access_name), so the key "
+        "is dynamic by construction and no fixed declared key can cover it",
+    ),
 }
+
+# Keys that ONLY the reader surface declares: nothing about them is in any PROPERTY_MAPPING, so they are
+# the probe for whether the union really reaches READER_OPTIONS. "BaseInputData" is the reserved key the
+# framework itself writes; the other two are read inside reader matching.
+READER_ONLY_KEYS: frozenset[str] = frozenset({"BaseInputData", "data_access_handle", "document_suffixes"})
+
+# Declared by the throwaway reader below, never by shipped code.
+_PROBE_READER_KEY = "uor_leaked_test_tree_probe_key"
 
 
 @pytest.fixture(scope="module", autouse=True)
-def _load_all_plugins() -> None:
-    """Load every shipped plugin so declared_union enumerates the full FeatureGroup set."""
+def _load_all_plugins() -> Iterator[None]:
+    """Load every shipped plugin so the declared unions enumerate the full plugin set.
+
+    The teardown gc pass reclaims the throwaway reader this module builds: a test-local
+    ``BaseInputData`` subclass sits in reference cycles, so it would otherwise linger in
+    ``BaseInputData.__subclasses__()`` where other tests enumerate readers.
+    """
     PluginLoader().all()
+    yield
+    gc.collect()
+    gc.collect()
+
+
+def _make_leaked_reader_probe() -> type[BaseInputData]:
+    """A throwaway reader declaring one distinctive key, built here so it stays collectable.
+
+    It deliberately does not override ``load_data`` and declares no ``_final_reader_requires``, so
+    ``is_final_reader()`` is False and reader discovery never collects it.
+    """
+
+    class UorLeakedTestTreeReaderProbe(BaseInputData):
+        READER_OPTIONS: ClassVar[dict[str, ReaderOptionSpec]] = {
+            _PROBE_READER_KEY: ReaderOptionSpec("Test-tree only; must never reach the declared union."),
+        }
+
+    return UorLeakedTestTreeReaderProbe
 
 
 class _Read(NamedTuple):
@@ -291,7 +334,7 @@ def find_violations(
     return violations
 
 
-def declared_union() -> frozenset[str]:
+def property_mapping_declared_union() -> frozenset[str]:
     """Every PROPERTY_MAPPING key declared by any shipped (mloda_plugins) FeatureGroup subclass.
 
     Restricting to ``mloda_plugins`` modules drops throwaway test subclasses that other modules leak into
@@ -304,10 +347,30 @@ def declared_union() -> frozenset[str]:
     return frozenset(keys)
 
 
+def reader_declared_union() -> frozenset[str]:
+    """Every READER_OPTIONS key declared by ``BaseInputData`` or a shipped reader subclass.
+
+    Filtered by module prefix for the same reason as the PROPERTY_MAPPING side, with one extra prefix:
+    ``BaseInputData`` itself lives under ``mloda.core`` and is what declares the reserved
+    ``"BaseInputData"`` key, so the filter admits ``mloda.core`` while still excluding ``tests.*``.
+    """
+    readers: list[type[BaseInputData]] = [BaseInputData, *get_all_subclasses(BaseInputData)]
+    keys: set[str] = set()
+    for cls in readers:
+        if cls.__module__.startswith(("mloda_plugins", "mloda.core")):
+            keys |= set(cls.declared_reader_option_keys())
+    return frozenset(keys)
+
+
+def declared_union() -> frozenset[str]:
+    """Both declaration surfaces: a key passes when EITHER a FeatureGroup or a reader declares it."""
+    return property_mapping_declared_union() | reader_declared_union()
+
+
 def test_no_undeclared_static_option_reads() -> None:
-    """No experimental plugin reads an Options key that no FeatureGroup declares (outside the narrow allowlist)."""
+    """No shipped feature_group plugin reads an Options key that nothing declares (outside the narrow allowlist)."""
     assert SCAN_ROOT.exists(), SCAN_ROOT
-    assert _count_reads(SCAN_ROOT) >= 25, "scan found too few reads; SCAN_ROOT is likely misconfigured"
+    assert _count_reads(SCAN_ROOT) >= 40, "scan found too few reads; SCAN_ROOT is likely misconfigured"
     violations = find_violations(
         SCAN_ROOT,
         declared_union(),
@@ -316,7 +379,8 @@ def test_no_undeclared_static_option_reads() -> None:
         ALLOWED_DYNAMIC_READS,
     )
     assert violations == [], (
-        "Undeclared option reads (declare the key in the plugin's PROPERTY_MAPPING):\n" + "\n".join(violations)
+        "Undeclared option reads (declare the key in the plugin's PROPERTY_MAPPING or READER_OPTIONS):\n"
+        + "\n".join(violations)
     )
 
 
@@ -331,6 +395,81 @@ def test_artifact_storage_path_declared_by_sklearn_groups() -> None:
     assert "artifact_storage_path" in EncodingFeatureGroup.declared_option_keys()
     assert "artifact_storage_path" in ScalingFeatureGroup.declared_option_keys()
     assert "artifact_storage_path" in SklearnPipelineFeatureGroup.declared_option_keys()
+
+
+def test_allowlist_paths_are_relative_to_the_scan_root() -> None:
+    """Every allowlist path resolves under SCAN_ROOT; a stale path silently stops matching and flags nothing."""
+    for path_rel, _, _ in ALLOWED_LITERAL_KEYS.values():
+        assert (SCAN_ROOT / path_rel).exists(), path_rel
+    for path_rel, _ in ALLOWED_DYNAMIC_READS:
+        assert (SCAN_ROOT / path_rel).exists(), path_rel
+
+
+def test_literal_allowlist_is_load_bearing() -> None:
+    """Drop the literal allowlist and its one key is flagged, so the entry (and its path) really matches."""
+    violations = find_violations(SCAN_ROOT, declared_union(), FRAMEWORK_KEYS, {}, ALLOWED_DYNAMIC_READS)
+
+    assert any("'initial_requested_data'" in v for v in violations), violations
+
+
+@pytest.mark.parametrize("key", sorted(READER_ONLY_KEYS))
+def test_declared_union_recognizes_reader_declarations(key: str) -> None:
+    """The union covers the READER_OPTIONS surface, not just PROPERTY_MAPPING."""
+    assert key in reader_declared_union()
+    assert key in declared_union()
+
+
+@pytest.mark.parametrize("key", sorted(READER_ONLY_KEYS))
+def test_reader_keys_are_attributable_to_the_reader_surface_alone(key: str) -> None:
+    """No PROPERTY_MAPPING and no framework-reserved key covers these, so only READER_OPTIONS carries them."""
+    assert key not in property_mapping_declared_union()
+    assert key not in FRAMEWORK_KEYS
+
+
+def test_reader_declarations_are_load_bearing_for_the_tree_wide_scan() -> None:
+    """Exclude the reader surface from the union and the readers' own match-time reads are flagged."""
+    violations = find_violations(
+        SCAN_ROOT,
+        property_mapping_declared_union(),
+        FRAMEWORK_KEYS,
+        ALLOWED_LITERAL_KEYS,
+        ALLOWED_DYNAMIC_READS,
+    )
+
+    assert any("'document_suffixes'" in v for v in violations), violations
+    assert any("'data_access_handle'" in v for v in violations), violations
+    assert all(v.startswith("input_data/") for v in violations), violations
+
+
+def test_reader_union_ignores_readers_declared_in_the_test_tree() -> None:
+    """A leaked test-tree reader is visible through __subclasses__() yet cannot widen the union."""
+    probe = _make_leaked_reader_probe()
+
+    assert _PROBE_READER_KEY in probe.declared_reader_option_keys()
+    reachable = {key for cls in get_all_subclasses(BaseInputData) for key in cls.declared_reader_option_keys()}
+    assert _PROBE_READER_KEY in reachable, "probe is unreachable, so the module-prefix filter is untested here"
+    assert _PROBE_READER_KEY not in reader_declared_union()
+    assert _PROBE_READER_KEY not in declared_union()
+
+
+def test_read_document_dynamic_allowlist_entry_is_load_bearing() -> None:
+    """Without its allowlist entry, the reader-selection read in ReadDocument.load_data is flagged."""
+    without_entry = {key: value for key, value in ALLOWED_DYNAMIC_READS.items() if key != READ_DOCUMENT_DYNAMIC_READ}
+    assert len(without_entry) == len(ALLOWED_DYNAMIC_READS) - 1
+
+    violations = find_violations(SCAN_ROOT, declared_union(), FRAMEWORK_KEYS, ALLOWED_LITERAL_KEYS, without_entry)
+
+    assert len(violations) == 1, violations
+    assert violations[0].startswith("input_data/read_document.py:"), violations[0]
+    assert "undocumented dynamic option read" in violations[0], violations[0]
+    assert "function load_data" in violations[0], violations[0]
+
+
+def test_read_document_selection_key_is_the_reader_class_name() -> None:
+    """The allowlisted read is keyed by the reader's own class name, so no fixed declared key can cover it."""
+    assert ALLOWED_DYNAMIC_READS[READ_DOCUMENT_DYNAMIC_READ][0] == ReadDocument.__name__
+    assert MarkdownDocumentReader.data_access_name() == MarkdownDocumentReader.__name__
+    assert MarkdownDocumentReader.__name__ not in declared_union()
 
 
 def test_scanner_flags_new_undeclared_literal_read(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #865.

## Problem

The `input_data` reader groups read user Options keys that no declaration owned. Declaring them as ordinary `PropertySpec` entries on the wrapper feature groups was the obvious move and the wrong one: reader options are consumed at match time, inside reader selection, which runs before the framework materializes anything. Every enforcement hook a `PropertySpec` advertises would have been inert for them, producing a second dialect indistinguishable from an enforced one.

Note the starting point differed from the issue text: PR #864 was closed unmerged, so there were no wrapper-group proxy declarations and no `reader_option_specs.py` on main to remove. This implements the issue`s preferred option from a clean base, which is also what the epic notes anticipated.

## Change

**A second surface, named as such.** `READER_OPTIONS` / `ReaderOptionSpec` on `BaseInputData` declares only what is true at selection time: the key, an explanation, the `runtime_default` the reader`s own code applies, and `framework_set` for the reserved `BaseInputData` key that holds the matched `(ReaderClass, data_access)` pair. Declarations merge across the MRO, most-derived winning, and are validated at class definition exactly as `PROPERTY_MAPPING` is. Readers read through `reader_option(key, options)`, which honors any present value and falls back to the declaration only for an absent one, so the declared default is load-bearing rather than decorative.

**One correction to the issue`s analysis.** `required_when` *is* enforced for a pattern-less feature group: its guard is installed from `FeatureGroup.__init_subclass__` and wraps `match_feature_group_criteria` rather than living inside the chain-parser matcher. Only `strict_validation` and the name-path presence rule need a parsed name. So `ConcatenatedFileContent` gets a real `PROPERTY_MAPPING` with enforced requiredness for `target_folder` and `document_reader_class`, and declared defaults for `file_type` and `disallowed_files` that reach the read site because the group calls `options_with_defaults` itself. `check_required_when` now records its non-match on the existing diagnostic seam, as the two sibling presence rules already do, so a missing required option produces a near-miss line naming the class and the key instead of vanishing.

**A bug this made visible.** The `file_paths` branch of `input_features` built a filtered list and never assigned it back, so `disallowed_files` had no effect there and newlines survived, while the `target_folder` branch filtered correctly. Both branches now agree, and an explicit list emptied by filtering raises instead of building an unreadable join.

**The sweep** covers the whole `feature_group` tree and unions both surfaces. The one remaining dynamic read, the selection key that equals the reader`s own class name, is recorded in the dynamic allowlist with its owner and reason.

## Review

Two independent deep reviews (Claude Opus and codex) ran on the first commit. They converged on two defects and the Opus pass found a third that mattered more than either: **this change set had blinded the sweep to two of the five keys it exists for**, because moving those reads behind `options_with_defaults` hid them from the scanner. All accepted findings are fixed in the second commit:

- the scanner recognizes `options_with_defaults` and the new accessor, with tests pinning that each real read site stays visible
- presence instead of truthiness, so a reader declaring a non-empty `runtime_default` can have it turned off
- `READER_OPTIONS` validated at class definition, instead of failing later as `AttributeError` on `runtime_default`
- an emptied explicit `file_paths` raises rather than crashing downstream in `calculate_feature`
- the merged declarations are cached in the class`s own `__dict__`, so selection does not rebuild the MRO merge per call, a subclass never answers from a warm parent cache, and nothing holds a reference to a reader class
- four documentation overclaims narrowed, and two comments corrected: the tuple default protects equality, not hashing, since a list and a tuple hash equal but compare unequal

Declined, with reasons: a `reader_option_spec()` factory (`property_spec` exists to validate invariants, and this type has none), and rewriting the pre-existing `inspect.getsource` assertions in `test_read_context_files.py`, filed as #892.

## Behavior changes worth knowing

- Every `ConcatenatedFileContent` feature now carries `file_type` and `disallowed_files` in its group options after intake, so default-equivalent twins merge instead of computing twice. That is the intended canonicalization, and it is why the `disallowed_files` default is a tuple.
- A feature missing `document_reader_class`, or missing both sources, is now a non-match at resolution rather than a late `ValueError`. The backstops inside `input_features` remain, both for direct callers and because requiredness reads presence, so a present-but-falsy value still needs them.
- Every `required_when` non-match anywhere now produces a near-miss reason. Nothing depended on their absence.

## Gate

`tox` reports 2 failed, 7368 passed, 170 skipped. Both failures are `get_feature_group_docs` live-subclass GC races, and pristine `main` fails the identical two tests with the same counts, verified back to back on the same machine. Runtime is unchanged (120.7s here, 127.2s on main). ruff, licenses, mypy `--strict` and bandit are green.