### PR TITLE
perf: freeze the imported graph so per-test gc.collect() stops rescanning it

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,15 +49,46 @@ def flight_server(flight_server_setup: ParallelRunnerFlightServer) -> Any:
     flight_server_setup.end_flight_server_process()
 
 
+NO_GC_FREEZE_ENV_VAR = "MLODA_NO_GC_FREEZE"
+
+# CPython 3.12 seeds the permanent generation with ~375 objects at interpreter startup (3.10, 3.11, 3.13 and 3.14
+# seed none), while freezing a realistic imported graph moves tens of thousands. A truthiness check would read
+# 3.12's seed as a host freeze and never freeze on that version, so ownership is decided against this floor.
+MIN_FROZEN_GRAPH_OBJECTS = 1000
+
+_froze_the_graph = False
+
+
+# The gc.collect() is load-bearing, not a tidy-up: a FeatureGroup subclass that is dead but not yet collected here
+# gets frozen alive and stays visible to get_all_subclasses(FeatureGroup) for the whole run, since objects frozen
+# before a collection are never reclaimed afterwards on any of 3.10-3.14. A non-empty permanent generation means a
+# host froze its own graph before calling pytest, and that freeze is not ours to touch. Freezing also empties
+# gc.get_objects() and hides frozen referrers from gc.get_referrers(), so MLODA_NO_GC_FREEZE opts out of it for
+# anyone debugging object retention inside the suite.
 def pytest_collection_finish(session: Any) -> None:
     """Freeze once all test modules are imported and no test has run, so later gc.collect() calls skip them."""
+    global _froze_the_graph
+    if os.getenv(NO_GC_FREEZE_ENV_VAR):
+        return
+    if gc.get_freeze_count() > MIN_FROZEN_GRAPH_OBJECTS:
+        return
     gc.collect()
     gc.freeze()
+    _froze_the_graph = True
 
 
+# tryfirst because hook impls run in reverse registration order: a deeper conftest or a later-registered plugin
+# that raises in pytest_sessionfinish would skip this unfreeze. A missed unfreeze surfaces as 'Fatal Python error:
+# gilstate_tss_set: failed to set current tstate (TSS)', which exits 134 serially but stays invisible under xdist,
+# where both workers abort and the run still exits 0.
+@pytest.hookimpl(tryfirst=True)
 def pytest_sessionfinish(session: Any, exitstatus: Any) -> None:
-    """Unfreeze before finalization, or the multiprocessing tests abort with a gilstate_tss_set fatal error."""
+    """Unfreeze our own freeze only, or the multiprocessing tests abort with a gilstate_tss_set fatal error."""
+    global _froze_the_graph
+    if not _froze_the_graph:
+        return
     gc.unfreeze()
+    _froze_the_graph = False
 
 
 CHECK_SKIP_COUNT_ENV_VAR = "CHECK_SKIP_COUNT"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import gc
 import os
 from typing import Any
 import pytest
@@ -46,6 +47,17 @@ def flight_server_setup() -> ParallelRunnerFlightServer:
 def flight_server(flight_server_setup: ParallelRunnerFlightServer) -> Any:
     yield flight_server_setup
     flight_server_setup.end_flight_server_process()
+
+
+def pytest_collection_finish(session: Any) -> None:
+    """Freeze once all test modules are imported and no test has run, so later gc.collect() calls skip them."""
+    gc.collect()
+    gc.freeze()
+
+
+def pytest_sessionfinish(session: Any, exitstatus: Any) -> None:
+    """Unfreeze before finalization, or the multiprocessing tests abort with a gilstate_tss_set fatal error."""
+    gc.unfreeze()
 
 
 CHECK_SKIP_COUNT_ENV_VAR = "CHECK_SKIP_COUNT"

--- a/tests/test_gc_freeze_contract.py
+++ b/tests/test_gc_freeze_contract.py
@@ -1,0 +1,94 @@
+"""Pin the gc.freeze contract that keeps the suite's per-test gc.collect() calls off the hot path.
+
+26 test modules run gc.collect() in an autouse fixture, because a throwaway FeatureGroup subclass
+defined in a test body lingers in FeatureGroup.__subclasses__() until a GC pass reclaims its reference
+cycle. Each collect rescans the whole imported heap (pandas, polars, duckdb, pyarrow, sklearn, every
+plugin and test module), so one collect costs ~280ms and gc dominates the suite's wall time. Freezing
+the imported graph into the permanent generation once collection has finished makes those collects
+free without weakening the isolation they buy.
+"""
+
+from __future__ import annotations
+
+import gc
+from typing import Any
+
+import pytest
+
+from mloda.core.abstract_plugins.components.utils import get_all_subclasses
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from tests import conftest as tests_conftest
+
+
+_THROWAWAY_NAME = "GcFreezeThrowawayFeatureGroup"
+
+_FREEZE_MISSING = (
+    "gc.get_freeze_count() is 0: the imported object graph is not frozen. tests/conftest.py must call "
+    "gc.freeze() once pytest collection has finished, so the per-test gc.collect() calls stop rescanning "
+    "the whole imported heap. Without it a single gc.collect() costs ~280ms and the suite spends most of "
+    "its wall time in gc."
+)
+
+_UNFREEZE_MISSING = (
+    "tests/conftest.py defines no pytest_sessionfinish hook. gc.freeze() must be undone with gc.unfreeze() "
+    "before the interpreter finalizes, or the multiprocessing tests abort with 'Fatal Python error: "
+    "gilstate_tss_set: failed to set current tstate (TSS)'."
+)
+
+
+@pytest.fixture(autouse=True)
+def _no_feature_group_registry_pollution() -> Any:
+    """Guarantee this module never leaks its throwaway FeatureGroup subclass (see the filter test's twin fixture)."""
+    yield
+    gc.collect()
+    gc.collect()
+    leaked = [c for c in get_all_subclasses(FeatureGroup) if c.__module__ == __name__]
+    assert not leaked, f"Leaked FeatureGroup subclasses from {__name__}: {[c.__name__ for c in leaked]}"
+
+
+def _define_throwaway_feature_group() -> type[FeatureGroup]:
+    """Define a FeatureGroup subclass inside a function body, exactly as the suite's throwaway probes do."""
+
+    class GcFreezeThrowawayFeatureGroup(FeatureGroup):
+        pass
+
+    return GcFreezeThrowawayFeatureGroup
+
+
+def _throwaway_is_registered() -> bool:
+    """True while a subclass named _THROWAWAY_NAME is still reachable from FeatureGroup."""
+    return any(cls.__name__ == _THROWAWAY_NAME for cls in get_all_subclasses(FeatureGroup))
+
+
+def test_import_graph_is_frozen_while_tests_run() -> None:
+    """The imported graph sits in the permanent generation for the whole run, so gc.collect() never rescans it."""
+    assert gc.get_freeze_count() > 0, _FREEZE_MISSING
+
+
+def test_gc_collect_still_reaps_throwaway_feature_groups_under_a_frozen_graph() -> None:
+    """Freezing must not extend the permanent generation to classes created later: one gc.collect() still reaps."""
+    assert gc.get_freeze_count() > 0, _FREEZE_MISSING
+
+    # Only booleans stay in this frame across the collect: a retained class reference, or an assert-rewrite
+    # temporary holding one, would pin the very cycle whose reclamation is under test.
+    control = _define_throwaway_feature_group()
+    registered_while_referenced = control in get_all_subclasses(FeatureGroup)
+    del control
+    gc.collect()
+    still_registered = _throwaway_is_registered()
+
+    assert registered_while_referenced, (
+        "Positive control failed: a FeatureGroup subclass defined in a function body is not reachable from "
+        "get_all_subclasses(FeatureGroup) even while strongly referenced, so this test can no longer detect "
+        "a leak. Fix the probe, not the freeze hook."
+    )
+    assert not still_registered, (
+        f"{_THROWAWAY_NAME} survived gc.collect() and stays in get_all_subclasses(FeatureGroup). Every autouse "
+        "isolation fixture in the suite depends on gc.collect() reaping throwaway subclasses; freezing the "
+        "import graph must leave classes created after the freeze collectable."
+    )
+
+
+def test_conftest_unfreezes_the_graph_at_session_finish() -> None:
+    """gc.freeze() is only safe when paired with gc.unfreeze() before interpreter finalization."""
+    assert callable(getattr(tests_conftest, "pytest_sessionfinish", None)), _UNFREEZE_MISSING

--- a/tests/test_gc_freeze_contract.py
+++ b/tests/test_gc_freeze_contract.py
@@ -1,39 +1,97 @@
 """Pin the gc.freeze contract that keeps the suite's per-test gc.collect() calls off the hot path.
 
-26 test modules run gc.collect() in an autouse fixture, because a throwaway FeatureGroup subclass
-defined in a test body lingers in FeatureGroup.__subclasses__() until a GC pass reclaims its reference
-cycle. Each collect rescans the whole imported heap (pandas, polars, duckdb, pyarrow, sklearn, every
-plugin and test module), so one collect costs ~280ms and gc dominates the suite's wall time. Freezing
-the imported graph into the permanent generation once collection has finished makes those collects
-free without weakening the isolation they buy.
+26 test modules call gc.collect() (13 from an autouse fixture, the rest inline in a test body or a finally
+block), because a throwaway FeatureGroup subclass defined in a test body lingers in
+FeatureGroup.__subclasses__() until a GC pass reclaims its reference cycle. Each collect rescans the whole
+imported heap (pandas, polars, duckdb, pyarrow, sklearn, every plugin and test module), so one collect costs
+hundreds of milliseconds and gc dominates the suite's wall time. Freezing the imported graph into the
+permanent generation once collection has finished makes those collects free without weakening the isolation
+they buy, but only if the freeze is owned: gc.unfreeze() is process-global, so the suite may only undo a
+freeze it made itself.
 """
 
 from __future__ import annotations
 
 import gc
+import os
+import subprocess  # nosec B404
+import sys
+from pathlib import Path
 from typing import Any
 
 import pytest
 
 from mloda.core.abstract_plugins.components.utils import get_all_subclasses
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
-from tests import conftest as tests_conftest
+
+# The floor the conftest predicate uses to tell its own freeze from a host's, imported rather than copied so
+# the predicate and these assertions cannot drift apart.
+from tests.conftest import MIN_FROZEN_GRAPH_OBJECTS, NO_GC_FREEZE_ENV_VAR
 
 
 _THROWAWAY_NAME = "GcFreezeThrowawayFeatureGroup"
 
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+_PROBE_MARKER = "GC_FREEZE_COUNTS"
+
 _FREEZE_MISSING = (
-    "gc.get_freeze_count() is 0: the imported object graph is not frozen. tests/conftest.py must call "
-    "gc.freeze() once pytest collection has finished, so the per-test gc.collect() calls stop rescanning "
-    "the whole imported heap. Without it a single gc.collect() costs ~280ms and the suite spends most of "
-    "its wall time in gc."
+    "Freezing the suite's imported graph moves tens of thousands of objects into the permanent generation, so a "
+    f"count at or below the ownership floor of {MIN_FROZEN_GRAPH_OBJECTS} is not that freeze: CPython 3.12 seeds "
+    "~375 objects there at interpreter startup, which is why a count above 0 proves nothing. tests/conftest.py "
+    "must call gc.freeze() once pytest collection has finished, so the per-test gc.collect() calls stop "
+    "rescanning the whole imported heap; without it a single gc.collect() costs hundreds of milliseconds and the "
+    f"suite spends most of its wall time in gc. A count of 0 with {NO_GC_FREEZE_ENV_VAR} set is that opt-out."
 )
 
 _UNFREEZE_MISSING = (
-    "tests/conftest.py defines no pytest_sessionfinish hook. gc.freeze() must be undone with gc.unfreeze() "
-    "before the interpreter finalizes, or the multiprocessing tests abort with 'Fatal Python error: "
-    "gilstate_tss_set: failed to set current tstate (TSS)'."
+    "tests/conftest.py must undo its own gc.freeze() with gc.unfreeze() in pytest_sessionfinish, or the "
+    "multiprocessing tests abort with 'Fatal Python error: gilstate_tss_set: failed to set current tstate "
+    "(TSS)'. Only an assertion can catch this: under -n both xdist workers abort while the run still exits 0."
 )
+
+_OWNERSHIP_VIOLATED = (
+    "gc.unfreeze() is process-global. A host process that froze its own graph and then runs this suite "
+    "in-process via pytest.main() loses its whole permanent generation, and the xdist controller has the same "
+    "shape: it never runs pytest_collection_finish but does run pytest_sessionfinish. tests/conftest.py must "
+    "unfreeze only the freeze it made itself."
+)
+
+# Only import gc and tests.conftest in the child: the probes must stay fast, and the freeze counts only need
+# a realistic imported graph, not the whole plugin universe.
+_PAIRED_HOOKS_PROBE = """
+import gc
+
+from tests import conftest
+
+baseline = gc.get_freeze_count()
+conftest.pytest_collection_finish(session=None)
+frozen = gc.get_freeze_count()
+conftest.pytest_sessionfinish(session=None, exitstatus=0)
+print("{marker}", baseline, frozen, gc.get_freeze_count())
+"""
+
+_HOST_FREEZE_PROBE = """
+import gc
+
+from tests import conftest
+
+gc.freeze()
+host = gc.get_freeze_count()
+{hooks}
+print("{marker}", host, gc.get_freeze_count())
+"""
+
+_SESSION_FINISH = "conftest.pytest_sessionfinish(session=None, exitstatus=0)"
+
+_COLLECTION_FINISH = "conftest.pytest_collection_finish(session=None)"
+
+# Two shapes reach pytest_sessionfinish with a freeze this suite does not own: the xdist controller, which
+# returns True from pytest_collection and so never runs pytest_collection_finish, and an embedding host that
+# froze before calling pytest.main().
+_HOST_HOOK_SEQUENCES: list[str] = [_SESSION_FINISH, f"{_COLLECTION_FINISH}\n{_SESSION_FINISH}"]
+
+_HOST_HOOK_IDS = ["sessionfinish_only", "collection_finish_then_sessionfinish"]
 
 
 @pytest.fixture(autouse=True)
@@ -60,27 +118,58 @@ def _throwaway_is_registered() -> bool:
     return any(cls.__name__ == _THROWAWAY_NAME for cls in get_all_subclasses(FeatureGroup))
 
 
+def _freeze_counts(probe: str) -> list[int]:
+    """Run probe in a fresh interpreter rooted at the repo and return the freeze counts it printed.
+
+    A subprocess, not this process: driving the conftest hooks in-process would unfreeze the live session and
+    make the sibling freeze tests order-dependent. The child never inherits the freeze opt-out, so these probes
+    measure the hooks themselves even when the ambient run is debugging object retention.
+    """
+    child_env = {name: value for name, value in os.environ.items() if name != NO_GC_FREEZE_ENV_VAR}
+    # Safe: fixed argv (sys.executable plus a probe built from module-level constants), no shell, no user input.
+    result = subprocess.run(  # nosec B603
+        [sys.executable, "-c", probe],
+        cwd=str(_REPO_ROOT),
+        env=child_env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"The freeze probe died in a fresh interpreter (returncode {result.returncode}).\n"
+        f"probe:\n{probe}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    marked = [line for line in result.stdout.splitlines() if line.startswith(_PROBE_MARKER)]
+    assert len(marked) == 1, f"Expected one {_PROBE_MARKER} line, got {marked}.\nstdout:\n{result.stdout}"
+    return [int(value) for value in marked[0].split()[1:]]
+
+
 def test_import_graph_is_frozen_while_tests_run() -> None:
     """The imported graph sits in the permanent generation for the whole run, so gc.collect() never rescans it."""
-    assert gc.get_freeze_count() > 0, _FREEZE_MISSING
+    frozen = gc.get_freeze_count()
+
+    assert frozen > MIN_FROZEN_GRAPH_OBJECTS, f"gc.get_freeze_count() is {frozen}. {_FREEZE_MISSING}"
 
 
 def test_gc_collect_still_reaps_throwaway_feature_groups_under_a_frozen_graph() -> None:
     """Freezing must not extend the permanent generation to classes created later: one gc.collect() still reaps."""
-    assert gc.get_freeze_count() > 0, _FREEZE_MISSING
+    frozen = gc.get_freeze_count()
+    assert frozen > MIN_FROZEN_GRAPH_OBJECTS, f"gc.get_freeze_count() is {frozen}. {_FREEZE_MISSING}"
 
     # Only booleans stay in this frame across the collect: a retained class reference, or an assert-rewrite
-    # temporary holding one, would pin the very cycle whose reclamation is under test.
+    # temporary holding one, would pin the very cycle whose reclamation is under test. The positive control
+    # runs the same probe as the measurement, so a drift between _THROWAWAY_NAME and the class name fails the
+    # control instead of silently making the measurement vacuous.
     control = _define_throwaway_feature_group()
-    registered_while_referenced = control in get_all_subclasses(FeatureGroup)
+    registered_while_referenced = _throwaway_is_registered()
     del control
     gc.collect()
     still_registered = _throwaway_is_registered()
 
     assert registered_while_referenced, (
-        "Positive control failed: a FeatureGroup subclass defined in a function body is not reachable from "
-        "get_all_subclasses(FeatureGroup) even while strongly referenced, so this test can no longer detect "
-        "a leak. Fix the probe, not the freeze hook."
+        f"Positive control failed: no subclass named {_THROWAWAY_NAME} is reachable from "
+        "get_all_subclasses(FeatureGroup) even while one is strongly referenced, so this test can no longer "
+        "detect a leak. Fix the probe, not the freeze hook."
     )
     assert not still_registered, (
         f"{_THROWAWAY_NAME} survived gc.collect() and stays in get_all_subclasses(FeatureGroup). Every autouse "
@@ -90,5 +179,31 @@ def test_gc_collect_still_reaps_throwaway_feature_groups_under_a_frozen_graph() 
 
 
 def test_conftest_unfreezes_the_graph_at_session_finish() -> None:
-    """gc.freeze() is only safe when paired with gc.unfreeze() before interpreter finalization."""
-    assert callable(getattr(tests_conftest, "pytest_sessionfinish", None)), _UNFREEZE_MISSING
+    """The hook pair is balanced: what pytest_collection_finish freezes, pytest_sessionfinish hands back."""
+    baseline, frozen, released = _freeze_counts(_PAIRED_HOOKS_PROBE.format(marker=_PROBE_MARKER))
+
+    assert frozen - baseline > MIN_FROZEN_GRAPH_OBJECTS, (
+        f"pytest_collection_finish moved {frozen - baseline} objects into the permanent generation "
+        f"(count {baseline} before, {frozen} after). {_FREEZE_MISSING}"
+    )
+    # Not `released == 0`: on CPython 3.12 the ~375 objects the interpreter seeds at startup come back into the
+    # permanent generation on the next full collection. Requiring the bulk back holds on 3.10 through 3.14.
+    assert released * 10 < frozen, (
+        f"pytest_sessionfinish left {released} of {frozen} objects frozen (count {baseline} before the freeze), "
+        f"so it did not release the graph it froze. {_UNFREEZE_MISSING}"
+    )
+
+
+@pytest.mark.parametrize("hooks", _HOST_HOOK_SEQUENCES, ids=_HOST_HOOK_IDS)
+def test_conftest_never_unfreezes_a_freeze_it_does_not_own(hooks: str) -> None:
+    """A freeze made before the suite ran survives pytest_sessionfinish, whether or not collection finished."""
+    host, remaining = _freeze_counts(_HOST_FREEZE_PROBE.format(hooks=hooks, marker=_PROBE_MARKER))
+
+    assert host > MIN_FROZEN_GRAPH_OBJECTS, (
+        f"Positive control failed: the host's own gc.freeze() left only {host} objects in the permanent "
+        f"generation, at or below the {MIN_FROZEN_GRAPH_OBJECTS} floor the conftest reads as an empty one, so "
+        "this probe no longer exercises the ownership path at all."
+    )
+    assert remaining >= host // 2, (
+        f"The host froze {host} objects and {remaining} are left after the conftest hooks ran. {_OWNERSHIP_VIOLATED}"
+    )


### PR DESCRIPTION
Closes #880.

## What was actually happening

CI did not grow to three minutes, it overran the step timeout by 40ms. The `python310` and `python314` jobs on main reported

```
python310: OK (179.95=setup[4.44]+cmd[142.14,0.13,0.10,0.00,0.34,0.31,18.50,14.00] seconds)
congratulations :) (180.04 seconds)
##[error]The action 'Run tox -e python310' has timed out after 3 minutes.
```

Every check green, then killed by `timeout-minutes: 3`. Only about 8 seconds of the job sits outside tox, so the whole problem is pytest: 142s of the 180s.

## Where the time went

Profiling every test by duration: **485 tests (6.6% of the suite) burned 68% of total test CPU time**, averaging 1.16s each against 39ms elsewhere. They are the modules whose autouse fixtures call `gc.collect()` to reap throwaway `FeatureGroup` subclasses. Ignoring just those 25 files took the suite from 179.55s to 59.90s.

The isolation is real and is kept. What costs is that each collect rescans the whole imported heap, roughly 278k tracked objects once pandas, polars, duckdb, pyarrow, sklearn and every plugin and test module are in: hundreds of milliseconds per collect, two to four collects per test. The tell that it is GC and not test work is that the same 485 tests cost 35s run alone and about 120s inside the full suite, so the cost tracks heap size rather than the tests.

## The change

`gc.freeze()` after collection has finished moves the already-imported graph into the permanent generation, so later collects never walk it. Collection finish is the moment: every test module is imported and no test has run yet. Classes created afterwards are still collectable, so the isolation the fixtures buy is unchanged.

Two independent A/Bs on the same machine, the only behavioural difference being the freeze:

| | unfrozen | frozen |
|---|---|---|
| full suite, `-n 8` | 179.55s | **55.16s** |
| full suite, `-n 4` | 206.4s | **77.5s** |
| one `gc.collect()`, suite collected | 377-600ms | ~0.0ms |
| peak RSS, `test_plugin_docs.py` | 332.1MB | 331.9MB |

In both A/Bs the unfrozen run's only failures were the new contract tests, which is the correct negative control: they are not vacuous. `tox -e python310` now finishes in 70.56s with 7379 passed and 170 skipped.

No test is excluded, no timeout is raised, no coverage is dropped, and memory is flat.

Verified on all five matrix interpreters (3.10 through 3.14) that a class created after the freeze is still reaped by a single `gc.collect()`. The surviving `get_all_subclasses(FeatureGroup)` universe across all the gc-using modules is byte-identical to the unfrozen run, 119 classes.

## Ownership, not a blanket unfreeze

`gc.unfreeze()` is process-global, so the paired unfreeze is gated on a flag recording that this process took the freeze. Without that, a host which froze its own graph and then ran the suite in-process via `pytest.main()` lost its whole permanent generation, reproduced going from 29968 frozen objects to 0. The xdist controller has the same shape: it never runs `pytest_collection_finish` but does run `pytest_sessionfinish`.

Ownership is decided against a floor of 1000 rather than a truthiness check, because **CPython 3.12 seeds the permanent generation with 375 objects at interpreter startup** while 3.10, 3.11, 3.13 and 3.14 seed none. Treating that seed as a host freeze would have silently disabled the optimization on 3.12 alone. A real freeze here is 57401 objects, so the floor sits 57x below it and 2.7x above the seed.

The unfreeze is load-bearing and the gate cannot see it fail: dropping it aborts the interpreter with `Fatal Python error: gilstate_tss_set: failed to set current tstate (TSS)`, which is exit 134 serially but **invisible under xdist**, where both workers abort and the run still exits 0. So the hook is `tryfirst` (a deeper conftest raising would otherwise skip it), and the contract test drives both hooks in a fresh interpreter and asserts the freeze is handed back, rather than only asserting a callable exists.

`MLODA_NO_GC_FREEZE` opts out, because freezing empties `gc.get_objects()` and hides frozen referrers, which would otherwise leave anyone debugging object retention in the suite with an unexplained empty heap.

## Not done on purpose

Raising `PYTEST_WORKERS` above 2. The `modes2` and multiprocessing tests spawn their own subprocesses on top of the xdist workers, and under CPU oversubscription they hit the 10s per-test timeout. More workers would buy wall time and pay for it in flakes.

## Reviews

Reviewed independently by two deep reviews before raising. Both are reflected above: the process-global unfreeze, the tryfirst ordering, the structural-versus-behavioural unfreeze assertion, a vacuity path in the reap test's positive control, and the `gc.get_objects()` blindness.