### PR TITLE
docs: record that the two declaration surfaces are protocol-driven and provisional

### DIFF
--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -156,6 +156,16 @@ That silence is a property of match-time consumption, not an oversight, and it i
 not declared as `PropertySpec`s: a spec would promise enforcement that could never fire, because
 selection is over before the framework touches the options.
 
+More precisely, selection has no rejection channel. `PropertySpec` enforcement means "reject this
+candidate and record why", but `feature_scope_data_access` tests `if matched_data_access:`, so a
+reader returns a data access or something falsy, and falsy already means "this reader does not handle
+this input". An invalid option value is therefore indistinguishable from the wrong reader, and
+raising is not an alternative: only `NotImplementedError` is a soft no-match, anything else aborts
+matching for every reader sharing the `DataAccessCollection`. So the split is protocol-driven and
+provisional. If reader selection gains a candidate-and-rejection model comparable to resolution's
+([#727](https://github.com/mloda-ai/mloda/issues/727)), the two types should collapse back into one
+`PropertySpec`.
+
 ### A pattern-less feature group sits in between
 
 A `FeatureGroup` that declares no `PREFIX_PATTERN` or `SUFFIX_PATTERN` (`ConcatenatedFileContent` is


### PR DESCRIPTION
Follow-up to #893, which merged without this last commit.

#893 introduced a second option-key declaration surface, `ReaderOptionSpec` in `READER_OPTIONS` on a `BaseInputData` reader, alongside `PropertySpec` in `PROPERTY_MAPPING` on a `FeatureGroup`. The docs explained that reader keys are consumed before the framework materializes anything, but not the sharper reason the two cannot be one type, nor that the split is expected to be temporary.

Adds both to the "Two declaration surfaces" section:

- Selection has no rejection channel. `PropertySpec` enforcement means "reject this candidate and record why", but `feature_scope_data_access` tests `if matched_data_access:`, so a reader returns a data access or something falsy, and falsy already means "this reader does not handle this input". An invalid option value is indistinguishable from the wrong reader, and raising is not an alternative since only `NotImplementedError` is a soft no-match; anything else aborts matching for every reader sharing the `DataAccessCollection`.
- The split is therefore protocol-driven and provisional: if reader selection gains a candidate-and-rejection model comparable to resolution`s (#727), the two types should collapse back into one `PropertySpec`.

The matching collapse condition is recorded on #727 as https://github.com/mloda-ai/mloda/issues/727#issuecomment-5133191834, so the decision is not stranded in a merged PR thread. Worth landing before the 0.11.0 cut makes both types public, since collapsing afterwards is a breaking change.

Docs only, no code. `tests/test_documentation` passes (113).