### PR TITLE
chore(ci): run the version-independent static gate once per CI run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,7 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         toxenv: ["-e core", "-e installed"]
+        # The python310 entry is the one that also runs the version-independent static gate (ruff, licenses, bandit).
         include:
           - python-version: "3.10"
             toxenv: "-e python310"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,7 @@ source .venv/bin/activate
 - **Python**: supported range is `>=3.10,<3.15`; CI matrixes 3.10, 3.11, 3.12, 3.13, 3.14.
 - **Type hints**: use modern forms (`list[str]`, `dict[str, int]`, `X | None`). Ruff enforces this via `UP006` and `UP007`.
 - **Formatting**: ruff format with line length 120.
+- **Static gate placement**: `ruff`, the `pip-licenses` checks and `bandit` are version-independent and run only in the default `python310` tox env, so CI pays for them once; `pytest` and `mypy` run per version, and `tox -e python312` alone therefore skips the static checks.
 - **Tests**: every new feature or bug fix must come with tests; follow the patterns in the existing `tests/` tree. Tests must be parallel-safe (pytest-xdist) and finish under the 10-second timeout. The default tox env asserts `EXPECTED_SKIP_COUNT=170`; if a test you add is skipped, update the count or unskip it.
 - **Supply chain**: `[tool.uv] exclude-newer = "7 days"` in `pyproject.toml` defers new dependency releases by 7 days. Do not edit this without a reason.
 - **Licenses**: dependencies must satisfy the allowlist in `tox.ini` (Apache-2.0, BSD, MIT, MPL-2.0, PSF, ISC, LGPLv2+). Adding a dependency with a non-listed license fails tox.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,16 +74,16 @@ source .venv/bin/activate
 
 ## Project Practices
 
-`tox` is the gate. It runs `pytest -n 8 --timeout=10`, then `ruff format --check`, `ruff check`, a `pip-licenses` allowlist check, `mypy --strict --ignore-missing-imports`, and `bandit`. All of these must pass before a PR is mergeable.
+`tox` is the gate. It runs `ruff format --check`, `ruff check`, a `pip-licenses` allowlist check, `pytest -n 8 --timeout=10`, `mypy --strict --ignore-missing-imports`, and `bandit`. All of these must pass before a PR is mergeable.
 
 - **Python**: supported range is `>=3.10,<3.15`; CI matrixes 3.10, 3.11, 3.12, 3.13, 3.14.
 - **Type hints**: use modern forms (`list[str]`, `dict[str, int]`, `X | None`). Ruff enforces this via `UP006` and `UP007`.
 - **Formatting**: ruff format with line length 120.
-- **Static gate placement**: `ruff`, the `pip-licenses` checks and `bandit` are version-independent and run only in the default `python310` tox env, so CI pays for them once; `pytest` and `mypy` run per version, and `tox -e python312` alone therefore skips the static checks.
+- **Static gate placement**: `ruff`, `bandit` and the two `pip-licenses` file writers are version-independent and run only in the default `python310` tox env, so CI pays for them once; `pytest`, `mypy` and the `pip-licenses` allowlist check run per version because the installed dependency set differs per interpreter. `tox -e python312` alone therefore skips ruff, bandit and the license-file writers.
 - **Tests**: every new feature or bug fix must come with tests; follow the patterns in the existing `tests/` tree. Tests must be parallel-safe (pytest-xdist) and finish under the 10-second timeout. The default tox env asserts `EXPECTED_SKIP_COUNT=170`; if a test you add is skipped, update the count or unskip it.
 - **Supply chain**: `[tool.uv] exclude-newer = "7 days"` in `pyproject.toml` defers new dependency releases by 7 days. Do not edit this without a reason.
 - **Licenses**: dependencies must satisfy the allowlist in `tox.ini` (Apache-2.0, BSD, MIT, MPL-2.0, PSF, ISC, LGPLv2+). Adding a dependency with a non-listed license fails tox.
-- **`attribution/ATTRIBUTION.md`**: `tox` regenerates this file from the installed dependency versions on every run, so a dependency change shows up as a diff here. This is intended: commit the update as part of the same change so the tracked file stays current. The release workflow does not regenerate it; it ships the committed copy, so keeping it up to date in PRs is what keeps releases accurate.
+- **`attribution/ATTRIBUTION.md`**: `tox` regenerates this file from the installed dependency versions in the default env only, so a dependency change shows up as a diff here. This is intended: commit the update as part of the same change so the tracked file stays current. The release workflow does not regenerate it; it ships the committed copy, so keeping it up to date in PRs is what keeps releases accurate.
 - **Commits**: use [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, `docs:`, `test:`, `refactor:`, `minor:`). semantic-release computes the next version. This project deviates from the standard: the minor version (middle number) bumps only on `minor:` commits; `feat:` is treated as a patch bump.
 
 ## Issue Creation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,16 +75,16 @@ source .venv/bin/activate
 
 ## Project Practices
 
-`tox` is the gate. It runs `pytest -n 8 --timeout=10`, then `ruff format --check`, `ruff check`, a `pip-licenses` allowlist check, `mypy --strict --ignore-missing-imports`, and `bandit`. All of these must pass before a PR is mergeable.
+`tox` is the gate. It runs `ruff format --check`, `ruff check`, a `pip-licenses` allowlist check, `pytest -n 8 --timeout=10`, `mypy --strict --ignore-missing-imports`, and `bandit`. All of these must pass before a PR is mergeable.
 
 - **Python**: supported range is `>=3.10,<3.15`; CI matrixes 3.10, 3.11, 3.12, 3.13, 3.14.
 - **Type hints**: use modern forms (`list[str]`, `dict[str, int]`, `X | None`). Ruff enforces this via `UP006` and `UP007`.
 - **Formatting**: ruff format with line length 120.
-- **Static gate placement**: `ruff`, the `pip-licenses` checks and `bandit` are version-independent and run only in the default `python310` tox env, so CI pays for them once; `pytest` and `mypy` run per version, and `tox -e python312` alone therefore skips the static checks.
+- **Static gate placement**: `ruff`, `bandit` and the two `pip-licenses` file writers are version-independent and run only in the default `python310` tox env, so CI pays for them once; `pytest`, `mypy` and the `pip-licenses` allowlist check run per version because the installed dependency set differs per interpreter. `tox -e python312` alone therefore skips ruff, bandit and the license-file writers.
 - **Tests**: every new feature or bug fix must come with tests; follow the patterns in the existing `tests/` tree. Tests must be parallel-safe (pytest-xdist) and finish under the 10-second timeout. The default tox env asserts `EXPECTED_SKIP_COUNT=170`; if a test you add is skipped, update the count or unskip it.
 - **Supply chain**: `[tool.uv] exclude-newer = "7 days"` in `pyproject.toml` defers new dependency releases by 7 days. Do not edit this without a reason.
 - **Licenses**: dependencies must satisfy the allowlist in `tox.ini` (Apache-2.0, BSD, MIT, MPL-2.0, PSF, ISC, LGPLv2+). Adding a dependency with a non-listed license fails tox.
-- **`attribution/ATTRIBUTION.md`**: `tox` regenerates this file from the installed dependency versions on every run, so a dependency change shows up as a diff here. This is intended: commit the update as part of the same change so the tracked file stays current. The release workflow does not regenerate it; it ships the committed copy, so keeping it up to date in PRs is what keeps releases accurate.
+- **`attribution/ATTRIBUTION.md`**: `tox` regenerates this file from the installed dependency versions in the default env only, so a dependency change shows up as a diff here. This is intended: commit the update as part of the same change so the tracked file stays current. The release workflow does not regenerate it; it ships the committed copy, so keeping it up to date in PRs is what keeps releases accurate.
 - **Commits**: use [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, `docs:`, `test:`, `refactor:`, `minor:`). semantic-release computes the next version. This project deviates from the standard: the minor version (middle number) bumps only on `minor:` commits; `feat:` is treated as a patch bump.
 
 ### mypy iteration notes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,7 @@ source .venv/bin/activate
 - **Python**: supported range is `>=3.10,<3.15`; CI matrixes 3.10, 3.11, 3.12, 3.13, 3.14.
 - **Type hints**: use modern forms (`list[str]`, `dict[str, int]`, `X | None`). Ruff enforces this via `UP006` and `UP007`.
 - **Formatting**: ruff format with line length 120.
+- **Static gate placement**: `ruff`, the `pip-licenses` checks and `bandit` are version-independent and run only in the default `python310` tox env, so CI pays for them once; `pytest` and `mypy` run per version, and `tox -e python312` alone therefore skips the static checks.
 - **Tests**: every new feature or bug fix must come with tests; follow the patterns in the existing `tests/` tree. Tests must be parallel-safe (pytest-xdist) and finish under the 10-second timeout. The default tox env asserts `EXPECTED_SKIP_COUNT=170`; if a test you add is skipped, update the count or unskip it.
 - **Supply chain**: `[tool.uv] exclude-newer = "7 days"` in `pyproject.toml` defers new dependency releases by 7 days. Do not edit this without a reason.
 - **Licenses**: dependencies must satisfy the allowlist in `tox.ini` (Apache-2.0, BSD, MIT, MPL-2.0, PSF, ISC, LGPLv2+). Adding a dependency with a non-listed license fails tox.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,8 @@ Run the full suite (linting, formatting, type checking, security, and tests). Al
 tox
 ```
 
+Plain `tox` runs the complete gate, while `tox -e python312` and the other per-version envs run only that interpreter's tests, type checking and license allowlist check.
+
 For quick iteration during development, you can run only the tests. Note that this skips linting, type checking, and security checks, so it is not a substitute for tox:
 
 ```bash
@@ -124,7 +126,7 @@ git checkout -b fix/short-description
 3. Make your changes and ensure `tox` passes locally.
 4. Commit using [Conventional Commits](https://www.conventionalcommits.org/) format.
 5. Push your branch to your fork and open a pull request targeting `main`.
-6. CI runs the full tox suite on Python 3.10, 3.11, 3.12, 3.13, and 3.14. All checks must pass before merge.
+6. CI runs tests, type checking and the license allowlist on Python 3.10, 3.11, 3.12, 3.13, and 3.14; formatting, linting and the security scan run once, in the 3.10 job. All checks must pass before merge.
 
 ## License
 

--- a/tests/test_static_gate_once_per_ci.py
+++ b/tests/test_static_gate_once_per_ci.py
@@ -1,0 +1,169 @@
+"""The version-independent half of the tox gate must cost one CI job, not one per interpreter."""
+
+import configparser
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+TOX_INI = PROJECT_ROOT / "tox.ini"
+CI_YAML = PROJECT_ROOT / ".github" / "workflows" / "ci.yaml"
+
+# Checks whose verdict cannot differ between interpreters: the CI matrix should pay for them once.
+VERSION_INDEPENDENT_CHECKS = ("ruff format", "ruff check", "pip-licenses", "bandit")
+# Checks that resolve differently per interpreter and must therefore run in every python3XX env.
+VERSION_DEPENDENT_CHECKS = ("pytest", "mypy")
+
+# A tox factor prefix, e.g. `python310: ruff check .`. Command bodies contain colons inside quoted shell
+# strings, so only a bare identifier plus colon at the very start of a line counts.
+FACTOR_PREFIX = re.compile(r"^(?P<factor>[A-Za-z0-9_][A-Za-z0-9_.,!-]*):\s*(?P<command>\S.*)$")
+
+NO_GATE_FACTOR = (
+    "The version-independent [testenv] commands do not share one tox factor prefix, so no single env owns "
+    "the static gate (see test_version_independent_checks_share_one_factor)."
+)
+
+
+def _tox_config() -> configparser.ConfigParser:
+    config = configparser.ConfigParser(interpolation=None)
+    config.read_string(TOX_INI.read_text(encoding="utf-8"))
+    return config
+
+
+def _envlist() -> list[str]:
+    """tox's default envs; the value carries a trailing `#` comment listing the ones CI adds."""
+    raw = _tox_config()["tox"]["envlist"].split("#", 1)[0]
+    return [env for env in re.split(r"[,\s]+", raw) if env]
+
+
+def _testenv_commands() -> list[str]:
+    """The `commands` lines of the default [testenv], without blank and comment lines."""
+    lines = [line.strip() for line in _tox_config()["testenv"]["commands"].splitlines()]
+    return [line for line in lines if line and not line.startswith("#")]
+
+
+def _factor_of(command: str) -> str | None:
+    match = FACTOR_PREFIX.match(command)
+    return match.group("factor") if match else None
+
+
+def _body_of(command: str) -> str:
+    match = FACTOR_PREFIX.match(command)
+    return match.group("command") if match else command
+
+
+def _commands_running(check: str) -> list[str]:
+    return [command for command in _testenv_commands() if check in _body_of(command)]
+
+
+def _version_independent_commands() -> list[str]:
+    """One command can run several checks (the pip-licenses lines), so walk the list once."""
+    return [
+        command
+        for command in _testenv_commands()
+        if any(check in _body_of(command) for check in VERSION_INDEPENDENT_CHECKS)
+    ]
+
+
+def _gate_factor() -> str | None:
+    """The one factor guarding the version-independent commands, or None if they disagree or are ungated."""
+    factors = {_factor_of(command) for command in _version_independent_commands()}
+    return factors.pop() if len(factors) == 1 else None
+
+
+def _short(command: str) -> str:
+    return command if len(command) <= 70 else f"{command[:70]}..."
+
+
+def _build_matrix() -> dict[str, Any]:
+    config: dict[Any, Any] = yaml.safe_load(CI_YAML.read_text(encoding="utf-8"))
+    matrix: dict[str, Any] = config["jobs"]["build"]["strategy"]["matrix"]
+    return matrix
+
+
+def _matrix_python_versions() -> list[str]:
+    return [str(version) for version in _build_matrix()["python-version"]]
+
+
+def _env_name(toxenv: str) -> str:
+    """`-e python310` -> `python310`."""
+    return toxenv.removeprefix("-e").strip()
+
+
+def _matrix_entries() -> list[tuple[str, str]]:
+    """(python version, tox env) for every job the build matrix expands to: base product plus includes."""
+    matrix = _build_matrix()
+    base: list[str] = [_env_name(str(toxenv)) for toxenv in matrix.get("toxenv", [])]
+    entries: list[tuple[str, str]] = [(version, env) for version in _matrix_python_versions() for env in base]
+    entries += [
+        (str(item["python-version"]), _env_name(str(item["toxenv"])))
+        for item in matrix.get("include", [])
+        if "python-version" in item and "toxenv" in item
+    ]
+    return entries
+
+
+@pytest.mark.parametrize("check", VERSION_INDEPENDENT_CHECKS)
+def test_version_independent_check_is_factor_gated(check: str) -> None:
+    commands = _commands_running(check)
+    assert commands, f"No [testenv] command runs {check!r} any more. Retarget this guard or drop the check."
+    unguarded = [command for command in commands if _factor_of(command) is None]
+    assert not unguarded, (
+        f"[testenv] command {_short(unguarded[0])!r} runs {check!r} in every python3XX env, but its verdict "
+        "cannot differ between interpreters. Prefix it with a tox factor (e.g. `python310: ...`) so the CI "
+        "matrix runs it once."
+    )
+
+
+@pytest.mark.parametrize("check", VERSION_DEPENDENT_CHECKS)
+def test_version_dependent_check_runs_in_every_env(check: str) -> None:
+    commands = _commands_running(check)
+    assert commands, f"No [testenv] command runs {check!r} any more. Retarget this guard or drop the check."
+    gated = [command for command in commands if _factor_of(command) is not None]
+    assert not gated, (
+        f"[testenv] command {_short(gated[0])!r} is gated on factor {_factor_of(gated[0])!r}, but {check!r} is "
+        "version-dependent: it must keep running on every interpreter in the matrix. Only version-independent "
+        "checks may carry a factor prefix."
+    )
+
+
+def test_version_independent_checks_share_one_factor() -> None:
+    factors = {_factor_of(command) for command in _version_independent_commands()}
+    assert len(factors) == 1 and None not in factors, (
+        "The version-independent checks must all carry the same tox factor prefix, otherwise the static gate is "
+        f"split across matrix jobs. Factors found (None = ungated): {sorted(str(factor) for factor in factors)}."
+    )
+
+
+def test_gate_factor_is_a_default_env() -> None:
+    factor = _gate_factor()
+    assert factor is not None, NO_GATE_FACTOR
+    envlist = _envlist()
+    assert factor in envlist, (
+        f"The static gate is bound to factor {factor!r}, which is not in [tox] envlist {envlist}. Plain `tox` and "
+        "the release workflow's `tox -e <default env>` would then skip ruff, bandit and the license checks."
+    )
+
+
+def test_gate_env_runs_in_exactly_one_matrix_entry() -> None:
+    factor = _gate_factor()
+    assert factor is not None, NO_GATE_FACTOR
+    versions = [version for version, env in _matrix_entries() if env == factor]
+    assert len(versions) == 1, (
+        f"The CI build matrix runs tox env {factor!r} in {len(versions)} jobs {versions}, so the static gate "
+        "executes that many times per CI run. Exactly one matrix entry must carry it."
+    )
+
+
+def test_matrix_keeps_one_versioned_env_per_python_version() -> None:
+    entries = _matrix_entries()
+    for version in _matrix_python_versions():
+        env = "python" + version.replace(".", "")
+        assert [v for v, e in entries if e == env] == [version], (
+            f"The CI build matrix must run tox env {env!r} exactly once, on Python {version}. Binding the static "
+            "gate to one env must not shrink the per-interpreter pytest and mypy coverage."
+        )

--- a/tests/test_static_gate_once_per_ci.py
+++ b/tests/test_static_gate_once_per_ci.py
@@ -2,6 +2,7 @@
 
 import configparser
 import re
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
@@ -12,15 +13,35 @@ import yaml
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 TOX_INI = PROJECT_ROOT / "tox.ini"
 CI_YAML = PROJECT_ROOT / ".github" / "workflows" / "ci.yaml"
+RELEASE_YAML = PROJECT_ROOT / ".github" / "workflows" / "release.yaml"
 
-# Checks whose verdict cannot differ between interpreters: the CI matrix should pay for them once.
-VERSION_INDEPENDENT_CHECKS = ("ruff format", "ruff check", "pip-licenses", "bandit")
-# Checks that resolve differently per interpreter and must therefore run in every python3XX env.
-VERSION_DEPENDENT_CHECKS = ("pytest", "mypy")
+# Checks whose verdict cannot differ between interpreters: the CI matrix should pay for them once. The two
+# pip-licenses writers belong here because nothing consumes their output per interpreter: the files are read
+# from the default env only (a contributor's `tox`, and the release workflow's `tox -e <gate env>`).
+VERSION_INDEPENDENT_CHECKS = ("ruff format", "ruff check", "bandit", "THIRD_PARTY_LICENSES", "ATTRIBUTION")
+# Checks that resolve differently per interpreter and must therefore run in every python3XX env. The
+# pip-licenses allowlist (`--allow-only`) inspects the *installed* distributions, and `runner =
+# uv-venv-lock-runner` installs a different set per interpreter (pandas 2.3.3 on 3.10 vs 3.0.3 on >=3.11,
+# psutil only on >=3.11, tomli only on 3.10), so gating it would leave 3.11-3.14 license-unchecked.
+VERSION_DEPENDENT_CHECKS = ("pytest", "mypy", "--allow-only")
 
-# A tox factor prefix, e.g. `python310: ruff check .`. Command bodies contain colons inside quoted shell
-# strings, so only a bare identifier plus colon at the very start of a line counts.
-FACTOR_PREFIX = re.compile(r"^(?P<factor>[A-Za-z0-9_][A-Za-z0-9_.,!-]*):\s*(?P<command>\S.*)$")
+# tox splits a factor prefix off a `commands` line at the first `:` followed by whitespace or the line end,
+# wherever it sits on the line (tox/config/loader/ini/factor.py::expand_factors). Negation (`!python310:`)
+# and brace groups (`{python311,python312}:`) are part of that prefix, so any whitespace-free text in front
+# of such a colon gates the command and must not be mistaken for the command itself.
+FACTOR_SEPARATOR = re.compile(r":(?=\s|$)")
+
+# The gate factor doubles as an env name in the CI matrix and the release workflow, so the guards below only
+# reason correctly about a single bare env: no negation, no brace group, no comma list.
+PLAIN_ENV_NAME = re.compile(r"[A-Za-z0-9_][A-Za-z0-9_.-]*")
+
+# tox drops (`-`) or inverts (`!`) the exit code of a command whose first token is that character.
+EXIT_CODE_OPT_OUTS = ("-", "!")
+
+# Defining any of these in `[testenv:<env>]` replaces the base `[testenv]` list wholesale.
+COMMAND_KEYS = ("commands", "commands_pre", "commands_post")
+
+TOX_ENV_INVOCATION = re.compile(r"\btox\b[^\n]*?\s-e[=\s]+(?P<env>[\w.-]+)")
 
 NO_GATE_FACTOR = (
     "The version-independent [testenv] commands do not share one tox factor prefix, so no single env owns "
@@ -35,9 +56,11 @@ def _tox_config() -> configparser.ConfigParser:
 
 
 def _envlist() -> list[str]:
-    """tox's default envs; the value carries a trailing `#` comment listing the ones CI adds."""
-    raw = _tox_config()["tox"]["envlist"].split("#", 1)[0]
-    return [env for env in re.split(r"[,\s]+", raw) if env]
+    """tox's default envs. `env_list` is tox 4's spelling; either key may carry per-line `#` comments."""
+    section = _tox_config()["tox"]
+    raw = next((section[key] for key in ("envlist", "env_list") if key in section), "")
+    uncommented = " ".join(line.split("#", 1)[0] for line in raw.splitlines())
+    return [env for env in re.split(r"[,\s]+", uncommented) if env]
 
 
 def _testenv_commands() -> list[str]:
@@ -46,14 +69,23 @@ def _testenv_commands() -> list[str]:
     return [line for line in lines if line and not line.startswith("#")]
 
 
+def _split_command(command: str) -> tuple[str | None, str]:
+    """(factor prefix, command body), read the way tox reads a `commands` line."""
+    marker = FACTOR_SEPARATOR.search(command)
+    if marker is None:
+        return None, command
+    candidate = command[: marker.start()].strip()
+    if not candidate or any(char.isspace() for char in candidate):
+        return None, command
+    return candidate, command[marker.end() :].strip()
+
+
 def _factor_of(command: str) -> str | None:
-    match = FACTOR_PREFIX.match(command)
-    return match.group("factor") if match else None
+    return _split_command(command)[0]
 
 
 def _body_of(command: str) -> str:
-    match = FACTOR_PREFIX.match(command)
-    return match.group("command") if match else command
+    return _split_command(command)[1]
 
 
 def _commands_running(check: str) -> list[str]:
@@ -73,6 +105,16 @@ def _gate_factor() -> str | None:
     """The one factor guarding the version-independent commands, or None if they disagree or are ungated."""
     factors = {_factor_of(command) for command in _version_independent_commands()}
     return factors.pop() if len(factors) == 1 else None
+
+
+def _env_section_keys(env: str) -> list[str]:
+    """The option names of `[testenv:<env>]` (the section name may be spelled with spaces), else []."""
+    config = _tox_config()
+    for name in config.sections():
+        head, separator, tail = name.partition(":")
+        if separator and head.strip() == "testenv" and tail.strip() == env:
+            return list(config[name])
+    return []
 
 
 def _short(command: str) -> str:
@@ -107,35 +149,70 @@ def _matrix_entries() -> list[tuple[str, str]]:
     return entries
 
 
+def _run_scripts(workflow: Path) -> Iterator[str]:
+    """Every `run:` script of a workflow, wherever it sits in the job/step tree."""
+
+    def walk(node: Any) -> Iterator[str]:
+        if isinstance(node, dict):
+            script = node.get("run")
+            if isinstance(script, str):
+                yield script
+            for value in node.values():
+                yield from walk(value)
+        elif isinstance(node, list):
+            for item in node:
+                yield from walk(item)
+
+    yield from walk(yaml.safe_load(workflow.read_text(encoding="utf-8")))
+
+
+def _release_tox_envs() -> list[str]:
+    envs = {
+        match.group("env") for script in _run_scripts(RELEASE_YAML) for match in TOX_ENV_INVOCATION.finditer(script)
+    }
+    return sorted(envs)
+
+
 @pytest.mark.parametrize("check", VERSION_INDEPENDENT_CHECKS)
 def test_version_independent_check_is_factor_gated(check: str) -> None:
     commands = _commands_running(check)
-    assert commands, f"No [testenv] command runs {check!r} any more. Retarget this guard or drop the check."
+    assert commands, f"No [testenv] command in {TOX_INI} mentions {check!r} any more. Retarget or drop this guard."
     unguarded = [command for command in commands if _factor_of(command) is None]
     assert not unguarded, (
-        f"[testenv] command {_short(unguarded[0])!r} runs {check!r} in every python3XX env, but its verdict "
-        "cannot differ between interpreters. Prefix it with a tox factor (e.g. `python310: ...`) so the CI "
-        "matrix runs it once."
+        f"{TOX_INI}: [testenv] command {_short(unguarded[0])!r} runs {check!r} in every python3XX env, but its "
+        "verdict cannot differ between interpreters. Prefix it with a tox factor (e.g. `python310: ...`) so the "
+        "CI matrix runs it once."
     )
 
 
 @pytest.mark.parametrize("check", VERSION_DEPENDENT_CHECKS)
 def test_version_dependent_check_runs_in_every_env(check: str) -> None:
     commands = _commands_running(check)
-    assert commands, f"No [testenv] command runs {check!r} any more. Retarget this guard or drop the check."
+    assert commands, f"No [testenv] command in {TOX_INI} mentions {check!r} any more. Retarget or drop this guard."
     gated = [command for command in commands if _factor_of(command) is not None]
     assert not gated, (
-        f"[testenv] command {_short(gated[0])!r} is gated on factor {_factor_of(gated[0])!r}, but {check!r} is "
-        "version-dependent: it must keep running on every interpreter in the matrix. Only version-independent "
-        "checks may carry a factor prefix."
+        f"{TOX_INI}: [testenv] command {_short(gated[0])!r} is gated on factor {_factor_of(gated[0])!r}, but "
+        f"{check!r} is version-dependent: `runner = uv-venv-lock-runner` installs a different distribution set "
+        "per interpreter, so it must keep running on every env in the matrix. Drop the factor prefix."
     )
 
 
 def test_version_independent_checks_share_one_factor() -> None:
     factors = {_factor_of(command) for command in _version_independent_commands()}
     assert len(factors) == 1 and None not in factors, (
-        "The version-independent checks must all carry the same tox factor prefix, otherwise the static gate is "
-        f"split across matrix jobs. Factors found (None = ungated): {sorted(str(factor) for factor in factors)}."
+        f"{TOX_INI}: the version-independent checks must all carry the same tox factor prefix, otherwise the "
+        "static gate is split across matrix jobs. Factors found (None = ungated): "
+        f"{sorted(str(factor) for factor in factors)}."
+    )
+
+
+def test_gate_factor_is_a_plain_env_name() -> None:
+    factor = _gate_factor()
+    assert factor is not None, NO_GATE_FACTOR
+    assert PLAIN_ENV_NAME.fullmatch(factor), (
+        f"{TOX_INI}: the static gate is bound to factor expression {factor!r}. A negation (`!env:`), a brace "
+        "group (`{env1,env2}:`) or a comma list selects a varying number of envs, so the gate would run zero or "
+        "many times. Use one bare env name."
     )
 
 
@@ -144,8 +221,44 @@ def test_gate_factor_is_a_default_env() -> None:
     assert factor is not None, NO_GATE_FACTOR
     envlist = _envlist()
     assert factor in envlist, (
-        f"The static gate is bound to factor {factor!r}, which is not in [tox] envlist {envlist}. Plain `tox` and "
-        "the release workflow's `tox -e <default env>` would then skip ruff, bandit and the license checks."
+        f"{TOX_INI}: the static gate is bound to factor {factor!r}, which is not in [tox] envlist {envlist}. Plain "
+        "`tox` and the release workflow's `tox -e <default env>` would then skip ruff, bandit and the license "
+        f"writers. Add {factor!r} to envlist."
+    )
+
+
+def test_no_env_section_redefines_the_gate_commands() -> None:
+    factor = _gate_factor()
+    assert factor is not None, NO_GATE_FACTOR
+    keys = _env_section_keys(factor)
+    overrides = [key for key in COMMAND_KEYS if key in keys]
+    assert not overrides, (
+        f"{TOX_INI}: section [testenv:{factor}] defines {overrides}, which replaces the [testenv] command list "
+        f"wholesale. Ruff, bandit and the license writers would vanish from plain `tox`, from `tox -e {factor}` "
+        f"and from the release workflow, with every other guard still green. Keep [testenv:{factor}] to settings "
+        "such as basepython and leave the commands in [testenv]."
+    )
+
+
+def test_gated_commands_do_not_ignore_their_exit_code() -> None:
+    offenders = [
+        command for command in _version_independent_commands() if _body_of(command).startswith(EXIT_CODE_OPT_OUTS)
+    ]
+    assert not offenders, (
+        f"{TOX_INI}: [testenv] command {_short(offenders[0])!r} starts with `-` or `!`, which makes tox ignore or "
+        "invert its exit code. The one job that owns the static gate would then report success no matter what "
+        "ruff, bandit or pip-licenses find. Drop the leading token."
+    )
+
+
+def test_release_workflow_runs_the_gate_env() -> None:
+    factor = _gate_factor()
+    assert factor is not None, NO_GATE_FACTOR
+    envs = _release_tox_envs()
+    assert envs == [factor], (
+        f"{RELEASE_YAML} invokes tox env(s) {envs}, while {TOX_INI} binds the static gate to factor {factor!r}. "
+        "That release step generates attribution/THIRD_PARTY_LICENSES.md from the gate env and fails the release "
+        f"if the file is missing, so it must run `tox -e {factor}`."
     )
 
 
@@ -154,8 +267,8 @@ def test_gate_env_runs_in_exactly_one_matrix_entry() -> None:
     assert factor is not None, NO_GATE_FACTOR
     versions = [version for version, env in _matrix_entries() if env == factor]
     assert len(versions) == 1, (
-        f"The CI build matrix runs tox env {factor!r} in {len(versions)} jobs {versions}, so the static gate "
-        "executes that many times per CI run. Exactly one matrix entry must carry it."
+        f"{CI_YAML}: the build matrix runs tox env {factor!r} in {len(versions)} jobs {versions}, so the static "
+        "gate executes that many times per CI run. Exactly one matrix entry must carry it."
     )
 
 
@@ -164,6 +277,7 @@ def test_matrix_keeps_one_versioned_env_per_python_version() -> None:
     for version in _matrix_python_versions():
         env = "python" + version.replace(".", "")
         assert [v for v, e in entries if e == env] == [version], (
-            f"The CI build matrix must run tox env {env!r} exactly once, on Python {version}. Binding the static "
-            "gate to one env must not shrink the per-interpreter pytest and mypy coverage."
+            f"{CI_YAML}: the build matrix must run tox env {env!r} exactly once, on Python {version}. Binding the "
+            "static gate to one env must not shrink the per-interpreter pytest, mypy and license-allowlist "
+            "coverage."
         )

--- a/tox.ini
+++ b/tox.ini
@@ -35,14 +35,15 @@ setenv =
     CHECK_SKIP_COUNT = {env:CHECK_SKIP_COUNT:1}
     TOX_LOCK_PATH = {env:TOX_LOCK_PATH:/tmp/mloda-tox.lock}
     MLODA_PLUGIN_REGISTRY_STRICT = {env:MLODA_PLUGIN_REGISTRY_STRICT:warn}
-# The `python310:` commands are version-independent, so they are bound to the default env and the CI matrix
-# pays for them once; plain `tox` and `tox -e python310` (used by the release workflow) still run the full gate.
-commands = sh -c "set -- pytest -n {env:PYTEST_WORKERS:8} --timeout=10 -m 'not notebooks' {env:DEACTIVATE_NOTEBOOK_AND_DOC_TESTS:--ignore=tests/test_documentation}; if [ -n \"$TOX_LOCK_PATH\" ] && command -v flock >/dev/null 2>&1; then [ -e \"$TOX_LOCK_PATH\" ] || (umask 0 && : > \"$TOX_LOCK_PATH\") 2>/dev/null; if [ -w \"$TOX_LOCK_PATH\" ]; then exec flock \"$TOX_LOCK_PATH\" \"$@\"; fi; fi; exec \"$@\""
-           python310: ruff format --check --line-length 120 .
+# The `python310:` commands are version-independent, so CI pays for them once; plain `tox` and `tox -e python310`
+# (release workflow) still run everything. The allowlist check stays ungated because it inspects the per-interpreter
+# installed set. tox reads a whitespace-free token before `: ` as a factor, so no command may start with word+colon.
+commands = python310: ruff format --check --line-length 120 .
            python310: ruff check --line-length 120 .
            python310: sh -c "if [ \"$WRITE_THIRD_PARTY_LICENSES\" = \"true\" ]; then pip-licenses --format=plain-vertical --with-urls --with-license-file | sed '/\/home\//d' > attribution/THIRD_PARTY_LICENSES.md; fi"
            python310: sh -c "if [ -z \"${NO_WRITE_ATTRIBUTION_MD}\" ]; then pip-licenses --format=markdown > attribution/ATTRIBUTION.md; fi"
-           python310: sh -c "pip-licenses --ignore-packages matplotlib-inline --allow-only='MPL-2.0 AND MIT; Apache-2.0 AND BSD-2-Clause; Apache-2.0 OR BSD-2-Clause; Apache-2.0 AND CNRI-Python; BSD-3-Clause AND 0BSD AND MIT AND Zlib AND CC0-1.0; 3-Clause BSD License;BSD-2-Clause;BSD-3-Clause;Apache-2.0;Apache Software License;MIT;The Unlicense (Unlicense);PSF-2.0;MIT License;Python Software Foundation License;BSD License;GNU Lesser General Public License v2 or later (LGPLv2+);ISC License (ISCL);ISC;Mozilla Public License 2.0 (MPL 2.0);Apache License, Version 2.0;Apache 2.0;Apache Software License 2.0;' > /dev/null"
+           sh -c "pip-licenses --ignore-packages matplotlib-inline --allow-only='MPL-2.0 AND MIT; Apache-2.0 AND BSD-2-Clause; Apache-2.0 OR BSD-2-Clause; Apache-2.0 AND CNRI-Python; BSD-3-Clause AND 0BSD AND MIT AND Zlib AND CC0-1.0; 3-Clause BSD License;BSD-2-Clause;BSD-3-Clause;Apache-2.0;Apache Software License;MIT;The Unlicense (Unlicense);PSF-2.0;MIT License;Python Software Foundation License;BSD License;GNU Lesser General Public License v2 or later (LGPLv2+);ISC License (ISCL);ISC;Mozilla Public License 2.0 (MPL 2.0);Apache License, Version 2.0;Apache 2.0;Apache Software License 2.0;' > /dev/null"
+           sh -c "set -- pytest -n {env:PYTEST_WORKERS:8} --timeout=10 -m 'not notebooks' {env:DEACTIVATE_NOTEBOOK_AND_DOC_TESTS:--ignore=tests/test_documentation}; if [ -n \"$TOX_LOCK_PATH\" ] && command -v flock >/dev/null 2>&1; then [ -e \"$TOX_LOCK_PATH\" ] || (umask 0 && : > \"$TOX_LOCK_PATH\") 2>/dev/null; if [ -w \"$TOX_LOCK_PATH\" ]; then exec flock \"$TOX_LOCK_PATH\" \"$@\"; fi; fi; exec \"$@\""
            mypy --strict --ignore-missing-imports .
            python310: bandit -c pyproject.toml -r -q .
 

--- a/tox.ini
+++ b/tox.ini
@@ -35,14 +35,16 @@ setenv =
     CHECK_SKIP_COUNT = {env:CHECK_SKIP_COUNT:1}
     TOX_LOCK_PATH = {env:TOX_LOCK_PATH:/tmp/mloda-tox.lock}
     MLODA_PLUGIN_REGISTRY_STRICT = {env:MLODA_PLUGIN_REGISTRY_STRICT:warn}
+# The `python310:` commands are version-independent, so they are bound to the default env and the CI matrix
+# pays for them once; plain `tox` and `tox -e python310` (used by the release workflow) still run the full gate.
 commands = sh -c "set -- pytest -n {env:PYTEST_WORKERS:8} --timeout=10 -m 'not notebooks' {env:DEACTIVATE_NOTEBOOK_AND_DOC_TESTS:--ignore=tests/test_documentation}; if [ -n \"$TOX_LOCK_PATH\" ] && command -v flock >/dev/null 2>&1; then [ -e \"$TOX_LOCK_PATH\" ] || (umask 0 && : > \"$TOX_LOCK_PATH\") 2>/dev/null; if [ -w \"$TOX_LOCK_PATH\" ]; then exec flock \"$TOX_LOCK_PATH\" \"$@\"; fi; fi; exec \"$@\""
-           ruff format --check --line-length 120 .
-           ruff check --line-length 120 .
-           sh -c "if [ \"$WRITE_THIRD_PARTY_LICENSES\" = \"true\" ]; then pip-licenses --format=plain-vertical --with-urls --with-license-file | sed '/\/home\//d' > attribution/THIRD_PARTY_LICENSES.md; fi"
-           sh -c "if [ -z \"${NO_WRITE_ATTRIBUTION_MD}\" ]; then pip-licenses --format=markdown > attribution/ATTRIBUTION.md; fi"
-           sh -c "pip-licenses --ignore-packages matplotlib-inline --allow-only='MPL-2.0 AND MIT; Apache-2.0 AND BSD-2-Clause; Apache-2.0 OR BSD-2-Clause; Apache-2.0 AND CNRI-Python; BSD-3-Clause AND 0BSD AND MIT AND Zlib AND CC0-1.0; 3-Clause BSD License;BSD-2-Clause;BSD-3-Clause;Apache-2.0;Apache Software License;MIT;The Unlicense (Unlicense);PSF-2.0;MIT License;Python Software Foundation License;BSD License;GNU Lesser General Public License v2 or later (LGPLv2+);ISC License (ISCL);ISC;Mozilla Public License 2.0 (MPL 2.0);Apache License, Version 2.0;Apache 2.0;Apache Software License 2.0;' > /dev/null"
+           python310: ruff format --check --line-length 120 .
+           python310: ruff check --line-length 120 .
+           python310: sh -c "if [ \"$WRITE_THIRD_PARTY_LICENSES\" = \"true\" ]; then pip-licenses --format=plain-vertical --with-urls --with-license-file | sed '/\/home\//d' > attribution/THIRD_PARTY_LICENSES.md; fi"
+           python310: sh -c "if [ -z \"${NO_WRITE_ATTRIBUTION_MD}\" ]; then pip-licenses --format=markdown > attribution/ATTRIBUTION.md; fi"
+           python310: sh -c "pip-licenses --ignore-packages matplotlib-inline --allow-only='MPL-2.0 AND MIT; Apache-2.0 AND BSD-2-Clause; Apache-2.0 OR BSD-2-Clause; Apache-2.0 AND CNRI-Python; BSD-3-Clause AND 0BSD AND MIT AND Zlib AND CC0-1.0; 3-Clause BSD License;BSD-2-Clause;BSD-3-Clause;Apache-2.0;Apache Software License;MIT;The Unlicense (Unlicense);PSF-2.0;MIT License;Python Software Foundation License;BSD License;GNU Lesser General Public License v2 or later (LGPLv2+);ISC License (ISCL);ISC;Mozilla Public License 2.0 (MPL 2.0);Apache License, Version 2.0;Apache 2.0;Apache Software License 2.0;' > /dev/null"
            mypy --strict --ignore-missing-imports .
-           bandit -c pyproject.toml -r -q .
+           python310: bandit -c pyproject.toml -r -q .
 
 [testenv: core]
 extras = test,pandas


### PR DESCRIPTION
Closes #895.

`ruff format --check`, `ruff check` and `bandit` produce the same verdict on every interpreter, but the CI matrix ran them in all five `python3XX` jobs. `bandit` alone is about 19s per job, so that was roughly 80s of duplicated runner time per CI run.

## What changed

The version-independent commands in `[testenv]` now carry tox's `python310:` factor prefix, so they resolve only in the default env. `ci.yaml` needs no matrix change: its five `python3XX` jobs then run the gate exactly once, in the 3.10 job. Plain `tox` still runs the complete gate, which keeps `CLAUDE.md`'s "tox is the gate" promise intact, and the release workflow's `tox -e python310` still generates the license files.

Per-env resolution after the change:

| env | commands |
|-----|----------|
| `python310` (plain `tox`, release workflow) | all eight |
| `python311` to `python314` | license allowlist, pytest, mypy |

`mypy` stays per version: it type checks against each interpreter's semantics, so those five runs are five different checks.

## The license allowlist stays per interpreter

Review caught that `pip-licenses --allow-only` is not version-independent. `[testenv]` uses `runner = uv-venv-lock-runner`, and `uv.lock` resolves a different distribution set per interpreter (pandas 2.3.3 on 3.10 vs 3.0.3 on 3.11+, scikit-learn 1.7.2 vs 1.8.0, `psutil` only on 3.11+, `tomli` only on 3.10). Since pip-licenses inspects the installed distributions, gating it would have left 3.11 to 3.14 license-unchecked, and a dependency that only resolves on newer Pythons could ship a disallowed license through a green CI run. It stays ungated; only the two commands that write `attribution/THIRD_PARTY_LICENSES.md` and `attribution/ATTRIBUTION.md` are bound to the default env, since nothing consumes those per interpreter.

The fast checks also moved ahead of the pytest line, so a red test suite in the one job that owns the gate no longer hides the ruff and license verdicts. `bandit` stays last so the local edit-test loop does not pay 19s before seeing test results.

Side effect: `tox -e python311` and friends no longer rewrite `attribution/ATTRIBUTION.md`, which reduces the spurious-diff churn from #612.

## Guard test

`tests/test_static_gate_once_per_ci.py` pins the arrangement, because a gate that stops running fails open and looks exactly like a green run. It parses `tox.ini`, `ci.yaml` and `release.yaml` (no subprocess, 0.15s) and asserts that the version-independent checks share one factor, that pytest, mypy and the allowlist carry none, that the factor is a default env running in exactly one matrix entry, and that every interpreter keeps its own job.

It reads factor prefixes the way tox itself does, so the bypasses found during review now fail closed: `!python310:` or `{python311,python312}:` on a command (the first silently removes mypy from the gate env), a `[testenv:python310]` section redefining `commands` (which deletes the whole gate, including the release workflow's license generation), a `-` or `!` prefix that makes tox ignore a check's exit code, and a release workflow whose hardcoded tox env has drifted from the gate factor.

## Verification

- `tox` green: 7395 passed, 170 skipped; `python310: OK (73.16=setup[0.13]+cmd[0.04,0.04,0.00,0.53,0.61,51.87,1.23,18.71])`, showing ruff first, the allowlist before pytest, bandit last.
- `tox c -e python312 -k commands` resolves exactly the allowlist, pytest and mypy.