### PR TITLE
docs: state that match_feature_group_criteria's options view depends on the caller

### DIFF
--- a/docs/docs/in_depth/feature-group-matching.md
+++ b/docs/docs/in_depth/feature-group-matching.md
@@ -25,6 +25,8 @@ def match_feature_group_criteria(cls, feature_name, options, data_access_collect
 
 Do not call `FeatureChainParser.match_configuration_feature_chain_parser` directly from a match hook: it raises on an option value the `PROPERTY_MAPPING` rejects, and an exception out of the hook aborts feature identification for every candidate, not just yours. `match_parser_criteria` turns that rejection into a non-match, and the reason still reaches the user in the "No feature groups found" error.
 
+An override that reads option values should also know that the options view depends on the caller: feature resolution passes declared (pre-default) options, while filter matching calls the same hook after intake and observes effective (post-default) ones. See [Applying declared defaults](property-mapping.md#applying-declared-defaults).
+
 ### 2. PROPERTY_MAPPING Configuration
 
 The `PROPERTY_MAPPING` defines how configuration-based features are validated:

--- a/docs/docs/in_depth/feature-group-matching.md
+++ b/docs/docs/in_depth/feature-group-matching.md
@@ -25,7 +25,7 @@ def match_feature_group_criteria(cls, feature_name, options, data_access_collect
 
 Do not call `FeatureChainParser.match_configuration_feature_chain_parser` directly from a match hook: it raises on an option value the `PROPERTY_MAPPING` rejects, and an exception out of the hook aborts feature identification for every candidate, not just yours. `match_parser_criteria` turns that rejection into a non-match, and the reason still reaches the user in the "No feature groups found" error.
 
-An override that reads option values should also know that the options view depends on the caller: feature resolution passes declared (pre-default) options, while filter matching calls the same hook after intake and observes effective (post-default) ones. See [Applying declared defaults](property-mapping.md#applying-declared-defaults).
+The options view depends on the caller: feature resolution passes declared (pre-default) options, while filter matching runs after intake and passes the resolved feature's effective (post-default) options merged onto the filter feature's own. Matching logic that reads option values can see different values on the two paths. See [Applying declared defaults](property-mapping.md#applying-declared-defaults).
 
 ### 2. PROPERTY_MAPPING Configuration
 

--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -394,7 +394,7 @@ Which stage sees which view of the options:
 
 | Stage | Options view |
 | --- | --- |
-| Parse, bind, match, resolve (subtype resolution applies defaults internally) | declared (pre-default) |
+| Parse, bind, resolution match, resolve (subtype resolution applies defaults internally) | declared (pre-default) |
 | `input_features()` and child option inheritance | declared (pre-default) |
 | Splitting, planning, filter matching, `validate_input_features`, compute | effective (post-default) |
 
@@ -403,8 +403,9 @@ path the safety net materializes inside `run_calculate_feature`, which is after
 `validate_input_features`, not before it.
 
 Filter matching is the one place the same classmethod sees both views: `GlobalFilter` calls
-`match_feature_group_criteria` again after intake, so it observes effective options where feature
-resolution saw declared ones.
+`match_feature_group_criteria` again after intake, passing the filter feature's own options
+enriched from the resolved feature's effective ones (`unify_options`), so a key the filter feature
+omits arrives materialized where feature resolution saw it declared.
 
 ``` python
 graph_type = feature.options.get("graph_type")  # the declared default when the caller omitted it

--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -378,7 +378,8 @@ For an engine-driven request intake has already run, so the compute-boundary cal
 no-op. It carries the work only for direct `FeatureSet` use that bypasses the engine, and there the
 collapsing twins raise instead of merging.
 
-Both sites run *after* resolution, so materialization never changes **matching**. It does change
+Both sites run *after* resolution, so materialization never changes **resolution matching** (filter
+matching runs after intake and does observe materialized values, see below). It does change
 how features **group**: intake materialization deliberately canonicalizes default-equivalent twins,
 so a feature that passes a declared default explicitly and one that omits it become equal and merge
 into a single feature (with a warning naming the duplicated request) instead of computing twice.

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -247,6 +247,9 @@ class FeatureChainParserMixin:
         variable ``MLODA_ALLOW_FORWARDED_NAME_MISMATCH=1`` downgrades this error to a
         warning.
 
+        The options view depends on the caller: feature resolution passes declared (pre-default)
+        options, filter matching a post-intake merge. See ``FeatureGroup.match_feature_group_criteria``.
+
         Args:
             feature_name: Feature name to match
             options: Options containing configuration

--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -603,11 +603,12 @@ class FeatureGroup(ABC):
         If you want to implement a concrete implementation, e.g. just accept specific names,
         then you can overwrite this function.
 
-        The options view depends on the caller: feature resolution passes declared (pre-default)
-        options, while GlobalFilter calls this method again after intake to match a filter feature
-        and observes effective (post-default) options. An override whose matching logic reads option
-        values can therefore behave differently on the two paths. See
-        docs/docs/in_depth/property-mapping.md ("Applying declared defaults") for the stage table.
+        The options view depends on the caller. Feature resolution passes declared (pre-default)
+        options. GlobalFilter matches a filter feature after intake, passing that feature's own
+        options enriched from the resolved feature's effective (post-default) ones: a key the filter
+        feature declares itself keeps its declared value, an omitted key arrives materialized.
+        Matching logic that reads option values can therefore see different values on the two paths.
+        See ``docs/in_depth/property-mapping.md`` ("Applying declared defaults").
         """
 
         base_feature_name = cls.get_column_base_feature(feature_name)

--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -602,6 +602,12 @@ class FeatureGroup(ABC):
         You can disallow them by removing them. However, often you can just use the default.
         If you want to implement a concrete implementation, e.g. just accept specific names,
         then you can overwrite this function.
+
+        The options view depends on the caller: feature resolution passes declared (pre-default)
+        options, while GlobalFilter calls this method again after intake to match a filter feature
+        and observes effective (post-default) options. An override whose matching logic reads option
+        values can therefore behave differently on the two paths. See
+        docs/docs/in_depth/property-mapping.md ("Applying declared defaults") for the stage table.
         """
 
         base_feature_name = cls.get_column_base_feature(feature_name)


### PR DESCRIPTION
## Summary

`FeatureGroup.match_feature_group_criteria` has two production call sites, and they hand it two different views of `Options`:

- `IdentifyFeatureGroupClass._filter_feature_group_by_criteria` resolves a feature, which runs before intake, so it passes **declared** (pre-default) options.
- `GlobalFilter.criteria` matches a filter feature, which runs after intake, so the values it passes have already been through `options_with_defaults` on the resolved feature.

Nothing in the classmethod's own docstring said so, which is the surface an author overriding it actually reads. Matching logic that inspects option values can behave differently between the two paths with no warning that this is even possible.

## What changed

Docs and docstrings only. No behavior change, no new tests: the contract is already pinned by `tests/test_core/test_filter/test_filter_criteria_effective_options.py`.

- `FeatureGroup.match_feature_group_criteria` gains a paragraph describing the rule.
- `FeatureChainParserMixin.match_feature_group_criteria` gains a two-line pointer to it. The mixin overrides the classmethod with its own docstring, so every group on the recommended authoring path was showing nothing.
- `in_depth/feature-group-matching.md` states the rule and links to the stage table.
- `in_depth/property-mapping.md`: the page asserted that materialization "never changes matching" while its own filter-matching paragraph said the opposite, and the stage table listed a bare "match" as observing declared options. Both are disambiguated to *resolution* matching.

## Precision worth noting

The second commit corrects an overstatement in the first. The filter path does not receive a materialized view of the filter feature's options. `GlobalFilter.unify_options` copies the resolved feature's effective options only for keys the filter feature does not already set, and never calls `options_with_defaults` on the filter feature itself. Verified against a spec declaring `default="D"`:

| filter feature declares | hook receives |
| --- | --- |
| nothing | `{'k': 'D'}` (materialized, from the resolved feature) |
| `{'k': None}` | `{'k': None}` (its own declared value survives) |
| `{'k': 'OWN'}` | `{'k': 'OWN'}` |

`GlobalFilter.add_filter` accepts a `Feature`, so a caller can reach that difference. The docs now describe it as a merge rather than a materialized view.

## Review

Two independent deep reviews. `tox` green: 7535 passed, 170 skipped, ruff, mypy --strict, bandit clean.

Two findings were real but outside a docs commit and will be filed separately: `in_depth/filter_data.md` describes filter matching inaccurately, and the comment at `mloda/core/core/engine.py:337-339` asserts the filter-feature intake call "must remain an identity no-op", which does not hold when a filter feature declares a defaulted key explicitly as `None`.