### PR TITLE
test: import render_resolution_failure from its owning module

### DIFF
--- a/tests/test_core/test_prepare/test_raising_matcher_containment.py
+++ b/tests/test_core/test_prepare/test_raising_matcher_containment.py
@@ -19,10 +19,8 @@ from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
-from mloda.core.prepare.identify_feature_group import (
-    IdentifyFeatureGroupClass,
-    render_resolution_failure,
-)
+from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+from mloda.core.prepare.resolution_failure_renderer import render_resolution_failure
 from mloda.steward import resolve_feature
 
 


### PR DESCRIPTION
## Summary

`main` is red on every CI job at 410ff53d. `test_no_call_site_imports_a_foreign_name_from_the_matcher` fails because the containment pins added alongside it import `render_resolution_failure` from `mloda.core.prepare.identify_feature_group`, which only re-imports the name. The guard forbids reaching through the matcher module for a name it does not own.

## Change

One import block in `tests/test_core/test_prepare/test_raising_matcher_containment.py`, split so `IdentifyFeatureGroupClass` keeps coming from the matcher and `render_resolution_failure` comes from `mloda.core.prepare.resolution_failure_renderer`, where it is defined.

The production code was already correct: nothing under `mloda/` changes, and the guard is not relaxed.

## Verification

`test_resolution_module_split.py` plus `test_raising_matcher_containment.py`: 15 passed. `ruff check` and `ruff format --check` clean on the touched file.