### PR TITLE
fix: take render_resolution_failure from its owning module

### DIFF
--- a/tests/test_core/test_prepare/test_raising_matcher_containment.py
+++ b/tests/test_core/test_prepare/test_raising_matcher_containment.py
@@ -19,10 +19,8 @@ from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
-from mloda.core.prepare.identify_feature_group import (
-    IdentifyFeatureGroupClass,
-    render_resolution_failure,
-)
+from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+from mloda.core.prepare.resolution_failure_renderer import render_resolution_failure
 from mloda.steward import resolve_feature
 
 


### PR DESCRIPTION
`main` is red at `410ff53d`: all 15 CI jobs fail on the same test.

```
FAILED tests/test_core/test_prepare/test_resolution_module_split.py::test_no_call_site_imports_a_foreign_name_from_the_matcher
  tests/test_core/test_prepare/test_raising_matcher_containment.py:22 -> render_resolution_failure
```

## Cause

A merge race between two changes that were each green on their own branch:

- #908 stopped `identify_feature_group` being a re-export facade and added the sweep that fails any call site importing a name the matcher does not own. `render_resolution_failure` is owned by `resolution_failure_renderer`.
- #897 added `test_raising_matcher_containment.py`, whose branch predated that sweep, so it still took the name from `identify_feature_group`.

They merged 51 seconds apart. The import still resolves at runtime, because the matcher imports the renderer for its own use in `evaluate_and_render`, which is why only the sweep fails and not the containment test itself.

## Fix

Take `render_resolution_failure` from its owning module. `IdentifyFeatureGroupClass` stays with the matcher, which owns it.

This clears two gates, not one: `mypy --strict` also rejected the old form as an implicit re-export (`Module "mloda.core.prepare.identify_feature_group" does not explicitly export attribute "render_resolution_failure"`). Only the pytest sweep showed up in CI because pytest runs first.

Moving the name into `MATCHER_KEPT_NAMES` instead would not work: `test_kept_names_stay_defined_in_the_matcher_module` asserts each kept name's `__module__` is the matcher, and `RENDERER_NAMES` already claims this one for the renderer.

## Test

Test-only change, one import line. The failing sweep is itself the regression test, so no new test is added. Full `tox` green locally: 7584 passed, 170 skipped, plus ruff, licenses, `mypy --strict`, bandit.
