### PR TITLE
docs: state the real filter-to-FeatureGroup matching rule

### DIFF
--- a/docs/docs/in_depth/filter_data.md
+++ b/docs/docs/in_depth/filter_data.md
@@ -172,19 +172,25 @@ The previous sections show how **users** create filters. This section explains h
 
 ### How filters reach your FeatureGroup
 
-When a user passes a `GlobalFilter`, the framework tests every `SingleFilter` against
-each FeatureGroup already resolved for a feature. Each filter is **deep-copied** first,
-and the copy is delivered only if it clears three gates in order: the group's own
-`match_feature_group_criteria()` on the filter feature's name and options, the domain,
-and the compute framework. Declaring the filter's column as an input is **not** the
+When a user passes a `GlobalFilter`, the framework tests every `SingleFilter` against the
+FeatureGroup that each feature already resolved to, using that feature's options, domain
+and compute framework. Each filter is **deep-copied** first, so everything below happens
+on the copy and never on the filter the user built. The copy is delivered only if it
+clears three gates, in order: the group's own `match_feature_group_criteria()` on the
+filter feature's name and options (plus the run's `DataAccessCollection`), then the filter
+feature's domain against the resolved feature's, then its compute framework against the
+resolved feature's. The last two gates also backfill: a filter feature that declares no
+domain or compute framework inherits the resolved feature's (the FeatureGroup's domain
+when the feature declares none). Declaring the filter's column as an input is **not** the
 test, and links are not re-checked here (feature resolution already covered them).
-That matcher sees the filter feature's own options enriched from the resolved
-feature's effective (post-default) ones, see
-[Applying declared defaults](property-mapping.md#applying-declared-defaults). If two
-FeatureGroups both match the same original filter, they each receive independent
-copies. This means a single `GlobalFilter` can be processed differently by different
-FeatureGroups in the same pipeline: one may use the mask engine for inline masking
-while another uses filters for row elimination.
+
+`match_feature_group_criteria()` sees the filter feature's own options enriched from the
+resolved feature's effective (post-default) ones (see
+[Applying declared defaults](property-mapping.md#applying-declared-defaults)). If two
+FeatureGroups both match the same original filter, they each receive independent copies.
+This means a single `GlobalFilter` can be processed differently by different FeatureGroups
+in the same pipeline: one may use the mask engine for inline masking while another uses
+filters for row elimination.
 
 Matched filters are attached to the `FeatureSet` before `calculate_feature()` is
 called. Inside your calculation you can access them via `features.filters`:
@@ -320,7 +326,7 @@ return pa.table({
 
 | Your FeatureGroup... | `final_filters()` | Uses [mask engine](mask_engine.md)? | Must preserve filter column? |
 |---------------------|:-----------------:|:------------------------:|:---------------------------:|
-| Ignores filters | `None` (default) | No | Yes (it is in `input_data`) |
+| Ignores filters | `None` (default) | No | Yes (elimination reads it from your output) |
 | Handles everything inline | `False` | Yes | No (elimination skipped) |
 | Uses inline logic + elimination | `True` | Yes | **Yes** |
 | Just forces elimination | `True` | No | Yes |

--- a/docs/docs/in_depth/filter_data.md
+++ b/docs/docs/in_depth/filter_data.md
@@ -172,12 +172,19 @@ The previous sections show how **users** create filters. This section explains h
 
 ### How filters reach your FeatureGroup
 
-When a user passes a `GlobalFilter`, the framework matches each `SingleFilter` to the
-FeatureGroups that declare the filter's column as an input. Each matched filter is
-**deep-copied** before delivery. If two FeatureGroups both match the same original
-filter, they each receive independent copies. This means a single `GlobalFilter` can
-be processed differently by different FeatureGroups in the same pipeline: one may use
-the mask engine for inline masking while another uses filters for row elimination.
+When a user passes a `GlobalFilter`, the framework tests every `SingleFilter` against
+each FeatureGroup already resolved for a feature. Each filter is **deep-copied** first,
+and the copy is delivered only if it clears three gates in order: the group's own
+`match_feature_group_criteria()` on the filter feature's name and options, the domain,
+and the compute framework. Declaring the filter's column as an input is **not** the
+test, and links are not re-checked here (feature resolution already covered them).
+That matcher sees the filter feature's own options enriched from the resolved
+feature's effective (post-default) ones, see
+[Applying declared defaults](property-mapping.md#applying-declared-defaults). If two
+FeatureGroups both match the same original filter, they each receive independent
+copies. This means a single `GlobalFilter` can be processed differently by different
+FeatureGroups in the same pipeline: one may use the mask engine for inline masking
+while another uses filters for row elimination.
 
 Matched filters are attached to the `FeatureSet` before `calculate_feature()` is
 called. Inside your calculation you can access them via `features.filters`:


### PR DESCRIPTION
Closes #905

## Problem

`docs/docs/in_depth/filter_data.md` opened its "How filters reach your FeatureGroup" section with a rule that does not exist in the code:

> the framework matches each `SingleFilter` to the FeatureGroups that declare the filter's column as an input

This is the page a user reads first for "how do filters get matched", so the wrong mental model is the one they leave with.

## What actually happens

`Engine._add_filter_feature` calls `GlobalFilter.identify_matched_filters` for the FeatureGroup a feature has **already resolved to**. Each filter is deep-copied first, then the copy must clear three gates in order:

1. the group's own `match_feature_group_criteria()` on the filter feature's name and options, plus the run's `DataAccessCollection`
2. the filter feature's domain against the resolved feature's
3. its compute framework against the resolved feature's

Links are deliberately not re-checked (resolution already covered them). The last two gates also backfill, which is why the copy has to be taken before any gate runs.

The section now also points at the options view the matcher sees on this path (the filter feature's own options enriched from the resolved feature's effective, post-default ones), which is already documented under "Applying declared defaults" rather than restated here.

## Second change

The Quick reference table 150 lines further down still said the filter column must be preserved because "it is in `input_data`", re-planting the exact misconception the paragraph above now removes. The real reason is that row elimination reads the column out of the FeatureGroup's returned data: `run_final_filter` extracts the column set from the calculated output and raises if the filter column is missing. The cell now says that.

## Verification

Docs only, no code changes. `tests/test_documentation` passes (113), which is what validates the new relative link and its `#applying-declared-defaults` anchor. Every claim in the new text was checked against `global_filter.py`, `engine.py`, `filter_engine.py` and `compute_framework.py` rather than taken from the issue.

Reviewed independently by two reviewers; the accuracy and readability findings from that pass are folded in.

## Known unrelated CI failure

`test_no_call_site_imports_a_foreign_name_from_the_matcher` fails on `main` itself and therefore on this branch. It is fixed by #913, which should land first.
