### PR TITLE
fix: stop the resolution hint suggesting the name that was asked for

### DIFF
--- a/mloda/core/prepare/resolution_failure_renderer.py
+++ b/mloda/core/prepare/resolution_failure_renderer.py
@@ -10,6 +10,8 @@ from mloda.core.prepare.resolution_types import EliminationStage, EvaluationResu
 
 TROUBLESHOOTING_URL = "https://mloda-ai.github.io/mloda/in_depth/troubleshooting/feature-group-resolution-errors/"
 
+MAX_SUGGESTIONS = 5
+
 
 def scope_callout(scope: str | type[FeatureGroup] | None) -> str | None:
     """Render the shared scope callout, or None when the scope is unset."""
@@ -115,12 +117,11 @@ def _render_none(result: EvaluationResult, feature: Feature, callout: str | None
     if near_miss is not None:
         msg += f"\n{near_miss}"
 
-    # A suggestion equal to the requested name, or echoing a candidate the near-miss block already named,
-    # carries nothing new: drop it before the cut so it cannot spend one of the five slots.
-    known_names = list(result.facts.known_names)
+    # A suggestion equal to the requested name, or echoing an already-named candidate, carries nothing new.
+    # Drop it, and the catalog's repeats, before the cut, so neither can spend a slot.
     droppable = {feature_name, *result.facts.eliminated_hints}
-    ranked = get_close_matches(feature_name, known_names, n=len(known_names), cutoff=0.5) if known_names else []
-    similar = [name for name in ranked if name not in droppable][:5]
+    known_names = [name for name in dict.fromkeys(result.facts.known_names) if name not in droppable]
+    similar = get_close_matches(feature_name, known_names, n=MAX_SUGGESTIONS, cutoff=0.5)
     if similar:
         msg += f"\nDid you mean one of: {similar}?"
 

--- a/mloda/core/prepare/resolution_failure_renderer.py
+++ b/mloda/core/prepare/resolution_failure_renderer.py
@@ -115,10 +115,12 @@ def _render_none(result: EvaluationResult, feature: Feature, callout: str | None
     if near_miss is not None:
         msg += f"\n{near_miss}"
 
-    similar = get_close_matches(feature_name, list(result.facts.known_names), n=5, cutoff=0.5)
-    # Drop suggestions that merely echo a candidate the near-miss block already named; if that empties the
-    # list, omit the line rather than repeat what was just eliminated.
-    similar = [name for name in similar if name not in result.facts.eliminated_hints]
+    # A suggestion equal to the requested name, or echoing a candidate the near-miss block already named,
+    # carries nothing new: drop it before the cut so it cannot spend one of the five slots.
+    known_names = list(result.facts.known_names)
+    droppable = {feature_name, *result.facts.eliminated_hints}
+    ranked = get_close_matches(feature_name, known_names, n=len(known_names), cutoff=0.5) if known_names else []
+    similar = [name for name in ranked if name not in droppable][:5]
     if similar:
         msg += f"\nDid you mean one of: {similar}?"
 

--- a/tests/test_core/test_prepare/test_raising_matcher_containment.py
+++ b/tests/test_core/test_prepare/test_raising_matcher_containment.py
@@ -19,10 +19,8 @@ from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
-from mloda.core.prepare.identify_feature_group import (
-    IdentifyFeatureGroupClass,
-    render_resolution_failure,
-)
+from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+from mloda.core.prepare.resolution_failure_renderer import render_resolution_failure
 from mloda.steward import resolve_feature
 
 

--- a/tests/test_core/test_prepare/test_resolution_failure_renderer.py
+++ b/tests/test_core/test_prepare/test_resolution_failure_renderer.py
@@ -11,7 +11,9 @@ All names are suffixed ``_791`` because test feature groups become global subcla
 """
 
 from abc import abstractmethod
+from ast import literal_eval
 from collections.abc import Callable, Iterator
+from difflib import get_close_matches
 from typing import Any, ClassVar, Optional, cast
 
 import pytest
@@ -55,6 +57,9 @@ NONE_ENABLED_FEATURE_791 = "renderer_none_enabled_791"
 TIE_FEATURE_791 = "renderer_tie_791"
 TIE_CAPABILITY_FEATURE_791 = "renderer_tie_capability_791"
 MISSING_OPTION_FEATURE_791 = "renderer_missing_option_791__sum_renderer791m"
+STRANDED_FEATURE_791 = "renderer_stranded_791"
+CUTOFF_FEATURE_791 = "renderer_cutoff_791"
+CUTOFF_CATALOG_NAME_791 = "renderer_cutoff_threshold_group_791"
 
 HEALTHY_DOMAIN_791 = "renderer_healthy_domain_791"
 BOOM_SUPPORTED_NAME_791 = "renderer_boom_supported_name_791"
@@ -67,6 +72,8 @@ TROUBLESHOOTING_LINE = (
     "For troubleshooting guide, see: "
     "https://mloda-ai.github.io/mloda/in_depth/troubleshooting/feature-group-resolution-errors/"
 )
+
+SUGGESTION_PREFIX = "Did you mean one of: "
 
 # Call counters for every provider-overridable hook, keyed "<ClassName>.<hook>". Reset per test.
 HOOK_CALLS: dict[str, int] = {}
@@ -363,6 +370,37 @@ class RendererNoneEnabledFG791(CountingFeatureGroup791):
     SUPPORTED_FRAMEWORKS = frozenset({"RendererFwTwo791"})
 
 
+class RendererStrandedFG791(CountingFeatureGroup791):
+    """Declares the requested name itself, then loses every framework the run could have enabled."""
+
+    MATCHES = frozenset({STRANDED_FEATURE_791})
+    SUPPORTED_NAMES = frozenset({STRANDED_FEATURE_791})
+    FRAMEWORK_RULE = {RendererFwOne791, RendererFwTwo791}
+
+
+class RendererCutoffAFG791(CountingFeatureGroup791):
+    """Eliminated candidate declaring the requested name, so the name catalog carries the exact echo."""
+
+    MATCHES = frozenset({CUTOFF_FEATURE_791})
+    SUPPORTED_NAMES = frozenset({CUTOFF_FEATURE_791})
+    FRAMEWORK_RULE = {RendererFwOne791, RendererFwTwo791}
+
+
+class RendererCutoffBFG791(CountingFeatureGroup791):
+    """Second eliminated candidate, contributing two more droppable hints: its class name and its prefix."""
+
+    MATCHES = frozenset({CUTOFF_FEATURE_791})
+    FRAMEWORK_RULE = {RendererFwOne791, RendererFwTwo791}
+
+
+class SpareNameCatalogFG791(CountingFeatureGroup791):
+    """Healthy catalog group, named far enough from the request that only its supported name can be suggested."""
+
+    MATCHES = frozenset({CUTOFF_CATALOG_NAME_791})
+    SUPPORTED_NAMES = frozenset({CUTOFF_CATALOG_NAME_791})
+    FRAMEWORK_RULE = {RendererFwOne791}
+
+
 class RendererDomainBoom791(RuntimeError):
     """Raised by a provider's get_domain() hook."""
 
@@ -638,6 +676,23 @@ def capability_none_enabled_scenario() -> Scenario:
     return Feature(NONE_ENABLED_FEATURE_791), {RendererNoneEnabledFG791: set()}
 
 
+def stranded_supported_name_scenario() -> Scenario:
+    """The requested name is declared by the one candidate the run then eliminates: nothing is left to suggest."""
+    return Feature(STRANDED_FEATURE_791), {RendererStrandedFG791: set()}
+
+
+def suggestion_cut_scenario() -> Scenario:
+    """Five droppable close matches (the echo plus both eliminated candidates' hints) outrank the useful name."""
+    return (
+        Feature(CUTOFF_FEATURE_791),
+        {
+            RendererCutoffAFG791: set(),
+            RendererCutoffBFG791: set(),
+            SpareNameCatalogFG791: {RendererFwOne791},
+        },
+    )
+
+
 def raising_domain_multiple_scenario() -> Scenario:
     """A 'multiple' failure where one identified candidate's get_domain() raises. The request has no domain."""
     raising, healthy = _build_raising_domain_groups()
@@ -718,6 +773,14 @@ def _render(scenario: Scenario) -> str:
     message = render_resolution_failure(_evaluate(scenario), feature)
     assert message is not None
     return message
+
+
+def _suggestions(message: str) -> list[str]:
+    """Names listed on the 'Did you mean' line, or an empty list when the renderer omitted the line."""
+    line = next((line for line in message.split("\n") if line.startswith(SUGGESTION_PREFIX)), None)
+    if line is None:
+        return []
+    return cast(list[str], literal_eval(line[len(SUGGESTION_PREFIX) : -1]))
 
 
 @pytest.fixture(autouse=True)
@@ -1200,3 +1263,53 @@ class TestSortTiesAreStable:
         assert _render((feature, b_first)) == expected
         # The suppressed suggestion must not echo the already-named eliminated candidate or its prefix.
         assert "Did you mean" not in _render((feature, a_first))
+
+
+class TestSuggestionsNeverEchoTheRequestedName:
+    """A suggestion equal to the requested name is worthless, whichever candidate contributed it."""
+
+    def test_eliminated_candidates_supported_name_is_never_suggested_back(self) -> None:
+        """A candidate declaring the requested name is eliminated: the message must not hand that name back."""
+        scenario = stranded_supported_name_scenario()
+        feature, _ = scenario
+        result = _evaluate(scenario)
+
+        # The name catalog carries the requested name, and the eliminated hints (class name and prefix only)
+        # cannot reach it, so suppression has to key on the requested name itself.
+        assert STRANDED_FEATURE_791 in result.facts.known_names
+        assert STRANDED_FEATURE_791 not in result.facts.eliminated_hints
+
+        message = render_resolution_failure(result, feature)
+        assert message is not None
+        assert "Did you mean" not in message
+        assert message == (
+            f"No feature groups found for feature name: '{STRANDED_FEATURE_791}'.\n"
+            f"Feature group(s) eliminated while matching '{STRANDED_FEATURE_791}':\n"
+            "  - RendererStrandedFG791 (compute framework): none of its compute frameworks are enabled for this run\n"
+            "Use resolve_feature(name, options=...) to debug feature resolution.\n"
+            f"{TROUBLESHOOTING_LINE}"
+        )
+
+    def test_droppable_matches_do_not_consume_the_suggestion_slots(self) -> None:
+        """Suggestions are filtered before the cut, so a useful name ranked behind five droppable ones survives."""
+        scenario = suggestion_cut_scenario()
+        feature, _ = scenario
+        result = _evaluate(scenario)
+
+        droppable = {CUTOFF_FEATURE_791, *result.facts.eliminated_hints}
+        # Premise of the scenario: cutting to five first spends every slot on a droppable name.
+        cut_first = get_close_matches(CUTOFF_FEATURE_791, list(result.facts.known_names), n=5, cutoff=0.5)
+        assert len(cut_first) == 5
+        assert set(cut_first) <= droppable
+        assert CUTOFF_CATALOG_NAME_791 not in cut_first
+
+        message = render_resolution_failure(result, feature)
+        assert message is not None
+        suggestions = _suggestions(message)
+
+        assert CUTOFF_CATALOG_NAME_791 in suggestions
+        assert droppable.isdisjoint(suggestions)
+        assert len(suggestions) <= 5
+        # Both eliminated candidates are still named where they belong, in the near-miss block.
+        assert "  - RendererCutoffAFG791 (compute framework):" in message
+        assert "  - RendererCutoffBFG791 (compute framework):" in message

--- a/tests/test_core/test_prepare/test_resolution_failure_renderer.py
+++ b/tests/test_core/test_prepare/test_resolution_failure_renderer.py
@@ -60,6 +60,28 @@ MISSING_OPTION_FEATURE_791 = "renderer_missing_option_791__sum_renderer791m"
 STRANDED_FEATURE_791 = "renderer_stranded_791"
 CUTOFF_FEATURE_791 = "renderer_cutoff_791"
 CUTOFF_CATALOG_NAME_791 = "renderer_cutoff_threshold_group_791"
+DUPLICATE_TYPO_FEATURE_791 = "renderer_duplcate_791"
+DUPLICATE_CATALOG_NAME_791 = "renderer_duplicate_791"
+DUPLICATE_SPARE_NAME_791 = "renderer_duplicate_spare_791"
+EMPTY_CATALOG_FEATURE_791 = "renderer_empty_catalog_791"
+DECLARED_UNMATCHED_FEATURE_791 = "renderer_declared_unmatched_791"
+WIDE_FEATURE_791 = "renderer_wide_791"
+
+# Eight names, all close to WIDE_FEATURE_791, so only the cut can bound the rendered line.
+WIDE_CATALOG_NAMES_791 = frozenset(
+    {
+        "renderer_wide_alpha_791",
+        "renderer_wide_bravo_791",
+        "renderer_wide_delta_791",
+        "renderer_wide_echo_791",
+        "renderer_wide_gamma_791",
+        "renderer_wide_kilo_791",
+        "renderer_wide_lima_791",
+        "renderer_wide_zulu_791",
+    }
+)
+
+MAX_RENDERED_SUGGESTIONS_791 = 5
 
 HEALTHY_DOMAIN_791 = "renderer_healthy_domain_791"
 BOOM_SUPPORTED_NAME_791 = "renderer_boom_supported_name_791"
@@ -401,6 +423,50 @@ class SpareNameCatalogFG791(CountingFeatureGroup791):
     FRAMEWORK_RULE = {RendererFwOne791}
 
 
+class RendererDuplicateNameFG791(CountingFeatureGroup791):
+    """Catalog candidate declaring the shared name; the four siblings below declare exactly the same one."""
+
+    SUPPORTED_NAMES = frozenset({DUPLICATE_CATALOG_NAME_791})
+    FRAMEWORK_RULE = {RendererFwOne791}
+
+
+class RendererDuplicateSiblingAFG791(RendererDuplicateNameFG791):
+    """Second contributor of the shared name."""
+
+
+class RendererDuplicateSiblingBFG791(RendererDuplicateNameFG791):
+    """Third contributor of the shared name."""
+
+
+class RendererDuplicateSiblingCFG791(RendererDuplicateNameFG791):
+    """Fourth contributor of the shared name."""
+
+
+class RendererDuplicateSiblingDFG791(RendererDuplicateNameFG791):
+    """Fifth contributor of the shared name, enough copies to fill every suggestion slot."""
+
+
+class RendererDuplicateSpareFG791(CountingFeatureGroup791):
+    """Catalog candidate holding the one genuinely different close name the copies push out."""
+
+    SUPPORTED_NAMES = frozenset({DUPLICATE_SPARE_NAME_791})
+    FRAMEWORK_RULE = {RendererFwOne791}
+
+
+class RendererDeclaredUnmatchedFG791(CountingFeatureGroup791):
+    """Declares the requested name but matches nothing, so nothing records it as an elimination."""
+
+    SUPPORTED_NAMES = frozenset({DECLARED_UNMATCHED_FEATURE_791})
+    FRAMEWORK_RULE = {RendererFwOne791}
+
+
+class RendererWideCatalogFG791(CountingFeatureGroup791):
+    """Catalog candidate declaring more close names than the message may ever list."""
+
+    SUPPORTED_NAMES = WIDE_CATALOG_NAMES_791
+    FRAMEWORK_RULE = {RendererFwOne791}
+
+
 class RendererDomainBoom791(RuntimeError):
     """Raised by a provider's get_domain() hook."""
 
@@ -693,6 +759,36 @@ def suggestion_cut_scenario() -> Scenario:
     )
 
 
+def duplicate_catalog_scenario() -> Scenario:
+    """Five candidates declare the SAME name, so its copies alone can fill every suggestion slot."""
+    return (
+        Feature(DUPLICATE_TYPO_FEATURE_791),
+        {
+            RendererDuplicateNameFG791: {RendererFwOne791},
+            RendererDuplicateSiblingAFG791: {RendererFwOne791},
+            RendererDuplicateSiblingBFG791: {RendererFwOne791},
+            RendererDuplicateSiblingCFG791: {RendererFwOne791},
+            RendererDuplicateSiblingDFG791: {RendererFwOne791},
+            RendererDuplicateSpareFG791: {RendererFwOne791},
+        },
+    )
+
+
+def empty_catalog_scenario() -> Scenario:
+    """No accessible plugin at all, so no name was ever captured and the catalog is empty."""
+    return Feature(EMPTY_CATALOG_FEATURE_791), {}
+
+
+def declared_unmatched_scenario() -> Scenario:
+    """The requested name is declared by a candidate that simply does not match it, so nothing is eliminated."""
+    return Feature(DECLARED_UNMATCHED_FEATURE_791), {RendererDeclaredUnmatchedFG791: {RendererFwOne791}}
+
+
+def wide_catalog_scenario() -> Scenario:
+    """More close names than slots, none of them droppable, so only the cut can bound the line."""
+    return Feature(WIDE_FEATURE_791), {RendererWideCatalogFG791: {RendererFwOne791}}
+
+
 def raising_domain_multiple_scenario() -> Scenario:
     """A 'multiple' failure where one identified candidate's get_domain() raises. The request has no domain."""
     raising, healthy = _build_raising_domain_groups()
@@ -775,11 +871,11 @@ def _render(scenario: Scenario) -> str:
     return message
 
 
-def _suggestions(message: str) -> list[str]:
-    """Names listed on the 'Did you mean' line, or an empty list when the renderer omitted the line."""
+def _suggestions(message: str) -> list[str] | None:
+    """Names listed on the 'Did you mean' line, or None when the renderer omitted the line entirely."""
     line = next((line for line in message.split("\n") if line.startswith(SUGGESTION_PREFIX)), None)
     if line is None:
-        return []
+        return None
     return cast(list[str], literal_eval(line[len(SUGGESTION_PREFIX) : -1]))
 
 
@@ -1307,9 +1403,94 @@ class TestSuggestionsNeverEchoTheRequestedName:
         assert message is not None
         suggestions = _suggestions(message)
 
+        assert suggestions is not None
         assert CUTOFF_CATALOG_NAME_791 in suggestions
         assert droppable.isdisjoint(suggestions)
-        assert len(suggestions) <= 5
         # Both eliminated candidates are still named where they belong, in the near-miss block.
         assert "  - RendererCutoffAFG791 (compute framework):" in message
         assert "  - RendererCutoffBFG791 (compute framework):" in message
+
+    def test_a_never_eliminated_candidates_same_name_is_suppressed_too(self) -> None:
+        """A candidate can declare the requested name without ever being eliminated; the echo is dropped anyway.
+
+        Nothing was eliminated here, so widening eliminated_hints to the eliminated candidates' supported
+        names would suppress nothing: only keying on the requested name itself does.
+        """
+        scenario = declared_unmatched_scenario()
+        feature, _ = scenario
+        result = _evaluate(scenario)
+
+        assert result.facts.eliminated_hints == frozenset()
+        assert DECLARED_UNMATCHED_FEATURE_791 in result.facts.known_names
+
+        message = render_resolution_failure(result, feature)
+        assert message is not None
+        suggestions = _suggestions(message)
+
+        assert suggestions is not None
+        assert DECLARED_UNMATCHED_FEATURE_791 not in suggestions
+        # The line still renders; it just carries the candidate's class name and prefix instead of the echo.
+        assert set(suggestions) == {"RendererDeclaredUnmatchedFG791", "RendererDeclaredUnmatchedFG791_"}
+
+
+class TestSuggestionSlotsListDistinctNames:
+    """The suggestion line lists distinct useful names, and the cut to five is what bounds it."""
+
+    def test_duplicate_catalog_entries_do_not_spend_the_suggestion_slots(self) -> None:
+        """One name declared by five candidates enters the catalog five times, but may fill only one slot."""
+        scenario = duplicate_catalog_scenario()
+        feature, _ = scenario
+        result = _evaluate(scenario)
+
+        # Premise of the scenario: ranking the catalog as captured spends every slot on copies of one name.
+        known_names = list(result.facts.known_names)
+        copies = get_close_matches(DUPLICATE_TYPO_FEATURE_791, known_names, n=MAX_RENDERED_SUGGESTIONS_791, cutoff=0.5)
+        assert copies == [DUPLICATE_CATALOG_NAME_791] * MAX_RENDERED_SUGGESTIONS_791
+
+        message = render_resolution_failure(result, feature)
+        assert message is not None
+        suggestions = _suggestions(message)
+
+        assert suggestions is not None
+        assert len(suggestions) == len(set(suggestions))
+        assert DUPLICATE_CATALOG_NAME_791 in suggestions
+        assert DUPLICATE_SPARE_NAME_791 in suggestions
+
+    def test_an_empty_name_catalog_renders_no_suggestion_line(self) -> None:
+        """No accessible plugin leaves the catalog empty: ranking it must not raise, and no line renders."""
+        scenario = empty_catalog_scenario()
+        feature, _ = scenario
+        result = _evaluate(scenario)
+
+        assert result.failure_kind == "none"
+        assert result.facts.known_names == ()
+
+        message = render_resolution_failure(result, feature)
+        assert message is not None
+        assert _suggestions(message) is None
+        assert message == (
+            f"No feature groups found for feature name: '{EMPTY_CATALOG_FEATURE_791}'.\n"
+            "Use resolve_feature(name, options=...) to debug feature resolution.\n"
+            f"{TROUBLESHOOTING_LINE}"
+        )
+
+    def test_more_surviving_close_names_than_slots_are_cut_to_five(self) -> None:
+        """Nothing is droppable here, so the cut is the only bound: exactly five of the pool are listed."""
+        scenario = wide_catalog_scenario()
+        feature, _ = scenario
+        result = _evaluate(scenario)
+
+        # Premise of the scenario: more than five distinct names clear the cutoff and none of them is droppable.
+        known_names = sorted(set(result.facts.known_names))
+        ranked = get_close_matches(WIDE_FEATURE_791, known_names, n=len(known_names), cutoff=0.5)
+        assert len(ranked) > MAX_RENDERED_SUGGESTIONS_791
+        assert result.facts.eliminated_hints == frozenset()
+        assert WIDE_FEATURE_791 not in known_names
+
+        message = render_resolution_failure(result, feature)
+        assert message is not None
+        suggestions = _suggestions(message)
+
+        assert suggestions is not None
+        assert len(suggestions) == MAX_RENDERED_SUGGESTIONS_791
+        assert set(suggestions) <= WIDE_CATALOG_NAMES_791


### PR DESCRIPTION
## Problem

When a feature group declares the requested name through `feature_names_supported()` and is then eliminated (for example none of its compute frameworks are enabled for the run), the resolution failure message told the user no feature group was found and suggested the name they had just typed:

```
No feature groups found for feature name: 'quarterly_revenue_repro'.
Feature group(s) eliminated while matching 'quarterly_revenue_repro':
  - StrandedFG (compute framework): none of its compute frameworks are enabled for this run
Did you mean one of: ['quarterly_revenue_repro']?
```

The suppression that already existed only knew each eliminated candidate's class name and prefix, never the names it declares, so the filter had nothing to drop the echo with.

## Change

`_render_none` in the failure renderer, only. `identify_feature_group.py` is untouched.

- Drop any close match equal to the requested name, whatever its source. This was chosen over widening `eliminated_hints` with each eliminated candidate's supported names, because a class name and a prefix are identifiers the near-miss block already prints, whereas a different name a candidate declares is new information. The exact-name rule also catches a same-name suggestion from a candidate that was never recorded as an elimination, which the other rule cannot reach.
- Filter the candidate pool before ranking instead of after. `get_close_matches` cut to five first, so droppable names could spend every slot and hide a useful suggestion behind them.
- Deduplicate the catalog. It is built by appending each candidate's class name, supported names and prefix with no dedup, so several groups declaring one name could fill the whole line with copies of it.

No information is lost by suppressing: the near-miss block still names the group and says why it lost.

## Tests

`tests/test_core/test_prepare/test_resolution_failure_renderer.py`:

- the reported shape, an eliminated candidate declaring the requested name
- filtering before the cut, where five droppable names outrank the useful one
- a same-name suggestion from a candidate that was never eliminated, which is what distinguishes the rule chosen here from the one rejected
- duplicate catalog entries
- an empty name catalog
- the cut to five itself, which nothing pinned before

## Unrelated commit

`test: import render_resolution_failure from the module that owns it` fixes a test import that makes `main` itself red. Two PRs crossed: one added the guard test forbidding call sites from taking a name the matcher module does not own, the other added a test importing `render_resolution_failure` from that module. Without it CI on this branch cannot be judged.

## Follow-up not taken here

A suggestion can still name a *sibling* feature name declared by an eliminated group, which fails with the same message. The obvious fix (fold supported names into `eliminated_hints`) has a false-suppression path: if an eliminated group and a healthy group both declare a name, the healthy group's name gets dropped too. The correct rule is to drop a name only when every group declaring it was eliminated, which needs a per-name capture that is out of scope here.

`tox` is green: 7590 passed, 170 skipped, plus ruff, mypy strict and bandit.
