### PR TITLE
test: drop the stale fork DeprecationWarning filter from pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -4,6 +4,3 @@ markers =
 filterwarnings =
     ignore::pytest.PytestUnhandledThreadExceptionWarning
     ignore:.*Jupyter is migrating its paths to use standard platformdirs:DeprecationWarning
-    # Silence the 3.12+ multi-threaded fork() deprecation. See #394; remove once
-    # we drop 3.13 or migrate WorkerManager to forkserver, whichever comes first.
-    ignore:.*process .* is multi-threaded, use of fork.*:DeprecationWarning


### PR DESCRIPTION
Closes #896

## Problem

`pytest.ini` silenced the 3.12+ multi-threaded `fork()` deprecation, and its comment promised removal once `WorkerManager` migrated off fork. That migration already happened: `mloda/core/runtime/mp_context.py` provides `mp_spawn_context()` and every entry point that starts a process goes through it (`worker_manager.py:36`, `flight/runner_flight_server.py:37`, `run.py:324`). The filter matches nothing and reads as a known-broken area.

## What changed

The three stale lines are gone. Nothing else.

## Why the scope is this small

An earlier revision of this PR also inverted the filter to `error:` and added a 382-line AST guard that scanned `mloda/` and `mloda_plugins/` for fork-selecting call sites. Both were dropped:

**The `error:` inversion does not work.** CPython emits this particular warning from C (`warn_about_fork_with_threads` in `posixmodule.c`), discarding the result, so the exception an `error:` filter would raise is never propagated. Verified on 3.12.3: a real fork from a multi-threaded parent under `warnings.simplefilter("error")` still forks and returns normally, while a control `warnings.warn(..., DeprecationWarning)` in the same interpreter escalates as expected. An `error:` line here would have been inert while reading like a guarantee, which is the same defect as the stale `ignore:` line it replaced.

**The static guard was out of proportion.** It protected four call sites with a hand-rolled linter (alias resolution, dotted-chain resolution, a fixed-point pass for manager subclasses) plus seven tests, six of which tested the guard rather than the codebase. It also missed the likeliest future spelling, `concurrent.futures.ProcessPoolExecutor`, whose default `mp_context` is the platform default. And the window is closing on its own: 3.14 already defaults to `forkserver` on Linux.

## Verification

`tox` (3.10) and `tox -e python312`: both fully green, 7774 passed / 170 skipped, skip count unchanged. `ruff format --check`, `ruff check`, `mypy --strict` and `bandit` clean.

Note that a green suite does not by itself prove no fork path is left, since the warning does not fail anything either way (that was the flaw in the issue's stated definition of done). The evidence for the deletion is direct instead: every process-starting site named above passes an explicit spawn context, and the multiprocessing test suites emit no fork warning at all on 3.12.
