### PR TITLE
fix: stop warning about a filter option divergence intake erases

### DIFF
--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -1,9 +1,13 @@
 from copy import deepcopy
 from datetime import datetime, timezone
+from itertools import chain
 from typing import Any, Optional
 
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.abstract_plugins.components.domain import Domain
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import option_key_is_present
+from mloda.core.abstract_plugins.components.feature_chainer.property_spec import is_no_default
+from mloda.core.abstract_plugins.components.utils import safe_field
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
@@ -87,6 +91,10 @@ class GlobalFilter:
         for filter in self.filters:
             # We are making a deepcopy so that, we do not change the original filter.
             _filter = deepcopy(filter)
+            # Reported here, not in unify_options: only this method holds the resolving group, whose spec
+            # decides what intake materializes. Safe on this side of the call, because unify_options only
+            # ADDS keys the filter feature does not declare and never rewrites a declared one.
+            self._warn_on_diverging_options(feature_group, feat.options, _filter.filter_feature.options)
             _filter.filter_feature.options = self.unify_options(feat.options, _filter.filter_feature.options)
 
             if self.criteria(feature_group, _filter, data_access_collection) is False:
@@ -101,18 +109,74 @@ class GlobalFilter:
         return matched_filters
 
     def unify_options(self, feat_options: Options, filter_options: Options) -> Options:
+        """Enrich the filter feature's declared options from the feature's effective ones.
+
+        Adds only; a declared value is never rewritten. Divergences are reported by the caller (#911).
+        """
         # Preserve each key's category so context keys do not leak into group (issue #712).
         for key, value in feat_options.group.items():
             if key not in filter_options:
                 filter_options.add_to_group(key, value)
-            elif filter_options[key] != value:
-                logger.warning(f"Options are not the same. {key} is different. {filter_options[key]} != {value}")
         for key, value in feat_options.context.items():
             if key not in filter_options:
                 filter_options.add_to_context(key, value)
-            elif filter_options[key] != value:
-                logger.warning(f"Options are not the same. {key} is different. {filter_options[key]} != {value}")
         return filter_options
+
+    def _warn_on_diverging_options(
+        self, feature_group: Optional[type[FeatureGroup]], feat_options: Options, filter_options: Options
+    ) -> None:
+        """Report every key the filter feature declares differently from the feature's effective value.
+
+        Both namespaces are covered. A key the filter feature does not declare is unify_options' business and
+        never reported. Silent where intake provably erases the difference (#911).
+        """
+        for key, value in chain(feat_options.group.items(), feat_options.context.items()):
+            if key not in filter_options:
+                continue
+            declared = filter_options[key]
+            if declared == value:
+                continue
+            fill = self._intake_fill(feature_group, key, filter_options)
+            if self._converges_at_intake(fill, value):
+                continue
+            if fill is None:
+                logger.warning(f"Options are not the same. {key} is different. {declared} != {value}")
+            else:
+                # Name what the filter feature will actually compute with: the SPEC default, not the
+                # feature's value, so the message does not read as "leave it None, it is filled with that".
+                logger.warning(
+                    f"Options are not the same. {key} is different. {declared!r} (intake fills {fill!r}) != {value!r}"
+                )
+
+    @staticmethod
+    def _intake_fill(feature_group: Optional[type[FeatureGroup]], key: str, filter_options: Options) -> Any:
+        """The value intake will materialize into the filter feature for ``key``, None when it fills nothing.
+
+        Mirrors ``FeatureGroup.options_with_defaults``: a concrete spec default fills a key the spec reads as
+        absent. Without the resolving group there is no spec to consult, so nothing is suppressed and every
+        difference keeps warning.
+        """
+        if feature_group is None:
+            return None
+        spec = (feature_group.PROPERTY_MAPPING or {}).get(key)
+        if spec is None or is_no_default(spec.default) or spec.default is None:
+            return None
+        # Absence, not None-ness: an allow_explicit_none key is present, so its None survives and stays divergent.
+        if option_key_is_present(spec, key, filter_options):
+            return None
+        return spec.default
+
+    @staticmethod
+    def _converges_at_intake(intake_fill: Any, feat_value: Any) -> bool:
+        """Does intake erase the divergence by filling the filter feature with the feature's own value (#911)?
+
+        safe_field: ``default`` is Any, so a third-party numpy or pandas default makes the comparison raise
+        out of a decision that only picks a log line. An uncomparable default is NOT convergent and keeps
+        warning, which is the behaviour before the spec was consulted at all.
+        """
+        if intake_fill is None:
+            return False
+        return safe_field(lambda: bool(intake_fill == feat_value), False)
 
     def criteria(
         self,

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -91,9 +91,7 @@ class GlobalFilter:
         for filter in self.filters:
             # We are making a deepcopy so that, we do not change the original filter.
             _filter = deepcopy(filter)
-            # Reported here, not in unify_options: only this method holds the resolving group, whose spec
-            # decides what intake materializes. Safe on this side of the call, because unify_options only
-            # ADDS keys the filter feature does not declare and never rewrites a declared one.
+            # Reported here, not in unify_options: only this method holds the resolving group.
             self._warn_on_diverging_options(feature_group, feat.options, _filter.filter_feature.options)
             _filter.filter_feature.options = self.unify_options(feat.options, _filter.filter_feature.options)
 
@@ -109,10 +107,7 @@ class GlobalFilter:
         return matched_filters
 
     def unify_options(self, feat_options: Options, filter_options: Options) -> Options:
-        """Enrich the filter feature's declared options from the feature's effective ones.
-
-        Adds only; a declared value is never rewritten. Divergences are reported by the caller (#911).
-        """
+        """Add the feature's options the filter feature omits. A declared value is never rewritten."""
         # Preserve each key's category so context keys do not leak into group (issue #712).
         for key, value in feat_options.group.items():
             if key not in filter_options:
@@ -125,11 +120,7 @@ class GlobalFilter:
     def _warn_on_diverging_options(
         self, feature_group: Optional[type[FeatureGroup]], feat_options: Options, filter_options: Options
     ) -> None:
-        """Report every key the filter feature declares differently from the feature's effective value.
-
-        Both namespaces are covered. A key the filter feature does not declare is unify_options' business and
-        never reported. Silent where intake provably erases the difference (#911).
-        """
+        """Report keys the filter feature declares differently, unless intake provably erases the difference."""
         for key, value in chain(feat_options.group.items(), feat_options.context.items()):
             if key not in filter_options:
                 continue
@@ -142,37 +133,34 @@ class GlobalFilter:
             if fill is None:
                 logger.warning(f"Options are not the same. {key} is different. {declared} != {value}")
             else:
-                # Name what the filter feature will actually compute with: the SPEC default, not the
-                # feature's value, so the message does not read as "leave it None, it is filled with that".
+                # Name the spec default, which is what the filter feature will actually compute with.
                 logger.warning(
                     f"Options are not the same. {key} is different. {declared!r} (intake fills {fill!r}) != {value!r}"
                 )
 
     @staticmethod
     def _intake_fill(feature_group: Optional[type[FeatureGroup]], key: str, filter_options: Options) -> Any:
-        """The value intake will materialize into the filter feature for ``key``, None when it fills nothing.
+        """The value intake materializes for ``key``, None when it fills nothing.
 
-        Mirrors ``FeatureGroup.options_with_defaults``: a concrete spec default fills a key the spec reads as
-        absent. Without the resolving group there is no spec to consult, so nothing is suppressed and every
-        difference keeps warning.
+        Mirrors ``FeatureGroup.options_with_defaults``: a concrete spec default fills a key the spec reads
+        as absent. Without a resolving group there is no spec to consult, so nothing is suppressed.
         """
         if feature_group is None:
             return None
         spec = (feature_group.PROPERTY_MAPPING or {}).get(key)
         if spec is None or is_no_default(spec.default) or spec.default is None:
             return None
-        # Absence, not None-ness: an allow_explicit_none key is present, so its None survives and stays divergent.
+        # Absence, not None-ness: an allow_explicit_none key is present, so its None survives.
         if option_key_is_present(spec, key, filter_options):
             return None
         return spec.default
 
     @staticmethod
     def _converges_at_intake(intake_fill: Any, feat_value: Any) -> bool:
-        """Does intake erase the divergence by filling the filter feature with the feature's own value (#911)?
+        """Does intake fill the filter feature with the feature's own value?
 
-        safe_field: ``default`` is Any, so a third-party numpy or pandas default makes the comparison raise
-        out of a decision that only picks a log line. An uncomparable default is NOT convergent and keeps
-        warning, which is the behaviour before the spec was consulted at all.
+        ``default`` is Any, so safe_field keeps an array-like default from raising out of a decision that
+        only picks a log line. An uncomparable default is not convergent and keeps warning.
         """
         if intake_fill is None:
             return False

--- a/tests/test_core/test_filter/test_option_divergence_warning_guards.py
+++ b/tests/test_core/test_filter/test_option_divergence_warning_guards.py
@@ -1,8 +1,7 @@
 """Pin the guard clauses and the rendered text of the filter-option divergence warning (#911).
 
-``test_unify_options_divergence_warning.py`` drives the same behaviour through the engine. These cases call
-the seam directly, because each guard below decides nothing but whether one log line is written: every early
-return is one token away from suppressing every divergence, and an engine run per guard buys no extra proof.
+``test_unify_options_divergence_warning.py`` drives the same behaviour through the engine. These cases
+call the seam directly: every guard below decides nothing but whether one log line is written.
 """
 
 from __future__ import annotations
@@ -48,10 +47,9 @@ class _ArrayLikeDefault:
 
 
 def _emit(mapping: Optional[dict[str, PropertySpec]], feat_options: Options, filter_options: Options) -> None:
-    """Run the divergence seam once against a throwaway group; ``mapping`` None means no resolving group.
+    """Run the seam once against a throwaway group; ``mapping`` None means no resolving group.
 
-    The probe class stays local to this frame, so it is unreachable once the call returns and cannot leak
-    into the registry (the asserts live in the caller, whose traceback never pins this frame).
+    The probe class stays local to this frame, so it cannot leak into the registry.
     """
     feature_group: Optional[type[FeatureGroup]] = None
     if mapping is not None:
@@ -74,7 +72,7 @@ def _messages(caplog: pytest.LogCaptureFixture, key: str) -> list[str]:
 
 
 def test_stays_silent_when_intake_materializes_the_features_own_value(caplog: pytest.LogCaptureFixture) -> None:
-    """The discriminating control: without it every guard case below could pass on a seam that never warns."""
+    """The control: without it every guard case below could pass on a seam that never warns."""
     with caplog.at_level(logging.WARNING):
         _emit(
             {DWG_KEY: PropertySpec("A group key with a concrete default.", context=False, default=DWG_DEFAULT)},
@@ -82,11 +80,11 @@ def test_stays_silent_when_intake_materializes_the_features_own_value(caplog: py
             Options(group={DWG_KEY: None}),
         )
 
-    assert _messages(caplog, DWG_KEY) == [], "a declared None that intake fills with the feature's value must not warn"
+    assert _messages(caplog, DWG_KEY) == []
 
 
 def test_warns_without_a_resolving_feature_group(caplog: pytest.LogCaptureFixture) -> None:
-    """No group means no spec to consult, so nothing is suppressed and every difference is reported."""
+    """No group means no spec to consult, so nothing is suppressed."""
     with caplog.at_level(logging.WARNING):
         _emit(None, Options(group={DWG_KEY: DWG_DEFAULT}), Options(group={DWG_KEY: None}))
 
@@ -130,7 +128,7 @@ def test_warns_when_the_spec_default_is_none(caplog: pytest.LogCaptureFixture) -
 
 
 def test_warns_when_the_spec_default_cannot_be_compared(caplog: pytest.LogCaptureFixture) -> None:
-    """A third-party default whose ``==`` returns a non-bool must not abort the run from a logging decision."""
+    """An uncomparable default must not abort the run from a decision that only picks a log line."""
     spec = PropertySpec("A group key defaulting to an array-like.", context=False, default=_ArrayLikeDefault())
     with caplog.at_level(logging.WARNING):
         _emit({DWG_KEY: spec}, Options(group={DWG_KEY: DWG_HOST_VAL}), Options(group={DWG_KEY: None}))
@@ -139,7 +137,7 @@ def test_warns_when_the_spec_default_cannot_be_compared(caplog: pytest.LogCaptur
     assert _messages(caplog, DWG_KEY) == [
         f"Options are not the same. {DWG_KEY} is different. "
         f"None (intake fills <array-like default>) != '{DWG_HOST_VAL}'"
-    ], "an uncomparable default is not convergent, so it must keep warning instead of raising"
+    ]
 
 
 def test_warns_for_a_context_key_divergence(caplog: pytest.LogCaptureFixture) -> None:
@@ -155,7 +153,7 @@ def test_warns_for_a_context_key_divergence(caplog: pytest.LogCaptureFixture) ->
 
 
 def test_the_surviving_none_warning_names_the_value_intake_materializes(caplog: pytest.LogCaptureFixture) -> None:
-    """The filter feature computes with the SPEC default, so naming the feature's value alone misleads."""
+    """The filter feature computes with the spec default, so naming the feature's value alone misleads."""
     with caplog.at_level(logging.WARNING):
         _emit(
             {DWG_KEY: PropertySpec("A group key with a concrete default.", context=False, default=DWG_DEFAULT)},
@@ -165,11 +163,11 @@ def test_the_surviving_none_warning_names_the_value_intake_materializes(caplog: 
 
     assert _messages(caplog, DWG_KEY) == [
         f"Options are not the same. {DWG_KEY} is different. None (intake fills '{DWG_DEFAULT}') != '{DWG_HOST_VAL}'"
-    ], "the message must name what intake materializes into the filter feature"
+    ]
 
 
 def test_the_plain_divergence_message_is_unchanged(caplog: pytest.LogCaptureFixture) -> None:
-    """Two explicit values reach compute time as declared, so their message keeps its pre-#911 wording."""
+    """Two explicit values reach compute time as declared, so their message keeps its original wording."""
     with caplog.at_level(logging.WARNING):
         _emit(
             {DWG_KEY: PropertySpec("A group key with a concrete default.", context=False, default=DWG_DEFAULT)},
@@ -179,4 +177,4 @@ def test_the_plain_divergence_message_is_unchanged(caplog: pytest.LogCaptureFixt
 
     assert _messages(caplog, DWG_KEY) == [
         f"Options are not the same. {DWG_KEY} is different. {DWG_FILTER_VAL} != {DWG_HOST_VAL}"
-    ], "a divergence intake does not touch must keep the original message"
+    ]

--- a/tests/test_core/test_filter/test_option_divergence_warning_guards.py
+++ b/tests/test_core/test_filter/test_option_divergence_warning_guards.py
@@ -1,0 +1,182 @@
+"""Pin the guard clauses and the rendered text of the filter-option divergence warning (#911).
+
+``test_unify_options_divergence_warning.py`` drives the same behaviour through the engine. These cases call
+the seam directly, because each guard below decides nothing but whether one log line is written: every early
+return is one token away from suppressing every divergence, and an engine run per guard buys no extra proof.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+import pytest
+
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.filter.global_filter import GlobalFilter
+from mloda.provider import PropertySpec
+
+
+# PROPERTY_MAPPING keys/values for the throwaway probes; the dwg_ prefix keeps them unique to this module.
+DWG_KEY = "dwg_key"
+DWG_CTX_KEY = "dwg_ctx_key"
+DWG_UNMAPPED_KEY = "dwg_unmapped_key"
+DWG_DEFAULT = "dwg_default_val"
+DWG_HOST_VAL = "dwg_host_val"
+DWG_FILTER_VAL = "dwg_filter_val"
+
+
+class _Ambiguous:
+    """A comparison result that refuses to be a bool, like the array a numpy ``==`` returns."""
+
+    def __bool__(self) -> bool:
+        raise ValueError("The truth value of an array with more than one element is ambiguous.")
+
+
+class _ArrayLikeDefault:
+    """A PROPERTY_MAPPING default whose ``==`` yields a non-bool, the shape numpy and pandas defaults have."""
+
+    def __eq__(self, other: object) -> Any:
+        return _Ambiguous()
+
+    def __hash__(self) -> int:
+        return 0
+
+    def __repr__(self) -> str:
+        return "<array-like default>"
+
+
+def _emit(mapping: Optional[dict[str, PropertySpec]], feat_options: Options, filter_options: Options) -> None:
+    """Run the divergence seam once against a throwaway group; ``mapping`` None means no resolving group.
+
+    The probe class stays local to this frame, so it is unreachable once the call returns and cannot leak
+    into the registry (the asserts live in the caller, whose traceback never pins this frame).
+    """
+    feature_group: Optional[type[FeatureGroup]] = None
+    if mapping is not None:
+
+        class DwgProbeFeatureGroup(FeatureGroup):
+            PROPERTY_MAPPING = mapping
+
+        feature_group = DwgProbeFeatureGroup
+
+    GlobalFilter()._warn_on_diverging_options(feature_group, feat_options, filter_options)
+
+
+def _messages(caplog: pytest.LogCaptureFixture, key: str) -> list[str]:
+    """Every warning-level message naming ``key``."""
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno >= logging.WARNING and key in record.getMessage()
+    ]
+
+
+def test_stays_silent_when_intake_materializes_the_features_own_value(caplog: pytest.LogCaptureFixture) -> None:
+    """The discriminating control: without it every guard case below could pass on a seam that never warns."""
+    with caplog.at_level(logging.WARNING):
+        _emit(
+            {DWG_KEY: PropertySpec("A group key with a concrete default.", context=False, default=DWG_DEFAULT)},
+            Options(group={DWG_KEY: DWG_DEFAULT}),
+            Options(group={DWG_KEY: None}),
+        )
+
+    assert _messages(caplog, DWG_KEY) == [], "a declared None that intake fills with the feature's value must not warn"
+
+
+def test_warns_without_a_resolving_feature_group(caplog: pytest.LogCaptureFixture) -> None:
+    """No group means no spec to consult, so nothing is suppressed and every difference is reported."""
+    with caplog.at_level(logging.WARNING):
+        _emit(None, Options(group={DWG_KEY: DWG_DEFAULT}), Options(group={DWG_KEY: None}))
+
+    assert _messages(caplog, DWG_KEY), "without a spec the fallback must report the divergence"
+
+
+def test_warns_when_the_key_is_absent_from_property_mapping(caplog: pytest.LogCaptureFixture) -> None:
+    """An unmapped key is never materialized by intake, so its divergence survives."""
+    with caplog.at_level(logging.WARNING):
+        _emit(
+            {DWG_KEY: PropertySpec("An unrelated mapped key.", context=False, default=DWG_DEFAULT)},
+            Options(group={DWG_UNMAPPED_KEY: DWG_DEFAULT}),
+            Options(group={DWG_UNMAPPED_KEY: None}),
+        )
+
+    assert _messages(caplog, DWG_UNMAPPED_KEY), "a key outside PROPERTY_MAPPING must keep warning"
+
+
+def test_warns_when_the_spec_declares_no_default(caplog: pytest.LogCaptureFixture) -> None:
+    """NO_DEFAULT fills nothing, so the declared None reaches compute time and stays divergent."""
+    with caplog.at_level(logging.WARNING):
+        _emit(
+            {DWG_KEY: PropertySpec("A required group key.", context=False)},
+            Options(group={DWG_KEY: DWG_DEFAULT}),
+            Options(group={DWG_KEY: None}),
+        )
+
+    assert _messages(caplog, DWG_KEY), "a key without a declared default must keep warning"
+
+
+def test_warns_when_the_spec_default_is_none(caplog: pytest.LogCaptureFixture) -> None:
+    """A declared default of None applies no value, so intake leaves the declared None alone."""
+    with caplog.at_level(logging.WARNING):
+        _emit(
+            {DWG_KEY: PropertySpec("A group key defaulting to None.", context=False, default=None)},
+            Options(group={DWG_KEY: DWG_DEFAULT}),
+            Options(group={DWG_KEY: None}),
+        )
+
+    assert _messages(caplog, DWG_KEY), "a spec default of None must keep warning"
+
+
+def test_warns_when_the_spec_default_cannot_be_compared(caplog: pytest.LogCaptureFixture) -> None:
+    """A third-party default whose ``==`` returns a non-bool must not abort the run from a logging decision."""
+    spec = PropertySpec("A group key defaulting to an array-like.", context=False, default=_ArrayLikeDefault())
+    with caplog.at_level(logging.WARNING):
+        _emit({DWG_KEY: spec}, Options(group={DWG_KEY: DWG_HOST_VAL}), Options(group={DWG_KEY: None}))
+
+    # The rendered fill proves the uncomparable default was reached, not skipped by an earlier guard.
+    assert _messages(caplog, DWG_KEY) == [
+        f"Options are not the same. {DWG_KEY} is different. "
+        f"None (intake fills <array-like default>) != '{DWG_HOST_VAL}'"
+    ], "an uncomparable default is not convergent, so it must keep warning instead of raising"
+
+
+def test_warns_for_a_context_key_divergence(caplog: pytest.LogCaptureFixture) -> None:
+    """The context namespace is reported too, not only the group one."""
+    with caplog.at_level(logging.WARNING):
+        _emit(
+            {DWG_CTX_KEY: PropertySpec("A context key with a concrete default.", default=DWG_DEFAULT)},
+            Options(context={DWG_CTX_KEY: DWG_HOST_VAL}),
+            Options(context={DWG_CTX_KEY: DWG_FILTER_VAL}),
+        )
+
+    assert _messages(caplog, DWG_CTX_KEY), "a context key divergence must be reported"
+
+
+def test_the_surviving_none_warning_names_the_value_intake_materializes(caplog: pytest.LogCaptureFixture) -> None:
+    """The filter feature computes with the SPEC default, so naming the feature's value alone misleads."""
+    with caplog.at_level(logging.WARNING):
+        _emit(
+            {DWG_KEY: PropertySpec("A group key with a concrete default.", context=False, default=DWG_DEFAULT)},
+            Options(group={DWG_KEY: DWG_HOST_VAL}),
+            Options(group={DWG_KEY: None}),
+        )
+
+    assert _messages(caplog, DWG_KEY) == [
+        f"Options are not the same. {DWG_KEY} is different. None (intake fills '{DWG_DEFAULT}') != '{DWG_HOST_VAL}'"
+    ], "the message must name what intake materializes into the filter feature"
+
+
+def test_the_plain_divergence_message_is_unchanged(caplog: pytest.LogCaptureFixture) -> None:
+    """Two explicit values reach compute time as declared, so their message keeps its pre-#911 wording."""
+    with caplog.at_level(logging.WARNING):
+        _emit(
+            {DWG_KEY: PropertySpec("A group key with a concrete default.", context=False, default=DWG_DEFAULT)},
+            Options(group={DWG_KEY: DWG_HOST_VAL}),
+            Options(group={DWG_KEY: DWG_FILTER_VAL}),
+        )
+
+    assert _messages(caplog, DWG_KEY) == [
+        f"Options are not the same. {DWG_KEY} is different. {DWG_FILTER_VAL} != {DWG_HOST_VAL}"
+    ], "a divergence intake does not touch must keep the original message"

--- a/tests/test_core/test_filter/test_unify_options_divergence_warning.py
+++ b/tests/test_core/test_filter/test_unify_options_divergence_warning.py
@@ -1,12 +1,10 @@
 """Pin the option divergence warning for a filter feature declaring a defaulted key as None (#911).
 
 Filter matching compares the host feature's EFFECTIVE options against the filter feature's DECLARED
-ones, so a filter feature declaring a defaulted key explicitly as None is reported as diverging from a
-value intake then materializes into it one call later. The warning must fire on a divergence that
-survives intake, not on one that provably converges.
-
-Every case drives the engine seam (``Engine._add_filter_feature``), because only there is the
-resolving feature group, and with it the spec that decides what intake will materialize, available.
+ones, so a defaulted key declared as None is reported as diverging from a value intake materializes
+into it one call later. The warning must fire on a divergence that survives intake, not on one that
+converges. Every case drives the engine seam, because only there is the resolving feature group,
+and with it the spec that decides what intake will materialize, available.
 """
 
 from __future__ import annotations
@@ -91,9 +89,8 @@ def _payload_rows(frames: list[Any], column: str) -> list[Any]:
 def _run(mapping: dict[str, PropertySpec], host_options: Options, filter_options: Options) -> dict[str, Any]:
     """Run UNW_HOST under a global EQUAL filter on UNW_TARGET; return plain-data views of both sides.
 
-    The probe class, the collector and the GlobalFilter (whose collection keys hold the class) are
-    deleted from THIS frame before the asserts, so a failing assert cannot pin the throwaway class into
-    a traceback and trip the no-leak fixture on top of the real failure.
+    The probe class, the collector and the GlobalFilter are deleted from THIS frame before the asserts,
+    so a failing assert cannot pin the throwaway class into a traceback and trip the no-leak fixture.
     """
     collector = PluginCollector.enabled_feature_groups({_make_probe_fg(mapping)})
     global_filter = GlobalFilter()
@@ -118,7 +115,7 @@ def _run(mapping: dict[str, PropertySpec], host_options: Options, filter_options
 
 
 def _warnings_naming(caplog: pytest.LogCaptureFixture, key: str) -> list[str]:
-    """Every warning-level message naming ``key``; location-agnostic, since the fix may move the check."""
+    """Every warning-level message naming ``key``; location-agnostic, since the check may move."""
     return [
         record.getMessage()
         for record in caplog.records
@@ -135,15 +132,13 @@ def _stored_value(observed: dict[str, Any], key: str) -> Any:
 
 
 def test_no_warning_when_a_declared_none_converges_on_the_group_default(caplog: pytest.LogCaptureFixture) -> None:
-    """A filter feature declaring a defaulted group key as None converges on the host's value, so no warning."""
+    """A defaulted group key declared as None converges on the host's value, so no warning."""
     with caplog.at_level(logging.WARNING):
         observed = _run({UNW_GRP_KEY: GRP_SPEC}, Options(), Options(group={UNW_GRP_KEY: None}))
 
-    assert observed["host_effective"][UNW_GRP_KEY] == UNW_DEFAULT, f"host must hold the default: {observed!r}"
-    assert _stored_value(observed, UNW_GRP_KEY) == UNW_DEFAULT, f"intake must fill the same default: {observed!r}"
-    assert _warnings_naming(caplog, UNW_GRP_KEY) == [], (
-        "a declared None that intake fills with the host's own value must not warn"
-    )
+    assert observed["host_effective"][UNW_GRP_KEY] == UNW_DEFAULT
+    assert _stored_value(observed, UNW_GRP_KEY) == UNW_DEFAULT
+    assert _warnings_naming(caplog, UNW_GRP_KEY) == []
 
 
 def test_no_warning_when_a_declared_none_converges_on_the_context_default(caplog: pytest.LogCaptureFixture) -> None:
@@ -151,23 +146,20 @@ def test_no_warning_when_a_declared_none_converges_on_the_context_default(caplog
     with caplog.at_level(logging.WARNING):
         observed = _run({UNW_CTX_KEY: CTX_SPEC}, Options(), Options(context={UNW_CTX_KEY: None}))
 
-    assert observed["host_effective"][UNW_CTX_KEY] == UNW_DEFAULT, f"host must hold the default: {observed!r}"
-    assert _stored_value(observed, UNW_CTX_KEY) == UNW_DEFAULT, f"intake must fill the same default: {observed!r}"
-    assert _warnings_naming(caplog, UNW_CTX_KEY) == [], (
-        "a declared None that intake fills with the host's own value must not warn"
-    )
+    assert observed["host_effective"][UNW_CTX_KEY] == UNW_DEFAULT
+    assert _stored_value(observed, UNW_CTX_KEY) == UNW_DEFAULT
+    assert _warnings_naming(caplog, UNW_CTX_KEY) == []
 
 
 def test_warns_when_a_declared_none_diverges_from_an_explicit_host_value(caplog: pytest.LogCaptureFixture) -> None:
-    """A declared None against an explicit host value is a real divergence: intake fills the SPEC default,
-    not the host's value, so the filter feature ends up computing with something else."""
+    """Intake fills the spec default, not the host's value, so the filter feature computes with something else."""
     with caplog.at_level(logging.WARNING):
         observed = _run(
             {UNW_GRP_KEY: GRP_SPEC}, Options(group={UNW_GRP_KEY: UNW_HOST_VAL}), Options(group={UNW_GRP_KEY: None})
         )
 
-    assert observed["host_effective"][UNW_GRP_KEY] == UNW_HOST_VAL, f"host must keep its value: {observed!r}"
-    assert _stored_value(observed, UNW_GRP_KEY) == UNW_DEFAULT, f"intake must fill the spec default: {observed!r}"
+    assert observed["host_effective"][UNW_GRP_KEY] == UNW_HOST_VAL
+    assert _stored_value(observed, UNW_GRP_KEY) == UNW_DEFAULT
     assert _warnings_naming(caplog, UNW_GRP_KEY), "a divergence that survives intake must still be reported"
 
 
@@ -180,8 +172,8 @@ def test_warns_when_two_explicit_values_differ(caplog: pytest.LogCaptureFixture)
             Options(group={UNW_GRP_KEY: UNW_FILTER_VAL}),
         )
 
-    assert observed["host_effective"][UNW_GRP_KEY] == UNW_HOST_VAL, f"host must keep its value: {observed!r}"
-    assert _stored_value(observed, UNW_GRP_KEY) == UNW_FILTER_VAL, f"the filter must keep its value: {observed!r}"
+    assert observed["host_effective"][UNW_GRP_KEY] == UNW_HOST_VAL
+    assert _stored_value(observed, UNW_GRP_KEY) == UNW_FILTER_VAL
     assert _warnings_naming(caplog, UNW_GRP_KEY), "two differing explicit values must still be reported"
 
 
@@ -190,11 +182,9 @@ def test_warns_when_an_opted_in_none_stays_divergent(caplog: pytest.LogCaptureFi
     with caplog.at_level(logging.WARNING):
         observed = _run({UNW_OPTIN_KEY: OPTIN_SPEC}, Options(), Options(group={UNW_OPTIN_KEY: None}))
 
-    assert observed["host_effective"][UNW_OPTIN_KEY] == UNW_DEFAULT, f"host must hold the default: {observed!r}"
-    assert _stored_value(observed, UNW_OPTIN_KEY) is None, f"the opted-in None must survive intake: {observed!r}"
-    assert _warnings_naming(caplog, UNW_OPTIN_KEY), (
-        "an honored None against a concrete host value must still be reported"
-    )
+    assert observed["host_effective"][UNW_OPTIN_KEY] == UNW_DEFAULT
+    assert _stored_value(observed, UNW_OPTIN_KEY) is None
+    assert _warnings_naming(caplog, UNW_OPTIN_KEY), "an honored None against a concrete host value must be reported"
 
 
 def test_absent_filter_keys_are_copied_into_their_own_namespace_without_warning(
@@ -209,8 +199,8 @@ def test_absent_filter_keys_are_copied_into_their_own_namespace_without_warning(
         )
 
     stored = observed["filter_stored"]
-    assert stored["group"].get(UNW_GRP_KEY) == UNW_HOST_VAL, f"a host group key must stay in group: {stored!r}"
-    assert stored["context"].get(UNW_CTX_KEY) == UNW_CTX_VAL, f"a host context key must stay in context: {stored!r}"
+    assert stored["group"].get(UNW_GRP_KEY) == UNW_HOST_VAL
+    assert stored["context"].get(UNW_CTX_KEY) == UNW_CTX_VAL
     assert UNW_CTX_KEY not in stored["group"], f"a context key must not leak into group: {stored!r}"
-    assert _warnings_naming(caplog, UNW_GRP_KEY) == [], "a copied group key must not warn"
-    assert _warnings_naming(caplog, UNW_CTX_KEY) == [], "a copied context key must not warn"
+    assert _warnings_naming(caplog, UNW_GRP_KEY) == []
+    assert _warnings_naming(caplog, UNW_CTX_KEY) == []

--- a/tests/test_core/test_filter/test_unify_options_divergence_warning.py
+++ b/tests/test_core/test_filter/test_unify_options_divergence_warning.py
@@ -1,0 +1,216 @@
+"""Pin the option divergence warning for a filter feature declaring a defaulted key as None (#911).
+
+Filter matching compares the host feature's EFFECTIVE options against the filter feature's DECLARED
+ones, so a filter feature declaring a defaulted key explicitly as None is reported as diverging from a
+value intake then materializes into it one call later. The warning must fire on a divergence that
+survives intake, not on one that provably converges.
+
+Every case drives the engine seam (``Engine._add_filter_feature``), because only there is the
+resolving feature group, and with it the spec that decides what intake will materialize, available.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.provider import DataCreator, PropertySpec
+from mloda.user import FilterType, GlobalFilter, PluginCollector, mloda
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
+
+
+# PROPERTY_MAPPING keys/values for the throwaway probes; the unw_ prefix keeps them unique to this module.
+UNW_GRP_KEY = "unw_grp_key"
+UNW_CTX_KEY = "unw_ctx_key"
+UNW_OPTIN_KEY = "unw_optin_key"
+UNW_DEFAULT = "unw_default_val"
+UNW_HOST_VAL = "unw_host_val"
+UNW_FILTER_VAL = "unw_filter_val"
+UNW_CTX_VAL = "unw_ctx_val"
+
+UNW_HOST = "unw_host_feature"  # the requested host feature the filter attaches to
+UNW_TARGET = "unw_target_feature"  # never requested, only reachable as a matched filter feature
+
+GRP_SPEC = PropertySpec("A group key with a concrete default.", context=False, default=UNW_DEFAULT)
+CTX_SPEC = PropertySpec("A context key with a concrete default.", context=True, default=UNW_DEFAULT)
+OPTIN_SPEC = PropertySpec(
+    "A group key honoring an explicit None.", context=False, default=UNW_DEFAULT, allow_explicit_none=True
+)
+
+
+def _make_probe_fg(mapping: dict[str, PropertySpec]) -> type[FeatureGroup]:
+    """A throwaway root FeatureGroup serving the host and the filter target, echoing its effective options."""
+
+    class UnwWarningProbeFeatureGroup(FeatureGroup):
+        PROPERTY_MAPPING = mapping
+
+        @classmethod
+        def input_data(cls) -> DataCreator:
+            return DataCreator({UNW_HOST, UNW_TARGET})
+
+        @classmethod
+        def final_filters(cls) -> bool:
+            # The payload is not filterable data, so the framework's row elimination must not run against it.
+            return False
+
+        @classmethod
+        def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+            observed = {str(f.name): {key: f.options.get(key) for key in mapping} for f in features.features}
+            return {str(feature.name): [observed] for feature in features.features}
+
+    return UnwWarningProbeFeatureGroup
+
+
+def _stored_filter_options(global_filter: GlobalFilter) -> list[dict[str, dict[str, Any]]]:
+    """Plain-data view of every collected filter feature's post-intake options, per namespace."""
+    return [
+        {"group": dict(single.filter_feature.options.group), "context": dict(single.filter_feature.options.context)}
+        for stored in global_filter.collection.values()
+        for single in stored
+    ]
+
+
+def _payload_rows(frames: list[Any], column: str) -> list[Any]:
+    """Every row stored under ``column``, tolerant of columnar dict or list-of-row-dicts frames."""
+    rows: list[Any] = []
+    for frame in frames:
+        if isinstance(frame, dict):
+            if column in frame:
+                rows.extend(frame[column])
+        else:
+            rows.extend(row[column] for row in frame if column in row)
+    return rows
+
+
+def _run(mapping: dict[str, PropertySpec], host_options: Options, filter_options: Options) -> dict[str, Any]:
+    """Run UNW_HOST under a global EQUAL filter on UNW_TARGET; return plain-data views of both sides.
+
+    The probe class, the collector and the GlobalFilter (whose collection keys hold the class) are
+    deleted from THIS frame before the asserts, so a failing assert cannot pin the throwaway class into
+    a traceback and trip the no-leak fixture on top of the real failure.
+    """
+    collector = PluginCollector.enabled_feature_groups({_make_probe_fg(mapping)})
+    global_filter = GlobalFilter()
+    global_filter.add_filter(Feature(UNW_TARGET, filter_options), FilterType.EQUAL, {"value": 1})
+    results = mloda.run_all(
+        [Feature(UNW_HOST, host_options)],
+        compute_frameworks={PythonDictFramework},
+        plugin_collector=collector,
+        global_filter=global_filter,
+    )
+
+    stored = _stored_filter_options(global_filter)
+    frames = list(results)
+    rows = _payload_rows(frames, UNW_HOST)
+    frames_repr = repr(frames)
+    del collector, global_filter, results, frames
+
+    assert len(rows) == 1, f"expected exactly one payload row for {UNW_HOST}, got frames: {frames_repr}"
+    assert isinstance(rows[0], dict), f"expected a payload dict for {UNW_HOST}, got: {rows[0]!r}"
+    assert len(stored) == 1, f"exactly one filter must have matched and been collected: {stored!r}"
+    return {"host_effective": rows[0][UNW_HOST], "filter_stored": stored[0]}
+
+
+def _warnings_naming(caplog: pytest.LogCaptureFixture, key: str) -> list[str]:
+    """Every warning-level message naming ``key``; location-agnostic, since the fix may move the check."""
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno >= logging.WARNING and key in record.getMessage()
+    ]
+
+
+def _stored_value(observed: dict[str, Any], key: str) -> Any:
+    """The filter feature's post-intake value for ``key``, whichever namespace it landed in."""
+    stored = observed["filter_stored"]
+    if key in stored["group"]:
+        return stored["group"][key]
+    return stored["context"].get(key)
+
+
+def test_no_warning_when_a_declared_none_converges_on_the_group_default(caplog: pytest.LogCaptureFixture) -> None:
+    """A filter feature declaring a defaulted group key as None converges on the host's value, so no warning."""
+    with caplog.at_level(logging.WARNING):
+        observed = _run({UNW_GRP_KEY: GRP_SPEC}, Options(), Options(group={UNW_GRP_KEY: None}))
+
+    assert observed["host_effective"][UNW_GRP_KEY] == UNW_DEFAULT, f"host must hold the default: {observed!r}"
+    assert _stored_value(observed, UNW_GRP_KEY) == UNW_DEFAULT, f"intake must fill the same default: {observed!r}"
+    assert _warnings_naming(caplog, UNW_GRP_KEY) == [], (
+        "a declared None that intake fills with the host's own value must not warn"
+    )
+
+
+def test_no_warning_when_a_declared_none_converges_on_the_context_default(caplog: pytest.LogCaptureFixture) -> None:
+    """The same for a context key: both namespaces must stop reporting the converging case."""
+    with caplog.at_level(logging.WARNING):
+        observed = _run({UNW_CTX_KEY: CTX_SPEC}, Options(), Options(context={UNW_CTX_KEY: None}))
+
+    assert observed["host_effective"][UNW_CTX_KEY] == UNW_DEFAULT, f"host must hold the default: {observed!r}"
+    assert _stored_value(observed, UNW_CTX_KEY) == UNW_DEFAULT, f"intake must fill the same default: {observed!r}"
+    assert _warnings_naming(caplog, UNW_CTX_KEY) == [], (
+        "a declared None that intake fills with the host's own value must not warn"
+    )
+
+
+def test_warns_when_a_declared_none_diverges_from_an_explicit_host_value(caplog: pytest.LogCaptureFixture) -> None:
+    """A declared None against an explicit host value is a real divergence: intake fills the SPEC default,
+    not the host's value, so the filter feature ends up computing with something else."""
+    with caplog.at_level(logging.WARNING):
+        observed = _run(
+            {UNW_GRP_KEY: GRP_SPEC}, Options(group={UNW_GRP_KEY: UNW_HOST_VAL}), Options(group={UNW_GRP_KEY: None})
+        )
+
+    assert observed["host_effective"][UNW_GRP_KEY] == UNW_HOST_VAL, f"host must keep its value: {observed!r}"
+    assert _stored_value(observed, UNW_GRP_KEY) == UNW_DEFAULT, f"intake must fill the spec default: {observed!r}"
+    assert _warnings_naming(caplog, UNW_GRP_KEY), "a divergence that survives intake must still be reported"
+
+
+def test_warns_when_two_explicit_values_differ(caplog: pytest.LogCaptureFixture) -> None:
+    """Two different non-None values stay different through intake, so the classic divergence still warns."""
+    with caplog.at_level(logging.WARNING):
+        observed = _run(
+            {UNW_GRP_KEY: GRP_SPEC},
+            Options(group={UNW_GRP_KEY: UNW_HOST_VAL}),
+            Options(group={UNW_GRP_KEY: UNW_FILTER_VAL}),
+        )
+
+    assert observed["host_effective"][UNW_GRP_KEY] == UNW_HOST_VAL, f"host must keep its value: {observed!r}"
+    assert _stored_value(observed, UNW_GRP_KEY) == UNW_FILTER_VAL, f"the filter must keep its value: {observed!r}"
+    assert _warnings_naming(caplog, UNW_GRP_KEY), "two differing explicit values must still be reported"
+
+
+def test_warns_when_an_opted_in_none_stays_divergent(caplog: pytest.LogCaptureFixture) -> None:
+    """allow_explicit_none=True honors the None, so it is never replaced by the default and stays divergent."""
+    with caplog.at_level(logging.WARNING):
+        observed = _run({UNW_OPTIN_KEY: OPTIN_SPEC}, Options(), Options(group={UNW_OPTIN_KEY: None}))
+
+    assert observed["host_effective"][UNW_OPTIN_KEY] == UNW_DEFAULT, f"host must hold the default: {observed!r}"
+    assert _stored_value(observed, UNW_OPTIN_KEY) is None, f"the opted-in None must survive intake: {observed!r}"
+    assert _warnings_naming(caplog, UNW_OPTIN_KEY), (
+        "an honored None against a concrete host value must still be reported"
+    )
+
+
+def test_absent_filter_keys_are_copied_into_their_own_namespace_without_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Keys absent from the filter options are copied per namespace and never warned about (#712)."""
+    with caplog.at_level(logging.WARNING):
+        observed = _run(
+            {UNW_GRP_KEY: GRP_SPEC, UNW_CTX_KEY: CTX_SPEC},
+            Options(group={UNW_GRP_KEY: UNW_HOST_VAL}, context={UNW_CTX_KEY: UNW_CTX_VAL}),
+            Options(),
+        )
+
+    stored = observed["filter_stored"]
+    assert stored["group"].get(UNW_GRP_KEY) == UNW_HOST_VAL, f"a host group key must stay in group: {stored!r}"
+    assert stored["context"].get(UNW_CTX_KEY) == UNW_CTX_VAL, f"a host context key must stay in context: {stored!r}"
+    assert UNW_CTX_KEY not in stored["group"], f"a context key must not leak into group: {stored!r}"
+    assert _warnings_naming(caplog, UNW_GRP_KEY) == [], "a copied group key must not warn"
+    assert _warnings_naming(caplog, UNW_CTX_KEY) == [], "a copied context key must not warn"


### PR DESCRIPTION
Closes #911

## Problem

Filter matching warned `Options are not the same. <key> is different. None != <default>` whenever a filter feature declared a defaulted `PROPERTY_MAPPING` key explicitly as `None`. Intake then materialized that same default, so the reported divergence never survived the next call.

## Deviation from the definition of done

The issue asks to silence the warning whenever the declared value is `None` for a defaulted key without `allow_explicit_none=True`. That would also hide a real divergence:

    spec default "D", host carries an explicit "X", filter declares None

    after unify_options : {'k': None}   (unify only fills keys the filter omits)
    after intake        : {'k': 'D'}    (the spec default, not the host's "X")
    host computes with  : 'X'

Suppression therefore requires the materialized default to *equal* the host's value, not merely to exist. Three cases keep warning: this one, two differing non-`None` values, and `allow_explicit_none` keys whose `None` survives intake.

## Implementation

The check needs the resolving FeatureGroup, which `unify_options` does not have. Of the two routes the issue offers, this takes the second: `unify_options` keeps its signature and goes back to "add the keys the filter feature omits", while `identify_matched_filters`, which holds the group, reports divergences. `GlobalFilter` is public, so adding a third parameter would break existing two-argument subclass overrides with a `TypeError`.

Suppression mirrors `FeatureGroup.options_with_defaults` via the same `option_key_is_present` helper. Two review findings are folded in: the surviving `None` warning now names what the filter actually computes with (`None (intake fills 'D') != 'X'`), and the comparison goes through `safe_field`, since `PropertySpec.default` is `Any` and an array-like default would otherwise raise out of a logging decision.

## Verification

`test_filter_feature_explicit_none_intake.py` emitted 10 such warnings before and zero after, with its tests still passing. New tests cover both suppression paths, the three divergence paths, the message text, and every guard clause. Full gate green: 7605 passed, 170 skipped.

Follow-up in #921: divergence is reported before the matching gates decide the filter attaches at all.
