### PR TITLE
fix: let SingleFilter own the feature it was built from

### DIFF
--- a/docs/docs/in_depth/filter_data.md
+++ b/docs/docs/in_depth/filter_data.md
@@ -34,6 +34,8 @@ The GlobalFilter provides methods to add filters to the collection. The preferre
 -   filter_type
 -   parameter
 
+A `Feature` passed as `filter_feature` is snapshotted, so later changes to your own object do not affect the stored filter.
+
 **add_time_and_time_travel_filters**: Adds time and time travel filtering to the GlobalFiltering. This is a convenience method. Due to the complexity of time in data/ml/ai projects, this function should be used.
 
 This method is useful for **filtering data based on time ranges** (event) and **validity periods** (valid).

--- a/mloda/core/abstract_plugins/components/feature.py
+++ b/mloda/core/abstract_plugins/components/feature.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from copy import copy
 from typing import TYPE_CHECKING, Any, Optional
 from uuid import uuid4
 from mloda.core.abstract_plugins.components.data_types import DataType
@@ -351,6 +352,24 @@ class Feature:
                 self._child_options_key(),
             )
         )
+
+    def __copy__(self) -> Feature:
+        """A value-equal Feature owning the mutable containers __eq__/__hash__ read (#910).
+
+        options and child_options are rebuilt while every option VALUE stays shared by reference:
+        _make_hashable falls back to repr() for an unhashable non-container leaf and the default repr
+        embeds the object address, so deep-copying a value would silently shift this Feature's hash and
+        break the very dedup the copy protects. Both containers are written in place by the engine
+        (intake forwarding, strict_type_enforcement, matcher writes), which is what the copy stops.
+        """
+        # One level: a Feature nested inside child_options.group keeps sharing its own options, the
+        # documented limitation class of _isolate_forwarded_value.
+        duplicate = self.__class__.__new__(self.__class__)
+        duplicate.__dict__.update(self.__dict__)
+        duplicate.options = copy(self.options)
+        if self.child_options is not None:
+            duplicate.child_options = copy(self.child_options)
+        return duplicate
 
     def _child_options_key(self) -> Any:
         """Cycle-safe identity view of child_options for __eq__/__hash__ (#608).

--- a/mloda/core/abstract_plugins/components/feature_set.py
+++ b/mloda/core/abstract_plugins/components/feature_set.py
@@ -166,4 +166,6 @@ class FeatureSet:
     def add_filters(self, single_filters: set[SingleFilter]) -> None:
         FeatureSetValidator.validate_filters_not_set(self.filters)
         FeatureSetValidator.validate_filters_is_set_type(single_filters)
-        self.filters = single_filters
+        # Copied here, at the storing end: callers hand over the live GlobalFilter.collection set,
+        # which keeps growing across sessions and would retroactively change this plan (#910).
+        self.filters = set(single_filters)

--- a/mloda/core/abstract_plugins/components/options.py
+++ b/mloda/core/abstract_plugins/components/options.py
@@ -273,18 +273,27 @@ class Options:
                 "Expected list, tuple, set, frozenset, str, or Feature object."
             )
 
+    def _rebuild(self, group: dict[str, Any], context: dict[str, Any]) -> "Options":
+        """A new Options over the given dicts, carrying this one's provenance bookkeeping over."""
+        copied = Options(group=group, context=context, propagate_context_keys=self.propagate_context_keys)
+        copied.inherited_group_keys = self.inherited_group_keys
+        copied.inherited_context_keys = self.inherited_context_keys
+        copied.last_forwarded_group_keys = self.last_forwarded_group_keys
+        return copied
+
+    def __copy__(self) -> "Options":
+        """A new Options owning its group/context dicts while sharing every value by reference.
+
+        Container ownership without __deepcopy__'s copy requirement on the values themselves.
+        """
+        return self._rebuild(dict(self.group), dict(self.context))
+
     def __deepcopy__(self, memo: dict[int, Any]) -> "Options":
         def safe_deepcopy_dict(d: dict[str, Any]) -> dict[str, Any]:
             """Safely deepcopy a dictionary, falling back to shallow copy for unpickleable objects."""
             return {key: _safe_deepcopy(value, memo) for key, value in d.items()}
 
-        copied_group = safe_deepcopy_dict(self.group)
-        copied_context = safe_deepcopy_dict(self.context)
-        copied = Options(group=copied_group, context=copied_context, propagate_context_keys=self.propagate_context_keys)
-        copied.inherited_group_keys = self.inherited_group_keys
-        copied.inherited_context_keys = self.inherited_context_keys
-        copied.last_forwarded_group_keys = self.last_forwarded_group_keys
-        return copied
+        return self._rebuild(safe_deepcopy_dict(self.group), safe_deepcopy_dict(self.context))
 
     def __str__(self) -> str:
         parts = f"Options(group={self.group}, context={self.context}"

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -44,7 +44,8 @@ class GlobalFilter:
         Parameters:
         - filter_feature: The feature or its name used for filtering. It can be a string or a `Feature` object.
             To identify if a filter is used, we need to check if the feature is part of the feature group.
-            During this process, we enrich the filter feature with the options of the feature.
+            A `Feature` is stored as a snapshot: identify_matched_filters enriches a per-match deepcopy
+            with the filtered feature's options, never the filter stored here.
         - filter_type: The type of filtering operation (e.g., equals, greater than). It can be a string or a `FilterType`.
             This filter_type does not need to match the FilterType, but it should be a string that is meaningful in the concrete
             Featuregroup implementation.

--- a/mloda/core/filter/single_filter.py
+++ b/mloda/core/filter/single_filter.py
@@ -1,3 +1,4 @@
+from copy import copy
 from typing import Any
 import uuid
 
@@ -46,7 +47,9 @@ class SingleFilter:
         from mloda.core.abstract_plugins.components.feature import Feature
 
         if isinstance(filter_feature, Feature):
-            return filter_feature
+            # The caller keeps its own object: Feature.__copy__ owns the containers that decide the
+            # hash, so a later write to them cannot lose this filter from a set it sits in (#910).
+            return copy(filter_feature)
         elif isinstance(filter_feature, str):
             return Feature(name=filter_feature)
         else:

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -1007,6 +1007,8 @@ class ExecutionPlan:
                 for feature in feature_set.features:
                     if feature.name == filtered_feature_name:
                         if len(relevant_filters) == 0:
+                            # Read-only alias of the live collection set; FeatureSet.add_filters
+                            # copies it once at the storing end (#910).
                             relevant_filters = single_filters
                         else:
                             if relevant_filters != single_filters:

--- a/tests/test_core/test_filter/test_execution_plan_filter_set_alias.py
+++ b/tests/test_core/test_filter/test_execution_plan_filter_set_alias.py
@@ -1,0 +1,100 @@
+"""Pin ``ExecutionPlan.add_single_filters_to_feature_set`` copying the filter set it hands out (#910).
+
+``relevant_filters = single_filters`` aliases the live ``GlobalFilter.collection`` set object into
+``FeatureSet.filters`` instead of copying it, so a planned ``FeatureSet`` keeps a live view of a
+mutable public set. Preparing a second session against the same ``GlobalFilter`` grows that set and
+retroactively changes what the first session's already-planned feature group receives.
+
+This is a separate defect from ``SingleFilter`` aliasing its filter feature: it survives that fix and
+needs its own copy at the handover.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.provider import DataCreator
+from mloda.user import Feature, FilterType, GlobalFilter, PluginCollector, mloda
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
+
+
+# The epa_ prefix keeps every feature name unique to this module.
+EPA_ROOT = "epa_root"
+EPA_TARGET_A = "epa_target_a"
+EPA_TARGET_B = "epa_target_b"
+
+
+def _make_fg() -> type[FeatureGroup]:
+    """A throwaway root feature group serving the host and both filter targets."""
+
+    class EpaHostFeatureGroup(FeatureGroup):
+        @classmethod
+        def input_data(cls) -> DataCreator:
+            return DataCreator({EPA_ROOT, EPA_TARGET_A, EPA_TARGET_B})
+
+        @classmethod
+        def final_filters(cls) -> bool:
+            # The payload is not filterable data: report features.filters inline instead of running
+            # post-calculation row elimination against it.
+            return False
+
+        @classmethod
+        def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+            delivered = len(features.filters) if features.filters else 0
+            return {str(feature.name): [delivered] for feature in features.features}
+
+    return EpaHostFeatureGroup
+
+
+def _delivered(results: list[Any]) -> list[int]:
+    """The filter count each frame reports for the host column."""
+    return [frame[EPA_ROOT][0] for frame in results if EPA_ROOT in frame]
+
+
+def _run_two_sessions() -> dict[str, Any]:
+    """Prepare and run two sessions against one GlobalFilter, then re-run the first one.
+
+    Every object referencing the throwaway feature group is dropped from this frame before returning,
+    so a failing assert in the caller cannot pin it into a traceback and trip the no-leak fixture.
+    """
+    collector = PluginCollector.enabled_feature_groups({_make_fg()})
+    global_filter = GlobalFilter()
+    global_filter.add_filter(Feature(EPA_TARGET_A), FilterType.EQUAL, {"value": 1})
+
+    first = mloda.prepare(
+        [EPA_ROOT],
+        compute_frameworks={PythonDictFramework},
+        plugin_collector=collector,
+        global_filter=global_filter,
+    )
+    observed: dict[str, Any] = {"first_run": _delivered(first.run())}
+
+    # A second filter on the same host, planned into a second session only.
+    global_filter.add_filter(Feature(EPA_TARGET_B), FilterType.EQUAL, {"value": 2})
+    second = mloda.prepare(
+        [EPA_ROOT],
+        compute_frameworks={PythonDictFramework},
+        plugin_collector=collector,
+        global_filter=global_filter,
+    )
+    observed["second_run"] = _delivered(second.run())
+    observed["first_rerun"] = _delivered(first.run())
+
+    del collector, global_filter, first, second
+    return observed
+
+
+def test_a_second_session_does_not_change_the_first_session_plan() -> None:
+    """The first session keeps the one filter it was prepared with (fails pre-fix: its FeatureSet
+    aliases the live collection set, so the second session's filter appears in it retroactively)."""
+    observed = _run_two_sessions()
+    assert observed["first_run"] == [1], f"the first session must be planned with one filter: {observed!r}"
+    assert observed["first_rerun"] == [1], f"the first session's plan must not change: {observed!r}"
+
+
+def test_the_second_session_sees_both_filters() -> None:
+    """Guard, passes pre-fix: the session prepared after the second add_filter plans both filters."""
+    observed = _run_two_sessions()
+    assert observed["second_run"] == [2], f"the second session must be planned with both filters: {observed!r}"

--- a/tests/test_core/test_filter/test_single_filter_owns_its_feature.py
+++ b/tests/test_core/test_filter/test_single_filter_owns_its_feature.py
@@ -1,0 +1,372 @@
+"""Pin ``SingleFilter`` owning its filter feature instead of aliasing the caller's object (#910).
+
+``handle_filter_feature`` stores the caller's ``Feature`` as-is, so anything that later rebinds or
+mutates one of the containers that feature hashes over shifts the hash of a ``SingleFilter`` already
+sitting in the public ``GlobalFilter.filters`` set. Three public paths reach it with
+``copy_features=False``: intake materializes a declared group default onto the shared feature,
+``strict_type_enforcement=True`` adds a group key to the shared ``Options`` in place, and that same
+in-place write lands on the ``child_options`` the engine stamped onto a cached input feature. Either
+way the set loses its own member and a value-equal ``add_filter`` stops deduplicating.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.provider import DataCreator, PropertySpec
+from mloda.user import DataType, Feature, FilterType, GlobalFilter, Options, PluginCollector, SingleFilter, mloda
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
+
+
+# The sfo_ prefix keeps every key and feature name unique to this module.
+SFO_GRP_KEY = "sfo_grp_key"
+SFO_GRP_DEFAULT = "sfo_grp_default_val"
+SFO_GRP_FEATURE = "sfo_grp_shared"
+SFO_TYPED_FEATURE = "sfo_typed_shared"
+SFO_UNIT_FEATURE = "sfo_unit_feature"
+SFO_UNIT_KEY = "sfo_unit_key"
+SFO_LATE_KEY = "sfo_late_key"
+SFO_CACHED_FEATURE = "sfo_cached_input"
+SFO_CONSUMER_FEATURE = "sfo_cached_consumer"
+SFO_CONSUMER_KEY = "sfo_consumer_key"
+SFO_LEAF_FEATURE = "sfo_leaf_feature"
+SFO_LEAF_KEY = "sfo_leaf_key"
+
+
+def _make_shared_fg(name: str, property_mapping: dict[str, PropertySpec]) -> type[FeatureGroup]:
+    """A throwaway root feature group serving one name and reporting the filters it received."""
+
+    class SfoSharedFeatureGroup(FeatureGroup):
+        PROPERTY_MAPPING = property_mapping
+
+        @classmethod
+        def input_data(cls) -> DataCreator:
+            return DataCreator({name})
+
+        @classmethod
+        def final_filters(cls) -> bool:
+            # The payload is not filterable data: report features.filters inline instead of running
+            # post-calculation row elimination against it.
+            return False
+
+        @classmethod
+        def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+            delivered = len(features.filters) if features.filters else 0
+            return {str(feature.name): [delivered] for feature in features.features}
+
+    return SfoSharedFeatureGroup
+
+
+def _observe(shared: Feature, twin: Feature, feature_group: type[FeatureGroup], strict: bool) -> dict[str, Any]:
+    """Share one ``Feature`` between ``add_filter`` and an uncopied run; return a plain-data view.
+
+    Every object referencing the throwaway feature group is dropped from this frame before returning,
+    so a failing assert in the caller cannot pin it into a traceback and trip the no-leak fixture on
+    top of the real failure.
+    """
+    column = str(shared.name)
+    global_filter = GlobalFilter()
+    global_filter.add_filter(shared, FilterType.EQUAL, {"value": 1})
+    stored = next(iter(global_filter.filters))
+
+    observed: dict[str, Any] = {
+        "aliases_caller": stored.filter_feature is shared,
+        "member_before": stored in global_filter.filters,
+    }
+    results = mloda.run_all(
+        [shared],
+        compute_frameworks={PythonDictFramework},
+        plugin_collector=PluginCollector.enabled_feature_groups({feature_group}),
+        global_filter=global_filter,
+        copy_features=False,
+        strict_type_enforcement=strict,
+    )
+    frames = list(results)
+
+    observed["member_after"] = stored in global_filter.filters
+    observed["stored_group"] = dict(stored.filter_feature.options.group)
+    observed["caller_group"] = dict(shared.options.group)
+    observed["filters"] = len(global_filter.filters)
+    # A declared twin of the original request: value-equal to what was added, so it must not grow the set.
+    global_filter.add_filter(twin, FilterType.EQUAL, {"value": 1})
+    observed["filters_after_readd"] = len(global_filter.filters)
+    observed["collected"] = {str(name): len(entries) for (_group, name), entries in global_filter.collection.items()}
+    observed["delivered"] = [frame[column][0] for frame in frames if column in frame]
+
+    del shared, twin, feature_group, global_filter, stored, results, frames
+    return observed
+
+
+def _run_group_key_default() -> dict[str, Any]:
+    """One feature declaring a group key as None, served by a group declaring a concrete default."""
+    return _observe(
+        Feature(SFO_GRP_FEATURE, Options(group={SFO_GRP_KEY: None})),
+        Feature(SFO_GRP_FEATURE, Options(group={SFO_GRP_KEY: None})),
+        _make_shared_fg(
+            SFO_GRP_FEATURE,
+            {SFO_GRP_KEY: PropertySpec("A group concrete default.", context=False, default=SFO_GRP_DEFAULT)},
+        ),
+        strict=False,
+    )
+
+
+def _run_strict_type_enforcement() -> dict[str, Any]:
+    """One typed feature, no declared default: strict_type_enforcement adds the group key in place."""
+    return _observe(
+        Feature(SFO_TYPED_FEATURE, Options(), data_type=DataType.INT64),
+        Feature(SFO_TYPED_FEATURE, Options(), data_type=DataType.INT64),
+        _make_shared_fg(SFO_TYPED_FEATURE, {}),
+        strict=True,
+    )
+
+
+def test_group_key_shared_filter_stays_findable_in_the_global_filter() -> None:
+    """The shared filter stays findable in ``GlobalFilter.filters`` after the run (fails pre-fix:
+    intake materializes the declared default onto the aliased feature, shifting the stored hash)."""
+    observed = _run_group_key_default()
+    assert observed["member_before"] is True, f"the filter must be in its own set before the run: {observed!r}"
+    assert observed["member_after"] is True, f"the filter must stay findable in its own set: {observed!r}"
+
+
+def test_group_key_shared_filter_keeps_its_declared_options() -> None:
+    """The filter keeps the options it was declared with, while the caller's feature is still filled
+    (fails pre-fix: both views are the same object, so the run rewrites the filter too)."""
+    observed = _run_group_key_default()
+    assert observed["stored_group"] == {SFO_GRP_KEY: None}, f"the filter must own its options: {observed!r}"
+    assert observed["caller_group"] == {SFO_GRP_KEY: SFO_GRP_DEFAULT}, (
+        f"intake must still materialize the caller's feature: {observed!r}"
+    )
+
+
+def test_group_key_shared_filter_dedupes_a_value_equal_readd_after_the_run() -> None:
+    """Re-adding a value-equal filter after the run does not grow the set (fails pre-fix: the stored
+    entry drifted to the materialized options, so the declared twin is no longer equal to it)."""
+    observed = _run_group_key_default()
+    assert observed["filters"] == 1, f"the run must not add filters: {observed!r}"
+    assert observed["filters_after_readd"] == 1, f"a value-equal re-add must deduplicate: {observed!r}"
+
+
+def test_group_key_shared_filter_is_still_matched_and_delivered() -> None:
+    """Guard, passes pre-fix: the filter must still match its host and reach the feature group."""
+    observed = _run_group_key_default()
+    assert observed["collected"] == {SFO_GRP_FEATURE: 1}, f"the run must collect exactly one filter: {observed!r}"
+    assert observed["delivered"] == [1], f"the feature group must receive exactly one filter: {observed!r}"
+
+
+def test_strict_type_enforcement_shared_filter_stays_findable_in_the_global_filter() -> None:
+    """A typed shared feature needs no declared default: strict_type_enforcement mutates the shared
+    Options in place (fails pre-fix: the added group key shifts the stored filter's hash)."""
+    observed = _run_strict_type_enforcement()
+    assert observed["member_before"] is True, f"the filter must be in its own set before the run: {observed!r}"
+    assert observed["member_after"] is True, f"the filter must stay findable in its own set: {observed!r}"
+
+
+def test_strict_type_enforcement_shared_filter_dedupes_a_value_equal_readd_after_the_run() -> None:
+    """Re-adding a value-equal typed filter after the run does not grow the set (fails pre-fix)."""
+    observed = _run_strict_type_enforcement()
+    assert observed["stored_group"] == {}, f"the filter must own its options: {observed!r}"
+    assert observed["filters_after_readd"] == 1, f"a value-equal re-add must deduplicate: {observed!r}"
+
+
+def test_strict_type_enforcement_shared_filter_is_still_matched_and_delivered() -> None:
+    """Guard, passes pre-fix: the typed filter must still match its host and reach the feature group."""
+    observed = _run_strict_type_enforcement()
+    assert observed["collected"] == {SFO_TYPED_FEATURE: 1}, f"the run must collect exactly one filter: {observed!r}"
+    assert observed["delivered"] == [1], f"the feature group must receive exactly one filter: {observed!r}"
+
+
+def _make_cached_input_chain() -> tuple[Feature, type[FeatureGroup], type[FeatureGroup]]:
+    """A consumer whose ``input_features`` hands out one cached ``Feature``, plus the root serving it."""
+    cached = Feature(SFO_CACHED_FEATURE)
+
+    class SfoCachedRoot(FeatureGroup):
+        @classmethod
+        def input_data(cls) -> DataCreator:
+            return DataCreator({SFO_CACHED_FEATURE})
+
+        @classmethod
+        def final_filters(cls) -> bool:
+            # The payload is not filterable data: report features.filters inline instead of running
+            # post-calculation row elimination against it.
+            return False
+
+        @classmethod
+        def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+            return {SFO_CACHED_FEATURE: [len(features.filters) if features.filters else 0]}
+
+    class SfoCachedConsumer(FeatureGroup):
+        def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature]:
+            # The same object every call, as a plugin holding a module-level or memoized Feature does.
+            return {cached}
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: Optional[DataAccessCollection] = None,
+        ) -> bool:
+            return str(feature_name) == SFO_CONSUMER_FEATURE
+
+        @classmethod
+        def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+            return {SFO_CONSUMER_FEATURE: list(data[SFO_CACHED_FEATURE])}
+
+    return cached, SfoCachedRoot, SfoCachedConsumer
+
+
+def _run_cached_input_feature() -> dict[str, Any]:
+    """Add a filter on the cached input feature between two runs sharing one requested ``Feature``.
+
+    Run one stamps ``cached.child_options`` with the consumer's live ``Options``; run two adds
+    ``strict_type_enforcement`` to that very object in place. Every object referencing the throwaway
+    feature groups is dropped from this frame before returning, so a failing assert in the caller
+    cannot pin one into a traceback and trip the no-leak fixture.
+    """
+    cached, root_fg, consumer_fg = _make_cached_input_chain()
+    collector = PluginCollector.enabled_feature_groups({root_fg, consumer_fg})
+    consumer = Feature(SFO_CONSUMER_FEATURE, Options(group={SFO_CONSUMER_KEY: "v"}), data_type=DataType.INT64)
+
+    mloda.run_all(
+        [consumer],
+        compute_frameworks={PythonDictFramework},
+        plugin_collector=collector,
+        copy_features=False,
+    )
+
+    global_filter = GlobalFilter()
+    global_filter.add_filter(cached, FilterType.EQUAL, {"value": 1})
+    stored = next(iter(global_filter.filters))
+    observed: dict[str, Any] = {
+        "stamped": cached.child_options is consumer.options,
+        "member_before": stored in global_filter.filters,
+    }
+
+    frames = list(
+        mloda.run_all(
+            [consumer],
+            compute_frameworks={PythonDictFramework},
+            plugin_collector=collector,
+            global_filter=global_filter,
+            copy_features=False,
+            strict_type_enforcement=True,
+        )
+    )
+
+    observed["member_after"] = stored in global_filter.filters
+    stored_child = stored.filter_feature.child_options
+    observed["stored_child_group"] = dict(stored_child.group) if stored_child is not None else None
+    observed["delivered"] = [frame[SFO_CONSUMER_FEATURE][0] for frame in frames if SFO_CONSUMER_FEATURE in frame]
+
+    del cached, root_fg, consumer_fg, collector, consumer, global_filter, stored, stored_child, frames
+    return observed
+
+
+def test_cached_input_feature_filter_stays_findable_in_the_global_filter() -> None:
+    """The filter on a cached input feature stays findable after a later run (fails pre-fix: the
+    stored feature shares the consumer's Options as child_options, so the in-place strict write
+    shifts its hash)."""
+    observed = _run_cached_input_feature()
+    assert observed["stamped"] is True, f"the engine must stamp the consumer's live Options: {observed!r}"
+    assert observed["member_before"] is True, f"the filter must be in its own set before the run: {observed!r}"
+    assert observed["member_after"] is True, f"the filter must stay findable in its own set: {observed!r}"
+
+
+def test_cached_input_feature_filter_keeps_the_child_options_it_was_stored_with() -> None:
+    """The stored filter keeps the child_options snapshot taken at add_filter (fails pre-fix)."""
+    observed = _run_cached_input_feature()
+    assert observed["stored_child_group"] == {SFO_CONSUMER_KEY: "v"}, (
+        f"the filter must own its child_options: {observed!r}"
+    )
+
+
+def test_cached_input_feature_filter_is_still_matched_and_delivered() -> None:
+    """Guard, passes pre-fix: the filter must still reach the root feature group through the chain."""
+    observed = _run_cached_input_feature()
+    assert observed["delivered"] == [1], f"the root feature group must receive exactly one filter: {observed!r}"
+
+
+def _unit_feature() -> Feature:
+    """A plain feature with one declared group key, for the engine-free ownership pins."""
+    return Feature(SFO_UNIT_FEATURE, Options(group={SFO_UNIT_KEY: "declared"}))
+
+
+def test_single_filter_does_not_alias_the_caller_feature() -> None:
+    """A SingleFilter owns its feature: value-equal to the caller's, never the same object."""
+    feature = _unit_feature()
+    single_filter = SingleFilter(feature, FilterType.EQUAL, {"value": 1})
+    assert single_filter.filter_feature is not feature, "the filter must not alias the caller's Feature"
+    assert single_filter.filter_feature == feature, "the filter's own feature must equal the caller's"
+
+
+def test_single_filter_hash_survives_a_mutation_of_the_caller_feature() -> None:
+    """Mutating the caller's Options after construction must not shift the filter's hash."""
+    feature = _unit_feature()
+    single_filter = SingleFilter(feature, FilterType.EQUAL, {"value": 1})
+    before = hash(single_filter)
+    feature.options.add_to_group(SFO_LATE_KEY, "late")
+    assert hash(single_filter) == before, "a caller-side mutation must not shift the filter's hash"
+
+
+def test_single_filter_stays_in_its_set_when_the_caller_feature_changes() -> None:
+    """A stored filter stays findable after the caller mutates and then rebinds its Options."""
+    feature = _unit_feature()
+    single_filter = SingleFilter(feature, FilterType.EQUAL, {"value": 1})
+    holder = {single_filter}
+    feature.options.add_to_group(SFO_LATE_KEY, "late")
+    assert single_filter in holder, "a caller-side mutation must not lose the filter from its set"
+    feature.options = Options(group={SFO_UNIT_KEY: "rebound"})
+    assert single_filter in holder, "a caller-side rebind must not lose the filter from its set"
+
+
+def test_string_filter_feature_still_builds_a_named_feature() -> None:
+    """Guard, passes pre-fix: a str filter feature still becomes a Feature and still names the filter."""
+    single_filter = SingleFilter(SFO_UNIT_FEATURE, FilterType.RANGE, {"min": 1, "max": 2})
+    assert single_filter.name == SFO_UNIT_FEATURE
+    assert str(single_filter.filter_feature.name) == SFO_UNIT_FEATURE
+
+
+def test_independently_built_filters_stay_value_equal_and_dedupe() -> None:
+    """Guard, passes pre-fix: equality stays by value, so equal filters still collapse in a set."""
+    first = SingleFilter(_unit_feature(), FilterType.EQUAL, {"value": 1})
+    second = SingleFilter(_unit_feature(), FilterType.EQUAL, {"value": 1})
+    assert first == second, "filters with equal feature, type and parameter must compare equal"
+    assert len({first, second}) == 1, "equal filters must deduplicate in a set"
+
+
+class _SfoUnhashableLeaf:
+    """An unhashable non-container option value; defining __eq__ alone drops __hash__ to None."""
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, _SfoUnhashableLeaf)
+
+
+def _leaf_feature(leaf: _SfoUnhashableLeaf) -> Feature:
+    """A filter feature whose single group value is that unhashable leaf."""
+    return Feature(SFO_LEAF_FEATURE, Options(group={SFO_LEAF_KEY: leaf}))
+
+
+def test_a_filter_feature_with_an_unhashable_option_value_keeps_its_hash() -> None:
+    """Structural pin: the ownership copy must SHARE every option value, never copy it.
+
+    _make_hashable falls back to repr() for an unhashable non-container leaf and the default repr
+    embeds the object address, so swapping the copy for a deepcopy silently shifts the stored hash.
+    """
+    feature = _leaf_feature(_SfoUnhashableLeaf())
+    global_filter = GlobalFilter()
+    global_filter.add_filter(feature, FilterType.EQUAL, {"value": 1})
+    stored = next(iter(global_filter.filters))
+    assert hash(stored.filter_feature) == hash(feature), "the stored feature must keep the caller's hash"
+
+
+def test_a_filter_feature_with_an_unhashable_option_value_still_dedupes() -> None:
+    """The same structural pin from the dedup side: a value-equal re-add must not grow the set."""
+    leaf = _SfoUnhashableLeaf()
+    global_filter = GlobalFilter()
+    global_filter.add_filter(_leaf_feature(leaf), FilterType.EQUAL, {"value": 1})
+    global_filter.add_filter(_leaf_feature(leaf), FilterType.EQUAL, {"value": 1})
+    assert len(global_filter.filters) == 1, "a value-equal re-add must deduplicate"


### PR DESCRIPTION
Closes #910

## Problem

`SingleFilter.handle_filter_feature` stored the caller's `Feature` object itself, so anything that later touched that object shifted the hash of a `SingleFilter` already sitting in the public `GlobalFilter.filters` set. `single_filter in global_filter.filters` then silently lied, and a later value-equal `add_filter` stopped deduplicating.

## Three reachable vectors

All three are in-place writes to a container that `Feature.__eq__` and `__hash__` read:

1. **`copy_features=False`**: `Engine.add_feature_to_collection` rebinds `feature.options` at intake, on the object the caller also handed to `add_filter`.
2. **`strict_type_enforcement=True`**: `_process_features` mutates the shared `Options` in place. No declared default needed.
3. **`child_options`**: the engine aliases it to the consumer's *live* `Options` object, so a `Feature` a plugin hands out from `input_features()` (a cached or module-level object) drifts as well. This one was found by review after the first pass and reproduced end to end:

       before: stored child_options is parent.options: True
               DRIFTED: hash 7013111468059095351 -> 2629616892135304538
               stored in gf.filters: False
       after:  stored child_options is parent.options: False
               no drift in any hash input
               stored in gf.filters: True

## Approach

`Feature` gains a `__copy__` that owns `options` and `child_options`, and `SingleFilter` just calls `copy()`. The policy lives next to `__eq__`/`__hash__` deliberately: keeping it inside `SingleFilter` is precisely why `child_options` was missed the first time, so the next person adding a hash input meets the copy policy in the same place.

**The copy is shallow at the value level on purpose.** `_make_hashable` falls back to `repr(value)` for an unhashable non-container leaf, and the default `repr` embeds the object address, so deep-copying an option value would silently give the stored filter a *different* hash than the feature it was built from, breaking exactly the dedup this restores. Ownership of the containers is what equality and hashing read; values stay shared so identity is preserved. A test pins this, and fails if someone swaps in `deepcopy`.

Every other `__eq__`/`__hash__` input was audited: `name`, `data_type` and `domain` cannot be mutated in place, and `compute_frameworks` is a mutable set that today is only ever rebound, never mutated (checked repo-wide). It stays shared, and that is the one to watch, so #924 records it.

## Second defect, which the issue asks to decide

`ExecutionPlan.add_single_filters_to_feature_set` handed the live `GlobalFilter.collection` set straight into `FeatureSet.filters`, so a second run on the same `GlobalFilter` retroactively changed the first run's plan. Reproduced deterministically through the public API: sessions observed `[1, 2, 2]` filters where `[1, 2, 1]` is correct. `FeatureSet.add_filters` now copies, which is the storing end where the invariant holds for every caller and costs one copy per call.

## Verification

17 new tests across two files. Against the pristine tree, 9 of the original 14 fail and the two `child_options` pins fail on the first-pass fix, so each is confirmed to bite. Guards pin what must not change: value equality and dedup across independently built filters, string filter features, and end to end that the filter is still matched and still delivered to the FeatureGroup.

Full gate green: 7720 passed, 170 skipped, plus `tests/test_documentation` at 113. `ruff format --check`, `ruff check` and `mypy --strict` all clean.

## Follow-ups

- #924: `compute_frameworks` is the remaining mutable hash input shared by reference.
- #925: a dict-valued filter parameter makes `hash(SingleFilter)` raise, pre-existing and found during the audit.
