### PR TITLE
fix: contain a raising match hook during filter matching

### DIFF
--- a/docs/docs/in_depth/feature-group-matching.md
+++ b/docs/docs/in_depth/feature-group-matching.md
@@ -27,7 +27,7 @@ Do not call `FeatureChainParser.match_configuration_feature_chain_parser` direct
 
 Containment covers plugin raises only: a framework-owned raise (a two-readers conflict, a forwarded value contradicting the feature name, a rejected effective-options build) still aborts the whole resolution, because it reports a misconfiguration you have to fix.
 
-Filter matching contains the same way: a raise there makes that filter a non-match for that probe, exactly as a `False` return would, logged at WARNING and recorded in `GlobalFilter.dropped_filters`. A framework-owned raise still aborts the run.
+Filter matching contains the same way: a raise is a non-match for that probe, like a `False` return, and is recorded in `GlobalFilter.dropped_filters`. A framework-owned raise still aborts.
 
 The options view depends on the caller: feature resolution passes declared (pre-default) options, while filter matching runs after intake and passes the resolved feature's effective (post-default) options merged onto the filter feature's own. Matching logic that reads option values can see different values on the two paths. See [Applying declared defaults](property-mapping.md#applying-declared-defaults).
 

--- a/docs/docs/in_depth/feature-group-matching.md
+++ b/docs/docs/in_depth/feature-group-matching.md
@@ -27,6 +27,8 @@ Do not call `FeatureChainParser.match_configuration_feature_chain_parser` direct
 
 Containment covers plugin raises only: a framework-owned raise (a two-readers conflict, a forwarded value contradicting the feature name, a rejected effective-options build) still aborts the whole resolution, because it reports a misconfiguration you have to fix.
 
+Filter matching contains the same way: a raise there drops only that filter for that feature group and logs the drop at WARNING, while a framework-owned raise still aborts the run.
+
 The options view depends on the caller: feature resolution passes declared (pre-default) options, while filter matching runs after intake and passes the resolved feature's effective (post-default) options merged onto the filter feature's own. Matching logic that reads option values can see different values on the two paths. See [Applying declared defaults](property-mapping.md#applying-declared-defaults).
 
 ### 2. PROPERTY_MAPPING Configuration

--- a/docs/docs/in_depth/feature-group-matching.md
+++ b/docs/docs/in_depth/feature-group-matching.md
@@ -27,7 +27,7 @@ Do not call `FeatureChainParser.match_configuration_feature_chain_parser` direct
 
 Containment covers plugin raises only: a framework-owned raise (a two-readers conflict, a forwarded value contradicting the feature name, a rejected effective-options build) still aborts the whole resolution, because it reports a misconfiguration you have to fix.
 
-Filter matching contains the same way: a raise there drops only that filter for that feature group and logs the drop at WARNING, while a framework-owned raise still aborts the run.
+Filter matching contains the same way: a raise there makes that filter a non-match for that probe, exactly as a `False` return would, logged at WARNING and recorded in `GlobalFilter.dropped_filters`. A framework-owned raise still aborts the run.
 
 The options view depends on the caller: feature resolution passes declared (pre-default) options, while filter matching runs after intake and passes the resolved feature's effective (post-default) options merged onto the filter feature's own. Matching logic that reads option values can see different values on the two paths. See [Applying declared defaults](property-mapping.md#applying-declared-defaults).
 

--- a/docs/docs/in_depth/filter_data.md
+++ b/docs/docs/in_depth/filter_data.md
@@ -181,8 +181,9 @@ filter, they each receive independent copies. This means a single `GlobalFilter`
 be processed differently by different FeatureGroups in the same pipeline: one may use
 the mask engine for inline masking while another uses filters for row elimination.
 
-If a FeatureGroup's `match_feature_group_criteria` raises while a filter is matched, only
-that filter is dropped for that FeatureGroup and the drop is logged at WARNING.
+If a FeatureGroup's `match_feature_group_criteria` raises while a filter is matched, that filter
+is a non-match for that probe, exactly as a `False` return would be, logged at WARNING and recorded
+in `GlobalFilter.dropped_filters`. A framework-owned raise still aborts the run.
 
 Matched filters are attached to the `FeatureSet` before `calculate_feature()` is
 called. Inside your calculation you can access them via `features.filters`:

--- a/docs/docs/in_depth/filter_data.md
+++ b/docs/docs/in_depth/filter_data.md
@@ -181,6 +181,9 @@ filter, they each receive independent copies. This means a single `GlobalFilter`
 be processed differently by different FeatureGroups in the same pipeline: one may use
 the mask engine for inline masking while another uses filters for row elimination.
 
+If a FeatureGroup's `match_feature_group_criteria` raises while a filter is matched, only
+that filter is dropped for that FeatureGroup and the drop is logged at WARNING.
+
 Matched filters are attached to the `FeatureSet` before `calculate_feature()` is
 called. Inside your calculation you can access them via `features.filters`:
 

--- a/docs/docs/in_depth/filter_data.md
+++ b/docs/docs/in_depth/filter_data.md
@@ -182,8 +182,8 @@ be processed differently by different FeatureGroups in the same pipeline: one ma
 the mask engine for inline masking while another uses filters for row elimination.
 
 If a FeatureGroup's `match_feature_group_criteria` raises while a filter is matched, that filter
-is a non-match for that probe, exactly as a `False` return would be, logged at WARNING and recorded
-in `GlobalFilter.dropped_filters`. A framework-owned raise still aborts the run.
+is a non-match for that probe, like a `False` return, and the drop is recorded in
+`GlobalFilter.dropped_filters`. A framework-owned raise still aborts.
 
 Matched filters are attached to the `FeatureSet` before `calculate_feature()` is
 called. Inside your calculation you can access them via `features.filters`:

--- a/mloda/core/abstract_plugins/components/utils.py
+++ b/mloda/core/abstract_plugins/components/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 from typing import Any, Callable, TypeVar
 
 import logging
@@ -57,6 +58,12 @@ def safe_field(
             # str(exc), not exc: a retained log record must not pin the traceback, its frames and the plugin class.
             logger.warning("Degraded field '%s': %s: %s", field, type(exc).__name__, str(exc))
         return fallback
+
+
+def contained_raise_reason(exc: BaseException) -> str:
+    """Text form of a contained raise: type and message, never the exception object."""
+    # partial, not a lambda: exc binds eagerly, so no closure keeps it and its traceback alive.
+    return f"raised {type(exc).__name__}: {safe_field(functools.partial(str, exc), type(exc).__name__)}"
 
 
 def safe_field_with_error(

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -1,3 +1,4 @@
+import functools
 from copy import deepcopy
 from datetime import datetime, timezone
 from typing import Any, Optional
@@ -8,6 +9,7 @@ from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.utils import is_match_abort, safe_field
 from mloda.core.filter.filter_type_enum import FilterType
 from mloda.core.filter.single_filter import SingleFilter
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
@@ -121,10 +123,29 @@ class GlobalFilter:
         filter: SingleFilter,
         data_access_collection: Optional[DataAccessCollection] = None,
     ) -> bool:
-        # Uncontained: the #845 match seam does not reach here, but the group is already identified.
-        return feature_group.match_feature_group_criteria(
-            filter.filter_feature.name, filter.filter_feature.options, data_access_collection
-        )
+        """A raising match hook is a non-match for this filter only, mirroring the resolution seam (#845).
+
+        WARNING regardless of exception type, unlike the seam's contained_raise_log_level: no resolution
+        failure message carries the reason here, and a dropped filter changes results silently. The reason
+        is kept as text, never an exception object whose traceback would pin the plugin class. No option
+        rollback: the hook sees a per-match deepcopy's options, discarded with the dropped filter.
+        """
+        try:
+            return feature_group.match_feature_group_criteria(
+                filter.filter_feature.name, filter.filter_feature.options, data_access_collection
+            )
+        except Exception as exc:  # noqa: BLE001  (contained: one broken matcher must not fail the whole run)
+            if is_match_abort(exc):
+                raise
+            # partial, not a lambda: exc binds eagerly, so no closure keeps it and its traceback alive.
+            reason = f"raised {type(exc).__name__}: {safe_field(functools.partial(str, exc), type(exc).__name__)}"
+            logger.warning(
+                "%s %s while matching filter feature '%s'; dropping that filter for this feature group.",
+                feature_group.get_class_name(),
+                reason,
+                filter.filter_feature.name,
+            )
+            return False
 
     def domain(self, filter: SingleFilter, feature_domain: None | Domain, feature_group: type[FeatureGroup]) -> bool:
         # We have matched already the feature group and the feature.

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -1,4 +1,3 @@
-import functools
 from copy import deepcopy
 from datetime import datetime, timezone
 from typing import Any, Optional
@@ -9,7 +8,7 @@ from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.feature import Feature
-from mloda.core.abstract_plugins.components.utils import is_match_abort, safe_field
+from mloda.core.abstract_plugins.components.utils import contained_raise_reason, is_match_abort
 from mloda.core.filter.filter_type_enum import FilterType
 from mloda.core.filter.single_filter import SingleFilter
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
@@ -30,12 +29,15 @@ class GlobalFilter:
            names and the uuid to the used single filter. This is used to track which features are associated with which filters for a specific feature group.
            This can be used to check after the fact if a feature is a filter feature for a specific feature group
            e.g. for debugging, logging or quality checks.
+        3. `dropped_filters`: The counterpart to `collection`, mapping (feature group, filter feature name) to the
+           reason a contained raise dropped that filter, which is otherwise indistinguishable from never matching.
 
         These attributes provide the foundation for adding, managing, and applying filters across various feature groups
         and features in the context of a data processing pipeline.
         """
         self.filters: set[SingleFilter] = set()
         self.collection: dict[tuple[type[FeatureGroup], FeatureName], set[SingleFilter]] = {}
+        self.dropped_filters: dict[tuple[type[FeatureGroup], str], str] = {}
 
     def add_filter(
         self, filter_feature: Feature | str, filter_type: str | FilterType, parameter: dict[str, Any]
@@ -125,10 +127,12 @@ class GlobalFilter:
     ) -> bool:
         """A raising match hook is a non-match for this filter only, mirroring the resolution seam (#845).
 
-        WARNING regardless of exception type, unlike the seam's contained_raise_log_level: no resolution
-        failure message carries the reason here, and a dropped filter changes results silently. The reason
-        is kept as text, never an exception object whose traceback would pin the plugin class. No option
-        rollback: the hook sees a per-match deepcopy's options, discarded with the dropped filter.
+        The level does not depend on the exception type, unlike the seam's contained_raise_log_level: the
+        first drop of a key warns, because no resolution failure message carries the reason here, and a
+        dropped filter changes results silently. The reason
+        is kept as text, never an exception object whose traceback would pin the plugin class, and the drop
+        is also recorded in the `dropped_filters` ledger. No option rollback: the hook sees a per-match
+        deepcopy's options, discarded with the dropped filter.
         """
         try:
             return feature_group.match_feature_group_criteria(
@@ -137,15 +141,25 @@ class GlobalFilter:
         except Exception as exc:  # noqa: BLE001  (contained: one broken matcher must not fail the whole run)
             if is_match_abort(exc):
                 raise
-            # partial, not a lambda: exc binds eagerly, so no closure keeps it and its traceback alive.
-            reason = f"raised {type(exc).__name__}: {safe_field(functools.partial(str, exc), type(exc).__name__)}"
-            logger.warning(
-                "%s %s while matching filter feature '%s'; dropping that filter for this feature group.",
-                feature_group.get_class_name(),
-                reason,
-                filter.filter_feature.name,
-            )
+            self._record_dropped_filter(feature_group, str(filter.filter_feature.name), contained_raise_reason(exc))
             return False
+
+    def _record_dropped_filter(self, feature_group: type[FeatureGroup], filter_feature_name: str, reason: str) -> None:
+        """Record the drop, WARNING the first time a key drops and DEBUG on every repeat.
+
+        identify_matched_filters runs once per feature the group serves, so one broken hook would
+        otherwise emit the same WARNING once per feature.
+        """
+        key = (feature_group, filter_feature_name)
+        first = key not in self.dropped_filters
+        self.dropped_filters.setdefault(key, reason)
+        logger.log(
+            logging.WARNING if first else logging.DEBUG,
+            "%s %s while matching filter feature '%s'; dropping that filter for this feature group.",
+            feature_group.get_class_name(),
+            reason,
+            filter_feature_name,
+        )
 
     def domain(self, filter: SingleFilter, feature_domain: None | Domain, feature_group: type[FeatureGroup]) -> bool:
         # We have matched already the feature group and the feature.

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -29,8 +29,7 @@ class GlobalFilter:
            names and the uuid to the used single filter. This is used to track which features are associated with which filters for a specific feature group.
            This can be used to check after the fact if a feature is a filter feature for a specific feature group
            e.g. for debugging, logging or quality checks.
-        3. `dropped_filters`: The counterpart to `collection`, mapping (feature group, filter feature name) to the
-           reason a contained raise dropped that filter, which is otherwise indistinguishable from never matching.
+        3. `dropped_filters`: maps (feature group, filter feature name) to the reason a contained raise dropped it.
 
         These attributes provide the foundation for adding, managing, and applying filters across various feature groups
         and features in the context of a data processing pipeline.
@@ -127,12 +126,9 @@ class GlobalFilter:
     ) -> bool:
         """A raising match hook is a non-match for this filter only, mirroring the resolution seam (#845).
 
-        The level does not depend on the exception type, unlike the seam's contained_raise_log_level: the
-        first drop of a key warns, because no resolution failure message carries the reason here, and a
-        dropped filter changes results silently. The reason
-        is kept as text, never an exception object whose traceback would pin the plugin class, and the drop
-        is also recorded in the `dropped_filters` ledger. No option rollback: the hook sees a per-match
-        deepcopy's options, discarded with the dropped filter.
+        The drop is recorded in `dropped_filters` and kept as text, never an exception object whose traceback
+        would pin the plugin class. The level ignores the exception type, unlike the seam, because nothing else
+        surfaces the reason here. No option rollback: the hook sees a per-match deepcopy.
         """
         try:
             return feature_group.match_feature_group_criteria(
@@ -145,11 +141,7 @@ class GlobalFilter:
             return False
 
     def _record_dropped_filter(self, feature_group: type[FeatureGroup], filter_feature_name: str, reason: str) -> None:
-        """Record the drop, WARNING the first time a key drops and DEBUG on every repeat.
-
-        identify_matched_filters runs once per feature the group serves, so one broken hook would
-        otherwise emit the same WARNING once per feature.
-        """
+        """Record the drop: WARNING on a key's first drop, DEBUG after, as the hook is probed per served feature."""
         key = (feature_group, filter_feature_name)
         first = key not in self.dropped_filters
         self.dropped_filters.setdefault(key, reason)

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -1,4 +1,3 @@
-import functools
 import inspect
 from collections.abc import Sequence
 from copy import deepcopy
@@ -32,6 +31,7 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
 from mloda.core.abstract_plugins.components.utils import (
     as_str,
     contained_raise_log_level,
+    contained_raise_reason,
     is_match_abort,
     safe_field,
 )
@@ -443,8 +443,7 @@ class IdentifyFeatureGroupClass:
                 logger.debug("%s rejected an option value while matching '%s': %s", feature_group, feature.name, exc)
                 record_match_rejection(feature_group.get_class_name(), str(exc))
             else:
-                # partial, not a lambda: exc binds eagerly, so no closure keeps it and its traceback alive.
-                reason = f"raised {type(exc).__name__}: {safe_field(functools.partial(str, exc), type(exc).__name__)}"
+                reason = contained_raise_reason(exc)
                 logger.log(
                     contained_raise_log_level(exc),
                     "%s %s while matching '%s'; treating it as a non-match.",

--- a/tests/test_core/test_filter/test_filter_matcher_containment.py
+++ b/tests/test_core/test_filter/test_filter_matcher_containment.py
@@ -1,0 +1,278 @@
+"""Red-phase pins for issue #899: a raising match hook during FILTER matching must be contained.
+
+``GlobalFilter.criteria`` calls ``match_feature_group_criteria`` uncontained, so one broken hook takes
+the whole run down, while the resolution seam (#845, ``IdentifyFeatureGroupClass._filter_feature_group_by_criteria``)
+treats the very same raise as a contained non-match. Containment here drops only that filter for that
+feature group and logs it at WARNING, deliberately not through the seam's ``contained_raise_log_level``:
+this path carries no resolution-failure message, and a silently dropped filter changes results. The
+reason stays TEXT, so no retained traceback pins the plugin class. A raise marked with
+``escalate_match_abort`` still propagates untouched, exactly as in the resolution seam.
+
+Probe classes live inside factory functions and are dropped before any assert runs, so a failing assert
+never pins a throwaway FeatureGroup into its traceback and trips the no-leak fixture in tests/conftest.py.
+"""
+
+from __future__ import annotations
+
+import gc
+import logging
+from collections.abc import Callable
+from functools import partial
+from typing import Any, Optional, TypeVar
+
+import pytest
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+from mloda.core.abstract_plugins.components.utils import escalate_match_abort
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.provider import DataCreator
+from mloda.user import Feature, FeatureName, FilterType, GlobalFilter, Options, PluginCollector, SingleFilter, mloda
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
+
+
+GF_LOGGER_NAME = "mloda.core.filter.global_filter"
+
+RAISE_MESSAGE = "boom_899_filter_matcher_exploded"
+RAISE_TYPE_NAME = "RuntimeError"
+ESCALATE_MESSAGE = "abort_899_filter_matcher_escalated"
+
+UNIT_CLASS_NAME = "RaisingFilterMatcherFG899"
+HOST_FEATURE = "gfc_host_feat_899"  # the resolved feature the filters are matched against
+FILTER_FEATURE_RAISING = "gfc_raising_filter_feat_899"  # the hook raises for this name
+FILTER_FEATURE_OK = "gfc_ok_filter_feat_899"  # the hook matches this name
+
+E2E_MAIN = "gfc_main_feat_899"  # requested root feature; must keep resolving
+E2E_TARGET = "gfc_target_feat_899"  # never requested directly; only reachable as a matched filter feature
+
+T = TypeVar("T")
+
+
+def _capture(call: Callable[[], T]) -> tuple[Optional[T], Optional[str]]:
+    """Run call, returning (value, None) or (None, 'Type: message'). No traceback is retained."""
+    try:
+        return call(), None
+    except Exception as exc:  # noqa: BLE001  (red-phase probe: an escape is the fact under test)
+        return None, f"{type(exc).__name__}: {exc}"
+
+
+def _single(filter_feature_name: str) -> SingleFilter:
+    """A minimal EQUAL filter on one feature name."""
+    return SingleFilter(filter_feature_name, FilterType.EQUAL, {"value": 1})
+
+
+def _make_raising_filter_matcher_fg() -> type[FeatureGroup]:
+    """A throwaway group whose hook raises for FILTER_FEATURE_RAISING and matches its other names."""
+    # Class objects are cyclic; collect leftovers from earlier tests before defining a twin.
+    gc.collect()
+
+    class RaisingFilterMatcherFG899(FeatureGroup):
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE, FILTER_FEATURE_OK}
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: Optional[DataAccessCollection] = None,
+        ) -> bool:
+            if str(feature_name) == FILTER_FEATURE_RAISING:
+                raise RuntimeError(RAISE_MESSAGE)
+            return str(feature_name) in cls.feature_names_supported()
+
+    return RaisingFilterMatcherFG899
+
+
+def _make_escalating_filter_matcher_fg(marker: BaseException) -> type[FeatureGroup]:
+    """A throwaway group whose hook raises the caller's own exception object, so identity is assertable."""
+    gc.collect()
+
+    class EscalatingFilterMatcherFG899(FeatureGroup):
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE, FILTER_FEATURE_OK}
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: Optional[DataAccessCollection] = None,
+        ) -> bool:
+            if str(feature_name) == FILTER_FEATURE_RAISING:
+                raise marker
+            return str(feature_name) in cls.feature_names_supported()
+
+    return EscalatingFilterMatcherFG899
+
+
+class TestFilterMatcherContainment:
+    """A raising match hook is a contained non-match for that filter, logged at WARNING as text."""
+
+    def test_criteria_contains_a_plain_raise(self) -> None:
+        """A plain raise out of the hook makes criteria return False instead of crossing the seam."""
+        fg = _make_raising_filter_matcher_fg()
+        matched, escaped = _capture(partial(GlobalFilter().criteria, fg, _single(FILTER_FEATURE_RAISING), None))
+        del fg
+        gc.collect()
+
+        assert escaped is None, f"the raise must not cross GlobalFilter.criteria: {escaped}"
+        assert matched is False, f"a raising hook is a non-match for that filter, got: {matched!r}"
+
+    def test_criteria_reraises_an_escalated_abort(self) -> None:
+        """An escalate_match_abort-marked raise crosses the seam as the SAME object, not a wrapper."""
+        marker = escalate_match_abort(RuntimeError(ESCALATE_MESSAGE))
+        fg = _make_escalating_filter_matcher_fg(marker)
+        caught: BaseException | None = None
+        try:
+            GlobalFilter().criteria(fg, _single(FILTER_FEATURE_RAISING), None)
+        except BaseException as exc:  # noqa: BLE001  (the escape itself is the fact under test)
+            caught = exc
+        is_marker = caught is marker
+        type_name = None if caught is None else type(caught).__name__
+        message = None if caught is None else str(caught)
+        # Drop the retained traceback: its frames pin the throwaway class through the hook's `cls`.
+        marker.__traceback__ = None
+        del fg, caught
+        gc.collect()
+
+        assert is_marker, f"the marked exception itself must escape, got: {type_name}: {message}"
+        assert type_name == RAISE_TYPE_NAME
+        assert message == ESCALATE_MESSAGE
+
+    def test_identify_matched_filters_drops_only_the_raising_filter(self) -> None:
+        """Containment is per filter: the raising one is dropped, the matching one still comes back."""
+        fg = _make_raising_filter_matcher_fg()
+        global_filter = GlobalFilter()
+        global_filter.add_filter(FILTER_FEATURE_RAISING, FilterType.EQUAL, {"value": 1})
+        global_filter.add_filter(FILTER_FEATURE_OK, FilterType.EQUAL, {"value": 2})
+        matched, escaped = _capture(
+            partial(global_filter.identify_matched_filters, fg, Feature(HOST_FEATURE), None),
+        )
+        names = [] if matched is None else sorted(single.name for single in matched)
+        del fg, matched, global_filter
+        gc.collect()
+
+        assert escaped is None, f"the raise must not cross identify_matched_filters: {escaped}"
+        assert names == [FILTER_FEATURE_OK], f"only the raising filter may be dropped, got: {names}"
+
+    def test_contained_raise_logs_a_warning_naming_group_filter_and_reason(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The drop is visible at WARNING and readable: group, filter feature, exception type and message."""
+        fg = _make_raising_filter_matcher_fg()
+        with caplog.at_level(logging.WARNING, logger=GF_LOGGER_NAME):
+            _, escaped = _capture(partial(GlobalFilter().criteria, fg, _single(FILTER_FEATURE_RAISING), None))
+        records = [record for record in caplog.records if record.name == GF_LOGGER_NAME]
+        messages = [record.getMessage() for record in records]
+        exc_infos = [record.exc_info for record in records]
+        del fg
+        gc.collect()
+
+        assert escaped is None, f"the raise must not cross GlobalFilter.criteria: {escaped}"
+        assert len(messages) == 1, f"exactly one WARNING must report the dropped filter, got: {messages}"
+        message = messages[0]
+        assert UNIT_CLASS_NAME in message, f"the warning must name the feature group: {message}"
+        assert FILTER_FEATURE_RAISING in message, f"the warning must name the filter feature: {message}"
+        assert RAISE_TYPE_NAME in message, f"the warning must name the exception type: {message}"
+        assert RAISE_MESSAGE in message, f"the warning must carry the raise message: {message}"
+        assert exc_infos == [None], "the reason is kept as text: no traceback may be retained on the record"
+
+
+def _make_e2e_probe_fg(escalate: bool) -> type[FeatureGroup]:
+    """A throwaway root group that resolves E2E_MAIN but raises when matched for the filter feature."""
+    gc.collect()
+
+    class FilterMatchRaiserFG899(FeatureGroup):
+        @classmethod
+        def input_data(cls) -> DataCreator:
+            return DataCreator({E2E_MAIN, E2E_TARGET})
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: Optional[DataAccessCollection] = None,
+        ) -> bool:
+            if str(feature_name) == E2E_TARGET:
+                if escalate:
+                    raise escalate_match_abort(RuntimeError(ESCALATE_MESSAGE))
+                raise RuntimeError(RAISE_MESSAGE)
+            return str(feature_name) == E2E_MAIN
+
+        @classmethod
+        def final_filters(cls) -> bool:
+            # Read features.filters inline instead: the payload is not filterable data, so the
+            # framework's own post-calculation row elimination must not run against it.
+            return False
+
+        @classmethod
+        def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+            payload = {
+                "names": sorted(str(f.name) for f in features.features),
+                "filter_count": len(features.filters) if features.filters else 0,
+            }
+            return {str(feature.name): [payload] for feature in features.features}
+
+    return FilterMatchRaiserFG899
+
+
+def _single_row(frame: Any, column: str) -> Any:
+    """Extract the single payload row, tolerant of columnar dict or list-of-row-dicts results."""
+    if isinstance(frame, dict):
+        values = list(frame[column])
+    else:
+        values = [row[column] for row in frame]
+    assert len(values) == 1, f"expected exactly one row for {column}, got {values!r}"
+    return values[0]
+
+
+def _run(escalate: bool) -> tuple[Optional[dict[str, Any]], Optional[str]]:
+    """Run E2E_MAIN under a global EQUAL filter on E2E_TARGET; return (E2E_MAIN payload, escaped text).
+
+    The escape is captured as text rather than caught by pytest.raises: an ExceptionInfo keeps the
+    hook frame alive, and that frame's `cls` pins the throwaway class for the no-leak fixture. `fg`
+    and `collector` are deleted from THIS frame before the asserts below for the same reason.
+    """
+    fg = _make_e2e_probe_fg(escalate)
+    collector = PluginCollector.enabled_feature_groups({fg})
+    global_filter = GlobalFilter()
+    global_filter.add_filter(E2E_TARGET, FilterType.EQUAL, {"value": 1})
+    results, escaped = _capture(
+        partial(
+            mloda.run_all,
+            [Feature(E2E_MAIN)],
+            compute_frameworks={PythonDictFramework},
+            plugin_collector=collector,
+            global_filter=global_filter,
+        )
+    )
+    del fg, collector
+    gc.collect()
+    if results is None:
+        return None, escaped
+    assert len(results) == 1, f"expected exactly one result frame, got: {results!r}"
+    payload = _single_row(results[0], E2E_MAIN)
+    assert isinstance(payload, dict)
+    return payload, escaped
+
+
+def test_contained_raise_does_not_abort_the_run() -> None:
+    """A hook raising for the filter feature only drops that filter; the requested feature still returns."""
+    payload, escaped = _run(escalate=False)
+
+    assert escaped is None, f"filter matching must not take the whole run down: {escaped}"
+    assert payload is not None
+    assert payload["names"] == [E2E_MAIN], f"the filter feature must not attach: {payload!r}"
+    assert payload["filter_count"] == 0, f"no filter may match: {payload!r}"
+
+
+def test_escalated_raise_still_aborts_the_run() -> None:
+    """An escalate_match_abort-marked raise during filter matching still aborts run_all, message intact."""
+    payload, escaped = _run(escalate=True)
+
+    assert payload is None, f"the marked abort must not be contained: {payload!r}"
+    assert escaped == f"{RAISE_TYPE_NAME}: {ESCALATE_MESSAGE}"

--- a/tests/test_core/test_filter/test_filter_matcher_containment.py
+++ b/tests/test_core/test_filter/test_filter_matcher_containment.py
@@ -1,21 +1,8 @@
-"""Red-phase pins for issue #899: a raising match hook during FILTER matching must be contained.
+"""Issue #899: a raising match hook during filter matching is contained as a non-match for that filter.
 
-``GlobalFilter.criteria`` calls ``match_feature_group_criteria`` uncontained, so one broken hook takes
-the whole run down, while the resolution seam (#845, ``IdentifyFeatureGroupClass._filter_feature_group_by_criteria``)
-treats the very same raise as a contained non-match. Containment here drops only that filter for that
-feature group and logs it at WARNING, deliberately not through the seam's ``contained_raise_log_level``:
-this path carries no resolution-failure message, and a silently dropped filter changes results. The
-reason stays TEXT, so no retained traceback pins the plugin class. A raise marked with
-``escalate_match_abort`` still propagates untouched, exactly as in the resolution seam.
-
-A log line is not a trace a caller can read, and ``identify_matched_filters`` runs once per processed
-feature, so the drop is also recorded in a per-instance ``GlobalFilter.dropped_filters`` ledger and only
-the first drop of a (group, filter feature) key warns; repeats fall back to DEBUG. The seam's own
-``except`` block reads the exception, so a double hostile to that read must not escape from in there
-either, mirroring tests/test_core/test_prepare/test_match_abort_marker_robustness.py.
-
-Probe classes live inside factory functions and are dropped before any assert runs, so a failing assert
-never pins a throwaway FeatureGroup into its traceback and trips the no-leak fixture in tests/conftest.py.
+The drop is recorded in ``GlobalFilter.dropped_filters`` and logged; a raise marked with ``escalate_match_abort``
+still aborts. Probe classes live inside factory functions and are dropped before any assert runs, so a failing
+assert never pins a throwaway FeatureGroup into its traceback and trips the no-leak fixture in tests/conftest.py.
 """
 
 from __future__ import annotations
@@ -234,11 +221,7 @@ def _make_hostile_filter_matcher_fg() -> type[FeatureGroup]:
 
 
 def _ledger(global_filter: GlobalFilter) -> Optional[dict[Any, Any]]:
-    """The instance drop ledger, or None while the attribute does not exist yet.
-
-    Read through getattr on purpose: a missing ledger must surface as a readable assert, not as an
-    AttributeError whose traceback pins the throwaway class through this frame.
-    """
+    """The instance drop ledger, read via getattr so a missing one asserts readably instead of pinning the class."""
     return cast(Optional[dict[Any, Any]], getattr(global_filter, "dropped_filters", None))
 
 
@@ -277,11 +260,7 @@ def _drive_criteria(
     caplog: pytest.LogCaptureFixture,
     calls: int = 1,
 ) -> _DropSnapshot:
-    """Call criteria `calls` times against ONE GlobalFilter and read the outcome out as plain data.
-
-    The group, the filter and the ledger are unbound in the finally, so a failing assert in the caller
-    never pins the throwaway class into its traceback through this frame.
-    """
+    """Call criteria `calls` times against ONE GlobalFilter; the finally unbinds every name that pins the class."""
     caplog.clear()
     fg = make_fg()
     global_filter = GlobalFilter()
@@ -349,11 +328,7 @@ class TestDroppedFilterIsRecorded:
         )
 
     def test_repeat_drops_of_one_key_warn_once_then_debug(self, caplog: pytest.LogCaptureFixture) -> None:
-        """identify_matched_filters runs per processed feature, so one broken hook may warn only once.
-
-        The dedupe rides on the per-instance ledger: a repeat is a key already recorded there, never
-        module state, which would silence the first drop of the next run.
-        """
+        """One broken hook may warn only once, deduped on the per-instance ledger, never on module state."""
         snapshot = _drive_criteria(_make_raising_filter_matcher_fg, FILTER_FEATURE_RAISING, caplog, calls=3)
 
         assert snapshot.escaped is None, f"the raise must not cross GlobalFilter.criteria: {snapshot.escaped}"
@@ -473,12 +448,7 @@ def _single_row(frame: Any, column: str) -> Any:
 
 
 def _run(escalate: bool) -> tuple[Optional[dict[str, Any]], Optional[str]]:
-    """Run E2E_MAIN under a global EQUAL filter on E2E_TARGET; return (E2E_MAIN payload, escaped text).
-
-    The escape is captured as text rather than caught by pytest.raises: an ExceptionInfo keeps the
-    hook frame alive, and that frame's `cls` pins the throwaway class for the no-leak fixture. `fg`
-    and `collector` are deleted from THIS frame before the asserts below for the same reason.
-    """
+    """Run E2E_MAIN under a filter; the escape is text, not pytest.raises, whose ExceptionInfo pins the class."""
     fg = _make_e2e_probe_fg(escalate)
     collector = PluginCollector.enabled_feature_groups({fg})
     global_filter = GlobalFilter()

--- a/tests/test_core/test_filter/test_filter_matcher_containment.py
+++ b/tests/test_core/test_filter/test_filter_matcher_containment.py
@@ -8,6 +8,12 @@ this path carries no resolution-failure message, and a silently dropped filter c
 reason stays TEXT, so no retained traceback pins the plugin class. A raise marked with
 ``escalate_match_abort`` still propagates untouched, exactly as in the resolution seam.
 
+A log line is not a trace a caller can read, and ``identify_matched_filters`` runs once per processed
+feature, so the drop is also recorded in a per-instance ``GlobalFilter.dropped_filters`` ledger and only
+the first drop of a (group, filter feature) key warns; repeats fall back to DEBUG. The seam's own
+``except`` block reads the exception, so a double hostile to that read must not escape from in there
+either, mirroring tests/test_core/test_prepare/test_match_abort_marker_robustness.py.
+
 Probe classes live inside factory functions and are dropped before any assert runs, so a failing assert
 never pins a throwaway FeatureGroup into its traceback and trips the no-leak fixture in tests/conftest.py.
 """
@@ -17,8 +23,9 @@ from __future__ import annotations
 import gc
 import logging
 from collections.abc import Callable
+from dataclasses import dataclass
 from functools import partial
-from typing import Any, Optional, TypeVar
+from typing import Any, Optional, TypeVar, cast
 
 import pytest
 
@@ -41,6 +48,11 @@ UNIT_CLASS_NAME = "RaisingFilterMatcherFG899"
 HOST_FEATURE = "gfc_host_feat_899"  # the resolved feature the filters are matched against
 FILTER_FEATURE_RAISING = "gfc_raising_filter_feat_899"  # the hook raises for this name
 FILTER_FEATURE_OK = "gfc_ok_filter_feat_899"  # the hook matches this name
+FILTER_FEATURE_UNKNOWN = "gfc_unknown_filter_feat_899"  # the hook answers False for this name, without raising
+
+HOSTILE_CLASS_NAME = "HostileFilterMatcherFG899"
+HOSTILE_TYPE_NAME = "HostileFilterMatcherError899"
+HOSTILE_STR_MESSAGE = "boom_899_hostile_str_raised"
 
 E2E_MAIN = "gfc_main_feat_899"  # requested root feature; must keep resolving
 E2E_TARGET = "gfc_target_feat_899"  # never requested directly; only reachable as a matched filter feature
@@ -179,6 +191,236 @@ class TestFilterMatcherContainment:
         assert RAISE_TYPE_NAME in message, f"the warning must name the exception type: {message}"
         assert RAISE_MESSAGE in message, f"the warning must carry the raise message: {message}"
         assert exc_infos == [None], "the reason is kept as text: no traceback may be retained on the record"
+
+
+def _is_dunder(name: str) -> bool:
+    """Dunder lookups stay untouched so the interpreter's own machinery keeps working on the double."""
+    return name.startswith("__") and name.endswith("__")
+
+
+class HostileFilterMatcherError899(Exception):
+    """Hostile to the except block that reads it: attribute access raises and so does str()."""
+
+    def __getattr__(self, name: str) -> Any:
+        if _is_dunder(name):
+            raise AttributeError(name)
+        raise RuntimeError(f"hostile attribute access for '{name}'")
+
+    def __str__(self) -> str:
+        raise RuntimeError(HOSTILE_STR_MESSAGE)
+
+
+def _make_hostile_filter_matcher_fg() -> type[FeatureGroup]:
+    """A throwaway group whose hook raises an exception hostile to every read the except block makes."""
+    gc.collect()
+
+    class HostileFilterMatcherFG899(FeatureGroup):
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE, FILTER_FEATURE_OK}
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: Optional[DataAccessCollection] = None,
+        ) -> bool:
+            if str(feature_name) == FILTER_FEATURE_RAISING:
+                raise HostileFilterMatcherError899(RAISE_MESSAGE)
+            return str(feature_name) in cls.feature_names_supported()
+
+    return HostileFilterMatcherFG899
+
+
+def _ledger(global_filter: GlobalFilter) -> Optional[dict[Any, Any]]:
+    """The instance drop ledger, or None while the attribute does not exist yet.
+
+    Read through getattr on purpose: a missing ledger must surface as a readable assert, not as an
+    AttributeError whose traceback pins the throwaway class through this frame.
+    """
+    return cast(Optional[dict[Any, Any]], getattr(global_filter, "dropped_filters", None))
+
+
+def _messages(caplog: pytest.LogCaptureFixture, level: int) -> tuple[str, ...]:
+    """Formatted messages GlobalFilter logged at exactly that level."""
+    records = [record for record in caplog.records if record.name == GF_LOGGER_NAME and record.levelno == level]
+    return tuple(record.getMessage() for record in records)
+
+
+def _capture_type_name(call: Callable[[], T]) -> tuple[Optional[T], Optional[str]]:
+    """Run call, returning (value, None) or (None, type name). Reads no message: a double's str() raises."""
+    try:
+        return call(), None
+    except Exception as exc:  # noqa: BLE001  (an escape is the fact under test)
+        return None, type(exc).__name__
+
+
+@dataclass(frozen=True)
+class _DropSnapshot:
+    """Plain-data readout of one or more criteria calls. Holds no class and no exception object."""
+
+    results: tuple[Optional[bool], ...]
+    escaped: Optional[str]
+    has_ledger: bool
+    keyed_by_group_and_filter: bool
+    entries: tuple[tuple[str, str], ...]  # (feature group class name, filter feature name), sorted
+    reasons: tuple[str, ...]  # reason text per entry, aligned with entries
+    reason_types: tuple[str, ...]  # type name of each stored reason, so text stays assertable
+    warnings: tuple[str, ...]
+    debugs: tuple[str, ...]
+
+
+def _drive_criteria(
+    make_fg: Callable[[], type[FeatureGroup]],
+    filter_feature_name: str,
+    caplog: pytest.LogCaptureFixture,
+    calls: int = 1,
+) -> _DropSnapshot:
+    """Call criteria `calls` times against ONE GlobalFilter and read the outcome out as plain data.
+
+    The group, the filter and the ledger are unbound in the finally, so a failing assert in the caller
+    never pins the throwaway class into its traceback through this frame.
+    """
+    caplog.clear()
+    fg = make_fg()
+    global_filter = GlobalFilter()
+    ledger: Optional[dict[Any, Any]] = None
+    items: list[tuple[Any, Any]] = []
+    try:
+        results: list[Optional[bool]] = []
+        escaped: Optional[str] = None
+        with caplog.at_level(logging.DEBUG, logger=GF_LOGGER_NAME):
+            for _ in range(calls):
+                value, failure = _capture_type_name(
+                    partial(global_filter.criteria, fg, _single(filter_feature_name), None)
+                )
+                results.append(value)
+                if failure is not None:
+                    escaped = failure
+                    break
+        ledger = _ledger(global_filter)
+        items = [] if ledger is None else sorted(ledger.items(), key=lambda item: str(item[0]))
+        return _DropSnapshot(
+            results=tuple(results),
+            escaped=escaped,
+            has_ledger=ledger is not None,
+            keyed_by_group_and_filter=ledger is not None and (fg, filter_feature_name) in ledger,
+            entries=tuple((str(key[0].get_class_name()), str(key[1])) for key, _ in items),
+            reasons=tuple(str(reason) for _, reason in items),
+            reason_types=tuple(type(reason).__name__ for _, reason in items),
+            warnings=_messages(caplog, logging.WARNING),
+            debugs=_messages(caplog, logging.DEBUG),
+        )
+    finally:
+        del fg, global_filter, ledger, items
+        gc.collect()
+
+
+class TestDroppedFilterIsRecorded:
+    """A dropped filter widens the result set, so it must leave a machine-readable trace, not just a log line."""
+
+    def test_fresh_global_filter_records_no_drops(self) -> None:
+        """The ledger is per instance and starts empty, so any entry in it means a real drop happened."""
+        ledger = _ledger(GlobalFilter())
+
+        assert ledger is not None, "GlobalFilter must expose a dropped_filters ledger"
+        assert ledger == {}, f"a fresh GlobalFilter has dropped nothing, got: {ledger!r}"
+
+    def test_contained_raise_records_group_filter_and_reason(self, caplog: pytest.LogCaptureFixture) -> None:
+        """One entry, keyed by (feature group, filter feature name), carrying the WARNING's own reason text."""
+        snapshot = _drive_criteria(_make_raising_filter_matcher_fg, FILTER_FEATURE_RAISING, caplog)
+
+        assert snapshot.escaped is None, f"the raise must not cross GlobalFilter.criteria: {snapshot.escaped}"
+        assert snapshot.has_ledger, "GlobalFilter must expose a dropped_filters ledger"
+        assert snapshot.entries == ((UNIT_CLASS_NAME, FILTER_FEATURE_RAISING),), (
+            f"exactly one drop, keyed by group and filter feature, got: {snapshot.entries}"
+        )
+        assert snapshot.keyed_by_group_and_filter, "the key must be the group CLASS, not its name or a stand-in"
+        assert snapshot.reason_types == ("str",), (
+            f"the reason stays text: no exception object may be stored, got: {snapshot.reason_types}"
+        )
+        reason = snapshot.reasons[0]
+        assert RAISE_TYPE_NAME in reason, f"the reason must name the exception type: {reason}"
+        assert RAISE_MESSAGE in reason, f"the reason must carry the raise message: {reason}"
+        assert len(snapshot.warnings) == 1, f"exactly one WARNING must report the drop, got: {snapshot.warnings}"
+        assert reason in snapshot.warnings[0], (
+            f"the stored reason must be the one the warning carries: {reason} vs {snapshot.warnings[0]}"
+        )
+
+    def test_repeat_drops_of_one_key_warn_once_then_debug(self, caplog: pytest.LogCaptureFixture) -> None:
+        """identify_matched_filters runs per processed feature, so one broken hook may warn only once.
+
+        The dedupe rides on the per-instance ledger: a repeat is a key already recorded there, never
+        module state, which would silence the first drop of the next run.
+        """
+        snapshot = _drive_criteria(_make_raising_filter_matcher_fg, FILTER_FEATURE_RAISING, caplog, calls=3)
+
+        assert snapshot.escaped is None, f"the raise must not cross GlobalFilter.criteria: {snapshot.escaped}"
+        assert snapshot.results == (False, False, False), (
+            f"every call is a non-match for that filter, got: {snapshot.results}"
+        )
+        assert len(snapshot.warnings) == 1, f"only the first drop of a key may warn, got: {snapshot.warnings}"
+        assert len(snapshot.debugs) == 2, f"every repeat drop must fall back to DEBUG, got: {snapshot.debugs}"
+        assert snapshot.entries == ((UNIT_CLASS_NAME, FILTER_FEATURE_RAISING),), (
+            f"repeats must not add entries, got: {snapshot.entries}"
+        )
+        reason = snapshot.reasons[0]
+        assert RAISE_TYPE_NAME in reason, f"a repeat must not rewrite the stored reason: {reason}"
+        assert RAISE_MESSAGE in reason, f"a repeat must not rewrite the stored reason: {reason}"
+
+    def test_escalated_abort_records_no_drop(self) -> None:
+        """A marked abort propagates instead of dropping a filter, so it must leave the ledger empty."""
+        marker = escalate_match_abort(RuntimeError(ESCALATE_MESSAGE))
+        fg = _make_escalating_filter_matcher_fg(marker)
+        global_filter = GlobalFilter()
+        _, escaped = _capture(partial(global_filter.criteria, fg, _single(FILTER_FEATURE_RAISING), None))
+        ledger = _ledger(global_filter)
+        has_ledger = ledger is not None
+        entry_count = 0 if ledger is None else len(ledger)
+        # Drop the retained traceback: its frames pin the throwaway class through the hook's `cls`.
+        marker.__traceback__ = None
+        del fg, global_filter, ledger
+        gc.collect()
+
+        assert escaped == f"{RAISE_TYPE_NAME}: {ESCALATE_MESSAGE}"
+        assert has_ledger, "GlobalFilter must expose a dropped_filters ledger"
+        assert entry_count == 0, f"a propagating abort is not a drop, got {entry_count} entries"
+
+    def test_plain_non_match_records_no_drop(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A hook that simply answers False is not a drop: only a contained raise may show up in the ledger."""
+        snapshot = _drive_criteria(_make_raising_filter_matcher_fg, FILTER_FEATURE_UNKNOWN, caplog)
+
+        assert snapshot.escaped is None, f"an ordinary non-match raises nothing: {snapshot.escaped}"
+        assert snapshot.results == (False,), f"an unsupported filter feature is a non-match, got: {snapshot.results}"
+        assert snapshot.has_ledger, "GlobalFilter must expose a dropped_filters ledger"
+        assert snapshot.entries == (), f"a non-match is not a drop, got: {snapshot.entries}"
+        assert snapshot.warnings == (), f"a non-match must not warn, got: {snapshot.warnings}"
+
+
+class TestHostileExceptionStaysInsideTheExceptBlock:
+    """The except block reads the exception itself, so a hostile double must not escape from in there."""
+
+    def test_hostile_raise_is_contained_recorded_and_logged(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Same exposure as the resolution seam (#845 R2): a raising __getattr__ and a raising __str__."""
+        snapshot = _drive_criteria(_make_hostile_filter_matcher_fg, FILTER_FEATURE_RAISING, caplog)
+
+        assert snapshot.escaped is None, f"nothing may escape the except block itself: {snapshot.escaped}"
+        assert snapshot.results == (False,), f"a hostile raise is still a non-match, got: {snapshot.results}"
+        assert snapshot.entries == ((HOSTILE_CLASS_NAME, FILTER_FEATURE_RAISING),), (
+            f"the drop must still be recorded, got: {snapshot.entries}"
+        )
+        assert snapshot.reason_types == ("str",), (
+            f"the reason stays text even when str() raises, got: {snapshot.reason_types}"
+        )
+        assert HOSTILE_TYPE_NAME in snapshot.reasons[0], (
+            f"the reason must name the exception type, the one read that cannot fail: {snapshot.reasons[0]}"
+        )
+        assert len(snapshot.warnings) == 1, f"the drop must still be logged once, got: {snapshot.warnings}"
+        assert HOSTILE_CLASS_NAME in snapshot.warnings[0], f"the warning must name the group: {snapshot.warnings[0]}"
+        assert FILTER_FEATURE_RAISING in snapshot.warnings[0], (
+            f"the warning must name the filter feature: {snapshot.warnings[0]}"
+        )
 
 
 def _make_e2e_probe_fg(escalate: bool) -> type[FeatureGroup]:


### PR DESCRIPTION
Closes #899.

`GlobalFilter.criteria` called `match_feature_group_criteria` outside the containment seam, so a raise there took the whole run down, even though the same raise is a contained non-match during feature resolution. The two paths disagreed: the same broken group was a survivable non-match while resolving the feature and a fatal error while matching its filters.

## What changed

- `GlobalFilter.criteria` now contains a raising match hook: that filter is a non-match for that probe, exactly as a `False` return is, and the run continues. A raise marked with `escalate_match_abort` still aborts, as in the resolution seam.
- The drop is recorded in a new `GlobalFilter.dropped_filters` ledger, the counterpart to `collection`: a drop is otherwise indistinguishable from a filter that never matched, and a dropped filter widens the result set. `identify_matched_filters` runs once per feature the group serves, so the first drop of a key warns and repeats log at DEBUG.
- The log level does not depend on the exception type, unlike the resolution seam's `contained_raise_log_level`. This path carries no resolution failure message, so the log and the ledger are the only channels.
- The reason is kept as text, never an exception object whose traceback would pin the plugin class. The reason builder both seams had inline is now `contained_raise_reason` in `utils`.
- No option rollback is needed here, unlike the resolution seam: the hook sees a per-match deepcopy's options, discarded with the dropped filter.

## Tests

12 new tests in `tests/test_core/test_filter/test_filter_matcher_containment.py`: containment and the escalation carve-out at both the unit and the `run_all` level, per-filter isolation, the ledger and the warn-once dedupe, and an exception whose `__getattr__` and `__str__` both raise, to pin that nothing escapes the except block itself.

## Reviewed

Two independent deep reviews. Accepted: the ledger and the log dedupe, the shared reason builder, the hostile-exception pin, and the docs wording. Rejected with reasons: special-casing `PropertyValueRejection` to DEBUG (this path has no near-miss render to carry the reason, so a dropped filter earns the same visibility), and two pre-existing behaviors outside this scope, filed as #927 and #928.

`tox` is green: 7621 passed, 170 skipped, ruff, mypy `--strict` and bandit clean.
