### PR TITLE
fix: guard the match-abort escalation sweep so it cannot rot silently

### DIFF
--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -274,8 +274,7 @@ class FeatureChainParser:
         if isinstance(spec, PropertySpec):
             return spec
 
-        # Contained: a mapping handed to the public entry point is the caller's defect, and the seam reads it
-        # as that candidate's non-match.
+        # Contained: a raw dict spec is that candidate's own defect, so the seam reads it as a non-match.
         raise ValueError(
             f"{owner_name}.PROPERTY_MAPPING['{key}'] is a {type(spec).__name__}, not a PropertySpec. "
             f"Raw dict specs are no longer accepted; construct PropertySpec(...) or use the "

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -15,7 +15,7 @@ from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
 from mloda.core.abstract_plugins.components.feature_chainer.parsed_feature_name import ParsedFeatureName
 from mloda.core.abstract_plugins.components.feature_chainer.property_spec import PropertySpec, is_no_default
-from mloda.core.abstract_plugins.components.utils import contained_raise_log_level, safe_field
+from mloda.core.abstract_plugins.components.utils import contained_raise_log_level, escalate_match_abort, safe_field
 
 logger = logging.getLogger(__name__)
 
@@ -113,6 +113,7 @@ class FeatureChainParser:
                 continue
 
             if len(parts) == 1 or not source_feature:
+                # Contained: a matched pattern with no source feature is this parser's own name verdict.
                 raise ValueError(f"Matches the pattern {pattern}, but has no source feature: {_feature_name}")
 
             return ParsedFeatureName(
@@ -198,6 +199,7 @@ class FeatureChainParser:
                 raised = exc
                 verdict = False
             if not verdict:
+                # Contained: a rejected option value is this candidate's own verdict, recorded as its reason.
                 raise PropertyValueRejection(
                     f"Property value '{found_property_val}' failed validation for '{property_name}'"
                 ) from raised
@@ -209,6 +211,7 @@ class FeatureChainParser:
             except TypeError:
                 is_member = False
             if not is_member:
+                # Contained: a rejected option value is this candidate's own verdict, recorded as its reason.
                 raise PropertyValueRejection(
                     f"Property value '{found_property_val}' not found in mapping for '{property_name}'"
                 )
@@ -236,9 +239,12 @@ class FeatureChainParser:
         """
 
         if property_name in options.group and property_name in options.context:
-            raise ValueError(
-                f"Parameter '{property_name}' exists in both group and context. "
-                "This is not allowed. Please choose one category."
+            # Marked: Options construction already rejects a key in both categories, so this is a broken invariant.
+            raise escalate_match_abort(
+                ValueError(
+                    f"Parameter '{property_name}' exists in both group and context. "
+                    "This is not allowed. Please choose one category."
+                )
             )
 
         if property_name in options.group:
@@ -268,6 +274,8 @@ class FeatureChainParser:
         if isinstance(spec, PropertySpec):
             return spec
 
+        # Contained: an unmigrated PROPERTY_MAPPING is that candidate's own defect, and the class-definition
+        # check rejects a shipped one loudly.
         raise ValueError(
             f"{owner_name}.PROPERTY_MAPPING['{key}'] is a {type(spec).__name__}, not a PropertySpec. "
             f"Raw dict specs are no longer accepted; construct PropertySpec(...) or use the "

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -274,8 +274,8 @@ class FeatureChainParser:
         if isinstance(spec, PropertySpec):
             return spec
 
-        # Contained: an unmigrated PROPERTY_MAPPING is that candidate's own defect, and the class-definition
-        # check rejects a shipped one loudly.
+        # Contained: a mapping handed to the public entry point is the caller's defect, and the seam reads it
+        # as that candidate's non-match.
         raise ValueError(
             f"{owner_name}.PROPERTY_MAPPING['{key}'] is a {type(spec).__name__}, not a PropertySpec. "
             f"Raw dict specs are no longer accepted; construct PropertySpec(...) or use the "

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -211,11 +211,13 @@ class FeatureChainParserMixin:
         count = len(in_features)
 
         if count < self.MIN_IN_FEATURES:
+            # Contained: an in_feature count below the declared MIN means this group cannot serve the feature.
             raise ValueError(
                 f"Feature '{feature_name}' requires at least {self.MIN_IN_FEATURES} in_feature(s), but found {count}"
             )
 
         if self.MAX_IN_FEATURES is not None and count > self.MAX_IN_FEATURES:
+            # Contained: an in_feature count above the declared MAX means this group cannot serve the feature.
             raise ValueError(
                 f"Feature '{feature_name}' allows at most {self.MAX_IN_FEATURES} in_feature(s), but found {count}"
             )

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -78,7 +78,12 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
 )
 from mloda.core.abstract_plugins.components.feature_chainer.property_spec import PropertySpec
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
-from mloda.core.abstract_plugins.components.utils import contained_raise_log_level, escalate_match_abort, safe_field
+from mloda.core.abstract_plugins.components.utils import (
+    contained_raise_log_level,
+    escalate_match_abort,
+    is_match_abort,
+    safe_field,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -316,10 +321,10 @@ class FeatureChainParserMixin:
         except PropertyValueRejection as exc:
             record_match_rejection(cls.__name__, str(exc))
             return False
-        # Known asymmetry deliberately kept in scope: a config error raised while merging name bindings on the
-        # string path (e.g. a key in both group and context) is still contained as a non-match here, while the
-        # required_when path surfaces it via build_effective_options (os-005 review note).
-        except ValueError:
+        # A marked raise crosses this containment; an unmarked ValueError stays a non-match.
+        except ValueError as exc:
+            if is_match_abort(exc):
+                raise
             return False
 
     @classmethod

--- a/mloda/core/abstract_plugins/components/input_data/base_input_data.py
+++ b/mloda/core/abstract_plugins/components/input_data/base_input_data.py
@@ -155,13 +155,14 @@ class BaseInputData(ABC):
 
     @classmethod
     def deal_with_base_input_data_name_as_cls_or_str(cls, key: Any) -> str:
-        # Contained: this runs per candidate over every option key, so one odd key must not abort the run (#845).
         if hasattr(key, "get_class_name"):
             if not issubclass(key, BaseInputData):
+                # Contained: this runs per candidate over every option key, so an odd key is a non-match (#845).
                 raise ValueError(f"Key {key} is not a subclass of BaseInputData.")
             key = key.get_class_name()
 
         if not isinstance(key, str):
+            # Contained: this runs per candidate over every option key, so one odd key must not abort the run (#845).
             raise ValueError(f"Key {key} is not a string.")
         return key
 

--- a/mloda/core/abstract_plugins/components/utils.py
+++ b/mloda/core/abstract_plugins/components/utils.py
@@ -26,7 +26,7 @@ def contained_raise_log_level(exc: BaseException) -> int:
 def escalate_match_abort(exc: E) -> E:
     """Mark a framework-owned raise so the match seam re-raises it instead of containing it as a non-match.
 
-    When to mark and when to contain: see the policy in IdentifyFeatureGroupClass._filter_feature_group_by_criteria.
+    Mark-or-contain policy: see IdentifyFeatureGroupClass._filter_feature_group_by_criteria.
     """
     # __dict__, not setattr: setattr raises on a frozen-dataclass exception, and failing to mark must not
     # replace the exception being marked.

--- a/mloda/core/abstract_plugins/components/utils.py
+++ b/mloda/core/abstract_plugins/components/utils.py
@@ -24,7 +24,10 @@ def contained_raise_log_level(exc: BaseException) -> int:
 
 
 def escalate_match_abort(exc: E) -> E:
-    """Mark a framework-owned raise so the match seam re-raises it instead of containing it as a non-match."""
+    """Mark a framework-owned raise so the match seam re-raises it instead of containing it as a non-match.
+
+    When to mark and when to contain: see the policy in IdentifyFeatureGroupClass._filter_feature_group_by_criteria.
+    """
     # __dict__, not setattr: setattr raises on a frozen-dataclass exception, and failing to mark must not
     # replace the exception being marked.
     try:

--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -36,7 +36,7 @@ from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options, _isolate_forwarded_value
 from mloda.core.abstract_plugins.components.index.index import Index
-from mloda.core.abstract_plugins.components.utils import get_all_subclasses, safe_field
+from mloda.core.abstract_plugins.components.utils import get_all_subclasses, is_match_abort, safe_field
 
 logger = logging.getLogger(__name__)
 
@@ -527,7 +527,7 @@ class FeatureGroup(ABC):
 
         The specific input features may depend on the provided options and the feature name.
         """
-        # Contained: an unimplemented hook is this candidate's own defect (#845).
+        # Contained: this is the root-feature protocol signal, which is_root reads as "this IS a root" (#845).
         raise NotImplementedError
 
     @classmethod
@@ -795,9 +795,11 @@ class FeatureGroup(ABC):
         except NotImplementedError:
             # input_features not implemented means this is a root feature.
             return True
-        except Exception:
+        except Exception as exc:
             # Errors in input_features (e.g. validation failures for this feature name)
             # mean the feature group does not match, so it is not a root.
+            if is_match_abort(exc):
+                raise
             logger.debug(
                 "%s.input_features raised an exception for feature '%s'",
                 type(self).__name__,

--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -527,6 +527,7 @@ class FeatureGroup(ABC):
 
         The specific input features may depend on the provided options and the feature name.
         """
+        # Contained: an unimplemented hook is this candidate's own defect (#845).
         raise NotImplementedError
 
     @classmethod

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -129,6 +129,9 @@ class GlobalFilter:
         The drop is recorded in `dropped_filters` and kept as text, never an exception object whose traceback
         would pin the plugin class. The level ignores the exception type, unlike the seam, because nothing else
         surfaces the reason here. No option rollback: the hook sees a per-match deepcopy.
+
+        When to mark and when to contain: see the policy in
+        IdentifyFeatureGroupClass._filter_feature_group_by_criteria.
         """
         try:
             return feature_group.match_feature_group_criteria(

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -130,8 +130,7 @@ class GlobalFilter:
         would pin the plugin class. The level ignores the exception type, unlike the seam, because nothing else
         surfaces the reason here. No option rollback: the hook sees a per-match deepcopy.
 
-        When to mark and when to contain: see the policy in
-        IdentifyFeatureGroupClass._filter_feature_group_by_criteria.
+        Mark-or-contain policy: see IdentifyFeatureGroupClass._filter_feature_group_by_criteria.
         """
         try:
             return feature_group.match_feature_group_criteria(

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -419,10 +419,12 @@ class IdentifyFeatureGroupClass:
     ) -> bool:
         """A raise out of the match hook is a non-match for that candidate only, not a run-wide abort (#845).
 
-        Policy: a candidate's own defect stays contained here, while escalate_match_abort marks the raises that
-        report a misconfiguration the user must fix, and those cross the seam untouched. A contained raise is
-        kept as text, never as an exception object whose traceback would pin the plugin class. The per-candidate
-        rejection window, reset in the finally, keys reasons by candidate class.
+        Policy: mark a raise with escalate_match_abort when it reports a misconfiguration, a contradiction or a
+        framework defect, so containing it cannot hide the problem while a rival candidate wins the feature; leave
+        a raise contained when it is one candidate's own judgment or own defect. Every raise the match path can
+        reach must say which it is, at the raise; tests/test_core/test_prepare/test_match_abort_sweep.py enforces
+        that. A contained raise is kept as text, never as an exception object whose traceback would pin the plugin
+        class. The per-candidate rejection window, reset in the finally, keys reasons by candidate class.
         """
         token = MATCH_REJECTION_REASONS.set({})
         # Shallow copies, taken per candidate so an earlier match's write survives a later candidate's raise.

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -420,11 +420,9 @@ class IdentifyFeatureGroupClass:
         """A raise out of the match hook is a non-match for that candidate only, not a run-wide abort (#845).
 
         Policy: mark a raise with escalate_match_abort when it reports a misconfiguration, a contradiction or a
-        framework defect, so containing it cannot hide the problem while a rival candidate wins the feature; leave
-        a raise contained when it is one candidate's own judgment or own defect. Every raise the match path can
-        reach must say which it is, at the raise; tests/test_core/test_prepare/test_match_abort_sweep.py enforces
-        that. A mark only survives when every handler between the raise and this seam re-raises it:
-        ``match_parser_criteria`` and ``is_root`` do, while ``safe_field`` deliberately degrades instead. A
+        framework defect; leave it contained when it is one candidate's own judgment or own defect. Every raise
+        the match path reaches must say which, at the raise: tests/test_core/test_prepare/test_match_abort_sweep.py
+        enforces that. A mark only survives if every handler in between re-raises it (``safe_field`` does not). A
         contained raise is kept as text, never as an exception object whose traceback would pin the plugin
         class. The per-candidate rejection window, reset in the finally, keys reasons by candidate class.
         """

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -423,7 +423,9 @@ class IdentifyFeatureGroupClass:
         framework defect, so containing it cannot hide the problem while a rival candidate wins the feature; leave
         a raise contained when it is one candidate's own judgment or own defect. Every raise the match path can
         reach must say which it is, at the raise; tests/test_core/test_prepare/test_match_abort_sweep.py enforces
-        that. A contained raise is kept as text, never as an exception object whose traceback would pin the plugin
+        that. A mark only survives when every handler between the raise and this seam re-raises it:
+        ``match_parser_criteria`` and ``is_root`` do, while ``safe_field`` deliberately degrades instead. A
+        contained raise is kept as text, never as an exception object whose traceback would pin the plugin
         class. The per-candidate rejection window, reset in the finally, keys reasons by candidate class.
         """
         token = MATCH_REJECTION_REASONS.set({})

--- a/tests/test_core/test_prepare/test_match_abort_escalation.py
+++ b/tests/test_core/test_prepare/test_match_abort_escalation.py
@@ -3,16 +3,24 @@
 The provenance marker must preserve the exception object exactly, because callers assert on its original
 type at the matcher boundary. ``resolve_feature`` keeps its never-raises contract: a marked raise reaches
 ``ResolvedFeature.error`` instead of propagating. Doubles are dropped per test.
+
+A mark is only worth anything if every handler BETWEEN the raise and the seam re-raises it. Two sit on the
+normal path and are covered here: ``FeatureChainParserMixin.match_parser_criteria`` (which turns a parser
+error into a non-match) and ``FeatureGroup.is_root`` (which turns a raising ``input_features`` into "not a
+root"). ``utils.safe_field`` is the deliberate exception: it degrades one field in rendering paths and
+swallows a marked exception on purpose.
 """
 
 import gc
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import partial
-from typing import Optional, TypeVar
+from typing import ClassVar, Optional, TypeVar
 
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
+from mloda.core.abstract_plugins.components.feature_chainer.property_spec import PropertySpec, property_spec
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.components.utils import escalate_match_abort, is_match_abort
@@ -32,6 +40,16 @@ UNMARKED_CLASS_NAME = "UnmarkedRaiseFG845e"
 RAISE_TYPE_NAME = "ValueError"
 MATCHER_ERROR_STAGE = "matcher_error"
 
+# Name-bound probe for the parser's own marked raise: the key is a named capture of the pattern.
+BINDING_KEY = "op_845f_both_categories"
+BINDING_PATTERN = r".*__(?P<op_845f_both_categories>\w+)_845f$"
+BINDING_FEATURE = "src845f__alpha_845f"
+# Same pattern, nothing before the separator: parse_name's own UNMARKED "no source feature" ValueError.
+NO_SOURCE_FEATURE = "__alpha_845f"
+BOTH_CATEGORIES_FRAGMENT = "exists in both group and context"
+IS_ROOT_MARKED_MESSAGE = "boom_845f_marked_input_features"
+IS_ROOT_UNMARKED_MESSAGE = "boom_845f_unmarked_input_features"
+
 T = TypeVar("T")
 
 
@@ -39,12 +57,27 @@ class MatchAbortFw845e(ComputeFramework):
     """Dummy compute framework for the match-abort escalation tests."""
 
 
-def _capture(call: Callable[[], T]) -> tuple[Optional[T], Optional[str]]:
-    """Run call, returning (value, None) or (None, 'Type: message'). No traceback is retained."""
+@dataclass(frozen=True)
+class _RaiseReadout:
+    """Plain-data readout of an escaping raise. Holds no exception object and no traceback."""
+
+    marked: bool
+    type_name: str
+    message: str
+
+
+def _outcome(call: Callable[[], T]) -> tuple[Optional[T], Optional[_RaiseReadout]]:
+    """Run call, returning (value, None) or (None, readout of the escaping raise)."""
     try:
         return call(), None
     except Exception as exc:  # noqa: BLE001  (an escape, or its absence, is the fact under test)
-        return None, f"{type(exc).__name__}: {exc}"
+        return None, _RaiseReadout(is_match_abort(exc), type(exc).__name__, str(exc))
+
+
+def _capture(call: Callable[[], T]) -> tuple[Optional[T], Optional[str]]:
+    """Run call, returning (value, None) or (None, 'Type: message'). No traceback is retained."""
+    value, readout = _outcome(call)
+    return value, None if readout is None else f"{readout.type_name}: {readout.message}"
 
 
 def _make_marked_raise_fg() -> type[FeatureGroup]:
@@ -219,6 +252,181 @@ class TestMatchAbortCrossesTheMatchSeam:
         assert snapshot.reason is not None
         assert RAISE_TYPE_NAME in snapshot.reason
         assert UNMARKED_MESSAGE in snapshot.reason
+
+
+class BothCategoriesMixin845f(FeatureChainParserMixin):
+    """Chain-parser probe: its name binding drives the parser into the marked both-categories raise.
+
+    A mixin, not a FeatureGroup: nothing here may join another test's candidate universe.
+    """
+
+    PREFIX_PATTERN = BINDING_PATTERN
+    # Annotated exactly as FeatureGroup declares it, so the FeatureGroup subclass below stays consistent.
+    PROPERTY_MAPPING: ClassVar[Optional[dict[str, PropertySpec]]] = {
+        BINDING_KEY: property_spec("the key the feature name carries")
+    }
+
+
+def _both_categories_options() -> Options:
+    """Options holding BINDING_KEY in group AND context, the shape _determine_parameter_category rejects."""
+    # Mutated after construction: Options() itself rejects a key present in both categories, so this state
+    # is only reachable by writing the second dict directly.
+    options = Options(group={BINDING_KEY: None})
+    options.context[BINDING_KEY] = "from_context_845f"
+    # The group value is None so the merge reads the key as absent and asks which category it belongs in.
+    return options
+
+
+def _make_both_categories_fg() -> type[FeatureGroup]:
+    """Candidate whose inherited chain-parser matcher hits the marked both-categories raise."""
+    # Class objects are cyclic; collect leftovers from earlier tests before defining a twin.
+    gc.collect()
+
+    class BothCategoriesFG845f(BothCategoriesMixin845f, FeatureGroup):
+        """Stands in for a normal chain-parser group asked to match a contradictory option set."""
+
+        @classmethod
+        def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+            return {MatchAbortFw845e}
+
+        def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+            return None
+
+    return BothCategoriesFG845f
+
+
+def _evaluate_both_categories() -> Optional[_RaiseReadout]:
+    """Evaluate the both-categories candidate through the seam; read any escaping raise out as plain data."""
+    probe_fg = _make_both_categories_fg()
+    try:
+        feature = Feature(BINDING_FEATURE, _both_categories_options())
+        plugins: FeatureGroupEnvironmentMapping = {probe_fg: {MatchAbortFw845e}}
+        result, readout = _outcome(partial(IdentifyFeatureGroupClass.evaluate, feature, plugins, None))
+        del result
+        del plugins
+        return readout
+    finally:
+        del probe_fg
+        gc.collect()
+
+
+def _make_is_root_fg(raiser: Callable[[], None]) -> type[FeatureGroup]:
+    """Candidate whose input_features raises whatever ``raiser`` raises."""
+    gc.collect()
+
+    class IsRootProbeFG845f(FeatureGroup):
+        """Stands in for a group whose input_features cannot answer for this feature name."""
+
+        def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+            raiser()
+            return None
+
+    return IsRootProbeFG845f
+
+
+def _is_root_outcome(raiser: Callable[[], None]) -> tuple[Optional[bool], Optional[_RaiseReadout]]:
+    """(verdict, None) when is_root answers, (None, readout) when the raise escapes it."""
+    probe_fg = _make_is_root_fg(raiser)
+    try:
+        instance = probe_fg()
+        verdict, readout = _outcome(partial(instance.is_root, Options(), "is_root_probe_845f"))
+        del instance
+        return verdict, readout
+    finally:
+        del probe_fg
+        gc.collect()
+
+
+def _raise_marked_value_error() -> None:
+    raise escalate_match_abort(ValueError(IS_ROOT_MARKED_MESSAGE))
+
+
+def _raise_unmarked_value_error() -> None:
+    raise ValueError(IS_ROOT_UNMARKED_MESSAGE)
+
+
+def _raise_not_implemented() -> None:
+    raise NotImplementedError
+
+
+class TestMarkedRaiseSurvivesTheChainParserContainment:
+    """match_parser_criteria contains a parser error as a non-match, but never a MARKED one."""
+
+    def test_marked_config_error_escapes_match_parser_criteria(self) -> None:
+        """The both-categories raise is a framework invariant break: it must not read as a non-match."""
+        verdict, readout = _outcome(
+            partial(BothCategoriesMixin845f.match_parser_criteria, BINDING_FEATURE, _both_categories_options())
+        )
+
+        assert verdict is None, "a marked raise was swallowed into a match verdict by match_parser_criteria"
+        assert readout is not None
+        assert readout.marked is True
+        assert readout.type_name == RAISE_TYPE_NAME
+        assert BINDING_KEY in readout.message
+        assert BOTH_CATEGORIES_FRAGMENT in readout.message
+
+    def test_marked_config_error_escapes_match_feature_group_criteria(self) -> None:
+        """The mark survives the matcher the engine actually calls, not just the parser helper."""
+        verdict, readout = _outcome(
+            partial(BothCategoriesMixin845f.match_feature_group_criteria, BINDING_FEATURE, _both_categories_options())
+        )
+
+        assert verdict is None, "a marked raise was swallowed into a match verdict by match_feature_group_criteria"
+        assert readout is not None
+        assert readout.marked is True
+        assert readout.type_name == RAISE_TYPE_NAME
+        assert BOTH_CATEGORIES_FRAGMENT in readout.message
+
+    def test_unmarked_parser_error_is_still_a_non_match(self) -> None:
+        """Containment stays the default: parse_name's own unmarked ValueError is a non-match, not a raise."""
+        verdict, readout = _outcome(
+            partial(BothCategoriesMixin845f.match_parser_criteria, NO_SOURCE_FEATURE, Options())
+        )
+
+        assert readout is None, "an unmarked parser error must stay contained as a non-match"
+        assert verdict is False
+
+    def test_marked_config_error_crosses_the_match_seam(self) -> None:
+        """The raise reaches the caller of evaluate() with mark and message intact.
+
+        The mark lives on that one exception object, so reading it back at the caller is what shows the
+        object crossed rather than being re-wrapped or downgraded into a verdict on the way.
+        """
+        readout = _evaluate_both_categories()
+
+        assert readout is not None, "the marked raise never reached the seam; a handler on the way swallowed it"
+        assert readout.marked is True
+        assert readout.type_name == RAISE_TYPE_NAME
+        assert BINDING_KEY in readout.message
+        assert BOTH_CATEGORIES_FRAGMENT in readout.message
+
+
+class TestIsRootRespectsTheMark:
+    """is_root reads a raising input_features as "not a root", except when the raise is marked."""
+
+    def test_marked_input_features_raise_escapes_is_root(self) -> None:
+        """A framework-owned raise must not be downgraded into a root verdict."""
+        verdict, readout = _is_root_outcome(_raise_marked_value_error)
+
+        assert verdict is None, "a marked raise was swallowed into an is_root verdict"
+        assert readout is not None
+        assert readout.marked is True
+        assert readout.type_name == RAISE_TYPE_NAME
+        assert readout.message == IS_ROOT_MARKED_MESSAGE
+
+    def test_unmarked_input_features_raise_still_means_not_root(self) -> None:
+        """Unchanged: an unmarked failure in input_features means this group does not match."""
+        verdict, readout = _is_root_outcome(_raise_unmarked_value_error)
+
+        assert readout is None, "an unmarked raise out of input_features must stay contained"
+        assert verdict is False
+
+    def test_not_implemented_input_features_still_means_root(self) -> None:
+        """Unchanged: an unimplemented input_features is the documented way to declare a root feature."""
+        verdict, readout = _is_root_outcome(_raise_not_implemented)
+
+        assert readout is None
+        assert verdict is True
 
 
 class TestResolveFeatureStillNeverRaises:

--- a/tests/test_core/test_prepare/test_match_abort_escalation.py
+++ b/tests/test_core/test_prepare/test_match_abort_escalation.py
@@ -4,11 +4,9 @@ The provenance marker must preserve the exception object exactly, because caller
 type at the matcher boundary. ``resolve_feature`` keeps its never-raises contract: a marked raise reaches
 ``ResolvedFeature.error`` instead of propagating. Doubles are dropped per test.
 
-A mark is only worth anything if every handler BETWEEN the raise and the seam re-raises it. Two sit on the
-normal path and are covered here: ``FeatureChainParserMixin.match_parser_criteria`` (which turns a parser
-error into a non-match) and ``FeatureGroup.is_root`` (which turns a raising ``input_features`` into "not a
-root"). ``utils.safe_field`` is the deliberate exception: it degrades one field in rendering paths and
-swallows a marked exception on purpose.
+A mark is only worth anything if every handler BETWEEN the raise and the seam re-raises it. The two on the
+normal path are covered here: ``match_parser_criteria`` and ``FeatureGroup.is_root``. ``utils.safe_field``
+is the deliberate exception: it degrades one field in a rendering path and swallows a marked exception.
 """
 
 import gc
@@ -255,10 +253,7 @@ class TestMatchAbortCrossesTheMatchSeam:
 
 
 class BothCategoriesMixin845f(FeatureChainParserMixin):
-    """Chain-parser probe: its name binding drives the parser into the marked both-categories raise.
-
-    A mixin, not a FeatureGroup: nothing here may join another test's candidate universe.
-    """
+    """Probe for the marked both-categories raise; a mixin, so it joins no other test's candidate universe."""
 
     PREFIX_PATTERN = BINDING_PATTERN
     # Annotated exactly as FeatureGroup declares it, so the FeatureGroup subclass below stays consistent.
@@ -269,8 +264,7 @@ class BothCategoriesMixin845f(FeatureChainParserMixin):
 
 def _both_categories_options() -> Options:
     """Options holding BINDING_KEY in group AND context, the shape _determine_parameter_category rejects."""
-    # Mutated after construction: Options() itself rejects a key present in both categories, so this state
-    # is only reachable by writing the second dict directly.
+    # Options() itself rejects a key in both categories, so this state needs a write to the second dict.
     options = Options(group={BINDING_KEY: None})
     options.context[BINDING_KEY] = "from_context_845f"
     # The group value is None so the merge reads the key as absent and asks which category it belongs in.
@@ -279,7 +273,6 @@ def _both_categories_options() -> Options:
 
 def _make_both_categories_fg() -> type[FeatureGroup]:
     """Candidate whose inherited chain-parser matcher hits the marked both-categories raise."""
-    # Class objects are cyclic; collect leftovers from earlier tests before defining a twin.
     gc.collect()
 
     class BothCategoriesFG845f(BothCategoriesMixin845f, FeatureGroup):
@@ -387,11 +380,7 @@ class TestMarkedRaiseSurvivesTheChainParserContainment:
         assert verdict is False
 
     def test_marked_config_error_crosses_the_match_seam(self) -> None:
-        """The raise reaches the caller of evaluate() with mark and message intact.
-
-        The mark lives on that one exception object, so reading it back at the caller is what shows the
-        object crossed rather than being re-wrapped or downgraded into a verdict on the way.
-        """
+        """Reading the mark back at evaluate()'s caller shows that one object crossed, unwrapped."""
         readout = _evaluate_both_categories()
 
         assert readout is not None, "the marked raise never reached the seam; a handler on the way swallowed it"

--- a/tests/test_core/test_prepare/test_match_abort_sweep.py
+++ b/tests/test_core/test_prepare/test_match_abort_sweep.py
@@ -1,0 +1,456 @@
+"""Static sweep: every raise a match hook can reach must state whether it escalates or stays contained.
+
+``IdentifyFeatureGroupClass._filter_feature_group_by_criteria`` contains any raise out of
+``match_feature_group_criteria`` as a non-match for that candidate, unless the exception was marked with
+``escalate_match_abort``. The marked set is hand-maintained, so a NEW unmarked raise on the match path is
+silently downgraded to "this candidate does not match" and a rival plugin wins the feature. This sweep walks
+the static call graph from the match seams through the declared match-path modules and requires every raise
+it reaches to carry a decision: either the escalation call, or a ``# Contained: <reason>`` comment anchored to
+that individual raise.
+
+What it deliberately does NOT cover:
+
+* Plugin code under ``mloda_plugins``. Their match hooks are user-shaped code; containment is the point.
+* Dynamic dispatch. The graph resolves calls by NAME inside the declared modules only, so a hook reached
+  purely through a runtime-built callable is invisible here. ``check_required_when`` is seeded for exactly
+  that reason: it runs inside the matcher wrapper ``install_required_when_guard`` installs, and no static
+  call edge reaches it from the seams.
+* Whether a contained raise is the RIGHT call. The comment records the author's decision; this sweep only
+  proves a decision was made and written down next to the raise.
+
+Anchoring policy: the reason must sit on the raise line or in the contiguous comment block directly above the
+raise. A reason merely present somewhere in the enclosing function is not accepted, otherwise a second raise
+added later would inherit the first one's reason and the gate would rot.
+"""
+
+from __future__ import annotations
+
+import ast
+import io
+import tokenize
+from collections import deque
+from functools import lru_cache
+from pathlib import Path
+from typing import Literal, NamedTuple
+
+# Anchor the scan to the repo layout via __file__, not the cwd: a cwd-relative root makes every lookup below
+# empty and the sweep pass vacuously. This file sits three parents below the repo root.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_CORE_ROOT = _REPO_ROOT / "mloda"
+assert _CORE_ROOT.is_dir(), f"core root not found; check the parents index for the repo root: {_CORE_ROOT}"
+
+# Modules the match path runs through, repo-relative. The graph never leaves this set, so a module missing
+# here is a blind spot; test_every_declared_module_is_reachable keeps stale entries out.
+MATCH_PATH_MODULES: dict[str, str] = {
+    "mloda/core/prepare/identify_feature_group.py": "the containment seam itself",
+    "mloda/core/abstract_plugins/feature_group.py": "the default matcher every group inherits",
+    "mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py": (
+        "the chain-parser matcher, the most common override"
+    ),
+    "mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py": (
+        "name parsing and property resolution run inside that matcher"
+    ),
+    "mloda/core/abstract_plugins/components/feature_chainer/feature_chain_author_guards.py": (
+        "the required_when guard wrapped around a group's matcher"
+    ),
+    "mloda/core/abstract_plugins/components/feature_chainer/property_spec.py": (
+        "PropertySpec resolution feeds the matcher's option reads"
+    ),
+    "mloda/core/abstract_plugins/components/input_data/base_input_data.py": (
+        "reader matching and file pinning, reached from the input-data matchers"
+    ),
+    "mloda/core/abstract_plugins/components/input_data/api/api_input_data.py": "the api reader's match hook",
+    "mloda/core/abstract_plugins/components/input_data/creator/data_creator.py": "the data-creator match hook",
+    "mloda/core/abstract_plugins/components/match_data/match_data.py": "reader selection during matching",
+}
+
+for _module in MATCH_PATH_MODULES:
+    assert (_REPO_ROOT / _module).exists(), f"declared match-path module not found: {_module}"
+
+# Entry points of the walk. The first two are the seam; the last two are reached from code the graph cannot
+# see, so they are seeded by hand.
+SEEDS: dict[str, str] = {
+    "match_feature_group_criteria": "the match hook every candidate is asked",
+    "_filter_feature_group_by_criteria": "the seam that contains a raising hook",
+    "_resolve_pinned_file": "framework helper invoked from reader match hooks that live in mloda_plugins",
+    "check_required_when": "runs inside the matcher wrapper install_required_when_guard installs",
+}
+
+# Raising functions OUTSIDE the declared modules that the match path calls. Each needs a decision too, but it
+# is recorded here instead of at the raise, because these functions serve callers far away from matching.
+RAISING_HELPERS_OUTSIDE_THE_PATH: dict[tuple[str, str], str] = {
+    ("mloda/core/abstract_plugins/components/options.py", "get_in_features"): (
+        "contained: a malformed in_features declaration is that candidate's own defect"
+    ),
+    ("mloda/core/abstract_plugins/plugin_loader/plugin_loader.py", "load_group"): (
+        "contained: reader auto-load runs during matching, and a broken plugin group must not abort a run "
+        "another candidate can serve"
+    ),
+    ("mloda/core/abstract_plugins/plugin_loader/plugin_loader.py", "all"): (
+        "contained: reader auto-load runs during matching, and a broken plugin group must not abort a run "
+        "another candidate can serve"
+    ),
+}
+
+_ESCALATION = "escalate_match_abort"
+_CONTAINED_TAG = "Contained:"
+_MARKED_TAG = "Marked:"
+
+# Attribute calls whose name is a public method of a builtin container are never a framework function, so
+# `"".join(...)` and friends must not pull an unrelated same-named function into the graph.
+_BUILTIN_CONTAINER_METHODS: frozenset[str] = frozenset(
+    name
+    for container in (str, list, dict, set, tuple, frozenset, int, bytes)
+    for name in dir(container)
+    if not name.startswith("_")
+)
+
+Kind = Literal["marked", "contained", "mismarked", "unannotated"]
+
+
+class RaiseSite(NamedTuple):
+    """One ``raise <exc>`` statement and the escalation decision written at it."""
+
+    module: str
+    lineno: int
+    function: str
+    kind: Kind
+    reason: str | None
+
+    def location(self) -> str:
+        return f"{self.module}:{self.lineno} {self.function}()"
+
+
+class ExternalCall(NamedTuple):
+    """A call from the match path into a raising function defined outside the declared modules."""
+
+    module: str
+    function: str
+    caller: str
+
+
+class _Definition(NamedTuple):
+    module: str
+    node: ast.FunctionDef | ast.AsyncFunctionDef
+
+
+class _Sweep(NamedTuple):
+    sites: tuple[RaiseSite, ...]
+    reachable: frozenset[tuple[str, str]]
+    external: tuple[ExternalCall, ...]
+
+
+def _called_names(node: ast.AST) -> set[str]:
+    """Every name called inside ``node``: ``f(...)`` by id, ``x.f(...)`` by attribute."""
+    names: set[str] = set()
+    for sub in ast.walk(node):
+        if not isinstance(sub, ast.Call):
+            continue
+        func = sub.func
+        if isinstance(func, ast.Name):
+            names.add(func.id)
+        elif isinstance(func, ast.Attribute) and func.attr not in _BUILTIN_CONTAINER_METHODS:
+            names.add(func.attr)
+    return names
+
+
+def _escalates(node: ast.AST) -> bool:
+    """True when ``escalate_match_abort`` is called anywhere inside ``node``."""
+    return _ESCALATION in _called_names(node)
+
+
+def _raises_an_exception(node: ast.AST) -> bool:
+    """True when ``node`` contains a ``raise <exc>``; a bare re-raise does not count."""
+    return any(isinstance(sub, ast.Raise) and sub.exc is not None for sub in ast.walk(node))
+
+
+def _own_line_and_trailing_comments(source: str) -> tuple[dict[int, str], dict[int, str]]:
+    """Comment text per line, split into own-line comments and comments trailing code.
+
+    tokenize, not a raw ``#`` scan: a ``#`` inside a string literal is not a comment token.
+    """
+    lines = source.splitlines()
+    own_line: dict[int, str] = {}
+    trailing: dict[int, str] = {}
+    for token in tokenize.generate_tokens(io.StringIO(source).readline):
+        if token.type != tokenize.COMMENT:
+            continue
+        row, col = token.start
+        text = token.string.lstrip("#").strip()
+        if lines[row - 1][:col].strip():
+            trailing[row] = text
+        else:
+            own_line[row] = text
+    return own_line, trailing
+
+
+def _tagged_reason(text: str, tag: str) -> str | None:
+    """The reason behind ``tag`` in one comment, or None when the tag is absent or the reason is empty."""
+    if not text.startswith(tag):
+        return None
+    reason = text[len(tag) :].strip()
+    return reason or None
+
+
+def _anchored_reason(
+    own_line: dict[int, str],
+    trailing: dict[int, str],
+    lineno: int,
+    tag: str,
+) -> str | None:
+    """The tagged reason for the raise at ``lineno``: trailing on that line, or in the block directly above.
+
+    The block ends at the first line that is not an own-line comment, so a blank or code line separates a
+    raise from a reason written for something else.
+    """
+    reason = _tagged_reason(trailing.get(lineno, ""), tag)
+    if reason is not None:
+        return reason
+    row = lineno - 1
+    while row in own_line:
+        reason = _tagged_reason(own_line[row], tag)
+        if reason is not None:
+            return reason
+        row -= 1
+    return None
+
+
+def _collect_raises(
+    node: ast.AST,
+    functions: list[str],
+    handler: ast.ExceptHandler | None,
+    out: list[tuple[ast.Raise, list[str], ast.ExceptHandler | None]],
+) -> None:
+    """Walk ``node``, recording each raise with its enclosing function chain and except handler."""
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            # A nested def leaves the handler's scope: its raises are not that handler's re-raise.
+            _collect_raises(child, [*functions, child.name], None, out)
+        elif isinstance(child, ast.ExceptHandler):
+            _collect_raises(child, functions, child, out)
+        else:
+            if isinstance(child, ast.Raise):
+                out.append((child, functions, handler))
+            _collect_raises(child, functions, handler, out)
+
+
+def classify_raises(source: str, module: str, functions: frozenset[str] | None = None) -> list[RaiseSite]:
+    """Classify every ``raise <exc>`` in ``source``, restricted to the named functions when given.
+
+    A pure function over text so the classifier can be exercised on snippets, independent of the tree.
+    ``functions`` filters by name: a raise counts when any function enclosing it is named in the filter.
+    """
+    tree = ast.parse(source, filename=module)
+    own_line, trailing = _own_line_and_trailing_comments(source)
+    found: list[tuple[ast.Raise, list[str], ast.ExceptHandler | None]] = []
+    _collect_raises(tree, [], None, found)
+
+    sites: list[RaiseSite] = []
+    for raise_node, chain, handler in found:
+        if not chain:
+            continue
+        if functions is not None and not any(name in functions for name in chain):
+            continue
+        if raise_node.exc is None:
+            # A bare re-raise carries no decision of its own: it sits under the escalate_match_abort line.
+            continue
+        marked = _escalates(raise_node.exc) or (handler is not None and any(_escalates(s) for s in handler.body))
+        claimed = _anchored_reason(own_line, trailing, raise_node.lineno, _MARKED_TAG)
+        contained = _anchored_reason(own_line, trailing, raise_node.lineno, _CONTAINED_TAG)
+        kind: Kind
+        if marked:
+            kind, reason = "marked", claimed
+        elif claimed is not None:
+            kind, reason = "mismarked", claimed
+        elif contained is not None:
+            kind, reason = "contained", contained
+        else:
+            kind, reason = "unannotated", None
+        sites.append(RaiseSite(module, raise_node.lineno, chain[-1], kind, reason))
+    return sorted(sites)
+
+
+def _index_functions(root: Path) -> dict[str, list[_Definition]]:
+    """Every function defined under ``root``, indexed by name; one name can hold several definitions."""
+    index: dict[str, list[_Definition]] = {}
+    for path in sorted(root.rglob("*.py")):
+        module = path.relative_to(_REPO_ROOT).as_posix()
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=module)
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                index.setdefault(node.name, []).append(_Definition(module, node))
+    return index
+
+
+@lru_cache(maxsize=1)
+def sweep() -> _Sweep:
+    """Walk the match path from the seeds and classify every raise it reaches.
+
+    Indexing ``mloda/`` (not ``mloda_plugins/``) is what lets the walk notice calls that leave the declared
+    modules; the walk itself never follows them.
+    """
+    core_index = _index_functions(_CORE_ROOT)
+    declared_index: dict[str, list[_Definition]] = {}
+    for name, definitions in core_index.items():
+        inside = [d for d in definitions if d.module in MATCH_PATH_MODULES]
+        if inside:
+            declared_index[name] = inside
+
+    queue: deque[_Definition] = deque()
+    # A definition is identified by (module, line): two same-named methods in one module stay distinct.
+    visited: set[tuple[str, int]] = set()
+    for seed in SEEDS:
+        for definition in declared_index.get(seed, []):
+            if (definition.module, definition.node.lineno) not in visited:
+                visited.add((definition.module, definition.node.lineno))
+                queue.append(definition)
+
+    reachable: set[tuple[str, str]] = set()
+    external: set[ExternalCall] = set()
+    while queue:
+        definition = queue.popleft()
+        reachable.add((definition.module, definition.node.name))
+        caller = f"{definition.module}::{definition.node.name}"
+        for called in _called_names(definition.node):
+            for target in declared_index.get(called, []):
+                key = (target.module, target.node.lineno)
+                if key not in visited:
+                    visited.add(key)
+                    queue.append(target)
+            for target in core_index.get(called, []):
+                if target.module not in MATCH_PATH_MODULES and _raises_an_exception(target.node):
+                    external.add(ExternalCall(target.module, called, caller))
+
+    sites: list[RaiseSite] = []
+    for module in sorted({module for module, _ in reachable}):
+        names = frozenset(name for reached_module, name in reachable if reached_module == module)
+        source = (_REPO_ROOT / module).read_text(encoding="utf-8")
+        sites.extend(classify_raises(source, module, names))
+
+    return _Sweep(tuple(sorted(sites)), frozenset(reachable), tuple(sorted(external)))
+
+
+def _of_kind(kind: Kind) -> list[RaiseSite]:
+    return [site for site in sweep().sites if site.kind == kind]
+
+
+def test_every_reachable_raise_is_marked_or_contained() -> None:
+    """No raise the match path can reach is left without an escalation decision."""
+    unannotated = _of_kind("unannotated")
+
+    assert unannotated == [], (
+        "Raise sites reachable from the match seams with no escalation decision:\n"
+        + "\n".join(f"  {site.location()}" for site in unannotated)
+        + "\n\nFor each one, decide and record it at the raise: wrap the exception in "
+        f"{_ESCALATION}(...) when the run must fail instead of silently losing the candidate, or write "
+        f"'# {_CONTAINED_TAG} <reason>' directly above the raise when the seam may read it as a non-match."
+    )
+
+
+def test_no_marked_comment_without_an_escalation() -> None:
+    """No raise claims to be marked while nothing at the site actually escalates."""
+    mismarked = _of_kind("mismarked")
+
+    assert mismarked == [], (
+        f"Raise sites carrying a '# {_MARKED_TAG}' comment that no {_ESCALATION} call backs:\n"
+        + "\n".join(f"  {site.location()}: {site.reason}" for site in mismarked)
+    )
+
+
+def test_calls_into_raising_helpers_outside_the_path_are_declared() -> None:
+    """Every raising helper the match path calls outside the declared modules is declared with a reason."""
+    undeclared = [
+        call for call in sweep().external if (call.module, call.function) not in RAISING_HELPERS_OUTSIDE_THE_PATH
+    ]
+
+    assert undeclared == [], (
+        "The match path calls raising functions outside the declared modules:\n"
+        + "\n".join(f"  {call.module}::{call.function} from {call.caller}" for call in undeclared)
+        + "\n\nEither declare the (module, function) pair in RAISING_HELPERS_OUTSIDE_THE_PATH with the reason "
+        "its raises may stay contained, or add the module to MATCH_PATH_MODULES so its raises are swept."
+    )
+
+
+def test_declared_helpers_outside_the_path_are_still_called() -> None:
+    """Every declared helper is still reached, so stale entries cannot accumulate."""
+    called = {(call.module, call.function) for call in sweep().external}
+    stale = sorted(entry for entry in RAISING_HELPERS_OUTSIDE_THE_PATH if entry not in called)
+
+    assert stale == [], f"RAISING_HELPERS_OUTSIDE_THE_PATH entries the match path no longer calls: {stale}"
+
+
+def test_every_declared_module_is_reachable() -> None:
+    """Each declared module contributes at least one reachable function."""
+    reached = {module for module, _ in sweep().reachable}
+    unreached = sorted(set(MATCH_PATH_MODULES) - reached)
+
+    assert unreached == [], (
+        f"MATCH_PATH_MODULES entries no seed reaches: {unreached}. Drop the entry, or add the seed that "
+        "reaches it if the call edge is dynamic."
+    )
+
+
+def test_known_escalations_are_enumerated() -> None:
+    """Canary: the escalations that exist today are all seen, so a silently empty sweep cannot pass."""
+    base_input_data = "mloda/core/abstract_plugins/components/input_data/base_input_data.py"
+    match_data = "mloda/core/abstract_plugins/components/match_data/match_data.py"
+    mixin = "mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py"
+    expected = {
+        (base_input_data, "add_base_input_data_to_options"),
+        (base_input_data, "_resolve_pinned_file"),
+        (match_data, "add_base_input_data_to_options"),
+        (mixin, "_validate_forwarded_name_mismatch"),
+    }
+
+    marked = {(site.module, site.function) for site in _of_kind("marked")}
+
+    assert expected <= marked, f"known escalations missing from the sweep: {sorted(expected - marked)}"
+    # Vacuity floor, not a target: 18 sites today, so removing one stays a legitimate change.
+    assert len(sweep().sites) >= 15, f"sweep enumerated only {len(sweep().sites)} raise sites; it is not walking"
+
+
+def test_classifier_flags_an_unannotated_raise() -> None:
+    """A raise with no decision at it is reported, whatever the enclosing function says elsewhere."""
+    source = (
+        "def match_feature_group_criteria(cls, feature, options):\n"
+        '    """# Contained: a docstring mention is not a decision at the raise."""\n'
+        "    if feature is None:\n"
+        "        raise ValueError('no feature')\n"
+        "    return True\n"
+    )
+
+    sites = classify_raises(source, "snippet.py", frozenset({"match_feature_group_criteria"}))
+
+    assert [site.kind for site in sites] == ["unannotated"]
+    assert sites[0].function == "match_feature_group_criteria"
+
+
+def test_classifier_accepts_a_contained_comment_and_an_escalation() -> None:
+    """Both ways of recording a decision are accepted, and neither is reported as unannotated."""
+    source = (
+        "def match_feature_group_criteria(cls, feature, options):\n"
+        "    if feature is None:\n"
+        "        # Contained: a missing feature is this candidate's own defect.\n"
+        "        raise ValueError('no feature')\n"
+        "    if options is None:\n"
+        "        raise escalate_match_abort(ValueError('no options'))\n"
+        "    return True\n"
+    )
+
+    sites = classify_raises(source, "snippet.py", frozenset({"match_feature_group_criteria"}))
+
+    assert [site.kind for site in sites] == ["contained", "marked"]
+    assert sites[0].reason == "a missing feature is this candidate's own defect."
+
+
+def test_classifier_flags_a_marked_comment_without_an_escalation() -> None:
+    """A comment that claims escalation without one is a lie the sweep must catch, not accept as annotated."""
+    source = (
+        "def match_feature_group_criteria(cls, feature, options):\n"
+        "    # Marked: claims to escalate, nothing here does.\n"
+        "    raise ValueError('no feature')\n"
+    )
+
+    sites = classify_raises(source, "snippet.py", frozenset({"match_feature_group_criteria"}))
+
+    assert [site.kind for site in sites] == ["mismarked"]

--- a/tests/test_core/test_prepare/test_match_abort_sweep.py
+++ b/tests/test_core/test_prepare/test_match_abort_sweep.py
@@ -12,9 +12,16 @@ What it deliberately does NOT cover:
 
 * Plugin code under ``mloda_plugins``. Their match hooks are user-shaped code; containment is the point.
 * Dynamic dispatch. The graph resolves calls by NAME inside the declared modules only, so a hook reached
-  purely through a runtime-built callable is invisible here. ``check_required_when`` is seeded for exactly
-  that reason: it runs inside the matcher wrapper ``install_required_when_guard`` installs, and no static
-  call edge reaches it from the seams.
+  purely through a runtime-built callable is invisible here. ``check_required_when`` and ``guarded`` are
+  seeded for exactly that reason: they run inside the matcher wrappers the two ``__init_subclass__`` hooks
+  install, and no static call edge reaches them from the seams.
+* Decorators. A decorator is not a call edge here: it runs at definition time, not when the match path calls
+  the function, and counting it would resolve ``@functools.wraps`` onto same-named framework functions.
+* Handlers BETWEEN a marked raise and the seam. A mark only survives if every ``except`` on the way
+  re-raises when ``is_match_abort`` holds, and this sweep reads raises, not handlers.
+  ``FeatureChainParserMixin.match_parser_criteria`` and ``FeatureGroup.is_root`` are the two handlers a mark
+  crosses on the normal path; test_match_abort_escalation.py owns that behavior. ``utils.safe_field``
+  swallows a marked exception deliberately: its contract is to degrade one field in a rendering path.
 * Whether a contained raise is the RIGHT call. The comment records the author's decision; this sweep only
   proves a decision was made and written down next to the raise.
 
@@ -54,7 +61,9 @@ MATCH_PATH_MODULES: dict[str, str] = {
         "the required_when guard wrapped around a group's matcher"
     ),
     "mloda/core/abstract_plugins/components/feature_chainer/property_spec.py": (
-        "PropertySpec resolution feeds the matcher's option reads"
+        "the matcher's required-key check reads the spec sentinel here (is_no_default); the module's own "
+        "raises all sit in PropertySpec construction, which runs at class definition, and stay declared so a "
+        "match-time construction would be swept instead of slipping past"
     ),
     "mloda/core/abstract_plugins/components/input_data/base_input_data.py": (
         "reader matching and file pinning, reached from the input-data matchers"
@@ -67,28 +76,53 @@ MATCH_PATH_MODULES: dict[str, str] = {
 for _module in MATCH_PATH_MODULES:
     assert (_REPO_ROOT / _module).exists(), f"declared match-path module not found: {_module}"
 
-# Entry points of the walk. The first two are the seam; the last two are reached from code the graph cannot
-# see, so they are seeded by hand.
+# Entry points of the walk. The first two are the seam; the rest are reached from code the graph cannot see,
+# so they are seeded by hand.
 SEEDS: dict[str, str] = {
     "match_feature_group_criteria": "the match hook every candidate is asked",
     "_filter_feature_group_by_criteria": "the seam that contains a raising hook",
     "_resolve_pinned_file": "framework helper invoked from reader match hooks that live in mloda_plugins",
     "check_required_when": "runs inside the matcher wrapper install_required_when_guard installs",
+    "guarded": (
+        "the installed guard closures ARE the resolved match_feature_group_criteria of a guarded class; "
+        "the setattr that installs them is no static call edge"
+    ),
 }
 
 # Raising functions OUTSIDE the declared modules that the match path calls. Each needs a decision too, but it
 # is recorded here instead of at the raise, because these functions serve callers far away from matching.
+# Resolution is by name, so an entry can also be a name COLLISION rather than a real call edge; those say so
+# and are declared to keep the sweep closed, not because the match path calls them.
+_CANDIDATE_OWN_DECLARATION = (
+    "contained: this validates the requesting feature's own declaration while a candidate is being tried, so "
+    "the seam reads a raise as that candidate's non-match"
+)
+_READER_AUTO_LOAD = (
+    "contained: reader auto-load runs during matching, and a broken plugin group must not abort a run another "
+    "candidate can serve"
+)
+
 RAISING_HELPERS_OUTSIDE_THE_PATH: dict[tuple[str, str], str] = {
-    ("mloda/core/abstract_plugins/components/options.py", "get_in_features"): (
-        "contained: a malformed in_features declaration is that candidate's own defect"
+    ("mloda/core/abstract_plugins/components/options.py", "__init__"): _CANDIDATE_OWN_DECLARATION,
+    ("mloda/core/abstract_plugins/components/options.py", "add_to_group"): _CANDIDATE_OWN_DECLARATION,
+    ("mloda/core/abstract_plugins/components/options.py", "get_in_features"): _CANDIDATE_OWN_DECLARATION,
+    ("mloda/core/abstract_plugins/components/feature.py", "__init__"): _CANDIDATE_OWN_DECLARATION,
+    ("mloda/core/abstract_plugins/plugin_loader/plugin_loader.py", "__init__"): _READER_AUTO_LOAD,
+    ("mloda/core/abstract_plugins/plugin_loader/plugin_loader.py", "load_group"): _READER_AUTO_LOAD,
+    ("mloda/core/abstract_plugins/plugin_loader/plugin_loader.py", "all"): _READER_AUTO_LOAD,
+    ("mloda/core/abstract_plugins/components/link.py", "matches"): (
+        "name collision, not a call edge: the match path calls the input-data match hooks named matches, never "
+        "Link.matches"
     ),
-    ("mloda/core/abstract_plugins/plugin_loader/plugin_loader.py", "load_group"): (
-        "contained: reader auto-load runs during matching, and a broken plugin group must not abort a run "
-        "another candidate can serve"
+    ("mloda/core/abstract_plugins/components/utils.py", "get_all_subclasses"): (
+        "a real edge with a collided verdict: it only walks classes the run already imported and raises "
+        "nothing itself; it counts as raising through the set.add / set.update name collision"
     ),
-    ("mloda/core/abstract_plugins/plugin_loader/plugin_loader.py", "all"): (
-        "contained: reader auto-load runs during matching, and a broken plugin group must not abort a run "
-        "another candidate can serve"
+    ("mloda/core/prepare/resolve_links.py", "update"): (
+        "name collision, not a call edge: the match path calls dict.update, not the link resolver's update"
+    ),
+    ("mloda/core/runtime/run.py", "join"): (
+        "name collision, not a call edge: the match path calls str.join, not the runner's join"
     ),
 }
 
@@ -96,14 +130,8 @@ _ESCALATION = "escalate_match_abort"
 _CONTAINED_TAG = "Contained:"
 _MARKED_TAG = "Marked:"
 
-# Attribute calls whose name is a public method of a builtin container are never a framework function, so
-# `"".join(...)` and friends must not pull an unrelated same-named function into the graph.
-_BUILTIN_CONTAINER_METHODS: frozenset[str] = frozenset(
-    name
-    for container in (str, list, dict, set, tuple, frozenset, int, bytes)
-    for name in dir(container)
-    if not name.startswith("_")
-)
+# Constructing a class runs these, so a call on a class name is an edge into them.
+_CONSTRUCTORS: frozenset[str] = frozenset({"__init__", "__post_init__"})
 
 Kind = Literal["marked", "contained", "mismarked", "unannotated"]
 
@@ -140,28 +168,42 @@ class _Sweep(NamedTuple):
     external: tuple[ExternalCall, ...]
 
 
-def _called_names(node: ast.AST) -> set[str]:
-    """Every name called inside ``node``: ``f(...)`` by id, ``x.f(...)`` by attribute."""
+def _scan(node: ast.AST) -> tuple[frozenset[str], bool]:
+    """One walk of ``node``: the names it calls, and whether it contains a ``raise <exc>``.
+
+    Called names are ``f(...)`` by id and ``x.f(...)`` by attribute, decorators excluded (they run at
+    definition time, not when the match path calls the function). No builtin-method filter: ``"".join(...)``
+    does pull in a framework function named ``join``, a name collision rather than a call edge, and
+    RAISING_HELPERS_OUTSIDE_THE_PATH records those as such. Filtering them here would also hide every
+    framework method named ``get``, ``update`` or ``add``. A bare re-raise is not a raise of its own.
+
+    One walk, not two: the index scans every function under ``mloda/``, so a second pass costs real time.
+    """
     names: set[str] = set()
-    for sub in ast.walk(node):
-        if not isinstance(sub, ast.Call):
-            continue
-        func = sub.func
-        if isinstance(func, ast.Name):
-            names.add(func.id)
-        elif isinstance(func, ast.Attribute) and func.attr not in _BUILTIN_CONTAINER_METHODS:
-            names.add(func.attr)
-    return names
+    raises = False
+    stack: list[ast.AST] = [node]
+    while stack:
+        current = stack.pop()
+        if isinstance(current, ast.Call):
+            func = current.func
+            if isinstance(func, ast.Name):
+                names.add(func.id)
+            elif isinstance(func, ast.Attribute):
+                names.add(func.attr)
+        elif isinstance(current, ast.Raise) and current.exc is not None:
+            raises = True
+        for field, value in ast.iter_fields(current):
+            if field == "decorator_list":
+                continue
+            for child in value if isinstance(value, list) else [value]:
+                if isinstance(child, ast.AST):
+                    stack.append(child)
+    return frozenset(names), raises
 
 
 def _escalates(node: ast.AST) -> bool:
     """True when ``escalate_match_abort`` is called anywhere inside ``node``."""
-    return _ESCALATION in _called_names(node)
-
-
-def _raises_an_exception(node: ast.AST) -> bool:
-    """True when ``node`` contains a ``raise <exc>``; a bare re-raise does not count."""
-    return any(isinstance(sub, ast.Raise) and sub.exc is not None for sub in ast.walk(node))
+    return _ESCALATION in _scan(node)[0]
 
 
 def _own_line_and_trailing_comments(source: str) -> tuple[dict[int, str], dict[int, str]]:
@@ -215,23 +257,15 @@ def _anchored_reason(
     return None
 
 
-def _collect_raises(
-    node: ast.AST,
-    functions: list[str],
-    handler: ast.ExceptHandler | None,
-    out: list[tuple[ast.Raise, list[str], ast.ExceptHandler | None]],
-) -> None:
-    """Walk ``node``, recording each raise with its enclosing function chain and except handler."""
+def _collect_raises(node: ast.AST, functions: list[str], out: list[tuple[ast.Raise, list[str]]]) -> None:
+    """Walk ``node``, recording each raise with its enclosing function chain."""
     for child in ast.iter_child_nodes(node):
         if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            # A nested def leaves the handler's scope: its raises are not that handler's re-raise.
-            _collect_raises(child, [*functions, child.name], None, out)
-        elif isinstance(child, ast.ExceptHandler):
-            _collect_raises(child, functions, child, out)
+            _collect_raises(child, [*functions, child.name], out)
         else:
             if isinstance(child, ast.Raise):
-                out.append((child, functions, handler))
-            _collect_raises(child, functions, handler, out)
+                out.append((child, functions))
+            _collect_raises(child, functions, out)
 
 
 def classify_raises(source: str, module: str, functions: frozenset[str] | None = None) -> list[RaiseSite]:
@@ -242,11 +276,11 @@ def classify_raises(source: str, module: str, functions: frozenset[str] | None =
     """
     tree = ast.parse(source, filename=module)
     own_line, trailing = _own_line_and_trailing_comments(source)
-    found: list[tuple[ast.Raise, list[str], ast.ExceptHandler | None]] = []
-    _collect_raises(tree, [], None, found)
+    found: list[tuple[ast.Raise, list[str]]] = []
+    _collect_raises(tree, [], found)
 
     sites: list[RaiseSite] = []
-    for raise_node, chain, handler in found:
+    for raise_node, chain in found:
         if not chain:
             continue
         if functions is not None and not any(name in functions for name in chain):
@@ -254,7 +288,9 @@ def classify_raises(source: str, module: str, functions: frozenset[str] | None =
         if raise_node.exc is None:
             # A bare re-raise carries no decision of its own: it sits under the escalate_match_abort line.
             continue
-        marked = _escalates(raise_node.exc) or (handler is not None and any(_escalates(s) for s in handler.body))
+        # Only the raised expression itself counts. Crediting an escalation elsewhere in the enclosing
+        # handler would bless every later raise added next to it.
+        marked = _escalates(raise_node.exc)
         claimed = _anchored_reason(own_line, trailing, raise_node.lineno, _MARKED_TAG)
         contained = _anchored_reason(own_line, trailing, raise_node.lineno, _CONTAINED_TAG)
         kind: Kind
@@ -270,16 +306,61 @@ def classify_raises(source: str, module: str, functions: frozenset[str] | None =
     return sorted(sites)
 
 
-def _index_functions(root: Path) -> dict[str, list[_Definition]]:
-    """Every function defined under ``root``, indexed by name; one name can hold several definitions."""
-    index: dict[str, list[_Definition]] = {}
-    for path in sorted(root.rglob("*.py")):
+class _Index(NamedTuple):
+    """Every definition under ``mloda/``, plus the names whose call can raise."""
+
+    functions: dict[str, list[_Definition]]
+    constructors: dict[str, list[_Definition]]
+    raising: frozenset[str]
+
+
+def _raising_names(calls_per_name: dict[str, frozenset[str]], direct: frozenset[str]) -> frozenset[str]:
+    """Names that can raise: directly, or through anything they call.
+
+    Depth-1 detection is defeated by one non-raising wrapper in an undeclared module, so this is transitive.
+    The graph resolves calls by NAME, so the raising verdict is a name's too: a name raises when any
+    definition of it does. Cycle-safe: a name only ever joins the set, so the fixed point terminates.
+    """
+    callers: dict[str, set[str]] = {}
+    for name, called in calls_per_name.items():
+        for callee in called:
+            callers.setdefault(callee, set()).add(name)
+
+    raising = set(direct)
+    queue = deque(sorted(raising))
+    while queue:
+        for caller in callers.get(queue.popleft(), ()):
+            if caller not in raising:
+                raising.add(caller)
+                queue.append(caller)
+    return frozenset(raising)
+
+
+@lru_cache(maxsize=1)
+def _index() -> _Index:
+    """Index ``mloda/`` by name: functions, the constructors a class name runs, and the names that can raise."""
+    functions: dict[str, list[_Definition]] = {}
+    constructors: dict[str, list[_Definition]] = {}
+    calls: dict[str, set[str]] = {}
+    direct: set[str] = set()
+    for path in sorted(_CORE_ROOT.rglob("*.py")):
         module = path.relative_to(_REPO_ROOT).as_posix()
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=module)
         for node in ast.walk(tree):
             if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                index.setdefault(node.name, []).append(_Definition(module, node))
-    return index
+                called, raises = _scan(node)
+                functions.setdefault(node.name, []).append(_Definition(module, node))
+                calls.setdefault(node.name, set()).update(called)
+                if raises:
+                    direct.add(node.name)
+            elif isinstance(node, ast.ClassDef):
+                # Options(...) / Feature(...) is an ast.Call on a CLASS name: the edge is into what
+                # construction runs, which no call node names.
+                for child in node.body:
+                    if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)) and child.name in _CONSTRUCTORS:
+                        constructors.setdefault(node.name, []).append(_Definition(module, child))
+    frozen = {name: frozenset(called) for name, called in calls.items()}
+    return _Index(functions, constructors, _raising_names(frozen, frozenset(direct)))
 
 
 @lru_cache(maxsize=1)
@@ -289,19 +370,17 @@ def sweep() -> _Sweep:
     Indexing ``mloda/`` (not ``mloda_plugins/``) is what lets the walk notice calls that leave the declared
     modules; the walk itself never follows them.
     """
-    core_index = _index_functions(_CORE_ROOT)
-    declared_index: dict[str, list[_Definition]] = {}
-    for name, definitions in core_index.items():
-        inside = [d for d in definitions if d.module in MATCH_PATH_MODULES]
-        if inside:
-            declared_index[name] = inside
+    index = _index()
+
+    def targets_of(called: str) -> list[_Definition]:
+        return index.functions.get(called, []) + index.constructors.get(called, [])
 
     queue: deque[_Definition] = deque()
     # A definition is identified by (module, line): two same-named methods in one module stay distinct.
     visited: set[tuple[str, int]] = set()
     for seed in SEEDS:
-        for definition in declared_index.get(seed, []):
-            if (definition.module, definition.node.lineno) not in visited:
+        for definition in targets_of(seed):
+            if definition.module in MATCH_PATH_MODULES and (definition.module, definition.node.lineno) not in visited:
                 visited.add((definition.module, definition.node.lineno))
                 queue.append(definition)
 
@@ -311,15 +390,15 @@ def sweep() -> _Sweep:
         definition = queue.popleft()
         reachable.add((definition.module, definition.node.name))
         caller = f"{definition.module}::{definition.node.name}"
-        for called in _called_names(definition.node):
-            for target in declared_index.get(called, []):
-                key = (target.module, target.node.lineno)
-                if key not in visited:
-                    visited.add(key)
-                    queue.append(target)
-            for target in core_index.get(called, []):
-                if target.module not in MATCH_PATH_MODULES and _raises_an_exception(target.node):
-                    external.add(ExternalCall(target.module, called, caller))
+        for called in _scan(definition.node)[0]:
+            for target in targets_of(called):
+                if target.module in MATCH_PATH_MODULES:
+                    key = (target.module, target.node.lineno)
+                    if key not in visited:
+                        visited.add(key)
+                        queue.append(target)
+                elif target.node.name in index.raising:
+                    external.add(ExternalCall(target.module, target.node.name, caller))
 
     sites: list[RaiseSite] = []
     for module in sorted({module for module, _ in reachable}):
@@ -379,6 +458,24 @@ def test_declared_helpers_outside_the_path_are_still_called() -> None:
     assert stale == [], f"RAISING_HELPERS_OUTSIDE_THE_PATH entries the match path no longer calls: {stale}"
 
 
+def test_every_seed_resolves_inside_a_declared_module() -> None:
+    """A seed that no longer names a definition seeds nothing, and the walk would shrink in silence."""
+    index = _index()
+    unresolved = sorted(
+        seed
+        for seed in SEEDS
+        if not any(
+            definition.module in MATCH_PATH_MODULES
+            for definition in index.functions.get(seed, []) + index.constructors.get(seed, [])
+        )
+    )
+
+    assert unresolved == [], (
+        f"SEEDS entries that name no definition in a declared module: {unresolved}. A renamed closure or "
+        "helper drops its whole subgraph from the sweep, so rename the seed with it."
+    )
+
+
 def test_every_declared_module_is_reachable() -> None:
     """Each declared module contributes at least one reachable function."""
     reached = {module for module, _ in sweep().reachable}
@@ -407,6 +504,29 @@ def test_known_escalations_are_enumerated() -> None:
     assert expected <= marked, f"known escalations missing from the sweep: {sorted(expected - marked)}"
     # Vacuity floor, not a target: 18 sites today, so removing one stays a legitimate change.
     assert len(sweep().sites) >= 15, f"sweep enumerated only {len(sweep().sites)} raise sites; it is not walking"
+
+
+def test_classifier_flags_an_unannotated_raise_inside_an_escalating_handler() -> None:
+    """An escalation elsewhere in the handler annotates nothing: only the raised expression counts.
+
+    Crediting the handler would let a new raise added next to an ``escalate_match_abort(exc); raise`` inherit
+    a mark it does not carry.
+    """
+    source = (
+        "def match_feature_group_criteria(cls, feature, options):\n"
+        "    try:\n"
+        "        return probe(feature)\n"
+        "    except ValueError as exc:\n"
+        "        escalate_match_abort(exc)\n"
+        "        if options is None:\n"
+        "            raise ValueError('brand new')\n"
+        "        raise\n"
+    )
+
+    sites = classify_raises(source, "snippet.py", frozenset({"match_feature_group_criteria"}))
+
+    assert [site.kind for site in sites] == ["unannotated"]
+    assert sites[0].lineno == 7
 
 
 def test_classifier_flags_an_unannotated_raise() -> None:

--- a/tests/test_core/test_prepare/test_match_abort_sweep.py
+++ b/tests/test_core/test_prepare/test_match_abort_sweep.py
@@ -1,33 +1,15 @@
 """Static sweep: every raise a match hook can reach must state whether it escalates or stays contained.
 
-``IdentifyFeatureGroupClass._filter_feature_group_by_criteria`` contains any raise out of
-``match_feature_group_criteria`` as a non-match for that candidate, unless the exception was marked with
-``escalate_match_abort``. The marked set is hand-maintained, so a NEW unmarked raise on the match path is
-silently downgraded to "this candidate does not match" and a rival plugin wins the feature. This sweep walks
-the static call graph from the match seams through the declared match-path modules and requires every raise
-it reaches to carry a decision: either the escalation call, or a ``# Contained: <reason>`` comment anchored to
-that individual raise.
+``IdentifyFeatureGroupClass._filter_feature_group_by_criteria`` contains a raise out of
+``match_feature_group_criteria`` as a non-match unless ``escalate_match_abort`` marked it, so a NEW unmarked
+raise on the match path silently loses the feature to a rival plugin. This sweep walks the static call graph
+from the match seams through the declared match-path modules and requires a decision at each individual
+raise: the escalation call, or a ``# Contained: <reason>`` comment on the raise line or in the comment block
+directly above it. A reason elsewhere in the enclosing function is not accepted; a later raise would inherit
+it and the gate would rot.
 
-What it deliberately does NOT cover:
-
-* Plugin code under ``mloda_plugins``. Their match hooks are user-shaped code; containment is the point.
-* Dynamic dispatch. The graph resolves calls by NAME inside the declared modules only, so a hook reached
-  purely through a runtime-built callable is invisible here. ``check_required_when`` and ``guarded`` are
-  seeded for exactly that reason: they run inside the matcher wrappers the two ``__init_subclass__`` hooks
-  install, and no static call edge reaches them from the seams.
-* Decorators. A decorator is not a call edge here: it runs at definition time, not when the match path calls
-  the function, and counting it would resolve ``@functools.wraps`` onto same-named framework functions.
-* Handlers BETWEEN a marked raise and the seam. A mark only survives if every ``except`` on the way
-  re-raises when ``is_match_abort`` holds, and this sweep reads raises, not handlers.
-  ``FeatureChainParserMixin.match_parser_criteria`` and ``FeatureGroup.is_root`` are the two handlers a mark
-  crosses on the normal path; test_match_abort_escalation.py owns that behavior. ``utils.safe_field``
-  swallows a marked exception deliberately: its contract is to degrade one field in a rendering path.
-* Whether a contained raise is the RIGHT call. The comment records the author's decision; this sweep only
-  proves a decision was made and written down next to the raise.
-
-Anchoring policy: the reason must sit on the raise line or in the contiguous comment block directly above the
-raise. A reason merely present somewhere in the enclosing function is not accepted, otherwise a second raise
-added later would inherit the first one's reason and the gate would rot.
+Not covered: plugin code under ``mloda_plugins``; dynamic dispatch, which is why SEEDS is hand-written;
+decorators; handlers between a marked raise and the seam (test_match_abort_escalation.py owns those).
 """
 
 from __future__ import annotations
@@ -40,8 +22,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Literal, NamedTuple
 
-# Anchor the scan to the repo layout via __file__, not the cwd: a cwd-relative root makes every lookup below
-# empty and the sweep pass vacuously. This file sits three parents below the repo root.
+# Anchored via __file__, not the cwd: a cwd-relative root makes every lookup empty and the sweep vacuous.
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _CORE_ROOT = _REPO_ROOT / "mloda"
 assert _CORE_ROOT.is_dir(), f"core root not found; check the parents index for the repo root: {_CORE_ROOT}"
@@ -51,23 +32,11 @@ assert _CORE_ROOT.is_dir(), f"core root not found; check the parents index for t
 MATCH_PATH_MODULES: dict[str, str] = {
     "mloda/core/prepare/identify_feature_group.py": "the containment seam itself",
     "mloda/core/abstract_plugins/feature_group.py": "the default matcher every group inherits",
-    "mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py": (
-        "the chain-parser matcher, the most common override"
-    ),
-    "mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py": (
-        "name parsing and property resolution run inside that matcher"
-    ),
-    "mloda/core/abstract_plugins/components/feature_chainer/feature_chain_author_guards.py": (
-        "the required_when guard wrapped around a group's matcher"
-    ),
-    "mloda/core/abstract_plugins/components/feature_chainer/property_spec.py": (
-        "the matcher's required-key check reads the spec sentinel here (is_no_default); the module's own "
-        "raises all sit in PropertySpec construction, which runs at class definition, and stay declared so a "
-        "match-time construction would be swept instead of slipping past"
-    ),
-    "mloda/core/abstract_plugins/components/input_data/base_input_data.py": (
-        "reader matching and file pinning, reached from the input-data matchers"
-    ),
+    "mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py": "the chain-parser matcher",
+    "mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py": "the parsing that matcher runs",
+    "mloda/core/abstract_plugins/components/feature_chainer/feature_chain_author_guards.py": "the required_when guard",
+    "mloda/core/abstract_plugins/components/feature_chainer/property_spec.py": "the matcher reads the spec sentinel",
+    "mloda/core/abstract_plugins/components/input_data/base_input_data.py": "reader matching and file pinning",
     "mloda/core/abstract_plugins/components/input_data/api/api_input_data.py": "the api reader's match hook",
     "mloda/core/abstract_plugins/components/input_data/creator/data_creator.py": "the data-creator match hook",
     "mloda/core/abstract_plugins/components/match_data/match_data.py": "reader selection during matching",
@@ -76,31 +45,19 @@ MATCH_PATH_MODULES: dict[str, str] = {
 for _module in MATCH_PATH_MODULES:
     assert (_REPO_ROOT / _module).exists(), f"declared match-path module not found: {_module}"
 
-# Entry points of the walk. The first two are the seam; the rest are reached from code the graph cannot see,
-# so they are seeded by hand.
+# Entry points. The first two are the seam; the rest are reached from code the graph cannot see.
 SEEDS: dict[str, str] = {
     "match_feature_group_criteria": "the match hook every candidate is asked",
     "_filter_feature_group_by_criteria": "the seam that contains a raising hook",
-    "_resolve_pinned_file": "framework helper invoked from reader match hooks that live in mloda_plugins",
-    "check_required_when": "runs inside the matcher wrapper install_required_when_guard installs",
-    "guarded": (
-        "the installed guard closures ARE the resolved match_feature_group_criteria of a guarded class; "
-        "the setattr that installs them is no static call edge"
-    ),
+    "_resolve_pinned_file": "called from reader match hooks in mloda_plugins",
+    "check_required_when": "runs inside the wrapper install_required_when_guard installs",
+    "guarded": "the installed closure IS a guarded class's matcher; the setattr is no call edge",
 }
 
-# Raising functions OUTSIDE the declared modules that the match path calls. Each needs a decision too, but it
-# is recorded here instead of at the raise, because these functions serve callers far away from matching.
-# Resolution is by name, so an entry can also be a name COLLISION rather than a real call edge; those say so
-# and are declared to keep the sweep closed, not because the match path calls them.
-_CANDIDATE_OWN_DECLARATION = (
-    "contained: this validates the requesting feature's own declaration while a candidate is being tried, so "
-    "the seam reads a raise as that candidate's non-match"
-)
-_READER_AUTO_LOAD = (
-    "contained: reader auto-load runs during matching, and a broken plugin group must not abort a run another "
-    "candidate can serve"
-)
+# Raising functions OUTSIDE the declared modules that the match path calls; the decision is recorded here
+# instead of at the raise. Resolution is by name, so an entry can be a name COLLISION, not a call edge.
+_CANDIDATE_OWN_DECLARATION = "contained: validates the requesting feature's own declaration during matching"
+_READER_AUTO_LOAD = "contained: reader auto-load during matching; a broken plugin group must not abort the run"
 
 RAISING_HELPERS_OUTSIDE_THE_PATH: dict[tuple[str, str], str] = {
     ("mloda/core/abstract_plugins/components/options.py", "__init__"): _CANDIDATE_OWN_DECLARATION,
@@ -111,19 +68,13 @@ RAISING_HELPERS_OUTSIDE_THE_PATH: dict[tuple[str, str], str] = {
     ("mloda/core/abstract_plugins/plugin_loader/plugin_loader.py", "load_group"): _READER_AUTO_LOAD,
     ("mloda/core/abstract_plugins/plugin_loader/plugin_loader.py", "all"): _READER_AUTO_LOAD,
     ("mloda/core/abstract_plugins/components/link.py", "matches"): (
-        "name collision, not a call edge: the match path calls the input-data match hooks named matches, never "
-        "Link.matches"
+        "name collision: the match path calls the input-data hooks named matches, not Link.matches"
     ),
     ("mloda/core/abstract_plugins/components/utils.py", "get_all_subclasses"): (
-        "a real edge with a collided verdict: it only walks classes the run already imported and raises "
-        "nothing itself; it counts as raising through the set.add / set.update name collision"
+        "real edge, collided verdict: it raises nothing itself; the set.add / set.update names do"
     ),
-    ("mloda/core/prepare/resolve_links.py", "update"): (
-        "name collision, not a call edge: the match path calls dict.update, not the link resolver's update"
-    ),
-    ("mloda/core/runtime/run.py", "join"): (
-        "name collision, not a call edge: the match path calls str.join, not the runner's join"
-    ),
+    ("mloda/core/prepare/resolve_links.py", "update"): "name collision: dict.update, not the link resolver's",
+    ("mloda/core/runtime/run.py", "join"): "name collision: str.join, not the runner's join",
 }
 
 _ESCALATION = "escalate_match_abort"
@@ -169,16 +120,7 @@ class _Sweep(NamedTuple):
 
 
 def _scan(node: ast.AST) -> tuple[frozenset[str], bool]:
-    """One walk of ``node``: the names it calls, and whether it contains a ``raise <exc>``.
-
-    Called names are ``f(...)`` by id and ``x.f(...)`` by attribute, decorators excluded (they run at
-    definition time, not when the match path calls the function). No builtin-method filter: ``"".join(...)``
-    does pull in a framework function named ``join``, a name collision rather than a call edge, and
-    RAISING_HELPERS_OUTSIDE_THE_PATH records those as such. Filtering them here would also hide every
-    framework method named ``get``, ``update`` or ``add``. A bare re-raise is not a raise of its own.
-
-    One walk, not two: the index scans every function under ``mloda/``, so a second pass costs real time.
-    """
+    """The names ``node`` calls and whether it raises, in one walk (the index scans all of ``mloda/``)."""
     names: set[str] = set()
     raises = False
     stack: list[ast.AST] = [node]
@@ -194,6 +136,7 @@ def _scan(node: ast.AST) -> tuple[frozenset[str], bool]:
             raises = True
         for field, value in ast.iter_fields(current):
             if field == "decorator_list":
+                # A decorator runs at definition time, not when the match path calls the function.
                 continue
             for child in value if isinstance(value, list) else [value]:
                 if isinstance(child, ast.AST):
@@ -202,15 +145,11 @@ def _scan(node: ast.AST) -> tuple[frozenset[str], bool]:
 
 
 def _escalates(node: ast.AST) -> bool:
-    """True when ``escalate_match_abort`` is called anywhere inside ``node``."""
     return _ESCALATION in _scan(node)[0]
 
 
 def _own_line_and_trailing_comments(source: str) -> tuple[dict[int, str], dict[int, str]]:
-    """Comment text per line, split into own-line comments and comments trailing code.
-
-    tokenize, not a raw ``#`` scan: a ``#`` inside a string literal is not a comment token.
-    """
+    """Comment text per line, split into own-line and trailing; tokenize, so a ``#`` in a string is not one."""
     lines = source.splitlines()
     own_line: dict[int, str] = {}
     trailing: dict[int, str] = {}
@@ -240,11 +179,7 @@ def _anchored_reason(
     lineno: int,
     tag: str,
 ) -> str | None:
-    """The tagged reason for the raise at ``lineno``: trailing on that line, or in the block directly above.
-
-    The block ends at the first line that is not an own-line comment, so a blank or code line separates a
-    raise from a reason written for something else.
-    """
+    """The tagged reason for the raise at ``lineno``: trailing on that line, or in the block directly above."""
     reason = _tagged_reason(trailing.get(lineno, ""), tag)
     if reason is not None:
         return reason
@@ -269,11 +204,7 @@ def _collect_raises(node: ast.AST, functions: list[str], out: list[tuple[ast.Rai
 
 
 def classify_raises(source: str, module: str, functions: frozenset[str] | None = None) -> list[RaiseSite]:
-    """Classify every ``raise <exc>`` in ``source``, restricted to the named functions when given.
-
-    A pure function over text so the classifier can be exercised on snippets, independent of the tree.
-    ``functions`` filters by name: a raise counts when any function enclosing it is named in the filter.
-    """
+    """Classify every ``raise <exc>`` in ``source``, restricted to raises inside the named functions."""
     tree = ast.parse(source, filename=module)
     own_line, trailing = _own_line_and_trailing_comments(source)
     found: list[tuple[ast.Raise, list[str]]] = []
@@ -288,8 +219,7 @@ def classify_raises(source: str, module: str, functions: frozenset[str] | None =
         if raise_node.exc is None:
             # A bare re-raise carries no decision of its own: it sits under the escalate_match_abort line.
             continue
-        # Only the raised expression itself counts. Crediting an escalation elsewhere in the enclosing
-        # handler would bless every later raise added next to it.
+        # Only the raised expression counts: crediting the enclosing handler would bless later raises too.
         marked = _escalates(raise_node.exc)
         claimed = _anchored_reason(own_line, trailing, raise_node.lineno, _MARKED_TAG)
         contained = _anchored_reason(own_line, trailing, raise_node.lineno, _CONTAINED_TAG)
@@ -315,12 +245,7 @@ class _Index(NamedTuple):
 
 
 def _raising_names(calls_per_name: dict[str, frozenset[str]], direct: frozenset[str]) -> frozenset[str]:
-    """Names that can raise: directly, or through anything they call.
-
-    Depth-1 detection is defeated by one non-raising wrapper in an undeclared module, so this is transitive.
-    The graph resolves calls by NAME, so the raising verdict is a name's too: a name raises when any
-    definition of it does. Cycle-safe: a name only ever joins the set, so the fixed point terminates.
-    """
+    """Names that raise directly or through anything they call: one non-raising wrapper defeats depth-1."""
     callers: dict[str, set[str]] = {}
     for name, called in calls_per_name.items():
         for callee in called:
@@ -354,8 +279,7 @@ def _index() -> _Index:
                 if raises:
                     direct.add(node.name)
             elif isinstance(node, ast.ClassDef):
-                # Options(...) / Feature(...) is an ast.Call on a CLASS name: the edge is into what
-                # construction runs, which no call node names.
+                # A call on a CLASS name is an edge into what construction runs, which no call node names.
                 for child in node.body:
                     if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)) and child.name in _CONSTRUCTORS:
                         constructors.setdefault(node.name, []).append(_Definition(module, child))
@@ -365,11 +289,8 @@ def _index() -> _Index:
 
 @lru_cache(maxsize=1)
 def sweep() -> _Sweep:
-    """Walk the match path from the seeds and classify every raise it reaches.
-
-    Indexing ``mloda/`` (not ``mloda_plugins/``) is what lets the walk notice calls that leave the declared
-    modules; the walk itself never follows them.
-    """
+    """Walk the match path from the seeds and classify every raise it reaches."""
+    # The index covers all of mloda/, so a call leaving the declared modules is seen, though never followed.
     index = _index()
 
     def targets_of(called: str) -> list[_Definition]:
@@ -414,20 +335,17 @@ def _of_kind(kind: Kind) -> list[RaiseSite]:
 
 
 def test_every_reachable_raise_is_marked_or_contained() -> None:
-    """No raise the match path can reach is left without an escalation decision."""
     unannotated = _of_kind("unannotated")
 
     assert unannotated == [], (
         "Raise sites reachable from the match seams with no escalation decision:\n"
         + "\n".join(f"  {site.location()}" for site in unannotated)
-        + "\n\nFor each one, decide and record it at the raise: wrap the exception in "
-        f"{_ESCALATION}(...) when the run must fail instead of silently losing the candidate, or write "
-        f"'# {_CONTAINED_TAG} <reason>' directly above the raise when the seam may read it as a non-match."
+        + f"\n\nRecord the decision at the raise: wrap the exception in {_ESCALATION}(...), or write "
+        f"'# {_CONTAINED_TAG} <reason>' directly above it."
     )
 
 
 def test_no_marked_comment_without_an_escalation() -> None:
-    """No raise claims to be marked while nothing at the site actually escalates."""
     mismarked = _of_kind("mismarked")
 
     assert mismarked == [], (
@@ -437,7 +355,6 @@ def test_no_marked_comment_without_an_escalation() -> None:
 
 
 def test_calls_into_raising_helpers_outside_the_path_are_declared() -> None:
-    """Every raising helper the match path calls outside the declared modules is declared with a reason."""
     undeclared = [
         call for call in sweep().external if (call.module, call.function) not in RAISING_HELPERS_OUTSIDE_THE_PATH
     ]
@@ -445,13 +362,13 @@ def test_calls_into_raising_helpers_outside_the_path_are_declared() -> None:
     assert undeclared == [], (
         "The match path calls raising functions outside the declared modules:\n"
         + "\n".join(f"  {call.module}::{call.function} from {call.caller}" for call in undeclared)
-        + "\n\nEither declare the (module, function) pair in RAISING_HELPERS_OUTSIDE_THE_PATH with the reason "
-        "its raises may stay contained, or add the module to MATCH_PATH_MODULES so its raises are swept."
+        + "\n\nDeclare the (module, function) pair in RAISING_HELPERS_OUTSIDE_THE_PATH with a reason, or add "
+        "the module to MATCH_PATH_MODULES so its raises are swept."
     )
 
 
 def test_declared_helpers_outside_the_path_are_still_called() -> None:
-    """Every declared helper is still reached, so stale entries cannot accumulate."""
+    """Stale entries cannot accumulate: every declared helper must still be reached."""
     called = {(call.module, call.function) for call in sweep().external}
     stale = sorted(entry for entry in RAISING_HELPERS_OUTSIDE_THE_PATH if entry not in called)
 
@@ -471,19 +388,17 @@ def test_every_seed_resolves_inside_a_declared_module() -> None:
     )
 
     assert unresolved == [], (
-        f"SEEDS entries that name no definition in a declared module: {unresolved}. A renamed closure or "
-        "helper drops its whole subgraph from the sweep, so rename the seed with it."
+        f"SEEDS entries that name no definition in a declared module: {unresolved}. Rename the seed with the "
+        "definition it points at."
     )
 
 
 def test_every_declared_module_is_reachable() -> None:
-    """Each declared module contributes at least one reachable function."""
     reached = {module for module, _ in sweep().reachable}
     unreached = sorted(set(MATCH_PATH_MODULES) - reached)
 
     assert unreached == [], (
-        f"MATCH_PATH_MODULES entries no seed reaches: {unreached}. Drop the entry, or add the seed that "
-        "reaches it if the call edge is dynamic."
+        f"MATCH_PATH_MODULES entries no seed reaches: {unreached}. Drop the entry, or add the seed that reaches it."
     )
 
 
@@ -507,11 +422,7 @@ def test_known_escalations_are_enumerated() -> None:
 
 
 def test_classifier_flags_an_unannotated_raise_inside_an_escalating_handler() -> None:
-    """An escalation elsewhere in the handler annotates nothing: only the raised expression counts.
-
-    Crediting the handler would let a new raise added next to an ``escalate_match_abort(exc); raise`` inherit
-    a mark it does not carry.
-    """
+    """An escalation elsewhere in the handler annotates nothing: only the raised expression counts."""
     source = (
         "def match_feature_group_criteria(cls, feature, options):\n"
         "    try:\n"
@@ -530,7 +441,7 @@ def test_classifier_flags_an_unannotated_raise_inside_an_escalating_handler() ->
 
 
 def test_classifier_flags_an_unannotated_raise() -> None:
-    """A raise with no decision at it is reported, whatever the enclosing function says elsewhere."""
+    """A '# Contained:' mention inside a docstring is not a decision at the raise."""
     source = (
         "def match_feature_group_criteria(cls, feature, options):\n"
         '    """# Contained: a docstring mention is not a decision at the raise."""\n'
@@ -546,7 +457,6 @@ def test_classifier_flags_an_unannotated_raise() -> None:
 
 
 def test_classifier_accepts_a_contained_comment_and_an_escalation() -> None:
-    """Both ways of recording a decision are accepted, and neither is reported as unannotated."""
     source = (
         "def match_feature_group_criteria(cls, feature, options):\n"
         "    if feature is None:\n"
@@ -564,7 +474,6 @@ def test_classifier_accepts_a_contained_comment_and_an_escalation() -> None:
 
 
 def test_classifier_flags_a_marked_comment_without_an_escalation() -> None:
-    """A comment that claims escalation without one is a lie the sweep must catch, not accept as annotated."""
     source = (
         "def match_feature_group_criteria(cls, feature, options):\n"
         "    # Marked: claims to escalate, nothing here does.\n"


### PR DESCRIPTION
## Summary

The set of framework raises marked with `escalate_match_abort` was hand-maintained, so a new unmarked raise on the match path was silently downgraded to a non-match and a rival plugin could win the feature.

## What this does

`tests/test_core/test_prepare/test_match_abort_sweep.py` walks the call graph from the match seams through a declared set of match-path modules and enumerates every `raise <exc>` it reaches (18 today: 6 marked, 12 contained). Each must record a decision at the raise: the `escalate_match_abort` call, or a `# Contained: <reason>` comment anchored to that raise, not merely present in the enclosing function. Four checks keep the sweep from passing vacuously (declared modules reachable, seeds resolving, declared out-of-scope helpers still called, known escalations enumerated) and three snippet tests prove it reports an unannotated raise.

The walk resolves calls by name, so it over-approximates. Name collisions are declared as such rather than filtered, because filtering by name would also hide a framework method called `get` or `update`.

Ten sites had no decision. Nine were contained. One is now marked: the option declared in both group and context, which `Options` construction already rejects, so reaching it is a broken invariant.

## Keeping a mark alive

Review found that mark never reached the seam: `match_parser_criteria` caught it in a blanket `except ValueError` and `is_root` did the same for `input_features`. Both now re-raise on `is_match_abort`. `utils.safe_field` deliberately keeps swallowing, since its contract is to degrade one field in a rendering path.

## The rule

`IdentifyFeatureGroupClass._filter_feature_group_by_criteria` now states it once (mark a misconfiguration, contradiction or framework defect that containment would hide; contain a per-candidate judgment), names the sweep as its enforcer, and notes that a mark only survives if every handler on the way re-raises it. `escalate_match_abort` and the filter seam point at it.

Follow-ups filed: #931 (gate the handlers, not just the raises), #932 (the option-write conflict one level below reader selection).

## Testing

`tox` passes: 7639 passed, 170 skipped, ruff, `mypy --strict` and bandit clean. Behavior changes covered in `test_match_abort_escalation.py`.

Closes #898
