### PR TITLE
docs: close plugin README directory fence

### DIFF
--- a/mloda_plugins/README.md
+++ b/mloda_plugins/README.md
@@ -52,8 +52,9 @@ To create effective and maintainable plugins:
 - Make plugins configurable for different use cases
 
 ## Directory Structure
-```
+```text
 mloda_plugins/
 ├── compute_framework/   # Compute framework implementations
 ├── feature_group/       # Feature group implementations
 └── function_extender/   # Function extender implementations
+```


### PR DESCRIPTION
## Summary

Closes the unterminated directory-tree code fence in `mloda_plugins/README.md` and marks the block as plain text so Markdown renderers do not guess a language.

The missing closing delimiter left the fence open through EOF. GitHub tolerates that today, but stricter Markdown tooling rejects it and any future content appended to the README would be rendered inside the tree block.

## Related issue

Closes #936

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [x] Documentation (`docs:`)
- [ ] Refactor / maintenance (`refactor:` / `chore:`)
- [ ] Other (explain below)

## Validation

- Confirmed the README has a balanced pair of fenced-code delimiters.
- Confirmed the documented tree matches the three current top-level plugin directories.
- Ran `PYTEST_WORKERS=4 tox`: 7,639 tests passed, 170 expected skips; Ruff format/check, dependency-license checks, strict mypy, and Bandit passed.

No test was added because this is a docs-only delimiter correction and the repository does not have a general Markdown-lint test to extend; a file-specific regression test would be disproportionate.

## Checklist

- [x] `tox` passes locally (tests, `ruff format --check`, `ruff check`, `mypy --strict`, `bandit`, license check)
- [ ] Tests added or updated for the change (and the skip count adjusted if needed)
- [x] Documentation updated where relevant
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
