### PR TITLE
fix: make an unresolvable in_features value a plain non-match

### DIFF
--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -514,7 +514,7 @@ class FeatureChainParserMixin:
                     count = 0
                 else:
                     # An in_features value this matcher cannot count is a non-match, not an error:
-                    # skipping MIN/MAX would let the group win a resolution its own cap says it must lose (#884).
+                    # skipping MIN/MAX would let the group win a resolution its own cap says it must lose.
                     # The catch is narrow on purpose; another exception class is a defect to surface, not a value.
                     try:
                         count = len(options.get_in_features())

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -81,6 +81,7 @@ from mloda.core.abstract_plugins.components.feature_chainer.property_spec import
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
 from mloda.core.abstract_plugins.components.utils import (
     contained_raise_log_level,
+    contained_raise_reason,
     escalate_match_abort,
     is_match_abort,
 )
@@ -512,18 +513,26 @@ class FeatureChainParserMixin:
                     # Present but empty: zero in_features, a non-match rather than an error.
                     count = 0
                 else:
-                    # An in_features shape this matcher cannot count (SourceInputFeature stores join
-                    # tuples there) is a NON-MATCH: a group that cannot even count the in_features
-                    # cannot consume them. Skipping MIN/MAX here would accept the feature and let the
-                    # group win a resolution its own cap says it must lose. A value get_in_features
-                    # cannot resolve at all (every falsy one) is that same non-match, not a raise (#884).
+                    # An in_features shape this matcher cannot count (SourceInputFeature stores join tuples)
+                    # is a NON-MATCH: a group that cannot even count them cannot consume them, and skipping
+                    # MIN/MAX would let it win a resolution its own cap says it must lose. get_in_features
+                    # also rejects a falsy non-collection ("", 0, False, {}); None is gated above and an empty
+                    # collection counted as zero, so only those reach here, and they are that same non-match
+                    # (#884). Narrow on purpose: another class out of it is a defect for the seam to surface,
+                    # not a value judged here. The DEBUG line therefore also fires for the join-tuple shape.
                     try:
                         count = len(options.get_in_features())
                     except (TypeError, ValueError) as exc:
                         # A marked raise crosses this containment as the same object, as everywhere else.
                         if is_match_abort(exc):
                             raise
-                        logger.debug("%s cannot resolve in_features value %r: %s", cls.__name__, in_features_raw, exc)
+                        # Text, not exc: a retained record must not pin this frame, its cls and the plugin class.
+                        logger.debug(
+                            "%s cannot resolve in_features value %r: %s",
+                            cls.__name__,
+                            in_features_raw,
+                            contained_raise_reason(exc),
+                        )
                         return False
                 if count < cls.MIN_IN_FEATURES:
                     return False

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -513,17 +513,12 @@ class FeatureChainParserMixin:
                     # Present but empty: zero in_features, a non-match rather than an error.
                     count = 0
                 else:
-                    # An in_features shape this matcher cannot count (SourceInputFeature stores join tuples)
-                    # is a NON-MATCH: a group that cannot even count them cannot consume them, and skipping
-                    # MIN/MAX would let it win a resolution its own cap says it must lose. get_in_features
-                    # also rejects a falsy non-collection ("", 0, False, {}); None is gated above and an empty
-                    # collection counted as zero, so only those reach here, and they are that same non-match
-                    # (#884). Narrow on purpose: another class out of it is a defect for the seam to surface,
-                    # not a value judged here. The DEBUG line therefore also fires for the join-tuple shape.
+                    # An in_features value this matcher cannot count is a non-match, not an error:
+                    # skipping MIN/MAX would let the group win a resolution its own cap says it must lose (#884).
+                    # The catch is narrow on purpose; another exception class is a defect to surface, not a value.
                     try:
                         count = len(options.get_in_features())
                     except (TypeError, ValueError) as exc:
-                        # A marked raise crosses this containment as the same object, as everywhere else.
                         if is_match_abort(exc):
                             raise
                         # Text, not exc: a retained record must not pin this frame, its cls and the plugin class.

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -83,7 +83,6 @@ from mloda.core.abstract_plugins.components.utils import (
     contained_raise_log_level,
     escalate_match_abort,
     is_match_abort,
-    safe_field,
 )
 
 logger = logging.getLogger(__name__)
@@ -257,7 +256,8 @@ class FeatureChainParserMixin:
         invalid. See the module docstring for the full validation design.
 
         Also enforces MIN_IN_FEATURES / MAX_IN_FEATURES constraints when
-        in_features is present in options.
+        in_features is present in options. An in_features value the matcher cannot
+        resolve is a non-match.
 
         ``required_when`` is NOT evaluated here. The guard installed at class definition
         runs the predicates after this method (or any override of it) returns True.
@@ -515,13 +515,16 @@ class FeatureChainParserMixin:
                     # An in_features shape this matcher cannot count (SourceInputFeature stores join
                     # tuples there) is a NON-MATCH: a group that cannot even count the in_features
                     # cannot consume them. Skipping MIN/MAX here would accept the feature and let the
-                    # group win a resolution its own cap says it must lose.
-                    in_features: frozenset[Feature] | None = safe_field(
-                        options.get_in_features, None, catching=(TypeError,)
-                    )
-                    if in_features is None:
+                    # group win a resolution its own cap says it must lose. A value get_in_features
+                    # cannot resolve at all (every falsy one) is that same non-match, not a raise (#884).
+                    try:
+                        count = len(options.get_in_features())
+                    except (TypeError, ValueError) as exc:
+                        # A marked raise crosses this containment as the same object, as everywhere else.
+                        if is_match_abort(exc):
+                            raise
+                        logger.debug("%s cannot resolve in_features value %r: %s", cls.__name__, in_features_raw, exc)
                         return False
-                    count = len(in_features)
                 if count < cls.MIN_IN_FEATURES:
                     return False
                 if cls.MAX_IN_FEATURES is not None and count > cls.MAX_IN_FEATURES:

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_feature_chain_parser_mixin.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_feature_chain_parser_mixin.py
@@ -17,7 +17,7 @@ from mloda.provider import DefaultOptionKeys, PropertySpec
 
 MIXIN_LOGGER_NAME = "mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin"
 
-ABORT_MESSAGE_884 = "abort_884_in_features_escalated"
+ABORT_MESSAGE = "abort_in_features_escalated"
 
 
 class MockFeatureGroup(FeatureChainParserMixin):
@@ -524,7 +524,7 @@ class TestFeatureChainParserMixinMinMaxInFeatures:
 
     @pytest.mark.parametrize("value", UNRESOLVABLE_IN_FEATURES, ids=UNRESOLVABLE_IDS)
     def test_unresolvable_in_features_is_a_plain_non_match(self, value: Any) -> None:
-        """An in_features value the matcher cannot resolve is a non-match, never a raise (#884)."""
+        """An in_features value the matcher cannot resolve is a non-match, never a raise."""
         options = Options(context={"operation": "op1", "in_features": value})
         result = MockFeatureGroupWithMinMax.match_feature_group_criteria("any_name", options)
         assert result is False
@@ -570,7 +570,7 @@ class TestFeatureChainParserMixinMinMaxInFeatures:
     @pytest.mark.parametrize("error_type", [ValueError, TypeError], ids=["value_error", "type_error"])
     def test_marked_match_abort_still_escapes_the_in_features_gate(self, error_type: type[Exception]) -> None:
         """A raise marked with escalate_match_abort crosses the matcher as the SAME object, never contained."""
-        marker = escalate_match_abort(error_type(ABORT_MESSAGE_884))
+        marker = escalate_match_abort(error_type(ABORT_MESSAGE))
         # A resolvable-looking raw value, so the gate gets as far as calling get_in_features at all.
         options = _MarkedAbortOptions(context={"operation": "op1", "in_features": ["a", "b"]})
         options.marker = marker

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_feature_chain_parser_mixin.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_feature_chain_parser_mixin.py
@@ -1,6 +1,7 @@
 """Tests for FeatureChainParserMixin."""
 
-from typing import Optional
+import logging
+from typing import Any, Optional
 
 import pytest
 
@@ -10,7 +11,14 @@ from mloda.user import Options
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import (
     FeatureChainParserMixin,
 )
+from mloda.core.abstract_plugins.components.utils import escalate_match_abort
 from mloda.provider import DefaultOptionKeys, PropertySpec
+
+
+# The mixin's own logger: where an in_features rejection has to become visible (#884).
+MIXIN_LOGGER_NAME = "mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin"
+
+ABORT_MESSAGE_884 = "abort_884_in_features_escalated"
 
 
 class MockFeatureGroup(FeatureChainParserMixin):
@@ -391,6 +399,30 @@ class TestFeatureChainParserMixinEdgeCases:
         assert feature_names == {"first", "second", "third"}
 
 
+class _MarkedAbortOptions(Options):
+    """Options whose in_features read raises the caller's own exception, so its identity stays assertable."""
+
+    marker: BaseException
+
+    def get_in_features(self) -> "frozenset[Feature]":
+        raise self.marker
+
+
+# Every in_features value the matcher cannot resolve. The falsy ones raise today, the truthy ones
+# already answer False; False and 0 need explicit ids, since pytest gives them the same one.
+UNRESOLVABLE_IN_FEATURES = [
+    pytest.param("", id="empty_str"),
+    pytest.param(0, id="zero_int"),
+    pytest.param(0.0, id="zero_float"),
+    pytest.param(False, id="false"),
+    pytest.param({}, id="empty_dict"),
+    pytest.param(5, id="int"),
+    pytest.param(1.5, id="float"),
+    pytest.param(True, id="true"),
+    pytest.param({"a": 1}, id="non_empty_dict"),
+]
+
+
 class TestFeatureChainParserMixinMinMaxInFeatures:
     """Tests for MIN_IN_FEATURES / MAX_IN_FEATURES enforcement in match_feature_group_criteria."""
 
@@ -499,6 +531,83 @@ class TestFeatureChainParserMixinMinMaxInFeatures:
         )
         result = MockFeatureGroupSingleInFeature.match_feature_group_criteria("any_name", options)
         assert result is False
+
+    @pytest.mark.parametrize("value", UNRESOLVABLE_IN_FEATURES)
+    def test_unresolvable_in_features_is_a_plain_non_match(self, value: Any) -> None:
+        """An in_features value the matcher cannot resolve is a non-match, never a raise (#884)."""
+        options = Options(context={"operation": "op1", "in_features": value})
+
+        result = MockFeatureGroupWithMinMax.match_feature_group_criteria("any_name", options)
+
+        assert result is False
+
+    @pytest.mark.parametrize(
+        "value",
+        [pytest.param("", id="falsy_empty_str"), pytest.param({"a": 1}, id="truthy_dict")],
+    )
+    def test_unresolvable_in_features_logs_one_debug_line_carrying_the_value(
+        self, value: Any, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The rejection is readable at DEBUG, carries the offending value, and stays quiet above DEBUG."""
+        options = Options(context={"operation": "op1", "in_features": value})
+
+        with caplog.at_level(logging.DEBUG, logger=MIXIN_LOGGER_NAME):
+            result = MockFeatureGroupWithMinMax.match_feature_group_criteria("any_name", options)
+        records = [record for record in caplog.records if record.name == MIXIN_LOGGER_NAME]
+        debugs = [record.getMessage() for record in records if record.levelno == logging.DEBUG]
+        loud = [record.getMessage() for record in records if record.levelno >= logging.WARNING]
+
+        assert result is False
+        assert len(debugs) == 1, f"exactly one DEBUG record must report the rejection, got: {debugs}"
+        assert repr(value) in debugs[0], f"the DEBUG record must carry the offending value: {debugs[0]}"
+        assert loud == [], f"an unresolvable value is one group's non-match, not a defect, got: {loud}"
+
+    def test_absent_in_features_still_matches(self) -> None:
+        """Regression pin, passes today: an absent in_features never enters the MIN/MAX gate."""
+        options = Options(context={"operation": "op1"})
+
+        assert MockFeatureGroupWithMinMax.match_feature_group_criteria("any_name", options) is True
+
+    def test_none_in_features_still_matches(self) -> None:
+        """Regression pin, passes today: an explicit None skips the gate; it is not an unresolvable value."""
+        options = Options(context={"operation": "op1", "in_features": None})
+
+        assert MockFeatureGroupWithMinMax.match_feature_group_criteria("any_name", options) is True
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            pytest.param([], id="empty_list"),
+            pytest.param((), id="empty_tuple"),
+            pytest.param(frozenset(), id="empty_frozenset"),
+        ],
+    )
+    def test_empty_collection_still_counts_as_zero_in_features(self, value: Any) -> None:
+        """Regression pin, passes today: an empty collection means zero in_features, below MIN=2."""
+        options = Options(context={"operation": "op1", "in_features": value})
+
+        assert MockFeatureGroupWithMinMax.match_feature_group_criteria("any_name", options) is False
+
+    def test_resolvable_in_features_still_matches(self) -> None:
+        """Regression pin, passes today: a value the matcher can count keeps its current behavior."""
+        options = Options(context={"operation": "op1", "in_features": frozenset({Feature("a"), Feature("b")})})
+
+        assert MockFeatureGroupWithMinMax.match_feature_group_criteria("any_name", options) is True
+
+    def test_marked_match_abort_still_escapes_the_in_features_gate(self) -> None:
+        """A raise marked with escalate_match_abort crosses the matcher as the SAME object, never contained.
+
+        Mirrors match_parser_criteria, the pattern any new in_features handler has to follow.
+        """
+        marker = escalate_match_abort(ValueError(ABORT_MESSAGE_884))
+        # A resolvable-looking raw value, so the gate gets as far as calling get_in_features at all.
+        options = _MarkedAbortOptions(context={"operation": "op1", "in_features": ["a", "b"]})
+        options.marker = marker
+
+        with pytest.raises(ValueError) as exc_info:
+            MockFeatureGroupWithMinMax.match_feature_group_criteria("any_name", options)
+
+        assert exc_info.value is marker, f"the marked exception itself must escape, got: {exc_info.value!r}"
 
 
 class TestFeatureChainParserMixinListValuedOptions:

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_feature_chain_parser_mixin.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_feature_chain_parser_mixin.py
@@ -408,8 +408,9 @@ class _MarkedAbortOptions(Options):
         raise self.marker
 
 
-# Every in_features value the matcher cannot resolve. The falsy ones raise today, the truthy ones
-# already answer False; False and 0 need explicit ids, since pytest gives them the same one.
+# Every in_features value the matcher cannot resolve: get_in_features raises a ValueError on the falsy
+# ones and a TypeError on the truthy ones, and the mixin answers False to both. The ids are explicit
+# because pytest would name the two dicts value4 / value8 and give "" an empty id.
 UNRESOLVABLE_IN_FEATURES = [
     pytest.param("", id="empty_str"),
     pytest.param(0, id="zero_int"),
@@ -594,17 +595,23 @@ class TestFeatureChainParserMixinMinMaxInFeatures:
 
         assert MockFeatureGroupWithMinMax.match_feature_group_criteria("any_name", options) is True
 
-    def test_marked_match_abort_still_escapes_the_in_features_gate(self) -> None:
+    @pytest.mark.parametrize(
+        "error_type",
+        [pytest.param(ValueError, id="value_error"), pytest.param(TypeError, id="type_error")],
+    )
+    def test_marked_match_abort_still_escapes_the_in_features_gate(self, error_type: type[Exception]) -> None:
         """A raise marked with escalate_match_abort crosses the matcher as the SAME object, never contained.
 
-        Mirrors match_parser_criteria, the pattern any new in_features handler has to follow.
+        Mirrors match_parser_criteria, the pattern any new in_features handler has to follow. The TypeError case
+        is the one that regressed: the old safe_field(..., catching=(TypeError,)) swallowed a marked TypeError,
+        because safe_field has no is_match_abort check.
         """
-        marker = escalate_match_abort(ValueError(ABORT_MESSAGE_884))
+        marker = escalate_match_abort(error_type(ABORT_MESSAGE_884))
         # A resolvable-looking raw value, so the gate gets as far as calling get_in_features at all.
         options = _MarkedAbortOptions(context={"operation": "op1", "in_features": ["a", "b"]})
         options.marker = marker
 
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(error_type) as exc_info:
             MockFeatureGroupWithMinMax.match_feature_group_criteria("any_name", options)
 
         assert exc_info.value is marker, f"the marked exception itself must escape, got: {exc_info.value!r}"

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_feature_chain_parser_mixin.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_feature_chain_parser_mixin.py
@@ -15,7 +15,6 @@ from mloda.core.abstract_plugins.components.utils import escalate_match_abort
 from mloda.provider import DefaultOptionKeys, PropertySpec
 
 
-# The mixin's own logger: where an in_features rejection has to become visible (#884).
 MIXIN_LOGGER_NAME = "mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin"
 
 ABORT_MESSAGE_884 = "abort_884_in_features_escalated"
@@ -408,20 +407,10 @@ class _MarkedAbortOptions(Options):
         raise self.marker
 
 
-# Every in_features value the matcher cannot resolve: get_in_features raises a ValueError on the falsy
-# ones and a TypeError on the truthy ones, and the mixin answers False to both. The ids are explicit
-# because pytest would name the two dicts value4 / value8 and give "" an empty id.
-UNRESOLVABLE_IN_FEATURES = [
-    pytest.param("", id="empty_str"),
-    pytest.param(0, id="zero_int"),
-    pytest.param(0.0, id="zero_float"),
-    pytest.param(False, id="false"),
-    pytest.param({}, id="empty_dict"),
-    pytest.param(5, id="int"),
-    pytest.param(1.5, id="float"),
-    pytest.param(True, id="true"),
-    pytest.param({"a": 1}, id="non_empty_dict"),
-]
+# Every in_features value the matcher cannot resolve: get_in_features raises a ValueError on the falsy ones and a
+# TypeError on the truthy ones. The ids are explicit; pytest would name the two dicts value4 / value8 and give "" none.
+UNRESOLVABLE_IN_FEATURES = ["", 0, 0.0, False, {}, 5, 1.5, True, {"a": 1}]
+UNRESOLVABLE_IDS = "empty_str zero_int zero_float false empty_dict int float true non_empty_dict".split()
 
 
 class TestFeatureChainParserMixinMinMaxInFeatures:
@@ -533,25 +522,19 @@ class TestFeatureChainParserMixinMinMaxInFeatures:
         result = MockFeatureGroupSingleInFeature.match_feature_group_criteria("any_name", options)
         assert result is False
 
-    @pytest.mark.parametrize("value", UNRESOLVABLE_IN_FEATURES)
+    @pytest.mark.parametrize("value", UNRESOLVABLE_IN_FEATURES, ids=UNRESOLVABLE_IDS)
     def test_unresolvable_in_features_is_a_plain_non_match(self, value: Any) -> None:
         """An in_features value the matcher cannot resolve is a non-match, never a raise (#884)."""
         options = Options(context={"operation": "op1", "in_features": value})
-
         result = MockFeatureGroupWithMinMax.match_feature_group_criteria("any_name", options)
-
         assert result is False
 
-    @pytest.mark.parametrize(
-        "value",
-        [pytest.param("", id="falsy_empty_str"), pytest.param({"a": 1}, id="truthy_dict")],
-    )
+    @pytest.mark.parametrize("value", ["", {"a": 1}], ids=["falsy_empty_str", "truthy_dict"])
     def test_unresolvable_in_features_logs_one_debug_line_carrying_the_value(
         self, value: Any, caplog: pytest.LogCaptureFixture
     ) -> None:
         """The rejection is readable at DEBUG, carries the offending value, and stays quiet above DEBUG."""
         options = Options(context={"operation": "op1", "in_features": value})
-
         with caplog.at_level(logging.DEBUG, logger=MIXIN_LOGGER_NAME):
             result = MockFeatureGroupWithMinMax.match_feature_group_criteria("any_name", options)
         records = [record for record in caplog.records if record.name == MIXIN_LOGGER_NAME]
@@ -564,53 +547,33 @@ class TestFeatureChainParserMixinMinMaxInFeatures:
         assert loud == [], f"an unresolvable value is one group's non-match, not a defect, got: {loud}"
 
     def test_absent_in_features_still_matches(self) -> None:
-        """Regression pin, passes today: an absent in_features never enters the MIN/MAX gate."""
+        """Regression pin: an absent in_features never enters the MIN/MAX gate."""
         options = Options(context={"operation": "op1"})
-
         assert MockFeatureGroupWithMinMax.match_feature_group_criteria("any_name", options) is True
 
     def test_none_in_features_still_matches(self) -> None:
-        """Regression pin, passes today: an explicit None skips the gate; it is not an unresolvable value."""
+        """Regression pin: an explicit None skips the gate; it is not an unresolvable value."""
         options = Options(context={"operation": "op1", "in_features": None})
-
         assert MockFeatureGroupWithMinMax.match_feature_group_criteria("any_name", options) is True
 
-    @pytest.mark.parametrize(
-        "value",
-        [
-            pytest.param([], id="empty_list"),
-            pytest.param((), id="empty_tuple"),
-            pytest.param(frozenset(), id="empty_frozenset"),
-        ],
-    )
+    @pytest.mark.parametrize("value", [[], (), frozenset()], ids=["empty_list", "empty_tuple", "empty_frozenset"])
     def test_empty_collection_still_counts_as_zero_in_features(self, value: Any) -> None:
-        """Regression pin, passes today: an empty collection means zero in_features, below MIN=2."""
+        """Regression pin: an empty collection means zero in_features, below MIN=2."""
         options = Options(context={"operation": "op1", "in_features": value})
-
         assert MockFeatureGroupWithMinMax.match_feature_group_criteria("any_name", options) is False
 
     def test_resolvable_in_features_still_matches(self) -> None:
-        """Regression pin, passes today: a value the matcher can count keeps its current behavior."""
+        """Regression pin: a value the matcher can count keeps its current behavior."""
         options = Options(context={"operation": "op1", "in_features": frozenset({Feature("a"), Feature("b")})})
-
         assert MockFeatureGroupWithMinMax.match_feature_group_criteria("any_name", options) is True
 
-    @pytest.mark.parametrize(
-        "error_type",
-        [pytest.param(ValueError, id="value_error"), pytest.param(TypeError, id="type_error")],
-    )
+    @pytest.mark.parametrize("error_type", [ValueError, TypeError], ids=["value_error", "type_error"])
     def test_marked_match_abort_still_escapes_the_in_features_gate(self, error_type: type[Exception]) -> None:
-        """A raise marked with escalate_match_abort crosses the matcher as the SAME object, never contained.
-
-        Mirrors match_parser_criteria, the pattern any new in_features handler has to follow. The TypeError case
-        is the one that regressed: the old safe_field(..., catching=(TypeError,)) swallowed a marked TypeError,
-        because safe_field has no is_match_abort check.
-        """
+        """A raise marked with escalate_match_abort crosses the matcher as the SAME object, never contained."""
         marker = escalate_match_abort(error_type(ABORT_MESSAGE_884))
         # A resolvable-looking raw value, so the gate gets as far as calling get_in_features at all.
         options = _MarkedAbortOptions(context={"operation": "op1", "in_features": ["a", "b"]})
         options.marker = marker
-
         with pytest.raises(error_type) as exc_info:
             MockFeatureGroupWithMinMax.match_feature_group_criteria("any_name", options)
 

--- a/tests/test_core/test_filter/test_filter_matcher_containment.py
+++ b/tests/test_core/test_filter/test_filter_matcher_containment.py
@@ -42,7 +42,6 @@ HOSTILE_CLASS_NAME = "HostileFilterMatcherFG899"
 HOSTILE_TYPE_NAME = "HostileFilterMatcherError899"
 HOSTILE_STR_MESSAGE = "boom_899_hostile_str_raised"
 
-# Issue #884: a mixin group asked for an in_features value it cannot resolve.
 FILTER_FEATURE_IN_FEATURES = "gfc_in_features_filter_feat_884"
 
 E2E_MAIN = "gfc_main_feat_899"  # requested root feature; must keep resolving
@@ -384,9 +383,7 @@ def _make_in_features_mixin_fg() -> type[FeatureGroup]:
     gc.collect()
 
     class InFeaturesMixinFilterFG884(FeatureChainParserMixin, FeatureGroup):
-        PROPERTY_MAPPING = {
-            "operation": property_spec("operation the group serves", allowed_values=("op1",), context=True),
-        }
+        PROPERTY_MAPPING = {"operation": property_spec("operation", allowed_values=("op1",), context=True)}
 
         def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
             return None
@@ -395,10 +392,8 @@ def _make_in_features_mixin_fg() -> type[FeatureGroup]:
 
 
 class TestUnresolvableInFeaturesIsNotADrop:
-    """Issue #884: an in_features value the matcher cannot resolve is a plain non-match, not a contained raise."""
-
     def test_unresolvable_in_features_is_a_non_match_without_a_drop(self, caplog: pytest.LogCaptureFixture) -> None:
-        """The falsy value never leaves the matcher, so the filter seam records no drop and warns about nothing."""
+        """Issue #884: the value never leaves the matcher, so the seam records no drop and warns about nothing."""
         snapshot = _drive_criteria(
             _make_in_features_mixin_fg,
             FILTER_FEATURE_IN_FEATURES,

--- a/tests/test_core/test_filter/test_filter_matcher_containment.py
+++ b/tests/test_core/test_filter/test_filter_matcher_containment.py
@@ -398,7 +398,7 @@ class TestUnresolvableInFeaturesIsNotADrop:
     """Issue #884: an in_features value the matcher cannot resolve is a plain non-match, not a contained raise."""
 
     def test_unresolvable_in_features_is_a_non_match_without_a_drop(self, caplog: pytest.LogCaptureFixture) -> None:
-        """Today the falsy value raises out of the matcher, so the filter seam records a drop and warns about it."""
+        """The falsy value never leaves the matcher, so the filter seam records no drop and warns about nothing."""
         snapshot = _drive_criteria(
             _make_in_features_mixin_fg,
             FILTER_FEATURE_IN_FEATURES,

--- a/tests/test_core/test_filter/test_filter_matcher_containment.py
+++ b/tests/test_core/test_filter/test_filter_matcher_containment.py
@@ -393,7 +393,7 @@ def _make_in_features_mixin_fg() -> type[FeatureGroup]:
 
 class TestUnresolvableInFeaturesIsNotADrop:
     def test_unresolvable_in_features_is_a_non_match_without_a_drop(self, caplog: pytest.LogCaptureFixture) -> None:
-        """Issue #884: the value never leaves the matcher, so the seam records no drop and warns about nothing."""
+        """The value never leaves the matcher, so the seam records no drop and warns about nothing."""
         snapshot = _drive_criteria(
             _make_in_features_mixin_fg,
             FILTER_FEATURE_IN_FEATURES,

--- a/tests/test_core/test_filter/test_filter_matcher_containment.py
+++ b/tests/test_core/test_filter/test_filter_matcher_containment.py
@@ -17,10 +17,11 @@ from typing import Any, Optional, TypeVar, cast
 import pytest
 
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.utils import escalate_match_abort
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
-from mloda.provider import DataCreator
+from mloda.provider import DataCreator, DefaultOptionKeys, property_spec
 from mloda.user import Feature, FeatureName, FilterType, GlobalFilter, Options, PluginCollector, SingleFilter, mloda
 from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
 
@@ -41,6 +42,9 @@ HOSTILE_CLASS_NAME = "HostileFilterMatcherFG899"
 HOSTILE_TYPE_NAME = "HostileFilterMatcherError899"
 HOSTILE_STR_MESSAGE = "boom_899_hostile_str_raised"
 
+# Issue #884: a mixin group asked for an in_features value it cannot resolve.
+FILTER_FEATURE_IN_FEATURES = "gfc_in_features_filter_feat_884"
+
 E2E_MAIN = "gfc_main_feat_899"  # requested root feature; must keep resolving
 E2E_TARGET = "gfc_target_feat_899"  # never requested directly; only reachable as a matched filter feature
 
@@ -55,9 +59,10 @@ def _capture(call: Callable[[], T]) -> tuple[Optional[T], Optional[str]]:
         return None, f"{type(exc).__name__}: {exc}"
 
 
-def _single(filter_feature_name: str) -> SingleFilter:
-    """A minimal EQUAL filter on one feature name."""
-    return SingleFilter(filter_feature_name, FilterType.EQUAL, {"value": 1})
+def _single(filter_feature_name: str, options: Optional[Options] = None) -> SingleFilter:
+    """A minimal EQUAL filter on one feature name, optionally carrying that filter feature's own options."""
+    filter_feature: Feature | str = filter_feature_name if options is None else Feature(filter_feature_name, options)
+    return SingleFilter(filter_feature, FilterType.EQUAL, {"value": 1})
 
 
 def _make_raising_filter_matcher_fg() -> type[FeatureGroup]:
@@ -259,6 +264,7 @@ def _drive_criteria(
     filter_feature_name: str,
     caplog: pytest.LogCaptureFixture,
     calls: int = 1,
+    options: Optional[Options] = None,
 ) -> _DropSnapshot:
     """Call criteria `calls` times against ONE GlobalFilter; the finally unbinds every name that pins the class."""
     caplog.clear()
@@ -272,7 +278,7 @@ def _drive_criteria(
         with caplog.at_level(logging.DEBUG, logger=GF_LOGGER_NAME):
             for _ in range(calls):
                 value, failure = _capture_type_name(
-                    partial(global_filter.criteria, fg, _single(filter_feature_name), None)
+                    partial(global_filter.criteria, fg, _single(filter_feature_name, options), None)
                 )
                 results.append(value)
                 if failure is not None:
@@ -369,6 +375,39 @@ class TestDroppedFilterIsRecorded:
         assert snapshot.escaped is None, f"an ordinary non-match raises nothing: {snapshot.escaped}"
         assert snapshot.results == (False,), f"an unsupported filter feature is a non-match, got: {snapshot.results}"
         assert snapshot.has_ledger, "GlobalFilter must expose a dropped_filters ledger"
+        assert snapshot.entries == (), f"a non-match is not a drop, got: {snapshot.entries}"
+        assert snapshot.warnings == (), f"a non-match must not warn, got: {snapshot.warnings}"
+
+
+def _make_in_features_mixin_fg() -> type[FeatureGroup]:
+    """A throwaway mixin group that matches on its option set, so only the in_features gate can reject a filter."""
+    gc.collect()
+
+    class InFeaturesMixinFilterFG884(FeatureChainParserMixin, FeatureGroup):
+        PROPERTY_MAPPING = {
+            "operation": property_spec("operation the group serves", allowed_values=("op1",), context=True),
+        }
+
+        def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+            return None
+
+    return InFeaturesMixinFilterFG884
+
+
+class TestUnresolvableInFeaturesIsNotADrop:
+    """Issue #884: an in_features value the matcher cannot resolve is a plain non-match, not a contained raise."""
+
+    def test_unresolvable_in_features_is_a_non_match_without_a_drop(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Today the falsy value raises out of the matcher, so the filter seam records a drop and warns about it."""
+        snapshot = _drive_criteria(
+            _make_in_features_mixin_fg,
+            FILTER_FEATURE_IN_FEATURES,
+            caplog,
+            options=Options(context={"operation": "op1", DefaultOptionKeys.in_features: ""}),
+        )
+
+        assert snapshot.escaped is None, f"nothing may cross GlobalFilter.criteria: {snapshot.escaped}"
+        assert snapshot.results == (False,), f"an unresolvable in_features is a non-match, got: {snapshot.results}"
         assert snapshot.entries == (), f"a non-match is not a drop, got: {snapshot.entries}"
         assert snapshot.warnings == (), f"a non-match must not warn, got: {snapshot.warnings}"
 

--- a/tests/test_core/test_prepare/test_hostile_in_features_non_match.py
+++ b/tests/test_core/test_prepare/test_hostile_in_features_non_match.py
@@ -1,0 +1,145 @@
+"""Issue #884: an in_features value the matcher cannot resolve is a plain non-match at the resolution seam.
+
+A falsy value (``""``, ``0``, ``False``, ``{}``) makes ``Options.get_in_features`` raise a ValueError the mixin does
+not catch, so the engine contains it and records the candidate as a ``matcher_error`` near-miss. A truthy value the
+matcher cannot count (``{"a": 1}``) is already a plain non-match, so the two shapes must resolve identically.
+
+Assertions read structured facts off the EvaluationResult, per the seam's own docstring. The probe class lives inside
+a factory and is dropped before any assert runs, so a failing assert never pins a throwaway FeatureGroup into its
+traceback and trips the no-leak fixture in tests/conftest.py.
+"""
+
+from __future__ import annotations
+
+import gc
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
+from mloda.core.abstract_plugins.components.feature_chainer.property_spec import property_spec
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from mloda.core.prepare.identify_feature_group import FeatureResolutionError
+from mloda.core.prepare.resolution_types import EvaluationResult
+from tests.test_core.test_prepare.identify_seam import evaluate_or_raise
+
+
+IN_FEATURES_FEATURE_884 = "src__op1_infeat884"
+IN_FEATURES_CLASS_NAME_884 = "InFeaturesMixinFG884"
+RESOLUTION_ERROR_NAME = "FeatureResolutionError"
+MATCHER_ERROR_STAGE = "matcher_error"
+
+
+class InFeaturesFw884(ComputeFramework):
+    """Dummy compute framework for the unresolvable-in_features tests."""
+
+
+def _make_in_features_mixin_fg() -> type[FeatureGroup]:
+    """A mixin candidate matched by its own name, so only the in_features gate can still reject it."""
+    # Class objects are cyclic; collect leftovers from earlier tests before defining a twin.
+    gc.collect()
+
+    class InFeaturesMixinFG884(FeatureChainParserMixin, FeatureGroup):
+        """Matches its own name pattern and declares one compute framework."""
+
+        PREFIX_PATTERN = r".*__(?P<operation>\w+)_infeat884$"
+        PROPERTY_MAPPING = {
+            "operation": property_spec("operation carried by the name", allowed_values=("op1",), context=True),
+        }
+
+        @classmethod
+        def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+            return {InFeaturesFw884}
+
+        def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+            return None
+
+    return InFeaturesMixinFG884
+
+
+@dataclass(frozen=True)
+class _ResolutionSnapshot:
+    """Plain-data readout of one evaluation. Holds no class and no exception object."""
+
+    error_type: Optional[str]
+    identified_names: tuple[str, ...]
+    eliminations: tuple[tuple[str, str, str], ...]  # (class name, stage, reason), sorted
+
+
+def _resolve(in_features: Any) -> _ResolutionSnapshot:
+    """Evaluate one feature carrying that in_features value and read the outcome out as plain data."""
+    feature_group = _make_in_features_mixin_fg()
+    try:
+        feature = Feature(IN_FEATURES_FEATURE_884, Options(context={DefaultOptionKeys.in_features: in_features}))
+        plugins: FeatureGroupEnvironmentMapping = {feature_group: {InFeaturesFw884}}
+        error_type: Optional[str] = None
+        result: Optional[EvaluationResult] = None
+        try:
+            result = evaluate_or_raise(feature, plugins, None)
+        except FeatureResolutionError as exc:
+            error_type = type(exc).__name__
+            result = exc.result
+        except Exception as exc:  # noqa: BLE001  (an untyped escape is a fact this test wants to report)
+            error_type = type(exc).__name__
+        snapshot = _ResolutionSnapshot(
+            error_type=error_type,
+            identified_names=()
+            if result is None
+            else tuple(sorted(group.get_class_name() for group in result.identified)),
+            eliminations=()
+            if result is None
+            else tuple(
+                sorted(
+                    (group.get_class_name(), str(elimination.stage), str(elimination.reason))
+                    for group, elimination in result.eliminations.items()
+                )
+            ),
+        )
+        del result, plugins, feature
+        return snapshot
+    finally:
+        del feature_group
+        gc.collect()
+
+
+class TestUnresolvableInFeaturesIsAPlainNonMatch:
+    """A candidate that cannot resolve the requested in_features simply loses; it is not a broken matcher."""
+
+    def test_falsy_in_features_records_no_matcher_error(self) -> None:
+        """An empty string is a value the matcher cannot resolve, so it is a non-match, not a raise to contain."""
+        snapshot = _resolve("")
+
+        assert snapshot.error_type == RESOLUTION_ERROR_NAME, (
+            f"the failure must stay the typed resolution error, got: {snapshot.error_type}"
+        )
+        assert snapshot.identified_names == (), f"nothing may win this resolution, got: {snapshot.identified_names}"
+        matcher_errors = [entry for entry in snapshot.eliminations if entry[1] == MATCHER_ERROR_STAGE]
+        assert matcher_errors == [], f"a non-match must not be recorded as a matcher defect, got: {matcher_errors}"
+
+    def test_truthy_uncountable_in_features_records_nothing(self) -> None:
+        """The contrast case, passing today: a value the matcher cannot count records no elimination at all."""
+        snapshot = _resolve({"a": 1})
+
+        assert snapshot.error_type == RESOLUTION_ERROR_NAME
+        assert snapshot.identified_names == ()
+        assert snapshot.eliminations == (), f"an uncountable value is a silent non-match, got: {snapshot.eliminations}"
+
+    def test_both_unresolvable_shapes_resolve_identically(self) -> None:
+        """Falsy and truthy unresolvable values are the same kind of non-match, so their outcomes must agree."""
+        falsy = _resolve("")
+        truthy = _resolve({"a": 1})
+
+        assert falsy == truthy, f"the two shapes must be one behavior: {falsy} vs {truthy}"
+
+    def test_resolvable_in_features_still_identifies_the_candidate(self) -> None:
+        """Sanity pin, passes today: the candidate is really reachable, so the assertions above are not vacuous."""
+        snapshot = _resolve(["a", "b"])
+
+        assert snapshot.error_type is None, f"a resolvable value must still resolve, got: {snapshot.error_type}"
+        assert snapshot.identified_names == (IN_FEATURES_CLASS_NAME_884,)
+        assert snapshot.eliminations == ()

--- a/tests/test_core/test_prepare/test_unresolvable_in_features_non_match.py
+++ b/tests/test_core/test_prepare/test_unresolvable_in_features_non_match.py
@@ -1,7 +1,6 @@
 """Issue #884: an in_features value the matcher cannot resolve is a plain non-match at the resolution seam.
 
-The probe class is dropped under gc.collect() before any assert runs, so a failing assert cannot pin a
-FeatureGroup into its traceback and trip the no-leak fixture in tests/conftest.py.
+The probe class is dropped under gc.collect() before any assert, so no failing assert pins it (tests/conftest.py).
 """
 
 from __future__ import annotations
@@ -39,9 +38,7 @@ def _make_in_features_mixin_fg() -> type[FeatureGroup]:
 
     class InFeaturesMixinFG884(FeatureChainParserMixin, FeatureGroup):
         PREFIX_PATTERN = r".*__(?P<operation>\w+)_infeat884$"
-        PROPERTY_MAPPING = {
-            "operation": property_spec("operation carried by the name", allowed_values=("op1",), context=True),
-        }
+        PROPERTY_MAPPING = {"operation": property_spec("operation", allowed_values=("op1",), context=True)}
 
         @classmethod
         def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
@@ -78,8 +75,6 @@ def _resolve(in_features: Any) -> tuple[Optional[str], tuple[str, ...], tuple[tu
 
 
 class TestUnresolvableInFeaturesIsAPlainNonMatch:
-    """A candidate that cannot resolve the requested in_features simply loses; it is not a broken matcher."""
-
     def test_falsy_in_features_records_no_matcher_error(self) -> None:
         """An empty string is a value the matcher cannot resolve, so it is a non-match, not a raise to contain."""
         error_type, identified, eliminations = _resolve("")

--- a/tests/test_core/test_prepare/test_unresolvable_in_features_non_match.py
+++ b/tests/test_core/test_prepare/test_unresolvable_in_features_non_match.py
@@ -1,8 +1,9 @@
 """Issue #884: an in_features value the matcher cannot resolve is a plain non-match at the resolution seam.
 
-A falsy value (``""``, ``0``, ``False``, ``{}``) makes ``Options.get_in_features`` raise a ValueError the mixin does
-not catch, so the engine contains it and records the candidate as a ``matcher_error`` near-miss. A truthy value the
-matcher cannot count (``{"a": 1}``) is already a plain non-match, so the two shapes must resolve identically.
+A falsy value (``""``, ``0``, ``False``, ``{}``) makes ``Options.get_in_features`` raise a ValueError, which the mixin
+now catches and answers False to, so nothing reaches the engine and no ``matcher_error`` near-miss is recorded. Before
+the fix it escaped as a raise. A truthy value the matcher cannot count (``{"a": 1}``) was always a plain non-match, so
+the two shapes must resolve identically.
 
 Assertions read structured facts off the EvaluationResult, per the seam's own docstring. The probe class lives inside
 a factory and is dropped before any assert runs, so a failing assert never pins a throwaway FeatureGroup into its

--- a/tests/test_core/test_prepare/test_unresolvable_in_features_non_match.py
+++ b/tests/test_core/test_prepare/test_unresolvable_in_features_non_match.py
@@ -1,4 +1,4 @@
-"""Issue #884: an in_features value the matcher cannot resolve is a plain non-match at the resolution seam.
+"""An in_features value the matcher cannot resolve is a plain non-match at the resolution seam.
 
 The probe class is dropped under gc.collect() before any assert, so no failing assert pins it (tests/conftest.py).
 """

--- a/tests/test_core/test_prepare/test_unresolvable_in_features_non_match.py
+++ b/tests/test_core/test_prepare/test_unresolvable_in_features_non_match.py
@@ -1,19 +1,12 @@
 """Issue #884: an in_features value the matcher cannot resolve is a plain non-match at the resolution seam.
 
-A falsy value (``""``, ``0``, ``False``, ``{}``) makes ``Options.get_in_features`` raise a ValueError, which the mixin
-now catches and answers False to, so nothing reaches the engine and no ``matcher_error`` near-miss is recorded. Before
-the fix it escaped as a raise. A truthy value the matcher cannot count (``{"a": 1}``) was always a plain non-match, so
-the two shapes must resolve identically.
-
-Assertions read structured facts off the EvaluationResult, per the seam's own docstring. The probe class lives inside
-a factory and is dropped before any assert runs, so a failing assert never pins a throwaway FeatureGroup into its
-traceback and trips the no-leak fixture in tests/conftest.py.
+The probe class is dropped under gc.collect() before any assert runs, so a failing assert cannot pin a
+FeatureGroup into its traceback and trip the no-leak fixture in tests/conftest.py.
 """
 
 from __future__ import annotations
 
 import gc
-from dataclasses import dataclass
 from typing import Any, Optional
 
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
@@ -42,12 +35,9 @@ class InFeaturesFw884(ComputeFramework):
 
 def _make_in_features_mixin_fg() -> type[FeatureGroup]:
     """A mixin candidate matched by its own name, so only the in_features gate can still reject it."""
-    # Class objects are cyclic; collect leftovers from earlier tests before defining a twin.
-    gc.collect()
+    gc.collect()  # class objects are cyclic: collect leftovers before defining a twin
 
     class InFeaturesMixinFG884(FeatureChainParserMixin, FeatureGroup):
-        """Matches its own name pattern and declares one compute framework."""
-
         PREFIX_PATTERN = r".*__(?P<operation>\w+)_infeat884$"
         PROPERTY_MAPPING = {
             "operation": property_spec("operation carried by the name", allowed_values=("op1",), context=True),
@@ -63,49 +53,28 @@ def _make_in_features_mixin_fg() -> type[FeatureGroup]:
     return InFeaturesMixinFG884
 
 
-@dataclass(frozen=True)
-class _ResolutionSnapshot:
-    """Plain-data readout of one evaluation. Holds no class and no exception object."""
-
-    error_type: Optional[str]
-    identified_names: tuple[str, ...]
-    eliminations: tuple[tuple[str, str, str], ...]  # (class name, stage, reason), sorted
-
-
-def _resolve(in_features: Any) -> _ResolutionSnapshot:
-    """Evaluate one feature carrying that in_features value and read the outcome out as plain data."""
+def _resolve(in_features: Any) -> tuple[Optional[str], tuple[str, ...], tuple[tuple[str, str, str], ...]]:
+    """Evaluate one feature carrying that value: (error type, winner names, (class, stage, reason) per elimination)."""
     feature_group = _make_in_features_mixin_fg()
+    feature = Feature(IN_FEATURES_FEATURE_884, Options(context={DefaultOptionKeys.in_features: in_features}))
+    plugins: FeatureGroupEnvironmentMapping = {feature_group: {InFeaturesFw884}}
     try:
-        feature = Feature(IN_FEATURES_FEATURE_884, Options(context={DefaultOptionKeys.in_features: in_features}))
-        plugins: FeatureGroupEnvironmentMapping = {feature_group: {InFeaturesFw884}}
         error_type: Optional[str] = None
-        result: Optional[EvaluationResult] = None
-        try:
-            result = evaluate_or_raise(feature, plugins, None)
-        except FeatureResolutionError as exc:
-            error_type = type(exc).__name__
-            result = exc.result
-        except Exception as exc:  # noqa: BLE001  (an untyped escape is a fact this test wants to report)
-            error_type = type(exc).__name__
-        snapshot = _ResolutionSnapshot(
-            error_type=error_type,
-            identified_names=()
-            if result is None
-            else tuple(sorted(group.get_class_name() for group in result.identified)),
-            eliminations=()
-            if result is None
-            else tuple(
-                sorted(
-                    (group.get_class_name(), str(elimination.stage), str(elimination.reason))
-                    for group, elimination in result.eliminations.items()
-                )
-            ),
+        result: Optional[EvaluationResult] = evaluate_or_raise(feature, plugins, None)
+    except FeatureResolutionError as exc:
+        error_type, result = type(exc).__name__, exc.result
+    except Exception as exc:  # noqa: BLE001  (an untyped escape is a fact this test wants to report)
+        error_type, result = type(exc).__name__, None
+    identified: tuple[str, ...] = ()
+    eliminations: tuple[tuple[str, str, str], ...] = ()
+    if result is not None:
+        identified = tuple(sorted(g.get_class_name() for g in result.identified))
+        eliminations = tuple(
+            sorted((g.get_class_name(), str(e.stage), str(e.reason)) for g, e in result.eliminations.items())
         )
-        del result, plugins, feature
-        return snapshot
-    finally:
-        del feature_group
-        gc.collect()
+    del result, plugins, feature, feature_group
+    gc.collect()
+    return error_type, identified, eliminations
 
 
 class TestUnresolvableInFeaturesIsAPlainNonMatch:
@@ -113,34 +82,31 @@ class TestUnresolvableInFeaturesIsAPlainNonMatch:
 
     def test_falsy_in_features_records_no_matcher_error(self) -> None:
         """An empty string is a value the matcher cannot resolve, so it is a non-match, not a raise to contain."""
-        snapshot = _resolve("")
+        error_type, identified, eliminations = _resolve("")
 
-        assert snapshot.error_type == RESOLUTION_ERROR_NAME, (
-            f"the failure must stay the typed resolution error, got: {snapshot.error_type}"
-        )
-        assert snapshot.identified_names == (), f"nothing may win this resolution, got: {snapshot.identified_names}"
-        matcher_errors = [entry for entry in snapshot.eliminations if entry[1] == MATCHER_ERROR_STAGE]
+        assert error_type == RESOLUTION_ERROR_NAME, f"the failure must stay the typed resolution error: {error_type}"
+        assert identified == (), f"nothing may win this resolution, got: {identified}"
+        matcher_errors = [entry for entry in eliminations if entry[1] == MATCHER_ERROR_STAGE]
         assert matcher_errors == [], f"a non-match must not be recorded as a matcher defect, got: {matcher_errors}"
 
     def test_truthy_uncountable_in_features_records_nothing(self) -> None:
-        """The contrast case, passing today: a value the matcher cannot count records no elimination at all."""
-        snapshot = _resolve({"a": 1})
+        """Contrast case, passing today: a value the matcher cannot count records no elimination at all."""
+        error_type, identified, eliminations = _resolve({"a": 1})
 
-        assert snapshot.error_type == RESOLUTION_ERROR_NAME
-        assert snapshot.identified_names == ()
-        assert snapshot.eliminations == (), f"an uncountable value is a silent non-match, got: {snapshot.eliminations}"
+        assert error_type == RESOLUTION_ERROR_NAME
+        assert identified == ()
+        assert eliminations == (), f"an uncountable value is a silent non-match, got: {eliminations}"
 
     def test_both_unresolvable_shapes_resolve_identically(self) -> None:
-        """Falsy and truthy unresolvable values are the same kind of non-match, so their outcomes must agree."""
         falsy = _resolve("")
         truthy = _resolve({"a": 1})
 
         assert falsy == truthy, f"the two shapes must be one behavior: {falsy} vs {truthy}"
 
     def test_resolvable_in_features_still_identifies_the_candidate(self) -> None:
-        """Sanity pin, passes today: the candidate is really reachable, so the assertions above are not vacuous."""
-        snapshot = _resolve(["a", "b"])
+        """Sanity pin: the candidate is really reachable, so the assertions above are not vacuous."""
+        error_type, identified, eliminations = _resolve(["a", "b"])
 
-        assert snapshot.error_type is None, f"a resolvable value must still resolve, got: {snapshot.error_type}"
-        assert snapshot.identified_names == (IN_FEATURES_CLASS_NAME_884,)
-        assert snapshot.eliminations == ()
+        assert error_type is None, f"a resolvable value must still resolve, got: {error_type}"
+        assert identified == (IN_FEATURES_CLASS_NAME_884,)
+        assert eliminations == ()


### PR DESCRIPTION
`Options.get_in_features` rejects every falsy value with a `ValueError`, and `_validate_in_features` guarded only `TypeError`, so one user mistake had two outcomes:

| `in_features` | before | after |
|---|---|---|
| `""`, `0`, `0.0`, `False`, `{}` | raise out of the matcher | non-match |
| `5`, `1.5`, `True`, `{"a": 1}` | non-match | non-match |
| `[]`, `()`, `frozenset()` | zero in_features | zero in_features |
| absent or `None` | gate skipped | gate skipped |

The seam contains that raise, so resolution did not abort, but it recorded the candidate as a `matcher_error` near-miss blaming the plugin's match hook, and filter matching warned and dropped the filter.

Both shapes are now the same non-match, logged once at DEBUG with the value. A raise marked with `escalate_match_abort` still crosses as the same object, which the old `safe_field` guard swallowed for a marked `TypeError`.

Trade-off: the falsy half loses its line in the resolution failure report, in exchange for matching the truthy half that was always silent. Whether an unresolvable `in_features` deserves a recorded reason at all is #943.

Closes #884
