### PR TITLE
fix: stop the resolution hint suggesting names that cannot resolve

### DIFF
--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -12,6 +12,7 @@ from mloda.core.prepare.resolution_types import (
     Elimination,
     EliminationStage,
     EvaluationResult,
+    NAME_INDEPENDENT_STAGES,
     PARTIAL_RECORDS_CAP,
     RenderFacts,
     ResolutionRecord,
@@ -105,6 +106,8 @@ class IdentifyFeatureGroupClass:
     # they are scoped to one resolution attempt and never cache across runs.
     _domain_outcomes: dict[type[FeatureGroup], tuple[Optional[Domain], Optional[Exception]]]
     _declared_frameworks: dict[type[FeatureGroup], frozenset[type[ComputeFramework]]]
+    _supported_names: dict[type[FeatureGroup], frozenset[str]]
+    _prefixes: dict[type[FeatureGroup], str]
 
     def __init__(self, data_access_collection: Optional[DataAccessCollection] = None) -> None:
         self._criteria_matched_feature_groups = set()
@@ -117,6 +120,8 @@ class IdentifyFeatureGroupClass:
         self._eliminations = {}
         self._domain_outcomes = {}
         self._declared_frameworks = {}
+        self._supported_names = {}
+        self._prefixes = {}
         self._data_access_collection = data_access_collection
 
     @staticmethod
@@ -178,6 +183,7 @@ class IdentifyFeatureGroupClass:
             concrete_frameworks=self._concrete_implementation_frameworks(result, accessible_plugins),
             known_names=self._capture_known_names(accessible_plugins),
             eliminated_hints=self._capture_eliminated_hints(result),
+            dead_only_names=self._capture_dead_only_names(result, accessible_plugins),
         )
 
     def _capture_eliminated_hints(self, result: EvaluationResult) -> frozenset[str]:
@@ -269,16 +275,64 @@ class IdentifyFeatureGroupClass:
             frameworks.update(self._declared_framework_names(candidate))
         return tuple(sorted(frameworks))
 
+    def _supported_names_of(self, feature_group: type[FeatureGroup]) -> frozenset[str]:
+        """Memoized feature_names_supported(): the name catalog and the dead-name capture share one call.
+
+        Degrades exactly as _supported_feature_names does: a raising hook costs that candidate its whole catalog.
+        """
+        if feature_group not in self._supported_names:
+            self._supported_names[feature_group] = frozenset(_supported_feature_names(feature_group))
+        return self._supported_names[feature_group]
+
+    def _prefix_of(self, feature_group: type[FeatureGroup]) -> str:
+        """Memoized prefix(), read by the name catalog and by the live side of the dead-name difference."""
+        if feature_group not in self._prefixes:
+            self._prefixes[feature_group] = _prefix_name(feature_group)
+        return self._prefixes[feature_group]
+
+    def _catalog_names_of(self, feature_group: type[FeatureGroup]) -> list[str]:
+        """One candidate's whole contribution to the name catalog, in capture order."""
+        # get_class_name() is @final, so it cannot raise on a provider's behalf and needs no guard.
+        names = [feature_group.get_class_name(), *self._supported_names_of(feature_group)]
+        prefix = self._prefix_of(feature_group)
+        if prefix:
+            names.append(prefix)
+        return names
+
     def _capture_known_names(self, accessible_plugins: FeatureGroupEnvironmentMapping) -> tuple[str, ...]:
         known_names: list[str] = []
         for fg_class in accessible_plugins:
-            # get_class_name() is @final, so it cannot raise on a provider's behalf and needs no guard.
-            known_names.append(fg_class.get_class_name())
-            known_names.extend(_supported_feature_names(fg_class))
-            prefix = _prefix_name(fg_class)
-            if prefix:
-                known_names.append(prefix)
+            known_names.extend(self._catalog_names_of(fg_class))
         return tuple(known_names)
+
+    def _is_dead(
+        self,
+        result: EvaluationResult,
+        feature_group: type[FeatureGroup],
+        compute_frameworks: set[type[ComputeFramework]],
+    ) -> bool:
+        """No name at all can resolve to this candidate: it lost at a name-blind gate, or has no framework left."""
+        elimination = result.eliminations.get(feature_group)
+        if elimination is None:
+            return False
+        return elimination.stage in NAME_INDEPENDENT_STAGES or not compute_frameworks
+
+    def _capture_dead_only_names(
+        self, result: EvaluationResult, accessible_plugins: FeatureGroupEnvironmentMapping
+    ) -> frozenset[str]:
+        """Declared names left with no live declarer, so suggesting one would fail again with the same message.
+
+        A difference, not a per-candidate drop: one accessible group that is still alive keeps its name
+        suggestible, whatever a dead sibling also declares.
+        """
+        dead: set[str] = set()
+        live: set[str] = set()
+        for feature_group, compute_frameworks in accessible_plugins.items():
+            if self._is_dead(result, feature_group, compute_frameworks):
+                dead.update(self._supported_names_of(feature_group))
+            else:
+                live.update(self._catalog_names_of(feature_group))
+        return frozenset(dead - live)
 
     def _filter_loop(
         self,

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -173,10 +173,10 @@ class IdentifyFeatureGroupClass:
         """Capture the non-elimination facts the messages still need, precedence-free.
 
         The renderer alone owns which message wins, so this does not mirror its branch order: it captures
-        all three facts unconditionally (the failure path is rare). domains feeds the multiple message,
-        concrete_frameworks the abstract_only message, known_names the none message. Only reached when the
-        pass has no single winner. Every provider hook here is best-effort: a raising one degrades its own
-        fact, never this call or a sibling's fact.
+        all five facts unconditionally (the failure path is rare). domains feeds the multiple message,
+        concrete_frameworks the abstract_only message, and known_names, eliminated_hints and dead_only_names
+        the none message. Only reached when the pass has no single winner. Every provider hook here is
+        best-effort: a raising one degrades its own fact, never this call or a sibling's fact.
         """
         return RenderFacts(
             domains=self._capture_domains(result),
@@ -192,7 +192,7 @@ class IdentifyFeatureGroupClass:
         hints: set[str] = set()
         for feature_group in result.eliminations:
             hints.add(feature_group.get_class_name())
-            prefix = _prefix_name(feature_group)
+            prefix = self._prefix_of(feature_group)
             if prefix:
                 hints.add(prefix)
         return frozenset(hints)
@@ -311,28 +311,40 @@ class IdentifyFeatureGroupClass:
         feature_group: type[FeatureGroup],
         compute_frameworks: set[type[ComputeFramework]],
     ) -> bool:
-        """No name at all can resolve to this candidate: it lost at a name-blind gate, or has no framework left."""
+        """No name at all can resolve to this candidate: it has no framework left, or it lost at a name-blind gate.
+
+        The framework set is tested before the elimination lookup because it kills the candidate without one:
+        a record only exists for the name that was asked about, while an empty set routes EVERY name to
+        frameworks_not_enabled.
+        """
+        if not compute_frameworks:
+            return True
         elimination = result.eliminations.get(feature_group)
-        if elimination is None:
-            return False
-        return elimination.stage in NAME_INDEPENDENT_STAGES or not compute_frameworks
+        return elimination is not None and elimination.stage in NAME_INDEPENDENT_STAGES
 
     def _capture_dead_only_names(
         self, result: EvaluationResult, accessible_plugins: FeatureGroupEnvironmentMapping
     ) -> frozenset[str]:
-        """Declared names left with no live declarer, so suggesting one would fail again with the same message.
+        """Declared names that no live candidate declares and no live candidate's prefix covers.
 
         A difference, not a per-candidate drop: one accessible group that is still alive keeps its name
-        suggestible, whatever a dead sibling also declares.
+        suggestible, whatever a dead sibling also declares. Prefixes because the default matcher owns names
+        by class-name prefix too, so a live group covers names it never declares. The matcher's data-access
+        branches stay out: deciding one needs the speculative second match the renderer's contract refuses.
         """
         dead: set[str] = set()
         live: set[str] = set()
+        live_prefixes: set[str] = set()
         for feature_group, compute_frameworks in accessible_plugins.items():
             if self._is_dead(result, feature_group, compute_frameworks):
                 dead.update(self._supported_names_of(feature_group))
-            else:
-                live.update(self._catalog_names_of(feature_group))
-        return frozenset(dead - live)
+                continue
+            live.update(self._catalog_names_of(feature_group))
+            # Non-empty only: _prefix_name degrades a raising prefix() to "", which every name starts with.
+            prefix = self._prefix_of(feature_group)
+            if prefix:
+                live_prefixes.add(prefix)
+        return frozenset(name for name in dead - live if not any(name.startswith(prefix) for prefix in live_prefixes))
 
     def _filter_loop(
         self,

--- a/mloda/core/prepare/resolution_failure_renderer.py
+++ b/mloda/core/prepare/resolution_failure_renderer.py
@@ -117,9 +117,9 @@ def _render_none(result: EvaluationResult, feature: Feature, callout: str | None
     if near_miss is not None:
         msg += f"\n{near_miss}"
 
-    # A suggestion equal to the requested name, or echoing an already-named candidate, carries nothing new.
-    # Drop it, and the catalog's repeats, before the cut, so neither can spend a slot.
-    droppable = {feature_name, *result.facts.eliminated_hints}
+    # A suggestion equal to the requested name, echoing an already-named candidate, or reaching only groups this
+    # pass killed, carries nothing new. Drop it, and the catalog's repeats, before the cut, so none spends a slot.
+    droppable = {feature_name, *result.facts.eliminated_hints, *result.facts.dead_only_names}
     known_names = [name for name in dict.fromkeys(result.facts.known_names) if name not in droppable]
     similar = get_close_matches(feature_name, known_names, n=MAX_SUGGESTIONS, cutoff=0.5)
     if similar:

--- a/mloda/core/prepare/resolution_types.py
+++ b/mloda/core/prepare/resolution_types.py
@@ -53,7 +53,8 @@ class RenderFacts:
     # Class name and prefix of each eliminated near-miss, so a "Did you mean" suggestion that merely echoes
     # a candidate the near-miss block already named can be suppressed.
     eliminated_hints: frozenset[str] = frozenset()
-    # Names no surviving accessible group declares, so suggesting one would fail again with the same message.
+    # Names that no live accessible group declares and that no live group's class-name prefix covers, so no
+    # surviving candidate is known to own them.
     dead_only_names: frozenset[str] = frozenset()
 
 

--- a/mloda/core/prepare/resolution_types.py
+++ b/mloda/core/prepare/resolution_types.py
@@ -27,6 +27,10 @@ EliminationStage = Literal[
     "links",
 ]
 
+# A stage belongs here when its gate's hook cannot receive the feature name, so the outcome is the same for
+# every name the candidate declares.
+NAME_INDEPENDENT_STAGES: frozenset[EliminationStage] = frozenset({"domain", "scope", "frameworks_not_enabled", "links"})
+
 
 @dataclass(frozen=True)
 class Elimination:
@@ -49,6 +53,8 @@ class RenderFacts:
     # Class name and prefix of each eliminated near-miss, so a "Did you mean" suggestion that merely echoes
     # a candidate the near-miss block already named can be suppressed.
     eliminated_hints: frozenset[str] = frozenset()
+    # Names no surviving accessible group declares, so suggesting one would fail again with the same message.
+    dead_only_names: frozenset[str] = frozenset()
 
 
 @dataclass(frozen=True)

--- a/tests/test_core/test_prepare/test_resolution_failure_renderer.py
+++ b/tests/test_core/test_prepare/test_resolution_failure_renderer.py
@@ -14,7 +14,7 @@ from abc import abstractmethod
 from ast import literal_eval
 from collections.abc import Callable, Iterator
 from difflib import get_close_matches
-from typing import Any, ClassVar, Optional, cast
+from typing import Any, ClassVar, Optional, cast, get_args
 
 import pytest
 
@@ -22,6 +22,7 @@ from mloda.core.abstract_plugins.components.data_access_collection import DataAc
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
 from mloda.core.abstract_plugins.components.domain import Domain
 from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import PropertyValueRejection
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
 from mloda.core.abstract_plugins.components.feature_chainer.property_spec import property_spec
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
@@ -31,12 +32,14 @@ from mloda.core.abstract_plugins.components.plugin_option.plugin_collector impor
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.api.plugin_docs import resolve_feature
+from mloda.core.prepare import resolution_types
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
 from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
 from mloda.core.prepare.resolution_failure_renderer import render_resolution_failure
 from mloda.core.prepare.resolution_types import (
     CandidateFrameworks,
     Elimination,
+    EliminationStage,
     EvaluationResult,
     RenderFacts,
 )
@@ -66,6 +69,28 @@ DUPLICATE_SPARE_NAME_791 = "renderer_duplicate_spare_791"
 EMPTY_CATALOG_FEATURE_791 = "renderer_empty_catalog_791"
 DECLARED_UNMATCHED_FEATURE_791 = "renderer_declared_unmatched_791"
 WIDE_FEATURE_791 = "renderer_wide_791"
+DEAD_SIBLING_FEATURE_791 = "renderer_dead_sibling_revenue_791"
+DEAD_SIBLING_SPARE_791 = "renderer_dead_sibling_profit_791"
+SHARED_TYPO_FEATURE_791 = "renderer_shared_naem_791"
+SHARED_LIVE_NAME_791 = "renderer_shared_name_791"
+SHARED_DEAD_NAME_791 = "renderer_shared_dead_791"
+VALUE_STAGE_FEATURE_791 = "renderer_value_stage_791"
+VALUE_STAGE_SPARE_791 = "renderer_value_stage_spare_791"
+CAPABILITY_STAGE_FEATURE_791 = "renderer_capability_stage_791"
+CAPABILITY_STAGE_SPARE_791 = "renderer_capability_stage_spare_791"
+RAISING_DEAD_NAMES_FEATURE_791 = "renderer_raising_dead_names_791"
+RAISING_DEAD_NAMES_SPARE_791 = "renderer_raising_dead_names_spare_791"
+
+VALUE_STAGE_REJECTION_REASON_791 = "renderer_value_stage_791 declines every value of this option"
+
+# The stages whose gate CAN see the feature name, so a sibling name of a candidate eliminated there may still
+# resolve. Pinned here as the complement of NAME_INDEPENDENT_STAGES: a ninth stage fails the partition test.
+NAME_DEPENDENT_STAGES_791: frozenset[EliminationStage] = frozenset(
+    {"value_rejection", "matcher_error", "capability", "framework_pin"}
+)
+EXPECTED_NAME_INDEPENDENT_STAGES_791: frozenset[EliminationStage] = frozenset(
+    {"domain", "scope", "frameworks_not_enabled", "links"}
+)
 
 # Eight names, all close to WIDE_FEATURE_791, so only the cut can bound the rendered line.
 WIDE_CATALOG_NAMES_791 = frozenset(
@@ -467,6 +492,58 @@ class RendererWideCatalogFG791(CountingFeatureGroup791):
     FRAMEWORK_RULE = {RendererFwOne791}
 
 
+class RendererDeadSiblingFG791(CountingFeatureGroup791):
+    """The reported repro: declares the requested name AND a sibling, then loses every framework."""
+
+    MATCHES = frozenset({DEAD_SIBLING_FEATURE_791})
+    SUPPORTED_NAMES = frozenset({DEAD_SIBLING_FEATURE_791, DEAD_SIBLING_SPARE_791})
+    FRAMEWORK_RULE = {RendererFwOne791, RendererFwTwo791}
+
+
+class RendererSharedDeadFG791(CountingFeatureGroup791):
+    """Dead contributor of two names: one it shares with the live group below, one only it declares."""
+
+    MATCHES = frozenset({SHARED_TYPO_FEATURE_791})
+    SUPPORTED_NAMES = frozenset({SHARED_LIVE_NAME_791, SHARED_DEAD_NAME_791})
+    FRAMEWORK_RULE = {RendererFwOne791, RendererFwTwo791}
+
+
+class RendererSharedLiveFG791(CountingFeatureGroup791):
+    """Live contributor of the shared name: it matches nothing here, so nothing ever eliminates it."""
+
+    SUPPORTED_NAMES = frozenset({SHARED_LIVE_NAME_791})
+    FRAMEWORK_RULE = {RendererFwOne791}
+
+
+class RendererValueStageFG791(CountingFeatureGroup791):
+    """Eliminated at value_rejection, a name-DEPENDENT stage: it declined THIS name's value."""
+
+    MATCHES = frozenset({VALUE_STAGE_FEATURE_791})
+    SUPPORTED_NAMES = frozenset({VALUE_STAGE_SPARE_791})
+    FRAMEWORK_RULE = {RendererFwOne791}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        # Name-guarded, so this globally visible class stays inert for every other name it is asked about.
+        if not super().match_feature_group_criteria(feature_name, options, data_access_collection):
+            return False
+        raise PropertyValueRejection(VALUE_STAGE_REJECTION_REASON_791)
+
+
+class RendererCapabilityStageFG791(CountingFeatureGroup791):
+    """Eliminated at capability: the per-feature hook rejected the one framework the run enabled."""
+
+    MATCHES = frozenset({CAPABILITY_STAGE_FEATURE_791})
+    SUPPORTED_NAMES = frozenset({CAPABILITY_STAGE_SPARE_791})
+    FRAMEWORK_RULE = {RendererFwOne791}
+    SUPPORTED_FRAMEWORKS = frozenset({"RendererFwThree791"})
+
+
 class RendererDomainBoom791(RuntimeError):
     """Raised by a provider's get_domain() hook."""
 
@@ -571,6 +648,26 @@ def _build_raising_names_group() -> type[CountingFeatureGroup791]:
             return set()
 
     return _armed(RendererRaisingNamesFG791)
+
+
+def _build_raising_dead_names_group() -> type[CountingFeatureGroup791]:
+    """Build a group that is eliminated with no framework left AND whose feature_names_supported() raises."""
+
+    class RendererRaisingDeadNamesFG791(RaisingHookGroup791):
+        """Dead candidate whose declared names can never be read."""
+
+        MATCHES = frozenset({RAISING_DEAD_NAMES_FEATURE_791})
+        SUPPORTED_NAMES = frozenset({RAISING_DEAD_NAMES_SPARE_791})
+        FRAMEWORK_RULE = {RendererFwOne791, RendererFwTwo791}
+
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            _record(cls.get_class_name(), "feature_names_supported")
+            if cls.ARMED:
+                raise RendererNamesBoom791("feature_names_supported exploded 791")
+            return set(cls.SUPPORTED_NAMES)
+
+    return _armed(RendererRaisingDeadNamesFG791)
 
 
 def _build_raising_rejection_group() -> type[CountingFeatureGroup791]:
@@ -789,6 +886,39 @@ def wide_catalog_scenario() -> Scenario:
     return Feature(WIDE_FEATURE_791), {RendererWideCatalogFG791: {RendererFwOne791}}
 
 
+def dead_sibling_scenario() -> Scenario:
+    """The reported repro: the sole candidate declaring both names loses every framework the run could enable."""
+    return Feature(DEAD_SIBLING_FEATURE_791), {RendererDeadSiblingFG791: set()}
+
+
+def shared_dead_and_live_name_scenario() -> Scenario:
+    """One name is declared by both a dead and a live candidate, the other only by the dead one."""
+    return (
+        Feature(SHARED_TYPO_FEATURE_791),
+        {RendererSharedDeadFG791: set(), RendererSharedLiveFG791: {RendererFwOne791}},
+    )
+
+
+def value_stage_scenario() -> Scenario:
+    """A value_rejection near-miss that keeps an enabled framework, so a sibling name could still resolve to it."""
+    return Feature(VALUE_STAGE_FEATURE_791), {RendererValueStageFG791: {RendererFwOne791}}
+
+
+def value_stage_without_frameworks_scenario() -> Scenario:
+    """The same value_rejection candidate minus every enabled framework: no name can resolve to it."""
+    return Feature(VALUE_STAGE_FEATURE_791), {RendererValueStageFG791: set()}
+
+
+def capability_stage_scenario() -> Scenario:
+    """A capability near-miss: the per-feature hook rejected the enabled framework for THIS name."""
+    return Feature(CAPABILITY_STAGE_FEATURE_791), {RendererCapabilityStageFG791: {RendererFwOne791}}
+
+
+def raising_dead_names_scenario() -> Scenario:
+    """A dead candidate whose feature_names_supported() raises, so it can contribute no name at all."""
+    return Feature(RAISING_DEAD_NAMES_FEATURE_791), {_build_raising_dead_names_group(): set()}
+
+
 def raising_domain_multiple_scenario() -> Scenario:
     """A 'multiple' failure where one identified candidate's get_domain() raises. The request has no domain."""
     raising, healthy = _build_raising_domain_groups()
@@ -835,6 +965,12 @@ FAILING_SCENARIOS: dict[str, Callable[[], Scenario]] = {
     "scoped_none": scoped_none_scenario,
     "capability_narrow_enabled": capability_narrow_enabled_scenario,
     "capability_none_enabled": capability_none_enabled_scenario,
+    "dead_sibling": dead_sibling_scenario,
+    "shared_dead_and_live_name": shared_dead_and_live_name_scenario,
+    "value_stage": value_stage_scenario,
+    "value_stage_without_frameworks": value_stage_without_frameworks_scenario,
+    "capability_stage": capability_stage_scenario,
+    "raising_dead_names": raising_dead_names_scenario,
     "raising_domain_multiple": raising_domain_multiple_scenario,
     "raising_prefix_none": raising_prefix_none_scenario,
     "raising_names_none": raising_names_none_scenario,
@@ -1494,3 +1630,143 @@ class TestSuggestionSlotsListDistinctNames:
         assert suggestions is not None
         assert len(suggestions) == MAX_RENDERED_SUGGESTIONS_791
         assert set(suggestions) <= WIDE_CATALOG_NAMES_791
+
+
+class TestSuggestionsNeverPointAtADeadGroupsSiblingName:
+    """A name only dead groups declare cannot resolve either, so suggesting it hands back the same failure.
+
+    A candidate is dead when it was eliminated AND either the gate that dropped it structurally could not see
+    the feature name (NAME_INDEPENDENT_STAGES), or it has no accessible compute framework left at all. The
+    rule is per NAME, not per candidate: one live declarer is enough to keep a name suggestible.
+    """
+
+    def test_a_dead_groups_sibling_name_is_never_suggested(self) -> None:
+        """The reported repro: following the suggested sibling would fail with a byte-identical message."""
+        scenario = dead_sibling_scenario()
+        feature, _ = scenario
+        result = _evaluate(scenario)
+
+        assert result.eliminations[RendererDeadSiblingFG791].stage == "frameworks_not_enabled"
+        # Premise: the requested name and the eliminated hints cannot reach the sibling, so only this rule can.
+        droppable = {DEAD_SIBLING_FEATURE_791, *result.facts.eliminated_hints}
+        survivors = [name for name in dict.fromkeys(result.facts.known_names) if name not in droppable]
+        ranked = get_close_matches(DEAD_SIBLING_FEATURE_791, survivors, n=MAX_RENDERED_SUGGESTIONS_791, cutoff=0.5)
+        assert ranked == [DEAD_SIBLING_SPARE_791]
+        assert DEAD_SIBLING_SPARE_791 in result.facts.dead_only_names
+
+        message = render_resolution_failure(result, feature)
+        assert message is not None
+        assert message == (
+            f"No feature groups found for feature name: '{DEAD_SIBLING_FEATURE_791}'.\n"
+            f"Feature group(s) eliminated while matching '{DEAD_SIBLING_FEATURE_791}':\n"
+            "  - RendererDeadSiblingFG791 (compute framework): "
+            "none of its compute frameworks are enabled for this run\n"
+            "Use resolve_feature(name, options=...) to debug feature resolution.\n"
+            f"{TROUBLESHOOTING_LINE}"
+        )
+
+    def test_a_name_a_live_group_also_declares_is_still_suggested(self) -> None:
+        """Suppression keys on the name: the live declarer would resolve it, so only the dead-only name goes."""
+        scenario = shared_dead_and_live_name_scenario()
+        feature, _ = scenario
+        result = _evaluate(scenario)
+
+        assert result.eliminations[RendererSharedDeadFG791].stage == "frameworks_not_enabled"
+        assert RendererSharedLiveFG791 not in result.eliminations
+        assert SHARED_LIVE_NAME_791 not in result.facts.dead_only_names
+        assert SHARED_DEAD_NAME_791 in result.facts.dead_only_names
+
+        message = render_resolution_failure(result, feature)
+        assert message is not None
+        suggestions = _suggestions(message)
+
+        assert suggestions is not None
+        assert set(suggestions) == {SHARED_LIVE_NAME_791, "RendererSharedLiveFG791", "RendererSharedLiveFG791_"}
+
+    def test_a_value_rejection_candidates_sibling_name_is_still_suggested(self) -> None:
+        """value_rejection is name-DEPENDENT: the candidate declined this name's value, not the sibling's."""
+        scenario = value_stage_scenario()
+        feature, _ = scenario
+        result = _evaluate(scenario)
+
+        assert result.eliminations == {
+            RendererValueStageFG791: Elimination(stage="value_rejection", reason=VALUE_STAGE_REJECTION_REASON_791)
+        }
+        assert VALUE_STAGE_SPARE_791 not in result.facts.dead_only_names
+
+        message = render_resolution_failure(result, feature)
+        assert message is not None
+        assert _suggestions(message) == [VALUE_STAGE_SPARE_791]
+
+    def test_a_capability_candidates_sibling_name_is_still_suggested(self) -> None:
+        """capability comes from supports_compute_framework(feature.name, ...), so a sibling name may pass it."""
+        scenario = capability_stage_scenario()
+        feature, _ = scenario
+        result = _evaluate(scenario)
+
+        assert result.eliminations[RendererCapabilityStageFG791].stage == "capability"
+        assert CAPABILITY_STAGE_SPARE_791 not in result.facts.dead_only_names
+
+        message = render_resolution_failure(result, feature)
+        assert message is not None
+        assert _suggestions(message) == [CAPABILITY_STAGE_SPARE_791]
+
+    def test_a_name_dependent_stage_without_any_framework_is_dead_anyway(self) -> None:
+        """Same candidate and same stage as above, minus every framework: no name can reach it, so it is dead."""
+        scenario = value_stage_without_frameworks_scenario()
+        feature, _ = scenario
+        result = _evaluate(scenario)
+
+        assert result.eliminations[RendererValueStageFG791].stage == "value_rejection"
+        assert VALUE_STAGE_SPARE_791 in result.facts.known_names
+        assert VALUE_STAGE_SPARE_791 in result.facts.dead_only_names
+
+        message = render_resolution_failure(result, feature)
+        assert message is not None
+        assert _suggestions(message) is None
+
+    def test_a_raising_names_hook_on_a_dead_candidate_contributes_nothing(self) -> None:
+        """A dead candidate whose name hook raises degrades to no dead name, and takes nothing else down."""
+        scenario = raising_dead_names_scenario()
+        feature, accessible_plugins = scenario
+        (raising,) = accessible_plugins
+
+        result = _evaluate(scenario)
+
+        assert result.eliminations[raising].stage == "frameworks_not_enabled"
+        assert RAISING_DEAD_NAMES_SPARE_791 not in result.facts.known_names
+        assert result.facts.dead_only_names == frozenset()
+
+        message = render_resolution_failure(result, feature)
+        assert message is not None
+        assert message == (
+            f"No feature groups found for feature name: '{RAISING_DEAD_NAMES_FEATURE_791}'.\n"
+            f"Feature group(s) eliminated while matching '{RAISING_DEAD_NAMES_FEATURE_791}':\n"
+            f"  - {raising.__name__} (compute framework): none of its compute frameworks are enabled for this run\n"
+            "Use resolve_feature(name, options=...) to debug feature resolution.\n"
+            f"{TROUBLESHOOTING_LINE}"
+        )
+
+    def test_feature_names_supported_is_read_once_per_candidate(self) -> None:
+        """The name catalog and the dead-name capture read the same candidate, and share one hook call."""
+        result = _evaluate(dead_sibling_scenario())
+
+        # Both readers ran: the catalog holds the sibling and the dead-name capture claimed it.
+        assert DEAD_SIBLING_SPARE_791 in result.facts.known_names
+        assert DEAD_SIBLING_SPARE_791 in result.facts.dead_only_names
+        assert HOOK_CALLS["RendererDeadSiblingFG791.feature_names_supported"] == 1
+
+
+class TestEveryEliminationStageIsClassified:
+    """A ninth stage must be classified before it ships: an unclassified one silently keeps or drops names."""
+
+    def test_the_two_stage_sets_partition_the_stage_literal(self) -> None:
+        """NAME_INDEPENDENT_STAGES and its name-dependent complement cover EliminationStage exactly once."""
+        # Read off the module rather than name-imported, so a missing constant fails this test alone and not
+        # the whole module's collection.
+        name_independent = resolution_types.NAME_INDEPENDENT_STAGES
+        stages = frozenset(get_args(EliminationStage))
+
+        assert name_independent == EXPECTED_NAME_INDEPENDENT_STAGES_791
+        assert name_independent.isdisjoint(NAME_DEPENDENT_STAGES_791)
+        assert name_independent | NAME_DEPENDENT_STAGES_791 == stages

--- a/tests/test_core/test_prepare/test_resolution_failure_renderer.py
+++ b/tests/test_core/test_prepare/test_resolution_failure_renderer.py
@@ -80,6 +80,14 @@ CAPABILITY_STAGE_FEATURE_791 = "renderer_capability_stage_791"
 CAPABILITY_STAGE_SPARE_791 = "renderer_capability_stage_spare_791"
 RAISING_DEAD_NAMES_FEATURE_791 = "renderer_raising_dead_names_791"
 RAISING_DEAD_NAMES_SPARE_791 = "renderer_raising_dead_names_spare_791"
+DISABLED_PAIR_FEATURE_791 = "renderer_disabled_pair_revenue_791"
+DISABLED_PAIR_SPARE_791 = "renderer_disabled_pair_profit_791"
+
+# Built around the class names below, because the default matcher also owns a name by class-name PREFIX.
+# The request drops the trailing underscore, so nothing matches it while both declared names stay close to it.
+LIVE_PREFIX_FEATURE_791 = "RendererLivePrefixFG791sum_791"
+LIVE_PREFIX_COVERED_791 = "RendererLivePrefixFG791_sum_791"
+DEAD_PREFIX_UNCOVERED_791 = "RendererDeadPrefixFG791_sum_791"
 
 VALUE_STAGE_REJECTION_REASON_791 = "renderer_value_stage_791 declines every value of this option"
 
@@ -87,9 +95,6 @@ VALUE_STAGE_REJECTION_REASON_791 = "renderer_value_stage_791 declines every valu
 # resolve. Pinned here as the complement of NAME_INDEPENDENT_STAGES: a ninth stage fails the partition test.
 NAME_DEPENDENT_STAGES_791: frozenset[EliminationStage] = frozenset(
     {"value_rejection", "matcher_error", "capability", "framework_pin"}
-)
-EXPECTED_NAME_INDEPENDENT_STAGES_791: frozenset[EliminationStage] = frozenset(
-    {"domain", "scope", "frameworks_not_enabled", "links"}
 )
 
 # Eight names, all close to WIDE_FEATURE_791, so only the cut can bound the rendered line.
@@ -544,6 +549,48 @@ class RendererCapabilityStageFG791(CountingFeatureGroup791):
     SUPPORTED_FRAMEWORKS = frozenset({"RendererFwThree791"})
 
 
+class RendererDisabledPairFG791(CountingFeatureGroup791):
+    """Declares and matches BOTH names, then loses every framework: whichever one is requested, it is eliminated."""
+
+    MATCHES = frozenset({DISABLED_PAIR_FEATURE_791, DISABLED_PAIR_SPARE_791})
+    SUPPORTED_NAMES = frozenset({DISABLED_PAIR_FEATURE_791, DISABLED_PAIR_SPARE_791})
+    FRAMEWORK_RULE = {RendererFwOne791, RendererFwTwo791}
+
+
+class SpareNoFrameworkFG791(CountingFeatureGroup791):
+    """Declares the spare name and matches nothing, so nothing records the empty framework set that kills it.
+
+    Named far from both feature names on purpose: only its declared name may ever reach the suggestion line.
+    """
+
+    SUPPORTED_NAMES = frozenset({DISABLED_PAIR_SPARE_791})
+    FRAMEWORK_RULE = {RendererFwOne791}
+
+
+class RendererLivePrefixFG791(CountingFeatureGroup791):
+    """Live group matching by class-name prefix, the default rule, so it owns names it never declares."""
+
+    FRAMEWORK_RULE = {RendererFwOne791}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        _record(cls.get_class_name(), "match_feature_group_criteria")
+        return cls.feature_name_contains_class_name_as_prefix(str(feature_name))
+
+
+class RendererDeadPrefixFG791(CountingFeatureGroup791):
+    """Dead declarer of two names: one the live prefix above covers, one only its own dead prefix covers."""
+
+    MATCHES = frozenset({LIVE_PREFIX_FEATURE_791})
+    SUPPORTED_NAMES = frozenset({LIVE_PREFIX_COVERED_791, DEAD_PREFIX_UNCOVERED_791})
+    FRAMEWORK_RULE = {RendererFwOne791, RendererFwTwo791}
+
+
 class RendererDomainBoom791(RuntimeError):
     """Raised by a provider's get_domain() hook."""
 
@@ -914,6 +961,38 @@ def capability_stage_scenario() -> Scenario:
     return Feature(CAPABILITY_STAGE_FEATURE_791), {RendererCapabilityStageFG791: {RendererFwOne791}}
 
 
+def disabled_pair_scenario() -> Scenario:
+    """Two groups with no enabled framework; only the one that matched the request is recorded as eliminated."""
+    return (
+        Feature(DISABLED_PAIR_FEATURE_791),
+        {RendererDisabledPairFG791: set(), SpareNoFrameworkFG791: set()},
+    )
+
+
+def disabled_pair_reverse_scenario() -> Scenario:
+    """The same two groups, now requesting the spare name the other direction suggests."""
+    return (
+        Feature(DISABLED_PAIR_SPARE_791),
+        {RendererDisabledPairFG791: set(), SpareNoFrameworkFG791: set()},
+    )
+
+
+def live_prefix_scenario() -> Scenario:
+    """A dead group's two names next to a live group whose prefix owns one of them."""
+    return (
+        Feature(LIVE_PREFIX_FEATURE_791),
+        {RendererDeadPrefixFG791: set(), RendererLivePrefixFG791: {RendererFwOne791}},
+    )
+
+
+def live_prefix_success_scenario() -> Scenario:
+    """The same two groups, requesting the covered name: the live group's prefix resolves it."""
+    return (
+        Feature(LIVE_PREFIX_COVERED_791),
+        {RendererDeadPrefixFG791: set(), RendererLivePrefixFG791: {RendererFwOne791}},
+    )
+
+
 def raising_dead_names_scenario() -> Scenario:
     """A dead candidate whose feature_names_supported() raises, so it can contribute no name at all."""
     return Feature(RAISING_DEAD_NAMES_FEATURE_791), {_build_raising_dead_names_group(): set()}
@@ -970,6 +1049,9 @@ FAILING_SCENARIOS: dict[str, Callable[[], Scenario]] = {
     "value_stage": value_stage_scenario,
     "value_stage_without_frameworks": value_stage_without_frameworks_scenario,
     "capability_stage": capability_stage_scenario,
+    "disabled_pair": disabled_pair_scenario,
+    "disabled_pair_reverse": disabled_pair_reverse_scenario,
+    "live_prefix": live_prefix_scenario,
     "raising_dead_names": raising_dead_names_scenario,
     "raising_domain_multiple": raising_domain_multiple_scenario,
     "raising_prefix_none": raising_prefix_none_scenario,
@@ -1757,16 +1839,92 @@ class TestSuggestionsNeverPointAtADeadGroupsSiblingName:
         assert HOOK_CALLS["RendererDeadSiblingFG791.feature_names_supported"] == 1
 
 
+class TestAGroupWithoutAnyFrameworkIsDeadWithoutAnElimination:
+    """A group with no accessible framework can never be identified, for ANY name, so it declares nothing live.
+
+    It is only recorded as eliminated for the name it was asked about, so an elimination record is the wrong
+    liveness test: a second such group that never matched would otherwise keep the whole dead pair suggestible.
+    """
+
+    def test_two_disabled_groups_never_suggest_each_others_names(self) -> None:
+        """Neither direction may suggest the other name: both requests hit the same pair of disabled groups."""
+        scenario = disabled_pair_scenario()
+        feature, _ = scenario
+        result = _evaluate(scenario)
+
+        assert result.eliminations[RendererDisabledPairFG791].stage == "frameworks_not_enabled"
+        # The spare group never matched this name, so nothing records it: only its empty framework set kills it.
+        assert SpareNoFrameworkFG791 not in result.eliminations
+
+        # Premise: the spare name is the one suggestion this request ranks, so only this rule can drop it.
+        droppable = {DISABLED_PAIR_FEATURE_791, *result.facts.eliminated_hints}
+        survivors = [name for name in dict.fromkeys(result.facts.known_names) if name not in droppable]
+        ranked = get_close_matches(DISABLED_PAIR_FEATURE_791, survivors, n=MAX_RENDERED_SUGGESTIONS_791, cutoff=0.5)
+        assert ranked == [DISABLED_PAIR_SPARE_791]
+
+        message = render_resolution_failure(result, feature)
+        assert message is not None
+        assert message == (
+            f"No feature groups found for feature name: '{DISABLED_PAIR_FEATURE_791}'.\n"
+            f"Feature group(s) eliminated while matching '{DISABLED_PAIR_FEATURE_791}':\n"
+            "  - RendererDisabledPairFG791 (compute framework): "
+            "none of its compute frameworks are enabled for this run\n"
+            "Use resolve_feature(name, options=...) to debug feature resolution.\n"
+            f"{TROUBLESHOOTING_LINE}"
+        )
+        assert DISABLED_PAIR_SPARE_791 in result.facts.dead_only_names
+
+        # The other direction of the ping-pong: following the spare name may not point back at the first one.
+        reverse = disabled_pair_reverse_scenario()
+        reverse_feature, _ = reverse
+        reverse_result = _evaluate(reverse)
+
+        reverse_message = render_resolution_failure(reverse_result, reverse_feature)
+        assert reverse_message is not None
+        assert _suggestions(reverse_message) is None
+        assert DISABLED_PAIR_FEATURE_791 in reverse_result.facts.dead_only_names
+
+
+class TestALivePrefixKeepsACoveredNameSuggestible:
+    """The default matcher also owns names by class-name prefix, so a live group covers names it never declares.
+
+    Subtracting only the exact names live groups declare misses that coverage and suppresses a name that resolves.
+    """
+
+    def test_only_the_name_no_live_prefix_covers_is_suppressed(self) -> None:
+        """One dead group, two dead names: the live prefix keeps one suggestible, the other stays suppressed."""
+        scenario = live_prefix_scenario()
+        feature, _ = scenario
+        result = _evaluate(scenario)
+
+        assert result.eliminations[RendererDeadPrefixFG791].stage == "frameworks_not_enabled"
+        assert RendererLivePrefixFG791 not in result.eliminations
+        # Premise: the live prefix covers one of the two dead names, and no live prefix covers the other.
+        assert LIVE_PREFIX_COVERED_791.startswith(RendererLivePrefixFG791.prefix())
+        assert not DEAD_PREFIX_UNCOVERED_791.startswith(RendererLivePrefixFG791.prefix())
+
+        # Coverage is resolution, not just text: requesting the covered name identifies that one live group.
+        success = _evaluate(live_prefix_success_scenario())
+        assert success.failure_kind is None
+        assert set(success.identified) == {RendererLivePrefixFG791}
+
+        message = render_resolution_failure(result, feature)
+        assert message is not None
+        suggestions = _suggestions(message)
+
+        assert suggestions is not None
+        assert set(suggestions) == {LIVE_PREFIX_COVERED_791, "RendererLivePrefixFG791", "RendererLivePrefixFG791_"}
+        assert LIVE_PREFIX_COVERED_791 not in result.facts.dead_only_names
+        assert DEAD_PREFIX_UNCOVERED_791 in result.facts.dead_only_names
+
+
 class TestEveryEliminationStageIsClassified:
     """A ninth stage must be classified before it ships: an unclassified one silently keeps or drops names."""
 
     def test_the_two_stage_sets_partition_the_stage_literal(self) -> None:
         """NAME_INDEPENDENT_STAGES and its name-dependent complement cover EliminationStage exactly once."""
-        # Read off the module rather than name-imported, so a missing constant fails this test alone and not
-        # the whole module's collection.
         name_independent = resolution_types.NAME_INDEPENDENT_STAGES
         stages = frozenset(get_args(EliminationStage))
 
-        assert name_independent == EXPECTED_NAME_INDEPENDENT_STAGES_791
         assert name_independent.isdisjoint(NAME_DEPENDENT_STAGES_791)
         assert name_independent | NAME_DEPENDENT_STAGES_791 == stages


### PR DESCRIPTION
## Problem

When resolution fails, the message ends with a difflib "Did you mean one of: [...]?" hint. A feature group eliminated during matching still contributed the names it declares to that catalog, so the hint could name a sibling feature that fails with a byte-identical message:

```
No feature groups found for feature name: 'quarterly_revenue'.
Feature group(s) eliminated while matching 'quarterly_revenue':
  - StrandedFG (compute framework): none of its compute frameworks are enabled for this run
Did you mean one of: ['quarterly_profit']?
```

`quarterly_profit` is the same dead group's other name. The elimination reason is independent of which name was asked for, so following the hint loops. #918 fixed the narrower case where the hint echoed the exact name requested; this is the sibling case.

Sibling names are not a rare shape. They share the group's naming convention, so they sit near the top of any similarity ranking, and #918's suppression of the class name and prefix actively promotes them into the surviving slots.

## Rule

A suggested name is dropped only when every accessible group declaring it is dead, where dead means:

- eliminated at a gate that structurally cannot see the feature name (`domain`, `scope`, `frameworks_not_enabled`, `links`), or
- no accessible compute framework at all, which routes every name to `frameworks_not_enabled` regardless of any elimination record.

`value_rejection`, `matcher_error`, `capability` and `framework_pin` stay name-dependent, so their siblings remain suggestible. `capability` comes from `supports_compute_framework(feature.name, options, cfw)`, a deliberately per-feature hook, and `framework_pin` is tested against that hook's per-name output, so both can differ for a sibling name.

The rule is a difference over the catalog rather than a per-candidate drop, which is what keeps a name a live group also declares suggestible. Live class-name prefixes count on the live side too, since the default matcher owns names by prefix as well as by declaration.

`known_names` stays unfiltered. Suppression is renderer policy; the captured facts still travel intact through `FeatureResolutionError`, `mlodaAPI.diagnose()` and `session.resolution_report()`.

## Scope left open, deliberately

The matcher's data-access branches can also own a name, but deciding one needs the speculative second match the renderer's projection contract refuses, so a name reachable only that way can still be suppressed. A group outside the requested domain or scope is likewise dead for every name yet only recorded when it matched the name asked about; closing that needs gate evaluation for non-matching candidates on the failure path and is filed separately.

## Tests

Ten tests in `tests/test_core/test_prepare/test_resolution_failure_renderer.py`, all registered in the module's determinism and no-provider-hook-during-render sweeps: the reported repro, the over-suppression guard where a live group shares the name, name-dependent stages keeping their siblings (`value_rejection` and `capability`), the zero-framework case with and without an elimination record, the two-disabled-groups ping-pong, live-prefix coverage, a raising `feature_names_supported()` contributing to neither side, a once-per-candidate hook-read guard, and a partition test so a ninth elimination stage fails CI until it is classified.

`NAME_INDEPENDENT_STAGES` is exported from `resolution_types` and `RenderFacts.dead_only_names` is additive, so the existing shape is unchanged.