### PR TITLE
fix: render a near-miss line for an unlabeled elimination stage

### DIFF
--- a/mloda/core/prepare/resolution_failure_renderer.py
+++ b/mloda/core/prepare/resolution_failure_renderer.py
@@ -1,5 +1,6 @@
 """Projection of a failed EvaluationResult into its message; imports the types, never the matcher."""
 
+import logging
 from difflib import get_close_matches
 
 from mloda.core.abstract_plugins.components.utils import safe_field, as_str
@@ -7,6 +8,8 @@ from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.prepare.resolution_types import EliminationStage, EvaluationResult
 
+
+logger = logging.getLogger(__name__)
 
 TROUBLESHOOTING_URL = "https://mloda-ai.github.io/mloda/in_depth/troubleshooting/feature-group-resolution-errors/"
 
@@ -52,15 +55,24 @@ _STAGE_LABELS: dict[EliminationStage, str] = {
 }
 
 
+def _stage_label(stage: EliminationStage) -> str:
+    """Near-miss label of one elimination stage, degrading to the raw token when no label covers it."""
+    label = _STAGE_LABELS.get(stage)
+    if label is None:
+        # An unlabeled stage is a build defect, so it is reported; crashing the failure path is worse than an
+        # unlabeled line.
+        logger.warning("Elimination stage '%s' carries no near-miss label.", stage)
+        return stage
+    return label
+
+
 def _render_near_miss_block(result: EvaluationResult, feature: Feature) -> str | None:
     """Shared section naming each eliminated near-miss candidate, its gate label, and its reason."""
     if not result.eliminations:
         return None
-    # An unlabeled stage falls back to its raw token: crashing the failure path is worse than an unlabeled line.
     lines = "\n".join(
-        f"  - {fg.__name__} ({_STAGE_LABELS.get(result.eliminations[fg].stage, result.eliminations[fg].stage)}): "
-        f"{result.eliminations[fg].reason}"
-        for fg in sorted(result.eliminations, key=_candidate_sort_key)
+        f"  - {fg.__name__} ({_stage_label(elimination.stage)}): {elimination.reason}"
+        for fg, elimination in sorted(result.eliminations.items(), key=lambda item: _candidate_sort_key(item[0]))
     )
     return f"Feature group(s) eliminated while matching '{str(feature.name)}':\n{lines}"
 

--- a/mloda/core/prepare/resolution_failure_renderer.py
+++ b/mloda/core/prepare/resolution_failure_renderer.py
@@ -56,8 +56,10 @@ def _render_near_miss_block(result: EvaluationResult, feature: Feature) -> str |
     """Shared section naming each eliminated near-miss candidate, its gate label, and its reason."""
     if not result.eliminations:
         return None
+    # An unlabeled stage falls back to its raw token: crashing the failure path is worse than an unlabeled line.
     lines = "\n".join(
-        f"  - {fg.__name__} ({_STAGE_LABELS[result.eliminations[fg].stage]}): {result.eliminations[fg].reason}"
+        f"  - {fg.__name__} ({_STAGE_LABELS.get(result.eliminations[fg].stage, result.eliminations[fg].stage)}): "
+        f"{result.eliminations[fg].reason}"
         for fg in sorted(result.eliminations, key=_candidate_sort_key)
     )
     return f"Feature group(s) eliminated while matching '{str(feature.name)}':\n{lines}"

--- a/tests/test_core/test_prepare/test_candidate_elimination_reasons.py
+++ b/tests/test_core/test_prepare/test_candidate_elimination_reasons.py
@@ -396,8 +396,9 @@ def _fail(
 
 
 class TestEliminationStages:
-    """One test per stage: the eliminated candidate maps to the expected (stage, reason), and the
-    near-miss message line carries the contract's stage label."""
+    """One test per stage except matcher_error: the eliminated candidate maps to the expected (stage, reason),
+    and the near-miss message line carries the contract's stage label. matcher_error needs a raising matcher, so
+    it is covered in tests/test_core/test_prepare/test_raising_matcher_containment.py."""
 
     def test_value_rejection_stage(self) -> None:
         feature = Feature(VALUE_FEATURE)

--- a/tests/test_core/test_prepare/test_resolution_failure_renderer.py
+++ b/tests/test_core/test_prepare/test_resolution_failure_renderer.py
@@ -10,6 +10,7 @@ hook. The feature groups below count every such hook, so a renderer that calls o
 All names are suffixed ``_791`` because test feature groups become global subclasses.
 """
 
+import logging
 from abc import abstractmethod
 from ast import literal_eval
 from collections.abc import Callable, Iterator
@@ -101,6 +102,9 @@ NAME_DEPENDENT_STAGES_791: frozenset[EliminationStage] = frozenset(
 UNLABELED_STAGE_791 = "renderer_unlabeled_stage_791"
 UNLABELED_STAGE_FEATURE_791 = "renderer_unlabeled_stage_feature_791"
 UNLABELED_STAGE_REASON_791 = "eliminated at a stage this build has no label for"
+
+# The renderer's own module logger: the degrade must be reported by the module that degrades.
+RENDERER_LOGGER_791 = "mloda.core.prepare.resolution_failure_renderer"
 
 # Eight names, all close to WIDE_FEATURE_791, so only the cut can bound the rendered line.
 WIDE_CATALOG_NAMES_791 = frozenset(
@@ -1924,7 +1928,7 @@ class TestALivePrefixKeepsACoveredNameSuggestible:
 
 
 class TestEveryEliminationStageIsClassified:
-    """A ninth stage must be classified before it ships: an unclassified one silently keeps or drops names."""
+    """A ninth stage must be classified and labelled before it ships, or it silently misrenders or misdrops names."""
 
     def test_the_two_stage_sets_partition_the_stage_literal(self) -> None:
         """NAME_INDEPENDENT_STAGES and its name-dependent complement cover EliminationStage exactly once."""
@@ -1961,6 +1965,43 @@ class TestAnUnlabeledStageStillRenders:
 
         message = render_resolution_failure(result, feature)
 
+        assert message == (
+            f"No feature groups found for feature name: '{UNLABELED_STAGE_FEATURE_791}'.\n"
+            f"Feature group(s) eliminated while matching '{UNLABELED_STAGE_FEATURE_791}':\n"
+            f"  - RendererSuccessFG791 ({UNLABELED_STAGE_791}): {UNLABELED_STAGE_REASON_791}\n"
+            "Use resolve_feature(name, options=...) to debug feature resolution.\n"
+            f"{TROUBLESHOOTING_LINE}"
+        )
+
+    def test_a_stage_without_a_label_warns_and_still_renders(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A missing label is a build defect, not an expected degrade, so the renderer warns while degrading."""
+        feature = Feature(UNLABELED_STAGE_FEATURE_791)
+        result = EvaluationResult(
+            identified={},
+            eliminations={
+                RendererSuccessFG791: Elimination(
+                    stage=cast(EliminationStage, UNLABELED_STAGE_791),
+                    reason=UNLABELED_STAGE_REASON_791,
+                )
+            },
+        )
+
+        # Premise: this failure reaches the near-miss block, and no label covers the stage it carries.
+        assert result.failure_kind == "none"
+        assert UNLABELED_STAGE_791 not in _STAGE_LABELS
+
+        with caplog.at_level(logging.WARNING, logger=RENDERER_LOGGER_791):
+            message = render_resolution_failure(result, feature)
+
+        warnings = [
+            record.getMessage()
+            for record in caplog.records
+            if record.levelno == logging.WARNING and record.name == RENDERER_LOGGER_791
+        ]
+        assert len(warnings) == 1, f"Expected exactly one WARNING from the renderer, got {warnings}"
+        assert UNLABELED_STAGE_791 in warnings[0], "The warning must name the stage token that carries no label"
+
+        # The warning reports the degrade, it never replaces it: the whole message still renders unchanged.
         assert message == (
             f"No feature groups found for feature name: '{UNLABELED_STAGE_FEATURE_791}'.\n"
             f"Feature group(s) eliminated while matching '{UNLABELED_STAGE_FEATURE_791}':\n"

--- a/tests/test_core/test_prepare/test_resolution_failure_renderer.py
+++ b/tests/test_core/test_prepare/test_resolution_failure_renderer.py
@@ -35,7 +35,7 @@ from mloda.core.api.plugin_docs import resolve_feature
 from mloda.core.prepare import resolution_types
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
 from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
-from mloda.core.prepare.resolution_failure_renderer import render_resolution_failure
+from mloda.core.prepare.resolution_failure_renderer import _STAGE_LABELS, render_resolution_failure
 from mloda.core.prepare.resolution_types import (
     CandidateFrameworks,
     Elimination,
@@ -96,6 +96,11 @@ VALUE_STAGE_REJECTION_REASON_791 = "renderer_value_stage_791 declines every valu
 NAME_DEPENDENT_STAGES_791: frozenset[EliminationStage] = frozenset(
     {"value_rejection", "matcher_error", "capability", "framework_pin"}
 )
+
+# Stands in for a ninth stage shipped without a near-miss label: no entry of the label table covers this token.
+UNLABELED_STAGE_791 = "renderer_unlabeled_stage_791"
+UNLABELED_STAGE_FEATURE_791 = "renderer_unlabeled_stage_feature_791"
+UNLABELED_STAGE_REASON_791 = "eliminated at a stage this build has no label for"
 
 # Eight names, all close to WIDE_FEATURE_791, so only the cut can bound the rendered line.
 WIDE_CATALOG_NAMES_791 = frozenset(
@@ -1928,3 +1933,38 @@ class TestEveryEliminationStageIsClassified:
 
         assert name_independent.isdisjoint(NAME_DEPENDENT_STAGES_791)
         assert name_independent | NAME_DEPENDENT_STAGES_791 == stages
+
+    def test_every_stage_carries_a_near_miss_label(self) -> None:
+        """dict[EliminationStage, str] does not force an entry per member, so the table is pinned complete here."""
+        assert set(_STAGE_LABELS) == set(get_args(EliminationStage))
+
+
+class TestAnUnlabeledStageStillRenders:
+    """Rendering is a best-effort projection: every other field degrades via safe_field, so a label must too."""
+
+    def test_a_stage_without_a_label_falls_back_to_its_raw_token(self) -> None:
+        """The near-miss line names the candidate, the raw stage token and the reason; the rest still renders."""
+        feature = Feature(UNLABELED_STAGE_FEATURE_791)
+        result = EvaluationResult(
+            identified={},
+            eliminations={
+                RendererSuccessFG791: Elimination(
+                    stage=cast(EliminationStage, UNLABELED_STAGE_791),
+                    reason=UNLABELED_STAGE_REASON_791,
+                )
+            },
+        )
+
+        # Premise: this failure reaches the near-miss block, and no label covers the stage it carries.
+        assert result.failure_kind == "none"
+        assert UNLABELED_STAGE_791 not in _STAGE_LABELS
+
+        message = render_resolution_failure(result, feature)
+
+        assert message == (
+            f"No feature groups found for feature name: '{UNLABELED_STAGE_FEATURE_791}'.\n"
+            f"Feature group(s) eliminated while matching '{UNLABELED_STAGE_FEATURE_791}':\n"
+            f"  - RendererSuccessFG791 ({UNLABELED_STAGE_791}): {UNLABELED_STAGE_REASON_791}\n"
+            "Use resolve_feature(name, options=...) to debug feature resolution.\n"
+            f"{TROUBLESHOOTING_LINE}"
+        )


### PR DESCRIPTION
## Problem

`_STAGE_LABELS` in `mloda/core/prepare/resolution_failure_renderer.py` maps every `EliminationStage` to the label the near-miss block prints, and `_render_near_miss_block` subscripted it directly. `EliminationStage` is a closed `Literal`, but `dict[EliminationStage, str]` does not make mypy require an entry per member, so adding a ninth stage and forgetting its label raised `KeyError` while rendering a resolution failure message. That turns a helpful message into a crash, on the path least likely to be exercised before release.

## Change

- The label lookup moves into `_stage_label`, which degrades an unlabeled stage to its raw token and warns. Rendering is a pure best-effort projection: every other field it reads already degrades through `safe_field`, so a missing label degrades too. `safe_field` warns on a labelled degrade and is silent only where degrading is expected, and a missing label is a build defect rather than an expected degrade, so this one warns.
- The helper binds each `Elimination` once per rendered line, replacing three repeated lookups into the mapping.
- A test pins `set(_STAGE_LABELS) == set(get_args(EliminationStage))`, so a new stage still fails CI until it is labelled. The fallback is the safety net, not a licence to skip the label.

Output for the eight labelled stages is byte-identical.

## Other per-stage tables

`NAME_INDEPENDENT_STAGES` is the only other one. It is read with `in`, so it cannot raise, its default direction for an unclassified stage is the conservative one, and it is already pinned complete by the existing partition test. No change needed. Nothing else in `mloda/` or `mloda_plugins/` indexes by stage.

## Tests

`tests/test_core/test_prepare/test_resolution_failure_renderer.py`: the completeness assertion, plus a test that an unlabeled stage renders its raw token and warns instead of raising. Two docstrings corrected alongside, including `TestEliminationStages`, which claimed one test per stage while `matcher_error` is covered in the raising-matcher suite.

Full `tox` green: 7750 passed, 170 skipped.
