### PR TITLE
feat: share the match-rejection channel with input-data reader selection

### DIFF
--- a/docs/docs/in_depth/data-access-patterns.md
+++ b/docs/docs/in_depth/data-access-patterns.md
@@ -84,6 +84,52 @@ The matched `(ReaderClass, data_access)` pair is stored under the reserved `"Bas
 
 For non-file sources such as HTTP endpoints, subclassing `ReadFile` and overriding `match_subclass_data_access` plus `load_data` is a supported pattern; on that path `suffix()` is never consulted (it is inert). `ApiInputData` injects in-memory data passed through the API request and is not an HTTP client.
 
+### Reader selection vs feature-group resolution
+
+Reader selection answers "which plugin handles this input" the way [feature-group resolution](feature-group-matching.md) answers "which feature group owns this name". It is not a second resolver: it runs nested inside the criteria gate of feature-group resolution, where `match_feature_group_criteria` calls the reader family's `matches()`. The two deliberately share no request, environment, or outcome abstractions; they share only the low-level rejection channel described below.
+
+| Aspect | Feature-group resolution | Reader selection |
+|--------|--------------------------|------------------|
+| **Candidate discovery** | Registered accessible plugins | Structural walk over the family's final readers (`is_final_reader()`); no reader code executed |
+| **Auto-loading** | Up-front plugin loading | Lazy per-family `_auto_load_group`, triggered only when no final readers are found |
+| **Accessibility policy** | Strict mode, collector policy, enabled compute frameworks | None: every final reader of the family is a candidate |
+| **Matching** | Criteria, domain, scope, capability, framework-pin, and links gates | Per-reader file, suffix, column-validation, and pinning rules |
+| **Ambiguity** | Multiple winners resolved by subclass preference, then reported | First match wins; a second conflicting reader for the same feature raises |
+| **Outcome and diagnostics** | Structured evaluation result rendered into failure messages | A matched `(ReaderClass, data_access)` pair written into options; declines surface through the shared rejection channel |
+
+### Declining with an attributable reason
+
+A reader that owns an input but cannot serve the requested feature can record why it declined; the reason then appears in the near-miss block of the "No feature groups found" error message. `record_match_rejection` is exported via `mloda.provider`:
+
+``` python
+from mloda.provider import record_match_rejection
+from mloda_plugins.feature_group.input_data.read_files.csv import CsvReader
+
+class SensorCsvReader(CsvReader):
+    @classmethod
+    def validate_columns(cls, file_name: str, feature_names: list[str]) -> bool:
+        columns = cls.get_column_names(file_name)
+        missing = [name for name in feature_names if name not in columns]
+        if missing:
+            record_match_rejection(
+                cls.get_class_name(),
+                f"{cls.get_class_name()} owns {file_name} but it lacks: {', '.join(missing)}",
+            )
+            return False
+        return True
+```
+
+Rules for reader authors:
+
+- Record only when ownership is established but the content fails: right suffix but a missing column, valid credentials but a declined feature.
+- Plain non-matches (wrong suffix, invalid credentials, `NotImplementedError`) stay silent.
+- Never raise to decline: anything but `NotImplementedError` in the DB match hooks aborts matching for every reader sharing the `DataAccessCollection`. Record, then return a falsy value.
+- Recording outside an engine-opened window is a no-op, so readers stay usable standalone.
+- A reader that ultimately matches discards its recorded reasons; only a decline surfaces them.
+- Name the reader and the concrete input in the reason, as the example does.
+
+`ReadFile` column validation and the `ReadDB` feature check (`check_feature_in_data_access`) already record automatically; a custom reader only needs this for its own decline points.
+
 ## MatchData Pattern
 
 ### Purpose

--- a/docs/docs/in_depth/data-access-patterns.md
+++ b/docs/docs/in_depth/data-access-patterns.md
@@ -99,33 +99,52 @@ Reader selection answers "which plugin handles this input" the way [feature-grou
 
 ### Declining with an attributable reason
 
-A reader that owns an input but cannot serve the requested feature can record why it declined; the reason then appears in the near-miss block of the "No feature groups found" error message. `record_match_rejection` is exported via `mloda.provider`:
+A reader that owns an input but cannot serve the requested feature can record why it declined; the reason then appears in the near-miss block of the "No feature groups found" error message, labeled `(input data)`. `record_match_rejection` is exported via `mloda.provider`. A custom reader owns its own suffix and overrides `load_data` wholesale; its own decline points sit beyond the automatic column validation, for example a required schema marker in the header:
 
 ``` python
-from mloda.provider import record_match_rejection
-from mloda_plugins.feature_group.input_data.read_files.csv import CsvReader
+from typing import Any
 
-class SensorCsvReader(CsvReader):
+from mloda.provider import FeatureSet, record_match_rejection
+from mloda_plugins.feature_group.input_data.read_file import ReadFile
+
+class SensorCsvReader(ReadFile):
+    @classmethod
+    def suffix(cls) -> tuple[str, ...]:
+        return (".sensorcsv",)
+
+    @classmethod
+    def load_data(cls, data_access: Any, features: FeatureSet) -> Any: ...
+
     @classmethod
     def validate_columns(cls, file_name: str, feature_names: list[str]) -> bool:
-        columns = cls.get_column_names(file_name)
-        missing = [name for name in feature_names if name not in columns]
-        if missing:
+        if super().validate_columns(file_name, feature_names) is False:
+            return False
+        with open(file_name, encoding="utf-8") as handle:
+            header = handle.readline()
+        if "#sensor-schema" not in header:
             record_match_rejection(
                 cls.get_class_name(),
-                f"{cls.get_class_name()} owns {file_name} but it lacks: {', '.join(missing)}",
+                f"{cls.get_class_name()} matched the suffix of {file_name} "
+                f"but its header lacks the #sensor-schema marker",
+                stage="input_data",
             )
             return False
         return True
 ```
 
+The recorded decline renders as a near-miss line of the resolution failure:
+
+```
+  - SensorFeatureGroup (input data): SensorCsvReader matched the suffix of /data/run1.sensorcsv but its header lacks the #sensor-schema marker
+```
+
 Rules for reader authors:
 
 - Record only when ownership is established but the content fails: right suffix but a missing column, valid credentials but a declined feature.
-- Plain non-matches (wrong suffix, invalid credentials, `NotImplementedError`) stay silent.
+- Plain non-matches (wrong suffix, invalid credentials) stay silent. `NotImplementedError` from `is_valid_credentials` is a silent non-match; from `check_feature_in_data_access` it is an accept (the reader matches on credentials alone).
 - Never raise to decline: anything but `NotImplementedError` in the DB match hooks aborts matching for every reader sharing the `DataAccessCollection`. Record, then return a falsy value.
 - Recording outside an engine-opened window is a no-op, so readers stay usable standalone.
-- A reader that ultimately matches discards its recorded reasons; only a decline surfaces them.
+- Recorded reasons are discarded at the enclosing candidate level: when the reader ultimately matches, when a sibling reader matches, or when the feature group matches by another rule. Only a decline surfaces them.
 - Name the reader and the concrete input in the reason, as the example does.
 
 `ReadFile` column validation and the `ReadDB` feature check (`check_feature_in_data_access`) already record automatically; a custom reader only needs this for its own decline points.

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_author_guards.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_author_guards.py
@@ -22,8 +22,8 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
     CHAIN_SEPARATOR,
     FeatureChainParser,
     option_key_is_present,
-    record_match_rejection,
 )
+from mloda.core.abstract_plugins.components.match_rejection import record_match_rejection
 from mloda.core.abstract_plugins.components.feature_chainer.parsed_feature_name import ParsedFeatureName
 from mloda.core.abstract_plugins.components.feature_chainer.property_spec import PropertySpec
 from mloda.core.abstract_plugins.components.utils import contained_raise_log_level, escalate_match_abort, safe_field

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -4,13 +4,13 @@ Feature chain parser for handling feature name chaining across feature groups.
 
 from __future__ import annotations
 
-import contextvars
 import logging
 import re
 from typing import Any, Optional
 
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.match_rejection import record_match_rejection
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
 from mloda.core.abstract_plugins.components.feature_chainer.parsed_feature_name import ParsedFeatureName
@@ -23,21 +23,6 @@ logger = logging.getLogger(__name__)
 CHAIN_SEPARATOR = "__"  # Separates chained transformations (source→suffix)
 COLUMN_SEPARATOR = "~"  # Separates multi-column output index
 INPUT_SEPARATOR = "&"  # Separates multiple input features
-
-# Active for one candidate's match call: the engine opens a window per candidate. Maps the recording
-# site's owner name to the first structured rejection reason the real match pass produced, and the
-# engine attributes the harvest to the candidate class object it called (os-005 replaces the replay).
-MATCH_REJECTION_REASONS: contextvars.ContextVar[dict[str, str] | None] = contextvars.ContextVar(
-    "mloda_match_rejection_reasons", default=None
-)
-
-
-def record_match_rejection(owner_name: str, reason: str) -> None:
-    """Record a match rejection; the first reason per owner wins, and outside an active evaluation it is a no-op."""
-    reasons = MATCH_REJECTION_REASONS.get()
-    if reasons is None:
-        return
-    reasons.setdefault(owner_name, reason)
 
 
 def option_key_is_present(spec: PropertySpec, key: str, options: Options) -> bool:

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -75,8 +75,8 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
     INPUT_SEPARATOR,
     PropertyValueRejection,
     option_key_is_present,
-    record_match_rejection,
 )
+from mloda.core.abstract_plugins.components.match_rejection import record_match_rejection
 from mloda.core.abstract_plugins.components.feature_chainer.property_spec import PropertySpec
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
 from mloda.core.abstract_plugins.components.utils import (

--- a/mloda/core/abstract_plugins/components/match_rejection.py
+++ b/mloda/core/abstract_plugins/components/match_rejection.py
@@ -4,18 +4,31 @@ Neutral home so reader code does not depend on the feature-chainer module."""
 from __future__ import annotations
 
 import contextvars
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class MatchRejection:
+    """One recorded rejection: the reason plus a free-form stage hint the engine maps at the harvest.
+
+    Unknown stage values fall back to value_rejection there; this neutral module does not validate them.
+    """
+
+    reason: str
+    stage: str = "value_rejection"
+
 
 # Active for one candidate's match call: the engine opens a window per candidate. Maps the recording
-# site's owner name to the first structured rejection reason the real match pass produced, and the
+# site's owner name to the first structured rejection the real match pass produced, and the
 # engine attributes the harvest to the candidate class object it called.
-MATCH_REJECTION_REASONS: contextvars.ContextVar[dict[str, str] | None] = contextvars.ContextVar(
+MATCH_REJECTION_REASONS: contextvars.ContextVar[dict[str, MatchRejection] | None] = contextvars.ContextVar(
     "mloda_match_rejection_reasons", default=None
 )
 
 
-def record_match_rejection(owner_name: str, reason: str) -> None:
-    """Record a match rejection; the first reason per owner wins, and outside an active evaluation it is a no-op."""
+def record_match_rejection(owner_name: str, reason: str, stage: str = "value_rejection") -> None:
+    """Record a match rejection; the first per owner wins, and outside an active evaluation it is a no-op."""
     reasons = MATCH_REJECTION_REASONS.get()
     if reasons is None:
         return
-    reasons.setdefault(owner_name, reason)
+    reasons.setdefault(owner_name, MatchRejection(reason, stage))

--- a/mloda/core/abstract_plugins/components/match_rejection.py
+++ b/mloda/core/abstract_plugins/components/match_rejection.py
@@ -1,0 +1,21 @@
+"""Per-candidate match-rejection window shared by feature-group matching and input-data reader selection.
+Neutral home so reader code does not depend on the feature-chainer module."""
+
+from __future__ import annotations
+
+import contextvars
+
+# Active for one candidate's match call: the engine opens a window per candidate. Maps the recording
+# site's owner name to the first structured rejection reason the real match pass produced, and the
+# engine attributes the harvest to the candidate class object it called.
+MATCH_REJECTION_REASONS: contextvars.ContextVar[dict[str, str] | None] = contextvars.ContextVar(
+    "mloda_match_rejection_reasons", default=None
+)
+
+
+def record_match_rejection(owner_name: str, reason: str) -> None:
+    """Record a match rejection; the first reason per owner wins, and outside an active evaluation it is a no-op."""
+    reasons = MATCH_REJECTION_REASONS.get()
+    if reasons is None:
+        return
+    reasons.setdefault(owner_name, reason)

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -24,9 +24,9 @@ from mloda.core.prepare.resolution_failure_renderer import (
 )
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.domain import Domain
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import (
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import PropertyValueRejection
+from mloda.core.abstract_plugins.components.match_rejection import (
     MATCH_REJECTION_REASONS,
-    PropertyValueRejection,
     record_match_rejection,
 )
 from mloda.core.abstract_plugins.components.utils import (

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -27,6 +27,7 @@ from mloda.core.abstract_plugins.components.domain import Domain
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import PropertyValueRejection
 from mloda.core.abstract_plugins.components.match_rejection import (
     MATCH_REJECTION_REASONS,
+    MatchRejection,
     record_match_rejection,
 )
 from mloda.core.abstract_plugins.components.utils import (
@@ -98,7 +99,7 @@ class IdentifyFeatureGroupClass:
     _criteria_matched_feature_groups: set[type[FeatureGroup]]
     _abstract_matched_feature_groups: set[type[FeatureGroup]]
     _candidate_frameworks: dict[type[FeatureGroup], CandidateFrameworks]
-    _match_rejections: dict[type[FeatureGroup], str]
+    _match_rejections: dict[type[FeatureGroup], MatchRejection]
     _matcher_errors: dict[type[FeatureGroup], str]
     _eliminations: dict[type[FeatureGroup], Elimination]
     _data_access_collection: Optional[DataAccessCollection]
@@ -363,13 +364,16 @@ class IdentifyFeatureGroupClass:
             # never probed. Recorded regardless of domain/scope or of the overall outcome (a sibling may win).
             if not self._filter_feature_group_by_criteria(feature_group, feature, data_access_collection):
                 # A contained matcher raise is always a near-miss: the raise says nothing about name ownership.
+                # Deliberate precedence: a contained crash outranks a recorded decline for the same candidate.
                 matcher_error = self._matcher_errors.get(feature_group)
                 if matcher_error is not None:
                     self._record_elimination(feature_group, "matcher_error", matcher_error)
                     continue
-                reason = self._value_rejection_reason(feature_group)
-                if reason is not None:
-                    self._record_elimination(feature_group, "value_rejection", reason)
+                rejection = self._value_rejection(feature_group)
+                if rejection is not None:
+                    # The stage is a free-form hint; only "input_data" is engine-known, the rest fall back.
+                    stage: EliminationStage = "input_data" if rejection.stage == "input_data" else "value_rejection"
+                    self._record_elimination(feature_group, stage, rejection.reason)
                 continue
 
             if not self._filter_feature_group_by_domain(feature_group, feature):
@@ -441,10 +445,10 @@ class IdentifyFeatureGroupClass:
         """Record the first gate a non-winning name-matching candidate failed; one entry per candidate."""
         self._eliminations.setdefault(feature_group, Elimination(stage=stage, reason=reason))
 
-    def _value_rejection_reason(self, feature_group: type[FeatureGroup]) -> Optional[str]:
-        """The reason the first match pass recorded for this candidate class, if any.
+    def _value_rejection(self, feature_group: type[FeatureGroup]) -> Optional[MatchRejection]:
+        """The MatchRejection the first match pass recorded for this candidate class, if any.
 
-        The candidate's criteria match records its own value rejection under a per-candidate window; this
+        The candidate's criteria match records its own rejection under a per-candidate window; this
         only reads that record back, so no rejection hook is ever reran on the failure path.
         """
         return self._match_rejections.get(feature_group)

--- a/mloda/core/prepare/resolution_failure_renderer.py
+++ b/mloda/core/prepare/resolution_failure_renderer.py
@@ -45,6 +45,7 @@ def _prefix_name(feature_group: type[FeatureGroup]) -> str:
 
 _STAGE_LABELS: dict[EliminationStage, str] = {
     "value_rejection": "option value",
+    "input_data": "input data",
     "matcher_error": "match hook",
     "domain": "domain",
     "scope": "scope",

--- a/mloda/core/prepare/resolution_types.py
+++ b/mloda/core/prepare/resolution_types.py
@@ -18,6 +18,7 @@ class CandidateFrameworks:
 
 EliminationStage = Literal[
     "value_rejection",
+    "input_data",
     "matcher_error",
     "domain",
     "scope",

--- a/mloda/provider/__init__.py
+++ b/mloda/provider/__init__.py
@@ -87,6 +87,9 @@ from mloda.core.abstract_plugins.components.feature_chainer.property_spec import
     property_spec,
 )
 
+# Match rejection recording
+from mloda.core.abstract_plugins.components.match_rejection import record_match_rejection
+
 # Subtype declaration
 from mloda.core.abstract_plugins.components.subtype_declaration import SubtypeDeclaration
 
@@ -168,6 +171,8 @@ __all__ = [
     "is_positive_int",
     "property_spec",
     "NO_DEFAULT",
+    # Match rejection recording
+    "record_match_rejection",
     # Subtype declaration
     "SubtypeDeclaration",
     # Transformers

--- a/mloda_plugins/feature_group/input_data/read_db.py
+++ b/mloda_plugins/feature_group/input_data/read_db.py
@@ -1,6 +1,6 @@
 from typing import Any, ClassVar
 from mloda.user import DataAccessCollection
-from mloda.provider import FeatureSet, BaseInputData, ReaderOptionSpec
+from mloda.provider import FeatureSet, BaseInputData, ReaderOptionSpec, record_match_rejection
 from mloda.user import Options
 
 
@@ -117,6 +117,7 @@ class ReadDB(BaseInputData):
 
     @classmethod
     def match_read_db_data_access(cls, data_accesses: list[Any], feature_names: list[str]) -> Any:
+        """Valid credentials with a declined feature record an attributable decline before moving on."""
         if len(feature_names) > 1:
             raise ValueError(
                 f"ReadDB.match_read_db_data_access expects exactly one feature name, "
@@ -130,6 +131,12 @@ class ReadDB(BaseInputData):
                     try:
                         if cls.check_feature_in_data_access(feature_names[0], data_access):
                             return data_access
+                        # Attributable decline: ownership established, content failed; plain non-matches stay silent.
+                        record_match_rejection(
+                            cls.get_class_name(),
+                            f"{cls.get_class_name()} accepted the credentials but declined "
+                            f"the feature '{feature_names[0]}'",
+                        )
                         continue
                     except NotImplementedError:
                         pass

--- a/mloda_plugins/feature_group/input_data/read_db.py
+++ b/mloda_plugins/feature_group/input_data/read_db.py
@@ -136,6 +136,7 @@ class ReadDB(BaseInputData):
                             cls.get_class_name(),
                             f"{cls.get_class_name()} accepted the credentials but declined "
                             f"the feature '{feature_names[0]}'",
+                            stage="input_data",
                         )
                         continue
                     except NotImplementedError:

--- a/mloda_plugins/feature_group/input_data/read_file.py
+++ b/mloda_plugins/feature_group/input_data/read_file.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Any, ClassVar
 from mloda.user import DataAccessCollection
 from mloda.provider import FeatureSet
-from mloda.provider import BaseInputData, ReaderOptionSpec
+from mloda.provider import BaseInputData, ReaderOptionSpec, record_match_rejection
 from mloda.user import Options
 
 
@@ -162,12 +162,18 @@ class ReadFile(BaseInputData):
 
     @classmethod
     def validate_columns(cls, file_name: str, feature_names: list[str]) -> bool:
+        """A suffix-owned file lacking a requested column records an attributable decline before returning False."""
         try:
             columns = cls.get_column_names(file_name)
         except NotImplementedError:
             return True
 
-        for feature in feature_names:
-            if feature not in columns:
-                return False
+        missing = [feature for feature in feature_names if feature not in columns]
+        if missing:
+            # Attributable decline: ownership established, content failed; plain non-matches stay silent.
+            record_match_rejection(
+                cls.get_class_name(),
+                f"{cls.get_class_name()} owns {file_name} but it lacks the column(s): {', '.join(missing)}",
+            )
+            return False
         return True

--- a/mloda_plugins/feature_group/input_data/read_file.py
+++ b/mloda_plugins/feature_group/input_data/read_file.py
@@ -173,7 +173,9 @@ class ReadFile(BaseInputData):
             # Attributable decline: ownership established, content failed; plain non-matches stay silent.
             record_match_rejection(
                 cls.get_class_name(),
-                f"{cls.get_class_name()} owns {file_name} but it lacks the column(s): {', '.join(missing)}",
+                f"{cls.get_class_name()} matched the suffix of {file_name} but it lacks the column(s): "
+                f"{', '.join(missing)}",
+                stage="input_data",
             )
             return False
         return True

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_author_guards_module_split.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_author_guards_module_split.py
@@ -78,16 +78,15 @@ PARSER_KEPT_METHODS = (
     "validate_property_mapping_defaults",
 )
 
-# Module-level names of the parser that carry a __module__ to check.
+# Module-level names of the parser that carry a __module__ to check. The match-rejection channel
+# lives in components.match_rejection now; the parser only re-exports record_match_rejection.
 PARSER_KEPT_MODULE_LEVEL = (
-    "record_match_rejection",
     "option_key_is_present",
     "PropertyValueRejection",
 )
 
 # Module-level parser constants, which have no __module__ to check.
 PARSER_KEPT_CONSTANTS = (
-    "MATCH_REJECTION_REASONS",
     "CHAIN_SEPARATOR",
     "COLUMN_SEPARATOR",
     "INPUT_SEPARATOR",

--- a/tests/test_core/test_abstract_plugins/test_components/test_match_rejection.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_match_rejection.py
@@ -1,16 +1,22 @@
-"""The match-rejection channel lives in a neutral module (issue #727, cycle 1).
+"""The match-rejection channel lives in a neutral module (issue #727, cycles 1 and 3).
 
 ``mloda.core.abstract_plugins.components.match_rejection`` owns ``MATCH_REJECTION_REASONS`` and
 ``record_match_rejection`` so input-data reader code can record rejections without depending on the
 feature-chainer module. The documented ``feature_chain_parser`` seam keeps re-exporting the SAME
 function object, the engine harvests through the new home, and ``mloda.provider`` exports the
 recording function for plugin authors.
+
+Cycle 3: the window value is a frozen ``MatchRejection`` dataclass carrying the reason and a stage
+hint (default ``"value_rejection"``), so a reader decline can arrive stamped ``"input_data"``. The
+neutral module does not validate the stage string. ``MatchRejection`` is imported inside the test
+functions on purpose: while it does not exist yet, only these tests fail, not the whole collection.
 """
 
 from __future__ import annotations
 
 import contextvars
 from collections.abc import Iterator
+from typing import Any
 
 import pytest
 
@@ -26,9 +32,9 @@ from mloda.provider import record_match_rejection as provider_record_match_rejec
 
 
 @pytest.fixture
-def recording_window() -> Iterator[dict[str, str]]:
+def recording_window() -> Iterator[dict[str, Any]]:
     """Open a fresh recording window and always close it again, even when the test body fails."""
-    reasons: dict[str, str] = {}
+    reasons: dict[str, Any] = {}
     token = MATCH_REJECTION_REASONS.set(reasons)
     yield reasons
     MATCH_REJECTION_REASONS.reset(token)
@@ -64,19 +70,64 @@ class TestRecording:
 
         assert MATCH_REJECTION_REASONS.get() is None
 
-    def test_the_first_reason_per_owner_wins_and_owners_stay_separate(self, recording_window: dict[str, str]) -> None:
+    def test_the_first_reason_per_owner_wins_and_owners_stay_separate(self, recording_window: dict[str, Any]) -> None:
         """A second reason for the same owner never overwrites the first; a second owner gets its own slot."""
+        from mloda.core.abstract_plugins.components.match_rejection import MatchRejection
+
         record_match_rejection("FirstOwner727", "first reason 727")
         record_match_rejection("FirstOwner727", "second reason 727")
 
-        assert recording_window == {"FirstOwner727": "first reason 727"}
+        assert recording_window == {"FirstOwner727": MatchRejection(reason="first reason 727")}
 
         record_match_rejection("SecondOwner727", "other reason 727")
 
         assert recording_window == {
-            "FirstOwner727": "first reason 727",
-            "SecondOwner727": "other reason 727",
+            "FirstOwner727": MatchRejection(reason="first reason 727"),
+            "SecondOwner727": MatchRejection(reason="other reason 727"),
         }
+
+
+class TestStageHint:
+    """The window value carries a stage hint next to the reason (cycle 3)."""
+
+    def test_the_neutral_module_exposes_matchrejection(self) -> None:
+        """MatchRejection lives in the neutral module; its stage defaults to value_rejection."""
+        from mloda.core.abstract_plugins.components.match_rejection import MatchRejection
+
+        rejection = MatchRejection(reason="probe reason 727")
+
+        assert rejection.reason == "probe reason 727"
+        assert rejection.stage == "value_rejection"
+
+    def test_recording_without_a_stage_stores_the_value_rejection_default(
+        self, recording_window: dict[str, Any]
+    ) -> None:
+        """No stage argument: the stored MatchRejection carries the default value_rejection stage."""
+        from mloda.core.abstract_plugins.components.match_rejection import MatchRejection
+
+        record_match_rejection("DefaultStageOwner727", "default stage reason 727")
+
+        stored = recording_window["DefaultStageOwner727"]
+        assert stored == MatchRejection(reason="default stage reason 727", stage="value_rejection")
+
+    def test_recording_with_a_stage_stores_that_stage(self, recording_window: dict[str, Any]) -> None:
+        """stage='input_data' is stored verbatim on the MatchRejection."""
+        from mloda.core.abstract_plugins.components.match_rejection import MatchRejection
+
+        record_match_rejection("InputDataOwner727", "input data reason 727", stage="input_data")
+
+        stored = recording_window["InputDataOwner727"]
+        assert stored == MatchRejection(reason="input data reason 727", stage="input_data")
+
+    def test_the_first_recording_per_owner_wins_across_differing_stages(self, recording_window: dict[str, Any]) -> None:
+        """A later recording never overwrites the first, not even with a different stage."""
+        from mloda.core.abstract_plugins.components.match_rejection import MatchRejection
+
+        record_match_rejection("StageRaceOwner727", "first staged reason 727", stage="input_data")
+        record_match_rejection("StageRaceOwner727", "second staged reason 727")
+
+        expected = MatchRejection(reason="first staged reason 727", stage="input_data")
+        assert recording_window == {"StageRaceOwner727": expected}
 
 
 class TestProviderExport:

--- a/tests/test_core/test_abstract_plugins/test_components/test_match_rejection.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_match_rejection.py
@@ -1,0 +1,91 @@
+"""The match-rejection channel lives in a neutral module (issue #727, cycle 1).
+
+``mloda.core.abstract_plugins.components.match_rejection`` owns ``MATCH_REJECTION_REASONS`` and
+``record_match_rejection`` so input-data reader code can record rejections without depending on the
+feature-chainer module. The documented ``feature_chain_parser`` seam keeps re-exporting the SAME
+function object, the engine harvests through the new home, and ``mloda.provider`` exports the
+recording function for plugin authors.
+"""
+
+from __future__ import annotations
+
+import contextvars
+from collections.abc import Iterator
+
+import pytest
+
+from mloda import provider
+from mloda.core.abstract_plugins.components import match_rejection
+from mloda.core.abstract_plugins.components.feature_chainer import feature_chain_parser
+from mloda.core.abstract_plugins.components.match_rejection import (
+    MATCH_REJECTION_REASONS,
+    record_match_rejection,
+)
+from mloda.core.prepare import identify_feature_group
+from mloda.provider import record_match_rejection as provider_record_match_rejection
+
+
+@pytest.fixture
+def recording_window() -> Iterator[dict[str, str]]:
+    """Open a fresh recording window and always close it again, even when the test body fails."""
+    reasons: dict[str, str] = {}
+    token = MATCH_REJECTION_REASONS.set(reasons)
+    yield reasons
+    MATCH_REJECTION_REASONS.reset(token)
+
+
+class TestNeutralModuleOwnsTheChannel:
+    """The neutral module defines the channel and every old home aliases its objects."""
+
+    def test_the_neutral_module_exposes_the_channel(self) -> None:
+        """The new module carries the contextvar and the recording function."""
+        assert isinstance(match_rejection.MATCH_REJECTION_REASONS, contextvars.ContextVar)
+        assert callable(match_rejection.record_match_rejection)
+
+    def test_the_contextvar_defaults_to_inactive(self) -> None:
+        """In a fresh context the recorder holds None: recording is off."""
+        assert contextvars.Context().run(MATCH_REJECTION_REASONS.get) is None
+
+    def test_feature_chain_parser_reexports_the_same_function(self) -> None:
+        """The documented feature_chain_parser seam stays the SAME function object, not a copy."""
+        assert getattr(feature_chain_parser, "record_match_rejection") is match_rejection.record_match_rejection
+
+    def test_the_engine_harvests_through_the_new_home(self) -> None:
+        """identify_feature_group uses the neutral module's contextvar object, so the harvest still works."""
+        assert getattr(identify_feature_group, "MATCH_REJECTION_REASONS") is match_rejection.MATCH_REJECTION_REASONS
+
+
+class TestRecording:
+    """Recording is a no-op outside a window and first-reason-per-owner-wins inside one."""
+
+    def test_recording_outside_a_window_is_a_no_op(self) -> None:
+        """With the contextvar at its default None, recording raises nothing and stores nothing."""
+        record_match_rejection("InertOwner727", "inert reason 727")
+
+        assert MATCH_REJECTION_REASONS.get() is None
+
+    def test_the_first_reason_per_owner_wins_and_owners_stay_separate(self, recording_window: dict[str, str]) -> None:
+        """A second reason for the same owner never overwrites the first; a second owner gets its own slot."""
+        record_match_rejection("FirstOwner727", "first reason 727")
+        record_match_rejection("FirstOwner727", "second reason 727")
+
+        assert recording_window == {"FirstOwner727": "first reason 727"}
+
+        record_match_rejection("SecondOwner727", "other reason 727")
+
+        assert recording_window == {
+            "FirstOwner727": "first reason 727",
+            "SecondOwner727": "other reason 727",
+        }
+
+
+class TestProviderExport:
+    """mloda.provider exposes the recording function for plugin authors."""
+
+    def test_provider_exports_the_same_function(self) -> None:
+        """The provider export is the neutral module's function object."""
+        assert provider_record_match_rejection is match_rejection.record_match_rejection
+
+    def test_provider_all_lists_the_export(self) -> None:
+        """The export is part of the provider's public surface."""
+        assert "record_match_rejection" in provider.__all__

--- a/tests/test_core/test_prepare/test_first_pass_rejection_recording.py
+++ b/tests/test_core/test_prepare/test_first_pass_rejection_recording.py
@@ -24,6 +24,7 @@ from mloda.core.abstract_plugins.components.default_options_key import DefaultOp
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.match_rejection import (
     MATCH_REJECTION_REASONS,
+    MatchRejection,
     record_match_rejection,
 )
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
@@ -323,4 +324,4 @@ class TestRecorderActivation:
         recorded = MATCH_REJECTION_REASONS.get()
         MATCH_REJECTION_REASONS.reset(token)
 
-        assert recorded == {"FirstWinsOwnerOs005r": "first reason os005r"}
+        assert recorded == {"FirstWinsOwnerOs005r": MatchRejection(reason="first reason os005r")}

--- a/tests/test_core/test_prepare/test_first_pass_rejection_recording.py
+++ b/tests/test_core/test_prepare/test_first_pass_rejection_recording.py
@@ -22,7 +22,7 @@ import pytest
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
 from mloda.core.abstract_plugins.components.feature import Feature
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import (
+from mloda.core.abstract_plugins.components.match_rejection import (
     MATCH_REJECTION_REASONS,
     record_match_rejection,
 )

--- a/tests/test_core/test_prepare/test_required_when_rejection_recording.py
+++ b/tests/test_core/test_prepare/test_required_when_rejection_recording.py
@@ -23,7 +23,7 @@ from typing import Optional
 import pytest
 
 from mloda.core.abstract_plugins.components.feature import Feature
-from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import MATCH_REJECTION_REASONS
+from mloda.core.abstract_plugins.components.match_rejection import MATCH_REJECTION_REASONS
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework

--- a/tests/test_core/test_prepare/test_resolution_failure_renderer.py
+++ b/tests/test_core/test_prepare/test_resolution_failure_renderer.py
@@ -93,9 +93,9 @@ DEAD_PREFIX_UNCOVERED_791 = "RendererDeadPrefixFG791_sum_791"
 VALUE_STAGE_REJECTION_REASON_791 = "renderer_value_stage_791 declines every value of this option"
 
 # The stages whose gate CAN see the feature name, so a sibling name of a candidate eliminated there may still
-# resolve. Pinned here as the complement of NAME_INDEPENDENT_STAGES: a ninth stage fails the partition test.
+# resolve. Pinned here as the complement of NAME_INDEPENDENT_STAGES: a tenth stage fails the partition test.
 NAME_DEPENDENT_STAGES_791: frozenset[EliminationStage] = frozenset(
-    {"value_rejection", "matcher_error", "capability", "framework_pin"}
+    {"value_rejection", "input_data", "matcher_error", "capability", "framework_pin"}
 )
 
 # Stands in for a ninth stage shipped without a near-miss label: no entry of the label table covers this token.
@@ -1928,7 +1928,7 @@ class TestALivePrefixKeepsACoveredNameSuggestible:
 
 
 class TestEveryEliminationStageIsClassified:
-    """A ninth stage must be classified and labelled before it ships, or it silently misrenders or misdrops names."""
+    """A tenth stage must be classified and labelled before it ships, or it silently misrenders or misdrops names."""
 
     def test_the_two_stage_sets_partition_the_stage_literal(self) -> None:
         """NAME_INDEPENDENT_STAGES and its name-dependent complement cover EliminationStage exactly once."""

--- a/tests/test_mloda_imports.py
+++ b/tests/test_mloda_imports.py
@@ -152,6 +152,8 @@ def test_import_provider_base_classes() -> None:
         COLUMNWISE_HOOKS,
         COLUMN_DISCOVERY_HOOKS,
         missing_columnwise_hooks,
+        # Match rejection recording
+        record_match_rejection,
         # Transformers
         BaseTransformer,
         ComputeFrameworkTransformer,
@@ -193,6 +195,8 @@ def test_import_provider_base_classes() -> None:
     assert COLUMNWISE_HOOKS
     assert COLUMN_DISCOVERY_HOOKS > COLUMNWISE_HOOKS
     assert callable(missing_columnwise_hooks)
+    # Match rejection recording
+    assert callable(record_match_rejection)
     # Transformers
     assert BaseTransformer is not None
     assert ComputeFrameworkTransformer is not None

--- a/tests/test_plugins/feature_group/input_data/test_reader_match_rejections.py
+++ b/tests/test_plugins/feature_group/input_data/test_reader_match_rejections.py
@@ -1,0 +1,264 @@
+"""Readers decline with an attributable reason (issue #727, cycle 2).
+
+A reader that ESTABLISHED OWNERSHIP of an input (suffix match for files, valid credentials for
+databases) but whose content rule fails must record an attributable reason via
+``record_match_rejection``; a plain non-match (wrong suffix, unrecognized or invalid credentials)
+records nothing, and so does a successful match. The engine harvests a recorded reason into a
+``value_rejection`` elimination that ``render_resolution_failure`` prints as a near-miss line.
+
+All names carry a ``rej727`` marker and the file suffixes are globally unique: the readers and the
+feature group defined here become global subclasses discovered process-wide, so under pytest-xdist
+they must stay inert for every other test's inputs. The ReadDB doubles are additionally never final
+readers (no load_data or hook overrides), so reader discovery never returns them at all.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from mloda.core.abstract_plugins.components.match_rejection import MATCH_REJECTION_REASONS
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+from mloda.core.prepare.resolution_failure_renderer import render_resolution_failure
+from mloda.provider import BaseInputData, FeatureGroup, FeatureSet
+from mloda.user import DataAccessCollection, Feature, FeatureName, Options
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.feature_group.input_data.read_db import ReadDB
+from mloda_plugins.feature_group.input_data.read_file import ReadFile
+
+
+FEATURE_NAME_REJ727 = "rej727_column"
+FILE_SUFFIX_REJ727 = ".rej727csv"
+NIE_SUFFIX_REJ727 = ".rej727nie"
+DB_MARKER_KEY_REJ727 = "rej727db_marker"
+DB_ACCESS_REJ727: dict[str, Any] = {DB_MARKER_KEY_REJ727: True}
+
+
+class Rej727ReaderFamily(ReadFile):
+    """Family base of this module's readers; it overrides nothing, so it never classifies as final."""
+
+
+class Rej727CsvHeaderReader(Rej727ReaderFamily):
+    """Final reader owning the unique .rej727csv suffix; introspects the comma-separated header line."""
+
+    @classmethod
+    def suffix(cls) -> tuple[str, ...]:
+        return (FILE_SUFFIX_REJ727,)
+
+    @classmethod
+    def get_column_names(cls, file_name: str) -> list[str]:
+        with open(file_name, encoding="utf-8") as handle:
+            return handle.readline().strip().split(",")
+
+    @classmethod
+    def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
+        return {FEATURE_NAME_REJ727: [1]}
+
+
+class Rej727NoIntrospectionReader(Rej727ReaderFamily):
+    """Final reader owning the unique .rej727nie suffix; get_column_names stays NotImplementedError."""
+
+    @classmethod
+    def suffix(cls) -> tuple[str, ...]:
+        return (NIE_SUFFIX_REJ727,)
+
+    @classmethod
+    def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
+        return {FEATURE_NAME_REJ727: [1]}
+
+
+class Rej727DecliningDbReader(ReadDB):
+    """Recognizes only the marker credentials, then declines every feature at the content rule."""
+
+    @classmethod
+    def is_valid_credentials(cls, credentials: dict[str, Any]) -> bool:
+        return credentials.get(DB_MARKER_KEY_REJ727) is True
+
+    @classmethod
+    def check_feature_in_data_access(cls, feature_name: str, data_access: Any) -> bool:
+        return False
+
+
+class Rej727AgnosticDbReader(ReadDB):
+    """Accepts the marker credentials, soft-declines unknown ones; cannot introspect features."""
+
+    @classmethod
+    def is_valid_credentials(cls, credentials: dict[str, Any]) -> bool:
+        if credentials.get(DB_MARKER_KEY_REJ727) is not True:
+            raise NotImplementedError
+        return True
+
+
+class Rej727FileFG(FeatureGroup):
+    """Root feature group matching ONLY via its reader family: no name rule claims rej727_column."""
+
+    @classmethod
+    def input_data(cls) -> BaseInputData | None:
+        return Rej727ReaderFamily()
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        return None
+
+
+@pytest.fixture()
+def rejection_window() -> Iterator[dict[str, str]]:
+    """Open a recording window around one direct matcher call, mirroring the engine's per-candidate window."""
+    window: dict[str, str] = {}
+    token = MATCH_REJECTION_REASONS.set(window)
+    yield window
+    MATCH_REJECTION_REASONS.reset(token)
+
+
+def _write_csv(path: Path, header: str) -> str:
+    """Write a two-line comma-separated file and return its path as a string."""
+    path.write_text(f"{header}\n1,2\n", encoding="utf-8")
+    return str(path)
+
+
+class TestReadFileMatchRejections:
+    """Unit level: the suffix match establishes ownership, validate_columns judges the content."""
+
+    def test_missing_column_after_suffix_match_records_attributable_reason(
+        self, tmp_path: Path, rejection_window: dict[str, str]
+    ) -> None:
+        """Right suffix but the header lacks the feature: no match AND one reason naming reader, file, feature."""
+        file_path = _write_csv(tmp_path / f"data{FILE_SUFFIX_REJ727}", "other_a,other_b")
+
+        matched = Rej727CsvHeaderReader.match_subclass_data_access(file_path, [FEATURE_NAME_REJ727], Options())
+
+        assert matched is None
+        assert list(rejection_window) == [Rej727CsvHeaderReader.get_class_name()]
+        reason = rejection_window[Rej727CsvHeaderReader.get_class_name()]
+        assert Rej727CsvHeaderReader.get_class_name() in reason
+        assert file_path in reason
+        assert FEATURE_NAME_REJ727 in reason
+
+    def test_wrong_suffix_is_a_plain_non_match_and_records_nothing(
+        self, tmp_path: Path, rejection_window: dict[str, str]
+    ) -> None:
+        """Wrong suffix: ownership was never established, so even a missing column records nothing."""
+        file_path = _write_csv(tmp_path / "data.txt", "other_a,other_b")
+
+        matched = Rej727CsvHeaderReader.match_subclass_data_access(file_path, [FEATURE_NAME_REJ727], Options())
+
+        assert matched is None
+        assert rejection_window == {}
+
+    def test_successful_match_records_nothing(self, tmp_path: Path, rejection_window: dict[str, str]) -> None:
+        """Right suffix and the header contains the feature: the path matches and nothing is recorded."""
+        file_path = _write_csv(tmp_path / f"data{FILE_SUFFIX_REJ727}", f"{FEATURE_NAME_REJ727},other_b")
+
+        matched = Rej727CsvHeaderReader.match_subclass_data_access(file_path, [FEATURE_NAME_REJ727], Options())
+
+        assert matched == file_path
+        assert rejection_window == {}
+
+    def test_not_implemented_get_column_names_assumes_columns_and_records_nothing(
+        self, tmp_path: Path, rejection_window: dict[str, str]
+    ) -> None:
+        """A reader without column introspection keeps assuming the columns are there, silently."""
+        file_path = _write_csv(tmp_path / f"data{NIE_SUFFIX_REJ727}", "other_a,other_b")
+
+        assert Rej727NoIntrospectionReader.validate_columns(file_path, [FEATURE_NAME_REJ727]) is True
+        assert rejection_window == {}
+
+
+class TestPinnedFileMatchRejection:
+    """The pinned-file path (_resolve_pinned_file) also judges content only after ownership is established."""
+
+    def test_pinned_file_missing_column_records_attributable_reason(
+        self, tmp_path: Path, rejection_window: dict[str, str]
+    ) -> None:
+        """A pin routes the feature to one suffix-owned file; that file lacking the column is a recordable decline."""
+        file_path = _write_csv(tmp_path / f"pinned{FILE_SUFFIX_REJ727}", "other_a,other_b")
+        dac = DataAccessCollection(
+            files={"rej727_pin_handle": file_path},
+            column_to_file={FEATURE_NAME_REJ727: "rej727_pin_handle"},
+        )
+
+        matched = Rej727CsvHeaderReader.match_subclass_data_access(dac, [FEATURE_NAME_REJ727], Options())
+
+        assert matched is None
+        assert list(rejection_window) == [Rej727CsvHeaderReader.get_class_name()]
+        reason = rejection_window[Rej727CsvHeaderReader.get_class_name()]
+        assert Rej727CsvHeaderReader.get_class_name() in reason
+        assert file_path in reason
+        assert FEATURE_NAME_REJ727 in reason
+
+
+class TestReadDbMatchRejections:
+    """Unit level: valid credentials establish ownership, check_feature_in_data_access is the content rule."""
+
+    def test_declined_feature_with_valid_credentials_records_attributable_reason(
+        self, rejection_window: dict[str, str]
+    ) -> None:
+        """Ownership established, feature declined: no match AND one reason naming reader and feature."""
+        matched = Rej727DecliningDbReader.match_read_db_data_access([DB_ACCESS_REJ727], [FEATURE_NAME_REJ727])
+
+        assert matched is None
+        assert list(rejection_window) == [Rej727DecliningDbReader.get_class_name()]
+        reason = rejection_window[Rej727DecliningDbReader.get_class_name()]
+        assert Rej727DecliningDbReader.get_class_name() in reason
+        assert FEATURE_NAME_REJ727 in reason
+
+    def test_not_implemented_feature_check_matches_and_records_nothing(self, rejection_window: dict[str, str]) -> None:
+        """A reader that cannot introspect features keeps matching on credentials alone, silently."""
+        matched = Rej727AgnosticDbReader.match_read_db_data_access([DB_ACCESS_REJ727], [FEATURE_NAME_REJ727])
+
+        assert matched is DB_ACCESS_REJ727
+        assert rejection_window == {}
+
+    def test_not_implemented_credentials_check_records_nothing(self, rejection_window: dict[str, str]) -> None:
+        """NotImplementedError from is_valid_credentials is a soft no-match: no ownership, no recording."""
+        matched = Rej727AgnosticDbReader.match_read_db_data_access([{"rej727_unrelated": 1}], [FEATURE_NAME_REJ727])
+
+        assert matched is None
+        assert rejection_window == {}
+
+    def test_invalid_credentials_record_nothing(self, rejection_window: dict[str, str]) -> None:
+        """is_valid_credentials returning False is a plain non-match: no ownership, no recording."""
+        matched = Rej727DecliningDbReader.match_read_db_data_access([{"rej727_unrelated": 1}], [FEATURE_NAME_REJ727])
+
+        assert matched is None
+        assert rejection_window == {}
+
+
+class TestEngineHarvestsReaderRejection:
+    """Engine integration, deliberately WITHOUT a window fixture: the engine owns the per-candidate window."""
+
+    def test_wrong_header_becomes_a_value_rejection_elimination_and_renders(self, tmp_path: Path) -> None:
+        """The reader's recorded decline surfaces as a value_rejection elimination and a near-miss line."""
+        file_path = _write_csv(tmp_path / f"engine{FILE_SUFFIX_REJ727}", "other_a,other_b")
+        dac = DataAccessCollection(files={file_path})
+        feature = Feature(name=FEATURE_NAME_REJ727)
+        accessible_plugins: FeatureGroupEnvironmentMapping = {Rej727FileFG: {PandasDataFrame}}
+
+        result = IdentifyFeatureGroupClass.evaluate(feature, accessible_plugins, None, dac)
+
+        assert result.identified == {}
+        elimination = result.eliminations.get(Rej727FileFG)
+        assert elimination is not None
+        assert elimination.stage == "value_rejection"
+        assert Rej727CsvHeaderReader.get_class_name() in elimination.reason
+        assert file_path in elimination.reason
+
+        message = render_resolution_failure(result, feature)
+        assert message is not None
+        assert f"  - {Rej727FileFG.__name__} (option value): {elimination.reason}" in message
+
+    def test_matching_header_identifies_and_pins_the_reader_pair(self, tmp_path: Path) -> None:
+        """A content-passing file identifies the group and stores the (reader class, path) pair, unchanged."""
+        file_path = _write_csv(tmp_path / f"engine_ok{FILE_SUFFIX_REJ727}", f"{FEATURE_NAME_REJ727},other_b")
+        dac = DataAccessCollection(files={file_path})
+        feature = Feature(name=FEATURE_NAME_REJ727)
+        accessible_plugins: FeatureGroupEnvironmentMapping = {Rej727FileFG: {PandasDataFrame}}
+
+        result = IdentifyFeatureGroupClass.evaluate(feature, accessible_plugins, None, dac)
+
+        assert Rej727FileFG in result.identified
+        assert result.eliminations == {}
+        assert feature.options.get("BaseInputData") == (Rej727CsvHeaderReader, file_path)

--- a/tests/test_plugins/feature_group/input_data/test_reader_match_rejections.py
+++ b/tests/test_plugins/feature_group/input_data/test_reader_match_rejections.py
@@ -1,10 +1,14 @@
-"""Readers decline with an attributable reason (issue #727, cycle 2).
+"""Readers decline with an attributable reason (issue #727, cycles 2 and 3).
 
 A reader that ESTABLISHED OWNERSHIP of an input (suffix match for files, valid credentials for
 databases) but whose content rule fails must record an attributable reason via
 ``record_match_rejection``; a plain non-match (wrong suffix, unrecognized or invalid credentials)
-records nothing, and so does a successful match. The engine harvests a recorded reason into a
-``value_rejection`` elimination that ``render_resolution_failure`` prints as a near-miss line.
+records nothing, and so does a successful match.
+
+Cycle 3: a reader records a ``MatchRejection`` stamped ``stage="input_data"``, the engine harvests
+it into an ``input_data`` elimination and ``render_resolution_failure`` labels the near-miss line
+``(input data)``, no longer ``(option value)``. A stage string the engine does not know falls back
+to ``value_rejection`` without crashing the run.
 
 All names carry a ``rej727`` marker and the file suffixes are globally unique: the readers and the
 feature group defined here become global subclasses discovered process-wide, so under pytest-xdist
@@ -20,7 +24,10 @@ from typing import Any
 
 import pytest
 
-from mloda.core.abstract_plugins.components.match_rejection import MATCH_REJECTION_REASONS
+from mloda.core.abstract_plugins.components.match_rejection import (
+    MATCH_REJECTION_REASONS,
+    record_match_rejection,
+)
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
 from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
 from mloda.core.prepare.resolution_failure_renderer import render_resolution_failure
@@ -32,6 +39,8 @@ from mloda_plugins.feature_group.input_data.read_file import ReadFile
 
 
 FEATURE_NAME_REJ727 = "rej727_column"
+BOGUS_STAGE_FEATURE_REJ727 = "rej727_bogus_stage_column"
+BOGUS_STAGE_REASON_REJ727 = "custom decline"
 FILE_SUFFIX_REJ727 = ".rej727csv"
 NIE_SUFFIX_REJ727 = ".rej727nie"
 DB_MARKER_KEY_REJ727 = "rej727db_marker"
@@ -104,10 +113,26 @@ class Rej727FileFG(FeatureGroup):
         return None
 
 
+class Rej727BogusStageFG(FeatureGroup):
+    """Declines its single gated feature with an unknown custom stage; inert for every other name."""
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        if str(feature_name) != BOGUS_STAGE_FEATURE_REJ727:
+            return False
+        record_match_rejection(cls.get_class_name(), BOGUS_STAGE_REASON_REJ727, stage="rej727_bogus_stage")
+        return False
+
+
 @pytest.fixture()
-def rejection_window() -> Iterator[dict[str, str]]:
+def rejection_window() -> Iterator[dict[str, Any]]:
     """Open a recording window around one direct matcher call, mirroring the engine's per-candidate window."""
-    window: dict[str, str] = {}
+    window: dict[str, Any] = {}
     token = MATCH_REJECTION_REASONS.set(window)
     yield window
     MATCH_REJECTION_REASONS.reset(token)
@@ -123,22 +148,23 @@ class TestReadFileMatchRejections:
     """Unit level: the suffix match establishes ownership, validate_columns judges the content."""
 
     def test_missing_column_after_suffix_match_records_attributable_reason(
-        self, tmp_path: Path, rejection_window: dict[str, str]
+        self, tmp_path: Path, rejection_window: dict[str, Any]
     ) -> None:
-        """Right suffix but the header lacks the feature: no match AND one reason naming reader, file, feature."""
+        """Right suffix but the header lacks the feature: one input_data rejection naming reader, file, feature."""
         file_path = _write_csv(tmp_path / f"data{FILE_SUFFIX_REJ727}", "other_a,other_b")
 
         matched = Rej727CsvHeaderReader.match_subclass_data_access(file_path, [FEATURE_NAME_REJ727], Options())
 
         assert matched is None
         assert list(rejection_window) == [Rej727CsvHeaderReader.get_class_name()]
-        reason = rejection_window[Rej727CsvHeaderReader.get_class_name()]
-        assert Rej727CsvHeaderReader.get_class_name() in reason
-        assert file_path in reason
-        assert FEATURE_NAME_REJ727 in reason
+        stored = rejection_window[Rej727CsvHeaderReader.get_class_name()]
+        assert stored.stage == "input_data"
+        assert Rej727CsvHeaderReader.get_class_name() in stored.reason
+        assert file_path in stored.reason
+        assert FEATURE_NAME_REJ727 in stored.reason
 
     def test_wrong_suffix_is_a_plain_non_match_and_records_nothing(
-        self, tmp_path: Path, rejection_window: dict[str, str]
+        self, tmp_path: Path, rejection_window: dict[str, Any]
     ) -> None:
         """Wrong suffix: ownership was never established, so even a missing column records nothing."""
         file_path = _write_csv(tmp_path / "data.txt", "other_a,other_b")
@@ -148,7 +174,7 @@ class TestReadFileMatchRejections:
         assert matched is None
         assert rejection_window == {}
 
-    def test_successful_match_records_nothing(self, tmp_path: Path, rejection_window: dict[str, str]) -> None:
+    def test_successful_match_records_nothing(self, tmp_path: Path, rejection_window: dict[str, Any]) -> None:
         """Right suffix and the header contains the feature: the path matches and nothing is recorded."""
         file_path = _write_csv(tmp_path / f"data{FILE_SUFFIX_REJ727}", f"{FEATURE_NAME_REJ727},other_b")
 
@@ -158,7 +184,7 @@ class TestReadFileMatchRejections:
         assert rejection_window == {}
 
     def test_not_implemented_get_column_names_assumes_columns_and_records_nothing(
-        self, tmp_path: Path, rejection_window: dict[str, str]
+        self, tmp_path: Path, rejection_window: dict[str, Any]
     ) -> None:
         """A reader without column introspection keeps assuming the columns are there, silently."""
         file_path = _write_csv(tmp_path / f"data{NIE_SUFFIX_REJ727}", "other_a,other_b")
@@ -171,9 +197,9 @@ class TestPinnedFileMatchRejection:
     """The pinned-file path (_resolve_pinned_file) also judges content only after ownership is established."""
 
     def test_pinned_file_missing_column_records_attributable_reason(
-        self, tmp_path: Path, rejection_window: dict[str, str]
+        self, tmp_path: Path, rejection_window: dict[str, Any]
     ) -> None:
-        """A pin routes the feature to one suffix-owned file; that file lacking the column is a recordable decline."""
+        """A pin routes the feature to one suffix-owned file; that file lacking the column is an input_data decline."""
         file_path = _write_csv(tmp_path / f"pinned{FILE_SUFFIX_REJ727}", "other_a,other_b")
         dac = DataAccessCollection(
             files={"rej727_pin_handle": file_path},
@@ -184,42 +210,44 @@ class TestPinnedFileMatchRejection:
 
         assert matched is None
         assert list(rejection_window) == [Rej727CsvHeaderReader.get_class_name()]
-        reason = rejection_window[Rej727CsvHeaderReader.get_class_name()]
-        assert Rej727CsvHeaderReader.get_class_name() in reason
-        assert file_path in reason
-        assert FEATURE_NAME_REJ727 in reason
+        stored = rejection_window[Rej727CsvHeaderReader.get_class_name()]
+        assert stored.stage == "input_data"
+        assert Rej727CsvHeaderReader.get_class_name() in stored.reason
+        assert file_path in stored.reason
+        assert FEATURE_NAME_REJ727 in stored.reason
 
 
 class TestReadDbMatchRejections:
     """Unit level: valid credentials establish ownership, check_feature_in_data_access is the content rule."""
 
     def test_declined_feature_with_valid_credentials_records_attributable_reason(
-        self, rejection_window: dict[str, str]
+        self, rejection_window: dict[str, Any]
     ) -> None:
-        """Ownership established, feature declined: no match AND one reason naming reader and feature."""
+        """Ownership established, feature declined: one input_data rejection naming reader and feature."""
         matched = Rej727DecliningDbReader.match_read_db_data_access([DB_ACCESS_REJ727], [FEATURE_NAME_REJ727])
 
         assert matched is None
         assert list(rejection_window) == [Rej727DecliningDbReader.get_class_name()]
-        reason = rejection_window[Rej727DecliningDbReader.get_class_name()]
-        assert Rej727DecliningDbReader.get_class_name() in reason
-        assert FEATURE_NAME_REJ727 in reason
+        stored = rejection_window[Rej727DecliningDbReader.get_class_name()]
+        assert stored.stage == "input_data"
+        assert Rej727DecliningDbReader.get_class_name() in stored.reason
+        assert FEATURE_NAME_REJ727 in stored.reason
 
-    def test_not_implemented_feature_check_matches_and_records_nothing(self, rejection_window: dict[str, str]) -> None:
+    def test_not_implemented_feature_check_matches_and_records_nothing(self, rejection_window: dict[str, Any]) -> None:
         """A reader that cannot introspect features keeps matching on credentials alone, silently."""
         matched = Rej727AgnosticDbReader.match_read_db_data_access([DB_ACCESS_REJ727], [FEATURE_NAME_REJ727])
 
         assert matched is DB_ACCESS_REJ727
         assert rejection_window == {}
 
-    def test_not_implemented_credentials_check_records_nothing(self, rejection_window: dict[str, str]) -> None:
+    def test_not_implemented_credentials_check_records_nothing(self, rejection_window: dict[str, Any]) -> None:
         """NotImplementedError from is_valid_credentials is a soft no-match: no ownership, no recording."""
         matched = Rej727AgnosticDbReader.match_read_db_data_access([{"rej727_unrelated": 1}], [FEATURE_NAME_REJ727])
 
         assert matched is None
         assert rejection_window == {}
 
-    def test_invalid_credentials_record_nothing(self, rejection_window: dict[str, str]) -> None:
+    def test_invalid_credentials_record_nothing(self, rejection_window: dict[str, Any]) -> None:
         """is_valid_credentials returning False is a plain non-match: no ownership, no recording."""
         matched = Rej727DecliningDbReader.match_read_db_data_access([{"rej727_unrelated": 1}], [FEATURE_NAME_REJ727])
 
@@ -230,8 +258,8 @@ class TestReadDbMatchRejections:
 class TestEngineHarvestsReaderRejection:
     """Engine integration, deliberately WITHOUT a window fixture: the engine owns the per-candidate window."""
 
-    def test_wrong_header_becomes_a_value_rejection_elimination_and_renders(self, tmp_path: Path) -> None:
-        """The reader's recorded decline surfaces as a value_rejection elimination and a near-miss line."""
+    def test_wrong_header_becomes_an_input_data_elimination_and_renders(self, tmp_path: Path) -> None:
+        """The reader's recorded decline surfaces as an input_data elimination and an '(input data)' near-miss line."""
         file_path = _write_csv(tmp_path / f"engine{FILE_SUFFIX_REJ727}", "other_a,other_b")
         dac = DataAccessCollection(files={file_path})
         feature = Feature(name=FEATURE_NAME_REJ727)
@@ -242,13 +270,13 @@ class TestEngineHarvestsReaderRejection:
         assert result.identified == {}
         elimination = result.eliminations.get(Rej727FileFG)
         assert elimination is not None
-        assert elimination.stage == "value_rejection"
+        assert elimination.stage == "input_data"
         assert Rej727CsvHeaderReader.get_class_name() in elimination.reason
         assert file_path in elimination.reason
 
         message = render_resolution_failure(result, feature)
         assert message is not None
-        assert f"  - {Rej727FileFG.__name__} (option value): {elimination.reason}" in message
+        assert f"  - {Rej727FileFG.__name__} (input data): {elimination.reason}" in message
 
     def test_matching_header_identifies_and_pins_the_reader_pair(self, tmp_path: Path) -> None:
         """A content-passing file identifies the group and stores the (reader class, path) pair, unchanged."""
@@ -262,3 +290,20 @@ class TestEngineHarvestsReaderRejection:
         assert Rej727FileFG in result.identified
         assert result.eliminations == {}
         assert feature.options.get("BaseInputData") == (Rej727CsvHeaderReader, file_path)
+
+
+class TestEngineFallsBackOnUnknownStage:
+    """The neutral channel does not validate stages; the engine maps unknown ones to value_rejection."""
+
+    def test_unknown_recorded_stage_falls_back_to_value_rejection(self) -> None:
+        """A custom stage string neither crashes the run nor leaks into the elimination stage."""
+        feature = Feature(name=BOGUS_STAGE_FEATURE_REJ727)
+        accessible_plugins: FeatureGroupEnvironmentMapping = {Rej727BogusStageFG: {PandasDataFrame}}
+
+        result = IdentifyFeatureGroupClass.evaluate(feature, accessible_plugins, None, None)
+
+        assert result.identified == {}
+        elimination = result.eliminations.get(Rej727BogusStageFG)
+        assert elimination is not None
+        assert elimination.stage == "value_rejection"
+        assert elimination.reason == BOGUS_STAGE_REASON_REJ727


### PR DESCRIPTION
Closes #727.

## Decision

Reader selection does not adopt the request/environment/outcome resolution abstractions. It is not a second resolver: it runs nested inside the criteria gate of feature-group resolution, and the outcome types are FeatureGroup-typed end to end. What it shares is the low-level candidate-and-rejection machinery, which is exactly the split the issue asked to evaluate.

## What changed

- `MATCH_REJECTION_REASONS` and `record_match_rejection` move to a neutral, stdlib-only `mloda/core/abstract_plugins/components/match_rejection.py`, so reader code uses the channel without depending on the feature-chainer module. `record_match_rejection` is exported via `mloda.provider` for custom reader authors.
- Readers decline attributably where ownership is established but content fails: `ReadFile.validate_columns` (suffix matched, requested column missing; covers direct-file, folder-scan, and pinned-file paths) and `ReadDB.match_read_db_data_access` (valid credentials, declined feature). Plain non-matches stay silent, a matching candidate discards its recordings, and recording outside an engine window is a no-op, so raising is never needed to decline.
- The window stores `MatchRejection(reason, stage)`: reader declines carry `stage="input_data"` and render in the near-miss block as `(input data)` instead of the PropertySpec-specific `(option value)`. Unknown stages fall back to `value_rejection` at the harvest.
- Reader-specific file, suffix, column-validation, and pinning rules stay reader-owned and behaviorally unchanged, as does the matched `(ReaderClass, data_access)` side-effect protocol.
- `docs/docs/in_depth/data-access-patterns.md` gains the mapping the issue asked for (candidate discovery, auto-loading, accessibility, matching, ambiguity, diagnostics), the decision record, and author guidance for attributable declines.

## Notes

- `MATCH_REJECTION_REASONS` is no longer importable from `feature_chain_parser` (it was internal and never exported via `mloda.provider`); `record_match_rejection` keeps working from its old import path and is now canonical in `mloda.provider`.
- This delivers the rejection channel that the collapse condition recorded on #727 requires; the `ReaderOptionSpec` into `PropertySpec` collapse itself is filed as a follow-up.

## Testing

- `tox` green: pytest `-n 8`, ruff format and check, license allowlist, `mypy --strict` over 923 files, bandit.
- New parallel-safe tests: neutral-channel unit tests, reader unit tests (suffix ownership, column validation, pinned files, DB hook contract), engine integration (a reader decline becomes an `input_data` elimination and renders in the failure message; a content-passing file still identifies the group and pins the reader pair), and the unknown-stage fallback.