### PR TITLE
fix: judge the name-blind gates for candidates that never matched the name

### DIFF
--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -159,7 +159,7 @@ class IdentifyFeatureGroupClass:
         if result.failure_kind is not None:
             # Every elimination (value_rejection included) was already recorded during the single filter pass;
             # this only captures the non-elimination facts the messages still need.
-            result = replace(result, facts=self._capture_render_facts(result, accessible_plugins))
+            result = replace(result, facts=self._capture_render_facts(result, accessible_plugins, feature))
         # A captured exception pins its traceback, whose frames pin this instance: a refcount cycle that would
         # keep both alive until a gc pass. Dropping the outcomes here makes the memo's lifetime what it claims.
         self._domain_outcomes.clear()
@@ -169,6 +169,7 @@ class IdentifyFeatureGroupClass:
         self,
         result: EvaluationResult,
         accessible_plugins: FeatureGroupEnvironmentMapping,
+        feature: Feature,
     ) -> RenderFacts:
         """Capture the non-elimination facts the messages still need, precedence-free.
 
@@ -183,7 +184,7 @@ class IdentifyFeatureGroupClass:
             concrete_frameworks=self._concrete_implementation_frameworks(result, accessible_plugins),
             known_names=self._capture_known_names(accessible_plugins),
             eliminated_hints=self._capture_eliminated_hints(result),
-            dead_only_names=self._capture_dead_only_names(result, accessible_plugins),
+            dead_only_names=self._capture_dead_only_names(result, accessible_plugins, feature),
         )
 
     def _capture_eliminated_hints(self, result: EvaluationResult) -> frozenset[str]:
@@ -305,11 +306,22 @@ class IdentifyFeatureGroupClass:
             known_names.extend(self._catalog_names_of(fg_class))
         return tuple(known_names)
 
+    def _fails_name_blind_gate(self, feature_group: type[FeatureGroup], feature: Feature) -> bool:
+        """Capture-side retest of the two name-blind gates, scope then domain, that never raises."""
+        if not self._filter_feature_group_by_scope(feature_group, feature):
+            return True
+        if feature.domain is None:
+            return False
+        candidate_domain = self._domain_name(feature_group)
+        # A domain that could not be read is not a wrong domain, so a degraded read leaves the candidate live.
+        return candidate_domain is not None and candidate_domain != feature.domain.name
+
     def _is_dead(
         self,
         result: EvaluationResult,
         feature_group: type[FeatureGroup],
         compute_frameworks: set[type[ComputeFramework]],
+        feature: Feature,
     ) -> bool:
         """No name at all can resolve to this candidate: it has no framework left, or it lost at a name-blind gate.
 
@@ -319,11 +331,15 @@ class IdentifyFeatureGroupClass:
         """
         if not compute_frameworks:
             return True
+        # A candidate that never matched the requested name carries no record at all, so the name-blind gates
+        # are tested directly here; the record lookup below still owns the stages no gate here can retest.
+        if self._fails_name_blind_gate(feature_group, feature):
+            return True
         elimination = result.eliminations.get(feature_group)
         return elimination is not None and elimination.stage in NAME_INDEPENDENT_STAGES
 
     def _capture_dead_only_names(
-        self, result: EvaluationResult, accessible_plugins: FeatureGroupEnvironmentMapping
+        self, result: EvaluationResult, accessible_plugins: FeatureGroupEnvironmentMapping, feature: Feature
     ) -> frozenset[str]:
         """Declared names that no live candidate declares and no live candidate's prefix covers.
 
@@ -336,7 +352,7 @@ class IdentifyFeatureGroupClass:
         live: set[str] = set()
         live_prefixes: set[str] = set()
         for feature_group, compute_frameworks in accessible_plugins.items():
-            if self._is_dead(result, feature_group, compute_frameworks):
+            if self._is_dead(result, feature_group, compute_frameworks, feature):
                 dead.update(self._supported_names_of(feature_group))
                 continue
             live.update(self._catalog_names_of(feature_group))

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -312,9 +312,16 @@ class IdentifyFeatureGroupClass:
             return True
         if feature.domain is None:
             return False
-        candidate_domain = self._domain_name(feature_group)
-        # A domain that could not be read is not a wrong domain, so a degraded read leaves the candidate live.
-        return candidate_domain is not None and candidate_domain != feature.domain.name
+        domain, error = self._domain_outcome(feature_group)
+        # _domain_name is what reports either degrade, and both readers share one memo, so reading through it
+        # keeps this at a single get_domain() call per candidate.
+        if self._domain_name(feature_group) is None:
+            # A raise leaves the gate undecided, so nothing is known and the candidate stays live. A malformed
+            # return is decided: the gate compares it and drops the candidate, for every name it declares.
+            return error is None
+        # The gate's own comparison, never a name one: a Domain subclass with a custom __eq__ must not pass the
+        # gate and fail this retest.
+        return domain != feature.domain
 
     def _is_dead(
         self,
@@ -331,8 +338,13 @@ class IdentifyFeatureGroupClass:
         """
         if not compute_frameworks:
             return True
+        # _filter_loop parks an abstract base in abstract_matched and never in the identified mapping, whatever
+        # name it is asked about.
+        if inspect.isabstract(feature_group):
+            return True
         # A candidate that never matched the requested name carries no record at all, so the name-blind gates
-        # are tested directly here; the record lookup below still owns the stages no gate here can retest.
+        # are tested directly here. links is the one name-blind gate this predicate does not retest: doing so
+        # needs index_columns() and the run's links per candidate, provider hooks the capture makes nowhere else.
         if self._fails_name_blind_gate(feature_group, feature):
             return True
         elimination = result.eliminations.get(feature_group)
@@ -341,7 +353,7 @@ class IdentifyFeatureGroupClass:
     def _capture_dead_only_names(
         self, result: EvaluationResult, accessible_plugins: FeatureGroupEnvironmentMapping, feature: Feature
     ) -> frozenset[str]:
-        """Declared names that no live candidate declares and no live candidate's prefix covers.
+        """Catalog names of dead candidates that no live candidate owns and no live candidate's prefix covers.
 
         A difference, not a per-candidate drop: one accessible group that is still alive keeps its name
         suggestible, whatever a dead sibling also declares. Prefixes because the default matcher owns names
@@ -353,7 +365,9 @@ class IdentifyFeatureGroupClass:
         live_prefixes: set[str] = set()
         for feature_group, compute_frameworks in accessible_plugins.items():
             if self._is_dead(result, feature_group, compute_frameworks, feature):
-                dead.update(self._supported_names_of(feature_group))
+                # The whole catalog, as the live branch collects it: the default matcher owns a candidate's
+                # class name and its class-name prefix too, and a dead candidate resolves neither.
+                dead.update(self._catalog_names_of(feature_group))
                 continue
             live.update(self._catalog_names_of(feature_group))
             # Non-empty only: _prefix_name degrades a raising prefix() to "", which every name starts with.

--- a/mloda/core/prepare/resolution_failure_renderer.py
+++ b/mloda/core/prepare/resolution_failure_renderer.py
@@ -5,6 +5,7 @@ from difflib import get_close_matches
 
 from mloda.core.abstract_plugins.components.utils import safe_field, as_str
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.abstract_plugins.components.domain import Domain
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.prepare.resolution_types import EliminationStage, EvaluationResult
 
@@ -22,6 +23,13 @@ def scope_callout(scope: str | type[FeatureGroup] | None) -> str | None:
         return None
     scope_name = scope.get_class_name() if isinstance(scope, type) else scope
     return f"Scoped to feature group: '{scope_name}'."
+
+
+def domain_callout(domain: Domain | None) -> str | None:
+    """Render the shared domain callout, or None when the request carries no domain."""
+    if domain is None:
+        return None
+    return f"Requested domain: '{domain.name}'."
 
 
 def _candidate_sort_key(feature_group: type[FeatureGroup]) -> tuple[str, str]:
@@ -93,7 +101,9 @@ def _render_multiple(result: EvaluationResult, feature: Feature, callout: str | 
     )
 
 
-def _render_abstract_only(result: EvaluationResult, feature: Feature, callout: str | None) -> str:
+def _render_abstract_only(
+    result: EvaluationResult, feature: Feature, callout: str | None, domain_note: str | None
+) -> str:
     feature_name = str(feature.name)
     if not result.facts.concrete_frameworks:
         msg = (
@@ -109,10 +119,11 @@ def _render_abstract_only(result: EvaluationResult, feature: Feature, callout: s
             f"none of which are available or enabled for this run."
         )
 
-    # Place the callout on the sentence line, before the near-miss block, exactly as _render_none does, so it
-    # is never space-glued to the last near-miss bullet.
-    if callout:
-        msg += f" {callout}"
+    # Place the callouts on the sentence line, before the near-miss block, exactly as _render_none does, so
+    # neither is ever space-glued to the last near-miss bullet.
+    for note in (callout, domain_note):
+        if note:
+            msg += f" {note}"
 
     near_miss = _render_near_miss_block(result, feature)
     if near_miss is not None:
@@ -120,12 +131,13 @@ def _render_abstract_only(result: EvaluationResult, feature: Feature, callout: s
     return msg
 
 
-def _render_none(result: EvaluationResult, feature: Feature, callout: str | None) -> str:
+def _render_none(result: EvaluationResult, feature: Feature, callout: str | None, domain_note: str | None) -> str:
     feature_name = str(feature.name)
     msg = f"No feature groups found for feature name: '{feature_name}'."
 
-    if callout:
-        msg += f" {callout}"
+    for note in (callout, domain_note):
+        if note:
+            msg += f" {note}"
 
     near_miss = _render_near_miss_block(result, feature)
     if near_miss is not None:
@@ -139,6 +151,7 @@ def _render_none(result: EvaluationResult, feature: Feature, callout: str | None
     if similar:
         msg += f"\nDid you mean one of: {similar}?"
 
+    # Only the scope widens the pointer: resolve_feature takes the domain on the Feature, not as a keyword.
     pointer_args = "name, options=..., feature_group=..." if callout else "name, options=..."
     msg += (
         f"\nUse resolve_feature({pointer_args}) to debug feature resolution."
@@ -160,9 +173,12 @@ def render_resolution_failure(result: EvaluationResult, feature: Feature) -> str
     callout = scope_callout(feature.feature_group_scope)
 
     if kind == "multiple":
+        # No domain callout here: every candidate line of that message already carries its own domain.
         return _render_multiple(result, feature, callout)
 
-    if result.abstract_matched:
-        return _render_abstract_only(result, feature, callout)
+    domain_note = domain_callout(feature.domain)
 
-    return _render_none(result, feature, callout)
+    if result.abstract_matched:
+        return _render_abstract_only(result, feature, callout, domain_note)
+
+    return _render_none(result, feature, callout, domain_note)

--- a/tests/test_core/test_prepare/test_resolution_failure_renderer.py
+++ b/tests/test_core/test_prepare/test_resolution_failure_renderer.py
@@ -84,6 +84,26 @@ RAISING_DEAD_NAMES_SPARE_791 = "renderer_raising_dead_names_spare_791"
 DISABLED_PAIR_FEATURE_791 = "renderer_disabled_pair_revenue_791"
 DISABLED_PAIR_SPARE_791 = "renderer_disabled_pair_profit_791"
 
+# The name-blind gates. Each pair is a requested name nothing matches plus the sibling name the group that
+# loses at the gate declares, so only the gate can decide whether that sibling is worth suggesting.
+DOMAIN_GATE_FEATURE_791 = "renderer_domain_gate_revenue_791"
+DOMAIN_GATE_SIBLING_791 = "renderer_domain_gate_profit_791"
+SCOPE_GATE_FEATURE_791 = "renderer_scope_gate_revenue_791"
+SCOPE_GATE_SIBLING_791 = "renderer_scope_gate_profit_791"
+VALUE_DOMAIN_FEATURE_791 = "renderer_value_domain_revenue_791"
+VALUE_DOMAIN_SPARE_791 = "renderer_value_domain_profit_791"
+DEGRADED_DOMAIN_FEATURE_791 = "renderer_degraded_domain_revenue_791"
+DEGRADED_DOMAIN_SPARE_791 = "renderer_degraded_domain_profit_791"
+
+# The requested domain is declared by no candidate at all, so every domain-carrying request below fails it.
+REQUESTED_DOMAIN_791 = "renderer_requested_domain_791"
+OTHER_DOMAIN_791 = "renderer_other_domain_791"
+
+# Scope of the name-blind scope gate: a healthy group of this module, so the scope names a real accessible class.
+GATE_SCOPE_791 = "RendererKnownNamesFG791"
+
+VALUE_DOMAIN_REJECTION_REASON_791 = "ValueRejectingCrossDomainFG791 declines every value of this option"
+
 # Built around the class names below, because the default matcher also owns a name by class-name PREFIX.
 # The request drops the trailing underscore, so nothing matches it while both declared names stay close to it.
 LIVE_PREFIX_FEATURE_791 = "RendererLivePrefixFG791sum_791"
@@ -105,6 +125,9 @@ UNLABELED_STAGE_REASON_791 = "eliminated at a stage this build has no label for"
 
 # The renderer's own module logger: the degrade must be reported by the module that degrades.
 RENDERER_LOGGER_791 = "mloda.core.prepare.resolution_failure_renderer"
+
+# The matcher's own module logger: a degraded domain read happens during evaluate(), never during rendering.
+IDENTIFY_LOGGER_791 = "mloda.core.prepare.identify_feature_group"
 
 # Eight names, all close to WIDE_FEATURE_791, so only the cut can bound the rendered line.
 WIDE_CATALOG_NAMES_791 = frozenset(
@@ -600,6 +623,50 @@ class RendererDeadPrefixFG791(CountingFeatureGroup791):
     FRAMEWORK_RULE = {RendererFwOne791, RendererFwTwo791}
 
 
+class CrossDomainDeclarerFG791(CountingFeatureGroup791):
+    """Declares and matches the sibling name only, from a domain no request here asks for.
+
+    Named far from both feature names on purpose: only its declared name may ever reach the suggestion line.
+    """
+
+    MATCHES = frozenset({DOMAIN_GATE_SIBLING_791})
+    SUPPORTED_NAMES = frozenset({DOMAIN_GATE_SIBLING_791})
+    DOMAIN_NAME = OTHER_DOMAIN_791
+    FRAMEWORK_RULE = {RendererFwOne791}
+
+
+class OutsideScopeDeclarerFG791(CountingFeatureGroup791):
+    """Declares and matches the sibling name only, from outside the scope every request here asks for.
+
+    Named far from both feature names on purpose: only its declared name may ever reach the suggestion line.
+    """
+
+    MATCHES = frozenset({SCOPE_GATE_SIBLING_791})
+    SUPPORTED_NAMES = frozenset({SCOPE_GATE_SIBLING_791})
+    FRAMEWORK_RULE = {RendererFwOne791}
+
+
+class ValueRejectingCrossDomainFG791(CountingFeatureGroup791):
+    """Declines THIS name's value at the matcher AND sits in another domain: name-dependent record, name-blind gate."""
+
+    MATCHES = frozenset({VALUE_DOMAIN_FEATURE_791})
+    SUPPORTED_NAMES = frozenset({VALUE_DOMAIN_SPARE_791})
+    DOMAIN_NAME = OTHER_DOMAIN_791
+    FRAMEWORK_RULE = {RendererFwOne791}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        # Name-guarded, so this globally visible class stays inert for every other name it is asked about.
+        if not super().match_feature_group_criteria(feature_name, options, data_access_collection):
+            return False
+        raise PropertyValueRejection(VALUE_DOMAIN_REJECTION_REASON_791)
+
+
 class RendererDomainBoom791(RuntimeError):
     """Raised by a provider's get_domain() hook."""
 
@@ -667,6 +734,28 @@ def _build_raising_domain_groups() -> tuple[type[CountingFeatureGroup791], type[
         FRAMEWORK_RULE = {RendererFwOne791}
 
     return _armed(RendererRaisingDomainFG791), RendererHealthyDomainFG791
+
+
+def _build_unreadable_domain_group() -> type[CountingFeatureGroup791]:
+    """Build a non-matching declarer of a sibling name whose get_domain() raises, so no gate can judge it.
+
+    Named far from both feature names on purpose: only its declared name may ever reach the suggestion line.
+    """
+
+    class UnreadableDomainFG791(RaisingHookGroup791):
+        """Declarer whose domain can never be read, matching nothing."""
+
+        SUPPORTED_NAMES = frozenset({DEGRADED_DOMAIN_SPARE_791})
+        FRAMEWORK_RULE = {RendererFwOne791}
+
+        @classmethod
+        def get_domain(cls) -> Domain:
+            _record(cls.get_class_name(), "get_domain")
+            if cls.ARMED:
+                raise RendererDomainBoom791("get_domain exploded 791")
+            return Domain.get_default_domain()
+
+    return _armed(UnreadableDomainFG791)
 
 
 def _build_raising_prefix_group() -> type[CountingFeatureGroup791]:
@@ -1002,6 +1091,67 @@ def live_prefix_success_scenario() -> Scenario:
     )
 
 
+def domain_gate_scenario() -> Scenario:
+    """A domain-carrying request nothing matches, next to a declarer of the close sibling name in another domain."""
+    return (
+        Feature(DOMAIN_GATE_FEATURE_791, domain=REQUESTED_DOMAIN_791),
+        {CrossDomainDeclarerFG791: {RendererFwOne791}},
+    )
+
+
+def domain_gate_sibling_scenario() -> Scenario:
+    """The same request domain, now asking for the sibling name a suggestion would hand back."""
+    return (
+        Feature(DOMAIN_GATE_SIBLING_791, domain=REQUESTED_DOMAIN_791),
+        {CrossDomainDeclarerFG791: {RendererFwOne791}},
+    )
+
+
+def domainless_gate_scenario() -> Scenario:
+    """The same declarer on a request carrying NO domain, where the domain gate cannot fire at all."""
+    return Feature(DOMAIN_GATE_FEATURE_791), {CrossDomainDeclarerFG791: {RendererFwOne791}}
+
+
+def domain_hook_cost_scenario() -> Scenario:
+    """One candidate the decision pass compares by domain, one it never matches, on a domain-carrying request."""
+    return (
+        Feature(DOMAIN_GATE_SIBLING_791, domain=REQUESTED_DOMAIN_791),
+        {CrossDomainDeclarerFG791: {RendererFwOne791}, ValueRejectingCrossDomainFG791: {RendererFwOne791}},
+    )
+
+
+def scope_gate_scenario() -> Scenario:
+    """A scoped request nothing matches, next to a declarer of the close sibling name outside that scope."""
+    return (
+        Feature(SCOPE_GATE_FEATURE_791, feature_group=GATE_SCOPE_791),
+        {OutsideScopeDeclarerFG791: {RendererFwOne791}, RendererKnownNamesFG791: {RendererFwOne791}},
+    )
+
+
+def scope_gate_sibling_scenario() -> Scenario:
+    """The same scope, now asking for the sibling name a suggestion would hand back."""
+    return (
+        Feature(SCOPE_GATE_SIBLING_791, feature_group=GATE_SCOPE_791),
+        {OutsideScopeDeclarerFG791: {RendererFwOne791}, RendererKnownNamesFG791: {RendererFwOne791}},
+    )
+
+
+def value_rejection_cross_domain_scenario() -> Scenario:
+    """A candidate recorded at a name-DEPENDENT stage that the name-blind domain gate kills anyway."""
+    return (
+        Feature(VALUE_DOMAIN_FEATURE_791, domain=REQUESTED_DOMAIN_791),
+        {ValueRejectingCrossDomainFG791: {RendererFwOne791}},
+    )
+
+
+def degraded_domain_scenario() -> Scenario:
+    """A domain-carrying request whose only declarer of the close sibling name cannot report its domain."""
+    return (
+        Feature(DEGRADED_DOMAIN_FEATURE_791, domain=REQUESTED_DOMAIN_791),
+        {_build_unreadable_domain_group(): {RendererFwOne791}},
+    )
+
+
 def raising_dead_names_scenario() -> Scenario:
     """A dead candidate whose feature_names_supported() raises, so it can contribute no name at all."""
     return Feature(RAISING_DEAD_NAMES_FEATURE_791), {_build_raising_dead_names_group(): set()}
@@ -1061,6 +1211,10 @@ FAILING_SCENARIOS: dict[str, Callable[[], Scenario]] = {
     "disabled_pair": disabled_pair_scenario,
     "disabled_pair_reverse": disabled_pair_reverse_scenario,
     "live_prefix": live_prefix_scenario,
+    "domain_gate": domain_gate_scenario,
+    "scope_gate": scope_gate_scenario,
+    "value_rejection_cross_domain": value_rejection_cross_domain_scenario,
+    "degraded_domain": degraded_domain_scenario,
     "raising_dead_names": raising_dead_names_scenario,
     "raising_domain_multiple": raising_domain_multiple_scenario,
     "raising_prefix_none": raising_prefix_none_scenario,
@@ -1925,6 +2079,184 @@ class TestALivePrefixKeepsACoveredNameSuggestible:
         assert set(suggestions) == {LIVE_PREFIX_COVERED_791, "RendererLivePrefixFG791", "RendererLivePrefixFG791_"}
         assert LIVE_PREFIX_COVERED_791 not in result.facts.dead_only_names
         assert DEAD_PREFIX_UNCOVERED_791 in result.facts.dead_only_names
+
+
+class TestANameBlindGateKillsEveryNameItsCandidateDeclares:
+    """domain and scope are name-blind, so a candidate that loses at either resolves NO name it declares.
+
+    An elimination is recorded only for a candidate that first matched the requested name, so a wrong-domain or
+    out-of-scope group that never matched carries no record at all. Reading deadness off the record alone counts
+    such a group as a live declarer, and the suggestion then hands back a name that fails at the very same gate.
+    """
+
+    def test_a_wrong_domain_declarers_sibling_name_is_never_suggested(self) -> None:
+        """The declarer never matched the requested name, so only the gate itself can say it is dead."""
+        scenario = domain_gate_scenario()
+        feature, _ = scenario
+        result = _evaluate(scenario)
+
+        # Premise: nothing matched, so this candidate carries no elimination record to judge it by.
+        assert result.failure_kind == "none"
+        assert result.eliminations == {}
+        # Premise: the sibling is the one name this request ranks, so only this rule can drop it.
+        survivors = [name for name in dict.fromkeys(result.facts.known_names) if name != DOMAIN_GATE_FEATURE_791]
+        ranked = get_close_matches(DOMAIN_GATE_FEATURE_791, survivors, n=MAX_RENDERED_SUGGESTIONS_791, cutoff=0.5)
+        assert ranked == [DOMAIN_GATE_SIBLING_791]
+
+        # Suppression is resolution, not just text: requesting the sibling fails at the same gate.
+        sibling = _evaluate(domain_gate_sibling_scenario())
+        assert sibling.failure_kind == "none"
+        assert sibling.eliminations[CrossDomainDeclarerFG791].stage == "domain"
+
+        assert DOMAIN_GATE_SIBLING_791 in result.facts.dead_only_names
+
+        message = render_resolution_failure(result, feature)
+        assert message is not None
+        assert message == (
+            f"No feature groups found for feature name: '{DOMAIN_GATE_FEATURE_791}'.\n"
+            "Use resolve_feature(name, options=...) to debug feature resolution.\n"
+            f"{TROUBLESHOOTING_LINE}"
+        )
+
+    def test_an_out_of_scope_declarers_sibling_name_is_never_suggested(self) -> None:
+        """Same shape at the scope gate: the out-of-scope name goes, the in-scope group's own name stays."""
+        scenario = scope_gate_scenario()
+        feature, _ = scenario
+        result = _evaluate(scenario)
+
+        # Premise: nothing matched, so this candidate carries no elimination record to judge it by.
+        assert result.failure_kind == "none"
+        assert result.eliminations == {}
+        # Premise: the out-of-scope sibling outranks the in-scope group's own name, so only this rule can drop it.
+        survivors = [name for name in dict.fromkeys(result.facts.known_names) if name != SCOPE_GATE_FEATURE_791]
+        ranked = get_close_matches(SCOPE_GATE_FEATURE_791, survivors, n=MAX_RENDERED_SUGGESTIONS_791, cutoff=0.5)
+        assert ranked == [SCOPE_GATE_SIBLING_791, KNOWN_FEATURE_791]
+
+        # Suppression is resolution, not just text: requesting the sibling fails at the same gate.
+        sibling = _evaluate(scope_gate_sibling_scenario())
+        assert sibling.failure_kind == "none"
+        assert sibling.eliminations[OutsideScopeDeclarerFG791].stage == "scope"
+
+        assert SCOPE_GATE_SIBLING_791 in result.facts.dead_only_names
+        # The in-scope group is untouched by the gate, so its own name stays suggestible.
+        assert KNOWN_FEATURE_791 not in result.facts.dead_only_names
+
+        message = render_resolution_failure(result, feature)
+        assert message is not None
+        assert message == (
+            f"No feature groups found for feature name: '{SCOPE_GATE_FEATURE_791}'. "
+            f"Scoped to feature group: '{GATE_SCOPE_791}'.\n"
+            f"Did you mean one of: ['{KNOWN_FEATURE_791}']?\n"
+            "Use resolve_feature(name, options=..., feature_group=...) to debug feature resolution.\n"
+            f"{TROUBLESHOOTING_LINE}"
+        )
+
+    def test_a_name_dependent_record_does_not_revive_a_wrong_domain_candidate(self) -> None:
+        """The record says value_rejection, but the domain gate kills every name the candidate declares."""
+        scenario = value_rejection_cross_domain_scenario()
+        feature, _ = scenario
+        result = _evaluate(scenario)
+
+        # Premise: the recorded stage is name-DEPENDENT, so the record alone keeps this candidate live.
+        assert result.eliminations == {
+            ValueRejectingCrossDomainFG791: Elimination(
+                stage="value_rejection", reason=VALUE_DOMAIN_REJECTION_REASON_791
+            )
+        }
+        assert "value_rejection" in NAME_DEPENDENT_STAGES_791
+        # Premise: the spare is the one name this request ranks, so only this rule can drop it.
+        droppable = {VALUE_DOMAIN_FEATURE_791, *result.facts.eliminated_hints}
+        survivors = [name for name in dict.fromkeys(result.facts.known_names) if name not in droppable]
+        ranked = get_close_matches(VALUE_DOMAIN_FEATURE_791, survivors, n=MAX_RENDERED_SUGGESTIONS_791, cutoff=0.5)
+        assert ranked == [VALUE_DOMAIN_SPARE_791]
+
+        assert VALUE_DOMAIN_SPARE_791 in result.facts.dead_only_names
+
+        message = render_resolution_failure(result, feature)
+        assert message is not None
+        assert message == (
+            f"No feature groups found for feature name: '{VALUE_DOMAIN_FEATURE_791}'.\n"
+            f"Feature group(s) eliminated while matching '{VALUE_DOMAIN_FEATURE_791}':\n"
+            f"  - ValueRejectingCrossDomainFG791 (option value): {VALUE_DOMAIN_REJECTION_REASON_791}\n"
+            "Use resolve_feature(name, options=...) to debug feature resolution.\n"
+            f"{TROUBLESHOOTING_LINE}"
+        )
+
+
+class TestADegradedDomainReadNeverDecidesAgainstACandidate:
+    """A domain that cannot be read is not a wrong domain: the candidate stays live and the degrade is reported."""
+
+    def test_a_raising_get_domain_keeps_the_candidates_names_suggestible(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """evaluate() still returns, the message still renders, and the unreadable candidate keeps its names."""
+        scenario = degraded_domain_scenario()
+        feature, accessible_plugins = scenario
+        (unreadable,) = accessible_plugins
+
+        with caplog.at_level(logging.WARNING, logger=IDENTIFY_LOGGER_791):
+            result = _evaluate(scenario)
+
+        # Premise: the request carries a domain, and the candidate never matched, so no decision gate judged it.
+        assert feature.domain is not None
+        assert result.failure_kind == "none"
+        assert result.eliminations == {}
+
+        assert DEGRADED_DOMAIN_SPARE_791 not in result.facts.dead_only_names
+
+        message = render_resolution_failure(result, feature)
+        assert message is not None
+        assert _suggestions(message) == [DEGRADED_DOMAIN_SPARE_791]
+
+        warnings = [
+            record.getMessage()
+            for record in caplog.records
+            if record.levelno == logging.WARNING and record.name == IDENTIFY_LOGGER_791
+        ]
+        degraded_field = f"{unreadable.get_class_name()}.get_domain"
+        assert [warning for warning in warnings if degraded_field in warning], (
+            f"Expected a WARNING naming '{degraded_field}', got {warnings}"
+        )
+
+
+class TestTheNameBlindGateCaptureCostsNoExtraHookCall:
+    """The capture reuses the decision pass's memoized domain outcome, and asks for nothing it cannot use."""
+
+    def test_a_domainless_request_never_reads_a_non_matching_candidates_domain(self) -> None:
+        """Without a requested domain the gate cannot fire, so the hook must not be called at all."""
+        scenario = domainless_gate_scenario()
+        feature, _ = scenario
+        result = _evaluate(scenario)
+
+        # Premise: no domain to compare against, and the candidate never matched, so no gate can judge it.
+        assert feature.domain is None
+        assert result.failure_kind == "none"
+        assert result.eliminations == {}
+        # Premise: this candidate's counters are wired, so the assertion below is about the hook, not the key.
+        assert HOOK_CALLS["CrossDomainDeclarerFG791.match_feature_group_criteria"] == 1
+
+        assert "CrossDomainDeclarerFG791.get_domain" not in HOOK_CALLS
+        # The gate cannot fire, so the candidate stays live and keeps every name it declares suggestible.
+        assert result.facts.dead_only_names == frozenset()
+
+    def test_each_candidates_domain_is_read_at_most_once_per_evaluation(self) -> None:
+        """One decision-pass read plus one capture read of the same candidate is one hook call, not two."""
+        scenario = domain_hook_cost_scenario()
+        _, accessible_plugins = scenario
+        result = _evaluate(scenario)
+
+        # Premise: one candidate reached the decision-side domain gate, the other never matched at all.
+        assert result.eliminations[CrossDomainDeclarerFG791].stage == "domain"
+        assert ValueRejectingCrossDomainFG791 not in result.eliminations
+        # Premise: the capture really does need the second candidate's domain, so the bound is not vacuous.
+        assert VALUE_DOMAIN_SPARE_791 in result.facts.dead_only_names
+
+        counts = {
+            candidate.get_class_name(): HOOK_CALLS.get(f"{candidate.get_class_name()}.get_domain", 0)
+            for candidate in accessible_plugins
+        }
+        assert counts["CrossDomainDeclarerFG791"] == 1, counts
+        assert all(count <= 1 for count in counts.values()), counts
 
 
 class TestEveryEliminationStageIsClassified:

--- a/tests/test_core/test_prepare/test_resolution_failure_renderer.py
+++ b/tests/test_core/test_prepare/test_resolution_failure_renderer.py
@@ -10,6 +10,7 @@ hook. The feature groups below count every such hook, so a renderer that calls o
 All names are suffixed ``_791`` because test feature groups become global subclasses.
 """
 
+import inspect
 import logging
 from abc import abstractmethod
 from ast import literal_eval
@@ -94,6 +95,16 @@ VALUE_DOMAIN_FEATURE_791 = "renderer_value_domain_revenue_791"
 VALUE_DOMAIN_SPARE_791 = "renderer_value_domain_profit_791"
 DEGRADED_DOMAIN_FEATURE_791 = "renderer_degraded_domain_revenue_791"
 DEGRADED_DOMAIN_SPARE_791 = "renderer_degraded_domain_profit_791"
+MALFORMED_DOMAIN_FEATURE_791 = "renderer_malformed_domain_revenue_791"
+MALFORMED_DOMAIN_SPARE_791 = "renderer_malformed_domain_profit_791"
+
+# A get_domain() return that is not a Domain at all: the decision gate compares it and drops the candidate.
+MALFORMED_DOMAIN_VALUE_791 = "renderer_not_a_domain_791"
+
+# The name an abstract base and a framework-less concrete group both declare, plus a typo of it that
+# nothing matches: only whether the abstract base counts as a live declarer decides the suggestion.
+ABSTRACT_DECLARER_NAME_791 = "renderer_uninstantiable_revenue_791"
+ABSTRACT_DECLARER_TYPO_791 = "renderer_uninstantiable_revneue_791"
 
 # The requested domain is declared by no candidate at all, so every domain-carrying request below fails it.
 REQUESTED_DOMAIN_791 = "renderer_requested_domain_791"
@@ -109,6 +120,13 @@ VALUE_DOMAIN_REJECTION_REASON_791 = "ValueRejectingCrossDomainFG791 declines eve
 LIVE_PREFIX_FEATURE_791 = "RendererLivePrefixFG791sum_791"
 LIVE_PREFIX_COVERED_791 = "RendererLivePrefixFG791_sum_791"
 DEAD_PREFIX_UNCOVERED_791 = "RendererDeadPrefixFG791_sum_791"
+
+# The two names the default matcher owns by class identity: the class name itself and its prefix. Neither is
+# declared by anything, so only the candidate that carries them can keep them suggestible. The request is a
+# typo of the class name, close to both and matching neither.
+DEAD_CLASS_NAME_791 = "RendererCrossDomainNameFG791"
+DEAD_CLASS_PREFIX_791 = "RendererCrossDomainNameFG791_"
+DEAD_CLASS_NAME_TYPO_791 = "RendererCrossDoaminNameFG791"
 
 VALUE_STAGE_REJECTION_REASON_791 = "renderer_value_stage_791 declines every value of this option"
 
@@ -177,6 +195,15 @@ def _record_pair(class_name: str, framework_name: str) -> None:
     """Count one capability-hook call for a single (candidate, framework) pair."""
     key = (class_name, framework_name)
     PAIR_CALLS[key] = PAIR_CALLS.get(key, 0) + 1
+
+
+def _malformed(value: Any) -> Any:
+    """Return a deliberately ill-typed value.
+
+    A provider's annotation is a promise, not a guarantee: hiding the value from the type checker is how a
+    real plugin's runtime bug reaches mloda. The gate that compares it still decides, so the core must too.
+    """
+    return value
 
 
 class RendererFwOne791(ComputeFramework):
@@ -635,6 +662,36 @@ class CrossDomainDeclarerFG791(CountingFeatureGroup791):
     FRAMEWORK_RULE = {RendererFwOne791}
 
 
+class RendererCrossDomainNameFG791(CountingFeatureGroup791):
+    """Declares no name at all and owns two by class identity, from a domain no request here asks for.
+
+    Named CLOSE to its request on purpose: the class name and the prefix are the only names it can contribute.
+    """
+
+    DOMAIN_NAME = OTHER_DOMAIN_791
+    FRAMEWORK_RULE = {RendererFwOne791}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        _record(cls.get_class_name(), "match_feature_group_criteria")
+        # The two class-identity rules of the default matcher, and the two names the catalog captures for it.
+        name = str(feature_name)
+        return cls.feature_name_equal_to_class_name(name) or cls.feature_name_contains_class_name_as_prefix(name)
+
+
+class RendererLiveNameDeclarerFG791(CountingFeatureGroup791):
+    """Live declarer of the wrong-domain group's two class-identity names, in the requested domain."""
+
+    SUPPORTED_NAMES = frozenset({DEAD_CLASS_NAME_791, DEAD_CLASS_PREFIX_791})
+    DOMAIN_NAME = REQUESTED_DOMAIN_791
+    FRAMEWORK_RULE = {RendererFwOne791}
+
+
 class OutsideScopeDeclarerFG791(CountingFeatureGroup791):
     """Declares and matches the sibling name only, from outside the scope every request here asks for.
 
@@ -643,6 +700,34 @@ class OutsideScopeDeclarerFG791(CountingFeatureGroup791):
 
     MATCHES = frozenset({SCOPE_GATE_SIBLING_791})
     SUPPORTED_NAMES = frozenset({SCOPE_GATE_SIBLING_791})
+    FRAMEWORK_RULE = {RendererFwOne791}
+
+
+class SpareAbstractBaseFG791(CountingFeatureGroup791):
+    """Abstract base declaring and matching one name, in the requested domain: it can never be identified.
+
+    Named far from both feature names on purpose: only its declared name may ever reach the suggestion line.
+    """
+
+    MATCHES = frozenset({ABSTRACT_DECLARER_NAME_791})
+    SUPPORTED_NAMES = frozenset({ABSTRACT_DECLARER_NAME_791})
+    DOMAIN_NAME = REQUESTED_DOMAIN_791
+    FRAMEWORK_RULE = {RendererFwOne791}
+
+    @classmethod
+    @abstractmethod
+    def _renderer_spare_abstract_hook_791(cls) -> str:
+        """Abstract hook that keeps this base uninstantiable."""
+
+
+class SpareDeadTwinFG791(CountingFeatureGroup791):
+    """Concrete declarer of the same name, left without a single enabled framework by every run below.
+
+    Named far from both feature names on purpose: only its declared name may ever reach the suggestion line.
+    """
+
+    MATCHES = frozenset({ABSTRACT_DECLARER_NAME_791})
+    SUPPORTED_NAMES = frozenset({ABSTRACT_DECLARER_NAME_791})
     FRAMEWORK_RULE = {RendererFwOne791}
 
 
@@ -688,7 +773,9 @@ class RendererFrameworkRuleBoom791(RuntimeError):
 
 
 class RaisingHookGroup791(CountingFeatureGroup791):
-    """Base for the groups whose fact-capture hook raises. Its subclasses are ALWAYS built inside a function.
+    """Base for the groups whose fact-capture hook raises or returns a malformed value.
+
+    Its subclasses are ALWAYS built inside a function.
 
     ``ARMED`` is what makes that safe. A group built per test still outlives it: pytest keeps a failing
     test's traceback, and that traceback keeps the builder's frame (and so the class) alive and globally
@@ -756,6 +843,30 @@ def _build_unreadable_domain_group() -> type[CountingFeatureGroup791]:
             return Domain.get_default_domain()
 
     return _armed(UnreadableDomainFG791)
+
+
+def _build_malformed_domain_group() -> type[CountingFeatureGroup791]:
+    """Build a declarer of a sibling name whose get_domain() returns a bare str instead of a Domain.
+
+    Named far from both feature names on purpose: only its declared name may ever reach the suggestion line.
+    """
+
+    class BadDomainReturnFG791(RaisingHookGroup791):
+        """Declarer whose domain read is well-formed as a call and malformed as a value."""
+
+        MATCHES = frozenset({MALFORMED_DOMAIN_SPARE_791})
+        SUPPORTED_NAMES = frozenset({MALFORMED_DOMAIN_SPARE_791})
+        FRAMEWORK_RULE = {RendererFwOne791}
+
+        @classmethod
+        def get_domain(cls) -> Domain:
+            _record(cls.get_class_name(), "get_domain")
+            if cls.ARMED:
+                bad_domain: Domain = _malformed(MALFORMED_DOMAIN_VALUE_791)
+                return bad_domain
+            return Domain.get_default_domain()
+
+    return _armed(BadDomainReturnFG791)
 
 
 def _build_raising_prefix_group() -> type[CountingFeatureGroup791]:
@@ -1152,6 +1263,67 @@ def degraded_domain_scenario() -> Scenario:
     )
 
 
+def malformed_domain_scenario() -> Scenario:
+    """A domain-carrying request whose only declarer of the close sibling name returns a non-Domain domain."""
+    return (
+        Feature(MALFORMED_DOMAIN_FEATURE_791, domain=REQUESTED_DOMAIN_791),
+        {_build_malformed_domain_group(): {RendererFwOne791}},
+    )
+
+
+def malformed_domain_sibling_scenario() -> Scenario:
+    """The same request domain, now asking for the sibling name a suggestion would hand back."""
+    return (
+        Feature(MALFORMED_DOMAIN_SPARE_791, domain=REQUESTED_DOMAIN_791),
+        {_build_malformed_domain_group(): {RendererFwOne791}},
+    )
+
+
+def dead_class_name_scenario() -> Scenario:
+    """A domain-carrying request nothing matches, next to a wrong-domain group its typo names."""
+    return (
+        Feature(DEAD_CLASS_NAME_TYPO_791, domain=REQUESTED_DOMAIN_791),
+        {RendererCrossDomainNameFG791: {RendererFwOne791}},
+    )
+
+
+def dead_class_name_with_live_declarer_scenario() -> Scenario:
+    """The same request, now with a live group declaring both names the wrong-domain group owns."""
+    return (
+        Feature(DEAD_CLASS_NAME_TYPO_791, domain=REQUESTED_DOMAIN_791),
+        {RendererCrossDomainNameFG791: {RendererFwOne791}, RendererLiveNameDeclarerFG791: {RendererFwOne791}},
+    )
+
+
+def dead_class_name_echo_scenario(name: str) -> Scenario:
+    """The same request domain, now asking for one of the two names a suggestion would hand back."""
+    return Feature(name, domain=REQUESTED_DOMAIN_791), {RendererCrossDomainNameFG791: {RendererFwOne791}}
+
+
+def abstract_declarer_typo_scenario() -> Scenario:
+    """A typo nothing matches, next to an abstract declarer of the close name and a framework-less twin."""
+    return (
+        Feature(ABSTRACT_DECLARER_TYPO_791),
+        {SpareAbstractBaseFG791: {RendererFwOne791}, SpareDeadTwinFG791: set()},
+    )
+
+
+def abstract_declarer_name_scenario() -> Scenario:
+    """The same two groups, now asking for the name a suggestion would hand back."""
+    return (
+        Feature(ABSTRACT_DECLARER_NAME_791),
+        {SpareAbstractBaseFG791: {RendererFwOne791}, SpareDeadTwinFG791: set()},
+    )
+
+
+def abstract_domain_gate_scenario() -> Scenario:
+    """An abstract-only failure on a request that carries the domain the abstract base declares."""
+    return (
+        Feature(ABSTRACT_DECLARER_NAME_791, domain=REQUESTED_DOMAIN_791),
+        {SpareAbstractBaseFG791: {RendererFwOne791}},
+    )
+
+
 def raising_dead_names_scenario() -> Scenario:
     """A dead candidate whose feature_names_supported() raises, so it can contribute no name at all."""
     return Feature(RAISING_DEAD_NAMES_FEATURE_791), {_build_raising_dead_names_group(): set()}
@@ -1215,6 +1387,10 @@ FAILING_SCENARIOS: dict[str, Callable[[], Scenario]] = {
     "scope_gate": scope_gate_scenario,
     "value_rejection_cross_domain": value_rejection_cross_domain_scenario,
     "degraded_domain": degraded_domain_scenario,
+    "malformed_domain": malformed_domain_scenario,
+    "dead_class_name": dead_class_name_scenario,
+    "abstract_declarer_typo": abstract_declarer_typo_scenario,
+    "abstract_domain_gate": abstract_domain_gate_scenario,
     "raising_dead_names": raising_dead_names_scenario,
     "raising_domain_multiple": raising_domain_multiple_scenario,
     "raising_prefix_none": raising_prefix_none_scenario,
@@ -1971,7 +2147,7 @@ class TestSuggestionsNeverPointAtADeadGroupsSiblingName:
         assert _suggestions(message) is None
 
     def test_a_raising_names_hook_on_a_dead_candidate_contributes_nothing(self) -> None:
-        """A dead candidate whose name hook raises degrades to no dead name, and takes nothing else down."""
+        """A dead candidate whose name hook raises declares no dead name, and takes nothing else down."""
         scenario = raising_dead_names_scenario()
         feature, accessible_plugins = scenario
         (raising,) = accessible_plugins
@@ -1980,7 +2156,10 @@ class TestSuggestionsNeverPointAtADeadGroupsSiblingName:
 
         assert result.eliminations[raising].stage == "frameworks_not_enabled"
         assert RAISING_DEAD_NAMES_SPARE_791 not in result.facts.known_names
-        assert result.facts.dead_only_names == frozenset()
+        # The declared names could not be read, so all this dead candidate contributes is its class identity:
+        # the hook that raised names nothing at all.
+        assert RAISING_DEAD_NAMES_SPARE_791 not in result.facts.dead_only_names
+        assert result.facts.dead_only_names == frozenset({raising.get_class_name(), raising.prefix()})
 
         message = render_resolution_failure(result, feature)
         assert message is not None
@@ -2113,7 +2292,8 @@ class TestANameBlindGateKillsEveryNameItsCandidateDeclares:
         message = render_resolution_failure(result, feature)
         assert message is not None
         assert message == (
-            f"No feature groups found for feature name: '{DOMAIN_GATE_FEATURE_791}'.\n"
+            f"No feature groups found for feature name: '{DOMAIN_GATE_FEATURE_791}'. "
+            f"Requested domain: '{REQUESTED_DOMAIN_791}'.\n"
             "Use resolve_feature(name, options=...) to debug feature resolution.\n"
             f"{TROUBLESHOOTING_LINE}"
         )
@@ -2175,7 +2355,8 @@ class TestANameBlindGateKillsEveryNameItsCandidateDeclares:
         message = render_resolution_failure(result, feature)
         assert message is not None
         assert message == (
-            f"No feature groups found for feature name: '{VALUE_DOMAIN_FEATURE_791}'.\n"
+            f"No feature groups found for feature name: '{VALUE_DOMAIN_FEATURE_791}'. "
+            f"Requested domain: '{REQUESTED_DOMAIN_791}'.\n"
             f"Feature group(s) eliminated while matching '{VALUE_DOMAIN_FEATURE_791}':\n"
             f"  - ValueRejectingCrossDomainFG791 (option value): {VALUE_DOMAIN_REJECTION_REASON_791}\n"
             "Use resolve_feature(name, options=...) to debug feature resolution.\n"
@@ -2255,8 +2436,208 @@ class TestTheNameBlindGateCaptureCostsNoExtraHookCall:
             candidate.get_class_name(): HOOK_CALLS.get(f"{candidate.get_class_name()}.get_domain", 0)
             for candidate in accessible_plugins
         }
+        # Both counts are pinned EXACTLY: an upper bound also holds when a hook is never called at all, so an
+        # edit that stopped asking about the non-matching candidate entirely would slip through it.
         assert counts["CrossDomainDeclarerFG791"] == 1, counts
-        assert all(count <= 1 for count in counts.values()), counts
+        assert counts["ValueRejectingCrossDomainFG791"] == 1, counts
+
+
+class TestADomainCarryingFailureNamesTheRequestedDomain:
+    """A request that carries a domain says so in its failure message, exactly as a scoped request does.
+
+    The domain is a gate the user set and the reason nothing resolved, so a message that never mentions it
+    describes a run the user did not ask for. The callout sits where ``scope_callout``'s does: on the sentence
+    line, before any near-miss block. The pointer line is unchanged, because ``resolve_feature`` takes the
+    domain on the Feature and has no domain keyword to name.
+    """
+
+    def test_a_none_failure_states_the_requested_domain(self) -> None:
+        """The whole none message, with the domain the request carried on its sentence line."""
+        scenario = domain_gate_scenario()
+        feature, _ = scenario
+        result = _evaluate(scenario)
+
+        # Premise: the request carries a domain, and that domain is why nothing resolved.
+        assert feature.domain is not None
+        assert feature.domain.name == REQUESTED_DOMAIN_791
+        assert result.failure_kind == "none"
+
+        message = render_resolution_failure(result, feature)
+        assert message is not None
+        assert message.split("\n")[0].endswith(f"Requested domain: '{REQUESTED_DOMAIN_791}'.")
+        assert message == (
+            f"No feature groups found for feature name: '{DOMAIN_GATE_FEATURE_791}'. "
+            f"Requested domain: '{REQUESTED_DOMAIN_791}'.\n"
+            "Use resolve_feature(name, options=...) to debug feature resolution.\n"
+            f"{TROUBLESHOOTING_LINE}"
+        )
+
+    def test_an_abstract_only_failure_states_the_requested_domain(self) -> None:
+        """Same callout in the same place on the other message that carries one."""
+        scenario = abstract_domain_gate_scenario()
+        feature, _ = scenario
+        result = _evaluate(scenario)
+
+        # Premise: the abstract base declares the requested domain, so the request reaches the abstract message.
+        assert feature.domain is not None
+        assert result.failure_kind == "abstract_only"
+
+        message = render_resolution_failure(result, feature)
+        assert message == (
+            f"No feature groups found for feature name: '{ABSTRACT_DECLARER_NAME_791}'. "
+            "Only abstract feature group base(s) matched, which cannot be instantiated; "
+            "no concrete implementation is available or enabled. "
+            f"Requested domain: '{REQUESTED_DOMAIN_791}'."
+        )
+
+
+class TestAnAbstractBaseIsNeverALiveDeclarer:
+    """An accessible abstract base can be matched but never identified, so it keeps no name suggestible.
+
+    ``_filter_loop`` parks an abstract candidate in ``abstract_matched`` and never in the identified mapping,
+    whatever name it is asked about: exactly the predicate the dead-name capture computes. Counting it as a
+    live declarer cancels a dead sibling's suppression, and the suggestion then hands back a name whose own
+    message only says the base cannot be instantiated.
+    """
+
+    def test_an_abstract_declarer_does_not_keep_a_dead_siblings_name_suggestible(self) -> None:
+        """The base is accessible and enabled, so only its abstractness can say it declares nothing live."""
+        scenario = abstract_declarer_typo_scenario()
+        feature, _ = scenario
+        result = _evaluate(scenario)
+
+        # Premise: the base is abstract, and nothing else about this run kills it.
+        assert inspect.isabstract(SpareAbstractBaseFG791)
+        assert feature.domain is None
+        assert feature.feature_group_scope is None
+        # Premise: neither candidate matched the typo, so no elimination record judges either of them.
+        assert result.failure_kind == "none"
+        assert result.eliminations == {}
+        # Premise: the shared name is the one name this request ranks, so only this rule can drop it.
+        survivors = [name for name in dict.fromkeys(result.facts.known_names) if name != ABSTRACT_DECLARER_TYPO_791]
+        ranked = get_close_matches(ABSTRACT_DECLARER_TYPO_791, survivors, n=MAX_RENDERED_SUGGESTIONS_791, cutoff=0.5)
+        assert ranked == [ABSTRACT_DECLARER_NAME_791]
+
+        # Suppression is resolution, not just text: following the suggestion renders the abstract-only message.
+        sibling_feature, sibling_plugins = abstract_declarer_name_scenario()
+        sibling = _evaluate((sibling_feature, sibling_plugins))
+        assert sibling.failure_kind == "abstract_only"
+        assert sibling.abstract_matched == {SpareAbstractBaseFG791}
+        assert render_resolution_failure(sibling, sibling_feature) == (
+            f"No feature groups found for feature name: '{ABSTRACT_DECLARER_NAME_791}'. "
+            "Only abstract feature group base(s) matched, which cannot be instantiated; "
+            "no concrete implementation is available or enabled.\n"
+            f"Feature group(s) eliminated while matching '{ABSTRACT_DECLARER_NAME_791}':\n"
+            "  - SpareDeadTwinFG791 (compute framework): none of its compute frameworks are enabled for this run"
+        )
+
+        assert ABSTRACT_DECLARER_NAME_791 in result.facts.dead_only_names
+
+        message = render_resolution_failure(result, feature)
+        assert message is not None
+        assert _suggestions(message) is None
+
+
+class TestADeadCandidatesClassNameAndPrefixAreSuppressedToo:
+    """A dead candidate owns two more names than it declares: its class name and its class-name prefix.
+
+    The live branch of the difference contributes the whole catalog (class name, declared names, prefix) while
+    the dead branch contributes only the declared names, and a candidate that never matched carries no
+    eliminated_hints entry either. So nothing suppresses the two names the default matcher owns by class
+    identity, and both are handed back although both are eliminated at the very same gate.
+    """
+
+    def test_a_dead_candidates_class_name_and_prefix_are_never_suggested(self) -> None:
+        """The wrong-domain group declares no name at all, so only its class identity can be suggested."""
+        scenario = dead_class_name_scenario()
+        feature, _ = scenario
+        result = _evaluate(scenario)
+
+        # Premise: the two constants really are this candidate's class-identity names.
+        assert RendererCrossDomainNameFG791.get_class_name() == DEAD_CLASS_NAME_791
+        assert RendererCrossDomainNameFG791.prefix() == DEAD_CLASS_PREFIX_791
+        # Premise: nothing matched the typo, so no record and no eliminated hint can reach either name.
+        assert result.failure_kind == "none"
+        assert result.eliminations == {}
+        assert result.facts.eliminated_hints == frozenset()
+        # Premise: both names are what this request ranks, so only this rule can drop them.
+        survivors = [name for name in dict.fromkeys(result.facts.known_names) if name != DEAD_CLASS_NAME_TYPO_791]
+        ranked = get_close_matches(DEAD_CLASS_NAME_TYPO_791, survivors, n=MAX_RENDERED_SUGGESTIONS_791, cutoff=0.5)
+        assert ranked == [DEAD_CLASS_NAME_791, DEAD_CLASS_PREFIX_791]
+
+        # Suppression is resolution, not just text: both names really are eliminated at the same gate.
+        for echo_name in (DEAD_CLASS_NAME_791, DEAD_CLASS_PREFIX_791):
+            echo = _evaluate(dead_class_name_echo_scenario(echo_name))
+            assert echo.failure_kind == "none"
+            assert echo.eliminations[RendererCrossDomainNameFG791].stage == "domain"
+
+        assert DEAD_CLASS_NAME_791 in result.facts.dead_only_names
+        assert DEAD_CLASS_PREFIX_791 in result.facts.dead_only_names
+
+        message = render_resolution_failure(result, feature)
+        assert message is not None
+        assert _suggestions(message) is None
+
+    def test_a_live_declarer_of_the_same_two_names_keeps_them_suggestible(self) -> None:
+        """Still a difference, not a per-candidate drop: one live declarer keeps both names worth suggesting."""
+        scenario = dead_class_name_with_live_declarer_scenario()
+        feature, _ = scenario
+        result = _evaluate(scenario)
+
+        # Premise: the live group matched nothing here, so nothing ever eliminates it.
+        assert result.failure_kind == "none"
+        assert RendererLiveNameDeclarerFG791 not in result.eliminations
+        assert RendererLiveNameDeclarerFG791.get_domain() == Domain(REQUESTED_DOMAIN_791)
+
+        assert result.facts.dead_only_names == frozenset()
+
+        message = render_resolution_failure(result, feature)
+        assert message is not None
+        suggestions = _suggestions(message)
+
+        assert suggestions is not None
+        assert {DEAD_CLASS_NAME_791, DEAD_CLASS_PREFIX_791} <= set(suggestions)
+
+
+class TestAMalformedDomainReturnIsDecidedLikeTheGateDecidesIt:
+    """The decision gate is ``domain == feature.domain``, so a non-Domain return FAILS it for every name.
+
+    A raise is the other case: there the gate raises rather than deciding, so nothing is known and the
+    candidate stays live (TestADegradedDomainReadNeverDecidesAgainstACandidate). Reading both through one
+    best-effort name that maps them onto the same None makes the capture disagree with the gate it retests:
+    the same malformed read eliminates a name-matching candidate at 'domain' and keeps a non-matching one alive.
+    """
+
+    def test_a_malformed_get_domain_return_kills_the_names_it_declares(self) -> None:
+        """The candidate never matched, so only the retest decides, and the gate would have decided against it."""
+        scenario = malformed_domain_scenario()
+        feature, accessible_plugins = scenario
+        (malformed,) = accessible_plugins
+        result = _evaluate(scenario)
+
+        # Premise: the request carries a domain, and the candidate never matched, so no gate recorded it.
+        assert feature.domain is not None
+        assert result.failure_kind == "none"
+        assert result.eliminations == {}
+        # Premise: the return really is not a Domain, so the gate compares it and decides against it.
+        assert not isinstance(malformed.get_domain(), Domain)
+        # Premise: the spare is the one name this request ranks, so only this rule can drop it.
+        survivors = [name for name in dict.fromkeys(result.facts.known_names) if name != MALFORMED_DOMAIN_FEATURE_791]
+        ranked = get_close_matches(MALFORMED_DOMAIN_FEATURE_791, survivors, n=MAX_RENDERED_SUGGESTIONS_791, cutoff=0.5)
+        assert ranked == [MALFORMED_DOMAIN_SPARE_791]
+
+        # Suppression is resolution, not just text: requesting the spare is eliminated at the domain gate.
+        sibling_feature, sibling_plugins = malformed_domain_sibling_scenario()
+        (sibling_group,) = sibling_plugins
+        sibling = _evaluate((sibling_feature, sibling_plugins))
+        assert sibling.failure_kind == "none"
+        assert sibling.eliminations[sibling_group].stage == "domain"
+
+        assert MALFORMED_DOMAIN_SPARE_791 in result.facts.dead_only_names
+
+        message = render_resolution_failure(result, feature)
+        assert message is not None
+        assert _suggestions(message) is None
 
 
 class TestEveryEliminationStageIsClassified:


### PR DESCRIPTION
## Problem

A "Did you mean" suggestion is suppressed when only dead feature groups declare the name, and a group counts as dead when it lost at a gate that cannot see the feature name. But `_filter_loop` records an elimination only for a candidate that first matched the name being resolved.

`domain` and `scope` are both name-blind, so a group that loses at either is dead for every name it declares. A wrong-domain group that simply did not match the requested name therefore carried no record, `_is_dead` returned False, and it counted as a live declarer keeping its own sibling names suggestible. Following one of those suggestions failed identically at the same gate.

## Decision

The capture now retests the two name-blind gates directly instead of reading the elimination record alone. The epic's rule that capture stays cheap holds:

- the scope gate is a class walk with no provider hook,
- the domain read is skipped entirely unless the request carries a domain, and otherwise reuses the per-evaluation memo, so no candidate's `get_domain` runs more than once,
- `_capture_known_names` already calls `feature_names_supported()` and `prefix()` on every accessible candidate on this path, so this is the same shape of work, not a new one.

Rendering is untouched and stays a pure projection: the retest lives in `evaluate()`.

Testing the gates rather than the record also covers a candidate whose record is name-*dependent* while a name-blind gate kills it anyway, such as one that declines this name's option value from the wrong domain.

## Also in this change

Suppressing those names removed the last signal a domain-carrying failure had, since the near-miss block lists only candidates that matched the name. A `domain_callout` now sits beside the existing `scope_callout` on the sentence line of the none and abstract_only messages. The multiple message keeps its per-candidate `[domain: ...]` suffix instead.

Three corrections to the deadness rule, each one line and each making the predicate mean what its docstring says. The first two also affect the pre-existing zero-framework path:

- an accessible abstract base is dead, since it can never be identified for any name,
- a dead candidate's class name and prefix are suppressed with its declared names, because the default matcher owns a name through those channels too,
- a `get_domain()` returning a non-`Domain` is dead rather than live: the decision gate compares that value and drops the candidate for every name, so the capture compares through the same `Domain` equality rather than by name. A *raising* read still leaves the candidate live, since there the gate raises instead of deciding, and the degrade is warned.

## Residual

`links` is the third name-blind gate and has the same record-less hole. It is deliberately not retested here: doing so needs `index_columns()` and the run's links per candidate, provider hooks the capture makes nowhere else, so it is a cost decision of its own. `_is_dead` now names it rather than implying the split is complete. The pre-existing residual is unchanged: the matcher's data-access branches can own a name too, and deciding one needs the speculative second match the renderer's contract refuses.

## Tests

11 tests in `tests/test_core/test_prepare/test_resolution_failure_renderer.py`. Each asserts its premise (the eliminations really are empty, the suggestion really is the only thing the rule can remove) and re-evaluates the suggested name to prove it would have failed. Cost is pinned too: a domainless request never reads a non-matching candidate's domain, and no candidate's `get_domain` is read twice.

Full `tox` green: 7802 passed, 170 skipped.
