### PR TITLE
test: pin the rendered near-miss label of every elimination stage

### DIFF
--- a/tests/test_core/test_prepare/test_candidate_elimination_reasons.py
+++ b/tests/test_core/test_prepare/test_candidate_elimination_reasons.py
@@ -396,9 +396,11 @@ def _fail(
 
 
 class TestEliminationStages:
-    """One test per stage except matcher_error: the eliminated candidate maps to the expected (stage, reason),
-    and the near-miss message line carries the contract's stage label. matcher_error needs a raising matcher, so
-    it is covered in tests/test_core/test_prepare/test_raising_matcher_containment.py."""
+    """One test per stage except matcher_error and input_data: the eliminated candidate maps to the expected
+    (stage, reason), and the near-miss message line carries the contract's stage label. matcher_error needs a
+    raising matcher, so it is covered in tests/test_core/test_prepare/test_raising_matcher_containment.py;
+    input_data needs a declining reader, so it is covered in
+    tests/test_plugins/feature_group/input_data/test_reader_match_rejections.py."""
 
     def test_value_rejection_stage(self) -> None:
         feature = Feature(VALUE_FEATURE)

--- a/tests/test_core/test_prepare/test_raising_matcher_containment.py
+++ b/tests/test_core/test_prepare/test_raising_matcher_containment.py
@@ -33,7 +33,7 @@ NEIGHBOR_FEATURE = "contained_neighbor_feat_845"
 # Deliberately dissimilar, so no "Did you mean" suggestion can name the broken class.
 UNRELATED_FEATURE = "zqx_no_group_owns_this_845"
 MATCHER_ERROR_STAGE = "matcher_error"
-# The near-miss label the renderer prints for that stage. This file is the only place it is pinned.
+# The near-miss label of that stage; the table pin is EXPECTED_STAGE_LABELS_791 in test_resolution_failure_renderer.py.
 MATCHER_ERROR_LABEL = "match hook"
 
 T = TypeVar("T")
@@ -215,35 +215,17 @@ class TestRaisingMatcherContainment:
         assert RAISE_MESSAGE in snapshot.reason
 
     def test_near_miss_block_names_the_broken_class(self) -> None:
-        """render_resolution_failure names the broken class, its exception type and its message."""
-        snapshot = _evaluate_own_feature()
-
-        assert snapshot.escaped is None
-        assert snapshot.message is not None
-        message = snapshot.message
-        assert f"Feature group(s) eliminated while matching '{BROKEN_OWN_FEATURE}':" in message
-        bullets = [line for line in message.split("\n") if line.startswith(f"  - {BROKEN_CLASS_NAME} (")]
-        assert len(bullets) == 1
-        assert RAISE_TYPE_NAME in bullets[0]
-        assert RAISE_MESSAGE in bullets[0]
-
-    def test_near_miss_bullet_labels_the_stage_match_hook(self) -> None:
-        """The whole bullet is pinned: renaming the matcher_error label changes this user-visible line."""
+        """The whole bullet is pinned: the broken class, the matcher_error stage label, and the reason."""
         snapshot = _evaluate_own_feature()
 
         assert snapshot.escaped is None
         assert snapshot.message is not None
         assert snapshot.reason is not None
-        # Premise: this bullet renders the matcher_error stage, so it is that stage's label under test.
-        assert snapshot.stage == MATCHER_ERROR_STAGE
         message = snapshot.message
         reason = snapshot.reason
-
+        assert f"Feature group(s) eliminated while matching '{BROKEN_OWN_FEATURE}':" in message
         bullets = [line for line in message.split("\n") if line.startswith(f"  - {BROKEN_CLASS_NAME} (")]
         assert bullets == [f"  - {BROKEN_CLASS_NAME} ({MATCHER_ERROR_LABEL}): {reason}"]
-        # The reason the bullet carries is the contained raise, as text.
-        assert RAISE_TYPE_NAME in reason
-        assert RAISE_MESSAGE in reason
 
     def test_recorded_reason_is_a_plain_string(self) -> None:
         """The contained raise is recorded as text: no exception object (and no traceback) is retained."""

--- a/tests/test_core/test_prepare/test_raising_matcher_containment.py
+++ b/tests/test_core/test_prepare/test_raising_matcher_containment.py
@@ -33,6 +33,8 @@ NEIGHBOR_FEATURE = "contained_neighbor_feat_845"
 # Deliberately dissimilar, so no "Did you mean" suggestion can name the broken class.
 UNRELATED_FEATURE = "zqx_no_group_owns_this_845"
 MATCHER_ERROR_STAGE = "matcher_error"
+# The near-miss label the renderer prints for that stage. This file is the only place it is pinned.
+MATCHER_ERROR_LABEL = "match hook"
 
 T = TypeVar("T")
 
@@ -224,6 +226,24 @@ class TestRaisingMatcherContainment:
         assert len(bullets) == 1
         assert RAISE_TYPE_NAME in bullets[0]
         assert RAISE_MESSAGE in bullets[0]
+
+    def test_near_miss_bullet_labels_the_stage_match_hook(self) -> None:
+        """The whole bullet is pinned: renaming the matcher_error label changes this user-visible line."""
+        snapshot = _evaluate_own_feature()
+
+        assert snapshot.escaped is None
+        assert snapshot.message is not None
+        assert snapshot.reason is not None
+        # Premise: this bullet renders the matcher_error stage, so it is that stage's label under test.
+        assert snapshot.stage == MATCHER_ERROR_STAGE
+        message = snapshot.message
+        reason = snapshot.reason
+
+        bullets = [line for line in message.split("\n") if line.startswith(f"  - {BROKEN_CLASS_NAME} (")]
+        assert bullets == [f"  - {BROKEN_CLASS_NAME} ({MATCHER_ERROR_LABEL}): {reason}"]
+        # The reason the bullet carries is the contained raise, as text.
+        assert RAISE_TYPE_NAME in reason
+        assert RAISE_MESSAGE in reason
 
     def test_recorded_reason_is_a_plain_string(self) -> None:
         """The contained raise is recorded as text: no exception object (and no traceback) is retained."""

--- a/tests/test_core/test_prepare/test_resolution_failure_renderer.py
+++ b/tests/test_core/test_prepare/test_resolution_failure_renderer.py
@@ -136,7 +136,27 @@ NAME_DEPENDENT_STAGES_791: frozenset[EliminationStage] = frozenset(
     {"value_rejection", "input_data", "matcher_error", "capability", "framework_pin"}
 )
 
-# Stands in for a ninth stage shipped without a near-miss label: no entry of the label table covers this token.
+# The label each stage renders. The keys are pinned complete against EliminationStage, the values against
+# _STAGE_LABELS, so neither a new stage nor a renamed label can ship unstated. Two stages share one label on
+# purpose (capability and frameworks_not_enabled both render 'compute framework'): this is stage -> label, and
+# label uniqueness is deliberately NOT pinned.
+EXPECTED_STAGE_LABELS_791: dict[EliminationStage, str] = {
+    "value_rejection": "option value",
+    "input_data": "input data",
+    "matcher_error": "match hook",
+    "domain": "domain",
+    "scope": "scope",
+    "capability": "compute framework",
+    "frameworks_not_enabled": "compute framework",
+    "framework_pin": "compute framework pin",
+    "links": "links",
+}
+
+# One synthetic near-miss, rendered once per stage, so every label is read back off a real rendered line.
+STAGE_LABEL_FEATURE_791 = "renderer_stage_label_791"
+STAGE_LABEL_REASON_791 = "eliminated at this stage"
+
+# Stands in for a tenth stage shipped without a near-miss label: no entry of the label table covers this token.
 UNLABELED_STAGE_791 = "renderer_unlabeled_stage_791"
 UNLABELED_STAGE_FEATURE_791 = "renderer_unlabeled_stage_feature_791"
 UNLABELED_STAGE_REASON_791 = "eliminated at a stage this build has no label for"
@@ -2654,6 +2674,42 @@ class TestEveryEliminationStageIsClassified:
     def test_every_stage_carries_a_near_miss_label(self) -> None:
         """dict[EliminationStage, str] does not force an entry per member, so the table is pinned complete here."""
         assert set(_STAGE_LABELS) == set(get_args(EliminationStage))
+
+
+class TestEveryStageLabelIsPinned:
+    """The class above pins the label table's KEYS; this one pins its VALUES, as a table and as rendered text.
+
+    Seven stages are pinned end to end through real matching in
+    tests/test_core/test_prepare/test_candidate_elimination_reasons.py and one (input_data) in
+    tests/test_plugins/feature_group/input_data/test_reader_match_rejections.py; those stay. This guard is
+    what a tenth stage, or a renamed label, trips even when no hand-written line covers it.
+    """
+
+    def test_the_expected_table_names_every_stage(self) -> None:
+        """A tenth stage fails here until someone states the label it renders."""
+        assert frozenset(EXPECTED_STAGE_LABELS_791) == frozenset(get_args(EliminationStage))
+
+    def test_the_label_table_matches_the_expected_labels(self) -> None:
+        """Renaming a label in production fails here."""
+        assert _STAGE_LABELS == EXPECTED_STAGE_LABELS_791
+
+    @pytest.mark.parametrize(("stage", "label"), sorted(EXPECTED_STAGE_LABELS_791.items()))
+    def test_a_stage_renders_its_expected_label(self, stage: EliminationStage, label: str) -> None:
+        """The near-miss line of every stage reads '  - <class> (<label>): <reason>'."""
+        feature = Feature(STAGE_LABEL_FEATURE_791)
+        result = EvaluationResult(
+            identified={},
+            eliminations={RendererSuccessFG791: Elimination(stage=stage, reason=STAGE_LABEL_REASON_791)},
+        )
+
+        # Premise: this failure reaches the near-miss block, which is the only place a label renders.
+        assert result.failure_kind == "none"
+
+        message = render_resolution_failure(result, feature)
+
+        assert message is not None
+        bullets = [line for line in message.split("\n") if line.startswith("  - ")]
+        assert bullets == [f"  - RendererSuccessFG791 ({label}): {STAGE_LABEL_REASON_791}"]
 
 
 class TestAnUnlabeledStageStillRenders:

--- a/tests/test_core/test_prepare/test_resolution_failure_renderer.py
+++ b/tests/test_core/test_prepare/test_resolution_failure_renderer.py
@@ -136,10 +136,10 @@ NAME_DEPENDENT_STAGES_791: frozenset[EliminationStage] = frozenset(
     {"value_rejection", "input_data", "matcher_error", "capability", "framework_pin"}
 )
 
-# The label each stage renders. The keys are pinned complete against EliminationStage, the values against
-# _STAGE_LABELS, so neither a new stage nor a renamed label can ship unstated. Two stages share one label on
-# purpose (capability and frameworks_not_enabled both render 'compute framework'): this is stage -> label, and
-# label uniqueness is deliberately NOT pinned.
+# The label each stage renders, stated here independently of the renderer: EliminationStage is checked against
+# these keys and each rendered near-miss line against these values, so a new stage cannot ship unlabeled. Two
+# stages share one label on purpose (capability and frameworks_not_enabled both render 'compute framework'):
+# this is stage -> label, and label uniqueness is deliberately NOT pinned.
 EXPECTED_STAGE_LABELS_791: dict[EliminationStage, str] = {
     "value_rejection": "option value",
     "input_data": "input data",
@@ -2677,23 +2677,24 @@ class TestEveryEliminationStageIsClassified:
 
 
 class TestEveryStageLabelIsPinned:
-    """The class above pins the label table's KEYS; this one pins its VALUES, as a table and as rendered text.
+    """TestEveryEliminationStageIsClassified pins the label table's KEYS; this one pins its VALUES as rendered text.
 
-    Seven stages are pinned end to end through real matching in
-    tests/test_core/test_prepare/test_candidate_elimination_reasons.py and one (input_data) in
-    tests/test_plugins/feature_group/input_data/test_reader_match_rejections.py; those stay. This guard is
-    what a tenth stage, or a renamed label, trips even when no hand-written line covers it.
+    Every stage shipping today also has a hand-written rendered line: seven in
+    tests/test_core/test_prepare/test_candidate_elimination_reasons.py, input_data in
+    tests/test_plugins/feature_group/input_data/test_reader_match_rejections.py, matcher_error in
+    tests/test_core/test_prepare/test_raising_matcher_containment.py, so a RENAME is already caught per stage.
+    What this guard adds is that a NEW stage cannot ship with an unpinned label.
     """
 
     def test_the_expected_table_names_every_stage(self) -> None:
         """A tenth stage fails here until someone states the label it renders."""
         assert frozenset(EXPECTED_STAGE_LABELS_791) == frozenset(get_args(EliminationStage))
 
-    def test_the_label_table_matches_the_expected_labels(self) -> None:
-        """Renaming a label in production fails here."""
-        assert _STAGE_LABELS == EXPECTED_STAGE_LABELS_791
-
-    @pytest.mark.parametrize(("stage", "label"), sorted(EXPECTED_STAGE_LABELS_791.items()))
+    @pytest.mark.parametrize(
+        ("stage", "label"),
+        sorted(EXPECTED_STAGE_LABELS_791.items()),
+        ids=sorted(EXPECTED_STAGE_LABELS_791),
+    )
     def test_a_stage_renders_its_expected_label(self, stage: EliminationStage, label: str) -> None:
         """The near-miss line of every stage reads '  - <class> (<label>): <reason>'."""
         feature = Feature(STAGE_LABEL_FEATURE_791)


### PR DESCRIPTION
`_STAGE_LABELS` maps each `EliminationStage` member to the text a resolution-failure message prints on its near-miss bullets. The table's keys were pinned complete, but its values were not. Eight of the nine labels happened to be pinned line by line through real matching; `matcher_error` had none anywhere, so renaming that one label changed user-visible output with a fully green suite.

## What this adds

- The missing rendered bullet, in the suite that already owns a raising-matcher scenario. The existing near-miss test now pins the whole line rather than probing it for substrings, so it covers the label without defining another feature-group twin.
- One expected-label table, stated independently of the renderer, plus a per-stage render assertion. `EliminationStage` is checked against its keys, so a new stage cannot ship without someone stating the label it renders.

## Decisions recorded

- The seven per-stage assertions in `test_candidate_elimination_reasons.py` stay rather than being replaced by a table. They pin stage and reason end to end through real matching, which a synthetic renderer test cannot.
- The type-level alternative (an `if`/`elif` chain over the Literal closed by `typing.assert_never`) was weighed and rejected. It would make mypy reject an unhandled stage, but its runtime behavior raises, which contradicts the deliberate degrade-to-raw-token-with-a-warning contract: a crash on the failure path is the worse failure.

Two stages render the same label on purpose (`capability` and `frameworks_not_enabled` both print `compute framework`), so the pin is stage to label and label uniqueness is deliberately not asserted.

## Verification

Each new assertion was checked by mutation: renaming a label and adding a tenth stage each fail a test, and both were reverted. Test-only; nothing under `mloda/` or `mloda_plugins/` is touched. `tox` is green, skip count unchanged.