### PR TITLE
fix: let a Feature copy own its compute_frameworks set

### DIFF
--- a/mloda/core/abstract_plugins/components/feature.py
+++ b/mloda/core/abstract_plugins/components/feature.py
@@ -362,10 +362,10 @@ class Feature:
         break the very dedup the copy protects. Both containers are written in place by the engine
         (intake forwarding, strict_type_enforcement, matcher writes), which is what the copy stops.
 
-        compute_frameworks, read by __eq__/__hash__ too, is deliberately NOT rebuilt: the copy shares
-        that set by reference (#924). Safe only because every write site rebinds it and none mutates in place;
-        copying it would hide that GlobalFilter.compute_framework rebinds a filter feature's set from the
-        resolved one. Guard: test_compute_frameworks_sharing.py::test_no_module_mutates_compute_frameworks_in_place.
+        compute_frameworks, read by __eq__/__hash__ too, is owned as well (#924), same reason: a
+        caller-side in-place write must not shift this Feature's hash. A shallow set() copy suffices
+        here because the elements are classes, so unlike an option value there is no repr/address
+        hazard. Library-side writes still only rebind: test_compute_frameworks_sharing.py.
         """
         # One level: a Feature nested inside child_options.group keeps sharing its own options, the
         # documented limitation class of _isolate_forwarded_value.
@@ -374,6 +374,8 @@ class Feature:
         duplicate.options = copy(self.options)
         if self.child_options is not None:
             duplicate.child_options = copy(self.child_options)
+        if self.compute_frameworks is not None:
+            duplicate.compute_frameworks = set(self.compute_frameworks)
         return duplicate
 
     def _child_options_key(self) -> Any:

--- a/mloda/core/abstract_plugins/components/feature.py
+++ b/mloda/core/abstract_plugins/components/feature.py
@@ -362,10 +362,8 @@ class Feature:
         break the very dedup the copy protects. Both containers are written in place by the engine
         (intake forwarding, strict_type_enforcement, matcher writes), which is what the copy stops.
 
-        compute_frameworks, read by __eq__/__hash__ too, is owned as well (#924), same reason: a
-        caller-side in-place write must not shift this Feature's hash. A shallow set() copy suffices
-        here because the elements are classes, so unlike an option value there is no repr/address
-        hazard. Library-side writes still only rebind: test_compute_frameworks_sharing.py.
+        compute_frameworks is hashed too, so it is owned for the same reason. A shallow set() copy is
+        enough: its elements are classes, not option values with a repr/address hazard.
         """
         # One level: a Feature nested inside child_options.group keeps sharing its own options, the
         # documented limitation class of _isolate_forwarded_value.

--- a/mloda/core/abstract_plugins/components/feature.py
+++ b/mloda/core/abstract_plugins/components/feature.py
@@ -361,6 +361,11 @@ class Feature:
         embeds the object address, so deep-copying a value would silently shift this Feature's hash and
         break the very dedup the copy protects. Both containers are written in place by the engine
         (intake forwarding, strict_type_enforcement, matcher writes), which is what the copy stops.
+
+        compute_frameworks, read by __eq__/__hash__ too, is deliberately NOT rebuilt: the copy shares
+        that set by reference (#924). Safe only because every write site rebinds it and none mutates in place;
+        copying it would hide that GlobalFilter.compute_framework rebinds a filter feature's set from the
+        resolved one. Guard: test_compute_frameworks_sharing.py::test_no_module_mutates_compute_frameworks_in_place.
         """
         # One level: a Feature nested inside child_options.group keeps sharing its own options, the
         # documented limitation class of _isolate_forwarded_value.

--- a/tests/test_core/test_abstract_plugins/test_components/test_compute_frameworks_sharing.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_compute_frameworks_sharing.py
@@ -1,11 +1,17 @@
 """Rot guard: ``Feature.compute_frameworks`` is REBOUND, never mutated in place.
 
-The set is shared by reference (``Feature.__copy__`` hands the copy the same object, and
-``GlobalFilter.compute_framework`` aliases the resolved feature's set into the filter feature) while it also
-feeds ``Feature.__eq__`` and ``Feature.__hash__``. An in-place write therefore shifts the hash of every other
-holder and strands it in any set or dict it sits in; a rebind leaves the other holders untouched.
+The set is shared by reference (``GlobalFilter.compute_framework`` aliases the resolved feature's set into the
+filter feature; ``resolve_compute_frameworks.py:24-26`` binds ONE set to EVERY Feature of a ``PlannedQueue``
+entry, an N-holder alias) while it also feeds ``Feature.__eq__`` and ``Feature.__hash__``. An in-place write
+therefore shifts the hash of every other holder and strands it in any set or dict it sits in; a rebind leaves
+the other holders untouched.
 
-CfwManager.compute_frameworks is a dict, not this attribute, so an in-place write there is a false positive.
+Blind spot: a local alias (``cfs = feature.compute_frameworks``, then ``cfs.add(x)``) is invisible to a source
+scan, and ``identify_feature_group.py:131`` already binds such a local.
+
+Same-named attributes that are not this set, so a write there would be a false positive (none trips today):
+``CfwManager.compute_frameworks`` (dict), ``FeatureGroupInfo.compute_frameworks`` (list[str]),
+``SetupComputeFramework.compute_frameworks`` (the available-framework set).
 """
 
 from __future__ import annotations
@@ -54,9 +60,10 @@ SCAN_ROOTS = sorted(
 )
 
 _HINT = (
-    "Rebind instead: feature.compute_frameworks = {...}. The set is shared by reference (Feature.__copy__, "
-    "GlobalFilter.compute_framework) and feeds Feature.__eq__/__hash__, so an in-place write shifts the hash "
-    "of every other holder and loses it from any set or dict it sits in."
+    "Rebind instead: feature.compute_frameworks = {...}. The set is shared by reference "
+    "(GlobalFilter.compute_framework, ResolveComputeFrameworks.links) and feeds Feature.__eq__/__hash__, so an "
+    "in-place write shifts the hash of every other holder and loses it from any set or dict it sits in. "
+    "If the flagged holder is not a Feature, rename its attribute or teach the guard to skip it."
 )
 
 # Every form the guard must catch, one per line, as source text the guard parses but never executes.
@@ -144,7 +151,8 @@ def _configured_forms() -> set[str]:
 
 def test_no_module_mutates_compute_frameworks_in_place() -> None:
     """Every module under mloda/ and mloda_plugins/ must rebind the attribute instead of writing it in place."""
-    assert SCAN_ROOTS, "could not locate the mloda and mloda_plugins package directories"
+    # Vacuity floor, NOT a target: a sweep over half the tree would pass this guard trivially.
+    assert {root.name for root in SCAN_ROOTS} >= {"mloda", "mloda_plugins"}, f"roots: {SCAN_ROOTS}"
 
     violations: list[str] = []
     for root in SCAN_ROOTS:
@@ -154,9 +162,9 @@ def test_no_module_mutates_compute_frameworks_in_place() -> None:
 
 
 def test_the_sweep_reaches_both_trees() -> None:
-    """A sweep that reaches no files passes trivially, so the reach itself is pinned."""
-    assert {root.name for root in SCAN_ROOTS} >= {"mloda", "mloda_plugins"}, f"roots: {SCAN_ROOTS}"
+    """A sweep that reaches no files passes trivially, so the file count itself is pinned."""
     scanned = [path for root in SCAN_ROOTS for path in root.rglob("*.py")]
+    # Vacuity floor, NOT a target: well under the measured total (288 today) so deleting a module stays legitimate.
     assert len(scanned) > 100, f"only {len(scanned)} files scanned"
 
 
@@ -207,11 +215,13 @@ def _feature_with_framework(name: str = CFS_FEATURE) -> Feature:
     return Feature(name, compute_framework=PythonDictFramework.get_class_name())
 
 
-def test_copy_shares_the_compute_frameworks_set_by_reference() -> None:
-    """Characterization: __copy__ rebuilds options but hands the copy the very same set object."""
+def test_copy_owns_its_compute_frameworks_set() -> None:
+    """__copy__ owns that set exactly as it owns options: value-equal to the original, never the same object."""
     feature = _feature_with_framework()
     assert feature.compute_frameworks == {PythonDictFramework}
-    assert copy(feature).compute_frameworks is feature.compute_frameworks
+    duplicate = copy(feature)
+    assert duplicate.compute_frameworks == feature.compute_frameworks
+    assert duplicate.compute_frameworks is not feature.compute_frameworks
 
 
 def test_copy_of_a_feature_without_frameworks_keeps_none() -> None:
@@ -239,24 +249,30 @@ def test_two_independently_built_features_own_separate_sets() -> None:
     assert first.compute_frameworks is not second.compute_frameworks
 
 
+def _aliased_pair() -> tuple[Feature, Feature]:
+    """Two features sharing one set object, the sanctioned aliasing form the guard protects."""
+    feature = _feature_with_framework()
+    alias = _feature_with_framework(CFS_FILTER_FEATURE)
+    alias.compute_frameworks = feature.compute_frameworks
+    return feature, alias
+
+
 def test_an_in_place_write_through_an_alias_loses_a_feature_from_a_set() -> None:
     """Why the guard exists: the shared set feeds __hash__, so one alias's write strands the other holder."""
-    feature = _feature_with_framework()
-    alias = copy(feature)
+    feature, alias = _aliased_pair()
     holder = {feature}
     assert feature in holder
 
     assert alias.compute_frameworks is not None
     alias.compute_frameworks.add(SqliteFramework)
 
-    assert feature not in holder, "the in-place write must be what loses the feature, not the copy"
+    assert feature not in holder, "the in-place write must be what loses the feature, not the aliasing"
     assert feature.compute_frameworks == {PythonDictFramework, SqliteFramework}
 
 
 def test_a_rebind_through_an_alias_leaves_the_other_holder_findable() -> None:
     """The sanctioned form, from the same angle: rebinding the alias does not touch the stored feature."""
-    feature = _feature_with_framework()
-    alias = copy(feature)
+    feature, alias = _aliased_pair()
     holder = {feature}
 
     alias.compute_frameworks = {SqliteFramework}

--- a/tests/test_core/test_abstract_plugins/test_components/test_compute_frameworks_sharing.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_compute_frameworks_sharing.py
@@ -1,0 +1,265 @@
+"""Rot guard: ``Feature.compute_frameworks`` is REBOUND, never mutated in place.
+
+The set is shared by reference (``Feature.__copy__`` hands the copy the same object, and
+``GlobalFilter.compute_framework`` aliases the resolved feature's set into the filter feature) while it also
+feeds ``Feature.__eq__`` and ``Feature.__hash__``. An in-place write therefore shifts the hash of every other
+holder and strands it in any set or dict it sits in; a rebind leaves the other holders untouched.
+
+CfwManager.compute_frameworks is a dict, not this attribute, so an in-place write there is a false positive.
+"""
+
+from __future__ import annotations
+
+import ast
+from copy import copy
+from pathlib import Path
+
+import mloda
+import mloda_plugins
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.filter.filter_type_enum import FilterType
+from mloda.core.filter.global_filter import GlobalFilter
+from mloda.core.filter.single_filter import SingleFilter
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
+from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_framework import SqliteFramework
+
+ATTRIBUTE = "compute_frameworks"
+
+MUTATING_METHODS = frozenset(
+    {
+        "add",
+        "clear",
+        "difference_update",
+        "discard",
+        "intersection_update",
+        "pop",
+        "remove",
+        "symmetric_difference_update",
+        "update",
+    }
+)
+
+# The augmented assignments a set supports. An unlisted op on the attribute is still reported, by its node name.
+AUG_OP_SYMBOLS: dict[type[ast.operator], str] = {
+    ast.BitOr: "|=",
+    ast.BitAnd: "&=",
+    ast.Sub: "-=",
+    ast.BitXor: "^=",
+}
+
+# mloda is a namespace package, so __file__ is None: its directories come from __path__. An editable install
+# repeats a directory there, hence the dedup.
+SCAN_ROOTS = sorted(
+    {Path(entry).resolve() for entry in (*mloda.__path__, *mloda_plugins.__path__) if Path(entry).is_dir()}
+)
+
+_HINT = (
+    "Rebind instead: feature.compute_frameworks = {...}. The set is shared by reference (Feature.__copy__, "
+    "GlobalFilter.compute_framework) and feeds Feature.__eq__/__hash__, so an in-place write shifts the hash "
+    "of every other holder and loses it from any set or dict it sits in."
+)
+
+# Every form the guard must catch, one per line, as source text the guard parses but never executes.
+EVERY_IN_PLACE_FORM = """
+def rot(feature, framework):
+    feature.compute_frameworks.add(framework)
+    feature.compute_frameworks.update({framework})
+    feature.compute_frameworks.discard(framework)
+    feature.compute_frameworks.remove(framework)
+    feature.compute_frameworks.clear()
+    feature.compute_frameworks.pop()
+    feature.compute_frameworks.difference_update({framework})
+    feature.compute_frameworks.intersection_update({framework})
+    feature.compute_frameworks.symmetric_difference_update({framework})
+    feature.compute_frameworks |= {framework}
+    feature.compute_frameworks &= {framework}
+    feature.compute_frameworks -= {framework}
+    feature.compute_frameworks ^= {framework}
+"""
+
+# The sanctioned forms: rebinding, deliberate aliasing, reading, iterating, snapshotting, other attributes.
+LEGAL_FORMS = """
+def legal(feature, other, framework):
+    feature.compute_frameworks = {framework}
+    feature.compute_frameworks = None
+    other.compute_frameworks = feature.compute_frameworks
+    pinned = frozenset(feature.compute_frameworks)
+    if feature.compute_frameworks:
+        for entry in feature.compute_frameworks:
+            pinned |= {entry}
+    feature.other_set.add(framework)
+    feature.other_set |= {framework}
+    return pinned
+"""
+
+CFS_FEATURE = "cfs_shared_feature"
+CFS_FILTER_FEATURE = "cfs_filter_feature"
+
+
+def _is_target_attribute(node: ast.expr) -> bool:
+    """Any ``<expr>.compute_frameworks``, whatever the base expression is."""
+    return isinstance(node, ast.Attribute) and node.attr == ATTRIBUTE
+
+
+def _mutating_method(node: ast.Call) -> str | None:
+    """The set method a call mutates ``<expr>.compute_frameworks`` with, None for anything else."""
+    func = node.func
+    if not isinstance(func, ast.Attribute) or func.attr not in MUTATING_METHODS:
+        return None
+    return func.attr if _is_target_attribute(func.value) else None
+
+
+def _violations_in_source(source: str, filename: str) -> list[str]:
+    """In-place writes to a ``<expr>.compute_frameworks`` in one module's source."""
+    tree = ast.parse(source, filename=filename)
+    found: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            method = _mutating_method(node)
+            if method is not None:
+                found.append(f"{filename}:{node.lineno}: .{ATTRIBUTE}.{method}(...)")
+        elif isinstance(node, ast.AugAssign) and _is_target_attribute(node.target):
+            symbol = AUG_OP_SYMBOLS.get(type(node.op), f"{type(node.op).__name__}=")
+            found.append(f"{filename}:{node.lineno}: .{ATTRIBUTE} {symbol} ...")
+    return found
+
+
+def _violations(root: Path) -> list[str]:
+    found: list[str] = []
+    for path in sorted(root.rglob("*.py")):
+        found.extend(_violations_in_source(path.read_text(encoding="utf-8"), str(path)))
+    return found
+
+
+def _forms(violations: list[str]) -> list[str]:
+    """The write form each violation names, without its file:line."""
+    return [violation.rsplit(": ", 1)[1] for violation in violations]
+
+
+def _configured_forms() -> set[str]:
+    return {f".{ATTRIBUTE}.{name}(...)" for name in MUTATING_METHODS} | {
+        f".{ATTRIBUTE} {symbol} ..." for symbol in AUG_OP_SYMBOLS.values()
+    }
+
+
+def test_no_module_mutates_compute_frameworks_in_place() -> None:
+    """Every module under mloda/ and mloda_plugins/ must rebind the attribute instead of writing it in place."""
+    assert SCAN_ROOTS, "could not locate the mloda and mloda_plugins package directories"
+
+    violations: list[str] = []
+    for root in SCAN_ROOTS:
+        violations.extend(_violations(root))
+
+    assert violations == [], "compute_frameworks is written in place:\n" + "\n".join(violations) + "\n" + _HINT
+
+
+def test_the_sweep_reaches_both_trees() -> None:
+    """A sweep that reaches no files passes trivially, so the reach itself is pinned."""
+    assert {root.name for root in SCAN_ROOTS} >= {"mloda", "mloda_plugins"}, f"roots: {SCAN_ROOTS}"
+    scanned = [path for root in SCAN_ROOTS for path in root.rglob("*.py")]
+    assert len(scanned) > 100, f"only {len(scanned)} files scanned"
+
+
+def test_guard_flags_every_in_place_write_form() -> None:
+    """Positive control: without it the guard could rot into one that detects nothing."""
+    assert sorted(_forms(_violations_in_source(EVERY_IN_PLACE_FORM, "rot.py"))) == sorted(
+        [
+            ".compute_frameworks &= ...",
+            ".compute_frameworks -= ...",
+            ".compute_frameworks ^= ...",
+            ".compute_frameworks |= ...",
+            ".compute_frameworks.add(...)",
+            ".compute_frameworks.clear(...)",
+            ".compute_frameworks.difference_update(...)",
+            ".compute_frameworks.discard(...)",
+            ".compute_frameworks.intersection_update(...)",
+            ".compute_frameworks.pop(...)",
+            ".compute_frameworks.remove(...)",
+            ".compute_frameworks.symmetric_difference_update(...)",
+            ".compute_frameworks.update(...)",
+        ]
+    )
+
+
+def test_the_positive_control_covers_every_configured_form() -> None:
+    """Adding a method or operator to the configuration must not go untested."""
+    assert set(_forms(_violations_in_source(EVERY_IN_PLACE_FORM, "rot.py"))) == _configured_forms()
+
+
+def test_guard_reports_the_file_and_line_of_a_violation() -> None:
+    """The failure message must name the offending site, not just that one exists."""
+    source = "x = 1\nfeature.compute_frameworks.add(x)\n"
+    assert _violations_in_source(source, "some/module.py") == ["some/module.py:2: .compute_frameworks.add(...)"]
+
+
+def test_guard_flags_a_mutation_through_a_nested_base_expression() -> None:
+    """The base expression is irrelevant: only the attribute it ends in decides."""
+    source = "def rot(f, filters):\n    filters[0].filter_feature.compute_frameworks.add(f)\n"
+    assert _forms(_violations_in_source(source, "nested.py")) == [".compute_frameworks.add(...)"]
+
+
+def test_guard_allows_rebinding_reading_and_unrelated_attributes() -> None:
+    """Negative control: the sanctioned forms must stay unflagged or the guard is unusable."""
+    assert _violations_in_source(LEGAL_FORMS, "legal.py") == []
+
+
+def _feature_with_framework(name: str = CFS_FEATURE) -> Feature:
+    return Feature(name, compute_framework=PythonDictFramework.get_class_name())
+
+
+def test_copy_shares_the_compute_frameworks_set_by_reference() -> None:
+    """Characterization: __copy__ rebuilds options but hands the copy the very same set object."""
+    feature = _feature_with_framework()
+    assert feature.compute_frameworks == {PythonDictFramework}
+    assert copy(feature).compute_frameworks is feature.compute_frameworks
+
+
+def test_copy_of_a_feature_without_frameworks_keeps_none() -> None:
+    """Characterization: an unresolved feature copies as unresolved."""
+    feature = Feature(CFS_FEATURE)
+    assert feature.compute_frameworks is None
+    assert copy(feature).compute_frameworks is None
+
+
+def test_global_filter_aliases_the_features_set_into_a_filter_feature_without_one() -> None:
+    """Characterization: a filter feature with no framework adopts the resolved feature's set object."""
+    feat = _feature_with_framework()
+    single_filter = SingleFilter(Feature(CFS_FILTER_FEATURE), FilterType.EQUAL, {"value": 1})
+    assert single_filter.filter_feature.compute_frameworks is None
+
+    assert GlobalFilter().compute_framework(single_filter, feat) is True
+    assert single_filter.filter_feature.compute_frameworks is feat.compute_frameworks
+
+
+def test_two_independently_built_features_own_separate_sets() -> None:
+    """Characterization: the constructor allocates per instance, so sharing only ever comes from a copy or alias."""
+    first = _feature_with_framework()
+    second = _feature_with_framework()
+    assert first.compute_frameworks == second.compute_frameworks
+    assert first.compute_frameworks is not second.compute_frameworks
+
+
+def test_an_in_place_write_through_an_alias_loses_a_feature_from_a_set() -> None:
+    """Why the guard exists: the shared set feeds __hash__, so one alias's write strands the other holder."""
+    feature = _feature_with_framework()
+    alias = copy(feature)
+    holder = {feature}
+    assert feature in holder
+
+    assert alias.compute_frameworks is not None
+    alias.compute_frameworks.add(SqliteFramework)
+
+    assert feature not in holder, "the in-place write must be what loses the feature, not the copy"
+    assert feature.compute_frameworks == {PythonDictFramework, SqliteFramework}
+
+
+def test_a_rebind_through_an_alias_leaves_the_other_holder_findable() -> None:
+    """The sanctioned form, from the same angle: rebinding the alias does not touch the stored feature."""
+    feature = _feature_with_framework()
+    alias = copy(feature)
+    holder = {feature}
+
+    alias.compute_frameworks = {SqliteFramework}
+
+    assert feature in holder
+    assert feature.compute_frameworks == {PythonDictFramework}

--- a/tests/test_core/test_abstract_plugins/test_components/test_compute_frameworks_sharing.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_compute_frameworks_sharing.py
@@ -1,17 +1,8 @@
-"""Rot guard: ``Feature.compute_frameworks`` is REBOUND, never mutated in place.
+"""Rot guard: ``Feature.compute_frameworks`` is rebound, never mutated in place.
 
-The set is shared by reference (``GlobalFilter.compute_framework`` aliases the resolved feature's set into the
-filter feature; ``resolve_compute_frameworks.py:24-26`` binds ONE set to EVERY Feature of a ``PlannedQueue``
-entry, an N-holder alias) while it also feeds ``Feature.__eq__`` and ``Feature.__hash__``. An in-place write
-therefore shifts the hash of every other holder and strands it in any set or dict it sits in; a rebind leaves
-the other holders untouched.
-
-Blind spot: a local alias (``cfs = feature.compute_frameworks``, then ``cfs.add(x)``) is invisible to a source
-scan, and ``identify_feature_group.py:131`` already binds such a local.
-
-Same-named attributes that are not this set, so a write there would be a false positive (none trips today):
-``CfwManager.compute_frameworks`` (dict), ``FeatureGroupInfo.compute_frameworks`` (list[str]),
-``SetupComputeFramework.compute_frameworks`` (the available-framework set).
+The set is shared by reference and feeds ``__eq__``/``__hash__``, so an in-place write shifts the hash of
+every other holder. Blind spot: a local alias (``cfs = feature.compute_frameworks``) is invisible to this
+source scan, and a same-named attribute on a non-Feature class would be a false positive.
 """
 
 from __future__ import annotations
@@ -45,7 +36,6 @@ MUTATING_METHODS = frozenset(
     }
 )
 
-# The augmented assignments a set supports. An unlisted op on the attribute is still reported, by its node name.
 AUG_OP_SYMBOLS: dict[type[ast.operator], str] = {
     ast.BitOr: "|=",
     ast.BitAnd: "&=",
@@ -53,20 +43,16 @@ AUG_OP_SYMBOLS: dict[type[ast.operator], str] = {
     ast.BitXor: "^=",
 }
 
-# mloda is a namespace package, so __file__ is None: its directories come from __path__. An editable install
-# repeats a directory there, hence the dedup.
+# Namespace package: the directories come from __path__, and an editable install repeats one, hence the dedup.
 SCAN_ROOTS = sorted(
     {Path(entry).resolve() for entry in (*mloda.__path__, *mloda_plugins.__path__) if Path(entry).is_dir()}
 )
 
 _HINT = (
-    "Rebind instead: feature.compute_frameworks = {...}. The set is shared by reference "
-    "(GlobalFilter.compute_framework, ResolveComputeFrameworks.links) and feeds Feature.__eq__/__hash__, so an "
-    "in-place write shifts the hash of every other holder and loses it from any set or dict it sits in. "
-    "If the flagged holder is not a Feature, rename its attribute or teach the guard to skip it."
+    "Rebind instead: feature.compute_frameworks = {...}. The set is shared by reference and feeds "
+    "Feature.__eq__/__hash__. If the flagged holder is not a Feature, teach the guard to skip it."
 )
 
-# Every form the guard must catch, one per line, as source text the guard parses but never executes.
 EVERY_IN_PLACE_FORM = """
 def rot(feature, framework):
     feature.compute_frameworks.add(framework)
@@ -84,7 +70,6 @@ def rot(feature, framework):
     feature.compute_frameworks ^= {framework}
 """
 
-# The sanctioned forms: rebinding, deliberate aliasing, reading, iterating, snapshotting, other attributes.
 LEGAL_FORMS = """
 def legal(feature, other, framework):
     feature.compute_frameworks = {framework}
@@ -109,7 +94,7 @@ def _is_target_attribute(node: ast.expr) -> bool:
 
 
 def _mutating_method(node: ast.Call) -> str | None:
-    """The set method a call mutates ``<expr>.compute_frameworks`` with, None for anything else."""
+    """The set method the call mutates the attribute with, None for anything else."""
     func = node.func
     if not isinstance(func, ast.Attribute) or func.attr not in MUTATING_METHODS:
         return None
@@ -150,7 +135,7 @@ def _configured_forms() -> set[str]:
 
 
 def test_no_module_mutates_compute_frameworks_in_place() -> None:
-    """Every module under mloda/ and mloda_plugins/ must rebind the attribute instead of writing it in place."""
+    """Scope: every module under mloda/ and mloda_plugins/."""
     # Vacuity floor, NOT a target: a sweep over half the tree would pass this guard trivially.
     assert {root.name for root in SCAN_ROOTS} >= {"mloda", "mloda_plugins"}, f"roots: {SCAN_ROOTS}"
 
@@ -162,14 +147,14 @@ def test_no_module_mutates_compute_frameworks_in_place() -> None:
 
 
 def test_the_sweep_reaches_both_trees() -> None:
-    """A sweep that reaches no files passes trivially, so the file count itself is pinned."""
+    """A sweep over no files would pass trivially."""
     scanned = [path for root in SCAN_ROOTS for path in root.rglob("*.py")]
     # Vacuity floor, NOT a target: well under the measured total (288 today) so deleting a module stays legitimate.
     assert len(scanned) > 100, f"only {len(scanned)} files scanned"
 
 
 def test_guard_flags_every_in_place_write_form() -> None:
-    """Positive control: without it the guard could rot into one that detects nothing."""
+    """Positive control."""
     assert sorted(_forms(_violations_in_source(EVERY_IN_PLACE_FORM, "rot.py"))) == sorted(
         [
             ".compute_frameworks &= ...",
@@ -190,24 +175,22 @@ def test_guard_flags_every_in_place_write_form() -> None:
 
 
 def test_the_positive_control_covers_every_configured_form() -> None:
-    """Adding a method or operator to the configuration must not go untested."""
     assert set(_forms(_violations_in_source(EVERY_IN_PLACE_FORM, "rot.py"))) == _configured_forms()
 
 
 def test_guard_reports_the_file_and_line_of_a_violation() -> None:
-    """The failure message must name the offending site, not just that one exists."""
     source = "x = 1\nfeature.compute_frameworks.add(x)\n"
     assert _violations_in_source(source, "some/module.py") == ["some/module.py:2: .compute_frameworks.add(...)"]
 
 
 def test_guard_flags_a_mutation_through_a_nested_base_expression() -> None:
-    """The base expression is irrelevant: only the attribute it ends in decides."""
+    """Only the attribute the expression ends in decides."""
     source = "def rot(f, filters):\n    filters[0].filter_feature.compute_frameworks.add(f)\n"
     assert _forms(_violations_in_source(source, "nested.py")) == [".compute_frameworks.add(...)"]
 
 
 def test_guard_allows_rebinding_reading_and_unrelated_attributes() -> None:
-    """Negative control: the sanctioned forms must stay unflagged or the guard is unusable."""
+    """Negative control."""
     assert _violations_in_source(LEGAL_FORMS, "legal.py") == []
 
 
@@ -216,7 +199,7 @@ def _feature_with_framework(name: str = CFS_FEATURE) -> Feature:
 
 
 def test_copy_owns_its_compute_frameworks_set() -> None:
-    """__copy__ owns that set exactly as it owns options: value-equal to the original, never the same object."""
+    """Value-equal to the original, never the same object."""
     feature = _feature_with_framework()
     assert feature.compute_frameworks == {PythonDictFramework}
     duplicate = copy(feature)
@@ -225,14 +208,14 @@ def test_copy_owns_its_compute_frameworks_set() -> None:
 
 
 def test_copy_of_a_feature_without_frameworks_keeps_none() -> None:
-    """Characterization: an unresolved feature copies as unresolved."""
+    """Characterization."""
     feature = Feature(CFS_FEATURE)
     assert feature.compute_frameworks is None
     assert copy(feature).compute_frameworks is None
 
 
 def test_global_filter_aliases_the_features_set_into_a_filter_feature_without_one() -> None:
-    """Characterization: a filter feature with no framework adopts the resolved feature's set object."""
+    """Characterization: the alias is deliberate."""
     feat = _feature_with_framework()
     single_filter = SingleFilter(Feature(CFS_FILTER_FEATURE), FilterType.EQUAL, {"value": 1})
     assert single_filter.filter_feature.compute_frameworks is None
@@ -242,7 +225,7 @@ def test_global_filter_aliases_the_features_set_into_a_filter_feature_without_on
 
 
 def test_two_independently_built_features_own_separate_sets() -> None:
-    """Characterization: the constructor allocates per instance, so sharing only ever comes from a copy or alias."""
+    """Characterization: sharing only ever comes from a copy or an alias."""
     first = _feature_with_framework()
     second = _feature_with_framework()
     assert first.compute_frameworks == second.compute_frameworks
@@ -250,7 +233,7 @@ def test_two_independently_built_features_own_separate_sets() -> None:
 
 
 def _aliased_pair() -> tuple[Feature, Feature]:
-    """Two features sharing one set object, the sanctioned aliasing form the guard protects."""
+    """Two features sharing one set object, the sanctioned aliasing form."""
     feature = _feature_with_framework()
     alias = _feature_with_framework(CFS_FILTER_FEATURE)
     alias.compute_frameworks = feature.compute_frameworks
@@ -258,7 +241,7 @@ def _aliased_pair() -> tuple[Feature, Feature]:
 
 
 def test_an_in_place_write_through_an_alias_loses_a_feature_from_a_set() -> None:
-    """Why the guard exists: the shared set feeds __hash__, so one alias's write strands the other holder."""
+    """Why the guard exists."""
     feature, alias = _aliased_pair()
     holder = {feature}
     assert feature in holder
@@ -271,7 +254,7 @@ def test_an_in_place_write_through_an_alias_loses_a_feature_from_a_set() -> None
 
 
 def test_a_rebind_through_an_alias_leaves_the_other_holder_findable() -> None:
-    """The sanctioned form, from the same angle: rebinding the alias does not touch the stored feature."""
+    """The sanctioned form, from the same angle."""
     feature, alias = _aliased_pair()
     holder = {feature}
 

--- a/tests/test_core/test_filter/test_single_filter_owns_its_feature.py
+++ b/tests/test_core/test_filter/test_single_filter_owns_its_feature.py
@@ -8,8 +8,7 @@ sitting in the public ``GlobalFilter.filters`` set. Three public paths reach it 
 in-place write lands on the ``child_options`` the engine stamped onto a cached input feature. Either
 way the set loses its own member and a value-equal ``add_filter`` stops deduplicating.
 
-``compute_frameworks`` is hashed too, and a caller can write it in place at any time, so the filter
-feature owns that set as well (#924).
+``compute_frameworks`` is hashed too and a caller can write it in place, so the filter feature owns it as well.
 """
 
 from __future__ import annotations
@@ -329,24 +328,18 @@ def test_single_filter_stays_in_its_set_when_the_caller_feature_changes() -> Non
 
 
 def _cfw_feature() -> Feature:
-    """A plain feature pinned to one compute framework, for the compute_frameworks ownership pins."""
     return Feature(SFO_CFW_FEATURE, compute_framework=PythonDictFramework.get_class_name())
 
 
 def test_single_filter_does_not_alias_the_caller_features_compute_frameworks() -> None:
-    """A SingleFilter owns that set too: value-equal to the caller's, never the same object."""
+    """Value-equal to the caller's set, never the same object."""
     feature = _cfw_feature()
     single_filter = SingleFilter(feature, FilterType.EQUAL, {"value": 1})
-    assert single_filter.filter_feature.compute_frameworks == feature.compute_frameworks, (
-        "the filter's own compute_frameworks must equal the caller's"
-    )
-    assert single_filter.filter_feature.compute_frameworks is not feature.compute_frameworks, (
-        "the filter must not alias the caller's compute_frameworks set"
-    )
+    assert single_filter.filter_feature.compute_frameworks == feature.compute_frameworks, "must equal the caller's"
+    assert single_filter.filter_feature.compute_frameworks is not feature.compute_frameworks, "must not alias"
 
 
 def test_single_filter_hash_survives_an_in_place_compute_frameworks_write() -> None:
-    """Adding a framework to the caller's set in place must not shift the filter's hash."""
     feature = _cfw_feature()
     single_filter = SingleFilter(feature, FilterType.EQUAL, {"value": 1})
     before = hash(single_filter)
@@ -356,7 +349,7 @@ def test_single_filter_hash_survives_an_in_place_compute_frameworks_write() -> N
 
 
 def test_single_filter_stays_in_its_set_when_the_caller_adds_a_compute_framework() -> None:
-    """A stored filter stays findable after the caller writes compute_frameworks in place, then rebinds."""
+    """Findable after an in-place write, and after a rebind."""
     feature = _cfw_feature()
     single_filter = SingleFilter(feature, FilterType.EQUAL, {"value": 1})
     holder = {single_filter}

--- a/tests/test_core/test_filter/test_single_filter_owns_its_feature.py
+++ b/tests/test_core/test_filter/test_single_filter_owns_its_feature.py
@@ -7,6 +7,9 @@ sitting in the public ``GlobalFilter.filters`` set. Three public paths reach it 
 ``strict_type_enforcement=True`` adds a group key to the shared ``Options`` in place, and that same
 in-place write lands on the ``child_options`` the engine stamped onto a cached input feature. Either
 way the set loses its own member and a value-equal ``add_filter`` stops deduplicating.
+
+``compute_frameworks`` is hashed too, and a caller can write it in place at any time, so the filter
+feature owns that set as well (#924).
 """
 
 from __future__ import annotations
@@ -20,6 +23,7 @@ from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.provider import DataCreator, PropertySpec
 from mloda.user import DataType, Feature, FilterType, GlobalFilter, Options, PluginCollector, SingleFilter, mloda
 from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
+from mloda_plugins.compute_framework.base_implementations.sqlite.sqlite_framework import SqliteFramework
 
 
 # The sfo_ prefix keeps every key and feature name unique to this module.
@@ -35,6 +39,7 @@ SFO_CONSUMER_FEATURE = "sfo_cached_consumer"
 SFO_CONSUMER_KEY = "sfo_consumer_key"
 SFO_LEAF_FEATURE = "sfo_leaf_feature"
 SFO_LEAF_KEY = "sfo_leaf_key"
+SFO_CFW_FEATURE = "sfo_cfw_feature"
 
 
 def _make_shared_fg(name: str, property_mapping: dict[str, PropertySpec]) -> type[FeatureGroup]:
@@ -320,6 +325,45 @@ def test_single_filter_stays_in_its_set_when_the_caller_feature_changes() -> Non
     feature.options.add_to_group(SFO_LATE_KEY, "late")
     assert single_filter in holder, "a caller-side mutation must not lose the filter from its set"
     feature.options = Options(group={SFO_UNIT_KEY: "rebound"})
+    assert single_filter in holder, "a caller-side rebind must not lose the filter from its set"
+
+
+def _cfw_feature() -> Feature:
+    """A plain feature pinned to one compute framework, for the compute_frameworks ownership pins."""
+    return Feature(SFO_CFW_FEATURE, compute_framework=PythonDictFramework.get_class_name())
+
+
+def test_single_filter_does_not_alias_the_caller_features_compute_frameworks() -> None:
+    """A SingleFilter owns that set too: value-equal to the caller's, never the same object."""
+    feature = _cfw_feature()
+    single_filter = SingleFilter(feature, FilterType.EQUAL, {"value": 1})
+    assert single_filter.filter_feature.compute_frameworks == feature.compute_frameworks, (
+        "the filter's own compute_frameworks must equal the caller's"
+    )
+    assert single_filter.filter_feature.compute_frameworks is not feature.compute_frameworks, (
+        "the filter must not alias the caller's compute_frameworks set"
+    )
+
+
+def test_single_filter_hash_survives_an_in_place_compute_frameworks_write() -> None:
+    """Adding a framework to the caller's set in place must not shift the filter's hash."""
+    feature = _cfw_feature()
+    single_filter = SingleFilter(feature, FilterType.EQUAL, {"value": 1})
+    before = hash(single_filter)
+    assert feature.compute_frameworks is not None
+    feature.compute_frameworks.add(SqliteFramework)
+    assert hash(single_filter) == before, "a caller-side in-place write must not shift the filter's hash"
+
+
+def test_single_filter_stays_in_its_set_when_the_caller_adds_a_compute_framework() -> None:
+    """A stored filter stays findable after the caller writes compute_frameworks in place, then rebinds."""
+    feature = _cfw_feature()
+    single_filter = SingleFilter(feature, FilterType.EQUAL, {"value": 1})
+    holder = {single_filter}
+    assert feature.compute_frameworks is not None
+    feature.compute_frameworks.add(SqliteFramework)
+    assert single_filter in holder, "a caller-side in-place write must not lose the filter from its set"
+    feature.compute_frameworks = {SqliteFramework}
     assert single_filter in holder, "a caller-side rebind must not lose the filter from its set"
 
 


### PR DESCRIPTION
Closes #924.

The issue asked whether `Feature.compute_frameworks` being a mutable, shared-by-reference hash input was worth acting on, and framed it as latent: nothing mutates it in place today, so nothing is broken. That holds for library code. It does not hold at the API boundary, and the gap is a live bug.

## The bug

`SingleFilter.handle_filter_feature` copies the caller's `Feature` for one stated reason: `Feature.__copy__` owns the containers that decide the hash, so a later write cannot lose this filter from a set it sits in (#910). That copy owned `options` and `child_options`. It did not own `compute_frameworks`, which feeds `__eq__` and `__hash__` too.

```python
f = Feature("p", compute_framework=PythonDictFramework.get_class_name())
gf = GlobalFilter()
gf.add_filter(f, FilterType.EQUAL, {"value": 1})
stored = next(iter(gf.filters))

f.compute_frameworks.add(SqliteFramework)   # caller-side, ordinary public API

stored in gf.filters       # False. The filter is stranded.
gf.filters.discard(stored) # silent no-op.
```

The same sequence against `options` returns `True`, because #910 already closed that path. This is the third round of the shape the issue predicted, and it takes the same fix.

## The change

`Feature.__copy__` now gives the duplicate its own set. A shallow `set()` copy is sufficient and hash-preserving: the elements are `ComputeFramework` classes, so unlike an option value there is no repr/address hazard of the kind the surrounding docstring warns about.

A repo-wide scan of `mloda/` and `mloda_plugins/` confirms no library code writes the attribute in place; all four write sites rebind. That convention is now enforced rather than assumed, by an AST source-scan guard with a positive control over every mutating set method and augmented assignment, so it cannot rot into a test that detects nothing. The guard covers library code; the copy covers callers, which no source scan can reach.

Characterization tests pin the deliberate alias channels that remain: `GlobalFilter.compute_framework` rebinding a filter feature's set from the resolved one, and `ResolveComputeFrameworks.links` binding one set to every feature of a group.

The reason is recorded once next to `__copy__`, which was the point of the issue.

## Known limits, written down rather than implied

- An alias through a local variable (`cfs = feature.compute_frameworks; cfs.add(x)`) is invisible to a source scan. Inherent, now stated in the guard.
- Three other attributes share the name and are not this one: `CfwManager.compute_frameworks` (dict), `FeatureGroupInfo.compute_frameworks` (list), `SetupComputeFramework.compute_frameworks` (set). None trips the guard today; all three are named so a future false positive is diagnosed rather than silenced by deleting the guard.

## Verification

`tox` was green on the guard commit (7877 passed, 170 skipped, ruff format and check, mypy strict over 927 files, bandit). It was **not** re-run on the final commit at the requester's instruction. Evidence for the final state: the two target test files pass (33), `tests/test_core/test_filter` plus `test_components` pass (1645), and ruff format, ruff check and mypy strict are clean on the changed source. A full-suite run with the fix simulated gave 7993 passed, 170 skipped. CI is the remaining check.
