### PR TITLE
fix: reject unhashable filter parameter values at construction (#925)

### DIFF
--- a/docs/docs/in_depth/filter_data.md
+++ b/docs/docs/in_depth/filter_data.md
@@ -8,6 +8,7 @@ That however means that a data project typically contains multiple filters. For 
 
 -    filter_feature: It can be a Feature or a feature name as string.
 -    parameter: A dictionary of parameters to filter. Example: {"min": 2, "max": 3}
+    Parameter values must be hashable (scalars, or lists, sets or tuples of hashables); anything else raises `ValueError`.
 -    filter_type: It can be a str or a FilterType.
 
 #### FilterType

--- a/mloda/core/filter/filter_parameter.py
+++ b/mloda/core/filter/filter_parameter.py
@@ -1,3 +1,4 @@
+from collections.abc import Hashable
 from dataclasses import dataclass
 from typing import Any, Optional, Protocol, cast, runtime_checkable
 
@@ -34,13 +35,27 @@ def _make_hashable(value: Any) -> Any:
     return value
 
 
+def _is_hashable(value: Any) -> bool:
+    """A tuple reports as Hashable through its type, so its elements decide whether hashing works."""
+    if isinstance(value, tuple):
+        return all(_is_hashable(element) for element in value)
+    return isinstance(value, Hashable)
+
+
 @dataclass(frozen=True)
 class FilterParameterImpl:
     _raw: tuple[tuple[str, Any], ...]
 
     @classmethod
     def from_dict(cls, params: dict[str, Any]) -> "FilterParameterImpl":
-        return cls(_raw=tuple(sorted((k, _make_hashable(v)) for k, v in params.items())))
+        normalized = {k: _make_hashable(v) for k, v in params.items()}
+        for key, value in normalized.items():
+            if not _is_hashable(value):
+                raise ValueError(
+                    f"Filter parameter '{key}' has an unhashable value, "
+                    "allowed are scalars and flat lists, sets or tuples of scalars."
+                )
+        return cls(_raw=tuple(sorted(normalized.items())))
 
     @property
     def value(self) -> Optional[Any]:

--- a/mloda/core/filter/filter_parameter.py
+++ b/mloda/core/filter/filter_parameter.py
@@ -1,6 +1,7 @@
-from collections.abc import Hashable
 from dataclasses import dataclass
 from typing import Any, Optional, Protocol, cast, runtime_checkable
+
+from mloda.core.abstract_plugins.components.utils import safe_field
 
 
 @runtime_checkable
@@ -35,11 +36,17 @@ def _make_hashable(value: Any) -> Any:
     return value
 
 
-def _is_hashable(value: Any) -> bool:
-    """A tuple reports as Hashable through its type, so its elements decide whether hashing works."""
+def _unhashable_type(value: Any) -> str | None:
+    """Name of the first part of `value` that does not hash, None when the whole value hashes."""
+    # Probe the real hash, not isinstance(value, Hashable): a __hash__ that raises reports as hashable.
+    if safe_field(lambda: isinstance(hash(value), int), False):
+        return None
     if isinstance(value, tuple):
-        return all(_is_hashable(element) for element in value)
-    return isinstance(value, Hashable)
+        for element in value:
+            found = _unhashable_type(element)
+            if found is not None:
+                return found
+    return type(value).__name__
 
 
 @dataclass(frozen=True)
@@ -50,10 +57,11 @@ class FilterParameterImpl:
     def from_dict(cls, params: dict[str, Any]) -> "FilterParameterImpl":
         normalized = {k: _make_hashable(v) for k, v in params.items()}
         for key, value in normalized.items():
-            if not _is_hashable(value):
+            culprit = _unhashable_type(value)
+            if culprit is not None:
                 raise ValueError(
-                    f"Filter parameter '{key}' has an unhashable value, "
-                    "allowed are scalars and flat lists, sets or tuples of scalars."
+                    f"Filter parameter '{key}' holds an unhashable {culprit}; "
+                    "filter values must be hashable: scalars, or lists, sets or tuples of hashables."
                 )
         return cls(_raw=tuple(sorted(normalized.items())))
 

--- a/tests/test_core/test_filter/test_filter_parameter.py
+++ b/tests/test_core/test_filter/test_filter_parameter.py
@@ -1,8 +1,18 @@
 """Tests for FilterParameter Protocol and FilterParameterImpl."""
 
+import re
+from decimal import Decimal
+
 import pytest
 from typing import Any
 from mloda.core.filter.filter_parameter import FilterParameter, FilterParameterImpl
+
+
+class AlwaysRaisesOnHash:
+    """Defines __hash__, so it reports as hashable through its type, but raises when hashed."""
+
+    def __hash__(self) -> int:
+        raise TypeError("this object refuses to be hashed")
 
 
 # --- Creation tests ---
@@ -323,16 +333,13 @@ def test_list_and_tuple_values_are_equal_and_hash_equal() -> None:
 
 
 # --- Unhashable value rejection tests (see issue #925) ---
-#
-# Contract: a value that cannot be hashed is rejected at construction with a ValueError naming the
-# offending key, instead of surfacing later as an opaque `TypeError: unhashable type` at hash time.
 
 
 def test_from_dict_rejects_dict_value() -> None:
     """Test a dict value is rejected, since normalization leaves it raw and unhashable."""
     params: dict[str, Any] = {"value": {"a": 1}}
 
-    with pytest.raises(ValueError, match="value"):
+    with pytest.raises(ValueError, match=r"'value'"):
         FilterParameterImpl.from_dict(params)
 
 
@@ -364,7 +371,7 @@ def test_from_dict_rejects_unhashable_leaf_value() -> None:
     """Test an unhashable scalar such as bytearray is rejected."""
     params: dict[str, Any] = {"value": bytearray(b"abc")}
 
-    with pytest.raises(ValueError, match="value"):
+    with pytest.raises(ValueError, match=r"'value'"):
         FilterParameterImpl.from_dict(params)
 
 
@@ -384,9 +391,60 @@ def test_from_dict_error_names_the_offending_key() -> None:
         FilterParameterImpl.from_dict(params)
 
 
-def test_from_dict_accepts_every_hashable_value_shape() -> None:
-    """Test the rejection leaves the supported value shapes untouched."""
-    shapes: list[dict[str, Any]] = [
+@pytest.mark.parametrize(
+    "value",
+    [Decimal("sNaN"), memoryview(bytearray(b"ab")), AlwaysRaisesOnHash()],
+    ids=["signaling-nan", "writable-memoryview", "raising-hash"],
+)
+def test_from_dict_rejects_value_whose_hash_raises(value: Any) -> None:
+    """Test a value that defines __hash__ but raises is rejected, not deferred to a later hash call."""
+    with pytest.raises(ValueError, match=r"'value'"):
+        FilterParameterImpl.from_dict({"value": value})
+
+
+def test_from_dict_rejects_value_whose_hash_raises_inside_a_collection() -> None:
+    """Test the raising value is caught through a list too, not only as a bare scalar."""
+    params: dict[str, Any] = {"values": [1, AlwaysRaisesOnHash()]}
+
+    with pytest.raises(ValueError, match=r"'values'"):
+        FilterParameterImpl.from_dict(params)
+
+
+@pytest.mark.parametrize(
+    "params, key, culprit",
+    [
+        ({"value": {"a": 1}}, "value", "dict"),
+        ({"values": [{"a": 1}]}, "values", "dict"),
+        ({"values": [[1, 2]]}, "values", "list"),
+    ],
+    ids=["dict-value", "dict-in-list", "list-in-list"],
+)
+def test_from_dict_error_names_the_offending_type(params: dict[str, Any], key: str, culprit: str) -> None:
+    """Test the message names the inner type that cannot be hashed, since the key alone can mislead."""
+    with pytest.raises(ValueError) as excinfo:
+        FilterParameterImpl.from_dict(params)
+
+    message = str(excinfo.value)
+    assert f"'{key}'" in message, message
+    assert re.search(rf"\b{culprit}\b", message), message
+
+
+def test_from_dict_accepts_deeply_nested_tuple() -> None:
+    """Test a tuple nested past the Python recursion limit stays accepted, since hash() copes with it."""
+    deep: Any = ()
+    for _ in range(1000):
+        deep = (deep,)
+    hash(deep)
+
+    filter_param = FilterParameterImpl.from_dict({"value": deep})
+
+    assert filter_param.value is deep
+    hash(filter_param)
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
         {"value": 25},
         {"value": None},
         {"value": "EU"},
@@ -394,8 +452,11 @@ def test_from_dict_accepts_every_hashable_value_shape() -> None:
         {"values": ["A", "B"]},
         {"values": {"A", "B"}},
         {"values": ("A", "B")},
+        {"values": [(1, 2), (3, 4)]},
         {"min": 0, "max": 100, "max_exclusive": True},
-    ]
-
-    for params in shapes:
-        assert isinstance(hash(FilterParameterImpl.from_dict(params)), int)
+    ],
+    ids=["int", "none", "str", "str-values", "list", "set", "tuple", "list-of-tuples", "range"],
+)
+def test_from_dict_accepts_every_hashable_value_shape(params: dict[str, Any]) -> None:
+    """Test the rejection leaves the supported value shapes untouched."""
+    hash(FilterParameterImpl.from_dict(params))

--- a/tests/test_core/test_filter/test_filter_parameter.py
+++ b/tests/test_core/test_filter/test_filter_parameter.py
@@ -320,3 +320,82 @@ def test_list_and_tuple_values_are_equal_and_hash_equal() -> None:
     assert from_list == from_tuple
     assert hash(from_list) == hash(from_tuple)
     assert len({from_list, from_tuple}) == 1
+
+
+# --- Unhashable value rejection tests (see issue #925) ---
+#
+# Contract: a value that cannot be hashed is rejected at construction with a ValueError naming the
+# offending key, instead of surfacing later as an opaque `TypeError: unhashable type` at hash time.
+
+
+def test_from_dict_rejects_dict_value() -> None:
+    """Test a dict value is rejected, since normalization leaves it raw and unhashable."""
+    params: dict[str, Any] = {"value": {"a": 1}}
+
+    with pytest.raises(ValueError, match="value"):
+        FilterParameterImpl.from_dict(params)
+
+
+def test_from_dict_rejects_dict_nested_in_list_value() -> None:
+    """Test a list value holding a dict is rejected, since the shallow tuple conversion misses it."""
+    params: dict[str, Any] = {"values": [{"a": 1}]}
+
+    with pytest.raises(ValueError, match="values"):
+        FilterParameterImpl.from_dict(params)
+
+
+def test_from_dict_rejects_list_nested_in_list_value() -> None:
+    """Test a list value holding a list is rejected."""
+    params: dict[str, Any] = {"values": [[1, 2]]}
+
+    with pytest.raises(ValueError, match="values"):
+        FilterParameterImpl.from_dict(params)
+
+
+def test_from_dict_rejects_dict_nested_in_tuple_value() -> None:
+    """Test a tuple value holding a dict is rejected, even though the tuple itself is a hashable type."""
+    params: dict[str, Any] = {"values": ({"a": 1},)}
+
+    with pytest.raises(ValueError, match="values"):
+        FilterParameterImpl.from_dict(params)
+
+
+def test_from_dict_rejects_unhashable_leaf_value() -> None:
+    """Test an unhashable scalar such as bytearray is rejected."""
+    params: dict[str, Any] = {"value": bytearray(b"abc")}
+
+    with pytest.raises(ValueError, match="value"):
+        FilterParameterImpl.from_dict(params)
+
+
+def test_from_dict_rejects_unhashable_range_bound() -> None:
+    """Test the rejection is not limited to the value/values keys."""
+    params: dict[str, Any] = {"min": {"a": 1}, "max": 50}
+
+    with pytest.raises(ValueError, match="min"):
+        FilterParameterImpl.from_dict(params)
+
+
+def test_from_dict_error_names_the_offending_key() -> None:
+    """Test the message names the key that carries the unhashable value, not a neighbouring key."""
+    params: dict[str, Any] = {"min": 1, "payload": {"a": 1}}
+
+    with pytest.raises(ValueError, match="payload"):
+        FilterParameterImpl.from_dict(params)
+
+
+def test_from_dict_accepts_every_hashable_value_shape() -> None:
+    """Test the rejection leaves the supported value shapes untouched."""
+    shapes: list[dict[str, Any]] = [
+        {"value": 25},
+        {"value": None},
+        {"value": "EU"},
+        {"values": "EU"},
+        {"values": ["A", "B"]},
+        {"values": {"A", "B"}},
+        {"values": ("A", "B")},
+        {"min": 0, "max": 100, "max_exclusive": True},
+    ]
+
+    for params in shapes:
+        assert isinstance(hash(FilterParameterImpl.from_dict(params)), int)

--- a/tests/test_core/test_filter/test_global_filter.py
+++ b/tests/test_core/test_filter/test_global_filter.py
@@ -342,7 +342,7 @@ class TestGlobalFilterUnhashableParameter:
         """Test a dict value raises ValueError rather than the set insertion's TypeError."""
         parameter: dict[str, Any] = {"value": {"a": 1}}
 
-        with pytest.raises(ValueError, match="value"):
+        with pytest.raises(ValueError, match=r"'value'"):
             self.global_filter.add_filter(Feature("col"), FilterType.EQUAL, parameter)
 
         assert len(self.global_filter.filters) == 0
@@ -379,7 +379,7 @@ class TestGlobalFilterUnhashableParameter:
         self.global_filter.add_filter(Feature("age"), FilterType.RANGE, {"min": 25, "max": 50})
         parameter: dict[str, Any] = {"value": {"a": 1}}
 
-        with pytest.raises(ValueError, match="value"):
+        with pytest.raises(ValueError, match=r"'value'"):
             self.global_filter.add_filter(Feature("col"), FilterType.EQUAL, parameter)
 
         assert len(self.global_filter.filters) == 1

--- a/tests/test_core/test_filter/test_global_filter.py
+++ b/tests/test_core/test_filter/test_global_filter.py
@@ -330,3 +330,56 @@ class TestGlobalFilterCategoricalInclusion:
         self.global_filter.add_filter("region", FilterType.CATEGORICAL_INCLUSION, {"values": ["NA"]})
 
         assert len(self.global_filter.filters) == 2
+
+
+class TestGlobalFilterUnhashableParameter:
+    """An unhashable parameter value is rejected by add_filter with a ValueError (issue #925)."""
+
+    def setup_method(self) -> None:
+        self.global_filter = GlobalFilter()
+
+    def test_add_filter_rejects_dict_parameter_value(self) -> None:
+        """Test a dict value raises ValueError rather than the set insertion's TypeError."""
+        parameter: dict[str, Any] = {"value": {"a": 1}}
+
+        with pytest.raises(ValueError, match="value"):
+            self.global_filter.add_filter(Feature("col"), FilterType.EQUAL, parameter)
+
+        assert len(self.global_filter.filters) == 0
+
+    def test_add_filter_rejects_dict_nested_in_list_parameter_value(self) -> None:
+        """Test a dict nested in a list value is rejected and nothing is stored."""
+        parameter: dict[str, Any] = {"values": [{"a": 1}]}
+
+        with pytest.raises(ValueError, match="values"):
+            self.global_filter.add_filter(Feature("col"), FilterType.CATEGORICAL_INCLUSION, parameter)
+
+        assert len(self.global_filter.filters) == 0
+
+    def test_add_filter_rejects_list_nested_in_list_parameter_value(self) -> None:
+        """Test a list nested in a list value is rejected and nothing is stored."""
+        parameter: dict[str, Any] = {"values": [[1, 2]]}
+
+        with pytest.raises(ValueError, match="values"):
+            self.global_filter.add_filter("col", FilterType.CATEGORICAL_INCLUSION, parameter)
+
+        assert len(self.global_filter.filters) == 0
+
+    def test_add_filter_rejection_names_the_offending_key(self) -> None:
+        """Test the message names the key holding the unhashable value."""
+        parameter: dict[str, Any] = {"min": 25, "payload": {"a": 1}}
+
+        with pytest.raises(ValueError, match="payload"):
+            self.global_filter.add_filter(Feature("age"), FilterType.RANGE, parameter)
+
+        assert len(self.global_filter.filters) == 0
+
+    def test_add_filter_rejection_keeps_previously_added_filters(self) -> None:
+        """Test a rejected filter leaves the already collected filters intact."""
+        self.global_filter.add_filter(Feature("age"), FilterType.RANGE, {"min": 25, "max": 50})
+        parameter: dict[str, Any] = {"value": {"a": 1}}
+
+        with pytest.raises(ValueError, match="value"):
+            self.global_filter.add_filter(Feature("col"), FilterType.EQUAL, parameter)
+
+        assert len(self.global_filter.filters) == 1

--- a/tests/test_core/test_filter/test_single_filter_parameter_integration.py
+++ b/tests/test_core/test_filter/test_single_filter_parameter_integration.py
@@ -1,5 +1,9 @@
 """Tests for SingleFilter integration with FilterParameterImpl."""
 
+from typing import Any
+
+import pytest
+
 from mloda.user import SingleFilter
 from mloda.user import FilterType
 from mloda.core.filter.filter_parameter import FilterParameter, FilterParameterImpl
@@ -274,3 +278,46 @@ def test_filter_equality_with_unordered_parameters() -> None:
         parameter={"max": 50, "max_exclusive": True, "min": 25},
     )
     assert single_filter1 == single_filter2
+
+
+# --- Unhashable parameter rejection tests (see issue #925) ---
+#
+# SingleFilter is hashed as soon as it enters a set, so an unhashable parameter value has to be
+# refused while constructing the filter, where the caller can still see which key is at fault.
+
+
+def test_single_filter_rejects_dict_parameter_value() -> None:
+    """Test constructing a filter with a dict parameter value raises ValueError instead of building it."""
+    parameter: dict[str, Any] = {"value": {"a": 1}}
+
+    with pytest.raises(ValueError, match="value"):
+        SingleFilter(filter_feature="config", filter_type=FilterType.EQUAL, parameter=parameter)
+
+
+def test_single_filter_rejects_nested_unhashable_parameter_value() -> None:
+    """Test a dict nested in a list parameter value is refused at construction."""
+    parameter: dict[str, Any] = {"values": [{"a": 1}]}
+
+    with pytest.raises(ValueError, match="values"):
+        SingleFilter(filter_feature="category", filter_type=FilterType.CATEGORICAL_INCLUSION, parameter=parameter)
+
+
+def test_single_filter_rejection_names_the_offending_key() -> None:
+    """Test the raised message names the key holding the unhashable value."""
+    parameter: dict[str, Any] = {"min": 25, "payload": {"a": 1}}
+
+    with pytest.raises(ValueError, match="payload"):
+        SingleFilter(filter_feature="age", filter_type=FilterType.RANGE, parameter=parameter)
+
+
+def test_single_filter_still_accepts_collection_parameter_values() -> None:
+    """Test hashable collection parameters keep constructing and hashing after the rejection."""
+    parameter: dict[str, Any] = {"values": {"A", "B"}}
+    single_filter = SingleFilter(
+        filter_feature="category",
+        filter_type=FilterType.CATEGORICAL_INCLUSION,
+        parameter=parameter,
+    )
+
+    assert isinstance(hash(single_filter), int)
+    assert sorted(single_filter.parameter.values or []) == ["A", "B"]

--- a/tests/test_core/test_filter/test_single_filter_parameter_integration.py
+++ b/tests/test_core/test_filter/test_single_filter_parameter_integration.py
@@ -281,16 +281,13 @@ def test_filter_equality_with_unordered_parameters() -> None:
 
 
 # --- Unhashable parameter rejection tests (see issue #925) ---
-#
-# SingleFilter is hashed as soon as it enters a set, so an unhashable parameter value has to be
-# refused while constructing the filter, where the caller can still see which key is at fault.
 
 
 def test_single_filter_rejects_dict_parameter_value() -> None:
     """Test constructing a filter with a dict parameter value raises ValueError instead of building it."""
     parameter: dict[str, Any] = {"value": {"a": 1}}
 
-    with pytest.raises(ValueError, match="value"):
+    with pytest.raises(ValueError, match=r"'value'"):
         SingleFilter(filter_feature="config", filter_type=FilterType.EQUAL, parameter=parameter)
 
 
@@ -319,5 +316,8 @@ def test_single_filter_still_accepts_collection_parameter_values() -> None:
         parameter=parameter,
     )
 
-    assert isinstance(hash(single_filter), int)
-    assert sorted(single_filter.parameter.values or []) == ["A", "B"]
+    hash(single_filter)
+
+    values = single_filter.parameter.values
+    assert values is not None
+    assert sorted(values) == ["A", "B"]


### PR DESCRIPTION
Closes #925.

## Problem

`FilterParameterImpl.from_dict` normalizes list and set values to tuples, but a dict value skipped that normalization and stayed raw inside the frozen `_raw` tuple. `hash(SingleFilter)` then raised `TypeError: unhashable type: 'dict'` the moment `GlobalFilter.add_filter` inserted the filter into its set: an error that names `dict` and points at a hash, not at the parameter that caused it.

```python
gf = GlobalFilter()
gf.add_filter(Feature("col"), FilterType.EQUAL, {"value": {"a": 1}})
```

## Change

Reject rather than normalize, so the caller gets a `ValueError` at `add_filter` / `SingleFilter(...)` time naming both the offending key and the offending type.

Normalizing a dict into a frozen tuple was the other option in the issue, but every filter engine hands `parameter.value` / `.values` straight to a framework comparison (`==`, `isin`, `<`). A `tuple[tuple[str, Any], ...]` reaching `Column.isin` turns a loud failure into a silently empty result set, and there is no accessor that could reverse the normalization.

The guard probes the actual hash instead of testing `isinstance(value, Hashable)`. That predicate only means `__hash__` is not None, so values whose `__hash__` raises (`Decimal("sNaN")`, a writable `memoryview`, which raises `ValueError` rather than `TypeError`) would have slipped through into the same late failure. Probing also keeps the happy path a single C-level `hash()` call: the tuple walk runs only once a value has already failed, purely to name the culprit.

Coverage: dict values, unhashable values nested in a list or tuple, unhashable leaves, and any raising `__hash__`. Scalars, `None`, strings (never exploded), lists, sets, tuples, lists of tuples, and the `datetime` bounds used by `add_time_and_time_travel_filters` all stay accepted.

## Notes

Latent rather than a live failure: no shipped plugin passes a dict-valued parameter, and every filter-construction site in the repo passes a scalar or a flat scalar collection. This narrows the public API, but only for inputs that already crashed.

Reviewed by two independent deep reviews before raising. Both flagged the `Hashable` predicate; the message wording, a `RecursionError` on deeply nested tuples, and five vacuous `pytest.raises(match=...)` assertions came out of the same pass and are fixed here.