### PR TITLE
fix: gate name-based matching behind an owned reader veto

### DIFF
--- a/docs/docs/in_depth/data-access-patterns.md
+++ b/docs/docs/in_depth/data-access-patterns.md
@@ -149,6 +149,8 @@ Rules for reader authors:
 
 `ReadFile` column validation and the `ReadDB` feature check (`check_feature_in_data_access`) already record automatically; a custom reader only needs this for its own decline points.
 
+A recorded reader veto also gates the candidate's name-based match rules. A feature group whose reader declined attributably fails at resolution with that reason instead of resolving by name and crashing at load time in `init_reader`.
+
 ## MatchData Pattern
 
 ### Purpose

--- a/docs/docs/in_depth/data-access-patterns.md
+++ b/docs/docs/in_depth/data-access-patterns.md
@@ -104,7 +104,7 @@ A reader that owns an input but cannot serve the requested feature can record wh
 ``` python
 from typing import Any
 
-from mloda.provider import FeatureSet, record_match_rejection
+from mloda.provider import INPUT_DATA_STAGE, FeatureSet, record_match_rejection
 from mloda_plugins.feature_group.input_data.read_file import ReadFile
 
 class SensorCsvReader(ReadFile):
@@ -126,7 +126,7 @@ class SensorCsvReader(ReadFile):
                 cls.get_class_name(),
                 f"{cls.get_class_name()} matched the suffix of {file_name} "
                 f"but its header lacks the #sensor-schema marker",
-                stage="input_data",
+                stage=INPUT_DATA_STAGE,
             )
             return False
         return True

--- a/docs/docs/in_depth/data-access-patterns.md
+++ b/docs/docs/in_depth/data-access-patterns.md
@@ -144,12 +144,12 @@ Rules for reader authors:
 - Plain non-matches (wrong suffix, invalid credentials) stay silent. `NotImplementedError` from `is_valid_credentials` is a silent non-match; from `check_feature_in_data_access` it is an accept (the reader matches on credentials alone).
 - Never raise to decline: anything but `NotImplementedError` in the DB match hooks aborts matching for every reader sharing the `DataAccessCollection`. Record, then return a falsy value.
 - Recording outside an engine-opened window is a no-op, so readers stay usable standalone.
-- Recorded reasons are discarded at the enclosing candidate level: when the reader ultimately matches, when a sibling reader matches, or when the feature group matches by another rule. Only a decline surfaces them.
+- Recorded reasons are discarded at the enclosing candidate level: when the reader ultimately matches, when a sibling reader matches, or, for unowned recordings, when the feature group matches by another rule. An owned veto instead gates the name-based rules (see the paragraph below). Only a decline surfaces them.
 - Name the reader and the concrete input in the reason, as the example does.
 
 `ReadFile` column validation and the `ReadDB` feature check (`check_feature_in_data_access`) already record automatically; a custom reader only needs this for its own decline points.
 
-A recorded reader veto also gates the candidate's name-based match rules. A feature group whose reader declined attributably fails at resolution with that reason instead of resolving by name and crashing at load time in `init_reader`.
+A veto recorded while the user explicitly addressed the reader family (an option key equal to the reader's `data_access_name()`) gates the candidate's name-based match rules: the feature group fails at resolution with that reason instead of resolving by name and crashing at load time in `init_reader`. An unowned decline on the global probe stays near-miss material only, and the MatchData rule is not gated.
 
 ## MatchData Pattern
 

--- a/docs/docs/in_depth/feature-group-matching.md
+++ b/docs/docs/in_depth/feature-group-matching.md
@@ -115,6 +115,8 @@ For feature groups not yet modernized, the default matching criteria still apply
    feature_name in FeatureGroup.feature_names_supported()
    ```
 
+An owned reader veto recorded during rule 1 (the user addressed the reader family by name and its declaration rejected the request) gates the name-based rules 2 to 4; see [Data Access Patterns](data-access-patterns.md) for the recording contract.
+
 ## Matching Examples
 
 ### Modern Feature Group (Aggregation)

--- a/docs/docs/in_depth/feature-group-testing.md
+++ b/docs/docs/in_depth/feature-group-testing.md
@@ -18,6 +18,8 @@ assert ClusteringFeatureGroup.match_feature_group_criteria("customer_behavior__c
 assert not ClusteringFeatureGroup.match_feature_group_criteria("invalid_name", Options())
 ```
 
+The reader veto gate reads the engine's per-candidate rejection window, so a direct `match_feature_group_criteria` call without an active window does not exercise it; engine-shaped assertions go through `IdentifyFeatureGroupClass.evaluate`.
+
 ### 2. Input Feature Extraction
 
 Test that your feature group correctly extracts source features from feature names.

--- a/mloda/core/abstract_plugins/components/input_data/base_input_data.py
+++ b/mloda/core/abstract_plugins/components/input_data/base_input_data.py
@@ -5,7 +5,11 @@ from typing import Any, ClassVar, Optional
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.feature_chainer.property_spec import PropertySpec, is_no_default
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
-from mloda.core.abstract_plugins.components.match_rejection import record_match_rejection
+from mloda.core.abstract_plugins.components.match_rejection import (
+    INPUT_DATA_OWNED_STAGE,
+    INPUT_DATA_STAGE,
+    record_match_rejection,
+)
 from mloda.core.abstract_plugins.components.options import Options
 
 
@@ -148,7 +152,7 @@ class BaseInputData(ABC):
     @classmethod
     def _reader_options_admit(cls, options: Optional[Options], record_absence: bool) -> bool:
         """Check this candidate's merged declarations BEFORE its probe runs; a veto is its own non-match.
-        record_absence gates only absence recordings; a present-value strict rejection records on both paths."""
+        record_absence doubles as the ownership signal: it gates absence recordings and stages present-value ones."""
         for key, spec in cls._merged_reader_option_specs().items():
             if spec.framework_set:
                 continue
@@ -162,7 +166,7 @@ class BaseInputData(ABC):
                 if not cls._absent_reader_option_admits(key, spec, options, record_absence):
                     return False
             elif spec.strict_validation:
-                if not cls._present_reader_option_admits(key, spec, value):
+                if not cls._present_reader_option_admits(key, spec, value, owned=record_absence):
                     return False
         return True
 
@@ -194,7 +198,7 @@ class BaseInputData(ABC):
                         owner,
                         f"required reader option '{key}' is absent, but {owner} declares it required "
                         f"(required_when predicate {getattr(predicate, '__name__', repr(predicate))} is satisfied)",
-                        stage="input_data",
+                        stage=INPUT_DATA_OWNED_STAGE,
                     )
                 return False
             return True
@@ -203,15 +207,15 @@ class BaseInputData(ABC):
                 record_match_rejection(
                     owner,
                     f"required reader option '{key}' is absent, but {owner} declares it required (no default declared)",
-                    stage="input_data",
+                    stage=INPUT_DATA_OWNED_STAGE,
                 )
             return False
         return True
 
     @classmethod
-    def _present_reader_option_admits(cls, key: str, spec: PropertySpec, value: Any) -> bool:
+    def _present_reader_option_admits(cls, key: str, spec: PropertySpec, value: Any, owned: bool) -> bool:
         """Strict validation of a PRESENT value: list/tuple/set/frozenset unpack element-wise,
-        a str is one scalar, a dict one composite value."""
+        a str is one scalar, a dict one composite value; owned stages the recorded rejection."""
         elements = list(value) if isinstance(value, (list, tuple, set, frozenset)) else [value]
         for element in elements:
             if cls._reader_option_element_admits(key, spec, element):
@@ -220,7 +224,7 @@ class BaseInputData(ABC):
             record_match_rejection(
                 owner,
                 f"reader option '{key}' value {element!r} is rejected by the declaration of {owner}",
-                stage="input_data",
+                stage=INPUT_DATA_OWNED_STAGE if owned else INPUT_DATA_STAGE,
             )
             return False
         return True
@@ -293,7 +297,7 @@ class BaseInputData(ABC):
                 _key = cls.deal_with_base_input_data_name_as_cls_or_str(key)
 
                 if _key == subclass.data_access_name():
-                    # The user addressed this reader family by name (ownership), so absence vetoes record.
+                    # The user addressed this reader family by name (ownership), so vetoes record as owned.
                     if not subclass._reader_options_admit(options, record_absence=True):
                         break
                     matched_data_access = subclass.match_subclass_data_access(value, [feature_name], options=options)  # type: ignore[attr-defined]

--- a/mloda/core/abstract_plugins/components/match_rejection.py
+++ b/mloda/core/abstract_plugins/components/match_rejection.py
@@ -32,3 +32,11 @@ def record_match_rejection(owner_name: str, reason: str, stage: str = "value_rej
     if reasons is None:
         return
     reasons.setdefault(owner_name, MatchRejection(reason, stage))
+
+
+def has_match_rejection(stage: str) -> bool:
+    """True iff the active window holds a rejection with exactly this stage; False without an active window."""
+    reasons = MATCH_REJECTION_REASONS.get()
+    if reasons is None:
+        return False
+    return any(rejection.stage == stage for rejection in reasons.values())

--- a/mloda/core/abstract_plugins/components/match_rejection.py
+++ b/mloda/core/abstract_plugins/components/match_rejection.py
@@ -18,6 +18,11 @@ class MatchRejection:
     stage: str = "value_rejection"
 
 
+# The owned stage marks a veto recorded while the user explicitly addressed the reader family.
+INPUT_DATA_STAGE = "input_data"
+INPUT_DATA_OWNED_STAGE = "input_data_owned"
+
+
 # Active for one candidate's match call: the engine opens a window per candidate. Maps the recording
 # site's owner name to the first structured rejection the real match pass produced, and the
 # engine attributes the harvest to the candidate class object it called.

--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -31,6 +31,7 @@ from mloda.core.abstract_plugins.components.input_data.api.api_input_data import
 from mloda.core.abstract_plugins.components.input_data.base_input_data import BaseInputData
 from mloda.core.abstract_plugins.components.input_data.creator.data_creator import DataCreator
 from mloda.core.abstract_plugins.components.match_data.match_data import MatchData
+from mloda.core.abstract_plugins.components.match_rejection import has_match_rejection
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
@@ -616,12 +617,20 @@ class FeatureGroup(ABC):
         feature declares itself keeps its declared value, an omitted key arrives materialized.
         Matching logic that reads option values can therefore see different values on the two paths.
         See ``docs/in_depth/property-mapping.md`` ("Applying declared defaults").
+
+        A reader veto recorded during the input-data rule gates the later rules: when the reader
+        walk declined attributably, the candidate is a non-match instead of being recovered by name.
         """
 
         base_feature_name = cls.get_column_base_feature(feature_name)
 
         if cls._is_root_and_matches_input_data(base_feature_name, options, data_access_collection):
             return True
+
+        # A recorded reader veto means the user engaged this candidate's declared reader option
+        # space; a name-rule recovery would only defer the failure to load time in init_reader.
+        if has_match_rejection("input_data"):
+            return False
 
         if cls._matches_data(base_feature_name, options, data_access_collection):
             return True

--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -31,7 +31,7 @@ from mloda.core.abstract_plugins.components.input_data.api.api_input_data import
 from mloda.core.abstract_plugins.components.input_data.base_input_data import BaseInputData
 from mloda.core.abstract_plugins.components.input_data.creator.data_creator import DataCreator
 from mloda.core.abstract_plugins.components.match_data.match_data import MatchData
-from mloda.core.abstract_plugins.components.match_rejection import has_match_rejection
+from mloda.core.abstract_plugins.components.match_rejection import INPUT_DATA_OWNED_STAGE, has_match_rejection
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
@@ -618,8 +618,8 @@ class FeatureGroup(ABC):
         Matching logic that reads option values can therefore see different values on the two paths.
         See ``docs/in_depth/property-mapping.md`` ("Applying declared defaults").
 
-        A reader veto recorded during the input-data rule gates the later rules: when the reader
-        walk declined attributably, the candidate is a non-match instead of being recovered by name.
+        A veto recorded while the user explicitly addressed the reader family gates the name-based
+        rules below; the MatchData rule still decides on its own.
         """
 
         base_feature_name = cls.get_column_base_feature(feature_name)
@@ -627,13 +627,13 @@ class FeatureGroup(ABC):
         if cls._is_root_and_matches_input_data(base_feature_name, options, data_access_collection):
             return True
 
-        # A recorded reader veto means the user engaged this candidate's declared reader option
-        # space; a name-rule recovery would only defer the failure to load time in init_reader.
-        if has_match_rejection("input_data"):
-            return False
-
         if cls._matches_data(base_feature_name, options, data_access_collection):
             return True
+
+        # An owned veto: the user explicitly addressed this candidate's reader family and its declaration
+        # rejected the request; recovering by name would only defer the failure to load time in init_reader.
+        if has_match_rejection(INPUT_DATA_OWNED_STAGE):
+            return False
 
         if cls.feature_name_equal_to_class_name(base_feature_name):
             return True

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -26,6 +26,8 @@ from mloda.core.abstract_plugins.components.data_access_collection import DataAc
 from mloda.core.abstract_plugins.components.domain import Domain
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import PropertyValueRejection
 from mloda.core.abstract_plugins.components.match_rejection import (
+    INPUT_DATA_OWNED_STAGE,
+    INPUT_DATA_STAGE,
     MATCH_REJECTION_REASONS,
     MatchRejection,
     record_match_rejection,
@@ -401,8 +403,13 @@ class IdentifyFeatureGroupClass:
                     continue
                 rejection = self._value_rejection(feature_group)
                 if rejection is not None:
-                    # The stage is a free-form hint; only "input_data" is engine-known, the rest fall back.
-                    stage: EliminationStage = "input_data" if rejection.stage == "input_data" else "value_rejection"
+                    # The stage is a free-form hint; only the two input-data stages are engine-known and both
+                    # surface as the public "input_data" elimination stage, the rest fall back.
+                    stage: EliminationStage = (
+                        "input_data"
+                        if rejection.stage in (INPUT_DATA_STAGE, INPUT_DATA_OWNED_STAGE)
+                        else "value_rejection"
+                    )
                     self._record_elimination(feature_group, stage, rejection.reason)
                 continue
 

--- a/mloda/provider/__init__.py
+++ b/mloda/provider/__init__.py
@@ -87,7 +87,10 @@ from mloda.core.abstract_plugins.components.feature_chainer.property_spec import
 )
 
 # Match rejection recording
-from mloda.core.abstract_plugins.components.match_rejection import record_match_rejection
+from mloda.core.abstract_plugins.components.match_rejection import (
+    INPUT_DATA_STAGE,
+    record_match_rejection,
+)
 
 # Subtype declaration
 from mloda.core.abstract_plugins.components.subtype_declaration import SubtypeDeclaration
@@ -170,6 +173,7 @@ __all__ = [
     "property_spec",
     "NO_DEFAULT",
     # Match rejection recording
+    "INPUT_DATA_STAGE",
     "record_match_rejection",
     # Subtype declaration
     "SubtypeDeclaration",

--- a/mloda_plugins/feature_group/input_data/read_db.py
+++ b/mloda_plugins/feature_group/input_data/read_db.py
@@ -1,6 +1,7 @@
 from typing import Any, ClassVar
 from mloda.user import DataAccessCollection
 from mloda.provider import FeatureSet, BaseInputData, PropertySpec, record_match_rejection
+from mloda.core.abstract_plugins.components.match_rejection import INPUT_DATA_STAGE
 from mloda.user import Options
 
 
@@ -136,7 +137,7 @@ class ReadDB(BaseInputData):
                             cls.get_class_name(),
                             f"{cls.get_class_name()} accepted the credentials but declined "
                             f"the feature '{feature_names[0]}'",
-                            stage="input_data",
+                            stage=INPUT_DATA_STAGE,
                         )
                         continue
                     except NotImplementedError:

--- a/mloda_plugins/feature_group/input_data/read_file.py
+++ b/mloda_plugins/feature_group/input_data/read_file.py
@@ -4,6 +4,7 @@ from typing import Any, ClassVar
 from mloda.user import DataAccessCollection
 from mloda.provider import FeatureSet
 from mloda.provider import BaseInputData, PropertySpec, record_match_rejection
+from mloda.core.abstract_plugins.components.match_rejection import INPUT_DATA_STAGE
 from mloda.user import Options
 
 
@@ -175,7 +176,7 @@ class ReadFile(BaseInputData):
                 cls.get_class_name(),
                 f"{cls.get_class_name()} matched the suffix of {file_name} but it lacks the column(s): "
                 f"{', '.join(missing)}",
-                stage="input_data",
+                stage=INPUT_DATA_STAGE,
             )
             return False
         return True

--- a/tests/test_core/test_abstract_plugins/test_components/test_reader_option_enforcement.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_reader_option_enforcement.py
@@ -16,7 +16,12 @@ from mloda.core.abstract_plugins.components.feature_chainer.property_spec import
     is_no_default,
     is_positive_int,
 )
-from mloda.core.abstract_plugins.components.match_rejection import MATCH_REJECTION_REASONS, MatchRejection
+from mloda.core.abstract_plugins.components.match_rejection import (
+    INPUT_DATA_OWNED_STAGE,
+    INPUT_DATA_STAGE,
+    MATCH_REJECTION_REASONS,
+    MatchRejection,
+)
 from mloda.core.abstract_plugins.components.utils import get_all_subclasses
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
 from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
@@ -397,7 +402,7 @@ class TestFeatureScopeStrictValues:
         owner = RoeStrictValuesReader.get_class_name()
         assert list(rejection_window) == [owner]
         stored = rejection_window[owner]
-        assert stored.stage == "input_data"
+        assert stored.stage == INPUT_DATA_OWNED_STAGE
         assert owner in stored.reason
         assert ROE_FORMAT_KEY in stored.reason
         assert "roe_bogus" in stored.reason
@@ -434,7 +439,7 @@ class TestFeatureScopeStrictValues:
 
         assert matched is False
         stored = rejection_window[RoeStrictValuesReader.get_class_name()]
-        assert stored.stage == "input_data"
+        assert stored.stage == INPUT_DATA_OWNED_STAGE
         assert ROE_FORMAT_KEY in stored.reason
 
     def test_all_valid_container_elements_still_match(self, rejection_window: dict[str, MatchRejection]) -> None:
@@ -456,7 +461,7 @@ class TestFeatureScopeStrictValues:
 
         assert matched is False
         stored = rejection_window[RoeStrictValuesReader.get_class_name()]
-        assert stored.stage == "input_data"
+        assert stored.stage == INPUT_DATA_OWNED_STAGE
         assert ROE_CHAR_KEY in stored.reason
         assert "xyz" in stored.reason
 
@@ -470,7 +475,7 @@ class TestFeatureScopeStrictValues:
 
         assert matched is False
         stored = rejection_window[RoeStrictValuesReader.get_class_name()]
-        assert stored.stage == "input_data"
+        assert stored.stage == INPUT_DATA_OWNED_STAGE
         assert ROE_FORMAT_KEY in stored.reason
 
     def test_explicit_none_on_a_flagless_strict_spec_reads_absent(
@@ -537,7 +542,7 @@ class TestElementValidator:
 
         assert matched is False
         stored = rejection_window[RoeValidatorReader.get_class_name()]
-        assert stored.stage == "input_data"
+        assert stored.stage == INPUT_DATA_OWNED_STAGE
         assert RoeValidatorReader.get_class_name() in stored.reason
         assert ROE_COUNT_KEY in stored.reason
         assert "roe_member" in stored.reason
@@ -552,7 +557,7 @@ class TestElementValidator:
 
         assert matched is False
         stored = rejection_window[RoeValidatorReader.get_class_name()]
-        assert stored.stage == "input_data"
+        assert stored.stage == INPUT_DATA_OWNED_STAGE
         assert ROE_TOUCHY_KEY in stored.reason
 
 
@@ -572,7 +577,7 @@ class TestRequiredness:
         owner = RoeConditionalReader.get_class_name()
         assert list(rejection_window) == [owner]
         stored = rejection_window[owner]
-        assert stored.stage == "input_data"
+        assert stored.stage == INPUT_DATA_OWNED_STAGE
         assert owner in stored.reason
         assert ROE_COND_KEY in stored.reason
 
@@ -626,7 +631,7 @@ class TestRequiredness:
         owner = reader.get_class_name()
         assert list(rejection_window) == [owner]
         stored = rejection_window[owner]
-        assert stored.stage == "input_data"
+        assert stored.stage == INPUT_DATA_OWNED_STAGE
         assert owner in stored.reason
         assert ROE_REQUIRED_KEY in stored.reason
 
@@ -666,7 +671,7 @@ class TestRequiredness:
 
         assert matched is False
         stored = rejection_window[reader.get_class_name()]
-        assert stored.stage == "input_data"
+        assert stored.stage == INPUT_DATA_OWNED_STAGE
         assert ROE_NULLABLE_KEY in stored.reason
 
     def test_declared_defaults_keep_absent_keys_optional(self, rejection_window: dict[str, MatchRejection]) -> None:
@@ -695,7 +700,7 @@ class TestGlobalProbeEnforcement:
         owner = RoeStrictValuesReader.get_class_name()
         assert list(rejection_window) == [owner]
         stored = rejection_window[owner]
-        assert stored.stage == "input_data"
+        assert stored.stage == INPUT_DATA_STAGE
         assert owner in stored.reason
         assert ROE_FORMAT_KEY in stored.reason
         assert "roe_bogus" in stored.reason
@@ -757,7 +762,7 @@ class TestGlobalProbeEnforcement:
         solo = RoePairVetoedFamily.match_data_access([ROE_FEATURE_NAME], dac, options=options)
         assert solo == (None, None)
         stored = rejection_window[RoePairVetoedReader.get_class_name()]
-        assert stored.stage == "input_data"
+        assert stored.stage == INPUT_DATA_STAGE
 
         paired = RoePairFamily.match_data_access([ROE_FEATURE_NAME], dac, options=options)
         assert paired == (RoePairCleanReader, ROE_PAIR_CLEAN_ACCESS)
@@ -841,7 +846,7 @@ class TestEngineIntegration:
         assert result.identified == {}
         elimination = result.eliminations.get(RoeEnforcementFG)
         assert elimination is not None
-        assert elimination.stage == "input_data"
+        assert elimination.stage == INPUT_DATA_STAGE
         assert RoeEngineReader.get_class_name() in elimination.reason
         assert ROE_ENGINE_KEY in elimination.reason
         assert "roe_bogus" in elimination.reason

--- a/tests/test_core/test_abstract_plugins/test_components/test_reader_veto_gates_name_rules.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_reader_veto_gates_name_rules.py
@@ -1,0 +1,361 @@
+"""Pins issue #954: a reader veto recorded with ``stage="input_data"`` during a candidate's match
+window gates the name-based OR rules of ``match_feature_group_criteria``, so the candidate becomes
+an ``input_data`` elimination instead of being recovered by ``feature_names_supported``; sibling
+probing, input-data-free candidates and valid values keep resolving unchanged, and the helper
+``has_match_rejection`` reports the active window's stages.
+Leak policy: every name carries the vg954 marker so leaked classes are foreign-inert; the
+absence-firing required-key shape is test-local (factory + per-test tag + gc), never module-level.
+"""
+
+from __future__ import annotations
+
+import gc
+from collections.abc import Iterator
+from typing import Any, ClassVar
+
+import pytest
+
+from mloda.core.abstract_plugins.components.feature_chainer.property_spec import PropertySpec, is_no_default
+from mloda.core.abstract_plugins.components.match_rejection import (
+    MATCH_REJECTION_REASONS,
+    MatchRejection,
+    record_match_rejection,
+)
+from mloda.core.abstract_plugins.components.utils import get_all_subclasses
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+from mloda.core.prepare.resolution_failure_renderer import render_resolution_failure
+from mloda.provider import BaseInputData, FeatureGroup, FeatureSet
+from mloda.user import Feature, FeatureName, Options
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+
+
+VG954_FEATURE_NAME = "vg954_column"
+VG954_PLAIN_FEATURE_NAME = "vg954_plain_column"
+VG954_SIBLING_FEATURE_NAME = "vg954_sibling_column"
+VG954_REQUIRED_FEATURE_NAME = "vg954_required_column"
+
+VG954_GATE_ACCESS = "vg954_gate_access"
+VG954_FORMAT_KEY = "vg954_format"
+
+VG954_VETOED_ACCESS = "vg954_vetoed_access"
+VG954_CLEAN_ACCESS = "vg954_clean_access"
+VG954_SIBLING_KEY = "vg954_sibling_mode"
+
+VG954_REQUIRED_ACCESS = "vg954_required_access"
+VG954_REQUIRED_KEY = "vg954_required"
+
+VG954_UNIT_OWNER = "vg954_unit_owner"
+VG954_UNIT_REASON = "vg954 unit reason"
+
+
+class _Vg954MarkedReader(BaseInputData):
+    """Family base: a child matches ONLY its own module-unique access string."""
+
+    VG954_ACCESS: ClassVar[str] = ""
+
+    @classmethod
+    def match_subclass_data_access(
+        cls, data_access: Any, feature_names: list[str], options: Options | None = None
+    ) -> Any:
+        if cls.VG954_ACCESS and isinstance(data_access, str) and data_access == cls.VG954_ACCESS:
+            return data_access
+        return None
+
+
+class Vg954GateFamily(_Vg954MarkedReader):
+    """Scopes the probes of the gated-shape tests to exactly one final reader."""
+
+
+class Vg954GateReader(Vg954GateFamily):
+    """Final reader whose strict key vetoes the gated-shape bogus value; the default keeps it foreign-inert."""
+
+    VG954_ACCESS = VG954_GATE_ACCESS
+
+    READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+        VG954_FORMAT_KEY: PropertySpec(
+            "Strict membership key: it fires only on a PRESENT out-of-space value.",
+            allowed_values=("vg954_ok",),
+            strict_validation=True,
+            default="vg954_ok",
+        ),
+    }
+
+    @classmethod
+    def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
+        return {VG954_FEATURE_NAME: [1]}
+
+
+class Vg954GatedFG(FeatureGroup):
+    """Root FG whose name rule accepts ONLY vg954_column; the recorded reader veto must gate that rule."""
+
+    @classmethod
+    def input_data(cls) -> BaseInputData | None:
+        return Vg954GateFamily()
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        return None
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return {VG954_FEATURE_NAME}
+
+
+class Vg954SiblingFamily(_Vg954MarkedReader):
+    """Two-reader family: one spec-vetoed sibling plus one clean sibling, both addressed by name."""
+
+
+class Vg954VetoedSiblingReader(Vg954SiblingFamily):
+    """Final sibling whose strict key rejects the sibling test's supplied value."""
+
+    VG954_ACCESS = VG954_VETOED_ACCESS
+
+    READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+        VG954_SIBLING_KEY: PropertySpec(
+            "Strict key of the vetoed sibling; module-level safe because it declares a default.",
+            allowed_values=("vg954_ok",),
+            strict_validation=True,
+            default="vg954_ok",
+        ),
+    }
+
+    @classmethod
+    def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
+        return {VG954_SIBLING_FEATURE_NAME: [1]}
+
+
+class Vg954CleanSiblingReader(Vg954SiblingFamily):
+    """Final clean sibling; it must keep matching while its sibling is vetoed."""
+
+    VG954_ACCESS = VG954_CLEAN_ACCESS
+
+    @classmethod
+    def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
+        return {VG954_SIBLING_FEATURE_NAME: [1]}
+
+
+class Vg954SiblingFG(FeatureGroup):
+    """Root FG matching ONLY via its sibling reader family; unique names keep it inert elsewhere."""
+
+    @classmethod
+    def input_data(cls) -> BaseInputData | None:
+        return Vg954SiblingFamily()
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        return None
+
+
+class Vg954PlainFG(FeatureGroup):
+    """FG without input data: only its name rule claims vg954_plain_column."""
+
+    @classmethod
+    def input_data(cls) -> BaseInputData | None:
+        return None
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return {VG954_PLAIN_FEATURE_NAME}
+
+
+def _vg954_required_setup(tag: str) -> tuple[type[BaseInputData], type[FeatureGroup]]:
+    """(reader, feature group) with an unconditionally required key, built test-locally per the leak policy;
+    the per-test tag keys data_access_name() so a traceback-kept stale twin is never the addressed reader."""
+
+    class Vg954LocalRequiredFamily(_Vg954MarkedReader):
+        """Scopes the solo probe to the one required-key reader."""
+
+    class Vg954LocalRequiredReader(Vg954LocalRequiredFamily):
+        VG954_ACCESS = VG954_REQUIRED_ACCESS
+
+        READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+            VG954_REQUIRED_KEY: PropertySpec("Unconditionally required: declares no default, no required_when."),
+        }
+
+        @classmethod
+        def data_access_name(cls) -> str:
+            return f"Vg954LocalRequiredReader_{tag}"
+
+        @classmethod
+        def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
+            return {VG954_REQUIRED_FEATURE_NAME: [1]}
+
+    class Vg954LocalRequiredFG(FeatureGroup):
+        """Root FG whose name rule accepts ONLY vg954_required_column."""
+
+        @classmethod
+        def input_data(cls) -> BaseInputData | None:
+            return Vg954LocalRequiredFamily()
+
+        def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+            return None
+
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {VG954_REQUIRED_FEATURE_NAME}
+
+    return Vg954LocalRequiredReader, Vg954LocalRequiredFG
+
+
+@pytest.fixture()
+def rejection_window() -> Iterator[dict[str, MatchRejection]]:
+    """Open a recording window around one call, mirroring the engine's per-candidate window."""
+    window: dict[str, MatchRejection] = {}
+    token = MATCH_REJECTION_REASONS.set(window)
+    yield window
+    MATCH_REJECTION_REASONS.reset(token)
+
+
+@pytest.fixture()
+def collect_after() -> Iterator[None]:
+    """Reclaim test-local Vg954Local* classes out of __subclasses__ before the next test on this worker."""
+    yield
+    gc.collect()
+
+
+class TestHasMatchRejection:
+    """The helper reports whether the ACTIVE window holds a rejection with the exact stage."""
+
+    def test_no_active_window_reports_false(self) -> None:
+        """Without an open window nothing is recorded, so the helper answers False."""
+        from mloda.core.abstract_plugins.components.match_rejection import has_match_rejection
+
+        assert MATCH_REJECTION_REASONS.get() is None
+        assert has_match_rejection("input_data") is False
+
+    def test_a_window_holding_only_a_foreign_stage_reports_false(
+        self, rejection_window: dict[str, MatchRejection]
+    ) -> None:
+        """The stage comparison is exact: a value_rejection recording is not an input_data one."""
+        from mloda.core.abstract_plugins.components.match_rejection import has_match_rejection
+
+        record_match_rejection(VG954_UNIT_OWNER, VG954_UNIT_REASON)
+
+        assert has_match_rejection("input_data") is False
+
+    def test_a_window_holding_an_input_data_rejection_reports_true(
+        self, rejection_window: dict[str, MatchRejection]
+    ) -> None:
+        """An input_data recording in the active window flips the helper to True."""
+        from mloda.core.abstract_plugins.components.match_rejection import has_match_rejection
+
+        record_match_rejection(VG954_UNIT_OWNER, VG954_UNIT_REASON, stage="input_data")
+
+        assert has_match_rejection("input_data") is True
+
+
+class TestReaderVetoGatesNameRules:
+    """Engine level, deliberately WITHOUT a window fixture: the engine owns the per-candidate window."""
+
+    def test_a_strict_value_veto_gates_the_name_rule(self) -> None:
+        """The recorded strict-value veto must eliminate the candidate; the name rule must not recover it."""
+        feature = Feature(
+            name=VG954_FEATURE_NAME,
+            options={Vg954GateReader.__name__: VG954_GATE_ACCESS, VG954_FORMAT_KEY: "vg954_bogus"},
+        )
+        accessible_plugins: FeatureGroupEnvironmentMapping = {Vg954GatedFG: {PandasDataFrame}}
+
+        result = IdentifyFeatureGroupClass.evaluate(feature, accessible_plugins, None, None)
+
+        assert result.identified == {}
+        elimination = result.eliminations.get(Vg954GatedFG)
+        assert elimination is not None
+        assert elimination.stage == "input_data"
+        assert Vg954GateReader.get_class_name() in elimination.reason
+        assert VG954_FORMAT_KEY in elimination.reason
+        assert "vg954_bogus" in elimination.reason
+
+        message = render_resolution_failure(result, feature)
+        assert message is not None
+        assert f"  - {Vg954GatedFG.__name__} (input data): {elimination.reason}" in message
+
+    def test_an_absent_required_key_veto_gates_the_name_rule(self, collect_after: None) -> None:
+        """The recorded absence veto on the ownership path must eliminate the candidate too."""
+        reader, feature_group = _vg954_required_setup("gate_absent")
+        feature = Feature(
+            name=VG954_REQUIRED_FEATURE_NAME,
+            options={reader.data_access_name(): VG954_REQUIRED_ACCESS},
+        )
+        accessible_plugins: FeatureGroupEnvironmentMapping = {feature_group: {PandasDataFrame}}
+
+        result = IdentifyFeatureGroupClass.evaluate(feature, accessible_plugins, None, None)
+
+        identified_names = sorted(fg.__name__ for fg in result.identified)
+        elimination = result.eliminations.get(feature_group)
+        stage = None if elimination is None else elimination.stage
+        reason = "" if elimination is None else elimination.reason
+        # A failing assert's traceback must not pin the test-local classes, or the conftest leak guard errors too.
+        del reader, feature_group, accessible_plugins, result, elimination
+        assert identified_names == []
+        assert stage == "input_data"
+        assert VG954_REQUIRED_KEY in reason
+
+
+class TestUngatedShapesKeepResolving:
+    """The shapes the gate must NOT touch, pinned against today's behavior."""
+
+    def test_a_vetoed_sibling_still_lets_the_clean_sibling_match(self) -> None:
+        """One vetoed sibling must not gate the family: the clean sibling wins and pins the pair."""
+        feature = Feature(
+            name=VG954_SIBLING_FEATURE_NAME,
+            options={
+                Vg954VetoedSiblingReader.__name__: VG954_VETOED_ACCESS,
+                Vg954CleanSiblingReader.__name__: VG954_CLEAN_ACCESS,
+                VG954_SIBLING_KEY: "vg954_bogus",
+            },
+        )
+        accessible_plugins: FeatureGroupEnvironmentMapping = {Vg954SiblingFG: {PandasDataFrame}}
+
+        result = IdentifyFeatureGroupClass.evaluate(feature, accessible_plugins, None, None)
+
+        assert Vg954SiblingFG in result.identified
+        assert result.eliminations == {}
+        assert feature.options.get("BaseInputData") == (Vg954CleanSiblingReader, VG954_CLEAN_ACCESS)
+
+    def test_a_feature_group_without_input_data_keeps_resolving_by_name(self) -> None:
+        """Foreign reader-addressing keys in the options never gate an input-data-free candidate."""
+        feature = Feature(
+            name=VG954_PLAIN_FEATURE_NAME,
+            options={Vg954GateReader.__name__: VG954_GATE_ACCESS, VG954_FORMAT_KEY: "vg954_bogus"},
+        )
+        accessible_plugins: FeatureGroupEnvironmentMapping = {Vg954PlainFG: {PandasDataFrame}}
+
+        result = IdentifyFeatureGroupClass.evaluate(feature, accessible_plugins, None, None)
+
+        assert Vg954PlainFG in result.identified
+        assert result.eliminations == {}
+
+    def test_a_valid_strict_value_still_identifies_and_pins_the_pair(self) -> None:
+        """Control: the allowed value keeps the gated-shape candidate identified with its reader pair."""
+        feature = Feature(
+            name=VG954_FEATURE_NAME,
+            options={Vg954GateReader.__name__: VG954_GATE_ACCESS, VG954_FORMAT_KEY: "vg954_ok"},
+        )
+        accessible_plugins: FeatureGroupEnvironmentMapping = {Vg954GatedFG: {PandasDataFrame}}
+
+        result = IdentifyFeatureGroupClass.evaluate(feature, accessible_plugins, None, None)
+
+        assert Vg954GatedFG in result.identified
+        assert result.eliminations == {}
+        assert feature.options.get("BaseInputData") == (Vg954GateReader, VG954_GATE_ACCESS)
+
+
+class TestModuleLeakPolicy:
+    """The module's leak policy, machine-checked over every module-level final reader."""
+
+    def test_module_level_readers_cannot_fire_on_foreign_options(self) -> None:
+        """Every module-level final reader carries its marker and no absence-firing spec; Vg954Local* are exempt."""
+        module_level = [
+            cls
+            for cls in get_all_subclasses(BaseInputData)
+            if cls.__module__ == __name__ and cls.is_final_reader() and "Local" not in cls.__name__
+        ]
+
+        assert module_level, "expected this module's final readers to be reachable through __subclasses__()"
+        for cls in module_level:
+            assert getattr(cls, "VG954_ACCESS", ""), f"{cls.__name__} must declare its module-unique access marker"
+            for key, spec in cls.reader_option_specs().items():
+                if spec.framework_set:
+                    continue
+                assert not (is_no_default(spec.default) and spec.required_when is None), (
+                    f"{cls.__name__}.READER_OPTIONS['{key}'] would fire on every foreign probe"
+                )

--- a/tests/test_core/test_abstract_plugins/test_components/test_reader_veto_gates_name_rules.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_reader_veto_gates_name_rules.py
@@ -1,24 +1,22 @@
-"""Pins issue #954: a reader veto recorded with ``stage="input_data"`` during a candidate's match
-window gates the name-based OR rules of ``match_feature_group_criteria``, so the candidate becomes
-an ``input_data`` elimination instead of being recovered by ``feature_names_supported``; sibling
-probing, input-data-free candidates and valid values keep resolving unchanged, and the helper
-``has_match_rejection`` reports the active window's stages.
-Leak policy: every name carries the vg954 marker so leaked classes are foreign-inert; the
-absence-firing required-key shape is test-local (factory + per-test tag + gc), never module-level.
-"""
+"""Pins issue #954, corrected: ONLY an OWNED reader veto (the user addressed the reader via its
+``data_access_name()`` key and its READER_OPTIONS declined) gates the name-based OR rules of
+``match_feature_group_criteria``; unowned global-probe declines, the MatchData rule, sibling probing,
+input-data-free candidates and valid values keep resolving. Leaked vg954 fixtures stay foreign-inert."""
 
 from __future__ import annotations
 
-import gc
 from collections.abc import Iterator
+from pathlib import Path
 from typing import Any, ClassVar
 
 import pytest
 
 from mloda.core.abstract_plugins.components.feature_chainer.property_spec import PropertySpec, is_no_default
+from mloda.core.abstract_plugins.components.match_data.match_data import MatchData
 from mloda.core.abstract_plugins.components.match_rejection import (
     MATCH_REJECTION_REASONS,
     MatchRejection,
+    has_match_rejection,
     record_match_rejection,
 )
 from mloda.core.abstract_plugins.components.utils import get_all_subclasses
@@ -26,8 +24,9 @@ from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
 from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
 from mloda.core.prepare.resolution_failure_renderer import render_resolution_failure
 from mloda.provider import BaseInputData, FeatureGroup, FeatureSet
-from mloda.user import Feature, FeatureName, Options
+from mloda.user import DataAccessCollection, Feature, FeatureName, Options
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.feature_group.input_data.read_file import ReadFile
 
 
 VG954_FEATURE_NAME = "vg954_column"
@@ -45,21 +44,36 @@ VG954_SIBLING_KEY = "vg954_sibling_mode"
 VG954_REQUIRED_ACCESS = "vg954_required_access"
 VG954_REQUIRED_KEY = "vg954_required"
 
+VG954_GLOBAL_FEATURE_NAME = "vg954_global_column"
+VG954_GLOBAL_SUFFIX = ".vg954gcsv"
+
+VG954_UNOWNED_FEATURE_NAME = "vg954_unowned_column"
+VG954_UNOWNED_ACCESS = "vg954_unowned_access"
+VG954_UNOWNED_HANDLE = "vg954_unowned_handle"
+VG954_UNOWNED_KEY = "vg954_unowned_mode"
+
+VG954_MATCHDATA_FEATURE_NAME = "vg954_matchdata_column"
+
 VG954_UNIT_OWNER = "vg954_unit_owner"
 VG954_UNIT_REASON = "vg954 unit reason"
 
 
 class _Vg954MarkedReader(BaseInputData):
-    """Family base: a child matches ONLY its own module-unique access string."""
+    """Family base: a child matches ONLY its own module-unique access string or dac folder handle."""
 
     VG954_ACCESS: ClassVar[str] = ""
+    VG954_HANDLE: ClassVar[str] = ""
 
     @classmethod
     def match_subclass_data_access(
         cls, data_access: Any, feature_names: list[str], options: Options | None = None
     ) -> Any:
-        if cls.VG954_ACCESS and isinstance(data_access, str) and data_access == cls.VG954_ACCESS:
+        if not cls.VG954_ACCESS:
+            return None
+        if isinstance(data_access, str) and data_access == cls.VG954_ACCESS:
             return data_access
+        if isinstance(data_access, DataAccessCollection) and cls.VG954_HANDLE in data_access.folders:
+            return cls.VG954_ACCESS
         return None
 
 
@@ -87,7 +101,7 @@ class Vg954GateReader(Vg954GateFamily):
 
 
 class Vg954GatedFG(FeatureGroup):
-    """Root FG whose name rule accepts ONLY vg954_column; the recorded reader veto must gate that rule."""
+    """Root FG whose name rule accepts ONLY vg954_column; the recorded OWNED veto must gate that rule."""
 
     @classmethod
     def input_data(cls) -> BaseInputData | None:
@@ -157,6 +171,101 @@ class Vg954PlainFG(FeatureGroup):
         return {VG954_PLAIN_FEATURE_NAME}
 
 
+class Vg954GlobalFamily(ReadFile):
+    """Family base of the unowned-content shape; it overrides nothing, so it never classifies as final."""
+
+
+class Vg954GlobalCsvReader(Vg954GlobalFamily):
+    """Final reader owning the unique .vg954gcsv suffix; introspects the comma-separated header line."""
+
+    @classmethod
+    def suffix(cls) -> tuple[str, ...]:
+        return (VG954_GLOBAL_SUFFIX,)
+
+    @classmethod
+    def get_column_names(cls, file_name: str) -> list[str]:
+        with open(file_name, encoding="utf-8") as handle:
+            return handle.readline().strip().split(",")
+
+    @classmethod
+    def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
+        return {VG954_GLOBAL_FEATURE_NAME: [1]}
+
+
+class Vg954GlobalDeclineFG(FeatureGroup):
+    """Root FG whose name rule claims vg954_global_column while its reader family declines only globally."""
+
+    @classmethod
+    def input_data(cls) -> BaseInputData | None:
+        return Vg954GlobalFamily()
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        return None
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return {VG954_GLOBAL_FEATURE_NAME}
+
+
+class Vg954UnownedFamily(_Vg954MarkedReader):
+    """Scopes the unowned-strict-shape global probe to exactly one final reader."""
+
+
+class Vg954UnownedReader(Vg954UnownedFamily):
+    """Final reader claiming the unique dac folder handle; here its strict key vetoes only on the global probe."""
+
+    VG954_ACCESS = VG954_UNOWNED_ACCESS
+    VG954_HANDLE = VG954_UNOWNED_HANDLE
+
+    READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+        VG954_UNOWNED_KEY: PropertySpec(
+            "Strict membership key with a default, so it is not absence-firing and stays module-level safe.",
+            allowed_values=("vg954_ok",),
+            strict_validation=True,
+            default="vg954_ok",
+        ),
+    }
+
+    @classmethod
+    def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
+        return {VG954_UNOWNED_FEATURE_NAME: [1]}
+
+
+class Vg954UnownedFG(FeatureGroup):
+    """Root FG whose name rule claims vg954_unowned_column; the UNOWNED veto must not gate it."""
+
+    @classmethod
+    def input_data(cls) -> BaseInputData | None:
+        return Vg954UnownedFamily()
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        return None
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return {VG954_UNOWNED_FEATURE_NAME}
+
+
+class Vg954MatchDataFG(FeatureGroup, MatchData):
+    """Root MatchData FG claiming ONLY vg954_matchdata_column through its matches hook, never by name."""
+
+    @classmethod
+    def input_data(cls) -> BaseInputData | None:
+        return Vg954GateFamily()
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        return None
+
+    @classmethod
+    def matches(
+        cls,
+        feature_name: str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return feature_name == VG954_MATCHDATA_FEATURE_NAME
+
+
 def _vg954_required_setup(tag: str) -> tuple[type[BaseInputData], type[FeatureGroup]]:
     """(reader, feature group) with an unconditionally required key, built test-locally per the leak policy;
     the per-test tag keys data_access_name() so a traceback-kept stale twin is never the addressed reader."""
@@ -205,20 +314,11 @@ def rejection_window() -> Iterator[dict[str, MatchRejection]]:
     MATCH_REJECTION_REASONS.reset(token)
 
 
-@pytest.fixture()
-def collect_after() -> Iterator[None]:
-    """Reclaim test-local Vg954Local* classes out of __subclasses__ before the next test on this worker."""
-    yield
-    gc.collect()
-
-
 class TestHasMatchRejection:
     """The helper reports whether the ACTIVE window holds a rejection with the exact stage."""
 
     def test_no_active_window_reports_false(self) -> None:
         """Without an open window nothing is recorded, so the helper answers False."""
-        from mloda.core.abstract_plugins.components.match_rejection import has_match_rejection
-
         assert MATCH_REJECTION_REASONS.get() is None
         assert has_match_rejection("input_data") is False
 
@@ -226,8 +326,6 @@ class TestHasMatchRejection:
         self, rejection_window: dict[str, MatchRejection]
     ) -> None:
         """The stage comparison is exact: a value_rejection recording is not an input_data one."""
-        from mloda.core.abstract_plugins.components.match_rejection import has_match_rejection
-
         record_match_rejection(VG954_UNIT_OWNER, VG954_UNIT_REASON)
 
         assert has_match_rejection("input_data") is False
@@ -236,8 +334,6 @@ class TestHasMatchRejection:
         self, rejection_window: dict[str, MatchRejection]
     ) -> None:
         """An input_data recording in the active window flips the helper to True."""
-        from mloda.core.abstract_plugins.components.match_rejection import has_match_rejection
-
         record_match_rejection(VG954_UNIT_OWNER, VG954_UNIT_REASON, stage="input_data")
 
         assert has_match_rejection("input_data") is True
@@ -247,7 +343,7 @@ class TestReaderVetoGatesNameRules:
     """Engine level, deliberately WITHOUT a window fixture: the engine owns the per-candidate window."""
 
     def test_a_strict_value_veto_gates_the_name_rule(self) -> None:
-        """The recorded strict-value veto must eliminate the candidate; the name rule must not recover it."""
+        """The recorded OWNED strict-value veto must eliminate the candidate; the name rule must not recover it."""
         feature = Feature(
             name=VG954_FEATURE_NAME,
             options={Vg954GateReader.__name__: VG954_GATE_ACCESS, VG954_FORMAT_KEY: "vg954_bogus"},
@@ -268,7 +364,7 @@ class TestReaderVetoGatesNameRules:
         assert message is not None
         assert f"  - {Vg954GatedFG.__name__} (input data): {elimination.reason}" in message
 
-    def test_an_absent_required_key_veto_gates_the_name_rule(self, collect_after: None) -> None:
+    def test_an_absent_required_key_veto_gates_the_name_rule(self) -> None:
         """The recorded absence veto on the ownership path must eliminate the candidate too."""
         reader, feature_group = _vg954_required_setup("gate_absent")
         feature = Feature(
@@ -291,7 +387,7 @@ class TestReaderVetoGatesNameRules:
 
 
 class TestUngatedShapesKeepResolving:
-    """The shapes the gate must NOT touch, pinned against today's behavior."""
+    """The shapes the gate must NOT touch: unowned vetoes, the MatchData rule, siblings, gate-free candidates."""
 
     def test_a_vetoed_sibling_still_lets_the_clean_sibling_match(self) -> None:
         """One vetoed sibling must not gate the family: the clean sibling wins and pins the pair."""
@@ -311,18 +407,59 @@ class TestUngatedShapesKeepResolving:
         assert result.eliminations == {}
         assert feature.options.get("BaseInputData") == (Vg954CleanSiblingReader, VG954_CLEAN_ACCESS)
 
+    def test_an_unowned_global_content_decline_does_not_gate_the_name_rule(self, tmp_path: Path) -> None:
+        """A content decline on the global probe, without the user addressing the reader, must not gate."""
+        path = tmp_path / f"data{VG954_GLOBAL_SUFFIX}"
+        path.write_text("other_a,other_b\n1,2\n", encoding="utf-8")
+        dac = DataAccessCollection(files={str(path)})
+        feature = Feature(name=VG954_GLOBAL_FEATURE_NAME)
+        accessible_plugins: FeatureGroupEnvironmentMapping = {Vg954GlobalDeclineFG: {PandasDataFrame}}
+
+        result = IdentifyFeatureGroupClass.evaluate(feature, accessible_plugins, None, dac)
+
+        assert Vg954GlobalDeclineFG in result.identified
+        assert "BaseInputData" not in feature.options
+
+    def test_an_unowned_strict_value_rejection_does_not_gate_the_name_rule(self) -> None:
+        """A strict present-value rejection on the global probe, without ownership, must not gate."""
+        feature = Feature(name=VG954_UNOWNED_FEATURE_NAME, options={VG954_UNOWNED_KEY: "vg954_bogus"})
+        dac = DataAccessCollection(folders={VG954_UNOWNED_HANDLE: "/vg954/nowhere"})
+        accessible_plugins: FeatureGroupEnvironmentMapping = {Vg954UnownedFG: {PandasDataFrame}}
+
+        result = IdentifyFeatureGroupClass.evaluate(feature, accessible_plugins, None, dac)
+
+        assert Vg954UnownedFG in result.identified
+
+    def test_an_owned_veto_leaves_the_match_data_rule_deciding(self) -> None:
+        """An owned reader veto gates the name rules only; the MatchData rule must still identify."""
+        feature = Feature(
+            name=VG954_MATCHDATA_FEATURE_NAME,
+            options={Vg954GateReader.__name__: VG954_GATE_ACCESS, VG954_FORMAT_KEY: "vg954_bogus"},
+        )
+        accessible_plugins: FeatureGroupEnvironmentMapping = {Vg954MatchDataFG: {PandasDataFrame}}
+
+        result = IdentifyFeatureGroupClass.evaluate(feature, accessible_plugins, None, None)
+
+        assert Vg954MatchDataFG in result.identified
+
     def test_a_feature_group_without_input_data_keeps_resolving_by_name(self) -> None:
-        """Foreign reader-addressing keys in the options never gate an input-data-free candidate."""
+        """A sibling candidate's owned veto records in its own window and never gates a gate-free candidate."""
         feature = Feature(
             name=VG954_PLAIN_FEATURE_NAME,
             options={Vg954GateReader.__name__: VG954_GATE_ACCESS, VG954_FORMAT_KEY: "vg954_bogus"},
         )
-        accessible_plugins: FeatureGroupEnvironmentMapping = {Vg954PlainFG: {PandasDataFrame}}
+        accessible_plugins: FeatureGroupEnvironmentMapping = {
+            Vg954GatedFG: {PandasDataFrame},
+            Vg954PlainFG: {PandasDataFrame},
+        }
 
         result = IdentifyFeatureGroupClass.evaluate(feature, accessible_plugins, None, None)
 
+        gated_elimination = result.eliminations.get(Vg954GatedFG)
+        assert gated_elimination is not None
+        assert gated_elimination.stage == "input_data"
         assert Vg954PlainFG in result.identified
-        assert result.eliminations == {}
+        assert Vg954PlainFG not in result.eliminations
 
     def test_a_valid_strict_value_still_identifies_and_pins_the_pair(self) -> None:
         """Control: the allowed value keeps the gated-shape candidate identified with its reader pair."""
@@ -352,7 +489,10 @@ class TestModuleLeakPolicy:
 
         assert module_level, "expected this module's final readers to be reachable through __subclasses__()"
         for cls in module_level:
-            assert getattr(cls, "VG954_ACCESS", ""), f"{cls.__name__} must declare its module-unique access marker"
+            if issubclass(cls, ReadFile):
+                assert all("vg954" in s for s in cls.suffix()), f"{cls.__name__} must own only vg954-marked suffixes"
+            else:
+                assert getattr(cls, "VG954_ACCESS", ""), f"{cls.__name__} must declare its module-unique access marker"
             for key, spec in cls.reader_option_specs().items():
                 if spec.framework_set:
                     continue

--- a/tests/test_mloda_imports.py
+++ b/tests/test_mloda_imports.py
@@ -154,6 +154,7 @@ def test_import_provider_base_classes() -> None:
         missing_columnwise_hooks,
         # Match rejection recording
         record_match_rejection,
+        INPUT_DATA_STAGE,
         # Transformers
         BaseTransformer,
         ComputeFrameworkTransformer,
@@ -197,6 +198,7 @@ def test_import_provider_base_classes() -> None:
     assert callable(missing_columnwise_hooks)
     # Match rejection recording
     assert callable(record_match_rejection)
+    assert INPUT_DATA_STAGE == "input_data"
     # Transformers
     assert BaseTransformer is not None
     assert ComputeFrameworkTransformer is not None


### PR DESCRIPTION
## Summary

Closes #954.

Decision: gate. A reader veto recorded while the user explicitly addressed the reader family (an option key equals the reader's `data_access_name()`) now gates the root matcher's name-based acceptance rules. The candidate becomes a non-match and the recorded rejection surfaces as an `input_data` near-miss at resolution, instead of the feature resolving by name and crashing at load time inside `init_reader`.

Rationale: an owned veto means the user engaged that candidate's declared reader option space, so no `(reader, data_access)` pair can be written and a name-rule recovery only defers the failure. A user who opted into strict validation gets a resolution-time near-miss with the reader's reason.

## Scope

- Ownership-path spec vetoes (required key absent, strict value rejected) record the internal window stage `input_data_owned`; the gate in `match_feature_group_criteria` fires only on that stage and sits after the MatchData rule, so only the class-name, prefix, and `feature_names_supported` rules are gated.
- Unowned recordings are untouched near-miss material: global-probe strict rejections and reader content declines (a suffix-owned file lacking a column) never gate, so an unrelated file in a `DataAccessCollection` cannot suppress name-based resolution.
- The engine harvest maps both stages to the public `input_data` elimination; `EliminationStage` and rendering are unchanged. Sibling readers still probe first; feature groups that never declare input data cannot record and are untouched. Outside an active per-candidate window (for example the filter path) nothing records, so behavior there is unchanged.

## Tests

New suite `test_reader_veto_gates_name_rules.py`: owned strict-value and absent-required-key vetoes gate and render as `(input data)` near-misses; unowned global content declines and unowned strict rejections do not gate; an owned veto leaves the MatchData rule deciding; a vetoed sibling still lets the clean sibling match and pin the reader pair; input-data-free feature groups keep resolving by name in the same evaluation; `has_match_rejection` unit coverage; a machine-checked leak policy for the module's readers. Ownership-path stage pins in `test_reader_option_enforcement.py` updated to the new internal stage constants.

## Review pass

Two independent deep reviews on the first implementation round. Both flagged the gate sitting above the MatchData rule; one additionally proved unowned global-probe recordings could gate name rules of unrelated candidates. Both findings are fixed as described above; docs in `data-access-patterns.md`, `feature-group-matching.md`, and `feature-group-testing.md` state the ownership scope and the window-less direct-call divergence.
