### PR TITLE
fix: report when a FeatureSet filter was declined by one of its features

### DIFF
--- a/docs/docs/in_depth/feature-group-matching.md
+++ b/docs/docs/in_depth/feature-group-matching.md
@@ -29,6 +29,8 @@ Containment covers plugin raises only: a framework-owned raise (a two-readers co
 
 Filter matching contains the same way: a raise is a non-match for that probe, like a `False` return, and is recorded in `GlobalFilter.dropped_filters`. A framework-owned raise still aborts.
 
+The filter probe runs per feature, but a matched filter is attached to the whole `FeatureSet`, so a non-match for one feature does not suppress a filter a sibling of the same set matched. See [Filter scope](filter_data.md#filter-scope-is-the-featureset-matching-is-probed-per-feature).
+
 The options view depends on the caller: feature resolution passes declared (pre-default) options, while filter matching runs after intake and passes the resolved feature's effective (post-default) options merged onto the filter feature's own. Matching logic that reads option values can see different values on the two paths. See [Applying declared defaults](property-mapping.md#applying-declared-defaults).
 
 ### 2. PROPERTY_MAPPING Configuration

--- a/docs/docs/in_depth/feature-group-matching.md
+++ b/docs/docs/in_depth/feature-group-matching.md
@@ -29,7 +29,7 @@ Containment covers plugin raises only: a framework-owned raise (a two-readers co
 
 Filter matching contains the same way: a raise is a non-match for that probe, like a `False` return, and is recorded in `GlobalFilter.dropped_filters`. A framework-owned raise still aborts.
 
-The filter probe runs per feature, but a matched filter is attached to the whole `FeatureSet`, so a non-match for one feature does not suppress a filter a sibling of the same set matched. See [Filter scope](filter_data.md#filter-scope-is-the-featureset-matching-is-probed-per-feature).
+The probe runs per feature, but a matched filter attaches to the whole `FeatureSet`, so a non-match for one feature does not suppress a filter a sibling matched. See [Filter scope](filter_data.md#filter-scope-is-the-featureset).
 
 The options view depends on the caller: feature resolution passes declared (pre-default) options, while filter matching runs after intake and passes the resolved feature's effective (post-default) options merged onto the filter feature's own. Matching logic that reads option values can see different values on the two paths. See [Applying declared defaults](property-mapping.md#applying-declared-defaults).
 

--- a/docs/docs/in_depth/filter_data.md
+++ b/docs/docs/in_depth/filter_data.md
@@ -233,13 +233,27 @@ merged onto the filter feature's. The matched filters are then attached to the `
 not to the feature that matched them. So a feature that declined a filter is still filtered by
 it when a sibling feature of the same `FeatureSet` matched it, and a contained raise on one
 feature (recorded in `GlobalFilter.dropped_filters`) does not scope the drop to that feature
-either. Every divergence of this kind is logged as a WARNING naming the feature and the filter
-feature it declined.
+either.
+
+A divergence inside one `FeatureSet` is reported, not resolved, and how depends on its shape:
+
+| Divergence | Reported as |
+|------------|-------------|
+| one feature matched nothing, a sibling matched | WARNING naming the feature and the filter feature it did not match, once per divergence; the filter still applies to both |
+| two features matched different non-empty filter sets | `ValueError` out of `ExecutionPlan.add_single_filters_to_feature_set` |
+
+The second row also catches siblings that both match but whose enriched filter options differ,
+because the resulting `SingleFilter`s are then unequal.
 
 To scope a filter to some features only, make the deciding option a **group** option instead of
 a context option. Features are planned into one `FeatureSet` per compute framework, option set,
 data type and dependency level, so differing group options split them into separate
 `FeatureSet`s, and each set then gets only the filters matched for it.
+
+`GlobalFilter.probes` records what every probe matched, the empty result included, keyed by
+feature group, feature name and feature uuid. Like `collection` it accumulates across runs that
+share the `GlobalFilter`, and like `dropped_filters` it is there for debugging and quality
+checks, not for steering a calculation.
 
 ### Two independent concerns
 

--- a/docs/docs/in_depth/filter_data.md
+++ b/docs/docs/in_depth/filter_data.md
@@ -226,34 +226,15 @@ a reused `GlobalFilter` keeps the matches it has recorded. Which of the two empt
 get is therefore decided outside your FeatureGroup. `if features.filters:` covers both;
 `if features.filters is not None:` passes with nothing to iterate.
 
-### Filter scope is the `FeatureSet`, matching is probed per feature
+### Filter scope is the `FeatureSet`
 
-`match_feature_group_criteria()` is probed once per feature, with that feature's own options
-merged onto the filter feature's. The matched filters are then attached to the `FeatureSet`,
-not to the feature that matched them. So a feature that declined a filter is still filtered by
-it when a sibling feature of the same `FeatureSet` matched it, and a contained raise on one
-feature (recorded in `GlobalFilter.dropped_filters`) does not scope the drop to that feature
-either.
+Matching is probed per feature, but matched filters attach to the `FeatureSet`. A feature that
+declined a filter is still filtered by it once a sibling of its set matched it, a contained raise
+included; that is logged as a WARNING. Two features matching different non-empty filter sets
+raise `ValueError` instead. To scope a filter, make the deciding option a **group** option:
+differing group options split the features into separate `FeatureSet`s.
 
-A divergence inside one `FeatureSet` is reported, not resolved, and how depends on its shape:
-
-| Divergence | Reported as |
-|------------|-------------|
-| one feature matched nothing, a sibling matched | WARNING naming the feature and the filter feature it did not match, once per divergence; the filter still applies to both |
-| two features matched different non-empty filter sets | `ValueError` out of `ExecutionPlan.add_single_filters_to_feature_set` |
-
-The second row also catches siblings that both match but whose enriched filter options differ,
-because the resulting `SingleFilter`s are then unequal.
-
-To scope a filter to some features only, make the deciding option a **group** option instead of
-a context option. Features are planned into one `FeatureSet` per compute framework, option set,
-data type and dependency level, so differing group options split them into separate
-`FeatureSet`s, and each set then gets only the filters matched for it.
-
-`GlobalFilter.probes` records what every probe matched, the empty result included, keyed by
-feature group, feature name and feature uuid. Like `collection` it accumulates across runs that
-share the `GlobalFilter`, and like `dropped_filters` it is there for debugging and quality
-checks, not for steering a calculation.
+`GlobalFilter.probes` records what every probe matched, empty results included, for debugging.
 
 ### Two independent concerns
 

--- a/docs/docs/in_depth/filter_data.md
+++ b/docs/docs/in_depth/filter_data.md
@@ -226,6 +226,21 @@ a reused `GlobalFilter` keeps the matches it has recorded. Which of the two empt
 get is therefore decided outside your FeatureGroup. `if features.filters:` covers both;
 `if features.filters is not None:` passes with nothing to iterate.
 
+### Filter scope is the `FeatureSet`, matching is probed per feature
+
+`match_feature_group_criteria()` is probed once per feature, with that feature's own options
+merged onto the filter feature's. The matched filters are then attached to the `FeatureSet`,
+not to the feature that matched them. So a feature that declined a filter is still filtered by
+it when a sibling feature of the same `FeatureSet` matched it, and a contained raise on one
+feature (recorded in `GlobalFilter.dropped_filters`) does not scope the drop to that feature
+either. Every divergence of this kind is logged as a WARNING naming the feature and the filter
+feature it declined.
+
+To scope a filter to some features only, make the deciding option a **group** option instead of
+a context option. Features are planned into one `FeatureSet` per compute framework, option set,
+data type and dependency level, so differing group options split them into separate
+`FeatureSet`s, and each set then gets only the filters matched for it.
+
 ### Two independent concerns
 
 Filters involve two decisions that are **independent** of each other:

--- a/mloda/core/core/engine.py
+++ b/mloda/core/core/engine.py
@@ -338,7 +338,7 @@ class Engine:
                 self.add_feature_to_collection(feature_group_class, match.filter_feature, features.child_uuid)
                 self.global_filter.add_filter_to_collection(feature_group_class, feature.name, match)
 
-            # After the loop: the recorded objects are the renamed ones the collection holds.
+            # After the loop, so the recorded filters are the renamed ones.
             self.global_filter.record_probe(feature_group_class, feature.name, feature.uuid, matched_filters)
 
     def add_feature_link_to_links(self, feature: Feature) -> None:

--- a/mloda/core/core/engine.py
+++ b/mloda/core/core/engine.py
@@ -339,7 +339,7 @@ class Engine:
                 self.global_filter.add_filter_to_collection(feature_group_class, feature.name, match)
 
             # After the loop: the recorded objects are the renamed ones the collection holds.
-            self.global_filter.record_probe(feature_group_class, feature.name, matched_filters)
+            self.global_filter.record_probe(feature_group_class, feature.name, feature.uuid, matched_filters)
 
     def add_feature_link_to_links(self, feature: Feature) -> None:
         """With this functionality, we can add links with a feature instead via mloda API."""

--- a/mloda/core/core/engine.py
+++ b/mloda/core/core/engine.py
@@ -338,6 +338,9 @@ class Engine:
                 self.add_feature_to_collection(feature_group_class, match.filter_feature, features.child_uuid)
                 self.global_filter.add_filter_to_collection(feature_group_class, feature.name, match)
 
+            # After the loop: the recorded objects are the renamed ones the collection holds.
+            self.global_filter.record_probe(feature_group_class, feature.name, matched_filters)
+
     def add_feature_link_to_links(self, feature: Feature) -> None:
         """With this functionality, we can add links with a feature instead via mloda API."""
 

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 from datetime import datetime, timezone
 from itertools import chain
 from typing import Any, Optional
+from uuid import UUID
 
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.abstract_plugins.components.domain import Domain
@@ -26,7 +27,7 @@ logger = logging.getLogger(__name__)
 class GlobalFilter:
     def __init__(self) -> None:
         """
-        This constructor sets up two main attributes:
+        This constructor sets up the following attributes:
         1. `filters`: A set to store individual filter objects (`SingleFilter`). Each filter represents a condition
            used to restrict or sort data based on specific features.
         2. `collection`: A dictionary mapping a tuple of feature group types and feature names to a set of filter feature
@@ -34,7 +35,8 @@ class GlobalFilter:
            This can be used to check after the fact if a feature is a filter feature for a specific feature group
            e.g. for debugging, logging or quality checks.
         3. `dropped_filters`: maps (feature group, filter feature name) to the reason a contained raise dropped it.
-        4. `probes`: maps (feature group, feature name) to the filters that probe matched, empty set included.
+        4. `probes`: maps (feature group, feature name, feature uuid) to the filters that probe matched, empty
+           set included. The uuid keeps each probed feature instance separate, so one decline is never unioned away.
 
         These attributes provide the foundation for adding, managing, and applying filters across various feature groups
         and features in the context of a data processing pipeline.
@@ -42,16 +44,21 @@ class GlobalFilter:
         self.filters: set[SingleFilter] = set()
         self.collection: dict[tuple[type[FeatureGroup], FeatureName], set[SingleFilter]] = {}
         self.dropped_filters: dict[tuple[type[FeatureGroup], str], str] = {}
-        self.probes: dict[tuple[type[FeatureGroup], FeatureName], set[SingleFilter]] = {}
+        self.probes: dict[tuple[type[FeatureGroup], FeatureName, UUID], set[SingleFilter]] = {}
 
     def record_probe(
         self,
         feature_group: type[FeatureGroup],
         filtered_feature_name: FeatureName,
+        filtered_feature_uuid: UUID,
         matched_filters: set[SingleFilter],
     ) -> None:
         """Record what a probe matched, empty included, so a decline stays visible next to `collection`."""
-        self.probes.setdefault((feature_group, filtered_feature_name), set()).update(matched_filters)
+        if not self.filters:
+            return
+        self.probes.setdefault((feature_group, filtered_feature_name, filtered_feature_uuid), set()).update(
+            matched_filters
+        )
 
     def add_filter(
         self, filter_feature: Feature | str, filter_type: str | FilterType, parameter: dict[str, Any]

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -34,6 +34,7 @@ class GlobalFilter:
            This can be used to check after the fact if a feature is a filter feature for a specific feature group
            e.g. for debugging, logging or quality checks.
         3. `dropped_filters`: maps (feature group, filter feature name) to the reason a contained raise dropped it.
+        4. `probes`: maps (feature group, feature name) to the filters that probe matched, empty set included.
 
         These attributes provide the foundation for adding, managing, and applying filters across various feature groups
         and features in the context of a data processing pipeline.
@@ -41,6 +42,16 @@ class GlobalFilter:
         self.filters: set[SingleFilter] = set()
         self.collection: dict[tuple[type[FeatureGroup], FeatureName], set[SingleFilter]] = {}
         self.dropped_filters: dict[tuple[type[FeatureGroup], str], str] = {}
+        self.probes: dict[tuple[type[FeatureGroup], FeatureName], set[SingleFilter]] = {}
+
+    def record_probe(
+        self,
+        feature_group: type[FeatureGroup],
+        filtered_feature_name: FeatureName,
+        matched_filters: set[SingleFilter],
+    ) -> None:
+        """Record what a probe matched, empty included, so a decline stays visible next to `collection`."""
+        self.probes.setdefault((feature_group, filtered_feature_name), set()).update(matched_filters)
 
     def add_filter(
         self, filter_feature: Feature | str, filter_type: str | FilterType, parameter: dict[str, Any]

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -35,8 +35,7 @@ class GlobalFilter:
            This can be used to check after the fact if a feature is a filter feature for a specific feature group
            e.g. for debugging, logging or quality checks.
         3. `dropped_filters`: maps (feature group, filter feature name) to the reason a contained raise dropped it.
-        4. `probes`: maps (feature group, feature name, feature uuid) to the filters that probe matched, empty
-           set included. The uuid keeps each probed feature instance separate, so one decline is never unioned away.
+        4. `probes`: maps (feature group, feature name, feature uuid) to the filters that probe matched, empty included.
 
         These attributes provide the foundation for adding, managing, and applying filters across various feature groups
         and features in the context of a data processing pipeline.
@@ -53,7 +52,7 @@ class GlobalFilter:
         filtered_feature_uuid: UUID,
         matched_filters: set[SingleFilter],
     ) -> None:
-        """Record what a probe matched, empty included, so a decline stays visible next to `collection`."""
+        """Record what a probe matched, empty included."""
         if not self.filters:
             return
         self.probes.setdefault((feature_group, filtered_feature_name, filtered_feature_uuid), set()).update(

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -1019,7 +1019,31 @@ class ExecutionPlan:
                                       """
                                 )
 
+        self._warn_on_unmatched_features(feature_group, feature_set, relevant_filters)
         feature_set.add_filters(relevant_filters)
+
+    def _warn_on_unmatched_features(
+        self, feature_group: type[FeatureGroup], feature_set: FeatureSet, relevant_filters: set[SingleFilter]
+    ) -> None:
+        """Report features of the set that declined a filter the set gets anyway: the scope is the FeatureSet."""
+        if self.global_filter is None or not relevant_filters:
+            return
+
+        for feature in feature_set.features:
+            probed = self.global_filter.probes.get((feature_group, feature.name))
+            # No probe entry: filter and index features enter the collection without being probed.
+            if probed is None:
+                continue
+            unmatched = sorted({str(f.filter_feature.name) for f in relevant_filters - probed})
+            if not unmatched:
+                continue
+            logger.warning(
+                "Feature '%s' of %s did not match the filter feature(s) %s, but the filter still applies "
+                "because the filter scope is the FeatureSet.",
+                feature.name,
+                format_feature_group_class(feature_group),
+                ", ".join(f"'{name}'" for name in unmatched),
+            )
 
     def get_parent_children_mapping(self, parent_to_children_mapping: dict[UUID, set[UUID]]) -> dict[UUID, set[UUID]]:
         inverted_dict: dict[UUID, set[UUID]] = {}

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -45,6 +45,9 @@ class ExecutionPlan:
         # Helper variable
         self.feature_set_collections: list[set[UUID]] = []
 
+        # A feature can be planned into several feature sets: report each divergence once, then at DEBUG.
+        self.reported_unmatched: set[tuple[type[FeatureGroup], str, tuple[str, ...]]] = set()
+
     def __iter__(self) -> Generator[TransformFrameworkStep | JoinStep | FeatureGroupStep, None, None]:
         yield from self.execution_plan
 
@@ -1030,19 +1033,23 @@ class ExecutionPlan:
             return
 
         for feature in feature_set.features:
-            probed = self.global_filter.probes.get((feature_group, feature.name))
+            probed = self.global_filter.probes.get((feature_group, feature.name, feature.uuid))
             # No probe entry: filter and index features enter the collection without being probed.
             if probed is None:
                 continue
             unmatched = sorted({str(f.filter_feature.name) for f in relevant_filters - probed})
             if not unmatched:
                 continue
-            logger.warning(
-                "Feature '%s' of %s did not match the filter feature(s) %s, but the filter still applies "
+            key = (feature_group, str(feature.name), tuple(unmatched))
+            first = key not in self.reported_unmatched
+            self.reported_unmatched.add(key)
+            logger.log(
+                logging.WARNING if first else logging.DEBUG,
+                "The filter feature(s) %s were not matched for feature '%s' of %s, but the filter still applies "
                 "because the filter scope is the FeatureSet.",
+                ", ".join(f"'{name}'" for name in unmatched),
                 feature.name,
                 format_feature_group_class(feature_group),
-                ", ".join(f"'{name}'" for name in unmatched),
             )
 
     def get_parent_children_mapping(self, parent_to_children_mapping: dict[UUID, set[UUID]]) -> dict[UUID, set[UUID]]:

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -45,7 +45,7 @@ class ExecutionPlan:
         # Helper variable
         self.feature_set_collections: list[set[UUID]] = []
 
-        # A feature can be planned into several feature sets: report each divergence once, then at DEBUG.
+        # Report each divergence once, then at DEBUG.
         self.reported_unmatched: set[tuple[type[FeatureGroup], str, tuple[str, ...]]] = set()
 
     def __iter__(self) -> Generator[TransformFrameworkStep | JoinStep | FeatureGroupStep, None, None]:
@@ -1028,13 +1028,13 @@ class ExecutionPlan:
     def _warn_on_unmatched_features(
         self, feature_group: type[FeatureGroup], feature_set: FeatureSet, relevant_filters: set[SingleFilter]
     ) -> None:
-        """Report features of the set that declined a filter the set gets anyway: the scope is the FeatureSet."""
+        """Warn about features that declined a filter their feature set gets anyway."""
         if self.global_filter is None or not relevant_filters:
             return
 
         for feature in feature_set.features:
             probed = self.global_filter.probes.get((feature_group, feature.name, feature.uuid))
-            # No probe entry: filter and index features enter the collection without being probed.
+            # Filter and index features enter the collection without being probed.
             if probed is None:
                 continue
             unmatched = sorted({str(f.filter_feature.name) for f in relevant_filters - probed})

--- a/tests/test_core/test_filter/test_filter_scope_per_feature_set.py
+++ b/tests/test_core/test_filter/test_filter_scope_per_feature_set.py
@@ -1,9 +1,8 @@
 """Issue #928: filters are probed per feature but attached per FeatureSet, so a decline is silent.
 
-Two features of one group that differ only in a plain context option share one FeatureSet. When the
-group declines the filter while probing feature A and accepts it while probing feature B, the shared
-set still receives the filter, so A is filtered too. The scope stays per FeatureSet; the divergence
-must become observable as a WARNING, and moving the deciding option to the group split removes it.
+Features that differ only in a plain context option share one FeatureSet. When the group declines the
+filter for one of them and accepts it for another, the shared set is filtered anyway. The scope stays
+per FeatureSet; the divergence must become observable as a WARNING, once, per probed feature.
 """
 
 from __future__ import annotations
@@ -18,6 +17,7 @@ import pytest
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.prepare.execution_plan import ExecutionPlan
 from mloda.provider import DataCreator
 from mloda.user import Feature, FeatureName, FilterType, GlobalFilter, Options, PluginCollector, mloda
 from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
@@ -29,9 +29,13 @@ EP_LOGGER_NAME = "mloda.core.prepare.execution_plan"
 FSP_DECLINE = "fsp_decline_feat_928"  # probing this feature makes the group decline the filter
 FSP_ACCEPT = "fsp_accept_feat_928"  # probing this feature makes the group accept the filter
 FSP_FILTER = "fsp_filter_feat_928"  # the filter feature whose match hook answers per probing feature
+FSP_SAME = "fsp_same_feat_928"  # requested twice, once per mode: one name, two features, one set
+FSP_UNIFORM_A = "fsp_uniform_a_feat_928"  # two different names, identical options, both accepting
+FSP_UNIFORM_B = "fsp_uniform_b_feat_928"
 FSP_MODE_KEY = "fsp_mode_928"  # "a" declines, "b" accepts
 
-ALL_FSP_NAMES = (FSP_DECLINE, FSP_ACCEPT, FSP_FILTER)
+SERVED_FSP_NAMES = (FSP_DECLINE, FSP_ACCEPT, FSP_SAME, FSP_UNIFORM_A, FSP_UNIFORM_B)
+ALL_FSP_NAMES = SERVED_FSP_NAMES + (FSP_FILTER,)
 
 
 def _sentinel(features: FeatureSet) -> dict[str, list[int]]:
@@ -40,14 +44,14 @@ def _sentinel(features: FeatureSet) -> dict[str, list[int]]:
     return {str(feature.name): [delivered] for feature in features.features}
 
 
-def _make_fg() -> type[FeatureGroup]:
+def _make_fg(capture: list[tuple[Feature, ...]] | None = None) -> type[FeatureGroup]:
     """A throwaway root group whose filter-feature match depends on the mode carried by the probing feature."""
     gc.collect()
 
     class FspScopeFG928(FeatureGroup):
         @classmethod
         def input_data(cls) -> DataCreator:
-            return DataCreator({FSP_DECLINE, FSP_ACCEPT, FSP_FILTER})
+            return DataCreator(set(ALL_FSP_NAMES))
 
         @classmethod
         def match_feature_group_criteria(
@@ -59,7 +63,7 @@ def _make_fg() -> type[FeatureGroup]:
             if str(feature_name) == FSP_FILTER:
                 # identify_matched_filters enriched the filter feature with the probing feature's options.
                 return bool(options.get(FSP_MODE_KEY) == "b")
-            return str(feature_name) in {FSP_DECLINE, FSP_ACCEPT}
+            return str(feature_name) in SERVED_FSP_NAMES
 
         @classmethod
         def final_filters(cls) -> bool:
@@ -68,6 +72,8 @@ def _make_fg() -> type[FeatureGroup]:
 
         @classmethod
         def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+            if capture is not None:
+                capture.append(tuple(features.features))
             return _sentinel(features)
 
     return FspScopeFG928
@@ -80,18 +86,24 @@ def _filter_on_fsp() -> GlobalFilter:
     return global_filter
 
 
-def _options(mode: str, in_group: bool) -> Options:
+def _options(mode: str, in_group: bool = False) -> Options:
     """The deciding option, either as a plain context option or as a group option."""
     return Options(group={FSP_MODE_KEY: mode}) if in_group else Options(context={FSP_MODE_KEY: mode})
 
 
+def _mode_pair(in_group: bool) -> list[Feature | str]:
+    """The declining and the accepting feature, two names, one mode each."""
+    return [Feature(FSP_DECLINE, _options("a", in_group)), Feature(FSP_ACCEPT, _options("b", in_group))]
+
+
 @dataclass(frozen=True)
 class _RunSnapshot:
-    """Plain-data readout of one run: sentinels, divergence warnings, probe counts. Holds no class."""
+    """Plain-data readout of one run: sentinels, divergence warnings, probe entries. Holds no class."""
 
     sentinels: dict[str, int]
     warnings: tuple[str, ...]
-    probe_counts: Optional[dict[str, int]]
+    probe_entries: dict[str, tuple[int, ...]]
+    set_shapes: tuple[tuple[str, ...], ...]
 
 
 def _sentinels(results: list[Any], columns: tuple[str, ...]) -> dict[str, int]:
@@ -102,63 +114,75 @@ def _sentinels(results: list[Any], columns: tuple[str, ...]) -> dict[str, int]:
     return found
 
 
-def _fsp_warnings(caplog: pytest.LogCaptureFixture) -> tuple[str, ...]:
-    """WARNINGs the execution plan emitted about this module's feature names."""
+def _fsp_records(caplog: pytest.LogCaptureFixture) -> tuple[tuple[int, str], ...]:
+    """Level and message of every execution-plan record mentioning one of this module's feature names."""
     return tuple(
-        record.getMessage()
+        (record.levelno, record.getMessage())
         for record in caplog.records
-        if record.name == EP_LOGGER_NAME
-        and record.levelno == logging.WARNING
-        and any(name in record.getMessage() for name in ALL_FSP_NAMES)
+        if record.name == EP_LOGGER_NAME and any(name in record.getMessage() for name in ALL_FSP_NAMES)
     )
 
 
-def _probe_counts(global_filter: GlobalFilter) -> Optional[dict[str, int]]:
-    """Per probed feature name, how many filters that probe matched. None when the API does not exist."""
-    probes = getattr(global_filter, "probes", None)
-    if probes is None:
-        return None
+def _fsp_warnings(caplog: pytest.LogCaptureFixture) -> tuple[str, ...]:
+    """WARNINGs the execution plan emitted about this module's feature names."""
+    return tuple(message for level, message in _fsp_records(caplog) if level == logging.WARNING)
+
+
+def _probe_entries(global_filter: GlobalFilter) -> dict[str, tuple[int, ...]]:
+    """Per probed feature name, the sorted match counts of its probe entries, one entry per probed feature."""
+    entries: dict[str, list[int]] = {}
     # The key holds the feature group class: read the name only, never bind the class.
-    return {str(key[1]): len(matched) for key, matched in probes.items()}
+    for key, matched in global_filter.probes.items():
+        entries.setdefault(str(key[1]), []).append(len(matched))
+    return {name: tuple(sorted(counts)) for name, counts in entries.items()}
 
 
-def _run(mode_in_group: bool, caplog: pytest.LogCaptureFixture) -> _RunSnapshot:
-    """Run both features in one session and collect sentinels, warnings and probes as plain data.
+def _set_shapes(captured: list[tuple[Feature, ...]]) -> tuple[tuple[str, ...], ...]:
+    """The served feature names of every planned FeatureSet, one sorted tuple per set. Holds no feature."""
+    served = (tuple(sorted(str(feature.name) for feature in features)) for features in captured)
+    return tuple(sorted(served))
+
+
+def _run(
+    features: list[Feature | str],
+    columns: tuple[str, ...],
+    global_filter: GlobalFilter,
+    caplog: pytest.LogCaptureFixture,
+) -> _RunSnapshot:
+    """Run the given features in one session and collect sentinels, warnings and probes as plain data.
 
     Every object referencing the throwaway feature group is dropped before returning, so a failing
     assert in the caller cannot pin it into a traceback and trip the no-leak fixture.
     """
     caplog.clear()
-    fg = _make_fg()
+    captured: list[tuple[Feature, ...]] = []
+    fg = _make_fg(captured)
     collector = PluginCollector.enabled_feature_groups({fg})
-    global_filter = _filter_on_fsp()
 
     with caplog.at_level(logging.WARNING, logger=EP_LOGGER_NAME):
         results = mloda.run_all(
-            [
-                Feature(FSP_DECLINE, _options("a", mode_in_group)),
-                Feature(FSP_ACCEPT, _options("b", mode_in_group)),
-            ],
+            features,
             compute_frameworks={PythonDictFramework},
             plugin_collector=collector,
             global_filter=global_filter,
         )
 
     snapshot = _RunSnapshot(
-        sentinels=_sentinels(results, (FSP_DECLINE, FSP_ACCEPT)),
+        sentinels=_sentinels(results, columns),
         warnings=_fsp_warnings(caplog),
-        probe_counts=_probe_counts(global_filter),
+        probe_entries=_probe_entries(global_filter),
+        set_shapes=_set_shapes(captured),
     )
     # Records carry args that can hold the throwaway class; drop them with everything else.
     caplog.clear()
-    del fg, collector, global_filter, results
+    del fg, collector, results, captured
     gc.collect()
     return snapshot
 
 
 def test_the_declining_feature_is_filtered_anyway(caplog: pytest.LogCaptureFixture) -> None:
     """Characterization: the shared FeatureSet gets the filter, so the declining feature is filtered too."""
-    snapshot = _run(mode_in_group=False, caplog=caplog)
+    snapshot = _run(_mode_pair(False), (FSP_DECLINE, FSP_ACCEPT), _filter_on_fsp(), caplog)
 
     assert snapshot.sentinels[FSP_ACCEPT] == 1, f"the accepting feature must get its one filter: {snapshot!r}"
     assert snapshot.sentinels[FSP_DECLINE] == 1, (
@@ -168,7 +192,7 @@ def test_the_declining_feature_is_filtered_anyway(caplog: pytest.LogCaptureFixtu
 
 def test_the_divergence_is_reported_as_a_warning(caplog: pytest.LogCaptureFixture) -> None:
     """The silent widening must be observable: one WARNING naming the declining feature and the filter."""
-    snapshot = _run(mode_in_group=False, caplog=caplog)
+    snapshot = _run(_mode_pair(False), (FSP_DECLINE, FSP_ACCEPT), _filter_on_fsp(), caplog)
 
     assert len(snapshot.warnings) == 1, f"exactly one WARNING must report the divergence, got: {snapshot.warnings}"
     message = snapshot.warnings[0]
@@ -178,27 +202,144 @@ def test_the_divergence_is_reported_as_a_warning(caplog: pytest.LogCaptureFixtur
 
 def test_every_probe_is_recorded_including_the_empty_one(caplog: pytest.LogCaptureFixture) -> None:
     """The decline is only detectable if empty probe results are recorded, not just the matches."""
-    snapshot = _run(mode_in_group=False, caplog=caplog)
+    snapshot = _run(_mode_pair(False), (FSP_DECLINE, FSP_ACCEPT), _filter_on_fsp(), caplog)
 
-    assert snapshot.probe_counts is not None, "GlobalFilter must expose a probes ledger"
-    assert snapshot.probe_counts.get(FSP_DECLINE) == 0, f"the declining probe must be recorded as empty: {snapshot!r}"
-    assert snapshot.probe_counts.get(FSP_ACCEPT) == 1, f"the accepting probe must record its filter: {snapshot!r}"
+    assert snapshot.probe_entries.get(FSP_DECLINE) == (0,), (
+        f"the declining probe must be recorded as empty: {snapshot!r}"
+    )
+    assert snapshot.probe_entries.get(FSP_ACCEPT) == (1,), f"the accepting probe must record its filter: {snapshot!r}"
+
+
+def test_two_features_of_one_name_diverge_and_are_reported(caplog: pytest.LogCaptureFixture) -> None:
+    """One name requested with two context modes: the declining twin must still be reported, not unioned away."""
+    same_name: list[Feature | str] = [Feature(FSP_SAME, _options("a")), Feature(FSP_SAME, _options("b"))]
+    snapshot = _run(same_name, (FSP_SAME,), _filter_on_fsp(), caplog)
+
+    assert len(snapshot.set_shapes) == 1, f"the two twins must share one feature set: {snapshot.set_shapes}"
+    assert snapshot.set_shapes[0].count(FSP_SAME) == 2, (
+        f"both twins must be planned into that set: {snapshot.set_shapes}"
+    )
+    assert len(snapshot.warnings) == 1, (
+        f"the declining twin of one name must be reported exactly once: {snapshot.warnings}, probes {snapshot!r}"
+    )
+    message = snapshot.warnings[0]
+    assert FSP_SAME in message, f"the warning must name the diverging feature: {message}"
+    assert FSP_FILTER in message, f"the warning must name the filter feature: {message}"
+
+
+def _cross_run_warnings(caplog: pytest.LogCaptureFixture) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """Two runs of one name over one shared GlobalFilter: run 1 accepts, run 2 declines. Returns both warning sets."""
+    caplog.clear()
+    fg = _make_fg()
+    collector = PluginCollector.enabled_feature_groups({fg})
+    global_filter = _filter_on_fsp()
+
+    with caplog.at_level(logging.WARNING, logger=EP_LOGGER_NAME):
+        mloda.run_all(
+            [Feature(FSP_SAME, _options("b"))],
+            compute_frameworks={PythonDictFramework},
+            plugin_collector=collector,
+            global_filter=global_filter,
+        )
+        first = _fsp_warnings(caplog)
+        caplog.clear()
+        mloda.run_all(
+            [Feature(FSP_SAME, _options("a"))],
+            compute_frameworks={PythonDictFramework},
+            plugin_collector=collector,
+            global_filter=global_filter,
+        )
+        second = _fsp_warnings(caplog)
+
+    caplog.clear()
+    del fg, collector, global_filter
+    gc.collect()
+    return first, second
+
+
+def test_a_stale_probe_of_an_earlier_run_does_not_mask_a_later_decline(caplog: pytest.LogCaptureFixture) -> None:
+    """The second run declines the filter its stale collection entry still attaches: that must warn."""
+    first, second = _cross_run_warnings(caplog)
+
+    assert first == (), f"the accepting run must not warn: {first}"
+    assert len(second) == 1, f"the declining run must report the stale filter it is handed: {second}"
+    assert FSP_SAME in second[0], f"the warning must name the declining feature: {second[0]}"
+    assert FSP_FILTER in second[0], f"the warning must name the filter feature: {second[0]}"
+
+
+def test_a_filterless_run_records_no_probes(caplog: pytest.LogCaptureFixture) -> None:
+    """An empty GlobalFilter has nothing to probe, so the ledger must stay empty and hold no group class."""
+    snapshot = _run(_mode_pair(False), (FSP_DECLINE, FSP_ACCEPT), GlobalFilter(), caplog)
+
+    assert snapshot.sentinels == {FSP_DECLINE: -1, FSP_ACCEPT: -1}, f"no filter can be delivered: {snapshot!r}"
+    assert snapshot.probe_entries == {}, f"a run without filters must record no probe: {snapshot.probe_entries}"
+
+
+def _repeated_report_levels(caplog: pytest.LogCaptureFixture) -> tuple[tuple[int, str], ...]:
+    """Level and message of the divergence reports for one feature planned into two feature sets.
+
+    A genuine two-FeatureSet plan is not reachable within the timeout, so the dedup is pinned at the unit
+    level: one real run populates the GlobalFilter, then the plan step is replayed over two fresh sets
+    rebuilt from the features of the diverging set.
+    """
+    caplog.clear()
+    captured: list[tuple[Feature, ...]] = []
+    fg = _make_fg(captured)
+    collector = PluginCollector.enabled_feature_groups({fg})
+    global_filter = _filter_on_fsp()
+
+    with caplog.at_level(logging.DEBUG, logger=EP_LOGGER_NAME):
+        mloda.run_all(
+            _mode_pair(False),
+            compute_frameworks={PythonDictFramework},
+            plugin_collector=collector,
+            global_filter=global_filter,
+        )
+
+        diverging = [features for features in captured if any(str(feature.name) == FSP_DECLINE for feature in features)]
+        assert len(diverging) == 1, f"the run must plan exactly one set holding the declining feature: {diverging!r}"
+
+        plan = ExecutionPlan(global_filter=global_filter)
+        caplog.clear()
+        plan.add_single_filters_to_feature_set(fg, FeatureSet(diverging[0]))
+        plan.add_single_filters_to_feature_set(fg, FeatureSet(diverging[0]))
+        records = _fsp_records(caplog)
+
+    caplog.clear()
+    del fg, collector, global_filter, captured, diverging, plan
+    gc.collect()
+    return records
+
+
+def test_the_divergence_report_does_not_repeat(caplog: pytest.LogCaptureFixture) -> None:
+    """The same divergence reported twice must warn once and drop to DEBUG after, like a dropped filter."""
+    records = _repeated_report_levels(caplog)
+
+    levels = tuple(level for level, _ in records)
+    assert levels == (logging.WARNING, logging.DEBUG), f"first report WARNING, repeat DEBUG, got: {records}"
 
 
 def test_a_group_option_splits_the_sets_and_spares_the_declining_feature(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """The documented remedy: as a group option the mode splits the feature sets, so only one is filtered."""
-    snapshot = _run(mode_in_group=True, caplog=caplog)
+    snapshot = _run(_mode_pair(True), (FSP_DECLINE, FSP_ACCEPT), _filter_on_fsp(), caplog)
 
     assert snapshot.sentinels[FSP_ACCEPT] == 1, f"the accepting feature set must get its one filter: {snapshot!r}"
     assert snapshot.sentinels[FSP_DECLINE] == 0, (
         f"the declining feature set must get an empty filter set, not the filter: {snapshot!r}"
     )
+    assert len(snapshot.set_shapes) == 2, f"the group option must split the sets: {snapshot.set_shapes}"
+    assert snapshot.warnings == (), f"a single-feature set cannot diverge from itself: {snapshot.warnings}"
 
 
 def test_the_uniform_case_warns_about_nothing(caplog: pytest.LogCaptureFixture) -> None:
-    """Every feature of a set matched the same filters, so there is no divergence to report."""
-    snapshot = _run(mode_in_group=True, caplog=caplog)
+    """Two different names with identical options share one set and both match, so there is nothing to report."""
+    uniform: list[Feature | str] = [Feature(FSP_UNIFORM_A, _options("b")), Feature(FSP_UNIFORM_B, _options("b"))]
+    snapshot = _run(uniform, (FSP_UNIFORM_A, FSP_UNIFORM_B), _filter_on_fsp(), caplog)
 
+    assert len(snapshot.set_shapes) == 1, f"both names must share one feature set: {snapshot.set_shapes}"
+    assert snapshot.sentinels == {FSP_UNIFORM_A: 1, FSP_UNIFORM_B: 1}, (
+        f"both features of the uniform set must get the one filter: {snapshot!r}"
+    )
     assert snapshot.warnings == (), f"a uniform feature set must not warn: {snapshot.warnings}"

--- a/tests/test_core/test_filter/test_filter_scope_per_feature_set.py
+++ b/tests/test_core/test_filter/test_filter_scope_per_feature_set.py
@@ -1,0 +1,204 @@
+"""Issue #928: filters are probed per feature but attached per FeatureSet, so a decline is silent.
+
+Two features of one group that differ only in a plain context option share one FeatureSet. When the
+group declines the filter while probing feature A and accepts it while probing feature B, the shared
+set still receives the filter, so A is filtered too. The scope stays per FeatureSet; the divergence
+must become observable as a WARNING, and moving the deciding option to the group split removes it.
+"""
+
+from __future__ import annotations
+
+import gc
+import logging
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import pytest
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.provider import DataCreator
+from mloda.user import Feature, FeatureName, FilterType, GlobalFilter, Options, PluginCollector, mloda
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
+
+
+EP_LOGGER_NAME = "mloda.core.prepare.execution_plan"
+
+# The fsp_ prefix keeps every feature name unique to this module.
+FSP_DECLINE = "fsp_decline_feat_928"  # probing this feature makes the group decline the filter
+FSP_ACCEPT = "fsp_accept_feat_928"  # probing this feature makes the group accept the filter
+FSP_FILTER = "fsp_filter_feat_928"  # the filter feature whose match hook answers per probing feature
+FSP_MODE_KEY = "fsp_mode_928"  # "a" declines, "b" accepts
+
+ALL_FSP_NAMES = (FSP_DECLINE, FSP_ACCEPT, FSP_FILTER)
+
+
+def _sentinel(features: FeatureSet) -> dict[str, list[int]]:
+    """One row per served feature carrying the number of filters the set was handed (-1 for None)."""
+    delivered = -1 if features.filters is None else len(features.filters)
+    return {str(feature.name): [delivered] for feature in features.features}
+
+
+def _make_fg() -> type[FeatureGroup]:
+    """A throwaway root group whose filter-feature match depends on the mode carried by the probing feature."""
+    gc.collect()
+
+    class FspScopeFG928(FeatureGroup):
+        @classmethod
+        def input_data(cls) -> DataCreator:
+            return DataCreator({FSP_DECLINE, FSP_ACCEPT, FSP_FILTER})
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: Optional[DataAccessCollection] = None,
+        ) -> bool:
+            if str(feature_name) == FSP_FILTER:
+                # identify_matched_filters enriched the filter feature with the probing feature's options.
+                return bool(options.get(FSP_MODE_KEY) == "b")
+            return str(feature_name) in {FSP_DECLINE, FSP_ACCEPT}
+
+        @classmethod
+        def final_filters(cls) -> bool:
+            # The payload is a sentinel, not filterable data: report features.filters inline instead.
+            return False
+
+        @classmethod
+        def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+            return _sentinel(features)
+
+    return FspScopeFG928
+
+
+def _filter_on_fsp() -> GlobalFilter:
+    """A GlobalFilter carrying one filter on the filter feature."""
+    global_filter = GlobalFilter()
+    global_filter.add_filter(Feature(FSP_FILTER), FilterType.EQUAL, {"value": 1})
+    return global_filter
+
+
+def _options(mode: str, in_group: bool) -> Options:
+    """The deciding option, either as a plain context option or as a group option."""
+    return Options(group={FSP_MODE_KEY: mode}) if in_group else Options(context={FSP_MODE_KEY: mode})
+
+
+@dataclass(frozen=True)
+class _RunSnapshot:
+    """Plain-data readout of one run: sentinels, divergence warnings, probe counts. Holds no class."""
+
+    sentinels: dict[str, int]
+    warnings: tuple[str, ...]
+    probe_counts: Optional[dict[str, int]]
+
+
+def _sentinels(results: list[Any], columns: tuple[str, ...]) -> dict[str, int]:
+    """Map each requested column to the sentinel reported by the frame carrying it."""
+    found = {column: frame[column][0] for frame in results for column in columns if column in frame}
+    missing = [column for column in columns if column not in found]
+    assert not missing, f"no result frame carries {missing}: {results!r}"
+    return found
+
+
+def _fsp_warnings(caplog: pytest.LogCaptureFixture) -> tuple[str, ...]:
+    """WARNINGs the execution plan emitted about this module's feature names."""
+    return tuple(
+        record.getMessage()
+        for record in caplog.records
+        if record.name == EP_LOGGER_NAME
+        and record.levelno == logging.WARNING
+        and any(name in record.getMessage() for name in ALL_FSP_NAMES)
+    )
+
+
+def _probe_counts(global_filter: GlobalFilter) -> Optional[dict[str, int]]:
+    """Per probed feature name, how many filters that probe matched. None when the API does not exist."""
+    probes = getattr(global_filter, "probes", None)
+    if probes is None:
+        return None
+    # The key holds the feature group class: read the name only, never bind the class.
+    return {str(key[1]): len(matched) for key, matched in probes.items()}
+
+
+def _run(mode_in_group: bool, caplog: pytest.LogCaptureFixture) -> _RunSnapshot:
+    """Run both features in one session and collect sentinels, warnings and probes as plain data.
+
+    Every object referencing the throwaway feature group is dropped before returning, so a failing
+    assert in the caller cannot pin it into a traceback and trip the no-leak fixture.
+    """
+    caplog.clear()
+    fg = _make_fg()
+    collector = PluginCollector.enabled_feature_groups({fg})
+    global_filter = _filter_on_fsp()
+
+    with caplog.at_level(logging.WARNING, logger=EP_LOGGER_NAME):
+        results = mloda.run_all(
+            [
+                Feature(FSP_DECLINE, _options("a", mode_in_group)),
+                Feature(FSP_ACCEPT, _options("b", mode_in_group)),
+            ],
+            compute_frameworks={PythonDictFramework},
+            plugin_collector=collector,
+            global_filter=global_filter,
+        )
+
+    snapshot = _RunSnapshot(
+        sentinels=_sentinels(results, (FSP_DECLINE, FSP_ACCEPT)),
+        warnings=_fsp_warnings(caplog),
+        probe_counts=_probe_counts(global_filter),
+    )
+    # Records carry args that can hold the throwaway class; drop them with everything else.
+    caplog.clear()
+    del fg, collector, global_filter, results
+    gc.collect()
+    return snapshot
+
+
+def test_the_declining_feature_is_filtered_anyway(caplog: pytest.LogCaptureFixture) -> None:
+    """Characterization: the shared FeatureSet gets the filter, so the declining feature is filtered too."""
+    snapshot = _run(mode_in_group=False, caplog=caplog)
+
+    assert snapshot.sentinels[FSP_ACCEPT] == 1, f"the accepting feature must get its one filter: {snapshot!r}"
+    assert snapshot.sentinels[FSP_DECLINE] == 1, (
+        f"the decline does not suppress the filter on the shared feature set: {snapshot!r}"
+    )
+
+
+def test_the_divergence_is_reported_as_a_warning(caplog: pytest.LogCaptureFixture) -> None:
+    """The silent widening must be observable: one WARNING naming the declining feature and the filter."""
+    snapshot = _run(mode_in_group=False, caplog=caplog)
+
+    assert len(snapshot.warnings) == 1, f"exactly one WARNING must report the divergence, got: {snapshot.warnings}"
+    message = snapshot.warnings[0]
+    assert FSP_DECLINE in message, f"the warning must name the declining feature: {message}"
+    assert FSP_FILTER in message, f"the warning must name the filter feature: {message}"
+
+
+def test_every_probe_is_recorded_including_the_empty_one(caplog: pytest.LogCaptureFixture) -> None:
+    """The decline is only detectable if empty probe results are recorded, not just the matches."""
+    snapshot = _run(mode_in_group=False, caplog=caplog)
+
+    assert snapshot.probe_counts is not None, "GlobalFilter must expose a probes ledger"
+    assert snapshot.probe_counts.get(FSP_DECLINE) == 0, f"the declining probe must be recorded as empty: {snapshot!r}"
+    assert snapshot.probe_counts.get(FSP_ACCEPT) == 1, f"the accepting probe must record its filter: {snapshot!r}"
+
+
+def test_a_group_option_splits_the_sets_and_spares_the_declining_feature(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The documented remedy: as a group option the mode splits the feature sets, so only one is filtered."""
+    snapshot = _run(mode_in_group=True, caplog=caplog)
+
+    assert snapshot.sentinels[FSP_ACCEPT] == 1, f"the accepting feature set must get its one filter: {snapshot!r}"
+    assert snapshot.sentinels[FSP_DECLINE] == 0, (
+        f"the declining feature set must get an empty filter set, not the filter: {snapshot!r}"
+    )
+
+
+def test_the_uniform_case_warns_about_nothing(caplog: pytest.LogCaptureFixture) -> None:
+    """Every feature of a set matched the same filters, so there is no divergence to report."""
+    snapshot = _run(mode_in_group=True, caplog=caplog)
+
+    assert snapshot.warnings == (), f"a uniform feature set must not warn: {snapshot.warnings}"

--- a/tests/test_core/test_filter/test_filter_scope_per_feature_set.py
+++ b/tests/test_core/test_filter/test_filter_scope_per_feature_set.py
@@ -1,8 +1,5 @@
-"""Issue #928: filters are probed per feature but attached per FeatureSet, so a decline is silent.
-
-Features that differ only in a plain context option share one FeatureSet. When the group declines the
-filter for one of them and accepts it for another, the shared set is filtered anyway. The scope stays
-per FeatureSet; the divergence must become observable as a WARNING, once, per probed feature.
+"""Filters are probed per feature but attached per FeatureSet, so a decline is silently widened.
+The scope stays per FeatureSet; the divergence must be reported as a WARNING, once, per probed feature.
 """
 
 from __future__ import annotations
@@ -26,13 +23,13 @@ from mloda_plugins.compute_framework.base_implementations.python_dict.python_dic
 EP_LOGGER_NAME = "mloda.core.prepare.execution_plan"
 
 # The fsp_ prefix keeps every feature name unique to this module.
-FSP_DECLINE = "fsp_decline_feat_928"  # probing this feature makes the group decline the filter
-FSP_ACCEPT = "fsp_accept_feat_928"  # probing this feature makes the group accept the filter
-FSP_FILTER = "fsp_filter_feat_928"  # the filter feature whose match hook answers per probing feature
-FSP_SAME = "fsp_same_feat_928"  # requested twice, once per mode: one name, two features, one set
-FSP_UNIFORM_A = "fsp_uniform_a_feat_928"  # two different names, identical options, both accepting
-FSP_UNIFORM_B = "fsp_uniform_b_feat_928"
-FSP_MODE_KEY = "fsp_mode_928"  # "a" declines, "b" accepts
+FSP_DECLINE = "fsp_decline_feat"  # probing this feature makes the group decline the filter
+FSP_ACCEPT = "fsp_accept_feat"  # probing this feature makes the group accept the filter
+FSP_FILTER = "fsp_filter_feat"  # the filter feature whose match hook answers per probing feature
+FSP_SAME = "fsp_same_feat"  # requested twice, once per mode: one name, two features, one set
+FSP_UNIFORM_A = "fsp_uniform_a_feat"  # two different names, identical options, both accepting
+FSP_UNIFORM_B = "fsp_uniform_b_feat"
+FSP_MODE_KEY = "fsp_mode"  # "a" declines, "b" accepts
 
 SERVED_FSP_NAMES = (FSP_DECLINE, FSP_ACCEPT, FSP_SAME, FSP_UNIFORM_A, FSP_UNIFORM_B)
 ALL_FSP_NAMES = SERVED_FSP_NAMES + (FSP_FILTER,)
@@ -45,10 +42,10 @@ def _sentinel(features: FeatureSet) -> dict[str, list[int]]:
 
 
 def _make_fg(capture: list[tuple[Feature, ...]] | None = None) -> type[FeatureGroup]:
-    """A throwaway root group whose filter-feature match depends on the mode carried by the probing feature."""
+    """A throwaway root group whose filter-feature match depends on the probing feature's mode."""
     gc.collect()
 
-    class FspScopeFG928(FeatureGroup):
+    class FspScopeFG(FeatureGroup):
         @classmethod
         def input_data(cls) -> DataCreator:
             return DataCreator(set(ALL_FSP_NAMES))
@@ -67,7 +64,7 @@ def _make_fg(capture: list[tuple[Feature, ...]] | None = None) -> type[FeatureGr
 
         @classmethod
         def final_filters(cls) -> bool:
-            # The payload is a sentinel, not filterable data: report features.filters inline instead.
+            # The payload is a sentinel, not filterable data.
             return False
 
         @classmethod
@@ -76,7 +73,7 @@ def _make_fg(capture: list[tuple[Feature, ...]] | None = None) -> type[FeatureGr
                 capture.append(tuple(features.features))
             return _sentinel(features)
 
-    return FspScopeFG928
+    return FspScopeFG
 
 
 def _filter_on_fsp() -> GlobalFilter:
@@ -98,7 +95,7 @@ def _mode_pair(in_group: bool) -> list[Feature | str]:
 
 @dataclass(frozen=True)
 class _RunSnapshot:
-    """Plain-data readout of one run: sentinels, divergence warnings, probe entries. Holds no class."""
+    """Plain-data readout of one run. Holds no reference to the throwaway group."""
 
     sentinels: dict[str, int]
     warnings: tuple[str, ...]
@@ -115,7 +112,7 @@ def _sentinels(results: list[Any], columns: tuple[str, ...]) -> dict[str, int]:
 
 
 def _fsp_records(caplog: pytest.LogCaptureFixture) -> tuple[tuple[int, str], ...]:
-    """Level and message of every execution-plan record mentioning one of this module's feature names."""
+    """Level and message of every execution-plan record naming one of this module's features."""
     return tuple(
         (record.levelno, record.getMessage())
         for record in caplog.records
@@ -129,7 +126,7 @@ def _fsp_warnings(caplog: pytest.LogCaptureFixture) -> tuple[str, ...]:
 
 
 def _probe_entries(global_filter: GlobalFilter) -> dict[str, tuple[int, ...]]:
-    """Per probed feature name, the sorted match counts of its probe entries, one entry per probed feature."""
+    """Per probed feature name, the sorted match counts of its probe entries."""
     entries: dict[str, list[int]] = {}
     # The key holds the feature group class: read the name only, never bind the class.
     for key, matched in global_filter.probes.items():
@@ -138,7 +135,7 @@ def _probe_entries(global_filter: GlobalFilter) -> dict[str, tuple[int, ...]]:
 
 
 def _set_shapes(captured: list[tuple[Feature, ...]]) -> tuple[tuple[str, ...], ...]:
-    """The served feature names of every planned FeatureSet, one sorted tuple per set. Holds no feature."""
+    """The served feature names of every planned FeatureSet, one sorted tuple per set."""
     served = (tuple(sorted(str(feature.name) for feature in features)) for features in captured)
     return tuple(sorted(served))
 
@@ -149,10 +146,10 @@ def _run(
     global_filter: GlobalFilter,
     caplog: pytest.LogCaptureFixture,
 ) -> _RunSnapshot:
-    """Run the given features in one session and collect sentinels, warnings and probes as plain data.
+    """Run the features in one session and collect the readout as plain data.
 
-    Every object referencing the throwaway feature group is dropped before returning, so a failing
-    assert in the caller cannot pin it into a traceback and trip the no-leak fixture.
+    Everything referencing the throwaway group is dropped before returning, so a failing assert
+    cannot pin it into a traceback and trip the no-leak fixture.
     """
     caplog.clear()
     captured: list[tuple[Feature, ...]] = []
@@ -173,7 +170,7 @@ def _run(
         probe_entries=_probe_entries(global_filter),
         set_shapes=_set_shapes(captured),
     )
-    # Records carry args that can hold the throwaway class; drop them with everything else.
+    # Records carry args that can hold the throwaway class.
     caplog.clear()
     del fg, collector, results, captured
     gc.collect()
@@ -181,7 +178,7 @@ def _run(
 
 
 def test_the_declining_feature_is_filtered_anyway(caplog: pytest.LogCaptureFixture) -> None:
-    """Characterization: the shared FeatureSet gets the filter, so the declining feature is filtered too."""
+    """The shared FeatureSet gets the filter, so the declining feature is filtered too."""
     snapshot = _run(_mode_pair(False), (FSP_DECLINE, FSP_ACCEPT), _filter_on_fsp(), caplog)
 
     assert snapshot.sentinels[FSP_ACCEPT] == 1, f"the accepting feature must get its one filter: {snapshot!r}"
@@ -191,7 +188,7 @@ def test_the_declining_feature_is_filtered_anyway(caplog: pytest.LogCaptureFixtu
 
 
 def test_the_divergence_is_reported_as_a_warning(caplog: pytest.LogCaptureFixture) -> None:
-    """The silent widening must be observable: one WARNING naming the declining feature and the filter."""
+    """One WARNING names the declining feature and the filter."""
     snapshot = _run(_mode_pair(False), (FSP_DECLINE, FSP_ACCEPT), _filter_on_fsp(), caplog)
 
     assert len(snapshot.warnings) == 1, f"exactly one WARNING must report the divergence, got: {snapshot.warnings}"
@@ -201,7 +198,7 @@ def test_the_divergence_is_reported_as_a_warning(caplog: pytest.LogCaptureFixtur
 
 
 def test_every_probe_is_recorded_including_the_empty_one(caplog: pytest.LogCaptureFixture) -> None:
-    """The decline is only detectable if empty probe results are recorded, not just the matches."""
+    """Empty probe results are recorded too, not just the matches."""
     snapshot = _run(_mode_pair(False), (FSP_DECLINE, FSP_ACCEPT), _filter_on_fsp(), caplog)
 
     assert snapshot.probe_entries.get(FSP_DECLINE) == (0,), (
@@ -211,7 +208,7 @@ def test_every_probe_is_recorded_including_the_empty_one(caplog: pytest.LogCaptu
 
 
 def test_two_features_of_one_name_diverge_and_are_reported(caplog: pytest.LogCaptureFixture) -> None:
-    """One name requested with two context modes: the declining twin must still be reported, not unioned away."""
+    """One name requested with two context modes: the declining twin is still reported."""
     same_name: list[Feature | str] = [Feature(FSP_SAME, _options("a")), Feature(FSP_SAME, _options("b"))]
     snapshot = _run(same_name, (FSP_SAME,), _filter_on_fsp(), caplog)
 
@@ -228,7 +225,7 @@ def test_two_features_of_one_name_diverge_and_are_reported(caplog: pytest.LogCap
 
 
 def _cross_run_warnings(caplog: pytest.LogCaptureFixture) -> tuple[tuple[str, ...], tuple[str, ...]]:
-    """Two runs of one name over one shared GlobalFilter: run 1 accepts, run 2 declines. Returns both warning sets."""
+    """Two runs of one name over a shared GlobalFilter: run 1 accepts, run 2 declines."""
     caplog.clear()
     fg = _make_fg()
     collector = PluginCollector.enabled_feature_groups({fg})
@@ -258,7 +255,7 @@ def _cross_run_warnings(caplog: pytest.LogCaptureFixture) -> tuple[tuple[str, ..
 
 
 def test_a_stale_probe_of_an_earlier_run_does_not_mask_a_later_decline(caplog: pytest.LogCaptureFixture) -> None:
-    """The second run declines the filter its stale collection entry still attaches: that must warn."""
+    """The second run warns about the stale filter its earlier collection entry still attaches."""
     first, second = _cross_run_warnings(caplog)
 
     assert first == (), f"the accepting run must not warn: {first}"
@@ -268,7 +265,7 @@ def test_a_stale_probe_of_an_earlier_run_does_not_mask_a_later_decline(caplog: p
 
 
 def test_a_filterless_run_records_no_probes(caplog: pytest.LogCaptureFixture) -> None:
-    """An empty GlobalFilter has nothing to probe, so the ledger must stay empty and hold no group class."""
+    """An empty GlobalFilter has nothing to probe, so the ledger stays empty."""
     snapshot = _run(_mode_pair(False), (FSP_DECLINE, FSP_ACCEPT), GlobalFilter(), caplog)
 
     assert snapshot.sentinels == {FSP_DECLINE: -1, FSP_ACCEPT: -1}, f"no filter can be delivered: {snapshot!r}"
@@ -276,11 +273,10 @@ def test_a_filterless_run_records_no_probes(caplog: pytest.LogCaptureFixture) ->
 
 
 def _repeated_report_levels(caplog: pytest.LogCaptureFixture) -> tuple[tuple[int, str], ...]:
-    """Level and message of the divergence reports for one feature planned into two feature sets.
+    """Divergence reports for one feature planned into two feature sets.
 
-    A genuine two-FeatureSet plan is not reachable within the timeout, so the dedup is pinned at the unit
-    level: one real run populates the GlobalFilter, then the plan step is replayed over two fresh sets
-    rebuilt from the features of the diverging set.
+    A genuine two-FeatureSet plan is not reachable within the timeout, so one real run populates the
+    GlobalFilter and the plan step is then replayed twice over the diverging set.
     """
     caplog.clear()
     captured: list[tuple[Feature, ...]] = []
@@ -312,7 +308,7 @@ def _repeated_report_levels(caplog: pytest.LogCaptureFixture) -> tuple[tuple[int
 
 
 def test_the_divergence_report_does_not_repeat(caplog: pytest.LogCaptureFixture) -> None:
-    """The same divergence reported twice must warn once and drop to DEBUG after, like a dropped filter."""
+    """The same divergence warns once, then drops to DEBUG."""
     records = _repeated_report_levels(caplog)
 
     levels = tuple(level for level, _ in records)
@@ -322,7 +318,7 @@ def test_the_divergence_report_does_not_repeat(caplog: pytest.LogCaptureFixture)
 def test_a_group_option_splits_the_sets_and_spares_the_declining_feature(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """The documented remedy: as a group option the mode splits the feature sets, so only one is filtered."""
+    """As a group option the mode splits the feature sets, so only one is filtered."""
     snapshot = _run(_mode_pair(True), (FSP_DECLINE, FSP_ACCEPT), _filter_on_fsp(), caplog)
 
     assert snapshot.sentinels[FSP_ACCEPT] == 1, f"the accepting feature set must get its one filter: {snapshot!r}"
@@ -334,7 +330,7 @@ def test_a_group_option_splits_the_sets_and_spares_the_declining_feature(
 
 
 def test_the_uniform_case_warns_about_nothing(caplog: pytest.LogCaptureFixture) -> None:
-    """Two different names with identical options share one set and both match, so there is nothing to report."""
+    """Two names with identical options share one set and both match, so nothing is reported."""
     uniform: list[Feature | str] = [Feature(FSP_UNIFORM_A, _options("b")), Feature(FSP_UNIFORM_B, _options("b"))]
     snapshot = _run(uniform, (FSP_UNIFORM_A, FSP_UNIFORM_B), _filter_on_fsp(), caplog)
 


### PR DESCRIPTION
Filter matching is probed per feature, but matched filters attach to the shared `FeatureSet`, so a feature whose group declined a filter is filtered anyway once a sibling of the same set matched it.

The scope stays the `FeatureSet`: that is the unit `calculate_feature` receives filters on. Nothing changes about which filters attach, and no new abort is introduced (an abort would undo the contained-raise containment in `GlobalFilter.criteria`). The divergence becomes observable instead.

- `GlobalFilter.probes` records what every probe matched, empty results included, keyed by feature group, feature name and feature uuid, so two same-name features of one set stay separate and a stale entry of an earlier run cannot mask a later decline.
- `ExecutionPlan.add_single_filters_to_feature_set` logs a WARNING naming the feature and the filter feature(s) not matched for it, once per divergence and at DEBUG afterwards.
- Nothing is recorded when the `GlobalFilter` carries no filters.

`filter_data.md` states the scope, both report shapes (WARNING for a decline, the pre-existing `ValueError` for a partial divergence) and the remedy: a group option splits the features into separate `FeatureSet`s.
