### PR TITLE
fix: escalate the option-write conflict during reader selection

### DIFF
--- a/mloda/core/abstract_plugins/components/input_data/base_input_data.py
+++ b/mloda/core/abstract_plugins/components/input_data/base_input_data.py
@@ -22,7 +22,7 @@ class BaseInputData(ABC):
     READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
         "BaseInputData": PropertySpec(
             "The matched (ReaderClass, data_access) pair, written by add_base_input_data_to_options "
-            "and read back by init_reader; an explicitly stored None counts as present.",
+            "and read back by init_reader.",
             default=None,
             framework_set=True,
             allow_explicit_none=True,
@@ -372,8 +372,7 @@ class BaseInputData(ABC):
 
         if "BaseInputData" in options:
             existing_data = options.get("BaseInputData")
-            # `is True`, not a truth test: a non-bool __eq__ result (numpy array, DataFrame) must fall through
-            # to the marked escalation instead of raising "truth value is ambiguous" unmarked (#932).
+            # `is True`, not a truth test: a non-bool __eq__ result (numpy array) must not raise unmarked here.
             if (existing_data == (cls_to_be_added, matched_data_access)) is True:
                 return
 
@@ -383,10 +382,7 @@ class BaseInputData(ABC):
                 existing_label = type(existing_data).__name__
 
             # Marked: two conflicting readers for one feature is a user misconfiguration.
-            # Presence, not truthiness, is the identity, so the same contradiction is not left to raise unmarked
-            # one level down in Options.add_to_group (#932).
-            # The access value is deliberately named by TYPE only: it can carry credentials (ReadDB matches a
-            # credentials dict), and this message escalates to the caller and is logged.
+            # Keyed on presence so add_to_group cannot raise it unmarked; access named by type, it may hold secrets.
             raise escalate_match_abort(
                 ValueError(
                     f"BaseInputData already set with different values. "
@@ -413,7 +409,6 @@ class BaseInputData(ABC):
         if reader_data_access is None:
             raise ValueError(
                 f"'BaseInputData' key is missing in the provided Options for {self.__class__.__name__}.\n"
-                "Reader selection never leaves a None stored under it: there, a stored None is a conflict.\n"
                 "The 'BaseInputData' key in Options must map to a tuple of "
                 "(ReaderClass, data_access).\n"
                 "Example:\n"

--- a/mloda/core/abstract_plugins/components/input_data/base_input_data.py
+++ b/mloda/core/abstract_plugins/components/input_data/base_input_data.py
@@ -369,16 +369,18 @@ class BaseInputData(ABC):
         Adding the found data access class to the options.
         """
 
-        if options.get("BaseInputData"):
+        if "BaseInputData" in options:
             existing_data = options.get("BaseInputData")
             if existing_data == (cls_to_be_added, matched_data_access):
                 return
 
-            already_cls_to_be_added, _ = existing_data
             # Marked: two conflicting readers for one feature is a user misconfiguration.
+            # Presence, not truthiness, is the identity, so the same contradiction is not left to raise unmarked
+            # one level down in Options.add_to_group (#932).
             raise escalate_match_abort(
                 ValueError(
-                    f"BaseInputData already set with different values. {cls_to_be_added} != {already_cls_to_be_added}"
+                    f"BaseInputData already set with different values. "
+                    f"{(cls_to_be_added, matched_data_access)} != {existing_data}"
                 )
             )
         options.add_to_group("BaseInputData", (cls_to_be_added, matched_data_access))

--- a/mloda/core/abstract_plugins/components/input_data/base_input_data.py
+++ b/mloda/core/abstract_plugins/components/input_data/base_input_data.py
@@ -22,9 +22,10 @@ class BaseInputData(ABC):
     READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
         "BaseInputData": PropertySpec(
             "The matched (ReaderClass, data_access) pair, written by add_base_input_data_to_options "
-            "and read back by init_reader.",
+            "and read back by init_reader; an explicitly stored None counts as present.",
             default=None,
             framework_set=True,
+            allow_explicit_none=True,
         ),
     }
 
@@ -371,16 +372,26 @@ class BaseInputData(ABC):
 
         if "BaseInputData" in options:
             existing_data = options.get("BaseInputData")
-            if existing_data == (cls_to_be_added, matched_data_access):
+            # `is True`, not a truth test: a non-bool __eq__ result (numpy array, DataFrame) must fall through
+            # to the marked escalation instead of raising "truth value is ambiguous" unmarked (#932).
+            if (existing_data == (cls_to_be_added, matched_data_access)) is True:
                 return
+
+            if isinstance(existing_data, tuple) and len(existing_data) == 2:
+                existing_label = f"{existing_data[0]} (access type {type(existing_data[1]).__name__})"
+            else:
+                existing_label = type(existing_data).__name__
 
             # Marked: two conflicting readers for one feature is a user misconfiguration.
             # Presence, not truthiness, is the identity, so the same contradiction is not left to raise unmarked
             # one level down in Options.add_to_group (#932).
+            # The access value is deliberately named by TYPE only: it can carry credentials (ReadDB matches a
+            # credentials dict), and this message escalates to the caller and is logged.
             raise escalate_match_abort(
                 ValueError(
                     f"BaseInputData already set with different values. "
-                    f"{(cls_to_be_added, matched_data_access)} != {existing_data}"
+                    f"incoming={cls_to_be_added} (access type {type(matched_data_access).__name__}), "
+                    f"existing={existing_label}"
                 )
             )
         options.add_to_group("BaseInputData", (cls_to_be_added, matched_data_access))
@@ -401,7 +412,8 @@ class BaseInputData(ABC):
 
         if reader_data_access is None:
             raise ValueError(
-                f"'BaseInputData' key is missing or None in the provided Options for {self.__class__.__name__}.\n"
+                f"'BaseInputData' key is missing in the provided Options for {self.__class__.__name__}.\n"
+                "Reader selection never leaves a None stored under it: there, a stored None is a conflict.\n"
                 "The 'BaseInputData' key in Options must map to a tuple of "
                 "(ReaderClass, data_access).\n"
                 "Example:\n"

--- a/mloda/core/abstract_plugins/components/match_data/match_data.py
+++ b/mloda/core/abstract_plugins/components/match_data/match_data.py
@@ -92,12 +92,14 @@ class MatchData:
 
         cls_name = cls.get_class_name()
 
-        if options.get(cls_name):
+        if cls_name in options:
             existing_data = options.get(cls_name)
             if existing_data == matched_data_access:
                 return
 
             # Marked: two conflicting readers for one feature is a user misconfiguration.
+            # Presence, not truthiness, is the identity, so the same contradiction is not left to raise unmarked
+            # one level down in Options.add_to_group (#932).
             raise escalate_match_abort(
                 ValueError(f"{cls_name} already set with different values. {existing_data} != {matched_data_access}")
             )

--- a/mloda/core/abstract_plugins/components/match_data/match_data.py
+++ b/mloda/core/abstract_plugins/components/match_data/match_data.py
@@ -94,14 +94,21 @@ class MatchData:
 
         if cls_name in options:
             existing_data = options.get(cls_name)
-            if existing_data == matched_data_access:
+            # `is True`, not a truth test: a non-bool __eq__ result (numpy array, DataFrame) must fall through
+            # to the marked escalation instead of raising "truth value is ambiguous" unmarked (#932).
+            if (existing_data == matched_data_access) is True:
                 return
 
             # Marked: two conflicting readers for one feature is a user misconfiguration.
             # Presence, not truthiness, is the identity, so the same contradiction is not left to raise unmarked
             # one level down in Options.add_to_group (#932).
+            # The access value is deliberately named by TYPE only: it can carry credentials, and this message
+            # escalates to the caller and is logged.
             raise escalate_match_abort(
-                ValueError(f"{cls_name} already set with different values. {existing_data} != {matched_data_access}")
+                ValueError(
+                    f"{cls_name} already set with different values. "
+                    f"incoming={type(matched_data_access).__name__}, existing={type(existing_data).__name__}"
+                )
             )
         options.add_to_group(cls_name, matched_data_access)
 

--- a/mloda/core/abstract_plugins/components/match_data/match_data.py
+++ b/mloda/core/abstract_plugins/components/match_data/match_data.py
@@ -94,16 +94,12 @@ class MatchData:
 
         if cls_name in options:
             existing_data = options.get(cls_name)
-            # `is True`, not a truth test: a non-bool __eq__ result (numpy array, DataFrame) must fall through
-            # to the marked escalation instead of raising "truth value is ambiguous" unmarked (#932).
+            # `is True`, not a truth test: a non-bool __eq__ result (numpy array) must not raise unmarked here.
             if (existing_data == matched_data_access) is True:
                 return
 
             # Marked: two conflicting readers for one feature is a user misconfiguration.
-            # Presence, not truthiness, is the identity, so the same contradiction is not left to raise unmarked
-            # one level down in Options.add_to_group (#932).
-            # The access value is deliberately named by TYPE only: it can carry credentials, and this message
-            # escalates to the caller and is logged.
+            # Keyed on presence so add_to_group cannot raise it unmarked; access named by type, it may hold secrets.
             raise escalate_match_abort(
                 ValueError(
                     f"{cls_name} already set with different values. "

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -525,6 +525,9 @@ class IdentifyFeatureGroupClass:
         enforces that. A mark only survives if every handler in between re-raises it (``safe_field`` does not). A
         contained raise is kept as text, never as an exception object whose traceback would pin the plugin
         class. The per-candidate rejection window, reset in the finally, keys reasons by candidate class.
+
+        An option-write conflict during reader selection is a contradiction and escalates, decided at the
+        reader-selection raise rather than left to the deeper Options write (#932).
         """
         token = MATCH_REJECTION_REASONS.set({})
         # Shallow copies, taken per candidate so an earlier match's write survives a later candidate's raise.

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -525,9 +525,8 @@ class IdentifyFeatureGroupClass:
         enforces that. A mark only survives if every handler in between re-raises it (``safe_field`` does not). A
         contained raise is kept as text, never as an exception object whose traceback would pin the plugin
         class. The per-candidate rejection window, reset in the finally, keys reasons by candidate class.
-
-        An option-write conflict during reader selection is a contradiction and escalates, decided at the
-        reader-selection raise rather than left to the deeper Options write (#932).
+        An option-write conflict during reader selection escalates as a contradiction, decided at the
+        reader-selection raise.
         """
         token = MATCH_REJECTION_REASONS.set({})
         # Shallow copies, taken per candidate so an earlier match's write survives a later candidate's raise.

--- a/tests/test_core/test_prepare/test_match_abort_sweep.py
+++ b/tests/test_core/test_prepare/test_match_abort_sweep.py
@@ -59,9 +59,8 @@ SEEDS: dict[str, str] = {
 _CANDIDATE_OWN_DECLARATION = "contained: validates the requesting feature's own declaration during matching"
 _READER_AUTO_LOAD = "contained: reader auto-load during matching; a broken plugin group must not abort the run"
 _DECIDED_ABOVE_BY_READER_SELECTION = (
-    "decided above by the marked raise in reader selection (#932), for its two match-path callers "
-    "BaseInputData.add_base_input_data_to_options and MatchData.add_base_input_data_to_options; "
-    "from both, this write only ever reaches an absent key. A third caller needs its own decision"
+    "decided above by the marked raise in both add_base_input_data_to_options callers; this write only "
+    "ever reaches an absent key"
 )
 
 RAISING_HELPERS_OUTSIDE_THE_PATH: dict[tuple[str, str], str] = {

--- a/tests/test_core/test_prepare/test_match_abort_sweep.py
+++ b/tests/test_core/test_prepare/test_match_abort_sweep.py
@@ -58,10 +58,13 @@ SEEDS: dict[str, str] = {
 # instead of at the raise. Resolution is by name, so an entry can be a name COLLISION, not a call edge.
 _CANDIDATE_OWN_DECLARATION = "contained: validates the requesting feature's own declaration during matching"
 _READER_AUTO_LOAD = "contained: reader auto-load during matching; a broken plugin group must not abort the run"
+_DECIDED_ABOVE_BY_READER_SELECTION = (
+    "decided above by the marked raise in reader selection (#932); this write only ever reaches an absent key"
+)
 
 RAISING_HELPERS_OUTSIDE_THE_PATH: dict[tuple[str, str], str] = {
     ("mloda/core/abstract_plugins/components/options.py", "__init__"): _CANDIDATE_OWN_DECLARATION,
-    ("mloda/core/abstract_plugins/components/options.py", "add_to_group"): _CANDIDATE_OWN_DECLARATION,
+    ("mloda/core/abstract_plugins/components/options.py", "add_to_group"): _DECIDED_ABOVE_BY_READER_SELECTION,
     ("mloda/core/abstract_plugins/components/options.py", "get_in_features"): _CANDIDATE_OWN_DECLARATION,
     ("mloda/core/abstract_plugins/components/feature.py", "__init__"): _CANDIDATE_OWN_DECLARATION,
     ("mloda/core/abstract_plugins/plugin_loader/plugin_loader.py", "__init__"): _READER_AUTO_LOAD,

--- a/tests/test_core/test_prepare/test_match_abort_sweep.py
+++ b/tests/test_core/test_prepare/test_match_abort_sweep.py
@@ -59,7 +59,9 @@ SEEDS: dict[str, str] = {
 _CANDIDATE_OWN_DECLARATION = "contained: validates the requesting feature's own declaration during matching"
 _READER_AUTO_LOAD = "contained: reader auto-load during matching; a broken plugin group must not abort the run"
 _DECIDED_ABOVE_BY_READER_SELECTION = (
-    "decided above by the marked raise in reader selection (#932); this write only ever reaches an absent key"
+    "decided above by the marked raise in reader selection (#932), for its two match-path callers "
+    "BaseInputData.add_base_input_data_to_options and MatchData.add_base_input_data_to_options; "
+    "from both, this write only ever reaches an absent key. A third caller needs its own decision"
 )
 
 RAISING_HELPERS_OUTSIDE_THE_PATH: dict[tuple[str, str], str] = {

--- a/tests/test_core/test_prepare/test_option_write_conflict_stays_loud.py
+++ b/tests/test_core/test_prepare/test_option_write_conflict_stays_loud.py
@@ -1,0 +1,294 @@
+"""#932: an option-write conflict during reader selection must escalate, like the reader conflict above it.
+
+Both ``add_base_input_data_to_options`` twins guard on truthiness, so a reserved key PRESENT with a
+falsy value slips past the marked escalation and reaches ``Options.add_to_group``, which raises
+unmarked and is contained as a non-match. Doubles are per test and dropped afterwards.
+"""
+
+import gc
+from collections.abc import Callable
+from dataclasses import dataclass
+from functools import partial
+from typing import Any, Optional, TypeVar
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.input_data.base_input_data import BaseInputData
+from mloda.core.abstract_plugins.components.match_data.match_data import MatchData
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+
+
+MATCH_DATA_FEATURE = "option_write_match_data_feat_932"
+MATCH_DATA_CLASS_NAME = "OptionWriteMatchDataFG932"
+MATCH_DATA_RIVAL_NAME = "OptionWriteMatchDataRivalFG932"
+READER_FEATURE = "option_write_reader_feat_932"
+READER_RIVAL_NAME = "OptionWriteReaderRivalFG932"
+READER_CLASS_NAME = "OptionWriteReader932"
+RESERVED_KEY = "BaseInputData"
+SCOPE_ACCESS = "option_write_scope_access_932"
+GLOBAL_ACCESS = "option_write_global_access_932"
+RAISE_TYPE_NAME = "ValueError"
+
+T = TypeVar("T")
+
+
+class OptionWriteFw932(ComputeFramework):
+    """Dummy compute framework for the option-write conflict tests."""
+
+
+def _capture(call: Callable[[], T]) -> tuple[Optional[T], Optional[str]]:
+    """Run call, returning (value, None) or (None, 'Type: message'). No traceback is retained."""
+    try:
+        return call(), None
+    except Exception as exc:  # noqa: BLE001  (an escape, or its absence, is the fact under test)
+        return None, f"{type(exc).__name__}: {exc}"
+
+
+@dataclass(frozen=True)
+class _ConflictSnapshot:
+    """Plain-data readout of one evaluation. Holds no class and no exception object."""
+
+    escaped: Optional[str]
+    identified_names: tuple[str, ...]
+
+
+def _make_match_data_fg() -> type[FeatureGroup]:
+    """MatchData candidate whose reserved key is already PRESENT with a falsy value."""
+    # Class objects are cyclic; collect leftovers from earlier tests before defining a twin.
+    gc.collect()
+
+    class OptionWriteMatchDataFG932(FeatureGroup, MatchData):
+        """Resolves a global-scope access while its own class-name key sits in the options as None."""
+
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {MATCH_DATA_FEATURE}
+
+        @classmethod
+        def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+            return {OptionWriteFw932}
+
+        @classmethod
+        def match_data_access(
+            cls,
+            feature_name: str,
+            options: Options,
+            data_access_collection: Optional[DataAccessCollection] = None,
+            framework_connection_object: Optional[Any] = None,
+        ) -> Any:
+            if str(feature_name) != MATCH_DATA_FEATURE:
+                return None
+            if data_access_collection is None:
+                return None
+            return GLOBAL_ACCESS
+
+        def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+            return None
+
+    return OptionWriteMatchDataFG932
+
+
+def _make_match_data_rival_fg() -> type[FeatureGroup]:
+    """Rival claiming the MatchData feature name cleanly, so a contained conflict would let it win."""
+    gc.collect()
+
+    class OptionWriteMatchDataRivalFG932(FeatureGroup):
+        """The group that would silently win while the option-write conflict is swallowed."""
+
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {MATCH_DATA_FEATURE}
+
+        @classmethod
+        def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+            return {OptionWriteFw932}
+
+        def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+            return None
+
+    return OptionWriteMatchDataRivalFG932
+
+
+class OptionWriteReaderFamily932(BaseInputData):
+    """Family base of the test reader; never final itself, so only its child is discovered."""
+
+
+class OptionWriteReader932(OptionWriteReaderFamily932):
+    """Final reader that matches ONLY its own marker value, so process-wide discovery cannot collide."""
+
+    @classmethod
+    def match_subclass_data_access(
+        cls, data_access: Any, feature_names: list[str], options: Optional[Options] = None
+    ) -> Any:
+        if isinstance(data_access, DataAccessCollection):
+            if GLOBAL_ACCESS in data_access.connections.values():
+                return GLOBAL_ACCESS
+            return None
+        if data_access == SCOPE_ACCESS:
+            return SCOPE_ACCESS
+        return None
+
+    @classmethod
+    def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
+        return None
+
+
+def _make_reader_fg() -> type[FeatureGroup]:
+    """Reader-selecting candidate whose reserved 'BaseInputData' key is PRESENT with a falsy value."""
+    gc.collect()
+
+    class OptionWriteReaderFG932(FeatureGroup):
+        """Root feature group selecting the test reader family."""
+
+        @classmethod
+        def input_data(cls) -> Optional[BaseInputData]:
+            return OptionWriteReaderFamily932()
+
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {READER_FEATURE}
+
+        @classmethod
+        def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+            return {OptionWriteFw932}
+
+        def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+            return None
+
+    return OptionWriteReaderFG932
+
+
+def _make_reader_rival_fg() -> type[FeatureGroup]:
+    """Rival claiming the reader feature name cleanly, without touching any reader option."""
+    gc.collect()
+
+    class OptionWriteReaderRivalFG932(FeatureGroup):
+        """The group that would silently win while the option-write conflict is swallowed."""
+
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {READER_FEATURE}
+
+        @classmethod
+        def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+            return {OptionWriteFw932}
+
+        def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+            return None
+
+    return OptionWriteReaderRivalFG932
+
+
+def _evaluate(
+    feature_name: str,
+    options: Options,
+    conflict_fg: type[FeatureGroup],
+    rival_fg: Optional[type[FeatureGroup]],
+    data_access: Optional[DataAccessCollection],
+) -> _ConflictSnapshot:
+    """Evaluate one feature at the match seam and read the outcome out as plain data."""
+    feature = Feature(feature_name, options=options)
+    plugins: FeatureGroupEnvironmentMapping = {conflict_fg: {OptionWriteFw932}}
+    if rival_fg is not None:
+        plugins[rival_fg] = {OptionWriteFw932}
+    result, escaped = _capture(partial(IdentifyFeatureGroupClass.evaluate, feature, plugins, None, data_access))
+    identified = () if result is None else tuple(sorted(fg.get_class_name() for fg in result.identified))
+    snapshot = _ConflictSnapshot(escaped=escaped, identified_names=identified)
+    del result
+    del plugins
+    del feature
+    return snapshot
+
+
+def _evaluate_match_data_conflict(with_rival: bool) -> _ConflictSnapshot:
+    """MatchData twin: the class-name key is present as None while a global access resolves."""
+    conflict_fg = _make_match_data_fg()
+    rival_fg = _make_match_data_rival_fg() if with_rival else None
+    try:
+        options = Options(group={MATCH_DATA_CLASS_NAME: None})
+        data_access = DataAccessCollection(connections={"option_write_handle_932": GLOBAL_ACCESS})
+        return _evaluate(MATCH_DATA_FEATURE, options, conflict_fg, rival_fg, data_access)
+    finally:
+        del conflict_fg
+        del rival_fg
+        gc.collect()
+
+
+def _evaluate_reader_conflict(with_rival: bool, global_scope: bool) -> _ConflictSnapshot:
+    """BaseInputData twin: the reserved key is present as None while a reader resolves."""
+    conflict_fg = _make_reader_fg()
+    rival_fg = _make_reader_rival_fg() if with_rival else None
+    try:
+        group: dict[str, Any] = {RESERVED_KEY: None}
+        data_access: Optional[DataAccessCollection] = None
+        if global_scope:
+            data_access = DataAccessCollection(connections={"option_write_handle_932": GLOBAL_ACCESS})
+        else:
+            group[READER_CLASS_NAME] = SCOPE_ACCESS
+        return _evaluate(READER_FEATURE, Options(group=group), conflict_fg, rival_fg, data_access)
+    finally:
+        del conflict_fg
+        del rival_fg
+        gc.collect()
+
+
+class TestMatchDataOptionWriteConflictAbortsTheMatch:
+    """A contradicting option write under MatchData is a user contradiction, not a non-match."""
+
+    def test_conflict_reaches_the_caller(self) -> None:
+        snapshot = _evaluate_match_data_conflict(with_rival=False)
+
+        assert snapshot.escaped is not None, "the option-write conflict must not be contained as a non-match"
+        assert snapshot.escaped.startswith(f"{RAISE_TYPE_NAME}: "), (
+            f"the conflict's own ValueError must reach the caller, got: {snapshot.escaped}"
+        )
+        assert MATCH_DATA_CLASS_NAME in snapshot.escaped
+        assert snapshot.identified_names == ()
+
+    def test_conflict_is_not_dropped_when_a_rival_claims_the_name(self) -> None:
+        snapshot = _evaluate_match_data_conflict(with_rival=True)
+
+        assert snapshot.identified_names != (MATCH_DATA_RIVAL_NAME,), (
+            "the rival must not silently win while the option-write conflict is swallowed"
+        )
+        assert snapshot.escaped is not None, "a rival candidate must not hide the option-write conflict"
+        assert snapshot.escaped.startswith(f"{RAISE_TYPE_NAME}: ")
+        assert MATCH_DATA_CLASS_NAME in snapshot.escaped
+
+
+class TestBaseInputDataOptionWriteConflictAbortsTheMatch:
+    """The same contradiction during reader selection must escalate on both scope paths."""
+
+    def test_feature_scope_conflict_reaches_the_caller(self) -> None:
+        snapshot = _evaluate_reader_conflict(with_rival=False, global_scope=False)
+
+        assert snapshot.escaped is not None, "the option-write conflict must not be contained as a non-match"
+        assert snapshot.escaped.startswith(f"{RAISE_TYPE_NAME}: "), (
+            f"the conflict's own ValueError must reach the caller, got: {snapshot.escaped}"
+        )
+        assert RESERVED_KEY in snapshot.escaped
+        assert snapshot.identified_names == ()
+
+    def test_global_scope_conflict_reaches_the_caller(self) -> None:
+        snapshot = _evaluate_reader_conflict(with_rival=False, global_scope=True)
+
+        assert snapshot.escaped is not None, "the option-write conflict must not be contained as a non-match"
+        assert snapshot.escaped.startswith(f"{RAISE_TYPE_NAME}: ")
+        assert RESERVED_KEY in snapshot.escaped
+        assert snapshot.identified_names == ()
+
+    def test_conflict_is_not_dropped_when_a_rival_claims_the_name(self) -> None:
+        snapshot = _evaluate_reader_conflict(with_rival=True, global_scope=False)
+
+        assert snapshot.identified_names != (READER_RIVAL_NAME,), (
+            "the rival must not silently win while the option-write conflict is swallowed"
+        )
+        assert snapshot.escaped is not None, "a rival candidate must not hide the option-write conflict"
+        assert snapshot.escaped.startswith(f"{RAISE_TYPE_NAME}: ")
+        assert RESERVED_KEY in snapshot.escaped

--- a/tests/test_core/test_prepare/test_option_write_conflict_stays_loud.py
+++ b/tests/test_core/test_prepare/test_option_write_conflict_stays_loud.py
@@ -1,8 +1,8 @@
-"""#932: an option-write conflict during reader selection must escalate, like the reader conflict above it.
+"""#932: an option-write conflict during reader selection escalates, like the reader conflict above it.
 
-Both ``add_base_input_data_to_options`` twins guard on truthiness, so a reserved key PRESENT with a
-falsy value slips past the marked escalation and reaches ``Options.add_to_group``, which raises
-unmarked and is contained as a non-match. Doubles are per test and dropped afterwards.
+Both ``add_base_input_data_to_options`` twins decide on PRESENCE, so a reserved key present with any
+value (falsy, or truthy but malformed) escalates at their own marked raise, never reaching the unmarked
+``Options.add_to_group``. The escalated message names classes and types only, never the access value.
 """
 
 import gc
@@ -34,6 +34,9 @@ RESERVED_KEY = "BaseInputData"
 SCOPE_ACCESS = "option_write_scope_access_932"
 GLOBAL_ACCESS = "option_write_global_access_932"
 RAISE_TYPE_NAME = "ValueError"
+MALFORMED_ACCESS = "s3://bucket/f.parquet"
+# Pins WHICH raise escaped: Options.add_to_group raises a ValueError naming the key too.
+CONFLICT_TEXT = "already set with different values"
 
 T = TypeVar("T")
 
@@ -220,12 +223,12 @@ def _evaluate_match_data_conflict(with_rival: bool) -> _ConflictSnapshot:
         gc.collect()
 
 
-def _evaluate_reader_conflict(with_rival: bool, global_scope: bool) -> _ConflictSnapshot:
-    """BaseInputData twin: the reserved key is present as None while a reader resolves."""
+def _evaluate_reader_conflict(with_rival: bool, global_scope: bool, reserved_value: Any = None) -> _ConflictSnapshot:
+    """BaseInputData twin: the reserved key is present with reserved_value while a reader resolves."""
     conflict_fg = _make_reader_fg()
     rival_fg = _make_reader_rival_fg() if with_rival else None
     try:
-        group: dict[str, Any] = {RESERVED_KEY: None}
+        group: dict[str, Any] = {RESERVED_KEY: reserved_value}
         data_access: Optional[DataAccessCollection] = None
         if global_scope:
             data_access = DataAccessCollection(connections={"option_write_handle_932": GLOBAL_ACCESS})
@@ -249,6 +252,7 @@ class TestMatchDataOptionWriteConflictAbortsTheMatch:
             f"the conflict's own ValueError must reach the caller, got: {snapshot.escaped}"
         )
         assert MATCH_DATA_CLASS_NAME in snapshot.escaped
+        assert CONFLICT_TEXT in snapshot.escaped, "the twin's own raise must escape, not the deeper option write"
         assert snapshot.identified_names == ()
 
     def test_conflict_is_not_dropped_when_a_rival_claims_the_name(self) -> None:
@@ -260,6 +264,14 @@ class TestMatchDataOptionWriteConflictAbortsTheMatch:
         assert snapshot.escaped is not None, "a rival candidate must not hide the option-write conflict"
         assert snapshot.escaped.startswith(f"{RAISE_TYPE_NAME}: ")
         assert MATCH_DATA_CLASS_NAME in snapshot.escaped
+        assert CONFLICT_TEXT in snapshot.escaped
+
+    def test_conflict_message_names_no_access_value(self) -> None:
+        """The access can carry credentials, so only class and type names are reported."""
+        snapshot = _evaluate_match_data_conflict(with_rival=False)
+
+        assert snapshot.escaped is not None
+        assert GLOBAL_ACCESS not in snapshot.escaped
 
 
 class TestBaseInputDataOptionWriteConflictAbortsTheMatch:
@@ -273,6 +285,7 @@ class TestBaseInputDataOptionWriteConflictAbortsTheMatch:
             f"the conflict's own ValueError must reach the caller, got: {snapshot.escaped}"
         )
         assert RESERVED_KEY in snapshot.escaped
+        assert CONFLICT_TEXT in snapshot.escaped, "the twin's own raise must escape, not the deeper option write"
         assert snapshot.identified_names == ()
 
     def test_global_scope_conflict_reaches_the_caller(self) -> None:
@@ -281,7 +294,26 @@ class TestBaseInputDataOptionWriteConflictAbortsTheMatch:
         assert snapshot.escaped is not None, "the option-write conflict must not be contained as a non-match"
         assert snapshot.escaped.startswith(f"{RAISE_TYPE_NAME}: ")
         assert RESERVED_KEY in snapshot.escaped
+        assert CONFLICT_TEXT in snapshot.escaped
         assert snapshot.identified_names == ()
+
+    def test_present_truthy_malformed_value_reaches_the_caller(self) -> None:
+        """A user passing the access directly under the reserved key: present, truthy, not a pair."""
+        snapshot = _evaluate_reader_conflict(with_rival=False, global_scope=False, reserved_value=MALFORMED_ACCESS)
+
+        assert snapshot.escaped is not None, "a malformed reserved value must not be contained as a non-match"
+        assert snapshot.escaped.startswith(f"{RAISE_TYPE_NAME}: ")
+        assert RESERVED_KEY in snapshot.escaped
+        assert CONFLICT_TEXT in snapshot.escaped, "the unpack of the malformed value must not raise instead"
+        assert snapshot.identified_names == ()
+
+    def test_conflict_message_names_no_access_value(self) -> None:
+        """The access can carry credentials, so only class and type names are reported."""
+        snapshot = _evaluate_reader_conflict(with_rival=False, global_scope=False, reserved_value=MALFORMED_ACCESS)
+
+        assert snapshot.escaped is not None
+        assert MALFORMED_ACCESS not in snapshot.escaped
+        assert SCOPE_ACCESS not in snapshot.escaped
 
     def test_conflict_is_not_dropped_when_a_rival_claims_the_name(self) -> None:
         snapshot = _evaluate_reader_conflict(with_rival=True, global_scope=False)
@@ -292,3 +324,4 @@ class TestBaseInputDataOptionWriteConflictAbortsTheMatch:
         assert snapshot.escaped is not None, "a rival candidate must not hide the option-write conflict"
         assert snapshot.escaped.startswith(f"{RAISE_TYPE_NAME}: ")
         assert RESERVED_KEY in snapshot.escaped
+        assert CONFLICT_TEXT in snapshot.escaped

--- a/tests/test_core/test_prepare/test_option_write_conflict_stays_loud.py
+++ b/tests/test_core/test_prepare/test_option_write_conflict_stays_loud.py
@@ -1,8 +1,6 @@
-"""#932: an option-write conflict during reader selection escalates, like the reader conflict above it.
+"""An option-write conflict during reader selection escalates instead of being contained as a non-match.
 
-Both ``add_base_input_data_to_options`` twins decide on PRESENCE, so a reserved key present with any
-value (falsy, or truthy but malformed) escalates at their own marked raise, never reaching the unmarked
-``Options.add_to_group``. The escalated message names classes and types only, never the access value.
+Both ``add_base_input_data_to_options`` twins decide on presence, and report class and type names only.
 """
 
 import gc
@@ -42,11 +40,11 @@ T = TypeVar("T")
 
 
 class OptionWriteFw932(ComputeFramework):
-    """Dummy compute framework for the option-write conflict tests."""
+    pass
 
 
 def _capture(call: Callable[[], T]) -> tuple[Optional[T], Optional[str]]:
-    """Run call, returning (value, None) or (None, 'Type: message'). No traceback is retained."""
+    """Returns (value, None) or (None, 'Type: message'); no traceback is retained."""
     try:
         return call(), None
     except Exception as exc:  # noqa: BLE001  (an escape, or its absence, is the fact under test)
@@ -55,20 +53,18 @@ def _capture(call: Callable[[], T]) -> tuple[Optional[T], Optional[str]]:
 
 @dataclass(frozen=True)
 class _ConflictSnapshot:
-    """Plain-data readout of one evaluation. Holds no class and no exception object."""
+    """Readout of one evaluation, holding no class and no exception object."""
 
     escaped: Optional[str]
     identified_names: tuple[str, ...]
 
 
 def _make_match_data_fg() -> type[FeatureGroup]:
-    """MatchData candidate whose reserved key is already PRESENT with a falsy value."""
+    """MatchData candidate resolving a global access while its class-name key is present as None."""
     # Class objects are cyclic; collect leftovers from earlier tests before defining a twin.
     gc.collect()
 
     class OptionWriteMatchDataFG932(FeatureGroup, MatchData):
-        """Resolves a global-scope access while its own class-name key sits in the options as None."""
-
         @classmethod
         def feature_names_supported(cls) -> set[str]:
             return {MATCH_DATA_FEATURE}
@@ -102,8 +98,6 @@ def _make_match_data_rival_fg() -> type[FeatureGroup]:
     gc.collect()
 
     class OptionWriteMatchDataRivalFG932(FeatureGroup):
-        """The group that would silently win while the option-write conflict is swallowed."""
-
         @classmethod
         def feature_names_supported(cls) -> set[str]:
             return {MATCH_DATA_FEATURE}
@@ -123,7 +117,7 @@ class OptionWriteReaderFamily932(BaseInputData):
 
 
 class OptionWriteReader932(OptionWriteReaderFamily932):
-    """Final reader that matches ONLY its own marker value, so process-wide discovery cannot collide."""
+    """Matches only its own marker value, so process-wide discovery cannot collide."""
 
     @classmethod
     def match_subclass_data_access(
@@ -143,12 +137,10 @@ class OptionWriteReader932(OptionWriteReaderFamily932):
 
 
 def _make_reader_fg() -> type[FeatureGroup]:
-    """Reader-selecting candidate whose reserved 'BaseInputData' key is PRESENT with a falsy value."""
+    """Reader-selecting candidate whose reserved 'BaseInputData' key is already present."""
     gc.collect()
 
     class OptionWriteReaderFG932(FeatureGroup):
-        """Root feature group selecting the test reader family."""
-
         @classmethod
         def input_data(cls) -> Optional[BaseInputData]:
             return OptionWriteReaderFamily932()
@@ -172,8 +164,6 @@ def _make_reader_rival_fg() -> type[FeatureGroup]:
     gc.collect()
 
     class OptionWriteReaderRivalFG932(FeatureGroup):
-        """The group that would silently win while the option-write conflict is swallowed."""
-
         @classmethod
         def feature_names_supported(cls) -> set[str]:
             return {READER_FEATURE}
@@ -195,7 +185,7 @@ def _evaluate(
     rival_fg: Optional[type[FeatureGroup]],
     data_access: Optional[DataAccessCollection],
 ) -> _ConflictSnapshot:
-    """Evaluate one feature at the match seam and read the outcome out as plain data."""
+    """Evaluates one feature at the match seam and reads the outcome out as plain data."""
     feature = Feature(feature_name, options=options)
     plugins: FeatureGroupEnvironmentMapping = {conflict_fg: {OptionWriteFw932}}
     if rival_fg is not None:
@@ -210,7 +200,7 @@ def _evaluate(
 
 
 def _evaluate_match_data_conflict(with_rival: bool) -> _ConflictSnapshot:
-    """MatchData twin: the class-name key is present as None while a global access resolves."""
+    """MatchData twin: class-name key present as None while a global access resolves."""
     conflict_fg = _make_match_data_fg()
     rival_fg = _make_match_data_rival_fg() if with_rival else None
     try:
@@ -224,7 +214,7 @@ def _evaluate_match_data_conflict(with_rival: bool) -> _ConflictSnapshot:
 
 
 def _evaluate_reader_conflict(with_rival: bool, global_scope: bool, reserved_value: Any = None) -> _ConflictSnapshot:
-    """BaseInputData twin: the reserved key is present with reserved_value while a reader resolves."""
+    """BaseInputData twin: reserved key present with reserved_value while a reader resolves."""
     conflict_fg = _make_reader_fg()
     rival_fg = _make_reader_rival_fg() if with_rival else None
     try:
@@ -247,10 +237,8 @@ class TestMatchDataOptionWriteConflictAbortsTheMatch:
     def test_conflict_reaches_the_caller(self) -> None:
         snapshot = _evaluate_match_data_conflict(with_rival=False)
 
-        assert snapshot.escaped is not None, "the option-write conflict must not be contained as a non-match"
-        assert snapshot.escaped.startswith(f"{RAISE_TYPE_NAME}: "), (
-            f"the conflict's own ValueError must reach the caller, got: {snapshot.escaped}"
-        )
+        assert snapshot.escaped is not None
+        assert snapshot.escaped.startswith(f"{RAISE_TYPE_NAME}: ")
         assert MATCH_DATA_CLASS_NAME in snapshot.escaped
         assert CONFLICT_TEXT in snapshot.escaped, "the twin's own raise must escape, not the deeper option write"
         assert snapshot.identified_names == ()
@@ -258,16 +246,13 @@ class TestMatchDataOptionWriteConflictAbortsTheMatch:
     def test_conflict_is_not_dropped_when_a_rival_claims_the_name(self) -> None:
         snapshot = _evaluate_match_data_conflict(with_rival=True)
 
-        assert snapshot.identified_names != (MATCH_DATA_RIVAL_NAME,), (
-            "the rival must not silently win while the option-write conflict is swallowed"
-        )
-        assert snapshot.escaped is not None, "a rival candidate must not hide the option-write conflict"
+        assert snapshot.identified_names != (MATCH_DATA_RIVAL_NAME,)
+        assert snapshot.escaped is not None
         assert snapshot.escaped.startswith(f"{RAISE_TYPE_NAME}: ")
         assert MATCH_DATA_CLASS_NAME in snapshot.escaped
         assert CONFLICT_TEXT in snapshot.escaped
 
     def test_conflict_message_names_no_access_value(self) -> None:
-        """The access can carry credentials, so only class and type names are reported."""
         snapshot = _evaluate_match_data_conflict(with_rival=False)
 
         assert snapshot.escaped is not None
@@ -280,10 +265,8 @@ class TestBaseInputDataOptionWriteConflictAbortsTheMatch:
     def test_feature_scope_conflict_reaches_the_caller(self) -> None:
         snapshot = _evaluate_reader_conflict(with_rival=False, global_scope=False)
 
-        assert snapshot.escaped is not None, "the option-write conflict must not be contained as a non-match"
-        assert snapshot.escaped.startswith(f"{RAISE_TYPE_NAME}: "), (
-            f"the conflict's own ValueError must reach the caller, got: {snapshot.escaped}"
-        )
+        assert snapshot.escaped is not None
+        assert snapshot.escaped.startswith(f"{RAISE_TYPE_NAME}: ")
         assert RESERVED_KEY in snapshot.escaped
         assert CONFLICT_TEXT in snapshot.escaped, "the twin's own raise must escape, not the deeper option write"
         assert snapshot.identified_names == ()
@@ -291,24 +274,23 @@ class TestBaseInputDataOptionWriteConflictAbortsTheMatch:
     def test_global_scope_conflict_reaches_the_caller(self) -> None:
         snapshot = _evaluate_reader_conflict(with_rival=False, global_scope=True)
 
-        assert snapshot.escaped is not None, "the option-write conflict must not be contained as a non-match"
+        assert snapshot.escaped is not None
         assert snapshot.escaped.startswith(f"{RAISE_TYPE_NAME}: ")
         assert RESERVED_KEY in snapshot.escaped
         assert CONFLICT_TEXT in snapshot.escaped
         assert snapshot.identified_names == ()
 
     def test_present_truthy_malformed_value_reaches_the_caller(self) -> None:
-        """A user passing the access directly under the reserved key: present, truthy, not a pair."""
+        """The access passed directly under the reserved key: present, truthy, not a pair."""
         snapshot = _evaluate_reader_conflict(with_rival=False, global_scope=False, reserved_value=MALFORMED_ACCESS)
 
-        assert snapshot.escaped is not None, "a malformed reserved value must not be contained as a non-match"
+        assert snapshot.escaped is not None
         assert snapshot.escaped.startswith(f"{RAISE_TYPE_NAME}: ")
         assert RESERVED_KEY in snapshot.escaped
         assert CONFLICT_TEXT in snapshot.escaped, "the unpack of the malformed value must not raise instead"
         assert snapshot.identified_names == ()
 
     def test_conflict_message_names_no_access_value(self) -> None:
-        """The access can carry credentials, so only class and type names are reported."""
         snapshot = _evaluate_reader_conflict(with_rival=False, global_scope=False, reserved_value=MALFORMED_ACCESS)
 
         assert snapshot.escaped is not None
@@ -318,10 +300,8 @@ class TestBaseInputDataOptionWriteConflictAbortsTheMatch:
     def test_conflict_is_not_dropped_when_a_rival_claims_the_name(self) -> None:
         snapshot = _evaluate_reader_conflict(with_rival=True, global_scope=False)
 
-        assert snapshot.identified_names != (READER_RIVAL_NAME,), (
-            "the rival must not silently win while the option-write conflict is swallowed"
-        )
-        assert snapshot.escaped is not None, "a rival candidate must not hide the option-write conflict"
+        assert snapshot.identified_names != (READER_RIVAL_NAME,)
+        assert snapshot.escaped is not None
         assert snapshot.escaped.startswith(f"{RAISE_TYPE_NAME}: ")
         assert RESERVED_KEY in snapshot.escaped
         assert CONFLICT_TEXT in snapshot.escaped

--- a/tests/test_plugins/feature_group/input_data/test_init_reader_hoist.py
+++ b/tests/test_plugins/feature_group/input_data/test_init_reader_hoist.py
@@ -10,7 +10,7 @@ Contract:
         "Options were not set for {self.__class__.__name__}" and contains "BaseInputData",
         "Options(context=", and an example line containing "ReaderClass" and "data_access".
       - options.get("BaseInputData") is None (key missing or None): ValueError containing
-        "'BaseInputData' key is missing or None", the class name, and the same example hints.
+        "'BaseInputData' key is missing", the class name, and the same example hints.
       - happy path: options carrying {"BaseInputData": (SomeReaderClass, data_access)}
         returns (instance of SomeReaderClass, data_access).
 
@@ -86,7 +86,7 @@ class TestBaseInitReaderIsConcrete:
         with pytest.raises(ValueError) as excinfo:
             reader.init_reader(options)
         message = str(excinfo.value)
-        assert "'BaseInputData' key is missing or None" in message
+        assert "'BaseInputData' key is missing" in message
         assert "HoistBareInputData" in message
         assert "ReaderClass" in message
         assert "data_access" in message
@@ -121,5 +121,5 @@ class TestFamilyBehaviorAfterHoist:
         # bracket-access implementation must funnel a keyless Options into the same
         # ValueError as the base (never KeyError or a None-unpack TypeError).
         options = Options(context={"other_key": "value"})
-        with pytest.raises(ValueError, match="'BaseInputData' key is missing or None"):
+        with pytest.raises(ValueError, match="'BaseInputData' key is missing"):
             ReadDB().init_reader(options)


### PR DESCRIPTION
Closes #932.

## Decision

An option-write conflict during reader selection escalates as a user contradiction, consistent with the conflicting-reader write directly above it. Containing it would let a rival candidate win with the contradiction dropped.

## What was wrong

Both `add_base_input_data_to_options` twins guarded on truthiness (`options.get(key)`), not presence. A reserved reader key present with a falsy value slipped past the marked escalation into `Options.add_to_group`, whose `ValueError` is unmarked, so the match seam contained it as a `matcher_error` non-match.

## Change

- Presence, not truthiness, is the identity in both twins. An absent key cannot trip `validate_can_add_to_group`, so the deeper raise is unreachable from reader selection.
- The decision is recorded in the mark-or-contain policy docstring on `_filter_feature_group_by_criteria`, and the sweep's declaration for `options.py::add_to_group` is retargeted to match.
- Dropping the pair unpack also fixes a present-but-malformed value (the access passed directly under the reserved key), which previously raised unmarked and was contained.

Review follow-ups folded in:

- The message named the whole `(reader, access)` pair; a matched access can be a raw credentials dict (`ReadDB` returns one). Both twins now name the reader class and the access type only.
- The equality early return used a plain truth test, so a non-bool `__eq__` (numpy array) raised "truth value is ambiguous" unmarked. Comparing with `is True` falls through to the marked raise.
- The reserved key declared `allow_explicit_none=False` while the guard reads a stored `None` as present; it now declares what the guard does.

## Tests

`tests/test_core/test_prepare/test_option_write_conflict_stays_loud.py` drives both twins through the match seam: falsy value, truthy malformed value, feature and global scope, a rival that must not silently win, and the escalated message carrying no access value.

`tox` passes: 7940 passed, 170 skipped, ruff, licenses, mypy strict, bandit.
