### PR TITLE
fix: report filter option divergence only for filters that attach

### DIFF
--- a/docs/docs/in_depth/filter_data.md
+++ b/docs/docs/in_depth/filter_data.md
@@ -199,6 +199,11 @@ If a FeatureGroup's `match_feature_group_criteria` raises while a filter is matc
 is a non-match for that probe, like a `False` return, and the drop is recorded in
 `GlobalFilter.dropped_filters`. A framework-owned raise still aborts.
 
+Two diagnostics accompany matching. A warning about option values the filter feature declares
+differently fires only for a filter that actually attaches, and each distinct message is emitted
+once per setup. A filter that matches no FeatureGroup at all is reported once after setup with a
+warning containing "matched no feature group".
+
 Matched filters are attached to the `FeatureSet` before `calculate_feature()` is
 called. Inside your calculation you can access them via `features.filters`:
 

--- a/docs/docs/in_depth/filter_data.md
+++ b/docs/docs/in_depth/filter_data.md
@@ -199,10 +199,9 @@ If a FeatureGroup's `match_feature_group_criteria` raises while a filter is matc
 is a non-match for that probe, like a `False` return, and the drop is recorded in
 `GlobalFilter.dropped_filters`. A framework-owned raise still aborts.
 
-Two diagnostics accompany matching. A warning about option values the filter feature declares
-differently fires only for a filter that actually attaches, and each distinct message is emitted
-once per setup. A filter that matches no FeatureGroup at all is reported once after setup with a
-warning containing "matched no feature group".
+The option divergence warning fires only for a filter that actually attaches, once per distinct
+message per setup. A filter that matches no FeatureGroup at all is reported once after setup
+("matched no feature group").
 
 Matched filters are attached to the `FeatureSet` before `calculate_feature()` is
 called. Inside your calculation you can access them via `features.filters`:

--- a/mloda/core/core/engine.py
+++ b/mloda/core/core/engine.py
@@ -117,6 +117,9 @@ class Engine:
         raise ValueError("ExecutionOrchestrator setup failed.")
 
     def create_setup_execution_plan(self, features: Features) -> ExecutionPlan:
+        if self.global_filter:
+            self.global_filter.reset_match_tracking()
+
         self.setup_features_recursion(features)
 
         if self.global_filter:

--- a/mloda/core/core/engine.py
+++ b/mloda/core/core/engine.py
@@ -119,6 +119,9 @@ class Engine:
     def create_setup_execution_plan(self, features: Features) -> ExecutionPlan:
         self.setup_features_recursion(features)
 
+        if self.global_filter:
+            self.global_filter.warn_on_unmatched_filters()
+
         graph_builder = BuildGraph(self.feature_link_parents, self.feature_group_collection)
         graph_builder.build_graph_from_feature_links()
         graph = graph_builder.graph

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -36,6 +36,7 @@ class GlobalFilter:
            e.g. for debugging, logging or quality checks.
         3. `dropped_filters`: maps (feature group, filter feature name) to the reason a contained raise dropped it.
         4. `probes`: maps (feature group, feature name, feature uuid) to the filters that probe matched, empty included.
+        5. `matched_filter_uuids`: uuids of filters that cleared every gate at least once, across all calls.
 
         These attributes provide the foundation for adding, managing, and applying filters across various feature groups
         and features in the context of a data processing pipeline.
@@ -44,6 +45,7 @@ class GlobalFilter:
         self.collection: dict[tuple[type[FeatureGroup], FeatureName], set[SingleFilter]] = {}
         self.dropped_filters: dict[tuple[type[FeatureGroup], str], str] = {}
         self.probes: dict[tuple[type[FeatureGroup], FeatureName, UUID], set[SingleFilter]] = {}
+        self.matched_filter_uuids: set[UUID] = set()
 
     def record_probe(
         self,
@@ -112,8 +114,6 @@ class GlobalFilter:
         for filter in self.filters:
             # We are making a deepcopy so that, we do not change the original filter.
             _filter = deepcopy(filter)
-            # Reported here, not in unify_options: only this method holds the resolving group.
-            self._warn_on_diverging_options(feature_group, feat.options, _filter.filter_feature.options)
             _filter.filter_feature.options = self.unify_options(feat.options, _filter.filter_feature.options)
 
             if self.criteria(feature_group, _filter, data_access_collection) is False:
@@ -124,8 +124,18 @@ class GlobalFilter:
                 continue
             # we don't check links, because this is not necessary as this is covered by the feature and feature group before
 
+            # Reported after the gates: the warning only ever describes a filter that actually attaches (issue #921).
+            # The deepcopy's options were unified above, so compare against the original declared options.
+            self._warn_on_diverging_options(feature_group, feat.options, filter.filter_feature.options)
+            self.matched_filter_uuids.add(filter.uuid)
             matched_filters.add(_filter)
         return matched_filters
+
+    def warn_on_unmatched_filters(self) -> None:
+        """Warn once per filter that matched no feature group during the whole setup."""
+        for filter in self.filters:
+            if filter.uuid not in self.matched_filter_uuids:
+                logger.warning(f"Filter feature '{filter.filter_feature.name}' matched no feature group.")
 
     def unify_options(self, feat_options: Options, filter_options: Options) -> Options:
         """Add the feature's options the filter feature omits. A declared value is never rewritten."""

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -46,7 +46,6 @@ class GlobalFilter:
         self.dropped_filters: dict[tuple[type[FeatureGroup], str], str] = {}
         self.probes: dict[tuple[type[FeatureGroup], FeatureName, UUID], set[SingleFilter]] = {}
         self.matched_filter_uuids: set[UUID] = set()
-        # Rendered divergence messages already emitted this setup; cleared by reset_match_tracking.
         self._warned_divergences: set[str] = set()
 
     def reset_match_tracking(self) -> None:
@@ -131,15 +130,14 @@ class GlobalFilter:
                 continue
             # we don't check links, because this is not necessary as this is covered by the feature and feature group before
 
-            # Reported after the gates: the warning only ever describes a filter that actually attaches (issue #921).
-            # The deepcopy's options were unified above, so compare against the original declared options.
+            # After the gates, against the original declared options: only an attaching filter is described.
             self._warn_on_diverging_options(feature_group, feat.options, filter.filter_feature.options)
             self.matched_filter_uuids.add(filter.uuid)
             matched_filters.add(_filter)
         return matched_filters
 
     def warn_on_unmatched_filters(self) -> None:
-        """Warn once per filter that matched no feature group during the whole setup."""
+        """Warn once per filter that matched no feature group this setup."""
         for filter in sorted(self.filters, key=lambda f: f.name):
             if filter.uuid not in self.matched_filter_uuids:
                 logger.warning(f"Filter feature '{filter.name}' matched no feature group.")

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -36,7 +36,7 @@ class GlobalFilter:
            e.g. for debugging, logging or quality checks.
         3. `dropped_filters`: maps (feature group, filter feature name) to the reason a contained raise dropped it.
         4. `probes`: maps (feature group, feature name, feature uuid) to the filters that probe matched, empty included.
-        5. `matched_filter_uuids`: uuids of filters that cleared every gate at least once, across all calls.
+        5. `matched_filter_uuids`: uuids of filters that cleared every gate at least once this setup.
 
         These attributes provide the foundation for adding, managing, and applying filters across various feature groups
         and features in the context of a data processing pipeline.
@@ -46,6 +46,13 @@ class GlobalFilter:
         self.dropped_filters: dict[tuple[type[FeatureGroup], str], str] = {}
         self.probes: dict[tuple[type[FeatureGroup], FeatureName, UUID], set[SingleFilter]] = {}
         self.matched_filter_uuids: set[UUID] = set()
+        # Rendered divergence messages already emitted this setup; cleared by reset_match_tracking.
+        self._warned_divergences: set[str] = set()
+
+    def reset_match_tracking(self) -> None:
+        """Match and divergence-warning tracking is scoped to one engine setup."""
+        self.matched_filter_uuids.clear()
+        self._warned_divergences.clear()
 
     def record_probe(
         self,
@@ -133,9 +140,9 @@ class GlobalFilter:
 
     def warn_on_unmatched_filters(self) -> None:
         """Warn once per filter that matched no feature group during the whole setup."""
-        for filter in self.filters:
+        for filter in sorted(self.filters, key=lambda f: f.name):
             if filter.uuid not in self.matched_filter_uuids:
-                logger.warning(f"Filter feature '{filter.filter_feature.name}' matched no feature group.")
+                logger.warning(f"Filter feature '{filter.name}' matched no feature group.")
 
     def unify_options(self, feat_options: Options, filter_options: Options) -> Options:
         """Add the feature's options the filter feature omits. A declared value is never rewritten."""
@@ -162,12 +169,16 @@ class GlobalFilter:
             if self._converges_at_intake(fill, value):
                 continue
             if fill is None:
-                logger.warning(f"Options are not the same. {key} is different. {declared} != {value}")
+                message = f"Options are not the same. {key} is different. {declared} != {value}"
             else:
                 # Name the spec default, which is what the filter feature will actually compute with.
-                logger.warning(
+                message = (
                     f"Options are not the same. {key} is different. {declared!r} (intake fills {fill!r}) != {value!r}"
                 )
+            if message in self._warned_divergences:
+                continue
+            self._warned_divergences.add(message)
+            logger.warning(message)
 
     @staticmethod
     def _intake_fill(feature_group: Optional[type[FeatureGroup]], key: str, filter_options: Options) -> Any:

--- a/tests/test_core/test_filter/test_filter_divergence_attachment_gating.py
+++ b/tests/test_core/test_filter/test_filter_divergence_attachment_gating.py
@@ -1,0 +1,236 @@
+"""Pin attachment-gated divergence warnings and the unmatched-filter diagnostic (#921).
+
+The divergence warning must fire only for a filter that clears every matching gate, and a filter
+that never matches any feature group must be named by ``GlobalFilter.warn_on_unmatched_filters``,
+which the engine drives after setup. The fdg_ prefix keeps this module's keys unique.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+import pytest
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.provider import DataCreator, PropertySpec
+from mloda.user import FilterType, GlobalFilter, PluginCollector, mloda
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
+
+
+FDG_KEY = "fdg_key"
+FDG_REQ_KEY = "fdg_req_key"
+FDG_DEFAULT = "fdg_default_val"
+FDG_HOST_VAL = "fdg_host_val"
+FDG_FILTER_VAL = "fdg_filter_val"
+
+FDG_HOST = "fdg_host_feature"
+FDG_TARGET = "fdg_target_feature"
+FDG_NOWHERE = "fdg_nowhere_feature"  # a filter target no feature group ever serves
+
+UNMATCHED_PHRASE = "matched no feature group"
+
+
+def _rejecting_probe() -> type[FeatureGroup]:
+    class FdgRejectingProbeFeatureGroup(FeatureGroup):
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: Optional[DataAccessCollection] = None,
+        ) -> bool:
+            return False
+
+    return FdgRejectingProbeFeatureGroup
+
+
+def _accepting_probe() -> type[FeatureGroup]:
+    class FdgAcceptingProbeFeatureGroup(FeatureGroup):
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: Optional[DataAccessCollection] = None,
+        ) -> bool:
+            return str(feature_name) == FDG_TARGET
+
+    return FdgAcceptingProbeFeatureGroup
+
+
+def _engine_probe(served: set[str], mapping: dict[str, PropertySpec] | None = None) -> type[FeatureGroup]:
+    """A throwaway root FeatureGroup serving ``served``, echoing one payload row per feature."""
+
+    class FdgEngineProbeFeatureGroup(FeatureGroup):
+        PROPERTY_MAPPING = mapping or {}
+
+        @classmethod
+        def input_data(cls) -> DataCreator:
+            return DataCreator(served)
+
+        @classmethod
+        def final_filters(cls) -> bool:
+            # The payload is not filterable data, so row elimination must not run against it.
+            return False
+
+        @classmethod
+        def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+            return {str(feature.name): [1] for feature in features.features}
+
+    return FdgEngineProbeFeatureGroup
+
+
+def _warnings_naming(caplog: pytest.LogCaptureFixture, needle: str) -> list[str]:
+    """Every warning-level message naming ``needle``; location-agnostic, since the check may move."""
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno >= logging.WARNING and needle in record.getMessage()
+    ]
+
+
+def test_criteria_rejected_filter_emits_no_divergence_warning(caplog: pytest.LogCaptureFixture) -> None:
+    """A filter dropped by the criteria gate never attaches, so its divergence must not be reported."""
+    global_filter = GlobalFilter()
+    global_filter.add_filter(
+        Feature(FDG_TARGET, Options(group={FDG_KEY: FDG_FILTER_VAL})), FilterType.EQUAL, {"value": 1}
+    )
+    with caplog.at_level(logging.WARNING):
+        matched = global_filter.identify_matched_filters(
+            _rejecting_probe(), Feature(FDG_HOST, Options(group={FDG_KEY: FDG_HOST_VAL}))
+        )
+
+    assert matched == set()
+    assert _warnings_naming(caplog, FDG_KEY) == []
+
+
+def test_attaching_filter_still_reports_its_divergence(caplog: pytest.LogCaptureFixture) -> None:
+    """The control: a filter that clears every gate keeps the unchanged divergence message."""
+    global_filter = GlobalFilter()
+    global_filter.add_filter(
+        Feature(FDG_TARGET, Options(group={FDG_KEY: FDG_FILTER_VAL})), FilterType.EQUAL, {"value": 1}
+    )
+    with caplog.at_level(logging.WARNING):
+        matched = global_filter.identify_matched_filters(
+            _accepting_probe(), Feature(FDG_HOST, Options(group={FDG_KEY: FDG_HOST_VAL}))
+        )
+
+    assert len(matched) == 1
+    assert _warnings_naming(caplog, FDG_KEY) == [
+        f"Options are not the same. {FDG_KEY} is different. {FDG_FILTER_VAL} != {FDG_HOST_VAL}"
+    ]
+
+
+def test_warn_on_unmatched_filters_names_a_filter_no_group_matched(caplog: pytest.LogCaptureFixture) -> None:
+    """A filter every probe rejected is reported once, naming the filter feature."""
+    global_filter = GlobalFilter()
+    global_filter.add_filter(Feature(FDG_TARGET, Options()), FilterType.EQUAL, {"value": 1})
+    global_filter.identify_matched_filters(_rejecting_probe(), Feature(FDG_HOST, Options()))
+    with caplog.at_level(logging.WARNING):
+        global_filter.warn_on_unmatched_filters()
+
+    messages = _warnings_naming(caplog, FDG_TARGET)
+    assert len(messages) == 1, f"exactly one unmatched-filter warning expected, got: {messages!r}"
+    assert UNMATCHED_PHRASE in messages[0]
+
+
+def test_warn_on_unmatched_filters_is_silent_for_a_filter_matched_in_a_later_call(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Matching is tracked across identify calls: one attachment anywhere silences the diagnostic."""
+    global_filter = GlobalFilter()
+    global_filter.add_filter(Feature(FDG_TARGET, Options()), FilterType.EQUAL, {"value": 1})
+    global_filter.identify_matched_filters(_rejecting_probe(), Feature(FDG_HOST, Options()))
+    global_filter.identify_matched_filters(_accepting_probe(), Feature(FDG_HOST, Options()))
+    with caplog.at_level(logging.WARNING):
+        global_filter.warn_on_unmatched_filters()
+
+    assert _warnings_naming(caplog, FDG_TARGET) == []
+
+
+def _run(
+    served: set[str],
+    mapping: dict[str, PropertySpec] | None,
+    host_options: Options,
+    filter_target: str,
+    filter_options: Options,
+) -> dict[str, Any]:
+    """Run FDG_HOST under a global EQUAL filter on ``filter_target``; return plain-data observations.
+
+    The probe class, the collector and the GlobalFilter are deleted from THIS frame before the asserts,
+    so a failing assert cannot pin the throwaway class into a traceback and trip the no-leak fixture.
+    """
+    collector = PluginCollector.enabled_feature_groups({_engine_probe(served, mapping)})
+    global_filter = GlobalFilter()
+    global_filter.add_filter(Feature(filter_target, filter_options), FilterType.EQUAL, {"value": 1})
+    results = mloda.run_all(
+        [Feature(FDG_HOST, host_options)],
+        compute_frameworks={PythonDictFramework},
+        plugin_collector=collector,
+        global_filter=global_filter,
+    )
+
+    collection_size = len(global_filter.collection)
+    frames_repr = repr(list(results))
+    del collector, global_filter, results
+
+    return {"collection_size": collection_size, "frames_repr": frames_repr}
+
+
+def test_required_when_rejected_filter_is_reported_as_unmatched_without_divergence_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The #921 shape: a required_when key the filter declares as None rejects the match attributably.
+
+    Found while writing this: required_when is enforced by the guard installed at class definition
+    (feature_chain_author_guards.install_required_when_guard wrapping match_feature_group_criteria),
+    so GlobalFilter.criteria sees the rejection as an ordinary criteria non-match. A flagless
+    present-as-None key reads as absent (option_key_is_present), so the always-firing predicate
+    rejects the filter feature while the host, which supplies the value, matches.
+    """
+    mapping = {
+        FDG_REQ_KEY: PropertySpec(
+            "A group key required whenever the group matches.",
+            context=False,
+            default=FDG_DEFAULT,
+            required_when=lambda _opts: True,
+        )
+    }
+    with caplog.at_level(logging.WARNING):
+        observed = _run(
+            {FDG_HOST, FDG_TARGET},
+            mapping,
+            Options(group={FDG_REQ_KEY: FDG_DEFAULT}),
+            FDG_TARGET,
+            Options(group={FDG_REQ_KEY: None}),
+        )
+
+    assert observed["collection_size"] == 0, f"the filter must not attach: {observed!r}"
+    assert _warnings_naming(caplog, FDG_REQ_KEY) == []
+    unmatched = [message for message in _warnings_naming(caplog, FDG_TARGET) if UNMATCHED_PHRASE in message]
+    assert len(unmatched) == 1, f"exactly one unmatched-filter warning expected, got: {caplog.text!r}"
+
+
+def test_engine_reports_a_filter_targeting_a_name_nothing_serves(caplog: pytest.LogCaptureFixture) -> None:
+    """End-to-end: a filter no group serves is named exactly once after setup."""
+    with caplog.at_level(logging.WARNING):
+        observed = _run({FDG_HOST}, None, Options(), FDG_NOWHERE, Options())
+
+    assert observed["collection_size"] == 0
+    unmatched = [message for message in _warnings_naming(caplog, FDG_NOWHERE) if UNMATCHED_PHRASE in message]
+    assert len(unmatched) == 1, f"exactly one unmatched-filter warning expected, got: {caplog.text!r}"
+
+
+def test_engine_stays_silent_for_a_filter_that_attaches(caplog: pytest.LogCaptureFixture) -> None:
+    """The control: an attaching filter produces zero unmatched-filter warnings."""
+    with caplog.at_level(logging.WARNING):
+        observed = _run({FDG_HOST, FDG_TARGET}, None, Options(), FDG_TARGET, Options())
+
+    assert observed["collection_size"] >= 1, f"the filter must have attached: {observed!r}"
+    assert [message for message in _warnings_naming(caplog, FDG_TARGET) if UNMATCHED_PHRASE in message] == []

--- a/tests/test_core/test_filter/test_filter_divergence_attachment_gating.py
+++ b/tests/test_core/test_filter/test_filter_divergence_attachment_gating.py
@@ -1,8 +1,6 @@
-"""Pin attachment-gated divergence warnings and the unmatched-filter diagnostic (#921).
+"""Divergence warnings fire only for attaching filters; unmatched filters are reported after setup.
 
-The divergence warning must fire only for a filter that clears every matching gate, and a filter
-that never matches any feature group must be named by ``GlobalFilter.warn_on_unmatched_filters``,
-which the engine drives after setup. The fdg_ prefix keeps this module's keys unique.
+The fdg_ prefix keeps this module's keys unique.
 """
 
 from __future__ import annotations
@@ -165,11 +163,7 @@ def _run(
     filter_target: str,
     filter_options: Options,
 ) -> dict[str, Any]:
-    """Run FDG_HOST under a global EQUAL filter on ``filter_target``; return plain-data observations.
-
-    The probe class, the collector and the GlobalFilter are deleted from THIS frame before the asserts,
-    so a failing assert cannot pin the throwaway class into a traceback and trip the no-leak fixture.
-    """
+    """Run FDG_HOST under a global EQUAL filter on ``filter_target``; deletes probe refs in this frame."""
     collector = PluginCollector.enabled_feature_groups({_engine_probe(served, mapping)})
     global_filter = GlobalFilter()
     global_filter.add_filter(Feature(filter_target, filter_options), FilterType.EQUAL, {"value": 1})
@@ -190,14 +184,8 @@ def _run(
 def test_required_when_rejected_filter_is_reported_as_unmatched_without_divergence_warning(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """The #921 shape: a required_when key the filter declares as None rejects the match attributably.
-
-    Found while writing this: required_when is enforced by the guard installed at class definition
-    (feature_chain_author_guards.install_required_when_guard wrapping match_feature_group_criteria),
-    so GlobalFilter.criteria sees the rejection as an ordinary criteria non-match. A flagless
-    present-as-None key reads as absent (option_key_is_present), so the always-firing predicate
-    rejects the filter feature while the host, which supplies the value, matches.
-    """
+    """A required_when key declared as None reads as absent, so the guard rejects the filter feature
+    through the ordinary criteria gate while the host, which supplies the value, matches."""
     mapping = {
         FDG_REQ_KEY: PropertySpec(
             "A group key required whenever the group matches.",
@@ -246,11 +234,8 @@ def _run_reusing(
     mapping: dict[str, PropertySpec] | None = None,
     host_options: Options | None = None,
 ) -> None:
-    """One engine run of FDG_HOST against a throwaway probe, reusing the caller's GlobalFilter.
-
-    The probe class and its collector are deleted from THIS frame; the caller must delete its
-    GlobalFilter reference before asserting, since the collection pins attached probe classes.
-    """
+    """One engine run of FDG_HOST reusing the caller's GlobalFilter; the caller deletes its own
+    GlobalFilter reference before asserting, since the collection pins attached probe classes."""
     collector = PluginCollector.enabled_feature_groups({_engine_probe(served, mapping)})
     results = mloda.run_all(
         [Feature(FDG_HOST, host_options or Options())],

--- a/tests/test_core/test_filter/test_filter_divergence_attachment_gating.py
+++ b/tests/test_core/test_filter/test_filter_divergence_attachment_gating.py
@@ -35,6 +35,10 @@ FDG_NOWHERE = "fdg_nowhere_feature"  # a filter target no feature group ever ser
 
 UNMATCHED_PHRASE = "matched no feature group"
 
+FDG_RERUN_TARGET = "fdg_rerun_target_feature"
+FDG_DEDUP_KEY = "fdg_dedup_key"
+FDG_OTHER_HOST_VAL = "fdg_other_host_val"
+
 
 def _rejecting_probe() -> type[FeatureGroup]:
     class FdgRejectingProbeFeatureGroup(FeatureGroup):
@@ -234,3 +238,104 @@ def test_engine_stays_silent_for_a_filter_that_attaches(caplog: pytest.LogCaptur
 
     assert observed["collection_size"] >= 1, f"the filter must have attached: {observed!r}"
     assert [message for message in _warnings_naming(caplog, FDG_TARGET) if UNMATCHED_PHRASE in message] == []
+
+
+def _run_reusing(
+    global_filter: GlobalFilter,
+    served: set[str],
+    mapping: dict[str, PropertySpec] | None = None,
+    host_options: Options | None = None,
+) -> None:
+    """One engine run of FDG_HOST against a throwaway probe, reusing the caller's GlobalFilter.
+
+    The probe class and its collector are deleted from THIS frame; the caller must delete its
+    GlobalFilter reference before asserting, since the collection pins attached probe classes.
+    """
+    collector = PluginCollector.enabled_feature_groups({_engine_probe(served, mapping)})
+    results = mloda.run_all(
+        [Feature(FDG_HOST, host_options or Options())],
+        compute_frameworks={PythonDictFramework},
+        plugin_collector=collector,
+        global_filter=global_filter,
+    )
+    del collector, results
+
+
+def test_unmatched_tracking_is_scoped_to_a_single_engine_run(caplog: pytest.LogCaptureFixture) -> None:
+    """Reusing one GlobalFilter: a match in run 1 must not silence run 2's unmatched warning."""
+    global_filter = GlobalFilter()
+    global_filter.add_filter(Feature(FDG_RERUN_TARGET, Options()), FilterType.EQUAL, {"value": 1})
+    with caplog.at_level(logging.WARNING):
+        _run_reusing(global_filter, {FDG_HOST, FDG_RERUN_TARGET})
+    first = [message for message in _warnings_naming(caplog, FDG_RERUN_TARGET) if UNMATCHED_PHRASE in message]
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        _run_reusing(global_filter, {FDG_HOST})
+    del global_filter
+
+    assert first == [], f"the filter attached in run 1, so run 1 must stay silent: {first!r}"
+    second = [message for message in _warnings_naming(caplog, FDG_RERUN_TARGET) if UNMATCHED_PHRASE in message]
+    assert len(second) == 1, f"run 2 matched nothing, exactly one warning expected, got: {second!r}"
+
+
+def test_identical_divergence_message_is_emitted_once_per_setup(caplog: pytest.LogCaptureFixture) -> None:
+    """Three attachments rendering one byte-identical divergence message must warn once."""
+    global_filter = GlobalFilter()
+    global_filter.add_filter(
+        Feature(FDG_TARGET, Options(group={FDG_DEDUP_KEY: FDG_FILTER_VAL})), FilterType.EQUAL, {"value": 1}
+    )
+    probe = _accepting_probe()
+    with caplog.at_level(logging.WARNING):
+        for host in ("fdg_dedup_host_a", "fdg_dedup_host_b", "fdg_dedup_host_c"):
+            global_filter.identify_matched_filters(probe, Feature(host, Options(group={FDG_DEDUP_KEY: FDG_HOST_VAL})))
+    del probe, global_filter
+
+    assert _warnings_naming(caplog, FDG_DEDUP_KEY) == [
+        f"Options are not the same. {FDG_DEDUP_KEY} is different. {FDG_FILTER_VAL} != {FDG_HOST_VAL}"
+    ]
+
+
+def test_divergence_dedup_keeps_distinct_messages(caplog: pytest.LogCaptureFixture) -> None:
+    """The control: two hosts rendering two different messages must both be reported."""
+    global_filter = GlobalFilter()
+    global_filter.add_filter(
+        Feature(FDG_TARGET, Options(group={FDG_DEDUP_KEY: FDG_FILTER_VAL})), FilterType.EQUAL, {"value": 1}
+    )
+    probe = _accepting_probe()
+    with caplog.at_level(logging.WARNING):
+        global_filter.identify_matched_filters(
+            probe, Feature("fdg_dedup_host_a", Options(group={FDG_DEDUP_KEY: FDG_HOST_VAL}))
+        )
+        global_filter.identify_matched_filters(
+            probe, Feature("fdg_dedup_host_b", Options(group={FDG_DEDUP_KEY: FDG_OTHER_HOST_VAL}))
+        )
+    del probe, global_filter
+
+    assert sorted(_warnings_naming(caplog, FDG_DEDUP_KEY)) == sorted(
+        [
+            f"Options are not the same. {FDG_DEDUP_KEY} is different. {FDG_FILTER_VAL} != {FDG_HOST_VAL}",
+            f"Options are not the same. {FDG_DEDUP_KEY} is different. {FDG_FILTER_VAL} != {FDG_OTHER_HOST_VAL}",
+        ]
+    )
+
+
+def test_divergence_dedup_is_scoped_to_a_single_engine_run(caplog: pytest.LogCaptureFixture) -> None:
+    """Reusing one GlobalFilter: each engine run re-emits an identical divergence message once."""
+    mapping = {FDG_DEDUP_KEY: PropertySpec("A group key the filter feature declares differently.", context=False)}
+    host_options = Options(group={FDG_DEDUP_KEY: FDG_HOST_VAL})
+    global_filter = GlobalFilter()
+    global_filter.add_filter(
+        Feature(FDG_TARGET, Options(group={FDG_DEDUP_KEY: FDG_FILTER_VAL})), FilterType.EQUAL, {"value": 1}
+    )
+    with caplog.at_level(logging.WARNING):
+        _run_reusing(global_filter, {FDG_HOST, FDG_TARGET}, mapping, host_options)
+    first = _warnings_naming(caplog, FDG_DEDUP_KEY)
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        _run_reusing(global_filter, {FDG_HOST, FDG_TARGET}, mapping, host_options)
+    del global_filter
+
+    expected = f"Options are not the same. {FDG_DEDUP_KEY} is different. {FDG_FILTER_VAL} != {FDG_HOST_VAL}"
+    assert first == [expected], f"run 1 must emit the divergence message once: {first!r}"
+    second = _warnings_naming(caplog, FDG_DEDUP_KEY)
+    assert second == [expected], f"run 2 must emit the divergence message once again: {second!r}"


### PR DESCRIPTION
## Summary

`GlobalFilter.identify_matched_filters` reported an option divergence before the three matching gates (criteria, domain, compute framework) decided whether the filter attaches, so the message fired for filters that were then dropped, and a filter matching no FeatureGroup at all vanished silently. Closes #921.

## Changes

- The divergence warning now runs after all three gates, comparing the host's options against the filter feature's declared (pre-unification) options, so it only ever describes a filter that actually attaches. The #911 convergence-suppression semantics are unchanged.
- New diagnostic: `GlobalFilter.warn_on_unmatched_filters`, called by the engine after feature setup, warns once per filter that matched no feature group in that run.
- Match tracking and message dedup are scoped to one engine setup (`reset_match_tracking`), so a `GlobalFilter` reused across runs reports per run, and an identical rendered divergence message is emitted once per setup.
- Documented both diagnostics in `docs/docs/in_depth/filter_data.md`.

## Testing

- New test module `tests/test_core/test_filter/test_filter_divergence_attachment_gating.py` (11 tests): criteria-rejected filters stay silent, attaching filters keep the exact message, the `required_when` shape from the issue is reported as unmatched without a divergence warning, unmatched diagnostics end to end, run-scoping on a reused `GlobalFilter`, and dedup keeps distinct messages.
- Full `tox` gate passes.

## Review

Two independent deep reviews ran on the diff. One found a major issue (match tracking never reset on a reused `GlobalFilter`), which is fixed and pinned by tests; the remaining accepted findings (message dedup, docs, determinism nits) are included. The only rejected finding was a pre-existing by-reference copy in `unify_options`, out of scope here.
