### PR TITLE
fix: name the value behind an unusable option, filter key and doc example

### DIFF
--- a/docs/docs/in_depth/filter_data.md
+++ b/docs/docs/in_depth/filter_data.md
@@ -130,6 +130,9 @@ class ExampleOrderFilter(FeatureGroup):
                          }
         # The following algorithm is naive and rather should show an example than a normal use case.
         # The filter implementation highly depends on the feature group!
+        # features.filters is None or an empty set if no filter matched this feature set.
+        if not features.filters:
+            return _data_creator
         # Extract the filter value and filter_name information from the filters.
         for filter in features.filters:
             filter_value = filter.parameter.value

--- a/docs/docs/in_depth/filter_data.md
+++ b/docs/docs/in_depth/filter_data.md
@@ -112,7 +112,7 @@ The implementation of the concrete filters is dependent on the feature group. Th
 
 Further, the feature is a data creator, so we create the data here itself. 
 
-``` python
+```python
 from mloda.user import mloda
 from mloda.provider import FeatureGroup, FeatureSet, ComputeFramework, BaseInputData, DataCreator
 from typing import Any, Union, Set, Type, Optional
@@ -147,6 +147,10 @@ class ExampleOrderFilter(FeatureGroup):
             if key != filter_name
         }
         return filtered_data
+    @classmethod
+    def final_filters(cls) -> bool | None:
+        # This group applies the filter itself and drops the filter column, so framework row elimination must not run.
+        return False
     @classmethod
     def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
         return {PyArrowTable}

--- a/mloda/core/abstract_plugins/components/options.py
+++ b/mloda/core/abstract_plugins/components/options.py
@@ -273,7 +273,7 @@ class Options:
             return frozenset([_convert_to_feature(val)])
         else:
             raise TypeError(
-                f"Unsupported type for source feature: {type(val)}. "
+                f"Unsupported source feature {val!r} of type {type(val).__name__}. "
                 "Expected list, tuple, set, frozenset, str, or Feature object."
             )
 

--- a/mloda/core/abstract_plugins/components/options.py
+++ b/mloda/core/abstract_plugins/components/options.py
@@ -240,6 +240,10 @@ class Options:
         val = self.get(DefaultOptionKeys.in_features)
 
         if not val:
+            if DefaultOptionKeys.in_features in self:
+                raise ValueError(
+                    f"The key '{DefaultOptionKeys.in_features}' is set to {val!r}, which resolves to no input features."
+                )
             raise ValueError(
                 f"Input features not found in options. Please ensure that the key '{DefaultOptionKeys.in_features}' is set."
             )

--- a/mloda/core/filter/filter_parameter.py
+++ b/mloda/core/filter/filter_parameter.py
@@ -55,6 +55,10 @@ class FilterParameterImpl:
 
     @classmethod
     def from_dict(cls, params: dict[str, Any]) -> "FilterParameterImpl":
+        for key in params:
+            # Checked before the sort below, which would otherwise raise a TypeError naming nothing.
+            if not isinstance(key, str):
+                raise ValueError(f"Filter parameter key {key!r} is not a string.")
         normalized = {k: _make_hashable(v) for k, v in params.items()}
         for key, value in normalized.items():
             culprit = _unhashable_type(value)

--- a/mloda/core/filter/filter_parameter.py
+++ b/mloda/core/filter/filter_parameter.py
@@ -55,8 +55,8 @@ class FilterParameterImpl:
 
     @classmethod
     def from_dict(cls, params: dict[str, Any]) -> "FilterParameterImpl":
+        # Checked before the sort below, which would otherwise raise a TypeError naming nothing.
         for key in params:
-            # Checked before the sort below, which would otherwise raise a TypeError naming nothing.
             if not isinstance(key, str):
                 raise ValueError(f"Filter parameter key {key!r} is not a string.")
         normalized = {k: _make_hashable(v) for k, v in params.items()}

--- a/tests/test_core/test_abstract_plugins/test_components/test_options.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_options.py
@@ -448,9 +448,10 @@ class TestOptionsGetInFeaturesFalsyValue:
         return str(excinfo.value)
 
     def test_absent_key_names_the_key(self) -> None:
-        """An absent key still raises ValueError naming the key."""
+        """An absent key still raises ValueError naming the key, not the enum repr."""
         message = self._message(Options())
-        assert IN_FEATURES in message, message
+        assert f"'{IN_FEATURES}'" in message, message
+        assert "DefaultOptionKeys" not in message, message
 
     @pytest.mark.parametrize("falsy", ["", 0, {}], ids=["empty_str", "zero_int", "empty_dict"])
     def test_present_falsy_value_still_raises_value_error(self, falsy: Any) -> None:
@@ -460,9 +461,10 @@ class TestOptionsGetInFeaturesFalsyValue:
 
     @pytest.mark.parametrize("falsy", ["", 0, {}], ids=["empty_str", "zero_int", "empty_dict"])
     def test_present_falsy_value_message_names_the_key(self, falsy: Any) -> None:
-        """The falsy-value message names the key, so the user knows which option is at fault."""
+        """The falsy-value message names the key readably, so the user knows which option is at fault."""
         message = self._message(Options(context={IN_FEATURES: falsy}))
-        assert IN_FEATURES in message, message
+        assert f"'{IN_FEATURES}'" in message, message
+        assert "DefaultOptionKeys" not in message, message
 
     @pytest.mark.parametrize("falsy", ["", 0, {}], ids=["empty_str", "zero_int", "empty_dict"])
     def test_present_falsy_value_message_shows_the_value(self, falsy: Any) -> None:
@@ -480,5 +482,27 @@ class TestOptionsGetInFeaturesFalsyValue:
     def test_falsy_value_in_group_is_reported_the_same_way(self) -> None:
         """The distinction holds for a group key too, not only a context key."""
         message = self._message(Options(group={IN_FEATURES: ""}))
-        assert IN_FEATURES in message, message
+        assert f"'{IN_FEATURES}'" in message, message
+        assert "DefaultOptionKeys" not in message, message
         assert repr("") in message, message
+
+
+class TestOptionsGetInFeaturesUnresolvableTruthyValue:
+    """get_in_features names the offending value for a present, truthy but unresolvable in_features (#942)."""
+
+    def _message(self, value: Any) -> str:
+        with pytest.raises(TypeError) as excinfo:
+            Options(context={IN_FEATURES: value}).get_in_features()
+        return str(excinfo.value)
+
+    @pytest.mark.parametrize("value", [5, {"a": 1}], ids=["int", "dict"])
+    def test_unsupported_type_message_shows_the_value(self, value: Any) -> None:
+        """The unsupported-type message carries the offending value, not only its type."""
+        message = self._message(value)
+        assert repr(value) in message, message
+
+    @pytest.mark.parametrize("value", [5, {"a": 1}], ids=["int", "dict"])
+    def test_unsupported_type_message_still_shows_the_type(self, value: Any) -> None:
+        """The unsupported-type message keeps naming the type alongside the value."""
+        message = self._message(value)
+        assert type(value).__name__ in message, message

--- a/tests/test_core/test_abstract_plugins/test_components/test_options.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_options.py
@@ -3,7 +3,10 @@ from copy import deepcopy
 from typing import Any
 
 import pytest
+from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
 from mloda.user import Options
+
+IN_FEATURES = DefaultOptionKeys.in_features.value
 
 
 class _RaisesOnDeepcopy:
@@ -434,3 +437,48 @@ class TestOptionsGetDefault:
     def test_default_passed_by_keyword(self) -> None:
         """The default is accepted as a keyword argument."""
         assert Options().get("m", default="d") == "d"
+
+
+class TestOptionsGetInFeaturesFalsyValue:
+    """get_in_features distinguishes an absent in_features key from a present falsy one (#942)."""
+
+    def _message(self, options: Options) -> str:
+        with pytest.raises(ValueError) as excinfo:
+            options.get_in_features()
+        return str(excinfo.value)
+
+    def test_absent_key_names_the_key(self) -> None:
+        """An absent key still raises ValueError naming the key."""
+        message = self._message(Options())
+        assert IN_FEATURES in message, message
+
+    @pytest.mark.parametrize("falsy", ["", 0, {}], ids=["empty_str", "zero_int", "empty_dict"])
+    def test_present_falsy_value_still_raises_value_error(self, falsy: Any) -> None:
+        """A present but falsy value keeps raising ValueError, not another error type."""
+        with pytest.raises(ValueError):
+            Options(context={IN_FEATURES: falsy}).get_in_features()
+
+    @pytest.mark.parametrize("falsy", ["", 0, {}], ids=["empty_str", "zero_int", "empty_dict"])
+    def test_present_falsy_value_message_names_the_key(self, falsy: Any) -> None:
+        """The falsy-value message names the key, so the user knows which option is at fault."""
+        message = self._message(Options(context={IN_FEATURES: falsy}))
+        assert IN_FEATURES in message, message
+
+    @pytest.mark.parametrize("falsy", ["", 0, {}], ids=["empty_str", "zero_int", "empty_dict"])
+    def test_present_falsy_value_message_shows_the_value(self, falsy: Any) -> None:
+        """The falsy-value message carries the offending value, which the absent-key message cannot."""
+        message = self._message(Options(context={IN_FEATURES: falsy}))
+        assert repr(falsy) in message, message
+
+    @pytest.mark.parametrize("falsy", ["", 0, {}], ids=["empty_str", "zero_int", "empty_dict"])
+    def test_present_falsy_value_message_differs_from_absent_key_message(self, falsy: Any) -> None:
+        """A set key must not be reported with the same wording as a key that is not set at all."""
+        absent = self._message(Options())
+        present = self._message(Options(context={IN_FEATURES: falsy}))
+        assert present != absent, present
+
+    def test_falsy_value_in_group_is_reported_the_same_way(self) -> None:
+        """The distinction holds for a group key too, not only a context key."""
+        message = self._message(Options(group={IN_FEATURES: ""}))
+        assert IN_FEATURES in message, message
+        assert repr("") in message, message

--- a/tests/test_core/test_filter/test_filter_parameter.py
+++ b/tests/test_core/test_filter/test_filter_parameter.py
@@ -442,6 +442,54 @@ def test_from_dict_accepts_deeply_nested_tuple() -> None:
     hash(filter_param)
 
 
+# --- Non-string key rejection tests (see issue #959) ---
+
+
+def test_from_dict_rejects_non_string_key() -> None:
+    """Test a non-string key raises ValueError instead of the raw TypeError out of sorted()."""
+    params: dict[Any, Any] = {1: "a", "b": 2}
+
+    with pytest.raises(ValueError, match="1"):
+        FilterParameterImpl.from_dict(params)
+
+
+def test_from_dict_non_string_key_error_names_the_key() -> None:
+    """Test the message names the offending key rather than a neighbouring one."""
+    params: dict[Any, Any] = {"value": 25, ("tuple", "key"): 2}
+
+    with pytest.raises(ValueError) as excinfo:
+        FilterParameterImpl.from_dict(params)
+
+    message = str(excinfo.value)
+    assert "tuple" in message, message
+
+
+def test_from_dict_rejects_non_string_key_even_without_mixed_types() -> None:
+    """Test a key set that sorts fine is still rejected when the keys are not strings."""
+    params: dict[Any, Any] = {1: "a", 2: "b"}
+
+    with pytest.raises(ValueError, match="1"):
+        FilterParameterImpl.from_dict(params)
+
+
+def test_from_dict_rejects_none_key() -> None:
+    """Test None as a key is rejected with a ValueError."""
+    params: dict[Any, Any] = {None: "a"}
+
+    with pytest.raises(ValueError, match="None"):
+        FilterParameterImpl.from_dict(params)
+
+
+def test_from_dict_rejects_non_string_key_before_unhashable_value_check() -> None:
+    """Test the key check fires even when another key carries an unhashable value."""
+    params: dict[Any, Any] = {1: "a", "payload": {"a": 1}}
+
+    with pytest.raises(ValueError) as excinfo:
+        FilterParameterImpl.from_dict(params)
+
+    assert "1" in str(excinfo.value), str(excinfo.value)
+
+
 @pytest.mark.parametrize(
     "params",
     [

--- a/tests/test_core/test_filter/test_filter_parameter.py
+++ b/tests/test_core/test_filter/test_filter_parameter.py
@@ -449,7 +449,7 @@ def test_from_dict_rejects_non_string_key() -> None:
     """Test a non-string key raises ValueError instead of the raw TypeError out of sorted()."""
     params: dict[Any, Any] = {1: "a", "b": 2}
 
-    with pytest.raises(ValueError, match="1"):
+    with pytest.raises(ValueError, match=r"key 1 is not a string"):
         FilterParameterImpl.from_dict(params)
 
 
@@ -468,7 +468,7 @@ def test_from_dict_rejects_non_string_key_even_without_mixed_types() -> None:
     """Test a key set that sorts fine is still rejected when the keys are not strings."""
     params: dict[Any, Any] = {1: "a", 2: "b"}
 
-    with pytest.raises(ValueError, match="1"):
+    with pytest.raises(ValueError, match=r"key 1 is not a string"):
         FilterParameterImpl.from_dict(params)
 
 

--- a/tests/test_core/test_filter/test_global_filter.py
+++ b/tests/test_core/test_filter/test_global_filter.py
@@ -383,3 +383,41 @@ class TestGlobalFilterUnhashableParameter:
             self.global_filter.add_filter(Feature("col"), FilterType.EQUAL, parameter)
 
         assert len(self.global_filter.filters) == 1
+
+
+class TestGlobalFilterNonStringParameterKey:
+    """A non-string parameter key is rejected by add_filter with a ValueError (issue #959)."""
+
+    def setup_method(self) -> None:
+        self.global_filter = GlobalFilter()
+
+    def test_add_filter_rejects_non_string_parameter_key(self) -> None:
+        """Test a mixed-type key dict raises ValueError rather than the sort's TypeError."""
+        parameter: dict[Any, Any] = {1: "a", "value": 2}
+
+        with pytest.raises(ValueError, match="1"):
+            self.global_filter.add_filter(Feature("col"), FilterType.EQUAL, parameter)
+
+        assert len(self.global_filter.filters) == 0
+
+    def test_add_filter_rejection_names_the_non_string_key(self) -> None:
+        """Test the message names the offending key."""
+        parameter: dict[Any, Any] = {("tuple", "key"): "a", "value": 2}
+
+        with pytest.raises(ValueError) as excinfo:
+            self.global_filter.add_filter(Feature("col"), FilterType.EQUAL, parameter)
+
+        assert "tuple" in str(excinfo.value), str(excinfo.value)
+        assert len(self.global_filter.filters) == 0
+
+    def test_add_filter_still_rejects_non_dict_parameter(self) -> None:
+        """Test the existing non-dict rejection keeps working."""
+        with pytest.raises(ValueError):
+            self.global_filter.add_filter(Feature("col"), FilterType.EQUAL, "not_a_dict")  # type: ignore[arg-type]
+
+    def test_add_filter_still_rejects_empty_parameter(self) -> None:
+        """Test the existing empty-parameter rejection keeps working."""
+        parameter: dict[str, Any] = {}
+
+        with pytest.raises(ValueError):
+            self.global_filter.add_filter(Feature("col"), FilterType.EQUAL, parameter)

--- a/tests/test_core/test_filter/test_global_filter.py
+++ b/tests/test_core/test_filter/test_global_filter.py
@@ -395,7 +395,7 @@ class TestGlobalFilterNonStringParameterKey:
         """Test a mixed-type key dict raises ValueError rather than the sort's TypeError."""
         parameter: dict[Any, Any] = {1: "a", "value": 2}
 
-        with pytest.raises(ValueError, match="1"):
+        with pytest.raises(ValueError, match=r"key 1 is not a string"):
             self.global_filter.add_filter(Feature("col"), FilterType.EQUAL, parameter)
 
         assert len(self.global_filter.filters) == 0


### PR DESCRIPTION
Three related attributability fixes: in each case an error told the reader less than it knew.

## `get_in_features` on a key that is already set (#942)

`Options.get_in_features` treated every falsy value as "not found", so `Options(context={"in_features": ""}).get_in_features()` asked the user to set a key they had just set. An absent key and a present-but-empty value now raise distinct `ValueError`s, and the present case names the value it was set to.

The truthy-but-unresolvable case had the same gap one branch further down: `Unsupported type for source feature: <class 'int'>` named the type but never the value. It now names both. The raise types are unchanged (`ValueError`, `TypeError`), so callers catching them behave as before.

## A non-string filter parameter key (#959)

`FilterParameterImpl.from_dict` sorts parameter items to freeze them, so `{1: "a", "b": 2}` surfaced as `TypeError: '<' not supported between instances of 'str' and 'int'` from inside `sorted`, naming nothing. Non-string keys are now rejected before the sort with a message naming the offending key. Every accessor (`value`, `values`, `min`, `max`, `max_exclusive`) looks keys up by string, so such a key could never have been read anyway. Reachable from `GlobalFilter.add_filter`, covered there too. Latent: nothing in the repo passed one.

## The `ExampleOrderFilter` doc snippet (#939)

`filter_data.md` told FeatureGroup authors to guard with `if features.filters:` while the example earlier on the same page iterated `features.filters` unguarded and read the loop variables afterwards, so a reader copying it got a `TypeError` (filters `None`) or `NameError` (filters empty) as soon as the filter did not match. The example now carries the guard the page recommends.

Two further problems surfaced while fixing it:

- The snippet's fence was `` ``` python `` with a space, which `mktestdocs` does not match, so the example was never executed by `tests/test_documentation` despite living in a tested page. The fence is now `` ```python ``.
- Once actually executed, the example failed on its primary path: it drops the filter column itself but never overrode `final_filters()`, so the framework's default row elimination still ran and raised `output is missing filter column 'example_order_id'`. It now returns `False` from `final_filters()`, which is what the same page documents for a group that handles its filter itself, and produces the documented `ExampleOrderFilter: [[2,3]]`.

Both example paths are now exercised: the filtered run yields `[[2,3]]`, the unfiltered run `[[1,2,3]]`. The added block costs the doc test about 0.2s.

## Tests

25 tests added across `test_options.py`, `test_filter_parameter.py` and `test_global_filter.py`, covering the absent key, the falsy values (`""`, `0`, `{}`) in both group and context, the truthy-unresolvable values, direct `from_dict` rejection, and the public `add_filter` path. `tox` is green.
