### PR TITLE
fix(feature_chainer): count the name-carried sources in the in_feature gate and keep a guard raise as text

### DIFF
--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -212,6 +212,18 @@ class FeatureChainParserMixin:
         self._validate_in_feature_count(list(in_features_set), feature_name)
         return set(in_features_set)
 
+    @classmethod
+    def _in_feature_count_reason(cls, feature_name: str | FeatureName, count: int) -> str | None:
+        """The one home for the MIN/MAX in_feature wording; None when the count is inside the declared range.
+
+        Shared by the raising build-time path and the match-time recording site, so the two cannot drift.
+        """
+        if count < cls.MIN_IN_FEATURES:
+            return f"Feature '{feature_name}' requires at least {cls.MIN_IN_FEATURES} in_feature(s), but found {count}"
+        if cls.MAX_IN_FEATURES is not None and count > cls.MAX_IN_FEATURES:
+            return f"Feature '{feature_name}' allows at most {cls.MAX_IN_FEATURES} in_feature(s), but found {count}"
+        return None
+
     def _validate_in_feature_count(self, in_features: list[Any], feature_name: str) -> None:
         """
         Validate that in_feature count meets min/max constraints.
@@ -223,19 +235,10 @@ class FeatureChainParserMixin:
         Raises:
             ValueError: If constraints are violated
         """
-        count = len(in_features)
-
-        if count < self.MIN_IN_FEATURES:
-            # Contained: an in_feature count below the declared MIN means this group cannot serve the feature.
-            raise ValueError(
-                f"Feature '{feature_name}' requires at least {self.MIN_IN_FEATURES} in_feature(s), but found {count}"
-            )
-
-        if self.MAX_IN_FEATURES is not None and count > self.MAX_IN_FEATURES:
-            # Contained: an in_feature count above the declared MAX means this group cannot serve the feature.
-            raise ValueError(
-                f"Feature '{feature_name}' allows at most {self.MAX_IN_FEATURES} in_feature(s), but found {count}"
-            )
+        reason = self._in_feature_count_reason(feature_name, len(in_features))
+        if reason is not None:
+            # Contained: an in_feature count outside the declared MIN/MAX means this group cannot serve the feature.
+            raise ValueError(reason)
 
     @classmethod
     def match_feature_group_criteria(
@@ -256,9 +259,10 @@ class FeatureChainParserMixin:
         the guard raises an exception, it is caught and the value is treated as
         invalid. See the module docstring for the full validation design.
 
-        Also enforces MIN_IN_FEATURES / MAX_IN_FEATURES constraints when
-        in_features is present in options. An in_features value the matcher cannot
-        resolve is a non-match.
+        Also enforces MIN_IN_FEATURES / MAX_IN_FEATURES, counting the sources the name
+        carries when it identifies the group, else the in_features option value. A
+        name-carried count outside the range is recorded as a reportable rejection; an
+        in_features option value the matcher cannot resolve is a silent non-match.
 
         ``required_when`` is NOT evaluated here. The guard installed at class definition
         runs the predicates after this method (or any override of it) returns True.
@@ -313,7 +317,7 @@ class FeatureChainParserMixin:
         if not cls._validate_match_guards(result, effective_options, property_mapping):
             return False
 
-        if not cls._validate_in_features(result, options, name_sources):
+        if not cls._validate_in_features(result, options, name_sources, feature_name):
             return False
 
         return result
@@ -509,37 +513,49 @@ class FeatureChainParserMixin:
         return False
 
     @classmethod
-    def _validate_in_features(cls, result: bool, options: Options, name_sources: list[str] | None = None) -> bool:
+    def _validate_in_features(
+        cls,
+        result: bool,
+        options: Options,
+        name_sources: list[str] | None = None,
+        feature_name: str | FeatureName = "",
+    ) -> bool:
         # Enforce MIN/MAX_IN_FEATURES on the name-carried sources when there are any, else on the options value
         if not (result and hasattr(cls, "MIN_IN_FEATURES") and hasattr(cls, "MAX_IN_FEATURES")):
             return True
 
         if name_sources is not None:
-            count = len(name_sources)
-        else:
-            in_features_raw = options.get(DefaultOptionKeys.in_features)
-            if in_features_raw is None:
+            # The name relates this group to the feature, so a count it cannot serve is an actionable
+            # near-miss rather than a silent non-match; the option path keeps its "not mine" meaning.
+            reason = cls._in_feature_count_reason(feature_name, len(name_sources))
+            if reason is None:
                 return True
-            if isinstance(in_features_raw, (list, tuple, set, frozenset)) and not in_features_raw:
-                # Present but empty: zero in_features, a non-match rather than an error.
-                count = 0
-            else:
-                # An in_features value this matcher cannot count is a non-match, not an error:
-                # skipping MIN/MAX would let the group win a resolution its own cap says it must lose.
-                # The catch is narrow on purpose; another exception class is a defect to surface, not a value.
-                try:
-                    count = len(options.get_in_features())
-                except (TypeError, ValueError) as exc:
-                    if is_match_abort(exc):
-                        raise
-                    # Text, not exc: a retained record must not pin this frame, its cls and the plugin class.
-                    logger.debug(
-                        "%s cannot resolve in_features value %r: %s",
-                        cls.__name__,
-                        in_features_raw,
-                        contained_raise_reason(exc),
-                    )
-                    return False
+            record_match_rejection(cls.__name__, reason)
+            return False
+
+        in_features_raw = options.get(DefaultOptionKeys.in_features)
+        if in_features_raw is None:
+            return True
+        if isinstance(in_features_raw, (list, tuple, set, frozenset)) and not in_features_raw:
+            # Present but empty: zero in_features, a non-match rather than an error.
+            count = 0
+        else:
+            # An in_features value this matcher cannot count is a non-match, not an error:
+            # skipping MIN/MAX would let the group win a resolution its own cap says it must lose.
+            # The catch is narrow on purpose; another exception class is a defect to surface, not a value.
+            try:
+                count = len(options.get_in_features())
+            except (TypeError, ValueError) as exc:
+                if is_match_abort(exc):
+                    raise
+                # Text, not exc: a retained record must not pin this frame, its cls and the plugin class.
+                logger.debug(
+                    "%s cannot resolve in_features value %r: %s",
+                    cls.__name__,
+                    in_features_raw,
+                    contained_raise_reason(exc),
+                )
+                return False
 
         if count < cls.MIN_IN_FEATURES:
             return False

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -291,9 +291,13 @@ class FeatureChainParserMixin:
         # name-carried value is as visible to match_guard as an explicit one. A no-source ValueError cannot
         # reach here: it would already have made match_parser_criteria a non-match.
         effective_options = options
+        # The sources input_features would read off the name, so the in_feature gate counts the same ones.
+        name_sources: list[str] | None = None
         if result:
             parsed = FeatureChainParser.parse_name(feature_name, prefix_patterns, CHAIN_SEPARATOR)
             if FeatureChainParser._name_identifies_group(parsed, property_mapping):
+                if parsed.source_feature:
+                    name_sources = parsed.source_feature.split(cls.IN_FEATURE_SEPARATOR)
                 # Bound once and reused: the merge and the guards must see the name-derived value even
                 # when the legacy operation value is absent (a named-optional-first pattern).
                 bindings = FeatureChainParser.bind_name_captures(parsed, property_mapping or {})
@@ -309,7 +313,7 @@ class FeatureChainParserMixin:
         if not cls._validate_match_guards(result, effective_options, property_mapping):
             return False
 
-        if not cls._validate_in_features(result, options):
+        if not cls._validate_in_features(result, options, name_sources):
             return False
 
         return result
@@ -475,11 +479,12 @@ class FeatureChainParserMixin:
                 rejected = not guard(value)
             except Exception as exc:
                 level = contained_raise_log_level(exc)
+                # Text, not exc: a retained record must not pin the traceback, its frames and the plugin class.
                 if level == logging.DEBUG:
-                    logger.debug("match_guard for '%s' raised %s for value %r", key, exc, value)
+                    logger.debug("match_guard for '%s' %s for value %r", key, contained_raise_reason(exc), value)
                 else:
                     # The raw value stays out of WARNING logs; rerun with debug logging to see it.
-                    logger.warning("match_guard for '%s' raised %s", key, exc)
+                    logger.warning("match_guard for '%s' %s", key, contained_raise_reason(exc))
                 rejected = True
             if rejected:
                 return key, value
@@ -504,35 +509,42 @@ class FeatureChainParserMixin:
         return False
 
     @classmethod
-    def _validate_in_features(cls, result: bool, options: Options) -> bool:
-        # Enforce MIN/MAX_IN_FEATURES when in_features is present in options
-        if result and hasattr(cls, "MIN_IN_FEATURES") and hasattr(cls, "MAX_IN_FEATURES"):
+    def _validate_in_features(cls, result: bool, options: Options, name_sources: list[str] | None = None) -> bool:
+        # Enforce MIN/MAX_IN_FEATURES on the name-carried sources when there are any, else on the options value
+        if not (result and hasattr(cls, "MIN_IN_FEATURES") and hasattr(cls, "MAX_IN_FEATURES")):
+            return True
+
+        if name_sources is not None:
+            count = len(name_sources)
+        else:
             in_features_raw = options.get(DefaultOptionKeys.in_features)
-            if in_features_raw is not None:
-                if isinstance(in_features_raw, (list, tuple, set, frozenset)) and not in_features_raw:
-                    # Present but empty: zero in_features, a non-match rather than an error.
-                    count = 0
-                else:
-                    # An in_features value this matcher cannot count is a non-match, not an error:
-                    # skipping MIN/MAX would let the group win a resolution its own cap says it must lose.
-                    # The catch is narrow on purpose; another exception class is a defect to surface, not a value.
-                    try:
-                        count = len(options.get_in_features())
-                    except (TypeError, ValueError) as exc:
-                        if is_match_abort(exc):
-                            raise
-                        # Text, not exc: a retained record must not pin this frame, its cls and the plugin class.
-                        logger.debug(
-                            "%s cannot resolve in_features value %r: %s",
-                            cls.__name__,
-                            in_features_raw,
-                            contained_raise_reason(exc),
-                        )
-                        return False
-                if count < cls.MIN_IN_FEATURES:
+            if in_features_raw is None:
+                return True
+            if isinstance(in_features_raw, (list, tuple, set, frozenset)) and not in_features_raw:
+                # Present but empty: zero in_features, a non-match rather than an error.
+                count = 0
+            else:
+                # An in_features value this matcher cannot count is a non-match, not an error:
+                # skipping MIN/MAX would let the group win a resolution its own cap says it must lose.
+                # The catch is narrow on purpose; another exception class is a defect to surface, not a value.
+                try:
+                    count = len(options.get_in_features())
+                except (TypeError, ValueError) as exc:
+                    if is_match_abort(exc):
+                        raise
+                    # Text, not exc: a retained record must not pin this frame, its cls and the plugin class.
+                    logger.debug(
+                        "%s cannot resolve in_features value %r: %s",
+                        cls.__name__,
+                        in_features_raw,
+                        contained_raise_reason(exc),
+                    )
                     return False
-                if cls.MAX_IN_FEATURES is not None and count > cls.MAX_IN_FEATURES:
-                    return False
+
+        if count < cls.MIN_IN_FEATURES:
+            return False
+        if cls.MAX_IN_FEATURES is not None and count > cls.MAX_IN_FEATURES:
+            return False
         return True
 
     @classmethod

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_in_feature_count_gate_name_sources.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_in_feature_count_gate_name_sources.py
@@ -1,0 +1,101 @@
+"""The MIN/MAX_IN_FEATURES gate counts the sources the feature name carries (#944).
+
+When the name identifies the group, input_features splits the name and never reads the
+in_features option, so the gate must count the same sources the name path would use.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import (
+    FeatureChainParserMixin,
+)
+from mloda.provider import DefaultOptionKeys, PropertySpec
+from mloda.user import Feature, Options
+
+# A dict is uncountable for get_in_features: it raises TypeError instead of yielding features.
+JUNK_IN_FEATURES: dict[str, int] = {"a": 1}
+
+
+class _NameSourceGate944(FeatureChainParserMixin):
+    """Two to three in_features, with the sources readable from the name."""
+
+    PREFIX_PATTERN = r".*__([\w]+)_gate944$"
+    MIN_IN_FEATURES = 2
+    MAX_IN_FEATURES = 3
+    PROPERTY_MAPPING = {
+        "operation": PropertySpec(
+            "Operation to apply",
+            allowed_values={"op1": "Operation 1"},
+            context=True,
+            strict_validation=True,
+        )
+    }
+
+
+def _options(in_features: Any = None) -> Options:
+    context: dict[str, Any] = {"operation": "op1"}
+    if in_features is not None:
+        context[DefaultOptionKeys.in_features] = in_features
+    return Options(context=context)
+
+
+class TestNameSourcesDriveTheGate:
+    """The name path counts the name's own sources, not the option value."""
+
+    def test_junk_in_features_option_does_not_reject_a_name_carried_source_count(self) -> None:
+        """The name carries two sources, inside MIN=2 / MAX=3; the uncountable option is not consulted."""
+        result = _NameSourceGate944.match_feature_group_criteria("f1&f2__op1_gate944", _options(JUNK_IN_FEATURES))
+
+        assert result is True
+
+    def test_name_source_count_below_min_is_a_non_match(self) -> None:
+        """One name source is below MIN=2, even though the option value would have passed the gate."""
+        result = _NameSourceGate944.match_feature_group_criteria("f1__op1_gate944", _options(["a", "b"]))
+
+        assert result is False
+
+    def test_name_source_count_above_max_is_a_non_match(self) -> None:
+        """Four name sources exceed MAX=3, even though the option value would have passed the gate."""
+        result = _NameSourceGate944.match_feature_group_criteria("f1&f2&f3&f4__op1_gate944", _options(["a", "b"]))
+
+        assert result is False
+
+    def test_name_source_count_below_min_without_any_option_is_a_non_match(self) -> None:
+        """No in_features option at all: the name's single source still fails MIN=2."""
+        result = _NameSourceGate944.match_feature_group_criteria("f1__op1_gate944", _options())
+
+        assert result is False
+
+    def test_name_source_count_inside_range_still_matches(self) -> None:
+        """Regression pin: a name-carried count inside MIN/MAX matches with no option present."""
+        result = _NameSourceGate944.match_feature_group_criteria("f1&f2&f3__op1_gate944", _options())
+
+        assert result is True
+
+
+class TestOptionPathGateUnchanged:
+    """Without a name that identifies the group, the option value is still what gets counted."""
+
+    def test_uncountable_option_value_is_still_a_non_match(self) -> None:
+        result = _NameSourceGate944.match_feature_group_criteria("any_name", _options(JUNK_IN_FEATURES))
+
+        assert result is False
+
+    def test_option_count_below_min_is_still_a_non_match(self) -> None:
+        result = _NameSourceGate944.match_feature_group_criteria("any_name", _options("single_feature"))
+
+        assert result is False
+
+    def test_option_count_above_max_is_still_a_non_match(self) -> None:
+        in_features = frozenset({Feature("a"), Feature("b"), Feature("c"), Feature("d")})
+        result = _NameSourceGate944.match_feature_group_criteria("any_name", _options(in_features))
+
+        assert result is False
+
+    def test_option_count_inside_range_still_matches(self) -> None:
+        in_features = frozenset({Feature("a"), Feature("b")})
+        result = _NameSourceGate944.match_feature_group_criteria("any_name", _options(in_features))
+
+        assert result is True

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_in_feature_count_gate_name_sources.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_in_feature_count_gate_name_sources.py
@@ -6,11 +6,15 @@ in_features option, so the gate must count the same sources the name path would 
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from typing import Any
+
+import pytest
 
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import (
     FeatureChainParserMixin,
 )
+from mloda.core.abstract_plugins.components.match_rejection import MATCH_REJECTION_REASONS, MatchRejection
 from mloda.provider import DefaultOptionKeys, PropertySpec
 from mloda.user import Feature, Options
 
@@ -99,3 +103,58 @@ class TestOptionPathGateUnchanged:
         result = _NameSourceGate944.match_feature_group_criteria("any_name", _options(in_features))
 
         assert result is True
+
+
+OWNER_944 = "_NameSourceGate944"
+BELOW_MIN_NAME_944 = "f1__op1_gate944"
+ABOVE_MAX_NAME_944 = "f1&f2&f3&f4__op1_gate944"
+BELOW_MIN_REASON_944 = f"Feature '{BELOW_MIN_NAME_944}' requires at least 2 in_feature(s), but found 1"
+ABOVE_MAX_REASON_944 = f"Feature '{ABOVE_MAX_NAME_944}' allows at most 3 in_feature(s), but found 4"
+
+
+@pytest.fixture
+def rejection_window() -> Iterator[dict[str, MatchRejection]]:
+    """Open a per-test recording window and always close it again."""
+    reasons: dict[str, MatchRejection] = {}
+    token = MATCH_REJECTION_REASONS.set(reasons)
+    yield reasons
+    MATCH_REJECTION_REASONS.reset(token)
+
+
+class TestNameSourceCountRejectionIsRecorded:
+    """A name-carried count outside MIN/MAX is a reportable near-miss, not a silent non-match."""
+
+    def test_below_min_records_the_actionable_reason(self, rejection_window: dict[str, MatchRejection]) -> None:
+        """The reason keeps the pre-gate wording: the declared MIN and the count the name carries."""
+        result = _NameSourceGate944.match_feature_group_criteria(BELOW_MIN_NAME_944, _options())
+
+        assert result is False
+        assert rejection_window == {OWNER_944: MatchRejection(reason=BELOW_MIN_REASON_944, stage="value_rejection")}
+
+    def test_above_max_records_the_actionable_reason(self, rejection_window: dict[str, MatchRejection]) -> None:
+        """The reason keeps the pre-gate wording: the declared MAX and the count the name carries."""
+        result = _NameSourceGate944.match_feature_group_criteria(ABOVE_MAX_NAME_944, _options())
+
+        assert result is False
+        assert rejection_window == {OWNER_944: MatchRejection(reason=ABOVE_MAX_REASON_944, stage="value_rejection")}
+
+    def test_below_min_records_the_name_count_even_with_a_passing_option(
+        self, rejection_window: dict[str, MatchRejection]
+    ) -> None:
+        """The option value would pass the gate, so the reason must report the name's count, not the option's."""
+        _NameSourceGate944.match_feature_group_criteria(BELOW_MIN_NAME_944, _options(["a", "b"]))
+
+        assert rejection_window == {OWNER_944: MatchRejection(reason=BELOW_MIN_REASON_944, stage="value_rejection")}
+
+    def test_a_count_inside_the_range_records_nothing(self, rejection_window: dict[str, MatchRejection]) -> None:
+        result = _NameSourceGate944.match_feature_group_criteria("f1&f2&f3__op1_gate944", _options())
+
+        assert result is True
+        assert rejection_window == {}
+
+    def test_the_option_path_still_records_nothing(self, rejection_window: dict[str, MatchRejection]) -> None:
+        """Pinned contrast: only the name path reports; the option path stays a silent non-match."""
+        result = _NameSourceGate944.match_feature_group_criteria("any_name", _options("single_feature"))
+
+        assert result is False
+        assert rejection_window == {}

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_match_guard_log_no_exception_object.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_match_guard_log_no_exception_object.py
@@ -1,0 +1,118 @@
+"""A match_guard raise is logged as text, never as the exception object (#945).
+
+The object would land in LogRecord.args, and a retained record then pins exc.__traceback__,
+whose frames hold ``cls`` and with it the dynamically loaded FeatureGroup class.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+import pytest
+
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import (
+    FeatureChainParserMixin,
+)
+from mloda.provider import PropertySpec
+from mloda.user import Options
+
+MIXIN_LOGGER_NAME = "mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin"
+
+
+class GuardExploded(RuntimeError):
+    """An exception class no judgment failure uses, so the guard looks broken rather than undecided."""
+
+
+def _guard_raises_type_error(value: Any) -> bool:
+    raise TypeError("guard cannot judge this value")
+
+
+def _guard_raises_unexpected(value: Any) -> bool:
+    raise GuardExploded("guard is broken")
+
+
+class _JudgmentRaiseGuard945(FeatureChainParserMixin):
+    """Guard raising an expected judgment class, which takes the DEBUG branch."""
+
+    PREFIX_PATTERN = r".*__([\w]+)_g945debug$"
+    PROPERTY_MAPPING = {
+        "operation": PropertySpec("Operation", allowed_values={"op1": "Operation 1"}, context=True),
+        "items": PropertySpec("Guarded items", context=True, match_guard=_guard_raises_type_error),
+    }
+
+
+class _UnexpectedRaiseGuard945(FeatureChainParserMixin):
+    """Guard raising an unexpected class, which takes the WARNING branch."""
+
+    PREFIX_PATTERN = r".*__([\w]+)_g945warn$"
+    PROPERTY_MAPPING = {
+        "operation": PropertySpec("Operation", allowed_values={"op1": "Operation 1"}, context=True),
+        "items": PropertySpec("Guarded items", context=True, match_guard=_guard_raises_unexpected),
+    }
+
+
+def _exception_args(record: logging.LogRecord) -> list[BaseException]:
+    """Every exception object the record retains through its args, tuple form and dict form alike."""
+    args = record.args
+    if args is None:
+        return []
+    values = list(args.values()) if isinstance(args, Mapping) else list(args)
+    return [value for value in values if isinstance(value, BaseException)]
+
+
+def _guard_raise_records(caplog: pytest.LogCaptureFixture, level: int) -> list[logging.LogRecord]:
+    return [
+        record
+        for record in caplog.records
+        if record.name == MIXIN_LOGGER_NAME and record.levelno == level and "raised" in record.getMessage()
+    ]
+
+
+class TestMatchGuardRaiseLogsNoExceptionObject:
+    """The contained guard raise must reach the log as text only."""
+
+    def test_debug_branch_retains_no_exception_object(self, caplog: pytest.LogCaptureFixture) -> None:
+        options = Options(context={"operation": "op1", "items": 5})
+        with caplog.at_level(logging.DEBUG, logger=MIXIN_LOGGER_NAME):
+            result = _JudgmentRaiseGuard945.match_feature_group_criteria("src__op1_g945debug", options)
+
+        assert result is False
+        assert _guard_raise_records(caplog, logging.DEBUG), "the DEBUG branch must report the contained raise"
+        for record in caplog.records:
+            assert _exception_args(record) == [], f"record pins an exception object: {record.getMessage()}"
+            assert record.exc_info is None, f"record pins a traceback via exc_info: {record.getMessage()}"
+
+    def test_warning_branch_retains_no_exception_object(self, caplog: pytest.LogCaptureFixture) -> None:
+        options = Options(context={"operation": "op1", "items": 5})
+        with caplog.at_level(logging.DEBUG, logger=MIXIN_LOGGER_NAME):
+            result = _UnexpectedRaiseGuard945.match_feature_group_criteria("src__op1_g945warn", options)
+
+        assert result is False
+        assert _guard_raise_records(caplog, logging.WARNING), "the WARNING branch must report the contained raise"
+        for record in caplog.records:
+            assert _exception_args(record) == [], f"record pins an exception object: {record.getMessage()}"
+            assert record.exc_info is None, f"record pins a traceback via exc_info: {record.getMessage()}"
+
+    def test_debug_message_still_names_key_and_exception_type(self, caplog: pytest.LogCaptureFixture) -> None:
+        options = Options(context={"operation": "op1", "items": 5})
+        with caplog.at_level(logging.DEBUG, logger=MIXIN_LOGGER_NAME):
+            _JudgmentRaiseGuard945.match_feature_group_criteria("src__op1_g945debug", options)
+
+        messages = [record.getMessage() for record in _guard_raise_records(caplog, logging.DEBUG)]
+        assert len(messages) == 1, f"exactly one DEBUG record reports the raise, got: {messages}"
+        assert "items" in messages[0], f"the key must stay in the message: {messages[0]}"
+        assert "TypeError" in messages[0], f"the exception type must stay in the message: {messages[0]}"
+        assert "guard cannot judge this value" in messages[0], f"the reason must stay readable: {messages[0]}"
+
+    def test_warning_message_still_names_key_and_exception_type(self, caplog: pytest.LogCaptureFixture) -> None:
+        options = Options(context={"operation": "op1", "items": 5})
+        with caplog.at_level(logging.DEBUG, logger=MIXIN_LOGGER_NAME):
+            _UnexpectedRaiseGuard945.match_feature_group_criteria("src__op1_g945warn", options)
+
+        messages = [record.getMessage() for record in _guard_raise_records(caplog, logging.WARNING)]
+        assert len(messages) == 1, f"exactly one WARNING record reports the raise, got: {messages}"
+        assert "items" in messages[0], f"the key must stay in the message: {messages[0]}"
+        assert "GuardExploded" in messages[0], f"the exception type must stay in the message: {messages[0]}"
+        assert repr(5) not in messages[0], f"the raw value stays out of WARNING logs: {messages[0]}"

--- a/tests/test_core/test_prepare/test_name_source_count_elimination.py
+++ b/tests/test_core/test_prepare/test_name_source_count_elimination.py
@@ -1,0 +1,100 @@
+"""A name whose source count violates MIN_IN_FEATURES is a near-miss, not a bare "no feature groups found".
+
+The gate rejects at match time (#944), so the actionable in_feature-count message must reach the
+resolution-failure report as an elimination. The probe class is dropped under gc.collect() before any
+assert, so no failing assert pins it (tests/conftest.py).
+"""
+
+from __future__ import annotations
+
+import gc
+from typing import Optional
+
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser_mixin import FeatureChainParserMixin
+from mloda.core.abstract_plugins.components.feature_chainer.property_spec import property_spec
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from mloda.core.prepare.identify_feature_group import FeatureResolutionError
+from mloda.core.prepare.resolution_types import EvaluationResult
+from tests.test_core.test_prepare.identify_seam import evaluate_or_raise
+
+
+MIN_COUNT_CLASS_NAME = "MinInFeaturesMixinFG944"
+BELOW_MIN_FEATURE = "src1__op1_mincount944"
+INSIDE_RANGE_FEATURE = "src1&src2__op1_mincount944"
+RESOLUTION_ERROR_NAME = "FeatureResolutionError"
+VALUE_REJECTION_STAGE = "value_rejection"
+BELOW_MIN_REASON = f"Feature '{BELOW_MIN_FEATURE}' requires at least 2 in_feature(s), but found 1"
+
+
+class MinCountFw944(ComputeFramework):
+    """Dummy compute framework for the name-source-count elimination tests."""
+
+
+def _make_min_count_mixin_fg() -> type[FeatureGroup]:
+    """A mixin candidate whose name identifies it, so only the in_feature count gate can reject it."""
+    gc.collect()  # class objects are cyclic: collect leftovers before defining a twin
+
+    class MinInFeaturesMixinFG944(FeatureChainParserMixin, FeatureGroup):
+        PREFIX_PATTERN = r".*__(?P<operation>\w+)_mincount944$"
+        MIN_IN_FEATURES = 2
+        PROPERTY_MAPPING = {"operation": property_spec("operation", allowed_values=("op1",), context=True)}
+
+        @classmethod
+        def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+            return {MinCountFw944}
+
+        def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+            return None
+
+    return MinInFeaturesMixinFG944
+
+
+def _resolve(feature_name: str) -> tuple[Optional[str], tuple[str, ...], tuple[tuple[str, str, str], ...]]:
+    """Evaluate that name: (error type, winner names, (class, stage, reason) per elimination)."""
+    feature_group = _make_min_count_mixin_fg()
+    feature = Feature(feature_name, Options())
+    plugins: FeatureGroupEnvironmentMapping = {feature_group: {MinCountFw944}}
+    error_type: Optional[str] = None
+    result: Optional[EvaluationResult] = None
+    try:
+        result = evaluate_or_raise(feature, plugins, None)
+    except FeatureResolutionError as exc:
+        error_type, result = type(exc).__name__, exc.result
+    identified: tuple[str, ...] = ()
+    eliminations: tuple[tuple[str, str, str], ...] = ()
+    if result is not None:
+        identified = tuple(sorted(g.get_class_name() for g in result.identified))
+        eliminations = tuple(
+            sorted((g.get_class_name(), str(e.stage), str(e.reason)) for g, e in result.eliminations.items())
+        )
+    del result, plugins, feature, feature_group
+    gc.collect()
+    return error_type, identified, eliminations
+
+
+class TestNameSourceCountBelowMinIsANearMiss:
+    def test_resolution_still_fails(self) -> None:
+        error_type, identified, _ = _resolve(BELOW_MIN_FEATURE)
+
+        assert error_type == RESOLUTION_ERROR_NAME, f"the count gate must still reject, got: {error_type}"
+        assert identified == (), f"nothing may win this resolution, got: {identified}"
+
+    def test_the_in_feature_count_reason_is_reported_as_an_elimination(self) -> None:
+        """The pre-gate diagnostic survives: the report names the declared MIN and the count the name carries."""
+        _, _, eliminations = _resolve(BELOW_MIN_FEATURE)
+
+        expected = ((MIN_COUNT_CLASS_NAME, VALUE_REJECTION_STAGE, BELOW_MIN_REASON),)
+        assert eliminations == expected, f"the count reason must surface as a near-miss, got: {eliminations}"
+
+    def test_a_count_inside_the_range_still_identifies_the_candidate(self) -> None:
+        """Sanity pin: the candidate is really reachable, so the assertions above are not vacuous."""
+        error_type, identified, eliminations = _resolve(INSIDE_RANGE_FEATURE)
+
+        assert error_type is None, f"a count inside the range must still resolve, got: {error_type}"
+        assert identified == (MIN_COUNT_CLASS_NAME,)
+        assert eliminations == ()

--- a/tests/test_core/test_prepare/test_unresolvable_in_features_non_match.py
+++ b/tests/test_core/test_prepare/test_unresolvable_in_features_non_match.py
@@ -1,6 +1,8 @@
 """An in_features value the matcher cannot resolve is a plain non-match at the resolution seam.
 
-The probe class is dropped under gc.collect() before any assert, so no failing assert pins it (tests/conftest.py).
+The probe matches by options, not by name: a name that identifies the group carries its own sources and
+the option is never consulted (#944). The probe class is dropped under gc.collect() before any assert,
+so no failing assert pins it (tests/conftest.py).
 """
 
 from __future__ import annotations
@@ -22,7 +24,7 @@ from mloda.core.prepare.resolution_types import EvaluationResult
 from tests.test_core.test_prepare.identify_seam import evaluate_or_raise
 
 
-IN_FEATURES_FEATURE_884 = "src__op1_infeat884"
+IN_FEATURES_FEATURE_884 = "in_features_probe_884"
 IN_FEATURES_CLASS_NAME_884 = "InFeaturesMixinFG884"
 RESOLUTION_ERROR_NAME = "FeatureResolutionError"
 MATCHER_ERROR_STAGE = "matcher_error"
@@ -33,7 +35,7 @@ class InFeaturesFw884(ComputeFramework):
 
 
 def _make_in_features_mixin_fg() -> type[FeatureGroup]:
-    """A mixin candidate matched by its own name, so only the in_features gate can still reject it."""
+    """A mixin candidate matched by its options, so only the in_features gate can still reject it."""
     gc.collect()  # class objects are cyclic: collect leftovers before defining a twin
 
     class InFeaturesMixinFG884(FeatureChainParserMixin, FeatureGroup):
@@ -53,7 +55,8 @@ def _make_in_features_mixin_fg() -> type[FeatureGroup]:
 def _resolve(in_features: Any) -> tuple[Optional[str], tuple[str, ...], tuple[tuple[str, str, str], ...]]:
     """Evaluate one feature carrying that value: (error type, winner names, (class, stage, reason) per elimination)."""
     feature_group = _make_in_features_mixin_fg()
-    feature = Feature(IN_FEATURES_FEATURE_884, Options(context={DefaultOptionKeys.in_features: in_features}))
+    options = Options(context={"operation": "op1", DefaultOptionKeys.in_features: in_features})
+    feature = Feature(IN_FEATURES_FEATURE_884, options)
     plugins: FeatureGroupEnvironmentMapping = {feature_group: {InFeaturesFw884}}
     try:
         error_type: Optional[str] = None


### PR DESCRIPTION
Fixes #944, fixes #945.

## The in_feature count gate ignored the sources the name carries (#944)

`match_feature_group_criteria` passed raw options to `_validate_in_features`, so the MIN/MAX_IN_FEATURES gate judged only the `in_features` option. But `input_features` reads that option only when the name does not identify the group: when the name does identify it and carries a source feature, the sources come from the name and the option is never read. A junk option value therefore rejected a feature whose sources the name already carries.

The gate now counts the same sources `input_features` would use, reusing the name parse `match_feature_group_criteria` already performs. The option path is preserved branch for branch: absent option, present-but-empty collection, uncountable value, match-abort re-raise, and the debug log all behave as before.

## A match_guard rejection logged the exception object (#945)

`_first_rejecting_guard` passed the caught exception into the log record, so a retained record (caplog, MemoryHandler, breadcrumb collectors) pinned `exc.__traceback__`, its frames, and through them the plugin class. Both the DEBUG and the WARNING branch now log `contained_raise_reason(exc)`, which also adds the exception type the old message lacked. The WARNING branch still keeps the raw value out.

## Keeping the diagnostic that the gate change would have cost

Counting name-carried sources at match time means a name with the wrong number of sources is now rejected during matching, where it previously matched and then raised the actionable `Feature 'X' requires at least N in_feature(s), but found M` from `_validate_in_feature_count`. Left alone that would have traded the clearest message for a bare "No feature groups found". The name-source branch records the same message as a match rejection, so it surfaces as a near-miss elimination in the resolution-failure report. Both sites read the wording from one helper, so the raised and the recorded text cannot drift. The option path keeps its "not mine" meaning and records nothing.

## Notes

- `_validate_in_features` gained two defaulted parameters. It is a protected classmethod with no override in this repo or in mloda-registry, and the added parameters are defaulted, so existing call shapes stay valid.
- `tests/test_core/test_prepare/test_unresolvable_in_features_non_match.py` moved its probe from the name path to the option path. Its subject is the option path, and its old probe name pinned exactly the behavior #944 calls a bug. All four assertions are unchanged; the name path gained its own seam-level test.

## Validation

`tox` green: 8049 passed, 170 skipped, ruff format, ruff check, pip-licenses, `mypy --strict` (933 files), bandit.

Reviewed by two independent deep reviews before merge; the near-miss regression above was a review finding, not part of the original scope.