### PR TITLE
test: guard the handlers between a marked raise and the match seam

### DIFF
--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_author_guards.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_author_guards.py
@@ -252,9 +252,9 @@ def check_required_when(
         predicate = spec.required_when
         if predicate is None:
             continue
-        # A predicate that raises cannot judge the value, so the feature group is a non-match, not the run.
         try:
             is_required = bool(predicate(effective_options))
+        # Swallows: a predicate that raises cannot judge, so this is a non-match, not the run.
         except Exception as exc:
             logger.log(
                 contained_raise_log_level(exc),

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -163,11 +163,10 @@ class FeatureChainParser:
         element_validator = original_property_config.element_validator
 
         if element_validator is not None:
-            # A validator that raises cannot judge the value, so the value is rejected, not the run.
             raised: Exception | None = None
             try:
                 verdict = element_validator(found_property_val)
-            except Exception as exc:
+            except Exception as exc:  # Swallows: a validator that raises cannot judge the value, so it is rejected.
                 level = contained_raise_log_level(exc)
                 if level == logging.DEBUG:
                     logger.debug(
@@ -189,10 +188,10 @@ class FeatureChainParser:
                     f"Property value '{found_property_val}' failed validation for '{property_name}'"
                 ) from raised
         else:
-            # Fallback to membership check. An unhashable element (e.g. a dict) can never be
-            # a member of the accepted set, so it is a clean rejection, not a TypeError.
+            # Fallback to membership check.
             try:
                 is_member = found_property_val in property_value
+            # Swallows: an unhashable element can never be a member, so the TypeError is a clean rejection.
             except TypeError:
                 is_member = False
             if not is_member:

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -329,9 +329,11 @@ class FeatureChainParserMixin:
                 prefix_patterns=cls._get_prefix_patterns(),
                 owner_name=cls.__name__,
             )
-        # Swallows: the parser's own non-match verdict, recorded as the candidate's reason.
-        # A framework raise is marked instead and lands in the ValueError handler below.
+        # PropertyValueRejection subclasses ValueError, so this handler sits above the abort check and must
+        # run it: an unmarked rejection is the parser's non-match verdict, recorded as the candidate's reason.
         except PropertyValueRejection as exc:
+            if is_match_abort(exc):
+                raise
             record_match_rejection(cls.__name__, str(exc))
             return False
         # A marked raise crosses this containment; an unmarked ValueError stays a non-match.

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py
@@ -329,6 +329,8 @@ class FeatureChainParserMixin:
                 prefix_patterns=cls._get_prefix_patterns(),
                 owner_name=cls.__name__,
             )
+        # Swallows: the parser's own non-match verdict, recorded as the candidate's reason.
+        # A framework raise is marked instead and lands in the ValueError handler below.
         except PropertyValueRejection as exc:
             record_match_rejection(cls.__name__, str(exc))
             return False
@@ -473,6 +475,7 @@ class FeatureChainParserMixin:
                 continue
             try:
                 rejected = not guard(value)
+            # Swallows: a guard that raises cannot judge the value, so the value counts as rejected.
             except Exception as exc:
                 level = contained_raise_log_level(exc)
                 if level == logging.DEBUG:

--- a/mloda/core/abstract_plugins/components/input_data/base_input_data.py
+++ b/mloda/core/abstract_plugins/components/input_data/base_input_data.py
@@ -180,9 +180,9 @@ class BaseInputData(ABC):
         owner = cls.get_class_name()
         predicate = spec.required_when
         if predicate is not None:
-            # A predicate that raises cannot judge, so the reader is a silent non-match, not the run.
             try:
                 is_required = bool(predicate(options if options is not None else Options()))
+            # Swallows: a predicate that raises cannot judge, so the reader is a non-match, not the run.
             except Exception as exc:
                 logger.log(
                     contained_raise_log_level(exc),
@@ -235,10 +235,9 @@ class BaseInputData(ABC):
         """One element's verdict: a declared element_validator REPLACES membership."""
         validator = spec.element_validator
         if validator is not None:
-            # A validator that raises cannot judge the value, so the value is rejected, not the run.
             try:
                 return bool(validator(element))
-            except Exception as exc:
+            except Exception as exc:  # Swallows: a validator that raises cannot judge the value, so it is rejected.
                 logger.log(
                     contained_raise_log_level(exc),
                     "element_validator for reader option '%s' of %s raised %s; treating value as rejected.",
@@ -247,9 +246,9 @@ class BaseInputData(ABC):
                     exc,
                 )
                 return False
-        # An unhashable element can never be a member of the value space: a clean rejection, not a TypeError.
         try:
             return spec.allowed_values is not None and element in spec.allowed_values
+        # Swallows: an unhashable element can never be a member, so the TypeError is a clean rejection.
         except TypeError:
             return False
 
@@ -501,6 +500,7 @@ class BaseInputData(ABC):
         try:
             cls.suffix()  # type: ignore[attr-defined]
             return True
+        # Swallows: the probe asks whether suffix() is implemented, and both classes ARE that answer.
         except (NotImplementedError, AttributeError):
             return False
 

--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -801,8 +801,11 @@ class FeatureGroup(ABC):
             if self.input_features(options, feature_name) is None:
                 # No input features declared, so this is a root feature.
                 return True
-        # Swallows: an unimplemented input_features is the documented way to declare a root feature.
-        except NotImplementedError:
+        # An unimplemented input_features is the documented way to declare a root feature, but this handler
+        # sits above the abort check below it, so a marked raise has to cross it first.
+        except NotImplementedError as exc:
+            if is_match_abort(exc):
+                raise
             return True
         except Exception as exc:
             # Errors in input_features (e.g. validation failures for this feature name)

--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -801,8 +801,8 @@ class FeatureGroup(ABC):
             if self.input_features(options, feature_name) is None:
                 # No input features declared, so this is a root feature.
                 return True
+        # Swallows: an unimplemented input_features is the documented way to declare a root feature.
         except NotImplementedError:
-            # input_features not implemented means this is a root feature.
             return True
         except Exception as exc:
             # Errors in input_features (e.g. validation failures for this feature name)

--- a/tests/test_core/test_prepare/test_match_abort_sweep.py
+++ b/tests/test_core/test_prepare/test_match_abort_sweep.py
@@ -5,11 +5,12 @@
 raise on the match path silently loses the feature to a rival plugin. This sweep walks the static call graph
 from the match seams through the declared match-path modules and requires a decision at each individual
 raise: the escalation call, or a ``# Contained: <reason>`` comment on the raise line or in the comment block
-directly above it. A reason elsewhere in the enclosing function is not accepted; a later raise would inherit
-it and the gate would rot.
+directly above it at the raise's own column. A reason elsewhere in the enclosing function is not accepted; a
+later raise would inherit it and the gate would rot.
 
-A sibling sweep walks the same reachable set for ``except`` handlers: a mark only survives if every handler
-between the raise and the seam re-raises it, so each handler must re-raise on ``is_match_abort`` or carry a
+A sibling sweep walks the same reachable set for every place an exception can be dropped: an ``except``
+clause, a ``contextlib.suppress`` block, and a ``finally`` that returns. A mark only survives if each of them
+re-raises the caught object itself, so each must re-raise on ``is_match_abort`` or carry a
 ``# Swallows: <reason>`` comment.
 
 Not covered: plugin code under ``mloda_plugins``; dynamic dispatch, which is why SEEDS is hand-written;
@@ -66,6 +67,9 @@ _DECIDED_ABOVE_BY_READER_SELECTION = (
     "decided above by the marked raise in both add_base_input_data_to_options callers; this write only "
     "ever reaches an absent key"
 )
+_MATCHES_COLLISION = "name collision: the match path calls the input-data hooks named matches, not Link.matches"
+_UPDATE_COLLISION = "name collision: dict.update, not the link resolver's"
+_JOIN_COLLISION = "name collision: str.join, not the runner's join"
 
 RAISING_HELPERS_OUTSIDE_THE_PATH: dict[tuple[str, str], str] = {
     ("mloda/core/abstract_plugins/components/options.py", "__init__"): _CANDIDATE_OWN_DECLARATION,
@@ -75,17 +79,16 @@ RAISING_HELPERS_OUTSIDE_THE_PATH: dict[tuple[str, str], str] = {
     ("mloda/core/abstract_plugins/plugin_loader/plugin_loader.py", "__init__"): _READER_AUTO_LOAD,
     ("mloda/core/abstract_plugins/plugin_loader/plugin_loader.py", "load_group"): _READER_AUTO_LOAD,
     ("mloda/core/abstract_plugins/plugin_loader/plugin_loader.py", "all"): _READER_AUTO_LOAD,
-    ("mloda/core/abstract_plugins/components/link.py", "matches"): (
-        "name collision: the match path calls the input-data hooks named matches, not Link.matches"
-    ),
+    ("mloda/core/abstract_plugins/components/link.py", "matches"): _MATCHES_COLLISION,
     ("mloda/core/abstract_plugins/components/utils.py", "get_all_subclasses"): (
         "real edge, collided verdict: it raises nothing itself; the set.add / set.update names do"
     ),
-    ("mloda/core/prepare/resolve_links.py", "update"): "name collision: dict.update, not the link resolver's",
-    ("mloda/core/runtime/run.py", "join"): "name collision: str.join, not the runner's join",
+    ("mloda/core/prepare/resolve_links.py", "update"): _UPDATE_COLLISION,
+    ("mloda/core/runtime/run.py", "join"): _JOIN_COLLISION,
 }
 
-# Swallowing functions OUTSIDE the declared modules that the match path calls; a handler there is decided here.
+# Swallowing functions OUTSIDE the declared modules that the match path calls; the containment there is decided
+# here. The closure is transitive and resolves by name, so an entry can be a name COLLISION, not a call edge.
 SWALLOWING_HELPERS_OUTSIDE_THE_PATH: dict[tuple[str, str], str] = {
     ("mloda/core/abstract_plugins/components/utils.py", "safe_field"): (
         "it degrades one field in a rendering path, so swallowing a marked exception is its contract"
@@ -93,10 +96,25 @@ SWALLOWING_HELPERS_OUTSIDE_THE_PATH: dict[tuple[str, str], str] = {
     ("mloda/core/abstract_plugins/components/utils.py", "escalate_match_abort"): (
         "the guard around the marker write; failing to mark must not replace the exception being marked"
     ),
+    ("mloda/core/abstract_plugins/components/utils.py", "contained_raise_reason"): (
+        "it swallows only through safe_field, whose degrade-one-field contract is declared above"
+    ),
+    ("mloda/core/abstract_plugins/components/utils.py", "get_all_subclasses"): (
+        "real edge, collided verdict: it swallows nothing itself; the set.add / set.update names do"
+    ),
+    ("mloda/core/abstract_plugins/components/options.py", "__init__"): _CANDIDATE_OWN_DECLARATION,
+    ("mloda/core/abstract_plugins/components/feature.py", "__init__"): _CANDIDATE_OWN_DECLARATION,
+    ("mloda/core/abstract_plugins/plugin_loader/plugin_loader.py", "__init__"): _READER_AUTO_LOAD,
+    ("mloda/core/abstract_plugins/plugin_loader/plugin_loader.py", "load_group"): _READER_AUTO_LOAD,
+    ("mloda/core/abstract_plugins/plugin_loader/plugin_loader.py", "all"): _READER_AUTO_LOAD,
+    ("mloda/core/abstract_plugins/components/link.py", "matches"): _MATCHES_COLLISION,
+    ("mloda/core/prepare/resolve_links.py", "update"): _UPDATE_COLLISION,
+    ("mloda/core/runtime/run.py", "join"): _JOIN_COLLISION,
 }
 
 _ESCALATION = "escalate_match_abort"
 _ABORT_CHECK = "is_match_abort"
+_SUPPRESS = "suppress"
 _CONTAINED_TAG = "Contained:"
 _MARKED_TAG = "Marked:"
 _SWALLOW_TAG = "Swallows:"
@@ -185,27 +203,77 @@ def _escalates(node: ast.AST) -> bool:
     return _ESCALATION in _scan(node)[0]
 
 
-def _handler_escalates(handler: ast.ExceptHandler) -> bool:
-    """A raise as a direct child re-raises unconditionally; otherwise the abort check needs a raise beside it."""
-    if any(isinstance(statement, ast.Raise) for statement in handler.body):
+def _keeps_the_mark(node: ast.Raise, bound: str | None) -> bool:
+    """A re-raise the marker survives: bare, the caught name itself, or a replacement marked on its way out."""
+    if node.exc is None:
         return True
+    if bound is not None and isinstance(node.exc, ast.Name) and node.exc.id == bound:
+        return True
+    return _escalates(node.exc)
+
+
+def _handler_escalates(handler: ast.ExceptHandler) -> bool:
+    """A re-raise that keeps the mark, gated on the abort check or standing on every path out of the handler."""
+    nodes = [node for statement in handler.body for node in ast.walk(statement)]
+    if not any(isinstance(node, ast.Raise) and _keeps_the_mark(node, handler.name) for node in nodes):
+        return False
     calls: set[str] = set()
-    raises = False
     for statement in handler.body:
         calls |= _scan(statement)[0]
-        raises = raises or any(isinstance(node, ast.Raise) for node in ast.walk(statement))
-    return raises and _ABORT_CHECK in calls
+    if _ABORT_CHECK in calls:
+        return True
+    return not any(isinstance(node, (ast.Return, ast.Break, ast.Continue)) for node in nodes)
+
+
+class _Containment(NamedTuple):
+    """One place an exception can be dropped, with the header lines a trailing reason may sit on."""
+
+    lineno: int
+    col_offset: int
+    header_end: int
+    escalating: bool
+
+
+def _is_suppress(expr: ast.expr) -> bool:
+    if not isinstance(expr, ast.Call):
+        return False
+    func = expr.func
+    if isinstance(func, ast.Name):
+        return func.id == _SUPPRESS
+    return isinstance(func, ast.Attribute) and func.attr == _SUPPRESS
+
+
+def _finally_escapes(finalbody: list[ast.stmt]) -> bool:
+    """A return, break or continue leaving finally discards whatever exception is in flight."""
+    escapes = (ast.Return, ast.Break, ast.Continue)
+    return any(isinstance(node, escapes) for statement in finalbody for node in ast.walk(statement))
+
+
+def _containment_at(node: ast.AST) -> _Containment | None:
+    """The containment this node opens: an except clause, a suppress block, or a finally that escapes."""
+    if isinstance(node, ast.ExceptHandler):
+        return _Containment(node.lineno, node.col_offset, node.body[0].lineno - 1, _handler_escalates(node))
+    if isinstance(node, (ast.With, ast.AsyncWith)) and any(_is_suppress(item.context_expr) for item in node.items):
+        return _Containment(node.lineno, node.col_offset, node.body[0].lineno - 1, False)
+    if isinstance(node, ast.Try) and _finally_escapes(node.finalbody):
+        # ast exposes no position for the finally keyword, so the try line carries the decision.
+        return _Containment(node.lineno, node.col_offset, node.body[0].lineno - 1, False)
+    return None
 
 
 def _swallows(node: ast.AST) -> bool:
-    """Does this definition hold a handler that neither re-raises nor checks the marker."""
-    return any(isinstance(child, ast.ExceptHandler) and not _handler_escalates(child) for child in ast.walk(node))
+    """Does this definition hold a containment that neither re-raises nor checks the marker."""
+    for child in ast.walk(node):
+        containment = _containment_at(child)
+        if containment is not None and not containment.escalating:
+            return True
+    return False
 
 
-def _own_line_and_trailing_comments(source: str) -> tuple[dict[int, str], dict[int, str]]:
-    """Comment text per line, split into own-line and trailing; tokenize, so a ``#`` in a string is not one."""
+def _own_line_and_trailing_comments(source: str) -> tuple[dict[int, tuple[int, str]], dict[int, str]]:
+    """Comments per line, own-line ones with their column; tokenize, so a ``#`` inside a string is not one."""
     lines = source.splitlines()
-    own_line: dict[int, str] = {}
+    own_line: dict[int, tuple[int, str]] = {}
     trailing: dict[int, str] = {}
     for token in tokenize.generate_tokens(io.StringIO(source).readline):
         if token.type != tokenize.COMMENT:
@@ -215,7 +283,7 @@ def _own_line_and_trailing_comments(source: str) -> tuple[dict[int, str], dict[i
         if lines[row - 1][:col].strip():
             trailing[row] = text
         else:
-            own_line[row] = text
+            own_line[row] = (col, text)
     return own_line, trailing
 
 
@@ -228,20 +296,26 @@ def _tagged_reason(text: str, tag: str) -> str | None:
 
 
 def _anchored_reason(
-    own_line: dict[int, str],
+    own_line: dict[int, tuple[int, str]],
     trailing: dict[int, str],
     lineno: int,
+    col_offset: int,
     tag: str,
+    header_end: int | None = None,
 ) -> str | None:
-    """The tagged reason for the raise at ``lineno``: trailing on that line, or in the block directly above."""
-    reason = _tagged_reason(trailing.get(lineno, ""), tag)
-    if reason is not None:
-        return reason
-    row = lineno - 1
-    while row in own_line:
-        reason = _tagged_reason(own_line[row], tag)
+    """The tagged reason for the site: trailing anywhere in its header, or above it at its own column."""
+    for row in range(lineno, (lineno if header_end is None else header_end) + 1):
+        reason = _tagged_reason(trailing.get(row, ""), tag)
         if reason is not None:
             return reason
+    row = lineno - 1
+    while row in own_line:
+        comment_col, text = own_line[row]
+        # A reason deeper than the site belongs to the block it is written in, not to the site below it.
+        if comment_col == col_offset:
+            reason = _tagged_reason(text, tag)
+            if reason is not None:
+                return reason
         row -= 1
     return None
 
@@ -275,8 +349,9 @@ def classify_raises(source: str, module: str, functions: frozenset[str] | None =
             continue
         # Only the raised expression counts: crediting the enclosing handler would bless later raises too.
         marked = _escalates(raise_node.exc)
-        claimed = _anchored_reason(own_line, trailing, raise_node.lineno, _MARKED_TAG)
-        contained = _anchored_reason(own_line, trailing, raise_node.lineno, _CONTAINED_TAG)
+        column = raise_node.col_offset
+        claimed = _anchored_reason(own_line, trailing, raise_node.lineno, column, _MARKED_TAG)
+        contained = _anchored_reason(own_line, trailing, raise_node.lineno, column, _CONTAINED_TAG)
         kind: Kind
         if marked:
             kind, reason = "marked", claimed
@@ -290,54 +365,62 @@ def classify_raises(source: str, module: str, functions: frozenset[str] | None =
     return sorted(sites)
 
 
-def _collect_handlers(node: ast.AST, functions: list[str], out: list[tuple[ast.ExceptHandler, list[str]]]) -> None:
-    """Walk ``node``, recording each except clause with its enclosing function chain."""
+def _collect_handlers(node: ast.AST, functions: list[str], out: list[tuple[_Containment, list[str]]]) -> None:
+    """Walk ``node``, recording each containment with its enclosing function chain."""
     for child in ast.iter_child_nodes(node):
         if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
             _collect_handlers(child, [*functions, child.name], out)
         else:
-            if isinstance(child, ast.ExceptHandler):
-                out.append((child, functions))
+            containment = _containment_at(child)
+            if containment is not None:
+                out.append((containment, functions))
             _collect_handlers(child, functions, out)
 
 
 def classify_handlers(source: str, module: str, functions: frozenset[str] | None = None) -> list[HandlerSite]:
-    """Classify every ``except`` clause in ``source``, restricted to handlers inside the named functions."""
+    """Classify every containment in ``source``, restricted to the ones inside the named functions."""
     tree = ast.parse(source, filename=module)
     own_line, trailing = _own_line_and_trailing_comments(source)
-    found: list[tuple[ast.ExceptHandler, list[str]]] = []
+    found: list[tuple[_Containment, list[str]]] = []
     _collect_handlers(tree, [], found)
 
     sites: list[HandlerSite] = []
-    for handler, chain in found:
+    for containment, chain in found:
         if not chain:
             continue
         if functions is not None and not any(name in functions for name in chain):
             continue
-        escalating = _handler_escalates(handler)
-        # Anchored at the except line only: a reason elsewhere in the function would bless the next handler too.
-        declared = _anchored_reason(own_line, trailing, handler.lineno, _SWALLOW_TAG)
+        # Anchored at the site itself: a reason elsewhere in the function would bless the next handler too.
+        declared = _anchored_reason(
+            own_line,
+            trailing,
+            containment.lineno,
+            containment.col_offset,
+            _SWALLOW_TAG,
+            containment.header_end,
+        )
         kind: HandlerKind
-        if escalating:
+        if containment.escalating:
             kind, reason = ("misannotated", declared) if declared is not None else ("escalating", None)
         elif declared is not None:
             kind, reason = "swallowing", declared
         else:
             kind, reason = "unannotated", None
-        sites.append(HandlerSite(module, handler.lineno, chain[-1], kind, reason))
+        sites.append(HandlerSite(module, containment.lineno, chain[-1], kind, reason))
     return sorted(sites)
 
 
 class _Index(NamedTuple):
-    """Every definition under ``mloda/``, plus the names whose call can raise."""
+    """Every definition under ``mloda/``, plus the names whose call can raise and the ones that can swallow."""
 
     functions: dict[str, list[_Definition]]
     constructors: dict[str, list[_Definition]]
     raising: frozenset[str]
+    swallowing: frozenset[str]
 
 
 def _raising_names(calls_per_name: dict[str, frozenset[str]], direct: frozenset[str]) -> frozenset[str]:
-    """Names that raise directly or through anything they call: one non-raising wrapper defeats depth-1."""
+    """Names with the property directly or through anything they call: one clean wrapper defeats depth-1."""
     callers: dict[str, set[str]] = {}
     for name, called in calls_per_name.items():
         for callee in called:
@@ -355,11 +438,12 @@ def _raising_names(calls_per_name: dict[str, frozenset[str]], direct: frozenset[
 
 @lru_cache(maxsize=1)
 def _index() -> _Index:
-    """Index ``mloda/`` by name: functions, the constructors a class name runs, and the names that can raise."""
+    """Index ``mloda/`` by name: functions, the constructors a class name runs, and what a call can raise or drop."""
     functions: dict[str, list[_Definition]] = {}
     constructors: dict[str, list[_Definition]] = {}
     calls: dict[str, set[str]] = {}
     direct: set[str] = set()
+    direct_swallowers: set[str] = set()
     for path in sorted(_CORE_ROOT.rglob("*.py")):
         module = path.relative_to(_REPO_ROOT).as_posix()
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=module)
@@ -370,13 +454,20 @@ def _index() -> _Index:
                 calls.setdefault(node.name, set()).update(called)
                 if raises:
                     direct.add(node.name)
+                if _swallows(node):
+                    direct_swallowers.add(node.name)
             elif isinstance(node, ast.ClassDef):
                 # A call on a CLASS name is an edge into what construction runs, which no call node names.
                 for child in node.body:
                     if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)) and child.name in _CONSTRUCTORS:
                         constructors.setdefault(node.name, []).append(_Definition(module, child))
     frozen = {name: frozenset(called) for name, called in calls.items()}
-    return _Index(functions, constructors, _raising_names(frozen, frozenset(direct)))
+    return _Index(
+        functions,
+        constructors,
+        _raising_names(frozen, frozenset(direct)),
+        _raising_names(frozen, frozenset(direct_swallowers)),
+    )
 
 
 @lru_cache(maxsize=1)
@@ -414,7 +505,7 @@ def sweep() -> _Sweep:
                     continue
                 if target.node.name in index.raising:
                     external.add(ExternalCall(target.module, target.node.name, caller))
-                if _swallows(target.node):
+                if target.node.name in index.swallowing:
                     swallowing.add(ExternalCall(target.module, target.node.name, caller))
 
     sites: list[RaiseSite] = []
@@ -506,6 +597,16 @@ def test_every_declared_module_is_reachable() -> None:
     )
 
 
+def test_the_reachable_walk_does_not_collapse() -> None:
+    """One reached definition per module already satisfies the module canary, so pin the walk's size too."""
+    reachable = sweep().reachable
+
+    # Vacuity floor, not a target: 86 definitions today, so pruning a helper stays a legitimate change.
+    assert len(reachable) >= 70, (
+        f"the walk reached only {len(reachable)} definitions; it stopped following calls somewhere"
+    )
+
+
 def test_known_escalations_are_enumerated() -> None:
     """Canary: the escalations that exist today are all seen, so a silently empty sweep cannot pass."""
     base_input_data = "mloda/core/abstract_plugins/components/input_data/base_input_data.py"
@@ -521,7 +622,7 @@ def test_known_escalations_are_enumerated() -> None:
     marked = {(site.module, site.function) for site in _of_kind("marked")}
 
     assert expected <= marked, f"known escalations missing from the sweep: {sorted(expected - marked)}"
-    # Vacuity floor, not a target: 18 sites today, so removing one stays a legitimate change.
+    # Vacuity floor, not a target: 19 sites today, so removing one stays a legitimate change.
     assert len(sweep().sites) >= 15, f"sweep enumerated only {len(sweep().sites)} raise sites; it is not walking"
 
 
@@ -640,6 +741,23 @@ def test_declared_swallowing_helpers_outside_the_path_are_still_called() -> None
     stale = sorted(entry for entry in SWALLOWING_HELPERS_OUTSIDE_THE_PATH if entry not in called)
 
     assert stale == [], f"SWALLOWING_HELPERS_OUTSIDE_THE_PATH entries the match path no longer calls: {stale}"
+
+
+def test_the_swallowing_closure_is_transitive() -> None:
+    """One wrapper that swallows nothing itself must not hide the swallow two calls below it."""
+    loader = "mloda/core/abstract_plugins/plugin_loader/plugin_loader.py"
+    definitions = [definition for definition in _index().functions.get("load_group", []) if definition.module == loader]
+
+    assert definitions and not any(_swallows(definition.node) for definition in definitions), (
+        "load_group now swallows in its own body; pick another transitive-only entry of that chain"
+    )
+
+    pairs = {(call.module, call.function) for call in sweep().swallowing_external}
+
+    assert (loader, "load_group") in pairs, (
+        "get_all_filtered_subclasses calls load_group, which reaches _load_plugin, whose handler swallows. A "
+        f"depth-1 swallow check sees none of it. Seen instead: {sorted(pairs)}"
+    )
 
 
 def test_known_escalating_handlers_are_enumerated() -> None:
@@ -788,3 +906,242 @@ def test_handler_classifier_flags_a_swallows_comment_on_a_reraise() -> None:
 
     assert [site.kind for site in sites] == ["misannotated"]
     assert sites[0].reason == "stale, this handler re-raises."
+
+
+# A raise only escalates when the object leaving the handler is the marked one, and nothing skips it.
+
+
+def test_handler_classifier_flags_a_replacement_raise() -> None:
+    """A brand-new exception object carries no marker, so raising it contains the abort."""
+    source = (
+        "def match_feature_group_criteria(cls, feature, options):\n"
+        "    try:\n"
+        "        return probe(feature)\n"
+        "    except Exception:\n"
+        "        raise ValueError('brand new')\n"
+    )
+
+    sites = _handlers(source)
+
+    assert [site.kind for site in sites] == ["unannotated"]
+    assert sites[0].lineno == 4
+
+
+def test_handler_classifier_flags_a_replacement_raise_chained_from_the_caught_name() -> None:
+    """``from exc`` chains the traceback, not the marker: the object leaving the handler is still a new one."""
+    source = (
+        "def match_feature_group_criteria(cls, feature, options):\n"
+        "    try:\n"
+        "        return probe(feature)\n"
+        "    except Exception as exc:\n"
+        "        raise ValueError('brand new') from exc\n"
+    )
+
+    sites = _handlers(source)
+
+    assert [site.kind for site in sites] == ["unannotated"]
+
+
+def test_handler_classifier_accepts_a_reraise_of_the_bound_name() -> None:
+    """``raise exc`` re-raises the caught object itself, marker intact."""
+    source = (
+        "def match_feature_group_criteria(cls, feature, options):\n"
+        "    try:\n"
+        "        return probe(feature)\n"
+        "    except ValueError as exc:\n"
+        "        record(exc)\n"
+        "        raise exc\n"
+    )
+
+    sites = _handlers(source)
+
+    assert [site.kind for site in sites] == ["escalating"]
+
+
+def test_handler_classifier_accepts_a_raise_of_a_freshly_escalated_exception() -> None:
+    """Rewrapping is fine as long as the replacement is marked on its way out."""
+    source = (
+        "def match_feature_group_criteria(cls, feature, options):\n"
+        "    try:\n"
+        "        return probe(feature)\n"
+        "    except ValueError as exc:\n"
+        "        raise escalate_match_abort(RuntimeError('rewrapped'))\n"
+    )
+
+    sites = _handlers(source)
+
+    assert [site.kind for site in sites] == ["escalating"]
+
+
+def test_handler_classifier_flags_a_reraise_the_handler_can_skip() -> None:
+    """A bare raise on one path and a return on another swallows whenever the return wins."""
+    source = (
+        "def match_feature_group_criteria(cls, feature, options):\n"
+        "    try:\n"
+        "        return probe(feature)\n"
+        "    except ImportError:\n"
+        "        if options is None:\n"
+        "            return None\n"
+        "        raise\n"
+    )
+
+    sites = _handlers(source)
+
+    assert [site.kind for site in sites] == ["unannotated"]
+
+
+# ``except`` is not the only way to drop an exception: suppress() and an escaping finally do it too.
+
+
+def test_handler_classifier_flags_a_contextlib_suppress() -> None:
+    """``suppress`` discards the exception exactly as a bare except does, so it owes the same decision."""
+    source = (
+        "def match_feature_group_criteria(cls, feature, options):\n"
+        "    with contextlib.suppress(Exception):\n"
+        "        return probe(feature)\n"
+        "    return False\n"
+    )
+
+    sites = _handlers(source)
+
+    assert [site.kind for site in sites] == ["unannotated"]
+    assert sites[0].lineno == 2
+
+
+def test_handler_classifier_accepts_a_swallows_comment_on_a_suppress() -> None:
+    source = (
+        "def match_feature_group_criteria(cls, feature, options):\n"
+        "    with suppress(ValueError):  # Swallows: a malformed name is this candidate's own defect.\n"
+        "        return probe(feature)\n"
+        "    return False\n"
+    )
+
+    sites = _handlers(source)
+
+    assert [site.kind for site in sites] == ["swallowing"]
+    assert sites[0].reason == "a malformed name is this candidate's own defect."
+
+
+def test_handler_classifier_flags_a_finally_that_returns() -> None:
+    """A return in finally discards the in-flight exception, marker and all."""
+    source = (
+        "def match_feature_group_criteria(cls, feature, options):\n"
+        "    try:\n"
+        "        return probe(feature)\n"
+        "    finally:\n"
+        "        return False\n"
+    )
+
+    sites = _handlers(source)
+
+    assert [site.kind for site in sites] == ["unannotated"]
+    # Anchored at the try line: ast.Try carries no lineno for the finally keyword.
+    assert sites[0].lineno == 2
+
+
+def test_handler_classifier_accepts_a_swallows_comment_on_a_finally_that_returns() -> None:
+    source = (
+        "def match_feature_group_criteria(cls, feature, options):\n"
+        "    # Swallows: the cleanup verdict outranks the probe's, by this reader's contract.\n"
+        "    try:\n"
+        "        return probe(feature)\n"
+        "    finally:\n"
+        "        return False\n"
+    )
+
+    sites = _handlers(source)
+
+    assert [site.kind for site in sites] == ["swallowing"]
+    assert sites[0].reason == "the cleanup verdict outranks the probe's, by this reader's contract."
+
+
+# An own-line reason belongs to the site at its own column; a trailing one may sit anywhere in the site's header.
+
+
+def test_handler_classifier_ignores_a_swallows_comment_indented_past_the_except() -> None:
+    """A reason written as the last line of the try body sits deeper than the except and annotates nothing."""
+    source = (
+        "def match_feature_group_criteria(cls, feature, options):\n"
+        "    try:\n"
+        "        probe(feature)\n"
+        "        # Swallows: this belongs to the try body, not to the handler under it.\n"
+        "    except ValueError:\n"
+        "        return False\n"
+    )
+
+    sites = _handlers(source)
+
+    assert [site.kind for site in sites] == ["unannotated"]
+
+
+def test_handler_classifier_ignores_a_swallows_comment_left_in_an_earlier_handler_body() -> None:
+    """A reason trailing the previous handler's body is indented past the next except, so it cannot annotate it."""
+    source = (
+        "def match_feature_group_criteria(cls, feature, options):\n"
+        "    try:\n"
+        "        return probe(feature)\n"
+        "    except OSError:  # Swallows: a missing file is a non-match for this reader only.\n"
+        "        return False\n"
+        "        # Swallows: this trails the OSError body; the next handler needs its own reason.\n"
+        "    except ValueError:\n"
+        "        return False\n"
+    )
+
+    sites = _handlers(source)
+
+    assert [site.kind for site in sites] == ["swallowing", "unannotated"]
+
+
+def test_handler_classifier_accepts_a_trailing_comment_on_a_split_exception_tuple() -> None:
+    """ruff format pushes the tag onto the closing-paren line, past the except's own lineno."""
+    source = (
+        "def match_feature_group_criteria(cls, feature, options):\n"
+        "    try:\n"
+        "        return probe(feature)\n"
+        "    except (\n"
+        "        ValueError,\n"
+        "        TypeError,\n"
+        "    ):  # Swallows: a malformed name is this candidate's own defect.\n"
+        "        return False\n"
+    )
+
+    sites = _handlers(source)
+
+    assert [site.kind for site in sites] == ["swallowing"]
+    assert sites[0].lineno == 4
+    assert sites[0].reason == "a malformed name is this candidate's own defect."
+
+
+def _splice_blanket_handler(source: str, function: str) -> tuple[str, int]:
+    """Insert a blanket handler at the top of ``function``'s body; in memory only, never written back to disk."""
+    targets = [
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == function
+    ]
+    assert len(targets) == 1, f"{function} is not a single definition in this module: {len(targets)} found"
+    first = targets[0].body[0]
+    pad = " " * first.col_offset
+    block = [f"{pad}try:", f"{pad}    probe()", f"{pad}except Exception:", f"{pad}    return False"]
+    lines = source.splitlines()
+    at = first.lineno - 1
+    return "\n".join([*lines[:at], *block, *lines[at:]]) + "\n", first.lineno + 2
+
+
+def test_the_sweep_flags_a_blanket_handler_spliced_into_the_real_seam() -> None:
+    """End to end: the real reachable set and the classifier on real source, mutated in memory only."""
+    module = "mloda/core/prepare/identify_feature_group.py"
+    function = "_filter_feature_group_by_criteria"
+    names = frozenset(name for reached_module, name in sweep().reachable if reached_module == module)
+    assert function in names, f"{function} is no longer reachable; splice into another reached definition"
+
+    source = (_REPO_ROOT / module).read_text(encoding="utf-8")
+    assert [site for site in classify_handlers(source, module, names) if site.kind == "unannotated"] == []
+
+    mutated, lineno = _splice_blanket_handler(source, function)
+    spliced = [site for site in classify_handlers(mutated, module, names) if site.lineno == lineno]
+
+    assert [site.kind for site in spliced] == ["unannotated"], (
+        f"a blanket handler spliced into the seam itself was not flagged: {spliced}"
+    )
+    assert spliced[0].function == function

--- a/tests/test_core/test_prepare/test_match_abort_sweep.py
+++ b/tests/test_core/test_prepare/test_match_abort_sweep.py
@@ -8,8 +8,12 @@ raise: the escalation call, or a ``# Contained: <reason>`` comment on the raise 
 directly above it. A reason elsewhere in the enclosing function is not accepted; a later raise would inherit
 it and the gate would rot.
 
+A sibling sweep walks the same reachable set for ``except`` handlers: a mark only survives if every handler
+between the raise and the seam re-raises it, so each handler must re-raise on ``is_match_abort`` or carry a
+``# Swallows: <reason>`` comment.
+
 Not covered: plugin code under ``mloda_plugins``; dynamic dispatch, which is why SEEDS is hand-written;
-decorators; handlers between a marked raise and the seam (test_match_abort_escalation.py owns those).
+decorators.
 """
 
 from __future__ import annotations
@@ -81,14 +85,28 @@ RAISING_HELPERS_OUTSIDE_THE_PATH: dict[tuple[str, str], str] = {
     ("mloda/core/runtime/run.py", "join"): "name collision: str.join, not the runner's join",
 }
 
+# Swallowing functions OUTSIDE the declared modules that the match path calls; a handler there is decided here.
+SWALLOWING_HELPERS_OUTSIDE_THE_PATH: dict[tuple[str, str], str] = {
+    ("mloda/core/abstract_plugins/components/utils.py", "safe_field"): (
+        "it degrades one field in a rendering path, so swallowing a marked exception is its contract"
+    ),
+    ("mloda/core/abstract_plugins/components/utils.py", "escalate_match_abort"): (
+        "the guard around the marker write; failing to mark must not replace the exception being marked"
+    ),
+}
+
 _ESCALATION = "escalate_match_abort"
+_ABORT_CHECK = "is_match_abort"
 _CONTAINED_TAG = "Contained:"
 _MARKED_TAG = "Marked:"
+_SWALLOW_TAG = "Swallows:"
 
 # Constructing a class runs these, so a call on a class name is an edge into them.
 _CONSTRUCTORS: frozenset[str] = frozenset({"__init__", "__post_init__"})
 
 Kind = Literal["marked", "contained", "mismarked", "unannotated"]
+
+HandlerKind = Literal["escalating", "swallowing", "misannotated", "unannotated"]
 
 
 class RaiseSite(NamedTuple):
@@ -98,6 +116,19 @@ class RaiseSite(NamedTuple):
     lineno: int
     function: str
     kind: Kind
+    reason: str | None
+
+    def location(self) -> str:
+        return f"{self.module}:{self.lineno} {self.function}()"
+
+
+class HandlerSite(NamedTuple):
+    """One ``except`` clause and the containment decision written at it."""
+
+    module: str
+    lineno: int
+    function: str
+    kind: HandlerKind
     reason: str | None
 
     def location(self) -> str:
@@ -121,6 +152,8 @@ class _Sweep(NamedTuple):
     sites: tuple[RaiseSite, ...]
     reachable: frozenset[tuple[str, str]]
     external: tuple[ExternalCall, ...]
+    handlers: tuple[HandlerSite, ...]
+    swallowing_external: tuple[ExternalCall, ...]
 
 
 def _scan(node: ast.AST) -> tuple[frozenset[str], bool]:
@@ -150,6 +183,23 @@ def _scan(node: ast.AST) -> tuple[frozenset[str], bool]:
 
 def _escalates(node: ast.AST) -> bool:
     return _ESCALATION in _scan(node)[0]
+
+
+def _handler_escalates(handler: ast.ExceptHandler) -> bool:
+    """A raise as a direct child re-raises unconditionally; otherwise the abort check needs a raise beside it."""
+    if any(isinstance(statement, ast.Raise) for statement in handler.body):
+        return True
+    calls: set[str] = set()
+    raises = False
+    for statement in handler.body:
+        calls |= _scan(statement)[0]
+        raises = raises or any(isinstance(node, ast.Raise) for node in ast.walk(statement))
+    return raises and _ABORT_CHECK in calls
+
+
+def _swallows(node: ast.AST) -> bool:
+    """Does this definition hold a handler that neither re-raises nor checks the marker."""
+    return any(isinstance(child, ast.ExceptHandler) and not _handler_escalates(child) for child in ast.walk(node))
 
 
 def _own_line_and_trailing_comments(source: str) -> tuple[dict[int, str], dict[int, str]]:
@@ -240,6 +290,44 @@ def classify_raises(source: str, module: str, functions: frozenset[str] | None =
     return sorted(sites)
 
 
+def _collect_handlers(node: ast.AST, functions: list[str], out: list[tuple[ast.ExceptHandler, list[str]]]) -> None:
+    """Walk ``node``, recording each except clause with its enclosing function chain."""
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            _collect_handlers(child, [*functions, child.name], out)
+        else:
+            if isinstance(child, ast.ExceptHandler):
+                out.append((child, functions))
+            _collect_handlers(child, functions, out)
+
+
+def classify_handlers(source: str, module: str, functions: frozenset[str] | None = None) -> list[HandlerSite]:
+    """Classify every ``except`` clause in ``source``, restricted to handlers inside the named functions."""
+    tree = ast.parse(source, filename=module)
+    own_line, trailing = _own_line_and_trailing_comments(source)
+    found: list[tuple[ast.ExceptHandler, list[str]]] = []
+    _collect_handlers(tree, [], found)
+
+    sites: list[HandlerSite] = []
+    for handler, chain in found:
+        if not chain:
+            continue
+        if functions is not None and not any(name in functions for name in chain):
+            continue
+        escalating = _handler_escalates(handler)
+        # Anchored at the except line only: a reason elsewhere in the function would bless the next handler too.
+        declared = _anchored_reason(own_line, trailing, handler.lineno, _SWALLOW_TAG)
+        kind: HandlerKind
+        if escalating:
+            kind, reason = ("misannotated", declared) if declared is not None else ("escalating", None)
+        elif declared is not None:
+            kind, reason = "swallowing", declared
+        else:
+            kind, reason = "unannotated", None
+        sites.append(HandlerSite(module, handler.lineno, chain[-1], kind, reason))
+    return sorted(sites)
+
+
 class _Index(NamedTuple):
     """Every definition under ``mloda/``, plus the names whose call can raise."""
 
@@ -311,6 +399,7 @@ def sweep() -> _Sweep:
 
     reachable: set[tuple[str, str]] = set()
     external: set[ExternalCall] = set()
+    swallowing: set[ExternalCall] = set()
     while queue:
         definition = queue.popleft()
         reachable.add((definition.module, definition.node.name))
@@ -322,16 +411,27 @@ def sweep() -> _Sweep:
                     if key not in visited:
                         visited.add(key)
                         queue.append(target)
-                elif target.node.name in index.raising:
+                    continue
+                if target.node.name in index.raising:
                     external.add(ExternalCall(target.module, target.node.name, caller))
+                if _swallows(target.node):
+                    swallowing.add(ExternalCall(target.module, target.node.name, caller))
 
     sites: list[RaiseSite] = []
+    handlers: list[HandlerSite] = []
     for module in sorted({module for module, _ in reachable}):
         names = frozenset(name for reached_module, name in reachable if reached_module == module)
         source = (_REPO_ROOT / module).read_text(encoding="utf-8")
         sites.extend(classify_raises(source, module, names))
+        handlers.extend(classify_handlers(source, module, names))
 
-    return _Sweep(tuple(sorted(sites)), frozenset(reachable), tuple(sorted(external)))
+    return _Sweep(
+        tuple(sorted(sites)),
+        frozenset(reachable),
+        tuple(sorted(external)),
+        tuple(sorted(handlers)),
+        tuple(sorted(swallowing)),
+    )
 
 
 def _of_kind(kind: Kind) -> list[RaiseSite]:
@@ -487,3 +587,204 @@ def test_classifier_flags_a_marked_comment_without_an_escalation() -> None:
     sites = classify_raises(source, "snippet.py", frozenset({"match_feature_group_criteria"}))
 
     assert [site.kind for site in sites] == ["mismarked"]
+
+
+# The handler sweep: same reachable set, one decision per except clause.
+
+
+def _handlers_of_kind(kind: HandlerKind) -> list[HandlerSite]:
+    return [site for site in sweep().handlers if site.kind == kind]
+
+
+def _handlers(source: str) -> list[HandlerSite]:
+    return classify_handlers(source, "snippet.py", frozenset({"match_feature_group_criteria"}))
+
+
+def test_every_reachable_handler_escalates_or_declares_a_swallow() -> None:
+    unannotated = _handlers_of_kind("unannotated")
+
+    assert unannotated == [], (
+        "Handlers reachable from the match seams with no containment decision:\n"
+        + "\n".join(f"  {site.location()}" for site in unannotated)
+        + "\n\nA handler that swallows a marked raise undoes the escalation. Record the decision at the "
+        f"handler: re-raise when is_match_abort(exc) holds, or write '# {_SWALLOW_TAG} <reason>' on the except line."
+    )
+
+
+def test_no_swallows_comment_on_a_reraising_handler() -> None:
+    misannotated = _handlers_of_kind("misannotated")
+
+    assert misannotated == [], f"Handlers carrying a '# {_SWALLOW_TAG}' comment that re-raise anyway:\n" + "\n".join(
+        f"  {site.location()}: {site.reason}" for site in misannotated
+    )
+
+
+def test_calls_into_swallowing_helpers_outside_the_path_are_declared() -> None:
+    undeclared = [
+        call
+        for call in sweep().swallowing_external
+        if (call.module, call.function) not in SWALLOWING_HELPERS_OUTSIDE_THE_PATH
+    ]
+
+    assert undeclared == [], (
+        "The match path calls functions outside the declared modules that swallow exceptions:\n"
+        + "\n".join(f"  {call.module}::{call.function} from {call.caller}" for call in undeclared)
+        + "\n\nDeclare the (module, function) pair in SWALLOWING_HELPERS_OUTSIDE_THE_PATH with a reason, or add "
+        "the module to MATCH_PATH_MODULES so its handlers are swept."
+    )
+
+
+def test_declared_swallowing_helpers_outside_the_path_are_still_called() -> None:
+    """Stale entries cannot accumulate: every declared swallowing helper must still be reached."""
+    called = {(call.module, call.function) for call in sweep().swallowing_external}
+    stale = sorted(entry for entry in SWALLOWING_HELPERS_OUTSIDE_THE_PATH if entry not in called)
+
+    assert stale == [], f"SWALLOWING_HELPERS_OUTSIDE_THE_PATH entries the match path no longer calls: {stale}"
+
+
+def test_known_escalating_handlers_are_enumerated() -> None:
+    """Canary: the handlers that re-raise today are all seen, so a silently empty handler sweep cannot pass."""
+    seam = "mloda/core/prepare/identify_feature_group.py"
+    feature_group = "mloda/core/abstract_plugins/feature_group.py"
+    mixin = "mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py"
+    guards = "mloda/core/abstract_plugins/components/feature_chainer/feature_chain_author_guards.py"
+    expected = {
+        (seam, "_filter_feature_group_by_criteria"),
+        (feature_group, "is_root"),
+        (mixin, "match_parser_criteria"),
+        (guards, "check_required_when"),
+    }
+
+    escalating = {(site.module, site.function) for site in _handlers_of_kind("escalating")}
+
+    assert expected <= escalating, f"known escalating handlers missing from the sweep: {sorted(expected - escalating)}"
+    # Vacuity floor, not a target: 15 handlers today, so removing one stays a legitimate change.
+    assert len(sweep().handlers) >= 12, f"sweep enumerated only {len(sweep().handlers)} handlers; it is not walking"
+
+
+def test_handler_classifier_flags_a_blanket_handler() -> None:
+    source = (
+        "def match_feature_group_criteria(cls, feature, options):\n"
+        "    try:\n"
+        "        return probe(feature)\n"
+        "    except Exception:\n"
+        "        return False\n"
+    )
+
+    sites = _handlers(source)
+
+    assert [site.kind for site in sites] == ["unannotated"]
+    assert sites[0].lineno == 4
+
+
+def test_handler_classifier_accepts_a_conditional_reraise() -> None:
+    source = (
+        "def match_feature_group_criteria(cls, feature, options):\n"
+        "    try:\n"
+        "        return probe(feature)\n"
+        "    except ValueError as exc:\n"
+        "        if is_match_abort(exc):\n"
+        "            raise\n"
+        "        return False\n"
+    )
+
+    sites = _handlers(source)
+
+    assert [site.kind for site in sites] == ["escalating"]
+
+
+def test_handler_classifier_accepts_an_escalation_and_a_bare_reraise() -> None:
+    source = (
+        "def match_feature_group_criteria(cls, feature, options):\n"
+        "    try:\n"
+        "        return probe(feature)\n"
+        "    except Exception as exc:\n"
+        "        escalate_match_abort(exc)\n"
+        "        raise\n"
+    )
+
+    sites = _handlers(source)
+
+    assert [site.kind for site in sites] == ["escalating"]
+
+
+def test_handler_classifier_accepts_a_trailing_swallows_comment() -> None:
+    source = (
+        "def match_feature_group_criteria(cls, feature, options):\n"
+        "    try:\n"
+        "        return probe(feature)\n"
+        "    except ValueError:  # Swallows: a malformed name is this candidate's own defect.\n"
+        "        return False\n"
+    )
+
+    sites = _handlers(source)
+
+    assert [site.kind for site in sites] == ["swallowing"]
+    assert sites[0].reason == "a malformed name is this candidate's own defect."
+
+
+def test_handler_classifier_accepts_an_own_line_swallows_comment() -> None:
+    source = (
+        "def match_feature_group_criteria(cls, feature, options):\n"
+        "    try:\n"
+        "        return probe(feature)\n"
+        "    # Swallows: a missing file is a non-match for this reader only.\n"
+        "    except OSError:\n"
+        "        return False\n"
+    )
+
+    sites = _handlers(source)
+
+    assert [site.kind for site in sites] == ["swallowing"]
+    assert sites[0].reason == "a missing file is a non-match for this reader only."
+
+
+def test_handler_classifier_requires_a_raise_beside_the_abort_check() -> None:
+    """Reading is_match_abort without re-raising escalates nothing."""
+    source = (
+        "def match_feature_group_criteria(cls, feature, options):\n"
+        "    try:\n"
+        "        return probe(feature)\n"
+        "    except ValueError as exc:\n"
+        "        if is_match_abort(exc):\n"
+        "            record(exc)\n"
+        "        return False\n"
+    )
+
+    sites = _handlers(source)
+
+    assert [site.kind for site in sites] == ["unannotated"]
+
+
+def test_handler_classifier_does_not_inherit_a_swallows_reason() -> None:
+    """A reason on an earlier handler annotates nothing: the next handler needs its own."""
+    source = (
+        "def match_feature_group_criteria(cls, feature, options):\n"
+        "    try:\n"
+        "        return probe(feature)\n"
+        "    except OSError:  # Swallows: a missing file is a non-match for this reader only.\n"
+        "        return False\n"
+        "    except ValueError:\n"
+        "        return False\n"
+    )
+
+    sites = _handlers(source)
+
+    assert [site.kind for site in sites] == ["swallowing", "unannotated"]
+
+
+def test_handler_classifier_flags_a_swallows_comment_on_a_reraise() -> None:
+    source = (
+        "def match_feature_group_criteria(cls, feature, options):\n"
+        "    try:\n"
+        "        return probe(feature)\n"
+        "    except ValueError as exc:  # Swallows: stale, this handler re-raises.\n"
+        "        if is_match_abort(exc):\n"
+        "            raise\n"
+        "        return False\n"
+    )
+
+    sites = _handlers(source)
+
+    assert [site.kind for site in sites] == ["misannotated"]
+    assert sites[0].reason == "stale, this handler re-raises."


### PR DESCRIPTION
Closes #931.

`escalate_match_abort` only means anything if every `except` between the raise and the match seam re-raises when `is_match_abort(exc)` holds. The raise sweep added in #930 gates the raises; the handlers between them were still hand-maintained, and the two that swallowed marks were both found by review rather than by a test.

## What this adds

A sibling sweep in `test_match_abort_sweep.py` walks the same reachable set the raise sweep already computes and requires a decision at every containment it finds:

- **escalating**: a re-raise that keeps the marker, either gated on `is_match_abort` or standing on every path out of the handler.
- **swallowing**: a `# Swallows: <reason>` comment anchored at the site, the way a contained raise records its reason at the raise.

Anything else turns the gate red, so the next broad handler on the match path cannot slip in unannotated.

A containment is not only an `except`: `contextlib.suppress` and a `finally` that returns drop an in-flight exception just as effectively, and rewriting a handler as either would otherwise be the shortest way to make a gate failure disappear. Helpers outside the declared modules that swallow are declared in a table with a staleness check, mirroring the raising one, and that closure is transitive so a wrapper with no `try` of its own cannot hide a swallow below it.

15 containments are reachable today: 7 escalate, 8 record a deliberate swallow at a user-callback boundary (`required_when`, `element_validator`, `match_guard`) or a narrow probe (membership on an unhashable value, `suffix()`).

## Behavior change

Two handlers sat above a marked-aware handler on the same `try` and shadowed it, the same shape as the two bugs this issue describes:

- `match_parser_criteria`'s `except PropertyValueRejection`, which subclasses `ValueError` and so preceded the clause that checks the mark.
- `is_root`'s `except NotImplementedError`, which preceded the clause that checks the mark and returned `True`, claiming the group is a root.

Both run the abort check now. Nothing marks either type today, so this is inert in practice; it removes the ordering trap, since `check_required_when` marks whatever `build_effective_options` raises.

Everything else under `mloda/` in this PR is comments.

## Testing

`tox` passes: 8047 passed, 170 skipped, plus ruff format, ruff check, licenses, `mypy --strict` and bandit.

The gate is proven to fire, not just asserted: a blanket handler spliced into the real seam's source is classified unannotated, and the classifier tests cover the replacement raise, the skippable re-raise, `suppress`, an escaping `finally`, a reason indented past its site, and a reason left in an earlier handler.