### PR TITLE
fix: reject allow_explicit_none on a framework_set reader option

### DIFF
--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -144,7 +144,8 @@ consequences keep the shared type honest on this surface:
   reader does not have, so `BaseInputData.__init_subclass__` rejects them instead of leaving them
   silently inert (#865). `framework_set=True` marks the one framework-written key, the reserved
   `"BaseInputData"` pair written by `add_base_input_data_to_options` and read by `init_reader`.
-  Such keys are exempt from enforcement, so enforcement fields on them are rejected too; on
+  Such keys are exempt from enforcement, so enforcement fields on them are rejected too, as is
+  `allow_explicit_none`, which the admit path never reads on a framework-written key; on
   `PROPERTY_MAPPING` the field is rejected outright.
 
 `READER_OPTIONS` merges across the MRO (`reader_option_specs()`, most-derived declaration winning),

--- a/mloda/core/abstract_plugins/components/input_data/base_input_data.py
+++ b/mloda/core/abstract_plugins/components/input_data/base_input_data.py
@@ -29,7 +29,6 @@ class BaseInputData(ABC):
             "and read back by init_reader.",
             default=None,
             framework_set=True,
-            allow_explicit_none=True,
         ),
     }
 
@@ -80,6 +79,12 @@ class BaseInputData(ABC):
                         f"{cls.__name__}.READER_OPTIONS['{key}'] combines framework_set=True with a "
                         f"required_when predicate; the framework-written key is exempt from user-value "
                         f"validation, so the predicate would be silently inert."
+                    )
+                if spec.allow_explicit_none:
+                    raise ValueError(
+                        f"{cls.__name__}.READER_OPTIONS['{key}'] combines framework_set=True with "
+                        f"allow_explicit_none=True; the admit path skips the framework-written key, "
+                        f"so the flag would be silently inert."
                     )
                 if is_no_default(spec.default):
                     raise ValueError(

--- a/mloda/core/abstract_plugins/components/input_data/base_input_data.py
+++ b/mloda/core/abstract_plugins/components/input_data/base_input_data.py
@@ -84,7 +84,7 @@ class BaseInputData(ABC):
                     raise ValueError(
                         f"{cls.__name__}.READER_OPTIONS['{key}'] combines framework_set=True with "
                         f"allow_explicit_none=True; the admit path skips the framework-written key, "
-                        f"so the flag would be silently inert."
+                        f"so the flag cannot affect reader selection."
                     )
                 if is_no_default(spec.default):
                     raise ValueError(

--- a/tests/test_core/test_abstract_plugins/test_components/test_reader_option_declarations.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_reader_option_declarations.py
@@ -150,6 +150,14 @@ class TestReservedFrameworkKey:
         assert BaseInputData.reader_option_specs()["BaseInputData"].default is None
         assert BaseInputData.reader_option_default("BaseInputData") is None
 
+    def test_reserved_key_does_not_declare_allow_explicit_none(self) -> None:
+        """The flag is inert on a framework-written key, so the base must not declare it."""
+        assert BaseInputData.reader_option_specs()["BaseInputData"].allow_explicit_none is False
+
+    def test_base_declaration_passes_its_own_guard(self) -> None:
+        """``__init_subclass__`` never validates the base itself; this pin keeps the base honest."""
+        BaseInputData._validate_reader_options()
+
     def test_reserved_key_is_the_key_the_framework_actually_writes(self) -> None:
         """``add_base_input_data_to_options`` writes exactly the keys declared ``framework_set``.
 
@@ -749,6 +757,27 @@ class TestReaderOptionsAreValidatedAtClassDefinition:
         assert "rod_fw_bare_key" in message
         assert "framework_set" in message
         assert "default" in message
+
+    def test_framework_set_with_allow_explicit_none_rejected(self) -> None:
+        """The admit path skips framework keys before reading the flag, so declaring it is inert."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class RodFrameworkAllowNoneReader(BaseInputData):
+                READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+                    "rod_fw_allow_none_key": PropertySpec(
+                        "Framework-written.",
+                        allow_explicit_none=True,
+                        default=None,
+                        framework_set=True,
+                    ),
+                }
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "RodFrameworkAllowNoneReader" in message
+        assert "rod_fw_allow_none_key" in message
+        assert "framework_set" in message
+        assert "allow_explicit_none" in message
 
     def test_a_strict_allowed_values_declaration_defines_fine(self) -> None:
         """Strict specs are the point of the collapse; a valued one with an in-space default defines."""


### PR DESCRIPTION
## Summary

`PropertySpec.allow_explicit_none` was silently inert on a `framework_set` reader option: `_reader_options_admit` skips framework-written keys before it reads the flag. `_validate_reader_options` already rejects the three sibling inert combinations on such keys (`strict_validation`, `required_when`, missing default) but not this one, which let the reserved `"BaseInputData"` key carry a declaration that contradicted the actual treatment.

## Changes

- `_validate_reader_options` rejects `framework_set=True` combined with `allow_explicit_none=True` at class definition, mirroring the sibling guards. The message claims only what the admit-path skip makes true: the flag cannot affect reader selection.
- The reserved `"BaseInputData"` declaration drops `allow_explicit_none=True`. Behavior neutral: its declared default is `None`, so `reader_option` returns `None` for a stored `None` either way.
- Tests alongside the existing inert-combination tests: the new rejection with message pins, a pin that the reserved key does not declare the flag, and a pin that the base's own declaration passes its own guard (`__init_subclass__` never validates the base itself).
- `docs/docs/in_depth/property-mapping.md` names the new rejection.

## Review

Two independent deep reviews ran on the diff. Accepted: narrow the guard message (reader_option still reads the flag, so "inert everywhere" overstated it) and the doc clause. Deferred as a follow-up issue: a subclass redeclaring the reserved key without `framework_set=True` escapes all four guards (pre-existing).

## Testing

- `tox` green: 8090 passed, 170 skipped; ruff, mypy --strict, bandit, licenses clean.

Closes #968

🤖 Generated with [Claude Code](https://claude.com/claude-code)
