### PR TITLE
fix: rehash planned-queue feature sets after compute framework rewrite

### DIFF
--- a/mloda/core/core/engine.py
+++ b/mloda/core/core/engine.py
@@ -51,6 +51,7 @@ class Engine:
         column_ordering: Optional[str] = None,
     ) -> None:
         # setup variables which track the primary sources and the compute platforms
+        # Holds the Feature objects ResolveComputeFrameworks.links rewrites: hash-stale after planning, so only read it before planning (as today).
         self.feature_group_collection: dict[type[FeatureGroup], set[Feature]] = defaultdict(set)
 
         # use global filters

--- a/mloda/core/core/engine.py
+++ b/mloda/core/core/engine.py
@@ -463,6 +463,7 @@ class Engine:
                     f"Feature {feature.name} does not support compute framework {feature.compute_frameworks}."
                 )
         else:
+            # Hash-safe only because this runs before add_feature_to_collection stores the feature.
             feature.compute_frameworks = compute_frameworks
         return feature
 

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -278,6 +278,7 @@ class GlobalFilter:
     def compute_framework(self, filter: SingleFilter, feat: Feature) -> bool:
         # case that the filter feature has no cf set -> feature defines it
         if not filter.filter_feature.compute_frameworks:
+            # Hash-safe: the target is a per-match deepcopy, added to matched_filters only after all mutations.
             filter.filter_feature.compute_frameworks = feat.compute_frameworks
             return True
 

--- a/mloda/core/prepare/resolve_compute_frameworks.py
+++ b/mloda/core/prepare/resolve_compute_frameworks.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 from typing import Any
-from collections import defaultdict
+from collections import Counter, defaultdict
 from uuid import UUID
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.prepare.graph.graph import Graph
@@ -23,14 +23,24 @@ class ResolveComputeFrameworks:
                     if trekked_links:
                         new_compute_frameworks = self.resolve_trekked_links(trekked_links, feature.compute_frameworks)
                         for f in p[1]:
-                            f.compute_frameworks = new_compute_frameworks
+                            f.compute_frameworks = set(new_compute_frameworks)
 
                         self.trekker_right_left_adjuster(link_trekker, {_f.uuid for _f in p[1]})
 
-                        # Rewriting compute_frameworks moves member hashes: rehash so the set and aliases stay valid.
+                        # Rehash via list so hashes are recomputed (set(p[1]) reuses stale ones), keeping set and aliases valid.
                         members = list(p[1])
                         p[1].clear()
                         p[1].update(members)
+                        if len(p[1]) != len(members):
+                            names = sorted(
+                                name
+                                for name, count in Counter(str(member.name) for member in members).items()
+                                if count > 1
+                            )
+                            raise ValueError(
+                                "Compute framework rewrite collapsed features that were previously distinct "
+                                f"only by compute_frameworks. Affected: {names}"
+                            )
 
             new_planned_queue.append(p)
 

--- a/mloda/core/prepare/resolve_compute_frameworks.py
+++ b/mloda/core/prepare/resolve_compute_frameworks.py
@@ -27,6 +27,11 @@ class ResolveComputeFrameworks:
 
                         self.trekker_right_left_adjuster(link_trekker, {_f.uuid for _f in p[1]})
 
+                        # Rewriting compute_frameworks moves member hashes: rehash so the set and aliases stay valid.
+                        members = list(p[1])
+                        p[1].clear()
+                        p[1].update(members)
+
             new_planned_queue.append(p)
 
         link_trekker.order_links_by_frameworks()

--- a/tests/test_core/test_prepare/test_resolve_cfw_set_membership.py
+++ b/tests/test_core/test_prepare/test_resolve_cfw_set_membership.py
@@ -2,6 +2,8 @@
 
 from typing import Any
 
+import pytest
+
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.link import JoinSpec, Link
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
@@ -12,12 +14,22 @@ from mloda_plugins.compute_framework.base_implementations.pandas.dataframe impor
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
 
 
-class LeftGroup(FeatureGroup):
+class CfwRehashLeftFG(FeatureGroup):
     pass
 
 
-class RightGroup(FeatureGroup):
+class CfwRehashRightFG(FeatureGroup):
     pass
+
+
+def _links_call(planned_queue: list[Any], features: list[Feature]) -> Any:
+    link = Link.inner(JoinSpec(CfwRehashLeftFG, "idx"), JoinSpec(CfwRehashRightFG, "idx"))
+    trekker = (link, PandasDataFrame, PyArrowTable)
+
+    link_trekker = LinkTrekker()
+    link_trekker.data_ordered[trekker] = {feature.uuid for feature in features}
+
+    return ResolveComputeFrameworks(Graph()).links(planned_queue, link_trekker)
 
 
 def test_features_remain_set_members_after_links_rewrites_compute_frameworks() -> None:
@@ -28,23 +40,33 @@ def test_features_remain_set_members_after_links_rewrites_compute_frameworks() -
     feature_b.compute_frameworks = {PandasDataFrame, PyArrowTable}
 
     feature_set = {feature_a, feature_b}
-    planned_queue: list[Any] = [(LeftGroup, feature_set)]
+    planned_queue: list[Any] = [(CfwRehashLeftFG, feature_set)]
 
-    link = Link.inner(JoinSpec(LeftGroup, "idx"), JoinSpec(RightGroup, "idx"))
-    trekker = (link, PandasDataFrame, PyArrowTable)
-
-    link_trekker = LinkTrekker()
-    link_trekker.data_ordered[trekker] = {feature_a.uuid, feature_b.uuid}
-
-    result = ResolveComputeFrameworks(Graph()).links(planned_queue, link_trekker)
+    result = _links_call(planned_queue, [feature_a, feature_b])
 
     returned_set = result[0][1]
-    # The trekked path narrows the frameworks.
-    assert next(iter(returned_set)).compute_frameworks == {PandasDataFrame}
+    # The trekked path narrows the frameworks for every member.
+    for feature in returned_set:
+        assert feature.compute_frameworks == {PandasDataFrame}
 
     for feature in returned_set:
         assert feature in returned_set, f"{feature.name} stranded in returned queue set after rewrite"
 
     assert feature_set is returned_set
-    for feature in feature_set:
-        assert feature in feature_set, f"{feature.name} stranded in aliased source set after rewrite"
+
+
+def test_links_raises_when_rewrite_collapses_cfw_distinguished_twins() -> None:
+    """Twins distinct only by compute_frameworks collapse after the rewrite; links() must raise, not drop one."""
+    feature_a = Feature("twin_feature")
+    feature_b = Feature("twin_feature")
+    feature_a.compute_frameworks = {PandasDataFrame, PyArrowTable}
+    feature_b.compute_frameworks = {PandasDataFrame}
+
+    feature_set = {feature_a, feature_b}
+    # Differing compute_frameworks keep the twins unequal at insertion.
+    assert len(feature_set) == 2
+
+    planned_queue: list[Any] = [(CfwRehashLeftFG, feature_set)]
+
+    with pytest.raises(ValueError):
+        _links_call(planned_queue, [feature_a, feature_b])

--- a/tests/test_core/test_prepare/test_resolve_cfw_set_membership.py
+++ b/tests/test_core/test_prepare/test_resolve_cfw_set_membership.py
@@ -1,0 +1,50 @@
+"""Set membership of planned-queue features after ResolveComputeFrameworks.links rewrites compute_frameworks."""
+
+from typing import Any
+
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.link import JoinSpec, Link
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.prepare.graph.graph import Graph
+from mloda.core.prepare.resolve_compute_frameworks import ResolveComputeFrameworks
+from mloda.core.prepare.resolve_links import LinkTrekker
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+
+
+class LeftGroup(FeatureGroup):
+    pass
+
+
+class RightGroup(FeatureGroup):
+    pass
+
+
+def test_features_remain_set_members_after_links_rewrites_compute_frameworks() -> None:
+    """Rewriting compute_frameworks in links() must not strand features in their queue set."""
+    feature_a = Feature("feature_a")
+    feature_b = Feature("feature_b")
+    feature_a.compute_frameworks = {PandasDataFrame, PyArrowTable}
+    feature_b.compute_frameworks = {PandasDataFrame, PyArrowTable}
+
+    feature_set = {feature_a, feature_b}
+    planned_queue: list[Any] = [(LeftGroup, feature_set)]
+
+    link = Link.inner(JoinSpec(LeftGroup, "idx"), JoinSpec(RightGroup, "idx"))
+    trekker = (link, PandasDataFrame, PyArrowTable)
+
+    link_trekker = LinkTrekker()
+    link_trekker.data_ordered[trekker] = {feature_a.uuid, feature_b.uuid}
+
+    result = ResolveComputeFrameworks(Graph()).links(planned_queue, link_trekker)
+
+    returned_set = result[0][1]
+    # The trekked path narrows the frameworks.
+    assert next(iter(returned_set)).compute_frameworks == {PandasDataFrame}
+
+    for feature in returned_set:
+        assert feature in returned_set, f"{feature.name} stranded in returned queue set after rewrite"
+
+    assert feature_set is returned_set
+    for feature in feature_set:
+        assert feature in feature_set, f"{feature.name} stranded in aliased source set after rewrite"


### PR DESCRIPTION
## Summary

`ResolveComputeFrameworks.links` rebinds `compute_frameworks` on Feature objects that are live members of a `set[Feature]` in the planned queue (the same object as `ResolveGraph.nodes_per_feature_group[fg]`). Since `Feature.__hash__` includes `compute_frameworks`, the rebind moves the members' hashes in place and strands them: iteration still reaches them, membership lookups do not.

Fixes #957.

## Changes

- Rebuild the set in place after the rewrite (drain to a list, clear, re-add), so both the queue tuple and its aliases stay valid. Rebuilding via a list is load bearing: constructing a set from the stale set would reuse the stored hashes.
- Guard against silent collapse: when the rewrite makes features equal that were previously distinct only by `compute_frameworks`, raise instead of dropping a UUID-backed graph node, mirroring the existing collapse guard in `FeatureSet.materialize_option_defaults`.
- Give each rewritten feature its own `compute_frameworks` set copy instead of one shared mutable set.
- Document the sites that are safe only by ordering: the rebind in `Engine.set_compute_framework` (runs before the feature is stored), the rebind in `GlobalFilter.compute_framework` (targets a per-match deepcopy added after all mutations), and the hash-staleness constraint on `Engine.feature_group_collection`.

## Review

Two independent deep reviews were run on the diff. Their converging finding (silent collapse of framework-distinguished twins during the rehash) is addressed by the new guard; the remaining items were documented or split into follow-up issues #981 and #982.

## Testing

- New tests pin set membership after `links()` (including the alias) and the collapse guard.
- `tox` passes: full pytest suite, ruff format/check, license check, mypy strict, bandit.