### PR TITLE
refactor: share one hashability probe between the two _make_hashable helpers

### DIFF
--- a/mloda/core/abstract_plugins/components/feature.py
+++ b/mloda/core/abstract_plugins/components/feature.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 
 from mloda.core.abstract_plugins.components.domain import Domain
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
-from mloda.core.abstract_plugins.components.hashable_dict import _make_hashable
+from mloda.core.abstract_plugins.components.hashable_dict import _deep_hashable
 from mloda.core.abstract_plugins.components.index.index import Index
 from mloda.core.abstract_plugins.components.link import Link
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
@@ -357,7 +357,7 @@ class Feature:
         """A value-equal Feature owning the mutable containers __eq__/__hash__ read (#910).
 
         options and child_options are rebuilt while every option VALUE stays shared by reference:
-        _make_hashable falls back to repr() for an unhashable non-container leaf and the default repr
+        _deep_hashable falls back to repr() for an unhashable non-container leaf and the default repr
         embeds the object address, so deep-copying a value would silently shift this Feature's hash and
         break the very dedup the copy protects. Both containers are written in place by the engine
         (intake forwarding, strict_type_enforcement, matcher writes), which is what the copy stops.
@@ -415,7 +415,7 @@ class Feature:
             return frozenset(Feature._reduce(item, seen) for item in value)
         if isinstance(value, (list, tuple)):
             return tuple(Feature._reduce(item, seen) for item in value)
-        return _make_hashable(value)
+        return _deep_hashable(value)
 
     def is_different_data_type(self, other: Feature) -> bool:
         return self.name == other.name and self.data_type != other.data_type
@@ -428,7 +428,7 @@ class Feature:
         relevant = {key: context[key] for key in split_keys if key in context}
         if not relevant:
             return ()
-        return _make_hashable(relevant)
+        return _deep_hashable(relevant)
 
     def _grouping_hash(self, split_keys: frozenset[str] | None, include_data_type: bool) -> int:
         keys = self.options.inherited_context_keys if split_keys is None else split_keys

--- a/mloda/core/abstract_plugins/components/hashable_dict.py
+++ b/mloda/core/abstract_plugins/components/hashable_dict.py
@@ -18,11 +18,12 @@ def _deep_hashable(value: Any) -> Any:
         return tuple(_deep_hashable(item) for item in value)
     if isinstance(value, set):
         return frozenset(_deep_hashable(item) for item in value)
-    # This site coerces an unhashable leaf to repr so grouping never crashes; filter_parameter rejects instead.
+    # A leaf whose hash raises TypeError is coerced to repr so grouping never crashes; any other raise
+    # propagates. filter_parameter rejects broadly instead.
     # Residual constraint: two values that are __eq__-equal but unhashable must have
     # repr consistent with equality, else they over-split into separate groups (a
     # rare, non-crashing tradeoff).
-    if unhashable_part(value) is not None:
+    if unhashable_part(value, catching=(TypeError,)) is not None:
         return repr(value)
     return value
 

--- a/mloda/core/abstract_plugins/components/hashable_dict.py
+++ b/mloda/core/abstract_plugins/components/hashable_dict.py
@@ -1,9 +1,11 @@
 from typing import Any
 
+from mloda.core.abstract_plugins.components.utils import unhashable_part
 
-def _make_hashable(value: Any) -> Any:
+
+def _deep_hashable(value: Any) -> Any:
     if isinstance(value, dict):
-        items = [(k, _make_hashable(v)) for k, v in value.items()]
+        items = [(k, _deep_hashable(v)) for k, v in value.items()]
         # Mixed-type keys (e.g. reader class plus str) are unorderable; fall back to a
         # type-robust deterministic sort. The common orderable case stays unchanged.
         try:
@@ -13,16 +15,14 @@ def _make_hashable(value: Any) -> Any:
                 sorted(items, key=lambda kv: (kv[0].__class__.__module__, kv[0].__class__.__qualname__, repr(kv[0])))
             )
     if isinstance(value, (list, tuple)):
-        return tuple(_make_hashable(item) for item in value)
+        return tuple(_deep_hashable(item) for item in value)
     if isinstance(value, set):
-        return frozenset(_make_hashable(item) for item in value)
-    # Unhashable non-container leaves fall back to repr so grouping never crashes.
+        return frozenset(_deep_hashable(item) for item in value)
+    # This site coerces an unhashable leaf to repr so grouping never crashes; filter_parameter rejects instead.
     # Residual constraint: two values that are __eq__-equal but unhashable must have
     # repr consistent with equality, else they over-split into separate groups (a
     # rare, non-crashing tradeoff).
-    try:
-        hash(value)
-    except TypeError:
+    if unhashable_part(value) is not None:
         return repr(value)
     return value
 
@@ -32,7 +32,7 @@ class HashableDict:
         self.data = data
 
     def __hash__(self) -> int:
-        return hash(_make_hashable(self.data))
+        return hash(_deep_hashable(self.data))
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, HashableDict):

--- a/mloda/core/abstract_plugins/components/options.py
+++ b/mloda/core/abstract_plugins/components/options.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any, Optional, TYPE_CHECKING, cast
 from copy import deepcopy
 
-from mloda.core.abstract_plugins.components.hashable_dict import _make_hashable
+from mloda.core.abstract_plugins.components.hashable_dict import _deep_hashable
 from mloda.core.abstract_plugins.components.validators.options_validator import OptionsValidator
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
 
@@ -166,7 +166,7 @@ class Options:
         Hash based only on group parameters.
         Context parameters don't affect Feature Group resolution/splitting.
         """
-        return hash(_make_hashable(self.group))
+        return hash(_deep_hashable(self.group))
 
     def __eq__(self, other: object) -> bool:
         """

--- a/mloda/core/abstract_plugins/components/utils.py
+++ b/mloda/core/abstract_plugins/components/utils.py
@@ -89,15 +89,15 @@ def as_str(value: Any) -> str:
     return value
 
 
-def unhashable_part(value: Any) -> str | None:
-    """Name of the first part of `value` that does not hash, None when the whole value hashes."""
+def unhashable_part(value: Any, catching: tuple[type[Exception], ...] = (Exception,)) -> str | None:
+    """Name of the first part of `value` whose hash raises one of `catching`, None when the whole value hashes."""
     # Probe the real hash, not isinstance(value, Hashable): a tuple carrying a dict and a __hash__ that
     # raises both report as hashable.
-    if safe_field(lambda: isinstance(hash(value), int), False):
+    if safe_field(lambda: isinstance(hash(value), int), False, catching=catching):
         return None
     if isinstance(value, tuple):
         for element in value:
-            found = unhashable_part(element)
+            found = unhashable_part(element, catching=catching)
             if found is not None:
                 return found
     return type(value).__name__

--- a/mloda/core/abstract_plugins/components/utils.py
+++ b/mloda/core/abstract_plugins/components/utils.py
@@ -89,6 +89,20 @@ def as_str(value: Any) -> str:
     return value
 
 
+def unhashable_part(value: Any) -> str | None:
+    """Name of the first part of `value` that does not hash, None when the whole value hashes."""
+    # Probe the real hash, not isinstance(value, Hashable): a tuple carrying a dict and a __hash__ that
+    # raises both report as hashable.
+    if safe_field(lambda: isinstance(hash(value), int), False):
+        return None
+    if isinstance(value, tuple):
+        for element in value:
+            found = unhashable_part(element)
+            if found is not None:
+                return found
+    return type(value).__name__
+
+
 def get_all_subclasses(cls: Any) -> set[type[Any]]:
     all_subclasses = set()
 

--- a/mloda/core/filter/filter_parameter.py
+++ b/mloda/core/filter/filter_parameter.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Any, Optional, Protocol, cast, runtime_checkable
 
-from mloda.core.abstract_plugins.components.utils import safe_field
+from mloda.core.abstract_plugins.components.utils import unhashable_part
 
 
 @runtime_checkable
@@ -22,7 +22,7 @@ class FilterParameter(Protocol):
     def max_exclusive(self) -> bool: ...
 
 
-def _make_hashable(value: Any) -> Any:
+def _normalize_collections(value: Any) -> Any:
     """Normalize collection values to tuples so the frozen dataclass stays hashable.
 
     Sets are ordered deterministically, str/bytes stay scalar and are never exploded.
@@ -36,19 +36,6 @@ def _make_hashable(value: Any) -> Any:
     return value
 
 
-def _unhashable_type(value: Any) -> str | None:
-    """Name of the first part of `value` that does not hash, None when the whole value hashes."""
-    # Probe the real hash, not isinstance(value, Hashable): a __hash__ that raises reports as hashable.
-    if safe_field(lambda: isinstance(hash(value), int), False):
-        return None
-    if isinstance(value, tuple):
-        for element in value:
-            found = _unhashable_type(element)
-            if found is not None:
-                return found
-    return type(value).__name__
-
-
 @dataclass(frozen=True)
 class FilterParameterImpl:
     _raw: tuple[tuple[str, Any], ...]
@@ -59,9 +46,10 @@ class FilterParameterImpl:
         for key in params:
             if not isinstance(key, str):
                 raise ValueError(f"Filter parameter key {key!r} is not a string.")
-        normalized = {k: _make_hashable(v) for k, v in params.items()}
+        normalized = {k: _normalize_collections(v) for k, v in params.items()}
+        # This site rejects what still does not hash; _deep_hashable in hashable_dict coerces instead.
         for key, value in normalized.items():
-            culprit = _unhashable_type(value)
+            culprit = unhashable_part(value)
             if culprit is not None:
                 raise ValueError(
                     f"Filter parameter '{key}' holds an unhashable {culprit}; "

--- a/tests/test_core/test_abstract_plugins/test_components/test_options.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_options.py
@@ -298,7 +298,7 @@ class TestOptionsNestedStructureHashing:
 
     WHY THIS EXISTS:
     Options.group may contain nested dicts, lists, or sets for complex configuration.
-    The _make_hashable helper recursively converts these to hashable equivalents,
+    The _deep_hashable helper recursively converts these to hashable equivalents,
     enabling proper hashing and use in sets/dicts for feature group resolution.
     """
 

--- a/tests/test_core/test_abstract_plugins/test_components/test_similarity_hash_unhashable_context.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_similarity_hash_unhashable_context.py
@@ -1,11 +1,11 @@
 """Regression tests for similarity hashing over an unhashable INHERITED context value.
 
 Feature.similarity_hash / base_similarity_hash now fold INHERITED context VALUES into
-the grouping hash via _split_context_hashable -> _deep_hashable. _deep_hashable only
-unwraps dict/list/tuple/set; a context value that is itself unhashable and NOT a
-container (an object whose __hash__ is None) reaches the outer hash(...) untouched and
-raises TypeError. Pre-PR the context was never hashed, so propagated/inherited
-unhashable context values are a regression: grouping must not crash on them.
+the grouping hash via _split_context_hashable -> _deep_hashable. _deep_hashable unwraps
+dict/list/tuple/set and coerces a leaf whose hash raises TypeError (e.g. an object whose
+__hash__ is None) to its repr; any other raise propagates. Pre-PR the context was never
+hashed, so propagated/inherited unhashable context values are a regression: grouping must
+not crash on them.
 """
 
 from mloda.user import Feature, Options

--- a/tests/test_core/test_abstract_plugins/test_components/test_similarity_hash_unhashable_context.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_similarity_hash_unhashable_context.py
@@ -1,7 +1,7 @@
 """Regression tests for similarity hashing over an unhashable INHERITED context value.
 
 Feature.similarity_hash / base_similarity_hash now fold INHERITED context VALUES into
-the grouping hash via _split_context_hashable -> _make_hashable. _make_hashable only
+the grouping hash via _split_context_hashable -> _deep_hashable. _deep_hashable only
 unwraps dict/list/tuple/set; a context value that is itself unhashable and NOT a
 container (an object whose __hash__ is None) reaches the outer hash(...) untouched and
 raises TypeError. Pre-PR the context was never hashed, so propagated/inherited

--- a/tests/test_core/test_abstract_plugins/test_components/test_unhashable_part.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_unhashable_part.py
@@ -1,4 +1,8 @@
-"""Tests for the shared `unhashable_part` probe and its two call sites: filters reject, HashableDict coerces."""
+"""Tests for the shared `unhashable_part` probe and its two call sites.
+
+Filters reject on any probe failure; HashableDict coerces to repr for TypeError only, so a leaf
+whose __hash__ raises anything else still propagates instead of degrading to an address-bearing repr.
+"""
 
 from collections.abc import Hashable
 from typing import Any
@@ -9,9 +13,11 @@ from mloda.core.abstract_plugins.components import feature as feature_module
 from mloda.core.abstract_plugins.components import hashable_dict as hashable_dict_module
 from mloda.core.abstract_plugins.components import options as options_module
 from mloda.core.abstract_plugins.components.hashable_dict import HashableDict, _deep_hashable
+from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.components.utils import unhashable_part
 from mloda.core.filter import filter_parameter as filter_parameter_module
 from mloda.core.filter.filter_parameter import FilterParameterImpl, _normalize_collections
+from mloda.core.filter.global_filter import GlobalFilter
 
 
 class _RaisingHash:
@@ -28,6 +34,19 @@ class _RaisingHash:
 
     def __repr__(self) -> str:
         return f"_RaisingHash({self.token})"
+
+
+class _RaisingValueErrorHash:
+    """A leaf whose __hash__ raises ValueError, like a writable memoryview."""
+
+    def __init__(self, token: str) -> None:
+        self.token = token
+
+    def __hash__(self) -> int:
+        raise ValueError("boom")
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, _RaisingValueErrorHash) and self.token == other.token
 
 
 class TestUnhashablePartOnHashableValues:
@@ -83,6 +102,23 @@ class TestUnhashablePartProbesTheRealHash:
         assert unhashable_part(value) == "_RaisingHash"
 
 
+class TestUnhashablePartCatchingIsSelectable:
+    """`catching` narrows which probe failures count as unhashable; anything else propagates."""
+
+    def test_default_catching_names_a_value_error_raising_leaf(self) -> None:
+        assert unhashable_part(_RaisingValueErrorHash("leaf")) == "_RaisingValueErrorHash"
+
+    def test_type_error_only_catching_still_names_a_type_error_raising_leaf(self) -> None:
+        assert unhashable_part(_RaisingHash("leaf"), catching=(TypeError,)) == "_RaisingHash"
+
+    def test_type_error_only_catching_propagates_a_value_error(self) -> None:
+        with pytest.raises(ValueError):
+            unhashable_part(_RaisingValueErrorHash("leaf"), catching=(TypeError,))
+
+    def test_type_error_only_catching_still_names_a_plain_unhashable_value(self) -> None:
+        assert unhashable_part({"a": 1}, catching=(TypeError,)) == "dict"
+
+
 class TestFilterParameterRejects:
     """Filter policy: normalize collections shallowly, then REJECT anything that still does not hash."""
 
@@ -98,6 +134,14 @@ class TestFilterParameterRejects:
             FilterParameterImpl.from_dict({"value": _RaisingHash("leaf")})
         assert "_RaisingHash" in str(excinfo.value)
 
+    def test_value_error_raising_hash_value_is_rejected_by_name(self) -> None:
+        """The filter path keeps catching broadly: rejection message, not the leaf's own 'boom'."""
+        with pytest.raises(ValueError) as excinfo:
+            FilterParameterImpl.from_dict({"value": _RaisingValueErrorHash("leaf")})
+        message = str(excinfo.value)
+        assert "unhashable _RaisingValueErrorHash" in message
+        assert "boom" not in message
+
     def test_hashable_parameters_still_build(self) -> None:
         parameter = FilterParameterImpl.from_dict({"values": ["a", "b"]})
         assert parameter.values == ["a", "b"]
@@ -107,9 +151,6 @@ class TestFilterParameterRejects:
 
     def test_the_module_private_probe_is_gone(self) -> None:
         assert not hasattr(filter_parameter_module, "_unhashable_type")
-
-    def test_the_old_helper_name_is_gone(self) -> None:
-        assert not hasattr(filter_parameter_module, "_make_hashable")
 
 
 class TestNormalizeCollectionsStaysShallow:
@@ -162,8 +203,44 @@ class TestHashableDictCoerces:
     def test_call_site_uses_the_shared_probe(self) -> None:
         assert getattr(hashable_dict_module, "unhashable_part") is unhashable_part
 
-    def test_the_old_helper_name_is_gone(self) -> None:
-        assert not hasattr(hashable_dict_module, "_make_hashable")
+
+class TestHashableDictCoercesTypeErrorOnly:
+    """Deep path: only a TypeError-refusing leaf degrades to repr; any other raise stays loud."""
+
+    def test_deep_hashable_propagates_a_value_error_leaf(self) -> None:
+        with pytest.raises(ValueError):
+            _deep_hashable(_RaisingValueErrorHash("acme"))
+
+    def test_hashable_dict_propagates_a_value_error_leaf(self) -> None:
+        with pytest.raises(ValueError):
+            hash(HashableDict({"leaf": _RaisingValueErrorHash("acme")}))
+
+    def test_nested_value_error_leaf_also_propagates(self) -> None:
+        with pytest.raises(ValueError):
+            hash(HashableDict({"leaf": [{"inner": _RaisingValueErrorHash("acme")}]}))
+
+    def test_options_hash_propagates_a_value_error_leaf(self) -> None:
+        with pytest.raises(ValueError):
+            hash(Options(group={"leaf": _RaisingValueErrorHash("acme")}))
+
+
+class TestPublicEntryPoints:
+    """The two policies as a caller meets them: filters reject loudly, Options keeps grouping."""
+
+    def test_global_filter_add_filter_rejects_an_unhashable_nested_value(self) -> None:
+        global_filter = GlobalFilter()
+        with pytest.raises(ValueError) as excinfo:
+            global_filter.add_filter("some_feature", "equal", {"values": [{"a": 1}]})
+        message = str(excinfo.value)
+        assert "dict" in message
+        assert "values" in message
+        assert global_filter.filters == set()
+
+    def test_options_hashes_a_type_error_unhashable_leaf(self) -> None:
+        left = Options(group={"leaf": _RaisingHash("acme")})
+        right = Options(group={"leaf": _RaisingHash("acme")})
+        assert left == right
+        assert hash(left) == hash(right)
 
 
 class TestCrossModuleImportsFollowTheRename:
@@ -175,6 +252,6 @@ class TestCrossModuleImportsFollowTheRename:
     def test_feature_imports_deep_hashable(self) -> None:
         assert getattr(feature_module, "_deep_hashable") is _deep_hashable
 
-    @pytest.mark.parametrize("module", [options_module, feature_module])
-    def test_the_old_name_is_no_longer_imported(self, module: Any) -> None:
+    @pytest.mark.parametrize("module", [filter_parameter_module, hashable_dict_module, options_module, feature_module])
+    def test_the_old_helper_name_is_gone(self, module: Any) -> None:
         assert not hasattr(module, "_make_hashable")

--- a/tests/test_core/test_abstract_plugins/test_components/test_unhashable_part.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_unhashable_part.py
@@ -1,0 +1,180 @@
+"""Tests for the shared `unhashable_part` probe and its two call sites: filters reject, HashableDict coerces."""
+
+from collections.abc import Hashable
+from typing import Any
+
+import pytest
+
+from mloda.core.abstract_plugins.components import feature as feature_module
+from mloda.core.abstract_plugins.components import hashable_dict as hashable_dict_module
+from mloda.core.abstract_plugins.components import options as options_module
+from mloda.core.abstract_plugins.components.hashable_dict import HashableDict, _deep_hashable
+from mloda.core.abstract_plugins.components.utils import unhashable_part
+from mloda.core.filter import filter_parameter as filter_parameter_module
+from mloda.core.filter.filter_parameter import FilterParameterImpl, _normalize_collections
+
+
+class _RaisingHash:
+    """A leaf that advertises __hash__ but raises TypeError when actually hashed."""
+
+    def __init__(self, token: str) -> None:
+        self.token = token
+
+    def __hash__(self) -> int:
+        raise TypeError(f"{self.token} refuses to hash")
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, _RaisingHash) and self.token == other.token
+
+    def __repr__(self) -> str:
+        return f"_RaisingHash({self.token})"
+
+
+class TestUnhashablePartOnHashableValues:
+    """A value that hashes end to end reports no offender."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [1, "text", b"bytes", None, 3.5, True, (1, "a"), (), ((1, 2), (3, 4)), frozenset({1, 2}), (frozenset({1}),)],
+    )
+    def test_hashable_value_returns_none(self, value: Any) -> None:
+        assert unhashable_part(value) is None
+
+
+class TestUnhashablePartNamesTheOffender:
+    """The first non-hashing part is named by type, recursing into tuples."""
+
+    def test_dict_is_named(self) -> None:
+        assert unhashable_part({"a": 1}) == "dict"
+
+    def test_list_is_named(self) -> None:
+        assert unhashable_part([1, 2]) == "list"
+
+    def test_set_is_named(self) -> None:
+        assert unhashable_part({1, 2}) == "set"
+
+    def test_tuple_carrying_a_dict_names_the_nested_dict(self) -> None:
+        assert unhashable_part((1, {"a": 1})) == "dict"
+
+    def test_deeply_nested_offender_is_named(self) -> None:
+        assert unhashable_part((1, (2, (3, [4])))) == "list"
+
+    def test_first_offender_wins(self) -> None:
+        assert unhashable_part(({"a": 1}, [2])) == "dict"
+
+    def test_class_whose_hash_raises_is_named(self) -> None:
+        assert unhashable_part(_RaisingHash("leaf")) == "_RaisingHash"
+
+    def test_tuple_carrying_a_raising_hash_names_the_leaf(self) -> None:
+        assert unhashable_part((1, _RaisingHash("leaf"))) == "_RaisingHash"
+
+
+class TestUnhashablePartProbesTheRealHash:
+    """isinstance(value, Hashable) lies in exactly the two cases the probe must catch."""
+
+    def test_tuple_with_dict_advertises_hashable_but_is_not(self) -> None:
+        value = (1, {"a": 1})
+        assert isinstance(value, Hashable)
+        assert unhashable_part(value) == "dict"
+
+    def test_raising_hash_advertises_hashable_but_is_not(self) -> None:
+        value = _RaisingHash("leaf")
+        assert isinstance(value, Hashable)
+        assert unhashable_part(value) == "_RaisingHash"
+
+
+class TestFilterParameterRejects:
+    """Filter policy: normalize collections shallowly, then REJECT anything that still does not hash."""
+
+    def test_nested_dict_raises_value_error_naming_dict_and_key(self) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            FilterParameterImpl.from_dict({"values": [{"a": 1}]})
+        message = str(excinfo.value)
+        assert "dict" in message
+        assert "values" in message
+
+    def test_raising_hash_value_is_rejected_by_name(self) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            FilterParameterImpl.from_dict({"value": _RaisingHash("leaf")})
+        assert "_RaisingHash" in str(excinfo.value)
+
+    def test_hashable_parameters_still_build(self) -> None:
+        parameter = FilterParameterImpl.from_dict({"values": ["a", "b"]})
+        assert parameter.values == ["a", "b"]
+
+    def test_call_site_uses_the_shared_probe(self) -> None:
+        assert getattr(filter_parameter_module, "unhashable_part") is unhashable_part
+
+    def test_the_module_private_probe_is_gone(self) -> None:
+        assert not hasattr(filter_parameter_module, "_unhashable_type")
+
+    def test_the_old_helper_name_is_gone(self) -> None:
+        assert not hasattr(filter_parameter_module, "_make_hashable")
+
+
+class TestNormalizeCollectionsStaysShallow:
+    """`_normalize_collections` only reshapes the top level; it never recurses and never coerces."""
+
+    def test_str_stays_scalar(self) -> None:
+        assert _normalize_collections("abc") == "abc"
+
+    def test_bytes_stay_scalar(self) -> None:
+        assert _normalize_collections(b"abc") == b"abc"
+
+    def test_list_becomes_a_tuple(self) -> None:
+        assert _normalize_collections([1, 2]) == (1, 2)
+
+    def test_set_becomes_a_tuple_sorted_by_repr(self) -> None:
+        assert _normalize_collections({"b", "a"}) == ("a", "b")
+
+    def test_frozenset_becomes_a_tuple_sorted_by_repr(self) -> None:
+        assert _normalize_collections(frozenset({"b", "a"})) == ("a", "b")
+
+    def test_dict_is_left_unchanged_so_the_probe_can_reject_it(self) -> None:
+        assert _normalize_collections({"a": 1}) == {"a": 1}
+
+    def test_nested_list_is_not_recursed_into(self) -> None:
+        assert _normalize_collections([[1], [2]]) == ([1], [2])
+
+
+class TestHashableDictCoerces:
+    """HashableDict policy: name the offending leaf, then degrade it to repr so grouping never crashes."""
+
+    def test_hashing_a_raising_leaf_does_not_raise(self) -> None:
+        assert isinstance(hash(HashableDict({"leaf": _RaisingHash("acme")})), int)
+
+    def test_equal_repr_leaves_hash_alike(self) -> None:
+        left = HashableDict({"leaf": _RaisingHash("acme")})
+        right = HashableDict({"leaf": _RaisingHash("acme")})
+        assert hash(left) == hash(right)
+
+    def test_a_nested_raising_leaf_is_also_coerced(self) -> None:
+        left = HashableDict({"leaf": [{"inner": _RaisingHash("acme")}]})
+        right = HashableDict({"leaf": [{"inner": _RaisingHash("acme")}]})
+        assert hash(left) == hash(right)
+
+    def test_deep_hashable_coerces_the_leaf_to_its_repr(self) -> None:
+        assert _deep_hashable(_RaisingHash("acme")) == repr(_RaisingHash("acme"))
+
+    def test_deep_hashable_recurses_into_containers(self) -> None:
+        assert _deep_hashable({"a": [1, 2]}) == (("a", (1, 2)),)
+
+    def test_call_site_uses_the_shared_probe(self) -> None:
+        assert getattr(hashable_dict_module, "unhashable_part") is unhashable_part
+
+    def test_the_old_helper_name_is_gone(self) -> None:
+        assert not hasattr(hashable_dict_module, "_make_hashable")
+
+
+class TestCrossModuleImportsFollowTheRename:
+    """options and feature import the deep policy under its new name."""
+
+    def test_options_imports_deep_hashable(self) -> None:
+        assert getattr(options_module, "_deep_hashable") is _deep_hashable
+
+    def test_feature_imports_deep_hashable(self) -> None:
+        assert getattr(feature_module, "_deep_hashable") is _deep_hashable
+
+    @pytest.mark.parametrize("module", [options_module, feature_module])
+    def test_the_old_name_is_no_longer_imported(self, module: Any) -> None:
+        assert not hasattr(module, "_make_hashable")

--- a/tests/test_core/test_filter/test_single_filter_owns_its_feature.py
+++ b/tests/test_core/test_filter/test_single_filter_owns_its_feature.py
@@ -390,7 +390,7 @@ def _leaf_feature(leaf: _SfoUnhashableLeaf) -> Feature:
 def test_a_filter_feature_with_an_unhashable_option_value_keeps_its_hash() -> None:
     """Structural pin: the ownership copy must SHARE every option value, never copy it.
 
-    _make_hashable falls back to repr() for an unhashable non-container leaf and the default repr
+    _deep_hashable falls back to repr() for an unhashable non-container leaf and the default repr
     embeds the object address, so swapping the copy for a deepcopy silently shifts the stored hash.
     """
     feature = _leaf_feature(_SfoUnhashableLeaf())

--- a/tests/test_plugins/feature_group/input_data/test_read_context_files_option_declarations.py
+++ b/tests/test_plugins/feature_group/input_data/test_read_context_files_option_declarations.py
@@ -165,7 +165,7 @@ class TestDeclaredDefaults:
     def test_a_list_default_would_hash_equal_yet_compare_unequal(self) -> None:
         """The real reason the declared default is a tuple, pinned on ``Options`` itself.
 
-        Group hashing is NOT the problem: ``Options.__hash__`` runs ``_make_hashable``, which normalizes
+        Group hashing is NOT the problem: ``Options.__hash__`` runs ``_deep_hashable``, which normalizes
         a list to a tuple, so a list default hashes fine. The problem is that hashing and equality then
         disagree: the two forms land in the same hash bucket but compare unequal, so a caller who passes
         ``["__init__.py"]`` gets a feature that never merges with the materialized ``("__init__.py",)``.


### PR DESCRIPTION
Closes #962.

Two module-private helpers were both named `_make_hashable` and carried opposite policies, so reading one gave a wrong mental model of the other:

- `filter_parameter`: shallow, normalizes only the top level, rejects what does not hash.
- `hashable_dict`: deep and total, recurses everything, coerces an unhashable leaf to `repr` so grouping never crashes.

Fixing #925 meant writing a third piece of hashability logic because neither answered "does this hash, and if not, which part of it".

## Change

The detection is now one primitive, `utils.unhashable_part`, which probes the real hash (a tuple advertises `__hash__` even when it carries a dict) and names the first offending part. Each call site keeps its own policy, stated in one line where it applies: `filter_parameter` rejects, `hashable_dict` coerces. The helpers are renamed to `_normalize_collections` and `_deep_hashable` so the divergence is visible at a glance.

`unhashable_part` takes the same `catching` tuple `safe_field` does. The deep site passes `(TypeError,)` to keep its prior scope exactly: a leaf whose `__hash__` raises anything else (a writable `memoryview` raises `ValueError`) still propagates rather than degrading to an address-bearing `repr`, which would let two equal `Options` hash differently and stop deduplicating. The filter site keeps the broad default, since rejecting is the loud direction.

The `try/except TypeError` in `hashable_dict` is gone; no new one was added.

## Tests

New `test_unhashable_part.py` covers the probe directly, both call-site policies including which exception class each tolerates, and the two public entry points (`GlobalFilter.add_filter`, `Options.__hash__`). Existing behavior on both paths is unchanged.

`tox`: 8143 passed, 170 skipped, ruff, mypy --strict and bandit clean.