### PR TITLE
docs: cover the no-feature-groups-found failure on the troubleshooting page

### DIFF
--- a/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
+++ b/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
@@ -62,18 +62,18 @@ fields on `FeatureResolutionError`, `ResolutionDiagnosis`, and `ResolutionRecord
 ```
 FeatureResolutionError: No feature groups found for feature name: 'sales_revnue'. Requested domain: 'marketing'.
 Feature group(s) eliminated while matching 'sales_revnue':
+  - MarketingRevenueGroup (compute framework): none of its compute frameworks are enabled for this run
   - SalesFeatureGroup (domain): declares domain 'sales', but the run requested 'marketing'
-  - SalesRevenueGroup (compute framework): none of its compute frameworks are enabled for this run
 Did you mean one of: ['sales_revenue']?
 Use resolve_feature(name, options=...) to debug feature resolution.
 For troubleshooting guide, see: https://mloda-ai.github.io/mloda/in_depth/troubleshooting/feature-group-resolution-errors/
 ```
 
-No enabled feature group both declared the requested name and survived every matching gate. It is raised as `FeatureResolutionError` during planning; see [Catching resolution failures](#catching-resolution-failures) to inspect it, or follow the message's closing pointer: rerun the name through `resolve_feature`, shown at the top of this page, to get the same message without a run.
+No enabled feature group both declared the requested name and survived every matching gate. It is raised as `FeatureResolutionError` during planning; see [Catching resolution failures](#catching-resolution-failures) to inspect it, or follow the message's closing pointer and rerun the request through `resolve_feature`. Pass the same `Feature` and run arguments, as the top of this page describes; the bare name alone would drop the domain and default to all frameworks, changing the outcome.
 
 ### The eliminated candidates block
 
-Each line names a candidate that declared the requested name, the first gate that eliminated it (the parenthesized label), and that gate's reason.
+Each line names a candidate the matcher considered and dropped: the first gate that eliminated it (the parenthesized label) and that gate's reason. A line does not prove the candidate declared the requested name; a candidate whose match hook raised or whose input-data gate declined is recorded regardless.
 
 | Label | What eliminated the candidate | Typical fix |
 | --- | --- | --- |
@@ -83,16 +83,16 @@ Each line names a candidate that declared the requested name, the first gate tha
 | `domain` | The group declares a different domain than the request. | Align the requested domain ([domain solution below](#3-use-domains-to-separate-feature-groups)). |
 | `scope` | The group is outside the requested `feature_group` scope. | Widen or correct the scope ([scope solution below](#4-scope-a-feature-to-one-source-shared-keys-across-sources)). |
 | `compute framework` | None of the group's compute frameworks are usable: its capability hook rejected every enabled framework, or none of its frameworks is enabled for the run. | Enable a framework the group supports. |
-| `compute framework pin` | The `Feature` pins `compute_frameworks` to one the group does not support. | Change or drop the pin. |
+| `compute framework pin` | The `Feature` pins `compute_frameworks` to one that is not among the group's supported set for this run. | Change or drop the pin. |
 | `links` | No index column of the group matches the run's links. | Align the run's links with the group's index. |
 
 ### The Did you mean hint
 
-Suggestions are close matches drawn from the names that live, accessible groups declare. The hint drops what would only repeat: the requested name, names the eliminated-candidates block already covers, and names only eliminated groups declare. A missing hint therefore means no surviving group declares anything close, not that the matcher gave up.
+Suggestions are close matches drawn from the catalog of accessible groups: declared feature names, class names, and class-name prefixes. The hint drops what would only repeat or mislead: the requested name itself, names the eliminated-candidates block already covers, and names only unreachable groups declare (abstract, no enabled framework, or outside the requested domain, scope, or links). A missing hint therefore means no reachable group declares anything close. In the example above, 'sales_revenue' survives because a third, still-reachable group declares it; the two eliminated candidates could not have contributed it.
 
 ### Only abstract feature group bases matched
 
-A sibling variant fires when the name is declared, but only by abstract feature group bases:
+A sibling variant fires when an abstract base matched the name and no concrete group won:
 
 ```
 No feature groups found for feature name: 'my_feature'. Only abstract feature group base(s) matched, which cannot be instantiated; no concrete implementation is available or enabled.
@@ -101,10 +101,10 @@ No feature groups found for feature name: 'my_feature'. Only abstract feature gr
 or, when concrete implementations exist but their compute frameworks do not:
 
 ```
-No feature groups found for feature name: 'my_feature'. Its concrete implementations require compute framework(s) ['PandasDataframe'], none of which are available or enabled for this run.
+No feature groups found for feature name: 'my_feature'. Its concrete implementations require compute framework(s) ['PandasDataFrame'], none of which are available or enabled for this run.
 ```
 
-For the first shape, import or enable a concrete implementation. For the second, enable one of the named compute frameworks. This variant still renders the eliminated-candidates block, but no Did-you-mean suggestion and no trailing resolve_feature or troubleshooting lines.
+For the first shape, import or enable a concrete implementation. For the second, enable one of the named compute frameworks; the list comes from the base's accessible concrete implementations, so check that the one you enable actually serves the name. Eliminated candidates, if any, still render in the eliminated-candidates block; the Did-you-mean suggestion and the trailing pointer lines never do.
 
 ## Multiple Feature Groups Error
 
@@ -149,9 +149,11 @@ plugin_loader.load_group("feature_group") # load plugins only from mloda_plugins
 
 #### 3. Use Domains to Separate Feature Groups
 ```python
+from mloda.user import Domain
+
 @classmethod
 def get_domain(cls):
-    return "sales"  # Makes this FG only handle 'sales' domain features
+    return Domain("sales")  # Makes this FG only handle 'sales' domain features
 ```
 
 #### 4. Scope a feature to one source (shared keys across sources)

--- a/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
+++ b/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
@@ -55,6 +55,57 @@ which returns a `ResolutionDiagnosis` for the whole request. See
 [mlodaAPI](../mloda-api.md#diagnose-and-resolution_report) for both, plus the
 fields on `FeatureResolutionError`, `ResolutionDiagnosis`, and `ResolutionRecord`.
 
+## No Feature Groups Found Error
+
+### The Problem
+
+```
+FeatureResolutionError: No feature groups found for feature name: 'sales_revnue'. Requested domain: 'marketing'.
+Feature group(s) eliminated while matching 'sales_revnue':
+  - SalesFeatureGroup (domain): declares domain 'sales', but the run requested 'marketing'
+  - SalesRevenueGroup (compute framework): none of its compute frameworks are enabled for this run
+Did you mean one of: ['sales_revenue']?
+Use resolve_feature(name, options=...) to debug feature resolution.
+For troubleshooting guide, see: https://mloda-ai.github.io/mloda/in_depth/troubleshooting/feature-group-resolution-errors/
+```
+
+No enabled feature group both declared the requested name and survived every matching gate. It is raised as `FeatureResolutionError` during planning; see [Catching resolution failures](#catching-resolution-failures) to inspect it, or follow the message's closing pointer: rerun the name through `resolve_feature`, shown at the top of this page, to get the same message without a run.
+
+### The eliminated candidates block
+
+Each line names a candidate that declared the requested name, the first gate that eliminated it (the parenthesized label), and that gate's reason.
+
+| Label | What eliminated the candidate | Typical fix |
+| --- | --- | --- |
+| `option value` | The group declined an option value in the request. | Fix the value the reason names. |
+| `input data` | The input-data gate declined the request. | Point the request at data the group can read ([Data Access Patterns](../data-access-patterns.md)). |
+| `match hook` | The group's match hook raised; the error is contained and quoted. | Fix the plugin bug it names. |
+| `domain` | The group declares a different domain than the request. | Align the requested domain ([domain solution below](#3-use-domains-to-separate-feature-groups)). |
+| `scope` | The group is outside the requested `feature_group` scope. | Widen or correct the scope ([scope solution below](#4-scope-a-feature-to-one-source-shared-keys-across-sources)). |
+| `compute framework` | None of the group's compute frameworks are usable: its capability hook rejected every enabled framework, or none of its frameworks is enabled for the run. | Enable a framework the group supports. |
+| `compute framework pin` | The `Feature` pins `compute_frameworks` to one the group does not support. | Change or drop the pin. |
+| `links` | No index column of the group matches the run's links. | Align the run's links with the group's index. |
+
+### The Did you mean hint
+
+Suggestions are close matches drawn from the names that live, accessible groups declare. The hint drops what would only repeat: the requested name, names the eliminated-candidates block already covers, and names only eliminated groups declare. A missing hint therefore means no surviving group declares anything close, not that the matcher gave up.
+
+### Only abstract feature group bases matched
+
+A sibling variant fires when the name is declared, but only by abstract feature group bases:
+
+```
+No feature groups found for feature name: 'my_feature'. Only abstract feature group base(s) matched, which cannot be instantiated; no concrete implementation is available or enabled.
+```
+
+or, when concrete implementations exist but their compute frameworks do not:
+
+```
+No feature groups found for feature name: 'my_feature'. Its concrete implementations require compute framework(s) ['PandasDataframe'], none of which are available or enabled for this run.
+```
+
+For the first shape, import or enable a concrete implementation. For the second, enable one of the named compute frameworks. This variant still renders the eliminated-candidates block, but no Did-you-mean suggestion and no trailing resolve_feature or troubleshooting lines.
+
 ## Multiple Feature Groups Error
 
 ### The Problem

--- a/tests/test_documentation/test_near_miss_labels_in_docs.py
+++ b/tests/test_documentation/test_near_miss_labels_in_docs.py
@@ -89,13 +89,16 @@ def test_the_scanner_pattern_matches_a_rendered_near_miss_bullet() -> None:
     assert match.group("reason") == SCANNER_REASON
 
 
+# The troubleshooting page carries the full label table; the table guard below and DOC_BULLET_STAGES share it.
+LABEL_TABLE_PAGE = "in_depth/troubleshooting/feature-group-resolution-errors.md"
+
 # Pages reproducing a rendered near-miss bullet, pinned to their stage. This is the floor under the scan
 # above, which passes when it finds nothing, and the stage pin its set-membership check cannot be.
 DOC_BULLET_STAGES: dict[str, EliminationStage] = {
     "in_depth/compute-framework-integration.md": "framework_pin",
     "in_depth/data-access-patterns.md": "input_data",
     "in_depth/property-mapping.md": "value_rejection",
-    "in_depth/troubleshooting/feature-group-resolution-errors.md": "domain",
+    LABEL_TABLE_PAGE: "domain",
 }
 
 
@@ -144,17 +147,23 @@ class TestProseLabelMentions:
         )
 
 
-# The troubleshooting page carries the full label table, so every distinct label must appear on it.
-LABEL_TABLE_PAGE = "in_depth/troubleshooting/feature-group-resolution-errors.md"
+# A markdown table row whose first column is a backticked value; only the label table backticks its first column.
+LABEL_TABLE_ROW_PATTERN = re.compile(r"^\|\s*`(?P<label>[^`]+)`\s*\|")
 
 
-@pytest.mark.parametrize("label", sorted(ALLOWED_LABELS))
-def test_the_label_table_page_names_every_distinct_stage_label(label: str) -> None:
+def test_the_label_table_rows_are_exactly_the_distinct_stage_labels() -> None:
+    """Equality both ways: a deleted or renamed row fails, and so does a row naming a label no stage carries."""
     page = DOCS_ROOT / LABEL_TABLE_PAGE
     assert page.is_file(), f"{page} was moved or renamed; update LABEL_TABLE_PAGE"
 
-    spellings = (f"`{label}`", f"`({label})`")
-    text = page.read_text(encoding="utf-8")
-    assert any(spelling in text for spelling in spellings), (
-        f"{page} does not name the near-miss label '{label}' as any of {list(spellings)}."
-    )
+    rows = {
+        match.group("label")
+        for line in page.read_text(encoding="utf-8").splitlines()
+        if (match := LABEL_TABLE_ROW_PATTERN.match(line)) is not None
+    }
+
+    missing = ALLOWED_LABELS - rows
+    assert not missing, f"{page} label table lost the row(s) for label(s) {sorted(missing)}."
+
+    stale = rows - ALLOWED_LABELS
+    assert not stale, f"{page} label table names label(s) no stage carries: {sorted(stale)}."

--- a/tests/test_documentation/test_near_miss_labels_in_docs.py
+++ b/tests/test_documentation/test_near_miss_labels_in_docs.py
@@ -95,6 +95,7 @@ DOC_BULLET_STAGES: dict[str, EliminationStage] = {
     "in_depth/compute-framework-integration.md": "framework_pin",
     "in_depth/data-access-patterns.md": "input_data",
     "in_depth/property-mapping.md": "value_rejection",
+    "in_depth/troubleshooting/feature-group-resolution-errors.md": "domain",
 }
 
 
@@ -141,3 +142,19 @@ class TestProseLabelMentions:
         assert any(spelling in text for spelling in spellings), (
             f"{page} no longer names the '{stage}' near-miss label in prose as any of {list(spellings)}."
         )
+
+
+# The troubleshooting page carries the full label table, so every distinct label must appear on it.
+LABEL_TABLE_PAGE = "in_depth/troubleshooting/feature-group-resolution-errors.md"
+
+
+@pytest.mark.parametrize("label", sorted(ALLOWED_LABELS))
+def test_the_label_table_page_names_every_distinct_stage_label(label: str) -> None:
+    page = DOCS_ROOT / LABEL_TABLE_PAGE
+    assert page.is_file(), f"{page} was moved or renamed; update LABEL_TABLE_PAGE"
+
+    spellings = (f"`{label}`", f"`({label})`")
+    text = page.read_text(encoding="utf-8")
+    assert any(spelling in text for spelling in spellings), (
+        f"{page} does not name the near-miss label '{label}' as any of {list(spellings)}."
+    )


### PR DESCRIPTION
## Summary

The troubleshooting page every resolution failure message links to covered Multiple Feature Groups, FeatureGroup Redefinition, and EmptyResultError, but had no section for the most common failure, the "No feature groups found" message whose text carries that link. Five other in_depth pages mention fragments of that message; the page written for it never did.

This adds the missing section, first among the error sections since it is the failure most readers arrive with:

- A faithful rendered example (headline with the domain callout, the eliminated-candidates block, the "Did you mean" hint, and the closing pointer lines), checked by rendering through the real renderer.
- A label table for the eliminated-candidates block: one row per distinct stage label, what eliminated the candidate, and the typical fix. The shared "compute framework" label is explained as covering two causes.
- The suggestion's suppression rules: what the hint drops and what a missing hint means.
- The abstract-only sibling variant with both headline shapes and its exact trailing-line behavior.

Guards, extending the existing doc label guard:

- The page is registered in the doc-bullet table, pinned to the `domain` stage.
- A new equality guard scans the label table's rows and requires them to be exactly the distinct stage labels, so a renamed, deleted, or stale row fails the suite. A vacuous substring check found during review was replaced by this.

Also fixed in passing, because the new table links to it as the domain fix: the "Use Domains" snippet returned a bare string, but `get_domain` must return a `Domain` for the gate's equality check, so the snippet as written eliminated its group from every domain-carrying request.

## Review pass

Two independent deep reviews ran on the diff. Accepted findings folded in: the example's candidate naming and bullet order now match the renderer's sort and the domain gate's ordering implications, the reproduction guidance passes the full `Feature` and run arguments instead of the bare name, the candidates intro no longer claims every line proves name ownership, suggestion suppression is keyed on unreachable groups with the catalog spelled out, the abstract-only trigger and trailing lines are stated precisely, `PandasDataFrame` is spelled as the class name the renderer prints, and the label guard was strengthened to set equality.

## Testing

- Full tox gate green: 8087 passed, 170 skipped, ruff, mypy --strict, licenses, bandit.
- Doc suites green: the near-miss label guards and the executed-fence, link, and anchor checks.
