### PR TITLE
fix: keep contained raises out of log records at seven sites

### DIFF
--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_author_guards.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_author_guards.py
@@ -210,12 +210,11 @@ def warn_universal_optional_matcher(owner: type[Any]) -> None:
     try:
         universal = bool(matcher(_UNIVERSAL_MATCHER_PROBE_NAME, Options()))
     except Exception as exc:
-        # rebind: Python clears the "except ... as exc" name at block exit, so the closure needs a stable local
-        err = exc
+        # Text, not exc: a retained record must not pin the traceback, its frames and the plugin class.
         logger.debug(
-            "universal-matcher probe for %s raised %s; treating it as non-universal.",
+            "universal-matcher probe for %s %s; treating it as non-universal.",
             owner.__name__,
-            safe_field(lambda: str(err), type(err).__name__),
+            contained_raise_reason(exc),
         )
         return
     if not universal:

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_author_guards.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_author_guards.py
@@ -26,7 +26,12 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
 from mloda.core.abstract_plugins.components.match_rejection import record_match_rejection
 from mloda.core.abstract_plugins.components.feature_chainer.parsed_feature_name import ParsedFeatureName
 from mloda.core.abstract_plugins.components.feature_chainer.property_spec import PropertySpec
-from mloda.core.abstract_plugins.components.utils import contained_raise_log_level, escalate_match_abort, safe_field
+from mloda.core.abstract_plugins.components.utils import (
+    contained_raise_log_level,
+    contained_raise_reason,
+    escalate_match_abort,
+    safe_field,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -258,10 +263,10 @@ def check_required_when(
         except Exception as exc:
             logger.log(
                 contained_raise_log_level(exc),
-                "required_when predicate %s for '%s' raised %s; treating feature group %s as a non-match.",
+                "required_when predicate %s for '%s' %s; treating feature group %s as a non-match.",
                 getattr(predicate, "__name__", repr(predicate)),
                 key,
-                exc,
+                contained_raise_reason(exc),
                 owner_name,
             )
             return False

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -15,7 +15,12 @@ from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
 from mloda.core.abstract_plugins.components.feature_chainer.parsed_feature_name import ParsedFeatureName
 from mloda.core.abstract_plugins.components.feature_chainer.property_spec import PropertySpec, is_no_default
-from mloda.core.abstract_plugins.components.utils import contained_raise_log_level, escalate_match_abort, safe_field
+from mloda.core.abstract_plugins.components.utils import (
+    contained_raise_log_level,
+    contained_raise_reason,
+    escalate_match_abort,
+    safe_field,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -170,15 +175,17 @@ class FeatureChainParser:
                 level = contained_raise_log_level(exc)
                 if level == logging.DEBUG:
                     logger.debug(
-                        "element_validator for '%s' raised %s for value %r; treating value as rejected.",
+                        "element_validator for '%s' %s for value %r; treating value as rejected.",
                         property_name,
-                        exc,
+                        contained_raise_reason(exc),
                         found_property_val,
                     )
                 else:
                     # The raw value stays out of WARNING logs; rerun with debug logging to see it.
                     logger.warning(
-                        "element_validator for '%s' raised %s; treating value as rejected.", property_name, exc
+                        "element_validator for '%s' %s; treating value as rejected.",
+                        property_name,
+                        contained_raise_reason(exc),
                     )
                 raised = exc
                 verdict = False

--- a/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
+++ b/mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser.py
@@ -172,6 +172,7 @@ class FeatureChainParser:
             try:
                 verdict = element_validator(found_property_val)
             except Exception as exc:  # Swallows: a validator that raises cannot judge the value, so it is rejected.
+                # Text, not exc: a retained record must not pin the traceback, its frames and the plugin class.
                 level = contained_raise_log_level(exc)
                 if level == logging.DEBUG:
                     logger.debug(

--- a/mloda/core/abstract_plugins/components/input_data/base_input_data.py
+++ b/mloda/core/abstract_plugins/components/input_data/base_input_data.py
@@ -15,6 +15,7 @@ from mloda.core.abstract_plugins.components.options import Options
 
 from mloda.core.abstract_plugins.components.utils import (
     contained_raise_log_level,
+    contained_raise_reason,
     escalate_match_abort,
     get_all_subclasses,
 )
@@ -186,10 +187,10 @@ class BaseInputData(ABC):
             except Exception as exc:
                 logger.log(
                     contained_raise_log_level(exc),
-                    "required_when predicate %s for reader option '%s' raised %s; treating reader %s as a non-match.",
+                    "required_when predicate %s for reader option '%s' %s; treating reader %s as a non-match.",
                     getattr(predicate, "__name__", repr(predicate)),
                     key,
-                    exc,
+                    contained_raise_reason(exc),
                     owner,
                 )
                 return False
@@ -240,10 +241,10 @@ class BaseInputData(ABC):
             except Exception as exc:  # Swallows: a validator that raises cannot judge the value, so it is rejected.
                 logger.log(
                     contained_raise_log_level(exc),
-                    "element_validator for reader option '%s' of %s raised %s; treating value as rejected.",
+                    "element_validator for reader option '%s' of %s %s; treating value as rejected.",
                     key,
                     cls.get_class_name(),
-                    exc,
+                    contained_raise_reason(exc),
                 )
                 return False
         try:

--- a/mloda/core/abstract_plugins/components/input_data/base_input_data.py
+++ b/mloda/core/abstract_plugins/components/input_data/base_input_data.py
@@ -185,6 +185,7 @@ class BaseInputData(ABC):
                 is_required = bool(predicate(options if options is not None else Options()))
             # Swallows: a predicate that raises cannot judge, so the reader is a non-match, not the run.
             except Exception as exc:
+                # Text, not exc: a retained record must not pin the traceback, its frames and the plugin class.
                 logger.log(
                     contained_raise_log_level(exc),
                     "required_when predicate %s for reader option '%s' %s; treating reader %s as a non-match.",

--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -37,7 +37,12 @@ from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options, _isolate_forwarded_value
 from mloda.core.abstract_plugins.components.index.index import Index
-from mloda.core.abstract_plugins.components.utils import get_all_subclasses, is_match_abort, safe_field
+from mloda.core.abstract_plugins.components.utils import (
+    contained_raise_reason,
+    get_all_subclasses,
+    is_match_abort,
+    safe_field,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -812,11 +817,12 @@ class FeatureGroup(ABC):
             # mean the feature group does not match, so it is not a root.
             if is_match_abort(exc):
                 raise
+            # Text, not exc: a retained record must not pin the traceback, its frames and the plugin class.
             logger.debug(
-                "%s.input_features raised an exception for feature '%s'",
+                "%s.input_features %s for feature '%s'; treating it as a non-root.",
                 type(self).__name__,
+                contained_raise_reason(exc),
                 feature_name,
-                exc_info=True,
             )
         return False
 

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -1,3 +1,4 @@
+import functools
 import inspect
 from collections.abc import Sequence
 from copy import deepcopy
@@ -620,7 +621,13 @@ class IdentifyFeatureGroupClass:
             feature.options.context.clear()
             feature.options.context.update(context_before)
             if isinstance(exc, PropertyValueRejection):
-                logger.debug("%s rejected an option value while matching '%s': %s", feature_group, feature.name, exc)
+                # Text, not exc: a retained record must not pin the traceback, its frames and the plugin class.
+                logger.debug(
+                    "%s rejected an option value while matching '%s': %s",
+                    feature_group.get_class_name(),
+                    feature.name,
+                    safe_field(functools.partial(str, exc), type(exc).__name__),
+                )
                 record_match_rejection(feature_group.get_class_name(), str(exc))
             else:
                 reason = contained_raise_reason(exc)

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_contained_raise_log_no_exception_object.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_contained_raise_log_no_exception_object.py
@@ -72,6 +72,11 @@ def _raise_records(caplog: pytest.LogCaptureFixture, logger_name: str, level: in
     ]
 
 
+def _module_records(caplog: pytest.LogCaptureFixture, logger_name: str) -> list[logging.LogRecord]:
+    """Only the module under test; DEBUG capture is global, so a neighbour's record is not this contract."""
+    return [record for record in caplog.records if record.name == logger_name]
+
+
 def _run_validator(validator: Any, caplog: pytest.LogCaptureFixture) -> None:
     """Drive the parser's element_validator seam."""
     property_mapping = {
@@ -103,7 +108,7 @@ class TestParserElementValidatorRaiseLogsNoExceptionObject:
         _run_validator(_clr975_validator_raises_unexpected, caplog)
 
         assert _raise_records(caplog, PARSER_LOGGER_NAME, logging.WARNING), "the broken-looking validator warns"
-        for record in caplog.records:
+        for record in _module_records(caplog, PARSER_LOGGER_NAME):
             assert _exception_args(record) == [], f"record pins an exception object: {record.getMessage()}"
             assert record.exc_info is None, f"record pins a traceback via exc_info: {record.getMessage()}"
 
@@ -111,7 +116,7 @@ class TestParserElementValidatorRaiseLogsNoExceptionObject:
         _run_validator(_clr975_validator_raises_type_error, caplog)
 
         assert _raise_records(caplog, PARSER_LOGGER_NAME, logging.DEBUG), "the judgment failure reports at DEBUG"
-        for record in caplog.records:
+        for record in _module_records(caplog, PARSER_LOGGER_NAME):
             assert _exception_args(record) == [], f"record pins an exception object: {record.getMessage()}"
             assert record.exc_info is None, f"record pins a traceback via exc_info: {record.getMessage()}"
 
@@ -143,14 +148,14 @@ class TestRequiredWhenRaiseLogsNoExceptionObject:
     def test_warning_branch_retains_no_exception_object(self, caplog: pytest.LogCaptureFixture) -> None:
         assert _run_predicate(_clr975_predicate_raises_unexpected, caplog) is False
         assert _raise_records(caplog, GUARDS_LOGGER_NAME, logging.WARNING), "the broken-looking predicate warns"
-        for record in caplog.records:
+        for record in _module_records(caplog, GUARDS_LOGGER_NAME):
             assert _exception_args(record) == [], f"record pins an exception object: {record.getMessage()}"
             assert record.exc_info is None, f"record pins a traceback via exc_info: {record.getMessage()}"
 
     def test_debug_branch_retains_no_exception_object(self, caplog: pytest.LogCaptureFixture) -> None:
         assert _run_predicate(_clr975_predicate_raises_type_error, caplog) is False
         assert _raise_records(caplog, GUARDS_LOGGER_NAME, logging.DEBUG), "the judgment failure reports at DEBUG"
-        for record in caplog.records:
+        for record in _module_records(caplog, GUARDS_LOGGER_NAME):
             assert _exception_args(record) == [], f"record pins an exception object: {record.getMessage()}"
             assert record.exc_info is None, f"record pins a traceback via exc_info: {record.getMessage()}"
 

--- a/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_contained_raise_log_no_exception_object.py
+++ b/tests/test_core/test_abstract_plugins/test_components/feature_chainer/test_contained_raise_log_no_exception_object.py
@@ -1,0 +1,175 @@
+"""A contained chainer-side raise is logged as text, never as the exception object.
+
+A retained record holding the object would pin exc.__traceback__ and through it the plugin class.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+import pytest
+
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_author_guards import check_required_when
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import (
+    FeatureChainParser,
+    PropertyValueRejection,
+)
+from mloda.core.abstract_plugins.components.feature_chainer.property_spec import PropertySpec
+from mloda.user import Options
+
+PARSER_LOGGER_NAME = FeatureChainParser.__module__
+GUARDS_LOGGER_NAME = check_required_when.__module__
+
+CLR975_VALIDATOR_KEY = "clr975_validator_key"
+CLR975_PREDICATE_KEY = "clr975_predicate_key"
+CLR975_VALUE = "clr975_value"
+CLR975_FEATURE = "text__validated_clr975"
+CLR975_PREFIX_PATTERN = r".*__validated_clr975$"
+CLR975_OWNER = "Clr975Owner"
+
+CLR975_VALIDATOR_BROKEN_MESSAGE = "clr975 validator looks broken"
+CLR975_VALIDATOR_JUDGMENT_MESSAGE = "clr975 validator cannot judge"
+CLR975_PREDICATE_BROKEN_MESSAGE = "clr975 predicate looks broken"
+CLR975_PREDICATE_JUDGMENT_MESSAGE = "clr975 predicate cannot judge"
+
+
+class Clr975Exploded(RuntimeError):
+    """An exception type no judgment failure uses, so the callable looks broken rather than undecided."""
+
+
+def _clr975_validator_raises_unexpected(value: Any) -> bool:
+    raise Clr975Exploded(CLR975_VALIDATOR_BROKEN_MESSAGE)
+
+
+def _clr975_validator_raises_type_error(value: Any) -> bool:
+    raise TypeError(CLR975_VALIDATOR_JUDGMENT_MESSAGE)
+
+
+def _clr975_predicate_raises_unexpected(options: Any) -> bool:
+    raise Clr975Exploded(CLR975_PREDICATE_BROKEN_MESSAGE)
+
+
+def _clr975_predicate_raises_type_error(options: Any) -> bool:
+    raise TypeError(CLR975_PREDICATE_JUDGMENT_MESSAGE)
+
+
+def _exception_args(record: logging.LogRecord) -> list[BaseException]:
+    """Exception objects the record retains through its args, tuple form and dict form alike."""
+    args = record.args
+    if args is None:
+        return []
+    values = list(args.values()) if isinstance(args, Mapping) else list(args)
+    return [value for value in values if isinstance(value, BaseException)]
+
+
+def _raise_records(caplog: pytest.LogCaptureFixture, logger_name: str, level: int) -> list[logging.LogRecord]:
+    return [
+        record
+        for record in caplog.records
+        if record.name == logger_name and record.levelno == level and "raised" in record.getMessage()
+    ]
+
+
+def _run_validator(validator: Any, caplog: pytest.LogCaptureFixture) -> None:
+    """Drive the parser's element_validator seam."""
+    property_mapping = {
+        CLR975_VALIDATOR_KEY: PropertySpec(
+            "clr975 touchy", context=True, strict_validation=True, element_validator=validator
+        )
+    }
+    with caplog.at_level(logging.DEBUG, logger=PARSER_LOGGER_NAME):
+        with pytest.raises(PropertyValueRejection):
+            FeatureChainParser.match_configuration_feature_chain_parser(
+                CLR975_FEATURE,
+                Options(context={CLR975_VALIDATOR_KEY: [CLR975_VALUE]}),
+                property_mapping=property_mapping,
+                prefix_patterns=[CLR975_PREFIX_PATTERN],
+            )
+
+
+def _run_predicate(predicate: Any, caplog: pytest.LogCaptureFixture) -> bool:
+    """Drive the author-guard required_when seam."""
+    property_mapping = {CLR975_PREDICATE_KEY: PropertySpec("clr975 undecidable", required_when=predicate)}
+    with caplog.at_level(logging.DEBUG, logger=GUARDS_LOGGER_NAME):
+        return check_required_when(CLR975_OWNER, CLR975_FEATURE, [], property_mapping, Options())
+
+
+class TestParserElementValidatorRaiseLogsNoExceptionObject:
+    """The parser's contained element_validator raise must reach the log as text only."""
+
+    def test_warning_branch_retains_no_exception_object(self, caplog: pytest.LogCaptureFixture) -> None:
+        _run_validator(_clr975_validator_raises_unexpected, caplog)
+
+        assert _raise_records(caplog, PARSER_LOGGER_NAME, logging.WARNING), "the broken-looking validator warns"
+        for record in caplog.records:
+            assert _exception_args(record) == [], f"record pins an exception object: {record.getMessage()}"
+            assert record.exc_info is None, f"record pins a traceback via exc_info: {record.getMessage()}"
+
+    def test_debug_branch_retains_no_exception_object(self, caplog: pytest.LogCaptureFixture) -> None:
+        _run_validator(_clr975_validator_raises_type_error, caplog)
+
+        assert _raise_records(caplog, PARSER_LOGGER_NAME, logging.DEBUG), "the judgment failure reports at DEBUG"
+        for record in caplog.records:
+            assert _exception_args(record) == [], f"record pins an exception object: {record.getMessage()}"
+            assert record.exc_info is None, f"record pins a traceback via exc_info: {record.getMessage()}"
+
+    def test_warning_message_still_names_key_and_exception_type(self, caplog: pytest.LogCaptureFixture) -> None:
+        _run_validator(_clr975_validator_raises_unexpected, caplog)
+
+        messages = [record.getMessage() for record in _raise_records(caplog, PARSER_LOGGER_NAME, logging.WARNING)]
+        assert len(messages) == 1, f"exactly one WARNING record reports the raise, got: {messages}"
+        assert CLR975_VALIDATOR_KEY in messages[0], f"the key must stay in the message: {messages[0]}"
+        assert "Clr975Exploded" in messages[0], f"the exception type must stay in the message: {messages[0]}"
+        assert CLR975_VALIDATOR_BROKEN_MESSAGE in messages[0], f"the reason must stay readable: {messages[0]}"
+        assert "raised " in messages[0], f"the message must still read as a contained raise: {messages[0]}"
+        assert CLR975_VALUE not in messages[0], f"the raw value stays out of WARNING logs: {messages[0]}"
+
+    def test_debug_message_still_names_key_exception_type_and_value(self, caplog: pytest.LogCaptureFixture) -> None:
+        _run_validator(_clr975_validator_raises_type_error, caplog)
+
+        messages = [record.getMessage() for record in _raise_records(caplog, PARSER_LOGGER_NAME, logging.DEBUG)]
+        assert len(messages) == 1, f"exactly one DEBUG record reports the raise, got: {messages}"
+        assert CLR975_VALIDATOR_KEY in messages[0], f"the key must stay in the message: {messages[0]}"
+        assert "TypeError" in messages[0], f"the exception type must stay in the message: {messages[0]}"
+        assert CLR975_VALIDATOR_JUDGMENT_MESSAGE in messages[0], f"the reason must stay readable: {messages[0]}"
+        assert CLR975_VALUE in messages[0], f"DEBUG keeps the rejected value visible: {messages[0]}"
+
+
+class TestRequiredWhenRaiseLogsNoExceptionObject:
+    """The author guard's contained required_when raise must reach the log as text only."""
+
+    def test_warning_branch_retains_no_exception_object(self, caplog: pytest.LogCaptureFixture) -> None:
+        assert _run_predicate(_clr975_predicate_raises_unexpected, caplog) is False
+        assert _raise_records(caplog, GUARDS_LOGGER_NAME, logging.WARNING), "the broken-looking predicate warns"
+        for record in caplog.records:
+            assert _exception_args(record) == [], f"record pins an exception object: {record.getMessage()}"
+            assert record.exc_info is None, f"record pins a traceback via exc_info: {record.getMessage()}"
+
+    def test_debug_branch_retains_no_exception_object(self, caplog: pytest.LogCaptureFixture) -> None:
+        assert _run_predicate(_clr975_predicate_raises_type_error, caplog) is False
+        assert _raise_records(caplog, GUARDS_LOGGER_NAME, logging.DEBUG), "the judgment failure reports at DEBUG"
+        for record in caplog.records:
+            assert _exception_args(record) == [], f"record pins an exception object: {record.getMessage()}"
+            assert record.exc_info is None, f"record pins a traceback via exc_info: {record.getMessage()}"
+
+    def test_warning_message_still_names_key_and_exception_type(self, caplog: pytest.LogCaptureFixture) -> None:
+        _run_predicate(_clr975_predicate_raises_unexpected, caplog)
+
+        messages = [record.getMessage() for record in _raise_records(caplog, GUARDS_LOGGER_NAME, logging.WARNING)]
+        assert len(messages) == 1, f"exactly one WARNING record reports the raise, got: {messages}"
+        assert CLR975_PREDICATE_KEY in messages[0], f"the key must stay in the message: {messages[0]}"
+        assert CLR975_OWNER in messages[0], f"the owner must stay in the message: {messages[0]}"
+        assert "Clr975Exploded" in messages[0], f"the exception type must stay in the message: {messages[0]}"
+        assert CLR975_PREDICATE_BROKEN_MESSAGE in messages[0], f"the reason must stay readable: {messages[0]}"
+        assert "raised " in messages[0], f"the message must still read as a contained raise: {messages[0]}"
+
+    def test_debug_message_still_names_key_and_exception_type(self, caplog: pytest.LogCaptureFixture) -> None:
+        _run_predicate(_clr975_predicate_raises_type_error, caplog)
+
+        messages = [record.getMessage() for record in _raise_records(caplog, GUARDS_LOGGER_NAME, logging.DEBUG)]
+        assert len(messages) == 1, f"exactly one DEBUG record reports the raise, got: {messages}"
+        assert CLR975_PREDICATE_KEY in messages[0], f"the key must stay in the message: {messages[0]}"
+        assert "TypeError" in messages[0], f"the exception type must stay in the message: {messages[0]}"
+        assert CLR975_PREDICATE_JUDGMENT_MESSAGE in messages[0], f"the reason must stay readable: {messages[0]}"

--- a/tests/test_core/test_abstract_plugins/test_components/test_reader_option_contained_raise_log_no_exception_object.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_reader_option_contained_raise_log_no_exception_object.py
@@ -56,6 +56,11 @@ def _exception_args(record: logging.LogRecord) -> list[BaseException]:
     return [value for value in values if isinstance(value, BaseException)]
 
 
+def _reader_records(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    """Only the module under test; DEBUG capture is global, so a neighbour's record is not this contract."""
+    return [record for record in caplog.records if record.name == READER_LOGGER_NAME]
+
+
 def _raise_records(caplog: pytest.LogCaptureFixture, level: int) -> list[logging.LogRecord]:
     return [
         record
@@ -84,7 +89,7 @@ class TestRequiredWhenRaiseLogsNoExceptionObject:
 
         assert _absent_key_verdict(spec, caplog) is False
         assert _raise_records(caplog, logging.WARNING), "the broken-looking predicate must report at WARNING"
-        for record in caplog.records:
+        for record in _reader_records(caplog):
             assert _exception_args(record) == [], f"record pins an exception object: {record.getMessage()}"
             assert record.exc_info is None, f"record pins a traceback via exc_info: {record.getMessage()}"
 
@@ -93,7 +98,7 @@ class TestRequiredWhenRaiseLogsNoExceptionObject:
 
         assert _absent_key_verdict(spec, caplog) is False
         assert _raise_records(caplog, logging.DEBUG), "the expected judgment failure must report at DEBUG"
-        for record in caplog.records:
+        for record in _reader_records(caplog):
             assert _exception_args(record) == [], f"record pins an exception object: {record.getMessage()}"
             assert record.exc_info is None, f"record pins a traceback via exc_info: {record.getMessage()}"
 
@@ -129,7 +134,7 @@ class TestElementValidatorRaiseLogsNoExceptionObject:
 
         assert _element_verdict(spec, caplog) is False
         assert _raise_records(caplog, logging.WARNING), "the broken-looking validator must report at WARNING"
-        for record in caplog.records:
+        for record in _reader_records(caplog):
             assert _exception_args(record) == [], f"record pins an exception object: {record.getMessage()}"
             assert record.exc_info is None, f"record pins a traceback via exc_info: {record.getMessage()}"
 
@@ -140,7 +145,7 @@ class TestElementValidatorRaiseLogsNoExceptionObject:
 
         assert _element_verdict(spec, caplog) is False
         assert _raise_records(caplog, logging.DEBUG), "the expected judgment failure must report at DEBUG"
-        for record in caplog.records:
+        for record in _reader_records(caplog):
             assert _exception_args(record) == [], f"record pins an exception object: {record.getMessage()}"
             assert record.exc_info is None, f"record pins a traceback via exc_info: {record.getMessage()}"
 

--- a/tests/test_core/test_abstract_plugins/test_components/test_reader_option_contained_raise_log_no_exception_object.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_reader_option_contained_raise_log_no_exception_object.py
@@ -1,0 +1,170 @@
+"""A contained reader-option raise is logged as text, never as the exception object.
+
+A retained record holding the object would pin exc.__traceback__ and through it the reader class.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+import pytest
+
+from mloda.core.abstract_plugins.components.feature_chainer.property_spec import PropertySpec
+from mloda.core.abstract_plugins.components.input_data.base_input_data import BaseInputData
+from mloda.user import Options
+
+READER_LOGGER_NAME = BaseInputData.__module__
+
+RIC975_PREDICATE_KEY = "ric975_predicate_key"
+RIC975_VALIDATOR_KEY = "ric975_validator_key"
+RIC975_VALUE = "ric975_value"
+
+RIC975_BROKEN_MESSAGE = "ric975 predicate looks broken"
+RIC975_JUDGMENT_MESSAGE = "ric975 predicate cannot judge"
+RIC975_VALIDATOR_BROKEN_MESSAGE = "ric975 validator looks broken"
+RIC975_VALIDATOR_JUDGMENT_MESSAGE = "ric975 validator cannot judge"
+
+
+class Ric975Exploded(RuntimeError):
+    """An exception type no judgment failure uses, so the callable looks broken rather than undecided."""
+
+
+def _ric975_predicate_raises_unexpected(options: Any) -> bool:
+    raise Ric975Exploded(RIC975_BROKEN_MESSAGE)
+
+
+def _ric975_predicate_raises_type_error(options: Any) -> bool:
+    raise TypeError(RIC975_JUDGMENT_MESSAGE)
+
+
+def _ric975_validator_raises_unexpected(value: Any) -> bool:
+    raise Ric975Exploded(RIC975_VALIDATOR_BROKEN_MESSAGE)
+
+
+def _ric975_validator_raises_type_error(value: Any) -> bool:
+    raise TypeError(RIC975_VALIDATOR_JUDGMENT_MESSAGE)
+
+
+def _exception_args(record: logging.LogRecord) -> list[BaseException]:
+    """Exception objects the record retains through its args, tuple form and dict form alike."""
+    args = record.args
+    if args is None:
+        return []
+    values = list(args.values()) if isinstance(args, Mapping) else list(args)
+    return [value for value in values if isinstance(value, BaseException)]
+
+
+def _raise_records(caplog: pytest.LogCaptureFixture, level: int) -> list[logging.LogRecord]:
+    return [
+        record
+        for record in caplog.records
+        if record.name == READER_LOGGER_NAME and record.levelno == level and "raised" in record.getMessage()
+    ]
+
+
+def _absent_key_verdict(spec: PropertySpec, caplog: pytest.LogCaptureFixture) -> bool:
+    """Run the absent-key seam under DEBUG capture."""
+    with caplog.at_level(logging.DEBUG, logger=READER_LOGGER_NAME):
+        return BaseInputData._absent_reader_option_admits(RIC975_PREDICATE_KEY, spec, Options(), False)
+
+
+def _element_verdict(spec: PropertySpec, caplog: pytest.LogCaptureFixture) -> bool:
+    """Run the element seam under DEBUG capture."""
+    with caplog.at_level(logging.DEBUG, logger=READER_LOGGER_NAME):
+        return BaseInputData._reader_option_element_admits(RIC975_VALIDATOR_KEY, spec, RIC975_VALUE)
+
+
+class TestRequiredWhenRaiseLogsNoExceptionObject:
+    """The contained required_when raise of a reader option must reach the log as text only."""
+
+    def test_warning_branch_retains_no_exception_object(self, caplog: pytest.LogCaptureFixture) -> None:
+        spec = PropertySpec("ric975 undecidable", required_when=_ric975_predicate_raises_unexpected)
+
+        assert _absent_key_verdict(spec, caplog) is False
+        assert _raise_records(caplog, logging.WARNING), "the broken-looking predicate must report at WARNING"
+        for record in caplog.records:
+            assert _exception_args(record) == [], f"record pins an exception object: {record.getMessage()}"
+            assert record.exc_info is None, f"record pins a traceback via exc_info: {record.getMessage()}"
+
+    def test_debug_branch_retains_no_exception_object(self, caplog: pytest.LogCaptureFixture) -> None:
+        spec = PropertySpec("ric975 undecidable", required_when=_ric975_predicate_raises_type_error)
+
+        assert _absent_key_verdict(spec, caplog) is False
+        assert _raise_records(caplog, logging.DEBUG), "the expected judgment failure must report at DEBUG"
+        for record in caplog.records:
+            assert _exception_args(record) == [], f"record pins an exception object: {record.getMessage()}"
+            assert record.exc_info is None, f"record pins a traceback via exc_info: {record.getMessage()}"
+
+    def test_warning_message_still_names_key_and_exception_type(self, caplog: pytest.LogCaptureFixture) -> None:
+        spec = PropertySpec("ric975 undecidable", required_when=_ric975_predicate_raises_unexpected)
+        _absent_key_verdict(spec, caplog)
+
+        messages = [record.getMessage() for record in _raise_records(caplog, logging.WARNING)]
+        assert len(messages) == 1, f"exactly one WARNING record reports the raise, got: {messages}"
+        assert RIC975_PREDICATE_KEY in messages[0], f"the key must stay in the message: {messages[0]}"
+        assert "Ric975Exploded" in messages[0], f"the exception type must stay in the message: {messages[0]}"
+        assert RIC975_BROKEN_MESSAGE in messages[0], f"the reason must stay readable: {messages[0]}"
+        assert "raised " in messages[0], f"the message must still read as a contained raise: {messages[0]}"
+
+    def test_debug_message_still_names_key_and_exception_type(self, caplog: pytest.LogCaptureFixture) -> None:
+        spec = PropertySpec("ric975 undecidable", required_when=_ric975_predicate_raises_type_error)
+        _absent_key_verdict(spec, caplog)
+
+        messages = [record.getMessage() for record in _raise_records(caplog, logging.DEBUG)]
+        assert len(messages) == 1, f"exactly one DEBUG record reports the raise, got: {messages}"
+        assert RIC975_PREDICATE_KEY in messages[0], f"the key must stay in the message: {messages[0]}"
+        assert "TypeError" in messages[0], f"the exception type must stay in the message: {messages[0]}"
+        assert RIC975_JUDGMENT_MESSAGE in messages[0], f"the reason must stay readable: {messages[0]}"
+
+
+class TestElementValidatorRaiseLogsNoExceptionObject:
+    """The contained element_validator raise of a reader option must reach the log as text only."""
+
+    def test_warning_branch_retains_no_exception_object(self, caplog: pytest.LogCaptureFixture) -> None:
+        spec = PropertySpec(
+            "ric975 touchy", element_validator=_ric975_validator_raises_unexpected, strict_validation=True
+        )
+
+        assert _element_verdict(spec, caplog) is False
+        assert _raise_records(caplog, logging.WARNING), "the broken-looking validator must report at WARNING"
+        for record in caplog.records:
+            assert _exception_args(record) == [], f"record pins an exception object: {record.getMessage()}"
+            assert record.exc_info is None, f"record pins a traceback via exc_info: {record.getMessage()}"
+
+    def test_debug_branch_retains_no_exception_object(self, caplog: pytest.LogCaptureFixture) -> None:
+        spec = PropertySpec(
+            "ric975 touchy", element_validator=_ric975_validator_raises_type_error, strict_validation=True
+        )
+
+        assert _element_verdict(spec, caplog) is False
+        assert _raise_records(caplog, logging.DEBUG), "the expected judgment failure must report at DEBUG"
+        for record in caplog.records:
+            assert _exception_args(record) == [], f"record pins an exception object: {record.getMessage()}"
+            assert record.exc_info is None, f"record pins a traceback via exc_info: {record.getMessage()}"
+
+    def test_warning_message_still_names_key_and_exception_type(self, caplog: pytest.LogCaptureFixture) -> None:
+        spec = PropertySpec(
+            "ric975 touchy", element_validator=_ric975_validator_raises_unexpected, strict_validation=True
+        )
+        _element_verdict(spec, caplog)
+
+        messages = [record.getMessage() for record in _raise_records(caplog, logging.WARNING)]
+        assert len(messages) == 1, f"exactly one WARNING record reports the raise, got: {messages}"
+        assert RIC975_VALIDATOR_KEY in messages[0], f"the key must stay in the message: {messages[0]}"
+        assert "Ric975Exploded" in messages[0], f"the exception type must stay in the message: {messages[0]}"
+        assert RIC975_VALIDATOR_BROKEN_MESSAGE in messages[0], f"the reason must stay readable: {messages[0]}"
+        assert "raised " in messages[0], f"the message must still read as a contained raise: {messages[0]}"
+
+    def test_debug_message_still_names_key_and_exception_type(self, caplog: pytest.LogCaptureFixture) -> None:
+        spec = PropertySpec(
+            "ric975 touchy", element_validator=_ric975_validator_raises_type_error, strict_validation=True
+        )
+        _element_verdict(spec, caplog)
+
+        messages = [record.getMessage() for record in _raise_records(caplog, logging.DEBUG)]
+        assert len(messages) == 1, f"exactly one DEBUG record reports the raise, got: {messages}"
+        assert RIC975_VALIDATOR_KEY in messages[0], f"the key must stay in the message: {messages[0]}"
+        assert "TypeError" in messages[0], f"the exception type must stay in the message: {messages[0]}"
+        assert RIC975_VALIDATOR_JUDGMENT_MESSAGE in messages[0], f"the reason must stay readable: {messages[0]}"

--- a/tests/test_core/test_abstract_plugins/test_feature_group/test_is_root_raise_log_no_traceback.py
+++ b/tests/test_core/test_abstract_plugins/test_feature_group/test_is_root_raise_log_no_traceback.py
@@ -1,0 +1,95 @@
+"""A contained input_features raise is logged as text, never with exc_info.
+
+``exc_info=True`` puts (type, exc, traceback) on the record, and a retained record then pins the
+traceback frames and through them the dynamically loaded FeatureGroup class.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import Optional
+
+import pytest
+
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+
+FEATURE_GROUP_LOGGER_NAME = FeatureGroup.__module__
+
+ISROOT_FEATURE = "is_root_log_probe_feat"
+ISROOT_CLASS_NAME = "IsRootLogProbeFG"
+ISROOT_MESSAGE = "is_root probe cannot answer for this feature"
+
+
+class IsRootProbeExploded(RuntimeError):
+    """An unmarked exception type, so the raise stays contained as a non-match."""
+
+
+class IsRootLogProbeFG(FeatureGroup):
+    """Stands in for a group whose input_features cannot answer for this feature name.
+
+    Module level on purpose: a locally defined double is registered mid-test, and the record under
+    test pins it, so the registry-pollution guard would fire on the leak instead of the log contract.
+    """
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        raise IsRootProbeExploded(ISROOT_MESSAGE)
+
+
+def _exception_args(record: logging.LogRecord) -> list[BaseException]:
+    """Exception objects the record retains through its args, tuple form and dict form alike."""
+    args = record.args
+    if args is None:
+        return []
+    values = list(args.values()) if isinstance(args, Mapping) else list(args)
+    return [value for value in values if isinstance(value, BaseException)]
+
+
+def _feature_group_records(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    """Only the feature_group module's own records; a neighbouring module's DEBUG record is not this contract."""
+    return [record for record in caplog.records if record.name == FEATURE_GROUP_LOGGER_NAME]
+
+
+def _raise_records(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    return [
+        record
+        for record in _feature_group_records(caplog)
+        if record.levelno == logging.DEBUG and "input_features" in record.getMessage()
+    ]
+
+
+def _run_is_root(caplog: pytest.LogCaptureFixture) -> bool:
+    """Drive the contained input_features branch of is_root under DEBUG capture."""
+    with caplog.at_level(logging.DEBUG, logger=FEATURE_GROUP_LOGGER_NAME):
+        return IsRootLogProbeFG().is_root(Options(), ISROOT_FEATURE)
+
+
+class TestIsRootContainedRaiseLogsNoTraceback:
+    """The contained input_features raise must reach the log as text only."""
+
+    def test_record_retains_no_exception_object(self, caplog: pytest.LogCaptureFixture) -> None:
+        assert _run_is_root(caplog) is False
+
+        assert _raise_records(caplog), "the contained raise must report at DEBUG"
+        for record in _feature_group_records(caplog):
+            assert _exception_args(record) == [], f"record pins an exception object: {record.getMessage()}"
+
+    def test_record_retains_no_traceback_via_exc_info(self, caplog: pytest.LogCaptureFixture) -> None:
+        assert _run_is_root(caplog) is False
+
+        assert _raise_records(caplog), "the contained raise must report at DEBUG"
+        for record in _feature_group_records(caplog):
+            assert record.exc_info is None, f"record pins a traceback via exc_info: {record.getMessage()}"
+
+    def test_message_still_names_class_feature_and_exception(self, caplog: pytest.LogCaptureFixture) -> None:
+        _run_is_root(caplog)
+
+        messages = [record.getMessage() for record in _raise_records(caplog)]
+        assert len(messages) == 1, f"exactly one DEBUG record reports the raise, got: {messages}"
+        assert ISROOT_CLASS_NAME in messages[0], f"the class must stay in the message: {messages[0]}"
+        assert ISROOT_FEATURE in messages[0], f"the feature name must stay in the message: {messages[0]}"
+        assert "IsRootProbeExploded" in messages[0], f"the exception type must stay in the message: {messages[0]}"
+        assert ISROOT_MESSAGE in messages[0], f"the reason must stay readable: {messages[0]}"

--- a/tests/test_core/test_prepare/test_contained_rejection_log_no_pinning_object.py
+++ b/tests/test_core/test_prepare/test_contained_rejection_log_no_pinning_object.py
@@ -1,0 +1,157 @@
+"""A contained value rejection at the identify seam is logged as text, never as pinning objects.
+
+A retained record pins whatever sits in ``LogRecord.args``: the candidate class directly, and the
+rejection object through ``exc.__traceback__``, whose frames reach the same dynamically loaded class.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import Any, Optional
+
+import pytest
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import FeatureChainParser
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
+from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+from mloda.provider import PropertySpec
+
+IDENTIFY_LOGGER_NAME = IdentifyFeatureGroupClass.__module__
+
+CRLOG_KEY = "crlog_rejected_key"
+CRLOG_VALUE = "crlog_rejected_value"
+CRLOG_FEATURE = "source__rejected_crlog"
+CRLOG_PATTERN = r".*__rejected_crlog$"
+CRLOG_CLASS_NAME = "RejectingValueFGCrlog"
+CRLOG_VALIDATOR_MESSAGE = "crlog validator cannot judge"
+
+
+def _crlog_validator_raises(value: Any) -> bool:
+    raise TypeError(CRLOG_VALIDATOR_MESSAGE)
+
+
+CRLOG_PROPERTY_MAPPING = {
+    CRLOG_KEY: PropertySpec(
+        "crlog touchy", context=True, strict_validation=True, element_validator=_crlog_validator_raises
+    )
+}
+
+
+class CrlogFw(ComputeFramework):
+    """Dummy compute framework for the contained-rejection log tests."""
+
+
+class RejectingValueFGCrlog(FeatureGroup):
+    """Plugin double that calls the parser directly, so a rejection reaches the identify seam.
+
+    Module level on purpose: a locally defined double is registered mid-test, and the record under
+    test pins it, so the registry-pollution guard would fire on the leak instead of the log contract.
+    It is inert for every other feature name.
+    """
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]] | None:
+        return {CrlogFw}
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: Optional[DataAccessCollection] = None,
+    ) -> bool:
+        if str(feature_name) != CRLOG_FEATURE:
+            return False
+        return FeatureChainParser.match_configuration_feature_chain_parser(
+            str(feature_name),
+            options,
+            property_mapping=CRLOG_PROPERTY_MAPPING,
+            prefix_patterns=[CRLOG_PATTERN],
+        )
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return None
+
+
+def _exception_args(record: logging.LogRecord) -> list[BaseException]:
+    """Exception objects the record retains through its args, tuple form and dict form alike."""
+    args = record.args
+    if args is None:
+        return []
+    values = list(args.values()) if isinstance(args, Mapping) else list(args)
+    return [value for value in values if isinstance(value, BaseException)]
+
+
+def _class_args(record: logging.LogRecord) -> list[type]:
+    """Class objects the record retains through its args, tuple form and dict form alike."""
+    args = record.args
+    if args is None:
+        return []
+    values = list(args.values()) if isinstance(args, Mapping) else list(args)
+    return [value for value in values if isinstance(value, type)]
+
+
+def _rejection_records(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    """Only the identify seam's own records; a neighbouring module's DEBUG record is not this contract."""
+    return [
+        record
+        for record in caplog.records
+        if record.name == IDENTIFY_LOGGER_NAME
+        and record.levelno == logging.DEBUG
+        and "rejected an option value" in record.getMessage()
+    ]
+
+
+def _identify_records(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    return [record for record in caplog.records if record.name == IDENTIFY_LOGGER_NAME]
+
+
+def _evaluate(caplog: pytest.LogCaptureFixture) -> None:
+    """Drive one evaluation whose only candidate rejects the option value."""
+    feature = Feature(CRLOG_FEATURE, Options(context={CRLOG_KEY: [CRLOG_VALUE]}))
+    plugins: FeatureGroupEnvironmentMapping = {RejectingValueFGCrlog: {CrlogFw}}
+    with caplog.at_level(logging.DEBUG, logger=IDENTIFY_LOGGER_NAME):
+        result = IdentifyFeatureGroupClass.evaluate(feature, plugins, None)
+    assert not result.identified, "the rejected candidate must not win the feature"
+
+
+class TestContainedRejectionLogsNoPinningObject:
+    """The contained PropertyValueRejection must reach the log as text only."""
+
+    def test_record_retains_no_exception_object(self, caplog: pytest.LogCaptureFixture) -> None:
+        _evaluate(caplog)
+
+        assert _rejection_records(caplog), "the contained rejection must report at DEBUG"
+        for record in _identify_records(caplog):
+            assert _exception_args(record) == [], f"record pins an exception object: {record.getMessage()}"
+
+    def test_record_retains_no_class_object(self, caplog: pytest.LogCaptureFixture) -> None:
+        _evaluate(caplog)
+
+        assert _rejection_records(caplog), "the contained rejection must report at DEBUG"
+        for record in _identify_records(caplog):
+            assert _class_args(record) == [], f"record pins a class object: {record.getMessage()}"
+
+    def test_record_retains_no_traceback_via_exc_info(self, caplog: pytest.LogCaptureFixture) -> None:
+        _evaluate(caplog)
+
+        assert _rejection_records(caplog), "the contained rejection must report at DEBUG"
+        for record in _identify_records(caplog):
+            assert record.exc_info is None, f"record pins a traceback via exc_info: {record.getMessage()}"
+
+    def test_message_still_names_group_feature_and_reason(self, caplog: pytest.LogCaptureFixture) -> None:
+        _evaluate(caplog)
+
+        messages = [record.getMessage() for record in _rejection_records(caplog)]
+        assert len(messages) == 1, f"exactly one DEBUG record reports the rejection, got: {messages}"
+        assert CRLOG_CLASS_NAME in messages[0], f"the rejecting group must stay in the message: {messages[0]}"
+        assert CRLOG_FEATURE in messages[0], f"the feature name must stay in the message: {messages[0]}"
+        assert CRLOG_KEY in messages[0], f"the rejected key must stay in the message: {messages[0]}"
+        assert CRLOG_VALUE in messages[0], f"the rejection text must stay readable: {messages[0]}"


### PR DESCRIPTION
Closes #975.

A contained raise must reach a log record as text only. A handler that retains records (pytest `caplog`, `logging.handlers.MemoryHandler`, breadcrumb collectors) otherwise keeps `exc.__traceback__` alive, and through its frames a dynamically loaded FeatureGroup or reader class cannot be reclaimed.

## The five sites from the issue

`BaseInputData` (`required_when` predicate, `element_validator`), `FeatureChainParser` (both `element_validator` branches), and `check_required_when` all passed the raw `exc` into `LogRecord.args`. Each now passes `contained_raise_reason(exc)`. That helper already yields `raised <Type>: <message>`, so the format strings dropped their own literal `raised`. The DEBUG/WARNING split and the redaction of raw option values from WARNING logs are unchanged, as is the exception chaining in `FeatureChainParser`.

## Two more the review found

- The option-value rejection branch of the match seam logged the FeatureGroup **class object** at arg 0 and the `PropertyValueRejection` at arg 2. That exception is raised `from` the user's validator exception, so its `__cause__` carries the validator traceback: it undid the parser fix one frame later. It now logs the class name and the rejection text, matching the sibling branch just below it.
- `FeatureGroup.is_root` logged its contained `input_features` raise with `exc_info=True`, which pins the traceback on the record directly. The diagnosis now travels as text, so nothing is lost.

The universal-matcher probe also drops its hand-rolled `err` rebind plus lambda for the same helper, and each changed seam now states the invariant in one line.

## Tests

Four modules, one per containment family, each asserting the record holds no exception object in `args`, no class object where one used to sit, and no `exc_info`, plus that the message still names the key, the class, the exception type and its text. Every one of them fails on `main` for the intended reason.

`tox`: 8110 passed, 170 skipped, all gates green.