### PR TITLE
fix: attach the union of divergent sibling filter matches instead of aborting

### DIFF
--- a/docs/docs/in_depth/filter_data.md
+++ b/docs/docs/in_depth/filter_data.md
@@ -242,8 +242,10 @@ get is therefore decided outside your FeatureGroup. `if features.filters:` cover
 
 Matching is probed per feature, but matched filters attach to the `FeatureSet`. A feature that
 declined a filter is still filtered by it once a sibling of its set matched it, a contained raise
-included; that is logged as a WARNING. Two features matching different non-empty filter sets
-raise `ValueError` instead. To scope a filter, make the deciding option a **group** option:
+included; that is logged as a WARNING. Siblings matching different non-empty filter sets get the
+union attached. Matches of one filter that differ only in the enriched options count as that one
+filter: it attaches once and is not reported. To scope a filter, make the deciding option a
+**group** option:
 differing group options split the features into separate `FeatureSet`s.
 
 `GlobalFilter.probes` records what every probe matched, empty results included, for debugging.

--- a/docs/docs/in_depth/filter_data.md
+++ b/docs/docs/in_depth/filter_data.md
@@ -244,9 +244,9 @@ Matching is probed per feature, but matched filters attach to the `FeatureSet`. 
 declined a filter is still filtered by it once a sibling of its set matched it, a contained raise
 included; that is logged as a WARNING. Siblings matching different non-empty filter sets get the
 union attached. Matches of one filter that differ only in the enriched options count as that one
-filter: it attaches once and is not reported. To scope a filter, make the deciding option a
-**group** option:
-differing group options split the features into separate `FeatureSet`s.
+filter, attached once and not reported, only while they resolve to the same column: a per-sibling
+rename makes them distinct predicates and both attach. To scope a filter, make the deciding
+option a **group** option: differing group options split the features into separate `FeatureSet`s.
 
 `GlobalFilter.probes` records what every probe matched, empty results included, for debugging.
 

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -3,6 +3,7 @@ from typing import Any, Generator, Optional
 from uuid import UUID
 
 from mloda.core.abstract_plugins.components.error_utils import internal_invariant_error
+from mloda.core.abstract_plugins.components.utils import safe_field
 from mloda.core.abstract_plugins.components.index.index import Index
 
 from mloda.core.abstract_plugins.components.input_data.api.api_input_data_collection import (
@@ -32,11 +33,12 @@ logger = logging.getLogger(__name__)
 
 
 def _filter_options_sort_key(single_filter: SingleFilter) -> tuple[str, str]:
-    """Deterministic order over enrichment variants; repr keeps primitive option values comparable."""
+    """Order enrichment variants: stable for values with a value-based repr, repr-identity ordering
+    otherwise; a raising repr degrades to the value's type name."""
     options = single_filter.filter_feature.options
     return (
-        repr(sorted((str(k), repr(v)) for k, v in options.group.items())),
-        repr(sorted((str(k), repr(v)) for k, v in options.context.items())),
+        repr(sorted((str(k), safe_field(lambda: repr(v), type(v).__name__)) for k, v in options.group.items())),
+        repr(sorted((str(k), safe_field(lambda: repr(v), type(v).__name__)) for k, v in options.context.items())),
     )
 
 
@@ -1008,10 +1010,11 @@ class ExecutionPlan:
             return
 
         feature_names = {feature.name for feature in feature_set.features}
+        probed_union = self._probed_filters_for_set(feature_group, feature_set)
 
         # One representative per declared filter: enrichment variants of one declaration share
         # its uuid; the resolved column name stays in the key because renames change the predicate.
-        representatives: dict[tuple[UUID, str], SingleFilter] = {}
+        representatives: dict[tuple[UUID, str], tuple[tuple[int, str, str], SingleFilter]] = {}
         for (
             filtered_feature_group,
             filtered_feature_name,
@@ -1020,15 +1023,28 @@ class ExecutionPlan:
                 continue
             for single_filter in single_filters:
                 key = (single_filter.uuid, str(single_filter.filter_feature.name))
+                # A variant this run's features probed outranks stale ones a reused GlobalFilter kept.
+                rank = (0 if single_filter in probed_union else 1, *_filter_options_sort_key(single_filter))
                 current = representatives.get(key)
-                if current is None or _filter_options_sort_key(single_filter) < _filter_options_sort_key(current):
-                    representatives[key] = single_filter
+                if current is None or rank < current[0]:
+                    representatives[key] = (rank, single_filter)
 
-        # Fresh set so the live collection sets stay untouched.
-        relevant_filters = set(representatives.values())
+        # Fresh set; the elements remain the collection's live objects.
+        relevant_filters = {single_filter for _, single_filter in representatives.values()}
 
         self._warn_on_unmatched_features(feature_group, feature_set, relevant_filters)
         feature_set.add_filters(relevant_filters)
+
+    def _probed_filters_for_set(self, feature_group: type[FeatureGroup], feature_set: FeatureSet) -> set[SingleFilter]:
+        """Union of the filters this set's features probed; unprobed features contribute nothing."""
+        probed_union: set[SingleFilter] = set()
+        if self.global_filter is None:
+            return probed_union
+        for feature in feature_set.features:
+            probed = self.global_filter.probes.get((feature_group, feature.name, feature.uuid))
+            if probed is not None:
+                probed_union |= probed
+        return probed_union
 
     def _warn_on_unmatched_features(
         self, feature_group: type[FeatureGroup], feature_set: FeatureSet, relevant_filters: set[SingleFilter]

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -31,6 +31,15 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+def _filter_options_sort_key(single_filter: SingleFilter) -> tuple[str, str]:
+    """Deterministic order over enrichment variants; repr keeps primitive option values comparable."""
+    options = single_filter.filter_feature.options
+    return (
+        repr(sorted((str(k), repr(v)) for k, v in options.group.items())),
+        repr(sorted((str(k), repr(v)) for k, v in options.context.items())),
+    )
+
+
 class ExecutionPlan:
     def __init__(
         self,
@@ -998,29 +1007,25 @@ class ExecutionPlan:
         if len(self.global_filter.collection.keys()) == 0:
             return
 
-        relevant_filters: set[SingleFilter] = set()
+        feature_names = {feature.name for feature in feature_set.features}
 
+        # One representative per declared filter: enrichment variants of one declaration share
+        # its uuid; the resolved column name stays in the key because renames change the predicate.
+        representatives: dict[tuple[UUID, str], SingleFilter] = {}
         for (
             filtered_feature_group,
             filtered_feature_name,
         ), single_filters in self.global_filter.collection.items():
-            # check for correct feature group
-            if filtered_feature_group == feature_group:
-                # check if filter feature is a feature of this feature set
-                for feature in feature_set.features:
-                    if feature.name == filtered_feature_name:
-                        if len(relevant_filters) == 0:
-                            # Read-only alias of the live collection set; FeatureSet.add_filters
-                            # copies it once at the storing end (#910).
-                            relevant_filters = single_filters
-                        else:
-                            if relevant_filters != single_filters:
-                                raise ValueError(
-                                    f"""Feature group {feature_group} has different filters for different features {filtered_feature_name}.
-                                      This is currently not allowed. Please make sure that all features of the same feature group have the same filters.
-                                      If this has a business use case, where this does not make sense, please contact the developers.
-                                      """
-                                )
+            if filtered_feature_group != feature_group or filtered_feature_name not in feature_names:
+                continue
+            for single_filter in single_filters:
+                key = (single_filter.uuid, str(single_filter.filter_feature.name))
+                current = representatives.get(key)
+                if current is None or _filter_options_sort_key(single_filter) < _filter_options_sort_key(current):
+                    representatives[key] = single_filter
+
+        # Fresh set so the live collection sets stay untouched.
+        relevant_filters = set(representatives.values())
 
         self._warn_on_unmatched_features(feature_group, feature_set, relevant_filters)
         feature_set.add_filters(relevant_filters)
@@ -1037,7 +1042,15 @@ class ExecutionPlan:
             # Filter and index features enter the collection without being probed.
             if probed is None:
                 continue
-            unmatched = sorted({str(f.filter_feature.name) for f in relevant_filters - probed})
+            # Diff by declared-filter identity so a match under another enrichment still counts.
+            probed_keys = {(f.uuid, str(f.filter_feature.name)) for f in probed}
+            unmatched = sorted(
+                {
+                    str(f.filter_feature.name)
+                    for f in relevant_filters
+                    if (f.uuid, str(f.filter_feature.name)) not in probed_keys
+                }
+            )
             if not unmatched:
                 continue
             key = (feature_group, str(feature.name), tuple(unmatched))

--- a/tests/test_core/test_filter/test_filter_feature_explicit_none_intake.py
+++ b/tests/test_core/test_filter/test_filter_feature_explicit_none_intake.py
@@ -245,16 +245,16 @@ def test_group_key_filter_is_stored_once_when_the_host_is_reached_twice() -> Non
 def test_group_key_two_hosts_with_unequal_reach_keep_one_filter_each() -> None:
     """Two hosts of one group, one reached twice and one once, keep a filter each and the run finishes.
 
-    Fails pre-fix: the twice-reached host collects two entries against the once-reached host's one,
-    and ``ExecutionPlan.add_single_filters_to_feature_set`` aborts the run over the unequal sets
-    (``ValueError: ... has different filters for different features``). This is the hard symptom the
-    symmetric dedup tests cannot reach, because two equally stale sets still compare equal.
+    Fails pre-fix: the twice-reached host collects two entries against the once-reached host's one.
+    The plan no longer rejects unequal sets, it attaches the deduplicated union, so the entry-count
+    assertions are what guard the intake dedup now. Two equally stale sets still compare equal,
+    which is why the symmetric dedup tests cannot reach this shape.
     """
     observed = _run(GRP_PROBE, via_derived=True, second_host=True)
     collection = observed["collection"]
     counts = {name: entry["entries"] for name, entry in collection.items()}
     assert counts == {GRP_PROBE.root: 1, GRP_PROBE.root_b: 1}, (
-        f"each host must hold exactly one filter, else the plan rejects the unequal sets: {collection!r}"
+        f"each host must hold exactly one filter; the entry counts are what guard the dedup now: {collection!r}"
     )
     payload = observed["payload"]
     assert {GRP_PROBE.root, GRP_PROBE.root_b} <= set(payload["names"]), (

--- a/tests/test_core/test_filter/test_filter_sibling_divergence_scope.py
+++ b/tests/test_core/test_filter/test_filter_sibling_divergence_scope.py
@@ -1,0 +1,199 @@
+"""Sibling features of one FeatureSet may match different filters: the set gets the union,
+enrichment-only differences stay silent, and each genuinely unmatched filter warns per feature.
+"""
+
+from __future__ import annotations
+
+import gc
+import logging
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import pytest
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.provider import DataCreator
+from mloda.user import Feature, FeatureName, FilterType, GlobalFilter, Options, PluginCollector, mloda
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
+
+
+EP_LOGGER_NAME = "mloda.core.prepare.execution_plan"
+
+# The fsd_ prefix keeps every name unique to this module.
+FSD_A = "fsd_feat_a"
+FSD_B = "fsd_feat_b"
+FSD_SHARED_FILTER = "fsd_filter_shared"  # every probe matches it
+FSD_X_FILTER = "fsd_filter_x"  # matched only for mode "a"
+FSD_Y_FILTER = "fsd_filter_y"  # matched only for mode "b"
+FSD_MODE_KEY = "fsd_mode"
+FSD_NOTE_KEY = "fsd_note"  # unrelated context key the match hook never reads
+
+SERVED_FSD_NAMES = (FSD_A, FSD_B)
+ALL_FSD_NAMES = SERVED_FSD_NAMES + (FSD_SHARED_FILTER, FSD_X_FILTER, FSD_Y_FILTER)
+
+
+def _sentinel(features: FeatureSet) -> dict[str, list[int]]:
+    """One row per served feature carrying the number of filters the set was handed (-1 for None)."""
+    delivered = -1 if features.filters is None else len(features.filters)
+    return {str(feature.name): [delivered] for feature in features.features}
+
+
+def _make_fg(capture: list[tuple[Feature, ...]]) -> type[FeatureGroup]:
+    """A throwaway root group whose per-filter matches depend on the probing feature's mode."""
+    gc.collect()
+
+    class FsdDivergenceFG(FeatureGroup):
+        @classmethod
+        def input_data(cls) -> DataCreator:
+            return DataCreator(set(ALL_FSD_NAMES))
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: Optional[DataAccessCollection] = None,
+        ) -> bool:
+            name = str(feature_name)
+            if name == FSD_SHARED_FILTER:
+                return True
+            if name == FSD_X_FILTER:
+                return bool(options.get(FSD_MODE_KEY) == "a")
+            if name == FSD_Y_FILTER:
+                return bool(options.get(FSD_MODE_KEY) == "b")
+            return name in SERVED_FSD_NAMES
+
+        @classmethod
+        def final_filters(cls) -> bool:
+            # The payload is a sentinel, not filterable data.
+            return False
+
+        @classmethod
+        def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+            capture.append(tuple(features.features))
+            return _sentinel(features)
+
+    return FsdDivergenceFG
+
+
+def _filters_on(*names: str) -> GlobalFilter:
+    """A GlobalFilter carrying one equality filter per given filter feature name."""
+    global_filter = GlobalFilter()
+    for name in names:
+        global_filter.add_filter(Feature(name), FilterType.EQUAL, {"value": 1})
+    return global_filter
+
+
+def _pair(key: str, value_a: str, value_b: str) -> list[Feature | str]:
+    """The two sibling features, identical group options, one context value each."""
+    return [Feature(FSD_A, Options(context={key: value_a})), Feature(FSD_B, Options(context={key: value_b}))]
+
+
+@dataclass(frozen=True)
+class _RunSnapshot:
+    """Plain-data readout of one run. Holds no reference to the throwaway group."""
+
+    sentinels: dict[str, int]
+    warnings: tuple[str, ...]
+    set_shapes: tuple[tuple[str, ...], ...]
+
+
+def _sentinels(results: list[Any], columns: tuple[str, ...]) -> dict[str, int]:
+    """Map each requested column to the sentinel reported by the frame carrying it."""
+    found = {column: frame[column][0] for frame in results for column in columns if column in frame}
+    missing = [column for column in columns if column not in found]
+    assert not missing, f"no result frame carries {missing}: {results!r}"
+    return found
+
+
+def _fsd_warnings(caplog: pytest.LogCaptureFixture) -> tuple[str, ...]:
+    """WARNINGs the execution plan emitted about this module's feature names."""
+    return tuple(
+        record.getMessage()
+        for record in caplog.records
+        if record.name == EP_LOGGER_NAME
+        and record.levelno == logging.WARNING
+        and any(name in record.getMessage() for name in ALL_FSD_NAMES)
+    )
+
+
+def _set_shapes(captured: list[tuple[Feature, ...]]) -> tuple[tuple[str, ...], ...]:
+    """The served feature names of every planned FeatureSet, one sorted tuple per set."""
+    served = (tuple(sorted(str(feature.name) for feature in features)) for features in captured)
+    return tuple(sorted(served))
+
+
+def _run(
+    features: list[Feature | str],
+    global_filter: GlobalFilter,
+    caplog: pytest.LogCaptureFixture,
+) -> _RunSnapshot:
+    """Run in one session, then drop every reference to the throwaway group before returning."""
+    caplog.clear()
+    captured: list[tuple[Feature, ...]] = []
+    fg = _make_fg(captured)
+    collector = PluginCollector.enabled_feature_groups({fg})
+
+    with caplog.at_level(logging.WARNING, logger=EP_LOGGER_NAME):
+        results = mloda.run_all(
+            features,
+            compute_frameworks={PythonDictFramework},
+            plugin_collector=collector,
+            global_filter=global_filter,
+        )
+
+    snapshot = _RunSnapshot(
+        sentinels=_sentinels(results, SERVED_FSD_NAMES),
+        warnings=_fsd_warnings(caplog),
+        set_shapes=_set_shapes(captured),
+    )
+    # Records carry args that can hold the throwaway class.
+    caplog.clear()
+    del fg, collector, results, captured
+    gc.collect()
+    return snapshot
+
+
+def test_enrichment_only_divergence_is_silent(caplog: pytest.LogCaptureFixture) -> None:
+    """Differing unrelated context enrichment is no divergence: one filter, no warning."""
+    snapshot = _run(_pair(FSD_NOTE_KEY, "x", "y"), _filters_on(FSD_SHARED_FILTER), caplog)
+
+    assert len(snapshot.set_shapes) == 1, f"the siblings must share one feature set: {snapshot.set_shapes}"
+    assert {FSD_A, FSD_B} <= set(snapshot.set_shapes[0]), f"both siblings must be in it: {snapshot.set_shapes}"
+    assert snapshot.sentinels == {FSD_A: 1, FSD_B: 1}, f"both siblings must see the one filter once: {snapshot!r}"
+    assert snapshot.warnings == (), f"an enrichment-only difference must not warn: {snapshot.warnings}"
+
+
+def test_genuine_divergence_attaches_the_union_and_warns_per_feature(caplog: pytest.LogCaptureFixture) -> None:
+    """Each sibling matched one filter, gets both, and is warned about the other one."""
+    snapshot = _run(_pair(FSD_MODE_KEY, "a", "b"), _filters_on(FSD_X_FILTER, FSD_Y_FILTER), caplog)
+
+    assert len(snapshot.set_shapes) == 1, f"the siblings must share one feature set: {snapshot.set_shapes}"
+    assert {FSD_A, FSD_B} <= set(snapshot.set_shapes[0]), f"both siblings must be in it: {snapshot.set_shapes}"
+    assert snapshot.sentinels == {FSD_A: 2, FSD_B: 2}, f"the union of both filters must be attached: {snapshot!r}"
+    assert len(snapshot.warnings) == 2, f"one warning per sibling must report its unmatched filter: {snapshot.warnings}"
+    warnings_a = [message for message in snapshot.warnings if FSD_A in message]
+    warnings_b = [message for message in snapshot.warnings if FSD_B in message]
+    assert len(warnings_a) == 1, f"exactly one warning must name {FSD_A}: {snapshot.warnings}"
+    assert len(warnings_b) == 1, f"exactly one warning must name {FSD_B}: {snapshot.warnings}"
+    assert FSD_Y_FILTER in warnings_a[0], f"the warning for {FSD_A} must name the filter it did not match: {warnings_a}"
+    assert FSD_X_FILTER in warnings_b[0], f"the warning for {FSD_B} must name the filter it did not match: {warnings_b}"
+    for message in snapshot.warnings:
+        assert "still applies" in message, f"the scope warning must explain that the filter still applies: {message}"
+
+
+def test_the_shared_filter_is_not_reported_as_divergence(caplog: pytest.LogCaptureFixture) -> None:
+    """Only the genuinely unmatched filter warns; the shared one stays out of the report."""
+    snapshot = _run(_pair(FSD_MODE_KEY, "a", "b"), _filters_on(FSD_SHARED_FILTER, FSD_Y_FILTER), caplog)
+
+    assert len(snapshot.set_shapes) == 1, f"the siblings must share one feature set: {snapshot.set_shapes}"
+    assert {FSD_A, FSD_B} <= set(snapshot.set_shapes[0]), f"both siblings must be in it: {snapshot.set_shapes}"
+    assert snapshot.sentinels == {FSD_A: 2, FSD_B: 2}, f"both filters must be attached once each: {snapshot!r}"
+    assert len(snapshot.warnings) == 1, f"only the excluded filter must be reported, once: {snapshot.warnings}"
+    message = snapshot.warnings[0]
+    assert FSD_A in message, f"the warning must name the sibling that did not match: {message}"
+    assert FSD_Y_FILTER in message, f"the warning must name the genuinely unmatched filter: {message}"
+    assert FSD_SHARED_FILTER not in message, f"the shared filter was matched and must not be reported: {message}"
+    assert FSD_B not in message, f"the fully matched sibling must not be warned about: {message}"

--- a/tests/test_core/test_filter/test_filter_sibling_divergence_scope.py
+++ b/tests/test_core/test_filter/test_filter_sibling_divergence_scope.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import gc
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Optional
 
@@ -28,10 +29,19 @@ FSD_SHARED_FILTER = "fsd_filter_shared"  # every probe matches it
 FSD_X_FILTER = "fsd_filter_x"  # matched only for mode "a"
 FSD_Y_FILTER = "fsd_filter_y"  # matched only for mode "b"
 FSD_MODE_KEY = "fsd_mode"
-FSD_NOTE_KEY = "fsd_note"  # unrelated context key the match hook never reads
+FSD_NOTE_KEY = "fsd_note"  # unrelated context key the match hooks never read
 
 SERVED_FSD_NAMES = (FSD_A, FSD_B)
 ALL_FSD_NAMES = SERVED_FSD_NAMES + (FSD_SHARED_FILTER, FSD_X_FILTER, FSD_Y_FILTER)
+
+FSD_RN_A = "fsd_rn_feat_a"
+FSD_RN_B = "fsd_rn_feat_b"
+FSD_RN_FILTER = "fsd_rn_filter"  # declared filter name, renamed per probing mode
+FSD_COL_A = "fsd_col_a"  # the filter's resolved column for mode "a"
+FSD_COL_B = "fsd_col_b"  # the filter's resolved column for mode "b"
+
+FSD_FRESH_HOST = "fsd_fresh_host"
+FSD_FRESH_FILTER = "fsd_fresh_filter"  # always matches; its GlobalFilter is reused across two runs
 
 
 def _sentinel(features: FeatureSet) -> dict[str, list[int]]:
@@ -40,7 +50,13 @@ def _sentinel(features: FeatureSet) -> dict[str, list[int]]:
     return {str(feature.name): [delivered] for feature in features.features}
 
 
-def _make_fg(capture: list[tuple[Feature, ...]]) -> type[FeatureGroup]:
+def _attached_option_values(features: FeatureSet, key: str) -> tuple[str, ...]:
+    """The enriched value of `key` on every attached filter, sorted, absence rendered as text."""
+    attached = features.filters or set()
+    return tuple(sorted(str(single_filter.filter_feature.options.get(key)) for single_filter in attached))
+
+
+def _make_fg(capture: list[tuple[Feature, ...]], notes: list[tuple[str, ...]]) -> type[FeatureGroup]:
     """A throwaway root group whose per-filter matches depend on the probing feature's mode."""
     gc.collect()
 
@@ -73,9 +89,76 @@ def _make_fg(capture: list[tuple[Feature, ...]]) -> type[FeatureGroup]:
         @classmethod
         def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
             capture.append(tuple(features.features))
+            notes.append(_attached_option_values(features, FSD_NOTE_KEY))
             return _sentinel(features)
 
     return FsdDivergenceFG
+
+
+def _make_rename_fg(capture: list[tuple[Feature, ...]], notes: list[tuple[str, ...]]) -> type[FeatureGroup]:
+    """A throwaway root group renaming its one declared filter to a mode-specific column."""
+    gc.collect()
+
+    class FsdRenameFG(FeatureGroup):
+        @classmethod
+        def input_data(cls) -> DataCreator:
+            return DataCreator({FSD_RN_A, FSD_RN_B, FSD_RN_FILTER, FSD_COL_A, FSD_COL_B})
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: Optional[DataAccessCollection] = None,
+        ) -> bool:
+            return str(feature_name) in {FSD_RN_A, FSD_RN_B, FSD_RN_FILTER}
+
+        def set_feature_name(self, config: Options, feature_name: FeatureName) -> FeatureName:
+            if str(feature_name) == FSD_RN_FILTER:
+                return FeatureName(FSD_COL_A if config.get(FSD_MODE_KEY) == "a" else FSD_COL_B)
+            return feature_name
+
+        @classmethod
+        def final_filters(cls) -> bool:
+            return False
+
+        @classmethod
+        def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+            capture.append(tuple(features.features))
+            notes.append(_attached_option_values(features, FSD_NOTE_KEY))
+            return _sentinel(features)
+
+    return FsdRenameFG
+
+
+def _make_freshness_fg(modes: list[tuple[str, ...]]) -> type[FeatureGroup]:
+    """A throwaway root group serving one host, recording each run's attached enrichment mode."""
+    gc.collect()
+
+    class FsdFreshnessFG(FeatureGroup):
+        @classmethod
+        def input_data(cls) -> DataCreator:
+            return DataCreator({FSD_FRESH_HOST, FSD_FRESH_FILTER})
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: Optional[DataAccessCollection] = None,
+        ) -> bool:
+            return str(feature_name) in {FSD_FRESH_HOST, FSD_FRESH_FILTER}
+
+        @classmethod
+        def final_filters(cls) -> bool:
+            return False
+
+        @classmethod
+        def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+            modes.append(_attached_option_values(features, FSD_MODE_KEY))
+            return _sentinel(features)
+
+    return FsdFreshnessFG
 
 
 def _filters_on(*names: str) -> GlobalFilter:
@@ -98,6 +181,7 @@ class _RunSnapshot:
     sentinels: dict[str, int]
     warnings: tuple[str, ...]
     set_shapes: tuple[tuple[str, ...], ...]
+    filter_notes: tuple[tuple[str, ...], ...]
 
 
 def _sentinels(results: list[Any], columns: tuple[str, ...]) -> dict[str, int]:
@@ -113,9 +197,7 @@ def _fsd_warnings(caplog: pytest.LogCaptureFixture) -> tuple[str, ...]:
     return tuple(
         record.getMessage()
         for record in caplog.records
-        if record.name == EP_LOGGER_NAME
-        and record.levelno == logging.WARNING
-        and any(name in record.getMessage() for name in ALL_FSD_NAMES)
+        if record.name == EP_LOGGER_NAME and record.levelno == logging.WARNING and "fsd_" in record.getMessage()
     )
 
 
@@ -125,15 +207,21 @@ def _set_shapes(captured: list[tuple[Feature, ...]]) -> tuple[tuple[str, ...], .
     return tuple(sorted(served))
 
 
+_FgFactory = Callable[[list[tuple[Feature, ...]], list[tuple[str, ...]]], type[FeatureGroup]]
+
+
 def _run(
     features: list[Feature | str],
     global_filter: GlobalFilter,
     caplog: pytest.LogCaptureFixture,
+    make_fg: _FgFactory = _make_fg,
+    columns: tuple[str, ...] = SERVED_FSD_NAMES,
 ) -> _RunSnapshot:
     """Run in one session, then drop every reference to the throwaway group before returning."""
     caplog.clear()
     captured: list[tuple[Feature, ...]] = []
-    fg = _make_fg(captured)
+    notes: list[tuple[str, ...]] = []
+    fg = make_fg(captured, notes)
     collector = PluginCollector.enabled_feature_groups({fg})
 
     with caplog.at_level(logging.WARNING, logger=EP_LOGGER_NAME):
@@ -145,13 +233,14 @@ def _run(
         )
 
     snapshot = _RunSnapshot(
-        sentinels=_sentinels(results, SERVED_FSD_NAMES),
+        sentinels=_sentinels(results, columns),
         warnings=_fsd_warnings(caplog),
         set_shapes=_set_shapes(captured),
+        filter_notes=tuple(notes),
     )
     # Records carry args that can hold the throwaway class.
     caplog.clear()
-    del fg, collector, results, captured
+    del fg, collector, results, captured, notes
     gc.collect()
     return snapshot
 
@@ -197,3 +286,68 @@ def test_the_shared_filter_is_not_reported_as_divergence(caplog: pytest.LogCaptu
     assert FSD_Y_FILTER in message, f"the warning must name the genuinely unmatched filter: {message}"
     assert FSD_SHARED_FILTER not in message, f"the shared filter was matched and must not be reported: {message}"
     assert FSD_B not in message, f"the fully matched sibling must not be warned about: {message}"
+
+
+def test_the_attached_representative_carries_the_lower_enrichment_variant(caplog: pytest.LogCaptureFixture) -> None:
+    """Of the enrichment-only variants, exactly the deterministic lower-sorting one attaches."""
+    snapshot = _run(_pair(FSD_NOTE_KEY, "x", "y"), _filters_on(FSD_SHARED_FILTER), caplog)
+
+    assert snapshot.filter_notes == (("x",),), (
+        f"exactly one filter must attach, carrying the lower-sorting variant: {snapshot.filter_notes}"
+    )
+
+
+def test_a_per_sibling_rename_attaches_both_resolved_predicates(caplog: pytest.LogCaptureFixture) -> None:
+    """One declared filter renamed per sibling stays two predicates, each warned about crosswise."""
+    features: list[Feature | str] = [
+        Feature(FSD_RN_A, Options(context={FSD_MODE_KEY: "a"})),
+        Feature(FSD_RN_B, Options(context={FSD_MODE_KEY: "b"})),
+    ]
+    snapshot = _run(
+        features,
+        _filters_on(FSD_RN_FILTER),
+        caplog,
+        make_fg=_make_rename_fg,
+        columns=(FSD_RN_A, FSD_RN_B),
+    )
+
+    assert snapshot.sentinels == {FSD_RN_A: 2, FSD_RN_B: 2}, f"both resolved predicates must attach: {snapshot!r}"
+    assert len(snapshot.warnings) == 2, f"each sibling must be warned about the other's column: {snapshot.warnings}"
+    warnings_a = [message for message in snapshot.warnings if FSD_RN_A in message]
+    warnings_b = [message for message in snapshot.warnings if FSD_RN_B in message]
+    assert len(warnings_a) == 1, f"exactly one warning must name {FSD_RN_A}: {snapshot.warnings}"
+    assert len(warnings_b) == 1, f"exactly one warning must name {FSD_RN_B}: {snapshot.warnings}"
+    assert FSD_COL_B in warnings_a[0], f"the warning for {FSD_RN_A} must name the other resolved column: {warnings_a}"
+    assert FSD_COL_A in warnings_b[0], f"the warning for {FSD_RN_B} must name the other resolved column: {warnings_b}"
+
+
+def _cross_run_modes(caplog: pytest.LogCaptureFixture) -> tuple[tuple[str, ...], ...]:
+    """Two runs of the host over one reused GlobalFilter: run 1 probes mode "a", run 2 mode "b"."""
+    caplog.clear()
+    modes: list[tuple[str, ...]] = []
+    fg = _make_freshness_fg(modes)
+    collector = PluginCollector.enabled_feature_groups({fg})
+    global_filter = _filters_on(FSD_FRESH_FILTER)
+
+    with caplog.at_level(logging.WARNING, logger=EP_LOGGER_NAME):
+        for mode in ("a", "b"):
+            mloda.run_all(
+                [Feature(FSD_FRESH_HOST, Options(context={FSD_MODE_KEY: mode}))],
+                compute_frameworks={PythonDictFramework},
+                plugin_collector=collector,
+                global_filter=global_filter,
+            )
+
+    observed = tuple(modes)
+    caplog.clear()
+    del fg, collector, global_filter, modes
+    gc.collect()
+    return observed
+
+
+def test_a_reused_global_filter_serves_each_run_its_own_enrichment(caplog: pytest.LogCaptureFixture) -> None:
+    """The second run gets the variant its own feature probed, not the stale first-run variant."""
+    observed = _cross_run_modes(caplog)
+
+    assert observed[0] == ("a",), f"run 1 must be handed its own enrichment variant: {observed}"
+    assert observed[1] == ("b",), f"run 2 must be handed its fresh variant, not the stale one: {observed}"


### PR DESCRIPTION
## Summary

`ExecutionPlan.add_single_filters_to_feature_set` aborted the run with `ValueError` when two features of one `FeatureSet` matched different non-empty filter sets, while the all-or-nothing shape of the same divergence only warned and attached. The abort was reachable from a harmless source: per-feature option enrichment makes two matched copies of the same declared filter compare unequal when siblings differ in an unrelated context option.

## Decision

The divergent-but-matching shape is now reported like the all-or-nothing case instead of aborting or splitting the set:

- The union of sibling matches attaches to the `FeatureSet`.
- Enrichment variants of one declared filter collapse to one attached filter, keyed by the filter's identity and resolved column name; a per-sibling rename resolves to distinct predicates and both attach.
- The representative prefers the variant the current run's features actually probed, so a reused `GlobalFilter` no longer hands a later run a stale enrichment; ties break on a deterministic, raise-safe sort key.
- The existing per-feature scope warning reports genuinely unmatched filters by declared-filter identity, so a filter matched under another enrichment is not falsely reported.

Splitting the `FeatureSet` was rejected: set membership is fixed earlier in planning, and for the enrichment-only shape a split would duplicate work without changing the applied predicate.

## Changes

- `mloda/core/prepare/execution_plan.py`: union attachment with canonical dedup and probed-variant preference; identity-based warning diff.
- `docs/docs/in_depth/filter_data.md`: the scope section now describes the union behavior and the rename edge.
- New tests pin the silent enrichment-only shape, the union with per-feature warnings, the shared-filter non-report, cross-run enrichment freshness, the rename edge, and the deterministic representative; a stale test docstring describing the removed abort was updated.

`tox` passes.

Closes #965.
