### PR TITLE
test: make an uncollected doc snippet a failure instead of a silent skip

### DIFF
--- a/docs/docs/chapter1/api-request.md
+++ b/docs/docs/chapter1/api-request.md
@@ -37,7 +37,7 @@ result = mloda.run_all(
 result[0]
 ```
 Expected output:
-``` python
+```text
 pyarrow.Table
 V8: double
 id: int64
@@ -64,7 +64,7 @@ Typical examples where this applies:
 The two-phase API lets you pay the planning cost once at startup and then execute
 cheaply per request:
 
-``` python
+```python
 # 1. Prepare once (e.g. at server startup)
 session = mloda.prepare(feature_list, compute_frameworks=["PyArrowTable"], data_access_collection=data_access_collection)
 
@@ -78,7 +78,7 @@ See [mloda API: Two-Phase Execution](../in_depth/mloda-api.md#two-phase-executio
 
 LLMs can generate JSON feature requests without writing Python code:
 
-``` python
+```py
 from mloda.user import load_features_from_config
 
 llm_request = '["id", "V1", "V2", "Amount"]'

--- a/docs/docs/chapter1/compute-frameworks.md
+++ b/docs/docs/chapter1/compute-frameworks.md
@@ -31,7 +31,7 @@ feature_list = ["id","V1","V2","V3"]
 
 Expected Error when running.
 
-``` python
+```text
 mloda.run_all(
     feature_list,
     data_access_collection=data_access_collection
@@ -73,7 +73,7 @@ result = mloda.run_all(
 result[0]
 ```
 Expected output:
-``` python
+```text
 pyarrow.Table
 id: int64
 id: [[0,1,2,3,...]]
@@ -164,7 +164,7 @@ For example, without `polars` installed, `from mloda.user.polars import PolarsDa
 ##### Framework Examples
 
 Example using PythonDictFramework:
-``` python
+```python
 from mloda.user import mloda
 from mloda.user import Feature
 
@@ -183,7 +183,7 @@ A feature group running on PythonDictFramework may also return row-wise data as 
 
 `columnar_to_rows`, `homogenize_rows`, `is_columnar`, `result_rows`, `row_count`, `rows_to_columnar`, and `validate_columnar_dict` come from `mloda.user.python_dict`, next to `PythonDictFramework` itself. `columnar_to_rows` is strict: it raises `ValueError` on anything that is not a valid columnar dict. `result_rows` is the blessed tolerant unwrapper for PythonDict-framework `run_all` output (columnar dicts and row-dict lists): it flattens the partition list into row dicts, and a dict that satisfies `is_columnar` is always treated as a columnar partition, never as a row. It rejects other frameworks' result objects (convert those to rows first).
 
-``` python
+```py
 from mloda.user import mloda
 from mloda.user.python_dict import result_rows
 
@@ -193,7 +193,7 @@ rows = result_rows(mloda.run_all(...))
 Strictness stays in the library; `result_rows` packages the forgiving application-side policy.
 
 Example using Polars frameworks:
-``` python
+```python
 from mloda.user import mloda
 from mloda.user import Feature
 
@@ -211,7 +211,7 @@ result[0]  # Returns polars.DataFrame
 ```
 
 Example using DuckDB framework:
-``` python
+```py
 from mloda.user import mloda
 from mloda.user import Feature, DataAccessCollection
 import duckdb
@@ -236,7 +236,7 @@ result[0]  # Returns duckdb.DuckDBPyRelation
 **Note**: DuckDB framework requires a connection object and does not support mloda framework inherent multiprocessing. Multiprocessing from DuckDB still works. It's optimized for analytical workloads and provides SQL-like operations on data.
 
 Example using Iceberg framework:
-``` python
+```py
 from mloda.user import mloda
 from mloda.user import Feature, DataAccessCollection
 from pyiceberg.catalog import load_catalog
@@ -266,7 +266,7 @@ result[0]  # Returns pyiceberg.table.Table or pyarrow.Table
 **Note**: Iceberg framework requires a catalog connection object for table operations. It's optimized for data lake scenarios with schema evolution, time travel capabilities, and large-scale analytics. The framework uses PyArrow as an interchange format for compatibility with other mloda frameworks.
 
 Example using Spark framework:
-``` python
+```py
 from mloda.user import mloda
 from mloda.user import Feature, DataAccessCollection
 from pyspark.sql import SparkSession

--- a/docs/docs/chapter1/extender.md
+++ b/docs/docs/chapter1/extender.md
@@ -51,7 +51,7 @@ mloda.run_all(
 )
 ```
 Expected Output (Logged Execution Times)
-``` python
+```text
 ERROR    test_getting_started:test_getting_started.py:29 Time taken: 0.00454258918762207
 ERROR    test_getting_started:test_getting_started.py:29 Time taken: 0.001033782958984375
 ```

--- a/docs/docs/chapter1/feature-groups.md
+++ b/docs/docs/chapter1/feature-groups.md
@@ -54,7 +54,7 @@ result = mloda.run_all(
 result[0]
 ```
 Expected output:
-``` python
+```text
 pyarrow.Table
 Example_V28: double
 Example_id: int64

--- a/docs/docs/chapter1/installation.md
+++ b/docs/docs/chapter1/installation.md
@@ -14,7 +14,7 @@ pip install .
 
 ## 3. Verify Installation
 To verify the installation, run:
-``` python
+```python
 from importlib import metadata
 print(metadata.version("mloda"))
 ```
@@ -23,7 +23,7 @@ print(metadata.version("mloda"))
 
 Try this 30-second example:
 
-``` python
+```python
 from mloda.user import mloda, PluginLoader
 PluginLoader.all()
 

--- a/docs/docs/in_depth/access-feature-data.md
+++ b/docs/docs/in_depth/access-feature-data.md
@@ -29,7 +29,7 @@ When the collection holds more than one resource of the same kind, you can name 
 
 You can apply these options like so:
 
-``` python
+```py
 from mloda.user import Credential, DataAccessCollection
 
 data_access = DataAccessCollection()
@@ -74,7 +74,7 @@ print(result)
 
 Output
 
-``` python
+```text
 [  AExample  BExample
 0   Value1         2
 1   Value2         3]
@@ -88,7 +88,7 @@ with `ReadFile`.
 
 To read a structured file type as a document, use the `document_suffixes` option:
 
-``` python
+```py
 Feature("content", options={"document_suffixes": frozenset({".json"})})
 ```
 
@@ -101,7 +101,7 @@ When a `DataAccessCollection` holds multiple files that share the same column na
 
 Use `column_to_file` to pin each column to its canonical file:
 
-``` python
+```py
 from mloda.user import DataAccessCollection, mloda
 
 data_access = DataAccessCollection(
@@ -128,7 +128,7 @@ Rules:
 
 The existing per-feature alternative still works for one-off pinning:
 
-``` python
+```py
 Feature("SK_ID_CURR", options=Options({CsvReader: "application_train.csv"}))
 ```
 
@@ -142,7 +142,7 @@ If data needs to be added specifically for a single feature (or features from th
 We show the ReadFileFeature as example. It uses the input_data ReadFile. 
 In this case, we need to provide the specific reader class: CsvReader.
 
-``` python
+```py
 
 # This feature is already implemented as plugin, so do not run it again. This will raise intentional errors.
 class ReadFileFeature(FeatureGroup):
@@ -192,7 +192,7 @@ print(result)
 
 Output
 
-``` python
+```text
 [  AExample
 0   Value1
 1   Value2]
@@ -232,7 +232,7 @@ for res in result:
 
 Output:
 
-``` python
+```text
   FeatureInputAPITest
 0          TestValue3
 1          TestValue4
@@ -281,7 +281,7 @@ for res in result:
 
 Output
 
-``` python
+```text
   AFeatureInputCreator
 0          TestValue5
 1          TestValue6
@@ -348,7 +348,7 @@ print(result)
 
 Output:
 
-``` python
+```text
 [AFeatureInputCreator
 0           TestValue5
 1           TestValue6,    

--- a/docs/docs/in_depth/artifacts.md
+++ b/docs/docs/in_depth/artifacts.md
@@ -69,7 +69,7 @@ print(artifacts)
 
 Result:
 
-``` python
+```text
 {'BaseExampleArtifactFeature': 'BasicArtifact'}
 ```
 
@@ -84,7 +84,7 @@ mloda.run_all([feat], {PyArrowTable})
 
 Result:
 
-``` python
+```text
 "BasicArtifact is the loaded artifact."
 ```
 
@@ -117,7 +117,8 @@ result = session.run(artifacts=saved_artifacts)
 
 #### Cross-validation pattern
 
-``` title="pseudocode"
+```py
+# pseudocode
 session = mloda.prepare(["MyArtifactFeature"], {PyArrowTable})
 
 for fold_data in folds:

--- a/docs/docs/in_depth/compute-framework-integration.md
+++ b/docs/docs/in_depth/compute-framework-integration.md
@@ -10,7 +10,7 @@ One of mloda's key strengths is its ability to decouple feature definitions from
 
 Feature groups specify which compute frameworks they support through the `compute_framework_rule` method:
 
-``` python
+```py
 @classmethod
 def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
     """Define the compute frameworks this feature group supports."""
@@ -25,7 +25,7 @@ feature group runs on SQLite in general, but *this particular operation* is
 unsupported there." For that, override `supports_compute_framework`, a
 per-feature hook evaluated at match time:
 
-``` python
+```py
 @classmethod
 def supports_compute_framework(cls, feature_name, options, compute_framework) -> bool:
     """Reject an operation on a specific framework. Default returns True."""
@@ -84,7 +84,7 @@ instead of a hand-written `supports_compute_framework`.
 
 **The data provider** declares the dimension once with `SUBTYPES`:
 
-``` python
+```py
 class RankFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     SUBTYPES = SubtypeDeclaration(
         key="rank_type",
@@ -108,7 +108,7 @@ Two shapes, enforced at class definition; a half declaration fails at import:
 - Shape B (multi-axis families collapsed into one subtype id): declare the
   universe explicitly with a resolver:
 
-``` python
+```py
 def resolve_window(feature_name: str, options: Options) -> str | None:
     return options.get("window_function")
 
@@ -220,7 +220,7 @@ FeatureGroup
 
 The base class defines the interface and common functionality:
 
-``` python
+```py
 class MyFeatureGroup(FeatureGroup):
     """Base class for MyFeatureGroup."""
     
@@ -239,7 +239,7 @@ Each framework-specific implementation:
 - Specifies which compute frameworks it supports
 - Implements the calculation logic for that framework
 
-``` python
+```py
 class PandasMyFeatureGroup(MyFeatureGroup):
     @classmethod
     def compute_framework_rule(cls):
@@ -278,7 +278,7 @@ For more details on how data transformation works between compute frameworks, se
 
 For a clustering feature group:
 
-``` python
+```py
 # Base class (framework-agnostic)
 class ClusteringFeatureGroup(FeatureGroup):
     def input_features(self, options, feature_name):
@@ -311,7 +311,7 @@ class PyArrowClusteringFeatureGroup(ClusteringFeatureGroup):
 
 For an aggregated feature group with Polars support:
 
-``` python
+```py
 # Base class (framework-agnostic)
 class AggregatedFeatureGroup(FeatureGroup):
     def input_features(self, options, feature_name):
@@ -337,7 +337,7 @@ Note that Polars supports both eager (`PolarsDataFrame`) and lazy (`PolarsLazyDa
 
 For an analytical feature group with DuckDB support:
 
-``` python
+```py
 # Base class (framework-agnostic)
 class AnalyticalFeatureGroup(FeatureGroup):
     def input_features(self, options, feature_name):
@@ -365,7 +365,7 @@ class DuckDBAnalyticalFeatureGroup(AnalyticalFeatureGroup):
 
 For a distributed processing feature group with Spark support:
 
-``` python
+```py
 # Base class (framework-agnostic)
 class DistributedFeatureGroup(FeatureGroup):
     def input_features(self, options, feature_name):
@@ -402,7 +402,7 @@ The `.types` property returns column types aligned with `.columns`. The element 
 - `DuckdbRelation.types` returns DuckDB-native dtype objects.
 - `SqliteRelation.types` returns PyArrow `pa.DataType` objects (from propagated hints, falling back to SQLite affinity inference).
 
-``` python
+```py
 relation.columns   # ["user_id", "amount"]
 relation.types     # backend-specific dtype objects, same order as columns
 ```
@@ -411,7 +411,7 @@ relation.types     # backend-specific dtype objects, same order as columns
 
 `with_row_number` appends a `ROW_NUMBER()` column; `window` appends an arbitrary window expression. Both quote every identifier and raise `ValueError` if the new `alias` collides with an existing column.
 
-``` python
+```py
 from mloda_plugins.compute_framework.base_implementations.sql.sql_window import (
     OrderBy,
     WindowFrame,

--- a/docs/docs/in_depth/data-access-patterns.md
+++ b/docs/docs/in_depth/data-access-patterns.md
@@ -28,7 +28,7 @@ BaseInputData is an **abstract base class** that defines how feature groups **lo
 For detailed examples of these use cases, see the [data access documentation](access-feature-data.md).
 
 ### Example Implementation
-``` python
+```py
 from mloda.provider import BaseInputData, FeatureGroup, FeatureSet
 
 class ReadFileFeature(FeatureGroup):
@@ -74,7 +74,7 @@ Readers are classified structurally; no reader code is executed for classificati
 
 A feature selects a specific reader with an Option whose key equals the reader's class name (`BaseInputData.data_access_name()`, i.e. `cls.__name__`, unique per class, so sibling readers cannot collide):
 
-``` python
+```py
 Feature("value", options={UbaAirReader.__name__: url})
 ```
 
@@ -101,7 +101,7 @@ Reader selection answers "which plugin handles this input" the way [feature-grou
 
 A reader that owns an input but cannot serve the requested feature can record why it declined; the reason then appears in the near-miss block of the "No feature groups found" error message, labeled `(input data)`. `record_match_rejection` is exported via `mloda.provider`. A custom reader owns its own suffix and overrides `load_data` wholesale; its own decline points sit beyond the automatic column validation, for example a required schema marker in the header:
 
-``` python
+```python
 from typing import Any
 
 from mloda.provider import INPUT_DATA_STAGE, FeatureSet, record_match_rejection
@@ -175,7 +175,7 @@ MatchData is **only** used in these specific scenarios:
 - Enabling flexible connection configuration for stateful frameworks
 
 ### Example Implementation
-``` python
+```py
 from mloda.provider import MatchData, FeatureGroup
 
 class DuckDBFeatureGroup(FeatureGroup, MatchData):
@@ -225,7 +225,7 @@ BaseInputData and MatchData serve **different purposes** and are used in **diffe
 3. **Only applies** to specific compute frameworks like DuckDB that require persistent connections
 
 ### Combined Usage Example
-``` python
+```py
 class DuckDBAnalyticsFeature(FeatureGroup, MatchData):
     @classmethod
     def input_data(cls) -> Optional[BaseInputData]:
@@ -249,7 +249,7 @@ class DuckDBAnalyticsFeature(FeatureGroup, MatchData):
 **Use Case**: Reading CSV files with Pandas
 **Pattern**: Only BaseInputData is needed
 
-``` python
+```py
 class CsvProcessingFeature(FeatureGroup):
     @classmethod
     def input_data(cls) -> Optional[BaseInputData]:
@@ -261,7 +261,7 @@ class CsvProcessingFeature(FeatureGroup):
 **Use Case**: Analytics with DuckDB requiring connection objects
 **Pattern**: Both BaseInputData and MatchData are needed
 
-``` python
+```py
 class DuckDBAnalyticsFeature(FeatureGroup, MatchData):
     @classmethod
     def input_data(cls) -> Optional[BaseInputData]:
@@ -280,7 +280,7 @@ For database connection patterns, see [Framework Connection Object](framework-co
 **Use Case**: Creating synthetic data with Pandas
 **Pattern**: Only BaseInputData is needed
 
-``` python
+```py
 class SyntheticDataFeature(FeatureGroup):
     @classmethod
     def input_data(cls) -> Optional[BaseInputData]:

--- a/docs/docs/in_depth/data-quality.md
+++ b/docs/docs/in_depth/data-quality.md
@@ -126,10 +126,11 @@ class DocExamplePanderaValidator(BaseValidator):
 
 The validator should raise an error again.
 
-```py
+```text
 results = mloda.run_all(
             ["DocCustomValidateInputFeatures"], {PyArrowTable}
         )
+SchemaError: Column 'DocBaseValidateInputFeaturesBase' failed element-wise validator: in_range(1, 2)
 ```
 
 ###### Log only validator and Extender use
@@ -228,10 +229,11 @@ class DocBaseValidateOutputFeaturesBaseNegativePandera(DocBaseValidateOutputFeat
 
 This one should fail:
 
-```py
+```text
 results = mloda.run_all(
             ["DocBaseValidateOutputFeaturesBaseNegativePandera"], {PyArrowTable}
         )
+SchemaError: Column 'DocBaseValidateOutputFeaturesBaseNegativePandera' failed element-wise validator: in_range(1, 2)
 ```
 
 ###### Log only validator and Extender use

--- a/docs/docs/in_depth/data-quality.md
+++ b/docs/docs/in_depth/data-quality.md
@@ -55,7 +55,7 @@ class DocSimpleValidateInputFeatures(FeatureGroup):
 
 As we run it, it will return an error.
 
-``` python
+```text
 results = mloda.run_all(
             ["DocSimpleValidateInputFeatures"], {PyArrowTable}
         )
@@ -126,7 +126,7 @@ class DocExamplePanderaValidator(BaseValidator):
 
 The validator should raise an error again.
 
-``` python
+```py
 results = mloda.run_all(
             ["DocCustomValidateInputFeatures"], {PyArrowTable}
         )
@@ -228,7 +228,7 @@ class DocBaseValidateOutputFeaturesBaseNegativePandera(DocBaseValidateOutputFeat
 
 This one should fail:
 
-``` python
+```py
 results = mloda.run_all(
             ["DocBaseValidateOutputFeaturesBaseNegativePandera"], {PyArrowTable}
         )

--- a/docs/docs/in_depth/data-type-enforcement.md
+++ b/docs/docs/in_depth/data-type-enforcement.md
@@ -185,7 +185,8 @@ feature = Feature.int64_of(
 
 Type mismatches raise `DataTypeMismatchError`:
 
-```python title="Error handling example"
+```py
+# Error handling example
 from mloda.user import mloda
 from mloda.user import Feature
 from mloda.provider import DataTypeMismatchError

--- a/docs/docs/in_depth/discover-plugins.md
+++ b/docs/docs/in_depth/discover-plugins.md
@@ -6,7 +6,7 @@ mloda provides functions to discover, inspect, and debug plugins at runtime. The
 
 Use `resolve_feature()` to find which FeatureGroup handles a specific feature name:
 
-``` python
+```python
 from mloda.steward import resolve_feature
 
 # Check which FeatureGroup handles a feature
@@ -51,7 +51,7 @@ too. Pass a `Feature` as the single source of truth for name, `options`, domain,
 compute-framework pin, and scope; passing `options` or `feature_group` alongside
 a `Feature` raises `TypeError`.
 
-``` python
+```python
 from mloda.user import Feature, Options
 
 result = resolve_feature(Feature("sales__sum_aggr", options=Options(group={"partition_by": ["customer_id"]})))
@@ -79,7 +79,7 @@ A FeatureGroup whose `match_feature_group_criteria` or
 supply it. Without `options` the evaluation uses empty `Options`, and such a
 group reports no candidates:
 
-``` python
+```python
 from mloda.steward import resolve_feature
 from mloda.user import Options, PluginLoader
 
@@ -102,7 +102,7 @@ When several FeatureGroups match the same name, such as the framework-specific
 string (the string matches the named class and its subclasses), the same forms
 as `Feature(..., feature_group=...)`:
 
-``` python
+```python
 result = resolve_feature("sales__sum_aggr", feature_group="PandasAggregatedFeatureGroup")
 ```
 
@@ -123,7 +123,7 @@ matched), `candidates` lists the classes that matched. When the environment
 build itself failed (for example a redefinition conflict), no matching runs,
 so `candidates` is empty and the error text carries the details:
 
-``` python
+```python
 result = resolve_feature("my_feature")
 if result.error:
     print(f"Error: {result.error}")
@@ -134,7 +134,7 @@ if result.error:
 
 Get documentation for available feature groups:
 
-``` python
+```python
 from mloda.steward import get_feature_group_docs
 
 # Get all feature groups
@@ -158,7 +158,7 @@ when the declaration is invalid). See
 
 Get documentation for compute frameworks:
 
-``` python
+```python
 from mloda.steward import get_compute_framework_docs
 
 # List every framework (is_available flags whether its backend library is installed)
@@ -172,7 +172,7 @@ available_frameworks = get_compute_framework_docs(available_only=True)
 
 Get documentation for extenders:
 
-``` python
+```python
 from mloda.steward import get_extender_docs
 
 # Get all extenders
@@ -246,7 +246,7 @@ including features it has nothing to do with. The way out is to scope it out of
 the universe. Both filters below drop the class before its declaration is ever
 consulted, so the build succeeds and the feature is an ordinary no-match:
 
-``` python
+```py
 # One broken third-party plugin, and every call reports its failure:
 resolve_feature("timestamp_unix").error
 # "Failed to build the plugin environment: RuntimeError: ... (raised by pkg.module:BrokenFG while declaring its compute frameworks)"

--- a/docs/docs/in_depth/feature-chain-parser.md
+++ b/docs/docs/in_depth/feature-chain-parser.md
@@ -67,7 +67,7 @@ The new `Options` class separates parameters into two categories:
 - **Group Parameters**: Affect Feature Group resolution and splitting (stored in `options.group`)
 - **Context Parameters**: Metadata that doesn't affect splitting (stored in `options.context`)
 
-``` python
+```python
 from mloda.user import Options
 from typing import Optional
 
@@ -87,7 +87,7 @@ options = Options(
 
 Modern feature creation uses the Options architecture:
 
-``` python
+```python
 from mloda.user import Feature, Options
 
 # Traditional string-based approach:
@@ -111,7 +111,7 @@ The `FeatureChainParserMixin` provides default implementations for common featur
 
 ### Basic Usage
 
-``` python
+```py
 from mloda.provider import FeatureGroup, FeatureChainParserMixin
 from mloda.provider import DefaultOptionKeys, PropertySpec
 
@@ -168,7 +168,7 @@ implement them. Both constants come from `mloda.provider`.
 | `COLUMNWISE_HOOKS` | `_check_source_features_exist` and `_add_result_to_data` |
 | `COLUMN_DISCOVERY_HOOKS` | those two plus `_get_available_columns` |
 
-``` python
+```python
 from mloda.provider import COLUMN_DISCOVERY_HOOKS, FeatureChainParserMixin, FeatureGroup
 from mloda.user.pandas import PandasDataFrame
 
@@ -199,7 +199,7 @@ class PandasRolling(RollingBase):
 not implement. Assert it empty in your own test suite to catch a skipped hook there rather than
 mid-run:
 
-``` python
+```python
 from mloda.provider import missing_columnwise_hooks
 
 def test_pandas_rolling_implements_its_hooks():
@@ -221,7 +221,7 @@ retired.
 - For a **recognition-only** pattern (the name identifies the group but all values come from
   options), set `RECOGNITION_ONLY_PATTERN = True`:
 
-``` python
+```py
 RECOGNITION_ONLY_PATTERN = True
 ```
 
@@ -235,7 +235,7 @@ working, but logs a definition-time warning until it either adds a named capture
 
 Override this hook when you need custom validation for string-based feature names:
 
-``` python
+```py
 class ClusteringFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     @classmethod
     def _validate_string_match(cls, feature_name: str, operation_config: str, in_feature: str) -> bool:
@@ -252,7 +252,7 @@ class ClusteringFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 
 Override when you need to add additional input features (e.g., time filter):
 
-``` python
+```py
 class TimeWindowFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     def input_features(self, options: Options, feature_name: FeatureName) -> Optional[Set[Feature]]:
         # Try string-based parsing first
@@ -273,7 +273,7 @@ Override for the rules a `PROPERTY_MAPPING` spec cannot express, then delegate. 
 requirements belong in `required_when` instead: it is enforced by a guard installed at class
 definition, so it still runs on an override.
 
-``` python
+```py
 class SklearnPipelineFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     @classmethod
     def match_feature_group_criteria(cls, feature_name, options, data_access_collection=None) -> bool:
@@ -288,7 +288,7 @@ class SklearnPipelineFeatureGroup(FeatureChainParserMixin, FeatureGroup):
 
 Use this helper to extract the operation type from either the feature name pattern or a config key, without calling `FeatureChainParser` directly:
 
-``` python
+```py
 class AggregatedFeatureGroup(FeatureChainParserMixin, FeatureGroup):
     AGGREGATION_TYPE = "aggregation_type"
 
@@ -308,7 +308,7 @@ Give a spec a `match_guard` callable to validate the shape of the raw option val
 
 Reach for `match_guard` when the constraint is about the value as a whole (a list of strings, a dict, an ordering). Reach for `element_validator` with `strict_validation=True` when the constraint is about each element on its own.
 
-``` python
+```py
 def _is_list_of_strings(value):
     return isinstance(value, list) and all(isinstance(item, str) for item in value)
 
@@ -331,7 +331,7 @@ The full model, which invariant fires at which moment, the precedence between th
 
 The modern approach uses `PROPERTY_MAPPING` to define parameter validation and classification:
 
-``` python
+```py
 from mloda.provider import FeatureGroup
 from mloda.user import FeatureName
 from mloda.provider import DefaultOptionKeys, PropertySpec
@@ -363,7 +363,7 @@ class MyFeatureGroup(FeatureGroup):
 
 `FeatureChainParserMixin` already implements this; override it only to add your own checks, and reach the parser through `cls.match_parser_criteria`:
 
-``` python
+```py
 @classmethod
 def match_feature_group_criteria(cls, feature_name, options, data_access_collection=None):
     return cls.match_parser_criteria(feature_name, options)
@@ -375,7 +375,7 @@ def match_feature_group_criteria(cls, feature_name, options, data_access_collect
 
 Handle both string-based and configuration-based features:
 
-``` python
+```py
 def input_features(self, options: Options, feature_name: FeatureName) -> Optional[Set[Feature]]:
     """Extract source feature from either configuration-based options or string parsing."""
 
@@ -399,7 +399,7 @@ def input_features(self, options: Options, feature_name: FeatureName) -> Optiona
 
 Support dual approach in feature processing:
 
-``` python
+```py
 def calculate_feature(self, features, options):
     for feature in features.features:
         # Try configuration-based approach first
@@ -427,7 +427,7 @@ def calculate_feature(self, features, options):
 
 For per-element rules that a fixed value list cannot express:
 
-``` python
+```py
 PROPERTY_MAPPING = {
     "dimension": PropertySpec(
         "Number of dimensions for reduction",
@@ -441,7 +441,7 @@ PROPERTY_MAPPING = {
 
 Specify default values for optional parameters:
 
-``` python
+```py
 PROPERTY_MAPPING = {
     "window_size": PropertySpec(
         "Rolling window length in days",
@@ -461,7 +461,7 @@ checked when the `PropertySpec` is constructed. Omitting `default` makes the key
 
 There is no `group` field: a group parameter is `context=False`.
 
-``` python
+```py
 PROPERTY_MAPPING = {
     # Group parameter - affects Feature Group resolution
     "data_source": PropertySpec(
@@ -493,7 +493,7 @@ the consumer's group options (except `in_features`) onto that child. Configurati
 on a requested feature travels down self-resolving chains (for example
 `price__mean_imputed__sum_aggr`) to the end of the chain without any ceremony:
 
-``` python
+```python
 from typing import Optional
 
 from mloda.provider import FeatureGroup
@@ -529,7 +529,7 @@ directive on the child `Feature` you return from `input_features()`:
 | `forward_group={"kg_backend"}` | Allowlist: only the listed keys flow. |
 | `forward_group_exclude={"query_text"}` | Everything flows except the listed keys. |
 
-``` python
+```python
 from mloda.user import Feature
 
 # Only kg_backend flows; query_text and top_k stay on the consumer.
@@ -555,7 +555,7 @@ Context options never flow implicitly, and `forward_group` does not touch them. 
 child needs a consumer **context** value, list it in `inherit_context_keys`; the engine
 copies the listed keys from the consumer's context into the child's context:
 
-``` python
+```python
 from mloda.user import Feature
 
 child = Feature("knowledge_graph", inherit_context_keys={"tenant"})
@@ -599,7 +599,7 @@ Some feature groups produce multiple result columns from a single input feature.
 
 Use `apply_naming_convention()` to create properly named columns:
 
-``` python
+```py
 from mloda.provider import FeatureGroup, FeatureSet
 
 class MultiColumnProducer(FeatureGroup):
@@ -620,7 +620,7 @@ class MultiColumnProducer(FeatureGroup):
 
 Use `resolve_multi_column_feature()` to automatically discover columns:
 
-``` python
+```py
 class MultiColumnConsumer(FeatureGroup):
     def input_features(self, options: Options, feature_name: FeatureName) -> Optional[Set[Feature]]:
         # Request base feature without ~N suffix
@@ -646,7 +646,7 @@ class MultiColumnConsumer(FeatureGroup):
 
 For backwards compatibility, you can still access specific columns:
 
-``` python
+```python
 # Manual specification of specific columns
 base_feature = "category__onehot_encoded"  # Creates all columns
 specific_column = "category__onehot_encoded~0"  # Access first column

--- a/docs/docs/in_depth/feature-config.md
+++ b/docs/docs/in_depth/feature-config.md
@@ -13,7 +13,7 @@ Use cases:
 
 ## Basic Usage
 
-``` python
+```py
 from mloda.user import load_features_from_config, mloda
 
 config = '''
@@ -243,7 +243,7 @@ This produces a feature named `pca_result~0`.
 
 By default, context parameters are local to each feature and do not propagate through feature chains. Use `propagate_context_keys` to specify which context keys should flow to dependent features:
 
-``` json
+```json
 [
     {
         "name": "my_feature",
@@ -260,7 +260,7 @@ In this example, `session_id` propagates to any features that depend on `my_feat
 
 ## Complete Example
 
-``` python
+```py
 from mloda.user import load_features_from_config, mloda
 
 config = '''

--- a/docs/docs/in_depth/feature-group-matching.md
+++ b/docs/docs/in_depth/feature-group-matching.md
@@ -103,17 +103,17 @@ For feature groups not yet modernized, the default matching criteria still apply
 1. **Root Feature with Matching Input Data**: The feature group is a root feature (has no dependencies) and its input data matches the feature.
 
 2. **Class Name Match**: The feature name exactly matches the feature group's class name.
-   ``` python
+   ```py
    feature_name == FeatureGroup.get_class_name()
    ```
 
 3. **Prefix Match**: The feature name starts with the feature group's class name as a prefix.
-   ``` python
+   ```py
    feature_name.startswith(FeatureGroup.prefix())  # Default prefix is "ClassName_"
    ```
 
 4. **Explicitly Supported**: The feature name is in the set of explicitly supported feature names.
-   ``` python
+   ```py
    feature_name in FeatureGroup.feature_names_supported()
    ```
 
@@ -123,7 +123,9 @@ An owned reader veto recorded during rule 1 (the user addressed the reader famil
 
 ### Modern Feature Group (Aggregation)
 
-``` python
+```python
+from mloda.user import Feature, Options
+
 # String-based matching
 feature = Feature("sales__sum_aggr")  # Matches via pattern
 
@@ -141,7 +143,7 @@ feature = Feature(
 
 The group/context parameter separation affects matching behavior:
 
-``` python
+```python
 # These create different Feature Group instances (different group parameters)
 feature1 = Feature("placeholder", Options(
     group={"data_source": "production"},

--- a/docs/docs/in_depth/feature-group-testing.md
+++ b/docs/docs/in_depth/feature-group-testing.md
@@ -25,7 +25,7 @@ The reader veto gate reads the engine's per-candidate rejection window, so a dir
 Test that your feature group correctly extracts source features from feature names.
 
 **Example:**
-``` python
+```py
 # Test extracting source features from a feature name
 input_features = feature_group.input_features(Options(), FeatureName("sales__sum_aggr"))
 assert Feature("sales") in input_features
@@ -36,7 +36,7 @@ assert Feature("sales") in input_features
 Test that your feature group correctly transforms input data into output features.
 
 **Example:**
-``` python
+```py
 from mloda.user import Feature
 from mloda.provider import FeatureSet
 from mloda_plugins.feature_group.experimental.clustering.pandas import PandasClusteringFeatureGroup
@@ -53,7 +53,7 @@ assert "feature1,feature2__cluster_kmeans_2" in result.columns
 Test that your feature group correctly parses features from configuration options.
 
 **Example:**
-``` python
+```py
 # Test creating features from options
 options = Options({
     "aggregation_type": "sum",
@@ -68,7 +68,7 @@ assert feature_name == "sales__sum_aggr"
 Test that your feature group works correctly with the mloda API.
 
 **Example:**
-``` python
+```py
 from mloda.user import mloda
 from mloda.user.pandas import PandasDataFrame
 
@@ -82,7 +82,7 @@ assert "source_feature__my_operation" in result[0].columns
 When testing a FeatureGroup that depends on another FeatureGroup, you can inject mock data by combining `disabled_feature_groups` with `api_data`:
 
 **Example:**
-``` python
+```py
 from mloda.user import mlodaAPI, PluginCollector
 
 # Disable the real dependency FeatureGroup

--- a/docs/docs/in_depth/filter_data.md
+++ b/docs/docs/in_depth/filter_data.md
@@ -15,7 +15,7 @@ That however means that a data project typically contains multiple filters. For 
 
 This class is supposed to create similarity in the framework and by framework users.
 
-``` python
+```py
 class FilterType(Enum):
     MIN = "min"
     MAX = "max"
@@ -76,7 +76,7 @@ global_filter.filters
 
 Result
 
-``` python
+```text
 {<SingleFilter(feature_name=example_order_id, type=equal, parameters=FilterParameterImpl(_raw=(('value', 1),)))>}
 ```
 
@@ -99,7 +99,7 @@ global_filter.filters
 
 Result
 
-``` python
+```text
 {<SingleFilter(feature_name=time_travel, type=range, parameters=FilterParameterImpl(_raw=(('max', datetime.datetime(2022, 12, 31, 0, 0, tzinfo=datetime.timezone.utc)), ('max_exclusive', True), ('min', datetime.datetime(2022, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)))))>,
  <SingleFilter(feature_name=reference_time, type=range, parameters=FilterParameterImpl(_raw=(('max', datetime.datetime(2023, 12, 31, 0, 0, tzinfo=datetime.timezone.utc)), ('max_exclusive', True), ('min', datetime.datetime(2023, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)))))>}
 ```

--- a/docs/docs/in_depth/framework-connection-object.md
+++ b/docs/docs/in_depth/framework-connection-object.md
@@ -39,7 +39,7 @@ Other frameworks don't require connection objects:
 
 The base `ComputeFramework` class provides methods to manage connection objects:
 
-``` python
+```py
 class ComputeFramework:
     def __init__(self) -> None:
         # Connection object for frameworks that need persistent connections
@@ -62,7 +62,7 @@ class ComputeFramework:
 
 Framework transformers receive the connection object as a parameter:
 
-``` python
+```py
 @classmethod
 def transform_other_fw_to_fw(cls, data: Any, framework_connection_object: Optional[Any] = None) -> Any:
     """
@@ -79,7 +79,7 @@ def transform_other_fw_to_fw(cls, data: Any, framework_connection_object: Option
 
 ### Using DuckDB with mloda API
 
-``` python
+```py
 from mloda.user import mloda
 from mloda.user import DataAccessCollection
 import duckdb
@@ -100,7 +100,7 @@ result = mloda.run_all(
 
 ### Using Spark with mloda API
 
-``` python
+```py
 from mloda.user import mloda
 from mloda.user import DataAccessCollection
 from pyspark.sql import SparkSession
@@ -127,7 +127,7 @@ result = mloda.run_all(
 
 The `DuckDBPyarrowTransformer` requires a connection object for PyArrow → DuckDB transformations:
 
-``` python
+```py
 class DuckDBPyarrowTransformer(BaseTransformer):
     @classmethod
     def transform_other_fw_to_fw(cls, data: Any, framework_connection_object: Optional[Any] = None) -> Any:
@@ -148,7 +148,7 @@ class DuckDBPyarrowTransformer(BaseTransformer):
 When implementing a new compute framework that requires a connection object:
 
 1. **Override `set_framework_connection_object`**:
-``` python
+```py
 def set_framework_connection_object(self, framework_connection_object: Optional[Any] = None) -> None:
     if framework_connection_object is not None:
         if not isinstance(framework_connection_object, ExpectedConnectionType):
@@ -163,20 +163,20 @@ def set_framework_connection_object(self, framework_connection_object: Optional[
 When implementing transformers for stateful frameworks:
 
 1. **Accept the connection object parameter**:
-``` python
+```py
 @classmethod
 def transform_other_fw_to_fw(cls, data: Any, framework_connection_object: Optional[Any] = None) -> Any:
     # Implementation here
 ```
 
 2. **Validate the connection object** when required:
-``` python
+```py
 if framework_connection_object is None:
     raise ValueError("Connection object is required for this transformation.")
 ```
 
 3. **Use the connection object** for the transformation:
-``` python
+```py
 return framework_connection_object.from_other_format(data)
 ```
 ## Troubleshooting

--- a/docs/docs/in_depth/framework-transformers.md
+++ b/docs/docs/in_depth/framework-transformers.md
@@ -49,7 +49,7 @@ PluginLoader.disable_auto_load("compute_framework")
 
 The `PandasPyArrowTransformer` is a concrete implementation of `BaseTransformer` that handles conversions between Pandas DataFrames and PyArrow Tables.
 
-``` python
+```py
 class PandasPyArrowTransformer(BaseTransformer):
     """
     Transformer for converting between Pandas DataFrame and PyArrow Table.
@@ -65,7 +65,7 @@ Key features:
 
 The `DuckDBPyArrowTransformer` is a concrete implementation of `BaseTransformer`, via `SqlBasePyArrowTransformer`, that handles conversions between DuckDB Relations and PyArrow Tables.
 
-``` python
+```py
 class DuckDBPyArrowTransformer(SqlBasePyArrowTransformer):
     """
     Transformer for converting between DuckDB relations and PyArrow Table.
@@ -84,7 +84,7 @@ Key features:
 
 The `SparkPyArrowTransformer` is a concrete implementation of `BaseTransformer` that handles conversions between Spark DataFrames and PyArrow Tables.
 
-``` python
+```py
 class SparkPyArrowTransformer(BaseTransformer):
     """
     Transformer for converting between Spark DataFrame and PyArrow Table.
@@ -214,7 +214,7 @@ The `ComputeFramework` class uses the transformer system to convert data between
 
 The transformation is handled automatically by the `apply_compute_framework_transformer` method:
 
-``` python
+```py
 def apply_compute_framework_transformer(self, data: Any) -> Any:
     _from_fw = type(data)
     _to_fw = self.expected_data_framework()

--- a/docs/docs/in_depth/join_data.md
+++ b/docs/docs/in_depth/join_data.md
@@ -319,7 +319,7 @@ When multiple batches match (e.g. three subclasses all matching a base-class lin
 
 #### mlodaAPI
 
-``` python
+```py
 from mloda.user import mloda
 
 set_of_links = {link}
@@ -339,7 +339,7 @@ In the following section, we will see how this can look like.
 The compute framework uses the base class BaseMergeEngine as configuration.
 In this example, we show the PandasMergeEngine.
 
-``` python
+```py
 class PandasDataFrame(ComputeFramework):
     def merge_engine(self) -> Type[BaseMergeEngine]:
         return PandasMergeEngine
@@ -356,7 +356,7 @@ The merge can implement:
 
 These methods are invoked via the final implementation in the abstract class **BaseMergeEngine**:
 
-``` python
+```py
 @final
 def merge(self, left_data: Any, right_data: Any, jointype: JoinType, left_index: Index, right_index: Index) -> Any:
     if jointype == JoinType.INNER:
@@ -367,7 +367,7 @@ def merge(self, left_data: Any, right_data: Any, jointype: JoinType, left_index:
 ```
 
 A simplified MergeEngine implementation looks like this:
-``` python
+```py
 class PandasMergeEngine(BaseMergeEngine):
     def merge_inner(self, left_data: Any, right_data: Any, left_index: Index, right_index: Index) -> Any:
         return self.join_logic("inner", left_data, right_data, left_index, right_index, JoinType.INNER)

--- a/docs/docs/in_depth/mloda-api.md
+++ b/docs/docs/in_depth/mloda-api.md
@@ -38,7 +38,7 @@ This means, depending on your needs, you can run them all at once (**batch run**
     Accepts `"alphabetical"` (sort columns A-Z) or `"request_order"`
     (preserve the order features were requested). Default: `None` (no guaranteed order).
 
-``` python
+```py
 from mloda.user import mloda
 
 # Alphabetical ordering
@@ -59,7 +59,7 @@ result = mloda.run_all(
 For realtime or inference scenarios, split configuration from execution.
 `prepare()` builds the execution plan once; `run()` executes it with fresh data each time.
 
-``` python
+```py
 from mloda.user import mloda
 
 # 1. Prepare once
@@ -99,7 +99,7 @@ from mloda.steward import (
 
 Resolve a single feature name (or a `Feature`) to its matching FeatureGroup without running the request, reporting failures in `result.error` instead of raising. It takes `feature` (`str | Feature`) positionally plus keyword-only `options`, `plugin_collector`, `feature_group`, `links`, `data_access_collection`, and `compute_frameworks`, and returns a `ResolvedFeature` (8 fields, including `candidates`, `error`, `supported_compute_frameworks`, `subtype`).
 
-``` python
+```python
 from mloda.steward import resolve_feature
 
 result = resolve_feature("my_feature_name")
@@ -117,7 +117,7 @@ The runtime counterpart to `resolve_feature`: `mlodaAPI.explain(...)` builds the
 
 `explain` re-resolves the plan from scratch. It answers "what would this request resolve to", it is not a record of a prior `run_all` execution. For the plan of a run that actually happened, use the return value directly: `run_all` returns a `RunResult` (a `list` with a read-only `plan` property) and `stream_all` returns a `ResultStream` (generator-compatible, `plan` available before consuming). One planning pass serves both the results and the plan, unlike `explain`, which re-resolves.
 
-``` python
+```py
 from mloda.user import mloda
 
 results = mloda.run_all(["sales__mean_aggr"], compute_frameworks=["PandasDataFrame"])
@@ -127,7 +127,7 @@ for step in results.plan:
 
 To match a `run_all` resolution, pass the same `parallelization_modes`: `run_all` defaults to `{ParallelizationMode.SYNC}`, `prepare`/`explain` default to `None`, and compute frameworks are filtered by mode.
 
-``` python
+```py
 from mloda.user import mloda
 
 # "sales" here stands for a root feature one of your own FeatureGroups provides.
@@ -158,7 +158,7 @@ The requested/injected split above is derived from a per-feature flag, not from 
 - `FeatureSet.get_initial_requested_features()` returns the sorted, deduplicated names of the flagged features in that set.
 - `PlanStep.requested_feature_names` is that accessor's output for a compute step's FeatureSet; `injected_feature_names` is the rest of `feature_names`. Both are sorted, so they do not follow the order of `feature_names`, and both are empty on join and transform steps, which carry no FeatureSet.
 
-``` python
+```py
 from mloda.user import mloda
 
 for step in mloda.explain(["sales__mean_aggr"], compute_frameworks=["PandasDataFrame"]):
@@ -173,7 +173,7 @@ for step in mloda.explain(["sales__mean_aggr"], compute_frameworks=["PandasDataF
 
 `session.resolution_report()` returns the `list[ResolutionRecord]` captured while `prepare()` planned the request, one per feature, available before or after `run()`.
 
-``` python
+```python
 from mloda.user import mlodaAPI
 
 diagnosis = mlodaAPI.diagnose(["sales__mean_aggr"], compute_frameworks=["PandasDataFrame"])
@@ -190,7 +190,7 @@ When the same request is run rather than diagnosed, the failure raises `FeatureR
 
 Import the typed resolution surfaces from `mloda.provider` (also re-exported from `mloda.user` and `mloda.steward`):
 
-``` python
+```python
 from mloda.provider import FeatureResolutionError, ResolutionDiagnosis, ResolutionRecord
 ```
 
@@ -204,7 +204,7 @@ from mloda.provider import FeatureResolutionError, ResolutionDiagnosis, Resoluti
 
 Get documentation for feature groups with optional filtering.
 
-``` python
+```python
 from mloda.steward import get_feature_group_docs
 
 # Get all feature groups
@@ -230,7 +230,7 @@ fgs = get_feature_group_docs(compute_framework="PandasDataframe")
 
 Get documentation for compute frameworks with optional filtering.
 
-``` python
+```python
 from mloda.steward import get_compute_framework_docs
 
 # List every framework (is_available flags whether its backend library is installed)
@@ -252,7 +252,7 @@ available_frameworks = get_compute_framework_docs(available_only=True)
 
 Get documentation for extenders with optional filtering.
 
-``` python
+```python
 from mloda.steward import get_extender_docs
 
 # Get all extenders

--- a/docs/docs/in_depth/multiple_result_columns.md
+++ b/docs/docs/in_depth/multiple_result_columns.md
@@ -34,7 +34,7 @@ temperature~std
 
 When implementing a feature group that returns multiple columns:
 
-``` python
+```py
 class MultiColumnFeatureGroup(FeatureGroup):
     @classmethod
     def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
@@ -54,7 +54,7 @@ class MultiColumnFeatureGroup(FeatureGroup):
 
 Use the `resolve_multi_column_feature()` utility to automatically discover all columns matching the pattern:
 
-``` python
+```py
 class MultiColumnConsumer(FeatureGroup):
     def input_features(self, options: Options, feature_name: FeatureName) -> Optional[Set[Feature]]:
         return {Feature.not_typed("MultiColumnFeature")}
@@ -84,7 +84,7 @@ class MultiColumnConsumer(FeatureGroup):
 
 For backwards compatibility, you can still access columns manually:
 
-``` python
+```py
 class MultiColumnConsumer(FeatureGroup):
     def input_features(self, options: Options, feature_name: FeatureName) -> Optional[Set[Feature]]:
         return {Feature.not_typed("MultiColumnFeature")}
@@ -106,7 +106,7 @@ class MultiColumnConsumer(FeatureGroup):
 
 You can declare a dependency on a specific sub-column directly, without needing all columns:
 
-``` python
+```py
 class SpecificSubColumnConsumer(FeatureGroup):
     def input_features(self, options: Options, feature_name: FeatureName) -> Optional[Set[Feature]]:
         # Depend on ONLY base_feature~1, not all columns
@@ -142,7 +142,7 @@ The mloda framework automatically handles the selection of columns that follow t
 
 2. This is implemented in the `identify_naming_convention` method in the `ComputeFramework` class:
 
-``` python
+```py
 def identify_naming_convention(self, selected_feature_names: Set[FeatureName], column_names: Set[str]) -> Set[str]:
     feature_name_strings = {f.name for f in selected_feature_names}
     _selected_feature_names: Set[str] = set()

--- a/docs/docs/in_depth/named-data-access-handles.md
+++ b/docs/docs/in_depth/named-data-access-handles.md
@@ -8,7 +8,7 @@ For background, see [issue #443](https://github.com/mloda-ai/mloda/issues/443).
 
 A DAC holds resources of four kinds. Each kind has its own keyed dict:
 
-``` py
+```py
 DataAccessCollection(
     connections={"warehouse": warehouse_conn, "analytics": analytics_conn},
     files={"transactions": "/data/tx.parquet", "users": "/data/users.csv"},
@@ -21,7 +21,7 @@ Handle names are arbitrary strings you choose. They are globally unique across k
 
 Mutators mirror the keyed-dict shape:
 
-``` py
+```py
 dac.add_connection("warehouse", warehouse_conn)
 dac.add_file("transactions", "/data/tx.parquet")
 dac.add_folder("raw", "/data/raw/")
@@ -62,7 +62,7 @@ Every kind accepts more than one input shape. Each shape earned its place at a d
 
 The named/auto split applies to the mutators as well:
 
-``` py
+```python
 dac.add_file("/data/tx.parquet")                       # auto-named
 dac.add_file("tx", "/data/tx.parquet")                 # named (when you need a handle)
 ```
@@ -78,14 +78,14 @@ Naming is only required when:
 
 Credentials are the one kind where the named form and the value itself look identical, because a credential *is* a dict. These two lines differ only in brackets but mean completely different things:
 
-``` py
+```py
 credentials={"sqlite": "/data/x.db"}    # named form: handle "sqlite" -> credential "/data/x.db"
 credentials=[{"sqlite": "/data/x.db"}]  # one credential whose mapping is {"sqlite": "/data/x.db"}
 ```
 
 The first shape is almost never what you mean: it registers the string `"/data/x.db"` as the credential, which then fails every connector's `is_valid_credentials` check. The typed `Credential` class removes the ambiguity, so the meaning comes from the type instead of the nesting depth:
 
-``` py
+```python
 from mloda.user import Credential, DataAccessCollection
 
 DataAccessCollection(credentials=Credential(sqlite="/data/x.db"))       # kwargs form
@@ -151,7 +151,7 @@ assert "missing" in str(excinfo.value)
 
 When more than one resource of the same kind matches a feature's requirements, you disambiguate by setting `data_access_handle` on the feature's `Options`:
 
-``` py
+```py
 from mloda.user import DataAccessCollection, Options, Feature, mloda
 
 dac = DataAccessCollection(
@@ -175,7 +175,7 @@ The key works across `read_file`, `read_document`, and `read_db` on a per-featur
 
 `DataAccessCollection.handles()` returns a `{handle: kind}` map of everything registered. Use it for audits, logging, or to surface candidates in your own error messages:
 
-``` py
+```python
 dac.handles()
 # {"warehouse": "connection", "analytics": "connection",
 #  "transactions": "file", "users": "file",
@@ -186,7 +186,7 @@ dac.handles()
 
 `column_to_file` is a file-specific override that takes precedence over the resolver. Its values may be either a **file handle** (key of the `files` dict) or a **file path** (value of the `files` dict); both are accepted and normalized to handles internally:
 
-``` py
+```python
 DataAccessCollection(
     files={"train": "application_train.csv", "bureau": "bureau.csv"},
     column_to_file={

--- a/docs/docs/in_depth/plugin-loader.md
+++ b/docs/docs/in_depth/plugin-loader.md
@@ -84,7 +84,8 @@ my-pkg = "my_pkg.manifest:COMPUTE_FRAMEWORKS"
 
 The manifest module lists the concrete classes explicitly:
 
-```python title="my_pkg/manifest.py"
+```py
+# my_pkg/manifest.py
 from mloda.provider import FeatureGroup
 
 class CustomerChurnFeatureGroup(FeatureGroup):

--- a/docs/docs/in_depth/plugin-loader.md
+++ b/docs/docs/in_depth/plugin-loader.md
@@ -74,7 +74,8 @@ Separately installed packages publish plugins through three entry-point groups, 
 
 A package declares one entry per group it ships plugins for. The entry points at a module attribute, the manifest: a plain sequence of plugin classes. The entry-point name (`my-pkg` below) is a package label only, never a registry key; registered classes keep the usual `module:qualname` keys.
 
-```toml title="pyproject.toml"
+```toml
+# pyproject.toml
 [project.entry-points."mloda.feature_groups"]
 my-pkg = "my_pkg.manifest:FEATURE_GROUPS"
 

--- a/docs/docs/in_depth/plugin_registry.md
+++ b/docs/docs/in_depth/plugin_registry.md
@@ -209,7 +209,8 @@ Pass the collector into the API via the `plugin_collector=` keyword, as with str
 
 Manual registrations mutate the process-global default registry, so tests can leak state into each other. mloda ships a pytest plugin (registered through the `pytest11` entry point in its packaging) that provides the `isolated_plugin_registry` fixture: it snapshots the default registry and its installed policy before each test and restores both afterwards, also resetting the policy-denial warning dedup. Any project with mloda installed gets the fixture automatically; no `conftest.py` re-export is needed. Request it in tests that register plugins:
 
-```python title="test_my_plugin.py"
+```py
+# test_my_plugin.py
 def test_my_feature_group_registration(isolated_plugin_registry):
     key = isolated_plugin_registry.register(MyFeatureGroup)
     assert isolated_plugin_registry.get(key) is MyFeatureGroup

--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -15,7 +15,7 @@ Two rules carry most of the model:
 
 ## The spec type
 
-``` python
+```python
 from mloda.provider import PropertySpec
 
 PROPERTY_MAPPING = {
@@ -48,7 +48,7 @@ returns and the type the schema is validated against, so reach for it directly w
 the class itself (subclassing, `isinstance` checks, or constructing a spec programmatically).
 Both are exported from `mloda.provider`.
 
-``` python
+```python
 from mloda.provider import property_spec
 
 PROPERTY_MAPPING = {
@@ -248,7 +248,9 @@ candidate feature group).
 Container syntax is not part of the contract. For membership and `element_validator`, every
 sequence unpacks element-wise and identically:
 
-``` python
+```python
+from mloda.user import Options
+
 # All four hand the element_validator exactly "a" and then "b".
 Options(context={"ops": ["a", "b"]})
 Options(context={"ops": ("a", "b")})
@@ -303,7 +305,7 @@ Under `strict_validation=True`, a declared non-`None` `default` must be a value 
 accepts, either by membership or through the `element_validator`. This closes the gap where
 omitting the key would apply an unrevalidated default.
 
-``` python
+```py
 # ValueError at construction: "mul" is not accepted.
 PropertySpec(
     "Arithmetic operation",
@@ -331,7 +333,7 @@ Optionality is the `default` field, and the three states are distinct:
 | `default=None` | The key is **optional**; no value is applied when it is absent. |
 | `default=<value>` | The key is **optional**; the value is materialized when it is absent (see [Applying declared defaults](#applying-declared-defaults)), and is checked under strict. |
 
-``` python
+```python
 from mloda.provider import PropertySpec
 
 PROPERTY_MAPPING = {
@@ -350,7 +352,7 @@ every field is always present, so a plain `None` cannot say both "no default dec
 To ask whether a spec declares a default, use `is_no_default`, also exported from
 `mloda.provider`:
 
-``` python
+```py
 from mloda.provider import is_no_default
 
 if is_no_default(spec.default):
@@ -419,7 +421,7 @@ Filter matching is the one place the same classmethod sees both views: `GlobalFi
 enriched from the resolved feature's effective ones (`unify_options`), so a key the filter feature
 omits arrives materialized where feature resolution saw it declared.
 
-``` python
+```py
 graph_type = feature.options.get("graph_type")  # the declared default when the caller omitted it
 ```
 
@@ -436,7 +438,7 @@ required-presence and `required_when` checks and is seen by membership, `element
 `match_guard`, while every flagless spec is unchanged. The flag defaults to `False`, so the existing
 `is not None` presence tests keep working.)
 
-``` python
+```py
 graph_type = feature.options.get("graph_type", "spring")  # explicit value; else the spec default; else "spring"
 ```
 
@@ -444,7 +446,7 @@ graph_type = feature.options.get("graph_type", "spring")  # explicit value; else
 
 There is no `group` field: a group parameter is `context=False`.
 
-``` python
+```python
 PROPERTY_MAPPING = {
     # Context parameter (the default): does not affect feature group splitting
     "aggregation_type": PropertySpec(
@@ -494,7 +496,7 @@ match-time name capture (parsed by the plugin from the name, or supplied downstr
 `deferred_binding=True`, which exempts it from this check only and leaves it required on the
 config path. `ClusteringFeatureGroup` marks its name-parsed `k_value` key this way:
 
-``` python
+```python
 from mloda.provider import PropertySpec
 
 PROPERTY_MAPPING = {
@@ -533,7 +535,7 @@ effective `Options` and returns `True` when the option is required. This works f
 config-based and string-based features alike (for the latter, the operation parsed from the
 feature name is merged in first, so predicates see values from both sources).
 
-``` python
+```python
 _ORDER_DEPENDENT = {"first", "last"}
 
 def _needs_order_by(options: Options) -> bool:
@@ -649,7 +651,7 @@ By default context parameters are local: they do not flow through dependency cha
 which is correct for feature-specific config. For cross-cutting metadata (session
 IDs, environment flags), use `propagate_context_keys`:
 
-``` python
+```python
 Options(
     context={"session_id": "abc", "window_function": "sum"},
     propagate_context_keys=frozenset({"session_id"}),  # only session_id flows on
@@ -683,7 +685,7 @@ consumer and its input feature, default forwarding is group-to-group only: a con
 `context` key is not compared against a same-named child `group` key, so the two are
 independent roles, not a conflict:
 
-``` python
+```python
 consumer = Options(context={"algo": "sum"})
 child = Options(group={"algo": "mean"})
 

--- a/docs/docs/in_depth/streaming.md
+++ b/docs/docs/in_depth/streaming.md
@@ -2,7 +2,7 @@
 
 `stream_all` lets you consume results incrementally instead of waiting for every feature group to finish.  Each time a feature group completes, its result is yielded immediately so you can begin processing it while the remaining groups are still computing.  It accepts the same parameters as `run_all` (see [mloda API](mloda-api.md)).
 
-``` python3
+```py
 from mloda.user import mloda
 
 for result in mloda.stream_all(["FeatureA", "FeatureB", "FeatureC"]):
@@ -15,7 +15,7 @@ for result in mloda.stream_all(["FeatureA", "FeatureB", "FeatureC"]):
 
 `run_all` returns all results at once after every feature group has finished:
 
-``` python3
+```py
 from mloda.user import mloda
 
 results = mloda.run_all(["FeatureA", "FeatureB", "FeatureC"])
@@ -24,7 +24,7 @@ results = mloda.run_all(["FeatureA", "FeatureB", "FeatureC"])
 
 `stream_all` yields each result as soon as its group is done:
 
-``` python3
+```py
 from mloda.user import mloda
 
 for result in mloda.stream_all(["FeatureA", "FeatureB", "FeatureC"]):
@@ -64,7 +64,7 @@ All patterns below build on the [two-phase execution API (`prepare()` / `run()`)
 
 The recommended pattern for continuous processing. Call `prepare()` once to build the execution plan, then loop `run()` for each micro-batch. The plan is reused across calls, so only the first call pays the planning cost.
 
-``` python3
+```py
 from mloda.user import mloda
 
 def data_source():
@@ -91,7 +91,7 @@ This works with any iterable source.
 
 Combines plan reuse with per-group streaming. Call `prepare()` once, then `stream_run()` for each micro-batch. Each feature group's result is yielded as soon as it completes, while the execution plan is reused across calls.
 
-``` python3
+```py
 from mloda.user import mloda
 
 def sensor_source():
@@ -123,7 +123,7 @@ for batch in sensor_source():
 
 When you don't need plan reuse and want a single-call streaming API, use `mloda.stream_all()`. It internally calls `prepare()` + `stream_run()`.
 
-``` python3
+```py
 from mloda.user import mloda
 
 for result in mloda.stream_all(["FeatureA", "FeatureB", "FeatureC"], api_data=batch):

--- a/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
+++ b/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
@@ -7,7 +7,7 @@ run would, without raising: the failure lands in `result.error` instead of an
 exception, so for the matching failures on this page the message below is the
 message you get back.
 
-``` python
+```python
 from mloda.provider import resolve_feature
 
 result = resolve_feature("my_feature")  # or resolve_feature(Feature(...)) for a full request
@@ -35,7 +35,7 @@ Inside a run, a feature that does not resolve to exactly one FeatureGroup raises
 subclass, so existing `except ValueError` handlers keep working, but you can now
 catch it specifically and inspect why it failed:
 
-``` python
+```python
 from mloda.provider import FeatureResolutionError
 from mloda.user import mloda
 
@@ -74,7 +74,7 @@ If you previously hit this in a notebook because of a redefined feature group (r
 #### 1. Use PluginCollector to enable or disable feature groups
 Control which feature groups are loaded to prevent conflicts:
 
-``` python
+```py
 from mloda.user import PluginCollector
 
 # Disable specific conflicting feature groups
@@ -106,7 +106,7 @@ def get_domain(cls):
 #### 4. Scope a feature to one source (shared keys across sources)
 When two enabled sources declare the same column (for example a shared join key), requesting that column by bare name is ambiguous. Scope the request to one source. The scope is resolution-only and does not affect feature identity.
 
-``` python
+```py
 # class object, collision-proof
 Feature("subject_token", feature_group=ClaimsReader)
 
@@ -116,7 +116,7 @@ Feature("subject_token", feature_group="ClaimsReader")
 
 The same scope in a JSON config ([feature config](../feature-config.md)):
 
-``` json
+```json
 [
     {"name": "subject_token", "feature_group": "ClaimsReader"}
 ]
@@ -126,7 +126,7 @@ The config form takes the class-name string only, because JSON cannot express a 
 
 Both forms match the scoped class and its subclasses, preferring the most specific one. Naming an abstract family base therefore selects the concrete subclass, so a config can scope to the family without naming a compute-framework-specific class:
 
-``` json
+```json
 [
     {"name": "age__mean_aggr", "feature_group": "AggregatedFeatureGroup"}
 ]
@@ -228,7 +228,7 @@ relevant entries, return a *schema-bearing* empty result: keep the columns and
 drop the rows. On PythonDict that is a dict with empty column lists; on the
 other frameworks it is an empty typed table or frame with the right columns.
 
-``` python
+```py
 class MyFeatureGroup(FeatureGroup):
     @classmethod
     def calculate_feature(cls, data, features):

--- a/tests/test_docs_fences.py
+++ b/tests/test_docs_fences.py
@@ -1,0 +1,373 @@
+"""Fence vocabulary guard for docs/docs markdown.
+
+Pure string parsing with no runtime dependency, so it lives outside
+tests/test_documentation, which the default tox env ignores.
+"""
+
+import re
+from collections.abc import Callable, Iterator, Mapping
+from pathlib import Path
+from typing import cast
+
+import pytest
+from mktestdocs import grab_code_blocks
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+DOCS_ROOT = REPO_ROOT / "docs" / "docs"
+
+RUNNABLE_TAG = "python"
+ILLUSTRATIVE_TAG = "py"
+OUTPUT_TAG = "text"
+
+PYTHON_LOOKING = re.compile(r"i?py(thon)?[0-9]*(-repl)?|pycon", re.IGNORECASE)
+
+VOCABULARY_HINT = (
+    f"Use ```{RUNNABLE_TAG} when the block runs, ```{ILLUSTRATIVE_TAG} when it is an "
+    f"illustrative fragment that must not run, ```{OUTPUT_TAG} when it is output."
+)
+
+# Repo-relative doc path -> permitted number of ```py blocks. An absent file permits zero.
+ILLUSTRATIVE_BLOCK_ALLOWLIST: dict[str, int] = {
+    "docs/docs/chapter1/api-request.md": 1,
+    "docs/docs/chapter1/compute-frameworks.md": 4,
+    "docs/docs/in_depth/access-feature-data.md": 5,
+    "docs/docs/in_depth/artifacts.md": 1,
+    "docs/docs/in_depth/compute-framework-integration.md": 12,
+    "docs/docs/in_depth/data-access-patterns.md": 7,
+    "docs/docs/in_depth/data-type-enforcement.md": 1,
+    "docs/docs/in_depth/discover-plugins.md": 1,
+    "docs/docs/in_depth/feature-chain-parser.md": 16,
+    "docs/docs/in_depth/feature-config.md": 2,
+    "docs/docs/in_depth/feature-group-matching.md": 3,
+    "docs/docs/in_depth/feature-group-testing.md": 5,
+    "docs/docs/in_depth/filter_data.md": 1,
+    "docs/docs/in_depth/framework-connection-object.md": 9,
+    "docs/docs/in_depth/framework-transformers.md": 4,
+    "docs/docs/in_depth/join_data.md": 4,
+    "docs/docs/in_depth/mloda-api.md": 5,
+    "docs/docs/in_depth/multiple_result_columns.md": 5,
+    "docs/docs/in_depth/named-data-access-handles.md": 4,
+    "docs/docs/in_depth/plugin-loader.md": 1,
+    "docs/docs/in_depth/plugin_registry.md": 1,
+    "docs/docs/in_depth/property-mapping.md": 4,
+    "docs/docs/in_depth/streaming.md": 6,
+    "docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md": 3,
+}
+
+MAX_REPORTED_VIOLATIONS = 60
+
+
+FENCE_OPENING = re.compile(r"(?P<marker>`{3,}|~{3,})(?P<info>.*)$")
+
+
+class Fence:
+    """One opening code fence in a markdown file."""
+
+    def __init__(self, path: Path, lineno: int, text: str, marker: str, info: str) -> None:
+        self.path = path
+        self.lineno = lineno
+        self.text = text
+        self.marker = marker
+        self.info = info
+
+    @property
+    def tag(self) -> str:
+        parts = self.info.strip().split()
+        return parts[0] if parts else ""
+
+    @property
+    def has_leading_space(self) -> bool:
+        return bool(self.info) and self.info[0].isspace() and bool(self.info.strip())
+
+    @property
+    def has_trailing_space(self) -> bool:
+        return self.info != self.info.rstrip()
+
+    @property
+    def is_tilde(self) -> bool:
+        return self.marker.startswith("~")
+
+    @property
+    def is_overlong(self) -> bool:
+        return not self.is_tilde and len(self.marker) > 3
+
+    @property
+    def location(self) -> str:
+        return f"{self.path}:{self.lineno}"
+
+
+def _scan_fences(path: Path) -> tuple[list[Fence], Fence | None]:
+    """Return the opening fences of a markdown file and the one left unclosed, if any."""
+    # CommonMark closing rules; mktestdocs instead toggles on any line containing three
+    # backticks, so a doc showing a fence inside a fence would desynchronize the two.
+    openings: list[Fence] = []
+    open_fence: Fence | None = None
+    for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        match = FENCE_OPENING.match(line.lstrip())
+        if match is None:
+            continue
+        marker, info = match.group("marker"), match.group("info")
+        if open_fence is not None:
+            closes = marker[0] == open_fence.marker[0] and len(marker) >= len(open_fence.marker)
+            if closes and not info.strip():
+                open_fence = None
+            continue
+        open_fence = Fence(path=path, lineno=lineno, text=line.lstrip(), marker=marker, info=info)
+        openings.append(open_fence)
+    return openings, open_fence
+
+
+def _iter_fence_openings(path: Path) -> Iterator[Fence]:
+    """Yield the opening fences of a markdown file, skipping fence bodies."""
+    openings, _ = _scan_fences(path)
+    return iter(openings)
+
+
+def _doc_files() -> list[Path]:
+    files = sorted(DOCS_ROOT.rglob("*.md"))
+    assert files, f"no markdown files under {DOCS_ROOT}, the fence checks would pass vacuously"
+    return files
+
+
+def _suggested_tag(tag: str) -> str:
+    if tag.lower() == "pycon":
+        return OUTPUT_TAG
+    return RUNNABLE_TAG
+
+
+def _violations_in_file(path: Path) -> list[str]:
+    """Report the fence spellings of one markdown file that never reach the doc runner."""
+    messages: list[str] = []
+    openings, unterminated = _scan_fences(path)
+    for fence in openings:
+        tag = fence.tag
+        python_looking = bool(PYTHON_LOOKING.fullmatch(tag))
+        if fence.has_leading_space:
+            unspaced = f"```{fence.info.strip()}"
+            messages.append(f"{fence.location}: spaced fence {fence.text!r} -> write {unspaced!r}. {VOCABULARY_HINT}")
+            continue
+        if tag and fence.info.strip() != tag:
+            messages.append(
+                f"{fence.location}: fence {fence.text!r} carries attributes after the tag, so it does not "
+                f"render as a code block -> write a bare ```{tag} with the title in a comment. {VOCABULARY_HINT}"
+            )
+            continue
+        if not python_looking:
+            continue
+        if fence.is_tilde:
+            messages.append(
+                f"{fence.location}: fence {fence.text!r} highlights as Python but is never executed, "
+                f"only a backtick fence is collected -> write ```{_suggested_tag(tag)}. {VOCABULARY_HINT}"
+            )
+            continue
+        if fence.is_overlong:
+            messages.append(
+                f"{fence.location}: fence {fence.text!r} looks like Python but is never executed, "
+                f"only a three-backtick fence is executed -> write ```{_suggested_tag(tag)}. {VOCABULARY_HINT}"
+            )
+            continue
+        if fence.has_trailing_space:
+            messages.append(
+                f"{fence.location}: fence {fence.text!r} has trailing whitespace after the tag and is never "
+                f"executed -> write ```{tag} without it. {VOCABULARY_HINT}"
+            )
+            continue
+        if tag in {RUNNABLE_TAG, ILLUSTRATIVE_TAG}:
+            continue
+        messages.append(
+            f"{fence.location}: fence {fence.text!r} looks like Python but is never executed, "
+            f"write ```{_suggested_tag(tag)}. {VOCABULARY_HINT}"
+        )
+    if unterminated is not None:
+        messages.append(
+            f"{unterminated.location}: fence {unterminated.text!r} is never closed, so nothing inside it is "
+            f"collected -> close it. {VOCABULARY_HINT}"
+        )
+    return messages
+
+
+def _fence_violations() -> list[str]:
+    return [message for path in _doc_files() for message in _violations_in_file(path)]
+
+
+def _stale_allowlist_keys(allowlist: Mapping[str, int]) -> list[str]:
+    """Report the allowlist keys that no longer name an existing doc file."""
+    return [key for key in sorted(allowlist) if not (REPO_ROOT / key).exists()]
+
+
+def _format(violations: list[str]) -> str:
+    shown = violations[:MAX_REPORTED_VIOLATIONS]
+    lines = list(shown)
+    omitted = len(violations) - len(shown)
+    if omitted:
+        lines.append(f"... and {omitted} more omitted.")
+    return "\n".join(lines)
+
+
+def test_doc_fences_use_the_documented_vocabulary() -> None:
+    violations = _fence_violations()
+    assert not violations, f"{len(violations)} doc fence violation(s):\n{_format(violations)}"
+
+
+def test_illustrative_py_blocks_match_allowlist() -> None:
+    errors: list[str] = []
+    for path in _doc_files():
+        actual = sum(1 for fence in _iter_fence_openings(path) if fence.info.strip() == ILLUSTRATIVE_TAG)
+        allowed = ILLUSTRATIVE_BLOCK_ALLOWLIST.get(str(path.relative_to(REPO_ROOT)), 0)
+        if actual > allowed:
+            errors.append(
+                f"{path}: {actual} ```{ILLUSTRATIVE_TAG} block(s) but only {allowed} allowed. "
+                f"Promote the block to ```{RUNNABLE_TAG} (or ```{OUTPUT_TAG} if it is output), "
+                f"or raise its ILLUSTRATIVE_BLOCK_ALLOWLIST entry."
+            )
+        elif actual < allowed:
+            errors.append(
+                f"{path}: {actual} ```{ILLUSTRATIVE_TAG} block(s) but {allowed} allowed. "
+                f"Lower the ILLUSTRATIVE_BLOCK_ALLOWLIST entry to {actual}."
+            )
+    assert not errors, "```py allowlist drift:\n" + "\n".join(errors)
+
+
+# Helpers the guard is expected to expose so it can be driven over synthetic input.
+VIOLATIONS_HELPER = "_violations_in_file"
+STALE_KEYS_HELPER = "_stale_allowlist_keys"
+
+
+def _violations_for(path: Path) -> list[str]:
+    """Report the fence violations of a single markdown file."""
+    helper = globals().get(VIOLATIONS_HELPER)
+    assert callable(helper), (
+        f"{__name__} must expose {VIOLATIONS_HELPER}(path) -> list[str] so the fence scanner "
+        f"can be exercised on synthetic markdown instead of only on the whole docs tree"
+    )
+    return cast(Callable[[Path], list[str]], helper)(path)
+
+
+def _stale_keys(allowlist: Mapping[str, int]) -> list[str]:
+    """Report the allowlist keys that no longer name an existing doc file."""
+    helper = globals().get(STALE_KEYS_HELPER)
+    assert callable(helper), (
+        f"{__name__} must expose {STALE_KEYS_HELPER}(allowlist) -> list[str] so a key whose file "
+        f"was deleted or renamed is reported instead of rotting unvisited"
+    )
+    return cast(Callable[[Mapping[str, int]], list[str]], helper)(allowlist)
+
+
+SNIPPET = 'print("collected")'
+
+TRAILING_SPACE_OPEN = "```python "  # one trailing space, which the guard's strip() throws away
+FOUR_BACKTICK_OPEN = "````python"
+TILDE_OPEN = "~~~python"
+
+
+def _markdown(opening: str, closing: str | None) -> str:
+    """Build a one-block markdown document, leaving the block open when closing is None."""
+    lines = ["# Synthetic", "", opening, SNIPPET]
+    if closing is not None:
+        lines.append(closing)
+    return "\n".join(lines) + "\n"
+
+
+def _write(tmp_path: Path, name: str, text: str) -> Path:
+    path = tmp_path / name
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+class TestUncollectedPythonFenceSpellings:
+    """Fence spellings that read as runnable Python but that mktestdocs never collects."""
+
+    def test_a_plain_python_fence_is_collected(self) -> None:
+        """Control: the ground-truth assertions of this class are not vacuous."""
+        assert grab_code_blocks(_markdown("```python", "```"), lang="python") == [f"{SNIPPET}\n"]
+
+    def test_a_trailing_space_after_the_tag_is_reported(self, tmp_path: Path) -> None:
+        text = _markdown(TRAILING_SPACE_OPEN, "```")
+        assert grab_code_blocks(text, lang="python") == [], (
+            f"ground truth changed: mktestdocs now collects {TRAILING_SPACE_OPEN!r}"
+        )
+        path = _write(tmp_path, "trailing_space.md", text)
+        violations = _violations_for(path)
+        assert violations, (
+            f"{TRAILING_SPACE_OPEN!r} looks runnable and is never executed, "
+            f"because mktestdocs compares the info string against 'python' without rstrip"
+        )
+
+    def test_a_four_backtick_fence_is_reported(self, tmp_path: Path) -> None:
+        text = _markdown(FOUR_BACKTICK_OPEN, "````")
+        assert grab_code_blocks(text, lang="python") == [], (
+            f"ground truth changed: mktestdocs now collects {FOUR_BACKTICK_OPEN!r}"
+        )
+        path = _write(tmp_path, "four_backticks.md", text)
+        violations = _violations_for(path)
+        assert violations, (
+            f"{FOUR_BACKTICK_OPEN!r} looks runnable and is never executed, "
+            f"because mktestdocs slices exactly three backticks and reads the tag as '`python'"
+        )
+
+    def test_a_tilde_fence_is_reported(self, tmp_path: Path) -> None:
+        text = _markdown(TILDE_OPEN, "~~~")
+        assert grab_code_blocks(text, lang="python") == [], (
+            f"ground truth changed: mktestdocs now collects {TILDE_OPEN!r}"
+        )
+        path = _write(tmp_path, "tilde.md", text)
+        violations = _violations_for(path)
+        assert violations, (
+            f"{TILDE_OPEN!r} highlights as Python and is never executed, "
+            f"because mktestdocs only recognises backtick fences"
+        )
+
+    def test_an_unterminated_python_fence_is_reported(self, tmp_path: Path) -> None:
+        text = _markdown("```python", None)
+        assert grab_code_blocks(text, lang="python") == [], (
+            "ground truth changed: mktestdocs now collects a block with no closing fence"
+        )
+        path = _write(tmp_path, "unterminated.md", text)
+        violations = _violations_for(path)
+        assert violations, (
+            "an unclosed ```python block at end of file is never executed, "
+            "because mktestdocs only emits a block once it sees the closing fence"
+        )
+
+    @pytest.mark.parametrize("tag", ["ipython", "python-repl"])
+    def test_a_python_highlighting_alias_is_reported(self, tmp_path: Path, tag: str) -> None:
+        text = _markdown(f"```{tag}", "```")
+        assert grab_code_blocks(text, lang="python") == [], f"ground truth changed: mktestdocs now collects ```{tag}"
+        path = _write(tmp_path, f"{tag.replace('-', '_')}.md", text)
+        violations = _violations_for(path)
+        assert violations, f"```{tag} highlights as Python and is never executed, yet PYTHON_LOOKING misses it"
+
+
+class TestAllowlistKeysStayCurrent:
+    """An allowlist key whose file is gone is never visited by the file loop."""
+
+    def test_every_allowlist_key_names_an_existing_doc(self) -> None:
+        missing = _stale_keys(ILLUSTRATIVE_BLOCK_ALLOWLIST)
+        assert not missing, (
+            f"ILLUSTRATIVE_BLOCK_ALLOWLIST key(s) name files that do not exist: {missing}. "
+            f"Drop the entry, or fix the path if the doc was renamed."
+        )
+
+    def test_the_helper_reports_a_key_whose_file_is_gone(self) -> None:
+        stale = _stale_keys({**ILLUSTRATIVE_BLOCK_ALLOWLIST, "docs/docs/deleted-page.md": 1})
+        assert stale == ["docs/docs/deleted-page.md"], f"a deleted doc stayed unreported, got {stale}"
+
+
+class TestDocCorpusIsNotCwdDependent:
+    """A CWD-relative DOCS_ROOT lets both static checks pass over an empty corpus."""
+
+    def test_doc_files_are_found_from_any_working_directory(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from_repo_root = _doc_files()
+        assert from_repo_root, "the doc corpus is empty even from the repo root"
+
+        monkeypatch.chdir(tmp_path)
+        from_elsewhere = _doc_files()
+        assert from_elsewhere, (
+            "DOCS_ROOT resolves against the process CWD, so from any other directory the fence "
+            "vocabulary and allowlist checks pass over an empty corpus"
+        )
+        assert [path.name for path in from_elsewhere] == [path.name for path in from_repo_root]
+        assert all(path.exists() for path in from_elsewhere)

--- a/tests/test_documentation/test_doc_fence_vocabulary.py
+++ b/tests/test_documentation/test_doc_fence_vocabulary.py
@@ -1,0 +1,210 @@
+"""Fence vocabulary guard for docs/docs markdown."""
+
+import re
+import textwrap
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from tests.test_documentation.test_documentation import run_md_file_isolated
+
+DOCS_ROOT = Path("docs/docs")
+
+RUNNABLE_TAG = "python"
+ILLUSTRATIVE_TAG = "py"
+OUTPUT_TAG = "text"
+
+PYTHON_LOOKING = re.compile(r"py(thon)?[0-9]*|pycon", re.IGNORECASE)
+
+VOCABULARY_HINT = (
+    f"Use ```{RUNNABLE_TAG} when the block runs, ```{ILLUSTRATIVE_TAG} when it is an "
+    f"illustrative fragment that must not run, ```{OUTPUT_TAG} when it is output."
+)
+
+# Repo-relative doc path -> permitted number of ```py blocks. An absent file permits zero.
+ILLUSTRATIVE_BLOCK_ALLOWLIST: dict[str, int] = {
+    "docs/docs/chapter1/api-request.md": 1,
+    "docs/docs/chapter1/compute-frameworks.md": 4,
+    "docs/docs/in_depth/access-feature-data.md": 5,
+    "docs/docs/in_depth/artifacts.md": 1,
+    "docs/docs/in_depth/compute-framework-integration.md": 12,
+    "docs/docs/in_depth/data-access-patterns.md": 7,
+    "docs/docs/in_depth/data-quality.md": 2,
+    "docs/docs/in_depth/data-type-enforcement.md": 1,
+    "docs/docs/in_depth/discover-plugins.md": 1,
+    "docs/docs/in_depth/feature-chain-parser.md": 16,
+    "docs/docs/in_depth/feature-config.md": 2,
+    "docs/docs/in_depth/feature-group-matching.md": 3,
+    "docs/docs/in_depth/feature-group-testing.md": 5,
+    "docs/docs/in_depth/filter_data.md": 1,
+    "docs/docs/in_depth/framework-connection-object.md": 9,
+    "docs/docs/in_depth/framework-transformers.md": 4,
+    "docs/docs/in_depth/join_data.md": 4,
+    "docs/docs/in_depth/mloda-api.md": 5,
+    "docs/docs/in_depth/multiple_result_columns.md": 5,
+    "docs/docs/in_depth/named-data-access-handles.md": 4,
+    "docs/docs/in_depth/plugin-loader.md": 1,
+    "docs/docs/in_depth/plugin_registry.md": 1,
+    "docs/docs/in_depth/property-mapping.md": 4,
+    "docs/docs/in_depth/streaming.md": 6,
+    "docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md": 3,
+}
+
+MAX_REPORTED_VIOLATIONS = 60
+
+
+class Fence:
+    """One opening code fence in a markdown file."""
+
+    def __init__(self, path: Path, lineno: int, text: str, info: str) -> None:
+        self.path = path
+        self.lineno = lineno
+        self.text = text
+        self.info = info
+
+    @property
+    def tag(self) -> str:
+        parts = self.info.strip().split()
+        return parts[0] if parts else ""
+
+    @property
+    def has_leading_space(self) -> bool:
+        return bool(self.info) and self.info[0].isspace() and bool(self.info.strip())
+
+    @property
+    def location(self) -> str:
+        return f"{self.path}:{self.lineno}"
+
+
+def _iter_fence_openings(path: Path) -> Iterator[Fence]:
+    """Yield the opening fences of a markdown file, skipping fence bodies."""
+    inside = False
+    for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        stripped = line.strip()
+        if not stripped.startswith("```"):
+            continue
+        backticks = len(stripped) - len(stripped.lstrip("`"))
+        info = stripped[backticks:]
+        if inside:
+            if not info.strip():
+                inside = False
+            continue
+        inside = True
+        yield Fence(path=path, lineno=lineno, text=stripped, info=info)
+
+
+def _doc_files() -> list[Path]:
+    return sorted(DOCS_ROOT.rglob("*.md"))
+
+
+def _suggested_tag(tag: str) -> str:
+    if tag.lower() == "pycon":
+        return OUTPUT_TAG
+    return RUNNABLE_TAG
+
+
+def _fence_violations() -> list[tuple[Path, int, str]]:
+    violations: list[tuple[Path, int, str]] = []
+    for path in _doc_files():
+        for fence in _iter_fence_openings(path):
+            tag = fence.tag
+            if fence.has_leading_space:
+                unspaced = f"```{fence.info.strip()}"
+                violations.append(
+                    (
+                        path,
+                        fence.lineno,
+                        f"{fence.location}: spaced fence {fence.text!r} -> write {unspaced!r}. {VOCABULARY_HINT}",
+                    )
+                )
+                continue
+            if not PYTHON_LOOKING.fullmatch(tag):
+                continue
+            if fence.info.strip() == tag and tag in {RUNNABLE_TAG, ILLUSTRATIVE_TAG}:
+                continue
+            if fence.info.strip() != tag:
+                remedy = (
+                    f"attributes after the tag also stop collection -> write a bare ```{RUNNABLE_TAG} "
+                    f"with the title in a comment, or ```{ILLUSTRATIVE_TAG} if it must not run"
+                )
+            else:
+                remedy = f"write ```{_suggested_tag(tag)}"
+            violations.append(
+                (
+                    path,
+                    fence.lineno,
+                    f"{fence.location}: fence {fence.text!r} looks like Python but is never executed, "
+                    f"{remedy}. {VOCABULARY_HINT}",
+                )
+            )
+    return sorted(violations, key=lambda item: (str(item[0]), item[1]))
+
+
+def _format(violations: list[tuple[Path, int, str]]) -> str:
+    shown = violations[:MAX_REPORTED_VIOLATIONS]
+    lines = [message for _, _, message in shown]
+    omitted = len(violations) - len(shown)
+    if omitted:
+        lines.append(f"... and {omitted} more omitted.")
+    return "\n".join(lines)
+
+
+def test_doc_fences_use_the_documented_vocabulary() -> None:
+    violations = _fence_violations()
+    assert not violations, f"{len(violations)} doc fence violation(s):\n{_format(violations)}"
+
+
+def test_illustrative_py_blocks_match_allowlist() -> None:
+    errors: list[str] = []
+    for path in _doc_files():
+        actual = sum(1 for fence in _iter_fence_openings(path) if fence.info.strip() == ILLUSTRATIVE_TAG)
+        allowed = ILLUSTRATIVE_BLOCK_ALLOWLIST.get(str(path), 0)
+        if actual > allowed:
+            errors.append(
+                f"{path}: {actual} ```{ILLUSTRATIVE_TAG} block(s) but only {allowed} allowed. "
+                f"Promote the block to ```{RUNNABLE_TAG} (or ```{OUTPUT_TAG} if it is output), "
+                f"or raise its ILLUSTRATIVE_BLOCK_ALLOWLIST entry."
+            )
+        elif actual < allowed:
+            errors.append(
+                f"{path}: {actual} ```{ILLUSTRATIVE_TAG} block(s) but {allowed} allowed. "
+                f"Lower the ILLUSTRATIVE_BLOCK_ALLOWLIST entry to {actual}."
+            )
+    assert not errors, "```py allowlist drift:\n" + "\n".join(errors)
+
+
+FAILING_SNIPPET = 'raise RuntimeError("doc fence collection contract")'
+
+RUNNABLE_MD = textwrap.dedent(
+    f"""\
+    # Runnable
+
+    ```{RUNNABLE_TAG}
+    {FAILING_SNIPPET}
+    ```
+    """
+)
+
+ILLUSTRATIVE_MD = textwrap.dedent(
+    f"""\
+    # Illustrative
+
+    ```{ILLUSTRATIVE_TAG}
+    {FAILING_SNIPPET}
+    ```
+    """
+)
+
+
+@pytest.mark.timeout(120)
+def test_collection_contract_of_python_and_py_fences(tmp_path: Path) -> None:
+    """```python is executed by the doc runner, ```py is not."""
+    runnable = tmp_path / "runnable.md"
+    runnable.write_text(RUNNABLE_MD, encoding="utf-8")
+    with pytest.raises(AssertionError):
+        run_md_file_isolated(runnable)
+
+    illustrative = tmp_path / "illustrative.md"
+    illustrative.write_text(ILLUSTRATIVE_MD, encoding="utf-8")
+    run_md_file_isolated(illustrative)

--- a/tests/test_documentation/test_doc_fence_vocabulary.py
+++ b/tests/test_documentation/test_doc_fence_vocabulary.py
@@ -1,178 +1,17 @@
-"""Fence vocabulary guard for docs/docs markdown."""
+"""Collection contract of the doc fence vocabulary.
 
-import re
+Only the subprocess-backed contract lives here; the static string checks moved
+to tests/test_docs_fences.py so the default tox env runs them.
+"""
+
 import textwrap
-from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
+from mktestdocs import grab_code_blocks
 
+from tests.test_docs_fences import ILLUSTRATIVE_TAG, RUNNABLE_TAG
 from tests.test_documentation.test_documentation import run_md_file_isolated
-
-DOCS_ROOT = Path("docs/docs")
-
-RUNNABLE_TAG = "python"
-ILLUSTRATIVE_TAG = "py"
-OUTPUT_TAG = "text"
-
-PYTHON_LOOKING = re.compile(r"py(thon)?[0-9]*|pycon", re.IGNORECASE)
-
-VOCABULARY_HINT = (
-    f"Use ```{RUNNABLE_TAG} when the block runs, ```{ILLUSTRATIVE_TAG} when it is an "
-    f"illustrative fragment that must not run, ```{OUTPUT_TAG} when it is output."
-)
-
-# Repo-relative doc path -> permitted number of ```py blocks. An absent file permits zero.
-ILLUSTRATIVE_BLOCK_ALLOWLIST: dict[str, int] = {
-    "docs/docs/chapter1/api-request.md": 1,
-    "docs/docs/chapter1/compute-frameworks.md": 4,
-    "docs/docs/in_depth/access-feature-data.md": 5,
-    "docs/docs/in_depth/artifacts.md": 1,
-    "docs/docs/in_depth/compute-framework-integration.md": 12,
-    "docs/docs/in_depth/data-access-patterns.md": 7,
-    "docs/docs/in_depth/data-quality.md": 2,
-    "docs/docs/in_depth/data-type-enforcement.md": 1,
-    "docs/docs/in_depth/discover-plugins.md": 1,
-    "docs/docs/in_depth/feature-chain-parser.md": 16,
-    "docs/docs/in_depth/feature-config.md": 2,
-    "docs/docs/in_depth/feature-group-matching.md": 3,
-    "docs/docs/in_depth/feature-group-testing.md": 5,
-    "docs/docs/in_depth/filter_data.md": 1,
-    "docs/docs/in_depth/framework-connection-object.md": 9,
-    "docs/docs/in_depth/framework-transformers.md": 4,
-    "docs/docs/in_depth/join_data.md": 4,
-    "docs/docs/in_depth/mloda-api.md": 5,
-    "docs/docs/in_depth/multiple_result_columns.md": 5,
-    "docs/docs/in_depth/named-data-access-handles.md": 4,
-    "docs/docs/in_depth/plugin-loader.md": 1,
-    "docs/docs/in_depth/plugin_registry.md": 1,
-    "docs/docs/in_depth/property-mapping.md": 4,
-    "docs/docs/in_depth/streaming.md": 6,
-    "docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md": 3,
-}
-
-MAX_REPORTED_VIOLATIONS = 60
-
-
-class Fence:
-    """One opening code fence in a markdown file."""
-
-    def __init__(self, path: Path, lineno: int, text: str, info: str) -> None:
-        self.path = path
-        self.lineno = lineno
-        self.text = text
-        self.info = info
-
-    @property
-    def tag(self) -> str:
-        parts = self.info.strip().split()
-        return parts[0] if parts else ""
-
-    @property
-    def has_leading_space(self) -> bool:
-        return bool(self.info) and self.info[0].isspace() and bool(self.info.strip())
-
-    @property
-    def location(self) -> str:
-        return f"{self.path}:{self.lineno}"
-
-
-def _iter_fence_openings(path: Path) -> Iterator[Fence]:
-    """Yield the opening fences of a markdown file, skipping fence bodies."""
-    inside = False
-    for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
-        stripped = line.strip()
-        if not stripped.startswith("```"):
-            continue
-        backticks = len(stripped) - len(stripped.lstrip("`"))
-        info = stripped[backticks:]
-        if inside:
-            if not info.strip():
-                inside = False
-            continue
-        inside = True
-        yield Fence(path=path, lineno=lineno, text=stripped, info=info)
-
-
-def _doc_files() -> list[Path]:
-    return sorted(DOCS_ROOT.rglob("*.md"))
-
-
-def _suggested_tag(tag: str) -> str:
-    if tag.lower() == "pycon":
-        return OUTPUT_TAG
-    return RUNNABLE_TAG
-
-
-def _fence_violations() -> list[tuple[Path, int, str]]:
-    violations: list[tuple[Path, int, str]] = []
-    for path in _doc_files():
-        for fence in _iter_fence_openings(path):
-            tag = fence.tag
-            if fence.has_leading_space:
-                unspaced = f"```{fence.info.strip()}"
-                violations.append(
-                    (
-                        path,
-                        fence.lineno,
-                        f"{fence.location}: spaced fence {fence.text!r} -> write {unspaced!r}. {VOCABULARY_HINT}",
-                    )
-                )
-                continue
-            if not PYTHON_LOOKING.fullmatch(tag):
-                continue
-            if fence.info.strip() == tag and tag in {RUNNABLE_TAG, ILLUSTRATIVE_TAG}:
-                continue
-            if fence.info.strip() != tag:
-                remedy = (
-                    f"attributes after the tag also stop collection -> write a bare ```{RUNNABLE_TAG} "
-                    f"with the title in a comment, or ```{ILLUSTRATIVE_TAG} if it must not run"
-                )
-            else:
-                remedy = f"write ```{_suggested_tag(tag)}"
-            violations.append(
-                (
-                    path,
-                    fence.lineno,
-                    f"{fence.location}: fence {fence.text!r} looks like Python but is never executed, "
-                    f"{remedy}. {VOCABULARY_HINT}",
-                )
-            )
-    return sorted(violations, key=lambda item: (str(item[0]), item[1]))
-
-
-def _format(violations: list[tuple[Path, int, str]]) -> str:
-    shown = violations[:MAX_REPORTED_VIOLATIONS]
-    lines = [message for _, _, message in shown]
-    omitted = len(violations) - len(shown)
-    if omitted:
-        lines.append(f"... and {omitted} more omitted.")
-    return "\n".join(lines)
-
-
-def test_doc_fences_use_the_documented_vocabulary() -> None:
-    violations = _fence_violations()
-    assert not violations, f"{len(violations)} doc fence violation(s):\n{_format(violations)}"
-
-
-def test_illustrative_py_blocks_match_allowlist() -> None:
-    errors: list[str] = []
-    for path in _doc_files():
-        actual = sum(1 for fence in _iter_fence_openings(path) if fence.info.strip() == ILLUSTRATIVE_TAG)
-        allowed = ILLUSTRATIVE_BLOCK_ALLOWLIST.get(str(path), 0)
-        if actual > allowed:
-            errors.append(
-                f"{path}: {actual} ```{ILLUSTRATIVE_TAG} block(s) but only {allowed} allowed. "
-                f"Promote the block to ```{RUNNABLE_TAG} (or ```{OUTPUT_TAG} if it is output), "
-                f"or raise its ILLUSTRATIVE_BLOCK_ALLOWLIST entry."
-            )
-        elif actual < allowed:
-            errors.append(
-                f"{path}: {actual} ```{ILLUSTRATIVE_TAG} block(s) but {allowed} allowed. "
-                f"Lower the ILLUSTRATIVE_BLOCK_ALLOWLIST entry to {actual}."
-            )
-    assert not errors, "```py allowlist drift:\n" + "\n".join(errors)
-
 
 FAILING_SNIPPET = 'raise RuntimeError("doc fence collection contract")'
 
@@ -199,12 +38,12 @@ ILLUSTRATIVE_MD = textwrap.dedent(
 
 @pytest.mark.timeout(120)
 def test_collection_contract_of_python_and_py_fences(tmp_path: Path) -> None:
-    """```python is executed by the doc runner, ```py is not."""
+    """```python is executed by the doc runner, ```py is not collected at all."""
     runnable = tmp_path / "runnable.md"
     runnable.write_text(RUNNABLE_MD, encoding="utf-8")
     with pytest.raises(AssertionError):
         run_md_file_isolated(runnable)
 
-    illustrative = tmp_path / "illustrative.md"
-    illustrative.write_text(ILLUSTRATIVE_MD, encoding="utf-8")
-    run_md_file_isolated(illustrative)
+    assert grab_code_blocks(ILLUSTRATIVE_MD, lang="python") == [], (
+        f"```{ILLUSTRATIVE_TAG} reached the collector, so it would be executed"
+    )

--- a/tests/test_documentation/test_documentation.py
+++ b/tests/test_documentation/test_documentation.py
@@ -85,8 +85,8 @@ def test_files_good() -> None:
     run_md_files_isolated(sorted(Path("docs").glob("**/*.md")))
 
 
-CODE_BLOCK_PATTERN = re.compile(r"```python\n(.*?)```", re.DOTALL)
-TEST_IMPORT_PATTERN = re.compile(r"^\s*from\s+tests\.", re.MULTILINE)
+CODE_BLOCK_PATTERN = re.compile(r"```(?:python|py)\n(.*?)```", re.DOTALL)
+TEST_IMPORT_PATTERN = re.compile(r"^\s*from\s+tests\..*$", re.MULTILINE)
 
 
 @pytest.mark.parametrize("fpath", sorted(Path("docs/docs").rglob("*.md")), ids=str)
@@ -97,6 +97,21 @@ def test_no_test_imports_in_docs(fpath: Path) -> None:
         for match in TEST_IMPORT_PATTERN.finditer(block.group(1)):
             violations.append(match.group().strip())
     assert not violations, f"{fpath} imports from test modules (not available to users): {violations}"
+
+
+ILLUSTRATIVE_BLOCK_WITH_TEST_IMPORT = "# Doc\n\n```py\nfrom tests.foo import bar\n```\n"
+
+
+def test_test_imports_in_illustrative_blocks_are_scanned() -> None:
+    """A ```py block is read by users too, so its test imports must be caught."""
+    found = [
+        match.group().strip()
+        for block in CODE_BLOCK_PATTERN.finditer(ILLUSTRATIVE_BLOCK_WITH_TEST_IMPORT)
+        for match in TEST_IMPORT_PATTERN.finditer(block.group(1))
+    ]
+    assert found == ["from tests.foo import bar"], (
+        f"CODE_BLOCK_PATTERN matches only ```python, so blocks retagged to ```py go unscanned, got {found}"
+    )
 
 
 DOCS_ROOT = Path("docs/docs")


### PR DESCRIPTION
Closes #974.

A fence written `` ``` python `` (with a space) is dropped by mktestdocs, which compares `first_line.lstrip()[3:] != lang`. So a runnable snippet spelled that way was never executed, and a broken example could sit in a "tested" page indefinitely. Worse, a deliberately-unexecuted block (showing output) and an accidentally-unexecuted one were spelled identically, so neither a reader nor a test could tell them apart.

## One vocabulary

- ` ```python ` runs. It is collected and executed by the doc tests, and it is the only spelling that means that.
- ` ```py ` is an illustrative fragment that deliberately does not run.
- ` ```text ` is output: a repr, a table, a traceback.

Every offending fence in the tree is triaged into it. **45 blocks now execute for the first time**, 107 are marked illustrative, 15 were output all along.

## What the check rejects

Any fence that looks like runnable Python but is not collected: a space (or a tab) after the backticks, a trailing space after the tag, four backticks instead of three, a tilde fence, an alias like `python3` / `ipython` / `pycon`, or an opening that is never closed. A fence carrying anything past the bare tag is rejected for **any** language, not only Python, because under this markdown setup it does not render as a code block at all. One `toml title=` fence was broken on the published site exactly that way and is fixed here.

The number of illustrative blocks is held per file against an explicit allowlist, so it cannot grow unnoticed, and a key whose file is gone fails rather than rotting. A separate test pins the collection contract against mktestdocs itself, so the vocabulary cannot drift from what the runner actually does.

The two static checks live outside `tests/test_documentation`, which the default tox env ignores. They are pure string parsing, so they now run on every leg instead of only the 3.14 one.

## Notes

Only three promoted blocks were broken, all missing an import in the file's shared namespace; they are fixed. Some framework examples (DuckDB, Iceberg, Spark) and placeholder-feature examples stay illustrative because making them runnable needs real fixtures rather than a fence change.

`tox`: 8099 passed, 170 skipped, all gates green.