### PR TITLE
fix: guard the deep hashers against cyclic option containers

### DIFF
--- a/mloda/core/abstract_plugins/components/feature.py
+++ b/mloda/core/abstract_plugins/components/feature.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 
 from mloda.core.abstract_plugins.components.domain import Domain
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
-from mloda.core.abstract_plugins.components.hashable_dict import _deep_hashable
+from mloda.core.abstract_plugins.components.hashable_dict import _CYCLE, _deep_hashable
 from mloda.core.abstract_plugins.components.index.index import Index
 from mloda.core.abstract_plugins.components.link import Link
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
@@ -407,6 +407,11 @@ class Feature:
             )
         if isinstance(value, Options):
             return ("options", Feature._reduce(value.group, seen))
+        if isinstance(value, (dict, list, tuple, frozenset, set)):
+            # _reduce handles containers itself, so it needs the same cycle guard as _deep_hashable.
+            if id(value) in seen:
+                return _CYCLE
+            seen = seen | {id(value)}
         if isinstance(value, dict):
             return tuple(
                 sorted(((key, Feature._reduce(val, seen)) for key, val in value.items()), key=lambda kv: kv[0])

--- a/mloda/core/abstract_plugins/components/hashable_dict.py
+++ b/mloda/core/abstract_plugins/components/hashable_dict.py
@@ -3,9 +3,29 @@ from typing import Any
 from mloda.core.abstract_plugins.components.utils import unhashable_part
 
 
-# Stand-in for a container already on the recursion path, so a cyclic value hashes
-# instead of raising RecursionError. Mirrors the id() visited guard in Feature._reduce.
-_CYCLE = ("<cycle>",)
+class _CycleMarker:
+    """Stand-in for a container already on the recursion path.
+
+    Its own type keeps it distinct from every normalized user value, so a literal ``"<cycle>"``
+    cannot collide with a real back-reference. Hash is constant so it stays stable across processes.
+    """
+
+    __slots__ = ()
+
+    def __hash__(self) -> int:
+        return hash("mloda-deep-hashable-cycle")
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, _CycleMarker)
+
+    def __repr__(self) -> str:
+        return "<cycle>"
+
+
+# A cyclic value hashes instead of raising RecursionError. Mirrors the id() visited guard in
+# Feature._reduce. Equality is not cycle-safe: two separately built cyclic values reduce alike,
+# so a dict/set insertion of both still reaches the recursive == of Options/HashableDict.
+_CYCLE = _CycleMarker()
 
 
 def _deep_hashable(value: Any, seen: frozenset[int] = frozenset()) -> Any:

--- a/mloda/core/abstract_plugins/components/hashable_dict.py
+++ b/mloda/core/abstract_plugins/components/hashable_dict.py
@@ -3,9 +3,18 @@ from typing import Any
 from mloda.core.abstract_plugins.components.utils import unhashable_part
 
 
-def _deep_hashable(value: Any) -> Any:
+# Stand-in for a container already on the recursion path, so a cyclic value hashes
+# instead of raising RecursionError. Mirrors the id() visited guard in Feature._reduce.
+_CYCLE = ("<cycle>",)
+
+
+def _deep_hashable(value: Any, seen: frozenset[int] = frozenset()) -> Any:
+    if isinstance(value, (dict, list, tuple, set)):
+        if id(value) in seen:
+            return _CYCLE
+        seen = seen | {id(value)}
     if isinstance(value, dict):
-        items = [(k, _deep_hashable(v)) for k, v in value.items()]
+        items = [(k, _deep_hashable(v, seen)) for k, v in value.items()]
         # Mixed-type keys (e.g. reader class plus str) are unorderable; fall back to a
         # type-robust deterministic sort. The common orderable case stays unchanged.
         try:
@@ -15,9 +24,9 @@ def _deep_hashable(value: Any) -> Any:
                 sorted(items, key=lambda kv: (kv[0].__class__.__module__, kv[0].__class__.__qualname__, repr(kv[0])))
             )
     if isinstance(value, (list, tuple)):
-        return tuple(_deep_hashable(item) for item in value)
+        return tuple(_deep_hashable(item, seen) for item in value)
     if isinstance(value, set):
-        return frozenset(_deep_hashable(item) for item in value)
+        return frozenset(_deep_hashable(item, seen) for item in value)
     # A leaf whose hash raises TypeError is coerced to repr so grouping never crashes; any other raise
     # propagates. filter_parameter rejects broadly instead.
     # Residual constraint: two values that are __eq__-equal but unhashable must have

--- a/tests/test_core/test_abstract_plugins/test_components/test_unhashable_part.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_unhashable_part.py
@@ -12,7 +12,8 @@ import pytest
 from mloda.core.abstract_plugins.components import feature as feature_module
 from mloda.core.abstract_plugins.components import hashable_dict as hashable_dict_module
 from mloda.core.abstract_plugins.components import options as options_module
-from mloda.core.abstract_plugins.components.hashable_dict import HashableDict, _deep_hashable
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.hashable_dict import _CYCLE, HashableDict, _deep_hashable
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.components.utils import unhashable_part
 from mloda.core.filter import filter_parameter as filter_parameter_module
@@ -254,7 +255,14 @@ class TestDeepHashableCycleGuard:
     def test_self_referential_dict_hashes(self) -> None:
         cyclic: dict[str, Any] = {}
         cyclic["self"] = cyclic
-        assert isinstance(hash(Options(group={"a": cyclic})), int)
+        assert _deep_hashable(cyclic) == (("self", _CYCLE),)
+
+    def test_structurally_equal_cycles_hash_alike(self) -> None:
+        left: list[Any] = []
+        left.append(left)
+        right: list[Any] = []
+        right.append(right)
+        assert hash(Options(group={"a": left})) == hash(Options(group={"a": right}))
 
     def test_mutually_referential_containers_hash(self) -> None:
         left: list[Any] = []
@@ -270,11 +278,23 @@ class TestDeepHashableCycleGuard:
     def test_the_back_reference_becomes_the_cycle_marker(self) -> None:
         cyclic: list[Any] = []
         cyclic.append(cyclic)
-        assert _deep_hashable(cyclic) == (("<cycle>",),)
+        assert _deep_hashable(cyclic) == (_CYCLE,)
+
+    def test_the_marker_is_not_reproducible_from_user_data(self) -> None:
+        cyclic: list[Any] = []
+        cyclic.append(cyclic)
+        assert _deep_hashable([["<cycle>"]]) != _deep_hashable(cyclic)
 
     def test_repeated_sibling_is_not_treated_as_a_cycle(self) -> None:
         shared = [1, 2]
         assert _deep_hashable([shared, shared]) == ((1, 2), (1, 2))
+
+    def test_feature_hashes_a_cyclic_child_option_value(self) -> None:
+        cyclic: list[Any] = []
+        cyclic.append(cyclic)
+        feature = Feature(name="f")
+        feature.child_options = Options(group={"a": cyclic})
+        assert isinstance(hash(feature), int)
 
 
 class TestCrossModuleImportsFollowTheRename:

--- a/tests/test_core/test_abstract_plugins/test_components/test_unhashable_part.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_unhashable_part.py
@@ -243,6 +243,40 @@ class TestPublicEntryPoints:
         assert hash(left) == hash(right)
 
 
+class TestDeepHashableCycleGuard:
+    """A self-referential container collapses to a back-reference marker instead of recursing forever."""
+
+    def test_self_referential_list_hashes(self) -> None:
+        cyclic: list[Any] = []
+        cyclic.append(cyclic)
+        assert isinstance(hash(Options(group={"a": cyclic})), int)
+
+    def test_self_referential_dict_hashes(self) -> None:
+        cyclic: dict[str, Any] = {}
+        cyclic["self"] = cyclic
+        assert isinstance(hash(Options(group={"a": cyclic})), int)
+
+    def test_mutually_referential_containers_hash(self) -> None:
+        left: list[Any] = []
+        right: dict[str, Any] = {"left": left}
+        left.append(right)
+        assert isinstance(hash(HashableDict({"a": left})), int)
+
+    def test_cycle_nested_under_a_tuple_hashes(self) -> None:
+        cyclic: list[Any] = []
+        cyclic.append(cyclic)
+        assert isinstance(hash(HashableDict({"a": (cyclic,)})), int)
+
+    def test_the_back_reference_becomes_the_cycle_marker(self) -> None:
+        cyclic: list[Any] = []
+        cyclic.append(cyclic)
+        assert _deep_hashable(cyclic) == (("<cycle>",),)
+
+    def test_repeated_sibling_is_not_treated_as_a_cycle(self) -> None:
+        shared = [1, 2]
+        assert _deep_hashable([shared, shared]) == ((1, 2), (1, 2))
+
+
 class TestCrossModuleImportsFollowTheRename:
     """options and feature import the deep policy under its new name."""
 


### PR DESCRIPTION
## Summary

A self-referential container in `Options.group` recursed forever in `_deep_hashable`, so `Options.__hash__` raised `RecursionError`. Both deep hashers now carry an `id()` visited set through their container branches and collapse a back-reference to a marker, the way `Feature._reduce` already did for features.

- `_deep_hashable`: path-local `frozenset[int]` of container ids, rebound per node so two siblings pointing at the same object are not mistaken for a cycle.
- The marker is its own type rather than a tuple, so no user value can reproduce it and collide in similarity-hash grouping. Its hash is constant, so it stays stable across processes.
- `Feature._reduce` handles dict/list/tuple/set itself and only fell through to `_deep_hashable` for leaves, so it had the same hole for a cyclic value under `child_options`. It now applies the same guard.

Equality stays as it was: two separately built cyclic values reduce alike, so inserting both into one dict still reaches the recursive `==` of `Options`/`HashableDict`. That is noted next to the marker and tracked separately.

## Tests

`tests/test_core/test_abstract_plugins/test_components/test_unhashable_part.py` covers a self-referential list and dict, mutual references, a cycle under a tuple, hash stability across two structurally equal cycles, the marker not being forgeable from user data, a shared sibling not counting as a cycle, and `Feature.__hash__` with a cyclic child option.

Closes #985