### PR TITLE
fix: one name source for SingleFilter and a rehash of GlobalFilter's stored filter sets

### DIFF
--- a/docs/docs/in_depth/filter_data.md
+++ b/docs/docs/in_depth/filter_data.md
@@ -229,6 +229,9 @@ def calculate_feature(cls, data, features: FeatureSet):
             # ... use however you need
 ```
 
+`single_filter.name` is the resolved column name, i.e. after the FeatureGroup's `set_feature_name`
+rename, and is read-only.
+
 Guard on truthiness, not on `is not None`. `features.filters` has three states:
 
 | State | When |

--- a/mloda/core/core/engine.py
+++ b/mloda/core/core/engine.py
@@ -142,6 +142,10 @@ class Engine:
             planned_queue, resolver.resolver_links.get_link_trekker()
         )
 
+        if self.global_filter:
+            # The rewrite mutates filter Features shared with GlobalFilter's hash-keyed sets.
+            self.global_filter.rehash_after_framework_rewrite()
+
         execution_planner = ExecutionPlan(self.global_filter, self.api_input_data_collection)
         execution_planner.create_execution_plan(planned_queue, graph, resolver.resolver_links.get_link_trekker())
         return execution_planner

--- a/mloda/core/core/engine.py
+++ b/mloda/core/core/engine.py
@@ -143,8 +143,8 @@ class Engine:
         )
 
         if self.global_filter:
-            # The rewrite mutates filter Features shared with GlobalFilter's hash-keyed sets.
-            self.global_filter.rehash_after_framework_rewrite()
+            # Setup and planning both mutate filter Features shared with GlobalFilter's hash-keyed sets.
+            self.global_filter.rehash_stored_filters()
 
         execution_planner = ExecutionPlan(self.global_filter, self.api_input_data_collection)
         execution_planner.create_execution_plan(planned_queue, graph, resolver.resolver_links.get_link_trekker())

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -55,6 +55,11 @@ class GlobalFilter:
         self.matched_filter_uuids.clear()
         self._warned_divergences.clear()
 
+    def rehash_after_framework_rewrite(self) -> None:
+        """Reinsert stored filters so their hashes reflect frameworks planning rewrote in place."""
+        self.collection = {key: set(list(value)) for key, value in self.collection.items()}
+        self.probes = {key: set(list(value)) for key, value in self.probes.items()}
+
     def record_probe(
         self,
         feature_group: type[FeatureGroup],

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -55,8 +55,11 @@ class GlobalFilter:
         self.matched_filter_uuids.clear()
         self._warned_divergences.clear()
 
-    def rehash_after_framework_rewrite(self) -> None:
-        """Reinsert stored filters so their hashes reflect frameworks planning rewrote in place."""
+    def rehash_stored_filters(self) -> None:
+        """Reinsert stored filters whose hashes went stale: Engine._add_filter_feature renames matched filter
+        features while their SingleFilters sit in probes, and planning rewrites shared filter Features' frameworks."""
+        # list() forces a rehash; set(value) would reuse the stale stored hashes.
+        # Duplicates that became equal after the rewrite intentionally merge here (same declared filter, same predicate).
         self.collection = {key: set(list(value)) for key, value in self.collection.items()}
         self.probes = {key: set(list(value)) for key, value in self.probes.items()}
 

--- a/mloda/core/filter/single_filter.py
+++ b/mloda/core/filter/single_filter.py
@@ -28,9 +28,13 @@ class SingleFilter:
         self.filter_feature = self.handle_filter_feature(filter_feature)
         self.filter_type = self.handle_filter_type(filter_type)
         self.parameter = self.handle_parameter(parameter)
-        self.name = str(self.filter_feature.name)
 
         self.uuid = uuid.uuid4()
+
+    @property
+    def name(self) -> str:
+        """Read-through to the filter feature so a later rename stays visible."""
+        return str(self.filter_feature.name)
 
     def handle_filter_type(self, filter_type: str | FilterType) -> str:
         if not filter_type:

--- a/mloda/core/prepare/resolve_compute_frameworks.py
+++ b/mloda/core/prepare/resolve_compute_frameworks.py
@@ -18,8 +18,13 @@ class ResolveComputeFrameworks:
         for p in planned_queue:
             if isinstance(p, tuple):
                 if not isinstance(p[0], Link):
-                    feature = next(iter(p[1]))
-                    trekked_links = self.access_link_by_child_uuid(feature.uuid, link_trekker)
+                    # Filter features carry no trekker entry, so the probe must scan the set.
+                    feature, trekked_links = next(iter(p[1])), []
+                    for candidate in p[1]:
+                        trekked_links = self.access_link_by_child_uuid(candidate.uuid, link_trekker)
+                        if trekked_links:
+                            feature = candidate
+                            break
                     if trekked_links:
                         new_compute_frameworks = self.resolve_trekked_links(trekked_links, feature.compute_frameworks)
                         for f in p[1]:

--- a/tests/test_core/test_filter/test_filter_link_cfw_rewrite_strands_filters.py
+++ b/tests/test_core/test_filter/test_filter_link_cfw_rewrite_strands_filters.py
@@ -1,0 +1,120 @@
+"""Regression test: a link-driven compute framework rewrite must not strand stored SingleFilters.
+
+Narrowing the link child's frameworks rebinds the shared filter Feature, which staled the hash-keyed
+sets in GlobalFilter.collection.
+"""
+
+from typing import Any
+
+import pyarrow as pa
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.provider import BaseInputData, ComputeFramework, DataCreator, FeatureGroup, FeatureSet
+from mloda.user import (
+    Feature,
+    FeatureName,
+    Features,
+    GlobalFilter,
+    Index,
+    JoinSpec,
+    Link,
+    Options,
+    ParallelizationMode,
+    PluginCollector,
+)
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+from tests.test_core.test_tooling import MlodaTestRunner
+
+
+class CfwStrandSecondCfw(PyArrowTable):
+    """A second PyArrow-based framework so the link child starts with two candidates."""
+
+
+class CfwStrandLeftSrc(FeatureGroup):
+    @classmethod
+    def input_data(cls) -> BaseInputData | None:
+        return DataCreator({"cfwstr_left"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return pa.table({"cfwstr_left": [1, 2, 3], "cfwstr_idx": ["a", "b", "c"]})
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {CfwStrandSecondCfw}
+
+
+class CfwStrandRightSrc(FeatureGroup):
+    @classmethod
+    def input_data(cls) -> BaseInputData | None:
+        return DataCreator({"cfwstr_right"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return pa.table({"cfwstr_right": [4, 5, 6], "cfwstr_idx": ["a", "b", "c"]})
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {CfwStrandSecondCfw}
+
+
+class CfwStrandConsumer(FeatureGroup):
+    """Link child whose frameworks get narrowed by the link resolution."""
+
+    SUPPORTED = frozenset({"cfwstr_a", "cfwstr_b", "cfwstr_ts"})
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) in cls.SUPPORTED
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        return {Feature("cfwstr_left"), Feature("cfwstr_right")}
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return pa.table({"cfwstr_a": [1, 2, 3], "cfwstr_b": [4, 5, 6], "cfwstr_ts": [10, 20, 30]})
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PyArrowTable, CfwStrandSecondCfw}
+
+
+_ENABLED = PluginCollector.enabled_feature_groups({CfwStrandLeftSrc, CfwStrandRightSrc, CfwStrandConsumer})
+
+
+def test_link_cfw_rewrite_keeps_stored_filters_usable(flight_server: Any) -> None:
+    """The run must succeed and apply the filter."""
+    idx = Index(("cfwstr_idx",))
+    links = {Link("inner", JoinSpec(CfwStrandLeftSrc, idx), JoinSpec(CfwStrandRightSrc, idx))}
+
+    global_filter = GlobalFilter()
+    global_filter.add_filter("cfwstr_ts", "min", {"value": 15})
+
+    features = Features([Feature("cfwstr_a"), Feature("cfwstr_b")])
+
+    result = MlodaTestRunner.run_api(
+        features,
+        compute_frameworks={PyArrowTable, CfwStrandSecondCfw},
+        parallelization_modes={ParallelizationMode.SYNC},
+        flight_server=flight_server,
+        global_filter=global_filter,
+        links=links,
+        plugin_collector=_ENABLED,
+    )
+
+    merged: dict[str, list[Any]] = {}
+    for res in result.results:
+        merged.update(res.to_pydict())
+
+    assert merged["cfwstr_a"] == [2, 3]
+    assert merged["cfwstr_b"] == [5, 6]
+
+    # Every stored SingleFilter must still be findable in its own hash-keyed set.
+    for stored_set in global_filter.collection.values():
+        for single_filter in stored_set:
+            assert single_filter in stored_set

--- a/tests/test_core/test_filter/test_filter_link_cfw_rewrite_strands_filters.py
+++ b/tests/test_core/test_filter/test_filter_link_cfw_rewrite_strands_filters.py
@@ -9,6 +9,7 @@ from typing import Any
 import pyarrow as pa
 
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.filter.single_filter import SingleFilter
 from mloda.provider import BaseInputData, ComputeFramework, DataCreator, FeatureGroup, FeatureSet
 from mloda.user import (
     Feature,
@@ -24,10 +25,7 @@ from mloda.user import (
 )
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
 from tests.test_core.test_tooling import MlodaTestRunner
-
-
-class CfwStrandSecondCfw(PyArrowTable):
-    """A second PyArrow-based framework so the link child starts with two candidates."""
+from tests.test_plugins.compute_framework.test_tooling.shared_compute_frameworks import SecondCfw
 
 
 class CfwStrandLeftSrc(FeatureGroup):
@@ -41,7 +39,7 @@ class CfwStrandLeftSrc(FeatureGroup):
 
     @classmethod
     def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
-        return {CfwStrandSecondCfw}
+        return {SecondCfw}
 
 
 class CfwStrandRightSrc(FeatureGroup):
@@ -55,7 +53,7 @@ class CfwStrandRightSrc(FeatureGroup):
 
     @classmethod
     def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
-        return {CfwStrandSecondCfw}
+        return {SecondCfw}
 
 
 class CfwStrandConsumer(FeatureGroup):
@@ -81,13 +79,13 @@ class CfwStrandConsumer(FeatureGroup):
 
     @classmethod
     def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
-        return {PyArrowTable, CfwStrandSecondCfw}
+        return {PyArrowTable, SecondCfw}
 
 
 _ENABLED = PluginCollector.enabled_feature_groups({CfwStrandLeftSrc, CfwStrandRightSrc, CfwStrandConsumer})
 
 
-def test_link_cfw_rewrite_keeps_stored_filters_usable(flight_server: Any) -> None:
+def test_link_cfw_rewrite_keeps_stored_filters_usable() -> None:
     """The run must succeed and apply the filter."""
     idx = Index(("cfwstr_idx",))
     links = {Link("inner", JoinSpec(CfwStrandLeftSrc, idx), JoinSpec(CfwStrandRightSrc, idx))}
@@ -99,9 +97,8 @@ def test_link_cfw_rewrite_keeps_stored_filters_usable(flight_server: Any) -> Non
 
     result = MlodaTestRunner.run_api(
         features,
-        compute_frameworks={PyArrowTable, CfwStrandSecondCfw},
+        compute_frameworks={PyArrowTable, SecondCfw},
         parallelization_modes={ParallelizationMode.SYNC},
-        flight_server=flight_server,
         global_filter=global_filter,
         links=links,
         plugin_collector=_ENABLED,
@@ -118,3 +115,40 @@ def test_link_cfw_rewrite_keeps_stored_filters_usable(flight_server: Any) -> Non
     for stored_set in global_filter.collection.values():
         for single_filter in stored_set:
             assert single_filter in stored_set
+
+    # Link resolution narrowed the queue-shared filter Feature to one framework; the other per-match
+    # copy is never placed in the rewritten queue set and keeps the declared two-candidate pair.
+    narrowed = [
+        single_filter
+        for stored_set in global_filter.collection.values()
+        for single_filter in stored_set
+        if single_filter.filter_feature.compute_frameworks == {SecondCfw}
+    ]
+    assert narrowed, "no stored SingleFilter was narrowed by the link-driven framework rewrite"
+
+
+def test_rehash_stored_filters_restores_membership_and_is_idempotent() -> None:
+    """A mutated stored filter must be findable again after the rehash; a second call changes nothing."""
+    global_filter = GlobalFilter()
+    single_filter = SingleFilter("cfwstr_unit_ts", "min", {"value": 1})
+    global_filter.filters.add(single_filter)
+
+    feature_name = FeatureName("cfwstr_unit_ts")
+    feature_uuid = single_filter.filter_feature.uuid
+    global_filter.add_filter_to_collection(CfwStrandConsumer, feature_name, single_filter)
+    global_filter.record_probe(CfwStrandConsumer, feature_name, feature_uuid, {single_filter})
+
+    single_filter.filter_feature.compute_frameworks = {SecondCfw}
+    assert single_filter not in global_filter.collection[(CfwStrandConsumer, feature_name)]
+    assert single_filter not in global_filter.probes[(CfwStrandConsumer, feature_name, feature_uuid)]
+
+    global_filter.rehash_stored_filters()
+
+    assert single_filter in global_filter.collection[(CfwStrandConsumer, feature_name)]
+    assert single_filter in global_filter.probes[(CfwStrandConsumer, feature_name, feature_uuid)]
+
+    collection_snapshot = {key: set(value) for key, value in global_filter.collection.items()}
+    probes_snapshot = {key: set(value) for key, value in global_filter.probes.items()}
+    global_filter.rehash_stored_filters()
+    assert global_filter.collection == collection_snapshot
+    assert global_filter.probes == probes_snapshot

--- a/tests/test_core/test_filter/test_filter_renamed_filter_feature_desync.py
+++ b/tests/test_core/test_filter/test_filter_renamed_filter_feature_desync.py
@@ -38,7 +38,7 @@ class RnfilRenamingFG(FeatureGroup):
 _ENABLED = PluginCollector.enabled_feature_groups({RnfilRenamingFG})
 
 
-def test_filter_on_renamed_filter_feature_filters_rows(flight_server: Any) -> None:
+def test_filter_on_renamed_filter_feature_filters_rows() -> None:
     """A min filter on the pre-rename name must apply to the renamed column."""
     features = Features([Feature("rnfil_value")])
 
@@ -49,7 +49,6 @@ def test_filter_on_renamed_filter_feature_filters_rows(flight_server: Any) -> No
         features,
         compute_frameworks={PythonDictFramework},
         parallelization_modes={ParallelizationMode.SYNC},
-        flight_server=flight_server,
         global_filter=global_filter,
         plugin_collector=_ENABLED,
     )

--- a/tests/test_core/test_filter/test_filter_renamed_filter_feature_desync.py
+++ b/tests/test_core/test_filter/test_filter_renamed_filter_feature_desync.py
@@ -1,0 +1,67 @@
+"""Regression tests: SingleFilter.name must follow a set_feature_name rename of its filter feature.
+
+A name snapshotted at construction makes the filter engines target a column that no longer exists.
+"""
+
+from typing import Any
+
+from mloda.core.filter.single_filter import SingleFilter
+from mloda.provider import BaseInputData, ComputeFramework, DataCreator, FeatureGroup, FeatureSet
+from mloda.user import Feature, FeatureName, Features, GlobalFilter, Options, ParallelizationMode, PluginCollector
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
+    PythonDictFramework,
+)
+from tests.test_core.test_tooling import MlodaTestRunner
+
+
+class RnfilRenamingFG(FeatureGroup):
+    """Root group that renames the raw filter column via set_feature_name."""
+
+    @classmethod
+    def input_data(cls) -> BaseInputData | None:
+        return DataCreator({"rnfil_value", "rnfil_event_time"})
+
+    def set_feature_name(self, config: Options, feature_name: FeatureName) -> FeatureName:
+        if str(feature_name) == "rnfil_event_time":
+            return FeatureName("rnfil_event_time_utc")
+        return feature_name
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PythonDictFramework}
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {"rnfil_value": [1, 2, 3], "rnfil_event_time_utc": [10, 20, 30]}
+
+
+_ENABLED = PluginCollector.enabled_feature_groups({RnfilRenamingFG})
+
+
+def test_filter_on_renamed_filter_feature_filters_rows(flight_server: Any) -> None:
+    """A min filter on the pre-rename name must apply to the renamed column."""
+    features = Features([Feature("rnfil_value")])
+
+    global_filter = GlobalFilter()
+    global_filter.add_filter("rnfil_event_time", "min", {"value": 15})
+
+    result = MlodaTestRunner.run_api(
+        features,
+        compute_frameworks={PythonDictFramework},
+        parallelization_modes={ParallelizationMode.SYNC},
+        flight_server=flight_server,
+        global_filter=global_filter,
+        plugin_collector=_ENABLED,
+    )
+
+    assert len(result.results) == 1
+    assert result.results[0]["rnfil_value"] == [2, 3]
+
+
+def test_single_filter_name_tracks_filter_feature_rename() -> None:
+    """SingleFilter.name must reflect a later rename of filter_feature.name."""
+    single_filter = SingleFilter("rnfil_track_col", "min", {"value": 1})
+
+    single_filter.filter_feature.name = FeatureName("rnfil_track_col_utc")
+
+    assert single_filter.name == "rnfil_track_col_utc"


### PR DESCRIPTION
## Summary

Two independent filter-layer fixes.

- A filter feature renamed by a FeatureGroup's set_feature_name left SingleFilter.name at its construction-time snapshot, so applicability checked the renamed column while the filter engines applied the predicate to the stale one, silently filtering a nonexistent or wrong column. SingleFilter.name is now a read-through property over filter_feature.name, giving application and applicability one name source. Closes #990.

- Stored SingleFilters sit in the hash-keyed sets GlobalFilter.collection and GlobalFilter.probes while their filter Features are mutated afterwards: setup renames matched filter features, and planning's compute framework rewrite rebinds the queue-shared filter Feature's frameworks. Elements became unfindable in their own sets, corrupting membership-based logic downstream. The engine now rebuilds those sets right after planning's rewrite (reinserting via list, since building a set from a set reuses the stored hashes). Closes #982.

## Tests

- End-to-end regression: a min filter on a pre-rename name applies to the renamed column (previously returned an empty result).
- End-to-end regression: a link-driven framework narrowing of the filtered consumer keeps stored filters findable in their own sets, with the narrowing itself asserted.
- Unit test: rehash_stored_filters restores collection and probes membership and is idempotent.

## Review

Two independent deep reviews (Claude Opus and codex) ran on the diff; the accepted findings (cause-neutral naming, load-bearing comments, narrowing assertion, unit test, doc sentence, fixture cleanup) are in the second commit. The suggested ownership-copy redesign is tracked separately in #1003.

tox is green (pytest, ruff, mypy strict, pip-licenses, bandit).