### PR TITLE
fix: close the abstract-only failure with debug pointers and correct doc-taught values

### DIFF
--- a/docs/docs/in_depth/compute-framework-integration.md
+++ b/docs/docs/in_depth/compute-framework-integration.md
@@ -29,7 +29,7 @@ per-feature hook evaluated at match time:
 @classmethod
 def supports_compute_framework(cls, feature_name, options, compute_framework) -> bool:
     """Reject an operation on a specific framework. Default returns True."""
-    if compute_framework is SQLiteFramework and is_median_op(feature_name, options):
+    if compute_framework is SqliteFramework and is_median_op(feature_name, options):
         return False  # median is unsupported on SQLite
     return True
 ```
@@ -48,8 +48,9 @@ feature only**:
 ```
 No feature groups found for feature name: 'X'.
 Feature group(s) eliminated while matching 'X':
-  - MedianFeatureGroup (compute framework pin): pinned compute framework 'SQLiteFramework' is not among its supported ['DuckDBFramework', 'PandasDataFrame']
+  - MedianFeatureGroup (compute framework pin): pinned compute framework 'SqliteFramework' is not among its supported ['DuckDBFramework', 'PandasDataFrame']
 Use resolve_feature(name, options=...) to debug feature resolution.
+For troubleshooting guide, see: https://mloda-ai.github.io/mloda/in_depth/troubleshooting/feature-group-resolution-errors/
 ```
 
 The rejected framework is named as a near-miss with its reason rather than

--- a/docs/docs/in_depth/discover-plugins.md
+++ b/docs/docs/in_depth/discover-plugins.md
@@ -144,7 +144,7 @@ all_fgs = get_feature_group_docs()
 fgs = get_feature_group_docs(name="timestamp")
 
 # Filter by compute framework
-fgs = get_feature_group_docs(compute_framework="PandasDataframe")
+fgs = get_feature_group_docs(compute_framework="PandasDataFrame")
 ```
 
 Each `FeatureGroupInfo` also carries the subtype declaration: `subtype_key`

--- a/docs/docs/in_depth/domain.md
+++ b/docs/docs/in_depth/domain.md
@@ -33,7 +33,7 @@ class ExampleFeature(FeatureGroup):
     @classmethod
     def get_domain(cls) -> Domain:
         """This function should return the domain for the feature group"""
-        return "example_domain"
+        return Domain("example_domain")
 ```
 For feature groups, the default domain is default_domain.
 

--- a/docs/docs/in_depth/mloda-api.md
+++ b/docs/docs/in_depth/mloda-api.md
@@ -214,7 +214,7 @@ all_fgs = get_feature_group_docs()
 fgs = get_feature_group_docs(name="timestamp")
 
 # Filter by compute framework
-fgs = get_feature_group_docs(compute_framework="PandasDataframe")
+fgs = get_feature_group_docs(compute_framework="PandasDataFrame")
 ```
 
 **Parameters:**

--- a/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
+++ b/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
@@ -96,15 +96,19 @@ A sibling variant fires when an abstract base matched the name and no concrete g
 
 ```
 No feature groups found for feature name: 'my_feature'. Only abstract feature group base(s) matched, which cannot be instantiated; no concrete implementation is available or enabled.
+Use resolve_feature(name, options=...) to debug feature resolution.
+For troubleshooting guide, see: https://mloda-ai.github.io/mloda/in_depth/troubleshooting/feature-group-resolution-errors/
 ```
 
 or, when concrete implementations exist but their compute frameworks do not:
 
 ```
 No feature groups found for feature name: 'my_feature'. Its concrete implementations require compute framework(s) ['PandasDataFrame'], none of which are available or enabled for this run.
+Use resolve_feature(name, options=...) to debug feature resolution.
+For troubleshooting guide, see: https://mloda-ai.github.io/mloda/in_depth/troubleshooting/feature-group-resolution-errors/
 ```
 
-For the first shape, import or enable a concrete implementation. For the second, enable one of the named compute frameworks; the list comes from the base's accessible concrete implementations, so check that the one you enable actually serves the name. Eliminated candidates, if any, still render in the eliminated-candidates block; the Did-you-mean suggestion and the trailing pointer lines never do.
+For the first shape, import or enable a concrete implementation. For the second, enable one of the named compute frameworks; the list comes from the base's accessible concrete implementations, so check that the one you enable actually serves the name. Eliminated candidates, if any, still render in the eliminated-candidates block, and the message closes with the same pointer and troubleshooting-link lines as the ordinary form. Only the Did-you-mean suggestion never renders here: the requested name is declared, so there is nothing to suggest.
 
 ## Multiple Feature Groups Error
 

--- a/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
+++ b/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
@@ -108,7 +108,7 @@ Use resolve_feature(name, options=...) to debug feature resolution.
 For troubleshooting guide, see: https://mloda-ai.github.io/mloda/in_depth/troubleshooting/feature-group-resolution-errors/
 ```
 
-For the first shape, import or enable a concrete implementation. For the second, enable one of the named compute frameworks; the list comes from the base's accessible concrete implementations, so check that the one you enable actually serves the name. Eliminated candidates, if any, still render in the eliminated-candidates block, and the message closes with the same pointer and troubleshooting-link lines as the ordinary form. Only the Did-you-mean suggestion never renders here: the requested name is declared, so there is nothing to suggest.
+For the first shape, import or enable a concrete implementation. For the second, enable one of the named compute frameworks; the list comes from the base's accessible concrete implementations, so check that the one you enable actually serves the name. Eliminated candidates still render in their block, and the message closes with the same pointer lines as the ordinary form. Only the Did-you-mean suggestion is dropped, because the requested name is declared.
 
 ## Multiple Feature Groups Error
 

--- a/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
+++ b/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
@@ -108,7 +108,7 @@ Use resolve_feature(name, options=...) to debug feature resolution.
 For troubleshooting guide, see: https://mloda-ai.github.io/mloda/in_depth/troubleshooting/feature-group-resolution-errors/
 ```
 
-For the first shape, import or enable a concrete implementation. For the second, enable one of the named compute frameworks; the list comes from the base's accessible concrete implementations, so check that the one you enable actually serves the name. Eliminated candidates still render in their block, and the message closes with the same pointer lines as the ordinary form. Only the Did-you-mean suggestion is dropped, because the requested name is declared.
+For the first shape, import or enable a concrete implementation. For the second, enable one of the named compute frameworks; the list comes from the base's accessible concrete implementations, so check that the one you enable actually serves the name. Eliminated candidates, if any, still render in their block, and the message closes with the same pointer lines as the ordinary form. Only the Did-you-mean suggestion is dropped, because the name already matched a base.
 
 ## Multiple Feature Groups Error
 

--- a/mloda/core/prepare/resolution_failure_renderer.py
+++ b/mloda/core/prepare/resolution_failure_renderer.py
@@ -88,6 +88,8 @@ def _render_near_miss_block(result: EvaluationResult, feature: Feature) -> str |
 
 def _render_multiple(result: EvaluationResult, feature: Feature, callout: str | None) -> str:
     # Every identified candidate gets a line; only a candidate with a captured domain gets the suffix.
+    # The resolve_feature pointer is deliberately omitted: the message already names every candidate,
+    # which is what the pointer would surface.
     lines = "\n".join(
         f"  - {fg.__name__} ({fg.__module__})"
         + (f" [domain: {result.facts.domains[fg]}]" if fg in result.facts.domains else "")
@@ -103,7 +105,8 @@ def _render_multiple(result: EvaluationResult, feature: Feature, callout: str | 
 
 
 def _pointer_lines(callout: str | None) -> str:
-    """The trailing resolve_feature pointer and troubleshooting-link lines."""
+    """The trailing resolve_feature pointer and troubleshooting-link lines; the returned string starts
+    with a newline so callers append it bare."""
     # Only the scope widens the pointer: resolve_feature takes the domain on the Feature, not as a keyword.
     pointer_args = "name, options=..., feature_group=..." if callout else "name, options=..."
     return (

--- a/mloda/core/prepare/resolution_failure_renderer.py
+++ b/mloda/core/prepare/resolution_failure_renderer.py
@@ -102,6 +102,16 @@ def _render_multiple(result: EvaluationResult, feature: Feature, callout: str | 
     )
 
 
+def _pointer_lines(callout: str | None) -> str:
+    """The trailing resolve_feature pointer and troubleshooting-link lines."""
+    # Only the scope widens the pointer: resolve_feature takes the domain on the Feature, not as a keyword.
+    pointer_args = "name, options=..., feature_group=..." if callout else "name, options=..."
+    return (
+        f"\nUse resolve_feature({pointer_args}) to debug feature resolution."
+        f"\nFor troubleshooting guide, see: {TROUBLESHOOTING_URL}"
+    )
+
+
 def _render_abstract_only(
     result: EvaluationResult, feature: Feature, callout: str | None, domain_note: str | None
 ) -> str:
@@ -129,7 +139,7 @@ def _render_abstract_only(
     near_miss = _render_near_miss_block(result, feature)
     if near_miss is not None:
         msg += f"\n{near_miss}"
-    return msg
+    return msg + _pointer_lines(callout)
 
 
 def _render_none(result: EvaluationResult, feature: Feature, callout: str | None, domain_note: str | None) -> str:
@@ -152,13 +162,7 @@ def _render_none(result: EvaluationResult, feature: Feature, callout: str | None
     if similar:
         msg += f"\nDid you mean one of: {similar}?"
 
-    # Only the scope widens the pointer: resolve_feature takes the domain on the Feature, not as a keyword.
-    pointer_args = "name, options=..., feature_group=..." if callout else "name, options=..."
-    msg += (
-        f"\nUse resolve_feature({pointer_args}) to debug feature resolution."
-        f"\nFor troubleshooting guide, see: {TROUBLESHOOTING_URL}"
-    )
-    return msg
+    return msg + _pointer_lines(callout)
 
 
 def render_resolution_failure(result: EvaluationResult, feature: Feature) -> str | None:

--- a/tests/test_core/test_prepare/test_resolution_failure_renderer.py
+++ b/tests/test_core/test_prepare/test_resolution_failure_renderer.py
@@ -1545,6 +1545,12 @@ def abstract_domain_gate_scenario() -> Scenario:
     )
 
 
+def abstract_domain_and_scope_gate_scenario() -> Scenario:
+    """The same abstract-only failure, requested with a feature_group scope on top of the domain."""
+    feature = Feature(ABSTRACT_DECLARER_NAME_791, domain=REQUESTED_DOMAIN_791, feature_group=SpareAbstractBaseFG791)
+    return feature, {SpareAbstractBaseFG791: {RendererFwOne791}}
+
+
 def raising_dead_names_scenario() -> Scenario:
     """A dead candidate whose feature_names_supported() raises, so it can contribute no name at all."""
     return Feature(RAISING_DEAD_NAMES_FEATURE_791), {_build_raising_dead_names_group(): set()}
@@ -1613,6 +1619,7 @@ FAILING_SCENARIOS: dict[str, Callable[[], Scenario]] = {
     "dead_class_name": dead_class_name_scenario,
     "abstract_declarer_typo": abstract_declarer_typo_scenario,
     "abstract_domain_gate": abstract_domain_gate_scenario,
+    "abstract_domain_and_scope_gate": abstract_domain_and_scope_gate_scenario,
     "raising_dead_names": raising_dead_names_scenario,
     "raising_domain_multiple": raising_domain_multiple_scenario,
     "raising_prefix_none": raising_prefix_none_scenario,
@@ -2996,6 +3003,28 @@ class TestADomainCarryingFailureNamesTheRequestedDomain:
             "no concrete implementation is available or enabled. "
             f"Requested domain: '{REQUESTED_DOMAIN_791}'.\n"
             "Use resolve_feature(name, options=...) to debug feature resolution.\n"
+            f"{TROUBLESHOOTING_LINE}"
+        )
+
+    def test_a_scoped_abstract_only_failure_states_scope_then_domain(self) -> None:
+        """Both callouts compose on the sentence line, scope first, and the pointer widens for the scope."""
+        scenario = abstract_domain_and_scope_gate_scenario()
+        feature, _ = scenario
+        result = _evaluate(scenario)
+
+        # Premise: the request carries both gates the user set, and the failure is still abstract-only.
+        assert feature.domain is not None
+        assert feature.feature_group_scope is SpareAbstractBaseFG791
+        assert result.failure_kind == "abstract_only"
+
+        message = render_resolution_failure(result, feature)
+        assert message == (
+            f"No feature groups found for feature name: '{ABSTRACT_DECLARER_NAME_791}'. "
+            "Only abstract feature group base(s) matched, which cannot be instantiated; "
+            "no concrete implementation is available or enabled. "
+            "Scoped to feature group: 'SpareAbstractBaseFG791'. "
+            f"Requested domain: '{REQUESTED_DOMAIN_791}'.\n"
+            "Use resolve_feature(name, options=..., feature_group=...) to debug feature resolution.\n"
             f"{TROUBLESHOOTING_LINE}"
         )
 

--- a/tests/test_core/test_prepare/test_resolution_failure_renderer.py
+++ b/tests/test_core/test_prepare/test_resolution_failure_renderer.py
@@ -1194,6 +1194,12 @@ def abstract_bare_scenario() -> Scenario:
     return Feature(ABSTRACT_FEATURE_791), {RendererAbstractBaseFG791: {RendererFwOne791}}
 
 
+def scoped_abstract_bare_scenario() -> Scenario:
+    """Abstract-only failure while scoped to the abstract base itself."""
+    feature = Feature(ABSTRACT_FEATURE_791, feature_group=RendererAbstractBaseFG791)
+    return feature, {RendererAbstractBaseFG791: {RendererFwOne791}}
+
+
 def ordinary_none_scenario() -> Scenario:
     """No match: one candidate rejects an option value, another supplies the name catalog."""
     feature = Feature(
@@ -1586,6 +1592,7 @@ FAILING_SCENARIOS: dict[str, Callable[[], Scenario]] = {
     "capability": capability_scenario,
     "abstract_with_frameworks": abstract_with_frameworks_scenario,
     "abstract_bare": abstract_bare_scenario,
+    "scoped_abstract_bare": scoped_abstract_bare_scenario,
     "ordinary_none": ordinary_none_scenario,
     "scoped_none": scoped_none_scenario,
     "capability_narrow_enabled": capability_narrow_enabled_scenario,
@@ -1727,7 +1734,10 @@ class TestRenderResolutionFailureMessages:
             "['RendererFwOne791', 'RendererFwTwo791'], "
             "none of which are available or enabled for this run.\n"
             f"Feature group(s) eliminated while matching '{ABSTRACT_FEATURE_791}':\n"
-            "  - RendererConcreteSubFG791 (compute framework): none of its compute frameworks are enabled for this run"
+            "  - RendererConcreteSubFG791 (compute framework): "
+            "none of its compute frameworks are enabled for this run\n"
+            "Use resolve_feature(name, options=...) to debug feature resolution.\n"
+            f"{TROUBLESHOOTING_LINE}"
         )
 
     def test_abstract_only_without_concrete_implementation(self) -> None:
@@ -1737,8 +1747,24 @@ class TestRenderResolutionFailureMessages:
         assert message == (
             f"No feature groups found for feature name: '{ABSTRACT_FEATURE_791}'. "
             "Only abstract feature group base(s) matched, which cannot be instantiated; "
-            "no concrete implementation is available or enabled."
+            "no concrete implementation is available or enabled.\n"
+            "Use resolve_feature(name, options=...) to debug feature resolution.\n"
+            f"{TROUBLESHOOTING_LINE}"
         )
+
+    def test_scoped_abstract_only_renders_callout_and_scoped_pointer(self) -> None:
+        """A scoped abstract-only failure carries the scope callout and the widened resolve_feature pointer."""
+        scenario = scoped_abstract_bare_scenario()
+        feature, _ = scenario
+        result = _evaluate(scenario)
+
+        assert result.failure_kind == "abstract_only"
+
+        message = render_resolution_failure(result, feature)
+        assert message is not None
+        assert "Scoped to feature group: 'RendererAbstractBaseFG791'." in message
+        assert "Use resolve_feature(name, options=..., feature_group=...) to debug feature resolution." in message
+        assert message.endswith(TROUBLESHOOTING_LINE)
 
     def test_ordinary_none_renders_rejections_suggestion_and_pointers(self) -> None:
         """The near-miss block, then 'Did you mean', then the resolve_feature and troubleshooting lines."""
@@ -2022,7 +2048,9 @@ class TestFactCaptureNeverTakesEvaluateDown:
             "no concrete implementation is available or enabled.\n"
             f"Feature group(s) eliminated while matching '{RAISING_ABSTRACT_FEATURE_791}':\n"
             "  - RendererRaisingConcreteSubFG791 (compute framework): "
-            "none of its compute frameworks are enabled for this run"
+            "none of its compute frameworks are enabled for this run\n"
+            "Use resolve_feature(name, options=...) to debug feature resolution.\n"
+            f"{TROUBLESHOOTING_LINE}"
         )
 
     def test_resolve_feature_still_reports_candidates_when_get_domain_raises(self) -> None:
@@ -2872,7 +2900,10 @@ class TestADeadNameIsCapturedOnlyForTheMessageThatReadsIt:
             "['RendererFwOne791', 'RendererFwTwo791'], "
             "none of which are available or enabled for this run.\n"
             f"Feature group(s) eliminated while matching '{ABSTRACT_FEATURE_791}':\n"
-            "  - RendererConcreteSubFG791 (compute framework): none of its compute frameworks are enabled for this run"
+            "  - RendererConcreteSubFG791 (compute framework): "
+            "none of its compute frameworks are enabled for this run\n"
+            "Use resolve_feature(name, options=...) to debug feature resolution.\n"
+            f"{TROUBLESHOOTING_LINE}"
         )
 
 
@@ -2963,7 +2994,9 @@ class TestADomainCarryingFailureNamesTheRequestedDomain:
             f"No feature groups found for feature name: '{ABSTRACT_DECLARER_NAME_791}'. "
             "Only abstract feature group base(s) matched, which cannot be instantiated; "
             "no concrete implementation is available or enabled. "
-            f"Requested domain: '{REQUESTED_DOMAIN_791}'."
+            f"Requested domain: '{REQUESTED_DOMAIN_791}'.\n"
+            "Use resolve_feature(name, options=...) to debug feature resolution.\n"
+            f"{TROUBLESHOOTING_LINE}"
         )
 
 
@@ -3004,7 +3037,9 @@ class TestAnAbstractBaseIsNeverALiveDeclarer:
             "Only abstract feature group base(s) matched, which cannot be instantiated; "
             "no concrete implementation is available or enabled.\n"
             f"Feature group(s) eliminated while matching '{ABSTRACT_DECLARER_NAME_791}':\n"
-            "  - SpareDeadTwinFG791 (compute framework): none of its compute frameworks are enabled for this run"
+            "  - SpareDeadTwinFG791 (compute framework): none of its compute frameworks are enabled for this run\n"
+            "Use resolve_feature(name, options=...) to debug feature resolution.\n"
+            f"{TROUBLESHOOTING_LINE}"
         )
 
         assert ABSTRACT_DECLARER_NAME_791 in result.facts.dead_only_names

--- a/tests/test_core/test_prepare/test_single_pass_exactly_once.py
+++ b/tests/test_core/test_prepare/test_single_pass_exactly_once.py
@@ -1244,7 +1244,9 @@ class TestMalformedHookValuesDegradeLikeARaise:
         assert render_resolution_failure(result, feature) == (
             f"No feature groups found for feature name: '{BAD_DECLARATION_FEATURE_782}'. "
             "Its concrete implementations require compute framework(s) ['SinglePassFwTwo_782'], "
-            "none of which are available or enabled for this run."
+            "none of which are available or enabled for this run.\n"
+            "Use resolve_feature(name, options=...) to debug feature resolution.\n"
+            f"{TROUBLESHOOTING_LINE_782}"
         )
 
     def test_malformed_framework_declaration_alone_falls_back_to_the_bare_abstract_message(self) -> None:
@@ -1259,7 +1261,9 @@ class TestMalformedHookValuesDegradeLikeARaise:
         assert render_resolution_failure(result, feature) == (
             f"No feature groups found for feature name: '{BAD_DECLARATION_FEATURE_782}'. "
             "Only abstract feature group base(s) matched, which cannot be instantiated; "
-            "no concrete implementation is available or enabled."
+            "no concrete implementation is available or enabled.\n"
+            "Use resolve_feature(name, options=...) to debug feature resolution.\n"
+            f"{TROUBLESHOOTING_LINE_782}"
         )
 
 

--- a/tests/test_docs_taught_values.py
+++ b/tests/test_docs_taught_values.py
@@ -1,7 +1,7 @@
 """Doc-taught value guards for docs/docs markdown.
 
-The doc runner executes ```python fences, but defining a class never calls get_domain and the
-docs filter matches framework names case-insensitively, so these taught values need static checks.
+The doc runner executes ```python fences, but defining a class never calls get_domain, the docs
+filter matches framework names case-insensitively, and a fenced identifier is never resolved.
 """
 
 import difflib
@@ -10,20 +10,38 @@ from pathlib import Path
 
 import pytest
 
+from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.utils import get_all_subclasses
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.prepare.resolution_failure_renderer import render_resolution_failure
+from mloda.core.prepare.resolution_types import EvaluationResult, RenderFacts
 from mloda.user import PluginLoader
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 DOCS_ROOT = REPO_ROOT / "docs" / "docs"
 
-# The two doc spellings that teach a framework name: a quoted keyword and a single-line quoted list.
-SINGULAR_NAME = re.compile(r'compute_framework="(?P<name>[^"]+)"')
-PLURAL_LIST = re.compile(r"compute_frameworks=\[(?P<body>[^\]]*)\]")
-QUOTED_NAME = re.compile(r'"([^"]+)"')
+# The doc spellings that teach a framework name: quoted keyword, quoted dict key, and quoted list/set bodies.
+SINGULAR_NAME = re.compile(r"""compute_framework\s*=\s*(?P<quote>["'])(?P<name>[^"']+)(?P=quote)""")
+DICT_KEY_NAME = re.compile(
+    r"""(?P<key_quote>["'])compute_framework(?P=key_quote)\s*:\s*(?P<quote>["'])(?P<name>[^"']+)(?P=quote)"""
+)
+PLURAL_LIST = re.compile(r"compute_frameworks\s*=\s*\[(?P<body>[^\]]*)\]", re.DOTALL)
+PLURAL_SET = re.compile(r"compute_frameworks\s*=\s*\{(?P<body>[^}]*)\}", re.DOTALL)
+QUOTED_NAME = re.compile(r"""(?P<quote>["'])(?P<name>[^"']+)(?P=quote)""")
 
+# These fence-block regexes rely on tests/test_docs_fences.py banning the fence spellings (tilde,
+# four-backtick, spaced, attributed) they would mishandle.
 PYTHON_BLOCK = re.compile(r"```(?:python|py)\n(.*?)```", re.DOTALL)
+# Any fenced block, whatever its info string: quoted error output teaches framework class names too.
+FENCED_BLOCK = re.compile(r"```[^\n]*\n(.*?)```", re.DOTALL)
+FRAMEWORK_LIKE_IDENTIFIER = re.compile(r"\b[A-Z]\w*(?:DataFrame|Table|Framework)\b")
+
+# Framework-like fenced identifiers that are legitimately not loaded classes: the abstract base plus the
+# placeholder classes of the transformer and type-enforcement examples.
+FRAMEWORK_IDENTIFIER_ALLOWLIST = frozenset({"ComputeFramework", "CustomFramework", "MyFramework", "OtherFramework"})
+
 GET_DOMAIN_MARKER = "def get_domain"
 DOMAIN_RETURN_MARKER = "return Domain("
 
@@ -34,15 +52,32 @@ def _doc_files() -> list[Path]:
     return files
 
 
+def _line_of(text: str, offset: int) -> int:
+    """1-based line number of a character offset."""
+    return text[:offset].count("\n") + 1
+
+
 def _taught_framework_names(text: str) -> list[tuple[int, str]]:
-    """Return (1-based line number, name) for every framework name a markdown line teaches."""
-    names: list[tuple[int, str]] = []
-    for lineno, line in enumerate(text.splitlines(), 1):
-        for singular in SINGULAR_NAME.finditer(line):
-            names.append((lineno, singular.group("name")))
-        for plural in PLURAL_LIST.finditer(line):
-            names.extend((lineno, name) for name in QUOTED_NAME.findall(plural.group("body")))
-    return names
+    """Return (1-based line number, name) for every framework name the markdown teaches, in text order."""
+    found: list[tuple[int, str]] = []
+    for pattern in (SINGULAR_NAME, DICT_KEY_NAME):
+        for match in pattern.finditer(text):
+            found.append((match.start("name"), match.group("name")))
+    for pattern in (PLURAL_LIST, PLURAL_SET):
+        for match in pattern.finditer(text):
+            body_start = match.start("body")
+            for quoted in QUOTED_NAME.finditer(match.group("body")):
+                found.append((body_start + quoted.start("name"), quoted.group("name")))
+    return [(_line_of(text, offset), name) for offset, name in sorted(found)]
+
+
+def _framework_like_identifiers(text: str) -> list[tuple[int, str]]:
+    """Return (1-based line number, identifier) for every framework-like class name inside a fenced block."""
+    found: list[tuple[int, str]] = []
+    for block in FENCED_BLOCK.finditer(text):
+        for match in FRAMEWORK_LIKE_IDENTIFIER.finditer(block.group(1)):
+            found.append((_line_of(text, block.start(1) + match.start()), match.group(0)))
+    return found
 
 
 def _get_domain_blocks(text: str) -> list[str]:
@@ -50,9 +85,33 @@ def _get_domain_blocks(text: str) -> list[str]:
     return [block for block in PYTHON_BLOCK.findall(text) if GET_DOMAIN_MARKER in block]
 
 
-def _bare_get_domain_blocks(text: str) -> list[str]:
-    """Return the get_domain blocks that never return a Domain instance."""
-    return [block for block in _get_domain_blocks(text) if DOMAIN_RETURN_MARKER not in block]
+def _get_domain_bodies(block: str) -> list[str]:
+    """Slice each get_domain body: the lines after the def that are blank or indented deeper than it."""
+    lines = block.splitlines()
+    bodies: list[str] = []
+    for index, line in enumerate(lines):
+        if GET_DOMAIN_MARKER not in line:
+            continue
+        def_indent = len(line) - len(line.lstrip())
+        body: list[str] = []
+        for later in lines[index + 1 :]:
+            if later.strip() and len(later) - len(later.lstrip()) <= def_indent:
+                break
+            body.append(later)
+        bodies.append("\n".join(body))
+    return bodies
+
+
+def _bad_get_domain_bodies(text: str) -> list[str]:
+    """Return each get_domain body returning a bare string literal, or neither returning nor building a Domain."""
+    bad: list[str] = []
+    for block in _get_domain_blocks(text):
+        for body in _get_domain_bodies(block):
+            if 'return "' in body or "return '" in body:
+                bad.append(body)
+            elif "Domain(" not in body and "return" not in body:
+                bad.append(body)
+    return bad
 
 
 def _loaded_framework_names() -> set[str]:
@@ -86,12 +145,37 @@ def test_doc_taught_compute_framework_names_are_loaded_class_names() -> None:
     )
 
 
+def test_doc_fenced_framework_identifiers_are_loaded_class_names() -> None:
+    """A fenced example naming a framework class that does not exist teaches an unusable spelling."""
+    loaded = _loaded_framework_names()
+    assert loaded, "no ComputeFramework subclass is loaded, the identifier check would pass vacuously"
+    known = loaded | FRAMEWORK_IDENTIFIER_ALLOWLIST
+
+    violations: list[str] = []
+    for path in _doc_files():
+        for lineno, name in _framework_like_identifiers(path.read_text(encoding="utf-8")):
+            if name in known:
+                continue
+            hint = difflib.get_close_matches(name, sorted(loaded)) or sorted(loaded)
+            violations.append(f"{path}:{lineno}: names '{name}', did you mean one of {hint}?")
+
+    assert not violations, (
+        f"{len(violations)} fenced framework-like identifier(s) match no loaded class and no allowlist entry:\n"
+        + "\n".join(violations)
+    )
+
+
+def test_the_identifier_allowlist_names_no_loaded_class() -> None:
+    """An allowlist entry shadowing a real class would exempt that class from the identifier guard."""
+    assert not FRAMEWORK_IDENTIFIER_ALLOWLIST & _loaded_framework_names()
+
+
 def test_doc_get_domain_examples_return_a_domain_instance() -> None:
     """Domain.__eq__ returns NotImplemented for non-Domain, so a bare-string return matches nothing."""
     violations: list[str] = []
     for path in _doc_files():
-        for block in _bare_get_domain_blocks(path.read_text(encoding="utf-8")):
-            violations.append(f"{path}: get_domain block without '{DOMAIN_RETURN_MARKER}': {_excerpt(block)}")
+        for body in _bad_get_domain_bodies(path.read_text(encoding="utf-8")):
+            violations.append(f"{path}: get_domain body without a Domain return: {_excerpt(body)}")
 
     assert not violations, (
         f"{len(violations)} doc get_domain example(s) return a value the domain gate rejects, "
@@ -130,11 +214,39 @@ class TestScannedPagesStayScannable:
 
 
 SINGULAR_MARKDOWN = 'fgs = get_feature_group_docs(compute_framework="PandasDataFrame")\n'
+SINGLE_QUOTED_MARKDOWN = "fgs = get_feature_group_docs(compute_framework='PandasDataFrame')\n"
+SPACED_EQUALS_MARKDOWN = 'fgs = get_feature_group_docs(compute_framework = "PyArrowTable")\n'
+DICT_KEY_MARKDOWN = (
+    'feature = Feature("id", options={"compute_framework": "PyArrowTable"})\n'
+    "feature = Feature('id', options={'compute_framework': 'PandasDataFrame'})\n"
+)
+SET_FORM_MARKDOWN = 'entry = RegistryEntry(compute_frameworks={"PyArrowTable"})\n'
+CLASS_OBJECT_SET_MARKDOWN = "entry = RegistryEntry(compute_frameworks={PyArrowTable, PandasDataFrame})\n"
 PLURAL_MARKDOWN = (
     'session = mloda.prepare(feature_list, compute_frameworks=["PyArrowTable"])\n'
     'result = mloda.run_all(features, compute_frameworks=["PandasDataFrame", "PyArrowTable"])\n'
 )
+MULTILINE_LIST_MARKDOWN = (
+    "result = mloda.run_all(\n"
+    "    features,\n"
+    "    compute_frameworks = [\n"
+    '        "PandasDataFrame",\n'
+    "        'PyArrowTable',\n"
+    "    ],\n"
+    ")\n"
+)
 EMPTY_LIST_MARKDOWN = "a catalog entry with `compute_frameworks=[]` stays framework-free\n"
+
+IDENTIFIER_MARKDOWN = (
+    "PandasDataFrame in prose is never captured.\n"
+    "```python\n"
+    "if compute_framework is SQLiteFramework:\n"
+    "    return pd.DataFrame()\n"
+    "```\n"
+    "```\n"
+    "pinned compute framework 'SparkFramework' is not among its supported\n"
+    "```\n"
+)
 
 GOOD_DOMAIN_MARKDOWN = (
     "```python\n"
@@ -152,6 +264,32 @@ BARE_DOMAIN_MARKDOWN = (
     '        return "example_domain"\n'
     "```\n"
 )
+MIXED_DOMAIN_MARKDOWN = (
+    "```python\n"
+    "class Good(FeatureGroup):\n"
+    "    @classmethod\n"
+    "    def get_domain(cls) -> Domain:\n"
+    '        return Domain("example_domain")\n'
+    "\n"
+    "class Bare(FeatureGroup):\n"
+    "    @classmethod\n"
+    "    def get_domain(cls) -> Domain:\n"
+    '        return "example_domain"\n'
+    "```\n"
+)
+INDIRECT_DOMAIN_MARKDOWN = (
+    "```python\n"
+    'SALES = Domain("sales")\n'
+    "\n"
+    "class Indirect(FeatureGroup):\n"
+    "    @classmethod\n"
+    "    def get_domain(cls) -> Domain:\n"
+    "        return SALES\n"
+    "```\n"
+)
+RETURNLESS_DOMAIN_MARKDOWN = (
+    "```python\nclass Stub(FeatureGroup):\n    @classmethod\n    def get_domain(cls) -> Domain:\n        ...\n```\n"
+)
 
 
 class TestTaughtValueExtraction:
@@ -160,18 +298,88 @@ class TestTaughtValueExtraction:
     def test_the_singular_form_is_captured(self) -> None:
         assert _taught_framework_names(SINGULAR_MARKDOWN) == [(1, "PandasDataFrame")]
 
+    def test_a_single_quoted_singular_form_is_captured(self) -> None:
+        assert _taught_framework_names(SINGLE_QUOTED_MARKDOWN) == [(1, "PandasDataFrame")]
+
+    def test_spaces_around_the_equals_sign_are_accepted(self) -> None:
+        assert _taught_framework_names(SPACED_EQUALS_MARKDOWN) == [(1, "PyArrowTable")]
+
+    def test_the_dict_key_form_is_captured_with_either_quote(self) -> None:
+        assert _taught_framework_names(DICT_KEY_MARKDOWN) == [(1, "PyArrowTable"), (2, "PandasDataFrame")]
+
+    def test_a_quoted_set_form_is_captured(self) -> None:
+        assert _taught_framework_names(SET_FORM_MARKDOWN) == [(1, "PyArrowTable")]
+
+    def test_an_unquoted_class_object_set_is_ignored(self) -> None:
+        assert _taught_framework_names(CLASS_OBJECT_SET_MARKDOWN) == []
+
     def test_every_name_of_a_plural_list_is_captured(self) -> None:
         expected = [(1, "PyArrowTable"), (2, "PandasDataFrame"), (2, "PyArrowTable")]
         assert _taught_framework_names(PLURAL_MARKDOWN) == expected
 
+    def test_a_multi_line_list_is_captured_with_per_name_line_numbers(self) -> None:
+        assert _taught_framework_names(MULTILINE_LIST_MARKDOWN) == [(4, "PandasDataFrame"), (5, "PyArrowTable")]
+
     def test_an_empty_list_captures_nothing(self) -> None:
         assert _taught_framework_names(EMPTY_LIST_MARKDOWN) == []
 
+    def test_framework_like_identifiers_are_captured_inside_any_fence(self) -> None:
+        """Prose (line 1) and attribute access (line 4) contribute nothing; both fences are read."""
+        assert _framework_like_identifiers(IDENTIFIER_MARKDOWN) == [(3, "SQLiteFramework"), (7, "SparkFramework")]
+
     def test_a_domain_returning_block_is_not_flagged(self) -> None:
         assert _get_domain_blocks(GOOD_DOMAIN_MARKDOWN), "the good block was not even collected"
-        assert _bare_get_domain_blocks(GOOD_DOMAIN_MARKDOWN) == []
+        assert _bad_get_domain_bodies(GOOD_DOMAIN_MARKDOWN) == []
 
     def test_a_bare_string_return_is_flagged(self) -> None:
-        flagged = _bare_get_domain_blocks(BARE_DOMAIN_MARKDOWN)
-        assert len(flagged) == 1, f"expected exactly the bare block flagged, got {flagged}"
-        assert GET_DOMAIN_MARKER in flagged[0]
+        flagged = _bad_get_domain_bodies(BARE_DOMAIN_MARKDOWN)
+        assert len(flagged) == 1, f"expected exactly the bare body flagged, got {flagged}"
+        assert 'return "example_domain"' in flagged[0]
+
+    def test_a_fence_mixing_good_and_bad_definitions_flags_only_the_bad_body(self) -> None:
+        flagged = _bad_get_domain_bodies(MIXED_DOMAIN_MARKDOWN)
+        assert len(flagged) == 1, f"expected exactly the bare body flagged, got {flagged}"
+        assert 'return "example_domain"' in flagged[0]
+
+    def test_a_body_returning_a_fence_bound_domain_is_not_flagged(self) -> None:
+        assert _get_domain_blocks(INDIRECT_DOMAIN_MARKDOWN), "the indirect block was not even collected"
+        assert _bad_get_domain_bodies(INDIRECT_DOMAIN_MARKDOWN) == []
+
+    def test_a_returnless_body_is_flagged(self) -> None:
+        flagged = _bad_get_domain_bodies(RETURNLESS_DOMAIN_MARKDOWN)
+        assert len(flagged) == 1, f"expected exactly the returnless body flagged, got {flagged}"
+
+
+TROUBLESHOOTING_PAGE = "docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md"
+ABSTRACT_ONLY_HEADING = "### Only abstract feature group bases matched"
+
+
+def _abstract_only_doc_blocks() -> tuple[str, str]:
+    """Return the two messages fenced after the abstract-only heading: the bare variant, then the frameworks one."""
+    page = REPO_ROOT / TROUBLESHOOTING_PAGE
+    assert page.is_file(), f"{page} was moved or renamed; update TROUBLESHOOTING_PAGE"
+    text = page.read_text(encoding="utf-8")
+    assert ABSTRACT_ONLY_HEADING in text, f"{page} lost the heading '{ABSTRACT_ONLY_HEADING}'"
+    blocks = FENCED_BLOCK.findall(text[text.index(ABSTRACT_ONLY_HEADING) :])
+    assert len(blocks) >= 2, f"{page} no longer fences two messages after '{ABSTRACT_ONLY_HEADING}'"
+    return blocks[0].rstrip("\n"), blocks[1].rstrip("\n")
+
+
+class TestTroubleshootingAbstractOnlyBlocksAreLiveRendererOutput:
+    """The two quoted abstract-only messages must stay byte-identical to what the renderer emits."""
+
+    def test_the_bare_variant_is_the_rendered_message(self) -> None:
+        result = EvaluationResult(identified={}, abstract_matched={FeatureGroup})
+        assert result.failure_kind == "abstract_only"
+        bare_block, _ = _abstract_only_doc_blocks()
+        assert render_resolution_failure(result, Feature("my_feature")) == bare_block
+
+    def test_the_frameworks_variant_is_the_rendered_message(self) -> None:
+        result = EvaluationResult(
+            identified={},
+            abstract_matched={FeatureGroup},
+            facts=RenderFacts(concrete_frameworks=("PandasDataFrame",)),
+        )
+        assert result.failure_kind == "abstract_only"
+        _, frameworks_block = _abstract_only_doc_blocks()
+        assert render_resolution_failure(result, Feature("my_feature")) == frameworks_block

--- a/tests/test_docs_taught_values.py
+++ b/tests/test_docs_taught_values.py
@@ -1,0 +1,177 @@
+"""Doc-taught value guards for docs/docs markdown.
+
+The doc runner executes ```python fences, but defining a class never calls get_domain and the
+docs filter matches framework names case-insensitively, so these taught values need static checks.
+"""
+
+import difflib
+import re
+from pathlib import Path
+
+import pytest
+
+from mloda.core.abstract_plugins.components.utils import get_all_subclasses
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.user import PluginLoader
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+DOCS_ROOT = REPO_ROOT / "docs" / "docs"
+
+# The two doc spellings that teach a framework name: a quoted keyword and a single-line quoted list.
+SINGULAR_NAME = re.compile(r'compute_framework="(?P<name>[^"]+)"')
+PLURAL_LIST = re.compile(r"compute_frameworks=\[(?P<body>[^\]]*)\]")
+QUOTED_NAME = re.compile(r'"([^"]+)"')
+
+PYTHON_BLOCK = re.compile(r"```(?:python|py)\n(.*?)```", re.DOTALL)
+GET_DOMAIN_MARKER = "def get_domain"
+DOMAIN_RETURN_MARKER = "return Domain("
+
+
+def _doc_files() -> list[Path]:
+    files = sorted(DOCS_ROOT.rglob("*.md"))
+    assert files, f"no markdown files under {DOCS_ROOT}, the taught-value checks would pass vacuously"
+    return files
+
+
+def _taught_framework_names(text: str) -> list[tuple[int, str]]:
+    """Return (1-based line number, name) for every framework name a markdown line teaches."""
+    names: list[tuple[int, str]] = []
+    for lineno, line in enumerate(text.splitlines(), 1):
+        for singular in SINGULAR_NAME.finditer(line):
+            names.append((lineno, singular.group("name")))
+        for plural in PLURAL_LIST.finditer(line):
+            names.extend((lineno, name) for name in QUOTED_NAME.findall(plural.group("body")))
+    return names
+
+
+def _get_domain_blocks(text: str) -> list[str]:
+    """Return every python/py fenced block that defines get_domain."""
+    return [block for block in PYTHON_BLOCK.findall(text) if GET_DOMAIN_MARKER in block]
+
+
+def _bare_get_domain_blocks(text: str) -> list[str]:
+    """Return the get_domain blocks that never return a Domain instance."""
+    return [block for block in _get_domain_blocks(text) if DOMAIN_RETURN_MARKER not in block]
+
+
+def _loaded_framework_names() -> set[str]:
+    PluginLoader.all()
+    return {subclass.__name__ for subclass in get_all_subclasses(ComputeFramework)}
+
+
+def _excerpt(block: str) -> str:
+    lines = [line.strip() for line in block.splitlines() if line.strip()]
+    shown = lines[:3]
+    suffix = " ..." if len(lines) > len(shown) else ""
+    return " / ".join(shown) + suffix
+
+
+def test_doc_taught_compute_framework_names_are_loaded_class_names() -> None:
+    """The docs filter matches case-insensitively, but framework pins by name do not."""
+    loaded = _loaded_framework_names()
+    assert loaded, "no ComputeFramework subclass is loaded, the name check would pass vacuously"
+
+    violations: list[str] = []
+    for path in _doc_files():
+        for lineno, name in _taught_framework_names(path.read_text(encoding="utf-8")):
+            if name in loaded:
+                continue
+            hint = difflib.get_close_matches(name, sorted(loaded)) or sorted(loaded)
+            violations.append(f"{path}:{lineno}: teaches '{name}', did you mean one of {hint}?")
+
+    assert not violations, (
+        f"{len(violations)} doc-taught compute framework name(s) match no loaded class; "
+        "case-sensitive surfaces reject them:\n" + "\n".join(violations)
+    )
+
+
+def test_doc_get_domain_examples_return_a_domain_instance() -> None:
+    """Domain.__eq__ returns NotImplemented for non-Domain, so a bare-string return matches nothing."""
+    violations: list[str] = []
+    for path in _doc_files():
+        for block in _bare_get_domain_blocks(path.read_text(encoding="utf-8")):
+            violations.append(f"{path}: get_domain block without '{DOMAIN_RETURN_MARKER}': {_excerpt(block)}")
+
+    assert not violations, (
+        f"{len(violations)} doc get_domain example(s) return a value the domain gate rejects, "
+        f"write '{DOMAIN_RETURN_MARKER}...)':\n" + "\n".join(violations)
+    )
+
+
+# Pages the scans above must keep finding something on.
+FRAMEWORK_NAME_PAGES = (
+    "docs/docs/in_depth/discover-plugins.md",
+    "docs/docs/in_depth/mloda-api.md",
+)
+
+GET_DOMAIN_PAGES = (
+    "docs/docs/in_depth/domain.md",
+    "docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md",
+)
+
+
+class TestScannedPagesStayScannable:
+    """A moved or reworded page would otherwise silently empty the scans above."""
+
+    @pytest.mark.parametrize("relative_path", FRAMEWORK_NAME_PAGES)
+    def test_the_page_still_teaches_a_framework_name(self, relative_path: str) -> None:
+        page = REPO_ROOT / relative_path
+        assert page.is_file(), f"{page} was moved or renamed; update FRAMEWORK_NAME_PAGES"
+        names = _taught_framework_names(page.read_text(encoding="utf-8"))
+        assert names, f"{page} no longer teaches a compute framework name the scanner reads"
+
+    @pytest.mark.parametrize("relative_path", GET_DOMAIN_PAGES)
+    def test_the_page_still_shows_a_get_domain_block(self, relative_path: str) -> None:
+        page = REPO_ROOT / relative_path
+        assert page.is_file(), f"{page} was moved or renamed; update GET_DOMAIN_PAGES"
+        blocks = _get_domain_blocks(page.read_text(encoding="utf-8"))
+        assert blocks, f"{page} no longer shows a get_domain block the scanner reads"
+
+
+SINGULAR_MARKDOWN = 'fgs = get_feature_group_docs(compute_framework="PandasDataFrame")\n'
+PLURAL_MARKDOWN = (
+    'session = mloda.prepare(feature_list, compute_frameworks=["PyArrowTable"])\n'
+    'result = mloda.run_all(features, compute_frameworks=["PandasDataFrame", "PyArrowTable"])\n'
+)
+EMPTY_LIST_MARKDOWN = "a catalog entry with `compute_frameworks=[]` stays framework-free\n"
+
+GOOD_DOMAIN_MARKDOWN = (
+    "```python\n"
+    "class Good(FeatureGroup):\n"
+    "    @classmethod\n"
+    "    def get_domain(cls) -> Domain:\n"
+    '        return Domain("example_domain")\n'
+    "```\n"
+)
+BARE_DOMAIN_MARKDOWN = (
+    "```python\n"
+    "class Bare(FeatureGroup):\n"
+    "    @classmethod\n"
+    "    def get_domain(cls) -> Domain:\n"
+    '        return "example_domain"\n'
+    "```\n"
+)
+
+
+class TestTaughtValueExtraction:
+    """The extraction helpers driven over literal markdown."""
+
+    def test_the_singular_form_is_captured(self) -> None:
+        assert _taught_framework_names(SINGULAR_MARKDOWN) == [(1, "PandasDataFrame")]
+
+    def test_every_name_of_a_plural_list_is_captured(self) -> None:
+        expected = [(1, "PyArrowTable"), (2, "PandasDataFrame"), (2, "PyArrowTable")]
+        assert _taught_framework_names(PLURAL_MARKDOWN) == expected
+
+    def test_an_empty_list_captures_nothing(self) -> None:
+        assert _taught_framework_names(EMPTY_LIST_MARKDOWN) == []
+
+    def test_a_domain_returning_block_is_not_flagged(self) -> None:
+        assert _get_domain_blocks(GOOD_DOMAIN_MARKDOWN), "the good block was not even collected"
+        assert _bare_get_domain_blocks(GOOD_DOMAIN_MARKDOWN) == []
+
+    def test_a_bare_string_return_is_flagged(self) -> None:
+        flagged = _bare_get_domain_blocks(BARE_DOMAIN_MARKDOWN)
+        assert len(flagged) == 1, f"expected exactly the bare block flagged, got {flagged}"
+        assert GET_DOMAIN_MARKER in flagged[0]


### PR DESCRIPTION
Two related fixes to the resolution-failure UX and the published docs, plus static guards so the doc defect class cannot recur silently.

## Abstract-only failure message

`_render_abstract_only` rendered its headline and, when candidates were eliminated, the near-miss block, then stopped. Unlike the sibling "none" and "multiple" forms it printed neither the `resolve_feature` debug pointer nor the troubleshooting link, even though the troubleshooting page now covers the abstract-only variant. The message now closes with the same two trailing lines as the ordinary form, via a helper shared with `_render_none` (the pointer widens with `feature_group=...` under a scope callout). The Did-you-mean suggestion stays deliberately absent: the name already matched a base, so there is nothing to suggest.

- All exact-message pins extended, plus new pins for the scoped and the domain-plus-scope compositions.
- The troubleshooting page's abstract-only examples now show the full message, and a new test keeps both quoted blocks byte-identical to live renderer output.

## Doc-taught values the code rejects

- `domain.md` showed `get_domain` returning a bare string; `Domain.__eq__` rejects non-Domain values, so that group fails every domain-carrying request. The snippet now returns `Domain("example_domain")`.
- Two pages spelled the Pandas framework `PandasDataframe`; the class is `PandasDataFrame`. The docs-filter argument happens to match case-insensitively, but case-sensitive surfaces (framework pins by name) reject the misspelling.
- Review of the change surfaced the same defect once more: two `SQLiteFramework` mentions (the class is `SqliteFramework`), and a quoted failure message missing its final troubleshooting line. Both fixed.

New static guards in `tests/test_docs_taught_values.py` run in the default gate and scan the published docs for taught values: compute-framework names in every quoted form (keyword, list, set, dict key, multi-line), framework-like identifiers in fenced blocks (with a small allowlist for illustrative names), and `get_domain` bodies that must return a `Domain`. Floor pins and synthetic self-tests keep the scanners from rotting into no-ops.

## Validation

Two independent deep reviews (all accepted findings applied, including the scanner widening and the sqlite spelling both reviews converged on). Full tox gate green: pytest, ruff format and check, pip-licenses, mypy --strict, bandit.
