### PR TITLE
fix: make option equality cycle-safe and release the caught exception

### DIFF
--- a/mloda/core/abstract_plugins/components/feature.py
+++ b/mloda/core/abstract_plugins/components/feature.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 
 from mloda.core.abstract_plugins.components.domain import Domain
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
-from mloda.core.abstract_plugins.components.hashable_dict import _CYCLE, _deep_hashable
+from mloda.core.abstract_plugins.components.hashable_dict import _CYCLE, _deep_equal, _deep_hashable
 from mloda.core.abstract_plugins.components.index.index import Index
 from mloda.core.abstract_plugins.components.link import Link
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
@@ -330,7 +330,8 @@ class Feature:
         return (
             self.name == other.name
             and self.options == other.options
-            and self.options.context == other.options.context
+            # __hash__ excludes context, so this probe meets cyclic contexts and needs the cycle-safe walk.
+            and _deep_equal(self.options.context, other.options.context)
             and self.domain == other.domain
             and self.compute_frameworks == other.compute_frameworks
             and self.data_type == other.data_type

--- a/mloda/core/abstract_plugins/components/hashable_dict.py
+++ b/mloda/core/abstract_plugins/components/hashable_dict.py
@@ -23,8 +23,7 @@ class _CycleMarker:
 
 
 # A cyclic value hashes instead of raising RecursionError. Mirrors the id() visited guard in
-# Feature._reduce. Equality is not cycle-safe: two separately built cyclic values reduce alike,
-# so a dict/set insertion of both still reaches the recursive == of Options/HashableDict.
+# Feature._reduce. _deep_equal carries the matching guard for the == that such a collision reaches.
 _CYCLE = _CycleMarker()
 
 
@@ -57,6 +56,24 @@ def _deep_hashable(value: Any, seen: frozenset[int] = frozenset()) -> Any:
     return value
 
 
+def _deep_equal(a: Any, b: Any, seen: frozenset[tuple[int, int]] = frozenset()) -> bool:
+    """Compare two values structurally, treating a repeated id pair on the recursion path as equal."""
+    if a is b:
+        return True
+    if type(a) is not type(b) or type(a) not in (dict, list, tuple):
+        return bool(a == b)
+    pair = (id(a), id(b))
+    if pair in seen:
+        return True
+    seen = seen | {pair}
+    if len(a) != len(b):
+        return False
+    if type(a) is dict:
+        # Keys keep their own hash and __eq__; only values are walked.
+        return all(k in b and _deep_equal(v, b[k], seen) for k, v in a.items())
+    return all(_deep_equal(x, y, seen) for x, y in zip(a, b))
+
+
 class HashableDict:
     def __init__(self, data: dict[Any, Any]) -> None:
         self.data = data
@@ -67,7 +84,7 @@ class HashableDict:
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, HashableDict):
             return False
-        return self.data == other.data
+        return _deep_equal(self.data, other.data)
 
     def items(self) -> Any:
         return self.data.items()

--- a/mloda/core/abstract_plugins/components/hashable_dict.py
+++ b/mloda/core/abstract_plugins/components/hashable_dict.py
@@ -23,7 +23,9 @@ class _CycleMarker:
 
 
 # A cyclic value hashes instead of raising RecursionError. Mirrors the id() visited guard in
-# Feature._reduce. _deep_equal carries the matching guard for the == that such a collision reaches.
+# Feature._reduce. _deep_equal mirrors this normalization for the == that such a collision reaches;
+# residual: set values, containers whose type overrides __eq__, and cycles routed through a nested
+# Options/HashableDict (where the path resets) are still plain ==.
 _CYCLE = _CycleMarker()
 
 
@@ -56,22 +58,45 @@ def _deep_hashable(value: Any, seen: frozenset[int] = frozenset()) -> Any:
     return value
 
 
-def _deep_equal(a: Any, b: Any, seen: frozenset[tuple[int, int]] = frozenset()) -> bool:
-    """Compare two values structurally, treating a repeated id pair on the recursion path as equal."""
-    if a is b:
-        return True
-    if type(a) is not type(b) or type(a) not in (dict, list, tuple):
-        return bool(a == b)
-    pair = (id(a), id(b))
-    if pair in seen:
-        return True
-    seen = seen | {pair}
+_CONTAINER_KINDS = (dict, list, tuple)
+
+
+def _container_kind(value: Any) -> type | None:
+    """The base container type value is walked as, or None when its own __eq__ must decide."""
+    # Exact types cannot override __eq__, so they skip the isinstance scan; this is the hot path.
+    if type(value) in _CONTAINER_KINDS:
+        return type(value)
+    for kind in _CONTAINER_KINDS:
+        if isinstance(value, kind) and type(value).__eq__ is kind.__eq__:
+            return kind
+    return None
+
+
+def _deep_equal(a: Any, b: Any) -> bool:
+    """Compare two values structurally, matching a back-reference only against another back-reference."""
+    return _walk_equal(a, b, set(), set())
+
+
+def _walk_equal(a: Any, b: Any, path_a: set[int], path_b: set[int]) -> bool:
+    kind = _container_kind(a)
+    if kind is None or _container_kind(b) is not kind:
+        return a is b or bool(a == b)
+    on_a, on_b = id(a) in path_a, id(b) in path_b
+    if on_a or on_b:
+        # A back-reference matches only another back-reference, as _deep_hashable's marker does.
+        return on_a and on_b
     if len(a) != len(b):
         return False
-    if type(a) is dict:
+    path_a.add(id(a))
+    path_b.add(id(b))
+    if kind is dict:
         # Keys keep their own hash and __eq__; only values are walked.
-        return all(k in b and _deep_equal(v, b[k], seen) for k, v in a.items())
-    return all(_deep_equal(x, y, seen) for x, y in zip(a, b))
+        equal = all(k in b and _walk_equal(v, b[k], path_a, path_b) for k, v in a.items())
+    else:
+        equal = all(_walk_equal(x, y, path_a, path_b) for x, y in zip(a, b))
+    path_a.discard(id(a))
+    path_b.discard(id(b))
+    return equal
 
 
 class HashableDict:

--- a/mloda/core/abstract_plugins/components/options.py
+++ b/mloda/core/abstract_plugins/components/options.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any, Optional, TYPE_CHECKING, cast
 from copy import deepcopy
 
-from mloda.core.abstract_plugins.components.hashable_dict import _deep_hashable
+from mloda.core.abstract_plugins.components.hashable_dict import _deep_equal, _deep_hashable
 from mloda.core.abstract_plugins.components.validators.options_validator import OptionsValidator
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
 
@@ -175,7 +175,7 @@ class Options:
         """
         if not isinstance(other, Options):
             return False
-        return self.group == other.group
+        return _deep_equal(self.group, other.group)
 
     def get(self, key: str, default: Any = None) -> Any:
         """Get a value, searching group then context; return ``default`` only when the key is absent from both.

--- a/mloda/core/core/cfw_manager.py
+++ b/mloda/core/core/cfw_manager.py
@@ -191,9 +191,11 @@ class CfwManager:
         """Retrieves the error flag."""
         return self.error
 
-    def get_error_exception(self) -> Any:
-        """Retrieves the original exception object, if captured."""
-        return self.exception
+    def take_error_exception(self) -> Any:
+        """Hands over the original exception object, if captured, and drops the register's reference."""
+        exception = self.exception
+        self.exception = None
+        return exception
 
     def get_error_msg(self) -> Any:
         """Retrieves the error message."""

--- a/mloda/core/core/cfw_manager.py
+++ b/mloda/core/core/cfw_manager.py
@@ -193,6 +193,7 @@ class CfwManager:
 
     def take_error_exception(self) -> Any:
         """Hands over the original exception object, if captured, and drops the register's reference."""
+        # error and msg stay set on purpose, so a later flag read still raises the typed fallback.
         exception = self.exception
         self.exception = None
         return exception

--- a/mloda/core/core/engine.py
+++ b/mloda/core/core/engine.py
@@ -30,6 +30,7 @@ from mloda.core.runtime.flight.runner_flight_server import ParallelRunnerFlightS
 from mloda.core.abstract_plugins.feature_group import FeatureGroup, format_feature_group_class
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_collection import Features
+from mloda.core.abstract_plugins.components.hashable_dict import _deep_equal
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.components.link import JoinType, Link
 from mloda.core.abstract_plugins.components.validators.link_validator import LinkValidator
@@ -403,7 +404,10 @@ class Engine:
     ) -> None:
         """Warn when a merge holds only post-materialization: the declared (pre-default) options differ."""
         survivor_declared = self._declared_options_by_uuid.get(existing_feature.uuid, existing_feature.options)
-        if declared_options.group == survivor_declared.group and declared_options.context == survivor_declared.context:
+        # Reached only when the feature equality probe matched, so cyclic values arrive here too.
+        if _deep_equal(declared_options.group, survivor_declared.group) and _deep_equal(
+            declared_options.context, survivor_declared.context
+        ):
             return
         logger.warning(
             f"Feature '{feature.name}' was requested twice with default-equivalent options: the requests "

--- a/mloda/core/runtime/run.py
+++ b/mloda/core/runtime/run.py
@@ -140,7 +140,9 @@ class ExecutionOrchestrator:
             error = self.cfw_register.get_error()
             if error:
                 logger.error(self.cfw_register.get_error_exc_info())
-                original = self.cfw_register.get_error_exception()
+                # The register outlives the raise; a retained exception pins its traceback frames
+                # and through them the dynamically loaded plugin class.
+                original = self.cfw_register.take_error_exception()
                 if isinstance(original, BaseException):
                     raise original
                 raise MlodaRunError(self.cfw_register.get_error_msg())

--- a/mloda/core/runtime/run.py
+++ b/mloda/core/runtime/run.py
@@ -140,8 +140,8 @@ class ExecutionOrchestrator:
             error = self.cfw_register.get_error()
             if error:
                 logger.error(self.cfw_register.get_error_exc_info())
-                # The register outlives the raise; a retained exception pins its traceback frames
-                # and through them the dynamically loaded plugin class.
+                # The register outlives the raise; on SYNC/THREADING a retained exception pins its
+                # traceback frames and through them the plugin class (pickling drops __traceback__).
                 original = self.cfw_register.take_error_exception()
                 if isinstance(original, BaseException):
                     raise original

--- a/tests/test_core/test_abstract_plugins/test_components/test_cycle_safe_equality.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_cycle_safe_equality.py
@@ -1,0 +1,169 @@
+"""Cycle-safe equality for Options and HashableDict, with acyclic semantics unchanged."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from mloda.core.abstract_plugins.components.hashable_dict import HashableDict
+from mloda.core.abstract_plugins.components.options import Options
+
+
+class _AlwaysEqual:
+    def __eq__(self, other: object) -> bool:
+        return True
+
+    def __hash__(self) -> int:
+        return 0
+
+
+class _NeverEqual:
+    def __eq__(self, other: object) -> bool:
+        return False
+
+    def __hash__(self) -> int:
+        return 0
+
+
+def _self_referential_list() -> list[Any]:
+    cyclic: list[Any] = []
+    cyclic.append(cyclic)
+    return cyclic
+
+
+def _self_referential_dict() -> dict[str, Any]:
+    cyclic: dict[str, Any] = {}
+    cyclic["self"] = cyclic
+    return cyclic
+
+
+class TestCyclicValuesCompareWithoutRecursing:
+    def test_options_with_two_cyclic_lists_usable_as_dict_keys(self) -> None:
+        left = Options(group={"k": _self_referential_list()})
+        right = Options(group={"k": _self_referential_list()})
+
+        mapping: dict[Options, int] = {left: 1}
+        mapping[right] = 2
+
+        assert left == right
+        assert len(mapping) == 1
+
+    def test_hashable_dict_with_two_cyclic_lists_usable_as_dict_keys(self) -> None:
+        left = HashableDict({"k": _self_referential_list()})
+        right = HashableDict({"k": _self_referential_list()})
+
+        mapping: dict[HashableDict, int] = {left: 1}
+        mapping[right] = 2
+
+        assert left == right
+        assert len(mapping) == 1
+
+    def test_options_with_two_cyclic_dicts_compare_equal(self) -> None:
+        assert Options(group={"k": _self_referential_dict()}) == Options(group={"k": _self_referential_dict()})
+
+    def test_hashable_dict_with_two_cyclic_dicts_compare_equal(self) -> None:
+        assert HashableDict({"k": _self_referential_dict()}) == HashableDict({"k": _self_referential_dict()})
+
+    def test_mutually_referential_containers_compare_equal(self) -> None:
+        def build() -> list[Any]:
+            outer: list[Any] = []
+            inner: dict[str, Any] = {"back": outer}
+            outer.append(inner)
+            return outer
+
+        assert Options(group={"k": build()}) == Options(group={"k": build()})
+
+    def test_cycle_nested_under_a_tuple_compares_equal(self) -> None:
+        assert Options(group={"k": (_self_referential_list(),)}) == Options(group={"k": (_self_referential_list(),)})
+
+    def test_differing_cycles_still_compare_unequal(self) -> None:
+        left: list[Any] = [1]
+        left.append(left)
+        right: list[Any] = [2]
+        right.append(right)
+
+        assert Options(group={"k": left}) != Options(group={"k": right})
+
+    def test_options_with_cyclic_content_usable_in_a_set(self) -> None:
+        collapsed = {Options(group={"k": _self_referential_list()}), Options(group={"k": _self_referential_list()})}
+        assert len(collapsed) == 1
+
+    def test_hashable_dict_with_cyclic_content_usable_in_a_set(self) -> None:
+        collapsed = {
+            HashableDict({"k": _self_referential_list()}),
+            HashableDict({"k": _self_referential_list()}),
+        }
+        assert len(collapsed) == 1
+
+
+class TestAcyclicSemanticsUnchanged:
+    def test_list_and_tuple_of_the_same_items_differ(self) -> None:
+        assert Options(group={"k": [1, 2]}) != Options(group={"k": (1, 2)})
+
+    def test_hashable_dict_list_and_tuple_of_the_same_items_differ(self) -> None:
+        assert HashableDict({"k": [1, 2]}) != HashableDict({"k": (1, 2)})
+
+    def test_equal_nested_structures_compare_equal(self) -> None:
+        def build() -> dict[str, Any]:
+            return {"a": [1, {"b": (2, [3])}], "c": {"d": ["e"]}}
+
+        assert Options(group={"k": build()}) == Options(group={"k": build()})
+        assert HashableDict(build()) == HashableDict(build())
+
+    def test_differing_leaf_value_compares_unequal(self) -> None:
+        assert Options(group={"k": {"a": [1, 2]}}) != Options(group={"k": {"a": [1, 3]}})
+
+    def test_differing_length_compares_unequal(self) -> None:
+        assert Options(group={"k": [1, 2]}) != Options(group={"k": [1, 2, 3]})
+        assert Options(group={"k": {"a": 1}}) != Options(group={"k": {"a": 1, "b": 2}})
+
+    def test_differing_keys_compare_unequal(self) -> None:
+        assert Options(group={"k": {"a": 1}}) != Options(group={"k": {"b": 1}})
+
+    def test_a_custom_eq_leaf_that_accepts_anything_decides(self) -> None:
+        assert Options(group={"k": [_AlwaysEqual()]}) == Options(group={"k": ["anything"]})
+
+    def test_a_custom_eq_leaf_that_rejects_everything_decides(self) -> None:
+        assert Options(group={"k": [_NeverEqual()]}) != Options(group={"k": [_NeverEqual()]})
+
+    def test_an_identical_leaf_short_circuits_before_its_custom_eq(self) -> None:
+        """Element identity wins, as it does in CPython's own list and dict compare."""
+        leaf = _NeverEqual()
+        assert Options(group={"k": [leaf]}) == Options(group={"k": [leaf]})
+        assert Options(group={"k": {"n": leaf}}) == Options(group={"k": {"n": leaf}})
+
+    def test_sets_still_compare_by_plain_equality(self) -> None:
+        assert Options(group={"k": {1, 2}}) == Options(group={"k": {2, 1}})
+        assert Options(group={"k": {1, 2}}) != Options(group={"k": {1, 3}})
+
+    def test_a_dict_subclass_is_not_walked_structurally(self) -> None:
+        class _Subclass(dict[str, Any]):
+            def __eq__(self, other: object) -> bool:
+                return False
+
+        assert Options(group={"k": _Subclass()}) != Options(group={"k": _Subclass()})
+
+    def test_options_against_a_non_options_is_false(self) -> None:
+        assert Options(group={"k": 1}) != {"k": 1}
+        assert Options(group={"k": 1}).__eq__("not options") is False
+
+    def test_hashable_dict_against_a_non_hashable_dict_is_false(self) -> None:
+        assert HashableDict({"k": 1}) != {"k": 1}
+        assert HashableDict({"k": 1}).__eq__("not a hashable dict") is False
+
+    def test_options_equality_still_ignores_context(self) -> None:
+        left = Options(group={"k": 1}, context={"c": "left"})
+        right = Options(group={"k": 1}, context={"c": "right"})
+
+        assert left == right
+
+    def test_options_equality_still_ignores_context_for_cyclic_values(self) -> None:
+        left = Options(group={"k": _self_referential_list()}, context={"c": "left"})
+        right = Options(group={"k": _self_referential_list()}, context={"c": "right"})
+
+        assert left == right
+
+    @pytest.mark.parametrize("value", [1, "text", None, 3.5, True, b"bytes", frozenset({1})])
+    def test_leaf_values_compare_as_before(self, value: Any) -> None:
+        assert Options(group={"k": value}) == Options(group={"k": value})

--- a/tests/test_core/test_abstract_plugins/test_components/test_cycle_safe_equality.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_cycle_safe_equality.py
@@ -1,11 +1,12 @@
-"""Cycle-safe equality for Options and HashableDict, with acyclic semantics unchanged."""
+"""Cycle-safe equality for Options, HashableDict and Feature, with acyclic semantics unchanged."""
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Callable
 
 import pytest
 
+from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.hashable_dict import HashableDict
 from mloda.core.abstract_plugins.components.options import Options
 
@@ -35,6 +36,44 @@ def _self_referential_list() -> list[Any]:
 def _self_referential_dict() -> dict[str, Any]:
     cyclic: dict[str, Any] = {}
     cyclic["self"] = cyclic
+    return cyclic
+
+
+def _two_node_cycle() -> list[Any]:
+    outer: list[Any] = []
+    inner: list[Any] = [outer]
+    outer.append(inner)
+    return outer
+
+
+def _mutually_referential() -> list[Any]:
+    outer: list[Any] = []
+    inner: dict[str, Any] = {"back": outer}
+    outer.append(inner)
+    return outer
+
+
+def _acyclic_nested() -> dict[str, Any]:
+    return {"a": [1, {"b": (2, [3])}], "c": {"d": ["e"]}}
+
+
+class _PlainDictSubclass(dict[str, Any]):
+    """A dict subclass that inherits dict equality."""
+
+
+class _PlainListSubclass(list[Any]):
+    """A list subclass that inherits list equality."""
+
+
+def _self_referential_dict_subclass() -> _PlainDictSubclass:
+    cyclic = _PlainDictSubclass()
+    cyclic["self"] = cyclic
+    return cyclic
+
+
+def _self_referential_list_subclass() -> _PlainListSubclass:
+    cyclic = _PlainListSubclass()
+    cyclic.append(cyclic)
     return cyclic
 
 
@@ -167,3 +206,201 @@ class TestAcyclicSemanticsUnchanged:
     @pytest.mark.parametrize("value", [1, "text", None, 3.5, True, b"bytes", frozenset({1})])
     def test_leaf_values_compare_as_before(self, value: Any) -> None:
         assert Options(group={"k": value}) == Options(group={"k": value})
+
+
+class TestFeatureEqualityWithCyclicContext:
+    """Feature.__eq__ compares context, which __hash__ excludes, so the probe must survive cycles."""
+
+    @staticmethod
+    def _feature_with_cyclic_context() -> Feature:
+        return Feature(name="x", options=Options(group={"g": 1}, context={"c": _self_referential_list()}))
+
+    def test_features_with_separately_built_cyclic_contexts_collapse_in_a_set(self) -> None:
+        collapsed = {self._feature_with_cyclic_context(), self._feature_with_cyclic_context()}
+        assert len(collapsed) == 1
+
+    def test_features_with_separately_built_cyclic_contexts_compare_equal(self) -> None:
+        assert self._feature_with_cyclic_context() == self._feature_with_cyclic_context()
+
+    def test_features_with_separately_built_cyclic_group_and_context_compare_equal(self) -> None:
+        def build() -> Feature:
+            return Feature(
+                name="x",
+                options=Options(group={"g": _self_referential_list()}, context={"c": _self_referential_dict()}),
+            )
+
+        assert build() == build()
+        assert len({build(), build()}) == 1
+
+    def test_features_with_differing_cyclic_contexts_compare_unequal(self) -> None:
+        def build(marker: int) -> Feature:
+            cyclic: list[Any] = [marker]
+            cyclic.append(cyclic)
+            return Feature(name="x", options=Options(group={"g": 1}, context={"c": cyclic}))
+
+        assert build(1) != build(2)
+
+    def test_features_with_differing_acyclic_contexts_compare_unequal(self) -> None:
+        left = Feature(name="x", options=Options(group={"g": 1}, context={"c": [1, 2]}))
+        right = Feature(name="x", options=Options(group={"g": 1}, context={"c": [1, 3]}))
+
+        assert left != right
+
+    def test_features_with_differing_context_keys_compare_unequal(self) -> None:
+        left = Feature(name="x", options=Options(group={"g": 1}, context={"a": _self_referential_list()}))
+        right = Feature(name="x", options=Options(group={"g": 1}, context={"b": _self_referential_list()}))
+
+        assert left != right
+
+
+class TestCyclicContainerSubclasses:
+    """dict/list subclasses without a custom __eq__ normalize for hashing, so equality must walk them too."""
+
+    def test_options_with_two_cyclic_dict_subclasses_collapse_in_a_set(self) -> None:
+        left = Options(group={"k": _self_referential_dict_subclass()})
+        right = Options(group={"k": _self_referential_dict_subclass()})
+
+        assert len({left, right}) == 1
+        assert left == right
+
+    def test_options_with_two_cyclic_list_subclasses_collapse_in_a_set(self) -> None:
+        left = Options(group={"k": _self_referential_list_subclass()})
+        right = Options(group={"k": _self_referential_list_subclass()})
+
+        assert len({left, right}) == 1
+        assert left == right
+
+    def test_hashable_dict_with_two_cyclic_dict_subclasses_collapse_in_a_set(self) -> None:
+        left = HashableDict({"k": _self_referential_dict_subclass()})
+        right = HashableDict({"k": _self_referential_dict_subclass()})
+
+        assert len({left, right}) == 1
+        assert left == right
+
+    def test_hashable_dict_with_two_cyclic_list_subclasses_collapse_in_a_set(self) -> None:
+        left = HashableDict({"k": _self_referential_list_subclass()})
+        right = HashableDict({"k": _self_referential_list_subclass()})
+
+        assert len({left, right}) == 1
+        assert left == right
+
+    def test_differing_cyclic_list_subclasses_compare_unequal(self) -> None:
+        def build(marker: int) -> _PlainListSubclass:
+            cyclic = _PlainListSubclass([marker])
+            cyclic.append(cyclic)
+            return cyclic
+
+        assert Options(group={"k": build(1)}) != Options(group={"k": build(2)})
+
+    def test_a_list_subclass_with_a_custom_eq_still_decides(self) -> None:
+        class _Subclass(list[Any]):
+            def __eq__(self, other: object) -> bool:
+                return False
+
+        assert Options(group={"k": _Subclass()}) != Options(group={"k": _Subclass()})
+
+    def test_a_dict_subclass_and_a_plain_dict_still_compare_by_value(self) -> None:
+        assert Options(group={"k": _PlainDictSubclass({"a": 1})}) == Options(group={"k": {"a": 1}})
+
+
+_HASH_CONTRACT_PAIRS: list[tuple[str, Callable[[], Any], Callable[[], Any]]] = [
+    ("one_node_vs_two_node_cycle", _self_referential_list, _two_node_cycle),
+    ("two_node_vs_one_node_cycle", _two_node_cycle, _self_referential_list),
+    ("same_shape_self_cycles", _self_referential_list, _self_referential_list),
+    ("same_shape_two_node_cycles", _two_node_cycle, _two_node_cycle),
+    ("same_shape_cyclic_dicts", _self_referential_dict, _self_referential_dict),
+    ("cyclic_dict_vs_cyclic_list", _self_referential_dict, _self_referential_list),
+    ("mutually_referential", _mutually_referential, _mutually_referential),
+    ("mutually_referential_vs_self_cycle", _mutually_referential, _self_referential_list),
+    ("cyclic_dict_subclasses", _self_referential_dict_subclass, _self_referential_dict_subclass),
+    ("cyclic_list_subclasses", _self_referential_list_subclass, _self_referential_list_subclass),
+    ("acyclic_nested", _acyclic_nested, _acyclic_nested),
+    ("acyclic_vs_cyclic", _acyclic_nested, _self_referential_dict),
+]
+
+
+class TestEqualityAgreesWithHashing:
+    """Equality follows the shape-based hasher: a back-reference matches only another back-reference."""
+
+    @pytest.mark.parametrize(
+        ("left_builder", "right_builder"),
+        [pytest.param(left, right, id=name) for name, left, right in _HASH_CONTRACT_PAIRS],
+    )
+    def test_equal_options_hash_alike(self, left_builder: Callable[[], Any], right_builder: Callable[[], Any]) -> None:
+        left = Options(group={"k": left_builder()})
+        right = Options(group={"k": right_builder()})
+
+        if left == right:
+            assert hash(left) == hash(right)
+
+    @pytest.mark.parametrize(
+        ("left_builder", "right_builder"),
+        [pytest.param(left, right, id=name) for name, left, right in _HASH_CONTRACT_PAIRS],
+    )
+    def test_equal_hashable_dicts_hash_alike(
+        self, left_builder: Callable[[], Any], right_builder: Callable[[], Any]
+    ) -> None:
+        left = HashableDict({"k": left_builder()})
+        right = HashableDict({"k": right_builder()})
+
+        if left == right:
+            assert hash(left) == hash(right)
+
+    def test_one_node_and_two_node_cycles_compare_unequal(self) -> None:
+        one_node = _self_referential_list()
+        two_node = _two_node_cycle()
+
+        assert Options(group={"k": one_node}) != Options(group={"k": two_node})
+        assert Options(group={"k": two_node}) != Options(group={"k": one_node})
+
+    def test_one_node_and_two_node_cycles_compare_unequal_for_hashable_dict(self) -> None:
+        one_node = _self_referential_list()
+        two_node = _two_node_cycle()
+
+        assert HashableDict({"k": one_node}) != HashableDict({"k": two_node})
+        assert HashableDict({"k": two_node}) != HashableDict({"k": one_node})
+
+
+class TestAcyclicParityWithPlainEquality:
+    """Cases where the walk must reproduce plain container == exactly."""
+
+    def test_equal_but_not_identical_string_keys_match(self) -> None:
+        left = {"".join(["ab", "cd"]): 1}
+        right = {"".join(["abc", "d"]): 1}
+
+        assert Options(group={"k": left}) == Options(group={"k": right})
+
+    def test_equal_but_not_identical_tuple_keys_match(self) -> None:
+        left = {(1, "".join(["a", "b"])): [1]}
+        right = {(1, "".join(["ab"])): [1]}
+
+        assert Options(group={"k": left}) == Options(group={"k": right})
+
+    def test_same_items_in_different_insertion_orders_compare_equal(self) -> None:
+        assert Options(group={"k": {"a": 1, "b": 2}}) == Options(group={"k": {"b": 2, "a": 1}})
+        assert HashableDict({"a": 1, "b": 2}) == HashableDict({"b": 2, "a": 1})
+
+    def test_true_and_one_keys_collide_as_in_plain_dicts(self) -> None:
+        assert Options(group={"k": {True: "x"}}) == Options(group={"k": {1: "x"}})
+        assert Options(group={"k": {True: "x"}}) != Options(group={"k": {1: "y"}})
+
+    def test_distinct_nan_leaves_compare_unequal(self) -> None:
+        assert Options(group={"k": [float("nan")]}) != Options(group={"k": [float("nan")]})
+        assert Options(group={"k": {"n": float("nan")}}) != Options(group={"k": {"n": float("nan")}})
+
+    def test_the_same_nan_object_compares_equal(self) -> None:
+        nan = float("nan")
+        assert Options(group={"k": [nan]}) == Options(group={"k": [nan]})
+        assert Options(group={"k": {"n": nan}}) == Options(group={"k": {"n": nan}})
+
+    def test_a_non_bool_eq_leaf_raises_as_plain_equality_did(self) -> None:
+        np = pytest.importorskip("numpy")
+
+        with pytest.raises(ValueError):
+            _ = Options(group={"k": [np.array([1, 2])]}) == Options(group={"k": [np.array([1, 2])]})
+
+    def test_a_top_level_non_bool_eq_value_raises_as_plain_equality_did(self) -> None:
+        np = pytest.importorskip("numpy")
+
+        with pytest.raises(ValueError):
+            _ = Options(group={"k": np.array([1, 2])}) == Options(group={"k": np.array([1, 2])})

--- a/tests/test_core/test_core/test_engine_cyclic_options_merge.py
+++ b/tests/test_core/test_core/test_engine_cyclic_options_merge.py
@@ -1,0 +1,97 @@
+"""The default-equivalent merge warning compares declared options, so it must survive cyclic values.
+
+The branch is reached exactly when the feature equality probe matched, which cycle-safe Options
+equality newly makes possible for cyclic group values.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from typing import Any
+
+import pytest
+
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.core.engine import Engine
+
+
+def _self_referential_list() -> list[Any]:
+    cyclic: list[Any] = []
+    cyclic.append(cyclic)
+    return cyclic
+
+
+def _self_referential_dict() -> dict[str, Any]:
+    cyclic: dict[str, Any] = {}
+    cyclic["self"] = cyclic
+    return cyclic
+
+
+def _intake_engine() -> Engine:
+    """An Engine carrying only the intake state add_feature_to_collection reads."""
+    engine = Engine.__new__(Engine)
+    engine.feature_group_collection = defaultdict(set)
+    engine.feature_link_parents = defaultdict(set)
+    engine._intake_options_memo = {}
+    engine._declared_options_by_uuid = {}
+    engine.links = None
+    return engine
+
+
+class TestCyclicOptionsAtIntake:
+    def test_merging_two_features_with_cyclic_group_options_does_not_recurse(self) -> None:
+        engine = _intake_engine()
+        first = Feature(name="x", options=Options(group={"g": _self_referential_list()}))
+        second = Feature(name="x", options=Options(group={"g": _self_referential_list()}))
+
+        assert engine.add_feature_to_collection(FeatureGroup, first, None) is True
+        assert engine.add_feature_to_collection(FeatureGroup, second, None) is False
+
+    def test_merging_two_features_with_cyclic_context_options_does_not_recurse(self) -> None:
+        engine = _intake_engine()
+        first = Feature(name="x", options=Options(group={"g": 1}, context={"c": _self_referential_dict()}))
+        second = Feature(name="x", options=Options(group={"g": 1}, context={"c": _self_referential_dict()}))
+
+        assert engine.add_feature_to_collection(FeatureGroup, first, None) is True
+        assert engine.add_feature_to_collection(FeatureGroup, second, None) is False
+
+    def test_equal_cyclic_declared_options_emit_no_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        engine = _intake_engine()
+        survivor = Feature(name="x", options=Options(group={"g": _self_referential_list()}))
+        arriving = Feature(name="x", options=Options(group={"g": _self_referential_list()}))
+        engine._declared_options_by_uuid[survivor.uuid] = survivor.options
+
+        with caplog.at_level(logging.WARNING, logger="mloda.core.core.engine"):
+            engine._warn_on_default_equivalent_merge(arriving, arriving.options, survivor)
+
+        assert "default-equivalent options" not in caplog.text
+
+    def test_differing_cyclic_declared_options_still_warn(self, caplog: pytest.LogCaptureFixture) -> None:
+        def build(marker: int) -> Options:
+            cyclic: list[Any] = [marker]
+            cyclic.append(cyclic)
+            return Options(group={"g": cyclic})
+
+        engine = _intake_engine()
+        survivor = Feature(name="x", options=build(1))
+        arriving = Feature(name="x", options=build(2))
+        engine._declared_options_by_uuid[survivor.uuid] = survivor.options
+
+        with caplog.at_level(logging.WARNING, logger="mloda.core.core.engine"):
+            engine._warn_on_default_equivalent_merge(arriving, arriving.options, survivor)
+
+        assert "default-equivalent options" in caplog.text
+
+    def test_differing_acyclic_declared_options_still_warn(self, caplog: pytest.LogCaptureFixture) -> None:
+        engine = _intake_engine()
+        survivor = Feature(name="x", options=Options(group={"g": 1}))
+        arriving = Feature(name="x", options=Options(group={"g": 2}))
+        engine._declared_options_by_uuid[survivor.uuid] = survivor.options
+
+        with caplog.at_level(logging.WARNING, logger="mloda.core.core.engine"):
+            engine._warn_on_default_equivalent_merge(arriving, arriving.options, survivor)
+
+        assert "default-equivalent options" in caplog.text

--- a/tests/test_core/test_runtime/test_error_exception_release.py
+++ b/tests/test_core/test_runtime/test_error_exception_release.py
@@ -1,0 +1,107 @@
+"""The error register hands the caught exception over instead of holding it."""
+
+from __future__ import annotations
+
+import gc
+import weakref
+from unittest.mock import Mock
+
+import pytest
+
+from mloda.core.abstract_plugins.components.error_utils import MlodaRunError
+from mloda.core.abstract_plugins.components.parallelization_modes import ParallelizationMode
+from mloda.core.core.cfw_manager import CfwManager
+from mloda.core.prepare.execution_plan import ExecutionPlan
+from mloda.core.runtime.run import ExecutionOrchestrator
+
+
+class _WorkerFailure(RuntimeError):
+    """Stand-in for an exception raised inside a worker step."""
+
+
+def _raise_worker_failure() -> None:
+    raise _WorkerFailure("worker failed")
+
+
+def _register_with_error() -> tuple[CfwManager, _WorkerFailure]:
+    register = CfwManager({ParallelizationMode.SYNC})
+    error = _WorkerFailure("worker failed")
+    register.set_error("worker failed", "formatted traceback", exception=error)
+    return register, error
+
+
+class TestTakeErrorException:
+    def test_take_returns_the_stored_exception(self) -> None:
+        register, error = _register_with_error()
+
+        assert register.take_error_exception() is error
+
+    def test_a_second_take_returns_none(self) -> None:
+        register, _ = _register_with_error()
+
+        register.take_error_exception()
+
+        assert register.take_error_exception() is None
+
+    def test_take_without_an_exception_returns_none(self) -> None:
+        register = CfwManager({ParallelizationMode.SYNC})
+        register.set_error("worker failed", "formatted traceback")
+
+        assert register.take_error_exception() is None
+
+    def test_take_leaves_flag_message_and_exc_info_untouched(self) -> None:
+        register, _ = _register_with_error()
+
+        register.take_error_exception()
+
+        assert register.get_error() is True
+        assert register.get_error_msg() == "worker failed"
+        assert register.get_error_exc_info() == "formatted traceback"
+
+    def test_take_releases_the_exception_for_collection(self) -> None:
+        register = CfwManager({ParallelizationMode.SYNC})
+        with pytest.raises(_WorkerFailure) as excinfo:
+            _raise_worker_failure()
+        register.set_error("worker failed", "formatted traceback", exception=excinfo.value)
+        collected = weakref.ref(excinfo.value)
+
+        taken = register.take_error_exception()
+        assert taken is excinfo.value
+
+        # The taken reference and pytest's ExceptionInfo both pin the traceback, whose frames form
+        # a cycle that only a collect resolves.
+        del taken
+        del excinfo
+        gc.collect()
+        assert collected() is None
+
+
+class TestCheckForErrorRaisePath:
+    def test_the_original_exception_is_still_reraised(self) -> None:
+        orchestrator = ExecutionOrchestrator(Mock(spec=ExecutionPlan))
+        register, error = _register_with_error()
+        orchestrator.cfw_register = register
+
+        with pytest.raises(_WorkerFailure) as excinfo:
+            orchestrator._check_for_error()
+
+        assert excinfo.value is error
+
+    def test_the_register_no_longer_holds_the_exception_after_the_raise(self) -> None:
+        orchestrator = ExecutionOrchestrator(Mock(spec=ExecutionPlan))
+        register, _ = _register_with_error()
+        orchestrator.cfw_register = register
+
+        with pytest.raises(_WorkerFailure):
+            orchestrator._check_for_error()
+
+        assert register.take_error_exception() is None
+
+    def test_an_error_without_an_exception_still_raises_the_typed_fallback(self) -> None:
+        orchestrator = ExecutionOrchestrator(Mock(spec=ExecutionPlan))
+        register = CfwManager({ParallelizationMode.SYNC})
+        register.set_error("critical error_out", "formatted traceback")
+        orchestrator.cfw_register = register
+
+        with pytest.raises(MlodaRunError, match="critical error_out"):
+            orchestrator._check_for_error()

--- a/tests/test_core/test_runtime/test_exception_preservation.py
+++ b/tests/test_core/test_runtime/test_exception_preservation.py
@@ -207,7 +207,7 @@ def test_check_for_error_raises_mloda_run_error_when_no_exception_captured() -> 
     """``_check_for_error`` must raise the typed ``MlodaRunError`` fallback.
 
     When a run reports an error but no original exception object was captured
-    (``get_error_exception()`` returns ``None`` -- e.g. the internal critical
+    (``take_error_exception()`` returns ``None`` -- e.g. the internal critical
     ``error_out`` path), the loop must raise ``MlodaRunError`` rather than a bare
     ``Exception``.
 
@@ -224,7 +224,7 @@ def test_check_for_error_raises_mloda_run_error_when_no_exception_captured() -> 
 
     cfw_register = MagicMock()
     cfw_register.get_error.return_value = True
-    cfw_register.get_error_exception.return_value = None
+    cfw_register.take_error_exception.return_value = None
     cfw_register.get_error_msg.return_value = "critical error_out"
     cfw_register.get_error_exc_info.return_value = "critical error_out"
     orchestrator.cfw_register = cfw_register


### PR DESCRIPTION
Closes #997. Closes #1002.

## Cycle-safe equality

`Options.__eq__` and `HashableDict.__eq__` compared their dicts with plain `==`, which CPython does not cycle-guard, so two separately built self-referential values raised `RecursionError`. Cycle-safe hashing made this reachable: both values now land in the same bucket, so a dict insertion reaches the equality probe.

`_deep_equal` walks `dict`/`list`/`tuple` under a path guard and delegates everything else to plain `==`, so acyclic semantics are unchanged (list vs tuple still differ, leaf `__eq__` still decides, dict keys keep their own hash and `__eq__`).

Two things the guard has to get right, both found in review:

- It carries one path set per side and matches a back-reference only against another back-reference, mirroring how the hasher normalizes a revisited container. A bisimulation-style guard would have called `a = [a]` and `b = [[b]]` equal while the hasher normalizes them by shape and hashes them apart, so equal values would have silently over-split feature groups.
- It gates on the container kind rather than the exact type, and only where the type inherits `dict`/`list`/`tuple` equality. Subclasses were already normalized by the hasher, so leaving them on the unguarded `==` kept the original crash alive for them; a subclass that overrides `__eq__` still decides for itself.

`Feature.__eq__` (whose hash excludes context) and the engine's default-equivalent merge warning compare options with plain `==` too. Both are reached only once the equality probe starts succeeding, so without them the crash moved one frame later instead of going away.

Residual, stated in the code: `set` values, containers whose type overrides `__eq__`, and cycles routed through a nested `Options`/`HashableDict` stay on plain `==`.

Equality now costs about 16 us on a small nested group against 0.24 us for a C-level dict compare. `Options.__hash__` already costs 13.7 us on the same value and runs on every dict/set operation, while equality runs only on hash collision, so the walk sits in the same order as the hashing that already dominates that path.

## Releasing the caught exception

`CfwRegister` stored the caught exception for the lifetime of the register, pinning its traceback and through it a dynamically loaded plugin class, which is what the surrounding log-record containment work exists to prevent. `take_error_exception` replaces the getter and drops the register's reference once the raise site has the object. The error flag and message stay set on purpose, so a later flag read still raises the typed fallback. On the multiprocessing path the exception is pickled into the manager process and arrives without a traceback, so the retention only ever mattered in-process; the comment says so.

## Testing

New tests cover the cyclic cases, the hash-and-equality invariant across a table of cyclic and acyclic pairs, container subclasses, the Feature and engine seams, and acyclic parity with the old plain `==` (equal-but-not-identical keys, insertion order, the `True`/`1` collision, NaN with and without shared identity, and a leaf whose `==` returns a non-bool). `tox` is green: 8410 passed, 170 skipped.