### PR TITLE
fix: resolve compute frameworks by group agreement instead of an arbitrary set representative

### DIFF
--- a/mloda/core/prepare/resolve_compute_frameworks.py
+++ b/mloda/core/prepare/resolve_compute_frameworks.py
@@ -18,20 +18,42 @@ class ResolveComputeFrameworks:
         for p in planned_queue:
             if isinstance(p, tuple):
                 if not isinstance(p[0], Link):
-                    # Filter features carry no trekker entry, so the probe must scan the set.
-                    feature, trekked_links = next(iter(p[1])), []
-                    for candidate in p[1]:
-                        trekked_links = self.access_link_by_child_uuid(candidate.uuid, link_trekker)
-                        if trekked_links:
-                            feature = candidate
-                            break
-                    if trekked_links:
-                        new_compute_frameworks = self.resolve_trekked_links(trekked_links, feature.compute_frameworks)
-                        for f in p[1]:
-                            f.compute_frameworks = set(new_compute_frameworks)
+                    trekker_members: dict[LinkFrameworkTrekker, list[Any]] = defaultdict(list)
+                    feature_trekkers: dict[UUID, list[LinkFrameworkTrekker]] = defaultdict(list)
+                    for f in p[1]:
+                        for trekker in self.access_link_by_child_uuid(f.uuid, link_trekker):
+                            trekker_members[trekker].append(f)
+                            feature_trekkers[f.uuid].append(trekker)
 
-                        self.trekker_right_left_adjuster(link_trekker, {_f.uuid for _f in p[1]})
+                    resolved: dict[LinkFrameworkTrekker, type[ComputeFramework]] = {}
+                    for trekker, members in trekker_members.items():
+                        resolved_cfw = self.resolve_trekker_for_group(trekker, members)
+                        if resolved_cfw is not None:
+                            resolved[trekker] = resolved_cfw
+                        # Adjust immediately so inversions collected for this trekker apply only to its sharing members.
+                        self.trekker_right_left_adjuster(link_trekker, {m.uuid for m in members})
 
+                    group_cfws = set(resolved.values())
+                    any_rewritten = False
+                    for f in p[1]:
+                        if f.uuid not in feature_trekkers:
+                            if group_cfws:
+                                f.compute_frameworks = set(group_cfws)
+                                any_rewritten = True
+                            continue
+                        new_cfws = {resolved[trekker] for trekker in feature_trekkers[f.uuid] if trekker in resolved}
+                        if not new_cfws:
+                            mismatches = sorted(
+                                f"{link}: neither {left.__name__} nor {right.__name__}"
+                                for link, left, right in feature_trekkers[f.uuid]
+                            )
+                            raise ValueError(
+                                f"No compute framework agreement for feature {f.name}. Unresolvable links: {mismatches}"
+                            )
+                        f.compute_frameworks = new_cfws
+                        any_rewritten = True
+
+                    if any_rewritten:
                         # Rehash via list so hashes are recomputed (set(p[1]) reuses stale ones), keeping set and aliases valid.
                         members = list(p[1])
                         p[1].clear()
@@ -127,35 +149,30 @@ class ResolveComputeFrameworks:
 
         self.to_invert_trekker_collection = []
 
-    def resolve_trekked_links(
-        self, trekked_links: list[LinkFrameworkTrekker], compute_frameworks: set[type[ComputeFramework]]
-    ) -> set[type[ComputeFramework]]:
-        new_cfws = set()
+    def resolve_trekker_for_group(
+        self, trekker: LinkFrameworkTrekker, members: list[Any]
+    ) -> type[ComputeFramework] | None:
+        link, left_cfw, right_cfw = trekker
 
-        for link, left_cfw, right_cfw in trekked_links:
-            if link.jointype == JoinType.RIGHT:
-                if right_cfw in compute_frameworks:
-                    new_cfws.add(right_cfw)
-                elif left_cfw in compute_frameworks:
-                    new_cfws.add(right_cfw)
-                    self.to_invert_trekker_collection.append((link, left_cfw, right_cfw))
-                continue
+        left_in_all = all(left_cfw in m.compute_frameworks for m in members)
+        right_in_all = all(right_cfw in m.compute_frameworks for m in members)
 
-            if link.jointype in JoinType:
-                if left_cfw in compute_frameworks and right_cfw in compute_frameworks:
-                    # We keep the left framework if possible. This can be dropped maybe later with more tests.
-                    new_cfws.add(left_cfw)
-                elif left_cfw in compute_frameworks:
-                    new_cfws.add(left_cfw)
-                elif right_cfw in compute_frameworks:
-                    new_cfws.add(right_cfw)
-                    self.to_invert_trekker_collection.append((link, left_cfw, right_cfw))
-                continue
+        if link.jointype == JoinType.RIGHT:
+            if right_in_all:
+                return right_cfw
+            if left_in_all:
+                self.to_invert_trekker_collection.append(trekker)
+                return right_cfw
+            return None
 
-            raise ValueError(
-                f"This jointype is not implemented: {link.jointype}. Possible types are: {[member.value for member in JoinType]}"
-            )
+        if link.jointype in JoinType:
+            if left_in_all:
+                return left_cfw
+            if right_in_all:
+                self.to_invert_trekker_collection.append(trekker)
+                return right_cfw
+            return None
 
-        if not new_cfws:
-            raise ValueError("No new compute frameworks have been found.")
-        return new_cfws
+        raise ValueError(
+            f"This jointype is not implemented: {link.jointype}. Possible types are: {[member.value for member in JoinType]}"
+        )

--- a/tests/test_core/test_abstract_plugins/test_eq_notimplemented.py
+++ b/tests/test_core/test_abstract_plugins/test_eq_notimplemented.py
@@ -14,6 +14,9 @@ from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.domain import Domain
 from mloda.core.abstract_plugins.components.options import Options
 
+# Docs enumeration source-hashes every FeatureGroup subclass; a cold cache under xdist load can exceed the default timeout.
+pytestmark = pytest.mark.timeout(30)
+
 
 class _EqTestFeatureGroup(FeatureGroup):
     """Concrete FeatureGroup subclass for __eq__ testing.

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_api_input_data_feature_registration.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_api_input_data_feature_registration.py
@@ -26,6 +26,9 @@ from mloda.provider import ApiInputDataFeature
 from mloda.user import PluginLoader, mloda
 from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
 
+# Docs enumeration source-hashes every FeatureGroup subclass; a cold cache under xdist load can exceed the default timeout.
+pytestmark = pytest.mark.timeout(30)
+
 ENV_VAR = "MLODA_PLUGIN_REGISTRY_STRICT"
 
 API_KEY = "ApiInputRegistryProbeSource"

--- a/tests/test_core/test_abstract_plugins/test_plugin_registry/test_docs_enumeration.py
+++ b/tests/test_core/test_abstract_plugins/test_plugin_registry/test_docs_enumeration.py
@@ -33,6 +33,9 @@ from mloda.core.api.plugin_docs import (
     get_feature_group_docs,
 )
 
+# Docs enumeration source-hashes every FeatureGroup subclass; a cold cache under xdist load can exceed the default timeout.
+pytestmark = pytest.mark.timeout(30)
+
 
 @pytest.fixture(autouse=True)
 def _reap_pending_dead_plugin_classes() -> None:

--- a/tests/test_core/test_api/test_plugin_docs.py
+++ b/tests/test_core/test_api/test_plugin_docs.py
@@ -19,6 +19,9 @@ from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.user import PluginLoader
 
+# Docs enumeration source-hashes every FeatureGroup subclass; a cold cache under xdist load can exceed the default timeout.
+pytestmark = pytest.mark.timeout(30)
+
 SAFE_FIELD_LOGGER = "mloda.core.abstract_plugins.components.utils"
 
 

--- a/tests/test_core/test_api/test_subtype_docs.py
+++ b/tests/test_core/test_api/test_subtype_docs.py
@@ -18,6 +18,9 @@ from mloda_plugins.compute_framework.base_implementations.python_dict.python_dic
     PythonDictFramework,
 )
 
+# Docs enumeration source-hashes every FeatureGroup subclass; a cold cache under xdist load can exceed the default timeout.
+pytestmark = pytest.mark.timeout(30)
+
 
 WINDOW_KEY = "sbdd_window_function"
 WINDOW_UNIVERSE = frozenset({"median", "sum", "lag"})

--- a/tests/test_core/test_api/test_subtype_docs_degradation.py
+++ b/tests/test_core/test_api/test_subtype_docs_degradation.py
@@ -23,6 +23,9 @@ from mloda_plugins.compute_framework.base_implementations.python_dict.python_dic
     PythonDictFramework,
 )
 
+# Docs enumeration source-hashes every FeatureGroup subclass; a cold cache under xdist load can exceed the default timeout.
+pytestmark = pytest.mark.timeout(30)
+
 
 SBFIX_HOOK_FEATURE = "sbfix_raising_hook_feature"
 SBFIX_DOC_KEY = "sbfixdoc_kind"

--- a/tests/test_core/test_prepare/test_feature_group_dedup.py
+++ b/tests/test_core/test_prepare/test_feature_group_dedup.py
@@ -39,6 +39,9 @@ from mloda.core.prepare.accessible_plugins import (
 from mloda.core.prepare.resolution_types import ResolutionDiagnosis
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 
+# Docs enumeration source-hashes every FeatureGroup subclass; a cold cache under xdist load can exceed the default timeout.
+pytestmark = pytest.mark.timeout(30)
+
 
 # Module-level reference store. This simulates IPython's ``_oh``/``Out[N]`` history,
 # which keeps strong refs to all cell-evaluated objects. It MUST be module-scoped so

--- a/tests/test_core/test_prepare/test_resolve_cfw_per_feature.py
+++ b/tests/test_core/test_prepare/test_resolve_cfw_per_feature.py
@@ -1,0 +1,121 @@
+"""Group agreement per trekked link in ResolveComputeFrameworks.links."""
+
+from typing import Any
+from uuid import UUID
+
+import pytest
+
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.link import JoinSpec, Link
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.prepare.graph.graph import Graph
+from mloda.core.prepare.resolve_compute_frameworks import ResolveComputeFrameworks
+from mloda.core.prepare.resolve_links import LinkTrekker
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+
+
+class CfwPerFeatureLeftFG(FeatureGroup):
+    pass
+
+
+class CfwPerFeatureRightFG(FeatureGroup):
+    pass
+
+
+def _make_trekker(trekked_uuids: set[UUID]) -> tuple[LinkTrekker, Any]:
+    link = Link.inner(JoinSpec(CfwPerFeatureLeftFG, "idx"), JoinSpec(CfwPerFeatureRightFG, "idx"))
+    trekker = (link, PandasDataFrame, PyArrowTable)
+
+    link_trekker = LinkTrekker()
+    link_trekker.data[trekker] = set(trekked_uuids)
+    link_trekker.data_ordered[trekker] = set(trekked_uuids)
+    return link_trekker, trekker
+
+
+def _resolve_two_feature_scenario() -> tuple[Feature, Feature, LinkTrekker, Any]:
+    """Both uuids trekked; feature_both holds both frameworks, feature_right only the right one."""
+    feature_both = Feature("feature_both")
+    feature_right = Feature("feature_right")
+    feature_both.compute_frameworks = {PandasDataFrame, PyArrowTable}
+    feature_right.compute_frameworks = {PyArrowTable}
+
+    link_trekker, trekker = _make_trekker({feature_both.uuid, feature_right.uuid})
+    planned_queue: list[Any] = [(CfwPerFeatureLeftFG, {feature_both, feature_right})]
+
+    ResolveComputeFrameworks(Graph()).links(planned_queue, link_trekker)
+    return feature_both, feature_right, link_trekker, trekker
+
+
+def test_group_agrees_on_right_when_left_is_not_shared_by_all() -> None:
+    feature_both, feature_right, _, _ = _resolve_two_feature_scenario()
+
+    assert feature_both.compute_frameworks == {PyArrowTable}
+    assert feature_right.compute_frameworks == {PyArrowTable}
+
+
+def test_inversion_is_all_or_nothing() -> None:
+    feature_both, feature_right, link_trekker, trekker = _resolve_two_feature_scenario()
+    link = trekker[0]
+    inverted = (link, PyArrowTable, PandasDataFrame)
+
+    assert trekker not in link_trekker.data_ordered
+    assert inverted in link_trekker.data_ordered
+    assert feature_both.uuid in link_trekker.data_ordered[inverted]
+    assert feature_right.uuid in link_trekker.data_ordered[inverted]
+
+
+def test_group_agrees_on_left_when_all_support_left() -> None:
+    feature_both = Feature("feature_both")
+    feature_left = Feature("feature_left")
+    feature_both.compute_frameworks = {PandasDataFrame, PyArrowTable}
+    feature_left.compute_frameworks = {PandasDataFrame}
+
+    link_trekker, trekker = _make_trekker({feature_both.uuid, feature_left.uuid})
+    planned_queue: list[Any] = [(CfwPerFeatureLeftFG, {feature_both, feature_left})]
+
+    ResolveComputeFrameworks(Graph()).links(planned_queue, link_trekker)
+
+    assert feature_both.compute_frameworks == {PandasDataFrame}
+    assert feature_left.compute_frameworks == {PandasDataFrame}
+
+    link = trekker[0]
+    inverted = (link, PyArrowTable, PandasDataFrame)
+    assert inverted not in link_trekker.data_ordered
+    assert link_trekker.data_ordered[trekker] == {feature_both.uuid, feature_left.uuid}
+
+
+def test_untrekked_feature_follows_group_rewrite() -> None:
+    feature_trekked = Feature("feature_trekked")
+    feature_free = Feature("feature_free")
+    feature_trekked.compute_frameworks = {PandasDataFrame}
+    feature_free.compute_frameworks = {PandasDataFrame, PyArrowTable}
+
+    link_trekker, _ = _make_trekker({feature_trekked.uuid})
+    planned_queue: list[Any] = [(CfwPerFeatureLeftFG, {feature_trekked, feature_free})]
+
+    ResolveComputeFrameworks(Graph()).links(planned_queue, link_trekker)
+
+    assert feature_trekked.compute_frameworks == {PandasDataFrame}
+    assert feature_free.compute_frameworks == {PandasDataFrame}
+
+
+def test_incompatible_members_raise_at_planning_time() -> None:
+    feature_left_only = Feature("feature_left_only")
+    feature_right_only = Feature("feature_right_only")
+    feature_left_only.compute_frameworks = {PandasDataFrame}
+    feature_right_only.compute_frameworks = {PyArrowTable}
+
+    link_trekker, _ = _make_trekker({feature_left_only.uuid, feature_right_only.uuid})
+    planned_queue: list[Any] = [(CfwPerFeatureLeftFG, {feature_left_only, feature_right_only})]
+
+    with pytest.raises(ValueError):
+        ResolveComputeFrameworks(Graph()).links(planned_queue, link_trekker)
+
+
+def test_resolution_is_deterministic_across_fresh_inputs() -> None:
+    for _ in range(20):
+        feature_both, feature_right, link_trekker, trekker = _resolve_two_feature_scenario()
+        assert feature_both.compute_frameworks == {PyArrowTable}
+        assert feature_right.compute_frameworks == {PyArrowTable}
+        assert trekker not in link_trekker.data_ordered


### PR DESCRIPTION
## Summary

`ResolveComputeFrameworks.links` picked an arbitrary set member (`next(iter(p[1]))`) as the representative: its uuid selected the trekked links and its `compute_frameworks` seeded the resolution, and the result was written to every feature in the group. With differing member framework sets the outcome depended on set iteration order.

Resolution now works by group agreement per trekked link:

- For each link shared by a group's members, the kept orientation is used when every sharing member supports it; otherwise the inverted orientation is used when every sharing member supports that, and all sharing uuids invert together (no mixed orientation state, which the execution plan cannot run).
- A link where neither orientation is supported by all sharing members contributes nothing, matching the existing chained-join behavior; a trekked feature left with no resolved framework raises a deterministic planning-time error naming the unresolvable links.
- Members with no trekked links (for example filter features) follow the group rewrite and receive the union of the group's resolved frameworks, so stored filters stay usable; groups where no member is trekked stay untouched.
- The rehash and collapse guard after the rewrite is unchanged.

Also raises the pytest timeout to 30s for the docs enumeration test modules: source-hashing every FeatureGroup subclass with a cold cache under xdist load can exceed the default 10s and flaked twice locally.

## Testing

- New tests in `tests/test_core/test_prepare/test_resolve_cfw_per_feature.py`: group agreement on left and on right, all-or-nothing inversion, untrekked members following the group rewrite, incompatible members raise, determinism over repeated fresh inputs.
- Rebased on current main; the stranded-filter runtime test introduced there passes under the new semantics.
- Full `tox` gate green (pytest, ruff, licenses, mypy strict, bandit).

## Review

Two independent review passes ran on the diff. The first flagged that pure per-feature resolution creates mixed link orientations the planned queue cannot execute; the design was revised to group agreement in response. Remaining findings were triaged as pre-existing behavior (silently skipped non-matching links for chained joins) or established practice (per-test timeout overrides).

Fixes #981
