### PR TITLE
fix: thread the deep cycle guards through a nested Options/HashableDict

### DIFF
--- a/mloda/core/abstract_plugins/components/feature.py
+++ b/mloda/core/abstract_plugins/components/feature.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 
 from mloda.core.abstract_plugins.components.domain import Domain
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
-from mloda.core.abstract_plugins.components.hashable_dict import _CYCLE, _deep_equal, _deep_hashable
+from mloda.core.abstract_plugins.components.hashable_dict import _CYCLE, HashableDict, _deep_equal, _deep_hashable
 from mloda.core.abstract_plugins.components.index.index import Index
 from mloda.core.abstract_plugins.components.link import Link
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
@@ -408,6 +408,9 @@ class Feature:
             )
         if isinstance(value, Options):
             return ("options", Feature._reduce(value.group, seen))
+        if isinstance(value, HashableDict):
+            # _reduce's output is an equality key, so a node keeps its type tag here.
+            return ("hashable_dict", Feature._reduce(value.data, seen))
         if isinstance(value, (dict, list, tuple, frozenset, set)):
             # _reduce handles containers itself, so it needs the same cycle guard as _deep_hashable.
             if id(value) in seen:

--- a/mloda/core/abstract_plugins/components/hashable_dict.py
+++ b/mloda/core/abstract_plugins/components/hashable_dict.py
@@ -1,4 +1,5 @@
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 from mloda.core.abstract_plugins.components.utils import unhashable_part
 
@@ -24,22 +25,35 @@ class _CycleMarker:
 
 # A cyclic value hashes instead of raising RecursionError. Mirrors the id() visited guard in
 # Feature._reduce. _deep_equal mirrors this normalization for the == that such a collision reaches;
-# residual: set values and containers whose type overrides __eq__ are still plain ==.
+# residual: set values and containers whose type overrides __eq__ (including subclasses of a
+# registered node) fall back to plain == and reset the path. A cycle routed through a nested Feature
+# also resets the path and still raises RecursionError: Feature equality reads more fields than a
+# dict target can express, so it is not a registered node and carries its own guard in _reduce.
 _CYCLE = _CycleMarker()
 
 # Nodes (Options, HashableDict) register themselves here: hashable_dict cannot import options,
 # since options imports it.
-_NODE_KINDS: list[tuple[type, Callable[[Any], dict[Any, Any]]]] = []
+_NODE_KINDS: dict[type, Callable[[Any], dict[Any, Any]]] = {}
+_NODE_TYPES: tuple[type, ...] = ()
 
 
 def register_deep_node(kind: type, target: Callable[[Any], dict[Any, Any]]) -> None:
-    """Values of ``kind`` are walked into via ``target``, so the visited path survives the nesting."""
-    _NODE_KINDS.append((kind, target))
+    """Values of ``kind`` are walked into via ``target``, so the visited path survives the nesting.
+
+    ``target`` must return the same dict object on every call for the same value: termination
+    depends on that dict's id landing in the visited path, and a rebuilt dict recurses unbounded.
+    Re-registering a kind replaces its entry.
+    """
+    global _NODE_TYPES
+    _NODE_KINDS[kind] = target
+    _NODE_TYPES = tuple(_NODE_KINDS)
 
 
 def _node_target(value: Any, dunder: str) -> tuple[type, dict[Any, Any]] | None:
     """The registered kind and the dict it is walked as, or None when its own dunder must decide."""
-    for kind, target in _NODE_KINDS:
+    if not isinstance(value, _NODE_TYPES):
+        return None
+    for kind, target in _NODE_KINDS.items():
         if isinstance(value, kind) and getattr(type(value), dunder) is getattr(kind, dunder):
             return kind, target(value)
     return None
@@ -99,15 +113,18 @@ def _deep_equal(a: Any, b: Any) -> bool:
 
 
 def _walk_equal(a: Any, b: Any, path_a: set[int], path_b: set[int]) -> bool:
-    node_a = _node_target(a, "__eq__")
-    if node_a is not None:
-        node_b = _node_target(b, "__eq__")
-        # Only matching kinds are walked; a differing or absent node keeps its own type identity.
-        if node_b is not None and node_b[0] is node_a[0]:
-            return _walk_equal(node_a[1], node_b[1], path_a, path_b)
-        return a is b or bool(a == b)
+    # _container_kind's exact-type fast path runs first; no registered kind is a dict/list/tuple
+    # subclass, so consulting the node registry only when it finds nothing is equivalent.
     kind = _container_kind(a)
-    if kind is None or _container_kind(b) is not kind:
+    if kind is None:
+        node_a = _node_target(a, "__eq__")
+        if node_a is not None:
+            node_b = _node_target(b, "__eq__")
+            # Only matching kinds are walked; a differing or absent node keeps its own type identity.
+            if node_b is not None and node_b[0] is node_a[0]:
+                return _walk_equal(node_a[1], node_b[1], path_a, path_b)
+        return a is b or bool(a == b)
+    if _container_kind(b) is not kind:
         return a is b or bool(a == b)
     on_a, on_b = id(a) in path_a, id(b) in path_b
     if on_a or on_b:

--- a/mloda/core/abstract_plugins/components/hashable_dict.py
+++ b/mloda/core/abstract_plugins/components/hashable_dict.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Callable
 
 from mloda.core.abstract_plugins.components.utils import unhashable_part
 
@@ -24,9 +24,25 @@ class _CycleMarker:
 
 # A cyclic value hashes instead of raising RecursionError. Mirrors the id() visited guard in
 # Feature._reduce. _deep_equal mirrors this normalization for the == that such a collision reaches;
-# residual: set values, containers whose type overrides __eq__, and cycles routed through a nested
-# Options/HashableDict (where the path resets) are still plain ==.
+# residual: set values and containers whose type overrides __eq__ are still plain ==.
 _CYCLE = _CycleMarker()
+
+# Nodes (Options, HashableDict) register themselves here: hashable_dict cannot import options,
+# since options imports it.
+_NODE_KINDS: list[tuple[type, Callable[[Any], dict[Any, Any]]]] = []
+
+
+def register_deep_node(kind: type, target: Callable[[Any], dict[Any, Any]]) -> None:
+    """Values of ``kind`` are walked into via ``target``, so the visited path survives the nesting."""
+    _NODE_KINDS.append((kind, target))
+
+
+def _node_target(value: Any, dunder: str) -> tuple[type, dict[Any, Any]] | None:
+    """The registered kind and the dict it is walked as, or None when its own dunder must decide."""
+    for kind, target in _NODE_KINDS:
+        if isinstance(value, kind) and getattr(type(value), dunder) is getattr(kind, dunder):
+            return kind, target(value)
+    return None
 
 
 def _deep_hashable(value: Any, seen: frozenset[int] = frozenset()) -> Any:
@@ -48,6 +64,11 @@ def _deep_hashable(value: Any, seen: frozenset[int] = frozenset()) -> Any:
         return tuple(_deep_hashable(item, seen) for item in value)
     if isinstance(value, set):
         return frozenset(_deep_hashable(item, seen) for item in value)
+    # A node normalizes to the same shape as its plain dict: collisions between unequal values are
+    # legal, and not tagging the type keeps hash consistent with equality for inherited dunders.
+    node = _node_target(value, "__hash__")
+    if node is not None:
+        return _deep_hashable(node[1], seen)
     # A leaf whose hash raises TypeError is coerced to repr so grouping never crashes; any other raise
     # propagates. filter_parameter rejects broadly instead.
     # Residual constraint: two values that are __eq__-equal but unhashable must have
@@ -78,6 +99,13 @@ def _deep_equal(a: Any, b: Any) -> bool:
 
 
 def _walk_equal(a: Any, b: Any, path_a: set[int], path_b: set[int]) -> bool:
+    node_a = _node_target(a, "__eq__")
+    if node_a is not None:
+        node_b = _node_target(b, "__eq__")
+        # Only matching kinds are walked; a differing or absent node keeps its own type identity.
+        if node_b is not None and node_b[0] is node_a[0]:
+            return _walk_equal(node_a[1], node_b[1], path_a, path_b)
+        return a is b or bool(a == b)
     kind = _container_kind(a)
     if kind is None or _container_kind(b) is not kind:
         return a is b or bool(a == b)
@@ -113,3 +141,6 @@ class HashableDict:
 
     def items(self) -> Any:
         return self.data.items()
+
+
+register_deep_node(HashableDict, lambda node: node.data)

--- a/mloda/core/abstract_plugins/components/options.py
+++ b/mloda/core/abstract_plugins/components/options.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any, Optional, TYPE_CHECKING, cast
 from copy import deepcopy
 
-from mloda.core.abstract_plugins.components.hashable_dict import _deep_equal, _deep_hashable
+from mloda.core.abstract_plugins.components.hashable_dict import _deep_equal, _deep_hashable, register_deep_node
 from mloda.core.abstract_plugins.components.validators.options_validator import OptionsValidator
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
 
@@ -440,3 +440,7 @@ class Options:
         self.last_forwarded_group_keys = frozenset(inherited)
         self.inherited_context_keys = self.inherited_context_keys | frozenset(inherited_context)
         return frozenset(inherited)
+
+
+# group only: equality and hashing ignore context.
+register_deep_node(Options, lambda node: node.group)

--- a/tests/test_core/test_abstract_plugins/test_components/test_nested_options_cycle_guard.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_nested_options_cycle_guard.py
@@ -1,0 +1,144 @@
+"""Cycle guards must thread through nested Options/HashableDict values instead of restarting there."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mloda.core.abstract_plugins.components.hashable_dict import HashableDict
+from mloda.core.abstract_plugins.components.options import Options
+
+
+def _options_cycle(marker: Any = None) -> Options:
+    inner: dict[str, Any] = {}
+    options = Options(group={"n": inner})
+    # Back-reference first: the walk must survive it before it ever reaches the marker.
+    inner["back"] = options
+    inner["marker"] = marker
+    return options
+
+
+def _hashable_dict_cycle(marker: Any = None) -> HashableDict:
+    inner: dict[str, Any] = {}
+    hashable = HashableDict({"n": inner})
+    inner["back"] = hashable
+    inner["marker"] = marker
+    return hashable
+
+
+def _cycle_through_nested_hashable_dict(marker: Any = None) -> Options:
+    return Options(group={"k": _hashable_dict_cycle(marker)})
+
+
+def _hashable_dict_cycle_via_options(marker: Any = None) -> HashableDict:
+    inner: dict[str, Any] = {}
+    hashable = HashableDict({"n": inner})
+    inner["back"] = Options(group={"o": hashable})
+    inner["marker"] = marker
+    return hashable
+
+
+def _acyclic_unrolled(marker: Any = None) -> Options:
+    """Same keys and lengths as _options_cycle, but the back-reference terminates."""
+    leaf = Options(group={"n": {"back": None, "marker": marker}})
+    return Options(group={"n": {"back": leaf, "marker": marker}})
+
+
+class TestHashingSurvivesCyclesThroughNestedNodes:
+    def test_cycle_through_a_nested_options_hashes(self) -> None:
+        assert isinstance(hash(_options_cycle()), int)
+
+    def test_cycle_through_a_nested_hashable_dict_hashes(self) -> None:
+        assert isinstance(hash(_cycle_through_nested_hashable_dict()), int)
+
+    def test_hashable_dict_cycle_hashes(self) -> None:
+        assert isinstance(hash(_hashable_dict_cycle()), int)
+
+    def test_hashable_dict_cycle_routed_through_options_hashes(self) -> None:
+        assert isinstance(hash(_hashable_dict_cycle_via_options()), int)
+
+    def test_hash_is_stable_across_repeated_calls(self) -> None:
+        options = _options_cycle()
+        assert hash(options) == hash(options)
+
+    def test_hashable_dict_hash_is_stable_across_repeated_calls(self) -> None:
+        hashable = _hashable_dict_cycle()
+        assert hash(hashable) == hash(hashable)
+
+    def test_structurally_identical_option_cycles_hash_equal(self) -> None:
+        assert hash(_options_cycle()) == hash(_options_cycle())
+
+    def test_structurally_identical_hashable_dict_cycles_hash_equal(self) -> None:
+        assert hash(_hashable_dict_cycle()) == hash(_hashable_dict_cycle())
+
+    def test_structurally_identical_mixed_cycles_hash_equal(self) -> None:
+        assert hash(_cycle_through_nested_hashable_dict()) == hash(_cycle_through_nested_hashable_dict())
+
+
+class TestEqualityAcrossNestedNodeCycles:
+    def test_independently_built_option_cycles_compare_equal(self) -> None:
+        assert _options_cycle() == _options_cycle()
+
+    def test_independently_built_hashable_dict_cycles_compare_equal(self) -> None:
+        assert _hashable_dict_cycle() == _hashable_dict_cycle()
+
+    def test_independently_built_mixed_cycles_compare_equal(self) -> None:
+        assert _cycle_through_nested_hashable_dict() == _cycle_through_nested_hashable_dict()
+
+    def test_equal_option_cycles_collapse_in_a_set(self) -> None:
+        assert len({_options_cycle(), _options_cycle()}) == 1
+
+    def test_equal_hashable_dict_cycles_collapse_in_a_set(self) -> None:
+        assert len({_hashable_dict_cycle(), _hashable_dict_cycle()}) == 1
+
+    def test_differing_markers_in_option_cycles_compare_unequal(self) -> None:
+        assert _options_cycle(1) != _options_cycle(2)
+
+    def test_differing_markers_in_hashable_dict_cycles_compare_unequal(self) -> None:
+        assert _hashable_dict_cycle(1) != _hashable_dict_cycle(2)
+
+    def test_a_cycle_does_not_equal_the_acyclic_unrolling(self) -> None:
+        assert _options_cycle() != _acyclic_unrolled()
+        assert _acyclic_unrolled() != _options_cycle()
+
+
+class TestNestedNodeTypeIdentityPreserved:
+    def test_a_nested_options_is_not_equal_to_a_plain_dict(self) -> None:
+        assert Options(group={"k": Options(group={"a": 1})}) != Options(group={"k": {"a": 1}})
+        assert Options(group={"k": {"a": 1}}) != Options(group={"k": Options(group={"a": 1})})
+
+    def test_a_nested_options_is_not_equal_to_a_hashable_dict(self) -> None:
+        assert Options(group={"k": Options(group={"a": 1})}) != Options(group={"k": HashableDict({"a": 1})})
+        assert Options(group={"k": HashableDict({"a": 1})}) != Options(group={"k": Options(group={"a": 1})})
+
+    def test_a_nested_hashable_dict_is_not_equal_to_a_plain_dict(self) -> None:
+        assert Options(group={"k": HashableDict({"a": 1})}) != Options(group={"k": {"a": 1}})
+        assert HashableDict({"k": HashableDict({"a": 1})}) != HashableDict({"k": {"a": 1}})
+
+
+class TestAcyclicNestedNodesUnchanged:
+    def test_equal_nested_options_compare_equal_and_hash_alike(self) -> None:
+        left = Options(group={"k": Options(group={"a": [1, {"b": 2}]})})
+        right = Options(group={"k": Options(group={"a": [1, {"b": 2}]})})
+
+        assert left == right
+        assert hash(left) == hash(right)
+
+    def test_differing_nested_options_compare_unequal(self) -> None:
+        assert Options(group={"k": Options(group={"a": 1})}) != Options(group={"k": Options(group={"a": 2})})
+
+    def test_equal_nested_hashable_dicts_compare_equal_and_hash_alike(self) -> None:
+        left = HashableDict({"k": HashableDict({"a": [1, {"b": 2}]})})
+        right = HashableDict({"k": HashableDict({"a": [1, {"b": 2}]})})
+
+        assert left == right
+        assert hash(left) == hash(right)
+
+    def test_differing_nested_hashable_dicts_compare_unequal(self) -> None:
+        assert HashableDict({"k": HashableDict({"a": 1})}) != HashableDict({"k": HashableDict({"a": 2})})
+
+    def test_nested_options_context_is_still_ignored(self) -> None:
+        left = Options(group={"k": Options(group={"a": 1}, context={"c": "left"})})
+        right = Options(group={"k": Options(group={"a": 1}, context={"c": "right"})})
+
+        assert left == right
+        assert hash(left) == hash(right)

--- a/tests/test_core/test_abstract_plugins/test_components/test_nested_options_cycle_guard.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_nested_options_cycle_guard.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.hashable_dict import HashableDict
 from mloda.core.abstract_plugins.components.options import Options
 
@@ -35,6 +36,40 @@ def _hashable_dict_cycle_via_options(marker: Any = None) -> HashableDict:
     inner["back"] = Options(group={"o": hashable})
     inner["marker"] = marker
     return hashable
+
+
+def _feature_with_child_option(value: Any) -> Feature:
+    feature = Feature(name="y", options={})
+    feature.child_options = Options(group={"k": value})
+    return feature
+
+
+class InheritingOptions(Options):
+    """Subclass adding nothing: both dunders stay Options'."""
+
+
+class InheritingHashableDict(HashableDict):
+    """Subclass adding nothing: both dunders stay HashableDict's."""
+
+
+class DisagreeingOptions(Options):
+    """Subclass whose own __eq__ refuses every comparison."""
+
+    def __eq__(self, other: object) -> bool:
+        return False
+
+    def __hash__(self) -> int:
+        return Options.__hash__(self)
+
+
+class DisagreeingHashableDict(HashableDict):
+    """Subclass whose own __eq__ refuses every comparison."""
+
+    def __eq__(self, other: object) -> bool:
+        return False
+
+    def __hash__(self) -> int:
+        return HashableDict.__hash__(self)
 
 
 def _acyclic_unrolled(marker: Any = None) -> Options:
@@ -142,3 +177,78 @@ class TestAcyclicNestedNodesUnchanged:
 
         assert left == right
         assert hash(left) == hash(right)
+
+
+class TestChildOptionsKeepsNestedNodeTypeIdentity:
+    def test_a_hashable_dict_child_option_is_not_equal_to_a_plain_dict(self) -> None:
+        assert _feature_with_child_option(HashableDict({"a": 1})) != _feature_with_child_option({"a": 1})
+        assert _feature_with_child_option({"a": 1}) != _feature_with_child_option(HashableDict({"a": 1}))
+
+    def test_a_hashable_dict_and_a_plain_dict_child_option_do_not_collapse_in_a_set(self) -> None:
+        features = {_feature_with_child_option(HashableDict({"a": 1})), _feature_with_child_option({"a": 1})}
+        assert len(features) == 2
+
+    def test_an_options_child_option_is_not_equal_to_a_plain_dict(self) -> None:
+        assert _feature_with_child_option(Options(group={"a": 1})) != _feature_with_child_option({"a": 1})
+        assert _feature_with_child_option({"a": 1}) != _feature_with_child_option(Options(group={"a": 1}))
+
+    def test_an_options_child_option_is_not_equal_to_a_hashable_dict(self) -> None:
+        assert _feature_with_child_option(Options(group={"a": 1})) != _feature_with_child_option(HashableDict({"a": 1}))
+        assert _feature_with_child_option(HashableDict({"a": 1})) != _feature_with_child_option(Options(group={"a": 1}))
+
+    def test_an_options_and_a_hashable_dict_child_option_do_not_collapse_in_a_set(self) -> None:
+        features = {
+            _feature_with_child_option(Options(group={"a": 1})),
+            _feature_with_child_option(HashableDict({"a": 1})),
+        }
+        assert len(features) == 2
+
+    def test_equal_hashable_dict_child_options_compare_equal_and_hash_alike(self) -> None:
+        left = _feature_with_child_option(HashableDict({"a": [1, {"b": 2}]}))
+        right = _feature_with_child_option(HashableDict({"a": [1, {"b": 2}]}))
+
+        assert left == right
+        assert hash(left) == hash(right)
+
+    def test_differing_hashable_dict_child_options_compare_unequal(self) -> None:
+        assert _feature_with_child_option(HashableDict({"a": 1})) != _feature_with_child_option(HashableDict({"a": 2}))
+
+    def test_a_cycle_in_a_hashable_dict_child_option_does_not_raise(self) -> None:
+        feature = _feature_with_child_option(_hashable_dict_cycle())
+        assert isinstance(hash(feature), int)
+        assert feature == feature
+
+    def test_a_cycle_in_an_options_child_option_does_not_raise(self) -> None:
+        feature = _feature_with_child_option(_options_cycle())
+        assert isinstance(hash(feature), int)
+        assert feature == feature
+
+
+class TestNodeSubclassesFollowTheirOwnDunders:
+    def test_an_inheriting_options_subclass_is_walked_as_options(self) -> None:
+        left = Options(group={"k": InheritingOptions(group={"a": 1})})
+        right = Options(group={"k": Options(group={"a": 1})})
+
+        assert left == right
+        assert right == left
+        assert hash(left) == hash(right)
+
+    def test_an_inheriting_hashable_dict_subclass_is_walked_as_hashable_dict(self) -> None:
+        left = Options(group={"k": InheritingHashableDict({"a": 1})})
+        right = Options(group={"k": HashableDict({"a": 1})})
+
+        assert left == right
+        assert right == left
+        assert hash(left) == hash(right)
+
+    def test_an_options_subclass_overriding_eq_decides_for_itself(self) -> None:
+        left = Options(group={"k": DisagreeingOptions(group={"a": 1})})
+        right = Options(group={"k": DisagreeingOptions(group={"a": 1})})
+
+        assert left != right
+
+    def test_a_hashable_dict_subclass_overriding_eq_decides_for_itself(self) -> None:
+        left = Options(group={"k": DisagreeingHashableDict({"a": 1})})
+        right = Options(group={"k": DisagreeingHashableDict({"a": 1})})
+
+        assert left != right


### PR DESCRIPTION
Closes #1010.

`_deep_hashable` and `_deep_equal` each carried their own visited path, and a nested `Options` or `HashableDict` was a leaf to both walks. Hashing or comparing one restarted the path from empty, so a cycle that left the plain container tree and came back through a nested node was never recognised and still raised `RecursionError`.

Both walks now recurse into a registered node (`Options.group`, `HashableDict.data`) carrying the current path. Registration keeps `hashable_dict` free of an import back to `options`. A subclass that overrides the relevant dunder is left to decide for itself, and only matching kinds are walked, so a nested `Options` stays unequal to a plain dict and to a `HashableDict`.

`Feature._reduce` feeds `Feature.__eq__`, not only `__hash__`, so it keeps an explicit type tag for a nested `HashableDict`; without it the flattened normalization would have let a `HashableDict` child option compare equal to a plain dict with the same contents.

The residual note now names what still resets the path: node subclasses that override `__eq__`, and cycles routed through a nested `Feature` (Feature equality reads more fields than a dict target can express, so it is not a registered node and carries its own guard in `_reduce`).

Tests cover hashing and equality through nested-node cycles, hash stability and cross-instance agreement, cycle versus acyclic unrolling, nested-node type identity through both `Options.__eq__` and `Feature._child_options_key`, subclass dunder behavior, and the acyclic regressions.

`tox` is green: 8458 passed, 170 skipped, ruff, mypy --strict and bandit clean.