### PR TITLE
fix: scope the owned reader restamp to the addressed probe

### DIFF
--- a/docs/docs/in_depth/data-access-patterns.md
+++ b/docs/docs/in_depth/data-access-patterns.md
@@ -72,7 +72,7 @@ Readers are classified structurally; no reader code is executed for classificati
 
 ### Selecting among sibling readers
 
-A feature selects a specific reader with an Option whose key equals the reader's class name (`BaseInputData.data_access_name()`, i.e. `cls.__name__`, unique per class, so sibling readers cannot collide):
+A feature selects a specific reader with an Option whose key equals the reader's `BaseInputData.data_access_name()`, which defaults to `cls.__name__` (unique per class, so sibling readers cannot collide) and which a reader that overrides it keeps unique within its family itself:
 
 ```py
 Feature("value", options={UbaAirReader.__name__: url})
@@ -145,7 +145,7 @@ Rules for reader authors:
 - Never raise to decline: anything but `NotImplementedError` in the DB match hooks aborts matching for every reader sharing the `DataAccessCollection`. Record, then return a falsy value.
 - Recording outside an engine-opened window is a no-op, so readers stay usable standalone.
 - Recorded reasons are discarded at the enclosing candidate level: when the reader ultimately matches, when a sibling reader matches, or, for unowned recordings, when the feature group matches by another rule. An owned veto instead gates the name-based rules (see the paragraph below). Only a decline surfaces them.
-- Name the reader and the concrete input in the reason, as the example does. The owner name is only a per-window dedupe key (the first recording per owner wins), so any name works, including an overridden `data_access_name()`.
+- Name the reader and the concrete input in the reason, as the example does. Any label works as the owner name, an overridden `data_access_name()` included, but it must be distinct among the reader's own decline points: the first recording per owner wins, so a later reason under a name already used in the same window is dropped and never reaches the owned stage.
 
 `ReadFile` column validation and the `ReadDB` feature check (`check_feature_in_data_access`) already record automatically; a custom reader only needs this for its own decline points.
 

--- a/docs/docs/in_depth/data-access-patterns.md
+++ b/docs/docs/in_depth/data-access-patterns.md
@@ -145,7 +145,7 @@ Rules for reader authors:
 - Never raise to decline: anything but `NotImplementedError` in the DB match hooks aborts matching for every reader sharing the `DataAccessCollection`. Record, then return a falsy value.
 - Recording outside an engine-opened window is a no-op, so readers stay usable standalone.
 - Recorded reasons are discarded at the enclosing candidate level: when the reader ultimately matches, when a sibling reader matches, or, for unowned recordings, when the feature group matches by another rule. An owned veto instead gates the name-based rules (see the paragraph below). Only a decline surfaces them.
-- Name the reader and the concrete input in the reason, as the example does, and pass `cls.get_class_name()` as the owner name: the ownership gate keys on it.
+- Name the reader and the concrete input in the reason, as the example does. The owner name is only a per-window dedupe key (the first recording per owner wins), so any name works, including an overridden `data_access_name()`.
 
 `ReadFile` column validation and the `ReadDB` feature check (`check_feature_in_data_access`) already record automatically; a custom reader only needs this for its own decline points.
 

--- a/mloda/core/abstract_plugins/components/input_data/base_input_data.py
+++ b/mloda/core/abstract_plugins/components/input_data/base_input_data.py
@@ -325,7 +325,8 @@ class BaseInputData(ABC):
             if not issubclass(key, BaseInputData):
                 # Contained: this runs per candidate over every option key, so an odd key is a non-match (#845).
                 raise ValueError(f"Key {key} is not a subclass of BaseInputData.")
-            key = key.get_class_name()
+            # Options normalizes a class key the same way, so an overridden alias stays the one identity.
+            key = key.data_access_name()
 
         if not isinstance(key, str):
             # Contained: this runs per candidate over every option key, so one odd key must not abort the run (#845).

--- a/mloda/core/abstract_plugins/components/input_data/base_input_data.py
+++ b/mloda/core/abstract_plugins/components/input_data/base_input_data.py
@@ -8,8 +8,9 @@ from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.match_rejection import (
     INPUT_DATA_OWNED_STAGE,
     INPUT_DATA_STAGE,
+    match_rejection_owners,
     record_match_rejection,
-    restamp_match_rejection,
+    restamp_match_rejections_since,
 )
 from mloda.core.abstract_plugins.components.options import Options
 
@@ -308,12 +309,13 @@ class BaseInputData(ABC):
                     # The user addressed this reader family by name (ownership), so vetoes record as owned.
                     if not subclass._reader_options_admit(options, record_absence=True):
                         break
+                    known_owners = match_rejection_owners()
                     matched_data_access = subclass.match_subclass_data_access(value, [feature_name], options=options)  # type: ignore[attr-defined]
                     if matched_data_access:
                         cls.add_base_input_data_to_options(subclass, matched_data_access, options)
                         return True
-                    # The addressed reader matched nothing, so a recorded content decline becomes an owned veto.
-                    restamp_match_rejection(subclass.get_class_name(), INPUT_DATA_STAGE, INPUT_DATA_OWNED_STAGE)
+                    # The addressed probe matched nothing, so whatever content decline it recorded becomes owned.
+                    restamp_match_rejections_since(known_owners, INPUT_DATA_STAGE, INPUT_DATA_OWNED_STAGE)
                     break  # This case is if a feature requests an input feature, which should have scoped access.
         return False
 

--- a/mloda/core/abstract_plugins/components/match_rejection.py
+++ b/mloda/core/abstract_plugins/components/match_rejection.py
@@ -39,13 +39,23 @@ def record_match_rejection(owner_name: str, reason: str, stage: str = "value_rej
     reasons.setdefault(owner_name, MatchRejection(reason, stage))
 
 
-def restamp_match_rejection(owner_name: str, from_stage: str, to_stage: str) -> None:
-    """Re-stamp the owner's recorded stage; a no-op outside a window, without a recording, or on a stage mismatch."""
+def match_rejection_owners() -> frozenset[str]:
+    """Owner names already recorded in the active window; empty outside one."""
+    reasons = MATCH_REJECTION_REASONS.get()
+    if reasons is None:
+        return frozenset()
+    return frozenset(reasons)
+
+
+def restamp_match_rejections_since(known_owners: frozenset[str], from_stage: str, to_stage: str) -> None:
+    """Re-stamp owners recorded after the snapshot whose stage is exactly from_stage; no-op outside a window."""
+    # Scoping by snapshot delta, not by owner name, covers whatever name an inner delegation stamped.
     reasons = MATCH_REJECTION_REASONS.get()
     if reasons is None:
         return
-    rejection = reasons.get(owner_name)
-    if rejection is not None and rejection.stage == from_stage:
+    for owner_name, rejection in list(reasons.items()):
+        if owner_name in known_owners or rejection.stage != from_stage:
+            continue
         reasons[owner_name] = MatchRejection(rejection.reason, to_stage)
 
 

--- a/tests/test_core/test_abstract_plugins/test_components/test_owned_content_decline_gates_name_rules.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_owned_content_decline_gates_name_rules.py
@@ -10,10 +10,13 @@ import pytest
 
 from mloda.core.abstract_plugins.components.feature_chainer.property_spec import is_no_default
 from mloda.core.abstract_plugins.components.match_rejection import (
+    INPUT_DATA_OWNED_STAGE,
+    INPUT_DATA_STAGE,
     MATCH_REJECTION_REASONS,
     MatchRejection,
+    match_rejection_owners,
     record_match_rejection,
-    restamp_match_rejection,
+    restamp_match_rejections_since,
 )
 from mloda.core.abstract_plugins.components.utils import get_all_subclasses
 from mloda.core.prepare.accessible_plugins import FeatureGroupEnvironmentMapping
@@ -32,8 +35,13 @@ VG961_FILE_SUFFIX = ".vg961csv"
 VG961_DB_FEATURE = "vg961_db_column"
 VG961_DB_MARKER = "vg961_db_marker"
 
-VG961_UNIT_OWNER = "vg961_unit_owner"
-VG961_UNIT_REASON = "vg961 unit reason"
+VG1006_FILE_FEATURE = "vg1006_file_column"
+VG1006_FILE_SUFFIX = ".vg961vg1006"
+VG1006_ALIAS_NAME = "vg1006_alias_access"
+
+VG1006_UNIT_OWNER = "vg1006_unit_owner"
+VG1006_UNIT_OTHER_OWNER = "vg1006_unit_other_owner"
+VG1006_UNIT_REASON = "vg1006 unit reason"
 
 
 class Vg961FileFamily(ReadFile):
@@ -107,6 +115,60 @@ class Vg961DbFG(FeatureGroup):
         return {VG961_DB_FEATURE}
 
 
+class Vg1006AliasFamily(ReadFile):
+    """Family base of the aliased file shape; it overrides nothing, so it never classifies as final."""
+
+
+class Vg1006AliasReader(Vg1006AliasFamily):
+    """Final reader addressed by an alias name, so it records its content decline under that name."""
+
+    @classmethod
+    def suffix(cls) -> tuple[str, ...]:
+        return (VG1006_FILE_SUFFIX,)
+
+    @classmethod
+    def data_access_name(cls) -> str:
+        return VG1006_ALIAS_NAME
+
+    @classmethod
+    def get_column_names(cls, file_name: str) -> list[str]:
+        with open(file_name, encoding="utf-8") as handle:
+            return handle.readline().strip().split(",")
+
+    @classmethod
+    def validate_columns(cls, file_name: str, feature_names: list[str]) -> bool:
+        columns = cls.get_column_names(file_name)
+        missing = [feature for feature in feature_names if feature not in columns]
+        if not missing:
+            return True
+        record_match_rejection(
+            cls.data_access_name(),
+            f"{cls.data_access_name()} matched the suffix of {file_name} but it lacks the column(s): "
+            f"{', '.join(missing)}",
+            stage=INPUT_DATA_STAGE,
+        )
+        return False
+
+    @classmethod
+    def load_data(cls, data_access: Any, features: FeatureSet) -> Any:
+        return {VG1006_FILE_FEATURE: [1]}
+
+
+class Vg1006AliasFG(FeatureGroup):
+    """Root FG whose name rule claims vg1006_file_column while its aliased reader declines on content."""
+
+    @classmethod
+    def input_data(cls) -> BaseInputData | None:
+        return Vg1006AliasFamily()
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        return None
+
+    @classmethod
+    def feature_names_supported(cls) -> set[str]:
+        return {VG1006_FILE_FEATURE}
+
+
 @pytest.fixture()
 def rejection_window() -> Iterator[dict[str, MatchRejection]]:
     """Open a recording window around one call, mirroring the engine's per-candidate window."""
@@ -116,42 +178,69 @@ def rejection_window() -> Iterator[dict[str, MatchRejection]]:
     MATCH_REJECTION_REASONS.reset(token)
 
 
-class TestRestampMatchRejection:
-    """The helper replaces one owner's recording stage in place."""
+class TestProbeScopedRestamp:
+    """The snapshot and delta restamp promote only what one probe recorded."""
+
+    def test_owners_outside_a_window_are_empty_and_open_none(self) -> None:
+        """Without an open window the snapshot is empty and no window is opened."""
+        assert MATCH_REJECTION_REASONS.get() is None
+        assert match_rejection_owners() == frozenset()
+        assert MATCH_REJECTION_REASONS.get() is None
+
+    def test_owners_inside_a_window_are_the_recorded_names(self, rejection_window: dict[str, MatchRejection]) -> None:
+        """Inside a window the snapshot holds every recorded owner name."""
+        record_match_rejection(VG1006_UNIT_OWNER, VG1006_UNIT_REASON, stage=INPUT_DATA_STAGE)
+        record_match_rejection(VG1006_UNIT_OTHER_OWNER, VG1006_UNIT_REASON, stage=INPUT_DATA_STAGE)
+
+        assert match_rejection_owners() == frozenset({VG1006_UNIT_OWNER, VG1006_UNIT_OTHER_OWNER})
 
     def test_no_active_window_is_a_no_op(self) -> None:
         """Without an open window the restamp neither raises nor opens one."""
         assert MATCH_REJECTION_REASONS.get() is None
-        restamp_match_rejection(VG961_UNIT_OWNER, "input_data", "input_data_owned")
+        restamp_match_rejections_since(frozenset(), INPUT_DATA_STAGE, INPUT_DATA_OWNED_STAGE)
         assert MATCH_REJECTION_REASONS.get() is None
 
-    def test_an_owner_without_a_recording_leaves_the_window_empty(
+    def test_an_owner_in_the_snapshot_keeps_its_stage(self, rejection_window: dict[str, MatchRejection]) -> None:
+        """A recording that predates the snapshot is not part of the probe's delta."""
+        record_match_rejection(VG1006_UNIT_OWNER, VG1006_UNIT_REASON, stage=INPUT_DATA_STAGE)
+        known_owners = match_rejection_owners()
+        restamp_match_rejections_since(known_owners, INPUT_DATA_STAGE, INPUT_DATA_OWNED_STAGE)
+
+        assert rejection_window[VG1006_UNIT_OWNER].stage == INPUT_DATA_STAGE
+
+    def test_a_delta_recording_is_restamped_with_the_reason_preserved(
         self, rejection_window: dict[str, MatchRejection]
     ) -> None:
-        """An owner nothing was recorded for stays absent from the window."""
-        restamp_match_rejection(VG961_UNIT_OWNER, "input_data", "input_data_owned")
+        """An owner recorded after the snapshot at the from_stage keeps its reason and takes the to_stage."""
+        known_owners = match_rejection_owners()
+        record_match_rejection(VG1006_UNIT_OWNER, VG1006_UNIT_REASON, stage=INPUT_DATA_STAGE)
+        restamp_match_rejections_since(known_owners, INPUT_DATA_STAGE, INPUT_DATA_OWNED_STAGE)
 
-        assert rejection_window == {}
+        rejection = rejection_window[VG1006_UNIT_OWNER]
+        assert rejection.reason == VG1006_UNIT_REASON
+        assert rejection.stage == INPUT_DATA_OWNED_STAGE
 
-    def test_a_recording_with_a_different_stage_keeps_its_stage(
+    def test_a_delta_recording_with_a_different_stage_keeps_its_stage(
         self, rejection_window: dict[str, MatchRejection]
     ) -> None:
-        """The from_stage comparison is exact: a default-stage recording is not an input_data one."""
-        record_match_rejection(VG961_UNIT_OWNER, VG961_UNIT_REASON)
-        restamp_match_rejection(VG961_UNIT_OWNER, "input_data", "input_data_owned")
+        """The from_stage comparison is exact: a default-stage delta recording is not an input_data one."""
+        known_owners = match_rejection_owners()
+        record_match_rejection(VG1006_UNIT_OWNER, VG1006_UNIT_REASON)
+        restamp_match_rejections_since(known_owners, INPUT_DATA_STAGE, INPUT_DATA_OWNED_STAGE)
 
-        assert rejection_window[VG961_UNIT_OWNER].stage == "value_rejection"
+        assert rejection_window[VG1006_UNIT_OWNER].stage == "value_rejection"
 
-    def test_a_matching_owner_and_stage_is_restamped_with_the_reason_preserved(
+    def test_only_the_recordings_after_the_snapshot_are_restamped(
         self, rejection_window: dict[str, MatchRejection]
     ) -> None:
-        """A matching owner and from_stage replaces the recording with the same reason and the to_stage."""
-        record_match_rejection(VG961_UNIT_OWNER, VG961_UNIT_REASON, stage="input_data")
-        restamp_match_rejection(VG961_UNIT_OWNER, "input_data", "input_data_owned")
+        """One window, two same-stage recordings: only the one the probe added is promoted."""
+        record_match_rejection(VG1006_UNIT_OWNER, VG1006_UNIT_REASON, stage=INPUT_DATA_STAGE)
+        known_owners = match_rejection_owners()
+        record_match_rejection(VG1006_UNIT_OTHER_OWNER, VG1006_UNIT_REASON, stage=INPUT_DATA_STAGE)
+        restamp_match_rejections_since(known_owners, INPUT_DATA_STAGE, INPUT_DATA_OWNED_STAGE)
 
-        rejection = rejection_window[VG961_UNIT_OWNER]
-        assert rejection.reason == VG961_UNIT_REASON
-        assert rejection.stage == "input_data_owned"
+        assert rejection_window[VG1006_UNIT_OWNER].stage == INPUT_DATA_STAGE
+        assert rejection_window[VG1006_UNIT_OTHER_OWNER].stage == INPUT_DATA_OWNED_STAGE
 
 
 class TestOwnedContentDeclineGatesNameRules:
@@ -242,6 +331,45 @@ class TestOwnedShapesThatMustNotGate:
         assert Vg961FileFG in result.identified
         assert result.eliminations == {}
         assert feature.options.get("BaseInputData") == (Vg961CsvReader, str(path_b))
+
+
+class TestAliasedDataAccessNameOwnership:
+    """Ownership keys on data_access_name(), so a decline recorded under that alias must gate the name rules too."""
+
+    def test_an_owned_decline_under_an_aliased_name_gates_the_name_rule(self, tmp_path: Path) -> None:
+        """The reader addressed by its alias owns the suffix but lacks the column: eliminated, not recovered."""
+        path = tmp_path / f"data{VG1006_FILE_SUFFIX}"
+        path.write_text("vg1006_other_a,vg1006_other_b\n1,2\n", encoding="utf-8")
+        feature = Feature(name=VG1006_FILE_FEATURE, options={VG1006_ALIAS_NAME: str(path)})
+        accessible_plugins: FeatureGroupEnvironmentMapping = {Vg1006AliasFG: {PandasDataFrame}}
+
+        result = IdentifyFeatureGroupClass.evaluate(feature, accessible_plugins, None, None)
+
+        assert result.identified == {}
+        elimination = result.eliminations.get(Vg1006AliasFG)
+        assert elimination is not None
+        assert elimination.stage == "input_data"
+        assert VG1006_ALIAS_NAME in elimination.reason
+        assert "lacks the column" in elimination.reason
+
+    def test_an_aliased_decline_on_one_file_with_a_match_on_another_still_pins_the_pair(self, tmp_path: Path) -> None:
+        """The pinned file declines with a recording, then the resolve fallback matches the other file."""
+        path_a = tmp_path / f"a{VG1006_FILE_SUFFIX}"
+        path_a.write_text("vg1006_other\n1\n", encoding="utf-8")
+        path_b = tmp_path / f"b{VG1006_FILE_SUFFIX}"
+        path_b.write_text(f"{VG1006_FILE_FEATURE}\n1\n", encoding="utf-8")
+        dac = DataAccessCollection(
+            files={"vg1006_a": str(path_a), "vg1006_b": str(path_b)},
+            column_to_file={VG1006_FILE_FEATURE: "vg1006_a"},
+        )
+        feature = Feature(name=VG1006_FILE_FEATURE, options={VG1006_ALIAS_NAME: dac})
+        accessible_plugins: FeatureGroupEnvironmentMapping = {Vg1006AliasFG: {PandasDataFrame}}
+
+        result = IdentifyFeatureGroupClass.evaluate(feature, accessible_plugins, None, None)
+
+        assert Vg1006AliasFG in result.identified
+        assert result.eliminations == {}
+        assert feature.options.get("BaseInputData") == (Vg1006AliasReader, str(path_b))
 
 
 class TestModuleLeakPolicy:

--- a/tests/test_core/test_abstract_plugins/test_components/test_owned_content_decline_gates_name_rules.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_owned_content_decline_gates_name_rules.py
@@ -29,6 +29,9 @@ from mloda_plugins.feature_group.input_data.read_db import ReadDB
 from mloda_plugins.feature_group.input_data.read_file import ReadFile
 
 
+MODULE_SUFFIX_MARKERS = ("vg961", "vg1006")
+"""Markers a module-level file reader's suffixes must carry, so none of them can fire on a foreign path."""
+
 VG961_FILE_FEATURE = "vg961_file_column"
 VG961_FILE_SUFFIX = ".vg961csv"
 
@@ -36,12 +39,15 @@ VG961_DB_FEATURE = "vg961_db_column"
 VG961_DB_MARKER = "vg961_db_marker"
 
 VG1006_FILE_FEATURE = "vg1006_file_column"
-VG1006_FILE_SUFFIX = ".vg961vg1006"
+VG1006_FILE_SUFFIX = ".vg1006csv"
 VG1006_ALIAS_NAME = "vg1006_alias_access"
 
 VG1006_UNIT_OWNER = "vg1006_unit_owner"
 VG1006_UNIT_OTHER_OWNER = "vg1006_unit_other_owner"
 VG1006_UNIT_REASON = "vg1006 unit reason"
+
+VG1006_FOREIGN_OWNER = "vg1006_foreign_owner"
+VG1006_FOREIGN_REASON = "vg1006 foreign reason"
 
 
 class Vg961FileFamily(ReadFile):
@@ -243,6 +249,25 @@ class TestProbeScopedRestamp:
         assert rejection_window[VG1006_UNIT_OTHER_OWNER].stage == INPUT_DATA_OWNED_STAGE
 
 
+class TestProbeScopedRestampAtTheCallSite:
+    """feature_scope_data_access snapshots the window before its probe, so it promotes only that probe's delta."""
+
+    def test_a_recording_predating_the_probe_keeps_its_stage_while_the_probe_decline_is_owned(
+        self, tmp_path: Path, rejection_window: dict[str, MatchRejection]
+    ) -> None:
+        """One window, one foreign recording seeded first: only the addressed reader's own decline is promoted."""
+        path = tmp_path / f"data{VG1006_FILE_SUFFIX}"
+        path.write_text("vg1006_other_a,vg1006_other_b\n1,2\n", encoding="utf-8")
+        record_match_rejection(VG1006_FOREIGN_OWNER, VG1006_FOREIGN_REASON, stage=INPUT_DATA_STAGE)
+        options = Options({VG1006_ALIAS_NAME: str(path)})
+
+        matched = Vg1006AliasFamily.feature_scope_data_access(options, VG1006_FILE_FEATURE)
+
+        assert matched is False
+        assert rejection_window[VG1006_FOREIGN_OWNER].stage == INPUT_DATA_STAGE
+        assert rejection_window[VG1006_ALIAS_NAME].stage == INPUT_DATA_OWNED_STAGE
+
+
 class TestOwnedContentDeclineGatesNameRules:
     """Engine level, deliberately WITHOUT a window fixture: the engine owns the per-candidate window."""
 
@@ -372,11 +397,23 @@ class TestAliasedDataAccessNameOwnership:
         assert feature.options.get("BaseInputData") == (Vg1006AliasReader, str(path_b))
 
 
+class TestReaderClassKeyNormalization:
+    """A class-object option key must normalize like Options normalizes it, through data_access_name()."""
+
+    def test_a_class_key_of_an_aliasing_reader_normalizes_to_its_alias(self) -> None:
+        """The helper agrees with the Options normalization, so a class key still addresses the aliased reader."""
+        assert BaseInputData.deal_with_base_input_data_name_as_cls_or_str(Vg1006AliasReader) == VG1006_ALIAS_NAME
+
+    def test_a_class_key_of_a_non_aliasing_reader_stays_its_class_name(self) -> None:
+        """A reader that does not override data_access_name() is unaffected by the normalization."""
+        assert BaseInputData.deal_with_base_input_data_name_as_cls_or_str(Vg961CsvReader) == "Vg961CsvReader"
+
+
 class TestModuleLeakPolicy:
-    """The module's leak policy, machine-checked over every module-level final reader."""
+    """The module's marker-based leak policy, machine-checked over every module-level final reader."""
 
     def test_module_level_readers_cannot_fire_on_foreign_options(self) -> None:
-        """Every final reader owns vg961-marked suffixes or requires the vg961 credentials marker, never absence."""
+        """Every final reader owns marker-carrying suffixes or requires the module-unique credentials marker."""
         module_level = [
             cls for cls in get_all_subclasses(BaseInputData) if cls.__module__ == __name__ and cls.is_final_reader()
         ]
@@ -384,9 +421,11 @@ class TestModuleLeakPolicy:
         assert module_level, "expected this module's final readers to be reachable through __subclasses__()"
         for cls in module_level:
             if issubclass(cls, ReadFile):
-                assert all("vg961" in s for s in cls.suffix()), f"{cls.__name__} must own only vg961-marked suffixes"
+                assert all(any(marker in s for marker in MODULE_SUFFIX_MARKERS) for s in cls.suffix()), (
+                    f"{cls.__name__} must own only suffixes carrying one of {MODULE_SUFFIX_MARKERS}"
+                )
             else:
-                assert issubclass(cls, ReadDB), f"{cls.__name__} must be a vg961 file or db reader"
+                assert issubclass(cls, ReadDB), f"{cls.__name__} must be a module-marked file or db reader"
                 assert cls.is_valid_credentials({"vg961_foreign": "x"}) is False, (
                     f"{cls.__name__} must stay inert on foreign credentials"
                 )


### PR DESCRIPTION
Closes #1006.

## Problem

Reader ownership is established by `data_access_name()`, but the restamp that turns an addressed reader's content decline into an owned veto was keyed on `get_class_name()`. A reader that overrides `data_access_name()` and records its declines under that name escaped the restamp, so the feature group was recovered by its name rule and crashed later at load time inside `init_reader`, which is exactly the shape the gate exists to remove. Nothing enforced the recording contract: the recording site is plugin code.

## Decision

The issue asked to either restamp both names when they differ, or enforce the recording-owner contract structurally. Neither: the restamp is now scoped to the probe rather than to an owner name.

The harvest side is already name-agnostic. `_filter_feature_group_by_criteria` attributes everything recorded in a candidate's window to that candidate whatever name an inner delegation stamped, and `has_match_rejection` scans stages, not names. The restamp was the last place reading the owner name as a contract. `feature_scope_data_access` now snapshots the window's owners before the addressed probe runs and, on a nothing-match, promotes whatever that probe recorded. That covers any owner label instead of widening a contract plugin code can silently violate, and it applies the same rule one level down from the candidate-level one that already exists.

`restamp_match_rejection` is replaced by `match_rejection_owners()` plus `restamp_match_rejections_since()`. It had one caller and was never exported through `mloda.provider`.

## Also fixed

`deal_with_base_input_data_name_as_cls_or_str` converted a class-object option key with `get_class_name()`, while `Options` normalizes the same key with `data_access_name()`. The two disagree for an overriding reader, so a class key added after construction (`add_to_group` or `set`, neither of which normalizes) never addressed it. Same defect class as the above, and a no-op for every reader that does not override the hook.

## Tests

- The override shape at the engine level: an addressed reader with an aliased `data_access_name()` recording its decline under that alias is eliminated instead of recovered by name.
- The negative: the same reader declining on one input and matching another still resolves and pins the pair.
- The probe scoping at its call site: a recording that predates the addressed probe keeps its stage while the probe's own decline is promoted. This one fails if the snapshot is dropped; the helper-level tests do not.
- Helper unit coverage for the snapshot and the delta restamp, and for the class-key normalization on both an aliasing and a non-aliasing reader.

`tox` passes: 8337 passed, 170 skipped, plus ruff, licenses, `mypy --strict` and bandit.
