### PR TITLE
fix: reject a reserved reader key declaration that drops framework_set

### DIFF
--- a/docs/docs/in_depth/property-mapping.md
+++ b/docs/docs/in_depth/property-mapping.md
@@ -82,7 +82,7 @@ does not understand can be absorbed silently.
 | Match time (guard installed at class definition) | `required_when` | A conditionally required option is present | `Options` | Non-match (`False`) |
 | Class definition (mixin) | Universal-matcher diagnostic | An all-optional `PROPERTY_MAPPING` inherits the configuration matcher, so it matches any name with empty options | The class | `logger.warning`, unless `ALLOW_UNIVERSAL_MATCHER = True` |
 | Author time (reader surface) | `mypy --strict` | `READER_OPTIONS` holds `PropertySpec` values | The constructor call | mypy error at the declaration |
-| Class definition (`BaseInputData.__init_subclass__`) | Spec type + surface guard | Every value IS a `PropertySpec` and declares nothing inert on a reader (`match_guard`, `deferred_binding`, `context=False`, enforcement fields on a `framework_set` key) | Every value in that class's declaration | `ValueError` naming class, key and field |
+| Class definition (`BaseInputData.__init_subclass__`) | Spec type + surface guard | Every value IS a `PropertySpec` and declares nothing inert on a reader (`match_guard`, `deferred_binding`, `context=False`, enforcement fields on a `framework_set` key); the reserved key's **winning** declaration across the MRO keeps `framework_set=True` | Every value in that class's declaration, plus the reserved key as the MRO merge resolves it | `ValueError` naming class, key and field |
 | Match time (reader selection) | Presence + strict validation | Required keys are present and present strict values pass, element-wise; `framework_set` keys exempt | The candidate's merged specs and the options | Reader non-match. Addressed-reader and supplied-value failures record a `stage="input_data"` rejection; unaddressed absence and an unjudgeable predicate decline silently |
 | Match time (reader code) | `reader_option(key, options)` | Supplied value, else the declared `default` | The key name and the options | `ValueError` for an undeclared key or an absent `NO_DEFAULT` one |
 
@@ -146,7 +146,9 @@ consequences keep the shared type honest on this surface:
   `"BaseInputData"` pair written by `add_base_input_data_to_options` and read by `init_reader`.
   Such keys are exempt from enforcement, so enforcement fields on them are rejected too, as is
   `allow_explicit_none`, which the admit path never reads on a framework-written key; on
-  `PROPERTY_MAPPING` the field is rejected outright.
+  `PROPERTY_MAPPING` the field is rejected outright. The reserved key is checked as the MRO merge
+  resolves it: its **winning** declaration must keep `framework_set=True`, so neither a subclass nor a
+  plain mixin can turn the framework-written key into a user-enforced one.
 
 `READER_OPTIONS` merges across the MRO (`reader_option_specs()`, most-derived declaration winning),
 so a concrete reader inherits its family's keys and redeclares nothing, and

--- a/mloda/core/abstract_plugins/components/input_data/base_input_data.py
+++ b/mloda/core/abstract_plugins/components/input_data/base_input_data.py
@@ -54,6 +54,12 @@ class BaseInputData(ABC):
                     f"{cls.__name__}.READER_OPTIONS['{key}'] is a {type(spec).__name__}, not a PropertySpec. "
                     f"Construct PropertySpec(...) instead."
                 )
+            if key == "BaseInputData" and not spec.framework_set:
+                raise ValueError(
+                    f"{cls.__name__}.READER_OPTIONS['{key}'] redeclares the reserved key without "
+                    f"framework_set=True; the framework writes this key itself, so the admit path would "
+                    f"judge a value no user ever supplies."
+                )
             if spec.match_guard is not None:
                 raise ValueError(
                     f"{cls.__name__}.READER_OPTIONS['{key}'] declares a match_guard, which is name-matching "

--- a/mloda/core/abstract_plugins/components/input_data/base_input_data.py
+++ b/mloda/core/abstract_plugins/components/input_data/base_input_data.py
@@ -23,10 +23,12 @@ from mloda.core.abstract_plugins.components.utils import (
 
 logger = logging.getLogger(__name__)
 
+RESERVED_READER_OPTION_KEY = "BaseInputData"
+
 
 class BaseInputData(ABC):
     READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
-        "BaseInputData": PropertySpec(
+        RESERVED_READER_OPTION_KEY: PropertySpec(
             "The matched (ReaderClass, data_access) pair, written by add_base_input_data_to_options "
             "and read back by init_reader.",
             default=None,
@@ -45,20 +47,32 @@ class BaseInputData(ABC):
         cls._validate_reader_options()
 
     @classmethod
+    def _validate_reserved_reader_option_key(cls) -> None:
+        """The reserved key must survive the MRO MERGE, not just cls's own dict: a plain mixin is never
+        validated itself, yet its declaration outranks the base's and is what selection reads."""
+        for klass in cls.__mro__:
+            declared = klass.__dict__.get("READER_OPTIONS", {})
+            if RESERVED_READER_OPTION_KEY not in declared:
+                continue
+            spec = declared[RESERVED_READER_OPTION_KEY]
+            if not isinstance(spec, PropertySpec) or not spec.framework_set:
+                raise ValueError(
+                    f"{cls.__name__} merges READER_OPTIONS['{RESERVED_READER_OPTION_KEY}'] to the declaration on "
+                    f"{klass.__name__}, which is not a PropertySpec with framework_set=True; the framework writes "
+                    f"this reserved key itself, so the admit path would judge a value no user ever supplies."
+                )
+            return
+
+    @classmethod
     def _validate_reader_options(cls) -> None:
         """Reject a reader-invalid declaration where it is written, not later deep in reader matching;
-        checks only this class's own declaration so a bad child under a valid parent still raises."""
+        the per-key checks read only this class's own declaration so a bad child under a valid parent raises."""
+        cls._validate_reserved_reader_option_key()
         for key, spec in cls.__dict__.get("READER_OPTIONS", {}).items():
             if not isinstance(spec, PropertySpec):
                 raise ValueError(
                     f"{cls.__name__}.READER_OPTIONS['{key}'] is a {type(spec).__name__}, not a PropertySpec. "
                     f"Construct PropertySpec(...) instead."
-                )
-            if key == "BaseInputData" and not spec.framework_set:
-                raise ValueError(
-                    f"{cls.__name__}.READER_OPTIONS['{key}'] redeclares the reserved key without "
-                    f"framework_set=True; the framework writes this key itself, so the admit path would "
-                    f"judge a value no user ever supplies."
                 )
             if spec.match_guard is not None:
                 raise ValueError(
@@ -389,8 +403,8 @@ class BaseInputData(ABC):
         Adding the found data access class to the options.
         """
 
-        if "BaseInputData" in options:
-            existing_data = options.get("BaseInputData")
+        if RESERVED_READER_OPTION_KEY in options:
+            existing_data = options.get(RESERVED_READER_OPTION_KEY)
             # `is True`, not a truth test: a non-bool __eq__ result (numpy array) must not raise unmarked here.
             if (existing_data == (cls_to_be_added, matched_data_access)) is True:
                 return
@@ -409,7 +423,7 @@ class BaseInputData(ABC):
                     f"existing={existing_label}"
                 )
             )
-        options.add_to_group("BaseInputData", (cls_to_be_added, matched_data_access))
+        options.add_to_group(RESERVED_READER_OPTION_KEY, (cls_to_be_added, matched_data_access))
 
     def init_reader(self, options: Optional[Options]) -> tuple["BaseInputData", Any]:
         if options is None:
@@ -423,7 +437,7 @@ class BaseInputData(ABC):
                 "  })"
             )
 
-        reader_data_access = options.get("BaseInputData")
+        reader_data_access = options.get(RESERVED_READER_OPTION_KEY)
 
         if reader_data_access is None:
             raise ValueError(

--- a/tests/test_core/test_abstract_plugins/test_components/test_reader_option_declarations.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_reader_option_declarations.py
@@ -189,6 +189,23 @@ class TestReservedFrameworkKey:
         assert specs["rod_key_a"].framework_set is False
         assert specs["rod_key_b"].framework_set is False
 
+    def test_the_reserved_key_stays_framework_written_on_every_reader(self) -> None:
+        """The invariant the redeclaration guard protects: a merged reserved key is never user-set."""
+
+        class RodReservedInvariantReader(BaseInputData):
+            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+                "BaseInputData": PropertySpec(
+                    "The matched (ReaderClass, data_access) pair, sharpened for this family.",
+                    default=None,
+                    framework_set=True,
+                ),
+            }
+
+        parent, child, _ = _decl_family()
+
+        for reader in (RodReservedInvariantReader, parent, child):
+            assert reader.reader_option_specs()["BaseInputData"].framework_set is True
+
 
 class TestMroMerge:
     """Declarations merge across ``cls.__mro__``, most-derived class winning on a collision."""
@@ -778,6 +795,67 @@ class TestReaderOptionsAreValidatedAtClassDefinition:
         assert "rod_fw_allow_none_key" in message
         assert "framework_set" in message
         assert "allow_explicit_none" in message
+
+    def test_reserved_key_redeclared_without_framework_set_rejected(self) -> None:
+        """Dropping the flag on the reserved key hands the framework-written key to the admit path."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class RodReservedShadowReader(BaseInputData):
+                READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+                    "BaseInputData": PropertySpec("shadowed", allow_explicit_none=True, default=None),
+                }
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "RodReservedShadowReader" in message
+        assert "BaseInputData" in message
+        assert "framework_set" in message
+
+    def test_reserved_key_redeclared_with_no_default_rejected(self) -> None:
+        """The harmful shape: a NO_DEFAULT redeclaration makes the reader veto itself on every match."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class RodReservedShadowNoDefaultReader(BaseInputData):
+                READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+                    "BaseInputData": PropertySpec("shadowed"),
+                }
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "RodReservedShadowNoDefaultReader" in message
+        assert "BaseInputData" in message
+        assert "framework_set" in message
+
+    def test_reserved_key_redeclared_plainly_rejected(self) -> None:
+        """framework_set=False is the whole defect; no second flag is needed to trigger it."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class RodReservedShadowPlainReader(BaseInputData):
+                READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+                    "BaseInputData": PropertySpec("shadowed", default=None),
+                }
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "RodReservedShadowPlainReader" in message
+        assert "BaseInputData" in message
+        assert "framework_set" in message
+
+    def test_reserved_key_redeclared_with_framework_set_defines_fine(self) -> None:
+        """Control: a legitimate redeclaration keeping the flag, a sharpened explanation, still defines."""
+
+        class RodReservedKeptFrameworkReader(BaseInputData):
+            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+                "BaseInputData": PropertySpec(
+                    "The matched (ReaderClass, data_access) pair, sharpened for this family.",
+                    default=None,
+                    framework_set=True,
+                ),
+            }
+
+        spec = RodReservedKeptFrameworkReader.reader_option_specs()["BaseInputData"]
+        assert spec.framework_set is True
+        assert spec.default is None
 
     def test_a_strict_allowed_values_declaration_defines_fine(self) -> None:
         """Strict specs are the point of the collapse; a valued one with an in-space default defines."""

--- a/tests/test_core/test_abstract_plugins/test_components/test_reader_option_declarations.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_reader_option_declarations.py
@@ -189,23 +189,6 @@ class TestReservedFrameworkKey:
         assert specs["rod_key_a"].framework_set is False
         assert specs["rod_key_b"].framework_set is False
 
-    def test_the_reserved_key_stays_framework_written_on_every_reader(self) -> None:
-        """The invariant the redeclaration guard protects: a merged reserved key is never user-set."""
-
-        class RodReservedInvariantReader(BaseInputData):
-            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
-                "BaseInputData": PropertySpec(
-                    "The matched (ReaderClass, data_access) pair, sharpened for this family.",
-                    default=None,
-                    framework_set=True,
-                ),
-            }
-
-        parent, child, _ = _decl_family()
-
-        for reader in (RodReservedInvariantReader, parent, child):
-            assert reader.reader_option_specs()["BaseInputData"].framework_set is True
-
 
 class TestMroMerge:
     """Declarations merge across ``cls.__mro__``, most-derived class winning on a collision."""
@@ -810,6 +793,7 @@ class TestReaderOptionsAreValidatedAtClassDefinition:
         assert "RodReservedShadowReader" in message
         assert "BaseInputData" in message
         assert "framework_set" in message
+        assert "reserved" in message
 
     def test_reserved_key_redeclared_with_no_default_rejected(self) -> None:
         """The harmful shape: a NO_DEFAULT redeclaration makes the reader veto itself on every match."""
@@ -825,6 +809,7 @@ class TestReaderOptionsAreValidatedAtClassDefinition:
         assert "RodReservedShadowNoDefaultReader" in message
         assert "BaseInputData" in message
         assert "framework_set" in message
+        assert "reserved" in message
 
     def test_reserved_key_redeclared_plainly_rejected(self) -> None:
         """framework_set=False is the whole defect; no second flag is needed to trigger it."""
@@ -840,6 +825,45 @@ class TestReaderOptionsAreValidatedAtClassDefinition:
         assert "RodReservedShadowPlainReader" in message
         assert "BaseInputData" in message
         assert "framework_set" in message
+        assert "reserved" in message
+
+    def test_reserved_key_shadowed_by_a_plain_mixin_rejected(self) -> None:
+        """A plain mixin runs no guard of its own, yet wins the merge ahead of the base; the subclass must raise."""
+
+        class RodShadowMixin:
+            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+                "BaseInputData": PropertySpec("shadowed"),
+            }
+
+        with pytest.raises(ValueError) as exc_info:
+
+            class RodMixinShadowedReader(RodShadowMixin, BaseInputData):
+                pass
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "RodMixinShadowedReader" in message
+        assert "BaseInputData" in message
+        assert "framework_set" in message
+        assert "reserved" in message
+
+    def test_reserved_key_mixin_losing_the_merge_defines_fine(self) -> None:
+        """Base-first ordering ranks the mixin BELOW the base, so the framework declaration wins and nothing raises."""
+
+        class RodLosingShadowMixin:
+            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+                "BaseInputData": PropertySpec("shadowed"),
+            }
+
+        class RodMixinLosesMergeReader(BaseInputData, RodLosingShadowMixin):
+            pass
+
+        mro = RodMixinLosesMergeReader.__mro__
+        spec = RodMixinLosesMergeReader.reader_option_specs()["BaseInputData"]
+
+        assert mro.index(BaseInputData) < mro.index(RodLosingShadowMixin)
+        assert spec.framework_set is True
+        assert spec.default is None
 
     def test_reserved_key_redeclared_with_framework_set_defines_fine(self) -> None:
         """Control: a legitimate redeclaration keeping the flag, a sharpened explanation, still defines."""


### PR DESCRIPTION
## Summary

A class redeclaring the reserved `"BaseInputData"` reader option key without `framework_set=True` escaped every framework-key guard. All four are keyed on `spec.framework_set` being True, so a `framework_set=False` redeclaration tripped none of them, and `_reader_options_admit` stopped skipping the key. The key the framework writes became a user-enforced admit key: harmless with a declared default, a self-veto on every match with `NO_DEFAULT`.

`_validate_reader_options` now rejects such a declaration at class definition.

## Following the merge, not the class dict

`READER_OPTIONS` merge across `cls.__mro__`, most-derived winning, so checking only the class's own declaration was not enough. A plain mixin that is not a `BaseInputData` subclass runs no validation of its own, yet outranks the base in the merge:

```python
class ShadowMixin:
    READER_OPTIONS = {"BaseInputData": PropertySpec("shadowed")}

class MixinReader(ShadowMixin, BaseInputData):
    ...
```

That defined cleanly and produced the same self-veto. The guard now walks the MRO most-derived-first and validates the declaration the merge actually resolves to, stopping there. A losing declaration is not rejected: `class R(BaseInputData, ShadowMixin)` ranks the base ahead of the mixin, so the framework declaration wins and the class defines fine. The walk is direct rather than through `_merged_reader_option_specs()`, so the per-class cache stays cold during `__init_subclass__`.

The reserved key is named once at module level and used wherever it is functionally written or read, so the guard cannot drift from the key `add_base_input_data_to_options` writes.

## Tests

Six tests alongside the existing declaration-validation ones: the reported reproduction, the `NO_DEFAULT` self-veto shape, a plain redeclaration, the mixin that wins the merge, the mixin that loses it, and a control that a legitimate redeclaration keeping `framework_set=True` still defines.

Closes #980