### PR TITLE
refactor: give the match-hook call one home across both seams

### DIFF
--- a/mloda/core/abstract_plugins/components/match_hook.py
+++ b/mloda/core/abstract_plugins/components/match_hook.py
@@ -1,0 +1,54 @@
+"""One home for the match-hook call: the containment, the marked-abort re-raise and the return coercion.
+
+Both match seams held their own try around ``match_feature_group_criteria`` and drifted apart twice (#991).
+Each keeps only its own recording and rollback now, driven by the outcome this helper hands back.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Optional
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.components.utils import is_match_abort
+
+if TYPE_CHECKING:
+    from mloda.core.abstract_plugins.feature_group import FeatureGroup
+
+
+@dataclass(frozen=True)
+class MatchHookOutcome:
+    """One match-hook call: the coerced verdict, the raw return, and the raise that was contained."""
+
+    matched: bool
+    returned: Any
+    error: Optional[Exception]
+
+
+def call_match_hook(
+    feature_group: type[FeatureGroup],
+    feature_name: FeatureName | str,
+    options: Options,
+    data_access_collection: Optional[DataAccessCollection] = None,
+) -> MatchHookOutcome:
+    """Ask one candidate's match hook: a raise out of it is a non-match for that candidate only (#845).
+
+    Policy: mark a raise with escalate_match_abort when it reports a misconfiguration, a contradiction or a
+    framework defect; leave it contained when it is one candidate's own judgment or own defect. Every raise
+    the match path reaches must say which, at the raise: tests/test_core/test_prepare/test_match_abort_sweep.py
+    enforces that. A mark only survives if every handler in between re-raises it (``safe_field`` does not). An
+    option-write conflict during reader selection escalates as a contradiction, decided at the reader-selection
+    raise.
+
+    The contained exception is handed back rather than judged here: each seam records and rolls back its own way.
+    """
+    try:
+        # bool() inside the try: reading a plugin's return is itself a plugin call (#927).
+        returned = feature_group.match_feature_group_criteria(feature_name, options, data_access_collection)
+        return MatchHookOutcome(bool(returned), returned, None)
+    except Exception as exc:  # noqa: BLE001  (contained: one broken matcher must not poison the whole run)
+        if is_match_abort(exc):
+            raise
+        return MatchHookOutcome(False, None, exc)

--- a/mloda/core/abstract_plugins/components/match_hook.py
+++ b/mloda/core/abstract_plugins/components/match_hook.py
@@ -51,4 +51,6 @@ def call_match_hook(
     except Exception as exc:  # noqa: BLE001  (contained: one broken matcher must not poison the whole run)
         if is_match_abort(exc):
             raise
-        return MatchHookOutcome(False, None, exc)
+        # The outcome outlives this except block, and the traceback's frames pin the plugin class and its raw
+        # return. with_traceback, not the attribute: a frozen-dataclass exception rejects the assignment.
+        return MatchHookOutcome(False, None, exc.with_traceback(None))

--- a/mloda/core/abstract_plugins/components/utils.py
+++ b/mloda/core/abstract_plugins/components/utils.py
@@ -26,7 +26,7 @@ def contained_raise_log_level(exc: BaseException) -> int:
 def escalate_match_abort(exc: E) -> E:
     """Mark a framework-owned raise so the match seam re-raises it instead of containing it as a non-match.
 
-    Mark-or-contain policy: see IdentifyFeatureGroupClass._filter_feature_group_by_criteria.
+    Mark-or-contain policy: see call_match_hook.
     """
     # __dict__, not setattr: setattr raises on a frozen-dataclass exception, and failing to mark must not
     # replace the exception being marked.

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -13,7 +13,8 @@ from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.feature import Feature
-from mloda.core.abstract_plugins.components.utils import contained_raise_reason, is_match_abort
+from mloda.core.abstract_plugins.components.match_hook import call_match_hook
+from mloda.core.abstract_plugins.components.utils import contained_raise_reason
 from mloda.core.filter.filter_type_enum import FilterType
 from mloda.core.filter.single_filter import SingleFilter
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
@@ -220,22 +221,18 @@ class GlobalFilter:
         would pin the plugin class. The level ignores the exception type, unlike the seam, because nothing else
         surfaces the reason here. No option rollback: the hook sees a per-match deepcopy.
 
-        Mark-or-contain policy: see IdentifyFeatureGroupClass._filter_feature_group_by_criteria.
+        Mark-or-contain policy: see call_match_hook.
         """
-        try:
-            # bool() inside the try: reading a plugin's return is itself a plugin call (#927).
-            returned = feature_group.match_feature_group_criteria(
-                filter.filter_feature.name, filter.filter_feature.options, data_access_collection
-            )
-            matched = bool(returned)
-            if not matched and not isinstance(returned, bool):
-                self._report_falsy_match(feature_group, str(filter.filter_feature.name), returned)
-            return matched
-        except Exception as exc:  # noqa: BLE001  (contained: one broken matcher must not fail the whole run)
-            if is_match_abort(exc):
-                raise
-            self._record_dropped_filter(feature_group, str(filter.filter_feature.name), contained_raise_reason(exc))
+        outcome = call_match_hook(
+            feature_group, filter.filter_feature.name, filter.filter_feature.options, data_access_collection
+        )
+        if outcome.error is not None:
+            reason = contained_raise_reason(outcome.error)
+            self._record_dropped_filter(feature_group, str(filter.filter_feature.name), reason)
             return False
+        if not outcome.matched and not isinstance(outcome.returned, bool):
+            self._report_falsy_match(feature_group, str(filter.filter_feature.name), outcome.returned)
+        return outcome.matched
 
     def _record_dropped_filter(self, feature_group: type[FeatureGroup], filter_feature_name: str, reason: str) -> None:
         """Record the drop: WARNING on a key's first drop, DEBUG after, as the hook is probed per served feature."""

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -248,7 +248,10 @@ class GlobalFilter:
         )
 
     def _report_falsy_match(self, feature_group: type[FeatureGroup], filter_feature_name: str, returned: Any) -> None:
-        """Report the detached filter: WARNING on a key's first report, DEBUG after, like `_record_dropped_filter`."""
+        """Report the detached filter: WARNING on a key's first report, DEBUG after, like `_record_dropped_filter`.
+
+        Both fields are plugin-owned reads and this runs past the hook call's containment, so each degrades alone.
+        """
         key = (feature_group, filter_feature_name)
         first = key not in self._reported_falsy_matches
         self._reported_falsy_matches.add(key)
@@ -256,9 +259,9 @@ class GlobalFilter:
             logging.WARNING if first else logging.DEBUG,
             "%s returned a falsy non-bool (%s) while matching filter feature '%s'; that filter is not attached. "
             "Return True explicitly to keep it.",
-            feature_group.get_class_name(),
+            safe_field(lambda: feature_group.get_class_name(), "<unnamed feature group>"),
             # The type name only: the value's own __repr__ is plugin code and must not run here.
-            type(returned).__name__,
+            safe_field(lambda: type(returned).__name__, "<unreadable type>"),
             filter_feature_name,
         )
 

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -33,11 +33,11 @@ from mloda.core.abstract_plugins.components.match_rejection import (
     MatchRejection,
     record_match_rejection,
 )
+from mloda.core.abstract_plugins.components.match_hook import call_match_hook
 from mloda.core.abstract_plugins.components.utils import (
     as_str,
     contained_raise_log_level,
     contained_raise_reason,
-    is_match_abort,
     safe_field,
 )
 from mloda.core.abstract_plugins.compute_framework import ComputeFramework
@@ -596,61 +596,53 @@ class IdentifyFeatureGroupClass:
     ) -> bool:
         """A raise out of the match hook is a non-match for that candidate only, not a run-wide abort (#845).
 
-        Policy: mark a raise with escalate_match_abort when it reports a misconfiguration, a contradiction or a
-        framework defect; leave it contained when it is one candidate's own judgment or own defect. Every raise
-        the match path reaches must say which, at the raise: tests/test_core/test_prepare/test_match_abort_sweep.py
-        enforces that. A mark only survives if every handler in between re-raises it (``safe_field`` does not). A
-        contained raise is kept as text, never as an exception object whose traceback would pin the plugin
-        class. The per-candidate rejection window, reset in the finally, keys reasons by candidate class.
-        An option-write conflict during reader selection escalates as a contradiction, decided at the
-        reader-selection raise.
+        A contained raise is kept as text, never as an exception object whose traceback would pin the plugin
+        class. The recording runs inside the per-candidate rejection window, reset in the finally, which keys
+        reasons by candidate class.
+
+        Mark-or-contain policy: see call_match_hook.
         """
         token = MATCH_REJECTION_REASONS.set({})
         # Shallow copies, taken per candidate so an earlier match's write survives a later candidate's raise.
         group_before = dict(feature.options.group)
         context_before = dict(feature.options.context)
         try:
-            # bool() inside the try: reading a plugin's return is itself a plugin call (#927).
-            matched = bool(
-                feature_group.match_feature_group_criteria(feature.name, feature.options, data_access_collection)
-            )
-        except Exception as exc:  # noqa: BLE001  (contained: one broken matcher must not poison other features)
-            if is_match_abort(exc):
-                raise
-            # Only the contained branch rolls back: a matcher that returns True keeps its write, which is how a
-            # matched reader is linked through mloda.
-            feature.options.group.clear()
-            feature.options.group.update(group_before)
-            feature.options.context.clear()
-            feature.options.context.update(context_before)
-            if isinstance(exc, PropertyValueRejection):
-                # Text, not exc: a retained record must not pin the traceback, its frames and the plugin class.
-                logger.debug(
-                    "%s rejected an option value while matching '%s': %s",
-                    feature_group.get_class_name(),
-                    feature.name,
-                    safe_field(functools.partial(str, exc), type(exc).__name__),
-                )
-                record_match_rejection(feature_group.get_class_name(), str(exc))
-            else:
-                reason = contained_raise_reason(exc)
-                logger.log(
-                    contained_raise_log_level(exc),
-                    "%s %s while matching '%s'; treating it as a non-match.",
-                    feature_group.get_class_name(),
-                    reason,
-                    feature.name,
-                )
-                self._matcher_errors[feature_group] = reason
-            matched = False
+            outcome = call_match_hook(feature_group, feature.name, feature.options, data_access_collection)
+            exc = outcome.error
+            if exc is not None:
+                # Only the contained branch rolls back: a matcher that returns True keeps its write,
+                # which is how a matched reader is linked through mloda.
+                feature.options.group.clear()
+                feature.options.group.update(group_before)
+                feature.options.context.clear()
+                feature.options.context.update(context_before)
+                if isinstance(exc, PropertyValueRejection):
+                    # Text, not exc: a retained record must not pin the traceback, its frames and the plugin class.
+                    logger.debug(
+                        "%s rejected an option value while matching '%s': %s",
+                        feature_group.get_class_name(),
+                        feature.name,
+                        safe_field(functools.partial(str, exc), type(exc).__name__),
+                    )
+                    record_match_rejection(feature_group.get_class_name(), str(exc))
+                else:
+                    reason = contained_raise_reason(exc)
+                    logger.log(
+                        contained_raise_log_level(exc),
+                        "%s %s while matching '%s'; treating it as a non-match.",
+                        feature_group.get_class_name(),
+                        reason,
+                        feature.name,
+                    )
+                    self._matcher_errors[feature_group] = reason
         finally:
             recorded = MATCH_REJECTION_REASONS.get() or {}
             MATCH_REJECTION_REASONS.reset(token)
-        if not matched and recorded:
+        if not outcome.matched and recorded:
             # Everything recorded during this candidate's window belongs to this candidate, whatever
             # owner name an inner delegation stamped; first recorded reason wins (insertion order).
             self._match_rejections[feature_group] = next(iter(recorded.values()))
-        return matched
+        return outcome.matched
 
     def _filter_feature_group_by_domain(self, feature_group: type[FeatureGroup], feature: Feature) -> bool:
         """Decision-side domain gate: unguarded, so a raising get_domain() still fails the engine loudly."""

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -635,14 +635,15 @@ class IdentifyFeatureGroupClass:
                         feature.name,
                     )
                     self._matcher_errors[feature_group] = reason
-        finally:
+            # Inside the try, where outcome is bound: only the reset belongs on a path the body never reached.
             recorded = MATCH_REJECTION_REASONS.get() or {}
+            if not outcome.matched and recorded:
+                # Everything recorded during this candidate's window belongs to this candidate, whatever
+                # owner name an inner delegation stamped; first recorded reason wins (insertion order).
+                self._match_rejections[feature_group] = next(iter(recorded.values()))
+            return outcome.matched
+        finally:
             MATCH_REJECTION_REASONS.reset(token)
-        if not outcome.matched and recorded:
-            # Everything recorded during this candidate's window belongs to this candidate, whatever
-            # owner name an inner delegation stamped; first recorded reason wins (insertion order).
-            self._match_rejections[feature_group] = next(iter(recorded.values()))
-        return outcome.matched
 
     def _filter_feature_group_by_domain(self, feature_group: type[FeatureGroup], feature: Feature) -> bool:
         """Decision-side domain gate: unguarded, so a raising get_domain() still fails the engine loudly."""

--- a/tests/test_core/test_abstract_plugins/test_components/test_match_hook.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_match_hook.py
@@ -17,6 +17,7 @@ import pytest
 
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import PropertyValueRejection
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
 from mloda.core.abstract_plugins.components.match_hook import MatchHookOutcome, call_match_hook
 from mloda.core.abstract_plugins.components.options import Options
@@ -42,6 +43,7 @@ RAISE_TYPE_NAME = "RuntimeError"
 RAISE_MESSAGE = "boom_991_match_hook_raised"
 BOOL_RAISE_MESSAGE = "boom_991_bool_exploded"
 ABORT_MESSAGE = "abort_991_marked_match_abort"
+REJECTION_MESSAGE = "reject_991_property_value"
 
 T = TypeVar("T")
 
@@ -289,6 +291,73 @@ class TestTheHelperContainsARaise:
             f"a marked abort must not be contained, got: {snapshot.escaped}"
         )
         assert snapshot.escaped_is_the_raised_object, "the marked exception itself must escape, not a wrapper"
+
+
+@dataclass(frozen=True)
+class _ContainedErrorSnapshot:
+    """Plain-data readout of the exception one contained raise hands back. Holds no exception object."""
+
+    escaped: Optional[str]
+    is_the_raised_object: bool
+    has_traceback: bool
+    type_name: Optional[str]
+    message: Optional[str]
+    is_a_property_value_rejection: bool
+
+
+def _drive_contained_error(marker: Exception) -> _ContainedErrorSnapshot:
+    """Contain one raise and read the exception the outcome carries, traceback included, out as plain data."""
+    fg = _make_probe_fg(partial(_raise, marker))
+    outcome: Optional[MatchHookOutcome] = None
+    error: Optional[Exception] = None
+    try:
+        outcome, escaped = _capture(partial(call_match_hook, fg, PROBE_FEATURE, Options(), None))
+        error = None if outcome is None else outcome.error
+        return _ContainedErrorSnapshot(
+            escaped=escaped,
+            is_the_raised_object=error is marker,
+            has_traceback=error is not None and error.__traceback__ is not None,
+            type_name=None if error is None else type(error).__name__,
+            message=None if error is None else str(error),
+            is_a_property_value_rejection=isinstance(error, PropertyValueRejection),
+        )
+    finally:
+        # The frames hold the helper's own `feature_group` and `returned` locals, which pin the probe class.
+        marker.__traceback__ = None
+        del fg, outcome, error
+        gc.collect()
+
+
+class TestTheContainedRaiseCarriesNoTraceback:
+    """The outcome crosses a module boundary, so what it carries must not keep the plugin's frames alive."""
+
+    def test_the_contained_exception_arrives_without_its_traceback(self) -> None:
+        """On the seams' own try, the exception died at the implicit del closing the except block."""
+        marker = RuntimeError(RAISE_MESSAGE)
+
+        snapshot = _drive_contained_error(marker)
+
+        assert snapshot.escaped is None, f"an unmarked raise must not cross the helper: {snapshot.escaped}"
+        assert snapshot.has_traceback is False, (
+            "the traceback's frames hold the helper's own feature_group and returned locals, so an outcome the "
+            "caller keeps pins the plugin class and the raw return; clear __traceback__ before handing it back"
+        )
+        assert snapshot.is_the_raised_object, "the exception itself must come back, never a copy or a wrapper"
+        assert snapshot.type_name == RAISE_TYPE_NAME, f"the type must survive the strip: {snapshot.type_name}"
+        assert snapshot.message == RAISE_MESSAGE, f"the message must survive the strip: {snapshot.message}"
+
+    def test_a_subclass_raise_still_answers_isinstance(self) -> None:
+        """The resolution seam tells a rejection from a defect by type, so a wrapper would silently reclassify it."""
+        marker = PropertyValueRejection(REJECTION_MESSAGE)
+
+        snapshot = _drive_contained_error(marker)
+
+        assert snapshot.escaped is None, f"an unmarked raise must not cross the helper: {snapshot.escaped}"
+        assert snapshot.has_traceback is False, "a rejection is handed back tracebackless like any contained raise"
+        assert snapshot.is_a_property_value_rejection, (
+            f"isinstance against the subclass must still hold after the strip, got: {snapshot.type_name}"
+        )
+        assert snapshot.message == REJECTION_MESSAGE, f"the message must survive the strip: {snapshot.message}"
 
 
 def _asked(args: tuple[Any, ...], kwargs: dict[str, Any]) -> tuple[str, str]:

--- a/tests/test_core/test_abstract_plugins/test_components/test_match_hook.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_match_hook.py
@@ -1,0 +1,368 @@
+"""Issue #991: one helper owns the match-hook call, the marked-abort re-raise and the return coercion.
+
+``call_match_hook`` answers with a ``MatchHookOutcome``: the coerced verdict, the raw hook return and the
+contained raise. The three existing match-seam files stay the behavior net; this one pins the helper itself
+and that both seams route through it. Probe classes are dropped before any assert, per tests/conftest.py.
+"""
+
+from __future__ import annotations
+
+import gc
+from collections.abc import Callable
+from dataclasses import dataclass
+from functools import partial
+from typing import Any, Optional, TypeVar
+
+import pytest
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.match_hook import MatchHookOutcome, call_match_hook
+from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.components.utils import escalate_match_abort
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.filter import global_filter as global_filter_module
+from mloda.core.filter.filter_type_enum import FilterType
+from mloda.core.filter.global_filter import GlobalFilter
+from mloda.core.prepare import identify_feature_group as identify_feature_group_module
+from mloda.core.prepare.identify_feature_group import IdentifyFeatureGroupClass
+
+
+# The name each seam must hold in its own namespace, so a spy can observe the one call it makes.
+HELPER_NAME = "call_match_hook"
+
+PROBE_CLASS_NAME = "MatchHookProbeFG991"
+PROBE_FEATURE = "match_hook_probe_feat_991"
+HOST_FEATURE = "match_hook_host_feat_991"  # the resolved feature the filters are matched against
+FILTER_FEATURE_A = "match_hook_filter_a_991"
+FILTER_FEATURE_B = "match_hook_filter_b_991"
+
+RAISE_TYPE_NAME = "RuntimeError"
+RAISE_MESSAGE = "boom_991_match_hook_raised"
+BOOL_RAISE_MESSAGE = "boom_991_bool_exploded"
+ABORT_MESSAGE = "abort_991_marked_match_abort"
+
+T = TypeVar("T")
+
+
+class FalsyBool991:
+    """A returned value that is not False and says no only through __bool__."""
+
+    def __bool__(self) -> bool:
+        return False
+
+    def __repr__(self) -> str:
+        return "<FalsyBool991>"
+
+
+class TruthyBool991:
+    """The mirror: a returned value that is not True and says yes only through __bool__."""
+
+    def __bool__(self) -> bool:
+        return True
+
+    def __repr__(self) -> str:
+        return "<TruthyBool991>"
+
+
+class ExplodingBool991:
+    """A returned value whose truthiness test raises: reading it is itself a plugin call."""
+
+    def __bool__(self) -> bool:
+        raise RuntimeError(BOOL_RAISE_MESSAGE)
+
+    def __repr__(self) -> str:
+        # Fixed text: a snapshot must be able to show this value without triggering the raise.
+        return "<ExplodingBool991>"
+
+
+# Keyed by id so parametrize stays readable; each row is ONE object, so identity pins the raw return.
+FALSY_NON_BOOL_RETURNS: dict[str, Any] = {
+    "none": None,
+    "zero": 0,
+    "empty_string": "",
+    "empty_list": [],
+    "falsy_bool_object": FalsyBool991(),
+}
+TRUTHY_NON_BOOL_RETURNS: dict[str, Any] = {
+    "non_empty_string": "yes",
+    "one": 1,
+    "non_empty_list": [1],
+    "truthy_bool_object": TruthyBool991(),
+}
+FALSY_RETURNS: dict[str, Any] = {**FALSY_NON_BOOL_RETURNS, "literal_false": False}
+TRUTHY_RETURNS: dict[str, Any] = {**TRUTHY_NON_BOOL_RETURNS, "literal_true": True}
+
+# The hook returned nothing at all, so the outcome's raw return must be None.
+_NOTHING = object()
+
+
+def _shown(value: Any) -> str:
+    """Type and repr of a value, so an identity assert can report it without a truthiness test."""
+    return f"{type(value).__name__} {value!r}"
+
+
+def _raise(exc: BaseException) -> Any:
+    """Raise ``exc``; a named function, so a probe's answer holds no throwaway class."""
+    raise exc
+
+
+def _capture(call: Callable[[], T]) -> tuple[Optional[T], Optional[str]]:
+    """Run call, returning (value, None) or (None, 'Type: message'). No traceback is retained."""
+    try:
+        return call(), None
+    except Exception as exc:  # noqa: BLE001  (red-phase probe: an escape is the fact under test)
+        return None, f"{type(exc).__name__}: {exc}"
+
+
+def _make_probe_fg(answer: Callable[[], Any]) -> type[FeatureGroup]:
+    """A throwaway group whose match hook returns, or raises, whatever ``answer`` does."""
+    # Class objects are cyclic; collect leftovers from earlier tests before defining a twin.
+    gc.collect()
+
+    class MatchHookProbeFG991(FeatureGroup):
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: Optional[DataAccessCollection] = None,
+        ) -> Any:  # Any, not bool: a non-bool out of a `-> bool` hook is exactly what the helper coerces.
+            return answer()
+
+    return MatchHookProbeFG991
+
+
+@dataclass(frozen=True)
+class _OutcomeSnapshot:
+    """Plain-data readout of one call_match_hook call. Holds no class and no exception object."""
+
+    escaped: Optional[str]
+    escaped_is_the_raised_object: bool
+    is_the_result_type: bool
+    matched_is_true: bool
+    matched_is_false: bool
+    matched_shown: str
+    returned_is_the_hook_value: bool
+    returned_shown: str
+    error_is_none: bool
+    error_is_the_raised_object: bool
+    error_type: Optional[str]
+    error_message: Optional[str]
+
+
+def _drive(
+    answer: Callable[[], Any],
+    returned: Any = _NOTHING,
+    raised: Optional[BaseException] = None,
+) -> _OutcomeSnapshot:
+    """Call the helper against one throwaway group and read the outcome out as plain data.
+
+    ``returned`` is the object the hook hands back, ``raised`` the object it raises. The finally unbinds
+    every name and clears every traceback that would pin the probe class.
+    """
+    fg = _make_probe_fg(answer)
+    outcome: Any = None
+    escaped: Optional[BaseException] = None
+    error: Optional[BaseException] = None
+    matched: Any = None
+    raw: Any = None
+    try:
+        try:
+            outcome = call_match_hook(fg, PROBE_FEATURE, Options(), None)
+        except BaseException as exc:  # noqa: BLE001  (an escape, or its absence, is the fact under test)
+            escaped = exc
+        if outcome is not None:
+            matched, raw, error = outcome.matched, outcome.returned, outcome.error
+        expected = None if returned is _NOTHING else returned
+        return _OutcomeSnapshot(
+            escaped=None if escaped is None else f"{type(escaped).__name__}: {escaped}",
+            escaped_is_the_raised_object=escaped is not None and escaped is raised,
+            is_the_result_type=isinstance(outcome, MatchHookOutcome),
+            matched_is_true=matched is True,
+            matched_is_false=matched is False,
+            matched_shown=_shown(matched),
+            returned_is_the_hook_value=raw is expected,
+            returned_shown=_shown(raw),
+            error_is_none=outcome is not None and error is None,
+            error_is_the_raised_object=error is not None and error is raised,
+            error_type=None if error is None else type(error).__name__,
+            error_message=None if error is None else str(error),
+        )
+    finally:
+        for exception in (escaped, error, raised):
+            if exception is not None:
+                # The frames hold the helper's own `feature_group` local, which pins the probe class.
+                exception.__traceback__ = None
+        del fg, outcome, escaped, error, matched, raw
+        gc.collect()
+
+
+class TestTheHelperCoercesTheReturn:
+    """One coercion for both seams: truthiness decides, and the verdict handed back is a real bool."""
+
+    @pytest.mark.parametrize("returned_id", sorted(TRUTHY_RETURNS))
+    def test_a_truthy_return_comes_back_as_true(self, returned_id: str) -> None:
+        value = TRUTHY_RETURNS[returned_id]
+
+        snapshot = _drive(lambda: value, returned=value)
+
+        assert snapshot.escaped is None, f"nothing may cross the helper: {snapshot.escaped}"
+        assert snapshot.is_the_result_type, f"the helper must answer with a MatchHookOutcome: {snapshot.matched_shown}"
+        assert snapshot.matched_is_true, f"a truthy return must come back as True, not raw: {snapshot.matched_shown}"
+        assert snapshot.error_is_none, f"a hook that returned contained nothing: {snapshot.error_type}"
+
+    @pytest.mark.parametrize("returned_id", sorted(FALSY_RETURNS))
+    def test_a_falsy_return_comes_back_as_false(self, returned_id: str) -> None:
+        value = FALSY_RETURNS[returned_id]
+
+        snapshot = _drive(lambda: value, returned=value)
+
+        assert snapshot.escaped is None, f"nothing may cross the helper: {snapshot.escaped}"
+        assert snapshot.is_the_result_type, f"the helper must answer with a MatchHookOutcome: {snapshot.matched_shown}"
+        assert snapshot.matched_is_false, f"a falsy return must come back as False, not raw: {snapshot.matched_shown}"
+        assert snapshot.error_is_none, f"a hook that returned contained nothing: {snapshot.error_type}"
+
+    @pytest.mark.parametrize("returned_id", sorted(FALSY_NON_BOOL_RETURNS))
+    def test_the_raw_return_survives_a_falsy_non_bool(self, returned_id: str) -> None:
+        """The filter seam reports a falsy non-bool, so the value itself must reach it through the outcome."""
+        value = FALSY_NON_BOOL_RETURNS[returned_id]
+
+        snapshot = _drive(lambda: value, returned=value)
+
+        assert snapshot.escaped is None, f"nothing may cross the helper: {snapshot.escaped}"
+        assert snapshot.returned_is_the_hook_value, (
+            f"the raw return must survive so the caller can report it, got: {snapshot.returned_shown}"
+        )
+        assert snapshot.matched_is_false, f"a falsy non-bool is still a non-match: {snapshot.matched_shown}"
+
+    @pytest.mark.parametrize("returned_id", sorted(TRUTHY_NON_BOOL_RETURNS))
+    def test_the_raw_return_survives_a_truthy_non_bool(self, returned_id: str) -> None:
+        """Same in the other direction, so the raw return is not a falsy-only afterthought."""
+        value = TRUTHY_NON_BOOL_RETURNS[returned_id]
+
+        snapshot = _drive(lambda: value, returned=value)
+
+        assert snapshot.escaped is None, f"nothing may cross the helper: {snapshot.escaped}"
+        assert snapshot.returned_is_the_hook_value, f"the raw return must survive, got: {snapshot.returned_shown}"
+        assert snapshot.matched_is_true, f"a truthy non-bool is still a match: {snapshot.matched_shown}"
+
+
+class TestTheHelperContainsARaise:
+    """The containment has one home: the raise comes back in the outcome, unless it is marked."""
+
+    def test_a_plain_raise_is_contained_and_handed_back(self) -> None:
+        """Each seam records it its own way, so the helper hands the exception over instead of judging it."""
+        marker = RuntimeError(RAISE_MESSAGE)
+
+        snapshot = _drive(partial(_raise, marker), raised=marker)
+
+        assert snapshot.escaped is None, f"an unmarked raise must not cross the helper: {snapshot.escaped}"
+        assert snapshot.matched_is_false, f"a raising hook is a non-match: {snapshot.matched_shown}"
+        assert snapshot.error_is_the_raised_object, (
+            f"the outcome must carry the raise itself, got: {snapshot.error_type}: {snapshot.error_message}"
+        )
+        assert snapshot.returned_is_the_hook_value, f"nothing came back from the hook: {snapshot.returned_shown}"
+
+    def test_a_return_that_explodes_on_bool_is_contained_too(self) -> None:
+        """bool() belongs inside the containment: reading a plugin's return is itself a plugin call (#927).
+
+        The raw return is deliberately unpinned here: a caller reads it only when nothing raised.
+        """
+        snapshot = _drive(lambda: ExplodingBool991())
+
+        assert snapshot.escaped is None, f"the raise must not cross the helper: {snapshot.escaped}"
+        assert snapshot.matched_is_false, f"an unreadable return is a non-match: {snapshot.matched_shown}"
+        assert snapshot.error_type == RAISE_TYPE_NAME, f"the coercion's raise must be contained: {snapshot.error_type}"
+        assert snapshot.error_message == BOOL_RAISE_MESSAGE, (
+            f"the outcome must carry the raise the coercion produced: {snapshot.error_message}"
+        )
+
+    def test_a_marked_abort_propagates_unchanged(self) -> None:
+        """A framework-owned raise crosses the helper as the SAME object, so both seams keep escalating it."""
+        marker = escalate_match_abort(RuntimeError(ABORT_MESSAGE))
+
+        snapshot = _drive(partial(_raise, marker), raised=marker)
+
+        assert snapshot.escaped == f"{RAISE_TYPE_NAME}: {ABORT_MESSAGE}", (
+            f"a marked abort must not be contained, got: {snapshot.escaped}"
+        )
+        assert snapshot.escaped_is_the_raised_object, "the marked exception itself must escape, not a wrapper"
+
+
+def _asked(args: tuple[Any, ...], kwargs: dict[str, Any]) -> tuple[str, str]:
+    """(group class name, feature name) of one helper call, read without assuming how it was spelled."""
+    values = [*args, *kwargs.values()]
+    group = next((value for value in values if isinstance(value, type) and issubclass(value, FeatureGroup)), None)
+    name = next((value for value in values if isinstance(value, str)), "?")
+    return ("?" if group is None else str(group.get_class_name()), str(name))
+
+
+class _Spy:
+    """Records one entry per helper call and delegates to the real helper, so the seam behaves normally."""
+
+    def __init__(self) -> None:
+        self.seen: list[tuple[str, str]] = []
+
+    def __call__(self, *args: Any, **kwargs: Any) -> MatchHookOutcome:
+        self.seen.append(_asked(args, kwargs))
+        return call_match_hook(*args, **kwargs)
+
+
+def test_the_filter_seam_calls_the_helper_once_per_filter(monkeypatch: pytest.MonkeyPatch) -> None:
+    """identify_matched_filters asks the shared helper once per registered filter, and reaches the hook no other way."""
+    assert hasattr(global_filter_module, HELPER_NAME), (
+        f"{global_filter_module.__name__} must import {HELPER_NAME} into its own namespace and route the hook "
+        "call through it; nothing here can observe a call the seam makes itself."
+    )
+    spy = _Spy()
+    monkeypatch.setattr(global_filter_module, HELPER_NAME, spy)
+    fg = _make_probe_fg(lambda: True)
+    global_filter = GlobalFilter()
+    global_filter.add_filter(FILTER_FEATURE_A, FilterType.EQUAL, {"value": 1})
+    global_filter.add_filter(FILTER_FEATURE_B, FilterType.EQUAL, {"value": 2})
+    matched: Any = None
+    escaped: Optional[str] = None
+    names: tuple[str, ...] = ()
+    try:
+        matched, escaped = _capture(partial(global_filter.identify_matched_filters, fg, Feature(HOST_FEATURE), None))
+        names = () if matched is None else tuple(sorted(single.name for single in matched))
+        seen = sorted(spy.seen)
+    finally:
+        del fg, global_filter, matched, spy
+        gc.collect()
+
+    assert escaped is None, f"nothing may cross identify_matched_filters: {escaped}"
+    assert seen == [(PROBE_CLASS_NAME, FILTER_FEATURE_A), (PROBE_CLASS_NAME, FILTER_FEATURE_B)], (
+        f"the filter seam must reach the hook only through {HELPER_NAME}, once per filter, got: {seen}"
+    )
+    assert names == (FILTER_FEATURE_A, FILTER_FEATURE_B), f"both filters must still attach, got: {list(names)}"
+
+
+def test_the_resolution_seam_calls_the_helper_once_per_candidate(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The resolution seam asks the same helper, once per candidate, and reaches the hook no other way."""
+    assert hasattr(identify_feature_group_module, HELPER_NAME), (
+        f"{identify_feature_group_module.__name__} must import {HELPER_NAME} into its own namespace and route "
+        "the hook call through it; nothing here can observe a call the seam makes itself."
+    )
+    spy = _Spy()
+    monkeypatch.setattr(identify_feature_group_module, HELPER_NAME, spy)
+    fg = _make_probe_fg(lambda: True)
+    identifier = IdentifyFeatureGroupClass()
+    verdict: Any = None
+    escaped: Optional[str] = None
+    try:
+        verdict, escaped = _capture(
+            partial(identifier._filter_feature_group_by_criteria, fg, Feature(PROBE_FEATURE), None)
+        )
+        seen = sorted(spy.seen)
+    finally:
+        del fg, identifier, spy
+        gc.collect()
+
+    assert escaped is None, f"nothing may cross the resolution seam: {escaped}"
+    assert seen == [(PROBE_CLASS_NAME, PROBE_FEATURE)], (
+        f"the resolution seam must reach the hook only through {HELPER_NAME}, once per candidate, got: {seen}"
+    )
+    assert verdict is True, f"the candidate still matches: {_shown(verdict)}"

--- a/tests/test_core/test_filter/test_filter_matcher_truthiness.py
+++ b/tests/test_core/test_filter/test_filter_matcher_truthiness.py
@@ -642,3 +642,237 @@ def test_a_none_returning_hook_attaches_no_filter_end_to_end() -> None:
     assert payload is not None
     assert payload["names"] == [E2E_MAIN], f"the filter feature must not attach: {payload!r}"
     assert payload["filter_count"] == 0, f"no filter may match: {payload!r}"
+
+
+# Issue #991: the report of a detached filter reads two plugin-owned fields, and a report is not worth a run.
+
+TYPE_NAME_RAISE_MESSAGE = "boom_991_type_name_exploded"
+CLASS_NAME_RAISE_MESSAGE = "boom_991_get_class_name_exploded"
+NONE_TYPE_NAME = "NoneType"  # the field that stays readable when the group cannot say what it is called
+
+
+class UnnameableTypeMeta991(type):
+    """A metaclass whose __name__ read raises, so type(returned).__name__ is itself a plugin call."""
+
+    @property
+    def __name__(cls) -> str:  # type: ignore[override]
+        raise RuntimeError(TYPE_NAME_RAISE_MESSAGE)
+
+
+class UnnameableFalsy991(metaclass=UnnameableTypeMeta991):
+    """A falsy non-bool return whose type name cannot be read: the field the report wants is the one that raises."""
+
+    def __bool__(self) -> bool:
+        return False
+
+    def __repr__(self) -> str:
+        # Fixed text: a snapshot must be able to show this value without triggering the raise.
+        return "<UnnameableFalsy991>"
+
+
+def _make_unnameable_group_fg() -> type[FeatureGroup]:
+    """A throwaway group that answers None for the filter feature and cannot say what it is called."""
+    gc.collect()
+
+    class UnnameableGroupFG991(FeatureGroup):
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE}
+
+        # The @final on get_class_name is a mypy pin; a plugin can still install this override at runtime.
+        @classmethod  # type: ignore[misc]
+        def get_class_name(cls) -> str:
+            raise RuntimeError(CLASS_NAME_RAISE_MESSAGE)
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: Optional[DataAccessCollection] = None,
+        ) -> Any:  # Any, not bool: the None below is the falsy non-bool whose report then names the group.
+            if str(feature_name) == FILTER_FEATURE:
+                return None
+            return str(feature_name) in cls.feature_names_supported()
+
+    return UnnameableGroupFG991
+
+
+@dataclass(frozen=True)
+class _DegradedReportSnapshot:
+    """Plain-data readout of criteria when a field the report itself reads is unreadable. Holds no class."""
+
+    is_false: bool
+    shown: str
+    escaped: Optional[str]
+    drops: int
+    warnings: tuple[str, ...]
+
+
+def _drive_criteria_of(
+    build: Callable[[], type[FeatureGroup]], caplog: pytest.LogCaptureFixture
+) -> _DegradedReportSnapshot:
+    """Call criteria once against a group `build` makes; the finally unbinds every name that pins the class."""
+    caplog.clear()
+    fg = build()
+    global_filter = GlobalFilter()
+    try:
+        with caplog.at_level(logging.DEBUG, logger=GF_LOGGER_NAME):
+            value, escaped = _capture(partial(global_filter.criteria, fg, _single(FILTER_FEATURE), None))
+        return _DegradedReportSnapshot(
+            is_false=value is False,
+            shown=_shown(value),
+            escaped=escaped,
+            # A count, not the keys: reading a key back would call the unreadable class name again.
+            drops=len(global_filter.dropped_filters),
+            warnings=_messages(caplog, logging.WARNING),
+        )
+    finally:
+        del fg, global_filter
+        gc.collect()
+
+
+@dataclass(frozen=True)
+class _MatchingPassSnapshot:
+    """Plain-data readout of one identify_matched_filters call. Holds no class and no filter object."""
+
+    escaped: Optional[str]
+    names: tuple[str, ...]
+    drops: int
+
+
+def _drive_matching_pass(build: Callable[[], type[FeatureGroup]]) -> _MatchingPassSnapshot:
+    """Match one registered filter against HOST_FEATURE and read the attached filter names out as text."""
+    fg = build()
+    global_filter = GlobalFilter()
+    global_filter.add_filter(FILTER_FEATURE, FilterType.EQUAL, {"value": 1})
+    matched = None
+    try:
+        matched, escaped = _capture(partial(global_filter.identify_matched_filters, fg, Feature(HOST_FEATURE), None))
+        return _MatchingPassSnapshot(
+            escaped=escaped,
+            names=() if matched is None else tuple(sorted(single.name for single in matched)),
+            drops=len(global_filter.dropped_filters),
+        )
+    finally:
+        del fg, global_filter, matched
+        gc.collect()
+
+
+class TestReportingADetachedFilterStaysContained:
+    """The report runs after the hook call, so its own plugin reads must degrade instead of ending the run."""
+
+    def test_criteria_survives_an_unreadable_type_name(self, caplog: pytest.LogCaptureFixture) -> None:
+        """`type(returned).__name__` is a read of a plugin-owned metaclass, not a safe formatting step."""
+        snapshot = _drive_criteria_of(partial(_make_non_bool_matcher_fg, UnnameableFalsy991()), caplog)
+
+        assert snapshot.escaped is None, (
+            f"reporting a non-match must not cross GlobalFilter.criteria and kill the run: {snapshot.escaped}"
+        )
+        assert snapshot.is_false, f"a falsy return is still a plain non-match, got: {snapshot.shown}"
+        assert snapshot.drops == 0, f"a falsy non-bool is a non-match, never a recorded drop, got: {snapshot.drops}"
+        assert len(snapshot.warnings) == 1, f"the detached filter must still be reported, got: {snapshot.warnings}"
+        message = snapshot.warnings[0]
+        assert PROBE_CLASS_NAME in message, f"the field that IS readable must still be named: {message}"
+        assert FILTER_FEATURE in message, f"the warning must name the filter feature: {message}"
+
+    def test_criteria_survives_an_unreadable_group_name(self, caplog: pytest.LogCaptureFixture) -> None:
+        """get_class_name is plugin-owned too: its @final is a mypy pin, and a runtime override raises here."""
+        snapshot = _drive_criteria_of(_make_unnameable_group_fg, caplog)
+
+        assert snapshot.escaped is None, (
+            f"reporting a non-match must not cross GlobalFilter.criteria and kill the run: {snapshot.escaped}"
+        )
+        assert snapshot.is_false, f"a falsy return is still a plain non-match, got: {snapshot.shown}"
+        assert snapshot.drops == 0, f"a falsy non-bool is a non-match, never a recorded drop, got: {snapshot.drops}"
+        assert len(snapshot.warnings) == 1, f"the detached filter must still be reported, got: {snapshot.warnings}"
+        message = snapshot.warnings[0]
+        assert NONE_TYPE_NAME in message, f"the field that IS readable must still be named: {message}"
+        assert FILTER_FEATURE in message, f"the warning must name the filter feature: {message}"
+
+    def test_the_matching_pass_survives_an_unreadable_type_name(self) -> None:
+        """The API boundary: one unreadable field on one candidate must not end the whole matching pass."""
+        snapshot = _drive_matching_pass(partial(_make_non_bool_matcher_fg, UnnameableFalsy991()))
+
+        assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
+        assert snapshot.names == (), f"a falsy return must attach no filter, got: {list(snapshot.names)}"
+        assert snapshot.drops == 0, f"a falsy non-bool is a non-match, never a recorded drop, got: {snapshot.drops}"
+
+    def test_the_matching_pass_survives_an_unreadable_group_name(self) -> None:
+        """Same at the boundary for the other plugin-owned field the report reads."""
+        snapshot = _drive_matching_pass(_make_unnameable_group_fg)
+
+        assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
+        assert snapshot.names == (), f"a falsy return must attach no filter, got: {list(snapshot.names)}"
+        assert snapshot.drops == 0, f"a falsy non-bool is a non-match, never a recorded drop, got: {snapshot.drops}"
+
+
+def _make_unreadable_report_e2e_fg() -> type[FeatureGroup]:
+    """The e2e twin of the probe above: it answers the filter feature with a value it cannot name."""
+    gc.collect()
+
+    class UnreadableReportE2EFG991(FeatureGroup):
+        @classmethod
+        def input_data(cls) -> DataCreator:
+            return DataCreator({E2E_MAIN, E2E_TARGET})
+
+        @classmethod
+        def match_feature_group_criteria(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            data_access_collection: Optional[DataAccessCollection] = None,
+        ) -> Any:  # Any, not bool: the falsy non-bool below is what the filter seam then tries to report.
+            if str(feature_name) == E2E_TARGET:
+                return UnnameableFalsy991()
+            return str(feature_name) == E2E_MAIN
+
+        @classmethod
+        def final_filters(cls) -> bool:
+            # The payload is not filterable data, so post-calculation row elimination must not run against it.
+            return False
+
+        @classmethod
+        def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+            payload = {
+                "names": sorted(str(f.name) for f in features.features),
+                "filter_count": len(features.filters) if features.filters else 0,
+            }
+            return {str(feature.name): [payload] for feature in features.features}
+
+    return UnreadableReportE2EFG991
+
+
+def _run_built(build: Callable[[], type[FeatureGroup]]) -> tuple[Optional[dict[str, Any]], Optional[str]]:
+    """Run E2E_MAIN under a filter matched by a group `build` makes; the escape is text, never an exception."""
+    fg = build()
+    collector = PluginCollector.enabled_feature_groups({fg})
+    global_filter = GlobalFilter()
+    global_filter.add_filter(E2E_TARGET, FilterType.EQUAL, {"value": 1})
+    results, escaped = _capture(
+        partial(
+            mloda.run_all,
+            [Feature(E2E_MAIN)],
+            compute_frameworks={PythonDictFramework},
+            plugin_collector=collector,
+            global_filter=global_filter,
+        )
+    )
+    del fg, collector
+    gc.collect()
+    if results is None:
+        return None, escaped
+    assert len(results) == 1, f"expected exactly one result frame, got: {results!r}"
+    payload = _single_row(results[0], E2E_MAIN)
+    assert isinstance(payload, dict)
+    return payload, escaped
+
+
+def test_an_unreadable_report_field_does_not_take_the_run_down_end_to_end() -> None:
+    """Through mloda.run_all: a filter that only fails to attach must never end the run it was declared for."""
+    payload, escaped = _run_built(_make_unreadable_report_e2e_fg)
+
+    assert escaped is None, f"reporting a detached filter must not take the run down: {escaped}"
+    assert payload is not None
+    assert payload["names"] == [E2E_MAIN], f"the filter feature must not attach: {payload!r}"
+    assert payload["filter_count"] == 0, f"no filter may match: {payload!r}"

--- a/tests/test_core/test_prepare/test_match_abort_sweep.py
+++ b/tests/test_core/test_prepare/test_match_abort_sweep.py
@@ -43,6 +43,7 @@ assert _CORE_ROOT.is_dir(), f"core root not found; check the parents index for t
 # Modules the match path runs through, repo-relative. The graph never leaves this set, so a module missing
 # here is a blind spot; test_every_declared_module_is_reachable keeps stale entries out.
 MATCH_PATH_MODULES: dict[str, str] = {
+    "mloda/core/abstract_plugins/components/match_hook.py": "the helper that owns the call and the containment",
     "mloda/core/prepare/identify_feature_group.py": "the containment seam itself",
     "mloda/core/abstract_plugins/feature_group.py": "the default matcher every group inherits",
     "mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py": "the chain-parser matcher",
@@ -893,12 +894,12 @@ def test_the_swallowing_closure_is_transitive() -> None:
 
 def test_known_escalating_handlers_are_enumerated() -> None:
     """Canary: the handlers that re-raise today are all seen, so a silently empty handler sweep cannot pass."""
-    seam = "mloda/core/prepare/identify_feature_group.py"
+    match_hook = "mloda/core/abstract_plugins/components/match_hook.py"
     feature_group = "mloda/core/abstract_plugins/feature_group.py"
     mixin = "mloda/core/abstract_plugins/components/feature_chainer/feature_chain_parser_mixin.py"
     guards = "mloda/core/abstract_plugins/components/feature_chainer/feature_chain_author_guards.py"
     expected = {
-        (seam, "_filter_feature_group_by_criteria"),
+        (match_hook, "call_match_hook"),
         (feature_group, "is_root"),
         (mixin, "match_parser_criteria"),
         (guards, "check_required_when"),
@@ -1490,8 +1491,8 @@ def _splice_narrow_handler(source: str, function: str) -> tuple[str, int]:
 
 def test_the_sweep_flags_a_narrow_handler_spliced_above_the_real_seam_check() -> None:
     """End to end: the real reachable set and the classifier on real source, mutated in memory only."""
-    module = "mloda/core/prepare/identify_feature_group.py"
-    function = "_filter_feature_group_by_criteria"
+    module = "mloda/core/abstract_plugins/components/match_hook.py"
+    function = "call_match_hook"
     names = frozenset(name for reached_module, name in sweep().reachable if reached_module == module)
     assert function in names, f"{function} is no longer reachable; splice into another reached definition"
 

--- a/tests/test_core/test_prepare/test_match_hook_call_site.py
+++ b/tests/test_core/test_prepare/test_match_hook_call_site.py
@@ -2,7 +2,9 @@
 
 Both seams called ``match_feature_group_criteria`` behind their own ``try`` and drifted apart twice, so this
 sweep parses every module under ``mloda/`` and requires the only hook call to sit in the shared helper, with
-no exception handler left at either seam. Blind spots: a ``getattr``-reached matcher, and ``mloda_plugins``.
+nothing at either seam that catches, suppresses or otherwise drops what the helper re-raised. A reference to
+the hook counts as a site too, since a bound method is called a line later. Blind spots: a matcher reached by
+string (``getattr``), and ``mloda_plugins``.
 """
 
 from __future__ import annotations
@@ -30,9 +32,14 @@ FILTER_SEAM = ("mloda/core/filter/global_filter.py", "criteria")
 RESOLUTION_SEAM = ("mloda/core/prepare/identify_feature_group.py", "_filter_feature_group_by_criteria")
 SEAMS = (FILTER_SEAM, RESOLUTION_SEAM)
 
+# The context var whose per-candidate window the resolution seam opens, and resets in its finally.
+CONTEXT_VAR = "MATCH_REJECTION_REASONS"
+
+SUPPRESS = "suppress"
+
 
 class CallSite(NamedTuple):
-    """One call of the match hook, with the function that makes it."""
+    """One place the match hook is reached, with the function that reaches it."""
 
     module: str
     lineno: int
@@ -42,13 +49,16 @@ class CallSite(NamedTuple):
         return f"{self.module}:{self.lineno} {self.function}()"
 
 
-def _is_super_delegation(node: ast.Call) -> bool:
-    """``super().<hook>(...)`` reaches a base implementation from an override; it is no caller site."""
-    func = node.func
-    if not isinstance(func, ast.Attribute):
-        return False
-    value = func.value
+def _is_super_attribute(node: ast.Attribute) -> bool:
+    """``super().<hook>`` reaches a base implementation from an override; it opens no seam of its own."""
+    value = node.value
     return isinstance(value, ast.Call) and isinstance(value.func, ast.Name) and value.func.id == "super"
+
+
+def _is_super_delegation(node: ast.Call) -> bool:
+    """``super().<hook>(...)``: the call form of the same delegation."""
+    func = node.func
+    return isinstance(func, ast.Attribute) and _is_super_attribute(func)
 
 
 def _is_hook_call(node: ast.Call) -> bool:
@@ -62,19 +72,32 @@ def _is_hook_call(node: ast.Call) -> bool:
     return isinstance(func, ast.Name) and func.id == HOOK
 
 
+def _is_hook_reference(node: ast.Attribute) -> bool:
+    """``<anything>.<hook>`` read as a value: bound here, called a line later, invisible to a call-only scan."""
+    return node.attr == HOOK and isinstance(node.ctx, ast.Load) and not _is_super_attribute(node)
+
+
 def _collect_calls(node: ast.AST, module: str, functions: list[str], out: list[CallSite]) -> None:
-    """Walk ``node``, recording each hook call with the function that encloses it."""
+    """Walk ``node``, recording each hook call and each hook reference with the function that encloses it."""
     for child in ast.iter_child_nodes(node):
         if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
             _collect_calls(child, module, [*functions, child.name], out)
             continue
-        if isinstance(child, ast.Call) and _is_hook_call(child) and not _is_super_delegation(child):
+        if isinstance(child, ast.Call) and _is_hook_call(child):
+            if not _is_super_delegation(child):
+                out.append(CallSite(module, child.lineno, functions[-1] if functions else "<module>"))
+            # Walk the func node's own children only: the node itself names the hook this call already reported.
+            _collect_calls(child.func, module, functions, out)
+            for argument in [*child.args, *(keyword.value for keyword in child.keywords)]:
+                _collect_calls(argument, module, functions, out)
+            continue
+        if isinstance(child, ast.Attribute) and _is_hook_reference(child):
             out.append(CallSite(module, child.lineno, functions[-1] if functions else "<module>"))
         _collect_calls(child, module, functions, out)
 
 
 def classify_calls(source: str, module: str) -> list[CallSite]:
-    """Every call of the match hook in ``source``, definitions and ``super()`` delegations excluded."""
+    """Every call or reference of the match hook in ``source``, definitions and ``super()`` delegations excluded."""
     out: list[CallSite] = []
     _collect_calls(ast.parse(source, filename=module), module, [], out)
     return sorted(out)
@@ -99,9 +122,9 @@ def sweep() -> _Sweep:
     return _Sweep(tuple(modules), tuple(sorted(sites)))
 
 
-def _definition(module: str, function: str) -> ast.FunctionDef | ast.AsyncFunctionDef:
-    """The single definition of ``function`` in ``module``; a missing or duplicated one fails here."""
-    tree = ast.parse((_REPO_ROOT / module).read_text(encoding="utf-8"), filename=module)
+def _definition_in(source: str, module: str, function: str) -> ast.FunctionDef | ast.AsyncFunctionDef:
+    """The single definition of ``function`` in ``source``; a missing or duplicated one fails here."""
+    tree = ast.parse(source, filename=module)
     found = [
         node
         for node in ast.walk(tree)
@@ -109,6 +132,41 @@ def _definition(module: str, function: str) -> ast.FunctionDef | ast.AsyncFuncti
     ]
     assert len(found) == 1, f"{module} holds {len(found)} definitions of {function}; this pin names exactly one"
     return found[0]
+
+
+def _definition(module: str, function: str) -> ast.FunctionDef | ast.AsyncFunctionDef:
+    """The single definition of ``function`` in ``module``, read from disk."""
+    return _definition_in((_REPO_ROOT / module).read_text(encoding="utf-8"), module, function)
+
+
+def _is_suppress(expr: ast.expr) -> bool:
+    """``suppress(...)`` or ``contextlib.suppress(...)``. Restated here, not imported: no test may import a test."""
+    if not isinstance(expr, ast.Call):
+        return False
+    func = expr.func
+    if isinstance(func, ast.Name):
+        return func.id == SUPPRESS
+    return isinstance(func, ast.Attribute) and func.attr == SUPPRESS
+
+
+def _finally_escapes(finalbody: list[ast.stmt]) -> bool:
+    """A return, break or continue leaving ``finally`` discards whatever exception is in flight."""
+    escapes = (ast.Return, ast.Break, ast.Continue)
+    return any(isinstance(node, escapes) for statement in finalbody for node in ast.walk(statement))
+
+
+def silent_drops(node: ast.AST) -> list[int]:
+    """Line of every place inside ``node`` that drops an exception with no ``except`` clause to show for it."""
+    drops: list[int] = []
+    for child in ast.walk(node):
+        if isinstance(child, (ast.With, ast.AsyncWith)) and any(
+            _is_suppress(item.context_expr) for item in child.items
+        ):
+            drops.append(child.lineno)
+        elif isinstance(child, ast.Try) and _finally_escapes(child.finalbody):
+            # ast exposes no position for the finally keyword, so the try line carries the decision.
+            drops.append(child.lineno)
+    return sorted(drops)
 
 
 def test_the_helper_module_is_scanned_and_holds_the_call() -> None:
@@ -122,6 +180,17 @@ def test_the_helper_module_is_scanned_and_holds_the_call() -> None:
     functions = [site.function for site in sweep().sites if site.module == HELPER_MODULE]
     assert functions == [HELPER_FUNCTION], (
         f"{HELPER_MODULE} must call {HOOK} exactly once, inside {HELPER_FUNCTION}(); found {functions}"
+    )
+
+
+def test_the_sweep_does_not_collapse() -> None:
+    """The helper canary is satisfied by a single scanned module, so pin the size of the walk too."""
+    scanned = sweep().modules
+
+    # Vacuity floor, not a target: 140 modules today, so deleting one stays a legitimate change.
+    assert len(scanned) >= 120, (
+        f"the sweep parsed only {len(scanned)} modules under mloda/; it stopped covering the tree, and both "
+        "call-site pins would pass while reading almost nothing"
     )
 
 
@@ -146,6 +215,36 @@ def test_neither_seam_holds_an_exception_handler_of_its_own(module: str, functio
         f"{module}::{function}() catches at line(s) {handlers}. The call, the marked-abort re-raise and the "
         f"bool() coercion belong to {HELPER_FUNCTION}(); read its outcome instead and keep only this seam's "
         "own recording and rollback here."
+    )
+
+
+@pytest.mark.parametrize(("module", "function"), SEAMS)
+def test_neither_seam_drops_an_exception_without_an_except(module: str, function: str) -> None:
+    """``except`` is not the only way to swallow: a suppress block and a returning finally do it with none."""
+    drops = silent_drops(_definition(module, function))
+
+    assert drops == [], (
+        f"{module}::{function}() drops an exception at line(s) {drops} with no except clause to show for it. A "
+        f"suppress block or a finally that returns swallows the marked abort {HELPER_FUNCTION}() deliberately "
+        "re-raised, and the handler pin beside this one sees none of it."
+    )
+
+
+def test_the_resolution_seam_keeps_only_the_context_var_reset_in_its_finally() -> None:
+    """``outcome`` is bound only where nothing raised, so every read of it belongs inside the same try."""
+    module, function = RESOLUTION_SEAM
+    definition = _definition(module, function)
+    blocks = [node for node in ast.walk(definition) if isinstance(node, ast.Try) and node.finalbody]
+
+    assert len(blocks) == 1, f"{module}::{function}() holds {len(blocks)} try/finally blocks; this pin names one"
+    statements = [ast.unparse(statement) for statement in blocks[0].finalbody]
+    assert len(statements) == 1 and statements[0].startswith(f"{CONTEXT_VAR}.reset("), (
+        f"the finally of {function}() must hold the window reset alone, got: {statements}. Harvesting there "
+        "keeps the harvest on a path the try body never reached."
+    )
+    assert isinstance(definition.body[-1], ast.Try), (
+        f"every path out of {function}() must leave through that try. A read of the outcome after it runs on a "
+        "path no handler binds, so the first except clause added to the try turns it into an UnboundLocalError."
     )
 
 
@@ -184,8 +283,49 @@ def test_the_scanner_ignores_a_super_delegation() -> None:
     assert classify_calls(source, "snippet.py") == []
 
 
-def _splice_hook_call(source: str, function: str) -> tuple[str, int]:
-    """Insert a hook call at the top of ``function``'s body; in memory only, never written back to disk."""
+def test_the_scanner_ignores_a_bound_super_delegation() -> None:
+    """Binding the base implementation first is the same delegation, one line apart."""
+    source = (
+        "class ProbeGroup(Base):\n"
+        "    @classmethod\n"
+        "    def match_feature_group_criteria(cls, feature_name, options, data_access_collection=None):\n"
+        "        inherited = super().match_feature_group_criteria\n"
+        "        return inherited(feature_name, options, data_access_collection)\n"
+    )
+
+    assert classify_calls(source, "snippet.py") == []
+
+
+def test_the_scanner_reports_a_hook_bound_for_a_later_call() -> None:
+    """A seam that binds the hook and calls the name is a seam; a call-only scan reads it as nothing at all."""
+    source = (
+        "def criteria(self, feature_group, filter, data_access_collection=None):\n"
+        "    hook = feature_group.match_feature_group_criteria\n"
+        "    return hook(filter.name, filter.options, None)\n"
+    )
+
+    sites = classify_calls(source, "snippet.py")
+
+    assert [(site.lineno, site.function) for site in sites] == [(2, "criteria")]
+
+
+def test_the_scanner_counts_a_call_once_and_a_reference_beside_it() -> None:
+    """The attribute inside a call the scanner already reported must not come back as a second site."""
+    source = (
+        "def criteria(self, feature_group, filter, data_access_collection=None):\n"
+        "    if filter is None:\n"
+        "        return feature_group.match_feature_group_criteria(filter.name, filter.options, None)\n"
+        "    hook = feature_group.match_feature_group_criteria\n"
+        "    return hook(filter.name, filter.options, None)\n"
+    )
+
+    sites = classify_calls(source, "snippet.py")
+
+    assert [(site.lineno, site.function) for site in sites] == [(3, "criteria"), (4, "criteria")]
+
+
+def _splice(source: str, function: str, block: list[str]) -> tuple[str, int]:
+    """Insert ``block`` at the top of ``function``'s body; in memory only, never written back to disk."""
     targets = [
         node
         for node in ast.walk(ast.parse(source))
@@ -196,8 +336,13 @@ def _splice_hook_call(source: str, function: str) -> tuple[str, int]:
     pad = " " * first.col_offset
     lines = source.splitlines()
     at = first.lineno - 1
-    spliced = f"{pad}feature_group.{HOOK}(filter.filter_feature.name, filter.filter_feature.options, None)"
-    return "\n".join([*lines[:at], spliced, *lines[at:]]) + "\n", first.lineno
+    return "\n".join([*lines[:at], *(f"{pad}{line}" for line in block), *lines[at:]]) + "\n", first.lineno
+
+
+def _splice_hook_call(source: str, function: str) -> tuple[str, int]:
+    """Insert a hook call at the top of ``function``'s body."""
+    call = f"feature_group.{HOOK}(filter.filter_feature.name, filter.filter_feature.options, None)"
+    return _splice(source, function, [call])
 
 
 def test_the_sweep_flags_a_hook_call_spliced_into_the_real_seam() -> None:
@@ -210,4 +355,81 @@ def test_the_sweep_flags_a_hook_call_spliced_into_the_real_seam() -> None:
 
     assert [site.function for site in spliced] == [function], (
         f"a {HOOK} call spliced into {function}() itself was not flagged: {spliced}"
+    )
+
+
+def test_the_sweep_flags_a_hook_reference_spliced_into_the_real_seam() -> None:
+    """The same end to end for the bound form, which no call node names."""
+    module, function = FILTER_SEAM
+    source = (_REPO_ROOT / module).read_text(encoding="utf-8")
+
+    mutated, lineno = _splice(source, function, [f"hook = feature_group.{HOOK}"])
+    spliced = [site for site in classify_calls(mutated, module) if site.lineno == lineno]
+
+    assert [site.function for site in spliced] == [function], (
+        f"a {HOOK} reference spliced into {function}() itself was not flagged: {spliced}"
+    )
+
+
+def test_the_drop_scanner_flags_a_suppress_block() -> None:
+    """``suppress`` discards the exception exactly as a bare except does, and shows no except clause."""
+    source = (
+        "def criteria(self, feature_group, filter, data_access_collection=None):\n"
+        "    with contextlib.suppress(Exception):\n"
+        "        return call_match_hook(feature_group, filter.name, filter.options, None).matched\n"
+        "    return False\n"
+    )
+
+    assert silent_drops(_definition_in(source, "snippet.py", "criteria")) == [2]
+
+
+def test_the_drop_scanner_flags_a_bare_suppress_import() -> None:
+    """``from contextlib import suppress`` spells the same drop without the module name."""
+    source = (
+        "def criteria(self, feature_group, filter, data_access_collection=None):\n"
+        "    with suppress(Exception):\n"
+        "        return call_match_hook(feature_group, filter.name, filter.options, None).matched\n"
+        "    return False\n"
+    )
+
+    assert silent_drops(_definition_in(source, "snippet.py", "criteria")) == [2]
+
+
+def test_the_drop_scanner_flags_a_finally_that_returns() -> None:
+    """A return in finally discards the in-flight exception, marker and all."""
+    source = (
+        "def criteria(self, feature_group, filter, data_access_collection=None):\n"
+        "    try:\n"
+        "        return call_match_hook(feature_group, filter.name, filter.options, None).matched\n"
+        "    finally:\n"
+        "        return False\n"
+    )
+
+    # Anchored at the try line: ast.Try carries no lineno for the finally keyword.
+    assert silent_drops(_definition_in(source, "snippet.py", "criteria")) == [2]
+
+
+def test_the_drop_scanner_passes_a_finally_that_only_cleans_up() -> None:
+    """The control: the resolution seam's own finally resets a context var and drops nothing."""
+    source = (
+        "def criteria(self, feature_group, filter, data_access_collection=None):\n"
+        "    token = MATCH_REJECTION_REASONS.set({})\n"
+        "    try:\n"
+        "        return call_match_hook(feature_group, filter.name, filter.options, None).matched\n"
+        "    finally:\n"
+        "        MATCH_REJECTION_REASONS.reset(token)\n"
+    )
+
+    assert silent_drops(_definition_in(source, "snippet.py", "criteria")) == []
+
+
+@pytest.mark.parametrize(("module", "function"), SEAMS)
+def test_the_drop_pin_flags_a_suppress_spliced_into_a_real_seam(module: str, function: str) -> None:
+    """End to end on real source, mutated in memory only: a suppress at either seam is reported."""
+    source = (_REPO_ROOT / module).read_text(encoding="utf-8")
+
+    mutated, lineno = _splice(source, function, ["with contextlib.suppress(Exception):", "    pass"])
+
+    assert silent_drops(_definition_in(mutated, module, function)) == [lineno], (
+        f"a suppress block spliced into {function}() itself was not flagged"
     )

--- a/tests/test_core/test_prepare/test_match_hook_call_site.py
+++ b/tests/test_core/test_prepare/test_match_hook_call_site.py
@@ -1,0 +1,213 @@
+"""Issue #991: one call site for the match hook, so a fix can no longer land on one seam only.
+
+Both seams called ``match_feature_group_criteria`` behind their own ``try`` and drifted apart twice, so this
+sweep parses every module under ``mloda/`` and requires the only hook call to sit in the shared helper, with
+no exception handler left at either seam. Blind spots: a ``getattr``-reached matcher, and ``mloda_plugins``.
+"""
+
+from __future__ import annotations
+
+import ast
+from functools import lru_cache
+from pathlib import Path
+from typing import NamedTuple
+
+import pytest
+
+# Anchored via __file__, not the cwd: a cwd-relative root makes every lookup empty and the sweep vacuous.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_CORE_ROOT = _REPO_ROOT / "mloda"
+assert _CORE_ROOT.is_dir(), f"core root not found; check the parents index for the repo root: {_CORE_ROOT}"
+
+HOOK = "match_feature_group_criteria"
+
+# The one home of the call, the marked-abort re-raise and the bool() coercion.
+HELPER_MODULE = "mloda/core/abstract_plugins/components/match_hook.py"
+HELPER_FUNCTION = "call_match_hook"
+
+# The two seams that keep only their own recording and rollback around that call.
+FILTER_SEAM = ("mloda/core/filter/global_filter.py", "criteria")
+RESOLUTION_SEAM = ("mloda/core/prepare/identify_feature_group.py", "_filter_feature_group_by_criteria")
+SEAMS = (FILTER_SEAM, RESOLUTION_SEAM)
+
+
+class CallSite(NamedTuple):
+    """One call of the match hook, with the function that makes it."""
+
+    module: str
+    lineno: int
+    function: str
+
+    def location(self) -> str:
+        return f"{self.module}:{self.lineno} {self.function}()"
+
+
+def _is_super_delegation(node: ast.Call) -> bool:
+    """``super().<hook>(...)`` reaches a base implementation from an override; it is no caller site."""
+    func = node.func
+    if not isinstance(func, ast.Attribute):
+        return False
+    value = func.value
+    return isinstance(value, ast.Call) and isinstance(value.func, ast.Name) and value.func.id == "super"
+
+
+def _is_hook_call(node: ast.Call) -> bool:
+    """A call of the hook by name: ``<anything>.<hook>(...)`` or a bare ``<hook>(...)``.
+
+    A ``def <hook>`` is a definition node, never a call, so definitions are out by construction.
+    """
+    func = node.func
+    if isinstance(func, ast.Attribute):
+        return func.attr == HOOK
+    return isinstance(func, ast.Name) and func.id == HOOK
+
+
+def _collect_calls(node: ast.AST, module: str, functions: list[str], out: list[CallSite]) -> None:
+    """Walk ``node``, recording each hook call with the function that encloses it."""
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            _collect_calls(child, module, [*functions, child.name], out)
+            continue
+        if isinstance(child, ast.Call) and _is_hook_call(child) and not _is_super_delegation(child):
+            out.append(CallSite(module, child.lineno, functions[-1] if functions else "<module>"))
+        _collect_calls(child, module, functions, out)
+
+
+def classify_calls(source: str, module: str) -> list[CallSite]:
+    """Every call of the match hook in ``source``, definitions and ``super()`` delegations excluded."""
+    out: list[CallSite] = []
+    _collect_calls(ast.parse(source, filename=module), module, [], out)
+    return sorted(out)
+
+
+class _Sweep(NamedTuple):
+    """The modules under ``mloda/`` the sweep parsed, and every hook call found in them."""
+
+    modules: tuple[str, ...]
+    sites: tuple[CallSite, ...]
+
+
+@lru_cache(maxsize=1)
+def sweep() -> _Sweep:
+    """Parse every module under ``mloda/`` and collect the hook calls."""
+    modules: list[str] = []
+    sites: list[CallSite] = []
+    for path in sorted(_CORE_ROOT.rglob("*.py")):
+        module = path.relative_to(_REPO_ROOT).as_posix()
+        modules.append(module)
+        sites.extend(classify_calls(path.read_text(encoding="utf-8"), module))
+    return _Sweep(tuple(modules), tuple(sorted(sites)))
+
+
+def _definition(module: str, function: str) -> ast.FunctionDef | ast.AsyncFunctionDef:
+    """The single definition of ``function`` in ``module``; a missing or duplicated one fails here."""
+    tree = ast.parse((_REPO_ROOT / module).read_text(encoding="utf-8"), filename=module)
+    found = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == function
+    ]
+    assert len(found) == 1, f"{module} holds {len(found)} definitions of {function}; this pin names exactly one"
+    return found[0]
+
+
+def test_the_helper_module_is_scanned_and_holds_the_call() -> None:
+    """Non-vacuity: a helper that moved or was never written must fail here, not make the sweep find nothing."""
+    scanned = sweep().modules
+
+    assert HELPER_MODULE in scanned, (
+        f"{HELPER_MODULE} is not among the {len(scanned)} modules swept under mloda/. Create the helper that "
+        f"owns the hook call, or update HELPER_MODULE to where it now lives."
+    )
+    functions = [site.function for site in sweep().sites if site.module == HELPER_MODULE]
+    assert functions == [HELPER_FUNCTION], (
+        f"{HELPER_MODULE} must call {HOOK} exactly once, inside {HELPER_FUNCTION}(); found {functions}"
+    )
+
+
+def test_the_helper_is_the_only_match_hook_call_site() -> None:
+    strays = [site for site in sweep().sites if site.module != HELPER_MODULE]
+
+    assert strays == [], (
+        f"These call {HOOK} outside the shared helper:\n"
+        + "\n".join(f"  {site.location()}" for site in strays)
+        + f"\n\nRoute the call through {HELPER_FUNCTION}() in {HELPER_MODULE}, which owns the call, the "
+        "marked-abort re-raise and the bool() coercion, and keep only the recording and the rollback at the "
+        "seam. A second call site means every fix has to land twice, and drift when it does not."
+    )
+
+
+@pytest.mark.parametrize(("module", "function"), SEAMS)
+def test_neither_seam_holds_an_exception_handler_of_its_own(module: str, function: str) -> None:
+    """A seam that catches again re-implements the containment policy the helper owns."""
+    handlers = [node.lineno for node in ast.walk(_definition(module, function)) if isinstance(node, ast.ExceptHandler)]
+
+    assert handlers == [], (
+        f"{module}::{function}() catches at line(s) {handlers}. The call, the marked-abort re-raise and the "
+        f"bool() coercion belong to {HELPER_FUNCTION}(); read its outcome instead and keep only this seam's "
+        "own recording and rollback here."
+    )
+
+
+def test_the_scanner_reports_a_plain_hook_call() -> None:
+    source = (
+        "def criteria(self, feature_group, filter, data_access_collection=None):\n"
+        "    return feature_group.match_feature_group_criteria(filter.name, filter.options, None)\n"
+    )
+
+    sites = classify_calls(source, "snippet.py")
+
+    assert [(site.lineno, site.function) for site in sites] == [(2, "criteria")]
+
+
+def test_the_scanner_ignores_the_hook_definition() -> None:
+    """A ``def`` is where the hook lives, never a place that calls it."""
+    source = (
+        "class ProbeGroup:\n"
+        "    @classmethod\n"
+        "    def match_feature_group_criteria(cls, feature_name, options, data_access_collection=None):\n"
+        "        return True\n"
+    )
+
+    assert classify_calls(source, "snippet.py") == []
+
+
+def test_the_scanner_ignores_a_super_delegation() -> None:
+    """An override reaching its base implementation keeps the default matcher; it opens no second seam."""
+    source = (
+        "class ProbeGroup(Base):\n"
+        "    @classmethod\n"
+        "    def match_feature_group_criteria(cls, feature_name, options, data_access_collection=None):\n"
+        "        return super().match_feature_group_criteria(feature_name, options, data_access_collection)\n"
+    )
+
+    assert classify_calls(source, "snippet.py") == []
+
+
+def _splice_hook_call(source: str, function: str) -> tuple[str, int]:
+    """Insert a hook call at the top of ``function``'s body; in memory only, never written back to disk."""
+    targets = [
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == function
+    ]
+    assert len(targets) == 1, f"{function} is not a single definition in this module: {len(targets)} found"
+    first = targets[0].body[0]
+    pad = " " * first.col_offset
+    lines = source.splitlines()
+    at = first.lineno - 1
+    spliced = f"{pad}feature_group.{HOOK}(filter.filter_feature.name, filter.filter_feature.options, None)"
+    return "\n".join([*lines[:at], spliced, *lines[at:]]) + "\n", first.lineno
+
+
+def test_the_sweep_flags_a_hook_call_spliced_into_the_real_seam() -> None:
+    """End to end on real source, mutated in memory only: a call that comes back at a seam is reported."""
+    module, function = FILTER_SEAM
+    source = (_REPO_ROOT / module).read_text(encoding="utf-8")
+
+    mutated, lineno = _splice_hook_call(source, function)
+    spliced = [site for site in classify_calls(mutated, module) if site.lineno == lineno]
+
+    assert [site.function for site in spliced] == [function], (
+        f"a {HOOK} call spliced into {function}() itself was not flagged: {spliced}"
+    )


### PR DESCRIPTION
Closes #991.

`GlobalFilter.criteria` and `IdentifyFeatureGroupClass._filter_feature_group_by_criteria` each held their own `try` around `match_feature_group_criteria`, so the containment, the marked-abort re-raise and the return coercion existed twice. The two drifted apart twice already, and both fixes had to be written twice.

`call_match_hook` now owns the call, the `bool()` coercion (still inside the `try`: reading a plugin's return is itself a plugin call) and the marked-abort re-raise, and hands back an outcome carrying the coerced verdict, the raw return and the contained exception. It judges nothing: each seam keeps only what is genuinely its own.

- resolution keeps the option rollback on the contained branch, the `PropertyValueRejection` branch, `_matcher_errors` and the per-candidate rejection window;
- the filter seam keeps `dropped_filters` and the falsy-non-bool report, which is why the raw return travels in the outcome.

A static test pins the helper as the single call site under `mloda/`, so a future fix cannot land on one seam only. It reads attribute loads as well as calls, and a companion pin rejects a seam growing its own `except`, `contextlib.suppress` or returning `finally`. Both carry self-checks and a splice canary against real source, so a scanner that stops finding anything cannot pass.

Two things the review turned up, both worth having on their own:

- the falsy-return report reads the plugin's class name and its return type, and it ran inside the old seam's `try`. Past the containment those reads could kill a run, so each degrades on its own now;
- the contained exception is handed back without its traceback, whose frames pinned the plugin class and the raw return. The `except` block used to release both on exit; `with_traceback` rather than the attribute, since a frozen-dataclass exception rejects the assignment.

The behavioral net for both seams (`test_filter_matcher_containment.py`, `test_filter_matcher_truthiness.py`, `test_match_abort_escalation.py`) passes untouched. The static sweep's canaries were repointed at the helper, with no assertion weakened and no vacuity floor moved.

`tox` passes.
