### PR TITLE
fix: validate reader option declarations that reach the merge unguarded

### DIFF
--- a/mloda/core/abstract_plugins/components/input_data/base_input_data.py
+++ b/mloda/core/abstract_plugins/components/input_data/base_input_data.py
@@ -44,6 +44,15 @@ class BaseInputData(ABC):
         pass
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
+        """Guards run at class definition only: mutating READER_OPTIONS afterwards or overriding
+        __init_subclass__ without calling super() defeats them."""
+        # Checked before super(): a cooperative later-in-MRO hook may warm the cache during the
+        # super() chain; here cls.__dict__ still holds only what the class body wrote.
+        if "_reader_option_specs_cache" in cls.__dict__:
+            raise ValueError(
+                f"{cls.__name__} assigns _reader_option_specs_cache in its class body; the merge cache "
+                f"is framework-written and must never be declared by a reader."
+            )
         super().__init_subclass__(**kwargs)
         cls._validate_reader_options()
 
@@ -67,54 +76,79 @@ class BaseInputData(ABC):
     @classmethod
     def _validate_reader_options(cls) -> None:
         """Reject a reader-invalid declaration where it is written, not later deep in reader matching;
-        the per-key checks read only this class's own declaration so a bad child under a valid parent raises."""
+        checks this class's own declaration plus any plain-mixin declaration reaching its merge."""
         cls._validate_reserved_reader_option_key()
-        for key, spec in cls.__dict__.get("READER_OPTIONS", {}).items():
-            if not isinstance(spec, PropertySpec):
+        for key, spec in cls._reader_options_declaration(cls).items():
+            cls._validate_reader_option_spec(cls.__name__, key, spec)
+        for klass in cls.__mro__[1:]:
+            # Real inheritance only: an ABC.register virtual subclass answers issubclass True
+            # without ever running __init_subclass__, so it never validated itself.
+            if BaseInputData in klass.__mro__:
+                continue
+            for key, spec in cls._reader_options_declaration(klass).items():
+                cls._validate_reader_option_spec(klass.__name__, key, spec, via=cls.__name__)
+
+    @staticmethod
+    def _reader_options_declaration(klass: type) -> dict[str, Any]:
+        """The class's own READER_OPTIONS, rejected loudly when it is not a dict."""
+        declared = klass.__dict__.get("READER_OPTIONS", {})
+        if not isinstance(declared, dict):
+            raise ValueError(
+                f"{klass.__name__}.READER_OPTIONS is a {type(declared).__name__}, not a dict. "
+                f"Declare a dict mapping option keys to PropertySpec instances."
+            )
+        return declared
+
+    @staticmethod
+    def _validate_reader_option_spec(owner: str, key: str, spec: Any, via: Optional[str] = None) -> None:
+        """The per-key reader rules; owner names the class the declaration is written on,
+        via names the class definition that reached it through the merge."""
+        suffix = "" if via is None else f" (reached defining {via})"
+        if not isinstance(spec, PropertySpec):
+            raise ValueError(
+                f"{owner}.READER_OPTIONS['{key}'] is a {type(spec).__name__}, not a PropertySpec. "
+                f"Construct PropertySpec(...) instead.{suffix}"
+            )
+        if spec.match_guard is not None:
+            raise ValueError(
+                f"{owner}.READER_OPTIONS['{key}'] declares a match_guard, which is name-matching "
+                f"machinery and silently inert on a reader.{suffix}"
+            )
+        if spec.deferred_binding:
+            raise ValueError(
+                f"{owner}.READER_OPTIONS['{key}'] declares deferred_binding=True, which is the "
+                f"name-capture exemption; a reader key has no name path.{suffix}"
+            )
+        if spec.context is False:
+            raise ValueError(
+                f"{owner}.READER_OPTIONS['{key}'] declares context=False, which places a "
+                f"materialized value; readers place none.{suffix}"
+            )
+        if spec.framework_set:
+            if spec.strict_validation:
                 raise ValueError(
-                    f"{cls.__name__}.READER_OPTIONS['{key}'] is a {type(spec).__name__}, not a PropertySpec. "
-                    f"Construct PropertySpec(...) instead."
+                    f"{owner}.READER_OPTIONS['{key}'] combines framework_set=True with "
+                    f"strict_validation=True; the framework-written key is exempt from user-value "
+                    f"validation, so strictness would be silently inert.{suffix}"
                 )
-            if spec.match_guard is not None:
+            if spec.required_when is not None:
                 raise ValueError(
-                    f"{cls.__name__}.READER_OPTIONS['{key}'] declares a match_guard, which is name-matching "
-                    f"machinery and silently inert on a reader."
+                    f"{owner}.READER_OPTIONS['{key}'] combines framework_set=True with a "
+                    f"required_when predicate; the framework-written key is exempt from user-value "
+                    f"validation, so the predicate would be silently inert.{suffix}"
                 )
-            if spec.deferred_binding:
+            if spec.allow_explicit_none:
                 raise ValueError(
-                    f"{cls.__name__}.READER_OPTIONS['{key}'] declares deferred_binding=True, which is the "
-                    f"name-capture exemption; a reader key has no name path."
+                    f"{owner}.READER_OPTIONS['{key}'] combines framework_set=True with "
+                    f"allow_explicit_none=True; the admit path skips the framework-written key, "
+                    f"so the flag cannot affect reader selection.{suffix}"
                 )
-            if spec.context is False:
+            if is_no_default(spec.default):
                 raise ValueError(
-                    f"{cls.__name__}.READER_OPTIONS['{key}'] declares context=False, which places a "
-                    f"materialized value; readers place none."
+                    f"{owner}.READER_OPTIONS['{key}'] declares framework_set=True without a "
+                    f"declared default; the framework-written key must declare its absent-state "
+                    f"default explicitly, None included.{suffix}"
                 )
-            if spec.framework_set:
-                if spec.strict_validation:
-                    raise ValueError(
-                        f"{cls.__name__}.READER_OPTIONS['{key}'] combines framework_set=True with "
-                        f"strict_validation=True; the framework-written key is exempt from user-value "
-                        f"validation, so strictness would be silently inert."
-                    )
-                if spec.required_when is not None:
-                    raise ValueError(
-                        f"{cls.__name__}.READER_OPTIONS['{key}'] combines framework_set=True with a "
-                        f"required_when predicate; the framework-written key is exempt from user-value "
-                        f"validation, so the predicate would be silently inert."
-                    )
-                if spec.allow_explicit_none:
-                    raise ValueError(
-                        f"{cls.__name__}.READER_OPTIONS['{key}'] combines framework_set=True with "
-                        f"allow_explicit_none=True; the admit path skips the framework-written key, "
-                        f"so the flag cannot affect reader selection."
-                    )
-                if is_no_default(spec.default):
-                    raise ValueError(
-                        f"{cls.__name__}.READER_OPTIONS['{key}'] declares framework_set=True without a "
-                        f"declared default; the framework-written key must declare its absent-state "
-                        f"default explicitly, None included."
-                    )
 
     @classmethod
     def _merged_reader_option_specs(cls) -> dict[str, PropertySpec]:

--- a/tests/test_core/test_abstract_plugins/test_components/test_reader_option_declarations.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_reader_option_declarations.py
@@ -956,6 +956,263 @@ class TestReaderOptionsAreValidatedAtClassDefinition:
         assert "rod_bad_key" in message
 
 
+class TestMixinReaderOptionsAreValidatedAtSubclassDefinition:
+    """A plain mixin's ``READER_OPTIONS`` reaches the merge, so the subclass definition validates it too."""
+
+    def test_mixin_string_value_rejected_at_subclass_definition(self) -> None:
+        """A non-spec mixin value raises where the subclass is written, naming the mixin and the key."""
+
+        class RodStrValueMixin:
+            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {"rod_mixin_bad_key": "not a spec"}  # type: ignore[dict-item]  # wrong type is the point
+
+        with pytest.raises(ValueError) as exc_info:
+
+            class RodStrMixinReader(RodStrValueMixin, BaseInputData):
+                pass
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "RodStrValueMixin" in message
+        assert "rod_mixin_bad_key" in message
+        assert "PropertySpec" in message
+
+    def test_mixin_match_guard_spec_rejected_at_subclass_definition(self) -> None:
+        """A mixin spec declaring ``match_guard`` is rejected like an own declaration."""
+
+        class RodGuardedMixin:
+            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+                "rod_mixin_guarded_key": PropertySpec("Guarded.", match_guard=_rod_match_guard, default=None),
+            }
+
+        with pytest.raises(ValueError) as exc_info:
+
+            class RodGuardedMixinReader(RodGuardedMixin, BaseInputData):
+                pass
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "RodGuardedMixin" in message
+        assert "rod_mixin_guarded_key" in message
+        assert "match_guard" in message
+
+    def test_mixin_framework_set_with_strict_validation_rejected(self) -> None:
+        """The framework_set combination rules apply to a mixin declaration too."""
+
+        class RodFrameworkStrictMixin:
+            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+                "rod_mixin_fw_strict_key": PropertySpec(
+                    "Framework-written.",
+                    allowed_values=("a", "b"),
+                    strict_validation=True,
+                    default="a",
+                    framework_set=True,
+                ),
+            }
+
+        with pytest.raises(ValueError) as exc_info:
+
+            class RodFrameworkStrictMixinReader(RodFrameworkStrictMixin, BaseInputData):
+                pass
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "RodFrameworkStrictMixin" in message
+        assert "rod_mixin_fw_strict_key" in message
+        assert "framework_set" in message
+        assert "strict_validation" in message
+
+    def test_mixin_framework_set_without_a_declared_default_rejected(self) -> None:
+        """A mixin framework key without a declared default is rejected like an own one."""
+
+        class RodFrameworkBareMixin:
+            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+                "rod_mixin_fw_bare_key": PropertySpec("Framework-written.", framework_set=True),
+            }
+
+        with pytest.raises(ValueError) as exc_info:
+
+            class RodFrameworkBareMixinReader(RodFrameworkBareMixin, BaseInputData):
+                pass
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "RodFrameworkBareMixin" in message
+        assert "rod_mixin_fw_bare_key" in message
+        assert "framework_set" in message
+        assert "default" in message
+
+    def test_a_valid_mixin_declaration_defines_fine_and_merges(self) -> None:
+        """Control: a valid mixin spec passes the guard and its key merges into the subclass."""
+
+        class RodValidMixin:
+            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+                "rod_mixin_valid_key": PropertySpec("Valid, declared on the mixin.", default="mixin_default"),
+            }
+
+        class RodValidMixinReader(RodValidMixin, BaseInputData):
+            pass
+
+        assert "rod_mixin_valid_key" in RodValidMixinReader.declared_reader_option_keys()
+        assert (
+            RodValidMixinReader.reader_option_specs()["rod_mixin_valid_key"]
+            is RodValidMixin.READER_OPTIONS["rod_mixin_valid_key"]
+        )
+        assert RodValidMixinReader.reader_option_default("rod_mixin_valid_key") == "mixin_default"
+
+    def test_a_bad_mixin_on_a_subclass_of_a_valid_reader_still_raises(self) -> None:
+        """The guard runs per class definition, so a valid parent buys no free pass for a bad mixin."""
+
+        class RodDeepGoodReader(BaseInputData):
+            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+                "rod_deep_good_key": PropertySpec("Valid.", default=None),
+            }
+
+        class RodDeepBadMixin:
+            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {"rod_deep_bad_key": "not a spec"}  # type: ignore[dict-item]  # wrong type is the point
+
+        with pytest.raises(ValueError) as exc_info:
+
+            class RodDeepBadMixinReader(RodDeepBadMixin, RodDeepGoodReader):
+                pass
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "RodDeepBadMixin" in message
+        assert "rod_deep_bad_key" in message
+
+    def test_a_plain_subclass_without_mixins_still_defines_fine(self) -> None:
+        """Control: the mixin guard changes nothing for a declaration-free subclass."""
+
+        class RodPlainNoMixinReader(BaseInputData):
+            pass
+
+        assert RodPlainNoMixinReader.declared_reader_option_keys() == {"BaseInputData"}
+
+    def test_a_virtually_registered_mixin_is_still_validated(self) -> None:
+        """``BaseInputData.register`` must not exempt a plain mixin from the merge validation."""
+
+        class RodVirtRegisteredBadMixin:
+            """Registered virtually below; never a real reader, so the registry leak stays inert."""
+
+            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {"rod_virt_bad_key": "not a spec"}  # type: ignore[dict-item]  # wrong type is the point
+
+        BaseInputData.register(RodVirtRegisteredBadMixin)
+
+        with pytest.raises(ValueError) as exc_info:
+
+            class RodVirtRegisteredMixinReader(RodVirtRegisteredBadMixin, BaseInputData):
+                pass
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "RodVirtRegisteredBadMixin" in message
+        assert "rod_virt_bad_key" in message
+
+    def test_a_mixin_rejection_names_the_triggering_subclass(self) -> None:
+        """The error must name the class statement that triggered validation, not only the mixin."""
+
+        class RodTrigBadMixin:
+            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {"rod_trig_bad_key": "not a spec"}  # type: ignore[dict-item]  # wrong type is the point
+
+        with pytest.raises(ValueError) as exc_info:
+
+            class RodTrigReader(RodTrigBadMixin, BaseInputData):
+                pass
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "RodTrigBadMixin" in message
+        assert "RodTrigReader" in message
+
+
+class TestNonMappingReaderOptionsAreRejected:
+    """A ``READER_OPTIONS`` that is not a dict is a loud ``ValueError`` where written, not an ``AttributeError``."""
+
+    def test_a_list_valued_own_declaration_raises_value_error_naming_the_class(self) -> None:
+        """A list-shaped own declaration is rejected as not-a-dict, naming the declaring class."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class RodListOwnDeclReader(BaseInputData):
+                READER_OPTIONS = ["rod_list_entry"]  # type: ignore[assignment]  # wrong shape is the point
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "RodListOwnDeclReader" in message
+        assert "READER_OPTIONS" in message
+        assert "dict" in message
+
+    def test_a_list_valued_mixin_declaration_raises_value_error_naming_the_mixin(self) -> None:
+        """A list-shaped mixin declaration reaching the merge is rejected the same way."""
+
+        class RodListDeclMixin:
+            READER_OPTIONS = ["rod_list_entry"]
+
+        with pytest.raises(ValueError) as exc_info:
+
+            class RodListDeclMixinReader(RodListDeclMixin, BaseInputData):  # type: ignore[misc]  # wrong shape is the point
+                pass
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "RodListDeclMixin" in message
+        assert "READER_OPTIONS" in message
+        assert "dict" in message
+
+
+class TestCacheAttributeAssignmentIsRejected:
+    """A class body assigning ``_reader_option_specs_cache`` bypasses the merge and is rejected where written."""
+
+    def test_dict_cache_assignment_rejected_at_class_definition(self) -> None:
+        """A hand-built cache dict raises, naming the class and the attribute."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class RodCacheAssignReader(BaseInputData):
+                _reader_option_specs_cache: ClassVar[dict[str, PropertySpec] | None] = {
+                    "BaseInputData": PropertySpec("Shadowed.", default=None, framework_set=True),
+                }
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "RodCacheAssignReader" in message
+        assert "_reader_option_specs_cache" in message
+
+    def test_none_cache_assignment_rejected_at_class_definition(self) -> None:
+        """Even a ``None`` assignment is rejected; any class-body write to the cache is a mistake."""
+        with pytest.raises(ValueError) as exc_info:
+
+            class RodCacheNoneReader(BaseInputData):
+                _reader_option_specs_cache: ClassVar[dict[str, PropertySpec] | None] = None
+
+        message = str(exc_info.value)
+        del exc_info
+        assert "RodCacheNoneReader" in message
+        assert "_reader_option_specs_cache" in message
+
+    def test_a_cooperative_hook_warming_the_cache_is_not_rejected(self) -> None:
+        """Only a class-body assignment is a mistake; a cooperative hook warming the cache defines fine."""
+
+        class RodIntrospectingMixin:
+            def __init_subclass__(cls, **kwargs: Any) -> None:
+                """Warms the merge cache after the base guard's super() chain, like real introspection."""
+                super().__init_subclass__(**kwargs)
+                cls.reader_option_specs()  # type: ignore[attr-defined]
+
+        class RodCoopWarmedReader(BaseInputData, RodIntrospectingMixin):
+            pass
+
+        assert "BaseInputData" in RodCoopWarmedReader.reader_option_specs()
+
+    def test_a_subclass_not_touching_the_cache_defines_fine(self) -> None:
+        """Control: only a class body writing the attribute is rejected, not ordinary subclassing."""
+
+        class RodCacheUntouchedReader(BaseInputData):
+            READER_OPTIONS: ClassVar[dict[str, PropertySpec]] = {
+                "rod_cache_untouched_key": PropertySpec("Valid.", default=None),
+            }
+
+        assert RodCacheUntouchedReader.reader_option_default("rod_cache_untouched_key") is None
+
+
 class TestDeclarationsDoNotAffectDiscovery:
     """The synthetic declaring classes stay invisible to reader selection."""
 


### PR DESCRIPTION
## Summary

`_validate_reader_options` inspected only `cls.__dict__["READER_OPTIONS"]`, but `_merged_reader_option_specs` merges declarations from every class in `cls.__mro__`. Two seams therefore put a declaration into the merged mapping that no guard ever saw:

- A plain mixin base never runs `__init_subclass__`, yet its declaration outranks the base in the merge. A non-spec value (for example a bare str) defined fine and later raised an `AttributeError` deep inside reader selection instead of at the class statement. The same held for every per-key rule (`match_guard`, `deferred_binding`, `context=False`, the `framework_set` combinations).
- A class body assigning the internal `_reader_option_specs_cache` bypassed the merge entirely: the reserved framework key got shadowed and the reader vetoed itself on every match.

## Changes

- The class-definition guard now validates every `READER_OPTIONS` declaration reaching the merge from a base that does not really inherit `BaseInputData`, with the same per-key rules, naming both the declaring class and the class definition that reached it.
- Real inheritance is tested via the MRO rather than `issubclass`, so an `ABC.register` virtual subclass cannot slip past the check.
- A non-dict `READER_OPTIONS` is rejected with a `ValueError` naming the class instead of a bare `AttributeError`.
- A class body assigning `_reader_option_specs_cache` is rejected at definition. The check runs before the cooperative `__init_subclass__` chain, so a later-in-MRO hook that legitimately warms the cache is not misread as a class-body assignment.
- The guard's docstring states its limits: post-definition mutation of `READER_OPTIONS` or an `__init_subclass__` override that skips `super()` defeats any class-definition guard.

Validation stays class-definition time only; the merge, its per-class cache, and the reader-selection hot path are unchanged for valid classes.

## Tests

New tests alongside the existing declaration-validation ones cover the mixin path for each rule, the virtual-subclass case, non-dict declarations, cache assignment (dict and None), a cooperative cache-warming hook, and controls for valid mixins and plain subclasses. `tox` passes fully (pytest, ruff, mypy --strict, pip-licenses, bandit).

Fixes #1019.
