### PR TITLE
fix: multi-link feature groups no longer schedule a link that collapses into a self merge

### DIFF
--- a/mloda/core/prepare/resolve_compute_frameworks.py
+++ b/mloda/core/prepare/resolve_compute_frameworks.py
@@ -40,12 +40,53 @@ class ResolveComputeFrameworks:
         for p in groups:
             self.rewrite_group_frameworks(p, resolved, feature_trekkers)
 
+        self.reject_self_merging_links(groups, link_trekker)
+
         new_planned_queue = list(planned_queue)
 
         link_trekker.order_links_by_frameworks()
 
         new_planned_queue = self.order_queue_by_trekker_order(new_planned_queue, link_trekker)
         return new_planned_queue
+
+    def reject_self_merging_links(self, groups: Any, link_trekker: LinkTrekker) -> None:
+        """Reject a scheduled link that joins in one framework none of its children run in.
+
+        Both join sides would then filter to the same uuids and the merge degenerates into a
+        self merge, dropping one parent's columns.
+        """
+        features_by_uuid = {f.uuid: f for p in groups for f in p[1]}
+
+        for (link, left_cfw, right_cfw), child_uuids in link_trekker.data.items():
+            if left_cfw != right_cfw:
+                continue
+
+            # A self join takes case_link_equal_feature_groups, which suppresses the join step.
+            if link.left_feature_group == link.right_feature_group:
+                continue
+
+            # APPEND and UNION pick one uuid per side by index and feature group, never by framework.
+            if link.jointype in (JoinType.APPEND, JoinType.UNION):
+                continue
+
+            children = [features_by_uuid[uuid] for uuid in child_uuids if uuid in features_by_uuid]
+            if not children:
+                continue
+
+            if any(child.compute_frameworks is None or left_cfw in child.compute_frameworks for child in children):
+                continue
+
+            cfw_name = left_cfw.__name__
+            left_name = link.left_feature_group.__name__
+            right_name = link.right_feature_group.__name__
+            names = sorted(str(child.name) for child in children)
+            raise ValueError(
+                f"Link {link.jointype.value} {left_name} {right_name} joins in {cfw_name}, "
+                f"which none of its children run in: {names}. "
+                "Both join sides would resolve to the same input. "
+                "Give the joined feature groups distinct compute frameworks, "
+                f"or bring the children of this link onto {cfw_name}."
+            )
 
     def rewrite_group_frameworks(
         self,

--- a/tests/test_core/test_prepare/test_multi_link_group_resolution.py
+++ b/tests/test_core/test_prepare/test_multi_link_group_resolution.py
@@ -1,0 +1,172 @@
+"""Groups whose trekked links resolve to different compute frameworks: a link with equal
+frameworks and no child on that framework is rejected, the distinct-framework shape here still runs."""
+
+from typing import Any
+
+import pytest
+
+from mloda.provider import BaseInputData, ComputeFramework, DataCreator, FeatureGroup, FeatureSet
+from mloda.user import (
+    Feature,
+    FeatureName,
+    Index,
+    JoinSpec,
+    Link,
+    Options,
+    ParallelizationMode,
+    PluginCollector,
+    mloda,
+)
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+
+# Import the transformer so the pandas/pyarrow hop is registered.
+import mloda_plugins.compute_framework.base_implementations.pandas.pandas_pyarrow_transformer  # noqa: F401
+
+from tests.test_plugins.compute_framework.test_tooling.shared_compute_frameworks import SecondCfw
+
+
+MLG_INDEX = Index(("mlg_idx",))
+
+
+def _joined_columns(data: Any, expected: set[str]) -> str:
+    """Report which of the expected input columns actually reached the child."""
+    return "|".join(sorted(expected.intersection(data.columns)))
+
+
+class MultiLinkRootA(FeatureGroup):
+    @classmethod
+    def input_data(cls) -> BaseInputData | None:
+        return DataCreator({"mlg_a"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {"mlg_a": [1, 2, 3], "mlg_idx": ["x", "y", "z"]}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PyArrowTable}
+
+
+class MultiLinkRootBSame(FeatureGroup):
+    """Root B on the same framework as root A, so the A-B link joins in one framework."""
+
+    @classmethod
+    def input_data(cls) -> BaseInputData | None:
+        return DataCreator({"mlg_b"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {"mlg_b": [10, 20, 30], "mlg_idx": ["x", "y", "z"]}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PyArrowTable}
+
+
+class MultiLinkRootBDistinct(FeatureGroup):
+    """Root B on a second framework, so the A-B link joins across two distinct frameworks."""
+
+    @classmethod
+    def input_data(cls) -> BaseInputData | None:
+        return DataCreator({"mlg_bd"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {"mlg_bd": [10, 20, 30], "mlg_idx": ["x", "y", "z"]}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {SecondCfw}
+
+
+class MultiLinkRootC(FeatureGroup):
+    @classmethod
+    def input_data(cls) -> BaseInputData | None:
+        return DataCreator({"mlg_c"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {"mlg_c": [100, 200, 300], "mlg_idx": ["x", "y", "z"]}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+
+class MultiLinkChildSame(FeatureGroup):
+    """Child of both links, restricted to a framework neither A-B side supports."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        return {Feature("mlg_a"), Feature("mlg_b"), Feature("mlg_c")}
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {cls.get_class_name(): [_joined_columns(data, {"mlg_a", "mlg_b", "mlg_c"})] * len(data)}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+
+class MultiLinkChildDistinct(FeatureGroup):
+    """Same shape, but the A-B link joins across two distinct frameworks."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        return {Feature("mlg_a"), Feature("mlg_bd"), Feature("mlg_c")}
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {cls.get_class_name(): [_joined_columns(data, {"mlg_a", "mlg_bd", "mlg_c"})] * len(data)}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+
+_ENABLED_SAME = PluginCollector.enabled_feature_groups(
+    {MultiLinkRootA, MultiLinkRootBSame, MultiLinkRootC, MultiLinkChildSame}
+)
+_ENABLED_DISTINCT = PluginCollector.enabled_feature_groups(
+    {MultiLinkRootA, MultiLinkRootBDistinct, MultiLinkRootC, MultiLinkChildDistinct}
+)
+
+
+def test_link_joining_in_a_framework_no_member_supports_raises() -> None:
+    """Both sides of the A-B join would resolve to the same input, so planning must stop."""
+    links = {
+        Link.inner(JoinSpec(MultiLinkRootA, MLG_INDEX), JoinSpec(MultiLinkRootBSame, MLG_INDEX)),
+        Link.inner(JoinSpec(MultiLinkRootA, MLG_INDEX), JoinSpec(MultiLinkRootC, MLG_INDEX)),
+    }
+
+    with pytest.raises(ValueError) as excinfo:
+        mloda.run_all(
+            [Feature(MultiLinkChildSame.get_class_name())],
+            links=links,
+            compute_frameworks={PyArrowTable, PandasDataFrame},
+            parallelization_modes={ParallelizationMode.SYNC},
+            plugin_collector=_ENABLED_SAME,
+        )
+
+    message = str(excinfo.value)
+    assert f"joins in {PyArrowTable.__name__}" in message
+    assert "Both join sides would resolve to the same input" in message
+
+
+def test_link_joining_across_distinct_frameworks_delivers_every_parent_column() -> None:
+    """The dropped trekker keeps distinguishable sides, so the chained join stays correct."""
+    links = {
+        Link.inner(JoinSpec(MultiLinkRootA, MLG_INDEX), JoinSpec(MultiLinkRootBDistinct, MLG_INDEX)),
+        Link.inner(JoinSpec(MultiLinkRootA, MLG_INDEX), JoinSpec(MultiLinkRootC, MLG_INDEX)),
+    }
+
+    results = mloda.run_all(
+        [Feature(MultiLinkChildDistinct.get_class_name())],
+        links=links,
+        compute_frameworks={PyArrowTable, PandasDataFrame, SecondCfw},
+        parallelization_modes={ParallelizationMode.SYNC},
+        plugin_collector=_ENABLED_DISTINCT,
+    )
+
+    seen = {value for result in results for value in result[MultiLinkChildDistinct.get_class_name()]}
+    assert seen == {"mlg_a|mlg_bd|mlg_c"}

--- a/tests/test_core/test_prepare/test_resolve_cfw_per_feature.py
+++ b/tests/test_core/test_prepare/test_resolve_cfw_per_feature.py
@@ -1,18 +1,21 @@
 """Group agreement per trekked link in ResolveComputeFrameworks.links."""
 
-from typing import Any
+from collections.abc import Callable
+from typing import Any, NamedTuple
 from uuid import UUID
 
 import pytest
 
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.link import JoinSpec, Link
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.prepare.graph.graph import Graph
 from mloda.core.prepare.resolve_compute_frameworks import ResolveComputeFrameworks
-from mloda.core.prepare.resolve_links import LinkTrekker
+from mloda.core.prepare.resolve_links import LinkFrameworkTrekker, LinkTrekker
 from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
 from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+from tests.test_plugins.compute_framework.test_tooling.shared_compute_frameworks import SecondCfw
 
 
 class CfwPerFeatureLeftFG(FeatureGroup):
@@ -31,6 +34,32 @@ def _make_trekker(trekked_uuids: set[UUID]) -> tuple[LinkTrekker, Any]:
     link_trekker.data[trekker] = set(trekked_uuids)
     link_trekker.data_ordered[trekker] = set(trekked_uuids)
     return link_trekker, trekker
+
+
+class _TrekkerSpec(NamedTuple):
+    """One trekker: its join index, framework pair, trekked uuids and link kind."""
+
+    join_index: str
+    frameworks: tuple[type[ComputeFramework], type[ComputeFramework]]
+    uuids: set[UUID]
+    link_factory: Callable[[JoinSpec, JoinSpec], Link] = Link.inner
+
+
+def _make_trekkers(*specs: _TrekkerSpec) -> tuple[LinkTrekker, list[LinkFrameworkTrekker]]:
+    """Register one trekker per spec over distinct links of the same feature group pair."""
+    link_trekker = LinkTrekker()
+    trekkers: list[LinkFrameworkTrekker] = []
+    for spec in specs:
+        left = JoinSpec(CfwPerFeatureLeftFG, spec.join_index)
+        right = JoinSpec(CfwPerFeatureRightFG, spec.join_index)
+        link = spec.link_factory(left, right)
+        trekker: LinkFrameworkTrekker = (link, spec.frameworks[0], spec.frameworks[1])
+        # data and data_ordered share one set object, as production does.
+        shared_uuids = set(spec.uuids)
+        link_trekker.data[trekker] = shared_uuids
+        link_trekker.data_ordered[trekker] = shared_uuids
+        trekkers.append(trekker)
+    return link_trekker, trekkers
 
 
 def _resolve_two_feature_scenario() -> tuple[Feature, Feature, LinkTrekker, Any]:
@@ -111,6 +140,95 @@ def test_incompatible_members_raise_at_planning_time() -> None:
 
     with pytest.raises(ValueError):
         ResolveComputeFrameworks(Graph()).links(planned_queue, link_trekker)
+
+
+def test_dropped_link_joining_in_one_unsupported_framework_raises() -> None:
+    """A dropped trekker with equal frameworks would send both join sides to the same input."""
+    feature_one = Feature("feature_one")
+    feature_two = Feature("feature_two")
+    feature_one.compute_frameworks = {PandasDataFrame}
+    feature_two.compute_frameworks = {PandasDataFrame}
+
+    trekked = {feature_one.uuid, feature_two.uuid}
+    link_trekker, _ = _make_trekkers(
+        _TrekkerSpec("idx", (PandasDataFrame, PyArrowTable), trekked),
+        _TrekkerSpec("second_idx", (PyArrowTable, PyArrowTable), trekked),
+    )
+    planned_queue: list[Any] = [(CfwPerFeatureLeftFG, {feature_one, feature_two})]
+
+    with pytest.raises(ValueError) as excinfo:
+        ResolveComputeFrameworks(Graph()).links(planned_queue, link_trekker)
+
+    message = str(excinfo.value)
+    assert f"joins in {PyArrowTable.__name__}" in message
+    assert "Both join sides would resolve to the same input" in message
+    assert "feature_one" in message
+    assert "feature_two" in message
+
+
+def test_dropped_link_is_kept_when_a_child_ends_on_its_framework() -> None:
+    """A child ending on the dropped link's framework keeps its two join sides distinguishable."""
+    feature_one = Feature("feature_one")
+    feature_two = Feature("feature_two")
+    feature_one.compute_frameworks = {PandasDataFrame}
+    feature_two.compute_frameworks = {PandasDataFrame, PyArrowTable}
+
+    link_trekker, (_, dropped, _) = _make_trekkers(
+        _TrekkerSpec("idx", (PandasDataFrame, PyArrowTable), {feature_one.uuid}),
+        _TrekkerSpec("second_idx", (PyArrowTable, PyArrowTable), {feature_one.uuid, feature_two.uuid}),
+        _TrekkerSpec("third_idx", (PyArrowTable, PandasDataFrame), {feature_two.uuid}),
+    )
+    planned_queue: list[Any] = [(CfwPerFeatureLeftFG, {feature_one}), (CfwPerFeatureRightFG, {feature_two})]
+
+    ResolveComputeFrameworks(Graph()).links(planned_queue, link_trekker)
+
+    assert feature_one.compute_frameworks == {PandasDataFrame}
+    assert feature_two.compute_frameworks == {PyArrowTable}
+    assert link_trekker.data[dropped] == {feature_one.uuid, feature_two.uuid}
+
+
+@pytest.mark.parametrize("link_factory", [Link.append, Link.union], ids=["append", "union"])
+def test_dropped_append_or_union_link_with_equal_frameworks_is_kept(
+    link_factory: Callable[[JoinSpec, JoinSpec], Link],
+) -> None:
+    """APPEND and UNION build their join step by index and feature group, never by framework."""
+    feature_one = Feature("feature_one")
+    feature_two = Feature("feature_two")
+    feature_one.compute_frameworks = {PandasDataFrame}
+    feature_two.compute_frameworks = {PandasDataFrame}
+
+    trekked = {feature_one.uuid, feature_two.uuid}
+    link_trekker, (_, dropped) = _make_trekkers(
+        _TrekkerSpec("idx", (PandasDataFrame, PyArrowTable), trekked),
+        _TrekkerSpec("second_idx", (PyArrowTable, PyArrowTable), trekked, link_factory),
+    )
+    planned_queue: list[Any] = [(CfwPerFeatureLeftFG, {feature_one, feature_two})]
+
+    ResolveComputeFrameworks(Graph()).links(planned_queue, link_trekker)
+
+    assert feature_one.compute_frameworks == {PandasDataFrame}
+    assert feature_two.compute_frameworks == {PandasDataFrame}
+    assert link_trekker.data[dropped] == trekked
+
+
+def test_dropped_link_joining_across_distinct_frameworks_is_skipped_silently() -> None:
+    feature_one = Feature("feature_one")
+    feature_two = Feature("feature_two")
+    feature_one.compute_frameworks = {PandasDataFrame}
+    feature_two.compute_frameworks = {PandasDataFrame}
+
+    trekked = {feature_one.uuid, feature_two.uuid}
+    link_trekker, (_, dropped) = _make_trekkers(
+        _TrekkerSpec("idx", (PandasDataFrame, PyArrowTable), trekked),
+        _TrekkerSpec("second_idx", (PyArrowTable, SecondCfw), trekked),
+    )
+    planned_queue: list[Any] = [(CfwPerFeatureLeftFG, {feature_one, feature_two})]
+
+    ResolveComputeFrameworks(Graph()).links(planned_queue, link_trekker)
+
+    assert feature_one.compute_frameworks == {PandasDataFrame}
+    assert feature_two.compute_frameworks == {PandasDataFrame}
+    assert link_trekker.data_ordered[dropped] == trekked
 
 
 def test_resolution_is_deterministic_across_fresh_inputs() -> None:


### PR DESCRIPTION
Closes #1021.

`ResolveComputeFrameworks.links` resolves each trekked link against its members. A link with no group agreement is dropped from the resolution but stays scheduled, and that is correct for a chained join whose two sides carry distinct compute frameworks. It is not correct when both sides carry the same framework and no child of the link ends on it: `run_link` then builds a join step whose destination and source frameworks are equal, both uuid sets are filled identically, and the merge degenerates into a self merge. The run does not fail. It returns one parent's columns duplicated, the other parent's columns missing, and which parent wins varies between runs.

Planning now rejects that shape. The check runs after the planned queue has been rewritten, so it reads every feature's final framework:

- both sides of the link must carry the same compute framework,
- the link must join two different feature groups (a self join is suppressed downstream by `case_link_equal_feature_groups`),
- the join type must not be APPEND or UNION (those pick one uuid per side by index and feature group, never by framework),
- and no child of the link may end on that framework (one child on it is enough for `case_link_fw_is_equal_to_children_fw` to partition the two sides correctly).

It is the trekked children that decide this, not the join's two sides: in the scenario the runtime test builds, the joined parents do end on the link's framework while the child does not, and it is the child framework that gates the disambiguation.

The error names the join, the framework, and the children, and points at the two ways out: give the joined feature groups distinct frameworks, or bring the children onto the framework the join lands in.

The second half of the issue, untrekked members receiving the union of the group's resolved frameworks, is already covered on main: `rewrite_group_frameworks` now requires an untrekked member to support every framework its group chose, so the set it receives can no longer contain one it does not support.

## Tests

- A runtime test for the rejected shape: two roots on one framework, a third on another, a child restricted to the third, and a link between each pair.
- A runtime test for the supported chained-join shape in the same layout, pinning that the fix does not over-reject it.
- Unit tests for the exemptions: a dropped link with a child that ends on its framework, APPEND and UNION links, and a dropped link whose two sides stay distinguishable.