### PR TITLE
fix: give GlobalFilter its own copy of every filter Feature it stores

### DIFF
--- a/mloda/core/core/engine.py
+++ b/mloda/core/core/engine.py
@@ -143,10 +143,6 @@ class Engine:
             planned_queue, resolver.resolver_links.get_link_trekker()
         )
 
-        if self.global_filter:
-            # Setup and planning both mutate filter Features shared with GlobalFilter's hash-keyed sets.
-            self.global_filter.rehash_stored_filters()
-
         execution_planner = ExecutionPlan(self.global_filter, self.api_input_data_collection)
         execution_planner.create_execution_plan(planned_queue, graph, resolver.resolver_links.get_link_trekker())
         return execution_planner
@@ -348,6 +344,9 @@ class Engine:
                 # Intake may materialize declared defaults into the filter feature's options: group fills shift
                 # SingleFilter's hash, context fills shift its equality, so intake must run before it is stored.
                 self.add_feature_to_collection(feature_group_class, match.filter_feature, features.child_uuid)
+                # The stored filter needs its own Feature: planner rewrites of the queue twin must not shift its hash.
+                # The copy stays shallow on purpose, a deepcopy would shift that hash instead.
+                match.filter_feature = match.handle_filter_feature(match.filter_feature)
                 self.global_filter.add_filter_to_collection(feature_group_class, feature.name, match)
 
             # After the loop, so the recorded filters are the renamed ones.

--- a/mloda/core/core/engine.py
+++ b/mloda/core/core/engine.py
@@ -143,6 +143,10 @@ class Engine:
             planned_queue, resolver.resolver_links.get_link_trekker()
         )
 
+        if self.global_filter:
+            # Setup re-stamps nested Feature option values that a stored filter feature shares by reference.
+            self.global_filter.rehash_stored_filters()
+
         execution_planner = ExecutionPlan(self.global_filter, self.api_input_data_collection)
         execution_planner.create_execution_plan(planned_queue, graph, resolver.resolver_links.get_link_trekker())
         return execution_planner
@@ -345,7 +349,8 @@ class Engine:
                 # SingleFilter's hash, context fills shift its equality, so intake must run before it is stored.
                 self.add_feature_to_collection(feature_group_class, match.filter_feature, features.child_uuid)
                 # The stored filter needs its own Feature: planner rewrites of the queue twin must not shift its hash.
-                # The copy stays shallow on purpose, a deepcopy would shift that hash instead.
+                # handle_filter_feature copies via Feature.__copy__, which owns the containers that decide the hash.
+                # The copy keeps the queue twin's uuid on purpose: nothing reads the stored filter feature's uuid.
                 match.filter_feature = match.handle_filter_feature(match.filter_feature)
                 self.global_filter.add_filter_to_collection(feature_group_class, feature.name, match)
 

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -56,6 +56,14 @@ class GlobalFilter:
         self.matched_filter_uuids.clear()
         self._warned_divergences.clear()
 
+    def rehash_stored_filters(self) -> None:
+        """Reinsert stored filters whose hashes went stale: a stored filter feature owns its option containers
+        but shares every value, so a nested Feature value re-stamped later in setup shifts the stored hash."""
+        # list() forces a rehash; set(value) would reuse the stale stored hashes.
+        # Duplicates that became equal again intentionally merge here (same declared filter, same predicate).
+        self.collection = {key: set(list(value)) for key, value in self.collection.items()}
+        self.probes = {key: set(list(value)) for key, value in self.probes.items()}
+
     def record_probe(
         self,
         feature_group: type[FeatureGroup],
@@ -66,8 +74,9 @@ class GlobalFilter:
         """Record what a probe matched, empty included."""
         if not self.filters:
             return
+        # Rehash via list so hashes are recomputed (update(<set>) reuses the caller's stale ones).
         self.probes.setdefault((feature_group, filtered_feature_name, filtered_feature_uuid), set()).update(
-            matched_filters
+            list(matched_filters)
         )
 
     def add_filter(

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -56,14 +56,6 @@ class GlobalFilter:
         self.matched_filter_uuids.clear()
         self._warned_divergences.clear()
 
-    def rehash_stored_filters(self) -> None:
-        """Reinsert stored filters whose hashes went stale: Engine._add_filter_feature renames matched filter
-        features while their SingleFilters sit in probes, and planning rewrites shared filter Features' frameworks."""
-        # list() forces a rehash; set(value) would reuse the stale stored hashes.
-        # Duplicates that became equal after the rewrite intentionally merge here (same declared filter, same predicate).
-        self.collection = {key: set(list(value)) for key, value in self.collection.items()}
-        self.probes = {key: set(list(value)) for key, value in self.probes.items()}
-
     def record_probe(
         self,
         feature_group: type[FeatureGroup],

--- a/tests/test_core/test_filter/test_filter_link_cfw_rewrite_strands_filters.py
+++ b/tests/test_core/test_filter/test_filter_link_cfw_rewrite_strands_filters.py
@@ -1,15 +1,10 @@
-"""Regression test: a link-driven compute framework rewrite must not strand stored SingleFilters.
-
-Narrowing the link child's frameworks rebinds the shared filter Feature, which staled the hash-keyed
-sets in GlobalFilter.collection.
-"""
+"""A link-driven framework rewrite rebinds queue Features, not the SingleFilters GlobalFilter stores."""
 
 from typing import Any
 
 import pyarrow as pa
 
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
-from mloda.core.filter.single_filter import SingleFilter
 from mloda.provider import BaseInputData, ComputeFramework, DataCreator, FeatureGroup, FeatureSet
 from mloda.user import (
     Feature,
@@ -116,39 +111,12 @@ def test_link_cfw_rewrite_keeps_stored_filters_usable() -> None:
         for single_filter in stored_set:
             assert single_filter in stored_set
 
-    # Link resolution narrowed the queue-shared filter Feature to one framework; the other per-match
-    # copy is never placed in the rewritten queue set and keeps the declared two-candidate pair.
-    narrowed = [
-        single_filter
+    # Stored filter features are GlobalFilter's own, so the planner's narrowing never reaches them.
+    candidate_sets: set[frozenset[type[ComputeFramework]]] = {
+        frozenset(single_filter.filter_feature.compute_frameworks or ())
         for stored_set in global_filter.collection.values()
         for single_filter in stored_set
-        if single_filter.filter_feature.compute_frameworks == {SecondCfw}
-    ]
-    assert narrowed, "no stored SingleFilter was narrowed by the link-driven framework rewrite"
-
-
-def test_rehash_stored_filters_restores_membership_and_is_idempotent() -> None:
-    """A mutated stored filter must be findable again after the rehash; a second call changes nothing."""
-    global_filter = GlobalFilter()
-    single_filter = SingleFilter("cfwstr_unit_ts", "min", {"value": 1})
-    global_filter.filters.add(single_filter)
-
-    feature_name = FeatureName("cfwstr_unit_ts")
-    feature_uuid = single_filter.filter_feature.uuid
-    global_filter.add_filter_to_collection(CfwStrandConsumer, feature_name, single_filter)
-    global_filter.record_probe(CfwStrandConsumer, feature_name, feature_uuid, {single_filter})
-
-    single_filter.filter_feature.compute_frameworks = {SecondCfw}
-    assert single_filter not in global_filter.collection[(CfwStrandConsumer, feature_name)]
-    assert single_filter not in global_filter.probes[(CfwStrandConsumer, feature_name, feature_uuid)]
-
-    global_filter.rehash_stored_filters()
-
-    assert single_filter in global_filter.collection[(CfwStrandConsumer, feature_name)]
-    assert single_filter in global_filter.probes[(CfwStrandConsumer, feature_name, feature_uuid)]
-
-    collection_snapshot = {key: set(value) for key, value in global_filter.collection.items()}
-    probes_snapshot = {key: set(value) for key, value in global_filter.probes.items()}
-    global_filter.rehash_stored_filters()
-    assert global_filter.collection == collection_snapshot
-    assert global_filter.probes == probes_snapshot
+    }
+    assert candidate_sets == {frozenset({PyArrowTable, SecondCfw})}, (
+        f"the planner must not narrow a stored filter feature: {candidate_sets!r}"
+    )

--- a/tests/test_core/test_filter/test_filter_stored_hashes_survive_planning.py
+++ b/tests/test_core/test_filter/test_filter_stored_hashes_survive_planning.py
@@ -1,0 +1,150 @@
+"""Every SingleFilter GlobalFilter stores must stay findable in its own hash-keyed set after planning.
+
+A rename shifts a matched filter's hash before record_probe merges the caller's set, and an option
+value that is itself a Feature gets re-stamped by a second host's input resolution after storage.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.filter.single_filter import SingleFilter
+from mloda.provider import BaseInputData, ComputeFramework, DataCreator, DefaultOptionKeys, FeatureGroup, FeatureSet
+from mloda.user import (
+    Feature,
+    FeatureName,
+    Features,
+    FilterType,
+    GlobalFilter,
+    Options,
+    ParallelizationMode,
+    PluginCollector,
+    mloda,
+)
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
+from tests.test_core.test_tooling import MlodaTestRunner
+
+# The sphr_ prefix (rename vector) and sphn_ prefix (nested option vector) keep these names unique repo-wide.
+SPHR_VALUE = "sphr_value"
+SPHR_EVENT_TIME = "sphr_event_time"
+SPHR_EVENT_TIME_UTC = "sphr_event_time_utc"
+
+SPHN_LEAF = "sphn_leaf"
+SPHN_HOST_ONE = "sphn_host_one"
+SPHN_HOST_TWO = "sphn_host_two"
+SPHN_FILTER = "sphn_filter_col"
+SPHN_VARIANT = "sphn_variant"
+
+
+def _stranded(stored_sets: Iterable[set[SingleFilter]]) -> list[str]:
+    """Names of the stored filters their own set can no longer find."""
+    return [single.name for stored in stored_sets for single in stored if single not in stored]
+
+
+class SphrRenamingRoot(FeatureGroup):
+    """Root that renames the filter column via set_feature_name."""
+
+    @classmethod
+    def input_data(cls) -> BaseInputData | None:
+        return DataCreator({SPHR_VALUE, SPHR_EVENT_TIME})
+
+    def set_feature_name(self, config: Options, feature_name: FeatureName) -> FeatureName:
+        if str(feature_name) == SPHR_EVENT_TIME:
+            return FeatureName(SPHR_EVENT_TIME_UTC)
+        return feature_name
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PythonDictFramework}
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {SPHR_VALUE: [1, 2, 3], SPHR_EVENT_TIME_UTC: [10, 20, 30]}
+
+
+_SPHR_ENABLED = PluginCollector.enabled_feature_groups({SphrRenamingRoot})
+
+
+def test_a_renaming_run_keeps_every_probed_filter_findable() -> None:
+    """The rename lands while the matched set is already built, so record_probe merges a stale hash."""
+    global_filter = GlobalFilter()
+    global_filter.add_filter(SPHR_EVENT_TIME, FilterType.MIN, {"value": 15})
+
+    MlodaTestRunner.run_api(
+        Features([Feature(SPHR_VALUE)]),
+        compute_frameworks={PythonDictFramework},
+        parallelization_modes={ParallelizationMode.SYNC},
+        global_filter=global_filter,
+        plugin_collector=_SPHR_ENABLED,
+    )
+
+    probed = {single.name for stored in global_filter.probes.values() for single in stored}
+    assert probed == {SPHR_EVENT_TIME_UTC}, f"the rename must reach the recorded filter: {probed!r}"
+    assert _stranded(global_filter.probes.values()) == [], "a probed filter must be findable in its own set"
+    assert _stranded(global_filter.collection.values()) == [], "a collected filter must be findable in its own set"
+
+
+# One shared input Feature, as a plugin holding a module-level or memoized Feature does.
+SPHN_NESTED = Feature(SPHN_LEAF, forward_group=False)
+
+
+class SphnRoot(FeatureGroup):
+    """Root serving the leaf column the shared nested Feature names."""
+
+    @classmethod
+    def input_data(cls) -> BaseInputData | None:
+        return DataCreator({SPHN_LEAF})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {SPHN_LEAF: [1, 2, 3]}
+
+
+class SphnConsumer(FeatureGroup):
+    """Consumer that takes its input features from the in_features option value."""
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) in {SPHN_HOST_ONE, SPHN_HOST_TWO, SPHN_FILTER}
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> set[Feature] | None:
+        if DefaultOptionKeys.in_features in options:
+            return set(options.get_in_features())
+        return None
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {str(feature.name): list(data[SPHN_LEAF]) for feature in features.features}
+
+
+_SPHN_ENABLED = PluginCollector.enabled_feature_groups({SphnRoot, SphnConsumer})
+
+
+def _host(name: str, variant: int) -> Feature:
+    """A host feature whose in_features option value is the one shared Feature."""
+    return Feature(name, Options(group={DefaultOptionKeys.in_features.value: SPHN_NESTED, SPHN_VARIANT: variant}))
+
+
+def test_a_restamped_nested_option_feature_keeps_stored_filters_findable() -> None:
+    """Resolving the second host re-stamps the shared Feature, shifting an already stored filter's hash."""
+    global_filter = GlobalFilter()
+    global_filter.add_filter(SPHN_FILTER, FilterType.MIN, {"value": 1})
+
+    mloda.prepare(
+        [_host(SPHN_HOST_ONE, 1), _host(SPHN_HOST_TWO, 2)],
+        compute_frameworks={PythonDictFramework},
+        plugin_collector=_SPHN_ENABLED,
+        global_filter=global_filter,
+    )
+
+    hosts = {str(name) for _group, name in global_filter.collection}
+    assert hosts == {SPHN_HOST_ONE, SPHN_HOST_TWO}, f"the filter must attach to both hosts: {hosts!r}"
+    assert _stranded(global_filter.collection.values()) == [], "a collected filter must be findable in its own set"
+    assert _stranded(global_filter.probes.values()) == [], "a probed filter must be findable in its own set"

--- a/tests/test_core/test_filter/test_global_filter_owns_stored_filter_feature.py
+++ b/tests/test_core/test_filter/test_global_filter_owns_stored_filter_feature.py
@@ -1,0 +1,108 @@
+"""GlobalFilter must own the filter Feature it stores, not the queue object the planner rewrites."""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.filter.single_filter import SingleFilter
+from mloda.provider import DataCreator
+from mloda.user import FeatureName, FilterType, GlobalFilter, PluginCollector, mloda
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
+
+
+# The gfo_ prefix keeps these names unique repo-wide.
+GFO_HOST = "gfo_owned_host"
+GFO_FILTER_ONLY = "gfo_owned_filter_only"
+
+
+class GfoOwnedRoot(FeatureGroup):
+    """Root serving the requested host column plus a column only a filter ever reaches."""
+
+    @classmethod
+    def input_data(cls) -> DataCreator:
+        return DataCreator({GFO_HOST, GFO_FILTER_ONLY})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {GFO_HOST: [1], GFO_FILTER_ONLY: [1]}
+
+
+_ENABLED = PluginCollector.enabled_feature_groups({GfoOwnedRoot})
+_COLLECTION_KEY = (GfoOwnedRoot, FeatureName(GFO_HOST))
+
+
+def _prepared() -> tuple[set[Feature], GlobalFilter]:
+    """Plan one request whose only filter targets a column that is never requested."""
+    global_filter = GlobalFilter()
+    global_filter.add_filter(GFO_FILTER_ONLY, FilterType.EQUAL, {"value": 1})
+
+    session = mloda.prepare(
+        [GFO_HOST],
+        compute_frameworks={PythonDictFramework},
+        plugin_collector=_ENABLED,
+        global_filter=global_filter,
+    )
+
+    engine = session.engine
+    assert engine is not None, "prepare must build an engine"
+    assert engine.global_filter is global_filter, "the session must plan against the caller's GlobalFilter"
+    return engine.feature_group_collection[GfoOwnedRoot], global_filter
+
+
+def _stored_filter(global_filter: GlobalFilter) -> SingleFilter:
+    stored = global_filter.collection[_COLLECTION_KEY]
+    assert len(stored) == 1, f"exactly one filter must attach to the host: {stored!r}"
+    return next(iter(stored))
+
+
+def _probe_key(global_filter: GlobalFilter) -> tuple[type[FeatureGroup], FeatureName, UUID]:
+    """The probe key for the host feature: its uuid only exists after planning."""
+    keys = [key for key in global_filter.probes if key[0] is GfoOwnedRoot and key[1] == GFO_HOST]
+    assert len(keys) == 1, f"exactly one probe must be recorded for the host: {list(global_filter.probes)!r}"
+    return keys[0]
+
+
+def test_the_stored_filter_feature_is_not_the_queue_feature() -> None:
+    queue, global_filter = _prepared()
+    stored_feature = _stored_filter(global_filter).filter_feature
+
+    assert not any(feature is stored_feature for feature in queue), (
+        "the stored filter feature must not be the queue Feature the planner rewrites"
+    )
+    assert any(feature == stored_feature for feature in queue), (
+        "the stored filter feature must stay value-equal to its queue twin"
+    )
+
+
+def test_a_framework_rewrite_of_the_queue_twin_does_not_strand_the_stored_filter() -> None:
+    """The stored filter stays findable after the rewrite, without any rehash step."""
+    queue, global_filter = _prepared()
+    stored = _stored_filter(global_filter)
+
+    twins = [feature for feature in queue if feature == stored.filter_feature]
+    assert len(twins) == 1, f"exactly one queue Feature must equal the stored filter feature: {twins!r}"
+    # What ResolveComputeFrameworks.links does to every queue Feature it resolves.
+    twins[0].compute_frameworks = {PyArrowTable}
+
+    assert stored in global_filter.collection[_COLLECTION_KEY], (
+        "the rewrite must not lose the stored filter from its own collection set"
+    )
+    assert stored in global_filter.probes[_probe_key(global_filter)], (
+        "the rewrite must not lose the stored filter from its own probes set"
+    )
+
+
+def test_the_filter_still_attaches_to_the_host_feature() -> None:
+    """Guard: without a matched filter the other tests would pass vacuously."""
+    _, global_filter = _prepared()
+
+    collected = {single_filter.name for single_filter in global_filter.collection[_COLLECTION_KEY]}
+    probed = {single_filter.name for single_filter in global_filter.probes[_probe_key(global_filter)]}
+
+    assert collected == {GFO_FILTER_ONLY}, f"the collection must name the resolved filter feature: {collected!r}"
+    assert probed == {GFO_FILTER_ONLY}, f"the probes must name the resolved filter feature: {probed!r}"

--- a/tests/test_core/test_filter/test_global_filter_stale_stored_hashes.py
+++ b/tests/test_core/test_filter/test_global_filter_stale_stored_hashes.py
@@ -1,0 +1,117 @@
+"""GlobalFilter's hash-keyed sets must stay usable when a stored filter's hash shifted.
+
+record_probe merges a caller-owned set and CPython's set_merge copies that set's stored hashes
+verbatim; rehash_stored_filters repairs a write that lands after storage.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.filter.single_filter import SingleFilter
+from mloda.user import FilterType, GlobalFilter, Options
+
+# The gfsh_ prefix keeps these names unique repo-wide.
+GFSH_COLUMN = "gfsh_probe_col"
+GFSH_RENAMED = "gfsh_probe_col_utc"
+GFSH_HOST = "gfsh_host"
+GFSH_LATE_KEY = "gfsh_late_key"
+
+
+class GfshKeyGroup(FeatureGroup):
+    """Inert key material for the hash-keyed sets: it never matches a feature."""
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return False
+
+
+def _declared() -> GlobalFilter:
+    """record_probe records nothing while `filters` is empty, so one declared filter is the setup."""
+    global_filter = GlobalFilter()
+    global_filter.add_filter(GFSH_COLUMN, FilterType.MIN, {"value": 1})
+    return global_filter
+
+
+def _matched() -> SingleFilter:
+    """A per-match copy as identify_matched_filters hands it to the engine."""
+    return SingleFilter(GFSH_COLUMN, FilterType.MIN, {"value": 1})
+
+
+def _record(global_filter: GlobalFilter, matched_filters: set[SingleFilter]) -> set[SingleFilter]:
+    """Record one probe against a fresh key and return the set it was stored in."""
+    host = FeatureName(GFSH_HOST)
+    host_uuid = uuid4()
+    global_filter.record_probe(GfshKeyGroup, host, host_uuid, matched_filters)
+    return global_filter.probes[(GfshKeyGroup, host, host_uuid)]
+
+
+def test_record_probe_stores_a_findable_filter_after_a_caller_side_rename() -> None:
+    """Engine._add_filter_feature renames a matched filter feature before recording the set."""
+    global_filter = _declared()
+    matched = _matched()
+    caller_set = {matched}
+
+    matched.filter_feature.name = FeatureName(GFSH_RENAMED)
+
+    stored = _record(global_filter, caller_set)
+    assert matched not in caller_set, "the caller's set must be stale, else this pin proves nothing"
+    assert matched in stored, "record_probe must store a findable filter, not the caller's stale hash"
+
+
+def test_record_probe_stores_a_findable_filter_after_a_caller_side_options_rebind() -> None:
+    """Intake rebinds a matched filter feature's options before recording the set."""
+    global_filter = _declared()
+    matched = _matched()
+    caller_set = {matched}
+
+    matched.filter_feature.options = Options(group={GFSH_LATE_KEY: "materialized"})
+
+    stored = _record(global_filter, caller_set)
+    assert matched not in caller_set, "the caller's set must be stale, else this pin proves nothing"
+    assert matched in stored, "record_probe must store a findable filter, not the caller's stale hash"
+
+
+def test_record_probe_keeps_a_healthy_filter_findable() -> None:
+    """Guard: an unmutated filter is findable, so the pins above are not passing vacuously."""
+    global_filter = _declared()
+    matched = _matched()
+
+    stored = _record(global_filter, {matched})
+    assert matched in stored, "an unmutated filter must be findable in its own probes set"
+
+
+def test_rehash_stored_filters_restores_membership_and_is_idempotent() -> None:
+    """A filter mutated after storage is findable again after the rehash; a second call changes nothing."""
+    global_filter = GlobalFilter()
+    single_filter = _matched()
+    global_filter.filters.add(single_filter)
+
+    host = FeatureName(GFSH_HOST)
+    host_uuid = uuid4()
+    global_filter.add_filter_to_collection(GfshKeyGroup, host, single_filter)
+    global_filter.record_probe(GfshKeyGroup, host, host_uuid, {single_filter})
+
+    # Reachable after storage: an option value shared with a queue Feature is written in place later.
+    single_filter.filter_feature.options.add_to_group(GFSH_LATE_KEY, "written after storage")
+    assert single_filter not in global_filter.collection[(GfshKeyGroup, host)]
+    assert single_filter not in global_filter.probes[(GfshKeyGroup, host, host_uuid)]
+
+    global_filter.rehash_stored_filters()
+
+    assert single_filter in global_filter.collection[(GfshKeyGroup, host)]
+    assert single_filter in global_filter.probes[(GfshKeyGroup, host, host_uuid)]
+
+    collection_snapshot = {key: set(value) for key, value in global_filter.collection.items()}
+    probes_snapshot = {key: set(value) for key, value in global_filter.probes.items()}
+    global_filter.rehash_stored_filters()
+    assert global_filter.collection == collection_snapshot
+    assert global_filter.probes == probes_snapshot


### PR DESCRIPTION
## Summary

`Engine._add_filter_feature` handed one `Feature` object to two owners: the planner queue and `GlobalFilter`'s hash-keyed sets. The link-driven compute framework rewrite rebinds queue Features, so the stored `SingleFilter`'s hash moved while it sat inside `collection` and `probes`, and siblings of one declared filter ended up carrying divergent framework sets (one narrowed by the planner, one keeping the pre-narrowing candidates).

The stored filter now snapshots its `Feature` after intake, using the same ownership copy `SingleFilter` already applies to a caller's feature. The planner can no longer reach what `GlobalFilter` stores, and every stored sibling keeps the candidate set it was matched with.

## Also in this change

`record_probe` merged the caller's set into `probes`. `set.update` of a set carries over the source's stored hashes rather than recomputing them, so the rename and the intake options rebind that the engine applies to a match after that set was built landed in `probes` as stale hashes. It now rehashes on insert.

The post-planning repair of the stored sets stays, narrowed to the one cause ownership cannot close: a stored filter feature owns its option containers but shares every option value by reference, so an option value that is itself a `Feature` can still have its `child_options` re-stamped later in setup. Its docstring now names only that cause.

## Tests

- Ownership at the storage boundary: the stored filter feature is not the queue object, and a framework rewrite of the queue twin leaves it findable with no repair step.
- The link rewrite regression now pins that no stored filter feature is narrowed, replacing the assertion that pinned the divergence.
- `record_probe` stores a findable entry after a caller-side rename and after an options rebind, plus end to end pins for a renaming feature group and for a re-stamped nested option feature.

`tox` passes.