### PR TITLE
fix: keep one link orientation across all groups sharing a link

### DIFF
--- a/mloda/core/core/step/join_step.py
+++ b/mloda/core/core/step/join_step.py
@@ -18,8 +18,10 @@ class JoinStep(Step):
         required_uuids: set[UUID],
         destination_framework_uuids: set[UUID],
         source_framework_uuids: set[UUID],
+        swap_merge_sides: bool = False,
     ) -> None:
         self.link = link
+        self.swap_merge_sides = swap_merge_sides
         self.destination_framework = destination_framework
         self.source_framework = source_framework
         self.required_uuids = required_uuids
@@ -37,7 +39,11 @@ class JoinStep(Step):
         framework_connection = cfw.get_framework_connection_object()
         merge_engine_instance = merge_engine_class(framework_connection)
 
-        cfw.data = merge_engine_instance.merge(cfw.data, from_cfw_data, self.link)
+        # Link indices are bound to the feature groups, so the left group's data must stay the left argument.
+        if self.swap_merge_sides:
+            cfw.data = merge_engine_instance.merge(from_cfw_data, cfw.data, self.link)
+        else:
+            cfw.data = merge_engine_instance.merge(cfw.data, from_cfw_data, self.link)
         cfw.set_column_names()
 
     def _upload_data_if_needed(self, cfw: ComputeFramework, cfw_register: CfwManager) -> None:

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -479,11 +479,34 @@ class ExecutionPlan:
                 required_uuids,
                 destination_framework_uuids,
                 source_framework_uuids,
+                self.join_runs_on_right_side(link, destination_framework_uuids, source_framework_uuids, graph),
             )
 
         # This makes sure that we do not write on the same datasets due to overlapping joins at once.
         self.joinstep_collection.add(js)
         return js
+
+    def join_runs_on_right_side(
+        self, link: Link, destination_uuids: set[UUID], source_uuids: set[UUID], graph: Graph
+    ) -> bool:
+        """True when the join executes in the right feature group's framework, so merge sides are swapped."""
+        if link.left_feature_group == link.right_feature_group:
+            return False
+        if not destination_uuids or not source_uuids:
+            return False
+
+        destination_fgs = {graph.get_nodes()[uuid].feature_group_class for uuid in destination_uuids}
+        source_fgs = {graph.get_nodes()[uuid].feature_group_class for uuid in source_uuids}
+
+        destination_is_right = all(
+            issubclass(fg, link.right_feature_group) and not issubclass(fg, link.left_feature_group)
+            for fg in destination_fgs
+        )
+        source_is_left = all(
+            issubclass(fg, link.left_feature_group) and not issubclass(fg, link.right_feature_group)
+            for fg in source_fgs
+        )
+        return destination_is_right and source_is_left
 
     def find_fg_per_uuid(
         self, pre_execution_plan: list[LinkFrameworkTrekker | FeatureGroupStep], uuid: UUID

--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -412,10 +412,14 @@ class ExecutionPlan:
                 children_uuids.update(uuids)
             # this part is not working!
 
+        swap_merge_sides = False
+
         if len(children_uuids) == 0:
             # No child needs the declared orientation, so destination and source are the other way around.
             destination_framework = link_fw[2]
             source_framework = link_fw[1]
+            # The join then executes in the right feature group's framework, so the merge arguments are inverted.
+            swap_merge_sides = True
 
             for stored_links, uuids in link_trekker.data.items():
                 if (link, destination_framework, source_framework) == stored_links:
@@ -479,34 +483,12 @@ class ExecutionPlan:
                 required_uuids,
                 destination_framework_uuids,
                 source_framework_uuids,
-                self.join_runs_on_right_side(link, destination_framework_uuids, source_framework_uuids, graph),
+                swap_merge_sides,
             )
 
         # This makes sure that we do not write on the same datasets due to overlapping joins at once.
         self.joinstep_collection.add(js)
         return js
-
-    def join_runs_on_right_side(
-        self, link: Link, destination_uuids: set[UUID], source_uuids: set[UUID], graph: Graph
-    ) -> bool:
-        """True when the join executes in the right feature group's framework, so merge sides are swapped."""
-        if link.left_feature_group == link.right_feature_group:
-            return False
-        if not destination_uuids or not source_uuids:
-            return False
-
-        destination_fgs = {graph.get_nodes()[uuid].feature_group_class for uuid in destination_uuids}
-        source_fgs = {graph.get_nodes()[uuid].feature_group_class for uuid in source_uuids}
-
-        destination_is_right = all(
-            issubclass(fg, link.right_feature_group) and not issubclass(fg, link.left_feature_group)
-            for fg in destination_fgs
-        )
-        source_is_left = all(
-            issubclass(fg, link.left_feature_group) and not issubclass(fg, link.right_feature_group)
-            for fg in source_fgs
-        )
-        return destination_is_right and source_is_left
 
     def find_fg_per_uuid(
         self, pre_execution_plan: list[LinkFrameworkTrekker | FeatureGroupStep], uuid: UUID

--- a/mloda/core/prepare/resolve_compute_frameworks.py
+++ b/mloda/core/prepare/resolve_compute_frameworks.py
@@ -24,13 +24,18 @@ class ResolveComputeFrameworks:
                     trekker_members[trekker].append(f)
                     feature_trekkers[f.uuid].append(trekker)
 
+        # Snapshot before resolving: invert_link mutates data_ordered while the loop runs.
+        trekked_uuids = {trekker: set(uuids) for trekker, uuids in link_trekker.data_ordered.items()}
+
         resolved: dict[LinkFrameworkTrekker, type[ComputeFramework]] = {}
         for trekker, members in trekker_members.items():
-            resolved_cfw = self.resolve_trekker_for_group(trekker, members)
+            if trekker not in trekked_uuids:
+                raise ValueError(f"Trekker bookkeeping is inconsistent: no uuids recorded for link {trekker[0]}.")
+            resolved_cfw = self.resolve_trekker(trekker, members)
             if resolved_cfw is not None:
                 resolved[trekker] = resolved_cfw
             # Invert every uuid of the trekker at once, so a link keeps a single orientation across all groups.
-            self.trekker_right_left_adjuster(link_trekker, set(link_trekker.data_ordered.get(trekker, set())))
+            self.trekker_right_left_adjuster(link_trekker, trekked_uuids[trekker])
 
         for p in groups:
             self.rewrite_group_frameworks(p, resolved, feature_trekkers)
@@ -56,6 +61,13 @@ class ResolveComputeFrameworks:
         for f in group[1]:
             if f.uuid not in feature_trekkers:
                 if group_cfws:
+                    supported = set(f.compute_frameworks) if f.compute_frameworks is not None else group_cfws
+                    unsupported = group_cfws - supported
+                    if unsupported:
+                        names = sorted(cfw.__name__ for cfw in unsupported)
+                        raise ValueError(
+                            f"Feature {f.name} does not support the compute framework(s) {names} chosen for its group."
+                        )
                     f.compute_frameworks = set(group_cfws)
                     any_rewritten = True
                 continue
@@ -158,9 +170,7 @@ class ResolveComputeFrameworks:
 
         self.to_invert_trekker_collection = []
 
-    def resolve_trekker_for_group(
-        self, trekker: LinkFrameworkTrekker, members: list[Any]
-    ) -> type[ComputeFramework] | None:
+    def resolve_trekker(self, trekker: LinkFrameworkTrekker, members: list[Any]) -> type[ComputeFramework] | None:
         link, left_cfw, right_cfw = trekker
 
         left_in_all = all(left_cfw in m.compute_frameworks for m in members)

--- a/mloda/core/prepare/resolve_compute_frameworks.py
+++ b/mloda/core/prepare/resolve_compute_frameworks.py
@@ -14,67 +14,76 @@ class ResolveComputeFrameworks:
         self.to_invert_trekker_collection: list[LinkFrameworkTrekker] = []
 
     def links(self, planned_queue: Any, link_trekker: LinkTrekker) -> Any:
-        new_planned_queue = []
-        for p in planned_queue:
-            if isinstance(p, tuple):
-                if not isinstance(p[0], Link):
-                    trekker_members: dict[LinkFrameworkTrekker, list[Any]] = defaultdict(list)
-                    feature_trekkers: dict[UUID, list[LinkFrameworkTrekker]] = defaultdict(list)
-                    for f in p[1]:
-                        for trekker in self.access_link_by_child_uuid(f.uuid, link_trekker):
-                            trekker_members[trekker].append(f)
-                            feature_trekkers[f.uuid].append(trekker)
+        groups = [p for p in planned_queue if isinstance(p, tuple) and not isinstance(p[0], Link)]
 
-                    resolved: dict[LinkFrameworkTrekker, type[ComputeFramework]] = {}
-                    for trekker, members in trekker_members.items():
-                        resolved_cfw = self.resolve_trekker_for_group(trekker, members)
-                        if resolved_cfw is not None:
-                            resolved[trekker] = resolved_cfw
-                        # Adjust immediately so inversions collected for this trekker apply only to its sharing members.
-                        self.trekker_right_left_adjuster(link_trekker, {m.uuid for m in members})
+        trekker_members: dict[LinkFrameworkTrekker, list[Any]] = defaultdict(list)
+        feature_trekkers: dict[UUID, list[LinkFrameworkTrekker]] = defaultdict(list)
+        for p in groups:
+            for f in p[1]:
+                for trekker in self.access_link_by_child_uuid(f.uuid, link_trekker):
+                    trekker_members[trekker].append(f)
+                    feature_trekkers[f.uuid].append(trekker)
 
-                    group_cfws = set(resolved.values())
-                    any_rewritten = False
-                    for f in p[1]:
-                        if f.uuid not in feature_trekkers:
-                            if group_cfws:
-                                f.compute_frameworks = set(group_cfws)
-                                any_rewritten = True
-                            continue
-                        new_cfws = {resolved[trekker] for trekker in feature_trekkers[f.uuid] if trekker in resolved}
-                        if not new_cfws:
-                            mismatches = sorted(
-                                f"{link}: neither {left.__name__} nor {right.__name__}"
-                                for link, left, right in feature_trekkers[f.uuid]
-                            )
-                            raise ValueError(
-                                f"No compute framework agreement for feature {f.name}. Unresolvable links: {mismatches}"
-                            )
-                        f.compute_frameworks = new_cfws
-                        any_rewritten = True
+        resolved: dict[LinkFrameworkTrekker, type[ComputeFramework]] = {}
+        for trekker, members in trekker_members.items():
+            resolved_cfw = self.resolve_trekker_for_group(trekker, members)
+            if resolved_cfw is not None:
+                resolved[trekker] = resolved_cfw
+            # Invert every uuid of the trekker at once, so a link keeps a single orientation across all groups.
+            self.trekker_right_left_adjuster(link_trekker, set(link_trekker.data_ordered.get(trekker, set())))
 
-                    if any_rewritten:
-                        # Rehash via list so hashes are recomputed (set(p[1]) reuses stale ones), keeping set and aliases valid.
-                        members = list(p[1])
-                        p[1].clear()
-                        p[1].update(members)
-                        if len(p[1]) != len(members):
-                            names = sorted(
-                                name
-                                for name, count in Counter(str(member.name) for member in members).items()
-                                if count > 1
-                            )
-                            raise ValueError(
-                                "Compute framework rewrite collapsed features that were previously distinct "
-                                f"only by compute_frameworks. Affected: {names}"
-                            )
+        for p in groups:
+            self.rewrite_group_frameworks(p, resolved, feature_trekkers)
 
-            new_planned_queue.append(p)
+        new_planned_queue = list(planned_queue)
 
         link_trekker.order_links_by_frameworks()
 
         new_planned_queue = self.order_queue_by_trekker_order(new_planned_queue, link_trekker)
         return new_planned_queue
+
+    def rewrite_group_frameworks(
+        self,
+        group: Any,
+        resolved: dict[LinkFrameworkTrekker, type[ComputeFramework]],
+        feature_trekkers: dict[UUID, list[LinkFrameworkTrekker]],
+    ) -> None:
+        group_cfws = {
+            resolved[trekker] for f in group[1] for trekker in feature_trekkers.get(f.uuid, []) if trekker in resolved
+        }
+
+        any_rewritten = False
+        for f in group[1]:
+            if f.uuid not in feature_trekkers:
+                if group_cfws:
+                    f.compute_frameworks = set(group_cfws)
+                    any_rewritten = True
+                continue
+            new_cfws = {resolved[trekker] for trekker in feature_trekkers[f.uuid] if trekker in resolved}
+            if not new_cfws:
+                mismatches = sorted(
+                    f"{link}: neither {left.__name__} nor {right.__name__}"
+                    for link, left, right in feature_trekkers[f.uuid]
+                )
+                raise ValueError(
+                    f"No compute framework agreement for feature {f.name}. Unresolvable links: {mismatches}"
+                )
+            f.compute_frameworks = new_cfws
+            any_rewritten = True
+
+        if not any_rewritten:
+            return
+
+        # Rehash via list so hashes are recomputed (set(group[1]) reuses stale ones), keeping set and aliases valid.
+        members = list(group[1])
+        group[1].clear()
+        group[1].update(members)
+        if len(group[1]) != len(members):
+            names = sorted(name for name, count in Counter(str(member.name) for member in members).items() if count > 1)
+            raise ValueError(
+                "Compute framework rewrite collapsed features that were previously distinct "
+                f"only by compute_frameworks. Affected: {names}"
+            )
 
     def order_queue_by_trekker_order(self, planned_queue: Any, link_trekker: LinkTrekker) -> Any:
         orders = link_trekker.order

--- a/tests/test_core/test_prepare/test_resolve_cfw_cross_group_link.py
+++ b/tests/test_core/test_prepare/test_resolve_cfw_cross_group_link.py
@@ -1,0 +1,104 @@
+"""One orientation per link: groups sharing a trekker agree on a single compute framework."""
+
+from typing import Any
+from uuid import UUID
+
+import pytest
+
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.link import JoinSpec, Link
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.prepare.graph.graph import Graph
+from mloda.core.prepare.resolve_compute_frameworks import ResolveComputeFrameworks
+from mloda.core.prepare.resolve_links import LinkTrekker
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+
+
+class CrossGroupLeftFG(FeatureGroup):
+    pass
+
+
+class CrossGroupRightFG(FeatureGroup):
+    pass
+
+
+class CrossGroupChildAFG(FeatureGroup):
+    pass
+
+
+class CrossGroupChildBFG(FeatureGroup):
+    pass
+
+
+def _make_trekker(trekked_uuids: set[UUID]) -> tuple[LinkTrekker, Any]:
+    link = Link.inner(JoinSpec(CrossGroupLeftFG, "idx"), JoinSpec(CrossGroupRightFG, "idx"))
+    trekker = (link, PandasDataFrame, PyArrowTable)
+
+    link_trekker = LinkTrekker()
+    link_trekker.data[trekker] = set(trekked_uuids)
+    link_trekker.data_ordered[trekker] = set(trekked_uuids)
+    return link_trekker, trekker
+
+
+def _orientations_present(link_trekker: LinkTrekker, link: Link) -> list[Any]:
+    return [key for key in link_trekker.data_ordered if key[0] == link]
+
+
+def _resolve_cross_group_scenario() -> tuple[Feature, Feature, LinkTrekker, Any]:
+    """Group A could take either framework, group B only the right one."""
+    feature_a = Feature("cross_group_feature_a")
+    feature_b = Feature("cross_group_feature_b")
+    feature_a.compute_frameworks = {PandasDataFrame, PyArrowTable}
+    feature_b.compute_frameworks = {PyArrowTable}
+
+    link_trekker, trekker = _make_trekker({feature_a.uuid, feature_b.uuid})
+    planned_queue: list[Any] = [
+        (CrossGroupChildAFG, {feature_a}),
+        (CrossGroupChildBFG, {feature_b}),
+    ]
+
+    ResolveComputeFrameworks(Graph()).links(planned_queue, link_trekker)
+    return feature_a, feature_b, link_trekker, trekker
+
+
+def test_single_orientation_survives_for_shared_link() -> None:
+    _, _, link_trekker, trekker = _resolve_cross_group_scenario()
+    link = trekker[0]
+
+    assert len(_orientations_present(link_trekker, link)) == 1
+    assert len([key for key in link_trekker.data if key[0] == link]) == 1
+
+
+def test_surviving_orientation_holds_every_trekked_uuid() -> None:
+    feature_a, feature_b, link_trekker, trekker = _resolve_cross_group_scenario()
+    link = trekker[0]
+
+    orientations = _orientations_present(link_trekker, link)
+    assert len(orientations) == 1
+    surviving = orientations[0]
+    assert link_trekker.data_ordered[surviving] == {feature_a.uuid, feature_b.uuid}
+    assert link_trekker.data[surviving] == {feature_a.uuid, feature_b.uuid}
+
+
+def test_both_groups_are_rewritten_to_the_same_framework() -> None:
+    feature_a, feature_b, _, _ = _resolve_cross_group_scenario()
+
+    assert feature_a.compute_frameworks == feature_b.compute_frameworks
+    assert feature_a.compute_frameworks == {PyArrowTable}
+
+
+def test_cross_group_disagreement_raises_at_planning_time() -> None:
+    feature_left_only = Feature("cross_group_left_only")
+    feature_right_only = Feature("cross_group_right_only")
+    feature_left_only.compute_frameworks = {PandasDataFrame}
+    feature_right_only.compute_frameworks = {PyArrowTable}
+
+    link_trekker, _ = _make_trekker({feature_left_only.uuid, feature_right_only.uuid})
+    planned_queue: list[Any] = [
+        (CrossGroupChildAFG, {feature_left_only}),
+        (CrossGroupChildBFG, {feature_right_only}),
+    ]
+
+    with pytest.raises(ValueError):
+        ResolveComputeFrameworks(Graph()).links(planned_queue, link_trekker)

--- a/tests/test_core/test_prepare/test_resolve_cfw_cross_group_link.py
+++ b/tests/test_core/test_prepare/test_resolve_cfw_cross_group_link.py
@@ -36,8 +36,10 @@ def _make_trekker(trekked_uuids: set[UUID]) -> tuple[LinkTrekker, Any]:
     trekker = (link, PandasDataFrame, PyArrowTable)
 
     link_trekker = LinkTrekker()
-    link_trekker.data[trekker] = set(trekked_uuids)
-    link_trekker.data_ordered[trekker] = set(trekked_uuids)
+    # Production shares one set object between data and data_ordered, and invert_link relies on that.
+    shared_uuids = set(trekked_uuids)
+    link_trekker.data[trekker] = shared_uuids
+    link_trekker.data_ordered[trekker] = shared_uuids
     return link_trekker, trekker
 
 
@@ -45,7 +47,7 @@ def _orientations_present(link_trekker: LinkTrekker, link: Link) -> list[Any]:
     return [key for key in link_trekker.data_ordered if key[0] == link]
 
 
-def _resolve_cross_group_scenario() -> tuple[Feature, Feature, LinkTrekker, Any]:
+def _resolve_cross_group_scenario(reverse_groups: bool = False) -> tuple[Feature, Feature, LinkTrekker, Any]:
     """Group A could take either framework, group B only the right one."""
     feature_a = Feature("cross_group_feature_a")
     feature_b = Feature("cross_group_feature_b")
@@ -57,6 +59,8 @@ def _resolve_cross_group_scenario() -> tuple[Feature, Feature, LinkTrekker, Any]
         (CrossGroupChildAFG, {feature_a}),
         (CrossGroupChildBFG, {feature_b}),
     ]
+    if reverse_groups:
+        planned_queue.reverse()
 
     ResolveComputeFrameworks(Graph()).links(planned_queue, link_trekker)
     return feature_a, feature_b, link_trekker, trekker
@@ -100,5 +104,29 @@ def test_cross_group_disagreement_raises_at_planning_time() -> None:
         (CrossGroupChildBFG, {feature_right_only}),
     ]
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="No compute framework agreement"):
+        ResolveComputeFrameworks(Graph()).links(planned_queue, link_trekker)
+
+
+def test_group_order_does_not_change_the_outcome() -> None:
+    feature_a, feature_b, link_trekker, trekker = _resolve_cross_group_scenario(reverse_groups=True)
+    link = trekker[0]
+
+    orientations = _orientations_present(link_trekker, link)
+    assert len(orientations) == 1
+    assert link_trekker.data_ordered[orientations[0]] == {feature_a.uuid, feature_b.uuid}
+    assert feature_a.compute_frameworks == {PyArrowTable}
+    assert feature_b.compute_frameworks == {PyArrowTable}
+
+
+def test_untrekked_feature_rejecting_group_framework_raises() -> None:
+    trekked = Feature("cross_group_trekked")
+    untrekked = Feature("cross_group_untrekked")
+    trekked.compute_frameworks = {PyArrowTable}
+    untrekked.compute_frameworks = {PandasDataFrame}
+
+    link_trekker, _ = _make_trekker({trekked.uuid})
+    planned_queue: list[Any] = [(CrossGroupChildAFG, {trekked, untrekked})]
+
+    with pytest.raises(ValueError, match="does not support the compute framework"):
         ResolveComputeFrameworks(Graph()).links(planned_queue, link_trekker)

--- a/tests/test_plugins/compute_framework/test_cross_group_link_orientation.py
+++ b/tests/test_plugins/compute_framework/test_cross_group_link_orientation.py
@@ -1,0 +1,145 @@
+"""Two child groups sharing one link between the same parent pair.
+
+Both must end up on a single orientation and see the joined columns.
+"""
+
+from typing import Any, Optional
+
+import pyarrow as pa
+import pytest
+
+from mloda.provider import BaseInputData
+from mloda.provider import ComputeFramework
+from mloda.provider import DataCreator
+from mloda.provider import FeatureGroup
+from mloda.provider import FeatureSet
+from mloda.user import Feature
+from mloda.user import FeatureName
+from mloda.user import Index
+from mloda.user import JoinSpec, Link
+from mloda.user import Options
+from mloda.user import ParallelizationMode
+from mloda.user import PluginCollector
+from mloda.user import mloda
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+
+
+class OrientParentLeft(FeatureGroup):
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={cls.get_class_name()})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {cls.get_class_name(): ["Same Value"], "orient_left_payload": ["left"]}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PyArrowTable}
+
+
+class OrientParentRight(FeatureGroup):
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={cls.get_class_name()})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {cls.get_class_name(): ["Same Value"], "orient_right_payload": ["right"]}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+
+def _column_names(data: Any) -> list[str]:
+    if isinstance(data, pa.Table):
+        return list(data.column_names)
+    return list(data.columns)
+
+
+class OrientChildFlexible(FeatureGroup):
+    """Supports both frameworks, so on its own it would keep the left orientation."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return {Feature(name=OrientParentLeft.get_class_name()), Feature(name=OrientParentRight.get_class_name())}
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        columns = _column_names(data)
+        for expected in ("orient_left_payload", "orient_right_payload"):
+            if expected not in columns:
+                raise ValueError(f"{expected} not in data: {columns}")
+
+        if isinstance(data, pa.Table):
+            return data.append_column(cls.get_class_name(), data[OrientParentLeft.get_class_name()])
+
+        data[cls.get_class_name()] = data[OrientParentLeft.get_class_name()]
+        return data
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PyArrowTable, PandasDataFrame}
+
+
+class OrientChildPandasOnly(FeatureGroup):
+    """Supports only the right framework, so on its own it would invert the link."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return {Feature(name=OrientParentLeft.get_class_name()), Feature(name=OrientParentRight.get_class_name())}
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        columns = _column_names(data)
+        for expected in ("orient_left_payload", "orient_right_payload"):
+            if expected not in columns:
+                raise ValueError(f"{expected} not in data: {columns}")
+
+        data[cls.get_class_name()] = data[OrientParentLeft.get_class_name()]
+        return data
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+
+@pytest.mark.parametrize(
+    "modes",
+    [
+        ({ParallelizationMode.SYNC}),
+        ({ParallelizationMode.THREADING}),
+    ],
+)
+class TestCrossGroupLinkOrientation:
+    def test_shared_link_serves_both_child_groups(self, modes: set[ParallelizationMode], flight_server: Any) -> None:
+        link = Link.inner(
+            left=JoinSpec(OrientParentLeft, Index((OrientParentLeft.get_class_name(),))),
+            right=JoinSpec(OrientParentRight, Index((OrientParentRight.get_class_name(),))),
+        )
+
+        result = mloda.run_all(
+            [
+                Feature(name=OrientChildFlexible.get_class_name()),
+                Feature(name=OrientChildPandasOnly.get_class_name()),
+            ],
+            links={link},
+            compute_frameworks=["PyArrowTable", "PandasDataFrame"],
+            plugin_collector=PluginCollector.enabled_feature_groups(
+                {
+                    OrientParentLeft,
+                    OrientParentRight,
+                    OrientChildFlexible,
+                    OrientChildPandasOnly,
+                }
+            ),
+            flight_server=flight_server,
+            parallelization_modes=modes,
+        )
+
+        seen: set[str] = set()
+        for res in result:
+            seen.update(_column_names(res))
+
+        assert OrientChildFlexible.get_class_name() in seen
+        assert OrientChildPandasOnly.get_class_name() in seen

--- a/tests/test_plugins/compute_framework/test_inverted_link_merge_sides.py
+++ b/tests/test_plugins/compute_framework/test_inverted_link_merge_sides.py
@@ -1,0 +1,101 @@
+"""Inverted link orientation: the left feature group's data must stay the left merge argument.
+
+Asymmetric key sets and differing index column names make a swapped merge observable.
+"""
+
+from typing import Any, Optional
+
+import pytest
+
+from mloda.provider import BaseInputData
+from mloda.provider import ComputeFramework
+from mloda.provider import DataCreator
+from mloda.provider import FeatureGroup
+from mloda.provider import FeatureSet
+from mloda.user import Feature
+from mloda.user import FeatureName
+from mloda.user import Index
+from mloda.user import JoinSpec, Link
+from mloda.user import Options
+from mloda.user import ParallelizationMode
+from mloda.user import PluginCollector
+from mloda.user import mloda
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+
+
+class AsymLeftSource(FeatureGroup):
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={"asym_left_key", "asym_left_payload"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {"asym_left_key": [4, 3, 2, 1], "asym_left_payload": ["l4", "l3", "l2", "l1"]}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PyArrowTable}
+
+
+class AsymRightSource(FeatureGroup):
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={"asym_right_key", "asym_right_payload"})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {"asym_right_key": [3, 4, 5], "asym_right_payload": ["r3", "r4", "r5"]}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+
+class AsymJoinChild(FeatureGroup):
+    """Only the right framework is supported, which inverts the declared link orientation."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return {
+            Feature(name="asym_left_key"),
+            Feature(name="asym_left_payload"),
+            Feature(name="asym_right_key"),
+            Feature(name="asym_right_payload"),
+        }
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        # Reading the left key column proves the left group's index drove the merge.
+        data[cls.get_class_name()] = (
+            data["asym_left_key"].astype(str) + ":" + data["asym_left_payload"] + data["asym_right_payload"]
+        )
+        return data
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+
+@pytest.mark.parametrize("modes", [({ParallelizationMode.SYNC}), ({ParallelizationMode.THREADING})])
+def test_inverted_link_keeps_left_group_as_left_merge_side(modes: set[ParallelizationMode], flight_server: Any) -> None:
+    link = Link.inner(
+        left=JoinSpec(AsymLeftSource, Index(("asym_left_key",))),
+        right=JoinSpec(AsymRightSource, Index(("asym_right_key",))),
+    )
+
+    result = mloda.run_all(
+        [Feature(name=AsymJoinChild.get_class_name())],
+        links={link},
+        compute_frameworks=["PyArrowTable", "PandasDataFrame"],
+        plugin_collector=PluginCollector.enabled_feature_groups({AsymLeftSource, AsymRightSource, AsymJoinChild}),
+        flight_server=flight_server,
+        parallelization_modes=modes,
+    )
+
+    joined = [res for res in result if AsymJoinChild.get_class_name() in list(res.columns)]
+    assert len(joined) == 1
+    data = joined[0]
+
+    assert len(data) == 2
+    # Left key order [4, 3] is kept, so the left group's data was the left merge argument.
+    assert list(data[AsymJoinChild.get_class_name()]) == ["4:l4r4", "3:l3r3"]


### PR DESCRIPTION
Closes #1012

## Problem

Compute framework agreement was computed per planned-queue feature group. Two groups sharing the same link could therefore resolve it to opposite orientations, leaving both `(link, left, right)` and `(link, right, left)` in `LinkTrekker.data_ordered` while the planned queue, built earlier, held only one link tuple. The execution plan emits a join only for the orientation present in the queue, so children of the other orientation ran against unmerged data and failed with missing-column errors.

## Change

Agreement is computed once per link over every trekked member across all groups, and the inversion applies to the whole trekker entry, so a link keeps a single orientation. Where no framework is supported by every trekked member, planning fails deterministically instead of producing a plan that cannot run.

The inverted orientation also needed the merge arguments the right way round: the link indices are bound to the feature groups, so the left feature group's data has to stay the left merge argument. That side is taken from the orientation the plan already resolved, rather than inferred from the parent feature group classes, which was both too broad (the destination uuids cover every parent of the child, not just this link's two sides) and blind to a right feature group that subclasses the left one.

An untrekked feature that does not support the framework chosen for its group now raises at planning time instead of running on a framework its feature group rejects.

## Tests

- Unit: two groups sharing a link land on one orientation holding every trekked uuid, independent of group order; cross-group disagreement raises; an untrekked member rejecting the group framework raises.
- Runtime: two child groups sharing one link between the same parent pair, which previously failed with a missing column; and an inverted link with asymmetric key sets and differing index column names, which pins the left group as the left merge argument.

`tox` passes.