### PR TITLE
test: assert every docs page is reachable from the mkdocs nav

### DIFF
--- a/tests/test_documentation/test_mkdocs_config.py
+++ b/tests/test_documentation/test_mkdocs_config.py
@@ -75,3 +75,54 @@ def test_getting_started_text_guides_before_notebooks() -> None:
             f"Last .md at index {last_md}, first .ipynb at index {first_ipynb}. "
             f"Order: {paths}"
         )
+
+
+def _collect_nav_paths(node: Any, found: set[str]) -> None:
+    """Collect every path string referenced anywhere in the nav tree.
+
+    The nav mixes three shapes at any depth: a plain string (``index.md``), a
+    single-key dict whose value is a path, and a dict whose value is a nested
+    list of more of the same. Recursing over all three keeps the collector
+    honest as the nav grows sections.
+    """
+    if isinstance(node, str):
+        found.add(node)
+    elif isinstance(node, dict):
+        for value in node.values():
+            _collect_nav_paths(value, found)
+    elif isinstance(node, list):
+        for item in node:
+            _collect_nav_paths(item, found)
+
+
+def _nav_markdown_paths() -> set[str]:
+    found: set[str] = set()
+    _collect_nav_paths(_load_mkdocs_config().get("nav", []), found)
+    # Only .md is asserted on: the nav also points at notebooks that are
+    # generated from .py sources during the docs build and are not in the tree.
+    return {path for path in found if path.endswith(".md")}
+
+
+def test_every_docs_page_is_reachable_from_the_nav() -> None:
+    """A page not listed in nav still builds, but is invisible on the site."""
+    docs_dir = MKDOCS_YML.parent / "docs"
+    on_disk = {path.relative_to(docs_dir).as_posix() for path in docs_dir.rglob("*.md")}
+
+    unreachable = sorted(on_disk - _nav_markdown_paths())
+
+    assert not unreachable, (
+        "These documentation pages exist under docs/docs/ but are not reachable "
+        "from the nav: block in docs/mkdocs.yml, so they build but never appear "
+        f"on the published site: {unreachable}"
+    )
+
+
+def test_every_nav_markdown_entry_points_at_a_real_page() -> None:
+    """The other direction: a typo in nav silently drops a page from the site."""
+    docs_dir = MKDOCS_YML.parent / "docs"
+
+    missing = sorted(path for path in _nav_markdown_paths() if not (docs_dir / path).is_file())
+
+    assert not missing, (
+        f"The nav: block in docs/mkdocs.yml references markdown pages that do not exist under docs/docs/: {missing}"
+    )


### PR DESCRIPTION
Closes #934.

Extends `tests/test_documentation/test_mkdocs_config.py`, where the three other mkdocs invariants already live.

## The collector

The nav mixes plain strings (`index.md`), single-key dicts whose value is a path, and dicts whose value is a nested list — and it nests three deep under *In Depth - Advanced*. `_collect_nav_paths` recurses over all three shapes rather than special-casing the current depth, so it keeps working as sections are added.

Scoped to `.md`, per the issue: the nav also references `examples/base_usage.ipynb` and `examples/sklearn_integration_basic.ipynb`, which are generated from `.py` sources during the docs build and are not in the tree.

## Two directions, not one

`test_every_docs_page_is_reachable_from_the_nav` is what the issue asks for: every `*.md` under `docs/docs/` must appear in the nav, and the failure message names the unreachable pages.

I added `test_every_nav_markdown_entry_points_at_a_real_page` as well. It's the same failure seen from the other side — a typo in a nav path silently drops a real page from the site — and it costs one set comprehension against the same collected set. Say the word if you'd rather it were dropped.

## Verified they actually bite

Both pass unchanged today (all 36 pages are in the nav), so I checked they aren't vacuous:

- Dropping an orphan `docs/docs/in_depth/orphan_probe.md` → `test_every_docs_page_is_reachable_from_the_nav` fails and names it.
- Misspelling `chapter1/installation.md` as `chapter1/instalation.md` in the nav → **both** fail, independently: the real page becomes unreachable, and the nav entry points at nothing.

```
FAILED …::test_every_docs_page_is_reachable_from_the_nav
FAILED …::test_every_nav_markdown_entry_points_at_a_real_page
2 failed, 3 passed
```

## Checks

- `pytest tests/test_documentation/` — 162 passed.
- `ruff check` — clean.
- `ruff format --check --line-length 120` — clean.
- `mypy --strict --ignore-missing-imports` — clean on the changed file.
