### PR TITLE
docs: refresh the stale directory tree in tests/README.md

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -4,40 +4,69 @@
 Testing is a critical aspect of the mloda framework, ensuring reliability, correctness, and maintainability. The testing approach combines unit tests, integration tests, and documentation tests to provide comprehensive coverage of the codebase.
 
 ## Directory Structure
+
+Directories to three levels deep; regenerate with
+`find tests -type d -not -path "*__pycache__*" | sort`.
+
 ```
 tests/
-├── conftest.py                  # Common pytest fixtures and configuration
-├── requirements-test.txt        # Test dependencies
-├── test_core/                   # Tests for core functionality
-│   ├── test_abstract_plugins/   # Tests for abstract plugin interfaces
-│   │   ├── test_components/     # Tests for component implementations
-│   │   │   └── test_merge_engine/  # Tests for merge engine functionality
-│   │   └── test_plugin_loader/  # Tests for plugin loading mechanism
-│   ├── test_api/               # Tests for API functionality
-│   ├── test_artifacts/         # Tests for artifact handling
-│   ├── test_core/              # Tests for core engine
-│   ├── test_filter/            # Tests for filtering mechanisms
-│   ├── test_flight/            # Tests for flight server
-│   ├── test_index/             # Tests for indexing functionality
-│   ├── test_integration/       # Core integration tests
-│   │   └── test_core/          # Tests for core integration scenarios
-│   ├── test_plugin_collector/  # Tests for plugin collection
-│   ├── test_setup/             # Tests for setup procedures
-│   └── test_validate_features/ # Tests for feature validation
-├── test_documentation/         # Tests for documentation examples
-├── test_examples/              # Tests for example code
-│   └── mloda_basics/           # Tests for basic mloda examples
-└── test_plugins/               # Tests for plugin implementations
-    ├── compute_framework/      # Tests for compute framework plugins
-    ├── extender/               # Tests for extender plugins
-    ├── feature_group/          # Tests for feature group plugins
-    │   ├── experimental/       # Tests for experimental features
-    │   │   ├── dynamic_feature_group_factory/  # Tests for dynamic feature groups
-    │   │   ├── environment/    # Tests for environment feature groups
-    │   │   └── test_source_input_features/  # Tests for source input features
-    │   └── input_data/         # Tests for input data handling
-    │       ├── test_classes/   # Tests for input classes
-    │       ├── test_read_dbs/  # Tests for database reading
-    │       └── test_read_files/  # Tests for file reading
-    └── integration_plugins/    # Tests for plugin integration
+├── conftest.py                     # Common pytest fixtures and configuration
+├── registry_isolation.py           # Helper: run a body in an isolated plugin registry
+├── registry_isolation_probe.py     # Helper: subprocess probe for registry isolation
+├── test_agent_docs_sync.py         # Agent-facing docs stay in sync with the code
+├── test_attributions.py            # Third-party attributions are complete
+├── test_ci_paths_ignore.py         # CI path filters do not skip real changes
+├── test_docs_fences.py             # Fenced code blocks in docs are well-formed
+├── test_docs_taught_values.py      # Values taught in docs match the code
+├── test_gc_freeze_contract.py      # GC freeze contract around plugin loading
+├── test_mloda_imports.py           # Public import surface of the package
+├── test_packaging_metadata_guard.py  # Packaging metadata stays consistent
+├── test_parallelization_modes_support.py  # Every parallelization mode is supported
+├── test_project_structure.py       # Repository layout invariants
+├── test_registry_isolation.py      # Plugin registry isolation between tests
+├── test_core/                      # Tests for core functionality
+│   ├── test_abstract_plugins/      # Tests for abstract plugin interfaces
+│   │   ├── test_components/        # Tests for component implementations
+│   │   ├── test_feature_group/     # Tests for the feature group base class
+│   │   ├── test_plugin_loader/     # Tests for plugin loading mechanism
+│   │   └── test_plugin_registry/   # Tests for the plugin registry
+│   ├── test_api/                   # Tests for API functionality
+│   │   └── feature_config/         # Tests for feature configuration
+│   ├── test_artifacts/             # Tests for artifact handling
+│   ├── test_core/                  # Tests for core engine
+│   │   └── test_step/              # Tests for execution steps
+│   ├── test_filter/                # Tests for filtering mechanisms
+│   ├── test_flight/                # Tests for flight server
+│   ├── test_index/                 # Tests for indexing functionality
+│   ├── test_integration/           # Core integration tests
+│   │   └── test_core/              # Tests for core integration scenarios
+│   ├── test_mask/                  # Tests for the mask engine
+│   ├── test_optional_dependency/   # Behaviour when an optional dependency is absent
+│   ├── test_optional_pyarrow/      # Behaviour when pyarrow is absent
+│   ├── test_plugin_collector/      # Tests for plugin collection
+│   ├── test_prepare/               # Tests for the planning/preparation phase
+│   │   └── test_validators/        # Tests for planning validators
+│   ├── test_resolution_parity/     # Parity between resolution paths
+│   ├── test_runtime/               # Tests for runtime behaviour
+│   ├── test_setup/                 # Tests for setup procedures
+│   └── test_tooling/               # Tests for internal test tooling
+├── test_documentation/             # Tests for documentation examples
+├── test_examples/                  # Tests for example code
+│   ├── mloda_basics/               # Tests for basic mloda examples
+│   └── sklearn_integration/        # Tests for the sklearn integration example
+└── test_plugins/                   # Tests for plugin implementations
+    ├── api/                        # Tests for plugin-facing API
+    ├── compute_framework/          # Tests for compute framework plugins
+    │   ├── base_implementations/   # Tests per framework (pandas, polars, pyarrow, ...)
+    │   └── test_tooling/           # Shared compute framework test tooling
+    ├── extender/                   # Tests for extender plugins
+    ├── feature_group/              # Tests for feature group plugins
+    │   ├── experimental/           # Tests for experimental feature groups
+    │   ├── input_data/             # Tests for input data handling
+    │   └── src/                    # Fixture sources for feature group tests
+    └── integration_plugins/        # Tests for plugin integration
+        ├── chainer/                # Tests for feature chaining
+        └── test_validate_features/ # Tests for feature validation
 ```
+
+Test dependencies are declared in the `test` extra in `pyproject.toml`.


### PR DESCRIPTION
Closes #935.

Regenerates the `## Directory Structure` block in `tests/README.md` from the current layout. Docs only.

## What changed

**Removed, as the issue notes:** `requirements-test.txt` (replaced by a line pointing at the `test` extra in `pyproject.toml`) and `tests/test_core/test_validate_features/`.

**Added under `test_core/`:** `test_mask/`, `test_optional_dependency/`, `test_optional_pyarrow/`, `test_prepare/`, `test_resolution_parity/`, `test_runtime/`, `test_tooling/`, plus `test_abstract_plugins/test_feature_group/`, `test_abstract_plugins/test_plugin_registry/`, `test_api/feature_config/`, `test_core/test_step/` and `test_prepare/test_validators/`.

**Added elsewhere:** `test_examples/sklearn_integration/`, `test_plugins/api/`, `compute_framework/{base_implementations,test_tooling}/`, `feature_group/src/`, `integration_plugins/{chainer,test_validate_features}/`.

**Added the top-level test modules**, which the old tree ignored entirely — all thirteen `test_*.py` sitting directly in `tests/`, plus the two `registry_isolation*.py` helpers beside them. `__init__.py` is the one file left out, being the only one there that isn't worth finding.

## Two things worth flagging

`test_validate_features/` hasn't disappeared — it **moved**, to `test_plugins/integration_plugins/test_validate_features/`. The issue lists it under "listed but absent", which is true of the old path; the tree now shows it at its real home rather than just dropping it, since "where did that go" is exactly the question this block exists to answer.

The tree stops at **three levels**, which covers everything the old block showed plus everything the issue lists. Going deeper would mean ~90 lines, mostly per-feature-group directories that a reader can see from the parent. I added a line recording the `find` command that produces it, so the next refresh is mechanical rather than archaeological — the block went stale because regenerating it was manual guesswork.

## Verified, not eyeballed

A script parsed the fenced block back out and checked it against the filesystem in both directions:

```
checked 57 entries
real dirs (depth<=3) missing from tree: none
tree dirs that do not exist           : none
problems: none
```

So every path in the block exists, and every real directory to depth three appears in the block.

`pytest tests/test_documentation tests/test_project_structure.py tests/test_agent_docs_sync.py` — 187 passed. No code touched.
