### PR TITLE
fix: gate filter matching on the declared feature_group scope

### DIFF
--- a/docs/docs/in_depth/feature-config.md
+++ b/docs/docs/in_depth/feature-config.md
@@ -80,7 +80,7 @@ Combine strings and objects:
 | `context_options` | object | No | Context parameters (metadata, doesn't affect resolution) |
 | `propagate_context_keys` | array | No | Context keys that propagate to dependent features |
 | `column_index` | integer | No | Index for multi-output features (adds `~N` suffix) |
-| `feature_group` | string | No | Feature Group class name the feature resolves to (resolution-only scope) |
+| `feature_group` | string | No | Feature Group class name the feature resolves to (scope read by feature resolution and filter matching) |
 
 ## Configuration Approaches
 
@@ -138,7 +138,7 @@ The string matches the named class and its subclasses, preferring the most speci
 
 The scope narrows candidates but does not break ties between them. If the run enables two compute frameworks whose concrete subclasses both match, the family base stays ambiguous and raises, exactly as the bare name does; enable one framework for the run. Two classes with the same name in different modules likewise both match and stay ambiguous, and the root `FeatureGroup` base is rejected.
 
-The scope is resolution-only and excluded from feature identity, so requesting the same name scoped to two different sources in one list raises `ValueError: Duplicate feature setup: <name>` rather than silently dropping one; see [Feature Group resolution errors](troubleshooting/feature-group-resolution-errors.md).
+The scope is read by feature resolution and by filter matching, and stays excluded from feature identity, so requesting the same name scoped to two different sources in one list raises `ValueError: Duplicate feature setup: <name>` rather than silently dropping one; see [Feature Group resolution errors](troubleshooting/feature-group-resolution-errors.md).
 
 `feature_group` is a top-level field next to `name`: writing it inside `options`, `group_options`, or `context_options` is rejected with a validation error.
 

--- a/docs/docs/in_depth/filter_data.md
+++ b/docs/docs/in_depth/filter_data.md
@@ -186,12 +186,14 @@ When a user passes a `GlobalFilter`, the framework tests every `SingleFilter` ag
 FeatureGroup that each feature already resolved to, using that feature's options, domain
 and compute framework. Each filter is **deep-copied** first, so everything below happens
 on the copy and never on the filter the user built. The copy is delivered only if it
-clears three gates, in order: the group's own `match_feature_group_criteria()` on the
+clears four gates, in order: the group's own `match_feature_group_criteria()` on the
 filter feature's name and options (plus the run's `DataAccessCollection`), then the filter
-feature's domain against the resolved feature's, then its compute framework against the
-resolved feature's. The last two gates also backfill: a filter feature that declares no
-domain or compute framework inherits the resolved feature's (the FeatureGroup's domain
-when the feature declares none). Declaring the filter's column as an input is **not** the
+feature's domain against the resolved feature's, then its `feature_group` scope against
+the probed FeatureGroup, honored with the same semantics as feature resolution (the named
+class and its subclasses, class-object and string forms alike), then its compute framework
+against the resolved feature's. The domain and compute framework gates also backfill: a
+filter feature that declares no domain or compute framework inherits the resolved
+feature's (the FeatureGroup's domain when the feature declares none). Declaring the filter's column as an input is **not** the
 test, and links are not re-checked here (feature resolution already covered them).
 
 `match_feature_group_criteria()` sees the filter feature's own options enriched from the
@@ -254,7 +256,8 @@ declined a filter is still filtered by it once a sibling of its set matched it, 
 included; that is logged as a WARNING. Siblings matching different non-empty filter sets get the
 union attached. Matches of one filter that differ only in the enriched options count as that one
 filter, attached once and not reported, only while they resolve to the same column: a per-sibling
-rename makes them distinct predicates and both attach. To scope a filter, make the deciding
+rename makes them distinct predicates and both attach. A filter feature declared with
+`feature_group=` attaches only within that feature group family. To scope a filter, make the deciding
 option a **group** option: differing group options split the features into separate `FeatureSet`s.
 
 `GlobalFilter.probes` records what every probe matched, empty results included, for debugging.

--- a/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
+++ b/docs/docs/in_depth/troubleshooting/feature-group-resolution-errors.md
@@ -161,7 +161,7 @@ def get_domain(cls):
 ```
 
 #### 4. Scope a feature to one source (shared keys across sources)
-When two enabled sources declare the same column (for example a shared join key), requesting that column by bare name is ambiguous. Scope the request to one source. The scope is resolution-only and does not affect feature identity.
+When two enabled sources declare the same column (for example a shared join key), requesting that column by bare name is ambiguous. Scope the request to one source. The scope is read by feature resolution and by filter matching, and does not affect feature identity.
 
 ```py
 # class object, collision-proof
@@ -195,7 +195,7 @@ Caveats:
 - The class object is collision-proof; the string form is not. Two classes with the same name in different modules both match the string, so the request stays ambiguous and raises.
 - Neither form pins one exact class: a subclass of the named class is preferred over it. To resolve to a specific implementation, name that implementation.
 - The root `FeatureGroup` base is rejected in either form: it names no family.
-- The scope is resolution-only and excluded from Feature identity, so two requests for the same column name scoped to different sources compare equal. Requesting both in one features list raises `ValueError: Duplicate feature setup: <name>` rather than silently dropping one, so you are told, not surprised. Inside a single `input_features()` returning a set literal, a second same-name feature with a different scope is silently deduplicated by the Python set itself before the engine ever sees it, so never scope the same name twice within one feature group. To read the same column from two sources side by side, give them distinct derived feature names.
+- The scope is read by feature resolution and by filter matching, and stays excluded from Feature identity, so two requests for the same column name scoped to different sources compare equal. Requesting both in one features list raises `ValueError: Duplicate feature setup: <name>` rather than silently dropping one, so you are told, not surprised. Inside a single `input_features()` returning a set literal, a second same-name feature with a different scope is silently deduplicated by the Python set itself before the engine ever sees it, so never scope the same name twice within one feature group. To read the same column from two sources side by side, give them distinct derived feature names.
 
 ## FeatureGroup Redefinition Errors
 

--- a/mloda/core/abstract_plugins/components/feature.py
+++ b/mloda/core/abstract_plugins/components/feature.py
@@ -56,7 +56,8 @@ class Feature:
         initial_requested_data (bool): Whether the data was initially requested.
         link (Optional[Link]): The link associated with the feature.
         index (Optional[Index]): The index associated with the feature.
-        feature_group_scope (str | type[FeatureGroup] | None): Resolution-only scope; excluded from identity.
+        feature_group_scope (str | type[FeatureGroup] | None): Read by feature resolution and filter
+            matching; excluded from identity.
 
     Quick start (recommended progression)::
 
@@ -141,7 +142,8 @@ class Feature:
         self.link = link
         self.index = index  # Index is a feature currently only used for append/union features.
 
-        # feature_group_scope is resolution-only metadata, excluded from equality and hash like link/index.
+        # feature_group_scope is read by feature resolution and by filter matching,
+        # excluded from equality and hash like link/index.
         self.feature_group_scope = self._set_feature_group_scope(feature_group)
 
         # Resolution-only metadata stamped by the engine: one (consumer class name, consumer

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -17,6 +17,7 @@ from mloda.core.abstract_plugins.components.match_hook import call_match_hook
 from mloda.core.abstract_plugins.components.utils import contained_raise_reason
 from mloda.core.filter.filter_type_enum import FilterType
 from mloda.core.filter.single_filter import SingleFilter
+from mloda.core.prepare.identify_feature_group import matches_feature_group_scope
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
 
 
@@ -122,6 +123,7 @@ class GlobalFilter:
         We need to figure out if the filter feature is a part of the feature class and thus can be used as filter.
 
         This is quite similar to identifying the feature itself.
+        The filter feature's feature_group scope is honored via the canonical predicate, as in feature resolution.
         Differences are in details:
             -   we use the options of the feature to enrich the filter feature options,
             -   we set the compute framework of the feature to determine the one of the filter feature,
@@ -137,6 +139,8 @@ class GlobalFilter:
             if not self.criteria(feature_group, _filter, data_access_collection):
                 continue
             if self.domain(_filter, feat.domain, feature_group) is False:
+                continue
+            if self.feature_group_scope(_filter, feature_group) is False:
                 continue
             if self.compute_framework(_filter, feat) is False:
                 continue
@@ -305,6 +309,10 @@ class GlobalFilter:
             return True
 
         return False
+
+    def feature_group_scope(self, filter: SingleFilter, feature_group: type[FeatureGroup]) -> bool:
+        scope = filter.filter_feature.feature_group_scope
+        return scope is None or matches_feature_group_scope(feature_group, scope)
 
     def compute_framework(self, filter: SingleFilter, feat: Feature) -> bool:
         # case that the filter feature has no cf set -> feature defines it

--- a/mloda/core/filter/single_filter.py
+++ b/mloda/core/filter/single_filter.py
@@ -71,15 +71,18 @@ class SingleFilter:
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, SingleFilter):
             return False
+        # Feature excludes feature_group_scope from its own identity, but the scope decides
+        # filter attachment, so the DECLARATION identity must include it.
         return (
             self.filter_feature == other.filter_feature
             and self.filter_type == other.filter_type
             and self.parameter == other.parameter
+            and self.filter_feature.feature_group_scope == other.filter_feature.feature_group_scope
         )
 
     def __hash__(self) -> int:
         # Combine the hashes of the feature, type, and parameter for a unique hash value
-        return hash((self.filter_feature, self.filter_type, self.parameter))
+        return hash((self.filter_feature, self.filter_type, self.parameter, self.filter_feature.feature_group_scope))
 
     def __repr__(self) -> str:
         return f"<SingleFilter(feature_name={self.filter_feature.name}, type={self.filter_type}, parameters={self.parameter})>"

--- a/tests/test_core/test_filter/test_filter_matcher_canonical_map.py
+++ b/tests/test_core/test_filter/test_filter_matcher_canonical_map.py
@@ -36,6 +36,8 @@ GROUP_DOMAIN_CLASS_NAME = "GroupDomainMatcherFG728"
 CAPABILITY_CLASS_NAME = "CapabilityRejectMatcherFG728"
 OWN_INDEX_CLASS_NAME = "OwnIndexMatcherFG728"
 SCOPE_BASE_CLASS_NAME = "ScopeBaseMatcherFG728"
+SCOPE_TARGET_A_CLASS_NAME = "ScopeTargetAMatcherFG728"
+SCOPE_TARGET_B_CLASS_NAME = "ScopeTargetBMatcherFG728"
 
 MISSING_SCOPE_728 = "CmapNoSuchScope728"  # a scope string naming no accessible class
 SCOPE_REASON = "outside the requested feature group scope"
@@ -121,6 +123,23 @@ def _make_plain_and_unrelated_fg() -> tuple[type[FeatureGroup], type[FeatureGrou
         pass
 
     return _make_plain_matcher_fg(), UnrelatedScopeFG728
+
+
+def _make_two_scope_target_fgs() -> tuple[type[FeatureGroup], type[FeatureGroup]]:
+    """Two unrelated throwaway matchers, each the class-object scope of one duplicate declaration."""
+    gc.collect()
+
+    class ScopeTargetAMatcherFG728(FeatureGroup):
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE, FILTER_FEATURE}
+
+    class ScopeTargetBMatcherFG728(FeatureGroup):
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE, FILTER_FEATURE}
+
+    return ScopeTargetAMatcherFG728, ScopeTargetBMatcherFG728
 
 
 def _make_group_domain_fg() -> type[FeatureGroup]:
@@ -216,12 +235,18 @@ class _MatchingSnapshot:
     names: tuple[str, ...]
     calls: int = 0
     scopes: tuple[str, ...] = ()
-    stored_scope: str = "None"
+    # None means the driver never read the stored scope; a genuinely unscoped read folds to the text "None".
+    stored_scope: str | None = None
 
 
 def _scope_as_text(scope: str | type[FeatureGroup] | None) -> str:
     """The scope as plain text: a class-object scope reads as its class name."""
     return scope.__name__ if isinstance(scope, type) else str(scope)
+
+
+def _matched_scope_texts(matched: set[SingleFilter] | None) -> tuple[str, ...]:
+    """The matched copies' scopes as sorted plain text."""
+    return tuple(sorted(_scope_as_text(single.filter_feature.feature_group_scope) for single in matched or ()))
 
 
 def _fixed_scope(scope: str | None) -> _ScopePick:
@@ -251,6 +276,40 @@ def _drive_scoped_matching(make: _ScopeFactory, pick_scope: _ScopePick, probe_in
         return _MatchingSnapshot(escaped=escaped, names=names, scopes=scopes, stored_scope=stored)
     finally:
         del made, classes, scope, global_filter, matched
+        gc.collect()
+
+
+@dataclass(frozen=True)
+class _TwoScopedSnapshot:
+    """Plain-data readout of two probes over one two-declaration GlobalFilter. Holds no class and no filter."""
+
+    escaped: tuple[str | None, str | None]
+    scopes_by_probe: tuple[tuple[str, ...], tuple[str, ...]]
+    stored_count: int
+
+
+def _drive_two_scope_duplicate_declarations() -> _TwoScopedSnapshot:
+    """Declare one predicate twice, once per class scope, then probe each scope class in turn."""
+    fg_a, fg_b = _make_two_scope_target_fgs()
+    global_filter = GlobalFilter()
+    global_filter.add_filter(Feature(FILTER_FEATURE, feature_group=fg_a), FilterType.EQUAL, {"value": 1})
+    global_filter.add_filter(Feature(FILTER_FEATURE, feature_group=fg_b), FilterType.EQUAL, {"value": 1})
+    matched_a = None
+    matched_b = None
+    try:
+        matched_a, escaped_a = _capture(
+            partial(global_filter.identify_matched_filters, fg_a, Feature(HOST_FEATURE), None)
+        )
+        matched_b, escaped_b = _capture(
+            partial(global_filter.identify_matched_filters, fg_b, Feature(HOST_FEATURE), None)
+        )
+        return _TwoScopedSnapshot(
+            escaped=(escaped_a, escaped_b),
+            scopes_by_probe=(_matched_scope_texts(matched_a), _matched_scope_texts(matched_b)),
+            stored_count=len(global_filter.filters),
+        )
+    finally:
+        del fg_a, fg_b, global_filter, matched_a, matched_b
         gc.collect()
 
 
@@ -532,12 +591,12 @@ class TestScopeGate:
         assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
         assert snapshot.names == (), f"a scope naming no class must detach the filter, got: {snapshot.names}"
 
-    def test_the_matched_copy_carries_the_scope_the_gate_read(self) -> None:
+    def test_a_string_scope_naming_the_probed_class_attaches_and_rides_the_matched_copy(self) -> None:
         """The scope survives SingleFilter's copy and the per-match deepcopy: read by the gate, never rewritten."""
         snapshot = _drive_scoped_matching(_make_plain_matcher_fg, _fixed_scope(PLAIN_CLASS_NAME))
 
         assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
-        assert snapshot.names == (FILTER_FEATURE,), f"a matching scope must attach, got: {snapshot.names}"
+        assert snapshot.names == (FILTER_FEATURE,), f"the probe's own name is in its MRO, got: {snapshot.names}"
         assert snapshot.scopes == (PLAIN_CLASS_NAME,), f"the scope must ride the matched copy, got: {snapshot.scopes}"
 
     def test_a_class_scope_naming_the_probed_class_attaches(self) -> None:
@@ -558,12 +617,6 @@ class TestScopeGate:
         assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
         assert snapshot.names == (), f"an unrelated class scope must detach the filter, got: {snapshot.names}"
 
-    def test_a_string_scope_naming_the_probed_class_attaches(self) -> None:
-        snapshot = _drive_scoped_matching(_make_plain_matcher_fg, _fixed_scope(PLAIN_CLASS_NAME))
-
-        assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
-        assert snapshot.names == (FILTER_FEATURE,), f"the probe's own name is in its MRO, got: {snapshot.names}"
-
     def test_a_string_scope_naming_the_base_attaches_to_the_subclass_probe(self) -> None:
         snapshot = _drive_scoped_matching(_make_scope_family_fg, _fixed_scope(SCOPE_BASE_CLASS_NAME), probe_index=1)
 
@@ -582,6 +635,21 @@ class TestScopeGate:
         assert snapshot.names == (FILTER_FEATURE,), f"the scoped filter must attach, got: {snapshot.names}"
         assert snapshot.stored_scope == PLAIN_CLASS_NAME, (
             f"the gate must never write the stored filter, got: {snapshot.stored_scope}"
+        )
+
+    def test_two_declarations_differing_only_in_scope_stay_two_filters_each_matching_its_scope(self) -> None:
+        """One predicate declared once per scope class: both survive the filters set, each probe attaches its own."""
+        snapshot = _drive_two_scope_duplicate_declarations()
+
+        assert snapshot.escaped == (None, None), f"nothing may cross identify_matched_filters: {snapshot.escaped}"
+        assert snapshot.stored_count == 2, (
+            f"two declarations differing only in scope must stay two stored filters, got {snapshot.stored_count}"
+        )
+        assert snapshot.scopes_by_probe[0] == (SCOPE_TARGET_A_CLASS_NAME,), (
+            f"probing A must attach exactly the A-scoped filter, got: {snapshot.scopes_by_probe[0]}"
+        )
+        assert snapshot.scopes_by_probe[1] == (SCOPE_TARGET_B_CLASS_NAME,), (
+            f"probing B must attach exactly the B-scoped filter, got: {snapshot.scopes_by_probe[1]}"
         )
 
     def test_the_canonical_seam_eliminates_the_same_scope_at_the_scope_gate(self) -> None:

--- a/tests/test_core/test_filter/test_filter_matcher_canonical_map.py
+++ b/tests/test_core/test_filter/test_filter_matcher_canonical_map.py
@@ -1,5 +1,5 @@
-"""Issue #728: map GlobalFilter.identify_matched_filters against the canonical resolver, axis by axis:
-scope, framework-pin cardinality, the capability hook, domain defaulting, links, and option enrichment.
+"""Issue #728: map GlobalFilter.identify_matched_filters against the canonical resolver, axis by axis: the scope
+gate both seams share, framework-pin cardinality, the capability hook, domain defaulting, links, and option enrichment.
 Truthiness (#927) and raise containment (#899) live in the sibling suites. Probe classes live inside factory
 functions and are dropped before any assert runs, so a failing assert never trips the no-leak conftest fixture.
 """
@@ -35,6 +35,7 @@ PLAIN_CLASS_NAME = "PlainMatcherFG728"
 GROUP_DOMAIN_CLASS_NAME = "GroupDomainMatcherFG728"
 CAPABILITY_CLASS_NAME = "CapabilityRejectMatcherFG728"
 OWN_INDEX_CLASS_NAME = "OwnIndexMatcherFG728"
+SCOPE_BASE_CLASS_NAME = "ScopeBaseMatcherFG728"
 
 MISSING_SCOPE_728 = "CmapNoSuchScope728"  # a scope string naming no accessible class
 SCOPE_REASON = "outside the requested feature group scope"
@@ -65,6 +66,11 @@ T = TypeVar("T")
 _CounterFactory = Callable[[], tuple[type[FeatureGroup], Callable[[], int]]]
 _ObservedOptions = tuple[tuple[tuple[str, str], ...], ...]
 
+# Scope probes hand the driver one class or a (base, child) pair; picks receive the uniform tuple form.
+_ScopeClasses = tuple[type[FeatureGroup], ...]
+_ScopeFactory = Callable[[], type[FeatureGroup] | _ScopeClasses]
+_ScopePick = Callable[[_ScopeClasses], str | type[FeatureGroup] | None]
+
 
 def _capture(call: Callable[[], T]) -> tuple[T | None, str | None]:
     """Run call, returning (value, None) or (None, 'Type: message'). No traceback is retained."""
@@ -90,6 +96,31 @@ def _make_plain_matcher_fg() -> type[FeatureGroup]:
             return {HOST_FEATURE, FILTER_FEATURE}
 
     return PlainMatcherFG728
+
+
+def _make_scope_family_fg() -> tuple[type[FeatureGroup], type[FeatureGroup]]:
+    """A throwaway (base, child) pair; the child inherits both module names from the base."""
+    gc.collect()
+
+    class ScopeBaseMatcherFG728(FeatureGroup):
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE, FILTER_FEATURE}
+
+    class ScopeChildMatcherFG728(ScopeBaseMatcherFG728):
+        pass
+
+    return ScopeBaseMatcherFG728, ScopeChildMatcherFG728
+
+
+def _make_plain_and_unrelated_fg() -> tuple[type[FeatureGroup], type[FeatureGroup]]:
+    """The plain matcher plus a throwaway group related only through the root, used as a class-object scope."""
+    gc.collect()
+
+    class UnrelatedScopeFG728(FeatureGroup):
+        pass
+
+    return _make_plain_matcher_fg(), UnrelatedScopeFG728
 
 
 def _make_group_domain_fg() -> type[FeatureGroup]:
@@ -185,24 +216,41 @@ class _MatchingSnapshot:
     names: tuple[str, ...]
     calls: int = 0
     scopes: tuple[str, ...] = ()
+    stored_scope: str = "None"
 
 
-def _drive_scoped_matching() -> _MatchingSnapshot:
-    """Match one filter declared with a scope naming no class."""
-    fg = _make_plain_matcher_fg()
+def _scope_as_text(scope: str | type[FeatureGroup] | None) -> str:
+    """The scope as plain text: a class-object scope reads as its class name."""
+    return scope.__name__ if isinstance(scope, type) else str(scope)
+
+
+def _fixed_scope(scope: str | None) -> _ScopePick:
+    """A pick ignoring the classes: string and unscoped declarations need no class in hand."""
+    return lambda _classes: scope
+
+
+def _drive_scoped_matching(make: _ScopeFactory, pick_scope: _ScopePick, probe_index: int = 0) -> _MatchingSnapshot:
+    """Match one filter declared with the picked scope against the probe class at probe_index."""
+    made = make()
+    classes: _ScopeClasses = made if isinstance(made, tuple) else (made,)
+    # The Feature is built while the classes exist, so a class-object scope never leaves the driver.
+    scope = pick_scope(classes)
     global_filter = GlobalFilter()
-    global_filter.add_filter(Feature(FILTER_FEATURE, feature_group=MISSING_SCOPE_728), FilterType.EQUAL, {"value": 1})
+    global_filter.add_filter(Feature(FILTER_FEATURE, feature_group=scope), FilterType.EQUAL, {"value": 1})
     matched = None
     try:
-        matched, escaped = _capture(partial(global_filter.identify_matched_filters, fg, Feature(HOST_FEATURE), None))
+        matched, escaped = _capture(
+            partial(global_filter.identify_matched_filters, classes[probe_index], Feature(HOST_FEATURE), None)
+        )
         names: tuple[str, ...] = ()
         scopes: tuple[str, ...] = ()
         if matched is not None:
             names = tuple(sorted(single.name for single in matched))
-            scopes = tuple(sorted(str(single.filter_feature.feature_group_scope) for single in matched))
-        return _MatchingSnapshot(escaped=escaped, names=names, scopes=scopes)
+            scopes = tuple(sorted(_scope_as_text(single.filter_feature.feature_group_scope) for single in matched))
+        stored = _scope_as_text(next(iter(global_filter.filters)).filter_feature.feature_group_scope)
+        return _MatchingSnapshot(escaped=escaped, names=names, scopes=scopes, stored_scope=stored)
     finally:
-        del fg, global_filter, matched
+        del made, classes, scope, global_filter, matched
         gc.collect()
 
 
@@ -475,20 +523,66 @@ def _drive_canonical_declared_options() -> _CanonicalObservationSnapshot:
         gc.collect()
 
 
-class TestScopeGateAbsence:
-    """The filter seam never reads feature_group_scope; the canonical resolver eliminates on it at "scope"."""
+class TestScopeGate:
+    """Scope is a shared axis: both seams gate through matches_feature_group_scope, reading and never writing."""
 
-    def test_the_filter_seam_attaches_a_filter_scoped_to_no_class(self) -> None:
-        snapshot = _drive_scoped_matching()
+    def test_the_filter_seam_detaches_a_filter_scoped_to_no_class(self) -> None:
+        snapshot = _drive_scoped_matching(_make_plain_matcher_fg, _fixed_scope(MISSING_SCOPE_728))
 
         assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
-        assert snapshot.names == (FILTER_FEATURE,), f"the scope must not detach the filter, got: {snapshot.names}"
+        assert snapshot.names == (), f"a scope naming no class must detach the filter, got: {snapshot.names}"
 
-    def test_the_matched_copy_still_carries_the_unread_scope(self) -> None:
-        """The scope survives SingleFilter's copy and the per-match deepcopy: present, just never read."""
-        snapshot = _drive_scoped_matching()
+    def test_the_matched_copy_carries_the_scope_the_gate_read(self) -> None:
+        """The scope survives SingleFilter's copy and the per-match deepcopy: read by the gate, never rewritten."""
+        snapshot = _drive_scoped_matching(_make_plain_matcher_fg, _fixed_scope(PLAIN_CLASS_NAME))
 
-        assert snapshot.scopes == (MISSING_SCOPE_728,), f"the scope must ride along unread, got: {snapshot.scopes}"
+        assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
+        assert snapshot.names == (FILTER_FEATURE,), f"a matching scope must attach, got: {snapshot.names}"
+        assert snapshot.scopes == (PLAIN_CLASS_NAME,), f"the scope must ride the matched copy, got: {snapshot.scopes}"
+
+    def test_a_class_scope_naming_the_probed_class_attaches(self) -> None:
+        snapshot = _drive_scoped_matching(_make_plain_matcher_fg, lambda classes: classes[0])
+
+        assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
+        assert snapshot.names == (FILTER_FEATURE,), f"the probed class is inside its own scope, got: {snapshot.names}"
+
+    def test_a_class_scope_naming_the_base_attaches_to_the_subclass_probe(self) -> None:
+        snapshot = _drive_scoped_matching(_make_scope_family_fg, lambda classes: classes[0], probe_index=1)
+
+        assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
+        assert snapshot.names == (FILTER_FEATURE,), f"a subclass sits inside its base's scope, got: {snapshot.names}"
+
+    def test_a_class_scope_naming_an_unrelated_group_detaches(self) -> None:
+        snapshot = _drive_scoped_matching(_make_plain_and_unrelated_fg, lambda classes: classes[1])
+
+        assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
+        assert snapshot.names == (), f"an unrelated class scope must detach the filter, got: {snapshot.names}"
+
+    def test_a_string_scope_naming_the_probed_class_attaches(self) -> None:
+        snapshot = _drive_scoped_matching(_make_plain_matcher_fg, _fixed_scope(PLAIN_CLASS_NAME))
+
+        assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
+        assert snapshot.names == (FILTER_FEATURE,), f"the probe's own name is in its MRO, got: {snapshot.names}"
+
+    def test_a_string_scope_naming_the_base_attaches_to_the_subclass_probe(self) -> None:
+        snapshot = _drive_scoped_matching(_make_scope_family_fg, _fixed_scope(SCOPE_BASE_CLASS_NAME), probe_index=1)
+
+        assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
+        assert snapshot.names == (FILTER_FEATURE,), f"the base name is a non-root ancestor, got: {snapshot.names}"
+
+    def test_an_unscoped_filter_still_attaches(self) -> None:
+        snapshot = _drive_scoped_matching(_make_plain_matcher_fg, _fixed_scope(None))
+
+        assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
+        assert snapshot.names == (FILTER_FEATURE,), f"no scope means no gate, got: {snapshot.names}"
+
+    def test_the_stored_original_filter_keeps_its_declared_scope(self) -> None:
+        snapshot = _drive_scoped_matching(_make_plain_matcher_fg, _fixed_scope(PLAIN_CLASS_NAME))
+
+        assert snapshot.names == (FILTER_FEATURE,), f"the scoped filter must attach, got: {snapshot.names}"
+        assert snapshot.stored_scope == PLAIN_CLASS_NAME, (
+            f"the gate must never write the stored filter, got: {snapshot.stored_scope}"
+        )
 
     def test_the_canonical_seam_eliminates_the_same_scope_at_the_scope_gate(self) -> None:
         snapshot = _drive_canonical(_make_plain_matcher_fg, scope=MISSING_SCOPE_728)

--- a/tests/test_core/test_filter/test_filter_scope_per_feature_set.py
+++ b/tests/test_core/test_filter/test_filter_scope_per_feature_set.py
@@ -339,3 +339,84 @@ def test_the_uniform_case_warns_about_nothing(caplog: pytest.LogCaptureFixture) 
         f"both features of the uniform set must get the one filter: {snapshot!r}"
     )
     assert snapshot.warnings == (), f"a uniform feature set must not warn: {snapshot.warnings}"
+
+
+# End-to-end scope pin through engine._add_filter_feature: real rows, one filter scoped to one of two groups.
+FSP_SCOPED_TARGET = "fsp_scoped_target_feat"  # served by the scope-named group; its rows get filtered
+FSP_OTHER_TARGET = "fsp_other_target_feat"  # served by the sibling group; its rows must stay complete
+FSP_SHARED_FILTER = "fsp_shared_filter_feat"  # both groups can serve the filter feature, only the scope decides
+FSP_SCOPED_CLASS_NAME = "FspScopedTargetFG"
+
+FSP_ALL_ROWS = [10, 20, 30]
+FSP_KEPT_ROWS = [10, 30]
+FSP_FILTER_ROWS = [1, 0, 1]  # equal(value=1) keeps rows 0 and 2
+
+
+def _target_rows(features: FeatureSet) -> dict[str, list[int]]:
+    """Fixed rows per served feature; the shared filter column decides which rows survive."""
+    rows = {FSP_SCOPED_TARGET: FSP_ALL_ROWS, FSP_OTHER_TARGET: FSP_ALL_ROWS, FSP_SHARED_FILTER: FSP_FILTER_ROWS}
+    return {str(feature.name): list(rows[str(feature.name)]) for feature in features.features}
+
+
+def _make_scoped_target_pair() -> tuple[type[FeatureGroup], type[FeatureGroup]]:
+    """Two throwaway root groups: each serves its own target and can serve the shared filter feature."""
+    gc.collect()
+
+    class FspScopedTargetFG(FeatureGroup):
+        @classmethod
+        def input_data(cls) -> DataCreator:
+            return DataCreator({FSP_SCOPED_TARGET, FSP_SHARED_FILTER})
+
+        @classmethod
+        def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+            return _target_rows(features)
+
+    class FspOtherTargetFG(FeatureGroup):
+        @classmethod
+        def input_data(cls) -> DataCreator:
+            return DataCreator({FSP_OTHER_TARGET, FSP_SHARED_FILTER})
+
+        @classmethod
+        def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+            return _target_rows(features)
+
+    return FspScopedTargetFG, FspOtherTargetFG
+
+
+def _drive_scoped_filter_run() -> dict[str, list[int]]:
+    """Run both targets with one filter string-scoped to the first group; plain column data comes back."""
+    fg_scoped, fg_other = _make_scoped_target_pair()
+    collector = PluginCollector.enabled_feature_groups({fg_scoped, fg_other})
+    global_filter = GlobalFilter()
+    global_filter.add_filter(
+        Feature(FSP_SHARED_FILTER, feature_group=FSP_SCOPED_CLASS_NAME), FilterType.EQUAL, {"value": 1}
+    )
+    requested: list[Feature | str] = [FSP_SCOPED_TARGET, FSP_OTHER_TARGET]
+
+    results = mloda.run_all(
+        requested,
+        compute_frameworks={PythonDictFramework},
+        plugin_collector=collector,
+        global_filter=global_filter,
+    )
+
+    columns = {
+        column: list(frame[column])
+        for frame in results
+        for column in (FSP_SCOPED_TARGET, FSP_OTHER_TARGET)
+        if column in frame
+    }
+    del fg_scoped, fg_other, collector, global_filter, results
+    gc.collect()
+    return columns
+
+
+def test_a_scoped_filter_filters_only_the_scope_named_groups_output() -> None:
+    """Through the public API: the scoped group's rows are eliminated, the sibling group's rows stay complete."""
+    columns = _drive_scoped_filter_run()
+
+    assert set(columns) == {FSP_SCOPED_TARGET, FSP_OTHER_TARGET}, f"both targets must come back: {columns}"
+    assert columns[FSP_SCOPED_TARGET] == FSP_KEPT_ROWS, (
+        f"the group inside the scope must have its rows filtered: {columns}"
+    )
+    assert columns[FSP_OTHER_TARGET] == FSP_ALL_ROWS, f"the group outside the scope must keep every row: {columns}"

--- a/tests/test_core/test_filter/test_single_filter.py
+++ b/tests/test_core/test_filter/test_single_filter.py
@@ -1,8 +1,11 @@
+import gc
+
 import pytest
 
 from mloda.user import Feature
 from mloda.user import SingleFilter
 from mloda.user import FilterType
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.filter.filter_parameter import FilterParameterImpl
 
 
@@ -56,3 +59,75 @@ class TestSingleFilter:
 
         filter_set = {single_filter1, single_filter2}
         assert len(filter_set) == 1  # Since they are equal, only one should be in the set
+
+
+SCOPE_A_ID = "ScopeIdA728x"
+SCOPE_B_ID = "ScopeIdB728x"
+
+
+def _scoped_filter(scope: str | type[FeatureGroup] | None) -> SingleFilter:
+    """An otherwise identical filter declaration carrying the given feature_group scope."""
+    return SingleFilter(Feature("age", feature_group=scope), FilterType.RANGE, {"min": 25, "max": 50})
+
+
+def _drive_class_scope_identity() -> tuple[bool, bool, int]:
+    """Plain-data readout (cross-scope equal, same-scope equal, set size) over two throwaway class scopes."""
+    gc.collect()
+
+    class ScopeIdClassAFG728x(FeatureGroup):
+        pass
+
+    class ScopeIdClassBFG728x(FeatureGroup):
+        pass
+
+    first_a = _scoped_filter(ScopeIdClassAFG728x)
+    second_a = _scoped_filter(ScopeIdClassAFG728x)
+    only_b = _scoped_filter(ScopeIdClassBFG728x)
+    try:
+        return first_a == only_b, first_a == second_a, len({first_a, second_a, only_b})
+    finally:
+        del ScopeIdClassAFG728x, ScopeIdClassBFG728x, first_a, second_a, only_b
+        gc.collect()
+
+
+class TestSingleFilterScopeIdentity:
+    """feature_group_scope is part of SingleFilter identity, so scope-distinct duplicates never collapse."""
+
+    def test_different_string_scopes_are_unequal_and_stay_two_in_a_set(self) -> None:
+        scoped_a = _scoped_filter(SCOPE_A_ID)
+        scoped_b = _scoped_filter(SCOPE_B_ID)
+
+        assert scoped_a != scoped_b, "two declarations differing only in scope must be unequal"
+        assert len({scoped_a, scoped_b}) == 2, "two string scopes must stay two set elements"
+
+    def test_a_scoped_and_an_unscoped_filter_are_unequal_and_stay_two_in_a_set(self) -> None:
+        scoped = _scoped_filter(SCOPE_A_ID)
+        unscoped = _scoped_filter(None)
+
+        assert scoped != unscoped, "a scoped and an unscoped declaration must be unequal"
+        assert len({scoped, unscoped}) == 2, "scoped and unscoped must stay two set elements"
+
+    def test_the_same_string_scope_still_merges_to_one(self) -> None:
+        """Identity must not overshoot: an identical scope keeps the duplicates one filter."""
+        first = _scoped_filter(SCOPE_A_ID)
+        second = _scoped_filter(SCOPE_A_ID)
+
+        assert first == second, "the same scope must keep the declarations equal"
+        assert hash(first) == hash(second), "equal same-scope filters must hash equal"
+        assert len({first, second}) == 1, "the same scope must merge to one set element"
+
+    def test_unscoped_duplicates_still_merge_to_one(self) -> None:
+        """Regression control: both scopes are None, so the duplicates keep merging."""
+        first = _scoped_filter(None)
+        second = _scoped_filter(None)
+
+        assert first == second, "unscoped duplicates must stay equal"
+        assert hash(first) == hash(second), "unscoped duplicates must hash equal"
+        assert len({first, second}) == 1, "unscoped duplicates must keep merging to one set element"
+
+    def test_class_object_scopes_split_on_the_class_and_merge_on_the_same_class(self) -> None:
+        cross_scope_equal, same_scope_equal, set_size = _drive_class_scope_identity()
+
+        assert cross_scope_equal is False, "two different class scopes must make the filters unequal"
+        assert same_scope_equal is True, "the same class scope twice must keep the filters equal"
+        assert set_size == 2, "three filters over two class scopes must land as two set elements"


### PR DESCRIPTION
## Summary

- `GlobalFilter.identify_matched_filters` never read `filter_feature.feature_group_scope`: a filter feature declared with `feature_group=` attached to every feature group that passed the criteria, domain, and compute framework gates, while an ordinary feature with the same declaration is scoped to the named class and its subclasses.
- The matcher now gates on the canonical `matches_feature_group_scope` predicate between the domain and compute framework gates: class-object and string forms, subclass semantics, and the None short-circuit, identical to feature resolution. The gate only reads the scope; criteria-first ordering stays aligned with the canonical resolver.
- Because the scope now decides attachment, it joins `SingleFilter` declaration identity: declarations differing only in scope stay distinct in `GlobalFilter.filters` instead of collapsing to whichever was added first, which would silently drop the other scope's filtering. Equal-scope and unscoped duplicates merge exactly as before.
- Characterization pins that asserted the old unscoped drift now pin the shared semantics. New coverage: scope forms and subclass matching at the matcher seam, declaration-identity pins, and an end-to-end run where a scoped filter filters only the scope-named group's output.
- Docs corrected where they enumerated three matching gates or described the scope as resolution-only.

Part of #728.

## Testing

- `tox` (pytest -n 8, ruff format and check, license allowlist, mypy --strict, bandit): green.