### PR TITLE
fix: skip non-forwarded option keys when unifying filter feature options

### DIFF
--- a/docs/docs/in_depth/filter_data.md
+++ b/docs/docs/in_depth/filter_data.md
@@ -198,7 +198,9 @@ test, and links are not re-checked here (feature resolution already covered them
 
 `match_feature_group_criteria()` sees the filter feature's own options enriched from the
 resolved feature's effective (post-default) ones (see
-[Applying declared defaults](property-mapping.md#applying-declared-defaults)). If two
+[Applying declared defaults](property-mapping.md#applying-declared-defaults)).
+`DefaultOptionKeys.in_features` is the exception: it is the resolved feature's own dependency
+declaration and is never imported into the filter feature's options. If two
 FeatureGroups both match the same original filter, they each receive independent copies.
 This means a single `GlobalFilter` can be processed differently by different FeatureGroups
 in the same pipeline: one may use the mask engine for inline masking while another uses

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -10,7 +10,7 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
 from mloda.core.abstract_plugins.components.feature_chainer.property_spec import is_no_default
 from mloda.core.abstract_plugins.components.utils import safe_field
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
-from mloda.core.abstract_plugins.components.options import Options
+from mloda.core.abstract_plugins.components.options import NON_FORWARDED_KEYS, Options
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.match_hook import call_match_hook
@@ -159,14 +159,18 @@ class GlobalFilter:
                 logger.warning(f"Filter feature '{filter.name}' matched no feature group.")
 
     def unify_options(self, feat_options: Options, filter_options: Options) -> Options:
-        """Add the feature's options the filter feature omits. A declared value is never rewritten."""
+        """Add the feature's options the filter feature omits, minus NON_FORWARDED_KEYS."""
         # Preserve each key's category so context keys do not leak into group (issue #712).
+        # Imported values stay shared by reference, so a shared Feature value under any key keeps a stored
+        # filter's hash live; the post-planning rehash still covers that.
         for key, value in feat_options.group.items():
-            if key not in filter_options:
-                filter_options.add_to_group(key, value)
+            if key in NON_FORWARDED_KEYS or key in filter_options:
+                continue
+            filter_options.add_to_group(key, value)
         for key, value in feat_options.context.items():
-            if key not in filter_options:
-                filter_options.add_to_context(key, value)
+            if key in NON_FORWARDED_KEYS or key in filter_options:
+                continue
+            filter_options.add_to_context(key, value)
         return filter_options
 
     def _warn_on_diverging_options(
@@ -174,6 +178,9 @@ class GlobalFilter:
     ) -> None:
         """Report keys the filter feature declares differently, unless intake provably erases the difference."""
         for key, value in chain(feat_options.group.items(), feat_options.context.items()):
+            # unify_options never imports these, so the divergence cannot be acted on.
+            if key in NON_FORWARDED_KEYS:
+                continue
             if key not in filter_options:
                 continue
             declared = filter_options[key]

--- a/tests/test_core/test_filter/test_filter_feature_non_forwarded_keys.py
+++ b/tests/test_core/test_filter/test_filter_feature_non_forwarded_keys.py
@@ -1,0 +1,142 @@
+"""A filter feature must not inherit a NON_FORWARDED_KEYS option from the feature it attaches to.
+
+Importing in_features hands the filter the host's dependency declaration and shares the host's
+mutable Feature value into the stored SingleFilter's hash.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import pytest
+
+from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
+from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_name import FeatureName
+from mloda.core.abstract_plugins.components.options import NON_FORWARDED_KEYS, Options
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.filter.single_filter import SingleFilter
+from mloda.user import FilterType, GlobalFilter
+
+# The nfk_ prefix keeps these names unique repo-wide.
+NFK_FILTER_COL = "nfk_filter_col"
+NFK_HOST_ONE = "nfk_host_one"
+NFK_HOST_TWO = "nfk_host_two"
+NFK_LEAF = "nfk_leaf"
+NFK_VARIANT = "nfk_variant"
+NFK_ORDINARY = "nfk_ordinary"
+NFK_HOST_VALUE = "nfk_host_value"
+NFK_OWN_VALUE = "nfk_own_value"
+
+_BLOCKED_KEYS = sorted(NON_FORWARDED_KEYS)
+
+
+class NfkHostGroup(FeatureGroup):
+    """Matches the filter column only, so identify_matched_filters attaches exactly one filter."""
+
+    @classmethod
+    def match_feature_group_criteria(
+        cls,
+        feature_name: FeatureName | str,
+        options: Options,
+        data_access_collection: DataAccessCollection | None = None,
+    ) -> bool:
+        return str(feature_name) == NFK_FILTER_COL
+
+
+def _stranded(stored_sets: Iterable[set[SingleFilter]]) -> list[str]:
+    """Names of the stored filters their own set can no longer find."""
+    return [single.name for stored in stored_sets for single in stored if single not in stored]
+
+
+def _host(name: str, variant: int, shared: Feature) -> Feature:
+    return Feature(name, Options(group={DefaultOptionKeys.in_features.value: shared, NFK_VARIANT: variant}))
+
+
+def _declared() -> GlobalFilter:
+    global_filter = GlobalFilter()
+    global_filter.add_filter(NFK_FILTER_COL, FilterType.MIN, {"value": 1})
+    return global_filter
+
+
+def _store_matches(global_filter: GlobalFilter, host: Feature) -> set[SingleFilter]:
+    """Match and store exactly as Engine._add_filter_feature does."""
+    matched = global_filter.identify_matched_filters(NfkHostGroup, host)
+    for match in matched:
+        # The stored filter takes its own Feature via Feature.__copy__: one level deep, values shared.
+        match.filter_feature = match.handle_filter_feature(match.filter_feature)
+        global_filter.add_filter_to_collection(NfkHostGroup, host.name, match)
+    global_filter.record_probe(NfkHostGroup, host.name, host.uuid, matched)
+    return matched
+
+
+def test_the_parametrized_key_list_is_populated() -> None:
+    """Guard: an emptied NON_FORWARDED_KEYS would silently skip every case below instead of failing it."""
+    assert DefaultOptionKeys.in_features in NON_FORWARDED_KEYS
+
+
+@pytest.mark.parametrize("blocked", _BLOCKED_KEYS)
+def test_unify_options_skips_a_blocked_group_key(blocked: str) -> None:
+    unified = GlobalFilter().unify_options(
+        Options(group={blocked: NFK_HOST_VALUE, NFK_ORDINARY: 1}),
+        Options(),
+    )
+
+    assert blocked not in unified, f"'{blocked}' must not be imported from the host: {unified}"
+    assert unified.group == {NFK_ORDINARY: 1}, f"every other host group key must still arrive: {unified.group}"
+
+
+@pytest.mark.parametrize("blocked", _BLOCKED_KEYS)
+def test_unify_options_skips_a_blocked_context_key(blocked: str) -> None:
+    unified = GlobalFilter().unify_options(
+        Options(context={blocked: NFK_HOST_VALUE, NFK_ORDINARY: 1}),
+        Options(),
+    )
+
+    assert blocked not in unified, f"'{blocked}' must not be imported from the host: {unified}"
+    assert unified.context == {NFK_ORDINARY: 1}, f"every other host context key must still arrive: {unified.context}"
+
+
+@pytest.mark.parametrize("blocked", _BLOCKED_KEYS)
+def test_unify_options_keeps_a_blocked_key_the_filter_feature_declared_itself(blocked: str) -> None:
+    """Guard: skipping the import must not turn into rewriting the filter feature's own declaration."""
+    unified = GlobalFilter().unify_options(
+        Options(group={blocked: NFK_HOST_VALUE}),
+        Options(group={blocked: NFK_OWN_VALUE}),
+    )
+
+    assert unified.group == {blocked: NFK_OWN_VALUE}, f"a declared value is never rewritten: {unified.group}"
+
+
+def test_a_matched_filter_does_not_inherit_the_host_input_feature_declaration() -> None:
+    """The host's in_features is its own dependency declaration, not the filter feature's."""
+    global_filter = _declared()
+
+    matched = global_filter.identify_matched_filters(NfkHostGroup, _host(NFK_HOST_ONE, 1, Feature(NFK_LEAF)))
+
+    names = {single.name for single in matched}
+    assert names == {NFK_FILTER_COL}, f"guard: exactly one filter must match the host: {names!r}"
+    options = next(iter(matched)).filter_feature.options
+    assert DefaultOptionKeys.in_features not in options, (
+        f"the filter feature must not carry the host's input-feature list: {options}"
+    )
+    assert options.group == {NFK_VARIANT: 1}, f"every other host group key must still arrive: {options.group}"
+
+
+def test_a_restamped_shared_input_feature_keeps_stored_filters_findable_without_the_repair() -> None:
+    """Two hosts share one input Feature; re-stamping it must not strand an already stored filter."""
+    global_filter = _declared()
+    shared = Feature(NFK_LEAF)
+
+    _store_matches(global_filter, _host(NFK_HOST_ONE, 1, shared))
+    _store_matches(global_filter, _host(NFK_HOST_TWO, 2, shared))
+
+    hosts = {str(name) for _group, name in global_filter.collection}
+    assert hosts == {NFK_HOST_ONE, NFK_HOST_TWO}, f"guard: the filter must attach to both hosts: {hosts!r}"
+
+    # What Features.build_feature_collection does to a shared input Feature while a later host resolves.
+    shared.child_options = Options(group={NFK_VARIANT: 2})
+
+    assert _stranded(global_filter.collection.values()) == [], "a collected filter must be findable in its own set"
+    assert _stranded(global_filter.probes.values()) == [], "a probed filter must be findable in its own set"

--- a/tests/test_core/test_filter/test_option_divergence_warning_guards.py
+++ b/tests/test_core/test_filter/test_option_divergence_warning_guards.py
@@ -11,6 +11,7 @@ from typing import Any, Optional
 
 import pytest
 
+from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.filter.global_filter import GlobalFilter
@@ -164,6 +165,24 @@ def test_the_surviving_none_warning_names_the_value_intake_materializes(caplog: 
     assert _messages(caplog, DWG_KEY) == [
         f"Options are not the same. {DWG_KEY} is different. None (intake fills '{DWG_DEFAULT}') != '{DWG_HOST_VAL}'"
     ]
+
+
+def test_stays_silent_for_a_non_forwarded_key_while_an_ordinary_key_still_warns(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """unify_options can never converge a non-forwarded key, so reporting its divergence is unactionable."""
+    blocked = DefaultOptionKeys.in_features.value
+    with caplog.at_level(logging.WARNING):
+        _emit(
+            None,
+            Options(group={blocked: DWG_HOST_VAL, DWG_KEY: DWG_HOST_VAL}),
+            Options(group={blocked: DWG_FILTER_VAL, DWG_KEY: DWG_FILTER_VAL}),
+        )
+
+    assert _messages(caplog, blocked) == [], "a non-forwarded key must not be reported"
+    assert _messages(caplog, DWG_KEY) == [
+        f"Options are not the same. {DWG_KEY} is different. {DWG_FILTER_VAL} != {DWG_HOST_VAL}"
+    ], "an ordinary diverging key must still warn"
 
 
 def test_the_plain_divergence_message_is_unchanged(caplog: pytest.LogCaptureFixture) -> None:


### PR DESCRIPTION
`GlobalFilter.unify_options` filled a filter feature's options from its host without the `NON_FORWARDED_KEYS` exclusion that `Options.inherit_from` applies, so the host's `in_features` value reached the filter feature. That value is the host's own dependency declaration, not the filter feature's.

`_warn_on_diverging_options` no longer warns for such a key either: `unify_options` can never converge it, so the warning was unactionable.

The post-planning rehash stays. The exclusion closes one way a live `Feature` reaches a stored `SingleFilter`'s hash, but not the general one: a `Feature` held under any ordinary option key still aliases into the stored filter, and a later write to that feature (for example when the engine resolves its compute framework) shifts the stored hash. Verified with a repro under a plain option key, which strands the stored filter in both `collection` and `probes` when the rehash is removed.

Docs: `filter_data.md` now names `in_features` as the exception to option enrichment.

Closes #1043