### PR TITLE
fix: name the link and both frameworks when an APPEND or UNION invariant breaks

### DIFF
--- a/mloda/core/prepare/execution_plan.py
+++ b/mloda/core/prepare/execution_plan.py
@@ -561,16 +561,22 @@ class ExecutionPlan:
                 f"Are the indexes for the append or union set correctly? {left_index.index, right_index.index}"
             )
 
-        # Sanity check for framework consistency
         if link_fw[1] != destination_framework:
             raise ValueError(
-                f"Destination framework does not match the left framework of the link. "
-                f"{destination_framework}. This is a sanity check!"
+                internal_invariant_error(
+                    "APPEND/UNION left link framework must match the framework of the left index feature.",
+                    f"link={link}, left_link_framework={link_fw[1].get_class_name()}, "
+                    f"left_feature_framework={destination_framework.get_class_name()}",
+                )
             )
+
         if link_fw[2] != source_framework:
             raise ValueError(
-                f"Source framework does not match the right framework of the link. "
-                f"{source_framework}. This is a sanity check!"
+                internal_invariant_error(
+                    "APPEND/UNION right link framework must match the framework of the right index feature.",
+                    f"link={link}, right_link_framework={link_fw[2].get_class_name()}, "
+                    f"right_feature_framework={source_framework.get_class_name()}",
+                )
             )
 
         return JoinStep(

--- a/tests/test_core/test_prepare/test_append_link_inverted_orientation.py
+++ b/tests/test_core/test_prepare/test_append_link_inverted_orientation.py
@@ -1,0 +1,204 @@
+"""An APPEND/UNION link framework that disagrees with its index feature violates a planning invariant.
+
+Frameworks that agree still plan a JoinStep.
+"""
+
+from typing import Any, Callable, NamedTuple
+from uuid import UUID
+
+import pytest
+
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+from mloda.core.abstract_plugins.components.index.index import Index
+from mloda.core.abstract_plugins.components.link import JoinSpec, Link
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.core.step.feature_group_step import FeatureGroupStep
+from mloda.core.core.step.join_step import JoinStep
+from mloda.core.prepare.execution_plan import ExecutionPlan
+from mloda.core.prepare.graph.graph import Graph
+from mloda.core.prepare.graph.properties import NodeProperties
+from mloda.core.prepare.resolve_links import LinkTrekker
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+
+
+LEFT_INDEX = Index(("stack_left_key",))
+RIGHT_INDEX = Index(("stack_right_key",))
+
+STACK_LINK_FACTORIES: list[Callable[[JoinSpec, JoinSpec], Link]] = [Link.append, Link.union]
+
+LEFT_FRAMEWORK_INVARIANT = "APPEND/UNION left link framework must match"
+RIGHT_FRAMEWORK_INVARIANT = "APPEND/UNION right link framework must match"
+
+
+class StackSource(FeatureGroup):
+    pass
+
+
+class StackOtherSource(FeatureGroup):
+    pass
+
+
+class StackConsumer(FeatureGroup):
+    pass
+
+
+class Planned(NamedTuple):
+    plan: ExecutionPlan
+    link_fw: tuple[Link, type[ComputeFramework], type[ComputeFramework]]
+    link_trekker: LinkTrekker
+    graph: Graph
+    pre_execution_plan: list[Any]
+    left_uuid: UUID
+    right_uuid: UUID
+
+
+def _feature(name: str, cfw: type[ComputeFramework], index: Index | None = None) -> Feature:
+    feature = Feature(name, index=index)
+    feature.compute_frameworks = {cfw}
+    return feature
+
+
+def _step(fg: type[FeatureGroup], feature: Feature, cfw: type[ComputeFramework]) -> FeatureGroupStep:
+    feature_set = FeatureSet()
+    feature_set.add(feature)
+    return FeatureGroupStep(fg, feature_set, set(), cfw)
+
+
+def _plan_link(
+    link_factory: Callable[[JoinSpec, JoinSpec], Link],
+    *,
+    right_feature_group: type[FeatureGroup] = StackSource,
+    left_cfw: type[ComputeFramework] = PyArrowTable,
+    right_cfw: type[ComputeFramework] = PandasDataFrame,
+    child_cfw: type[ComputeFramework] = PandasDataFrame,
+    orientation: tuple[type[ComputeFramework], type[ComputeFramework]] = (PandasDataFrame, PyArrowTable),
+) -> Planned:
+    """`orientation` is the trekked and queued left/right framework pair."""
+    link = link_factory(JoinSpec(StackSource, LEFT_INDEX), JoinSpec(right_feature_group, RIGHT_INDEX))
+
+    left = _feature("stack_left_payload", left_cfw, LEFT_INDEX)
+    right = _feature("stack_right_payload", right_cfw, RIGHT_INDEX)
+    child = _feature("stack_consumer", child_cfw)
+
+    graph = Graph()
+    graph.add_node(left.uuid, NodeProperties(left, StackSource))
+    graph.add_node(right.uuid, NodeProperties(right, right_feature_group))
+    graph.add_node(child.uuid, NodeProperties(child, StackConsumer))
+    graph.adjacency_list[left.uuid] = [child.uuid]
+    graph.adjacency_list[right.uuid] = [child.uuid]
+    graph.adjacency_list[child.uuid] = []
+    graph.parent_to_children_mapping[child.uuid] = {left.uuid, right.uuid}
+
+    trekker_key = (link, orientation[0], orientation[1])
+    link_trekker = LinkTrekker()
+    link_trekker.data[trekker_key] = {child.uuid}
+
+    pre_execution_plan: list[Any] = [
+        _step(StackSource, left, left_cfw),
+        _step(right_feature_group, right, right_cfw),
+        _step(StackConsumer, child, child_cfw),
+    ]
+
+    plan = ExecutionPlan()
+    plan.feature_set_collections = [{left.uuid}, {right.uuid}, {child.uuid}]
+
+    return Planned(plan, trekker_key, link_trekker, graph, pre_execution_plan, left.uuid, right.uuid)
+
+
+def _run(planned: Planned) -> JoinStep | None:
+    return planned.plan.run_link(planned.link_fw, planned.link_trekker, planned.graph, planned.pre_execution_plan)
+
+
+@pytest.mark.parametrize("link_factory", STACK_LINK_FACTORIES)
+def test_left_framework_mismatch_is_rejected_by_the_joinstep_builder(
+    link_factory: Callable[[JoinSpec, JoinSpec], Link],
+) -> None:
+    with pytest.raises(ValueError) as excinfo:
+        _run(_plan_link(link_factory))
+
+    assert "create_joinstep_in_case_of_append_or_union" in [entry.name for entry in excinfo.traceback]
+    assert LEFT_FRAMEWORK_INVARIANT in str(excinfo.value)
+
+
+@pytest.mark.parametrize("link_factory", STACK_LINK_FACTORIES)
+def test_left_framework_mismatch_names_the_link_and_both_frameworks(
+    link_factory: Callable[[JoinSpec, JoinSpec], Link],
+) -> None:
+    planned = _plan_link(link_factory)
+
+    with pytest.raises(ValueError) as excinfo:
+        _run(planned)
+
+    message = str(excinfo.value)
+    assert message.startswith("Internal error:")
+    assert "sanity check" not in message
+    assert str(planned.link_fw[0]) in message
+    assert PyArrowTable.get_class_name() in message
+    assert PandasDataFrame.get_class_name() in message
+
+
+@pytest.mark.parametrize("link_factory", STACK_LINK_FACTORIES)
+def test_right_framework_mismatch_names_the_link_and_both_frameworks(
+    link_factory: Callable[[JoinSpec, JoinSpec], Link],
+) -> None:
+    planned = _plan_link(
+        link_factory,
+        right_feature_group=StackOtherSource,
+        orientation=(PyArrowTable, PyArrowTable),
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        _run(planned)
+
+    assert "create_joinstep_in_case_of_append_or_union" in [entry.name for entry in excinfo.traceback]
+
+    message = str(excinfo.value)
+    assert RIGHT_FRAMEWORK_INVARIANT in message
+    assert message.startswith("Internal error:")
+    assert "sanity check" not in message
+    assert str(planned.link_fw[0]) in message
+    assert PyArrowTable.get_class_name() in message
+    assert PandasDataFrame.get_class_name() in message
+
+
+@pytest.mark.parametrize("link_factory", STACK_LINK_FACTORIES)
+def test_agreeing_frameworks_keep_planning_a_joinstep(
+    link_factory: Callable[[JoinSpec, JoinSpec], Link],
+) -> None:
+    planned = _plan_link(
+        link_factory,
+        right_feature_group=StackOtherSource,
+        child_cfw=PyArrowTable,
+        orientation=(PyArrowTable, PandasDataFrame),
+    )
+
+    join_step = _run(planned)
+
+    assert isinstance(join_step, JoinStep)
+    assert join_step.destination_framework is PyArrowTable
+    assert join_step.source_framework is PandasDataFrame
+    assert join_step.destination_framework_uuids == {planned.left_uuid}
+    assert join_step.source_framework_uuids == {planned.right_uuid}
+
+
+@pytest.mark.parametrize("link_factory", STACK_LINK_FACTORIES)
+def test_agreeing_frameworks_keep_planning_a_joinstep_for_one_feature_group(
+    link_factory: Callable[[JoinSpec, JoinSpec], Link],
+) -> None:
+    planned = _plan_link(
+        link_factory,
+        right_cfw=PyArrowTable,
+        child_cfw=PyArrowTable,
+        orientation=(PyArrowTable, PyArrowTable),
+    )
+
+    join_step = _run(planned)
+
+    assert isinstance(join_step, JoinStep)
+    assert join_step.destination_framework is PyArrowTable
+    assert join_step.source_framework is PyArrowTable
+    assert join_step.destination_framework_uuids == {planned.left_uuid}
+    assert join_step.source_framework_uuids == {planned.right_uuid}

--- a/tests/test_plugins/compute_framework/test_shared_append_link_orientation.py
+++ b/tests/test_plugins/compute_framework/test_shared_append_link_orientation.py
@@ -1,0 +1,134 @@
+"""An APPEND consumer resolving to a different framework than the left index feature hits a planning invariant.
+
+A second consumer sharing the same link does not change that outcome.
+"""
+
+from typing import Any, Optional
+
+import pytest
+
+from mloda.provider import BaseInputData
+from mloda.provider import ComputeFramework
+from mloda.provider import DataCreator
+from mloda.provider import FeatureGroup
+from mloda.provider import FeatureSet
+from mloda.user import Feature
+from mloda.user import FeatureName
+from mloda.user import Index
+from mloda.user import JoinSpec, Link
+from mloda.user import Options
+from mloda.user import ParallelizationMode
+from mloda.user import PluginCollector
+from mloda.user import mloda
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+
+
+LEFT_FRAMEWORK_INVARIANT = "APPEND/UNION left link framework must match"
+
+
+class SharedAppendSource(FeatureGroup):
+    """Serves both sides of the append; each side is pinned to a different framework."""
+
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(
+            supports_features={"stack_left_key", "stack_left_payload", "stack_right_key", "stack_right_payload"}
+        )
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        names = {str(feature.name) for feature in features.features}
+        if names & {"stack_left_key", "stack_left_payload"}:
+            return {"stack_left_key": [1, 2], "stack_left_payload": ["l1", "l2"]}
+        return {"stack_right_key": [3, 4], "stack_right_payload": ["r3", "r4"]}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PyArrowTable, PandasDataFrame}
+
+
+def _append_sides() -> set[Feature]:
+    return {
+        Feature(name="stack_left_payload", compute_framework="PyArrowTable", index=Index(("stack_left_key",))),
+        Feature(name="stack_right_payload", compute_framework="PandasDataFrame", index=Index(("stack_right_key",))),
+    }
+
+
+class SharedAppendPandasConsumer(FeatureGroup):
+    """Resolves to the right framework only, so it differs from the left index feature."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return _append_sides()
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        data[cls.get_class_name()] = data["stack_left_payload"]
+        return data
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+
+class SharedAppendFlexibleConsumer(FeatureGroup):
+    """Second consumer of the same link, kept unpinned so only the link is shared."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return _append_sides()
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        data[cls.get_class_name()] = data["stack_left_payload"]
+        return data
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PyArrowTable, PandasDataFrame}
+
+
+def _append_link() -> Link:
+    return Link.append(
+        left=JoinSpec(SharedAppendSource, Index(("stack_left_key",))),
+        right=JoinSpec(SharedAppendSource, Index(("stack_right_key",))),
+    )
+
+
+def _plan_append(link: Link, consumers: list[type[FeatureGroup]]) -> None:
+    mloda.run_all(
+        [Feature(name=consumer.get_class_name()) for consumer in consumers],
+        links={link},
+        compute_frameworks=["PyArrowTable", "PandasDataFrame"],
+        plugin_collector=PluginCollector.enabled_feature_groups({SharedAppendSource, *consumers}),
+        parallelization_modes={ParallelizationMode.SYNC},
+    )
+
+
+def test_consumer_framework_mismatch_is_rejected_while_building_the_joinstep() -> None:
+    with pytest.raises(ValueError) as excinfo:
+        _plan_append(_append_link(), [SharedAppendPandasConsumer])
+
+    assert "create_joinstep_in_case_of_append_or_union" in [entry.name for entry in excinfo.traceback]
+    assert LEFT_FRAMEWORK_INVARIANT in str(excinfo.value)
+
+
+def test_consumer_framework_mismatch_names_the_link_and_both_frameworks() -> None:
+    link = _append_link()
+
+    with pytest.raises(ValueError) as excinfo:
+        _plan_append(link, [SharedAppendPandasConsumer])
+
+    message = str(excinfo.value)
+    assert message.startswith("Internal error:")
+    assert "sanity check" not in message
+    assert str(link) in message
+    assert PyArrowTable.get_class_name() in message
+    assert PandasDataFrame.get_class_name() in message
+
+
+def test_a_second_consumer_of_the_same_link_raises_the_same_error() -> None:
+    with pytest.raises(ValueError) as excinfo:
+        _plan_append(_append_link(), [SharedAppendPandasConsumer, SharedAppendFlexibleConsumer])
+
+    assert "create_joinstep_in_case_of_append_or_union" in [entry.name for entry in excinfo.traceback]
+    assert LEFT_FRAMEWORK_INVARIANT in str(excinfo.value)


### PR DESCRIPTION
`create_joinstep_in_case_of_append_or_union` guards that the link's two framework slots match the frameworks its left and right index features resolved to. Both guards reported a bare "This is a sanity check!", and the right-hand one printed a raw `<class '...'>` repr, so a user who hit one got an internal assertion with nothing in it to act on.

Both now raise through `internal_invariant_error`, naming the link (join type, both feature groups, both indexes) and both compute frameworks. Tests reach each branch and assert the message, so a different `ValueError` from the same function cannot satisfy them.

The guard is deliberately not turned into a user-facing configuration error. Reaching it is not necessarily a user mistake: for a link whose two sides are the same feature group, link discovery records a reversed trekker key that was never declared, and which of the two survives is decided by a set-iteration-ordered framework pick. A single-consumer APPEND that plans and runs correctly raised in 1 of 12 fresh interpreters, and the advice such a message would give ("declare the link the other way around", "support framework X") was a no-op for that configuration. That root cause is tracked in #1050; the worse neighbour, where the same inversion between two distinct feature groups silently drops one side's rows, is #1049.

Refs #1040