### PR TITLE
fix: make compute framework selection deterministic during planning

### DIFF
--- a/mloda/core/abstract_plugins/components/feature.py
+++ b/mloda/core/abstract_plugins/components/feature.py
@@ -495,4 +495,4 @@ class Feature:
     def get_compute_framework(self) -> type[ComputeFramework]:
         FeatureValidator.validate_compute_frameworks_resolved(self.compute_frameworks, str(self.name))
         assert self.compute_frameworks is not None
-        return next(iter(self.compute_frameworks))
+        return ComputeFramework.select_deterministic(self.compute_frameworks)

--- a/mloda/core/abstract_plugins/components/validators/feature_validator.py
+++ b/mloda/core/abstract_plugins/components/validators/feature_validator.py
@@ -16,7 +16,7 @@ class FeatureValidator:
     def validate_compute_frameworks_resolved(
         compute_frameworks: Optional[set[type[ComputeFramework]]], feature_name: str
     ) -> None:
-        if compute_frameworks is None:
+        if not compute_frameworks:
             raise ValueError(
                 f"Feature {feature_name} does not have any compute framework. "
                 "This function can only be called when the frameworks were resolved."

--- a/mloda/core/abstract_plugins/compute_framework.py
+++ b/mloda/core/abstract_plugins/compute_framework.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from typing import Any, Optional, final
 from uuid import UUID, uuid4
 from mloda.core.abstract_plugins.components.data_types import DataType
@@ -600,6 +600,20 @@ class ComputeFramework(ABC):
     @final
     def get_class_name(cls) -> str:
         return cls.__name__
+
+    @staticmethod
+    @final
+    def select_deterministic(frameworks: Iterable[type["ComputeFramework"]]) -> type["ComputeFramework"]:
+        """Set iteration over class objects is id-based, so reduce by a total name key instead."""
+        candidates = list(frameworks)
+        if not candidates:
+            raise ValueError("Cannot select a compute framework from an empty collection.")
+
+        # Module and qualname break ties between frameworks sharing a class name; the name alone leaves those to id order.
+        def key(framework: type["ComputeFramework"]) -> tuple[str, str, str]:
+            return (framework.get_class_name(), framework.__module__, framework.__qualname__)
+
+        return min(candidates, key=key)
 
     @final
     def __eq__(self, other: object) -> bool:

--- a/mloda/core/core/engine.py
+++ b/mloda/core/core/engine.py
@@ -471,7 +471,7 @@ class Engine:
         This function ensures that the feature always has a compute framework set!
         """
         if feature.compute_frameworks:
-            if feature.get_compute_framework() not in compute_frameworks:
+            if not feature.compute_frameworks & compute_frameworks:
                 raise ValueError(
                     f"Feature {feature.name} does not support compute framework {feature.compute_frameworks}."
                 )

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -313,8 +313,8 @@ class GlobalFilter:
             filter.filter_feature.compute_frameworks = feat.compute_frameworks
             return True
 
-        # case that the filter feature has an cf -> it must be equal to the feature
-        if next(iter(filter.filter_feature.compute_frameworks)) == feat.get_compute_framework():
+        # case that the filter feature has an cf -> the feature framework must be one of the pinned ones
+        if feat.get_compute_framework() in filter.filter_feature.compute_frameworks:
             return True
 
         return False

--- a/mloda/core/prepare/resolve_compute_frameworks.py
+++ b/mloda/core/prepare/resolve_compute_frameworks.py
@@ -121,6 +121,8 @@ class ResolveComputeFrameworks:
                 raise ValueError(
                     f"No compute framework agreement for feature {f.name}. Unresolvable links: {mismatches}"
                 )
+            if len(new_cfws) > 1:
+                self.raise_on_link_disagreement(f, resolved, feature_trekkers[f.uuid])
             f.compute_frameworks = new_cfws
             any_rewritten = True
 
@@ -137,6 +139,34 @@ class ResolveComputeFrameworks:
                 "Compute framework rewrite collapsed features that were previously distinct "
                 f"only by compute_frameworks. Affected: {names}"
             )
+
+    @staticmethod
+    def raise_on_link_disagreement(
+        feature: Any,
+        resolved: dict[LinkFrameworkTrekker, type[ComputeFramework]],
+        trekkers: list[LinkFrameworkTrekker],
+    ) -> None:
+        """A self-join records every ordered parent pair, so only distinct feature groups can disagree."""
+        cross_group = [
+            trekker
+            for trekker in trekkers
+            if trekker in resolved and trekker[0].left_feature_group != trekker[0].right_feature_group
+        ]
+        cfws = {resolved[trekker] for trekker in cross_group}
+        if len(cfws) < 2:
+            return
+
+        names = sorted(cfw.get_class_name() for cfw in cfws)
+        links = sorted(
+            {
+                f"{link} ({left.get_class_name()}, {right.get_class_name()}) -> "
+                f"{resolved[(link, left, right)].get_class_name()}"
+                for link, left, right in cross_group
+            }
+        )
+        raise ValueError(
+            f"Feature {feature.name} resolves to more than one compute framework {names}. Disagreeing links: {links}"
+        )
 
     def order_queue_by_trekker_order(self, planned_queue: Any, link_trekker: LinkTrekker) -> Any:
         orders = link_trekker.order

--- a/mloda/core/prepare/resolve_links.py
+++ b/mloda/core/prepare/resolve_links.py
@@ -417,8 +417,9 @@ class ResolveLinks:
         left_frameworks: Optional[set[type[ComputeFramework]]] = None,
         right_frameworks: Optional[set[type[ComputeFramework]]] = None,
     ) -> LinkFrameworkTrekker:
+        """Both sides reduce exactly like Feature.get_compute_framework; the join lookup compares the two."""
         if left_frameworks is None or right_frameworks is None:
             raise ValueError("Left or right frameworks are not set!")
-        left_framework = next(iter(left_frameworks))
-        right_framework = next(iter(right_frameworks))
+        left_framework = ComputeFramework.select_deterministic(left_frameworks)
+        right_framework = ComputeFramework.select_deterministic(right_frameworks)
         return (link, left_framework, right_framework)

--- a/tests/test_core/test_abstract_plugins/test_components/test_validators/test_feature_validator.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_validators/test_feature_validator.py
@@ -105,14 +105,17 @@ class TestValidateComputeFrameworksResolved:
         with pytest.raises(ValueError):
             FeatureValidator.validate_compute_frameworks_resolved(compute_frameworks=None, feature_name="TestFeature")
 
-    def test_empty_set_does_not_raise(self) -> None:
-        """Empty set is valid (different from None) and should not raise."""
+    def test_empty_set_raises_and_names_the_feature(self) -> None:
+        """An empty set is unresolved too, and the raise must still say which feature."""
         empty_frameworks: set[type[ComputeFramework]] = set()
 
-        # Act & Assert - should not raise
-        FeatureValidator.validate_compute_frameworks_resolved(
-            compute_frameworks=empty_frameworks, feature_name="TestFeature"
-        )
+        # Act & Assert
+        with pytest.raises(ValueError) as exc_info:
+            FeatureValidator.validate_compute_frameworks_resolved(
+                compute_frameworks=empty_frameworks, feature_name="EmptySetFeature"
+            )
+
+        assert "EmptySetFeature" in str(exc_info.value)
 
     def test_error_message_includes_feature_name(self) -> None:
         """Should include the feature name in error message."""

--- a/tests/test_core/test_filter/test_filter_matcher_canonical_map.py
+++ b/tests/test_core/test_filter/test_filter_matcher_canonical_map.py
@@ -501,7 +501,7 @@ class TestScopeGateAbsence:
 
 
 class TestFrameworkPinCardinality:
-    """GlobalFilter.compute_framework reads one arbitrary pinned element; the canonical seam validates first."""
+    """GlobalFilter.compute_framework tests membership against the pinned set; the canonical seam validates first."""
 
     def test_an_unpinned_filter_feature_adopts_the_features_frameworks(self) -> None:
         """Enrichment control: no pin on the filter side means the feature's pin is written onto the filter."""
@@ -518,26 +518,21 @@ class TestFrameworkPinCardinality:
             "adoption shares the feature's set object, not a copy"
         )
 
-    def test_a_two_pin_filter_is_judged_by_the_first_yielded_set_element(self) -> None:
-        """No cardinality validation: only the first-yielded pin decides; membership alone loses."""
+    def test_a_two_pin_filter_matches_either_of_its_pins(self) -> None:
+        """No cardinality validation: the gate is a membership test, so every pin of the pair matches."""
         global_filter = GlobalFilter()
         single = _single()
-        pins: set[type[ComputeFramework]] = {PandasDataFrame, PyArrowTable}
-        single.filter_feature.compute_frameworks = pins
-        # Derived from the set itself: iteration over the same unmutated set object is stable in-process, and
-        # which element comes first is not pinned, so the pair of verdicts below is deterministic everywhere.
-        first = next(iter(pins))
-        other = next(pin for pin in pins if pin is not first)
-        feat_first = Feature(HOST_FEATURE)
-        feat_first.compute_frameworks = {first}
-        feat_other = Feature(HOST_FEATURE)
-        feat_other.compute_frameworks = {other}
+        single.filter_feature.compute_frameworks = {PandasDataFrame, PyArrowTable}
+        feat_pandas = Feature(HOST_FEATURE)
+        feat_pandas.compute_frameworks = {PandasDataFrame}
+        feat_pyarrow = Feature(HOST_FEATURE)
+        feat_pyarrow.compute_frameworks = {PyArrowTable}
 
-        first_verdict = global_filter.compute_framework(single, feat_first)
-        other_verdict = global_filter.compute_framework(single, feat_other)
+        pandas_verdict = global_filter.compute_framework(single, feat_pandas)
+        pyarrow_verdict = global_filter.compute_framework(single, feat_pyarrow)
 
-        assert first_verdict is True, f"the first-yielded pin must match its own framework, got: {first_verdict}"
-        assert other_verdict is False, f"a member the gate never reads must lose, got: {other_verdict}"
+        assert pandas_verdict is True, f"a pinned framework must match its own pin, got: {pandas_verdict}"
+        assert pyarrow_verdict is True, f"the second pin must match too, got: {pyarrow_verdict}"
 
     def test_a_two_pin_filter_against_a_third_framework_says_no(self) -> None:
         global_filter = GlobalFilter()
@@ -548,7 +543,7 @@ class TestFrameworkPinCardinality:
 
         verdict = global_filter.compute_framework(single, feat)
 
-        assert verdict is False, "neither pinned framework equals the feature's, whichever the set yields first"
+        assert verdict is False, "the feature's framework is not among the pins"
         assert single.filter_feature.compute_frameworks == {PandasDataFrame, PyArrowTable}, "the pin is not rewritten"
 
     def test_the_flow_detaches_a_mismatched_two_pin_quietly(self) -> None:

--- a/tests/test_core/test_prepare/determinism_probe.py
+++ b/tests/test_core/test_prepare/determinism_probe.py
@@ -1,0 +1,44 @@
+"""Prints one json line with the compute frameworks a fresh interpreter reduces to.
+No test_ prefix, so pytest never collects it; the determinism test runs it as a script.
+"""
+
+import json
+
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.link import JoinSpec, Link
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.prepare.graph.graph import Graph
+from mloda.core.prepare.resolve_links import ResolveLinks
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import PythonDictFramework
+
+
+class ProbeLeftFeatureGroup(FeatureGroup):
+    pass
+
+
+class ProbeRightFeatureGroup(FeatureGroup):
+    pass
+
+
+def collect() -> dict[str, str]:
+    """Both frameworks on both sides, so the reduction is the only thing deciding."""
+    # This pair is the one whose id order actually moves between interpreters, so it is the one worth probing.
+    both: set[type[ComputeFramework]] = {PythonDictFramework, PyArrowTable}
+
+    link = Link.inner(JoinSpec(ProbeLeftFeatureGroup, "idx"), JoinSpec(ProbeRightFeatureGroup, "idx"))
+    _, trekker_left, trekker_right = ResolveLinks(Graph()).create_link_trekker_key(link, set(both), set(both))
+
+    feature = Feature("determinism_probe_feature")
+    feature.compute_frameworks = set(both)
+
+    return {
+        "feature": feature.get_compute_framework().get_class_name(),
+        "trekker_left": trekker_left.get_class_name(),
+        "trekker_right": trekker_right.get_class_name(),
+    }
+
+
+if __name__ == "__main__":
+    print(json.dumps(collect(), sort_keys=True))

--- a/tests/test_core/test_prepare/test_deterministic_framework_selection.py
+++ b/tests/test_core/test_prepare/test_deterministic_framework_selection.py
@@ -1,0 +1,243 @@
+"""One compute framework wins every reduction, whatever the set iteration order.
+Set iteration over class objects is id-based, so the reduction pins to the lowest class name.
+"""
+
+import json
+import subprocess  # nosec B404
+import sys
+from pathlib import Path
+
+import pytest
+
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.link import JoinSpec, Link
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.prepare.accessible_plugins import PreFilterPlugins
+from mloda.core.prepare.graph.graph import Graph
+from mloda.core.prepare.resolve_links import ResolveLinks
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+
+_PROBE = Path(__file__).with_name("determinism_probe.py")
+_PROBE_TIMEOUT = 30.0
+# Each probe is a fresh interpreter importing PyArrowTable, so the count is what the gate budget allows.
+_PROBE_PROCESSES = 5
+_PROBE_EXPECTED = {"feature": "PyArrowTable", "trekker_left": "PyArrowTable", "trekker_right": "PyArrowTable"}
+
+
+class DeterminismLeftFeatureGroup(FeatureGroup):
+    pass
+
+
+class DeterminismRightFeatureGroup(FeatureGroup):
+    pass
+
+
+def _throwaway_frameworks() -> tuple[type[ComputeFramework], ...]:
+    """Defined per call and unavailable, so discovery never sees them; Zz sorts behind every shipped name."""
+
+    class ZzZuluThrowawayFramework(ComputeFramework):
+        @staticmethod
+        def is_available() -> bool:
+            return False
+
+    class ZzAlfaThrowawayFramework(ComputeFramework):
+        @staticmethod
+        def is_available() -> bool:
+            return False
+
+    class ZzTangoThrowawayFramework(ComputeFramework):
+        @staticmethod
+        def is_available() -> bool:
+            return False
+
+    class ZzBravoThrowawayFramework(ComputeFramework):
+        @staticmethod
+        def is_available() -> bool:
+            return False
+
+    # Definition order deliberately disagrees with name order.
+    return (ZzZuluThrowawayFramework, ZzAlfaThrowawayFramework, ZzTangoThrowawayFramework, ZzBravoThrowawayFramework)
+
+
+def _same_name_frameworks() -> tuple[type[ComputeFramework], type[ComputeFramework]]:
+    """Two frameworks sharing a class name, separated only by qualname."""
+
+    def alfa() -> type[ComputeFramework]:
+        class ZzSharedNameThrowawayFramework(ComputeFramework):
+            @staticmethod
+            def is_available() -> bool:
+                return False
+
+        return ZzSharedNameThrowawayFramework
+
+    def bravo() -> type[ComputeFramework]:
+        class ZzSharedNameThrowawayFramework(ComputeFramework):
+            @staticmethod
+            def is_available() -> bool:
+                return False
+
+        return ZzSharedNameThrowawayFramework
+
+    return alfa(), bravo()
+
+
+def _link() -> Link:
+    return Link.inner(
+        JoinSpec(DeterminismLeftFeatureGroup, "idx"),
+        JoinSpec(DeterminismRightFeatureGroup, "idx"),
+    )
+
+
+def _run_probes(count: int) -> list[dict[str, str]]:
+    assert _PROBE.is_file(), f"{_PROBE} does not exist"
+
+    outputs: list[dict[str, str]] = []
+    for _ in range(count):
+        # Safe: fixed argv, no shell, no user input.
+        completed = subprocess.run(  # nosec B603
+            [sys.executable, str(_PROBE)],
+            capture_output=True,
+            text=True,
+            timeout=_PROBE_TIMEOUT,
+        )
+        assert completed.returncode == 0, f"probe interpreter failed:\n{completed.stderr}"
+        lines = [line for line in completed.stdout.splitlines() if line.strip()]
+        assert len(lines) == 1, f"probe printed {len(lines)} lines, expected exactly one: {completed.stdout!r}"
+        parsed: dict[str, str] = json.loads(lines[0])
+        outputs.append(parsed)
+    return outputs
+
+
+def test_select_deterministic_ignores_input_order() -> None:
+    forward = ComputeFramework.select_deterministic([PandasDataFrame, PyArrowTable])
+    backward = ComputeFramework.select_deterministic([PyArrowTable, PandasDataFrame])
+
+    assert forward is backward
+    assert forward is PandasDataFrame
+
+
+def test_select_deterministic_returns_the_expected_name() -> None:
+    zulu, alfa, tango, bravo = _throwaway_frameworks()
+    expectations: list[tuple[tuple[type[ComputeFramework], ...], str]] = [
+        ((zulu, alfa), "ZzAlfaThrowawayFramework"),
+        ((zulu, tango), "ZzTangoThrowawayFramework"),
+        ((tango, bravo), "ZzBravoThrowawayFramework"),
+        ((zulu, tango, bravo), "ZzBravoThrowawayFramework"),
+        ((zulu, alfa, tango, bravo), "ZzAlfaThrowawayFramework"),
+    ]
+
+    for group, expected in expectations:
+        assert ComputeFramework.select_deterministic(set(group)).get_class_name() == expected
+
+
+def test_select_deterministic_breaks_a_shared_class_name_by_qualname() -> None:
+    """A shared class name would otherwise fall back to input order, which for a set is id-based."""
+    alfa, bravo = _same_name_frameworks()
+
+    forward = ComputeFramework.select_deterministic([alfa, bravo])
+    backward = ComputeFramework.select_deterministic([bravo, alfa])
+
+    assert forward is backward
+    assert forward is alfa
+    assert ".alfa." in forward.__qualname__, forward.__qualname__
+
+
+def test_select_deterministic_rejects_empty_input() -> None:
+    with pytest.raises(ValueError):
+        ComputeFramework.select_deterministic([])
+
+
+def test_the_throwaway_frameworks_stay_out_of_plugin_discovery() -> None:
+    """get_cfw_subclasses is what planning consults; nothing this module defines may reach it."""
+    held = set(_throwaway_frameworks()) | set(_same_name_frameworks())
+
+    discovered = PreFilterPlugins.get_cfw_subclasses()
+
+    assert not discovered & held, f"test-only frameworks reached discovery: {discovered & held}"
+    leaked = sorted(cfw.get_class_name() for cfw in discovered if cfw.__module__ == __name__)
+    assert leaked == [], f"test-only frameworks leaked into plugin discovery: {leaked}"
+
+
+def test_link_trekker_key_reduces_both_sides_to_the_expected_framework() -> None:
+    link = _link()
+
+    key = ResolveLinks(Graph()).create_link_trekker_key(
+        link, {PyArrowTable, PandasDataFrame}, {PyArrowTable, PandasDataFrame}
+    )
+
+    assert key == (link, PandasDataFrame, PandasDataFrame)
+
+
+def test_link_trekker_key_reduces_every_framework_pair_the_same_way() -> None:
+    resolver = ResolveLinks(Graph())
+    zulu, alfa, tango, bravo = _throwaway_frameworks()
+    expectations: list[tuple[tuple[type[ComputeFramework], type[ComputeFramework]], str]] = [
+        ((zulu, alfa), "ZzAlfaThrowawayFramework"),
+        ((zulu, tango), "ZzTangoThrowawayFramework"),
+        ((tango, bravo), "ZzBravoThrowawayFramework"),
+    ]
+
+    for (left, right), expected in expectations:
+        link = _link()
+        key = resolver.create_link_trekker_key(link, {left, right}, {left, right})
+
+        assert key[0] is link
+        assert key[1].get_class_name() == expected
+        assert key[2].get_class_name() == expected
+
+
+def test_link_trekker_key_keeps_single_framework_sides() -> None:
+    link = _link()
+
+    key = ResolveLinks(Graph()).create_link_trekker_key(link, {PandasDataFrame}, {PyArrowTable})
+
+    assert key == (link, PandasDataFrame, PyArrowTable)
+
+
+def test_feature_compute_framework_is_the_expected_framework() -> None:
+    feature = Feature("determinism_feature")
+    feature.compute_frameworks = {PyArrowTable, PandasDataFrame}
+
+    assert feature.get_compute_framework() is PandasDataFrame
+
+
+def test_feature_compute_framework_is_the_expected_framework_for_every_pair() -> None:
+    zulu, alfa, tango, bravo = _throwaway_frameworks()
+    expectations: list[tuple[tuple[type[ComputeFramework], type[ComputeFramework]], str]] = [
+        ((zulu, alfa), "ZzAlfaThrowawayFramework"),
+        ((zulu, tango), "ZzTangoThrowawayFramework"),
+        ((tango, bravo), "ZzBravoThrowawayFramework"),
+    ]
+
+    for (left, right), expected in expectations:
+        feature = Feature("determinism_feature")
+        feature.compute_frameworks = {left, right}
+
+        assert feature.get_compute_framework().get_class_name() == expected
+
+
+def test_feature_compute_framework_keeps_a_single_framework() -> None:
+    feature = Feature("determinism_single_feature")
+    feature.compute_frameworks = {PyArrowTable}
+
+    assert feature.get_compute_framework() is PyArrowTable
+
+
+def test_feature_compute_framework_rejects_an_empty_set() -> None:
+    feature = Feature("determinism_empty_feature")
+    feature.compute_frameworks = set()
+
+    with pytest.raises(ValueError, match="determinism_empty_feature"):
+        feature.get_compute_framework()
+
+
+# Fresh interpreters cost roughly a second each, so this one needs more than the suite-wide per-test budget.
+@pytest.mark.timeout(60)
+def test_fresh_interpreters_reduce_to_the_same_frameworks() -> None:
+    outputs = _run_probes(_PROBE_PROCESSES)
+
+    assert len(outputs) == _PROBE_PROCESSES, f"expected {_PROBE_PROCESSES} probe results, got {len(outputs)}"
+    for position, output in enumerate(outputs):
+        assert output == _PROBE_EXPECTED, f"probe {position} reduced to {output}, expected {_PROBE_EXPECTED}"

--- a/tests/test_core/test_prepare/test_resolve_cfw_multi_link_disagreement.py
+++ b/tests/test_core/test_prepare/test_resolve_cfw_multi_link_disagreement.py
@@ -1,0 +1,149 @@
+"""One feature on two cross-group links that resolve to different frameworks must fail planning.
+
+A self-join records every ordered parent pair, so it is exempt.
+"""
+
+from typing import Any
+from uuid import UUID
+
+import pytest
+
+from mloda.core.abstract_plugins.components.feature import Feature
+from mloda.core.abstract_plugins.components.link import JoinSpec, Link
+from mloda.core.abstract_plugins.feature_group import FeatureGroup
+from mloda.core.prepare.graph.graph import Graph
+from mloda.core.prepare.resolve_compute_frameworks import ResolveComputeFrameworks
+from mloda.core.prepare.resolve_links import LinkTrekker
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+
+
+class MultiLinkLeftFG(FeatureGroup):
+    pass
+
+
+class MultiLinkRightFG(FeatureGroup):
+    pass
+
+
+class MultiLinkOtherLeftFG(FeatureGroup):
+    pass
+
+
+class MultiLinkOtherRightFG(FeatureGroup):
+    pass
+
+
+class MultiLinkChildFG(FeatureGroup):
+    pass
+
+
+def _trek(link_trekker: LinkTrekker, trekker: Any, uuid: UUID) -> None:
+    # Production shares one set object between data and data_ordered, and invert_link relies on that.
+    shared_uuids = {uuid}
+    link_trekker.data[trekker] = shared_uuids
+    link_trekker.data_ordered[trekker] = shared_uuids
+
+
+def _two_link_scenario() -> tuple[Feature, list[Any], LinkTrekker]:
+    """Opposite orientations, so link_a resolves to pandas and link_b to pyarrow."""
+    feature = Feature("multi_link_feature")
+    feature.compute_frameworks = {PandasDataFrame, PyArrowTable}
+
+    link_a = Link.inner(JoinSpec(MultiLinkLeftFG, "idx"), JoinSpec(MultiLinkRightFG, "idx"))
+    link_b = Link.inner(JoinSpec(MultiLinkOtherLeftFG, "idx"), JoinSpec(MultiLinkOtherRightFG, "idx"))
+
+    link_trekker = LinkTrekker()
+    _trek(link_trekker, (link_a, PandasDataFrame, PyArrowTable), feature.uuid)
+    _trek(link_trekker, (link_b, PyArrowTable, PandasDataFrame), feature.uuid)
+
+    planned_queue: list[Any] = [(MultiLinkChildFG, {feature})]
+    return feature, planned_queue, link_trekker
+
+
+def test_two_links_resolving_to_different_frameworks_raise_at_planning_time() -> None:
+    _, planned_queue, link_trekker = _two_link_scenario()
+
+    with pytest.raises(ValueError, match="more than one compute framework"):
+        ResolveComputeFrameworks(Graph()).links(planned_queue, link_trekker)
+
+
+def test_the_disagreement_message_names_the_feature_and_both_frameworks() -> None:
+    feature, planned_queue, link_trekker = _two_link_scenario()
+
+    with pytest.raises(ValueError) as excinfo:
+        ResolveComputeFrameworks(Graph()).links(planned_queue, link_trekker)
+
+    message = str(excinfo.value)
+    assert str(feature.name) in message, message
+    assert PandasDataFrame.get_class_name() in message, message
+    assert PyArrowTable.get_class_name() in message, message
+
+
+def test_the_disagreement_message_reports_each_link_once_with_its_pair_and_verdict() -> None:
+    """The pair and the framework it resolved to is what tells the two links apart."""
+    _, planned_queue, link_trekker = _two_link_scenario()
+
+    with pytest.raises(ValueError) as excinfo:
+        ResolveComputeFrameworks(Graph()).links(planned_queue, link_trekker)
+
+    message = str(excinfo.value)
+    assert (
+        f"({PandasDataFrame.get_class_name()}, {PyArrowTable.get_class_name()}) -> {PandasDataFrame.get_class_name()}"
+        in message
+    ), message
+    assert (
+        f"({PyArrowTable.get_class_name()}, {PandasDataFrame.get_class_name()}) -> {PyArrowTable.get_class_name()}"
+        in message
+    ), message
+    assert message.count(str(MultiLinkLeftFG.get_class_name())) == 1, message
+
+
+def test_a_self_join_keeps_both_frameworks_instead_of_raising() -> None:
+    """A self-join child records every ordered parent pair, so the two orientations are not a disagreement."""
+    feature = Feature("multi_link_self_join_feature")
+    feature.compute_frameworks = {PandasDataFrame, PyArrowTable}
+
+    link = Link.inner(JoinSpec(MultiLinkLeftFG, "idx"), JoinSpec(MultiLinkLeftFG, "idx"))
+
+    link_trekker = LinkTrekker()
+    _trek(link_trekker, (link, PandasDataFrame, PyArrowTable), feature.uuid)
+    _trek(link_trekker, (link, PyArrowTable, PandasDataFrame), feature.uuid)
+
+    planned_queue: list[Any] = [(MultiLinkChildFG, {feature})]
+    ResolveComputeFrameworks(Graph()).links(planned_queue, link_trekker)
+
+    assert feature.compute_frameworks == {PandasDataFrame, PyArrowTable}
+
+
+def test_a_single_link_still_narrows_the_feature() -> None:
+    """Control: one trekker keeps rewriting instead of raising."""
+    feature = Feature("multi_link_control_feature")
+    feature.compute_frameworks = {PandasDataFrame, PyArrowTable}
+
+    link = Link.inner(JoinSpec(MultiLinkLeftFG, "idx"), JoinSpec(MultiLinkRightFG, "idx"))
+    link_trekker = LinkTrekker()
+    _trek(link_trekker, (link, PandasDataFrame, PyArrowTable), feature.uuid)
+
+    planned_queue: list[Any] = [(MultiLinkChildFG, {feature})]
+    ResolveComputeFrameworks(Graph()).links(planned_queue, link_trekker)
+
+    assert feature.compute_frameworks == {PandasDataFrame}
+
+
+def test_two_links_agreeing_on_one_framework_do_not_raise() -> None:
+    """Control: same orientation twice resolves to a single framework."""
+    feature = Feature("multi_link_agreeing_feature")
+    feature.compute_frameworks = {PandasDataFrame, PyArrowTable}
+
+    link_a = Link.inner(JoinSpec(MultiLinkLeftFG, "idx"), JoinSpec(MultiLinkRightFG, "idx"))
+    link_b = Link.inner(JoinSpec(MultiLinkOtherLeftFG, "idx"), JoinSpec(MultiLinkOtherRightFG, "idx"))
+
+    link_trekker = LinkTrekker()
+    _trek(link_trekker, (link_a, PandasDataFrame, PyArrowTable), feature.uuid)
+    _trek(link_trekker, (link_b, PandasDataFrame, PyArrowTable), feature.uuid)
+
+    planned_queue: list[Any] = [(MultiLinkChildFG, {feature})]
+    ResolveComputeFrameworks(Graph()).links(planned_queue, link_trekker)
+
+    assert feature.compute_frameworks == {PandasDataFrame}

--- a/tests/test_plugins/compute_framework/test_swapped_link_orientation_reconciliation.py
+++ b/tests/test_plugins/compute_framework/test_swapped_link_orientation_reconciliation.py
@@ -1,0 +1,159 @@
+"""Two child groups pinning the same link to swapped framework pairs.
+
+Resolution reconciles the two orientations at once, so both children see the joined columns.
+"""
+
+from typing import Any, Optional
+
+import pyarrow as pa
+import pytest
+
+from mloda.provider import BaseInputData
+from mloda.provider import ComputeFramework
+from mloda.provider import DataCreator
+from mloda.provider import FeatureGroup
+from mloda.provider import FeatureSet
+from mloda.user import Feature
+from mloda.user import FeatureName
+from mloda.user import Index
+from mloda.user import JoinSpec, Link
+from mloda.user import Options
+from mloda.user import ParallelizationMode
+from mloda.user import PluginCollector
+from mloda.user import mloda
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+from mloda_plugins.compute_framework.base_implementations.pyarrow.table import PyArrowTable
+
+LEFT_PAYLOAD = "swapped_left_payload"
+RIGHT_PAYLOAD = "swapped_right_payload"
+JOINED_VALUE = "left|right"
+
+
+def _column_names(data: Any) -> list[str]:
+    if isinstance(data, pa.Table):
+        return list(data.column_names)
+    return list(data.columns)
+
+
+def _values(data: Any, column: str) -> list[Any]:
+    if isinstance(data, pa.Table):
+        return list(data[column].to_pylist())
+    return list(data[column])
+
+
+def _add_joined_column(data: Any, name: str) -> Any:
+    """Writes the two parent payloads into one column, so the joined data itself is observable."""
+    joined = [f"{left}|{right}" for left, right in zip(_values(data, LEFT_PAYLOAD), _values(data, RIGHT_PAYLOAD))]
+    if isinstance(data, pa.Table):
+        return data.append_column(name, pa.array(joined))
+    data[name] = joined
+    return data
+
+
+class SwappedParentLeft(FeatureGroup):
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={cls.get_class_name()})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {cls.get_class_name(): ["Same Value"], LEFT_PAYLOAD: ["left"]}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PyArrowTable, PandasDataFrame}
+
+
+class SwappedParentRight(FeatureGroup):
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={cls.get_class_name()})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {cls.get_class_name(): ["Same Value"], RIGHT_PAYLOAD: ["right"]}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PyArrowTable, PandasDataFrame}
+
+
+class SwappedChildPandasLeft(FeatureGroup):
+    """Pins the left parent to pandas and the right parent to pyarrow."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return {
+            Feature(name=SwappedParentLeft.get_class_name(), compute_framework="PandasDataFrame"),
+            Feature(name=SwappedParentRight.get_class_name(), compute_framework="PyArrowTable"),
+        }
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return _add_joined_column(data, cls.get_class_name())
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PyArrowTable, PandasDataFrame}
+
+
+class SwappedChildPyArrowLeft(FeatureGroup):
+    """Pins the same two parents the other way round, so the link is recorded in both orientations."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return {
+            Feature(name=SwappedParentLeft.get_class_name(), compute_framework="PyArrowTable"),
+            Feature(name=SwappedParentRight.get_class_name(), compute_framework="PandasDataFrame"),
+        }
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return _add_joined_column(data, cls.get_class_name())
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PyArrowTable, PandasDataFrame}
+
+
+# Threading is left out: both orientations produce a JoinStep carrying the same link uuid as its completion
+# token, so a child can start once either join reported done. That predates this scenario.
+@pytest.mark.parametrize("modes", [({ParallelizationMode.SYNC})])
+class TestSwappedLinkOrientationReconciliation:
+    def test_both_children_receive_the_joined_columns(
+        self, modes: set[ParallelizationMode], flight_server: Any
+    ) -> None:
+        link = Link.inner(
+            left=JoinSpec(SwappedParentLeft, Index((SwappedParentLeft.get_class_name(),))),
+            right=JoinSpec(SwappedParentRight, Index((SwappedParentRight.get_class_name(),))),
+        )
+
+        result = mloda.run_all(
+            [
+                Feature(name=SwappedChildPandasLeft.get_class_name()),
+                Feature(name=SwappedChildPyArrowLeft.get_class_name()),
+            ],
+            links={link},
+            compute_frameworks=["PyArrowTable", "PandasDataFrame"],
+            plugin_collector=PluginCollector.enabled_feature_groups(
+                {
+                    SwappedParentLeft,
+                    SwappedParentRight,
+                    SwappedChildPandasLeft,
+                    SwappedChildPyArrowLeft,
+                }
+            ),
+            flight_server=flight_server,
+            parallelization_modes=modes,
+        )
+
+        joined: dict[str, list[Any]] = {}
+        for res in result:
+            for name in (SwappedChildPandasLeft.get_class_name(), SwappedChildPyArrowLeft.get_class_name()):
+                if name in _column_names(res):
+                    joined[name] = _values(res, name)
+
+        assert sorted(joined) == [
+            SwappedChildPandasLeft.get_class_name(),
+            SwappedChildPyArrowLeft.get_class_name(),
+        ], f"both children must produce a result, got: {sorted(joined)}"
+        for name, values in joined.items():
+            assert values == [JOINED_VALUE], f"{name} did not see both parent payloads, got: {values}"


### PR DESCRIPTION
Planning reduced compute framework sets with `next(iter(...))`. Class hashes are id based, so the reduction varied across processes and the same request could plan differently, and produce different data, from run to run.

## What changed

- `ComputeFramework.select_deterministic` reduces a framework set by a total `(class name, module, qualname)` key. The module and qualname matter: several framework classes in this tree share a class name, and a name-only key leaves those ties to id order.
- `Feature.get_compute_framework` and the link trekker key use it.
- Two gates compared one arbitrary pick against another and only agreed by accident. `GlobalFilter.compute_framework` and `Engine.set_compute_framework` are now membership and intersection tests, so a filter feature declaring two framework pins matches either of them.
- A feature whose links resolve to different frameworks is rejected at planning time, naming each link, its framework pair and what it resolved to. Self joins are exempt: link discovery records every ordered parent pair for them, so more than one framework there is normal, not a conflict.
- An empty framework set now raises naming the feature instead of surfacing a generic message later.
- A cross-process test runs the reduction in fresh interpreters and compares each result against a hard coded expectation.

## Two orientations of one link are reconciled, not rejected

A link can be recorded in both orientations when two children pin their parents to swapped frameworks. Resolution already inverts every uuid of a trekker at once, and both children do receive the fully joined columns, so this is a supported shape. `tests/test_plugins/compute_framework/test_swapped_link_orientation_reconciliation.py` pins it on the joined data. It pins SYNC only: under threading one child can still read unjoined data, because both orientations stamp the same completion token (#1054).

## Known consequence

A configuration where both joined parents declare several frameworks and the child declares only one now fails consistently with `No compute framework agreement`, where it previously succeeded on a coin flip. The reduction happens before the resolver knows what the children can run, so it can pick a framework no child supports. Narrowing the key by the child's frameworks was tried and makes it worse (the JoinStep silently vanishes and the run hangs), so it is tracked separately in #1053. Determinism is still the improvement here: of the runs that used to succeed on that shape, most returned the wrong columns.

Selection with nothing pinned now always lands on the alphabetically first installed framework, which is #1055.

Closes #1036
Closes #1041