### PR TITLE
fix: let only one step at a time occupy a compute framework

### DIFF
--- a/mloda/core/runtime/run.py
+++ b/mloda/core/runtime/run.py
@@ -68,6 +68,8 @@ class ExecutionOrchestrator:
         )
 
         self._step_lock = threading.Lock()
+        self._occupied_cfws: dict[UUID, frozenset[UUID]] = {}
+        self._register_modes: set[ParallelizationMode] = set()
 
         self.flight_server = None
         if flight_server:
@@ -99,6 +101,7 @@ class ExecutionOrchestrator:
         self.executor = ComputeFrameworkExecutor(
             self.cfw_register, self.worker_manager, tfs_connection_map=self.tfs_connection_map
         )
+        self._register_modes = self.cfw_register.get_parallelization_modes()
 
         finished_ids: set[UUID] = set()
         to_finish_ids: set[UUID] = set()
@@ -123,7 +126,9 @@ class ExecutionOrchestrator:
                     self._mark_step_as_finished(step.get_uuids(), finished_ids, currently_running_steps)
                 continue
 
-            if not self._can_run_step(step.required_uuids, step.get_uuids(), finished_ids, currently_running_steps):
+            if not self._can_run_step(
+                step.required_uuids, step.get_uuids(), finished_ids, currently_running_steps, step
+            ):
                 continue
             self._execute_step(step)
 
@@ -362,32 +367,71 @@ class ExecutionOrchestrator:
         """
         return self.data_lifecycle_manager.get_artifacts()
 
+    def _cfw_to_occupy(self, step: Any) -> UUID | None:
+        """Resolve the cfw a step needs exclusively, without creating one."""
+        if not isinstance(step, FeatureGroupStep):
+            return None
+
+        # A worker process owns one cfw and drains its command queue in order, so steps dispatched
+        # to it are already serialized.
+        if ParallelizationMode.MULTIPROCESSING in self._register_modes & step.get_parallelization_mode():
+            return None
+
+        class_name = step.compute_framework.get_class_name()
+
+        for tfs_id in step.tfs_ids:
+            cfw_uuid = self.cfw_register.get_cfw_uuid(class_name, tfs_id)
+            if cfw_uuid:
+                return cfw_uuid
+
+        if step.features.any_uuid is None:
+            return None
+        return self.cfw_register.get_cfw_uuid(class_name, step.features.any_uuid)
+
     def _can_run_step(
         self,
         required_uuids: set[UUID],
         step_uuid: set[UUID],
         finished_steps: set[UUID],
         currently_running_steps: set[UUID],
+        step: Any = None,
     ) -> bool:
         """
         Checks if a step can be run. If it can, add it to the currently_running_steps set.
+
+        A cfw instance holds a single data slot and is shared by every step of a chain within one
+        framework, so at most one feature group step may occupy it at a time.
         """
 
         with self._step_lock:
-            if required_uuids.issubset(finished_steps) and not step_uuid.intersection(currently_running_steps):
-                currently_running_steps.update(step_uuid)
-                return True
-            return False
+            if not required_uuids.issubset(finished_steps) or step_uuid.intersection(currently_running_steps):
+                return False
+
+            cfw_uuid = self._cfw_to_occupy(step)
+            if cfw_uuid is not None:
+                if cfw_uuid in self._occupied_cfws:
+                    return False
+                self._occupied_cfws[cfw_uuid] = frozenset(step_uuid)
+
+            currently_running_steps.update(step_uuid)
+            return True
 
     def _mark_step_as_finished(
         self, step_uuid: set[UUID], finished_steps: set[UUID], currently_running_steps: set[UUID]
     ) -> None:
         """
-        Marks a step as finished.
+        Marks a step as finished and releases the cfw it occupied.
+
+        The release happens here, not when the worker finishes, because the result is read off
+        cfw.data in _process_step_result, which runs immediately before this call.
         """
         with self._step_lock:
             currently_running_steps.difference_update(step_uuid)
             finished_steps.update(step_uuid)
+
+            for cfw_uuid, owner in list(self._occupied_cfws.items()):
+                if owner & step_uuid:
+                    del self._occupied_cfws[cfw_uuid]
 
     def get_result(self) -> list[Any]:
         """

--- a/tests/test_plugins/compute_framework/test_sibling_steps_share_one_cfw.py
+++ b/tests/test_plugins/compute_framework/test_sibling_steps_share_one_cfw.py
@@ -1,0 +1,120 @@
+"""Sibling feature groups on one parent resolve to a single compute framework instance.
+Both outputs must survive when the two steps overlap in time.
+"""
+
+import threading
+from typing import Any, Optional
+
+import pytest
+
+from mloda.provider import BaseInputData
+from mloda.provider import ComputeFramework
+from mloda.provider import DataCreator
+from mloda.provider import FeatureGroup
+from mloda.provider import FeatureSet
+from mloda.user import Feature
+from mloda.user import FeatureName
+from mloda.user import Options
+from mloda.user import ParallelizationMode
+from mloda.user import PluginCollector
+from mloda.user import mloda
+from mloda_plugins.compute_framework.base_implementations.pandas.dataframe import PandasDataFrame
+
+HANDSHAKE_TIMEOUT = 1.0
+
+late_reader_took_input = threading.Event()
+early_writer_stored_data = threading.Event()
+late_writer_stored_data = threading.Event()
+
+
+class SharedSiblingParent(FeatureGroup):
+    @classmethod
+    def input_data(cls) -> Optional[BaseInputData]:
+        return DataCreator(supports_features={cls.get_class_name()})
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        return {cls.get_class_name(): [1, 2, 3]}
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+
+class SiblingEarlyWriter(FeatureGroup):
+    """Stores its frame first, then holds its step open until the sibling has stored too."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return {Feature(name=SharedSiblingParent.get_class_name())}
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        late_reader_took_input.wait(HANDSHAKE_TIMEOUT)
+        return data.assign(**{cls.get_class_name(): data[SharedSiblingParent.get_class_name()]})
+
+    @classmethod
+    def validate_output_features(cls, data: Any, features: FeatureSet) -> None:
+        early_writer_stored_data.set()
+        late_writer_stored_data.wait(HANDSHAKE_TIMEOUT)
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+
+class SiblingLateWriter(FeatureGroup):
+    """Takes its input before the sibling writes, then stores its own frame last."""
+
+    def input_features(self, options: Options, feature_name: FeatureName) -> Optional[set[Feature]]:
+        return {Feature(name=SharedSiblingParent.get_class_name())}
+
+    @classmethod
+    def calculate_feature(cls, data: Any, features: FeatureSet) -> Any:
+        late_reader_took_input.set()
+        early_writer_stored_data.wait(HANDSHAKE_TIMEOUT)
+        return data.assign(**{cls.get_class_name(): data[SharedSiblingParent.get_class_name()]})
+
+    @classmethod
+    def validate_output_features(cls, data: Any, features: FeatureSet) -> None:
+        late_writer_stored_data.set()
+
+    @classmethod
+    def compute_framework_rule(cls) -> set[type[ComputeFramework]]:
+        return {PandasDataFrame}
+
+
+@pytest.fixture(autouse=True)
+def reset_handshake() -> None:
+    late_reader_took_input.clear()
+    early_writer_stored_data.clear()
+    late_writer_stored_data.clear()
+
+
+@pytest.mark.parametrize(
+    "modes",
+    [
+        ({ParallelizationMode.SYNC}),
+        ({ParallelizationMode.THREADING}),
+    ],
+)
+class TestSiblingStepsShareOneCfw:
+    def test_both_sibling_outputs_survive(self, modes: set[ParallelizationMode], flight_server: Any) -> None:
+        result = mloda.run_all(
+            [
+                Feature(name=SiblingEarlyWriter.get_class_name()),
+                Feature(name=SiblingLateWriter.get_class_name()),
+            ],
+            compute_frameworks=["PandasDataFrame"],
+            plugin_collector=PluginCollector.enabled_feature_groups(
+                {SharedSiblingParent, SiblingEarlyWriter, SiblingLateWriter}
+            ),
+            flight_server=flight_server,
+            parallelization_modes=modes,
+        )
+
+        seen: set[str] = set()
+        for res in result:
+            seen.update(res.columns)
+
+        assert SiblingEarlyWriter.get_class_name() in seen
+        assert SiblingLateWriter.get_class_name() in seen


### PR DESCRIPTION
## Problem

`main` is red. The job `build (3.11, -e installed)` fails on
`test_cross_group_link_orientation.py::TestCrossGroupLinkOrientation::test_shared_link_serves_both_child_groups[modes1]`,
either with a missing output column or with
`ValueError: No columns found that match feature names {...}`. Which of the two
child groups goes missing varies between runs.

Reproduced locally on 3.11 at 3 failures in 40 runs for THREADING, 0 in 40 for SYNC.

## Cause

A `ComputeFramework` instance owns a single `data` slot, and `CfwManager.get_cfw_uuid`
returns one instance per framework per `children_if_root` set. A whole chain of steps
within one framework therefore shares one instance. Instrumenting the failing run shows
both child groups reporting the same cfw uuid.

`ExecutionOrchestrator._can_run_step` gated only on step uuids and dependency completion,
so two sibling feature groups that become runnable in the same planner pass were both
launched. Under THREADING both threads run `ComputeFramework.run_calculation`, which ends
by replacing `self.data` and recomputing the column names. Last writer wins, and the step
whose result is collected second is read off the other group's frame.

This is not specific to links or joins: two plain sibling feature groups over one parent
are enough. The scheduling gate predates the link work that surfaced it.

SYNC survived only by luck, because feature groups that mutate their input frame in place
leave both columns on the shared object. A sibling that returns a new frame loses data
there too.

MULTIPROCESSING was already safe: a worker process owns one cfw and drains its command
queue in order.

## Change

A step claims its compute framework when it starts and releases it once its result has
been collected, which is where `cfw.data` is read. A step whose framework is occupied is
skipped and retried on the next planner pass, so nothing blocks or sleeps.
Multiprocessing steps are exempt, since their queue already serializes them.

## Test

`tests/test_plugins/compute_framework/test_sibling_steps_share_one_cfw.py` pins the
invariant with two sibling feature groups over one parent. Sleeps alone cannot hit the
window reliably, because the planner busy-spins and usually collects the first finisher
before the second overwrites the slot, so the test uses an event handshake to force the
interleaving: the late writer takes its input, the early writer stores its frame and holds
its step open in `validate_output_features`, then the late writer stores over it. Every
wait is bounded, so with the fix in place the handshake simply expires and the steps run
in sequence. It failed 10 out of 10 runs before the change.

## Verification

- New test: 10 of 10 runs green.
- The flaky test, on 3.11: 40 of 40 runs green, previously 3 failures in 40.
- `tox`: 8686 passed, 170 skipped, ruff, mypy strict, bandit and the license check all green.