### PR TITLE
fix: validate the filter framework pin and narrow it by the capability hook

### DIFF
--- a/docs/docs/in_depth/filter_data.md
+++ b/docs/docs/in_depth/filter_data.md
@@ -186,15 +186,21 @@ When a user passes a `GlobalFilter`, the framework tests every `SingleFilter` ag
 FeatureGroup that each feature already resolved to, using that feature's options, domain
 and compute framework. Each filter is **deep-copied** first, so everything below happens
 on the copy and never on the filter the user built. The copy is delivered only if it
-clears four gates, in order: the group's own `match_feature_group_criteria()` on the
+clears five gates, in order: the group's own `match_feature_group_criteria()` on the
 filter feature's name and options (plus the run's `DataAccessCollection`), then the filter
 feature's domain against the resolved feature's, then its `feature_group` scope against
 the probed FeatureGroup, honored with the same semantics as feature resolution (the named
-class and its subclasses, class-object and string forms alike), then its compute framework
-against the resolved feature's. The domain and compute framework gates also backfill: a
-filter feature that declares no domain or compute framework inherits the resolved
-feature's (the FeatureGroup's domain when the feature declares none). Declaring the filter's column as an input is **not** the
-test, and links are not re-checked here (feature resolution already covered them).
+class and its subclasses, class-object and string forms alike), then the group's
+`supports_compute_framework()` on the same name and options, which narrows the frameworks
+the filter rides to the hook-accepted ones (its own pin, else the resolved feature's),
+detaching the filter when none are accepted, then its compute framework against the
+resolved feature's. The domain and compute
+framework gates also backfill: a filter feature that declares no domain or compute
+framework inherits the resolved feature's (the FeatureGroup's domain when the feature
+declares none). Pinning a filter feature to more than one compute framework raises
+`ComputeFrameworkPinError` at `add_filter` time; feature resolution applies the same
+validation. Declaring the filter's column as an input is **not** the test, and links are
+not re-checked here (feature resolution already covered them).
 
 `match_feature_group_criteria()` sees the filter feature's own options enriched from the
 resolved feature's effective (post-default) ones (see

--- a/mloda/core/abstract_plugins/feature_group.py
+++ b/mloda/core/abstract_plugins/feature_group.py
@@ -755,6 +755,8 @@ class FeatureGroup(ABC):
         the concrete feature, so it can reject an op on one backend while allowing
         others. If every candidate framework is rejected, the matcher surfaces a
         distinguishable error instead of a generic "no feature group" message.
+        Filter matching consults the same hook and narrows the frameworks an
+        attached filter feature rides.
 
         The default gates a declared canonical subtype by ``supported_subtypes()``;
         everything else (no subtype dimension, unresolved or undeclared subtype) stays open.

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -4,6 +4,7 @@ from itertools import chain
 from typing import Any, Optional
 from uuid import UUID
 
+from mloda.core.abstract_plugins.compute_framework import ComputeFramework
 from mloda.core.abstract_plugins.feature_group import FeatureGroup
 from mloda.core.abstract_plugins.components.domain import Domain
 from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser import option_key_is_present
@@ -17,7 +18,7 @@ from mloda.core.abstract_plugins.components.match_hook import call_match_hook
 from mloda.core.abstract_plugins.components.utils import contained_raise_reason
 from mloda.core.filter.filter_type_enum import FilterType
 from mloda.core.filter.single_filter import SingleFilter
-from mloda.core.prepare.identify_feature_group import matches_feature_group_scope
+from mloda.core.prepare.identify_feature_group import matches_feature_group_scope, validate_single_framework_pin
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
 
 
@@ -95,8 +96,12 @@ class GlobalFilter:
             This filter_type does not need to match the FilterType, but it should be a string that is meaningful in the concrete
             Featuregroup implementation.
         - parameter: A dictionary of filter-specific options.
+
+        A filter feature pinned to more than one compute framework raises `ComputeFrameworkPinError` here.
         """
         _single_filter = SingleFilter(filter_feature, filter_type, parameter)
+        # Validated at declaration time: the raise must not depend on any probe running (#851).
+        validate_single_framework_pin(_single_filter.filter_feature)
         self.filters.add(_single_filter)
 
     def add_filter_to_collection(
@@ -127,6 +132,7 @@ class GlobalFilter:
         Differences are in details:
             -   we use the options of the feature to enrich the filter feature options,
             -   we set the compute framework of the feature to determine the one of the filter feature,
+            -   we consult the capability hook over the frameworks the filter would ride (its pin, else the feature's),
             -   we do not check links, as this is done earlier already and not needed anymore.
         """
 
@@ -142,7 +148,10 @@ class GlobalFilter:
                 continue
             if self.feature_group_scope(_filter, feature_group) is False:
                 continue
-            if self.compute_framework(_filter, feat) is False:
+            supported = self.capability(_filter, feat, feature_group)
+            if supported is not None and not supported:
+                continue
+            if self.compute_framework(_filter, feat, supported) is False:
                 continue
             # we don't check links, because this is not necessary as this is covered by the feature and feature group before
 
@@ -321,14 +330,34 @@ class GlobalFilter:
         scope = filter.filter_feature.feature_group_scope
         return scope is None or matches_feature_group_scope(feature_group, scope)
 
-    def compute_framework(self, filter: SingleFilter, feat: Feature) -> bool:
+    def capability(
+        self, filter: SingleFilter, feat: Feature, feature_group: type[FeatureGroup]
+    ) -> set[type[ComputeFramework]] | None:
+        """The hook removes rejected frameworks from what the filter would ride, as on the resolution seam.
+        Unguarded, unlike `criteria`: a raising hook fails loudly."""
+        ride_frameworks = filter.filter_feature.compute_frameworks or feat.compute_frameworks
+        if not ride_frameworks:
+            return None
+        return {
+            cfw
+            for cfw in ride_frameworks
+            if feature_group.supports_compute_framework(filter.filter_feature.name, filter.filter_feature.options, cfw)
+        }
+
+    def compute_framework(
+        self, filter: SingleFilter, feat: Feature, supported: set[type[ComputeFramework]] | None = None
+    ) -> bool:
         # case that the filter feature has no cf set -> feature defines it
         if not filter.filter_feature.compute_frameworks:
             # Hash-safe: the target is a per-match deepcopy, added to matched_filters only after all mutations.
-            filter.filter_feature.compute_frameworks = feat.compute_frameworks
+            # Adoption owns its set and, on the engine path, carries only the hook-accepted subset, mirroring
+            # the canonical seam where identified candidates hold only supported frameworks.
+            adopted = supported if supported is not None else feat.compute_frameworks
+            filter.filter_feature.compute_frameworks = set(adopted) if adopted is not None else None
             return True
 
-        # case that the filter feature has an cf -> the feature framework must be one of the pinned ones
+        # case that the filter feature has an cf -> the feature framework must be one of the pinned ones.
+        # Cardinality is validated at add_filter, so membership degenerates to the single pin's equality.
         if feat.get_compute_framework() in filter.filter_feature.compute_frameworks:
             return True
 

--- a/mloda/core/prepare/identify_feature_group.py
+++ b/mloda/core/prepare/identify_feature_group.py
@@ -98,6 +98,17 @@ def matches_feature_group_scope(feature_group: type[FeatureGroup], scope: str | 
     )
 
 
+def validate_single_framework_pin(feature: Feature) -> None:
+    """Raise if the user pinned more than one compute framework; this misuse is only a programmer error."""
+    pinned = feature.compute_frameworks
+    if pinned is not None and len(pinned) > 1:
+        names = ", ".join(sorted(cfw.get_class_name() for cfw in pinned))
+        raise ComputeFrameworkPinError(
+            f"Feature '{feature.name}' is pinned to more than one compute framework ({names}); "
+            f"pin at most one compute framework."
+        )
+
+
 class IdentifyFeatureGroupClass:
     _criteria_matched_feature_groups: set[type[FeatureGroup]]
     _abstract_matched_feature_groups: set[type[FeatureGroup]]
@@ -130,17 +141,6 @@ class IdentifyFeatureGroupClass:
         self._prefixes = {}
         self._data_access_collection = data_access_collection
 
-    @staticmethod
-    def _validate_single_framework_pin(feature: Feature) -> None:
-        """Raise if the user pinned more than one compute framework; this misuse is only a programmer error."""
-        pinned = feature.compute_frameworks
-        if pinned is not None and len(pinned) > 1:
-            names = ", ".join(sorted(cfw.get_class_name() for cfw in pinned))
-            raise ComputeFrameworkPinError(
-                f"Feature '{feature.name}' is pinned to more than one compute framework ({names}); "
-                f"pin at most one compute framework."
-            )
-
     @classmethod
     def evaluate(
         cls,
@@ -152,7 +152,7 @@ class IdentifyFeatureGroupClass:
         """Run the matching/filter logic without raising, returning a structured result."""
         # Pre-matching guard: a >1 pin fires regardless of whether any candidate matches (the old check
         # sat inside the filter loop, so it never ran when the name matched nothing).
-        cls._validate_single_framework_pin(feature)
+        validate_single_framework_pin(feature)
         self = cls(data_access_collection)
         try:
             identified = self._filter_loop(feature, accessible_plugins, links, data_access_collection)

--- a/tests/test_core/test_abstract_plugins/test_components/test_compute_frameworks_sharing.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_compute_frameworks_sharing.py
@@ -214,14 +214,15 @@ def test_copy_of_a_feature_without_frameworks_keeps_none() -> None:
     assert copy(feature).compute_frameworks is None
 
 
-def test_global_filter_aliases_the_features_set_into_a_filter_feature_without_one() -> None:
-    """Characterization: the alias is deliberate."""
+def test_global_filter_adoption_copies_the_features_set_never_aliases_it() -> None:
+    """Ownership: a later write into the adopted set can never reach the host's."""
     feat = _feature_with_framework()
     single_filter = SingleFilter(Feature(CFS_FILTER_FEATURE), FilterType.EQUAL, {"value": 1})
     assert single_filter.filter_feature.compute_frameworks is None
 
     assert GlobalFilter().compute_framework(single_filter, feat) is True
-    assert single_filter.filter_feature.compute_frameworks is feat.compute_frameworks
+    assert single_filter.filter_feature.compute_frameworks == feat.compute_frameworks
+    assert single_filter.filter_feature.compute_frameworks is not feat.compute_frameworks
 
 
 def test_two_independently_built_features_own_separate_sets() -> None:

--- a/tests/test_core/test_filter/test_filter_matcher_canonical_map.py
+++ b/tests/test_core/test_filter/test_filter_matcher_canonical_map.py
@@ -43,6 +43,7 @@ MISSING_SCOPE_728 = "CmapNoSuchScope728"  # a scope string naming no accessible 
 SCOPE_REASON = "outside the requested feature group scope"
 PIN_MESSAGE_PART = "more than one compute framework"
 CAPABILITY_REASON_PART = "supports_compute_framework rejected"
+CAPABILITY_RAISE_TEXT = "cmap capability hook raise 728"  # carried by the raising hook's RuntimeError
 LINKS_REASON = "no index column matches the run's links"
 
 GROUP_DOMAIN_728 = "cmap_group_domain_728"  # declared by the group-domain probe
@@ -67,6 +68,7 @@ T = TypeVar("T")
 # A factory handing back the throwaway class and a reader for its call counter, so no drive types the class.
 _CounterFactory = Callable[[], tuple[type[FeatureGroup], Callable[[], int]]]
 _ObservedOptions = tuple[tuple[tuple[str, str], ...], ...]
+_RecorderFactory = Callable[[], tuple[type[FeatureGroup], Callable[[], _ObservedOptions]]]
 
 # Scope probes hand the driver one class or a (base, child) pair; picks receive the uniform tuple form.
 _ScopeClasses = tuple[type[FeatureGroup], ...]
@@ -180,6 +182,129 @@ def _make_capability_reject_fg() -> tuple[type[FeatureGroup], Callable[[], int]]
             return False
 
     return CapabilityRejectMatcherFG728, lambda: CapabilityRejectMatcherFG728.calls
+
+
+def _make_capability_accept_fg() -> tuple[type[FeatureGroup], Callable[[], int]]:
+    """A throwaway matcher whose capability hook counts its calls and accepts every framework."""
+    gc.collect()
+
+    class CapabilityAcceptMatcherFG728(FeatureGroup):
+        calls: ClassVar[int] = 0
+
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE, FILTER_FEATURE}
+
+        @classmethod
+        def supports_compute_framework(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            compute_framework: type[ComputeFramework],
+        ) -> bool:
+            cls.calls += 1
+            return True
+
+    return CapabilityAcceptMatcherFG728, lambda: CapabilityAcceptMatcherFG728.calls
+
+
+def _make_capability_reject_pythondict_fg() -> tuple[type[FeatureGroup], Callable[[], int]]:
+    """A throwaway matcher whose capability hook counts its calls and rejects PythonDictFramework alone."""
+    gc.collect()
+
+    class CapabilityRejectPythonDictFG728(FeatureGroup):
+        calls: ClassVar[int] = 0
+
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE, FILTER_FEATURE}
+
+        @classmethod
+        def supports_compute_framework(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            compute_framework: type[ComputeFramework],
+        ) -> bool:
+            cls.calls += 1
+            return compute_framework is not PythonDictFramework
+
+    return CapabilityRejectPythonDictFG728, lambda: CapabilityRejectPythonDictFG728.calls
+
+
+def _make_capability_filter_reject_fg(
+    rejected: frozenset[type[ComputeFramework]],
+) -> tuple[type[FeatureGroup], Callable[[], int]]:
+    """A throwaway matcher rejecting the given frameworks for FILTER_FEATURE alone, counting those hook calls."""
+    gc.collect()
+
+    class CapabilityFilterRejectFG728(FeatureGroup):
+        filter_calls: ClassVar[int] = 0
+
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE, FILTER_FEATURE}
+
+        @classmethod
+        def supports_compute_framework(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            compute_framework: type[ComputeFramework],
+        ) -> bool:
+            if str(feature_name) != FILTER_FEATURE:
+                return True
+            cls.filter_calls += 1
+            return compute_framework not in rejected
+
+    return CapabilityFilterRejectFG728, lambda: CapabilityFilterRejectFG728.filter_calls
+
+
+def _make_capability_raising_fg() -> type[FeatureGroup]:
+    """A throwaway matcher whose capability hook raises."""
+    gc.collect()
+
+    class CapabilityRaisingMatcherFG728(FeatureGroup):
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE, FILTER_FEATURE}
+
+        @classmethod
+        def supports_compute_framework(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            compute_framework: type[ComputeFramework],
+        ) -> bool:
+            raise RuntimeError(CAPABILITY_RAISE_TEXT)
+
+    return CapabilityRaisingMatcherFG728
+
+
+def _make_capability_option_recorder_fg() -> tuple[type[FeatureGroup], Callable[[], _ObservedOptions]]:
+    """A throwaway matcher recording the option view its capability hook observes for FILTER_FEATURE."""
+    gc.collect()
+
+    class CapabilityOptionRecorderFG728(FeatureGroup):
+        observed: ClassVar[list[tuple[tuple[str, str], ...]]] = []
+
+        @classmethod
+        def feature_names_supported(cls) -> set[str]:
+            return {HOST_FEATURE, FILTER_FEATURE}
+
+        @classmethod
+        def supports_compute_framework(
+            cls,
+            feature_name: FeatureName | str,
+            options: Options,
+            compute_framework: type[ComputeFramework],
+        ) -> bool:
+            if str(feature_name) == FILTER_FEATURE:
+                keys = (SHARED_KEY_728, GROUP_ONLY_KEY_728, CONTEXT_ONLY_KEY_728)
+                cls.observed.append(tuple((key, str(options.get(key))) for key in keys))
+            return True
+
+    return CapabilityOptionRecorderFG728, lambda: tuple(CapabilityOptionRecorderFG728.observed)
 
 
 def _make_own_index_fg() -> tuple[type[FeatureGroup], Callable[[], int]]:
@@ -313,32 +438,36 @@ def _drive_two_scope_duplicate_declarations() -> _TwoScopedSnapshot:
         gc.collect()
 
 
-def _drive_two_pin_matching() -> _MatchingSnapshot:
-    """Match one two-pin filter against a PythonDict-pinned host."""
-    fg = _make_plain_matcher_fg()
+@dataclass(frozen=True)
+class _DeclarationSnapshot:
+    """Plain-data readout of one add_filter attempt. Holds no filter object."""
+
+    escaped: str | None
+    stored_count: int
+
+
+def _drive_two_pin_declaration() -> _DeclarationSnapshot:
+    """Declare one two-pin filter feature; the shared validator must reject it before anything is stored."""
     global_filter = GlobalFilter()
     pinned = Feature(FILTER_FEATURE)
     pinned.compute_frameworks = {PandasDataFrame, PyArrowTable}
-    global_filter.add_filter(pinned, FilterType.EQUAL, {"value": 1})
-    host = Feature(HOST_FEATURE)
-    host.compute_frameworks = {PythonDictFramework}
-    matched = None
     try:
-        matched, escaped = _capture(partial(global_filter.identify_matched_filters, fg, host, None))
-        return _MatchingSnapshot(
-            escaped=escaped,
-            names=() if matched is None else tuple(sorted(single.name for single in matched)),
-        )
+        _, escaped = _capture(partial(global_filter.add_filter, pinned, FilterType.EQUAL, {"value": 1}))
+        return _DeclarationSnapshot(escaped=escaped, stored_count=len(global_filter.filters))
     finally:
-        del fg, global_filter, matched
+        del global_filter, pinned
         gc.collect()
 
 
-def _drive_matching_counted(make: _CounterFactory, pin_host: bool) -> _MatchingSnapshot:
-    """Match one unpinned registered filter against HOST_FEATURE and read the probe's call counter."""
+def _drive_matching_counted(make: _CounterFactory, pin_host: bool, pin_filter: bool = False) -> _MatchingSnapshot:
+    """Match one registered filter against HOST_FEATURE, pinning either side when asked, and read the call counter."""
     fg, read_calls = make()
     global_filter = GlobalFilter()
-    global_filter.add_filter(FILTER_FEATURE, FilterType.EQUAL, {"value": 1})
+    filter_feature: Feature | str = FILTER_FEATURE
+    if pin_filter:
+        filter_feature = Feature(FILTER_FEATURE)
+        filter_feature.compute_frameworks = {PythonDictFramework}
+    global_filter.add_filter(filter_feature, FilterType.EQUAL, {"value": 1})
     host = Feature(HOST_FEATURE)
     if pin_host:
         host.compute_frameworks = {PythonDictFramework}
@@ -352,6 +481,73 @@ def _drive_matching_counted(make: _CounterFactory, pin_host: bool) -> _MatchingS
         )
     finally:
         del fg, read_calls, global_filter, matched
+        gc.collect()
+
+
+def _framework_names(frameworks: set[type[ComputeFramework]] | None) -> tuple[str, ...] | None:
+    """The frameworks as sorted class-name text; an unpinned None stays None."""
+    if frameworks is None:
+        return None
+    return tuple(sorted(cfw.__name__ for cfw in frameworks))
+
+
+@dataclass(frozen=True)
+class _NarrowingSnapshot:
+    """Plain-data readout of one two-framework matching pass. Holds no class and no filter object."""
+
+    escaped: str | None
+    names: tuple[str, ...]
+    # None when no copy attached; an attached copy's None pin also folds to None and fails the subset assert loudly.
+    matched_frameworks: tuple[str, ...] | None
+    host_frameworks: tuple[str, ...] | None
+    stored_frameworks: tuple[str, ...] | None
+    calls: int
+
+
+def _drive_matching_two_framework_host(make: _CounterFactory) -> _NarrowingSnapshot:
+    """Match one unpinned registered filter against a host riding PandasDataFrame and PyArrowTable."""
+    fg, read_calls = make()
+    global_filter = GlobalFilter()
+    global_filter.add_filter(FILTER_FEATURE, FilterType.EQUAL, {"value": 1})
+    host = Feature(HOST_FEATURE)
+    host.compute_frameworks = {PandasDataFrame, PyArrowTable}
+    matched = None
+    try:
+        matched, escaped = _capture(partial(global_filter.identify_matched_filters, fg, host, None))
+        names: tuple[str, ...] = ()
+        matched_frameworks: tuple[str, ...] | None = None
+        for single in matched or ():
+            names = (*names, single.name)
+            matched_frameworks = _framework_names(single.filter_feature.compute_frameworks)
+        return _NarrowingSnapshot(
+            escaped=escaped,
+            names=tuple(sorted(names)),
+            matched_frameworks=matched_frameworks,
+            host_frameworks=_framework_names(host.compute_frameworks),
+            stored_frameworks=_framework_names(next(iter(global_filter.filters)).filter_feature.compute_frameworks),
+            calls=read_calls(),
+        )
+    finally:
+        del fg, read_calls, global_filter, matched
+        gc.collect()
+
+
+def _drive_matching_raising_hook() -> _MatchingSnapshot:
+    """Match one unpinned registered filter against a PythonDict-pinned host on the raising-hook probe."""
+    fg = _make_capability_raising_fg()
+    global_filter = GlobalFilter()
+    global_filter.add_filter(FILTER_FEATURE, FilterType.EQUAL, {"value": 1})
+    host = Feature(HOST_FEATURE)
+    host.compute_frameworks = {PythonDictFramework}
+    matched = None
+    try:
+        matched, escaped = _capture(partial(global_filter.identify_matched_filters, fg, host, None))
+        return _MatchingSnapshot(
+            escaped=escaped,
+            names=() if matched is None else tuple(sorted(single.name for single in matched)),
+        )
+    finally:
+        del fg, global_filter, matched
         gc.collect()
 
 
@@ -520,9 +716,13 @@ def _options_as_pairs(options: Options) -> tuple[tuple[tuple[str, str], ...], tu
     return group, context
 
 
-def _drive_enriched_matching(filter_options: Options | None = None) -> _EnrichmentSnapshot:
+def _drive_enriched_matching(
+    filter_options: Options | None = None,
+    make: _RecorderFactory = _make_option_recorder_fg,
+    pin_host: bool = False,
+) -> _EnrichmentSnapshot:
     """Match the filter feature, declaring the given options (default: the shared key in group), against the host."""
-    fg, read_observed = _make_option_recorder_fg()
+    fg, read_observed = make()
     global_filter = GlobalFilter()
     declared = Options(group={SHARED_KEY_728: FILTER_VALUE}) if filter_options is None else filter_options
     global_filter.add_filter(Feature(FILTER_FEATURE, declared), FilterType.EQUAL, {"value": 1})
@@ -533,6 +733,8 @@ def _drive_enriched_matching(filter_options: Options | None = None) -> _Enrichme
             context={CONTEXT_ONLY_KEY_728: CONTEXT_ONLY_VALUE},
         ),
     )
+    if pin_host:
+        host.compute_frameworks = {PythonDictFramework}
     matched = None
     try:
         matched, escaped = _capture(partial(global_filter.identify_matched_filters, fg, host, None))
@@ -663,10 +865,10 @@ class TestScopeGate:
 
 
 class TestFrameworkPinCardinality:
-    """GlobalFilter.compute_framework tests membership against the pinned set; the canonical seam validates first."""
+    """Both seams validate the pin cardinality before matching via one shared validator; one pin gates on equality."""
 
     def test_an_unpinned_filter_feature_adopts_the_features_frameworks(self) -> None:
-        """Enrichment control: no pin on the filter side means the feature's pin is written onto the filter."""
+        """Enrichment control: no pin on the filter side means the feature's frameworks are copied onto the filter."""
         global_filter = GlobalFilter()
         single = _single()
         feat = Feature(HOST_FEATURE)
@@ -675,44 +877,47 @@ class TestFrameworkPinCardinality:
         verdict = global_filter.compute_framework(single, feat)
 
         assert verdict is True, "an unpinned filter feature must accept the feature's framework"
-        assert single.filter_feature.compute_frameworks == {PythonDictFramework}, "the feature's pin is adopted"
-        assert single.filter_feature.compute_frameworks is feat.compute_frameworks, (
-            "adoption shares the feature's set object, not a copy"
+        assert single.filter_feature.compute_frameworks == {PythonDictFramework}, "the feature's frameworks are adopted"
+        assert single.filter_feature.compute_frameworks is not feat.compute_frameworks, (
+            "the adopted set must be an owned copy, never the feature's own set object"
         )
 
-    def test_a_two_pin_filter_matches_either_of_its_pins(self) -> None:
-        """No cardinality validation: the gate is a membership test, so every pin of the pair matches."""
+    def test_a_single_pin_filter_gates_on_equality_with_the_features_framework(self) -> None:
+        """Pinned control: a single pin is the only cardinality that reaches this gate."""
         global_filter = GlobalFilter()
-        single = _single()
-        single.filter_feature.compute_frameworks = {PandasDataFrame, PyArrowTable}
-        feat_pandas = Feature(HOST_FEATURE)
-        feat_pandas.compute_frameworks = {PandasDataFrame}
-        feat_pyarrow = Feature(HOST_FEATURE)
-        feat_pyarrow.compute_frameworks = {PyArrowTable}
-
-        pandas_verdict = global_filter.compute_framework(single, feat_pandas)
-        pyarrow_verdict = global_filter.compute_framework(single, feat_pyarrow)
-
-        assert pandas_verdict is True, f"a pinned framework must match its own pin, got: {pandas_verdict}"
-        assert pyarrow_verdict is True, f"the second pin must match too, got: {pyarrow_verdict}"
-
-    def test_a_two_pin_filter_against_a_third_framework_says_no(self) -> None:
-        global_filter = GlobalFilter()
-        single = _single()
-        single.filter_feature.compute_frameworks = {PandasDataFrame, PyArrowTable}
+        matching = _single()
+        matching.filter_feature.compute_frameworks = {PythonDictFramework}
+        diverging = _single()
+        diverging.filter_feature.compute_frameworks = {PandasDataFrame}
         feat = Feature(HOST_FEATURE)
         feat.compute_frameworks = {PythonDictFramework}
 
-        verdict = global_filter.compute_framework(single, feat)
+        equal_verdict = global_filter.compute_framework(matching, feat)
+        diverging_verdict = global_filter.compute_framework(diverging, feat)
 
-        assert verdict is False, "the feature's framework is not among the pins"
-        assert single.filter_feature.compute_frameworks == {PandasDataFrame, PyArrowTable}, "the pin is not rewritten"
+        assert equal_verdict is True, f"a pin equal to the feature's framework must pass, got: {equal_verdict}"
+        assert diverging_verdict is False, f"a diverging pin must lose, got: {diverging_verdict}"
+        assert diverging.filter_feature.compute_frameworks == {PandasDataFrame}, "the pin is not rewritten"
 
-    def test_the_flow_detaches_a_mismatched_two_pin_quietly(self) -> None:
-        snapshot = _drive_two_pin_matching()
+    def test_add_filter_rejects_a_two_pin_declaration_and_stores_nothing(self) -> None:
+        snapshot = _drive_two_pin_declaration()
 
-        assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
-        assert snapshot.names == (), f"a mismatched two-pin filter must not attach, got: {snapshot.names}"
+        assert snapshot.escaped is not None, "add_filter must validate the pin cardinality at declaration time"
+        assert snapshot.escaped.startswith(f"{ComputeFrameworkPinError.__name__}: "), (
+            f"the declaration raise must be the canonical pin error, got: {snapshot.escaped}"
+        )
+        assert PIN_MESSAGE_PART in snapshot.escaped, f"the raise must name the misuse: {snapshot.escaped}"
+        assert FILTER_FEATURE in snapshot.escaped, f"the raise must name the pinned feature: {snapshot.escaped}"
+        assert snapshot.stored_count == 0, f"a rejected declaration must store nothing, got {snapshot.stored_count}"
+
+    def test_both_seams_raise_one_shared_pin_message(self) -> None:
+        """Byte-identical text for the same feature: the validation is shared, not duplicated."""
+        declared = _drive_two_pin_declaration()
+        canonical = _drive_canonical_two_pin_message()
+
+        assert declared.escaped == f"{ComputeFrameworkPinError.__name__}: {canonical}", (
+            f"both seams must speak the shared validator's message, got: {declared.escaped!r} vs {canonical!r}"
+        )
 
     def test_the_canonical_seam_rejects_the_same_two_pin_outright(self) -> None:
         """Validate-before-matching itself is pinned in
@@ -723,15 +928,95 @@ class TestFrameworkPinCardinality:
         assert FILTER_FEATURE in message, f"the raise must name the pinned feature: {message}"
 
 
-class TestCapabilityHookAbsence:
-    """The filter path never consults supports_compute_framework; the canonical seam splits frameworks on it."""
+class TestCapabilityHook:
+    """The filter seam consults the hook per ride framework (the pin, else the host's) and narrows to the accepted
+    subset, which the attached copy rides; the canonical seam consults it over a candidate's accessible frameworks."""
 
-    def test_the_filter_seam_attaches_without_asking_the_hook(self) -> None:
+    def test_the_filter_seam_asks_the_hook_and_detaches_on_rejection(self) -> None:
         snapshot = _drive_matching_counted(_make_capability_reject_fg, pin_host=True)
 
         assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
-        assert snapshot.names == (FILTER_FEATURE,), f"a rejecting hook must not detach here, got: {snapshot.names}"
-        assert snapshot.calls == 0, f"identify_matched_filters must never consult the hook, got {snapshot.calls} calls"
+        assert snapshot.names == (), f"a hook rejecting every framework must detach the filter, got: {snapshot.names}"
+        assert snapshot.calls == 1, f"a single-framework ride means exactly one consultation, got {snapshot.calls}"
+
+    def test_an_accepting_hook_attaches_and_was_consulted(self) -> None:
+        """Differential control: consultation alone must not detach."""
+        snapshot = _drive_matching_counted(_make_capability_accept_fg, pin_host=True)
+
+        assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
+        assert snapshot.names == (FILTER_FEATURE,), f"an accepting hook must keep the filter, got: {snapshot.names}"
+        assert snapshot.calls == 1, f"a single-framework ride means exactly one consultation, got {snapshot.calls}"
+
+    def test_a_hook_rejecting_one_of_two_ride_frameworks_narrows_the_attached_copy(self) -> None:
+        """The hook contract: a rejected framework leaves the candidate set for this feature only; the rest ride on."""
+        make = partial(_make_capability_filter_reject_fg, frozenset({PandasDataFrame}))
+        snapshot = _drive_matching_two_framework_host(make)
+
+        assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
+        assert snapshot.names == (FILTER_FEATURE,), f"one accepted framework must keep the filter: {snapshot.names}"
+        assert snapshot.matched_frameworks == (PyArrowTable.__name__,), (
+            f"the attached copy must ride the accepted subset alone, got: {snapshot.matched_frameworks}"
+        )
+        assert snapshot.host_frameworks == (PandasDataFrame.__name__, PyArrowTable.__name__), (
+            f"narrowing must never write the host's own frameworks, got: {snapshot.host_frameworks}"
+        )
+        assert snapshot.stored_frameworks is None, (
+            f"the stored original must stay unpinned, got: {snapshot.stored_frameworks}"
+        )
+        assert snapshot.calls == 2, f"the split has no short-circuit: one ask per ride framework, got {snapshot.calls}"
+
+    def test_a_hook_rejecting_both_ride_frameworks_detaches(self) -> None:
+        """The empty accepted subset generalizes the single-framework rejection: nothing is left to ride."""
+        make = partial(_make_capability_filter_reject_fg, frozenset({PandasDataFrame, PyArrowTable}))
+        snapshot = _drive_matching_two_framework_host(make)
+
+        assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
+        assert snapshot.names == (), f"an empty accepted subset must detach the filter, got: {snapshot.names}"
+        assert snapshot.calls == 2, f"both ride frameworks must have been asked about, got {snapshot.calls} calls"
+
+    def test_the_capability_hook_observes_the_enriched_option_view(self) -> None:
+        """The hook reads the union with declared values on top, exactly as the criteria hook does."""
+        snapshot = _drive_enriched_matching(make=_make_capability_option_recorder_fg, pin_host=True)
+
+        assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
+        assert snapshot.names == (FILTER_FEATURE,), f"the accepting recorder must keep the filter: {snapshot.names}"
+        assert snapshot.observed == (
+            (
+                (SHARED_KEY_728, FILTER_VALUE),
+                (GROUP_ONLY_KEY_728, GROUP_ONLY_VALUE),
+                (CONTEXT_ONLY_KEY_728, CONTEXT_ONLY_VALUE),
+            ),
+        ), f"one hook call, seeing the enriched view, got: {snapshot.observed}"
+
+    def test_a_rejected_pin_detaches_despite_equality_with_the_hosts_framework(self) -> None:
+        snapshot = _drive_matching_counted(_make_capability_reject_pythondict_fg, pin_host=True, pin_filter=True)
+
+        assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
+        assert snapshot.names == (), f"a rejected pin must detach even when equal to the host's: {snapshot.names}"
+        assert snapshot.calls == 1, f"the pin is the whole ride set, so exactly one consultation, got {snapshot.calls}"
+
+    def test_a_raising_hook_escapes_the_filter_seam(self) -> None:
+        """Unguarded, as on the canonical seam: never a quiet detach."""
+        snapshot = _drive_matching_raising_hook()
+
+        assert snapshot.escaped is not None, "a raising capability hook must escape identify_matched_filters"
+        assert snapshot.escaped.startswith("RuntimeError"), f"the escape must name the raised type: {snapshot.escaped}"
+        assert CAPABILITY_RAISE_TEXT in snapshot.escaped, f"the escape must carry the hook's text: {snapshot.escaped}"
+
+    def test_the_same_raising_hook_escapes_the_canonical_seam(self) -> None:
+        snapshot = _drive_canonical(_make_capability_raising_fg)
+
+        assert snapshot.escaped is not None, "a raising capability hook must escape evaluate"
+        assert snapshot.escaped.startswith("RuntimeError"), f"the escape must name the raised type: {snapshot.escaped}"
+        assert CAPABILITY_RAISE_TEXT in snapshot.escaped, f"the escape must carry the hook's text: {snapshot.escaped}"
+
+    def test_a_frameworkless_host_with_an_unpinned_filter_attaches_vacuously(self) -> None:
+        """No pin and no host framework leaves the hook nothing to split; the direct-probe drives rely on this."""
+        snapshot = _drive_matching_counted(_make_capability_reject_fg, pin_host=False)
+
+        assert snapshot.escaped is None, f"nothing may cross identify_matched_filters: {snapshot.escaped}"
+        assert snapshot.names == (FILTER_FEATURE,), f"a frameworkless match must stay vacuous, got: {snapshot.names}"
+        assert snapshot.calls == 0, f"there is no framework to ask the hook about, got {snapshot.calls} calls"
 
     def test_the_canonical_seam_asks_the_hook_and_eliminates_at_capability(self) -> None:
         snapshot = _drive_canonical_counted(_make_capability_reject_fg, with_links=False)

--- a/tests/test_core/test_prepare/test_resolution_module_split.py
+++ b/tests/test_core/test_prepare/test_resolution_module_split.py
@@ -53,6 +53,7 @@ RENDERER_NAMES = (
 # What stays in the matcher module, with its definition, and the only names a call site may import from it.
 MATCHER_KEPT_NAMES = (
     "matches_feature_group_scope",
+    "validate_single_framework_pin",
     "FeatureResolutionError",
     "ComputeFrameworkPinError",
     "IdentifyFeatureGroupClass",


### PR DESCRIPTION
## Summary

Filter matching in GlobalFilter diverged from feature resolution on the compute framework axis in two ways:

- A filter feature pinned to more than one compute framework was judged by an arbitrary element of the pin set (`next(iter(...))`), where feature resolution validates the pin before matching and raises `ComputeFrameworkPinError`.
- `supports_compute_framework`, the match-time capability hook, was never consulted for filter features, so a group could get a filter feature computed on a framework its own hook rejects for that name and options.

## Changes

- The single-pin validation is shared with feature resolution: `validate_single_framework_pin` is now a module-level function of the matcher, and `GlobalFilter.add_filter` applies it at declaration time, raising `ComputeFrameworkPinError` with the same message. The raise does not depend on any probe running, matching the placement feature resolution uses (#851).
- `identify_matched_filters` gained a capability gate between the scope and framework gates, mirroring the canonical gate order. The hook is consulted for the filter feature's name and enriched options over the frameworks the filter would ride (its declared pin, else the resolved feature's). Rejected frameworks are removed: the attached copy rides only the hook-accepted subset, and the filter detaches when none are accepted. The gate is unguarded, so a raising hook fails loudly on both seams alike.
- Unpinned adoption owns its framework set instead of aliasing the resolved feature's, so a later write into the adopted set cannot reach the host feature.
- A single declared framework keeps the equality-with-the-feature semantics.
- Docs: the filter matching section now describes the five gates and the declaration-time pin validation.

## Tests

- The canonical-map parity suite pins the identical pin message on both seams, the declaration-time raise storing nothing, rejection, narrowing and vacuous-pass semantics of the capability gate, exact hook consultation counts, the enriched option view the hook observes, and raising-hook parity.
- The frameworks-sharing suite pins adoption ownership.
- `tox` green locally (full suite, ruff, mypy strict, licenses, bandit).

Part of #728.