### PR TITLE
fix(options): NON_FORWARDED_KEYS stores the key string, not the enum member

### DIFF
--- a/mloda/core/abstract_plugins/components/options.py
+++ b/mloda/core/abstract_plugins/components/options.py
@@ -16,6 +16,11 @@ logger = logging.getLogger(__name__)
 NON_FORWARDED_KEYS: frozenset[str] = frozenset({DefaultOptionKeys.in_features.value})
 
 
+def is_non_forwarded_key(key: Any) -> bool:
+    """Match a never-forwarded key in either its string or its DefaultOptionKeys form."""
+    return str(key) in NON_FORWARDED_KEYS
+
+
 def _safe_deepcopy(value: Any, memo: dict[int, Any]) -> Any:
     """Deep-copy a single value, falling back to sharing the value by reference when it cannot be
     deep-copied for ANY reason (e.g. unpicklable objects, or values whose deepcopy raises under some
@@ -367,7 +372,6 @@ class Options:
 
         memo: dict[int, Any] = {}
 
-        excluded = NON_FORWARDED_KEYS
         validate_forwarding_directives(forward_group, forward_group_exclude)
 
         if forward_group is False:
@@ -386,7 +390,7 @@ class Options:
 
         inherited: set[str] = set()
         for key in sorted(group_keys):
-            if key in excluded or key not in consumer.group:
+            if is_non_forwarded_key(key) or key not in consumer.group:
                 continue
             if key in new_context and new_context[key] != consumer.group[key]:
                 owner_clause = f" on input feature '{owner}'" if owner is not None else " on the input feature"
@@ -411,7 +415,7 @@ class Options:
 
         inherited_context: set[str] = set()
         for key in inherit_context_keys:
-            if key in excluded or key not in consumer.context:
+            if is_non_forwarded_key(key) or key not in consumer.context:
                 continue
             value = _isolate_forwarded_value(consumer.context[key], memo)
             OptionsValidator.validate_can_add_to_context(key, value, new_group, new_context)
@@ -420,7 +424,9 @@ class Options:
 
         if consumer.propagate_context_keys and forward_group is not False:
             propagating = {
-                k: v for k, v in consumer.context.items() if k in consumer.propagate_context_keys and k not in excluded
+                k: v
+                for k, v in consumer.context.items()
+                if k in consumer.propagate_context_keys and not is_non_forwarded_key(k)
             }
 
             OptionsValidator.validate_no_context_group_conflicts(set(propagating.keys()), set(new_group.keys()))

--- a/mloda/core/abstract_plugins/components/options.py
+++ b/mloda/core/abstract_plugins/components/options.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-NON_FORWARDED_KEYS: frozenset[str] = frozenset({DefaultOptionKeys.in_features})
+NON_FORWARDED_KEYS: frozenset[str] = frozenset({DefaultOptionKeys.in_features.value})
 
 
 def _safe_deepcopy(value: Any, memo: dict[int, Any]) -> Any:

--- a/tests/test_core/test_abstract_plugins/test_components/test_options_inherit_from.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_options_inherit_from.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from enum import Enum
 from uuid import uuid4
 
 import pytest
@@ -1664,60 +1665,92 @@ class TestInheritFromCrossCategoryForwardConflictHint:
             child.inherit_from(consumer)
 
 
-class TestNonForwardedKeysConstant:
-    """
-    Test suite for the shared never-forwarded key set (NEW SPEC).
+class _DeMixedOptionKey(Enum):
+    """Stands in for a DefaultOptionKeys that no longer mixes in str."""
 
-    The hardcoded {DefaultOptionKeys.in_features} exclusion set, once duplicated across
-    Options.inherit_from and the resolution-failure forwarding hint, becomes a public
-    module-level constant NON_FORWARDED_KEYS in options.py. The hint itself is gone
-    (#791/#782); Options.inherit_from is now the only consumer of the constant.
-    """
+    in_features = "in_features"
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+
+class TestNonForwardedKeysConstant:
+    """The never-forwarded key set and its matcher, consumed by Options.inherit_from."""
 
     def test_constant_is_importable_frozenset_containing_in_features(self) -> None:
         """NON_FORWARDED_KEYS is importable from options.py and contains in_features."""
         from mloda.core.abstract_plugins.components.options import NON_FORWARDED_KEYS
 
         assert isinstance(NON_FORWARDED_KEYS, frozenset)
-        assert DefaultOptionKeys.in_features in NON_FORWARDED_KEYS
-
-    def test_constant_holds_plain_string_values_not_enum_members(self) -> None:
-        """The constant stores the key STRING, so membership does not depend on the
-        DefaultOptionKeys str mixin supplying str.__hash__ for enum members."""
-        from mloda.core.abstract_plugins.components.options import NON_FORWARDED_KEYS
-
-        assert all(type(key) is str for key in NON_FORWARDED_KEYS)
         assert DefaultOptionKeys.in_features.value in NON_FORWARDED_KEYS
 
-    def test_in_features_literal_string_key_never_forwarded(self) -> None:
-        """Options keyed with the literal string form are still excluded: this would fail
-        if the constant and the plain-string dict-key form ever diverged."""
-        consumer = Options(
-            group={"in_features": "consumer_source", "kg_backend": "neo4j"},
-            context={},
-        )
-        child = Options()
+    def test_constant_holds_plain_strings_only(self) -> None:
+        """Every element is a plain str, so exclusion matching never rides on enum hashing or equality."""
+        from mloda.core.abstract_plugins.components.options import NON_FORWARDED_KEYS
 
-        child.inherit_from(consumer)
-        child.inherit_from(consumer, forward_group=frozenset({"in_features"}))
+        offenders = [(key, type(key)) for key in NON_FORWARDED_KEYS if type(key) is not str]
+        assert offenders == [], f"NON_FORWARDED_KEYS holds non-plain-str elements: {offenders}"
 
-        assert "in_features" not in child.group
-        assert "in_features" not in child.context
-        assert child.group["kg_backend"] == "neo4j"
+    def test_is_non_forwarded_key_matches_both_key_forms(self) -> None:
+        """The matcher accepts the enum member and the plain string, and rejects anything else."""
+        from mloda.core.abstract_plugins.components.options import is_non_forwarded_key
+
+        assert is_non_forwarded_key(DefaultOptionKeys.in_features) is True
+        assert is_non_forwarded_key("in_features") is True
+        assert is_non_forwarded_key("kg_backend") is False
+        assert is_non_forwarded_key(Options) is False
+        assert is_non_forwarded_key(7) is False
+
+    def test_is_non_forwarded_key_does_not_ride_on_the_str_mixin(self) -> None:
+        """A de-mixed DefaultOptionKeys stand-in still matches, so exclusion cannot rely on str inheritance."""
+        from mloda.core.abstract_plugins.components.options import is_non_forwarded_key
+
+        assert not isinstance(_DeMixedOptionKey.in_features, str), "guard: the stand-in must not mix in str"
+        assert is_non_forwarded_key(_DeMixedOptionKey.in_features) is True
 
     def test_in_features_never_forwarded_regression_pin(self) -> None:
-        """Regression pin: in_features never flows through any inherit_from flow."""
-        consumer = Options(
+        """Regression pin: an enum-member-keyed in_features never flows through any inherit_from flow."""
+        group_consumer = Options(
             group={DefaultOptionKeys.in_features: "consumer_source", "kg_backend": "neo4j"},
             context={},
         )
+        context_consumer = Options(
+            context={DefaultOptionKeys.in_features: "consumer_source"},
+            propagate_context_keys=frozenset({DefaultOptionKeys.in_features}),
+        )
         child = Options()
 
-        child.inherit_from(consumer)
-        child.inherit_from(consumer, forward_group=frozenset({DefaultOptionKeys.in_features}))
+        child.inherit_from(group_consumer)
+        child.inherit_from(group_consumer, forward_group=frozenset({DefaultOptionKeys.in_features}))
+        child.inherit_from(context_consumer, inherit_context_keys=frozenset({DefaultOptionKeys.in_features}))
 
         assert DefaultOptionKeys.in_features not in child.group
         assert DefaultOptionKeys.in_features not in child.context
+        assert DefaultOptionKeys.in_features not in child.inherited_group_keys
+        assert DefaultOptionKeys.in_features not in child.inherited_context_keys
+        assert child.group["kg_backend"] == "neo4j"
+
+    def test_literal_string_key_excluded_at_every_flow(self) -> None:
+        """The plain string "in_features" is excluded from the group forward, the context pull, and the push."""
+        from mloda.core.abstract_plugins.components.options import NON_FORWARDED_KEYS
+
+        assert "in_features" in NON_FORWARDED_KEYS, "literal below must track DefaultOptionKeys.in_features"
+
+        group_consumer = Options(group={"in_features": "consumer_source", "kg_backend": "neo4j"})
+        context_consumer = Options(
+            context={"in_features": "consumer_source"},
+            propagate_context_keys=frozenset({"in_features"}),
+        )
+        child = Options()
+
+        child.inherit_from(group_consumer)
+        child.inherit_from(group_consumer, forward_group=frozenset({"in_features"}))
+        child.inherit_from(context_consumer, inherit_context_keys=frozenset({"in_features"}))
+
+        assert "in_features" not in child.group
+        assert "in_features" not in child.context
+        assert "in_features" not in child.inherited_group_keys
+        assert "in_features" not in child.inherited_context_keys
         assert child.group["kg_backend"] == "neo4j"
 
 

--- a/tests/test_core/test_abstract_plugins/test_components/test_options_inherit_from.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_options_inherit_from.py
@@ -1681,6 +1681,30 @@ class TestNonForwardedKeysConstant:
         assert isinstance(NON_FORWARDED_KEYS, frozenset)
         assert DefaultOptionKeys.in_features in NON_FORWARDED_KEYS
 
+    def test_constant_holds_plain_string_values_not_enum_members(self) -> None:
+        """The constant stores the key STRING, so membership does not depend on the
+        DefaultOptionKeys str mixin supplying str.__hash__ for enum members."""
+        from mloda.core.abstract_plugins.components.options import NON_FORWARDED_KEYS
+
+        assert all(type(key) is str for key in NON_FORWARDED_KEYS)
+        assert DefaultOptionKeys.in_features.value in NON_FORWARDED_KEYS
+
+    def test_in_features_literal_string_key_never_forwarded(self) -> None:
+        """Options keyed with the literal string form are still excluded: this would fail
+        if the constant and the plain-string dict-key form ever diverged."""
+        consumer = Options(
+            group={"in_features": "consumer_source", "kg_backend": "neo4j"},
+            context={},
+        )
+        child = Options()
+
+        child.inherit_from(consumer)
+        child.inherit_from(consumer, forward_group=frozenset({"in_features"}))
+
+        assert "in_features" not in child.group
+        assert "in_features" not in child.context
+        assert child.group["kg_backend"] == "neo4j"
+
     def test_in_features_never_forwarded_regression_pin(self) -> None:
         """Regression pin: in_features never flows through any inherit_from flow."""
         consumer = Options(

--- a/tests/test_plugins/feature_group/experimental/test_default_options_key.py
+++ b/tests/test_plugins/feature_group/experimental/test_default_options_key.py
@@ -59,6 +59,28 @@ class TestDefaultOptionKeys:
         for member in DefaultOptionKeys:
             assert member == member.name
 
+    def test_str_mixin_makes_members_interchangeable_with_their_value(self) -> None:
+        """The str mixin is load-bearing, not incidental.
+
+        `str` precedes `Enum` in the MRO, so members take str.__hash__/__eq__ and hash by
+        VALUE, not by member name. Dozens of call sites across mloda/ and mloda_plugins/
+        test an enum member against option dicts that hold plain strings, for example
+        `DefaultOptionKeys.in_features in options` in the feature-config loader and
+        `options.get(DefaultOptionKeys.strict_type_enforcement)` in the datatype validator.
+        Removing the mixin, or reordering the bases, would silently unmatch every one of
+        them. Only `is_non_forwarded_key` is independent of this, because it compares
+        `str(key)`.
+        """
+        for member in DefaultOptionKeys:
+            assert hash(member) == hash(member.value)
+            assert member in {member.value}
+            assert member.value in {member}
+            # The str-keyed dict is how option dicts are annotated; a member must reach both ways.
+            member_keyed: dict[str, int] = {member: 1}
+            value_keyed: dict[str, int] = {member.value: 1}
+            assert member_keyed[member.value] == 1
+            assert value_keyed[member] == 1
+
 
 class TestDefaultOptionKeysStrBehavior:
     def test_str_returns_value(self) -> None:


### PR DESCRIPTION
## Problem

`NON_FORWARDED_KEYS` holds the `DefaultOptionKeys.in_features` enum member, while option dicts hold plain strings. Every `key in NON_FORWARDED_KEYS` / `key in excluded` test in `inherit_from` only matches because `DefaultOptionKeys` subclasses `str`, so `str.__hash__` hashes the enum *value* instead of `enum.Enum.__hash__` hashing the member name.

That coincidence is load-bearing: the `DefaultOptionKeys` docstring says the enum value serves as both the option key and the default column name, so renaming a value (e.g. `in_features = "mloda_source_feature"`) is an expected kind of change. After such a rename the membership test would silently stop matching plain-string dict keys, and `in_features` would start being forwarded to input features with no test failing.

## Fix

Store the plain string value in the constant:

```python
NON_FORWARDED_KEYS: frozenset[str] = frozenset({DefaultOptionKeys.in_features.value})
```

The membership checks in the group loop, the context loop, and the `propagate_context_keys` block are now explicit string-vs-string comparisons, independent of the `str` mixin.

## Tests

Added to `TestNonForwardedKeysConstant`:

- `test_constant_holds_plain_string_values_not_enum_members` - pins that every entry is `type(...) is str` and that `DefaultOptionKeys.in_features.value` is a member
- `test_in_features_literal_string_key_never_forwarded` - keys the consumer options with the literal string `"in_features"` and asserts it is never forwarded through the default flow or an explicit `forward_group` allowlist, so it would fail if the constant and the plain-string dict-key form ever diverged

`tests/test_core` passes locally (the 2 failures in `test_feature_config_runtime_validation.py` are pre-existing on `main` in my environment and unrelated).

Fixes #1063