### PR TITLE
fix: match a never-forwarded option key in either key form

### DIFF
--- a/mloda/core/abstract_plugins/components/options.py
+++ b/mloda/core/abstract_plugins/components/options.py
@@ -16,6 +16,11 @@ logger = logging.getLogger(__name__)
 NON_FORWARDED_KEYS: frozenset[str] = frozenset({DefaultOptionKeys.in_features.value})
 
 
+def is_non_forwarded_key(key: Any) -> bool:
+    """Match a never-forwarded key in either its string or its DefaultOptionKeys form."""
+    return str(key) in NON_FORWARDED_KEYS
+
+
 def _safe_deepcopy(value: Any, memo: dict[int, Any]) -> Any:
     """Deep-copy a single value, falling back to sharing the value by reference when it cannot be
     deep-copied for ANY reason (e.g. unpicklable objects, or values whose deepcopy raises under some
@@ -367,7 +372,6 @@ class Options:
 
         memo: dict[int, Any] = {}
 
-        excluded = NON_FORWARDED_KEYS
         validate_forwarding_directives(forward_group, forward_group_exclude)
 
         if forward_group is False:
@@ -386,7 +390,7 @@ class Options:
 
         inherited: set[str] = set()
         for key in sorted(group_keys):
-            if key in excluded or key not in consumer.group:
+            if is_non_forwarded_key(key) or key not in consumer.group:
                 continue
             if key in new_context and new_context[key] != consumer.group[key]:
                 owner_clause = f" on input feature '{owner}'" if owner is not None else " on the input feature"
@@ -411,7 +415,7 @@ class Options:
 
         inherited_context: set[str] = set()
         for key in inherit_context_keys:
-            if key in excluded or key not in consumer.context:
+            if is_non_forwarded_key(key) or key not in consumer.context:
                 continue
             value = _isolate_forwarded_value(consumer.context[key], memo)
             OptionsValidator.validate_can_add_to_context(key, value, new_group, new_context)
@@ -420,7 +424,9 @@ class Options:
 
         if consumer.propagate_context_keys and forward_group is not False:
             propagating = {
-                k: v for k, v in consumer.context.items() if k in consumer.propagate_context_keys and k not in excluded
+                k: v
+                for k, v in consumer.context.items()
+                if k in consumer.propagate_context_keys and not is_non_forwarded_key(k)
             }
 
             OptionsValidator.validate_no_context_group_conflicts(set(propagating.keys()), set(new_group.keys()))

--- a/mloda/core/abstract_plugins/components/options.py
+++ b/mloda/core/abstract_plugins/components/options.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-NON_FORWARDED_KEYS: frozenset[str] = frozenset({DefaultOptionKeys.in_features})
+NON_FORWARDED_KEYS: frozenset[str] = frozenset({DefaultOptionKeys.in_features.value})
 
 
 def _safe_deepcopy(value: Any, memo: dict[int, Any]) -> Any:

--- a/mloda/core/filter/global_filter.py
+++ b/mloda/core/filter/global_filter.py
@@ -10,7 +10,7 @@ from mloda.core.abstract_plugins.components.feature_chainer.feature_chain_parser
 from mloda.core.abstract_plugins.components.feature_chainer.property_spec import is_no_default
 from mloda.core.abstract_plugins.components.utils import safe_field
 from mloda.core.abstract_plugins.components.feature_name import FeatureName
-from mloda.core.abstract_plugins.components.options import NON_FORWARDED_KEYS, Options
+from mloda.core.abstract_plugins.components.options import Options, is_non_forwarded_key
 from mloda.core.abstract_plugins.components.data_access_collection import DataAccessCollection
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.match_hook import call_match_hook
@@ -164,11 +164,11 @@ class GlobalFilter:
         # Imported values stay shared by reference, so a shared Feature value under any key keeps a stored
         # filter's hash live; the post-planning rehash still covers that.
         for key, value in feat_options.group.items():
-            if key in NON_FORWARDED_KEYS or key in filter_options:
+            if is_non_forwarded_key(key) or key in filter_options:
                 continue
             filter_options.add_to_group(key, value)
         for key, value in feat_options.context.items():
-            if key in NON_FORWARDED_KEYS or key in filter_options:
+            if is_non_forwarded_key(key) or key in filter_options:
                 continue
             filter_options.add_to_context(key, value)
         return filter_options
@@ -179,7 +179,7 @@ class GlobalFilter:
         """Report keys the filter feature declares differently, unless intake provably erases the difference."""
         for key, value in chain(feat_options.group.items(), feat_options.context.items()):
             # unify_options never imports these, so the divergence cannot be acted on.
-            if key in NON_FORWARDED_KEYS:
+            if is_non_forwarded_key(key):
                 continue
             if key not in filter_options:
                 continue

--- a/tests/test_core/test_abstract_plugins/test_components/test_options_inherit_from.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_options_inherit_from.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from enum import Enum
 from uuid import uuid4
 
 import pytest
@@ -1694,6 +1695,33 @@ class TestNonForwardedKeysConstant:
 
         assert DefaultOptionKeys.in_features not in child.group
         assert DefaultOptionKeys.in_features not in child.context
+        assert child.group["kg_backend"] == "neo4j"
+
+    def test_constant_holds_plain_strings_only(self) -> None:
+        """Every element is a plain str, so exclusion matching never rides on enum hashing or equality."""
+        from mloda.core.abstract_plugins.components.options import NON_FORWARDED_KEYS
+
+        offenders = [(key, type(key)) for key in NON_FORWARDED_KEYS if type(key) is not str]
+        assert offenders == [], f"NON_FORWARDED_KEYS holds non-plain-str elements: {offenders}"
+        assert not any(isinstance(key, Enum) for key in NON_FORWARDED_KEYS)
+
+    def test_literal_string_key_excluded_at_every_flow(self) -> None:
+        """The plain string "in_features" is excluded from the group forward, the context pull, and the push."""
+        group_consumer = Options(group={"in_features": "consumer_source", "kg_backend": "neo4j"})
+        context_consumer = Options(
+            context={"in_features": "consumer_source"},
+            propagate_context_keys=frozenset({"in_features"}),
+        )
+        child = Options()
+
+        child.inherit_from(group_consumer)
+        child.inherit_from(group_consumer, forward_group=frozenset({"in_features"}))
+        child.inherit_from(context_consumer, inherit_context_keys=frozenset({"in_features"}))
+
+        assert "in_features" not in child.group
+        assert "in_features" not in child.context
+        assert "in_features" not in child.inherited_group_keys
+        assert "in_features" not in child.inherited_context_keys
         assert child.group["kg_backend"] == "neo4j"
 
 

--- a/tests/test_core/test_abstract_plugins/test_components/test_options_inherit_from.py
+++ b/tests/test_core/test_abstract_plugins/test_components/test_options_inherit_from.py
@@ -1665,36 +1665,62 @@ class TestInheritFromCrossCategoryForwardConflictHint:
             child.inherit_from(consumer)
 
 
-class TestNonForwardedKeysConstant:
-    """
-    Test suite for the shared never-forwarded key set (NEW SPEC).
+class _DeMixedOptionKey(Enum):
+    """Stands in for a DefaultOptionKeys that no longer mixes in str."""
 
-    The hardcoded {DefaultOptionKeys.in_features} exclusion set, once duplicated across
-    Options.inherit_from and the resolution-failure forwarding hint, becomes a public
-    module-level constant NON_FORWARDED_KEYS in options.py. The hint itself is gone
-    (#791/#782); Options.inherit_from is now the only consumer of the constant.
-    """
+    in_features = "in_features"
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+
+class TestNonForwardedKeysConstant:
+    """The never-forwarded key set, consumed by Options.inherit_from and by GlobalFilter."""
 
     def test_constant_is_importable_frozenset_containing_in_features(self) -> None:
         """NON_FORWARDED_KEYS is importable from options.py and contains in_features."""
         from mloda.core.abstract_plugins.components.options import NON_FORWARDED_KEYS
 
         assert isinstance(NON_FORWARDED_KEYS, frozenset)
-        assert DefaultOptionKeys.in_features in NON_FORWARDED_KEYS
+        assert DefaultOptionKeys.in_features.value in NON_FORWARDED_KEYS
+
+    def test_is_non_forwarded_key_matches_both_key_forms(self) -> None:
+        """The matcher accepts the enum member and the plain string, and rejects anything else."""
+        from mloda.core.abstract_plugins.components.options import is_non_forwarded_key
+
+        assert is_non_forwarded_key(DefaultOptionKeys.in_features) is True
+        assert is_non_forwarded_key("in_features") is True
+        assert is_non_forwarded_key("kg_backend") is False
+        assert is_non_forwarded_key(Options) is False
+        assert is_non_forwarded_key(7) is False
+
+    def test_is_non_forwarded_key_does_not_ride_on_the_str_mixin(self) -> None:
+        """A de-mixed DefaultOptionKeys stand-in still matches, so exclusion cannot rely on str inheritance."""
+        from mloda.core.abstract_plugins.components.options import is_non_forwarded_key
+
+        assert not isinstance(_DeMixedOptionKey.in_features, str), "guard: the stand-in must not mix in str"
+        assert is_non_forwarded_key(_DeMixedOptionKey.in_features) is True
 
     def test_in_features_never_forwarded_regression_pin(self) -> None:
-        """Regression pin: in_features never flows through any inherit_from flow."""
-        consumer = Options(
+        """Regression pin: an enum-member-keyed in_features never flows through any inherit_from flow."""
+        group_consumer = Options(
             group={DefaultOptionKeys.in_features: "consumer_source", "kg_backend": "neo4j"},
             context={},
         )
+        context_consumer = Options(
+            context={DefaultOptionKeys.in_features: "consumer_source"},
+            propagate_context_keys=frozenset({DefaultOptionKeys.in_features}),
+        )
         child = Options()
 
-        child.inherit_from(consumer)
-        child.inherit_from(consumer, forward_group=frozenset({DefaultOptionKeys.in_features}))
+        child.inherit_from(group_consumer)
+        child.inherit_from(group_consumer, forward_group=frozenset({DefaultOptionKeys.in_features}))
+        child.inherit_from(context_consumer, inherit_context_keys=frozenset({DefaultOptionKeys.in_features}))
 
         assert DefaultOptionKeys.in_features not in child.group
         assert DefaultOptionKeys.in_features not in child.context
+        assert DefaultOptionKeys.in_features not in child.inherited_group_keys
+        assert DefaultOptionKeys.in_features not in child.inherited_context_keys
         assert child.group["kg_backend"] == "neo4j"
 
     def test_constant_holds_plain_strings_only(self) -> None:
@@ -1703,10 +1729,13 @@ class TestNonForwardedKeysConstant:
 
         offenders = [(key, type(key)) for key in NON_FORWARDED_KEYS if type(key) is not str]
         assert offenders == [], f"NON_FORWARDED_KEYS holds non-plain-str elements: {offenders}"
-        assert not any(isinstance(key, Enum) for key in NON_FORWARDED_KEYS)
 
     def test_literal_string_key_excluded_at_every_flow(self) -> None:
         """The plain string "in_features" is excluded from the group forward, the context pull, and the push."""
+        from mloda.core.abstract_plugins.components.options import NON_FORWARDED_KEYS
+
+        assert "in_features" in NON_FORWARDED_KEYS, "literal below must track DefaultOptionKeys.in_features"
+
         group_consumer = Options(group={"in_features": "consumer_source", "kg_backend": "neo4j"})
         context_consumer = Options(
             context={"in_features": "consumer_source"},

--- a/tests/test_core/test_filter/test_filter_feature_non_forwarded_keys.py
+++ b/tests/test_core/test_filter/test_filter_feature_non_forwarded_keys.py
@@ -73,7 +73,29 @@ def _store_matches(global_filter: GlobalFilter, host: Feature) -> set[SingleFilt
 
 def test_the_parametrized_key_list_is_populated() -> None:
     """Guard: an emptied NON_FORWARDED_KEYS would silently skip every case below instead of failing it."""
-    assert DefaultOptionKeys.in_features in NON_FORWARDED_KEYS
+    assert DefaultOptionKeys.in_features.value in NON_FORWARDED_KEYS
+
+
+def test_unify_options_skips_an_enum_member_keyed_group_key() -> None:
+    """Production option dicts key in_features with the enum member, not with the plain string."""
+    unified = GlobalFilter().unify_options(
+        Options(group={DefaultOptionKeys.in_features: NFK_HOST_VALUE, NFK_ORDINARY: 1}),
+        Options(),
+    )
+
+    assert DefaultOptionKeys.in_features not in unified, f"the enum-member key must not be imported: {unified}"
+    assert unified.group == {NFK_ORDINARY: 1}, f"every other host group key must still arrive: {unified.group}"
+
+
+def test_unify_options_skips_an_enum_member_keyed_context_key() -> None:
+    """The context import excludes the enum-member key just as the group import does."""
+    unified = GlobalFilter().unify_options(
+        Options(context={DefaultOptionKeys.in_features: NFK_HOST_VALUE, NFK_ORDINARY: 1}),
+        Options(),
+    )
+
+    assert DefaultOptionKeys.in_features not in unified, f"the enum-member key must not be imported: {unified}"
+    assert unified.context == {NFK_ORDINARY: 1}, f"every other host context key must still arrive: {unified.context}"
 
 
 @pytest.mark.parametrize("blocked", _BLOCKED_KEYS)


### PR DESCRIPTION
Closes #1063.

## Problem

`NON_FORWARDED_KEYS` held the `DefaultOptionKeys.in_features` enum member. Every
`key in NON_FORWARDED_KEYS` test matched a plain-string option key only because
`DefaultOptionKeys` subclasses `str`, so `str.__hash__` and `str.__eq__` ran instead of the
enum's. The `DefaultOptionKeys` docstring treats the enum value as a renameable column name,
so a rename would silently stop the exclusion from matching and `in_features` would start
being forwarded to input features.

Storing the plain string alone does not fix that, it inverts it: option dicts are keyed with
the enum member in production (`mloda/core/api/feature_config/loader.py`), so a string-keyed
constant would match those keys only via the same mixin.

## Change

`NON_FORWARDED_KEYS` now holds the key string, and every membership test goes through a new
`is_non_forwarded_key(key)` that compares `str(key)`. `DefaultOptionKeys.__str__` returns the
value, so the enum member and the plain string both match without relying on the `str` mixin,
and non-string keys (reader classes, ints) stringify to something never in the set.

Six call sites move to the helper: the group loop, the context loop and the
`propagate_context_keys` block in `Options.inherit_from`, plus `GlobalFilter.unify_options`
(group and context import) and `_warn_on_diverging_options`. Behavior is unchanged today.

Note for plugin authors: `NON_FORWARDED_KEYS` is public and its elements are now plain `str`
rather than enum members. Membership use is unaffected; code calling `.value` on an element
would need the string directly.

## Tests

- `is_non_forwarded_key` matches both key forms and rejects unrelated and non-string keys.
- A de-mixed enum stand-in carrying the same `__str__` still matches, which pins the
  independence from the `str` mixin and fails under the old membership shape.
- Enum-member-keyed and literal-string-keyed exclusion pinned across all three `inherit_from`
  flows and both `GlobalFilter.unify_options` imports.

tox passes: 8732 passed, 170 skipped, ruff, mypy --strict and bandit clean.